### PR TITLE
ui: Change title helper to page-title

### DIFF
--- a/ui/packages/consul-ui/app/templates/application.hbs
+++ b/ui/packages/consul-ui/app/templates/application.hbs
@@ -1,5 +1,5 @@
 <HeadLayout />
-{{title 'Consul' separator=' - '}}
+{{page-title 'Consul' separator=' - '}}
 {{#if (not-eq router.currentRouteName 'application')}}
   <HashicorpConsul
     id="wrapper"

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/edit.hbs
@@ -1,11 +1,11 @@
 {{#if isAuthorized }}
   {{#if create }}
-      {{title 'New Policy'}}
+      {{page-title 'New Policy'}}
   {{else}}
-      {{title 'Edit Policy'}}
+      {{page-title 'Edit Policy'}}
   {{/if}}
 {{else}}
-  {{title 'Access Controls'}}
+  {{page-title 'Access Controls'}}
 {{/if}}
 <AppView
   @authorized={{isAuthorized}}

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/index.hbs
@@ -1,7 +1,7 @@
 {{#if isAuthorized }}
-  {{title 'Policies'}}
+  {{page-title 'Policies'}}
 {{else}}
-  {{title 'Access Controls'}}
+  {{page-title 'Access Controls'}}
 {{/if}}
 {{#let (hash
   kinds=(if kind (split kind ',') undefined)

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/edit.hbs
@@ -1,11 +1,11 @@
 {{#if isAuthorized }}
   {{#if item.ID}}
-    {{title 'Edit Role'}}
+    {{page-title 'Edit Role'}}
   {{else}}
-    {{title 'New Role'}}
+    {{page-title 'New Role'}}
   {{/if}}
 {{else}}
-  {{title 'Access Controls'}}
+  {{page-title 'Access Controls'}}
 {{/if}}
 <AppView
   @authorized={{isAuthorized}}

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/index.hbs
@@ -1,7 +1,7 @@
 {{#if isAuthorized }}
-  {{title 'Roles'}}
+  {{page-title 'Roles'}}
 {{else}}
-  {{title 'Access Controls'}}
+  {{page-title 'Access Controls'}}
 {{/if}}
 
 {{#let (or sortBy "Name:asc") as |sort|}}

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/edit.hbs
@@ -1,11 +1,11 @@
 {{#if isAuthorized }}
   {{#if create}}
-    {{title 'New Token'}}
+    {{page-title 'New Token'}}
   {{else}}
-    {{title 'Edit Token'}}
+    {{page-title 'Edit Token'}}
   {{/if}}
 {{else}}
-  {{title 'Access Controls'}}
+  {{page-title 'Access Controls'}}
 {{/if}}
 <AppView
   @authorized={{isAuthorized}}

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/index.hbs
@@ -1,7 +1,7 @@
 {{#if isAuthorized }}
-  {{title 'Tokens'}}
+  {{page-title 'Tokens'}}
 {{else}}
-  {{title 'Access Controls'}}
+  {{page-title 'Access Controls'}}
 {{/if}}
 
 {{#let (hash

--- a/ui/packages/consul-ui/app/templates/dc/intentions/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/edit.hbs
@@ -1,7 +1,7 @@
 {{#if item.ID}}
-    {{title 'Edit Intention'}}
+    {{page-title 'Edit Intention'}}
 {{else}}
-    {{title 'New Intention'}}
+    {{page-title 'New Intention'}}
 {{/if}}
 <AppView>
     <BlockSlot @name="breadcrumbs">

--- a/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
@@ -1,4 +1,4 @@
-{{title 'Intentions'}}
+{{page-title 'Intentions'}}
 <DataLoader @src={{concat '/' nspace '/' dc '/intentions'}} as |api|>
 
   <BlockSlot @name="error">

--- a/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
@@ -1,7 +1,7 @@
 {{#if item.Key }}
-  {{title 'Edit Key/Value'}}
+  {{page-title 'Edit Key/Value'}}
 {{else}}
-  {{title 'New Key/Value'}}
+  {{page-title 'New Key/Value'}}
 {{/if}}
 <AppView>
   <BlockSlot @name="breadcrumbs">

--- a/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
@@ -1,4 +1,4 @@
-{{title 'Key/Value'}}
+{{page-title 'Key/Value'}}
 {{#let (or sortBy "isFolder:asc") as |sort|}}
   <AppView>
     <BlockSlot @name="breadcrumbs">

--- a/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
@@ -1,4 +1,4 @@
-{{title 'Nodes'}}
+{{page-title 'Nodes'}}
 <EventSource @src={{items}} />
 <EventSource @src={{leader}} />
 {{#let (hash

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
@@ -1,4 +1,4 @@
-{{title item.Node}}
+{{page-title item.Node}}
 <DataLoader as |api|>
 
   <BlockSlot @name="data">

--- a/ui/packages/consul-ui/app/templates/dc/nspaces/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nspaces/edit.hbs
@@ -1,7 +1,7 @@
 {{#if create }}
-  {{title 'New Namespace'}}
+  {{page-title 'New Namespace'}}
 {{else}}
-  {{title 'Edit Namespace'}}
+  {{page-title 'Edit Namespace'}}
 {{/if}}
 <AppView>
   <BlockSlot @name="notification" as |status type item error|>

--- a/ui/packages/consul-ui/app/templates/dc/nspaces/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nspaces/index.hbs
@@ -1,4 +1,4 @@
-{{title 'Namespaces'}}
+{{page-title 'Namespaces'}}
 {{#let (or sortBy "Name:asc") as |sort|}}
 <EventSource @src={{items}} />
 <AppView>

--- a/ui/packages/consul-ui/app/templates/dc/services/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/index.hbs
@@ -1,4 +1,4 @@
-{{title 'Services'}}
+{{page-title 'Services'}}
 <EventSource @src={{items}} />
 {{#let (hash
   statuses=(if status (split status ',') undefined)

--- a/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
@@ -1,4 +1,4 @@
-{{title item.Service.ID}}
+{{page-title item.Service.ID}}
 <EventSource @src={{item}} @onerror={{action "error"}} />
 <EventSource @src={{proxy}} />
 <EventSource @src={{proxyMeta}} />

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -4,7 +4,7 @@
 <EventSource @src={{proxies}} />
 <EventSource @src={{gatewayServices}} />
 <EventSource @src={{topology}} />
-{{title item.Service.Service}}
+{{page-title item.Service.Service}}
 <AppView>
   <BlockSlot @name="notification" as |status type|>
     <Consul::Service::Notifications

--- a/ui/packages/consul-ui/app/templates/settings.hbs
+++ b/ui/packages/consul-ui/app/templates/settings.hbs
@@ -1,4 +1,4 @@
-{{title "Settings"}}
+{{page-title "Settings"}}
 <AppView>
   <BlockSlot @name="header">
     <h1>


### PR DESCRIPTION
Removes a deprecation warning for the upgraded ember addon. A small note here, I kinda wish we'd made this part of the `<AppView />` component so:

`<AppView title="Title in here">`

Maybe something we can talk about doing in the future.