### PR TITLE
Add namespace support for metrics (OSS)

### DIFF
--- a/.changelog/9117.txt
+++ b/.changelog/9117.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+connect: Update Envoy metrics names and labels for Connect proxy listeners so that attributes like datacenter and namespace can be extracted. 
+```

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -976,38 +976,58 @@ func (s *Server) makeUpstreamListenerForDiscoveryChain(
 	}
 
 	useRDS := true
-	clusterName := ""
+	var (
+		clusterName                        string
+		destination, datacenter, namespace string
+	)
 	if chain == nil || chain.IsDefault() {
+		useRDS = false
+
 		dc := u.Datacenter
 		if dc == "" {
 			dc = cfgSnap.Datacenter
 		}
-		sni := connect.UpstreamSNI(u, "", dc, cfgSnap.Roots.TrustDomain)
+		destination, datacenter, namespace = u.DestinationName, dc, u.DestinationNamespace
 
-		useRDS = false
+		sni := connect.UpstreamSNI(u, "", dc, cfgSnap.Roots.TrustDomain)
 		clusterName = CustomizeClusterName(sni, chain)
 
-	} else if cfg.Protocol == "tcp" {
-		startNode := chain.Nodes[chain.StartNode]
-		if startNode == nil {
-			return nil, fmt.Errorf("missing first node in compiled discovery chain for: %s", chain.ServiceName)
-		} else if startNode.Type != structs.DiscoveryGraphNodeTypeResolver {
-			return nil, fmt.Errorf("unexpected first node in discovery chain using protocol=%q: %s", cfg.Protocol, startNode.Type)
-		}
-		targetID := startNode.Resolver.Target
-		target := chain.Targets[targetID]
+	} else {
+		destination, datacenter, namespace = chain.ServiceName, chain.Datacenter, chain.Namespace
 
-		useRDS = false
-		clusterName = CustomizeClusterName(target.Name, chain)
+		if cfg.Protocol == "tcp" {
+			useRDS = false
+
+			startNode := chain.Nodes[chain.StartNode]
+			if startNode == nil {
+				return nil, fmt.Errorf("missing first node in compiled discovery chain for: %s", chain.ServiceName)
+			}
+			if startNode.Type != structs.DiscoveryGraphNodeTypeResolver {
+				return nil, fmt.Errorf("unexpected first node in discovery chain using protocol=%q: %s", cfg.Protocol, startNode.Type)
+			}
+			targetID := startNode.Resolver.Target
+			target := chain.Targets[targetID]
+
+			clusterName = CustomizeClusterName(target.Name, chain)
+		}
+	}
+	filterName := fmt.Sprintf("%s.%s", destination, datacenter)
+	if namespace != "" {
+		filterName += fmt.Sprintf(".%s", namespace)
+	}
+	if u.DestinationType == structs.UpstreamDestTypePreparedQuery {
+		// Avoid encoding dc and namespace for prepared queries.
+		// Those are defined in the query itself and are not available here.
+		filterName = upstreamID
 	}
 
 	opts := listenerFilterOpts{
 		useRDS:          useRDS,
 		protocol:        cfg.Protocol,
-		filterName:      upstreamID,
+		filterName:      filterName,
 		routeName:       upstreamID,
 		cluster:         clusterName,
-		statPrefix:      "upstream_",
+		statPrefix:      "upstream.",
 		routePath:       "",
 		ingress:         false,
 		httpAuthzFilter: nil,
@@ -1130,7 +1150,7 @@ func makeStatPrefix(protocol, prefix, filterName string) string {
 	// Replace colons here because Envoy does that in the metrics for the actual
 	// clusters but doesn't in the stat prefix here while dashboards assume they
 	// will match.
-	return fmt.Sprintf("%s%s_%s", prefix, strings.Replace(filterName, ":", "_", -1), protocol)
+	return fmt.Sprintf("%s%s.%s", prefix, strings.Replace(filterName, ":", "_", -1), protocol)
 }
 
 func makeHTTPFilter(opts listenerFilterOpts) (*envoylistener.Filter, error) {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -577,7 +577,7 @@ func expectListenerJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot) ma
 								"name": "envoy.tcp_proxy",
 								"config": {
 									"cluster": "local_app",
-									"stat_prefix": "public_listener_tcp"
+									"stat_prefix": "public_listener.tcp"
 								}
 							}
 						]
@@ -600,7 +600,7 @@ func expectListenerJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot) ma
 							"name": "envoy.tcp_proxy",
 							"config": {
 								"cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-								"stat_prefix": "upstream_db_tcp"
+								"stat_prefix": "upstream.db.dc1.tcp"
 							}
 						}
 					]
@@ -623,7 +623,7 @@ func expectListenerJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot) ma
 							"name": "envoy.tcp_proxy",
 							"config": {
 								"cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-								"stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+								"stat_prefix": "upstream.prepared_query_geo-cache.tcp"
 							}
 						}
 					]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-13-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-14-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-15-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-16-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-13-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-14-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-15-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-16-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-13-x.golden
@@ -30,7 +30,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -58,7 +58,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -112,7 +112,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-14-x.golden
@@ -30,7 +30,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -58,7 +58,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -112,7 +112,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-15-x.golden
@@ -30,7 +30,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -58,7 +58,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -112,7 +112,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-16-x.golden
@@ -30,7 +30,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -58,7 +58,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -112,7 +112,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-13-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-14-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-15-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-16-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-13-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-14-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-15-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-16-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-13-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-14-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-15-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-16-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-13-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-14-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-15-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-16-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-13-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-14-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-15-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-16-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener.envoy-1-13-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener.envoy-1-14-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener.envoy-1-15-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener.envoy-1-16-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-13-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-14-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-15-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-16-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/defaults.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/defaults.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/defaults.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/defaults.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/defaults.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/defaults.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/defaults.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/defaults.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-13-x.golden
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -94,7 +94,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health2_21501_http",
+                  "stat_prefix": "exposed_path_filter_health2_21501.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -132,7 +132,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-14-x.golden
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -94,7 +94,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health2_21501_http",
+                  "stat_prefix": "exposed_path_filter_health2_21501.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -132,7 +132,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-15-x.golden
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -94,7 +94,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health2_21501_http",
+                  "stat_prefix": "exposed_path_filter_health2_21501.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -132,7 +132,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-16-x.golden
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -94,7 +94,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health2_21501_http",
+                  "stat_prefix": "exposed_path_filter_health2_21501.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -132,7 +132,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-13-x.golden
@@ -44,7 +44,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501_http",
+                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -96,7 +96,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -134,7 +134,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-14-x.golden
@@ -44,7 +44,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501_http",
+                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -96,7 +96,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -134,7 +134,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-15-x.golden
@@ -44,7 +44,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501_http",
+                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -96,7 +96,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -134,7 +134,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-16-x.golden
@@ -44,7 +44,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501_http",
+                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -96,7 +96,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500.http",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -134,7 +134,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/http-public-listener.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "public_listener_http",
+                  "stat_prefix": "public_listener.http",
                   "tracing": {
                         "random_sampling": {
                             }

--- a/agent/xds/testdata/listeners/http-public-listener.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "public_listener_http",
+                  "stat_prefix": "public_listener.http",
                   "tracing": {
                         "random_sampling": {
                             }

--- a/agent/xds/testdata/listeners/http-public-listener.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "public_listener_http",
+                  "stat_prefix": "public_listener.http",
                   "tracing": {
                         "random_sampling": {
                             }

--- a/agent/xds/testdata/listeners/http-public-listener.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -118,7 +118,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "public_listener_http",
+                  "stat_prefix": "public_listener.http",
                   "tracing": {
                         "random_sampling": {
                             }

--- a/agent/xds/testdata/listeners/http-upstream.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/http-upstream.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                                     "domains": [
                                           "*"
                                         ],
-                                    "name": "db",
+                                    "name": "db.dc1",
                                     "routes": [
                                           {
                                                 "match": {
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -70,7 +70,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -124,7 +124,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/http-upstream.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/http-upstream.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                                     "domains": [
                                           "*"
                                         ],
-                                    "name": "db",
+                                    "name": "db.dc1",
                                     "routes": [
                                           {
                                                 "match": {
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -70,7 +70,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -124,7 +124,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/http-upstream.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/http-upstream.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                                     "domains": [
                                           "*"
                                         ],
-                                    "name": "db",
+                                    "name": "db.dc1",
                                     "routes": [
                                           {
                                                 "match": {
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -70,7 +70,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -124,7 +124,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/http-upstream.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/http-upstream.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                                     "domains": [
                                           "*"
                                         ],
-                                    "name": "db",
+                                    "name": "db.dc1",
                                     "routes": [
                                           {
                                                 "match": {
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -70,7 +70,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -124,7 +124,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_443_http",
+                  "stat_prefix": "ingress_upstream_443.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -67,7 +67,7 @@
                             },
                         "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_8080_http",
+                  "stat_prefix": "ingress_upstream_8080.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_443_http",
+                  "stat_prefix": "ingress_upstream_443.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -67,7 +67,7 @@
                             },
                         "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_8080_http",
+                  "stat_prefix": "ingress_upstream_8080.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_443_http",
+                  "stat_prefix": "ingress_upstream_443.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -67,7 +67,7 @@
                             },
                         "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_8080_http",
+                  "stat_prefix": "ingress_upstream_8080.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_443_http",
+                  "stat_prefix": "ingress_upstream_443.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -67,7 +67,7 @@
                             },
                         "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_8080_http",
+                  "stat_prefix": "ingress_upstream_8080.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_9191_http",
+                  "stat_prefix": "ingress_upstream_9191.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_9191_http",
+                  "stat_prefix": "ingress_upstream_9191.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_9191_http",
+                  "stat_prefix": "ingress_upstream_9191.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_9191_http",
+                  "stat_prefix": "ingress_upstream_9191.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-13-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-14-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-15-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-16-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.dc1.default.grpc",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-13-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-14-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-15-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-16-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-port.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-port.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-port.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-port.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-port.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-port.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-port.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-port.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.dc1.tcp"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-13-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_bar_tcp"
+                  "stat_prefix": "mesh_gateway_local_bar.tcp"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc2.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc4.tcp"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc6.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_baz_tcp"
+                  "stat_prefix": "mesh_gateway_local_baz.tcp"
                 }
             }
           ]
@@ -180,7 +180,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -196,7 +196,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -212,7 +212,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -226,7 +226,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]
@@ -259,7 +259,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc2.tcp"
                 }
             }
           ]
@@ -275,7 +275,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc4.tcp"
                 }
             }
           ]
@@ -291,7 +291,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc6.tcp"
                 }
             }
           ]
@@ -305,7 +305,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_foo_tcp"
+                  "stat_prefix": "mesh_gateway_local_foo.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-14-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_bar_tcp"
+                  "stat_prefix": "mesh_gateway_local_bar.tcp"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc2.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc4.tcp"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc6.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_baz_tcp"
+                  "stat_prefix": "mesh_gateway_local_baz.tcp"
                 }
             }
           ]
@@ -180,7 +180,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -196,7 +196,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -212,7 +212,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -226,7 +226,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]
@@ -259,7 +259,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc2.tcp"
                 }
             }
           ]
@@ -275,7 +275,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc4.tcp"
                 }
             }
           ]
@@ -291,7 +291,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc6.tcp"
                 }
             }
           ]
@@ -305,7 +305,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_foo_tcp"
+                  "stat_prefix": "mesh_gateway_local_foo.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-15-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_bar_tcp"
+                  "stat_prefix": "mesh_gateway_local_bar.tcp"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc2.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc4.tcp"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc6.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_baz_tcp"
+                  "stat_prefix": "mesh_gateway_local_baz.tcp"
                 }
             }
           ]
@@ -180,7 +180,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -196,7 +196,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -212,7 +212,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -226,7 +226,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]
@@ -259,7 +259,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc2.tcp"
                 }
             }
           ]
@@ -275,7 +275,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc4.tcp"
                 }
             }
           ]
@@ -291,7 +291,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc6.tcp"
                 }
             }
           ]
@@ -305,7 +305,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_foo_tcp"
+                  "stat_prefix": "mesh_gateway_local_foo.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-16-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_bar_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_bar_tcp"
+                  "stat_prefix": "mesh_gateway_local_bar.tcp"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc2.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc4.tcp"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_baz_dc6.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_baz_tcp"
+                  "stat_prefix": "mesh_gateway_local_baz.tcp"
                 }
             }
           ]
@@ -180,7 +180,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -196,7 +196,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -212,7 +212,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -226,7 +226,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]
@@ -259,7 +259,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc2.tcp"
                 }
             }
           ]
@@ -275,7 +275,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc4.tcp"
                 }
             }
           ]
@@ -291,7 +291,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_foo_dc6.tcp"
                 }
             }
           ]
@@ -305,7 +305,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_foo_tcp"
+                  "stat_prefix": "mesh_gateway_local_foo.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-13-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-14-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-15-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-16-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-13-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_lan_tcp"
+                  "stat_prefix": "mesh_gateway_local_lan.tcp"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc2.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc4.tcp"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc6.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_wan_tcp"
+                  "stat_prefix": "mesh_gateway_local_wan.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-14-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_lan_tcp"
+                  "stat_prefix": "mesh_gateway_local_lan.tcp"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc2.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc4.tcp"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc6.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_wan_tcp"
+                  "stat_prefix": "mesh_gateway_local_wan.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-15-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_lan_tcp"
+                  "stat_prefix": "mesh_gateway_local_lan.tcp"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc2.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc4.tcp"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc6.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_wan_tcp"
+                  "stat_prefix": "mesh_gateway_local_wan.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-16-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_lan_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_lan_tcp"
+                  "stat_prefix": "mesh_gateway_local_lan.tcp"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc2.tcp"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc4.tcp"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_wan_dc6.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_wan_tcp"
+                  "stat_prefix": "mesh_gateway_local_wan.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-13-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-14-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-15-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-16-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.envoy-1-13-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.envoy-1-14-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.envoy-1-15-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.envoy-1-16-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc2.tcp"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc4.tcp"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote_default_dc6.tcp"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.dc1.default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache.tcp"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-13-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_foo.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_foo.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_foo.tcp"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_foo.tcp"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_foo_tcp"
+                  "stat_prefix": "terminating_gateway_foo.tcp"
                 }
             }
           ]
@@ -272,7 +272,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_wan.tcp"
                 }
             }
           ]
@@ -319,7 +319,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_wan.tcp"
                 }
             }
           ]
@@ -366,7 +366,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_wan.tcp"
                 }
             }
           ]
@@ -413,7 +413,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_wan.tcp"
                 }
             }
           ]
@@ -427,7 +427,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_wan_tcp"
+                  "stat_prefix": "terminating_gateway_wan.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-14-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_foo.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_foo.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_foo.tcp"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_foo.tcp"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_foo_tcp"
+                  "stat_prefix": "terminating_gateway_foo.tcp"
                 }
             }
           ]
@@ -272,7 +272,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_wan.tcp"
                 }
             }
           ]
@@ -319,7 +319,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_wan.tcp"
                 }
             }
           ]
@@ -366,7 +366,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_wan.tcp"
                 }
             }
           ]
@@ -413,7 +413,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_wan.tcp"
                 }
             }
           ]
@@ -427,7 +427,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_wan_tcp"
+                  "stat_prefix": "terminating_gateway_wan.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-15-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_foo.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_foo.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_foo.tcp"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_foo.tcp"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_foo_tcp"
+                  "stat_prefix": "terminating_gateway_foo.tcp"
                 }
             }
           ]
@@ -272,7 +272,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_wan.tcp"
                 }
             }
           ]
@@ -319,7 +319,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_wan.tcp"
                 }
             }
           ]
@@ -366,7 +366,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_wan.tcp"
                 }
             }
           ]
@@ -413,7 +413,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_wan.tcp"
                 }
             }
           ]
@@ -427,7 +427,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_wan_tcp"
+                  "stat_prefix": "terminating_gateway_wan.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-16-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_foo.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_foo.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_foo.tcp"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_foo_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_foo.tcp"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_foo_tcp"
+                  "stat_prefix": "terminating_gateway_foo.tcp"
                 }
             }
           ]
@@ -272,7 +272,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_wan.tcp"
                 }
             }
           ]
@@ -319,7 +319,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_wan.tcp"
                 }
             }
           ]
@@ -366,7 +366,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_wan.tcp"
                 }
             }
           ]
@@ -413,7 +413,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_wan_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_wan.tcp"
                 }
             }
           ]
@@ -427,7 +427,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_wan_tcp"
+                  "stat_prefix": "terminating_gateway_wan.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-13-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_default.tcp"
                 }
             }
           ]
@@ -161,7 +161,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-14-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_default.tcp"
                 }
             }
           ]
@@ -161,7 +161,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-15-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_default.tcp"
                 }
             }
           ]
@@ -161,7 +161,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-16-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_default.tcp"
                 }
             }
           ]
@@ -161,7 +161,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-13-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-14-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-15-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-16-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-13-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -204,7 +204,7 @@
                             },
                         "route_config_name": "v1.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -266,7 +266,7 @@
                             },
                         "route_config_name": "v2.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -328,7 +328,7 @@
                             },
                         "route_config_name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -347,7 +347,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-14-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -204,7 +204,7 @@
                             },
                         "route_config_name": "v1.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -266,7 +266,7 @@
                             },
                         "route_config_name": "v2.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -328,7 +328,7 @@
                             },
                         "route_config_name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -347,7 +347,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-15-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -204,7 +204,7 @@
                             },
                         "route_config_name": "v1.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -266,7 +266,7 @@
                             },
                         "route_config_name": "v2.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -328,7 +328,7 @@
                             },
                         "route_config_name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -347,7 +347,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-16-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -204,7 +204,7 @@
                             },
                         "route_config_name": "v1.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -266,7 +266,7 @@
                             },
                         "route_config_name": "v2.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -328,7 +328,7 @@
                             },
                         "route_config_name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway_default_web_default.http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -347,7 +347,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-13-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_default.tcp"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-14-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_default.tcp"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-15-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_default.tcp"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-16-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_api_default.tcp"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_cache_default.tcp"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_db_default.tcp"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway_default_web_default.tcp"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway_default.tcp"
                 }
             }
           ]

--- a/api/api.go
+++ b/api/api.go
@@ -305,7 +305,7 @@ type Config struct {
 	TokenFile string
 
 	// Namespace is the name of the namespace to send along for the request
-	// when no other Namespace ispresent in the QueryOptions
+	// when no other Namespace is present in the QueryOptions
 	Namespace string
 
 	TLSConfig TLSConfig

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -14,6 +14,12 @@ type BootstrapTplArgs struct {
 	// the agent to deliver the correct configuration.
 	ProxyID string
 
+	// ProxySourceService is the Consul service name to report for this proxy
+	// instance's source service label. For sidecars it should be the
+	// Proxy.DestinationServiceName. For gateways and similar it is the service
+	// name of the proxy service itself.
+	ProxySourceService string
+
 	// AgentCAPEM is the CA to use to verify the local agent gRPC service if
 	// TLS is enabled.
 	AgentCAPEM string
@@ -79,8 +85,8 @@ type BootstrapTplArgs struct {
 	// See https://www.envoyproxy.io/docs/envoy/v1.9.0/api-v2/config/trace/v2/trace.proto.
 	TracingConfigJSON string
 
-	// Namespace is the Consul Enterprise Namespace of the proxy service instance as
-	// registered with the Consul agent.
+	// Namespace is the Consul Enterprise Namespace of the proxy service instance
+	// as registered with the Consul agent.
 	Namespace string
 
 	// EnvoyVersion is the envoy version, which is necessary to generate the

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -30,7 +31,10 @@ func New(ui cli.Ui) *cmd {
 		Ui:           ui,
 	}
 
-	c := &cmd{UI: ui}
+	c := &cmd{
+		UI:        ui,
+		directOut: os.Stdout,
+	}
 	c.init()
 	return c
 }
@@ -43,6 +47,9 @@ type cmd struct {
 	http   *flags.HTTPFlags
 	help   string
 	client *api.Client
+	// DirectOut defaults to os.stdout but is a property to allow capture during
+	// tests to have more useful output.
+	directOut io.Writer
 
 	// flags
 	meshGateway          bool
@@ -64,6 +71,7 @@ type cmd struct {
 	deregAfterCritical string
 	bindAddresses      ServiceAddressMapValue
 	exposeServers      bool
+	omitDeprecatedTags bool
 
 	gatewaySvcName string
 	gatewayKind    api.ServiceKind
@@ -151,6 +159,11 @@ func (c *cmd) init() {
 
 	c.flags.StringVar(&c.deregAfterCritical, "deregister-after-critical", "6h",
 		"The amount of time the gateway services health check can be failing before being deregistered")
+
+	c.flags.BoolVar(&c.omitDeprecatedTags, "omit-deprecated-tags", false,
+		"In Consul 1.9.0 the format of metric tags for Envoy clusters was updated from consul.[service|dc|...] to "+
+			"consul.destination.[service|dc|...]. The old tags were preserved for backward compatibility,"+
+			"but can be disabled with this flag.")
 
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flags, c.http.ClientFlags())
@@ -364,7 +377,7 @@ func (c *cmd) run(args []string) int {
 
 	if c.bootstrap {
 		// Just output it and we are done
-		os.Stdout.Write(bootstrapJson)
+		c.directOut.Write(bootstrapJson)
 		return 0
 	}
 
@@ -431,10 +444,13 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 	// know service name yet, we will after we resolve the proxy's config in a bit
 	// and will update this then.
 	cluster := c.proxyID
+	proxySourceService := ""
 	if c.sidecarFor != "" {
 		cluster = c.sidecarFor
+		proxySourceService = c.sidecarFor
 	} else if c.gateway != "" && c.gatewaySvcName != "" {
 		cluster = c.gatewaySvcName
+		proxySourceService = c.gatewaySvcName
 	}
 
 	adminAccessLogPath := c.adminAccessLogPath
@@ -453,6 +469,7 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 		GRPC:                  grpcAddr,
 		ProxyCluster:          cluster,
 		ProxyID:               c.proxyID,
+		ProxySourceService:    proxySourceService,
 		AgentCAPEM:            caPEM,
 		AdminAccessLogPath:    adminAccessLogPath,
 		AdminBindAddress:      adminBindIP.String(),
@@ -483,29 +500,44 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		bsCfg.ReadyBindAddr = lanAddr
 	}
 
+	// Fetch any customization from the registration
+	svc, _, err := c.client.Agent().Service(c.proxyID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetch proxy config from local agent: %s", err)
+	}
+	if svc.Proxy == nil {
+		return nil, errors.New("service is not a Connect proxy or gateway")
+	}
+
+	if svc.Proxy.DestinationServiceName != "" {
+		// Override cluster now we know the actual service name
+		args.ProxyCluster = svc.Proxy.DestinationServiceName
+		args.ProxySourceService = svc.Proxy.DestinationServiceName
+	} else {
+		// Set the source service name from the proxy's own registration
+		args.ProxySourceService = svc.Service
+	}
+	if svc.Namespace != "" {
+		// In most cases where namespaces are enabled this will already be set
+		// correctly because the http client that fetched this will need to have
+		// had the namespace set on it which is also how we initially populate
+		// this. However in the case of "default" namespace being accessed because
+		// there was no namespace argument, args.Namespace will be empty even
+		// though Namespaces are actually being used and the request was
+		// implicitly interpreted as "default" namespace. Overriding it here
+		// ensure that we always set the Namespace arg if the cluster is using
+		// namespaces regardless.
+		args.Namespace = svc.Namespace
+	}
+
 	if !c.disableCentralConfig {
-		// Fetch any customization from the registration
-		svc, _, err := c.client.Agent().Service(c.proxyID, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed fetch proxy config from local agent: %s", err)
-		}
-
-		if svc.Proxy == nil {
-			return nil, errors.New("service is not a Connect proxy or gateway")
-		}
-
 		// Parse the bootstrap config
 		if err := mapstructure.WeakDecode(svc.Proxy.Config, &bsCfg); err != nil {
 			return nil, fmt.Errorf("failed parsing Proxy.Config: %s", err)
 		}
-
-		if svc.Proxy.DestinationServiceName != "" {
-			// Override cluster now we know the actual service name
-			args.ProxyCluster = svc.Proxy.DestinationServiceName
-		}
 	}
 
-	return bsCfg.GenerateJSON(args)
+	return bsCfg.GenerateJSON(args, c.omitDeprecatedTags)
 }
 
 // TODO: make method a function

--- a/command/connect/envoy/envoy_oss_test.go
+++ b/command/connect/envoy/envoy_oss_test.go
@@ -1,0 +1,9 @@
+// +build !consulent
+
+package envoy
+
+// enterpriseGenerateConfigTestCases returns enterprise-only configurations to
+// test in TestGenerateConfig.
+func enterpriseGenerateConfigTestCases() []generateConfigTestCase {
+	return nil
+}

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
@@ -47,6 +47,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -83,6 +139,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -47,6 +47,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -83,6 +139,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -47,6 +47,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -83,6 +139,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -60,6 +60,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -96,6 +152,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -51,6 +51,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -87,6 +143,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-addr-config.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -37,6 +37,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -73,6 +129,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -111,6 +111,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -147,6 +203,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "ingress-gateway"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "ingress-gateway"
       }
     ],

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -111,6 +111,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -147,6 +203,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "ingress-gateway"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "ingress-gateway"
       }
     ],

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -111,6 +111,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -147,6 +203,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "my-gateway-123"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "my-gateway-123"
       }
     ],

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -111,6 +111,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -147,6 +203,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "my-gateway"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "my-gateway"
       }
     ],

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -111,6 +111,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -147,6 +203,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "ingress-gateway-1"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "ingress-gateway-1"
       }
     ],

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -38,6 +38,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +130,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -62,6 +62,62 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)\\.[^.]+\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.([^.]+)\\.(?:[^.]+\\.)?[^.]+\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.((?:[^.]+\\.))?[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+\\.[^.]+\\.(?:[^.]+\\.)?([^.]+)\\.)",
+        "tag_name": "consul.upstream.protocol"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+\\.[^.]+\\.(?:[^.]+\\.)?[^.]+)\\.)",
+        "tag_name": "consul.upstream.full_target"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -98,6 +154,10 @@
       },
       {
         "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
         "fixed_value": "test-proxy"
       }
     ],

--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,6 +1,6 @@
-FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
+FROM hashicorp.jfrog.io/docker/fortio/fortio AS fortio
 
-FROM docker.mirror.hashicorp.services/bats/bats:latest
+FROM hashicorp.jfrog.io/docker/bats/bats:latest
 
 RUN apk add curl
 RUN apk add openssl

--- a/test/integration/connect/envoy/Dockerfile-consul-envoy
+++ b/test/integration/connect/envoy/Dockerfile-consul-envoy
@@ -3,5 +3,5 @@ ARG ENVOY_VERSION
 
 FROM consul-dev as consul
 
-FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
+FROM hashicorp.jfrog.io/docker/envoyproxy/envoy:v${ENVOY_VERSION}
 COPY --from=consul /bin/consul /bin/consul

--- a/test/integration/connect/envoy/case-centralconf/capture.sh
+++ b/test/integration/connect/envoy/case-centralconf/capture.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:19000 s1 primary || true

--- a/test/integration/connect/envoy/case-centralconf/verify.bats
+++ b/test/integration/connect/envoy/case-centralconf/verify.bats
@@ -42,15 +42,15 @@ load helpers
   # Should be labelling with local_cluster.
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]local_cluster="s1"[,}] '
+    '[\{,]consul_source_service="s1"[,}] '
 
   # Ensure we have http metrics for public listener
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]envoy_http_conn_manager_prefix="public_listener_http"[,}]'
+    '[\{,]envoy_http_conn_manager_prefix="public_listener"[,}]'
 
   # Ensure we have http metrics for s2 upstream
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]envoy_http_conn_manager_prefix="upstream_s2_http"[,}]'
+    '[\{,]consul_upstream_service="s2"[,}]'
 }

--- a/test/integration/connect/envoy/case-prometheus/capture.sh
+++ b/test/integration/connect/envoy/case-prometheus/capture.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:19000 s1 primary || true

--- a/test/integration/connect/envoy/case-prometheus/verify.bats
+++ b/test/integration/connect/envoy/case-prometheus/verify.bats
@@ -40,13 +40,13 @@ load helpers
     must_match_in_prometheus_response localhost:1234 \
     '^envoy_http_downstream_rq_active'
 
-  # Should be labelling with local_cluster.
+  # Should be labelling with consul_source_service.
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]local_cluster="s1"[,}] '
+    '[\{,]consul_source_service="s1"[,}] '
 
   # Should be labelling with http listener prefix.
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]envoy_http_conn_manager_prefix="public_listener_http"[,}]'
+    '[\{,]envoy_http_conn_manager_prefix="public_listener"[,}]'
 }

--- a/test/integration/connect/envoy/case-stats-proxy/verify.bats
+++ b/test/integration/connect/envoy/case-stats-proxy/verify.bats
@@ -48,12 +48,12 @@ load helpers
   # Response should include the http public listener.
   retry_default \
      must_match_in_stats_proxy_response localhost:1239 \
-    'stats' 'http.public_listener_http'
+    'stats' 'http.public_listener.http'
 
   # /stats/prometheus should also be reachable and labelling the local cluster.
   retry_default \
      must_match_in_stats_proxy_response localhost:1239 \
-    'stats/prometheus' '[\{,]local_cluster="s1"[,}]'
+    'stats/prometheus' '[\{,]consul_source_service="s1"[,}]'
 
   # /stats/prometheus should also be reachable and exposing metrics.
   retry_default \

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -229,6 +229,7 @@ function snapshot_envoy_admin {
   docker_wget "$DC" "http://${HOSTPORT}/config_dump" -q -O - > "${OUTDIR}/config_dump.json"
   docker_wget "$DC" "http://${HOSTPORT}/clusters?format=json" -q -O - > "${OUTDIR}/clusters.json"
   docker_wget "$DC" "http://${HOSTPORT}/stats" -q -O - > "${OUTDIR}/stats.txt"
+  docker_wget "$DC" "http://${HOSTPORT}/stats/prometheus" -q -O - > "${OUTDIR}/stats_prometheus.txt"
 }
 
 function reset_envoy_metrics {


### PR DESCRIPTION
This PR updates the tags that we generate for Envoy stats.

Several of these come with breaking changes, since we can't keep two stats prefixes for a filter. 

**For destination clusters:**
- `consul.destination.[namespace|service|subset|hash|datacenter|etc...]`
  - This is renamed from `consul.[service|etc..]` to disambiguate between cluster and listener filter labels.

**For upstream listeners:**
- `consul.upstream.[namespace|service|datacenter|protocol]`

**For the local cluster:**
- `consul.source.[namespace|service|datacenter]`