### PR TITLE
server: remove config entry CAS in legacy intention API bridge code

### DIFF
--- a/.changelog/9151.txt
+++ b/.changelog/9151.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+server: remove config entry CAS in legacy intention API bridge code
+```

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -19,10 +19,6 @@ type ConfigEntry struct {
 
 // Apply does an upsert of the given config entry.
 func (c *ConfigEntry) Apply(args *structs.ConfigEntryRequest, reply *bool) error {
-	return c.applyInternal(args, reply, nil)
-}
-
-func (c *ConfigEntry) applyInternal(args *structs.ConfigEntryRequest, reply *bool, normalizeAndValidateFn func(structs.ConfigEntry) error) error {
 	if err := c.srv.validateEnterpriseRequest(args.Entry.GetEnterpriseMeta(), true); err != nil {
 		return err
 	}
@@ -47,17 +43,11 @@ func (c *ConfigEntry) applyInternal(args *structs.ConfigEntryRequest, reply *boo
 	}
 
 	// Normalize and validate the incoming config entry as if it came from a user.
-	if normalizeAndValidateFn == nil {
-		if err := args.Entry.Normalize(); err != nil {
-			return err
-		}
-		if err := args.Entry.Validate(); err != nil {
-			return err
-		}
-	} else {
-		if err := normalizeAndValidateFn(args.Entry); err != nil {
-			return err
-		}
+	if err := args.Entry.Normalize(); err != nil {
+		return err
+	}
+	if err := args.Entry.Validate(); err != nil {
+		return err
 	}
 
 	if authz != nil && !args.Entry.CanWrite(authz) {

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -291,6 +291,11 @@ func (c *FSM) applyIntentionOperation(buf []byte, index uint64) interface{} {
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	defer metrics.MeasureSinceWithLabels([]string{"fsm", "intention"}, time.Now(),
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
+
+	if req.Mutation != nil {
+		return c.state.IntentionMutation(index, req.Op, req.Mutation)
+	}
+
 	switch req.Op {
 	case structs.IntentionOpCreate, structs.IntentionOpUpdate:
 		//nolint:staticcheck

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -73,7 +73,9 @@ func (s *Intention) Apply(args *structs.IntentionRequest, reply *string) error {
 		return err
 	}
 
-	args.Mutation = nil // not something the user can control
+	if args.Mutation != nil {
+		return fmt.Errorf("Mutation field is internal only and must not be set via RPC")
+	}
 
 	// Always set a non-nil intention to avoid nil-access below
 	if args.Intention == nil {

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -280,8 +280,13 @@ func (s *Intention) computeApplyChangesUpsert(
 	args.Intention.DefaultNamespaces(entMeta)
 
 	if !args.Intention.CanWrite(authz) {
+		sn := args.Intention.SourceServiceName()
+		dn := args.Intention.DestinationServiceName()
 		// todo(kit) Migrate intention access denial logging over to audit logging when we implement it
-		s.logger.Warn("Intention upsert denied due to ACLs", "accessorID", accessorID)
+		s.logger.Warn("Intention upsert denied due to ACLs",
+			"source", sn.String(),
+			"destination", dn.String(),
+			"accessorID", accessorID)
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -356,8 +361,13 @@ func (s *Intention) computeApplyChangesDelete(
 	args.Intention.DefaultNamespaces(entMeta)
 
 	if !args.Intention.CanWrite(authz) {
+		sn := args.Intention.SourceServiceName()
+		dn := args.Intention.DestinationServiceName()
 		// todo(kit) Migrate intention access denial logging over to audit logging when we implement it
-		s.logger.Warn("Intention delete denied due to ACLs", "accessorID", accessorID)
+		s.logger.Warn("Intention delete denied due to ACLs",
+			"source", sn.String(),
+			"destination", dn.String(),
+			"accessorID", accessorID)
 		return nil, acl.ErrPermissionDenied
 	}
 

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -205,10 +205,18 @@ func (s *Intention) computeApplyChangesLegacyCreate(
 	// config entry validation will fail so we don't have to check that
 	// explicitly here.
 
-	return &structs.IntentionMutation{
+	mut := &structs.IntentionMutation{
 		Destination: args.Intention.DestinationServiceName(),
 		Value:       args.Intention.ToSourceIntention(true),
-	}, nil
+	}
+
+	// Set the created/updated times. If this is an update instead of an insert
+	// the UpdateOver() will fix it up appropriately.
+	now := time.Now().UTC()
+	mut.Value.LegacyCreateTime = timePointer(now)
+	mut.Value.LegacyUpdateTime = timePointer(now)
+
+	return mut, nil
 }
 
 func (s *Intention) computeApplyChangesLegacyUpdate(
@@ -241,9 +249,6 @@ func (s *Intention) computeApplyChangesLegacyUpdate(
 		return nil, fmt.Errorf("Cannot modify DestinationNS or DestinationName for an intention once it exists.")
 	}
 
-	// We always update the updatedat field.
-	args.Intention.UpdatedAt = time.Now().UTC()
-
 	// Default source type
 	if args.Intention.SourceType == "" {
 		args.Intention.SourceType = structs.IntentionSourceConsul
@@ -260,10 +265,18 @@ func (s *Intention) computeApplyChangesLegacyUpdate(
 		return nil, err
 	}
 
-	return &structs.IntentionMutation{
+	mut := &structs.IntentionMutation{
 		ID:    args.Intention.ID,
 		Value: args.Intention.ToSourceIntention(true),
-	}, nil
+	}
+
+	// Set the created/updated times. If this is an update instead of an insert
+	// the UpdateOver() will fix it up appropriately.
+	now := time.Now().UTC()
+	mut.Value.LegacyCreateTime = timePointer(now)
+	mut.Value.LegacyUpdateTime = timePointer(now)
+
+	return mut, nil
 }
 
 func (s *Intention) computeApplyChangesUpsert(

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -21,22 +21,11 @@ var (
 	ErrIntentionNotFound = errors.New("Intention not found")
 )
 
-// NewIntentionEndpoint returns a new Intention endpoint.
-func NewIntentionEndpoint(srv *Server, logger hclog.Logger) *Intention {
-	return &Intention{
-		srv:                 srv,
-		logger:              logger,
-		configEntryEndpoint: &ConfigEntry{srv},
-	}
-}
-
 // Intention manages the Connect intentions.
 type Intention struct {
 	// srv is a pointer back to the server.
 	srv    *Server
 	logger hclog.Logger
-
-	configEntryEndpoint *ConfigEntry
 }
 
 func (s *Intention) checkIntentionID(id string) (bool, error) {
@@ -69,10 +58,7 @@ func (s *Intention) legacyUpgradeCheck() error {
 }
 
 // Apply creates or updates an intention in the data store.
-func (s *Intention) Apply(
-	args *structs.IntentionRequest,
-	reply *string) error {
-
+func (s *Intention) Apply(args *structs.IntentionRequest, reply *string) error {
 	// Ensure that all service-intentions config entry writes go to the primary
 	// datacenter. These will then be replicated to all the other datacenters.
 	args.Datacenter = s.srv.config.PrimaryDatacenter
@@ -86,6 +72,8 @@ func (s *Intention) Apply(
 	if err := s.legacyUpgradeCheck(); err != nil {
 		return err
 	}
+
+	args.Mutation = nil // not something the user can control
 
 	// Always set a non-nil intention to avoid nil-access below
 	if args.Intention == nil {
@@ -105,27 +93,26 @@ func (s *Intention) Apply(
 	}
 
 	var (
-		configOp    structs.ConfigEntryOp
-		configEntry *structs.ServiceIntentionsConfigEntry
+		mut         *structs.IntentionMutation
 		legacyWrite bool
 	)
 	switch args.Op {
 	case structs.IntentionOpCreate:
 		legacyWrite = true
-		configOp, configEntry, err = s.computeApplyChangesLegacyCreate(accessorID, authz, &entMeta, args)
+		mut, err = s.computeApplyChangesLegacyCreate(accessorID, authz, &entMeta, args)
 	case structs.IntentionOpUpdate:
 		legacyWrite = true
-		configOp, configEntry, err = s.computeApplyChangesLegacyUpdate(accessorID, authz, &entMeta, args)
+		mut, err = s.computeApplyChangesLegacyUpdate(accessorID, authz, &entMeta, args)
 	case structs.IntentionOpUpsert:
 		legacyWrite = false
-		configOp, configEntry, err = s.computeApplyChangesUpsert(&entMeta, args)
+		mut, err = s.computeApplyChangesUpsert(accessorID, authz, &entMeta, args)
 	case structs.IntentionOpDelete:
 		if args.Intention.ID == "" {
 			legacyWrite = false
-			configOp, configEntry, err = s.computeApplyChangesDelete(&entMeta, args)
+			mut, err = s.computeApplyChangesDelete(accessorID, authz, &entMeta, args)
 		} else {
 			legacyWrite = true
-			configOp, configEntry, err = s.computeApplyChangesLegacyDelete(accessorID, authz, &entMeta, args)
+			mut, err = s.computeApplyChangesLegacyDelete(accessorID, authz, &entMeta, args)
 		}
 	case structs.IntentionOpDeleteAll:
 		// This is an internal operation initiated by the leader and is not
@@ -145,54 +132,16 @@ func (s *Intention) Apply(
 		*reply = ""
 	}
 
-	if configOp == "" {
-		return nil // no-op
-	}
+	// Switch to the config entry manipulating flavor:
+	args.Mutation = mut
+	args.Intention = nil
 
-	// Commit indirectly by invoking the other RPC handler directly.
-
-	if configOp == structs.ConfigEntryDelete {
-		configReq := &structs.ConfigEntryRequest{
-			Datacenter:   args.Datacenter,
-			WriteRequest: args.WriteRequest,
-			Op:           structs.ConfigEntryDelete,
-			Entry:        configEntry,
-		}
-
-		var ignored struct{}
-		return s.configEntryEndpoint.Delete(configReq, &ignored)
-	}
-
-	if configOp != structs.ConfigEntryUpsertCAS {
-		return fmt.Errorf("Invalid Intention config entry operation: %v", configOp)
-	}
-
-	configReq := &structs.ConfigEntryRequest{
-		Datacenter:   args.Datacenter,
-		WriteRequest: args.WriteRequest,
-		Op:           structs.ConfigEntryUpsertCAS,
-		Entry:        configEntry,
-	}
-
-	var normalizeAndValidateFn func(raw structs.ConfigEntry) error
-	if legacyWrite {
-		normalizeAndValidateFn = func(raw structs.ConfigEntry) error {
-			entry := raw.(*structs.ServiceIntentionsConfigEntry)
-			if err := entry.LegacyNormalize(); err != nil {
-				return err
-			}
-
-			return entry.LegacyValidate()
-		}
-	}
-
-	var applied bool
-	if err = s.configEntryEndpoint.applyInternal(configReq, &applied, normalizeAndValidateFn); err != nil {
+	resp, err := s.srv.raftApply(structs.IntentionRequestType, args)
+	if err != nil {
 		return err
 	}
-
-	if !applied {
-		return fmt.Errorf("config entry failed to persist due to CAS failure: kind=%q, name=%q", configEntry.Kind, configEntry.Name)
+	if respErr, ok := resp.(error); ok {
+		return respErr
 	}
 
 	return nil
@@ -203,14 +152,11 @@ func (s *Intention) computeApplyChangesLegacyCreate(
 	authz acl.Authorizer,
 	entMeta *structs.EnterpriseMeta,
 	args *structs.IntentionRequest,
-) (structs.ConfigEntryOp, *structs.ServiceIntentionsConfigEntry, error) {
+) (*structs.IntentionMutation, error) {
 	// This variant is just for legacy UUID-based intentions.
 
 	args.Intention.DefaultNamespaces(entMeta)
 
-	// Even though the eventual config entry RPC will do an authz check and
-	// validation, if we do them here too we can generate error messages that
-	// make more sense for legacy edits.
 	if !args.Intention.CanWrite(authz) {
 		sn := args.Intention.SourceServiceName()
 		dn := args.Intention.DestinationServiceName()
@@ -219,7 +165,7 @@ func (s *Intention) computeApplyChangesLegacyCreate(
 			"source", sn.String(),
 			"destination", dn.String(),
 			"accessorID", accessorID)
-		return "", nil, acl.ErrPermissionDenied
+		return nil, acl.ErrPermissionDenied
 	}
 
 	// If no ID is provided, generate a new ID. This must be done prior to
@@ -227,13 +173,13 @@ func (s *Intention) computeApplyChangesLegacyCreate(
 	// the entry is in the log, the state update MUST be deterministic or
 	// the followers will not converge.
 	if args.Intention.ID != "" {
-		return "", nil, fmt.Errorf("ID must be empty when creating a new intention")
+		return nil, fmt.Errorf("ID must be empty when creating a new intention")
 	}
 
 	var err error
 	args.Intention.ID, err = lib.GenerateUUID(s.checkIntentionID)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 	// Set the created at
 	args.Intention.CreatedAt = time.Now().UTC()
@@ -245,36 +191,22 @@ func (s *Intention) computeApplyChangesLegacyCreate(
 	}
 
 	if err := s.validateEnterpriseIntention(args.Intention); err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	//nolint:staticcheck
 	if err := args.Intention.Validate(); err != nil {
-		return "", nil, err
+		return nil, err
 	}
-
-	_, configEntry, err := s.srv.fsm.State().ConfigEntry(nil, structs.ServiceIntentions, args.Intention.DestinationName, args.Intention.DestinationEnterpriseMeta())
-	if err != nil {
-		return "", nil, fmt.Errorf("service-intentions config entry lookup failed: %v", err)
-	}
-
-	if configEntry == nil {
-		return structs.ConfigEntryUpsertCAS, args.Intention.ToConfigEntry(true), nil
-	}
-	prevEntry := configEntry.(*structs.ServiceIntentionsConfigEntry)
-
-	if err := checkLegacyIntentionApplyAllowed(prevEntry); err != nil {
-		return "", nil, err
-	}
-
-	upsertEntry := prevEntry.Clone()
-	upsertEntry.Sources = append(upsertEntry.Sources, args.Intention.ToSourceIntention(true))
 
 	// NOTE: if the append of this source causes a duplicate source name the
 	// config entry validation will fail so we don't have to check that
 	// explicitly here.
 
-	return structs.ConfigEntryUpsertCAS, upsertEntry, nil
+	return &structs.IntentionMutation{
+		Destination: args.Intention.DestinationServiceName(),
+		Value:       args.Intention.ToSourceIntention(true),
+	}, nil
 }
 
 func (s *Intention) computeApplyChangesLegacyUpdate(
@@ -282,28 +214,21 @@ func (s *Intention) computeApplyChangesLegacyUpdate(
 	authz acl.Authorizer,
 	entMeta *structs.EnterpriseMeta,
 	args *structs.IntentionRequest,
-) (structs.ConfigEntryOp, *structs.ServiceIntentionsConfigEntry, error) {
+) (*structs.IntentionMutation, error) {
 	// This variant is just for legacy UUID-based intentions.
 
-	_, prevEntry, ixn, err := s.srv.fsm.State().IntentionGet(nil, args.Intention.ID)
+	_, _, ixn, err := s.srv.fsm.State().IntentionGet(nil, args.Intention.ID)
 	if err != nil {
-		return "", nil, fmt.Errorf("Intention lookup failed: %v", err)
+		return nil, fmt.Errorf("Intention lookup failed: %v", err)
 	}
-	if ixn == nil || prevEntry == nil {
-		return "", nil, fmt.Errorf("Cannot modify non-existent intention: '%s'", args.Intention.ID)
-	}
-
-	if err := checkLegacyIntentionApplyAllowed(prevEntry); err != nil {
-		return "", nil, err
+	if ixn == nil {
+		return nil, fmt.Errorf("Cannot modify non-existent intention: '%s'", args.Intention.ID)
 	}
 
-	// Even though the eventual config entry RPC will do an authz check and
-	// validation, if we do them here too we can generate error messages that
-	// make more sense for legacy edits.
 	if !ixn.CanWrite(authz) {
 		// todo(kit) Migrate intention access denial logging over to audit logging when we implement it
 		s.logger.Warn("Update operation on intention denied due to ACLs", "intention", args.Intention.ID, "accessorID", accessorID)
-		return "", nil, acl.ErrPermissionDenied
+		return nil, acl.ErrPermissionDenied
 	}
 
 	args.Intention.DefaultNamespaces(entMeta)
@@ -311,7 +236,7 @@ func (s *Intention) computeApplyChangesLegacyUpdate(
 	// Prior to v1.9.0 renames of the destination side of an intention were
 	// allowed, but that behavior doesn't work anymore.
 	if ixn.DestinationServiceName() != args.Intention.DestinationServiceName() {
-		return "", nil, fmt.Errorf("Cannot modify DestinationNS or DestinationName for an intention once it exists.")
+		return nil, fmt.Errorf("Cannot modify DestinationNS or DestinationName for an intention once it exists.")
 	}
 
 	// We always update the updatedat field.
@@ -323,86 +248,78 @@ func (s *Intention) computeApplyChangesLegacyUpdate(
 	}
 
 	if err := s.validateEnterpriseIntention(args.Intention); err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
 	// Validate. We do not validate on delete since it is valid to only
 	// send an ID in that case.
 	//nolint:staticcheck
 	if err := args.Intention.Validate(); err != nil {
-		return "", nil, err
+		return nil, err
 	}
 
-	upsertEntry := prevEntry.Clone()
-
-	foundMatch := upsertEntry.UpdateSourceByLegacyID(
-		args.Intention.ID,
-		args.Intention.ToSourceIntention(true),
-	)
-	if !foundMatch {
-		return "", nil, fmt.Errorf("Cannot modify non-existent intention: '%s'", args.Intention.ID)
-	}
-
-	return structs.ConfigEntryUpsertCAS, upsertEntry, nil
+	return &structs.IntentionMutation{
+		ID:    args.Intention.ID,
+		Value: args.Intention.ToSourceIntention(true),
+	}, nil
 }
 
 func (s *Intention) computeApplyChangesUpsert(
+	accessorID string,
+	authz acl.Authorizer,
 	entMeta *structs.EnterpriseMeta,
 	args *structs.IntentionRequest,
-) (structs.ConfigEntryOp, *structs.ServiceIntentionsConfigEntry, error) {
+) (*structs.IntentionMutation, error) {
 	// This variant is just for config-entry based intentions.
 
 	if args.Intention.ID != "" {
 		// This is a new-style only endpoint
-		return "", nil, fmt.Errorf("ID must not be specified")
+		return nil, fmt.Errorf("ID must not be specified")
 	}
 
 	args.Intention.DefaultNamespaces(entMeta)
 
-	prevEntry, err := s.getServiceIntentionsConfigEntry(args.Intention.DestinationName, args.Intention.DestinationEnterpriseMeta())
-	if err != nil {
-		return "", nil, err
+	if !args.Intention.CanWrite(authz) {
+		// todo(kit) Migrate intention access denial logging over to audit logging when we implement it
+		s.logger.Warn("Intention upsert denied due to ACLs", "accessorID", accessorID)
+		return nil, acl.ErrPermissionDenied
 	}
 
-	// TODO(intentions): have service-intentions validation functions
-	// return structured errors so that we can rewrite the field prefix
-	// here so that the validation errors are not misleading.
+	_, prevEntry, err := s.srv.fsm.State().ConfigEntry(nil, structs.ServiceIntentions, args.Intention.DestinationName, args.Intention.DestinationEnterpriseMeta())
+	if err != nil {
+		return nil, fmt.Errorf("Intention lookup failed: %v", err)
+	}
+
 	if prevEntry == nil {
 		// Meta is NOT permitted here, as it would need to be persisted on
 		// the enclosing config entry.
 		if len(args.Intention.Meta) > 0 {
-			return "", nil, fmt.Errorf("Meta must not be specified")
+			return nil, fmt.Errorf("Meta must not be specified")
 		}
+	} else {
+		if len(args.Intention.Meta) > 0 {
+			// Meta is NOT permitted here, but there is one exception. If
+			// you are updating a previous record, but that record lives
+			// within a config entry that itself has Meta, then you may
+			// incidentally ship the Meta right back to consul.
+			//
+			// In that case if Meta is provided, it has to be a perfect
+			// match for what is already on the enclosing config entry so
+			// it's safe to discard.
+			if !equalStringMaps(prevEntry.GetMeta(), args.Intention.Meta) {
+				return nil, fmt.Errorf("Meta must not be specified, or should be unchanged during an update.")
+			}
 
-		upsertEntry := args.Intention.ToConfigEntry(false)
-
-		return structs.ConfigEntryUpsertCAS, upsertEntry, nil
+			// Now it is safe to discard
+			args.Intention.Meta = nil
+		}
 	}
 
-	upsertEntry := prevEntry.Clone()
-
-	if len(args.Intention.Meta) > 0 {
-		// Meta is NOT permitted here, but there is one exception. If
-		// you are updating a previous record, but that record lives
-		// within a config entry that itself has Meta, then you may
-		// incidentally ship the Meta right back to consul.
-		//
-		// In that case if Meta is provided, it has to be a perfect
-		// match for what is already on the enclosing config entry so
-		// it's safe to discard.
-		if !equalStringMaps(upsertEntry.Meta, args.Intention.Meta) {
-			return "", nil, fmt.Errorf("Meta must not be specified, or should be unchanged during an update.")
-		}
-
-		// Now it is safe to discard
-		args.Intention.Meta = nil
-	}
-
-	sn := args.Intention.SourceServiceName()
-
-	upsertEntry.UpsertSourceByName(sn, args.Intention.ToSourceIntention(false))
-
-	return structs.ConfigEntryUpsertCAS, upsertEntry, nil
+	return &structs.IntentionMutation{
+		Destination: args.Intention.DestinationServiceName(),
+		Source:      args.Intention.SourceServiceName(),
+		Value:       args.Intention.ToSourceIntention(false),
+	}, nil
 }
 
 func (s *Intention) computeApplyChangesLegacyDelete(
@@ -410,93 +327,53 @@ func (s *Intention) computeApplyChangesLegacyDelete(
 	authz acl.Authorizer,
 	entMeta *structs.EnterpriseMeta,
 	args *structs.IntentionRequest,
-) (structs.ConfigEntryOp, *structs.ServiceIntentionsConfigEntry, error) {
-	_, prevEntry, ixn, err := s.srv.fsm.State().IntentionGet(nil, args.Intention.ID)
+) (*structs.IntentionMutation, error) {
+	_, _, ixn, err := s.srv.fsm.State().IntentionGet(nil, args.Intention.ID)
 	if err != nil {
-		return "", nil, fmt.Errorf("Intention lookup failed: %v", err)
+		return nil, fmt.Errorf("Intention lookup failed: %v", err)
 	}
-	if ixn == nil || prevEntry == nil {
-		return "", nil, fmt.Errorf("Cannot delete non-existent intention: '%s'", args.Intention.ID)
-	}
-
-	if err := checkLegacyIntentionApplyAllowed(prevEntry); err != nil {
-		return "", nil, err
+	if ixn == nil {
+		return nil, fmt.Errorf("Cannot delete non-existent intention: '%s'", args.Intention.ID)
 	}
 
-	// Even though the eventual config entry RPC will do an authz check and
-	// validation, if we do them here too we can generate error messages that
-	// make more sense for legacy edits.
 	if !ixn.CanWrite(authz) {
 		// todo(kit) Migrate intention access denial logging over to audit logging when we implement it
 		s.logger.Warn("Deletion operation on intention denied due to ACLs", "intention", args.Intention.ID, "accessorID", accessorID)
-		return "", nil, acl.ErrPermissionDenied
+		return nil, acl.ErrPermissionDenied
 	}
 
-	upsertEntry := prevEntry.Clone()
-
-	deleted := upsertEntry.DeleteSourceByLegacyID(args.Intention.ID)
-	if !deleted {
-		return "", nil, fmt.Errorf("Cannot delete non-existent intention: '%s'", args.Intention.ID)
-	}
-
-	if upsertEntry == nil || len(upsertEntry.Sources) == 0 {
-		return structs.ConfigEntryDelete, &structs.ServiceIntentionsConfigEntry{
-			Kind:           structs.ServiceIntentions,
-			Name:           prevEntry.Name,
-			EnterpriseMeta: prevEntry.EnterpriseMeta,
-		}, nil
-	}
-
-	return structs.ConfigEntryUpsertCAS, upsertEntry, nil
+	return &structs.IntentionMutation{
+		ID: args.Intention.ID,
+	}, nil
 }
 
 func (s *Intention) computeApplyChangesDelete(
+	accessorID string,
+	authz acl.Authorizer,
 	entMeta *structs.EnterpriseMeta,
 	args *structs.IntentionRequest,
-) (structs.ConfigEntryOp, *structs.ServiceIntentionsConfigEntry, error) {
+) (*structs.IntentionMutation, error) {
 	args.Intention.DefaultNamespaces(entMeta)
 
-	prevEntry, err := s.getServiceIntentionsConfigEntry(args.Intention.DestinationName, args.Intention.DestinationEnterpriseMeta())
+	if !args.Intention.CanWrite(authz) {
+		// todo(kit) Migrate intention access denial logging over to audit logging when we implement it
+		s.logger.Warn("Intention delete denied due to ACLs", "accessorID", accessorID)
+		return nil, acl.ErrPermissionDenied
+	}
+
+	// Pre-flight to avoid pointless raft operations.
+	_, _, ixn, err := s.srv.fsm.State().IntentionGetExact(nil, args.Intention.ToExact())
 	if err != nil {
-		return "", nil, err
+		return nil, fmt.Errorf("Intention lookup failed: %v", err)
+	}
+	if ixn == nil {
+		return nil, nil
 	}
 
-	if prevEntry == nil {
-		return "", nil, nil // no op means no-op
-	}
-
-	// NOTE: validation errors may be misleading!
-
-	upsertEntry := prevEntry.Clone()
-
-	sn := args.Intention.SourceServiceName()
-
-	deleted := upsertEntry.DeleteSourceByName(sn)
-	if !deleted {
-		return "", nil, nil // no op means no-op
-	}
-
-	if upsertEntry == nil || len(upsertEntry.Sources) == 0 {
-		return structs.ConfigEntryDelete, &structs.ServiceIntentionsConfigEntry{
-			Kind:           structs.ServiceIntentions,
-			Name:           prevEntry.Name,
-			EnterpriseMeta: prevEntry.EnterpriseMeta,
-		}, nil
-	}
-
-	return structs.ConfigEntryUpsertCAS, upsertEntry, nil
-}
-
-func checkLegacyIntentionApplyAllowed(prevEntry *structs.ServiceIntentionsConfigEntry) error {
-	if prevEntry == nil {
-		return nil
-	}
-	if prevEntry.LegacyIDFieldsAreAllSet() {
-		return nil
-	}
-
-	sn := prevEntry.DestinationServiceName()
-	return fmt.Errorf("cannot use legacy intention API to edit intentions with a destination of %q after editing them via a service-intentions config entry", sn.String())
+	return &structs.IntentionMutation{
+		Destination: args.Intention.DestinationServiceName(),
+		Source:      args.Intention.SourceServiceName(),
+	}, nil
 }
 
 // Get returns a single intention by ID.
@@ -833,23 +710,6 @@ func (s *Intention) validateEnterpriseIntention(ixn *structs.Intention) error {
 		return fmt.Errorf("Invalid destination namespace %q: %v", ixn.DestinationNS, err)
 	}
 	return nil
-}
-
-func (s *Intention) getServiceIntentionsConfigEntry(name string, entMeta *structs.EnterpriseMeta) (*structs.ServiceIntentionsConfigEntry, error) {
-	_, raw, err := s.srv.fsm.State().ConfigEntry(nil, structs.ServiceIntentions, name, entMeta)
-	if err != nil {
-		return nil, fmt.Errorf("Intention lookup failed: %v", err)
-	}
-
-	if raw == nil {
-		return nil, nil
-	}
-
-	configEntry, ok := raw.(*structs.ServiceIntentionsConfigEntry)
-	if !ok {
-		return nil, fmt.Errorf("invalid service config type %T", raw)
-	}
-	return configEntry, nil
 }
 
 func equalStringMaps(a, b map[string]string) bool {

--- a/agent/consul/server_register.go
+++ b/agent/consul/server_register.go
@@ -11,7 +11,7 @@ func init() {
 	registerEndpoint(func(s *Server) interface{} { return &FederationState{s} })
 	registerEndpoint(func(s *Server) interface{} { return &DiscoveryChain{s} })
 	registerEndpoint(func(s *Server) interface{} { return &Health{s} })
-	registerEndpoint(func(s *Server) interface{} { return NewIntentionEndpoint(s, s.loggers.Named(logging.Intentions)) })
+	registerEndpoint(func(s *Server) interface{} { return &Intention{s, s.loggers.Named(logging.Intentions)} })
 	registerEndpoint(func(s *Server) interface{} { return &Internal{s, s.loggers.Named(logging.Internal)} })
 	registerEndpoint(func(s *Server) interface{} { return &KVS{s, s.loggers.Named(logging.KV)} })
 	registerEndpoint(func(s *Server) interface{} { return &Operator{s, s.loggers.Named(logging.Operator)} })

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -259,7 +259,7 @@ func (s *Store) intentionMutationLegacyCreate(
 	dest structs.ServiceName,
 	value *structs.SourceIntention,
 ) error {
-	idx, configEntry, err := configEntryTxn(tx, nil, structs.ServiceIntentions, dest.Name, &dest.EnterpriseMeta)
+	_, configEntry, err := configEntryTxn(tx, nil, structs.ServiceIntentions, dest.Name, &dest.EnterpriseMeta)
 	if err != nil {
 		return fmt.Errorf("service-intentions config entry lookup failed: %v", err)
 	}

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -216,7 +216,7 @@ func (s *Store) IntentionMutation(idx uint64, op structs.IntentionOp, mut *struc
 		return err
 	}
 	if !usingConfigEntries {
-		return ErrLegacyIntentionsAreDisabled
+		return errors.New("state: IntentionMutation() is not allowed when intentions are not stored in config entries")
 	}
 
 	switch op {

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -361,7 +361,7 @@ func testStore_IntentionMutation(t *testing.T, s *Store) {
 				Action:         structs.IntentionActionDeny,
 				LegacyID:       id2,
 			},
-		}), `Sources[1] defines "web" more than once`)
+		}), `more than once`)
 	}
 
 	// Create intention with existing config entry
@@ -773,7 +773,7 @@ func testStore_IntentionMutation(t *testing.T, s *Store) {
 				Action:         structs.IntentionActionAllow,
 				LegacyID:       idFake,
 			},
-		}), `cannot use legacy intention API to edit intentions with a destination of "new" after editing them via a service-intentions config entry`)
+		}), `cannot use legacy intention API to edit intentions with a destination`)
 	}
 }
 

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -285,7 +285,6 @@ func TestStore_IntentionMutation(t *testing.T) {
 }
 
 func testStore_IntentionMutation(t *testing.T, s *Store) {
-	// TODO: namespaces
 	lastIndex := uint64(1)
 
 	defaultEntMeta := structs.DefaultEnterpriseMeta()

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -277,7 +277,7 @@ func TestStore_IntentionMutation(t *testing.T) {
 		if legacy {
 			mut := &structs.IntentionMutation{}
 			err := s.IntentionMutation(1, structs.IntentionOpCreate, mut)
-			testutil.RequireErrorContains(t, err, ErrLegacyIntentionsAreDisabled.Error())
+			testutil.RequireErrorContains(t, err, "state: IntentionMutation() is not allowed when intentions are not stored in config entries")
 		} else {
 			testStore_IntentionMutation(t, s)
 		}

--- a/agent/structs/config_entry_intentions_test.go
+++ b/agent/structs/config_entry_intentions_test.go
@@ -21,6 +21,14 @@ func generateUUID() (ret string) {
 }
 
 func TestServiceIntentionsConfigEntry(t *testing.T) {
+	var (
+		testLocation = time.FixedZone("UTC-8", -8*60*60)
+
+		testTimeA = time.Date(1955, 11, 5, 6, 15, 0, 0, testLocation)
+		testTimeB = time.Date(1985, 10, 26, 1, 35, 0, 0, testLocation)
+		testTimeC = time.Date(2015, 10, 21, 16, 29, 0, 0, testLocation)
+	)
+
 	type testcase struct {
 		entry        *ServiceIntentionsConfigEntry
 		legacy       bool
@@ -126,9 +134,11 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 				Name: "test",
 				Sources: []*SourceIntention{
 					{
-						LegacyID: legacyIDs[0],
-						Name:     "foo",
-						Action:   IntentionActionAllow,
+						LegacyID:         legacyIDs[0],
+						Name:             "foo",
+						Action:           IntentionActionAllow,
+						LegacyCreateTime: &testTimeA,
+						LegacyUpdateTime: &testTimeA,
 					},
 				},
 				Meta: map[string]string{
@@ -198,10 +208,12 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 				Name: "test",
 				Sources: []*SourceIntention{
 					{
-						LegacyID:    legacyIDs[0],
-						Name:        "foo",
-						Action:      IntentionActionAllow,
-						Description: strings.Repeat("x", 512),
+						LegacyID:         legacyIDs[0],
+						Name:             "foo",
+						Action:           IntentionActionAllow,
+						Description:      strings.Repeat("x", 512),
+						LegacyCreateTime: &testTimeA,
+						LegacyUpdateTime: &testTimeA,
 						LegacyMeta: map[string]string{ // stray Meta will be dropped
 							"old": "data",
 						},
@@ -217,10 +229,12 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 				Name: "test",
 				Sources: []*SourceIntention{
 					{
-						LegacyID:   legacyIDs[0],
-						Name:       "foo",
-						Action:     IntentionActionAllow,
-						LegacyMeta: makeStringMap(65, 5, 5),
+						LegacyID:         legacyIDs[0],
+						Name:             "foo",
+						Action:           IntentionActionAllow,
+						LegacyCreateTime: &testTimeA,
+						LegacyUpdateTime: &testTimeA,
+						LegacyMeta:       makeStringMap(65, 5, 5),
 					},
 				},
 			},
@@ -233,10 +247,12 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 				Name: "test",
 				Sources: []*SourceIntention{
 					{
-						LegacyID:   legacyIDs[0],
-						Name:       "foo",
-						Action:     IntentionActionAllow,
-						LegacyMeta: makeStringMap(64, 129, 5),
+						LegacyID:         legacyIDs[0],
+						Name:             "foo",
+						Action:           IntentionActionAllow,
+						LegacyCreateTime: &testTimeA,
+						LegacyUpdateTime: &testTimeA,
+						LegacyMeta:       makeStringMap(64, 129, 5),
 					},
 				},
 			},
@@ -249,10 +265,12 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 				Name: "test",
 				Sources: []*SourceIntention{
 					{
-						LegacyID:   legacyIDs[0],
-						Name:       "foo",
-						Action:     IntentionActionAllow,
-						LegacyMeta: makeStringMap(64, 128, 513),
+						LegacyID:         legacyIDs[0],
+						Name:             "foo",
+						Action:           IntentionActionAllow,
+						LegacyCreateTime: &testTimeA,
+						LegacyUpdateTime: &testTimeA,
+						LegacyMeta:       makeStringMap(64, 128, 513),
 					},
 				},
 			},
@@ -265,10 +283,12 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 				Name: "test",
 				Sources: []*SourceIntention{
 					{
-						LegacyID:   legacyIDs[0],
-						Name:       "foo",
-						Action:     IntentionActionAllow,
-						LegacyMeta: makeStringMap(64, 128, 512),
+						LegacyID:         legacyIDs[0],
+						Name:             "foo",
+						Action:           IntentionActionAllow,
+						LegacyCreateTime: &testTimeA,
+						LegacyUpdateTime: &testTimeA,
+						LegacyMeta:       makeStringMap(64, 128, 512),
 					},
 				},
 			},
@@ -280,9 +300,11 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 				Name: "test",
 				Sources: []*SourceIntention{
 					{
-						Name:        "foo",
-						Action:      IntentionActionAllow,
-						Description: strings.Repeat("x", 512),
+						Name:             "foo",
+						Action:           IntentionActionAllow,
+						Description:      strings.Repeat("x", 512),
+						LegacyCreateTime: &testTimeA,
+						LegacyUpdateTime: &testTimeA,
 					},
 				},
 			},
@@ -1008,8 +1030,10 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 						Action:   IntentionActionDeny,
 					},
 					{
-						Name:   "foo",
-						Action: IntentionActionAllow,
+						Name:             "foo",
+						Action:           IntentionActionAllow,
+						LegacyCreateTime: &testTimeA, // stray times will be dropped
+						LegacyUpdateTime: &testTimeA,
 					},
 					{
 						Name:   "bar",
@@ -1059,9 +1083,11 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 				Name: "test",
 				Sources: []*SourceIntention{
 					{
-						Name:     WildcardSpecifier,
-						Action:   IntentionActionDeny,
-						LegacyID: legacyIDs[0],
+						Name:             WildcardSpecifier,
+						Action:           IntentionActionDeny,
+						LegacyID:         legacyIDs[0],
+						LegacyCreateTime: &testTimeA,
+						LegacyUpdateTime: &testTimeA,
 					},
 					{
 						Name:     "foo",
@@ -1071,23 +1097,27 @@ func TestServiceIntentionsConfigEntry(t *testing.T) {
 							"key1": "val1",
 							"key2": "val2",
 						},
+						LegacyCreateTime: &testTimeB,
+						LegacyUpdateTime: &testTimeB,
 					},
 					{
-						Name:     "bar",
-						Action:   IntentionActionDeny,
-						LegacyID: legacyIDs[2],
+						Name:             "bar",
+						Action:           IntentionActionDeny,
+						LegacyID:         legacyIDs[2],
+						LegacyCreateTime: &testTimeC,
+						LegacyUpdateTime: &testTimeC,
 					},
 				},
 			},
 			check: func(t *testing.T, entry *ServiceIntentionsConfigEntry) {
 				require.Len(t, entry.Sources, 3)
 
-				assert.False(t, entry.Sources[0].LegacyCreateTime.IsZero())
-				assert.False(t, entry.Sources[0].LegacyUpdateTime.IsZero())
-				assert.False(t, entry.Sources[1].LegacyCreateTime.IsZero())
-				assert.False(t, entry.Sources[1].LegacyUpdateTime.IsZero())
-				assert.False(t, entry.Sources[2].LegacyCreateTime.IsZero())
-				assert.False(t, entry.Sources[2].LegacyUpdateTime.IsZero())
+				// assert.False(t, entry.Sources[0].LegacyCreateTime.IsZero())
+				// assert.False(t, entry.Sources[0].LegacyUpdateTime.IsZero())
+				// assert.False(t, entry.Sources[1].LegacyCreateTime.IsZero())
+				// assert.False(t, entry.Sources[1].LegacyUpdateTime.IsZero())
+				// assert.False(t, entry.Sources[2].LegacyCreateTime.IsZero())
+				// assert.False(t, entry.Sources[2].LegacyUpdateTime.IsZero())
 
 				assert.Equal(t, []*SourceIntention{
 					{
@@ -1299,6 +1329,8 @@ func TestMigrateIntentions(t *testing.T) {
 							LegacyMeta: map[string]string{
 								"key1": "val1",
 							},
+							LegacyCreateTime: &anyTime,
+							LegacyUpdateTime: &anyTime,
 						},
 					},
 				},
@@ -1349,6 +1381,8 @@ func TestMigrateIntentions(t *testing.T) {
 							LegacyMeta: map[string]string{
 								"key1": "val1",
 							},
+							LegacyCreateTime: &anyTime,
+							LegacyUpdateTime: &anyTime,
 						},
 						{
 							LegacyID:    legacyIDs[1],
@@ -1359,6 +1393,8 @@ func TestMigrateIntentions(t *testing.T) {
 							LegacyMeta: map[string]string{
 								"key2": "val2",
 							},
+							LegacyCreateTime: &anyTime,
+							LegacyUpdateTime: &anyTime,
 						},
 					},
 				},
@@ -1409,6 +1445,8 @@ func TestMigrateIntentions(t *testing.T) {
 							LegacyMeta: map[string]string{
 								"key1": "val1",
 							},
+							LegacyCreateTime: &anyTime,
+							LegacyUpdateTime: &anyTime,
 						},
 					},
 				},
@@ -1425,6 +1463,8 @@ func TestMigrateIntentions(t *testing.T) {
 							LegacyMeta: map[string]string{
 								"key2": "val2",
 							},
+							LegacyCreateTime: &anyTime,
+							LegacyUpdateTime: &anyTime,
 						},
 					},
 				},

--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -524,9 +524,20 @@ type IntentionRequest struct {
 	// Intention is the intention.
 	Intention *Intention
 
+	// TODO(rb): mutually exclusive with Intention
+	Mutation *IntentionMutation
+
 	// WriteRequest is a common struct containing ACL tokens and other
 	// write-related common elements for requests.
 	WriteRequest
+}
+
+// TODO(rb): raft only
+type IntentionMutation struct {
+	ID          string
+	Destination ServiceName
+	Source      ServiceName
+	Value       *SourceIntention
 }
 
 // RequestDatacenter returns the datacenter for a given request.

--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -522,9 +522,16 @@ type IntentionRequest struct {
 	Op IntentionOp
 
 	// Intention is the intention.
+	//
+	// This is mutually exclusive with the Mutation field.
 	Intention *Intention
 
-	// TODO(rb): mutually exclusive with Intention
+	// Mutation is a change to make to an Intention.
+	//
+	// This is mutually exclusive with the Intention field.
+	//
+	// This field is only set by the leader before writing to the raft log and
+	// is not settable via the API or an RPC.
 	Mutation *IntentionMutation
 
 	// WriteRequest is a common struct containing ACL tokens and other
@@ -532,7 +539,6 @@ type IntentionRequest struct {
 	WriteRequest
 }
 
-// TODO(rb): raft only
 type IntentionMutation struct {
 	ID          string
 	Destination ServiceName

--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -440,6 +440,9 @@ func (x *Intention) ToConfigEntry(legacy bool) *ServiceIntentionsConfigEntry {
 }
 
 func (x *Intention) ToSourceIntention(legacy bool) *SourceIntention {
+	ct := x.CreatedAt // copy
+	ut := x.UpdatedAt
+
 	src := &SourceIntention{
 		Name:             x.SourceName,
 		EnterpriseMeta:   *x.SourceEnterpriseMeta(),
@@ -450,8 +453,8 @@ func (x *Intention) ToSourceIntention(legacy bool) *SourceIntention {
 		Type:             x.SourceType,
 		Description:      x.Description,
 		LegacyMeta:       x.Meta,
-		LegacyCreateTime: nil, // Ignore
-		LegacyUpdateTime: nil, // Ignore
+		LegacyCreateTime: &ct,
+		LegacyUpdateTime: &ut,
 	}
 	if !legacy {
 		src.Permissions = x.Permissions


### PR DESCRIPTION
Change so line-item intention edits via the API are handled via the state store instead of via CAS operations.

Fixes #9143 