### PR TITLE
ui: Add triple curlies and reformat style attribute

### DIFF
--- a/ui/packages/consul-ui/app/components/tab-nav/index.hbs
+++ b/ui/packages/consul-ui/app/components/tab-nav/index.hbs
@@ -1,5 +1,12 @@
 <nav
-  style={{if selectedWidth (concat '--selected-width:' selectedWidth ';--selected-left:' selectedLeft ';--selected-height:' selectedHeight ';--selected-top:' selectedTop) undefined}}
+  style={{{if selectedWidth (concat
+      '--selected-width:' selectedWidth ';'
+      '--selected-left:' selectedLeft ';'
+      '--selected-height:' selectedHeight ';'
+      '--selected-top:' selectedTop
+    )
+    undefined
+  }}}
   role="tablist"
   class={{concat 'tab-nav' (if isAnimatable ' animatable' '')}}
   id={{guid}}>


### PR DESCRIPTION
This removes a deprecation warning in console.

<img width="493" alt="Screenshot 2020-11-17 at 20 13 38" src="https://user-images.githubusercontent.com/554604/99442531-6de77400-2911-11eb-9577-eebf725ebbeb.png">

We also formatted things slightly to make things easier to read.
