### PR TITLE
chore: use hashicorp docker mirror to prevent rate limit (#9070) (#9085)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,8 @@ version: 2
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:1.14.9
-    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.40
-    ember: &EMBER_IMAGE circleci/node:12-browsers
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.14.9
+    ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:12-browsers
 
   paths:
     test-results: &TEST_RESULTS_DIR /tmp/test-results
@@ -440,7 +439,7 @@ jobs:
   # upload dev docker image
   dev-upload-docker:
     docker:
-      - image: circleci/golang:latest # use a circleci image so the attach_workspace step works (has ca-certs installed)
+      - image: *GOLANG_IMAGE # use a circleci image so the attach_workspace step works (has ca-certs installed)
     environment:
       <<: *ENVIRONMENT
     steps:
@@ -456,7 +455,7 @@ jobs:
   # Run integration tests on nomad/v0.8.7
   nomad-integration-0_8:
     docker:
-      - image: circleci/golang:1.10
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.10
     environment:
       <<: *ENVIRONMENT
       NOMAD_WORKING_DIR: &NOMAD_WORKING_DIR /go/src/github.com/hashicorp/nomad
@@ -505,7 +504,7 @@ jobs:
 
   build-website-docker-image:
     docker:
-      - image: circleci/buildpack-deps
+      - image: docker.mirror.hashicorp.services/circleci/buildpack-deps
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
       - checkout
@@ -531,7 +530,7 @@ jobs:
 
   algolia-index:
     docker:
-      - image: node:12
+      - image: docker.mirror.hashicorp.services/node:12
     steps:
       - checkout
       - run:
@@ -822,7 +821,7 @@ jobs:
   # only runs on master: checks latest commit to see if the PR associated has a backport/* or docs* label to cherry-pick
   cherry-picker:
     docker:
-      - image: alpine:3.11
+      - image: docker.mirror.hashicorp.services/alpine:3.11
     steps:
       - run: apk add --no-cache --no-progress git bash curl ncurses jq openssh-client
       - checkout
@@ -834,7 +833,7 @@ jobs:
 
   trigger-oss-merge:
     docker:
-      - image: alpine:3.11
+      - image: docker.mirror.hashicorp.services/alpine:3.11
     steps:
       - run: apk add --no-cache --no-progress curl jq
       - run:

--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,12 +1,6 @@
-<<<<<<< HEAD
-FROM fortio/fortio AS fortio
+FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
 
-FROM bats/bats:latest
-=======
-FROM hashicorp.jfrog.io/docker/fortio/fortio AS fortio
-
-FROM hashicorp.jfrog.io/docker/bats/bats:latest
->>>>>>> 06b3b017d... Add namespace support for metrics (OSS) (#9117)
+FROM docker.mirror.hashicorp.services/bats/bats:latest
 
 RUN apk add curl
 RUN apk add openssl

--- a/test/integration/connect/envoy/Dockerfile-consul-envoy
+++ b/test/integration/connect/envoy/Dockerfile-consul-envoy
@@ -3,5 +3,5 @@ ARG ENVOY_VERSION
 
 FROM consul-dev as consul
 
-FROM hashicorp.jfrog.io/docker/envoyproxy/envoy:v${ENVOY_VERSION}
+FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
 COPY --from=consul /bin/consul /bin/consul

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -68,12 +68,12 @@ function init_workdir {
     find ${CASE_DIR}/${DC} -type f -name '*.hcl' -exec cp -f {} workdir/${DC}/consul \;
     find ${CASE_DIR}/${DC} -type f -name '*.bats' -exec cp -f {} workdir/${DC}/bats \;
   fi
-  
+
   if test -d "${CASE_DIR}/data"
   then
     cp -r ${CASE_DIR}/data/* workdir/${DC}/data
   fi
-  
+
   return 0
 }
 
@@ -432,7 +432,7 @@ function common_run_container_sidecar_proxy {
   docker run -d --name $(container_name_prev) \
     $WORKDIR_SNIPPET \
     $(network_snippet $DC) \
-    "envoyproxy/envoy:v${ENVOY_VERSION}" \
+    "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}" \
     envoy \
     -c /workdir/${DC}/envoy/${service}-bootstrap.json \
     -l debug \
@@ -495,7 +495,7 @@ function common_run_container_gateway {
   docker run -d --name $(container_name_prev) \
     $WORKDIR_SNIPPET \
     $(network_snippet $DC) \
-    "envoyproxy/envoy:v${ENVOY_VERSION}" \
+    "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}" \
     envoy \
     -c /workdir/${DC}/envoy/${name}-bootstrap.json \
     -l debug \

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.3-alpine
+FROM docker.mirror.hashicorp.services/node:10.16.3-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json


### PR DESCRIPTION
Manual backport of #9070 and #9085 to `release/1.9.x` to avoid merge conflicts.