### PR TITLE
ui: Remove ghost healthcheck from the service instance healthcheck list

### DIFF
--- a/ui/packages/consul-ui/app/templates/dc/services/instance/healthchecks.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance/healthchecks.hbs
@@ -1,9 +1,10 @@
 <div class="tab-section">
   <div role="tabpanel">
-    {{#if (gt item.Checks.length 0) }}
+  {{#let (append item.Checks (or proxy.Checks (array))) as |checks|}}
+    {{#if (gt checks.length 0) }}
       <section data-test-checks>
         <HealthcheckList
-          @items={{sort-by (comparator 'check' 'Status:asc') (append item.Checks proxy.Checks)}}
+          @items={{sort-by (comparator 'check' 'Status:asc') checks}}
           @exposed={{proxyMeta.ServiceProxy.Expose.Checks}}
         />
       </section>
@@ -16,5 +17,6 @@
         </BlockSlot>
       </EmptyState>
     {{/if}}
+  {{/let}}
   </div>
 </div>

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/instances/show.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/instances/show.feature
@@ -65,7 +65,7 @@ Feature: dc / services / instances / show: Show Service Instance
 
     And I don't see upstreams on the tabs
     And I see healthChecksIsSelected on the tabs
-    And I see 7 of the checks object
+    And I see 6 of the checks object
 
     When I click tags&Meta on the tabs
     And I see tags&MetaIsSelected on the tabs


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/9141 we removed the separate ProxyInfo tab and it's healthcheck listing for proxies and instead merged the healthchecks for proxies in with the healthchecks for the service instance itself in one listing under the healthchecks tabs

Although if an instance didn't have a proxy, this meant appending an `undefined` value to the list of healthchecks resulting in a 'ghost empty healthcheck' at the end of the listing:

<img width="865" alt="Screenshot 2020-11-18 at 15 21 13" src="https://user-images.githubusercontent.com/554604/99549590-b8b8c880-29b1-11eb-841e-b04392c88c42.png">

This PR checks for the existence of the Proxy.Checks and if it doesn't exist instead appends/concats an empty array, which therefore has no effect on the length of the healthchecks list.
