### PR TITLE
config: use fields to detect enterprise-only settings

### DIFF
--- a/agent/config/agent_limits_test.go
+++ b/agent/config/agent_limits_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestBuildAndValidate_HTTPMaxConnsPerClientExceedsRLimit(t *testing.T) {
-	t.Parallel()
 	hcl := `
 		limits{
 			# We put a very high value to be sure to fail

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -148,7 +148,7 @@ func NewBuilder(opts BuilderOpts) (*Builder, error) {
 	// we need to merge all slice values defined in flags before we
 	// merge the config files since the flag values for slices are
 	// otherwise appended instead of prepended.
-	slices, values := b.splitSlicesAndValues(opts.Config)
+	slices, values := splitSlicesAndValues(opts.Config)
 	b.Head = append(b.Head, newSource("flags.slices", slices))
 	for _, path := range opts.ConfigFiles {
 		sources, err := b.sourcesFromPath(path, opts.ConfigFormat)
@@ -1494,7 +1494,7 @@ func addrsUnique(inuse map[string]string, name string, addrs []net.Addr) error {
 
 // splitSlicesAndValues moves all slice values defined in c to 'slices'
 // and all other values to 'values'.
-func (b *Builder) splitSlicesAndValues(c Config) (slices, values Config) {
+func splitSlicesAndValues(c Config) (slices, values Config) {
 	v, t := reflect.ValueOf(c), reflect.TypeOf(c)
 	rs, rv := reflect.New(t), reflect.New(t)
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -316,8 +316,9 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 			return RuntimeConfig{}, fmt.Errorf("failed to parse %v: %s", s.Source(), unusedErr)
 		}
 
-		// for now this is a soft failure that will cause warnings but not actual problems
-		b.validateEnterpriseConfigKeys(&c2, md.Keys)
+		for _, err := range validateEnterpriseConfigKeys(&c2) {
+			b.warn("%s", err)
+		}
 
 		// if we have a single 'check' or 'service' we need to add them to the
 		// list of checks and services first since we cannot merge them
@@ -1845,8 +1846,18 @@ func (b *Builder) stringValWithDefault(v *string, defaultVal string) string {
 	return *v
 }
 
+// Deprecated: use the stringVal() function instead of this Builder method. This
+// method is being left here temporarily as there are many callers. It will be
+// removed in the future.
 func (b *Builder) stringVal(v *string) string {
 	return b.stringValWithDefault(v, "")
+}
+
+func stringVal(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
 }
 
 func (b *Builder) float64ValWithDefault(v *float64, defaultVal float64) float64 {

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/hashicorp/raft"
+
 	"github.com/hashicorp/consul/agent/checks"
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/version"
-	"github.com/hashicorp/raft"
 )
 
 // DefaultSource is the default agent configuration.

--- a/agent/config/runtime_oss_test.go
+++ b/agent/config/runtime_oss_test.go
@@ -12,16 +12,17 @@ var entTokenConfigSanitize = `"EnterpriseConfig": {},`
 
 func entFullRuntimeConfig(rt *RuntimeConfig) {}
 
-var enterpriseReadReplicaWarnings = []string{enterpriseConfigKeyError{key: "read_replica"}.Error()}
+var enterpriseReadReplicaWarnings = []string{enterpriseConfigKeyError{key: "read_replica (or the deprecated non_voting_server)"}.Error()}
 
-var enterpriseConfigKeyWarnings []string
-
-func init() {
-	for k := range enterpriseConfigMap {
-		if k == "non_voting_server" {
-			// this is an alias for "read_replica" so we shouldn't see it in warnings
-			continue
-		}
-		enterpriseConfigKeyWarnings = append(enterpriseConfigKeyWarnings, enterpriseConfigKeyError{key: k}.Error())
-	}
+var enterpriseConfigKeyWarnings = []string{
+	enterpriseConfigKeyError{key: "read_replica (or the deprecated non_voting_server)"}.Error(),
+	enterpriseConfigKeyError{key: "segment"}.Error(),
+	enterpriseConfigKeyError{key: "segments"}.Error(),
+	enterpriseConfigKeyError{key: "autopilot.redundancy_zone_tag"}.Error(),
+	enterpriseConfigKeyError{key: "autopilot.upgrade_version_tag"}.Error(),
+	enterpriseConfigKeyError{key: "autopilot.disable_upgrade_migration"}.Error(),
+	enterpriseConfigKeyError{key: "dns_config.prefer_namespace"}.Error(),
+	enterpriseConfigKeyError{key: "acl.msp_disable_bootstrap"}.Error(),
+	enterpriseConfigKeyError{key: "acl.tokens.managed_service_provider"}.Error(),
+	enterpriseConfigKeyError{key: "audit"}.Error(),
 }

--- a/agent/config/runtime_oss_test.go
+++ b/agent/config/runtime_oss_test.go
@@ -12,7 +12,7 @@ var entTokenConfigSanitize = `"EnterpriseConfig": {},`
 
 func entFullRuntimeConfig(rt *RuntimeConfig) {}
 
-var enterpriseReadReplicaWarnings []string = []string{enterpriseConfigKeyError{key: "read_replica"}.Error()}
+var enterpriseReadReplicaWarnings = []string{enterpriseConfigKeyError{key: "read_replica"}.Error()}
 
 var enterpriseConfigKeyWarnings []string
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent/cache"
@@ -35,10 +37,9 @@ import (
 type configTest struct {
 	desc           string
 	args           []string
-	pre, post      func()
+	pre            func()
 	json, jsontail []string
 	hcl, hcltail   []string
-	skipformat     bool
 	privatev4      func() ([]*net.IPAddr, error)
 	publicv6       func() ([]*net.IPAddr, error)
 	patch          func(rt *RuntimeConfig)
@@ -4821,7 +4822,6 @@ func TestBuilder_BuildAndValidate_ConfigFlagsAndEdgecases(t *testing.T) {
 }
 
 func testConfig(t *testing.T, tests []configTest, dataDir string) {
-	t.Helper()
 	for _, tt := range tests {
 		for pass, format := range []string{"json", "hcl"} {
 			// clean data dir before every test
@@ -4837,20 +4837,13 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 
 			// json and hcl sources need to be in sync
 			// to make sure we're generating the same config
-			if len(tt.json) != len(tt.hcl) && !tt.skipformat {
+			if len(tt.json) != len(tt.hcl) {
 				t.Fatal(tt.desc, ": JSON and HCL test case out of sync")
 			}
 
-			// select the source
 			srcs, tails := tt.json, tt.jsontail
 			if format == "hcl" {
 				srcs, tails = tt.hcl, tt.hcltail
-			}
-
-			// If we're skipping a format and the current format is empty,
-			// then skip it!
-			if tt.skipformat && len(srcs) == 0 {
-				continue
 			}
 
 			// build the description
@@ -4863,8 +4856,8 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 			}
 
 			t.Run(strings.Join(desc, ":"), func(t *testing.T) {
-				// first parse the flags
 				flags := BuilderOpts{}
+
 				fs := flag.NewFlagSet("", flag.ContinueOnError)
 				AddFlags(fs, &flags)
 				err := fs.Parse(tt.args)
@@ -4876,17 +4869,10 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 				if tt.pre != nil {
 					tt.pre()
 				}
-				defer func() {
-					if tt.post != nil {
-						tt.post()
-					}
-				}()
 
 				// Then create a builder with the flags.
 				b, err := NewBuilder(flags)
-				if err != nil {
-					t.Fatal("NewBuilder", err)
-				}
+				require.NoError(t, err)
 
 				patchBuilderShims(b)
 				if tt.hostname != nil {
@@ -4899,7 +4885,7 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 					b.getPublicIPv6 = tt.publicv6
 				}
 
-				// read the source fragements
+				// read the source fragments
 				for i, data := range srcs {
 					b.Sources = append(b.Sources, FileSource{
 						Name:   fmt.Sprintf("src-%d.%s", i, format),
@@ -4915,7 +4901,6 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 					})
 				}
 
-				// build/merge the config fragments
 				actual, err := b.BuildAndValidate()
 				if err == nil && tt.err != "" {
 					t.Fatalf("got no error want %q", tt.err)
@@ -4945,9 +4930,7 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 				x.getPrivateIPv4 = func() ([]*net.IPAddr, error) { return []*net.IPAddr{ipAddr("10.0.0.1")}, nil }
 				x.getPublicIPv6 = func() ([]*net.IPAddr, error) { return []*net.IPAddr{ipAddr("dead:beef::1")}, nil }
 				expected, err := x.Build()
-				if err != nil {
-					t.Fatalf("build default failed: %s", err)
-				}
+				require.NoError(t, err)
 				if tt.patch != nil {
 					tt.patch(&expected)
 				}
@@ -4961,9 +4944,16 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 				if tt.patchActual != nil {
 					tt.patchActual(&actual)
 				}
-				require.Equal(t, expected, actual)
+				assertDeepEqual(t, expected, actual, cmpopts.EquateEmpty())
 			})
 		}
+	}
+}
+
+func assertDeepEqual(t *testing.T, x, y interface{}, opts ...cmp.Option) {
+	t.Helper()
+	if diff := cmp.Diff(x, y, opts...); diff != "" {
+		t.Fatalf("assertion failed: values are not equal\n--- expected\n+++ actual\n%v", diff)
 	}
 }
 
@@ -7398,7 +7388,6 @@ func TestNonZero(t *testing.T) {
 }
 
 func TestConfigDecodeBytes(t *testing.T) {
-	t.Parallel()
 	// Test with some input
 	src := []byte("abc")
 	key := base64.StdEncoding.EncodeToString(src)


### PR DESCRIPTION
Now that config can come from non-file sources it is not safe to assumes that the mapstructure `Metdata.Keys` will contain all the keys because some config can be specified with command line flags or literals.

This change allows us to remove the json marshal/unmarshal cycle for command line flags, which will allow us to remove all of the hcl/json struct tags on config fields. That is done in #9250 which is a follow up to this PR.

This PR also does a bit of cleanup in some of the config tests to remove unused things and make the failure messages easier to understand.