### PR TITLE
agent: reduce AddService 2

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1912,7 +1912,7 @@ func (a *Agent) addServiceLocked(req AddServiceRequest) error {
 		return err
 	}
 
-	if a.config.EnableCentralServiceConfig {
+	if a.config.EnableCentralServiceConfig && (req.Service.IsSidecarProxy() || req.Service.IsGateway()) {
 		return a.serviceManager.AddService(req)
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3312,8 +3312,6 @@ func TestAgent_AddService_restoresSnapshot(t *testing.T) {
 }
 
 func testAgent_AddService_restoresSnapshot(t *testing.T, extraHCL string) {
-	t.Helper()
-
 	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -86,12 +86,7 @@ func (s *ServiceManager) registerOnce(args addServiceInternalRequest) error {
 	s.agent.stateLock.Lock()
 	defer s.agent.stateLock.Unlock()
 
-	if args.snap == nil {
-		args.snap = s.agent.snapshotCheckState()
-	}
-
-	err := s.agent.addServiceInternal(args)
-	if err != nil {
+	if err := s.agent.addServiceInternal(args); err != nil {
 		return fmt.Errorf("error updating service registration: %v", err)
 	}
 	return nil
@@ -200,10 +195,6 @@ func (w *serviceConfigWatch) RegisterAndStart(ctx context.Context, wg *sync.Wait
 	// make a copy of the AddServiceRequest
 	req := w.registration
 	req.Service = merged
-
-	// TODO: move this line? it seems out of place. Maybe this default should
-	// be set in addServiceInternal
-	req.snap = w.agent.snapshotCheckState() // requires Agent.stateLock
 
 	err = w.agent.addServiceInternal(addServiceInternalRequest{
 		addServiceLockedRequest: req,

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -122,15 +122,6 @@ func (s *ServiceManager) registerOnce(args addServiceInternalRequest) error {
 //
 // NOTE: the caller must hold the Agent.stateLock!
 func (s *ServiceManager) AddService(req AddServiceRequest) error {
-	req.Service.EnterpriseMeta.Normalize()
-
-	// For now only proxies have anything that can be configured
-	// centrally. So bypass the whole manager for regular services.
-	if !req.Service.IsSidecarProxy() && !req.Service.IsGateway() {
-		req.persistServiceConfig = false
-		return s.agent.addServiceInternal(addServiceInternalRequest{AddServiceRequest: req})
-	}
-
 	// TODO: replace serviceRegistration with AddServiceRequest
 	reg := &serviceRegistration{
 		service:               req.Service,

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -199,7 +199,7 @@ func (w *serviceConfigWatch) RegisterAndStart(ctx context.Context, wg *sync.Wait
 	err = w.agent.addServiceInternal(addServiceInternalRequest{
 		addServiceLockedRequest: req,
 		persistService:          w.registration.Service,
-		persistDefaults:         serviceDefaults,
+		persistServiceDefaults:  serviceDefaults,
 	})
 	if err != nil {
 		return fmt.Errorf("error updating service registration: %v", err)
@@ -346,7 +346,7 @@ func (w *serviceConfigWatch) handleUpdate(ctx context.Context, event cache.Updat
 		Args: addServiceInternalRequest{
 			addServiceLockedRequest: req,
 			persistService:          w.registration.Service,
-			persistDefaults:         serviceDefaults,
+			persistServiceDefaults:  serviceDefaults,
 		},
 		Reply: make(chan error, 1),
 	}


### PR DESCRIPTION
Branched from #9300 and building on those changes, this PR removes another branch from the `AddService` flow.

Also splits out some fields from the `AddServiceRequest` struct into internal structs to make their use more explicit. Removes an intermediary `serviceRegistration` struct which was populated from `AddServiceRequest`, and then used exclusively to build a new `AddServiceRequest` struct.

A couple of the fields on the new internal `addServiceRequestLocked` struct are replaced with a single field. Also adds some godoc for those fields to explain how they are used.

With the two branches removed, the flow now looks like this:
![mermaid-diagram-20201130183414](https://user-images.githubusercontent.com/442180/100678271-c9b2f380-333a-11eb-9972-e65785cf8093.png)
