### PR TITLE
ui: Nestable DataSources (plus glimmer upgrade)

### DIFF
--- a/ui/packages/consul-ui/app/components/data-source/README.mdx
+++ b/ui/packages/consul-ui/app/components/data-source/README.mdx
@@ -2,11 +2,14 @@
 
 ```handlebars
 <DataSource
-  @src="/dc/nspace/services"
+  @src="/nspace/dc/services"
   @loading="eager"
+  @disabled={{false}}
   @onchange={{action (mut items) value="data"}}
   @onerror={{action (mut error) value="error"}}
-/>
+as |source|>
+  <source.Source @src="" />
+</DataSource>
 ```
 
 ### Arguments
@@ -15,6 +18,7 @@
 | --- | --- | --- | --- |
 | `src` | `String` | | The source to subscribe to updates to, this should map to a string based URI |
 | `loading` | `String` | eager | Allows the browser to defer loading offscreen DataSources (`eager\|lazy`). Setting to `lazy` only loads the data when the DataSource is visible in the DOM (inc. `display: none\|block;`) |
+| `disabled` | `Boolean` | true | When disabled the DataSource is closed |
 | `open` | `Boolean` | false | Force the DataSource to open, used to force non-blocking data to refresh (has no effect for blocking data) |
 | `onchange` | `Function` |  | The action to fire when the data changes. Emits an Event-like object with a `data` property containing the data. |
 | `onerror` | `Function` |  | The action to fire when an error occurs. Emits ErrorEvent object with an `error` property containing the Error. |
@@ -30,28 +34,97 @@ Behind the scenes in the Consul UI we map URIs back to our `ember-data` backed `
 `DataSource` is not just restricted to HTTP API data, and can be configured to listen for data changes using a variety of methods and sources. For example we have also configured `DataSource` to listen to `LocalStorage` changes using the `settings://` pseudo-protocol in the URI (See examples below).
 
 
-### Example
+### Examples
 
-Straightforward usage can use `mut` to easily update data within a template
+Straightforward usage can use `mut` to easily update data within a template using an event handler approach.
 
 ```handlebars
   {{! listen for HTTP API changes}}
-  <DataSource @src="/dc/nspace/services"
+  <DataSource
+    @src="/nspace/dc/services"
     @onchange={{action (mut items) value="data"}}
     @onerror={{action (mut error) value="error"}}
   />
+  {{#if error}}
+    Something went wrong!
+  {{/if}}
+  {{#if (not items)}}
+    Loading...
+  {{/if}}
   {{! the value of items will change whenever the data changes}}
   {{#each items as |item|}}
     {{item.Name}} {{! < Prints the item name }}
   {{/each}}
 
   {{! listen for Settings (local storage) changes}}
-  <DataSource @src="settings://consul:token"
+  <DataSource
+    @src="settings://consul:token"
     @onchange={{action (mut token) value="data"}}
     @onerror={{action (mut error) value="error"}}
   />
   {{! the value of token will change whenever the data changes}}
   {{token.AccessorID}} {{! < Prints the token AccessorID }}
+```
+
+A property approach to easily update data within a template
+
+```handlebars
+  {{! listen for HTTP API changes}}
+  <DataSource
+    @src="/nspace/dc/services"
+  as |source|>
+    {{#if source.error}}
+      Something went wrong!
+    {{/if}}
+    {{#if (not source.data)}}
+      Loading...
+    {{/if}}
+    {{! the value of items will change whenever the data changes}}
+    {{#each source.data as |item|}}
+      {{item.Name}} {{! < Prints the item name }}
+    {{/each}}
+  </DataSource>
+```
+
+Both approaches can be used in tandem.
+
+DataSources can also be recursively nested for loading in series as opposed to in parallel. Nested DataSources will not start loading until the immediate parent has loaded (ie. it has data) as they are not placed into the DOM until this has happened. However, if a DataSource has started loading, and the immediate parent errors, the nested DataSource will stop receiving updates yet it and its properties will remain accessible within the DOM.
+
+```handlebars
+
+  {{! straightforwards error/loading states}}
+  {{#if error}}
+    Something went wrong!
+  {{else if (not loaded)}}
+    Loading...
+  {{/if}}
+
+  {{! listen for HTTP API changes}}
+  <DataSource
+    @src="/nspace/dc/services"
+    @onerror={{action (mut error) value="error"}}
+  as |source|>
+
+    <source.Source
+      @src="/nspace/dc/service/{{source.data.firstObject.Name}}"
+      @onerror={{action (mut error) value="error"}}
+    as |source|>
+
+      {{source.data.Service.Service.Name}} <== Detailed information for the first service
+
+      <source.Source
+        @src="/nspace/dc/proxy/for-service/{{source.data.Service.ID}}"
+        @onerror={{action (mut error) value="error"}}
+        @onchange={{action (mut loaded) true}}
+      as |source|>
+
+        {{source.data.DestinationName}}
+
+      </source.Source>
+
+    </source.Source>
+
+  </DataSource>
 ```
 
 ### See

--- a/ui/packages/consul-ui/app/components/data-source/index.hbs
+++ b/ui/packages/consul-ui/app/components/data-source/index.hbs
@@ -1,4 +1,24 @@
-{{#if (eq loading "lazy")}}
-{{! in order to use intersection observer we need a DOM element on the page}}
-  <data id={{guid}} aria-hidden="true" style="width: 0;height: 0;font-size: 0;padding: 0;margin: 0;" />
+{{#if (not this.disabled)}}
+  {{#if (eq this.loading "lazy")}}
+    {{! in order to use intersection observer we need a DOM element on the page}}
+    <data
+      {{did-insert this.connect}}
+      aria-hidden="true"
+      style="width: 0;height: 0;font-size: 0;padding: 0;margin: 0;"
+    />
+  {{else}}
+    {{did-insert this.connect}}
+  {{/if}}
+  {{did-update this.attributeChanged 'src' @src}}
+  {{did-update this.attributeChanged 'loading' @loading}}
+  {{will-destroy this.disconnect}}
 {{/if}}
+{{did-update this.attributeChanged 'disabled' @disabled}}
+{{yield (hash
+  data=this.data
+  error=this.error
+  Source=(if this.data
+    (component 'data-source' disabled=(not (eq this.error undefined)))
+    ''
+  )
+)}}

--- a/ui/packages/consul-ui/app/services/data-source/service.js
+++ b/ui/packages/consul-ui/app/services/data-source/service.js
@@ -1,5 +1,6 @@
 import Service, { inject as service } from '@ember/service';
 import { proxy } from 'consul-ui/utils/dom/event-source';
+import { schedule } from '@ember/runloop';
 
 import MultiMap from 'mnemonist/multi-map';
 
@@ -37,14 +38,18 @@ export default class DataSourceService extends Service {
   }
 
   willDestroy() {
-    this._listeners.remove();
-    sources.forEach(function(item) {
-      item.close();
+    // the will-destroy helper will fire AFTER services have had willDestroy
+    // called on them, schedule any destroying to fire after the final render
+    schedule('afterRender', () => {
+      this._listeners.remove();
+      sources.forEach(function(item) {
+        item.close();
+      });
+      cache = null;
+      sources = null;
+      usage.clear();
+      usage = null;
     });
-    cache = null;
-    sources = null;
-    usage.clear();
-    usage = null;
   }
 
   source(cb, attrs) {


### PR DESCRIPTION
There are a few things that we've thought of adding to our DataSources recently but held off on upgrading things until now, these are:

1. Add a property based approach. Previously you could only use DataSources with a callback/event handler approach meaning looping through component/DataSources could be problematic. Also, in order to use the `mut` or `set` helper a glimmer component requires a backing JS class. We'd decided that yielding the DataSources properties would help to avoid this and make it easier to load data outside of components that could otherwise be purely presentational.

```hbs
{{#each things as |thing|}}
  <DataSource @src={{ concat '/somewhere/thing/' thing.ID }} as |source|>
    <PresentationalThingComponent @item={{source.data}} />
  </DataSource>
{{/each}}
```

2. We'd like to be able to nest DataSources and have them load in series one after the other. Recursively yielding a further DataSource component that knew when its immediate parent was loaded would allow us to do that without having to manage the loading everytime we used it.

```hbs
  <DataSource @src="/somewhere/things" as |source|>
    <source.Source @src={{ concat '/somewhere/thing/' source.data.firstObject.ID }} as |source|>
      <PresentationalThingComponent @item={{source.data}} />
    </source.Source>
  </DataSource>
```

So this PR does the following:

1. Upgrades to a glimmer component
2. yields `data` and `error` properties when used as a block style component
3. yields a `Source` component, which is a DataSource component. This allows you to recursively nest DataSources without having to manage whether the immediate parent has loaded or not.

Notes:

1. We had to upgrade how we inject a mock service during testing. On first glance it seems like you can no longer inject services into glimmer components - they must be subclassed and their properties overwritten in order to achieve injection of services/properties.
2. Unfortunately, as we need to use `ember-render-helpers` here (sometimes we don't have an element to add a modifier to), this changes the overall app lifecycle slightly. Component `{{will-destroy}}` is now called after Services have had `willDestroy` called on them, but the methods of the Services are still available to be called. We therefore have reluctantly wrapped the `willDestroy` body in an `afterRender` to ensure that the components `will-destroy` is called before the Services `willDestroy` code.

Overall it makes it easy to wrap things in a DataSource to feed it data, for a little ad-hoc experiment I did it with our Service listing which, along with the lazy loading of DataSource, loads in Service sub data as rows are scrolled into view and then blocks on latest ones to enter the view.

![data-source](https://user-images.githubusercontent.com/554604/100246530-296f6000-2f31-11eb-91d5-c60ac33b12a0.gif)





 