### PR TITLE
Add DC and NS support for Envoy metrics

### DIFF
--- a/.changelog/9207.txt
+++ b/.changelog/9207.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+connect: Update Envoy metrics names and labels for proxy listeners so that attributes like datacenter and namespace can be extracted. 
+```

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -577,7 +577,7 @@ func expectListenerJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot) ma
 								"name": "envoy.tcp_proxy",
 								"config": {
 									"cluster": "local_app",
-									"stat_prefix": "public_listener_tcp"
+									"stat_prefix": "public_listener"
 								}
 							}
 						]
@@ -600,7 +600,7 @@ func expectListenerJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot) ma
 							"name": "envoy.tcp_proxy",
 							"config": {
 								"cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-								"stat_prefix": "upstream_db_tcp"
+								"stat_prefix": "upstream.db.default.dc1"
 							}
 						}
 					]
@@ -623,7 +623,7 @@ func expectListenerJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot) ma
 							"name": "envoy.tcp_proxy",
 							"config": {
 								"cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-								"stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+								"stat_prefix": "upstream.prepared_query_geo-cache"
 							}
 						}
 					]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-13-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-14-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-15-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.envoy-1-16-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-external-sni.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-13-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-14-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-15-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.envoy-1-16-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-13-x.golden
@@ -30,7 +30,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -58,7 +58,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -112,7 +112,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-14-x.golden
@@ -30,7 +30,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -58,7 +58,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -112,7 +112,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-15-x.golden
@@ -30,7 +30,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -58,7 +58,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -112,7 +112,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.envoy-1-16-x.golden
@@ -30,7 +30,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -58,7 +58,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -112,7 +112,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tcp-chain.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-13-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-14-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-15-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2-typed.envoy-1-16-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-13-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-14-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-15-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-2.envoy-1-16-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-13-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-14-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-15-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-missing.envoy-1-16-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-13-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-14-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-15-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http-typed.envoy-1-16-x.golden
@@ -95,7 +95,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -118,7 +118,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-13-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-14-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-15-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener-http.envoy-1-16-x.golden
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener.envoy-1-13-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener.envoy-1-14-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener.envoy-1-15-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-public-listener.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-public-listener.envoy-1-16-x.golden
@@ -71,7 +71,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream-typed-ignored-with-disco-chain.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-13-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-14-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-15-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-16-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/defaults.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/defaults.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/defaults.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/defaults.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/defaults.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/defaults.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/defaults.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/defaults.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-13-x.golden
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -94,7 +94,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health2_21501_http",
+                  "stat_prefix": "exposed_path_filter_health2_21501",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -132,7 +132,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-14-x.golden
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -94,7 +94,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health2_21501_http",
+                  "stat_prefix": "exposed_path_filter_health2_21501",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -132,7 +132,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-15-x.golden
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -94,7 +94,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health2_21501_http",
+                  "stat_prefix": "exposed_path_filter_health2_21501",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -132,7 +132,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.envoy-1-16-x.golden
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -94,7 +94,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health2_21501_http",
+                  "stat_prefix": "exposed_path_filter_health2_21501",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -132,7 +132,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-13-x.golden
@@ -44,7 +44,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501_http",
+                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -96,7 +96,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -134,7 +134,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-14-x.golden
@@ -44,7 +44,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501_http",
+                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -96,7 +96,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -134,7 +134,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-15-x.golden
@@ -44,7 +44,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501_http",
+                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -96,7 +96,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -134,7 +134,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.envoy-1-16-x.golden
@@ -44,7 +44,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501_http",
+                  "stat_prefix": "exposed_path_filter_grpchealthv1HealthCheck_21501",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -96,7 +96,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "exposed_path_filter_health1_21500_http",
+                  "stat_prefix": "exposed_path_filter_health1_21500",
                   "tracing": {
                         "random_sampling": {
                             }
@@ -134,7 +134,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/http-public-listener.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -118,7 +118,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "public_listener_http",
+                  "stat_prefix": "public_listener",
                   "tracing": {
                         "random_sampling": {
                             }

--- a/agent/xds/testdata/listeners/http-public-listener.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -118,7 +118,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "public_listener_http",
+                  "stat_prefix": "public_listener",
                   "tracing": {
                         "random_sampling": {
                             }

--- a/agent/xds/testdata/listeners/http-public-listener.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -118,7 +118,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "public_listener_http",
+                  "stat_prefix": "public_listener",
                   "tracing": {
                         "random_sampling": {
                             }

--- a/agent/xds/testdata/listeners/http-public-listener.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -118,7 +118,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "public_listener_http",
+                  "stat_prefix": "public_listener",
                   "tracing": {
                         "random_sampling": {
                             }

--- a/agent/xds/testdata/listeners/http-upstream.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/http-upstream.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                                     "domains": [
                                           "*"
                                         ],
-                                    "name": "db",
+                                    "name": "db.default.dc1",
                                     "routes": [
                                           {
                                                 "match": {
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -70,7 +70,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -124,7 +124,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/http-upstream.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/http-upstream.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                                     "domains": [
                                           "*"
                                         ],
-                                    "name": "db",
+                                    "name": "db.default.dc1",
                                     "routes": [
                                           {
                                                 "match": {
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -70,7 +70,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -124,7 +124,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/http-upstream.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/http-upstream.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                                     "domains": [
                                           "*"
                                         ],
-                                    "name": "db",
+                                    "name": "db.default.dc1",
                                     "routes": [
                                           {
                                                 "match": {
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -70,7 +70,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -124,7 +124,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/http-upstream.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/http-upstream.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                                     "domains": [
                                           "*"
                                         ],
-                                    "name": "db",
+                                    "name": "db.default.dc1",
                                     "routes": [
                                           {
                                                 "match": {
@@ -42,7 +42,7 @@
                                   }
                             ]
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -70,7 +70,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -124,7 +124,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway-bind-addrs.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -63,7 +63,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_443_http",
+                  "stat_prefix": "ingress_upstream.443",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -67,7 +67,7 @@
                             },
                         "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_8080_http",
+                  "stat_prefix": "ingress_upstream.8080",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_443_http",
+                  "stat_prefix": "ingress_upstream.443",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -67,7 +67,7 @@
                             },
                         "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_8080_http",
+                  "stat_prefix": "ingress_upstream.8080",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_443_http",
+                  "stat_prefix": "ingress_upstream.443",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -67,7 +67,7 @@
                             },
                         "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_8080_http",
+                  "stat_prefix": "ingress_upstream.8080",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_443_http",
+                  "stat_prefix": "ingress_upstream.443",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -67,7 +67,7 @@
                             },
                         "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_8080_http",
+                  "stat_prefix": "ingress_upstream.8080",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_9191_http",
+                  "stat_prefix": "ingress_upstream.9191",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_9191_http",
+                  "stat_prefix": "ingress_upstream.9191",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_9191_http",
+                  "stat_prefix": "ingress_upstream.9191",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_9191_http",
+                  "stat_prefix": "ingress_upstream.9191",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-13-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-14-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-15-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.envoy-1-16-x.golden
@@ -35,7 +35,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_grpc",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-external-sni.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-local-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tcp-chain-failover-through-remote-gateway.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-13-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-14-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-15-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-with-tls-listener.envoy-1-16-x.golden
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address-port.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-address.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-address.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-port.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-port.envoy-1-13-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-port.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-port.envoy-1-14-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-port.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-port.envoy-1-15-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/listener-bind-port.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/listener-bind-port.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_db_tcp"
+                  "stat_prefix": "upstream.db.default.dc1"
                 }
             }
           ]
@@ -40,7 +40,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -94,7 +94,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-13-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_bar_tcp"
+                  "stat_prefix": "mesh_gateway_local.bar"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc2"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc4"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc6"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_baz_tcp"
+                  "stat_prefix": "mesh_gateway_local.baz"
                 }
             }
           ]
@@ -180,7 +180,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -196,7 +196,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -212,7 +212,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -226,7 +226,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]
@@ -259,7 +259,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc2"
                 }
             }
           ]
@@ -275,7 +275,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc4"
                 }
             }
           ]
@@ -291,7 +291,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc6"
                 }
             }
           ]
@@ -305,7 +305,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_foo_tcp"
+                  "stat_prefix": "mesh_gateway_local.foo"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-14-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_bar_tcp"
+                  "stat_prefix": "mesh_gateway_local.bar"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc2"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc4"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc6"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_baz_tcp"
+                  "stat_prefix": "mesh_gateway_local.baz"
                 }
             }
           ]
@@ -180,7 +180,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -196,7 +196,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -212,7 +212,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -226,7 +226,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]
@@ -259,7 +259,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc2"
                 }
             }
           ]
@@ -275,7 +275,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc4"
                 }
             }
           ]
@@ -291,7 +291,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc6"
                 }
             }
           ]
@@ -305,7 +305,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_foo_tcp"
+                  "stat_prefix": "mesh_gateway_local.foo"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-15-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_bar_tcp"
+                  "stat_prefix": "mesh_gateway_local.bar"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc2"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc4"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc6"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_baz_tcp"
+                  "stat_prefix": "mesh_gateway_local.baz"
                 }
             }
           ]
@@ -180,7 +180,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -196,7 +196,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -212,7 +212,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -226,7 +226,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]
@@ -259,7 +259,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc2"
                 }
             }
           ]
@@ -275,7 +275,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc4"
                 }
             }
           ]
@@ -291,7 +291,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc6"
                 }
             }
           ]
@@ -305,7 +305,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_foo_tcp"
+                  "stat_prefix": "mesh_gateway_local.foo"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.envoy-1-16-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_bar_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.bar.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_bar_tcp"
+                  "stat_prefix": "mesh_gateway_local.bar"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc2"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc4"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_baz_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.baz.dc6"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_baz_tcp"
+                  "stat_prefix": "mesh_gateway_local.baz"
                 }
             }
           ]
@@ -180,7 +180,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -196,7 +196,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -212,7 +212,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -226,7 +226,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]
@@ -259,7 +259,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc2"
                 }
             }
           ]
@@ -275,7 +275,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc4"
                 }
             }
           ]
@@ -291,7 +291,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_foo_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.foo.dc6"
                 }
             }
           ]
@@ -305,7 +305,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_foo_tcp"
+                  "stat_prefix": "mesh_gateway_local.foo"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-13-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-14-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-15-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.envoy-1-16-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-13-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_lan_tcp"
+                  "stat_prefix": "mesh_gateway_local.lan"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc2"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc4"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc6"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_wan_tcp"
+                  "stat_prefix": "mesh_gateway_local.wan"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-14-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_lan_tcp"
+                  "stat_prefix": "mesh_gateway_local.lan"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc2"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc4"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc6"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_wan_tcp"
+                  "stat_prefix": "mesh_gateway_local.wan"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-15-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_lan_tcp"
+                  "stat_prefix": "mesh_gateway_local.lan"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc2"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc4"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc6"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_wan_tcp"
+                  "stat_prefix": "mesh_gateway_local.wan"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.envoy-1-16-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_lan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.lan.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_lan_tcp"
+                  "stat_prefix": "mesh_gateway_local.lan"
                 }
             }
           ]
@@ -101,7 +101,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc2"
                 }
             }
           ]
@@ -117,7 +117,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc4"
                 }
             }
           ]
@@ -133,7 +133,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_wan_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.wan.dc6"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_wan_tcp"
+                  "stat_prefix": "mesh_gateway_local.wan"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-13-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-14-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-15-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-using-federation-states.envoy-1-16-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.envoy-1-13-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.envoy-1-14-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.envoy-1-15-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/mesh-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.envoy-1-16-x.golden
@@ -22,7 +22,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc2"
                 }
             }
           ]
@@ -38,7 +38,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc4.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc4_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc4"
                 }
             }
           ]
@@ -54,7 +54,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "dc6.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "mesh_gateway_remote_default_dc6_tcp"
+                  "stat_prefix": "mesh_gateway_remote.default.dc6"
                 }
             }
           ]
@@ -68,7 +68,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                  "stat_prefix": "mesh_gateway_local.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-13-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-14-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-15-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.envoy-1-16-x.golden
@@ -28,7 +28,7 @@
                             },
                         "route_config_name": "db"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "upstream.db.default.dc1",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -56,7 +56,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                  "stat_prefix": "upstream.prepared_query_geo-cache"
                 }
             }
           ]
@@ -110,7 +110,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "local_app",
-                  "stat_prefix": "public_listener_tcp"
+                  "stat_prefix": "public_listener"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-13-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.foo"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.foo"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.foo"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.foo"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_foo_tcp"
+                  "stat_prefix": "terminating_gateway.foo"
                 }
             }
           ]
@@ -272,7 +272,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.wan"
                 }
             }
           ]
@@ -319,7 +319,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.wan"
                 }
             }
           ]
@@ -366,7 +366,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.wan"
                 }
             }
           ]
@@ -413,7 +413,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.wan"
                 }
             }
           ]
@@ -427,7 +427,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_wan_tcp"
+                  "stat_prefix": "terminating_gateway.wan"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-14-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.foo"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.foo"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.foo"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.foo"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_foo_tcp"
+                  "stat_prefix": "terminating_gateway.foo"
                 }
             }
           ]
@@ -272,7 +272,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.wan"
                 }
             }
           ]
@@ -319,7 +319,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.wan"
                 }
             }
           ]
@@ -366,7 +366,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.wan"
                 }
             }
           ]
@@ -413,7 +413,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.wan"
                 }
             }
           ]
@@ -427,7 +427,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_wan_tcp"
+                  "stat_prefix": "terminating_gateway.wan"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-15-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.foo"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.foo"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.foo"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.foo"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_foo_tcp"
+                  "stat_prefix": "terminating_gateway.foo"
                 }
             }
           ]
@@ -272,7 +272,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.wan"
                 }
             }
           ]
@@ -319,7 +319,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.wan"
                 }
             }
           ]
@@ -366,7 +366,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.wan"
                 }
             }
           ]
@@ -413,7 +413,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.wan"
                 }
             }
           ]
@@ -427,7 +427,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_wan_tcp"
+                  "stat_prefix": "terminating_gateway.wan"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-16-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.foo"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.foo"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.foo"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_foo_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.foo"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_foo_tcp"
+                  "stat_prefix": "terminating_gateway.foo"
                 }
             }
           ]
@@ -272,7 +272,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.wan"
                 }
             }
           ]
@@ -319,7 +319,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.wan"
                 }
             }
           ]
@@ -366,7 +366,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.wan"
                 }
             }
           ]
@@ -413,7 +413,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_wan_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.wan"
                 }
             }
           ]
@@ -427,7 +427,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_wan_tcp"
+                  "stat_prefix": "terminating_gateway.wan"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-13-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.default"
                 }
             }
           ]
@@ -161,7 +161,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-14-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.default"
                 }
             }
           ]
@@ -161,7 +161,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-15-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.default"
                 }
             }
           ]
@@ -161,7 +161,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-16-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.default"
                 }
             }
           ]
@@ -161,7 +161,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-13-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-14-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-15-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-services.envoy-1-16-x.golden
@@ -20,7 +20,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-13-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -204,7 +204,7 @@
                             },
                         "route_config_name": "v1.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -266,7 +266,7 @@
                             },
                         "route_config_name": "v2.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -328,7 +328,7 @@
                             },
                         "route_config_name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -347,7 +347,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-14-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -204,7 +204,7 @@
                             },
                         "route_config_name": "v1.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -266,7 +266,7 @@
                             },
                         "route_config_name": "v2.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -328,7 +328,7 @@
                             },
                         "route_config_name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -347,7 +347,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-15-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -204,7 +204,7 @@
                             },
                         "route_config_name": "v1.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -266,7 +266,7 @@
                             },
                         "route_config_name": "v2.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -328,7 +328,7 @@
                             },
                         "route_config_name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -347,7 +347,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-16-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -204,7 +204,7 @@
                             },
                         "route_config_name": "v1.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -266,7 +266,7 @@
                             },
                         "route_config_name": "v2.web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -328,7 +328,7 @@
                             },
                         "route_config_name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
                       },
-                  "stat_prefix": "terminating_gateway_default_web_default_http",
+                  "stat_prefix": "terminating_gateway.default.web.default",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -347,7 +347,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-13-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.default"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-14-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.default"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-15-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.default"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-16-x.golden
@@ -53,7 +53,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_api_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.api.default"
                 }
             }
           ]
@@ -100,7 +100,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_cache_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.cache.default"
                 }
             }
           ]
@@ -147,7 +147,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_db_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.db.default"
                 }
             }
           ]
@@ -194,7 +194,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                  "stat_prefix": "terminating_gateway_default_web_default_tcp"
+                  "stat_prefix": "terminating_gateway.default.web.default"
                 }
             }
           ]
@@ -208,7 +208,7 @@
               "name": "envoy.tcp_proxy",
               "config": {
                   "cluster": "",
-                  "stat_prefix": "terminating_gateway_default_tcp"
+                  "stat_prefix": "terminating_gateway.default"
                 }
             }
           ]

--- a/api/api.go
+++ b/api/api.go
@@ -310,7 +310,7 @@ type Config struct {
 	TokenFile string
 
 	// Namespace is the name of the namespace to send along for the request
-	// when no other Namespace ispresent in the QueryOptions
+	// when no other Namespace is present in the QueryOptions
 	Namespace string
 
 	TLSConfig TLSConfig

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -14,6 +14,12 @@ type BootstrapTplArgs struct {
 	// the agent to deliver the correct configuration.
 	ProxyID string
 
+	// ProxySourceService is the Consul service name to report for this proxy
+	// instance's source service label. For sidecars it should be the
+	// Proxy.DestinationServiceName. For gateways and similar it is the service
+	// name of the proxy service itself.
+	ProxySourceService string
+
 	// AgentCAPEM is the CA to use to verify the local agent gRPC service if
 	// TLS is enabled.
 	AgentCAPEM string
@@ -79,9 +85,12 @@ type BootstrapTplArgs struct {
 	// See https://www.envoyproxy.io/docs/envoy/v1.9.0/api-v2/config/trace/v2/trace.proto.
 	TracingConfigJSON string
 
-	// Namespace is the Consul Enterprise Namespace of the proxy service instance as
-	// registered with the Consul agent.
+	// Namespace is the Consul Enterprise Namespace of the proxy service instance
+	// as registered with the Consul agent.
 	Namespace string
+
+	// Datacenter is the datacenter where the proxy service instance is registered.
+	Datacenter string
 
 	// EnvoyVersion is the envoy version, which is necessary to generate the
 	// correct configuration.

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -30,7 +31,10 @@ func New(ui cli.Ui) *cmd {
 		Ui:           ui,
 	}
 
-	c := &cmd{UI: ui}
+	c := &cmd{
+		UI:        ui,
+		directOut: os.Stdout,
+	}
 	c.init()
 	return c
 }
@@ -43,6 +47,9 @@ type cmd struct {
 	http   *flags.HTTPFlags
 	help   string
 	client *api.Client
+	// DirectOut defaults to os.stdout but is a property to allow capture during
+	// tests to have more useful output.
+	directOut io.Writer
 
 	// flags
 	meshGateway          bool
@@ -64,6 +71,7 @@ type cmd struct {
 	deregAfterCritical string
 	bindAddresses      ServiceAddressMapValue
 	exposeServers      bool
+	omitDeprecatedTags bool
 
 	gatewaySvcName string
 	gatewayKind    api.ServiceKind
@@ -151,6 +159,11 @@ func (c *cmd) init() {
 
 	c.flags.StringVar(&c.deregAfterCritical, "deregister-after-critical", "6h",
 		"The amount of time the gateway services health check can be failing before being deregistered")
+
+	c.flags.BoolVar(&c.omitDeprecatedTags, "omit-deprecated-tags", false,
+		"In Consul 1.9.0 the format of metric tags for Envoy clusters was updated from consul.[service|dc|...] to "+
+			"consul.destination.[service|dc|...]. The old tags were preserved for backward compatibility,"+
+			"but can be disabled with this flag.")
 
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flags, c.http.ClientFlags())
@@ -364,7 +377,7 @@ func (c *cmd) run(args []string) int {
 
 	if c.bootstrap {
 		// Just output it and we are done
-		os.Stdout.Write(bootstrapJson)
+		c.directOut.Write(bootstrapJson)
 		return 0
 	}
 
@@ -431,10 +444,13 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 	// know service name yet, we will after we resolve the proxy's config in a bit
 	// and will update this then.
 	cluster := c.proxyID
+	proxySourceService := ""
 	if c.sidecarFor != "" {
 		cluster = c.sidecarFor
+		proxySourceService = c.sidecarFor
 	} else if c.gateway != "" && c.gatewaySvcName != "" {
 		cluster = c.gatewaySvcName
+		proxySourceService = c.gatewaySvcName
 	}
 
 	adminAccessLogPath := c.adminAccessLogPath
@@ -453,6 +469,7 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 		GRPC:                  grpcAddr,
 		ProxyCluster:          cluster,
 		ProxyID:               c.proxyID,
+		ProxySourceService:    proxySourceService,
 		AgentCAPEM:            caPEM,
 		AdminAccessLogPath:    adminAccessLogPath,
 		AdminBindAddress:      adminBindIP.String(),
@@ -483,29 +500,53 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		bsCfg.ReadyBindAddr = lanAddr
 	}
 
+	// Fetch any customization from the registration
+	svc, _, err := c.client.Agent().Service(c.proxyID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetch proxy config from local agent: %s", err)
+	}
+	if svc.Proxy == nil {
+		return nil, errors.New("service is not a Connect proxy or gateway")
+	}
+
+	if svc.Proxy.DestinationServiceName != "" {
+		// Override cluster now we know the actual service name
+		args.ProxyCluster = svc.Proxy.DestinationServiceName
+		args.ProxySourceService = svc.Proxy.DestinationServiceName
+	} else {
+		// Set the source service name from the proxy's own registration
+		args.ProxySourceService = svc.Service
+	}
+	if svc.Namespace != "" {
+		// In most cases where namespaces are enabled this will already be set
+		// correctly because the http client that fetched this will need to have
+		// had the namespace set on it which is also how we initially populate
+		// this. However in the case of "default" namespace being accessed because
+		// there was no namespace argument, args.Namespace will be empty even
+		// though Namespaces are actually being used and the namespace of the request was
+		// inferred from the ACL token or defaulted to the "default" namespace.
+		// Overriding it here ensures that we always set the Namespace arg if the
+		// cluster is using namespaces regardless.
+		args.Namespace = svc.Namespace
+	}
+	agent, err := c.client.Agent().Self()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch agent config: %v", err)
+	}
+	dc, ok := agent["Config"]["Datacenter"].(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to fetch datacenter from agent. DC is: %T", agent["Config"]["Datacenter"])
+	}
+	args.Datacenter = dc
+
 	if !c.disableCentralConfig {
-		// Fetch any customization from the registration
-		svc, _, err := c.client.Agent().Service(c.proxyID, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed fetch proxy config from local agent: %s", err)
-		}
-
-		if svc.Proxy == nil {
-			return nil, errors.New("service is not a Connect proxy or gateway")
-		}
-
 		// Parse the bootstrap config
 		if err := mapstructure.WeakDecode(svc.Proxy.Config, &bsCfg); err != nil {
 			return nil, fmt.Errorf("failed parsing Proxy.Config: %s", err)
 		}
-
-		if svc.Proxy.DestinationServiceName != "" {
-			// Override cluster now we know the actual service name
-			args.ProxyCluster = svc.Proxy.DestinationServiceName
-		}
 	}
 
-	return bsCfg.GenerateJSON(args)
+	return bsCfg.GenerateJSON(args, c.omitDeprecatedTags)
 }
 
 // TODO: make method a function

--- a/command/connect/envoy/envoy_oss_test.go
+++ b/command/connect/envoy/envoy_oss_test.go
@@ -1,0 +1,9 @@
+// +build !consulent
+
+package envoy
+
+// enterpriseGenerateConfigTestCases returns enterprise-only configurations to
+// test in TestGenerateConfig.
+func enterpriseGenerateConfigTestCases() []generateConfigTestCase {
+	return nil
+}

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -1,6 +1,7 @@
 package envoy
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"io/ioutil"
@@ -103,21 +104,24 @@ func testSetAndResetEnv(t *testing.T, env []string) func() {
 	}
 }
 
+type generateConfigTestCase struct {
+	Name              string
+	Flags             []string
+	Env               []string
+	Files             map[string]string
+	ProxyConfig       map[string]interface{}
+	NamespacesEnabled bool
+	GRPCPort          int // only used for testing custom-configured grpc port
+	WantArgs          BootstrapTplArgs
+	WantErr           string
+}
+
 // This tests the args we use to generate the template directly because they
 // encapsulate all the argument and default handling code which is where most of
 // the logic is. We also allow generating golden files but only for cases that
 // pass the test of having their template args generated as expected.
 func TestGenerateConfig(t *testing.T) {
-	cases := []struct {
-		Name        string
-		Flags       []string
-		Env         []string
-		Files       map[string]string
-		ProxyConfig map[string]interface{}
-		GRPCPort    int // only used for testing custom-configured grpc port
-		WantArgs    BootstrapTplArgs
-		WantErr     string
-	}{
+	cases := []generateConfigTestCase{
 		{
 			Name:    "no-args",
 			Flags:   []string{},
@@ -131,6 +135,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502", // Note this is the gRPC port
@@ -149,6 +156,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502", // Note this is the gRPC port
@@ -170,6 +180,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502", // Note this is the gRPC port
@@ -193,6 +206,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502", // Note this is the gRPC port
@@ -217,6 +233,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502", // Note this is the gRPC port
@@ -236,6 +255,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -259,6 +281,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -280,6 +305,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentSocket: "/var/run/consul.sock",
 				},
@@ -297,6 +325,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -317,6 +348,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -337,6 +371,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -355,6 +392,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -377,6 +417,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -395,6 +438,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -439,6 +485,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -473,6 +522,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -512,6 +564,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -538,6 +593,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -594,6 +652,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -612,6 +673,9 @@ func TestGenerateConfig(t *testing.T) {
 				EnvoyVersion: defaultEnvoyVersion,
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
+				// We don't know this til after the lookup so it will be empty in the
+				// initial args call we are testing here.
+				ProxySourceService: "",
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
@@ -630,9 +694,10 @@ func TestGenerateConfig(t *testing.T) {
 			Name:  "ingress-gateway",
 			Flags: []string{"-proxy-id", "ingress-gateway-1", "-gateway", "ingress"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: defaultEnvoyVersion,
-				ProxyCluster: "ingress-gateway",
-				ProxyID:      "ingress-gateway-1",
+				EnvoyVersion:       defaultEnvoyVersion,
+				ProxyCluster:       "ingress-gateway",
+				ProxyID:            "ingress-gateway-1",
+				ProxySourceService: "ingress-gateway",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -647,9 +712,10 @@ func TestGenerateConfig(t *testing.T) {
 			Name:  "ingress-gateway-address-specified",
 			Flags: []string{"-proxy-id", "ingress-gateway", "-gateway", "ingress", "-address", "1.2.3.4:7777"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: defaultEnvoyVersion,
-				ProxyCluster: "ingress-gateway",
-				ProxyID:      "ingress-gateway",
+				EnvoyVersion:       defaultEnvoyVersion,
+				ProxyCluster:       "ingress-gateway",
+				ProxyID:            "ingress-gateway",
+				ProxySourceService: "ingress-gateway",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -664,9 +730,10 @@ func TestGenerateConfig(t *testing.T) {
 			Name:  "ingress-gateway-register-with-service-without-proxy-id",
 			Flags: []string{"-gateway", "ingress", "-register", "-service", "my-gateway", "-address", "127.0.0.1:7777"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: defaultEnvoyVersion,
-				ProxyCluster: "my-gateway",
-				ProxyID:      "my-gateway",
+				EnvoyVersion:       defaultEnvoyVersion,
+				ProxyCluster:       "my-gateway",
+				ProxyID:            "my-gateway",
+				ProxySourceService: "my-gateway",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -681,9 +748,10 @@ func TestGenerateConfig(t *testing.T) {
 			Name:  "ingress-gateway-register-with-service-and-proxy-id",
 			Flags: []string{"-gateway", "ingress", "-register", "-service", "my-gateway", "-proxy-id", "my-gateway-123", "-address", "127.0.0.1:7777"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: defaultEnvoyVersion,
-				ProxyCluster: "my-gateway",
-				ProxyID:      "my-gateway-123",
+				EnvoyVersion:       defaultEnvoyVersion,
+				ProxyCluster:       "my-gateway",
+				ProxyID:            "my-gateway-123",
+				ProxySourceService: "my-gateway",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -698,9 +766,10 @@ func TestGenerateConfig(t *testing.T) {
 			Name:  "ingress-gateway-no-auto-register",
 			Flags: []string{"-gateway", "ingress", "-address", "127.0.0.1:7777"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: defaultEnvoyVersion,
-				ProxyCluster: "ingress-gateway",
-				ProxyID:      "ingress-gateway",
+				EnvoyVersion:       defaultEnvoyVersion,
+				ProxyCluster:       "ingress-gateway",
+				ProxyID:            "ingress-gateway",
+				ProxySourceService: "ingress-gateway",
 				GRPC: GRPC{
 					AgentAddress: "127.0.0.1",
 					AgentPort:    "8502",
@@ -712,6 +781,8 @@ func TestGenerateConfig(t *testing.T) {
 			},
 		},
 	}
+
+	cases = append(cases, enterpriseGenerateConfigTestCases()...)
 
 	copyAndReplaceAll := func(s []string, old, new string) []string {
 		out := make([]string, len(s))
@@ -736,7 +807,7 @@ func TestGenerateConfig(t *testing.T) {
 
 			// Run a mock agent API that just always returns the proxy config in the
 			// test.
-			srv := httptest.NewServer(testMockAgent(tc.ProxyConfig, tc.GRPCPort))
+			srv := httptest.NewServer(testMockAgent(tc.ProxyConfig, tc.GRPCPort, tc.NamespacesEnabled))
 			defer srv.Close()
 			client, err := api.NewClient(&api.Config{Address: srv.URL})
 			require.NoError(err)
@@ -749,6 +820,11 @@ func TestGenerateConfig(t *testing.T) {
 			c := New(ui)
 			// explicitly set the client to one which can connect to the httptest.Server
 			c.client = client
+
+			var outBuf bytes.Buffer
+			// Capture output since it clutters test output and we can assert on what
+			// was actually printed this way.
+			c.directOut = &outBuf
 
 			// Run the command
 			myFlags := copyAndReplaceAll(tc.Flags, "@@TEMPDIR@@", testDirPrefix)
@@ -770,10 +846,7 @@ func TestGenerateConfig(t *testing.T) {
 			require.NoError(err) // Error cases should have returned above
 			require.Equal(&tc.WantArgs, got)
 
-			// Actual template output goes to stdout direct to avoid prefix in UI, so
-			// generate it again here to assert on.
-			actual, err := c.generateConfig()
-			require.NoError(err)
+			actual := outBuf.Bytes()
 
 			// If we got the arg handling write, verify output
 			golden := filepath.Join("testdata", tc.Name+".golden")
@@ -880,15 +953,15 @@ func TestEnvoy_GatewayRegistration(t *testing.T) {
 // testMockAgent combines testMockAgentProxyConfig and testMockAgentSelf,
 // routing /agent/service/... requests to testMockAgentProxyConfig and
 // routing /agent/self requests to testMockAgentSelf.
-func testMockAgent(agentCfg map[string]interface{}, grpcPort int) http.HandlerFunc {
+func testMockAgent(agentCfg map[string]interface{}, grpcPort int, namespacesEnabled bool) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/agent/services") {
-			testMockAgentGatewayConfig()(w, r)
+			testMockAgentGatewayConfig(namespacesEnabled)(w, r)
 			return
 		}
 
 		if strings.Contains(r.URL.Path, "/agent/service") {
-			testMockAgentProxyConfig(agentCfg)(w, r)
+			testMockAgentProxyConfig(agentCfg, namespacesEnabled)(w, r)
 			return
 		}
 
@@ -901,7 +974,7 @@ func testMockAgent(agentCfg map[string]interface{}, grpcPort int) http.HandlerFu
 	})
 }
 
-func testMockAgentGatewayConfig() http.HandlerFunc {
+func testMockAgentGatewayConfig(namespacesEnabled bool) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse the proxy-id from the end of the URL (blindly assuming it's correct
 		// format)
@@ -924,6 +997,10 @@ func testMockAgentGatewayConfig() http.HandlerFunc {
 			},
 		}
 
+		if namespacesEnabled {
+			svc[string(kind)].Namespace = namespaceFromQuery(r)
+		}
+
 		cfgJSON, err := json.Marshal(svc)
 		if err != nil {
 			w.WriteHeader(500)
@@ -934,7 +1011,16 @@ func testMockAgentGatewayConfig() http.HandlerFunc {
 	})
 }
 
-func testMockAgentProxyConfig(cfg map[string]interface{}) http.HandlerFunc {
+func namespaceFromQuery(r *http.Request) string {
+	// Use the namespace in the request if there is one, otherwise
+	// use-default.
+	if queryNs := r.URL.Query().Get("ns"); queryNs != "" {
+		return queryNs
+	}
+	return "default"
+}
+
+func testMockAgentProxyConfig(cfg map[string]interface{}, namespacesEnabled bool) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Parse the proxy-id from the end of the URL (blindly assuming it's correct
 		// format)
@@ -950,6 +1036,10 @@ func testMockAgentProxyConfig(cfg map[string]interface{}) http.HandlerFunc {
 				DestinationServiceID:   serviceID,
 				Config:                 cfg,
 			},
+		}
+
+		if namespacesEnabled {
+			svc.Namespace = namespaceFromQuery(r)
 		}
 
 		cfgJSON, err := json.Marshal(svc)
@@ -1063,6 +1153,9 @@ func TestEnvoyCommand_canBindInternal(t *testing.T) {
 func testMockAgentSelf(wantGRPCPort int) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := agent.Self{
+			Config: map[string]interface{}{
+				"Datacenter": "dc1",
+			},
 			DebugConfig: map[string]interface{}{
 				"GRPCPort": wantGRPCPort,
 			},

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
@@ -47,6 +47,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -84,6 +132,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -47,6 +47,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -84,6 +132,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -47,6 +47,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -84,6 +132,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -60,6 +60,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -97,6 +145,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -51,6 +51,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -88,6 +136,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-addr-config.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -37,6 +37,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -74,6 +122,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -111,6 +111,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -148,6 +196,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "ingress-gateway"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "ingress-gateway"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -111,6 +111,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -148,6 +196,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "ingress-gateway"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "ingress-gateway"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -111,6 +111,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -148,6 +196,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "my-gateway-123"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "my-gateway-123"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -111,6 +111,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -148,6 +196,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "my-gateway"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "my-gateway"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -111,6 +111,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -148,6 +196,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "ingress-gateway-1"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "ingress-gateway-1"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -38,6 +38,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -75,6 +123,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -62,6 +62,54 @@
     "stats_tags": [
       {
         "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.destination.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.destination.full_target"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.(([^.]+)(?:\\.[^.]+)?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.service"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.[^.]+)?\\.([^.]+)\\.)",
+        "tag_name": "consul.upstream.datacenter"
+      },
+      {
+        "regex": "^(?:tcp|http)\\.upstream\\.([^.]+(?:\\.([^.]+))?\\.[^.]+\\.)",
+        "tag_name": "consul.upstream.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
         "tag_name": "consul.custom_hash"
       },
       {
@@ -99,6 +147,18 @@
       {
         "tag_name": "local_cluster",
         "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.service",
+        "fixed_value": "test-proxy"
+      },
+      {
+        "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.datacenter",
+        "fixed_value": "dc1"
       }
     ],
     "use_all_default_tags": true

--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,6 +1,6 @@
-FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
+FROM hashicorp.jfrog.io/docker/fortio/fortio AS fortio
 
-FROM docker.mirror.hashicorp.services/bats/bats:latest
+FROM hashicorp.jfrog.io/docker/bats/bats:latest
 
 RUN apk add curl
 RUN apk add openssl

--- a/test/integration/connect/envoy/Dockerfile-consul-envoy
+++ b/test/integration/connect/envoy/Dockerfile-consul-envoy
@@ -3,5 +3,5 @@ ARG ENVOY_VERSION
 
 FROM consul-dev as consul
 
-FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
+FROM hashicorp.jfrog.io/docker/envoyproxy/envoy:v${ENVOY_VERSION}
 COPY --from=consul /bin/consul /bin/consul

--- a/test/integration/connect/envoy/case-centralconf/capture.sh
+++ b/test/integration/connect/envoy/case-centralconf/capture.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:19000 s1 primary || true

--- a/test/integration/connect/envoy/case-centralconf/verify.bats
+++ b/test/integration/connect/envoy/case-centralconf/verify.bats
@@ -42,15 +42,15 @@ load helpers
   # Should be labelling with local_cluster.
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]local_cluster="s1"[,}] '
+    '[\{,]consul_source_service="s1"[,}] '
 
   # Ensure we have http metrics for public listener
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]envoy_http_conn_manager_prefix="public_listener_http"[,}]'
+    '[\{,]envoy_http_conn_manager_prefix="public_listener"[,}]'
 
   # Ensure we have http metrics for s2 upstream
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]envoy_http_conn_manager_prefix="upstream_s2_http"[,}]'
+    '[\{,]consul_upstream_service="s2"[,}]'
 }

--- a/test/integration/connect/envoy/case-prometheus/capture.sh
+++ b/test/integration/connect/envoy/case-prometheus/capture.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:19000 s1 primary || true

--- a/test/integration/connect/envoy/case-prometheus/verify.bats
+++ b/test/integration/connect/envoy/case-prometheus/verify.bats
@@ -40,13 +40,13 @@ load helpers
     must_match_in_prometheus_response localhost:1234 \
     '^envoy_http_downstream_rq_active'
 
-  # Should be labelling with local_cluster.
+  # Should be labelling with consul_source_service.
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]local_cluster="s1"[,}] '
+    '[\{,]consul_source_service="s1"[,}] '
 
   # Should be labelling with http listener prefix.
   retry_default \
     must_match_in_prometheus_response localhost:1234 \
-    '[\{,]envoy_http_conn_manager_prefix="public_listener_http"[,}]'
+    '[\{,]envoy_http_conn_manager_prefix="public_listener"[,}]'
 }

--- a/test/integration/connect/envoy/case-stats-proxy/verify.bats
+++ b/test/integration/connect/envoy/case-stats-proxy/verify.bats
@@ -48,12 +48,12 @@ load helpers
   # Response should include the http public listener.
   retry_default \
      must_match_in_stats_proxy_response localhost:1239 \
-    'stats' 'http.public_listener_http'
+    'stats' 'http.public_listener'
 
   # /stats/prometheus should also be reachable and labelling the local cluster.
   retry_default \
      must_match_in_stats_proxy_response localhost:1239 \
-    'stats/prometheus' '[\{,]local_cluster="s1"[,}]'
+    'stats/prometheus' '[\{,]consul_source_service="s1"[,}]'
 
   # /stats/prometheus should also be reachable and exposing metrics.
   retry_default \

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -229,6 +229,7 @@ function snapshot_envoy_admin {
   docker_wget "$DC" "http://${HOSTPORT}/config_dump" -q -O - > "${OUTDIR}/config_dump.json"
   docker_wget "$DC" "http://${HOSTPORT}/clusters?format=json" -q -O - > "${OUTDIR}/clusters.json"
   docker_wget "$DC" "http://${HOSTPORT}/stats" -q -O - > "${OUTDIR}/stats.txt"
+  docker_wget "$DC" "http://${HOSTPORT}/stats/prometheus" -q -O - > "${OUTDIR}/stats_prometheus.txt"
 }
 
 function reset_envoy_metrics {

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -33,7 +33,7 @@
     </div>
     {{#if this.hasMetricsProvider }}
       <TopologyMetrics::Series
-        @nspace={{@nspace}}
+        @nspace={{@service.Service.Namespace}}
         @dc={{@dc}}
         @service={{@service.Service.Service}}
         @protocol={{@topology.Protocol}}
@@ -41,7 +41,7 @@
       />
       {{#if (not-eq @service.Service.Kind 'ingress-gateway')}}
       <TopologyMetrics::Stats
-        @nspace={{@nspace}}
+        @nspace={{@service.Service.Namespace}}
         @dc={{@dc}}
         @endpoint='summary-for-service'
         @service={{@service.Service.Service}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/stats/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/stats/index.js
@@ -14,7 +14,11 @@ export default class TopologyMetricsStats extends Component {
     } else {
       // For up/downstreams we need to pull out the stats for the service we
       // represent.
-      this.stats = event.data.stats[this.args.item];
+      if ((this.args.nspace || '').length === 0) {
+        this.args.nspace = 'default';
+      }
+      let entity = `${this.args.item}.${this.args.nspace}.${this.args.dc}`;
+      this.stats = event.data.stats[entity];
     }
     // Limit to 4 metrics for now.
     this.stats = (this.stats || []).slice(0, 4);

--- a/ui/packages/consul-ui/app/services/repository/metrics.js
+++ b/ui/packages/consul-ui/app/services/repository/metrics.js
@@ -46,10 +46,10 @@ export default class MetricsService extends RepositoryService {
       return Promise.reject(this.error);
     }
     const promises = [
-      this.provider.serviceRecentSummarySeries(dc, nspace, slug, protocol, {}),
-      this.provider.serviceRecentSummaryStats(dc, nspace, slug, protocol, {}),
+      this.provider.serviceRecentSummarySeries(slug, dc, nspace, protocol, {}),
+      this.provider.serviceRecentSummaryStats(slug, dc, nspace, protocol, {}),
     ];
-    return Promise.all(promises).then(function(results) {
+    return Promise.all(promises).then(function (results) {
       return {
         meta: meta,
         series: results[0],
@@ -62,7 +62,7 @@ export default class MetricsService extends RepositoryService {
     if (this.error) {
       return Promise.reject(this.error);
     }
-    return this.provider.upstreamRecentSummaryStats(dc, nspace, slug, {}).then(function(result) {
+    return this.provider.upstreamRecentSummaryStats(slug, dc, nspace, {}).then(function (result) {
       result.meta = meta;
       return result;
     });
@@ -72,7 +72,7 @@ export default class MetricsService extends RepositoryService {
     if (this.error) {
       return Promise.reject(this.error);
     }
-    return this.provider.downstreamRecentSummaryStats(dc, nspace, slug, {}).then(function(result) {
+    return this.provider.downstreamRecentSummaryStats(slug, dc, nspace, {}).then(function (result) {
       result.meta = meta;
       return result;
     });

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/metrics-proxy/api/v1/query
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/metrics-proxy/api/v1/query
@@ -40,10 +40,10 @@
           // Match the relabel arguments since "downstream" appears in both
           // "service" and "upstream" type queries' metric names while
           // "upstream" appears in downstream query metric names (confusingly).
-          if (q.match('"upstream"')) {
-            type = 'upstream';
-          } else if (q.match('"downstream"')) {
-            type = 'downstream';
+          if (q.match('consul_destination_service=')) {
+            type = "downstream";
+          } else if (q.match('consul_upstream_service')) {
+            type = "upstream";
           }
 
           if (q.match('envoy_http_')) {
@@ -66,19 +66,45 @@
           }
 
           // Figure out the actual name for the target service
-          let targetService = 'invalid-local-cluster';
-          let m = q.match(/local_cluster="([^"]*)"/);
-          if (m && m.length >= 2 && m[1] !== '') {
+          var targetService = "invalid-local-cluster";
+          var m = q.match(/consul_source_service="([^"]*)"/);
+          if (m && m.length >= 2 && m[1] != "") {
             targetService = m[1];
           }
-          m = q.match(/consul_service="([^"]*)"/);
-          if (type === 'downstream' && m && m.length >= 2 && m[1] !== '') {
+          m = q.match(/consul_destination_service="([^"]*)"/);
+          if (type == "downstream" && m && m.length >= 2 && m[1] != "") {
             // downstreams don't have the same selector for the main service
             // name.
             targetService = m[1];
           }
 
-          let targets = [];
+          // Figure out the actual namespace for the target service
+          var targetNS = "invalid-local-ns";
+          var m = q.match(/consul_source_namespace="([^"]*)"/);
+          if (m && m.length >= 2 && m[1] != "") {
+            targetNS = m[1];
+          }
+          m = q.match(/consul_destination_namespace="([^"]*)"/);
+          if (type == "downstream" && m && m.length >= 2 && m[1] != "") {
+            // downstreams don't have the same selector for the main service
+            // name.
+            targetNS = m[1];
+          }
+
+          // Figure out the actual datacenter for the target service
+          var targetDC = "invalid-local-dc";
+          var m = q.match(/consul_source_datacenter="([^"]*)"/);
+          if (m && m.length >= 2 && m[1] != "") {
+            targetDC = m[1];
+          }
+          m = q.match(/consul_destination_datacenter="([^"]*)"/);
+          if (type == "downstream" && m && m.length >= 2 && m[1] != "") {
+            // downstreams don't have the same selector for the main service
+            // name.
+            targetDC = m[1];
+          }
+
+          var serviceNames = [];
           switch(type) {
             case 'downstream': // fallthrough
             case 'upstream':
@@ -156,12 +182,10 @@
             let metric = `{}`;
             switch(type) {
               case 'upstream':
-                // TODO: this should really return tcp proxy label for tcp
-                // metrics but we don't look at that for now.
-                metric = `{"upstream": "${item.Name}", "envoy_http_conn_manager_prefix": "${item.Name}"}`;
+                metric = `{"consul_upstream_service": "${item.Name}", "consul_upstream_datacenter": "${targetDC}", "consul_upstream_namespace": "${targetNS}"}`;
                 break;
-              case 'downstream':
-                metric = `{"downstream": "${item.Name}", "local_cluster": "${item.Name}"}`;
+              case "downstream":
+                metric = `{"consul_source_service": "${item.Name}", "consul_source_datacenter": "${targetDC}", "consul_source_namespace": "${targetNS}"}`;
                 break;
             }
             const timestamp = Date.now() / 1000;


### PR DESCRIPTION
Updated version of: #9117

This PR updates the tags that we generate for Envoy stats.

Several of these come with breaking changes, since we can't keep two stats prefixes for a filter. 

**For destination clusters:**
- `consul.destination.[namespace|service|subset|hash|datacenter|etc...]`
  - This is renamed from `consul.[service|etc..]` to disambiguate between cluster and listener filter labels.

**For upstream listeners:**
- `consul.upstream.[namespace|service|datacenter|protocol]`

**For the local cluster:**
- `consul.source.[namespace|service|datacenter]`

**Note**: The delimiter for gateway-related Envoy metrics was updated from `_` to `.`.