### PR TITLE
chore(backport): use HashiCorp Docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ jobs:
   # upload dev docker image
   dev-upload-docker:
     docker:
-      - image: circleci/golang:latest # use a circleci image so the attach_workspace step works (has ca-certs installed)
+      - image: *GOLANG_IMAGE # use a circleci image so the attach_workspace step works (has ca-certs installed)
     environment:
       <<: *ENVIRONMENT
     steps:
@@ -397,7 +397,7 @@ jobs:
   # Run integration tests on nomad/v0.8.7
   nomad-integration-0_8:
     docker:
-      - image: circleci/golang:1.10
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.10
     environment:
       <<: *ENVIRONMENT
       NOMAD_WORKING_DIR: &NOMAD_WORKING_DIR /go/src/github.com/hashicorp/nomad
@@ -445,7 +445,7 @@ jobs:
 
   build-website-docker-image:
     docker:
-      - image: circleci/buildpack-deps
+      - image: docker.mirror.hashicorp.services/circleci/buildpack-deps
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
       - checkout
@@ -687,7 +687,7 @@ jobs:
   # only runs on master: checks latest commit to see if the PR associated has a backport/* or docs* label to cherry-pick
   cherry-picker:
     docker:
-      - image: alpine:3.11
+      - image: docker.mirror.hashicorp.services/alpine:3.11
     steps:
       - run: apk add --no-cache --no-progress git bash curl ncurses jq openssh-client
       - checkout

--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,6 +1,6 @@
-FROM fortio/fortio AS fortio
+FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
 
-FROM bats/bats:latest
+FROM docker.mirror.hashicorp.services/bats/bats:latest
 
 RUN apk add curl
 RUN apk add openssl

--- a/test/integration/connect/envoy/Dockerfile-consul-envoy
+++ b/test/integration/connect/envoy/Dockerfile-consul-envoy
@@ -3,5 +3,5 @@ ARG ENVOY_VERSION
 
 FROM consul-dev as consul
 
-FROM envoyproxy/envoy:v${ENVOY_VERSION}
+FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
 COPY --from=consul /bin/consul /bin/consul

--- a/test/integration/connect/envoy/Dockerfile-tcpdump
+++ b/test/integration/connect/envoy/Dockerfile-tcpdump
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM docker.mirror.hashicorp.services/alpine:latest
 
 RUN apk add --no-cache tcpdump
 VOLUME  [ "/data" ]

--- a/test/integration/connect/envoy/docker-compose.yml
+++ b/test/integration/connect/envoy/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # This is a dummy container that we use to create volume and keep it
   # accessible while other containers are down.
   workdir:
-    image: alpine
+    image: docker.mirror.hashicorp.services/alpine
     volumes:
       - *workdir-volume
     command:
@@ -47,7 +47,7 @@ services:
   s1:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s1"
     command:
@@ -63,7 +63,7 @@ services:
   s2:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s2"
     command:
@@ -79,7 +79,7 @@ services:
   s2-v1:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s2-v1"
     command:
@@ -95,7 +95,7 @@ services:
   s2-v2:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s2-v2"
     command:
@@ -111,7 +111,7 @@ services:
   s3:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s3"
     command:
@@ -127,7 +127,7 @@ services:
   s3-v1:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s3-v1"
     command:
@@ -143,7 +143,7 @@ services:
   s3-v2:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s3-v2"
     command:
@@ -159,7 +159,7 @@ services:
   s3-alt:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s3-alt"
     command:
@@ -175,7 +175,7 @@ services:
   s4:
     depends_on:
       - consul-primary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s4"
     command:
@@ -191,7 +191,7 @@ services:
   s1-sidecar-proxy:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -212,7 +212,7 @@ services:
   s2-sidecar-proxy:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -233,7 +233,7 @@ services:
   s2-v1-sidecar-proxy:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -254,7 +254,7 @@ services:
   s2-v2-sidecar-proxy:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -275,7 +275,7 @@ services:
   s3-sidecar-proxy:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -296,7 +296,7 @@ services:
   s3-v1-sidecar-proxy:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -317,7 +317,7 @@ services:
   s3-v2-sidecar-proxy:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -338,7 +338,7 @@ services:
   s3-alt-sidecar-proxy:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -397,7 +397,7 @@ services:
   fake-statsd:
     depends_on:
       - consul-primary
-    image: "alpine/socat"
+    image: "docker.mirror.hashicorp.services/alpine/socat"
     command:
       - -u
       - UDP-RECVFROM:8125,fork,reuseaddr
@@ -412,7 +412,7 @@ services:
   wipe-volumes:
     volumes:
       - *workdir-volume
-    image: alpine
+    image: docker.mirror.hashicorp.services/alpine
     command:
       - sh
       - -c
@@ -424,7 +424,7 @@ services:
     volumes:
       - *workdir-volume
       - ./:/cwd
-    image: alpine
+    image: docker.mirror.hashicorp.services/alpine
     command:
       - cp
       - -r
@@ -434,13 +434,13 @@ services:
   zipkin:
     volumes:
       - *workdir-volume
-    image: openzipkin/zipkin
+    image: docker.mirror.hashicorp.services/openzipkin/zipkin
     network_mode: service:consul-primary
 
   jaeger:
     volumes:
       - *workdir-volume
-    image: jaegertracing/all-in-one:1.11
+    image: docker.mirror.hashicorp.services/jaegertracing/all-in-one:1.11
     network_mode: service:consul-primary
     command:
       - --collector.zipkin.http-port=9411
@@ -466,7 +466,7 @@ services:
   s1-secondary:
     depends_on:
       - consul-secondary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s1-secondary"
     command:
@@ -482,7 +482,7 @@ services:
   s2-secondary:
     depends_on:
       - consul-secondary
-    image: "fortio/fortio"
+    image: "docker.mirror.hashicorp.services/fortio/fortio"
     environment:
       - "FORTIO_NAME=s2-secondary"
     command:
@@ -498,7 +498,7 @@ services:
   s1-sidecar-proxy-secondary:
     depends_on:
       - consul-secondary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -519,7 +519,7 @@ services:
   s2-sidecar-proxy-secondary:
     depends_on:
       - consul-secondary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -540,7 +540,7 @@ services:
   gateway-primary:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -561,7 +561,7 @@ services:
   gateway-secondary:
     depends_on:
       - consul-secondary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -582,7 +582,7 @@ services:
   ingress-gateway-primary:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
      - "envoy"
      - "-c"
@@ -599,7 +599,7 @@ services:
   terminating-gateway-primary:
     depends_on:
       - consul-primary
-    image: "envoyproxy/envoy:v${ENVOY_VERSION}"
+    image: "docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}"
     command:
       - "envoy"
       - "-c"

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -195,7 +195,7 @@ function snapshot_envoy_admin {
   local ENVOY_NAME=$2
   local DC=${3:-primary}
   local OUTDIR="${LOG_DIR}/envoy-snapshots/${DC}/${ENVOY_NAME}"
-  
+
   mkdir -p "${OUTDIR}"
   docker_wget "$DC" "http://${HOSTPORT}/config_dump" -q -O - > "${OUTDIR}/config_dump.json"
   docker_wget "$DC" "http://${HOSTPORT}/clusters?format=json" -q -O - > "${OUTDIR}/clusters.json"
@@ -425,7 +425,7 @@ function docker_consul {
 function docker_wget {
   local DC=$1
   shift 1
-  docker run --rm --network container:envoy_consul-${DC}_1 alpine:3.9 wget "$@"
+  docker run --rm --network container:envoy_consul-${DC}_1 docker.mirror.hashicorp.services/alpine:3.9 wget "$@"
 }
 
 function docker_curl {

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -59,12 +59,12 @@ function init_workdir {
     find ${CASE_DIR}/${DC} -type f -name '*.hcl' -exec cp -f {} workdir/${DC}/consul \;
     find ${CASE_DIR}/${DC} -type f -name '*.bats' -exec cp -f {} workdir/${DC}/bats \;
   fi
-  
+
   if test -d "${CASE_DIR}/data"
   then
     cp -r ${CASE_DIR}/data/* workdir/${DC}/data
   fi
-  
+
   return 0
 }
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.3-alpine
+FROM docker.mirror.hashicorp.services/node:10.16.3-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json


### PR DESCRIPTION
"Backport" of #9070, #9080 and #9085, significantly reworked because of an intermediate Envoy integration tests refactor, would appreciate 👀 in case I missed anything.