### PR TITLE
ui: ServiceInstance.Name should be the Service.Name, never the Service.ID

### DIFF
--- a/ui/packages/consul-ui/app/models/service-instance.js
+++ b/ui/packages/consul-ui/app/models/service-instance.js
@@ -19,7 +19,11 @@ export default class ServiceInstance extends Model {
   @attr('number') SyncTime;
   @attr() meta;
 
-  @or('Service.ID', 'Service.Service') Name;
+  // The name is the Name of the Service (the grouoing of instances)
+  @alias('Service.Service') Name;
+
+  // If the ID is blank fallback to the Service.Service (the Name)
+  @or('Service.ID', 'Service.Service') ID;
   @or('Service.Address', 'Node.Service') Address;
 
   @alias('Service.Tags') Tags;

--- a/ui/packages/consul-ui/app/models/service-instance.js
+++ b/ui/packages/consul-ui/app/models/service-instance.js
@@ -19,7 +19,7 @@ export default class ServiceInstance extends Model {
   @attr('number') SyncTime;
   @attr() meta;
 
-  // The name is the Name of the Service (the grouoing of instances)
+  // The name is the Name of the Service (the grouping of instances)
   @alias('Service.Service') Name;
 
   // If the ID is blank fallback to the Service.Service (the Name)

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show.feature
@@ -112,4 +112,5 @@ Feature: dc / services / show: Show Service
       dc: dc1
       service: service-0
     ---
-    And I see href on the metricsAnchor like "https://example.com?service-0-with-id&dc1"
+    # The Metrics dashboard should use the Service.Name not the ID
+    And I see href on the metricsAnchor like "https://example.com?service-0&dc1"


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8591/files#diff-a1f4a97fe9f6d8df10052fd136117cc45447ad061541730926382df6198932f0R23 we added a convenience property to ServiceInstances called 'Name' that checked `Service.ID` but fellback to `Service.Name`.

This property is confusingly named as the `Name` should never be the `ID`.

This PR changes things to the following:

The `ServiceInstance.ID` should try `Service.ID` and fallback to `Service.Name`, not `ServiceInstance.Name`. `ServiceInstance.Name` is just an alias to `Service.Name` which is always set.

We barely use this property yet (luckily) but we did use it once, which caused the bug outlined in https://github.com/hashicorp/consul/issues/9304, so this change addresses that bug also.

Fixes https://github.com/hashicorp/consul/issues/9304

cc @danielehc (thanks for the find!)

I also noticed that one of our tests had been changed to expect the Service ID for the metrics dashboard link which is incorrect, it should actually be the Service Name. Fixing this bug makes the incorrect test fail, so I put it back to how it was originally, which then passes with this bugfix.