### PR TITLE
agent: reduce AddService

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1890,10 +1890,10 @@ func (a *Agent) readPersistedServiceConfigs() (map[structs.ServiceID]*structs.Se
 	return out, nil
 }
 
-// AddServiceAndReplaceChecks is used to add a service entry and its check. Any check for this service missing from chkTypes will be deleted.
+// AddService is used to add a service entry and its check. Any check for this service missing from chkTypes will be deleted.
 // This entry is persistent and the agent will make a best effort to
 // ensure it is registered
-func (a *Agent) AddServiceAndReplaceChecks(service *structs.NodeService, chkTypes []*structs.CheckType, persist bool, token string, source configSource) error {
+func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.CheckType, persist bool, token string, source configSource) error {
 	a.stateLock.Lock()
 	defer a.stateLock.Unlock()
 	return a.addServiceLocked(&addServiceRequest{
@@ -1910,10 +1910,12 @@ func (a *Agent) AddServiceAndReplaceChecks(service *structs.NodeService, chkType
 	})
 }
 
-// AddService is used to add a service entry.
+// AddServiceFromSource is used to add a service entry.
 // This entry is persistent and the agent will make a best effort to
-// ensure it is registered
-func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.CheckType, persist bool, token string, source configSource) error {
+// ensure it is registered.
+// TODO: move to _test.go
+// Deprecated: use AddService
+func (a *Agent) AddServiceFromSource(service *structs.NodeService, chkTypes []*structs.CheckType, persist bool, token string, source configSource) error {
 	a.stateLock.Lock()
 	defer a.stateLock.Unlock()
 	return a.addServiceLocked(&addServiceRequest{

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1901,14 +1901,12 @@ func (a *Agent) AddService(req AddServiceRequest) error {
 	defer a.stateLock.Unlock()
 
 	req.snap = a.State.Checks(structs.WildcardEnterpriseMeta())
-	return a.addServiceLocked(&req)
+	return a.addServiceLocked(req)
 }
 
 // addServiceLocked adds a service entry to the service manager if enabled, or directly
 // to the local state if it is not. This function assumes the state lock is already held.
-func (a *Agent) addServiceLocked(req *AddServiceRequest) error {
-	req.fixupForAddServiceLocked()
-
+func (a *Agent) addServiceLocked(req AddServiceRequest) error {
 	req.Service.EnterpriseMeta.Normalize()
 
 	if err := a.validateService(req.Service, req.chkTypes); err != nil {
@@ -1919,12 +1917,8 @@ func (a *Agent) addServiceLocked(req *AddServiceRequest) error {
 		return a.serviceManager.AddService(req)
 	}
 
-	// previousDefaults are ignored here because they are only relevant for central config.
-	req.persistService = nil
-	req.persistDefaults = nil
 	req.persistServiceConfig = false
-
-	return a.addServiceInternal(req)
+	return a.addServiceInternal(addServiceInternalRequest{AddServiceRequest: req})
 }
 
 // AddServiceRequest is the union of arguments for calling both
@@ -1942,8 +1936,6 @@ type AddServiceRequest struct {
 	chkTypes              []*structs.CheckType
 	previousDefaults      *structs.ServiceConfigResponse // just for: addServiceLocked
 	waitForCentralConfig  bool                           // just for: addServiceLocked
-	persistService        *structs.NodeService           // just for: addServiceInternal
-	persistDefaults       *structs.ServiceConfigResponse // just for: addServiceInternal
 	persist               bool
 	persistServiceConfig  bool
 	token                 string
@@ -1952,19 +1944,14 @@ type AddServiceRequest struct {
 	snap                  map[structs.CheckID]*structs.HealthCheck
 }
 
-func (r *AddServiceRequest) fixupForAddServiceLocked() {
-	r.persistService = nil
-	r.persistDefaults = nil
-}
-
-func (r *AddServiceRequest) fixupForAddServiceInternal() {
-	r.previousDefaults = nil
-	r.waitForCentralConfig = false
+type addServiceInternalRequest struct {
+	AddServiceRequest
+	persistService  *structs.NodeService
+	persistDefaults *structs.ServiceConfigResponse
 }
 
 // addServiceInternal adds the given service and checks to the local state.
-func (a *Agent) addServiceInternal(req *AddServiceRequest) error {
-	req.fixupForAddServiceInternal()
+func (a *Agent) addServiceInternal(req addServiceInternalRequest) error {
 	var (
 		service               = req.Service
 		chkTypes              = req.chkTypes
@@ -3100,7 +3087,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 		ns.Connect.SidecarService = nil
 
 		sid := ns.CompoundServiceID()
-		err = a.addServiceLocked(&AddServiceRequest{
+		err = a.addServiceLocked(AddServiceRequest{
 			Service:               ns,
 			chkTypes:              chkTypes,
 			previousDefaults:      persistedServiceConfigs[sid],
@@ -3119,7 +3106,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 		// If there is a sidecar service, register that too.
 		if sidecar != nil {
 			sidecarServiceID := sidecar.CompoundServiceID()
-			err = a.addServiceLocked(&AddServiceRequest{
+			err = a.addServiceLocked(AddServiceRequest{
 				Service:               sidecar,
 				chkTypes:              sidecarChecks,
 				previousDefaults:      persistedServiceConfigs[sidecarServiceID],
@@ -3216,7 +3203,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 				"service", serviceID.String(),
 				"file", file,
 			)
-			err = a.addServiceLocked(&AddServiceRequest{
+			err = a.addServiceLocked(AddServiceRequest{
 				Service:               p.Service,
 				chkTypes:              nil,
 				previousDefaults:      persistedServiceConfigs[serviceID],

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -992,25 +992,29 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		replaceExistingChecks = true
 	}
 
-	if replaceExistingChecks {
-		if err := s.agent.AddService(ns, chkTypes, true, token, ConfigSourceRemote); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := s.agent.AddServiceFromSource(ns, chkTypes, true, token, ConfigSourceRemote); err != nil {
-			return nil, err
-		}
+	addReq := addServiceRequest{
+		service:               ns,
+		chkTypes:              chkTypes,
+		persist:               true,
+		token:                 token,
+		source:                ConfigSourceRemote,
+		replaceExistingChecks: replaceExistingChecks,
 	}
-	// Add sidecar.
+	if err := s.agent.AddService(addReq); err != nil {
+		return nil, err
+	}
+
 	if sidecar != nil {
-		if replaceExistingChecks {
-			if err := s.agent.AddService(sidecar, sidecarChecks, true, sidecarToken, ConfigSourceRemote); err != nil {
-				return nil, err
-			}
-		} else {
-			if err := s.agent.AddServiceFromSource(sidecar, sidecarChecks, true, sidecarToken, ConfigSourceRemote); err != nil {
-				return nil, err
-			}
+		addReq := addServiceRequest{
+			service:               sidecar,
+			chkTypes:              sidecarChecks,
+			persist:               true,
+			token:                 sidecarToken,
+			source:                ConfigSourceRemote,
+			replaceExistingChecks: replaceExistingChecks,
+		}
+		if err := s.agent.AddService(addReq); err != nil {
+			return nil, err
 		}
 	}
 	s.syncChanges()

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -992,12 +992,12 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		replaceExistingChecks = true
 	}
 
-	addReq := addServiceRequest{
-		service:               ns,
+	addReq := AddServiceRequest{
+		Service:               ns,
 		chkTypes:              chkTypes,
 		persist:               true,
 		token:                 token,
-		source:                ConfigSourceRemote,
+		Source:                ConfigSourceRemote,
 		replaceExistingChecks: replaceExistingChecks,
 	}
 	if err := s.agent.AddService(addReq); err != nil {
@@ -1005,12 +1005,12 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 	}
 
 	if sidecar != nil {
-		addReq := addServiceRequest{
-			service:               sidecar,
+		addReq := AddServiceRequest{
+			Service:               sidecar,
 			chkTypes:              sidecarChecks,
 			persist:               true,
 			token:                 sidecarToken,
-			source:                ConfigSourceRemote,
+			Source:                ConfigSourceRemote,
 			replaceExistingChecks: replaceExistingChecks,
 		}
 		if err := s.agent.AddService(addReq); err != nil {

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -10,6 +10,12 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/mitchellh/hashstructure"
 
+	"github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/serf/coordinate"
+	"github.com/hashicorp/serf/serf"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/hashicorp/consul/acl"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/debug"
@@ -22,11 +28,6 @@ import (
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/logging/monitor"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-bexpr"
-	"github.com/hashicorp/serf/coordinate"
-	"github.com/hashicorp/serf/serf"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type Self struct {
@@ -992,22 +993,22 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 	}
 
 	if replaceExistingChecks {
-		if err := s.agent.AddServiceAndReplaceChecks(ns, chkTypes, true, token, ConfigSourceRemote); err != nil {
+		if err := s.agent.AddService(ns, chkTypes, true, token, ConfigSourceRemote); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := s.agent.AddService(ns, chkTypes, true, token, ConfigSourceRemote); err != nil {
+		if err := s.agent.AddServiceFromSource(ns, chkTypes, true, token, ConfigSourceRemote); err != nil {
 			return nil, err
 		}
 	}
 	// Add sidecar.
 	if sidecar != nil {
 		if replaceExistingChecks {
-			if err := s.agent.AddServiceAndReplaceChecks(sidecar, sidecarChecks, true, sidecarToken, ConfigSourceRemote); err != nil {
+			if err := s.agent.AddService(sidecar, sidecarChecks, true, sidecarToken, ConfigSourceRemote); err != nil {
 				return nil, err
 			}
 		} else {
-			if err := s.agent.AddService(sidecar, sidecarChecks, true, sidecarToken, ConfigSourceRemote); err != nil {
+			if err := s.agent.AddServiceFromSource(sidecar, sidecarChecks, true, sidecarToken, ConfigSourceRemote); err != nil {
 				return nil, err
 			}
 		}

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -18,6 +18,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/serf/serf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/connect"
@@ -34,11 +40,6 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/serf/serf"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/time/rate"
 )
 
 func makeReadOnlyAgentACL(t *testing.T, srv *HTTPHandlers) string {
@@ -735,21 +736,21 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 		ID:      "mysql",
 		Service: "mysql",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql2",
 		Service: "mysql2",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql3",
 		Service: "mysql3",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -933,42 +934,42 @@ func TestAgent_HealthServiceByName(t *testing.T) {
 		ID:      "mysql1",
 		Service: "mysql-pool-r",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql2",
 		Service: "mysql-pool-r",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql3",
 		Service: "mysql-pool-rw",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql4",
 		Service: "mysql-pool-rw",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "httpd1",
 		Service: "httpd",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "httpd2",
 		Service: "httpd",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1180,13 +1181,13 @@ func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
 		ID:      "mysql1",
 		Service: "mysql",
 	}
-	require.NoError(t, a.AddService(service, nil, false, "", ConfigSourceLocal))
+	require.NoError(t, a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal))
 
 	service = &structs.NodeService{
 		ID:      "foo1",
 		Service: "foo",
 	}
-	require.NoError(t, a.AddService(service, nil, false, "", ConfigSourceLocal))
+	require.NoError(t, a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal))
 
 	// no token
 	t.Run("no-token-health-by-id", func(t *testing.T) {
@@ -4014,10 +4015,10 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 			if tt.preRegister != nil {
-				require.NoError(a.AddService(tt.preRegister, nil, false, "", ConfigSourceLocal))
+				require.NoError(a.AddServiceFromSource(tt.preRegister, nil, false, "", ConfigSourceLocal))
 			}
 			if tt.preRegister2 != nil {
-				require.NoError(a.AddService(tt.preRegister2, nil, false, "", ConfigSourceLocal))
+				require.NoError(a.AddServiceFromSource(tt.preRegister2, nil, false, "", ConfigSourceLocal))
 			}
 
 			// Create an ACL token with require policy
@@ -4319,7 +4320,7 @@ func TestAgent_DeregisterService(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4351,7 +4352,7 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4429,7 +4430,7 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4476,7 +4477,7 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4517,7 +4518,7 @@ func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddService(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -736,21 +736,21 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 		ID:      "mysql",
 		Service: "mysql",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql2",
 		Service: "mysql2",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql3",
 		Service: "mysql3",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -934,42 +934,42 @@ func TestAgent_HealthServiceByName(t *testing.T) {
 		ID:      "mysql1",
 		Service: "mysql-pool-r",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql2",
 		Service: "mysql-pool-r",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql3",
 		Service: "mysql-pool-rw",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "mysql4",
 		Service: "mysql-pool-rw",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "httpd1",
 		Service: "httpd",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	service = &structs.NodeService{
 		ID:      "httpd2",
 		Service: "httpd",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1181,13 +1181,13 @@ func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
 		ID:      "mysql1",
 		Service: "mysql",
 	}
-	require.NoError(t, a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal))
+	require.NoError(t, a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal))
 
 	service = &structs.NodeService{
 		ID:      "foo1",
 		Service: "foo",
 	}
-	require.NoError(t, a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal))
+	require.NoError(t, a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal))
 
 	// no token
 	t.Run("no-token-health-by-id", func(t *testing.T) {
@@ -4015,10 +4015,10 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 			if tt.preRegister != nil {
-				require.NoError(a.AddServiceFromSource(tt.preRegister, nil, false, "", ConfigSourceLocal))
+				require.NoError(a.addServiceFromSource(tt.preRegister, nil, false, "", ConfigSourceLocal))
 			}
 			if tt.preRegister2 != nil {
-				require.NoError(a.AddServiceFromSource(tt.preRegister2, nil, false, "", ConfigSourceLocal))
+				require.NoError(a.addServiceFromSource(tt.preRegister2, nil, false, "", ConfigSourceLocal))
 			}
 
 			// Create an ACL token with require policy
@@ -4320,7 +4320,7 @@ func TestAgent_DeregisterService(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4352,7 +4352,7 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4430,7 +4430,7 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4477,7 +4477,7 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4518,7 +4518,7 @@ func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(service, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -529,7 +529,7 @@ func testAgent_AddService(t *testing.T, extraHCL string) {
 		t.Run(tt.desc, func(t *testing.T) {
 			// check the service registration
 			t.Run(tt.srv.ID, func(t *testing.T) {
-				err := a.AddService(tt.srv, tt.chkTypes, false, "", ConfigSourceLocal)
+				err := a.AddServiceFromSource(tt.srv, tt.chkTypes, false, "", ConfigSourceLocal)
 				if err != nil {
 					t.Fatalf("err: %v", err)
 				}
@@ -638,7 +638,7 @@ func testAgent_AddServices_AliasUpdateCheckNotReverted(t *testing.T, extraHCL st
 		chkTypes, err := service.CheckTypes()
 		require.NoError(t, err)
 
-		require.NoError(t, a.AddService(ns, chkTypes, false, service.Token, ConfigSourceLocal))
+		require.NoError(t, a.AddServiceFromSource(ns, chkTypes, false, service.Token, ConfigSourceLocal))
 	}
 
 	retry.Run(t, func(r *retry.R) {
@@ -665,7 +665,7 @@ func test_createAlias(t *testing.T, agent *TestAgent, chk *structs.CheckType, ex
 	if chk.CheckID == "" {
 		chk.CheckID = types.CheckID(fmt.Sprintf("check-%d", serviceNum))
 	}
-	err := agent.AddService(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
+	err := agent.AddServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
 	assert.NoError(t, err)
 	return func(r *retry.R) {
 		t.Helper()
@@ -712,7 +712,7 @@ func TestAgent_CheckAliasRPC(t *testing.T) {
 		// We ensure to not block and update Agent's index
 		srv.Tags = []string{fmt.Sprintf("tag-%s", time.Now())}
 		assert.NoError(t, a.waitForUp())
-		err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
+		err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
 		assert.NoError(t, err)
 	}
 	shutdownAgent := func() {
@@ -727,7 +727,7 @@ func TestAgent_CheckAliasRPC(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	assert.NoError(t, a.waitForUp())
-	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
+	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
 	assert.NoError(t, err)
 
 	retry.Run(t, func(r *retry.R) {
@@ -832,12 +832,12 @@ func testAgent_AddServiceNoExec(t *testing.T, extraHCL string) {
 		Interval:   15 * time.Second,
 	}
 
-	err := a.AddService(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
+	err := a.AddServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
 	if err == nil || !strings.Contains(err.Error(), "Scripts are disabled on this agent") {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = a.AddService(srv, []*structs.CheckType{chk}, false, "", ConfigSourceRemote)
+	err = a.AddServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceRemote)
 	if err == nil || !strings.Contains(err.Error(), "Scripts are disabled on this agent") {
 		t.Fatalf("err: %v", err)
 	}
@@ -879,7 +879,7 @@ func testAgent_AddServiceNoRemoteExec(t *testing.T, extraHCL string) {
 		Interval:   15 * time.Second,
 	}
 
-	err := a.AddService(srv, []*structs.CheckType{chk}, false, "", ConfigSourceRemote)
+	err := a.AddServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceRemote)
 	if err == nil || !strings.Contains(err.Error(), "Scripts are disabled on this agent") {
 		t.Fatalf("err: %v", err)
 	}
@@ -932,7 +932,7 @@ func TestCacheRateLimit(t *testing.T) {
 					Address: fmt.Sprintf("10.0.1.%d", i%255),
 				}
 
-				err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+				err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 				require.Nil(t, err)
 			}
 
@@ -1007,7 +1007,7 @@ func TestAddServiceIPv4TaggedDefault(t *testing.T) {
 		Address: "10.0.1.2",
 	}
 
-	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
@@ -1040,7 +1040,7 @@ func TestAddServiceIPv6TaggedDefault(t *testing.T) {
 		Address: "::5",
 	}
 
-	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
@@ -1079,7 +1079,7 @@ func TestAddServiceIPv4TaggedSet(t *testing.T) {
 		},
 	}
 
-	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
@@ -1118,7 +1118,7 @@ func TestAddServiceIPv6TaggedSet(t *testing.T) {
 		},
 	}
 
-	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
@@ -1173,7 +1173,7 @@ func testAgent_RemoveService(t *testing.T, extraHCL string) {
 		}
 		chkTypes := []*structs.CheckType{{TTL: time.Minute}}
 
-		if err := a.AddService(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
+		if err := a.AddServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -1208,7 +1208,7 @@ func testAgent_RemoveService(t *testing.T, extraHCL string) {
 			{TTL: time.Minute},
 			{TTL: 30 * time.Second},
 		}
-		if err := a.AddService(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
+		if err := a.AddServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -1222,7 +1222,7 @@ func testAgent_RemoveService(t *testing.T, extraHCL string) {
 			{TTL: time.Minute},
 			{TTL: 30 * time.Second},
 		}
-		if err := a.AddService(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
+		if err := a.AddServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -1294,7 +1294,7 @@ func testAgent_RemoveServiceRemovesAllChecks(t *testing.T, extraHCL string) {
 	}
 
 	// register service with chk1
-	if err := a.AddService(svc, []*structs.CheckType{chk1}, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, []*structs.CheckType{chk1}, false, "", ConfigSourceLocal); err != nil {
 		t.Fatal("Failed to register service", err)
 	}
 
@@ -1302,7 +1302,7 @@ func testAgent_RemoveServiceRemovesAllChecks(t *testing.T, extraHCL string) {
 	requireCheckExists(t, a, "chk1")
 
 	// update the service with chk2
-	if err := a.AddService(svc, []*structs.CheckType{chk2}, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, []*structs.CheckType{chk2}, false, "", ConfigSourceLocal); err != nil {
 		t.Fatal("Failed to update service", err)
 	}
 
@@ -1359,7 +1359,7 @@ func verifyIndexChurn(t *testing.T, tags []string) {
 		Tags:    tags,
 		Weights: weights,
 	}
-	if err := a.AddService(svc, nil, true, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1767,7 +1767,7 @@ func TestAgent_RestoreServiceWithAliasCheck(t *testing.T) {
 
 	registerServicesAndChecks := func(t *testing.T, a *TestAgent) {
 		// add one persistent service with a simple check
-		require.NoError(t, a.AddService(
+		require.NoError(t, a.AddServiceFromSource(
 			&structs.NodeService{
 				ID:      "ping",
 				Service: "ping",
@@ -1786,7 +1786,7 @@ func TestAgent_RestoreServiceWithAliasCheck(t *testing.T) {
 
 		// add one persistent sidecar service with an alias check in the manner
 		// of how sidecar_service would add it
-		require.NoError(t, a.AddService(
+		require.NoError(t, a.AddServiceFromSource(
 			&structs.NodeService{
 				ID:      "ping-sidecar-proxy",
 				Service: "ping-sidecar-proxy",
@@ -2276,7 +2276,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 	file := filepath.Join(a.Config.DataDir, servicesDir, stringHash(svc.ID))
 
 	// Check is not persisted unless requested
-	if err := a.AddService(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if _, err := os.Stat(file); err == nil {
@@ -2284,7 +2284,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 	}
 
 	// Persists to file if requested
-	if err := a.AddService(svc, nil, true, "mytoken", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, true, "mytoken", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if _, err := os.Stat(file); err != nil {
@@ -2308,7 +2308,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 
 	// Updates service definition on disk
 	svc.Port = 8001
-	if err := a.AddService(svc, nil, true, "mytoken", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, true, "mytoken", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	expected, err = json.Marshal(persistedService{
@@ -2431,7 +2431,7 @@ func testAgent_PurgeService(t *testing.T, extraHCL string) {
 	}
 
 	file := filepath.Join(a.Config.DataDir, servicesDir, stringHash(svc.ID))
-	if err := a.AddService(svc, nil, true, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	// Exists
@@ -2448,7 +2448,7 @@ func testAgent_PurgeService(t *testing.T, extraHCL string) {
 	}
 
 	// Re-add the service
-	if err := a.AddService(svc, nil, true, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2494,7 +2494,7 @@ func testAgent_PurgeServiceOnDuplicate(t *testing.T, extraHCL string) {
 	}
 
 	// First persist the service
-	require.NoError(t, a.AddService(svc1, nil, true, "", ConfigSourceLocal))
+	require.NoError(t, a.AddServiceFromSource(svc1, nil, true, "", ConfigSourceLocal))
 	a.Shutdown()
 
 	// Try bringing the agent back up with the service already
@@ -2742,9 +2742,9 @@ func TestAgent_DeregisterPersistedSidecarAfterRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	// First persist the check
-	err = a.AddService(srv, nil, true, "", ConfigSourceLocal)
+	err = a.AddServiceFromSource(srv, nil, true, "", ConfigSourceLocal)
 	require.NoError(t, err)
-	err = a.AddService(connectSrv, nil, true, "", ConfigSourceLocal)
+	err = a.AddServiceFromSource(connectSrv, nil, true, "", ConfigSourceLocal)
 	require.NoError(t, err)
 
 	// check both services were registered
@@ -2814,7 +2814,7 @@ func TestAgent_unloadChecks(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	if err := a.AddService(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3093,7 +3093,7 @@ func testAgent_unloadServices(t *testing.T, extraHCL string) {
 	}
 
 	// Register the service
-	if err := a.AddService(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3125,7 +3125,7 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 	}
 
 	// Register the service
-	if err := a.AddService(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3206,7 +3206,7 @@ func TestAgent_Service_Reap(t *testing.T) {
 	}
 
 	// Register the service.
-	if err := a.AddService(svc, chkTypes, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3263,7 +3263,7 @@ func TestAgent_Service_NoReap(t *testing.T) {
 	}
 
 	// Register the service.
-	if err := a.AddService(svc, chkTypes, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3310,7 +3310,7 @@ func testAgent_AddService_restoresSnapshot(t *testing.T, extraHCL string) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	require.NoError(t, a.AddService(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(t, a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Register a check
 	check1 := &structs.HealthCheck{
@@ -3325,7 +3325,7 @@ func testAgent_AddService_restoresSnapshot(t *testing.T, extraHCL string) {
 
 	// Re-registering the service preserves the state of the check
 	chkTypes := []*structs.CheckType{{TTL: 30 * time.Second}}
-	require.NoError(t, a.AddService(svc, chkTypes, false, "", ConfigSourceLocal))
+	require.NoError(t, a.AddServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal))
 	check := requireCheckExists(t, a, "service:redis")
 	require.Equal(t, api.HealthPassing, check.Status)
 }
@@ -3346,7 +3346,7 @@ func TestAgent_AddCheck_restoresSnapshot(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	if err := a.AddService(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3431,7 +3431,7 @@ func TestAgent_checkStateSnapshot(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	if err := a.AddService(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4250,7 +4250,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 			TLSSkipVerify: true,
 		},
 	}
-	if err := a.AddService(svc, chks, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, chks, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 
@@ -4273,7 +4273,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 			},
 		},
 	}
-	if err := a.AddService(proxy, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 
@@ -4326,7 +4326,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 			},
 		},
 	}
-	if err := a.AddService(proxy, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 
@@ -4369,7 +4369,7 @@ func TestAgent_RerouteNewHTTPChecks(t *testing.T) {
 		Address: "localhost",
 		Port:    8080,
 	}
-	if err := a.AddService(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 
@@ -4391,7 +4391,7 @@ func TestAgent_RerouteNewHTTPChecks(t *testing.T) {
 			},
 		},
 	}
-	if err := a.AddService(proxy, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -529,7 +529,7 @@ func testAgent_AddService(t *testing.T, extraHCL string) {
 		t.Run(tt.desc, func(t *testing.T) {
 			// check the service registration
 			t.Run(tt.srv.ID, func(t *testing.T) {
-				err := a.AddServiceFromSource(tt.srv, tt.chkTypes, false, "", ConfigSourceLocal)
+				err := a.addServiceFromSource(tt.srv, tt.chkTypes, false, "", ConfigSourceLocal)
 				if err != nil {
 					t.Fatalf("err: %v", err)
 				}
@@ -570,6 +570,20 @@ func testAgent_AddService(t *testing.T, extraHCL string) {
 			}
 		})
 	}
+}
+
+// addServiceFromSource is a test helper that exists to maintain an old function
+// signature that was used in many tests.
+// Deprecated: use AddService
+func (a *Agent) addServiceFromSource(service *structs.NodeService, chkTypes []*structs.CheckType, persist bool, token string, source configSource) error {
+	return a.AddService(AddServiceRequest{
+		Service:               service,
+		chkTypes:              chkTypes,
+		persist:               persist,
+		token:                 token,
+		replaceExistingChecks: false,
+		Source:                source,
+	})
 }
 
 func TestAgent_AddServices_AliasUpdateCheckNotReverted(t *testing.T) {
@@ -638,7 +652,7 @@ func testAgent_AddServices_AliasUpdateCheckNotReverted(t *testing.T, extraHCL st
 		chkTypes, err := service.CheckTypes()
 		require.NoError(t, err)
 
-		require.NoError(t, a.AddServiceFromSource(ns, chkTypes, false, service.Token, ConfigSourceLocal))
+		require.NoError(t, a.addServiceFromSource(ns, chkTypes, false, service.Token, ConfigSourceLocal))
 	}
 
 	retry.Run(t, func(r *retry.R) {
@@ -665,7 +679,7 @@ func test_createAlias(t *testing.T, agent *TestAgent, chk *structs.CheckType, ex
 	if chk.CheckID == "" {
 		chk.CheckID = types.CheckID(fmt.Sprintf("check-%d", serviceNum))
 	}
-	err := agent.AddServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
+	err := agent.addServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
 	assert.NoError(t, err)
 	return func(r *retry.R) {
 		t.Helper()
@@ -712,7 +726,7 @@ func TestAgent_CheckAliasRPC(t *testing.T) {
 		// We ensure to not block and update Agent's index
 		srv.Tags = []string{fmt.Sprintf("tag-%s", time.Now())}
 		assert.NoError(t, a.waitForUp())
-		err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
+		err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
 		assert.NoError(t, err)
 	}
 	shutdownAgent := func() {
@@ -727,7 +741,7 @@ func TestAgent_CheckAliasRPC(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	assert.NoError(t, a.waitForUp())
-	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
+	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceLocal)
 	assert.NoError(t, err)
 
 	retry.Run(t, func(r *retry.R) {
@@ -832,12 +846,12 @@ func testAgent_AddServiceNoExec(t *testing.T, extraHCL string) {
 		Interval:   15 * time.Second,
 	}
 
-	err := a.AddServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
+	err := a.addServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceLocal)
 	if err == nil || !strings.Contains(err.Error(), "Scripts are disabled on this agent") {
 		t.Fatalf("err: %v", err)
 	}
 
-	err = a.AddServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceRemote)
+	err = a.addServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceRemote)
 	if err == nil || !strings.Contains(err.Error(), "Scripts are disabled on this agent") {
 		t.Fatalf("err: %v", err)
 	}
@@ -879,7 +893,7 @@ func testAgent_AddServiceNoRemoteExec(t *testing.T, extraHCL string) {
 		Interval:   15 * time.Second,
 	}
 
-	err := a.AddServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceRemote)
+	err := a.addServiceFromSource(srv, []*structs.CheckType{chk}, false, "", ConfigSourceRemote)
 	if err == nil || !strings.Contains(err.Error(), "Scripts are disabled on this agent") {
 		t.Fatalf("err: %v", err)
 	}
@@ -932,7 +946,7 @@ func TestCacheRateLimit(t *testing.T) {
 					Address: fmt.Sprintf("10.0.1.%d", i%255),
 				}
 
-				err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+				err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 				require.Nil(t, err)
 			}
 
@@ -1007,7 +1021,7 @@ func TestAddServiceIPv4TaggedDefault(t *testing.T) {
 		Address: "10.0.1.2",
 	}
 
-	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
@@ -1040,7 +1054,7 @@ func TestAddServiceIPv6TaggedDefault(t *testing.T) {
 		Address: "::5",
 	}
 
-	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
@@ -1079,7 +1093,7 @@ func TestAddServiceIPv4TaggedSet(t *testing.T) {
 		},
 	}
 
-	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
@@ -1118,7 +1132,7 @@ func TestAddServiceIPv6TaggedSet(t *testing.T) {
 		},
 	}
 
-	err := a.AddServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
 	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
@@ -1173,7 +1187,7 @@ func testAgent_RemoveService(t *testing.T, extraHCL string) {
 		}
 		chkTypes := []*structs.CheckType{{TTL: time.Minute}}
 
-		if err := a.AddServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
+		if err := a.addServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -1208,7 +1222,7 @@ func testAgent_RemoveService(t *testing.T, extraHCL string) {
 			{TTL: time.Minute},
 			{TTL: 30 * time.Second},
 		}
-		if err := a.AddServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
+		if err := a.addServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -1222,7 +1236,7 @@ func testAgent_RemoveService(t *testing.T, extraHCL string) {
 			{TTL: time.Minute},
 			{TTL: 30 * time.Second},
 		}
-		if err := a.AddServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
+		if err := a.addServiceFromSource(srv, chkTypes, false, "", ConfigSourceLocal); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -1294,7 +1308,7 @@ func testAgent_RemoveServiceRemovesAllChecks(t *testing.T, extraHCL string) {
 	}
 
 	// register service with chk1
-	if err := a.AddServiceFromSource(svc, []*structs.CheckType{chk1}, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, []*structs.CheckType{chk1}, false, "", ConfigSourceLocal); err != nil {
 		t.Fatal("Failed to register service", err)
 	}
 
@@ -1302,7 +1316,7 @@ func testAgent_RemoveServiceRemovesAllChecks(t *testing.T, extraHCL string) {
 	requireCheckExists(t, a, "chk1")
 
 	// update the service with chk2
-	if err := a.AddServiceFromSource(svc, []*structs.CheckType{chk2}, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, []*structs.CheckType{chk2}, false, "", ConfigSourceLocal); err != nil {
 		t.Fatal("Failed to update service", err)
 	}
 
@@ -1359,7 +1373,7 @@ func verifyIndexChurn(t *testing.T, tags []string) {
 		Tags:    tags,
 		Weights: weights,
 	}
-	if err := a.AddServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1767,7 +1781,7 @@ func TestAgent_RestoreServiceWithAliasCheck(t *testing.T) {
 
 	registerServicesAndChecks := func(t *testing.T, a *TestAgent) {
 		// add one persistent service with a simple check
-		require.NoError(t, a.AddServiceFromSource(
+		require.NoError(t, a.addServiceFromSource(
 			&structs.NodeService{
 				ID:      "ping",
 				Service: "ping",
@@ -1786,7 +1800,7 @@ func TestAgent_RestoreServiceWithAliasCheck(t *testing.T) {
 
 		// add one persistent sidecar service with an alias check in the manner
 		// of how sidecar_service would add it
-		require.NoError(t, a.AddServiceFromSource(
+		require.NoError(t, a.addServiceFromSource(
 			&structs.NodeService{
 				ID:      "ping-sidecar-proxy",
 				Service: "ping-sidecar-proxy",
@@ -2276,7 +2290,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 	file := filepath.Join(a.Config.DataDir, servicesDir, stringHash(svc.ID))
 
 	// Check is not persisted unless requested
-	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if _, err := os.Stat(file); err == nil {
@@ -2284,7 +2298,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 	}
 
 	// Persists to file if requested
-	if err := a.AddServiceFromSource(svc, nil, true, "mytoken", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, true, "mytoken", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if _, err := os.Stat(file); err != nil {
@@ -2308,7 +2322,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 
 	// Updates service definition on disk
 	svc.Port = 8001
-	if err := a.AddServiceFromSource(svc, nil, true, "mytoken", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, true, "mytoken", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	expected, err = json.Marshal(persistedService{
@@ -2431,7 +2445,7 @@ func testAgent_PurgeService(t *testing.T, extraHCL string) {
 	}
 
 	file := filepath.Join(a.Config.DataDir, servicesDir, stringHash(svc.ID))
-	if err := a.AddServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	// Exists
@@ -2448,7 +2462,7 @@ func testAgent_PurgeService(t *testing.T, extraHCL string) {
 	}
 
 	// Re-add the service
-	if err := a.AddServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, true, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2494,7 +2508,7 @@ func testAgent_PurgeServiceOnDuplicate(t *testing.T, extraHCL string) {
 	}
 
 	// First persist the service
-	require.NoError(t, a.AddServiceFromSource(svc1, nil, true, "", ConfigSourceLocal))
+	require.NoError(t, a.addServiceFromSource(svc1, nil, true, "", ConfigSourceLocal))
 	a.Shutdown()
 
 	// Try bringing the agent back up with the service already
@@ -2742,9 +2756,9 @@ func TestAgent_DeregisterPersistedSidecarAfterRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	// First persist the check
-	err = a.AddServiceFromSource(srv, nil, true, "", ConfigSourceLocal)
+	err = a.addServiceFromSource(srv, nil, true, "", ConfigSourceLocal)
 	require.NoError(t, err)
-	err = a.AddServiceFromSource(connectSrv, nil, true, "", ConfigSourceLocal)
+	err = a.addServiceFromSource(connectSrv, nil, true, "", ConfigSourceLocal)
 	require.NoError(t, err)
 
 	// check both services were registered
@@ -2814,7 +2828,7 @@ func TestAgent_unloadChecks(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3093,7 +3107,7 @@ func testAgent_unloadServices(t *testing.T, extraHCL string) {
 	}
 
 	// Register the service
-	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3125,7 +3139,7 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 	}
 
 	// Register the service
-	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3206,7 +3220,7 @@ func TestAgent_Service_Reap(t *testing.T) {
 	}
 
 	// Register the service.
-	if err := a.AddServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3263,7 +3277,7 @@ func TestAgent_Service_NoReap(t *testing.T) {
 	}
 
 	// Register the service.
-	if err := a.AddServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3310,7 +3324,7 @@ func testAgent_AddService_restoresSnapshot(t *testing.T, extraHCL string) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	require.NoError(t, a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(t, a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Register a check
 	check1 := &structs.HealthCheck{
@@ -3325,7 +3339,7 @@ func testAgent_AddService_restoresSnapshot(t *testing.T, extraHCL string) {
 
 	// Re-registering the service preserves the state of the check
 	chkTypes := []*structs.CheckType{{TTL: 30 * time.Second}}
-	require.NoError(t, a.AddServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal))
+	require.NoError(t, a.addServiceFromSource(svc, chkTypes, false, "", ConfigSourceLocal))
 	check := requireCheckExists(t, a, "service:redis")
 	require.Equal(t, api.HealthPassing, check.Status)
 }
@@ -3346,7 +3360,7 @@ func TestAgent_AddCheck_restoresSnapshot(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -3431,7 +3445,7 @@ func TestAgent_checkStateSnapshot(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4250,7 +4264,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 			TLSSkipVerify: true,
 		},
 	}
-	if err := a.AddServiceFromSource(svc, chks, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, chks, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 
@@ -4273,7 +4287,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 			},
 		},
 	}
-	if err := a.AddServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 
@@ -4326,7 +4340,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 			},
 		},
 	}
-	if err := a.AddServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 
@@ -4369,7 +4383,7 @@ func TestAgent_RerouteNewHTTPChecks(t *testing.T) {
 		Address: "localhost",
 		Port:    8080,
 	}
-	if err := a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 
@@ -4391,7 +4405,7 @@ func TestAgent_RerouteNewHTTPChecks(t *testing.T) {
 			},
 		},
 	}
-	if err := a.AddServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(proxy, nil, false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add svc: %v", err)
 	}
 

--- a/agent/service_checks_test.go
+++ b/agent/service_checks_test.go
@@ -63,7 +63,7 @@ func TestAgent_ServiceHTTPChecksNotification(t *testing.T) {
 		},
 	}
 	// Adding TTL type should lead to a timeout, since only HTTP-based checks are watched
-	if err := a.AddServiceFromSource(&service, chkTypes[2:], false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(&service, chkTypes[2:], false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add service: %v", err)
 	}
 
@@ -75,7 +75,7 @@ func TestAgent_ServiceHTTPChecksNotification(t *testing.T) {
 	}
 
 	// Adding service with HTTP checks should lead notification for them
-	if err := a.AddServiceFromSource(&service, chkTypes[0:2], false, "", ConfigSourceLocal); err != nil {
+	if err := a.addServiceFromSource(&service, chkTypes[0:2], false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add service: %v", err)
 	}
 

--- a/agent/service_checks_test.go
+++ b/agent/service_checks_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/checks"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/require"
 )
 
 // Integration test for ServiceHTTPBasedChecks cache-type
@@ -62,7 +63,7 @@ func TestAgent_ServiceHTTPChecksNotification(t *testing.T) {
 		},
 	}
 	// Adding TTL type should lead to a timeout, since only HTTP-based checks are watched
-	if err := a.AddService(&service, chkTypes[2:], false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(&service, chkTypes[2:], false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add service: %v", err)
 	}
 
@@ -74,7 +75,7 @@ func TestAgent_ServiceHTTPChecksNotification(t *testing.T) {
 	}
 
 	// Adding service with HTTP checks should lead notification for them
-	if err := a.AddService(&service, chkTypes[0:2], false, "", ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(&service, chkTypes[0:2], false, "", ConfigSourceLocal); err != nil {
 		t.Fatalf("failed to add service: %v", err)
 	}
 

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -131,31 +131,20 @@ func (s *ServiceManager) AddService(req AddServiceRequest) error {
 		return s.agent.addServiceInternal(addServiceInternalRequest{AddServiceRequest: req})
 	}
 
-	var (
-		service               = req.Service
-		chkTypes              = req.chkTypes
-		previousDefaults      = req.previousDefaults
-		waitForCentralConfig  = req.waitForCentralConfig
-		persist               = req.persist
-		persistServiceConfig  = req.persistServiceConfig
-		token                 = req.token
-		replaceExistingChecks = req.replaceExistingChecks
-		source                = req.Source
-	)
-
+	// TODO: replace serviceRegistration with AddServiceRequest
 	reg := &serviceRegistration{
-		service:               service,
-		chkTypes:              chkTypes,
-		persist:               persist,
-		token:                 token,
-		replaceExistingChecks: replaceExistingChecks,
-		source:                source,
+		service:               req.Service,
+		chkTypes:              req.chkTypes,
+		persist:               req.persist,
+		token:                 req.token,
+		replaceExistingChecks: req.replaceExistingChecks,
+		source:                req.Source,
 	}
 
 	s.servicesLock.Lock()
 	defer s.servicesLock.Unlock()
 
-	sid := service.CompoundServiceID()
+	sid := req.Service.CompoundServiceID()
 
 	// If a service watch already exists, shut it down and replace it.
 	oldWatch, updating := s.services[sid]
@@ -174,9 +163,9 @@ func (s *ServiceManager) AddService(req AddServiceRequest) error {
 
 	err := watch.RegisterAndStart(
 		s.ctx,
-		previousDefaults,
-		waitForCentralConfig,
-		persistServiceConfig,
+		req.previousDefaults,
+		req.waitForCentralConfig,
+		req.persistServiceConfig,
 		&s.running,
 	)
 	if err != nil {
@@ -186,9 +175,9 @@ func (s *ServiceManager) AddService(req AddServiceRequest) error {
 	s.services[sid] = watch
 
 	if updating {
-		s.agent.logger.Debug("updated local registration for service", "service", service.ID)
+		s.agent.logger.Debug("updated local registration for service", "service", req.Service.ID)
 	} else {
-		s.agent.logger.Debug("added local registration for service", "service", service.ID)
+		s.agent.logger.Debug("added local registration for service", "service", req.Service.ID)
 	}
 
 	return nil

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -8,10 +8,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestServiceManager_RegisterService(t *testing.T) {
@@ -47,7 +48,7 @@ func TestServiceManager_RegisterService(t *testing.T) {
 		Port:           8000,
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
-	require.NoError(a.AddService(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify both the service and sidecar.
 	redisService := a.State.Service(structs.NewServiceID("redis", nil))
@@ -118,7 +119,7 @@ func TestServiceManager_RegisterSidecar(t *testing.T) {
 		},
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
-	require.NoError(a.AddService(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify sidecar got global config loaded
 	sidecarService := a.State.Service(structs.NewServiceID("web-sidecar-proxy", nil))
@@ -191,7 +192,7 @@ func TestServiceManager_RegisterMeshGateway(t *testing.T) {
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
 
-	require.NoError(a.AddService(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify gateway got global config loaded
 	gateway := a.State.Service(structs.NewServiceID("mesh-gateway", nil))
@@ -251,7 +252,7 @@ func TestServiceManager_RegisterTerminatingGateway(t *testing.T) {
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
 
-	require.NoError(a.AddService(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify gateway got global config loaded
 	gateway := a.State.Service(structs.NewServiceID("terminating-gateway", nil))
@@ -386,12 +387,12 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 	configFile := filepath.Join(a.Config.DataDir, serviceConfigDir, svcID.StringHash())
 
 	// Service is not persisted unless requested, but we always persist service configs.
-	require.NoError(a.AddService(svc, nil, false, "", ConfigSourceRemote))
+	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceRemote))
 	requireFileIsAbsent(t, svcFile)
 	requireFileIsPresent(t, configFile)
 
 	// Persists to file if requested
-	require.NoError(a.AddService(svc, nil, true, "mytoken", ConfigSourceRemote))
+	require.NoError(a.AddServiceFromSource(svc, nil, true, "mytoken", ConfigSourceRemote))
 	requireFileIsPresent(t, svcFile)
 	requireFileIsPresent(t, configFile)
 
@@ -432,7 +433,7 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 
 	// Updates service definition on disk
 	svc.Proxy.LocalServicePort = 8001
-	require.NoError(a.AddService(svc, nil, true, "mytoken", ConfigSourceRemote))
+	require.NoError(a.AddServiceFromSource(svc, nil, true, "mytoken", ConfigSourceRemote))
 	requireFileIsPresent(t, svcFile)
 	requireFileIsPresent(t, configFile)
 
@@ -720,7 +721,7 @@ func TestServiceManager_Disabled(t *testing.T) {
 		},
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
-	require.NoError(a.AddService(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify sidecar got global config loaded
 	sidecarService := a.State.Service(structs.NewServiceID("web-sidecar-proxy", nil))

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -48,7 +48,7 @@ func TestServiceManager_RegisterService(t *testing.T) {
 		Port:           8000,
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
-	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify both the service and sidecar.
 	redisService := a.State.Service(structs.NewServiceID("redis", nil))
@@ -119,7 +119,7 @@ func TestServiceManager_RegisterSidecar(t *testing.T) {
 		},
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
-	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify sidecar got global config loaded
 	sidecarService := a.State.Service(structs.NewServiceID("web-sidecar-proxy", nil))
@@ -192,7 +192,7 @@ func TestServiceManager_RegisterMeshGateway(t *testing.T) {
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
 
-	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify gateway got global config loaded
 	gateway := a.State.Service(structs.NewServiceID("mesh-gateway", nil))
@@ -252,7 +252,7 @@ func TestServiceManager_RegisterTerminatingGateway(t *testing.T) {
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
 
-	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify gateway got global config loaded
 	gateway := a.State.Service(structs.NewServiceID("terminating-gateway", nil))
@@ -387,12 +387,12 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 	configFile := filepath.Join(a.Config.DataDir, serviceConfigDir, svcID.StringHash())
 
 	// Service is not persisted unless requested, but we always persist service configs.
-	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceRemote))
+	require.NoError(a.addServiceFromSource(svc, nil, false, "", ConfigSourceRemote))
 	requireFileIsAbsent(t, svcFile)
 	requireFileIsPresent(t, configFile)
 
 	// Persists to file if requested
-	require.NoError(a.AddServiceFromSource(svc, nil, true, "mytoken", ConfigSourceRemote))
+	require.NoError(a.addServiceFromSource(svc, nil, true, "mytoken", ConfigSourceRemote))
 	requireFileIsPresent(t, svcFile)
 	requireFileIsPresent(t, configFile)
 
@@ -433,7 +433,7 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 
 	// Updates service definition on disk
 	svc.Proxy.LocalServicePort = 8001
-	require.NoError(a.AddServiceFromSource(svc, nil, true, "mytoken", ConfigSourceRemote))
+	require.NoError(a.addServiceFromSource(svc, nil, true, "mytoken", ConfigSourceRemote))
 	requireFileIsPresent(t, svcFile)
 	requireFileIsPresent(t, configFile)
 
@@ -721,7 +721,7 @@ func TestServiceManager_Disabled(t *testing.T) {
 		},
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	}
-	require.NoError(a.AddServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
+	require.NoError(a.addServiceFromSource(svc, nil, false, "", ConfigSourceLocal))
 
 	// Verify sidecar got global config loaded
 	sidecarService := a.State.Service(structs.NewServiceID("web-sidecar-proxy", nil))

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -29,7 +29,7 @@ func sidecarServiceID(serviceID string) string {
 // The third return argument is the effective Token to use for the sidecar
 // registration. This will be the same as the token parameter passed unless the
 // SidecarService definition contains a distinct one.
-// TODO: return addServiceRequest
+// TODO: return AddServiceRequest
 func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token string) (*structs.NodeService, []*structs.CheckType, string, error) {
 	if ns.Connect.SidecarService == nil {
 		return nil, nil, "", nil

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-func (a *Agent) sidecarServiceID(serviceID string) string {
+func sidecarServiceID(serviceID string) string {
 	return serviceID + "-sidecar-proxy"
 }
 
@@ -29,6 +29,7 @@ func (a *Agent) sidecarServiceID(serviceID string) string {
 // The third return argument is the effective Token to use for the sidecar
 // registration. This will be the same as the token parameter passed unless the
 // SidecarService definition contains a distinct one.
+// TODO: return addServiceRequest
 func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token string) (*structs.NodeService, []*structs.CheckType, string, error) {
 	if ns.Connect.SidecarService == nil {
 		return nil, nil, "", nil
@@ -39,7 +40,7 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 
 	// Override the ID which must always be consistent for a given outer service
 	// ID. We rely on this for lifecycle management of the nested definition.
-	sidecar.ID = a.sidecarServiceID(ns.ID)
+	sidecar.ID = sidecarServiceID(ns.ID)
 
 	// for now at least these must be identical
 	sidecar.EnterpriseMeta = ns.EnterpriseMeta

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
@@ -333,7 +334,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			defer a.Shutdown()
 
 			if tt.preRegister != nil {
-				err := a.AddService(tt.preRegister.NodeService(), nil, false, "", ConfigSourceLocal)
+				err := a.AddServiceFromSource(tt.preRegister.NodeService(), nil, false, "", ConfigSourceLocal)
 				require.NoError(err)
 			}
 

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -334,7 +334,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			defer a.Shutdown()
 
 			if tt.preRegister != nil {
-				err := a.AddServiceFromSource(tt.preRegister.NodeService(), nil, false, "", ConfigSourceLocal)
+				err := a.addServiceFromSource(tt.preRegister.NodeService(), nil, false, "", ConfigSourceLocal)
 				require.NoError(err)
 			}
 

--- a/command/maint/maint_test.go
+++ b/command/maint/maint_test.go
@@ -50,11 +50,14 @@ func TestMaintCommand_NoArgs(t *testing.T) {
 	defer a.Shutdown()
 
 	// Register the service and put it into maintenance mode
-	service := &structs.NodeService{
-		ID:      "test",
-		Service: "test",
+	addReq := agent.AddServiceRequest{
+		Service: &structs.NodeService{
+			ID:      "test",
+			Service: "test",
+		},
+		Source: agent.ConfigSourceLocal,
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
+	if err := a.AddService(addReq); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if err := a.EnableServiceMaintenance(structs.NewServiceID("test", nil), "broken 1", ""); err != nil {
@@ -158,11 +161,14 @@ func TestMaintCommand_EnableServiceMaintenance(t *testing.T) {
 	defer a.Shutdown()
 
 	// Register the service
-	service := &structs.NodeService{
-		ID:      "test",
-		Service: "test",
+	addReq := agent.AddServiceRequest{
+		Service: &structs.NodeService{
+			ID:      "test",
+			Service: "test",
+		},
+		Source: agent.ConfigSourceLocal,
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
+	if err := a.AddService(addReq); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -196,11 +202,14 @@ func TestMaintCommand_DisableServiceMaintenance(t *testing.T) {
 	defer a.Shutdown()
 
 	// Register the service
-	service := &structs.NodeService{
-		ID:      "test",
-		Service: "test",
+	addReq := agent.AddServiceRequest{
+		Service: &structs.NodeService{
+			ID:      "test",
+			Service: "test",
+		},
+		Source: agent.ConfigSourceLocal,
 	}
-	if err := a.AddServiceFromSource(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
+	if err := a.AddService(addReq); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/command/maint/maint_test.go
+++ b/command/maint/maint_test.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
+
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/mitchellh/cli"
 )
 
 func TestMaintCommand_noTabs(t *testing.T) {
@@ -53,7 +54,7 @@ func TestMaintCommand_NoArgs(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddService(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if err := a.EnableServiceMaintenance(structs.NewServiceID("test", nil), "broken 1", ""); err != nil {
@@ -161,7 +162,7 @@ func TestMaintCommand_EnableServiceMaintenance(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddService(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -199,7 +200,7 @@ func TestMaintCommand_DisableServiceMaintenance(t *testing.T) {
 		ID:      "test",
 		Service: "test",
 	}
-	if err := a.AddService(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
+	if err := a.AddServiceFromSource(service, nil, false, "", agent.ConfigSourceLocal); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 


### PR DESCRIPTION
This PR removes one of two nearly identical `Agent.AddService` functions by accepting a struct as parameters. The other function is deprecated and moved into test files, since it is used by many tests. It is now a wrapper around the single `AddService` so we know the live code path is actually being tested.

The `AddService` flow can be seen in the diagram below. This PR removes the `AddServiceAndReplaceChecks` branch in the logic.

![mermaid-diagram-20201130183250](https://user-images.githubusercontent.com/442180/100678132-7b055980-333a-11eb-88d6-c3c245056a0f.png)
