### PR TITLE
ui: ACL Tokens > Roles and Policy search and sort

### DIFF
--- a/ui/packages/consul-ui/app/components/child-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/child-selector/index.hbs
@@ -12,6 +12,7 @@
       />
     {{/if}}
       <PowerSelect
+          @searchEnabled={{true}}
           @search={{action "search"}}
           @options={{options}}
           @loadingMessage="Loading..."

--- a/ui/packages/consul-ui/app/services/sort.js
+++ b/ui/packages/consul-ui/app/services/sort.js
@@ -11,18 +11,33 @@ import policy from 'consul-ui/sort/comparators/policy';
 import nspace from 'consul-ui/sort/comparators/nspace';
 import node from 'consul-ui/sort/comparators/node';
 
+// returns an array of Property:asc, Property:desc etc etc
+const directionify = arr => {
+  return arr.reduce((prev, item) => prev.concat([`${item}:asc`, `${item}:desc`]), []);
+};
+// Specify a list of sortable properties, when called with a property
+// returns an array ready to be passed to ember @sort
+// properties(['Potential', 'Sortable', 'Properties'])('Sortable:asc') => ['Sortable:asc']
+const properties = (props = []) => key => {
+  const comparables = directionify(props);
+  return [comparables.find(item => item === key) || comparables[0]];
+};
+const options = {
+  properties,
+  directionify,
+};
 const comparators = {
-  service: service(),
-  serviceInstance: serviceInstance(),
-  ['upstream-instance']: upstreamInstance(),
-  kv: kv(),
-  check: check(),
-  intention: intention(),
-  token: token(),
-  role: role(),
-  policy: policy(),
-  nspace: nspace(),
-  node: node(),
+  service: service(options),
+  serviceInstance: serviceInstance(options),
+  ['upstream-instance']: upstreamInstance(options),
+  kv: kv(options),
+  check: check(options),
+  intention: intention(options),
+  token: token(options),
+  role: role(options),
+  policy: policy(options),
+  nspace: nspace(options),
+  node: node(options),
 };
 export default class SortService extends Service {
   comparator(type) {

--- a/ui/packages/consul-ui/app/sort/comparators/policy.js
+++ b/ui/packages/consul-ui/app/sort/comparators/policy.js
@@ -1,3 +1,3 @@
-export default () => key => {
-  return key;
+export default ({ properties }) => (key = 'Name:asc') => {
+  return properties(['Name'])(key);
 };

--- a/ui/packages/consul-ui/app/sort/comparators/role.js
+++ b/ui/packages/consul-ui/app/sort/comparators/role.js
@@ -1,3 +1,3 @@
-export default () => key => {
-  return key;
+export default ({ properties }) => (key = 'Name:asc') => {
+  return properties(['Name'])(key);
 };

--- a/ui/packages/consul-ui/app/sort/comparators/role.js
+++ b/ui/packages/consul-ui/app/sort/comparators/role.js
@@ -1,3 +1,3 @@
 export default ({ properties }) => (key = 'Name:asc') => {
-  return properties(['Name'])(key);
+  return properties(['Name', 'CreateIndex'])(key);
 };

--- a/ui/packages/consul-ui/app/sort/comparators/upstream-instance.js
+++ b/ui/packages/consul-ui/app/sort/comparators/upstream-instance.js
@@ -1,7 +1,3 @@
-const directionify = arr => {
-  return arr.reduce((prev, item) => prev.concat([`${item}:asc`, `${item}:desc`]), []);
-};
-export default () => key => {
-  const comparables = directionify(['DestinationName']);
-  return [comparables.find(item => item === key) || comparables[0]];
+export default ({ properties }) => (key = 'DestinationName:asc') => {
+  return properties(['DestinationName'])(key);
 };

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
@@ -22,10 +22,12 @@ Feature: dc / acls / policies / as many / add existing: Add existing policy
     ---
     Then the url should be /datacenter/acls/[Model]s/key
     And I click "form > #policies .ember-power-select-trigger"
+    And I type "Policy 1" into ".ember-power-select-search-input"
     And I click ".ember-power-select-option:first-child"
     And I see 1 policy model on the policies component
     And I click "form > #policies .ember-power-select-trigger"
-    And I click ".ember-power-select-option:nth-child(1)"
+    And I type "Policy 2" into ".ember-power-select-search-input"
+    And I click ".ember-power-select-option:first-child"
     And I see 2 policy models on the policies component
     And I submit
     Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" with the body from yaml

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
@@ -22,10 +22,12 @@ Feature: dc / acls / roles / as many / add existing: Add existing
     ---
     Then the url should be /datacenter/acls/tokens/key
     And I click "form > #roles .ember-power-select-trigger"
+    And I type "Role 1" into ".ember-power-select-search-input"
     And I click ".ember-power-select-option:first-child"
     And I see 1 role model on the roles component
     And I click "form > #roles .ember-power-select-trigger"
-    And I click ".ember-power-select-option:nth-child(1)"
+    And I type "Role 2" into ".ember-power-select-search-input"
+    And I click ".ember-power-select-option:first-child"
     And I see 2 role models on the roles component
     Then I fill in with yaml
     ---


### PR DESCRIPTION
This PR began as a fix for https://github.com/hashicorp/consul/issues/9227 but whilst we were there we progressed our comparator functions to use common utility functions slightly. There's potentially a follow up PR to be made after this to progress this further (I felt there was already quite a bit of change here for what we set out to do)

The Role and Policy selectors are now sorted by Name and text searchable.

Worthwhile noting that search functionality used to exist here but we lost it in an ember-power-select upgrade 😬 . A couple of small tests here should prevent that from ever happening again.
