### PR TITLE
changelog: merge release/1.9.0-beta3

### DIFF
--- a/.changelog/9119.txt
+++ b/.changelog/9119.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+chore: update to Go 1.14.11 with mitigation for [golang/go#42138](https://github.com/golang/go/issues/42138)
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## UNRELEASED
 
+## 1.9.0-beta3 (November 10, 2020)
+
+BREAKING CHANGES:
+
+* connect: Switch the default gateway port from 443 to 8443 to avoid assumption of Envoy running as root. [[GH-9113](https://github.com/hashicorp/consul/issues/9113)]
+* raft: Raft protocol v2 is no longer supported. If currently using protocol v2 then an intermediate upgrade to a version supporting both v2 and v3 protocols will be necessary (1.0.0 - 1.8.x). Note that the Raft protocol configured with the `raft_protocol` setting and the Consul RPC protocol configured with the `protocol` setting and output by the `consul version` command are distinct and supported Consul RPC protocol versions are not altered. [[GH-9103](https://github.com/hashicorp/consul/issues/9103)]
+
+FEATURES:
+
+* autopilot: A new `/v1/operator/autopilot/state` HTTP API was created to give greater visibility into what autopilot is doing and how it has classified all the servers it is tracking. [[GH-9103](https://github.com/hashicorp/consul/issues/9103)]
+
+IMPROVEMENTS:
+
+* autopilot: **(Enterprise Only)** Autopilot now supports using both Redundancy Zones and Automated Upgrades together. [[GH-9103](https://github.com/hashicorp/consul/issues/9103)]
+* chore: update to Go 1.14.11 with mitigation for [golang/go#42138](https://github.com/golang/go/issues/42138) [[GH-9119](https://github.com/hashicorp/consul/issues/9119)]
+
+BUG FIXES:
+
+* autopilot: **(Enterprise Only)** Previously servers in other zones would not be promoted when all servers in a second zone had failed. Now the actual behavior matches the docs and autopilot will promote a healthy non-voter from any zone to replace failure of an entire zone. [[GH-9103](https://github.com/hashicorp/consul/issues/9103)]
+
 ## 1.9.0-beta2 (November 07, 2020)
 
 BREAKING CHANGES:

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -14,7 +14,7 @@ export default function DownloadsPage({ releaseData }) {
         prerelease={{
           type: 'beta', // the type of prerelease: beta, release candidate, etc.
           name: 'v1.9.0', // the name displayed in text on the website
-          version: '1.9.0-beta2', // the actual version tag that was pushed to releases.hashicorp.com
+          version: '1.9.0-beta3', // the actual version tag that was pushed to releases.hashicorp.com
         }}
       >
         <p>


### PR DESCRIPTION
Cherry-picking #9155 upwards from release/1.9.x for changelog and website updates.