### PR TITLE
ci: publish bindata_assetfs.go for all release/.x branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -894,6 +894,7 @@ workflows:
             branches:
               only:
                 - master
+                - /release\/\d+\.\d+\.x$/
           requires:
             - build-static-assets
       - dev-build:


### PR DESCRIPTION
There might be a backporting issue here due to the generated file moving to `agent/uiserver/bindata_assetfs.go` recently.