### PR TITLE
ui: Default to glimmer components

### DIFF
--- a/ui/packages/consul-ui/.ember-cli
+++ b/ui/packages/consul-ui/.ember-cli
@@ -10,9 +10,5 @@
     We use a nested in /components folder structure:
     /components/component-name/index.{hbs,js}
   */
-  "componentStructure": "nested",
-  /**
-    We currently use classic components
-  */
-  "componentClass": "@ember/component"
+  "componentStructure": "nested"
 }


### PR DESCRIPTION
This means any components created using the ember component generator will now use the glimmer component blueprint by default.