### PR TITLE
Use error wrapping to preserve error type info

### DIFF
--- a/agent/pool/pool.go
+++ b/agent/pool/pool.go
@@ -519,7 +519,7 @@ START:
 	// Try to get a conn first
 	conn, err := p.acquire(dc, nodeName, addr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get conn: %v", err)
+		return nil, nil, fmt.Errorf("failed to get conn: %w", err)
 	}
 
 	// Get a client
@@ -533,7 +533,7 @@ START:
 			retries++
 			goto START
 		}
-		return nil, nil, fmt.Errorf("failed to start stream: %v", err)
+		return nil, nil, fmt.Errorf("failed to start stream: %w", err)
 	}
 	return conn, client, nil
 }
@@ -575,14 +575,14 @@ func (p *ConnPool) rpcInsecure(dc string, addr net.Addr, method string, args int
 	var codec rpc.ClientCodec
 	conn, _, err := p.dial(dc, addr, 0, RPCTLSInsecure)
 	if err != nil {
-		return fmt.Errorf("rpcinsecure error establishing connection: %v", err)
+		return fmt.Errorf("rpcinsecure error establishing connection: %w", err)
 	}
 	codec = msgpackrpc.NewCodecFromHandle(true, true, conn, structs.MsgpackHandle)
 
 	// Make the RPC call
 	err = msgpackrpc.CallWithCodec(codec, method, args, reply)
 	if err != nil {
-		return fmt.Errorf("rpcinsecure error making call: %v", err)
+		return fmt.Errorf("rpcinsecure error making call: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Same as #8976, wrapping errors allows using `Errors.Is()` and `Errors.As()` elsewhere instead of string comparing error messages.