### PR TITLE
ui: Surface 'detail' of API errors in the error page

### DIFF
--- a/ui/packages/consul-ui/app/components/empty-state/index.hbs
+++ b/ui/packages/consul-ui/app/components/empty-state/index.hbs
@@ -1,5 +1,8 @@
 {{yield}}
-<div class="empty-state" ...attributes>
+<div
+  class="empty-state"
+  ...attributes
+>
 {{#if hasHeader}}
   <header>
     {{#yield-slot name="header"}}

--- a/ui/packages/consul-ui/app/components/error-state/index.hbs
+++ b/ui/packages/consul-ui/app/components/error-state/index.hbs
@@ -12,13 +12,19 @@
     </BlockSlot>
 {{/if}}
     <BlockSlot @name="body">
-      <p>
-        You may have visited a URL that is loading an unknown resource, so you can try going back to the root or try re-submitting your ACL Token/SecretID by going back to ACLs.
-      </p>
+      {{#if error.detail}}
+        <p>
+          {{error.detail}}
+        </p>
+      {{else}}
+        <p>
+          You may have visited a URL that is loading an unknown resource, so you can try going back to the root or try re-submitting your ACL Token/SecretID by going back to ACLs.
+        </p>
+      {{/if}}
     </BlockSlot>
     <BlockSlot @name="actions">
       <li class="back-link">
-        <a data-test-home rel="home" href={{href-to 'index'}}>Go back to root</a>
+        <a data-test-home rel="home" href={{href-to 'index'}}>Go back</a>
       </li>
       <li class="docs-link">
         <a href="{{env 'CONSUL_DOCS_URL'}}" rel="noopener noreferrer" target="_blank">Read the documentation</a>

--- a/ui/packages/consul-ui/app/routes/application.js
+++ b/ui/packages/consul-ui/app/routes/application.js
@@ -41,7 +41,7 @@ export default Route.extend(WithBlockingActions, {
       };
       if (e.errors && e.errors[0]) {
         error = e.errors[0];
-        error.message = error.title || error.detail || 'Error';
+        error.message = error.message || error.title || error.detail || 'Error';
       }
       if (error.status === '') {
         error.message = 'Error';

--- a/ui/packages/consul-ui/app/services/repository/dc.js
+++ b/ui/packages/consul-ui/app/services/repository/dc.js
@@ -26,9 +26,8 @@ export default class DcService extends RepositoryService {
         });
       }
     }
-    const e = new Error();
+    const e = new Error('Page not found');
     e.status = '404';
-    e.detail = 'Page not found';
     return Promise.reject({ errors: [e] });
   }
 


### PR DESCRIPTION
This PR surfaces the API error response (if there is one) in our error pages giving pages that look like the following:

<img width="905" alt="Screenshot 2020-11-19 at 10 11 30" src="https://user-images.githubusercontent.com/554604/99676673-b6697380-2a70-11eb-876e-67b54be14c93.png">

