### PR TITLE
ui: Inline Topology Intention Actions 

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/down-lines/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/down-lines/index.hbs
@@ -47,6 +47,7 @@
   <TopologyMetrics::Popover
     @positions={{this.iconPositions}}
     @item={{item}}
+    @oncreate={{action @oncreate item @service}}
   />
 {{/each}}
 

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -2,7 +2,7 @@
 
 <div
   {{did-insert (action this.calculate)}}
-  {{did-update (action this.calculate) @topology}}
+  {{did-update (action this.calculate) @topology.Upstreams @topology.Downstreams}}
   class="topology-container"
 >
 {{#if (gt @topology.Downstreams.length 0)}}
@@ -17,7 +17,6 @@
     </div>
   {{#each @topology.Downstreams as |item|}}
     <TopologyMetrics::Card
-      {{did-update (action this.calculate) item}}
       @item={{item}}
       @service={{@service.Service}}
       @dc={{@topology.Datacenter}}
@@ -59,10 +58,12 @@
   <div id="downstream-lines">
     <TopologyMetrics::DownLines
       @type='downstream'
+      @service={{@service}}
       @view={{this.downView}}
       @center={{this.centerDimensions}}
       @lines={{this.downLines}}
       @items={{@topology.Downstreams}}
+      @oncreate={{action @oncreate}}
     />
   </div>
 {{#if (gt @topology.Upstreams.length 0)}}
@@ -72,7 +73,6 @@
       <p>{{dc}}</p>
     {{#each upstreams as |item|}}
       <TopologyMetrics::Card
-        {{did-update (action this.calculate) item}}
         @item={{item}}
         @service={{@service.Service}}
         @dc={{@topology.Datacenter}}
@@ -88,10 +88,12 @@
   <div id="upstream-lines">
     <TopologyMetrics::UpLines
       @type='upstream'
+      @service={{@service}}
       @view={{this.upView}}
       @center={{this.centerDimensions}}
       @lines={{this.upLines}}
       @items={{@topology.Upstreams}}
+      @oncreate={{action @oncreate}}
     />
   </div>
 </div>

--- a/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
@@ -22,9 +22,19 @@
       {{#if @item.Intention.HasExact}}
         <a href={{href-to 'dc.services.show.intentions.edit' (concat @item.Intention.ID)}}>Edit</a>
       {{else}}
-        <a href={{href-to 'dc.services.show.intentions.create'}}>Create</a>
+        <button
+          {{on "click" @oncreate}}
+          type="button"
+        >
+          Create
+        </button>
       {{/if}}
-        <button class="cancel" {{on "click" this.togglePopover}}>Cancel</button>
+        <button
+          {{on "click" this.togglePopover}}
+          class="cancel"
+        >
+          Cancel
+        </button>
       </div>
     </EmberPopover>
   </button>
@@ -48,7 +58,11 @@
       </div>
       <div class="actions">
         <a href={{href-to 'dc.services.show.intentions.edit' (concat @item.Intention.ID)}}>View</a>
-        <button {{on "click" this.togglePopover}}>Close</button>
+        <button
+          {{on "click" this.togglePopover}}
+        >
+          Close
+        </button>
       </div>
     </EmberPopover>
   </button>

--- a/ui/packages/consul-ui/app/components/topology-metrics/up-lines/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/up-lines/index.hbs
@@ -43,5 +43,6 @@
   <TopologyMetrics::Popover
     @positions={{this.iconPositions}}
     @item={{item}}
+    @oncreate={{action @oncreate @service item}}
   />
 {{/each}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/up-lines/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/up-lines/index.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class TopoloyMetricsUpLines extends Component {
+export default class TopologyMetricsUpLines extends Component {
   @tracked iconPositions;
 
   @action

--- a/ui/packages/consul-ui/app/routes/dc/services/show.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show.js
@@ -2,13 +2,27 @@ import { inject as service } from '@ember/service';
 import Route from 'consul-ui/routing/route';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
+import { action, setProperties } from '@ember/object';
 
 export default class ShowRoute extends Route {
-  @service('data-source/service')
-  data;
+  @service('data-source/service') data;
+  @service('repository/intention') repo;
+  @service('ui-config') config;
 
-  @service('ui-config')
-  config;
+  @action
+  async createIntention(source, destination) {
+    const intention = service.Intention;
+    const model = this.repo.create({
+      Datacenter: source.Datacenter,
+      SourceName: source.Name,
+      SourceNS: source.Namespace || 'default',
+      DestinationName: destination.Name,
+      DestinationNS: destination.Namespace || 'default',
+      Action: 'allow',
+    });
+    await this.repo.persist(model);
+    this.refresh();
+  }
 
   model(params, transition) {
     const dc = this.modelFor('dc').dc.Name;

--- a/ui/packages/consul-ui/app/serializers/topology.js
+++ b/ui/packages/consul-ui/app/serializers/topology.js
@@ -3,10 +3,13 @@ import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/topology';
 import { inject as service } from '@ember/service';
 
 export default class TopologySerializer extends Serializer {
+  @service('store') store;
+
   primaryKey = PRIMARY_KEY;
   slugKey = SLUG_KEY;
 
   respondForQueryRecord(respond, query) {
+    const intentionSerializer = this.store.serializerFor('intention');
     return super.respondForQueryRecord(function(cb) {
       return respond(function(headers, body) {
         body.Downstreams.forEach(item => {

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -11,6 +11,8 @@
         Datacenter=dc
         Service=items.firstObject
       )}}
+
+      @oncreate={{route-action 'createIntention'}}
     />
   {{else}}
     <EmptyState>

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -123,6 +123,7 @@
     "ember-ref-modifier": "^1.0.0",
     "ember-render-helpers": "^0.1.1",
     "ember-resolver": "^8.0.0",
+    "ember-route-action-helper": "^2.0.8",
     "ember-router-helpers": "^0.4.0",
     "ember-sinon-qunit": "5.0.0",
     "ember-source": "~3.20.5",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8031,6 +8031,13 @@ ember-export-application-global@^2.0.1:
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
 
+ember-factory-for-polyfill@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
+  integrity sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==
+  dependencies:
+    ember-cli-version-checker "^2.1.0"
+
 ember-get-config@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
@@ -8038,6 +8045,14 @@ ember-get-config@^0.2.4:
   dependencies:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^6.3.0"
+
+ember-getowner-polyfill@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
+  integrity sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==
+  dependencies:
+    ember-cli-version-checker "^2.1.0"
+    ember-factory-for-polyfill "^1.3.1"
 
 ember-href-to@^3.1.0:
   version "3.1.0"
@@ -8221,6 +8236,14 @@ ember-rfc176-data@^0.3.12, ember-rfc176-data@^0.3.13, ember-rfc176-data@^0.3.16:
   version "0.3.16"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.16.tgz#2ace0ac9cf9016d493a74a1d931643a308679803"
   integrity sha512-IYAzffS90r2ybAcx8c2qprYfkxa70G+/UPkxMN1hw55DU5S2aLOX6v3umKDZItoRhrvZMCnzwsdfKSrKdC9Wbg==
+
+ember-route-action-helper@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/ember-route-action-helper/-/ember-route-action-helper-2.0.8.tgz#f227fcccb73e839b65e9b814e241b322fe8c02fc"
+  integrity sha512-V+4uKwqaYveriVt2rl4e+9mzHJiQOr1B8dCPQQ2TS3iAcmi5RD2giRDFGtCK9d2XY9Arb/f9hJh0obP20iyt3A==
+  dependencies:
+    ember-cli-babel "^6.8.1"
+    ember-getowner-polyfill "^2.0.0"
 
 ember-router-generator@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Previously creating a new allowing Intention meant visiting the Intention edit form and manually creating a new intention. This adds an 'inline' action that creates a new allowing intention without leaving the topology page.