### PR TITLE
chore: update to Go 1.14.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 references:
   images:
-    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.14.9
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.14.11
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:12-browsers
 
   paths:

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.14.7
+ARG GOLANG_VERSION=1.14.11
 FROM golang:${GOLANG_VERSION}
 
 ARG GOTOOLS="github.com/elazarl/go-bindata-assetfs/... \

--- a/build-support/docker/Test-Flake.dockerfile
+++ b/build-support/docker/Test-Flake.dockerfile
@@ -1,6 +1,6 @@
 FROM travisci/ci-garnet:packer-1512502276-986baf0
 
-ENV GOLANG_VERSION 1.14.7
+ENV GOLANG_VERSION 1.14.11
 
 RUN mkdir -p /home/travis/go && chown -R travis /home/travis/go
 


### PR DESCRIPTION
Alternative to #9036, we should backport this to 1.9.x and 1.8.x for the fix to https://github.com/golang/go/issues/42138