### PR TITLE
ui: Lowercase the word 'instance' in Service listings

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/service/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/list/index.hbs
@@ -53,7 +53,7 @@
     <Consul::ExternalSource @item={{item}} />
   {{#if (and (not-eq item.InstanceCount 0) (and (not-eq item.Kind 'terminating-gateway') (not-eq item.Kind 'ingress-gateway'))) }}
     <span>
-      {{format-number item.InstanceCount}} {{pluralize item.InstanceCount 'Instance' without-count=true}}
+      {{format-number item.InstanceCount}} {{pluralize item.InstanceCount 'instance' without-count=true}}
     </span>
   {{/if}}
   {{#if (eq item.Kind 'terminating-gateway')}}


### PR DESCRIPTION
During https://github.com/hashicorp/consul/pull/9321 we noticed that most of our wording in listings was lowercased. This updates the word `Instance` to also be lowercased to be consistent.