### PR TITLE
Add docs for envoyExtraArgs

### DIFF
--- a/website/pages/docs/k8s/connect/index.mdx
+++ b/website/pages/docs/k8s/connect/index.mdx
@@ -256,6 +256,14 @@ Annotations can be used to configure the injection behavior.
   [defaultProtocol](/docs/k8s/helm#v-connectinject-centralconfig-defaultprotocol)
   option. Specific annotations will always override the default value.
 
+- `consul.hashicorp.com/envoy-extra-args` - A space-separated list of [arguments](https://www.envoyproxy.io/docs/envoy/latest/operations/cli)
+  to be passed to the injected envoy binary.
+
+  ```yaml
+  annotations:
+    consul.hashicorp.com/envoy-extra-args: "--log-level debug --disable-hot-restart"
+  ```
+
 - `consul.hashicorp.com/service-tags` - A comma separated list of tags that will
   be applied to the Consul service and its sidecar.
 

--- a/website/pages/docs/k8s/helm.mdx
+++ b/website/pages/docs/k8s/helm.mdx
@@ -753,6 +753,8 @@ and consider if they're appropriate for your deployment.
 
     - `reconcilePeriod` ((#v-connectinject-healthchecks-reconcileperiod)) (`string: "1m"`) - If `healthChecks.enabled` is set to true, reconcilePeriod defines how often a full state reconcile is done after the initial reconcile at startup is completed.
 
+  - `envoyExtraArgs` (((#v-connectinject-envoyextraargs))) (`string: ""`) - Pass [arguments](https://www.envoyproxy.io/docs/envoy/latest/operations/cli) to the injected envoy sidecar, e.g `"--log-level debug --disable-hot-restart"`
+
   - `imageConsul` ((#v-connectinject-imageconsul)) (`string: global.image`) - The name of the Docker
     image (including any tag) for Consul. This is used for proxy service registration, Envoy configuration, etc.
 


### PR DESCRIPTION
* Adds `envoyExtraArgs` to the helm doc
* Adds `consul.hashicorp.com/envoy-extra-arg` to the annotation doc