### PR TITLE
ui: Update to not return metrics for ingress gateways (#9081)

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/card.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/card.hbs
@@ -44,7 +44,7 @@
     </dl>
 {{/if}}
   </div>
-  {{#if @hasMetricsProvider }}
+  {{#if (and @hasMetricsProvider (not-eq @service.Kind 'ingress-gateway'))}}
     {{#if (eq @type 'upstream')}}
       <TopologyMetrics::Stats
         @endpoint='upstream-summary-for-service'

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -37,6 +37,7 @@
         @protocol={{@topology.Protocol}}
         @noMetricsReason={{this.noMetricsReason}}
       />
+      {{#if (not-eq @service.Service.Kind 'ingress-gateway')}}
       <TopologyMetrics::Stats
         @endpoint='summary-for-service'
         @service={{@service.Service.Service}}
@@ -44,6 +45,7 @@
         @protocol={{@topology.Protocol}}
         @noMetricsReason={{this.noMetricsReason}}
       />
+      {{/if}}
     {{/if}}
     <div class="link">
      {{#if @metricsHref}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -26,7 +26,10 @@ export default class TopologyMetrics extends Component {
     // TODO we can make the configurable even before we have a full solution for
     // multi-DC forwarding for Prometheus so providers that are global for all
     // DCs like an external managed APM can still load in all DCs.
-    if (this.env.var('CONSUL_DATACENTER_LOCAL') != this.args.topology.get('Datacenter')) {
+    if (
+      this.env.var('CONSUL_DATACENTER_LOCAL') !== this.args.topology.get('Datacenter') ||
+      this.args.service.Service.Kind === 'ingress-gateway'
+    ) {
       this.noMetricsReason = 'Unable to fetch metrics for a remote datacenter';
     }
   }

--- a/ui/packages/consul-ui/app/routes/dc/services/show/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/index.js
@@ -11,29 +11,25 @@ export default class IndexRoute extends Route {
     // so check the length here.
     let to = 'topology';
     const parentModel = this.modelFor(parent);
-    const hasProxy = get(parentModel, 'proxies');
+    const hasProxy = get(parentModel, 'proxies.length') !== 0;
     const kind = get(parentModel, 'items.firstObject.Service.Kind');
 
-    if (hasProxy.length === 0) {
-      to = 'instances';
-    } else {
-      switch (kind) {
-        case 'ingress-gateway':
-          if (!get(parentModel, 'topology.Datacenter')) {
-            to = 'upstreams';
-          }
-          break;
-        case 'terminating-gateway':
-          to = 'services';
-          break;
-        case 'mesh-gateway':
+    switch (kind) {
+      case 'ingress-gateway':
+        if (!get(parentModel, 'topology.Datacenter')) {
+          to = 'upstreams';
+        }
+        break;
+      case 'terminating-gateway':
+        to = 'services';
+        break;
+      case 'mesh-gateway':
+        to = 'instances';
+        break;
+      default:
+        if (!hasProxy || !get(parentModel, 'topology.Datacenter')) {
           to = 'instances';
-          break;
-        default:
-          if (!get(parentModel, 'topology.Datacenter')) {
-            to = 'instances';
-          }
-      }
+        }
     }
 
     this.replaceWith(`${parent}.${to}`, parentModel);

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -29,7 +29,7 @@
     <TabNav @items={{
       compact
           (array
-(if (and topology.Datacenter (gt proxies.length 0))
+(if (and topology.Datacenter (or (gt proxies.length 0) (eq item.Service.Kind 'ingress-gateway')))
             (hash label="Topology" href=(href-to "dc.services.show.topology") selected=(is-href "dc.services.show.topology"))
 '')
 (if (eq item.Service.Kind 'terminating-gateway')


### PR DESCRIPTION
Backports #9081

I resolved two sets of conflicts in `ui/packages/consul-ui/app/components/topology-metrics/card.hbs` that were pretty straightforward, taking the `@` ref (Glimmer style if I understand correctly) for:
```
<<<<<<< HEAD
        @item={{@item.Name}}
=======
        @item={{item.Name}}
>>>>>>> 56c2ff56e (ui: Update to not return metrics for ingress gateways (#9081))

```

There's two conflicts left in `ui/packages/consul-ui/app/components/topology-metrics/index.hbs` that I'm very much not sure how to resolve properly though...