### PR TITLE
Fix typo in explanation of connect command

### DIFF
--- a/website/pages/commands/connect/index.mdx
+++ b/website/pages/commands/connect/index.mdx
@@ -8,7 +8,7 @@ sidebar_title: connect
 
 Command: `consul connect`
 
-The `connect` command is used to interact with Connect
+The `connect` command is used to interact with Consul
 [Connect](/docs/connect/intentions) subsystems. It exposes commands for
 running the built-in mTLS proxy and viewing/updating the Certificate Authority
 (CA) configuration. This command is available in Consul 1.2 and later.


### PR DESCRIPTION
Change `Connect Connect` to `Consul Connect, which is consistent with the command output as shown on this page.