### PR TITLE
use streaming backend for connect service health

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -536,6 +536,10 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	// Start the proxy config manager.
+	cacheName := cachetype.HealthServicesName
+	if a.config.UseStreamingBackend {
+		cacheName = cachetype.StreamingHealthServicesName
+	}
 	a.proxyConfig, err = proxycfg.NewManager(proxycfg.ManagerConfig{
 		Cache:  a.cache,
 		Logger: a.logger.Named(logging.ProxyConfig),
@@ -549,8 +553,9 @@ func (a *Agent) Start(ctx context.Context) error {
 			Domain:    a.config.DNSDomain,
 			AltDomain: a.config.DNSAltDomain,
 		},
-		TLSConfigurator:       a.tlsConfigurator,
-		IntentionDefaultAllow: intentionDefaultAllow,
+		TLSConfigurator:        a.tlsConfigurator,
+		IntentionDefaultAllow:  intentionDefaultAllow,
+		ServiceHealthCacheName: cacheName,
 	})
 	if err != nil {
 		return err

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -536,12 +536,9 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	// Start the proxy config manager.
-	cacheName := cachetype.HealthServicesName
-	if a.config.UseStreamingBackend {
-		cacheName = cachetype.StreamingHealthServicesName
-	}
 	a.proxyConfig, err = proxycfg.NewManager(proxycfg.ManagerConfig{
 		Cache:  a.cache,
+		Health: a.rpcClientHealth,
 		Logger: a.logger.Named(logging.ProxyConfig),
 		State:  a.State,
 		Source: &structs.QuerySource{
@@ -553,9 +550,8 @@ func (a *Agent) Start(ctx context.Context) error {
 			Domain:    a.config.DNSDomain,
 			AltDomain: a.config.DNSAltDomain,
 		},
-		TLSConfigurator:        a.tlsConfigurator,
-		IntentionDefaultAllow:  intentionDefaultAllow,
-		ServiceHealthCacheName: cacheName,
+		TLSConfigurator:       a.tlsConfigurator,
+		IntentionDefaultAllow: intentionDefaultAllow,
 	})
 	if err != nil {
 		return err

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -377,8 +377,6 @@ func New(bd BaseDeps) (*Agent, error) {
 		Cache:     bd.Cache,
 		NetRPC:    &a,
 		CacheName: cacheName,
-		// Temporarily until streaming supports all connect events
-		CacheNameConnect: cachetype.HealthServicesName,
 	}
 
 	a.serviceManager = NewServiceManager(&a)

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -71,11 +71,18 @@ func serviceHealthSnapshot(db ReadDB, topic stream.Topic) stream.SnapshotFunc {
 			event := stream.Event{
 				Index: idx,
 				Topic: topic,
-				Payload: EventPayloadCheckServiceNode{
-					Op:    pbsubscribe.CatalogOp_Register,
-					Value: &n,
-				},
 			}
+			payload := EventPayloadCheckServiceNode{
+				Op:    pbsubscribe.CatalogOp_Register,
+				Value: &n,
+			}
+
+			// TODO: share this logic with serviceHealthToConnectEvents
+			if connect && n.Service.Kind == structs.ServiceKindConnectProxy {
+				payload.key = n.Service.Proxy.DestinationServiceName
+			}
+
+			event.Payload = payload
 
 			if !connect {
 				// append each event as a separate item so that they can be serialized

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -71,18 +71,11 @@ func serviceHealthSnapshot(db ReadDB, topic stream.Topic) stream.SnapshotFunc {
 			event := stream.Event{
 				Index: idx,
 				Topic: topic,
+				Payload: EventPayloadCheckServiceNode{
+					Op:    pbsubscribe.CatalogOp_Register,
+					Value: &n,
+				},
 			}
-			payload := EventPayloadCheckServiceNode{
-				Op:    pbsubscribe.CatalogOp_Register,
-				Value: &n,
-			}
-
-			// TODO: share this logic with serviceHealthToConnectEvents
-			if connect && n.Service.Kind == structs.ServiceKindConnectProxy {
-				payload.key = n.Service.Proxy.DestinationServiceName
-			}
-
-			event.Payload = payload
 
 			if !connect {
 				// append each event as a separate item so that they can be serialized

--- a/agent/consul/state/memdb.go
+++ b/agent/consul/state/memdb.go
@@ -202,9 +202,7 @@ func processDBChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
 
 func newSnapshotHandlers(db ReadDB) stream.SnapshotHandlers {
 	return stream.SnapshotHandlers{
-		topicServiceHealth: serviceHealthSnapshot(db, topicServiceHealth),
-		// The connect topic is temporarily disabled until the correct events are
-		// created for terminating gateway changes.
-		//topicServiceHealthConnect: serviceHealthSnapshot(db, topicServiceHealthConnect),
+		topicServiceHealth:        serviceHealthSnapshot(db, topicServiceHealth),
+		topicServiceHealthConnect: serviceHealthSnapshot(db, topicServiceHealthConnect),
 	}
 }

--- a/agent/proxycfg/manager.go
+++ b/agent/proxycfg/manager.go
@@ -4,11 +4,12 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/tlsutil"
-	"github.com/hashicorp/go-hclog"
 )
 
 var (
@@ -70,6 +71,9 @@ type ManagerConfig struct {
 	// logger is the agent's logger to be used for logging logs.
 	Logger          hclog.Logger
 	TLSConfigurator *tlsutil.Configurator
+
+	// TODO: replace this field with a type that exposes Notify
+	ServiceHealthCacheName string
 
 	// IntentionDefaultAllow is set by the agent so that we can pass this
 	// information to proxies that need to make intention decisions on their
@@ -187,7 +191,7 @@ func (m *Manager) ensureProxyServiceLocked(ns *structs.NodeService, token string
 	}
 
 	var err error
-	state, err = newState(ns, token)
+	state, err = newState(ns, token, m.ManagerConfig.ServiceHealthCacheName)
 	if err != nil {
 		return err
 	}

--- a/agent/proxycfg/manager.go
+++ b/agent/proxycfg/manager.go
@@ -59,6 +59,8 @@ type ManagerConfig struct {
 	// Cache is the agent's cache instance that can be used to retrieve, store and
 	// monitor state for the proxies.
 	Cache *cache.Cache
+	// Health provides service health updates on a notification channel.
+	Health Health
 	// state is the agent's local state to be watched for new proxy registrations.
 	State *local.State
 	// source describes the current agent's identity, it's used directly for
@@ -71,9 +73,6 @@ type ManagerConfig struct {
 	// logger is the agent's logger to be used for logging logs.
 	Logger          hclog.Logger
 	TLSConfigurator *tlsutil.Configurator
-
-	// TODO: replace this field with a type that exposes Notify
-	ServiceHealthCacheName string
 
 	// IntentionDefaultAllow is set by the agent so that we can pass this
 	// information to proxies that need to make intention decisions on their
@@ -191,7 +190,7 @@ func (m *Manager) ensureProxyServiceLocked(ns *structs.NodeService, token string
 	}
 
 	var err error
-	state, err = newState(ns, token, m.ManagerConfig.ServiceHealthCacheName)
+	state, err = newState(ns, token)
 	if err != nil {
 		return err
 	}
@@ -199,6 +198,7 @@ func (m *Manager) ensureProxyServiceLocked(ns *structs.NodeService, token string
 	// Set the necessary dependencies
 	state.logger = m.Logger.With("service_id", sid.String())
 	state.cache = m.Cache
+	state.health = m.Health
 	state.source = m.Source
 	state.dnsConfig = m.DNSConfig
 	state.intentionDefaultAllow = m.IntentionDefaultAllow

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/local"
+	"github.com/hashicorp/consul/agent/rpcclient/health"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -343,11 +344,11 @@ func testManager_BasicLifecycle(
 
 	// Create manager
 	m, err := NewManager(ManagerConfig{
-		Cache:                  c,
-		State:                  state,
-		Source:                 source,
-		Logger:                 logger,
-		ServiceHealthCacheName: cachetype.HealthServicesName,
+		Cache:  c,
+		Health: &health.Client{Cache: c, CacheName: cachetype.HealthServicesName},
+		State:  state,
+		Source: source,
+		Logger: logger,
 	})
 	require.NoError(err)
 

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -342,7 +342,13 @@ func testManager_BasicLifecycle(
 	state.TriggerSyncChanges = func() {}
 
 	// Create manager
-	m, err := NewManager(ManagerConfig{c, state, source, DNSConfig{}, logger, nil, false})
+	m, err := NewManager(ManagerConfig{
+		Cache:                  c,
+		State:                  state,
+		Source:                 source,
+		Logger:                 logger,
+		ServiceHealthCacheName: cachetype.HealthServicesName,
+	})
 	require.NoError(err)
 
 	// And run it

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -6,12 +6,13 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStateChanged(t *testing.T) {
@@ -111,7 +112,7 @@ func TestStateChanged(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			state, err := newState(tt.ns, tt.token)
+			state, err := newState(tt.ns, tt.token, cachetype.HealthServicesName)
 			require.NoError(err)
 			otherNS, otherToken := tt.mutate(*tt.ns, tt.token)
 			require.Equal(tt.want, state.Changed(otherNS, otherToken))
@@ -1509,7 +1510,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			state, err := newState(&tc.ns, "")
+			state, err := newState(&tc.ns, "", cachetype.HealthServicesName)
 
 			// verify building the initial state worked
 			require.NoError(t, err)

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
+	"github.com/hashicorp/consul/agent/rpcclient/health"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
 )
@@ -112,7 +113,7 @@ func TestStateChanged(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			state, err := newState(tt.ns, tt.token, cachetype.HealthServicesName)
+			state, err := newState(tt.ns, tt.token)
 			require.NoError(err)
 			otherNS, otherToken := tt.mutate(*tt.ns, tt.token)
 			require.Equal(tt.want, state.Changed(otherNS, otherToken))
@@ -142,6 +143,10 @@ func (cn *testCacheNotifier) Notify(ctx context.Context, t string, r cache.Reque
 	cn.notifiers[correlationId] = testCacheNotifierRequest{t, r, ch}
 	cn.lock.Unlock()
 	return nil
+}
+
+func (cn *testCacheNotifier) Get(ctx context.Context, t string, r cache.Request) (interface{}, cache.ResultMeta, error) {
+	panic("Get: not implemented")
 }
 
 func (cn *testCacheNotifier) getNotifierRequest(t testing.TB, correlationId string) testCacheNotifierRequest {
@@ -1510,7 +1515,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			state, err := newState(&tc.ns, "", cachetype.HealthServicesName)
+			state, err := newState(&tc.ns, "")
 
 			// verify building the initial state worked
 			require.NoError(t, err)
@@ -1522,6 +1527,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 			// setup a new testing cache notifier
 			cn := newTestCacheNotifier()
 			state.cache = cn
+			state.health = &health.Client{Cache: cn, CacheName: cachetype.HealthServicesName}
 
 			// setup the local datacenter information
 			state.source = &structs.QuerySource{

--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -12,8 +12,6 @@ type Client struct {
 	Cache  CacheGetter
 	// CacheName to use for service health.
 	CacheName string
-	// CacheNameConnect is the name of the cache to use for connect service health.
-	CacheNameConnect string
 }
 
 type NetRPC interface {
@@ -54,12 +52,7 @@ func (c *Client) getServiceNodes(
 		return out, cache.ResultMeta{}, err
 	}
 
-	cacheName := c.CacheName
-	if req.Connect {
-		cacheName = c.CacheNameConnect
-	}
-
-	raw, md, err := c.Cache.Get(ctx, cacheName, &req)
+	raw, md, err := c.Cache.Get(ctx, c.CacheName, &req)
 	if err != nil {
 		return out, md, err
 	}

--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -20,6 +20,7 @@ type NetRPC interface {
 
 type CacheGetter interface {
 	Get(ctx context.Context, t string, r cache.Request) (interface{}, cache.ResultMeta, error)
+	Notify(ctx context.Context, t string, r cache.Request, cID string, ch chan<- cache.UpdateEvent) error
 }
 
 func (c *Client) ServiceNodes(
@@ -63,4 +64,13 @@ func (c *Client) getServiceNodes(
 	}
 
 	return *value, md, nil
+}
+
+func (c *Client) Notify(
+	ctx context.Context,
+	req structs.ServiceSpecificRequest,
+	correlationID string,
+	ch chan<- cache.UpdateEvent,
+) error {
+	return c.Cache.Notify(ctx, c.CacheName, &req, correlationID, ch)
 }


### PR DESCRIPTION
Should be merged after #9671

Enables the connect streaming topic.
Enables the use of the streaming cache in connect.
Also fixes a bug in the snapshot for the connect topic.