### PR TITLE
ae: remove extra sync lock from Agent

### DIFF
--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -171,7 +171,7 @@ func (s *StateSyncer) runFSM(fs fsmState, next func(fsmState) fsmState) {
 func (s *StateSyncer) nextFSMState(fs fsmState) fsmState {
 	switch fs {
 	case fullSyncState:
-		if s.Paused() {
+		if s.isPaused() {
 			return retryFullSyncState
 		}
 
@@ -200,7 +200,7 @@ func (s *StateSyncer) nextFSMState(fs fsmState) fsmState {
 			return fullSyncState
 
 		case syncChangesNotifEvent:
-			if s.Paused() {
+			if s.isPaused() {
 				return partialSyncState
 			}
 
@@ -323,7 +323,7 @@ func (s *StateSyncer) Pause() {
 }
 
 // Paused returns whether sync runs are temporarily disabled.
-func (s *StateSyncer) Paused() bool {
+func (s *StateSyncer) isPaused() bool {
 	s.pauseLock.Lock()
 	defer s.pauseLock.Unlock()
 	return s.paused != 0

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -13,32 +13,6 @@ import (
 	"github.com/hashicorp/consul/logging"
 )
 
-// scaleThreshold is the number of nodes after which regular sync runs are
-// spread out farther apart. The value should be a power of 2 since the
-// scale function uses log2.
-//
-// When set to 128 nodes the delay between regular runs is doubled when the
-// cluster is larger than 128 nodes. It doubles again when it passes 256
-// nodes, and again at 512 nodes and so forth. At 8192 nodes, the delay
-// factor is 8.
-//
-// If you update this, you may need to adjust the tuning of
-// CoordinateUpdatePeriod and CoordinateUpdateMaxBatchSize.
-const scaleThreshold = 128
-
-// scaleFactor returns a factor by which the next sync run should be delayed to
-// avoid saturation of the cluster. The larger the cluster grows the farther
-// the sync runs should be spread apart.
-//
-// The current implementation uses a log2 scale which doubles the delay between
-// runs every time the cluster doubles in size.
-func scaleFactor(nodes int) int {
-	if nodes <= scaleThreshold {
-		return 1.0
-	}
-	return int(math.Ceil(math.Log2(float64(nodes))-math.Log2(float64(scaleThreshold))) + 1.0)
-}
-
 type SyncState interface {
 	SyncChanges() error
 	SyncFull() error
@@ -64,10 +38,8 @@ type StateSyncer struct {
 	// Logger is the logger.
 	Logger hclog.Logger
 
-	// ClusterSize returns the number of members in the cluster to
-	// allow staggering the sync runs based on cluster size.
-	// This needs to be set before Run() is called.
-	ClusterSize func() int
+	// TODO: accept this value from the constructor instead of setting the field
+	Delayer Delayer
 
 	// SyncFull allows triggering an immediate but staggered full sync
 	// in a non-blocking way.
@@ -89,9 +61,6 @@ type StateSyncer struct {
 	// retryFailInterval is the time after which a failed full sync is retried.
 	retryFailInterval time.Duration
 
-	// stagger randomly picks a duration between 0s and the given duration.
-	stagger func(time.Duration) time.Duration
-
 	// retrySyncFullEvent generates an event based on multiple conditions
 	// when the state machine is trying to retry a full state sync.
 	retrySyncFullEvent func() event
@@ -103,6 +72,12 @@ type StateSyncer struct {
 	// nextFullSyncCh is a chan that receives a time.Time when the next
 	// full sync should occur.
 	nextFullSyncCh <-chan time.Time
+}
+
+// Delayer calculates a duration used to delay the next sync operation after a sync
+// is performed.
+type Delayer interface {
+	Jitter(time.Duration) time.Duration
 }
 
 const (
@@ -134,7 +109,6 @@ func NewStateSyncer(state SyncState, intv time.Duration, shutdownCh chan struct{
 	// we can mock them for testing.
 	s.retrySyncFullEvent = s.retrySyncFullEventFn
 	s.syncChangesEvent = s.syncChangesEventFn
-	s.stagger = s.staggerFn
 
 	return s
 }
@@ -152,9 +126,6 @@ const (
 // Run is the long running method to perform state synchronization
 // between local and remote servers.
 func (s *StateSyncer) Run() {
-	if s.ClusterSize == nil {
-		panic("ClusterSize not set")
-	}
 	s.resetNextFullSyncCh()
 	s.runFSM(fullSyncState, s.nextFSMState)
 }
@@ -245,7 +216,7 @@ func (s *StateSyncer) retrySyncFullEventFn() event {
 	// stagger the delay to avoid a thundering herd.
 	case <-s.SyncFull.Notif():
 		select {
-		case <-time.After(s.stagger(s.serverUpInterval)):
+		case <-time.After(s.Delayer.Jitter(s.serverUpInterval)):
 			return syncFullNotifEvent
 		case <-s.ShutdownCh:
 			return shutdownEvent
@@ -253,7 +224,7 @@ func (s *StateSyncer) retrySyncFullEventFn() event {
 
 	// retry full sync after some time
 	// it is using retryFailInterval because it is retrying the sync
-	case <-time.After(s.retryFailInterval + s.stagger(s.retryFailInterval)):
+	case <-time.After(s.retryFailInterval + s.Delayer.Jitter(s.retryFailInterval)):
 		s.resetNextFullSyncCh()
 		return syncFullTimerEvent
 
@@ -273,7 +244,7 @@ func (s *StateSyncer) syncChangesEventFn() event {
 	// stagger the delay to avoid a thundering herd.
 	case <-s.SyncFull.Notif():
 		select {
-		case <-time.After(s.stagger(s.serverUpInterval)):
+		case <-time.After(s.Delayer.Jitter(s.serverUpInterval)):
 			s.resetNextFullSyncCh()
 			return syncFullNotifEvent
 		case <-s.ShutdownCh:
@@ -297,23 +268,51 @@ func (s *StateSyncer) syncChangesEventFn() event {
 // resetNextFullSyncCh resets nextFullSyncCh and sets it to interval+stagger.
 // Call this function everytime a full sync is performed.
 func (s *StateSyncer) resetNextFullSyncCh() {
-	if s.stagger != nil {
-		s.nextFullSyncCh = time.After(s.Interval + s.stagger(s.Interval))
-	} else {
-		s.nextFullSyncCh = time.After(s.Interval)
-	}
+	s.nextFullSyncCh = time.After(s.Interval + s.Delayer.Jitter(s.Interval))
 }
 
-// stubbed out for testing
+// shim for testing
 var libRandomStagger = lib.RandomStagger
 
-// staggerFn returns a random duration which depends on the cluster size
+func NewClusterSizeDelayer(size func() int) Delayer {
+	return delayer{fn: size}
+}
+
+type delayer struct {
+	fn func() int
+}
+
+// Jitter returns a random duration which depends on the cluster size
 // and a random factor which should provide some timely distribution of
-// cluster wide events. This function should not be called directly
-// but through s.stagger to allow mocking for testing.
-func (s *StateSyncer) staggerFn(d time.Duration) time.Duration {
-	f := scaleFactor(s.ClusterSize())
-	return libRandomStagger(time.Duration(f) * d)
+// cluster wide events.
+func (d delayer) Jitter(delay time.Duration) time.Duration {
+	return libRandomStagger(time.Duration(scaleFactor(d.fn())) * delay)
+}
+
+// scaleThreshold is the number of nodes after which regular sync runs are
+// spread out farther apart. The value should be a power of 2 since the
+// scale function uses log2.
+//
+// When set to 128 nodes the delay between regular runs is doubled when the
+// cluster is larger than 128 nodes. It doubles again when it passes 256
+// nodes, and again at 512 nodes and so forth. At 8192 nodes, the delay
+// factor is 8.
+//
+// If you update this, you may need to adjust the tuning of
+// CoordinateUpdatePeriod and CoordinateUpdateMaxBatchSize.
+const scaleThreshold = 128
+
+// scaleFactor returns a factor by which the next sync run should be delayed to
+// avoid saturation of the cluster. The larger the cluster grows the farther
+// the sync runs should be spread apart.
+//
+// The current implementation uses a log2 scale which doubles the delay between
+// runs every time the cluster doubles in size.
+func scaleFactor(nodes int) int {
+	if nodes <= scaleThreshold {
+		return 1.0
+	}
+	return int(math.Ceil(math.Log2(float64(nodes))-math.Log2(float64(scaleThreshold))) + 1.0)
 }
 
 // Pause temporarily disables sync runs.

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func TestAE_scaleFactor(t *testing.T) {
@@ -37,24 +38,24 @@ func TestAE_scaleFactor(t *testing.T) {
 func TestAE_Pause_nestedPauseResume(t *testing.T) {
 	t.Parallel()
 	l := NewStateSyncer(nil, 0, nil, nil)
-	if l.Paused() != false {
+	if l.isPaused() != false {
 		t.Fatal("syncer should be unPaused after init")
 	}
 	l.Pause()
-	if l.Paused() != true {
+	if l.isPaused() != true {
 		t.Fatal("syncer should be Paused after first call to Pause()")
 	}
 	l.Pause()
-	if l.Paused() != true {
+	if l.isPaused() != true {
 		t.Fatal("syncer should STILL be Paused after second call to Pause()")
 	}
 	gotR := l.Resume()
-	if l.Paused() != true {
+	if l.isPaused() != true {
 		t.Fatal("syncer should STILL be Paused after FIRST call to Resume()")
 	}
 	assert.False(t, gotR)
 	gotR = l.Resume()
-	if l.Paused() != false {
+	if l.isPaused() != false {
 		t.Fatal("syncer should NOT be Paused after SECOND call to Resume()")
 	}
 	assert.True(t, gotR)

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -83,18 +84,22 @@ func TestAE_Pause_ResumeTriggersSyncChanges(t *testing.T) {
 	}
 }
 
-func TestAE_staggerDependsOnClusterSize(t *testing.T) {
+func TestDelayer_Jitter(t *testing.T) {
 	libRandomStagger = func(d time.Duration) time.Duration { return d }
 	defer func() { libRandomStagger = lib.RandomStagger }()
 
-	l := testSyncer(t)
-	if got, want := l.staggerFn(10*time.Millisecond), 10*time.Millisecond; got != want {
-		t.Fatalf("got %v want %v", got, want)
-	}
-	l.ClusterSize = func() int { return 256 }
-	if got, want := l.staggerFn(10*time.Millisecond), 20*time.Millisecond; got != want {
-		t.Fatalf("got %v want %v", got, want)
-	}
+	t.Run("cluster size 1", func(t *testing.T) {
+
+		delayer := NewClusterSizeDelayer(func() int { return 1 })
+		actual := delayer.Jitter(10 * time.Millisecond)
+		require.Equal(t, 10*time.Millisecond, actual)
+	})
+
+	t.Run("cluster size 256", func(t *testing.T) {
+		delayer := NewClusterSizeDelayer(func() int { return 256 })
+		actual := delayer.Jitter(10 * time.Millisecond)
+		require.Equal(t, 20*time.Millisecond, actual)
+	})
 }
 
 func TestAE_Run_SyncFullBeforeChanges(t *testing.T) {
@@ -126,17 +131,6 @@ func TestAE_Run_SyncFullBeforeChanges(t *testing.T) {
 }
 
 func TestAE_Run_Quit(t *testing.T) {
-	t.Run("Run panics without ClusterSize", func(t *testing.T) {
-		defer func() {
-			err := recover()
-			if err == nil {
-				t.Fatal("Run should panic")
-			}
-		}()
-		l := testSyncer(t)
-		l.ClusterSize = nil
-		l.Run()
-	})
 	t.Run("runFSM quits", func(t *testing.T) {
 		// start timer which explodes if runFSM does not quit
 		tm := time.AfterFunc(time.Second, func() { panic("timeout") })
@@ -407,8 +401,13 @@ func testSyncer(t *testing.T) *StateSyncer {
 	})
 
 	l := NewStateSyncer(nil, time.Second, nil, logger)
-	l.stagger = func(d time.Duration) time.Duration { return d }
-	l.ClusterSize = func() int { return 1 }
+	l.Delayer = constDelayer{}
 	l.resetNextFullSyncCh()
 	return l
+}
+
+type constDelayer struct{}
+
+func (constDelayer) Jitter(d time.Duration) time.Duration {
+	return d
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -187,11 +187,6 @@ type Agent struct {
 	// and the remote state.
 	sync *ae.StateSyncer
 
-	// syncMu and syncCh are used to coordinate agent endpoints that are blocking
-	// on local state during a config reload.
-	syncMu sync.Mutex
-	syncCh chan struct{}
-
 	// cache is the in-memory cache for data the Agent requests.
 	cache *cache.Cache
 
@@ -1587,55 +1582,6 @@ func (a *Agent) StartSync() {
 	a.logger.Info("started state syncer")
 }
 
-// PauseSync is used to pause anti-entropy while bulk changes are made. It also
-// sets state that agent-local watches use to "ride out" config reloads and bulk
-// updates which might spuriously unload state and reload it again.
-func (a *Agent) PauseSync() {
-	// Do this outside of lock as it has it's own locking
-	a.sync.Pause()
-
-	// Coordinate local state watchers
-	a.syncMu.Lock()
-	defer a.syncMu.Unlock()
-	if a.syncCh == nil {
-		a.syncCh = make(chan struct{})
-	}
-}
-
-// ResumeSync is used to unpause anti-entropy after bulk changes are make
-func (a *Agent) ResumeSync() {
-	// a.sync maintains a stack/ref count of Pause calls since we call
-	// Pause/Resume in nested way during a reload and AddService. We only want to
-	// trigger local state watchers if this Resume call actually started sync back
-	// up again (i.e. was the last resume on the stack). We could check that
-	// separately with a.sync.Paused but that is racey since another Pause call
-	// might be made between our Resume and checking Paused.
-	resumed := a.sync.Resume()
-
-	if !resumed {
-		// Return early so we don't notify local watchers until we are actually
-		// resumed.
-		return
-	}
-
-	// Coordinate local state watchers
-	a.syncMu.Lock()
-	defer a.syncMu.Unlock()
-
-	if a.syncCh != nil {
-		close(a.syncCh)
-		a.syncCh = nil
-	}
-}
-
-// SyncPausedCh returns either a channel or nil. If nil sync is not paused. If
-// non-nil, the channel will be closed when sync resumes.
-func (a *Agent) SyncPausedCh() <-chan struct{} {
-	a.syncMu.Lock()
-	defer a.syncMu.Unlock()
-	return a.syncCh
-}
-
 // GetLANCoordinate returns the coordinates of this node in the local pools
 // (assumes coordinates are enabled, so check that before calling).
 func (a *Agent) GetLANCoordinate() (lib.CoordinateSet, error) {
@@ -1996,8 +1942,8 @@ func (a *Agent) addServiceInternal(req addServiceInternalRequest) error {
 	service := req.Service
 
 	// Pause the service syncs during modification
-	a.PauseSync()
-	defer a.ResumeSync()
+	a.sync.Pause()
+	defer a.sync.Resume()
 
 	// Set default tagged addresses
 	serviceIP := net.ParseIP(service.Address)
@@ -3604,8 +3550,8 @@ func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 	}
 
 	// Bulk update the services and checks
-	a.PauseSync()
-	defer a.ResumeSync()
+	a.sync.Pause()
+	defer a.sync.Resume()
 
 	a.stateLock.Lock()
 	defer a.stateLock.Unlock()
@@ -3752,9 +3698,9 @@ func (a *Agent) LocalBlockingQuery(alwaysBlock bool, hash string, wait time.Dura
 		// case it's likely that local state just got unloaded and may or may not be
 		// reloaded yet. Wait a short amount of time for Sync to resume to ride out
 		// typical config reloads.
-		if syncPauseCh := a.SyncPausedCh(); syncPauseCh != nil {
+		if resume := a.sync.WaitResume(); resume != nil {
 			select {
-			case <-syncPauseCh:
+			case <-resume:
 			case <-ctx.Done():
 			}
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -509,7 +509,9 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	// the staggering of the state syncing depends on the cluster size.
-	a.sync.ClusterSize = func() int { return len(a.delegate.LANMembers()) }
+	a.sync.Delayer = ae.NewClusterSizeDelayer(func() int {
+		return len(a.delegate.LANMembers())
+	})
 
 	// link the state with the consul server/client and the state syncer
 	// via callbacks. After several attempts this was easier than using


### PR DESCRIPTION
Instead of adding another lock to the Agent, use the existing lock in `ae.StateSyncer` and move the missing functionality into that struct.

This change removes 2 fields and 3 methods from `Agent`, as a small step in shrinking Agent.

Also consolidates two hooks `ClusterSize`, and `stagger` into a single interface.

Best viewed by individual commit.