### PR TITLE
Log replication warnings when no error suppression is defined

### DIFF
--- a/.changelog/9320.txt
+++ b/.changelog/9320.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+replication: Correctly log all replication warnings that should not be suppressed
+```

--- a/agent/consul/replication.go
+++ b/agent/consul/replication.go
@@ -104,7 +104,7 @@ func (r *Replicator) Run(ctx context.Context) error {
 			// the next round of replication
 			atomic.StoreUint64(&r.lastRemoteIndex, 0)
 
-			if r.suppressErrorLog != nil && !r.suppressErrorLog(err) {
+			if r.suppressErrorLog == nil || !r.suppressErrorLog(err) {
 				r.logger.Warn("replication error (will retry if still leader)", "error", err)
 			}
 


### PR DESCRIPTION
Previously this conditional accidentally skipped over all replicators that did not configure `r. suppressErrorLog`.