### PR TITLE
add note about future metric fixes and deprecations under disable_com…

### DIFF
--- a/.changelog/9181.txt
+++ b/.changelog/9181.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+telemetry: the disable_compat_1.9 config will cover more metrics fixes in future 1.9 point releases. These metrics will be emitted twice for backwards compatibility - if the flag is true, only the new metric name will be written.
+```
+```release-note:deprecation
+telemetry: the disable_compat_1.9 config will cover more metrics deprecations in future 1.9 point releases. These metrics will be emitted twice for backwards compatibility - if the flag is true, only the new metric name will be written.
+```

--- a/.changelog/9181.txt
+++ b/.changelog/9181.txt
@@ -1,6 +1,3 @@
-```release-note:bug
-telemetry: the disable_compat_1.9 config will cover more metrics fixes in future 1.9 point releases. These metrics will be emitted twice for backwards compatibility - if the flag is true, only the new metric name will be written.
-```
 ```release-note:deprecation
 telemetry: the disable_compat_1.9 config will cover more metrics deprecations in future 1.9 point releases. These metrics will be emitted twice for backwards compatibility - if the flag is true, only the new metric name will be written.
 ```


### PR DESCRIPTION
…pat_1.9

Added two similar entries covering future bug fixes and deprecations that we expect to use the `disable_compat_1.9` flag to give users the option of disabling the changed behavior.