### PR TITLE
ui: Correct AdapterError import

### DIFF
--- a/ui/packages/consul-ui/app/adapters/http.js
+++ b/ui/packages/consul-ui/app/adapters/http.js
@@ -1,7 +1,6 @@
 import { inject as service } from '@ember/service';
 import Adapter from '@ember-data/adapter';
-import {
-  AdapterError,
+import AdapterError, {
   AbortError,
   TimeoutError,
   ServerError,


### PR DESCRIPTION
`AdapterError` is the default export from `@ember-data/adapter/error` not a named export.