### PR TITLE
ui: All metrics cards should default to the default nspace if not set

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/card.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/card.hbs
@@ -47,7 +47,7 @@
   {{#if (and @hasMetricsProvider (not-eq @service.Kind 'ingress-gateway'))}}
     {{#if (eq @type 'upstream')}}
       <TopologyMetrics::Stats
-        @nspace={{@item.Namespace}}
+        @nspace={{or @item.Namespace 'default'}}
         @dc={{@item.Datacenter}}
         @endpoint='upstream-summary-for-service'
         @service={{@service.Service}}
@@ -56,7 +56,7 @@
       />
     {{else}}
       <TopologyMetrics::Stats
-        @nspace={{@item.Namespace}}
+        @nspace={{or @item.Namespace 'default'}}
         @dc={{@item.Datacenter}}
         @endpoint='downstream-summary-for-service'
         @service={{@service.Service}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -17,7 +17,7 @@
     </div>
   {{#each @topology.Downstreams as |item|}}
     <TopologyMetrics::Card
-      @nspace={{or @service.Service.Namespace 'default'}}
+      @nspace={{@nspace}}
       @dc={{@dc}}
       @service={{@service.Service}}
       @item={{item}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -17,7 +17,7 @@
     </div>
   {{#each @topology.Downstreams as |item|}}
     <TopologyMetrics::Card
-      @nspace={{@nspace}}
+      @nspace={{or @service.Service.Namespace 'default'}}
       @dc={{@dc}}
       @service={{@service.Service}}
       @item={{item}}
@@ -33,7 +33,7 @@
     </div>
     {{#if this.hasMetricsProvider }}
       <TopologyMetrics::Series
-        @nspace={{@service.Service.Namespace}}
+        @nspace={{or @service.Service.Namespace 'default'}}
         @dc={{@dc}}
         @service={{@service.Service.Service}}
         @protocol={{@topology.Protocol}}
@@ -41,7 +41,7 @@
       />
       {{#if (not-eq @service.Service.Kind 'ingress-gateway')}}
       <TopologyMetrics::Stats
-        @nspace={{@service.Service.Namespace}}
+        @nspace={{or @service.Service.Namespace 'default'}}
         @dc={{@dc}}
         @endpoint='summary-for-service'
         @service={{@service.Service.Service}}


### PR DESCRIPTION
This ensures that a nspace is used in the request for metrics, whether in OSS or Enterprise Consul. Without this the metrics provider will just return empty results.