### PR TITLE
ci: reword cherry-picker comment

### DIFF
--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -133,7 +133,7 @@ pr_number=$(echo "$resp" | jq '.items[].number')
 
 # comment on the PR with the build number to make it easy to re-run the job when
 # cherry-pick labels are added in the future
-github_message=":cherries: Starting backport cherry picking.\n\nTo cherry-pick post-merge, add backport labels and re-run ${CIRCLE_BUILD_URL}."
+github_message=":cherries: If backport labels were added before merging, cherry-picking will start automatically.\n\nTo retroactively trigger a backport after merging, add backport labels and re-run ${CIRCLE_BUILD_URL}."
 curl -f -s -H "Authorization: token ${GITHUB_TOKEN}" \
     -X POST \
     -d "{ \"body\": \"${github_message}\"}" \


### PR DESCRIPTION
It was a little confusing seeing "Starting backport cherry picking." on a PR that intentionally wasn't being backported, hopefully this will be a little more clear - open to suggestions on language here.

Refs #9130