### PR TITLE
connect: Fix issue with updating config in secondary

### DIFF
--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -624,6 +624,27 @@ func TestConnectCAConfig_UpdateSecondary(t *testing.T) {
 		assert.Equal("web", reply.Service)
 		assert.Equal(spiffeId.URI().String(), reply.ServiceURI)
 	}
+
+	// Update a minor field in the config that doesn't trigger an intermediate refresh.
+	{
+		newConfig := &structs.CAConfiguration{
+			Provider: "consul",
+			Config: map[string]interface{}{
+				"PrivateKey":     newKey,
+				"RootCert":       "",
+				"RotationPeriod": 180 * 24 * time.Hour,
+			},
+		}
+		{
+			args := &structs.CARequest{
+				Datacenter: "secondary",
+				Config:     newConfig,
+			}
+			var reply interface{}
+
+			require.NoError(msgpackrpc.CallWithCodec(codec, "ConnectCA.ConfigurationSet", args, &reply))
+		}
+	}
 }
 
 // Test CA signing

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -579,7 +579,7 @@ func (c *CAManager) persistNewRootAndConfig(provider ca.Provider, newActiveRoot 
 	var newRoots structs.CARoots
 	for _, r := range oldRoots {
 		newRoot := *r
-		if newRoot.Active {
+		if newRoot.Active && newActiveRoot != nil {
 			newRoot.Active = false
 			newRoot.RotatedOutAt = time.Now()
 		}


### PR DESCRIPTION
Follow-on PR to #9009 to fix an issue I found when backporting to 1.8 - don't unset the active root in the secondary unless there's a new one replacing it.