### PR TITLE
docs: adding Consul 1.9.x to compat matrix and link to Envoy compat matrix

### DIFF
--- a/website/pages/docs/k8s/upgrade/compatibility.mdx
+++ b/website/pages/docs/k8s/upgrade/compatibility.mdx
@@ -22,4 +22,4 @@ the Helm chart which will ensure a compatible version of the Consul Kubernetes b
 
 ## Supported Envoy versions
 
-Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions). The recommended best practice is to use the default version of Envoy that is provided in the Helm values.yml file, as that is the version that has been tested with the default Consul and Consul Kubernetes binaries.  
+Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions). The recommended best practice is to use the default version of Envoy that is provided in the Helm values.yml file, as that is the version that has been tested with the default Consul and Consul Kubernetes binaries for a given Helm chart.  

--- a/website/pages/docs/k8s/upgrade/compatibility.mdx
+++ b/website/pages/docs/k8s/upgrade/compatibility.mdx
@@ -22,4 +22,4 @@ the Helm chart which will ensure a compatible version of the Consul Kubernetes b
 
 ## Supported Envoy versions
 
-Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions).
+Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions). The recommended best practice is to use the default version of Envoy that is provided in the Helm values.yml file, as that is the version that has been tested with the defaul Consul and Consul Kubernetes binaries.  

--- a/website/pages/docs/k8s/upgrade/compatibility.mdx
+++ b/website/pages/docs/k8s/upgrade/compatibility.mdx
@@ -22,4 +22,4 @@ the Helm chart which will ensure a compatible version of the Consul Kubernetes b
 
 ## Supported Envoy versions
 
-Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions). The recommended best practice is to use the default version of Envoy that is provided in the Helm values.yml file, as that is the version that has been tested with the defaul Consul and Consul Kubernetes binaries.  
+Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions). The recommended best practice is to use the default version of Envoy that is provided in the Helm values.yml file, as that is the version that has been tested with the default Consul and Consul Kubernetes binaries.  

--- a/website/pages/docs/k8s/upgrade/compatibility.mdx
+++ b/website/pages/docs/k8s/upgrade/compatibility.mdx
@@ -15,6 +15,11 @@ the Helm chart which will ensure a compatible version of the Consul Kubernetes b
 
 | Consul Version | Compatible Consul Helm Versions |
 | -------------- | ------------------------------- |
+| 1.9.x          | 0.26.0                          |
 | 1.8.x          | 0.22.0 - 0.26.0                 |
 | 1.7.x          | 0.17.0 - 0.21.0                 |
 | 1.6.x          | 0.10.0 - 0.16.2                 |
+
+## Envoy 
+
+Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions)

--- a/website/pages/docs/k8s/upgrade/compatibility.mdx
+++ b/website/pages/docs/k8s/upgrade/compatibility.mdx
@@ -11,7 +11,7 @@ Consul Kubernetes (consul-k8s) is managed using Consul Helm. For every release o
 Helm chart and Consul Kubernetes binary is released through the HashiCorp Helm repository. The recommended best practice is to upgrade
 the Helm chart which will ensure a compatible version of the Consul Kubernetes binary is used.
 
-## Supported Versions
+## Supported Consul Versions
 
 | Consul Version | Compatible Consul Helm Versions |
 | -------------- | ------------------------------- |

--- a/website/pages/docs/k8s/upgrade/compatibility.mdx
+++ b/website/pages/docs/k8s/upgrade/compatibility.mdx
@@ -11,7 +11,7 @@ Consul Kubernetes (consul-k8s) is managed using Consul Helm. For every release o
 Helm chart and Consul Kubernetes binary is released through the HashiCorp Helm repository. The recommended best practice is to upgrade
 the Helm chart which will ensure a compatible version of the Consul Kubernetes binary is used.
 
-## Supported Consul Versions
+## Supported Consul versions
 
 | Consul Version | Compatible Consul Helm Versions |
 | -------------- | ------------------------------- |
@@ -20,6 +20,6 @@ the Helm chart which will ensure a compatible version of the Consul Kubernetes b
 | 1.7.x          | 0.17.0 - 0.21.0                 |
 | 1.6.x          | 0.10.0 - 0.16.2                 |
 
-## Envoy 
+## Supported Envoy versions
 
 Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions).

--- a/website/pages/docs/k8s/upgrade/compatibility.mdx
+++ b/website/pages/docs/k8s/upgrade/compatibility.mdx
@@ -22,4 +22,4 @@ the Helm chart which will ensure a compatible version of the Consul Kubernetes b
 
 ## Envoy 
 
-Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions)
+Supported versions of Envoy for Consul versions are also found in [Envoy - Supported Versions](https://www.consul.io/docs/connect/proxies/envoy#supported-versions).


### PR DESCRIPTION
Adding 1.9.x and link to Envoy compat matrix