### PR TITLE
agent: fix bug with multiple listeners

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -797,18 +797,7 @@ func (a *Agent) listenHTTP() ([]apiServer, error) {
 				httpServer.ConnState = connLimitFn
 			}
 
-			servers = append(servers, apiServer{
-				Protocol: proto,
-				Addr:     l.Addr(),
-				Shutdown: httpServer.Shutdown,
-				Run: func() error {
-					err := httpServer.Serve(l)
-					if err == nil || err == http.ErrServerClosed {
-						return nil
-					}
-					return fmt.Errorf("%s server %s failed: %w", proto, l.Addr(), err)
-				},
-			})
+			servers = append(servers, newAPIServerHTTP(proto, l, httpServer))
 		}
 		return nil
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -4714,6 +4714,10 @@ func TestSharedRPCRouter(t *testing.T) {
 }
 
 func TestAgent_ListenHTTP_MultipleAddresses(t *testing.T) {
+	ports, err := freeport.Take(2)
+	require.NoError(t, err)
+	t.Cleanup(func() { freeport.Return(ports) })
+
 	caConfig := tlsutil.Config{}
 	tlsConf, err := tlsutil.NewConfigurator(caConfig, hclog.New(nil))
 	require.NoError(t, err)
@@ -4725,8 +4729,8 @@ func TestAgent_ListenHTTP_MultipleAddresses(t *testing.T) {
 		},
 		RuntimeConfig: &config.RuntimeConfig{
 			HTTPAddrs: []net.Addr{
-				&net.TCPAddr{IP: net.ParseIP("127.0.0.1")},
-				&net.TCPAddr{IP: net.ParseIP("127.0.0.1")},
+				&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: ports[0]},
+				&net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: ports[1]},
 			},
 		},
 		Cache: cache.New(cache.Options{}),

--- a/agent/apiserver.go
+++ b/agent/apiserver.go
@@ -2,7 +2,9 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -91,4 +93,19 @@ func (s *apiServers) Shutdown(ctx context.Context) {
 // must be called before WaitForShutdown, otherwise it will block forever.
 func (s *apiServers) WaitForShutdown() error {
 	return s.group.Wait()
+}
+
+func newAPIServerHTTP(proto string, l net.Listener, httpServer *http.Server) apiServer {
+	return apiServer{
+		Protocol: proto,
+		Addr:     l.Addr(),
+		Shutdown: httpServer.Shutdown,
+		Run: func() error {
+			err := httpServer.Serve(l)
+			if err == nil || err == http.ErrServerClosed {
+				return nil
+			}
+			return fmt.Errorf("%s server %s failed: %w", proto, l.Addr(), err)
+		},
+	}
 }


### PR DESCRIPTION
Fixes #9214

Previously the listener was being passed to a closure in a loop without capturing the loop variable. The result is only the last listener is used, so the http/https servers only listen on one address.

This problem is fixed by capturing the variable by passing it into a function.

There was a fix for this in https://github.com/hashicorp/consul/pull/8623/files#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR765, but that PR has not merged yet.