### PR TITLE
docs: mark streaming as experimental

### DIFF
--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -1828,9 +1828,10 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 
 - `rpc` configuration for Consul servers.
 
-  - `enable_streaming` ((#rpc_enable_streaming)) enables the gRPC subscribe endpoint on a Consul Server. All
+  - `enable_streaming` ((#rpc_enable_streaming)) (experimental) enables the gRPC subscribe endpoint on a Consul Server. All
     servers in all federated datacenters must have this enabled before any client can use
-    [`use_streaming_backend`](#use_streaming_backend). This setting will default to true in a future release of Consul.
+    [`use_streaming_backend`](#use_streaming_backend).
+    This setting will default to true in a future version of Consul.
 
 - `segment` <EnterpriseAlert inline /> - Equivalent to the [`-segment` command-line flag](#_segment).
 
@@ -2204,13 +2205,14 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     currently only supports numeric IDs.
   - `mode` - The permission bits to set on the file.
 
-- `use_streaming_backend` when enabled Consul client agents will use streaming rpc to
-  populate, instead of the traditional blocking queries, for endpoints which support
+- `use_streaming_backend` (experimental) when enabled Consul client agents will use
+  streaming rpc, instead of the traditional blocking queries, for endpoints which support
   streaming. All servers must have [`rpc.enable_streaming`](#rpc_enable_streaming)
   enabled before any client can enable `use_streaming_backend`.
   At least one of [`dns.use_cache`](#dns_use_cache) or
   [`http_config.use_cache`](#http_config_use_cache) must be enabled, otherwise
   this setting has no effect.
+  `use_streaming_backend` will default to true in a future version of Consul.
 
 - `verify_incoming` - If set to true, Consul
   requires that all incoming connections make use of TLS and that the client


### PR DESCRIPTION
Adds `(experimental)` to the docs for the two config settings used to enable streaming. Also fixes some minor errors in those sections.