### PR TITLE
Prevent panic if autopilot health is requested prior to leader establishment finishing.

### DIFF
--- a/.changelog/9204.txt
+++ b/.changelog/9204.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+autopilot: Prevent panic when requesting the autopilot health immediately after a leader is elected.
+```

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -100,6 +100,12 @@ func (op *Operator) ServerHealth(args *structs.DCSpecificRequest, reply *structs
 
 	state := op.srv.autopilot.GetState()
 
+	if state == nil {
+		// this behavior seems odd but its functionally equivalent to 1.8.5 where if
+		// autopilot didn't have a health reply yet it would just return no error
+		return nil
+	}
+
 	health := structs.AutopilotHealthReply{
 		Healthy:          state.Healthy,
 		FailureTolerance: state.FailureTolerance,


### PR DESCRIPTION
Running `go test -count 100 ./agent -run TestOperator_ServerHealth_Unhealthy` was a reliable way to test this locally.

As for unit tests its pretty much impossible to time things just right such that we make the request after raft has elected a leader and before leader establishment has finished (which will create the autopilot state)