### PR TITLE
ui: Ensure per service intentions link to the correct place

### DIFF
--- a/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
@@ -38,7 +38,7 @@
                   <:idle as |list|>
                     <list.CustomResourceNotice />
                     <list.CheckNotice />
-                    <list.Table />
+                    <list.Table @routeName="dc.services.show.intentions.edit" />
                   </:idle>
                   <:empty as |list|>
                     <EmptyState>

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/intentions.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/intentions.feature
@@ -38,6 +38,8 @@ Feature: dc / services / show / intentions: Intentions per service
     And I see intentionsIsSelected on the tabs
   Scenario: I can see intentions
     And I see 3 intention models on the intentionList component
+    And I click intention on the intentionList.intentions component
+    Then the url should be /dc1/services/service-0/intentions/default:name:default:destination
   Scenario: I can delete intentions
     And I click actions on the intentionList.intentions component
     And I click delete on the intentionList.intentions component


### PR DESCRIPTION
Per service intentions should NOT take the user to the global intention edit form in order to edit the intention, instead they should be editable in place within the service itself.

The intention list has a `routeName` attribute to control where it links to which was left out in a previous PR.

This adds it back in again, plus a simple test to warn us if its left out again.