### PR TITLE
ci: Make backporting post-merge a bit easier

### DIFF
--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -131,6 +131,16 @@ fi
 # save PR number
 pr_number=$(echo "$resp" | jq '.items[].number')
 
+# comment on the PR with the build number to make it easy to re-run the job when
+# cherry-pick labels are added in the future
+github_message=":cherries: Starting backport cherry picking.\n\nTo cherry-pick post-merge, add backport labels and re-run ${CIRCLE_BUILD_URL}."
+curl -f -s -H "Authorization: token ${GITHUB_TOKEN}" \
+    -X POST \
+    -d "{ \"body\": \"${github_message}\"}" \
+    "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${pr_number}/comments"
+
+
+
 # If the API returned a non-zero count, we have found a PR with that commit so we find
 # the labels from the PR
 


### PR DESCRIPTION
If we forgot to add backport labels, or decide later that we want to backport a PR it requires finding the Circle CI job that ran as a result of the PR merge. 

This PR makes that process a bit easier by commenting on every PR after it is merged with the CircleCI job url. With this change we can start the backport job from the github PR page by adding labels and clicking the link.

I tested this on my fork, and you can see the message [here](https://github.com/dnephin/consul/pull/3#issuecomment-723338392). It shows up as coming from me on my fork because I used a token with my creds. Our CI uses a token for the hashicorp-ci bot, so it will show up the same way as other comments from the bot.

An alternative approach would be to run the cherry-pick job automatically any time a label is added to a merged PR, using github actions. That might be a little more work, but if we prefer that flow I can try it out.