### PR TITLE
docs: add warning in 0.9.0 upgrade notes

### DIFF
--- a/website/pages/docs/upgrading/upgrade-specific.mdx
+++ b/website/pages/docs/upgrading/upgrade-specific.mdx
@@ -593,6 +593,11 @@ as part of upgrading agents. If this is set to `true`, you should also enable
 to provide control over which users are allowed to register health checks that
 could potentially execute scripts on the agent machines.
 
+!> **Security Warning:** Using `enable_script_checks` without ACLs and without
+`allow_write_http_from` is _DANGEROUS_. Use the `enable_local_script_checks` setting
+introduced in v0.9.4 instead. See [this article](https://www.hashicorp.com/blog/protecting-consul-from-rce-risk-in-specific-configurations/)
+for more information.
+
 #### Web UI Is No Longer Released Separately
 
 Consul releases will no longer include a `web_ui.zip` file with the compiled


### PR DESCRIPTION
For users upgrading from very old versions, we mentioned adding `enable_script_checks` in the specific upgrade notes, but have no mention of `enable_local_script_checks` when that was added. Based on how this is worded for 0.9.0, it sounds like users _should turn this on_ – which was true at that time if they wanted to use script checks. As of 0.9.4, it's recommended that `enable_local_script_checks` is used instead. The message being displayed is based off of the message [here](https://github.com/hashicorp/consul/blob/master/agent/config/builder.go#L2338).

If all you check are the specific upgrade notes, you could mistakenly enable this feature without realizing the potential security impact. This note should help with that.