### PR TITLE
merge: release/1.9.0

### DIFF
--- a/.changelog/8685.txt
+++ b/.changelog/8685.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-fixed a bug that caused logs to be flooded with `[WARN] agent.router: Non-server in server-only area`
+telemetry: fixed a bug that caused logs to be flooded with `[WARN] agent.router: Non-server in server-only area`
 ```

--- a/.changelog/8703.txt
+++ b/.changelog/8703.txt
@@ -1,4 +1,4 @@
-```release-note:feature
+```release-note:improvement
 server: create new memdb table for storing system metadata
 ```
 

--- a/.changelog/8822.txt
+++ b/.changelog/8822.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-deps: Update raft to v1.2.0 to prevent non-voters from becoming eligible for leader elections and adding peer id as metric label to reduce cardinality in metric names
+raft: Update raft to v1.2.0 to prevent non-voters from becoming eligible for leader elections and adding peer id as metric label to reduce cardinality in metric names
 ```

--- a/.changelog/8834.txt
+++ b/.changelog/8834.txt
@@ -1,6 +1,6 @@
-```release-note:feature
+```release-note:improvement
 connect: intentions are now managed as a new config entry kind "service-intentions"
 ```
 ```release-note:breaking-change
-connect: intention destinations can no longer be renamed
+connect: intention destinations can no longer be reassigned
 ```

--- a/.changelog/8877.txt
+++ b/.changelog/8877.txt
@@ -1,9 +1,9 @@
 ```release-note:improvement
-agent: add counter `consul.api.http` with labels for each HTTP path and method. This is intended to replace `consul.http...`
+telemetry: add counter `consul.api.http` with labels for each HTTP path and method. This is intended to replace `consul.http...`
 ```
 ```release-note:improvement
-agent: add config flag `telemetry { disable_compat_1.9 = (true|false) }` to disable deprecated metrics in 1.9
+telemetry: add config flag `telemetry { disable_compat_1.9 = (true|false) }` to disable deprecated metrics in 1.9
 ```
 ```release-note:deprecation
-agent: The measurements in all of the `consul.http...` prefixed metrics have been migrated to `consul.api.http`. `consul.http...` prefixed metrics will be removed in a future version of Consul.
+telemetry: The measurements in all of the `consul.http...` prefixed metrics have been migrated to `consul.api.http`. `consul.http...` prefixed metrics will be removed in a future version of Consul.
 ```

--- a/.changelog/9036.txt
+++ b/.changelog/9036.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+chore: Update to Go 1.15 with mitigation for [golang/go#42138](https://github.com/golang/go/issues/42138)
+```
+```release-note:deprecation
+Go 1.15 has dropped support for 32-bit binaries for Darwin, so darwin_386 builds will not be available for any 1.9.x+ releases.
+```

--- a/.changelog/9198.txt
+++ b/.changelog/9198.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-agent: All metrics should be present and available to prometheus scrapers when Consul starts. If any non-deprecated metrics are missing please submit an issue with its name.
+telemetry: All metrics should be present and available to prometheus scrapers when Consul starts. If any non-deprecated metrics are missing please submit an issue with its name.
 ```

--- a/.changelog/changelog.tmpl
+++ b/.changelog/changelog.tmpl
@@ -2,7 +2,7 @@
 BREAKING CHANGES:
 
 {{range index .NotesByType "breaking-change" -}}
-* {{ template "note" .}}
+* {{ template "note" . }}
 {{ end -}}
 {{- end -}}
 
@@ -14,7 +14,7 @@ SECURITY:
 {{ end -}}
 {{- end -}}
 
-{{- if .NotesByType.feature -}}
+{{- if .NotesByType.feature }}
 FEATURES:
 
 {{range .NotesByType.feature -}}

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.12
 replace github.com/hashicorp/consul/sdk => ../sdk
 
 require (
-	github.com/hashicorp/consul/sdk v0.6.0
+	github.com/hashicorp/consul/sdk v0.7.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-hclog v0.12.0
 	github.com/hashicorp/go-rootcerts v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -28,8 +28,8 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v1.2.0
 	github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2
-	github.com/hashicorp/consul/api v1.7.0
-	github.com/hashicorp/consul/sdk v0.6.0
+	github.com/hashicorp/consul/api v1.8.0
+	github.com/hashicorp/consul/sdk v0.7.0
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-bexpr v0.1.2
 	github.com/hashicorp/go-checkpoint v0.5.0

--- a/website/data/version.js
+++ b/website/data/version.js
@@ -1,1 +1,1 @@
-export default '1.8.6'
+export default '1.9.0'

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -11,11 +11,6 @@ export default function DownloadsPage({ releaseData }) {
         product="Consul"
         version={VERSION}
         releaseData={releaseData}
-        prerelease={{
-          type: 'beta', // the type of prerelease: beta, release candidate, etc.
-          name: 'v1.9.0', // the name displayed in text on the website
-          version: '1.9.0-beta3', // the actual version tag that was pushed to releases.hashicorp.com
-        }}
       >
         <p>
           <a href="/docs/download-tools">&raquo; Download Consul Tools</a>


### PR DESCRIPTION
Updates changelog entries, versions and website banner from changes made directly on `release/1.9.0` branch. Companion to https://github.com/hashicorp/consul/pull/9270