### PR TITLE
[1.9.0] command: when generating envoy bootstrap configs use the datacenter returned from the agent services endpoint

### DIFF
--- a/.changelog/9229.txt
+++ b/.changelog/9229.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+command: when generating envoy bootstrap configs use the datacenter returned from the agent services endpoint
+```

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -365,8 +365,9 @@ func TestAgent_Service(t *testing.T) {
 			Passing: 1,
 			Warning: 1,
 		},
-		Meta: map[string]string{},
-		Tags: []string{},
+		Meta:       map[string]string{},
+		Tags:       []string{},
+		Datacenter: "dc1",
 	}
 	fillAgentServiceEnterpriseMeta(expectedResponse, structs.DefaultEnterpriseMeta())
 
@@ -391,8 +392,9 @@ func TestAgent_Service(t *testing.T) {
 				Port:    1818,
 			},
 		},
-		Meta: map[string]string{},
-		Tags: []string{},
+		Meta:       map[string]string{},
+		Tags:       []string{},
+		Datacenter: "dc1",
 	}
 	fillAgentServiceEnterpriseMeta(expectWebResponse, structs.DefaultEnterpriseMeta())
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -94,7 +94,7 @@ type AgentService struct {
 	// For now though, ignoring it works well enough.
 	Namespace string `json:",omitempty" bexpr:"-" hash:"ignore"`
 	// Datacenter is only ever returned and is ignored if presented.
-	Datacenter string `json:"-" hash:"ignore"`
+	Datacenter string `json:"-" bexpr:"-" hash:"ignore"`
 }
 
 // AgentServiceChecksInfo returns information about a Service and its checks

--- a/api/agent.go
+++ b/api/agent.go
@@ -92,8 +92,9 @@ type AgentService struct {
 	// NOTE: If we ever set the ContentHash outside of singular service lookup then we may need
 	// to include the Namespace in the hash. When we do, then we are in for lots of fun with tests.
 	// For now though, ignoring it works well enough.
-	Namespace  string `json:",omitempty" bexpr:"-" hash:"ignore"`
-	Datacenter string `hash:"ignore"`
+	Namespace string `json:",omitempty" bexpr:"-" hash:"ignore"`
+	// Datacenter is only ever returned and is ignored if presented.
+	Datacenter string `json:"-" hash:"ignore"`
 }
 
 // AgentServiceChecksInfo returns information about a Service and its checks

--- a/api/agent.go
+++ b/api/agent.go
@@ -92,7 +92,8 @@ type AgentService struct {
 	// NOTE: If we ever set the ContentHash outside of singular service lookup then we may need
 	// to include the Namespace in the hash. When we do, then we are in for lots of fun with tests.
 	// For now though, ignoring it works well enough.
-	Namespace string `json:",omitempty" bexpr:"-" hash:"ignore"`
+	Namespace  string `json:",omitempty" bexpr:"-" hash:"ignore"`
+	Datacenter string `hash:"ignore"`
 }
 
 // AgentServiceChecksInfo returns information about a Service and its checks

--- a/api/agent.go
+++ b/api/agent.go
@@ -94,7 +94,7 @@ type AgentService struct {
 	// For now though, ignoring it works well enough.
 	Namespace string `json:",omitempty" bexpr:"-" hash:"ignore"`
 	// Datacenter is only ever returned and is ignored if presented.
-	Datacenter string `json:"-" bexpr:"-" hash:"ignore"`
+	Datacenter string `json:",omitempty" bexpr:"-" hash:"ignore"`
 }
 
 // AgentServiceChecksInfo returns information about a Service and its checks

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -726,8 +726,9 @@ func TestAPI_AgentService(t *testing.T) {
 			Passing: 1,
 			Warning: 1,
 		},
-		Meta:      map[string]string{},
-		Namespace: defaultNamespace,
+		Meta:       map[string]string{},
+		Namespace:  defaultNamespace,
+		Datacenter: "dc1",
 	}
 	require.Equal(expect, got)
 	require.Equal(expect.ContentHash, qm.LastContentHash)

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -478,6 +478,7 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 		LocalAgentClusterName: xds.LocalAgentClusterName,
 		Namespace:             httpCfg.Namespace,
 		EnvoyVersion:          c.envoyVersion,
+		Datacenter:            httpCfg.Datacenter,
 	}, nil
 }
 
@@ -529,15 +530,11 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		// cluster is using namespaces regardless.
 		args.Namespace = svc.Namespace
 	}
-	agent, err := c.client.Agent().Self()
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch agent config: %v", err)
+
+	if svc.Datacenter != "" {
+		// The agent will definitely have the definitive answer here.
+		args.Datacenter = svc.Datacenter
 	}
-	dc, ok := agent["Config"]["Datacenter"].(string)
-	if !ok {
-		return nil, fmt.Errorf("failed to fetch datacenter from agent. DC is: %T", agent["Config"]["Datacenter"])
-	}
-	args.Datacenter = dc
 
 	if !c.disableCentralConfig {
 		// Parse the bootstrap config

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -991,9 +991,10 @@ func testMockAgentGatewayConfig(namespacesEnabled bool) http.HandlerFunc {
 
 		svc := map[string]*api.AgentService{
 			string(kind): {
-				Kind:    kind,
-				ID:      string(kind),
-				Service: string(kind),
+				Kind:       kind,
+				ID:         string(kind),
+				Service:    string(kind),
+				Datacenter: "dc1",
 			},
 		}
 
@@ -1036,6 +1037,7 @@ func testMockAgentProxyConfig(cfg map[string]interface{}, namespacesEnabled bool
 				DestinationServiceID:   serviceID,
 				Config:                 cfg,
 			},
+			Datacenter: "dc1",
 		}
 
 		if namespacesEnabled {

--- a/website/pages/api-docs/agent/service.mdx
+++ b/website/pages/api-docs/agent/service.mdx
@@ -74,6 +74,7 @@ $ curl \
     "Port": 8000,
     "Address": "",
     "EnableTagOverride": false,
+    "Datacenter": "dc1",
     "Weights": {
       "Passing": 10,
       "Warning": 1
@@ -185,6 +186,7 @@ $ curl \
     "Warning": 1
   },
   "EnableTagOverride": false,
+  "Datacenter": "dc1",
   "ContentHash": "4ecd29c7bc647ca8",
   "Proxy": {
     "DestinationServiceName": "web",
@@ -304,6 +306,7 @@ curl localhost:8500/v1/agent/health/service/name/web
       "Meta": null,
       "Port": 80,
       "EnableTagOverride": false,
+      "Datacenter": "dc1",
       "Connect": {
         "Native": false,
         "Proxy": null
@@ -331,6 +334,7 @@ curl localhost:8500/v1/agent/health/service/name/web
       "Meta": null,
       "Port": 80,
       "EnableTagOverride": false,
+      "Datacenter": "dc1",
       "Connect": {
         "Native": false,
         "Proxy": null
@@ -380,6 +384,7 @@ curl localhost:8500/v1/agent/health/service/id/web2
     "Meta": null,
     "Port": 80,
     "EnableTagOverride": false,
+    "Datacenter": "dc1",
     "Connect": {
       "Native": false,
       "Proxy": null
@@ -425,6 +430,7 @@ curl localhost:8500/v1/agent/health/service/id/web1
     "Meta": null,
     "Port": 80,
     "EnableTagOverride": false,
+    "Datacenter": "dc1",
     "Connect": {
       "Native": false,
       "Proxy": null


### PR DESCRIPTION
Manual backport of #9229 into 1.9.0 branch

Fixes #9215