### PR TITLE
ae: simplify StateSyncer

### DIFF
--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -112,15 +112,9 @@ const (
 // Run is the long running method to perform state synchronization
 // between local and remote servers.
 func (s *StateSyncer) Run() {
-	s.runFSM(fullSyncState, s.nextFSMState)
-}
-
-// runFSM runs the state machine.
-func (s *StateSyncer) runFSM(fs fsmState, next func(fsmState) fsmState) {
-	for {
-		if fs = next(fs); fs == doneState {
-			return
-		}
+	state := fullSyncState
+	for state != doneState {
+		state = s.nextFSMState(state)
 	}
 }
 

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -171,7 +171,7 @@ func (s *StateSyncer) runFSM(fs fsmState, next func(fsmState) fsmState) {
 func (s *StateSyncer) nextFSMState(fs fsmState) fsmState {
 	switch fs {
 	case fullSyncState:
-		if s.Paused() {
+		if s.isPaused() {
 			return retryFullSyncState
 		}
 
@@ -200,7 +200,7 @@ func (s *StateSyncer) nextFSMState(fs fsmState) fsmState {
 			return fullSyncState
 
 		case syncChangesNotifEvent:
-			if s.Paused() {
+			if s.isPaused() {
 				return partialSyncState
 			}
 
@@ -323,7 +323,7 @@ func (s *StateSyncer) Pause() {
 }
 
 // Paused returns whether sync runs are temporarily disabled.
-func (s *StateSyncer) Paused() bool {
+func (s *StateSyncer) isPaused() bool {
 	s.pauseLock.Lock()
 	defer s.pauseLock.Unlock()
 	return s.paused != 0

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -13,32 +13,6 @@ import (
 	"github.com/hashicorp/consul/logging"
 )
 
-// scaleThreshold is the number of nodes after which regular sync runs are
-// spread out farther apart. The value should be a power of 2 since the
-// scale function uses log2.
-//
-// When set to 128 nodes the delay between regular runs is doubled when the
-// cluster is larger than 128 nodes. It doubles again when it passes 256
-// nodes, and again at 512 nodes and so forth. At 8192 nodes, the delay
-// factor is 8.
-//
-// If you update this, you may need to adjust the tuning of
-// CoordinateUpdatePeriod and CoordinateUpdateMaxBatchSize.
-const scaleThreshold = 128
-
-// scaleFactor returns a factor by which the next sync run should be delayed to
-// avoid saturation of the cluster. The larger the cluster grows the farther
-// the sync runs should be spread apart.
-//
-// The current implementation uses a log2 scale which doubles the delay between
-// runs every time the cluster doubles in size.
-func scaleFactor(nodes int) int {
-	if nodes <= scaleThreshold {
-		return 1.0
-	}
-	return int(math.Ceil(math.Log2(float64(nodes))-math.Log2(float64(scaleThreshold))) + 1.0)
-}
-
 type SyncState interface {
 	SyncChanges() error
 	SyncFull() error
@@ -64,10 +38,8 @@ type StateSyncer struct {
 	// Logger is the logger.
 	Logger hclog.Logger
 
-	// ClusterSize returns the number of members in the cluster to
-	// allow staggering the sync runs based on cluster size.
-	// This needs to be set before Run() is called.
-	ClusterSize func() int
+	// TODO: accept this value from the constructor instead of setting the field
+	Delayer Delayer
 
 	// SyncFull allows triggering an immediate but staggered full sync
 	// in a non-blocking way.
@@ -89,9 +61,6 @@ type StateSyncer struct {
 	// retryFailInterval is the time after which a failed full sync is retried.
 	retryFailInterval time.Duration
 
-	// stagger randomly picks a duration between 0s and the given duration.
-	stagger func(time.Duration) time.Duration
-
 	// retrySyncFullEvent generates an event based on multiple conditions
 	// when the state machine is trying to retry a full state sync.
 	retrySyncFullEvent func() event
@@ -103,6 +72,12 @@ type StateSyncer struct {
 	// nextFullSyncCh is a chan that receives a time.Time when the next
 	// full sync should occur.
 	nextFullSyncCh <-chan time.Time
+}
+
+// Delayer calculates a duration used to delay the next sync operation after a sync
+// is performed.
+type Delayer interface {
+	Jitter(time.Duration) time.Duration
 }
 
 const (
@@ -134,7 +109,6 @@ func NewStateSyncer(state SyncState, intv time.Duration, shutdownCh chan struct{
 	// we can mock them for testing.
 	s.retrySyncFullEvent = s.retrySyncFullEventFn
 	s.syncChangesEvent = s.syncChangesEventFn
-	s.stagger = s.staggerFn
 
 	return s
 }
@@ -152,9 +126,6 @@ const (
 // Run is the long running method to perform state synchronization
 // between local and remote servers.
 func (s *StateSyncer) Run() {
-	if s.ClusterSize == nil {
-		panic("ClusterSize not set")
-	}
 	s.resetNextFullSyncCh()
 	s.runFSM(fullSyncState, s.nextFSMState)
 }
@@ -245,7 +216,7 @@ func (s *StateSyncer) retrySyncFullEventFn() event {
 	// stagger the delay to avoid a thundering herd.
 	case <-s.SyncFull.Notif():
 		select {
-		case <-time.After(s.stagger(s.serverUpInterval)):
+		case <-time.After(s.Delayer.Jitter(s.serverUpInterval)):
 			return syncFullNotifEvent
 		case <-s.ShutdownCh:
 			return shutdownEvent
@@ -253,7 +224,7 @@ func (s *StateSyncer) retrySyncFullEventFn() event {
 
 	// retry full sync after some time
 	// it is using retryFailInterval because it is retrying the sync
-	case <-time.After(s.retryFailInterval + s.stagger(s.retryFailInterval)):
+	case <-time.After(s.retryFailInterval + s.Delayer.Jitter(s.retryFailInterval)):
 		s.resetNextFullSyncCh()
 		return syncFullTimerEvent
 
@@ -273,7 +244,7 @@ func (s *StateSyncer) syncChangesEventFn() event {
 	// stagger the delay to avoid a thundering herd.
 	case <-s.SyncFull.Notif():
 		select {
-		case <-time.After(s.stagger(s.serverUpInterval)):
+		case <-time.After(s.Delayer.Jitter(s.serverUpInterval)):
 			s.resetNextFullSyncCh()
 			return syncFullNotifEvent
 		case <-s.ShutdownCh:
@@ -297,23 +268,51 @@ func (s *StateSyncer) syncChangesEventFn() event {
 // resetNextFullSyncCh resets nextFullSyncCh and sets it to interval+stagger.
 // Call this function everytime a full sync is performed.
 func (s *StateSyncer) resetNextFullSyncCh() {
-	if s.stagger != nil {
-		s.nextFullSyncCh = time.After(s.Interval + s.stagger(s.Interval))
-	} else {
-		s.nextFullSyncCh = time.After(s.Interval)
-	}
+	s.nextFullSyncCh = time.After(s.Interval + s.Delayer.Jitter(s.Interval))
 }
 
-// stubbed out for testing
+// shim for testing
 var libRandomStagger = lib.RandomStagger
 
-// staggerFn returns a random duration which depends on the cluster size
+func NewClusterSizeDelayer(size func() int) Delayer {
+	return delayer{fn: size}
+}
+
+type delayer struct {
+	fn func() int
+}
+
+// Jitter returns a random duration which depends on the cluster size
 // and a random factor which should provide some timely distribution of
-// cluster wide events. This function should not be called directly
-// but through s.stagger to allow mocking for testing.
-func (s *StateSyncer) staggerFn(d time.Duration) time.Duration {
-	f := scaleFactor(s.ClusterSize())
-	return libRandomStagger(time.Duration(f) * d)
+// cluster wide events.
+func (d delayer) Jitter(delay time.Duration) time.Duration {
+	return libRandomStagger(time.Duration(scaleFactor(d.fn())) * delay)
+}
+
+// scaleThreshold is the number of nodes after which regular sync runs are
+// spread out farther apart. The value should be a power of 2 since the
+// scale function uses log2.
+//
+// When set to 128 nodes the delay between regular runs is doubled when the
+// cluster is larger than 128 nodes. It doubles again when it passes 256
+// nodes, and again at 512 nodes and so forth. At 8192 nodes, the delay
+// factor is 8.
+//
+// If you update this, you may need to adjust the tuning of
+// CoordinateUpdatePeriod and CoordinateUpdateMaxBatchSize.
+const scaleThreshold = 128
+
+// scaleFactor returns a factor by which the next sync run should be delayed to
+// avoid saturation of the cluster. The larger the cluster grows the farther
+// the sync runs should be spread apart.
+//
+// The current implementation uses a log2 scale which doubles the delay between
+// runs every time the cluster doubles in size.
+func scaleFactor(nodes int) int {
+	if nodes <= scaleThreshold {
+		return 1.0
+	}
+	return int(math.Ceil(math.Log2(float64(nodes))-math.Log2(float64(scaleThreshold))) + 1.0)
 }
 
 // Pause temporarily disables sync runs.

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -214,7 +214,7 @@ func (s *StateSyncer) retrySyncFullEventFn() event {
 	// trigger a full sync immediately.
 	// this is usually called when a consul server was added to the cluster.
 	// stagger the delay to avoid a thundering herd.
-	case <-s.SyncFull.Notif():
+	case <-s.SyncFull.wait():
 		select {
 		case <-time.After(s.Delayer.Jitter(s.serverUpInterval)):
 			return syncFullNotifEvent
@@ -242,7 +242,7 @@ func (s *StateSyncer) syncChangesEventFn() event {
 	// trigger a full sync immediately
 	// this is usually called when a consul server was added to the cluster.
 	// stagger the delay to avoid a thundering herd.
-	case <-s.SyncFull.Notif():
+	case <-s.SyncFull.wait():
 		select {
 		case <-time.After(s.Delayer.Jitter(s.serverUpInterval)):
 			s.resetNextFullSyncCh()
@@ -257,7 +257,7 @@ func (s *StateSyncer) syncChangesEventFn() event {
 		return syncFullTimerEvent
 
 	// do partial syncs on demand
-	case <-s.SyncChanges.Notif():
+	case <-s.SyncChanges.wait():
 		return syncChangesNotifEvent
 
 	case <-s.ShutdownCh:

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -142,10 +142,12 @@ func (s *StateSyncer) nextFSMState(fs fsmState) fsmState {
 		return partialSyncState
 
 	case retryFullSyncState:
+		// FIXME: We enter this state if StateSyncer.isPaused, but Resume does
+		// not SyncFull.Trigger. It only calls SyncChanges.Trigger. This seems
+		// like an oversight. Entering this loop will block until a server is
+		// added (rare), an acl token is changed (rare), or after waiting
+		// for the retryFailInterval.
 		select {
-		// trigger a full sync immediately.
-		// this is usually called when a consul server was added to the cluster.
-		// stagger the delay to avoid a thundering herd.
 		case <-s.SyncFull.wait():
 			select {
 			case <-time.After(s.Delayer.Jitter(s.serverUpInterval)):

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func TestAE_scaleFactor(t *testing.T) {
@@ -37,24 +38,24 @@ func TestAE_scaleFactor(t *testing.T) {
 func TestAE_Pause_nestedPauseResume(t *testing.T) {
 	t.Parallel()
 	l := NewStateSyncer(nil, 0, nil, nil)
-	if l.Paused() != false {
+	if l.isPaused() != false {
 		t.Fatal("syncer should be unPaused after init")
 	}
 	l.Pause()
-	if l.Paused() != true {
+	if l.isPaused() != true {
 		t.Fatal("syncer should be Paused after first call to Pause()")
 	}
 	l.Pause()
-	if l.Paused() != true {
+	if l.isPaused() != true {
 		t.Fatal("syncer should STILL be Paused after second call to Pause()")
 	}
 	gotR := l.Resume()
-	if l.Paused() != true {
+	if l.isPaused() != true {
 		t.Fatal("syncer should STILL be Paused after FIRST call to Resume()")
 	}
 	assert.False(t, gotR)
 	gotR = l.Resume()
-	if l.Paused() != false {
+	if l.isPaused() != false {
 		t.Fatal("syncer should NOT be Paused after SECOND call to Resume()")
 	}
 	assert.True(t, gotR)

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -163,7 +163,7 @@ func TestStateSyncer_Run_PauseSyncFull(t *testing.T) {
 	logger := hclog.New(nil)
 	l := NewStateSyncer(state, time.Millisecond, shutdownCh, logger)
 	l.Delayer = constDelayer{}
-	l.retryFailInterval = time.Nanosecond
+	l.retryFailInterval = time.Millisecond
 
 	l.Pause()
 

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -80,9 +80,9 @@ func TestStateSyncer_Resume_TriggersSyncChanges(t *testing.T) {
 	l.Pause()
 	l.Resume()
 	select {
-	case <-l.SyncChanges.Notif():
+	case <-l.SyncChanges.wait():
 		// expected
-	case <-l.SyncFull.Notif():
+	case <-l.SyncFull.wait():
 		t.Fatal("resume triggered SyncFull instead of SyncChanges")
 	default:
 		t.Fatal("resume did not trigger SyncFull")

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -147,7 +147,7 @@ func TestAE_Run_Quit(t *testing.T) {
 	})
 }
 
-func TestAE_FSM(t *testing.T) {
+func TestStateSyncer_NextFSMState(t *testing.T) {
 	t.Run("fullSyncState", func(t *testing.T) {
 		t.Run("Paused -> retryFullSyncState", func(t *testing.T) {
 			l := testSyncer(t)

--- a/agent/ae/trigger.go
+++ b/agent/ae/trigger.go
@@ -18,6 +18,7 @@ func (t Trigger) Trigger() {
 	}
 }
 
-func (t Trigger) Notif() <-chan struct{} {
+// wait returns a channel that blocks until Trigger is called.
+func (t Trigger) wait() <-chan struct{} {
 	return t.ch
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -487,7 +487,9 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	// the staggering of the state syncing depends on the cluster size.
-	a.sync.ClusterSize = func() int { return len(a.delegate.LANMembers()) }
+	a.sync.Delayer = ae.NewClusterSizeDelayer(func() int {
+		return len(a.delegate.LANMembers())
+	})
 
 	// link the state with the consul server/client and the state syncer
 	// via callbacks. After several attempts this was easier than using


### PR DESCRIPTION
Branched from #9285

This PR makes significant changes to the implementation of `ae.StateSyncer`. The changes were made in many small commits to show the process and make it easier to review. The previous implementation suffered from a number of problems:
* there were multiple testing shims which replaced methods in `StateSyncer`. Testing shims are a great tool, but when they replace parts of the unit under test (instead of external dependencies) that is a signal of problems with the design. It also means that tests can't properly test the full implementation because parts will also be replaced with fakes.
* it used both `fsmState` and `events` to control the flow, when in practice the problem has very few states. All of those types and constants end up being a significant distraction from the control flow. After this refactor there is now only two `select` statements and effectively two states which are implemented by `sync` and `fullSync`.

The new implementation is functionally identical, but is significantly smaller (2 functions which nearly fit on a single screen) and has much less indirection (no more states and events, just function calls).

Since the existing tests relied heavily on fakes which replaced parts of the implementation it was not possible to preserve many of the existing tests.

The diagram below shows the logical flow. The logic closely matches this diagram in the second-to-last commit. After the change to remove recursion it is slightly less obvious, but should still be pretty easy to match to the diagram. The biggest change is around `waitFullSyncDelay`, which I find is a bit strange, because it delays an explicit trigger of `SyncFull` by seconds. But all the existing behaviour should be preserved.

`select` nodes are in yellow, calls to `State.Sync` are in blue. `sleep=x` transitions are actually `time.After()` in a select/case, and will have some jitter applied based on the size of the cluster. The values are used as an approximation. The `running` transition means "not paused".

![mermaid-diagram-20201127161322](https://user-images.githubusercontent.com/442180/100484915-370d1d00-30cc-11eb-9ed7-0926fc0ae94b.png)
