### PR TITLE
testing: skip slow tests with -short

### DIFF
--- a/agent/acl_endpoint_legacy_test.go
+++ b/agent/acl_endpoint_legacy_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestACL_Legacy_Disabled_Response(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -70,6 +74,10 @@ func makeTestACL(t *testing.T, srv *HTTPHandlers) string {
 }
 
 func TestACL_Legacy_Update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -100,6 +108,10 @@ func TestACL_Legacy_Update(t *testing.T) {
 }
 
 func TestACL_Legacy_UpdateUpsert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -129,6 +141,10 @@ func TestACL_Legacy_UpdateUpsert(t *testing.T) {
 }
 
 func TestACL_Legacy_Destroy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -161,6 +177,10 @@ func TestACL_Legacy_Destroy(t *testing.T) {
 }
 
 func TestACL_Legacy_Clone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -205,6 +225,10 @@ func TestACL_Legacy_Clone(t *testing.T) {
 }
 
 func TestACL_Legacy_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("wrong id", func(t *testing.T) {
 		a := NewTestAgent(t, TestACLConfig())
@@ -250,6 +274,10 @@ func TestACL_Legacy_Get(t *testing.T) {
 }
 
 func TestACL_Legacy_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -278,6 +306,10 @@ func TestACL_Legacy_List(t *testing.T) {
 }
 
 func TestACLReplicationStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -27,6 +27,10 @@ import (
 //       functionality as that will be done with other tests.
 
 func TestACL_Disabled_Response(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -84,6 +88,10 @@ func jsonBody(v interface{}) io.Reader {
 }
 
 func TestACL_Bootstrap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig()+`
       acl_master_token = ""
@@ -132,6 +140,10 @@ func TestACL_Bootstrap(t *testing.T) {
 }
 
 func TestACL_HTTP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -1124,6 +1136,10 @@ func TestACL_HTTP(t *testing.T) {
 }
 
 func TestACL_LoginProcedure_HTTP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This tests AuthMethods, BindingRules, Login, and Logout.
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
@@ -1625,6 +1641,10 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 }
 
 func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, TestACLConfigWithParams(nil))
@@ -1787,6 +1807,10 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 }
 
 func TestACL_Authorize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, TestACLConfigWithParams(nil))
 	defer a1.Shutdown()

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -274,6 +274,10 @@ func TestAE_FSM(t *testing.T) {
 }
 
 func TestAE_RetrySyncFullEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("trigger shutdownEvent", func(t *testing.T) {
 		l := testSyncer(t)
 		l.ShutdownCh = make(chan struct{})
@@ -318,6 +322,10 @@ func TestAE_RetrySyncFullEvent(t *testing.T) {
 }
 
 func TestAE_SyncChangesEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("trigger shutdownEvent", func(t *testing.T) {
 		l := testSyncer(t)
 		l.ShutdownCh = make(chan struct{})

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -56,6 +56,10 @@ func makeReadOnlyAgentACL(t *testing.T, srv *HTTPHandlers) string {
 }
 
 func TestAgent_Services(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -84,6 +88,10 @@ func TestAgent_Services(t *testing.T) {
 }
 
 func TestAgent_ServicesFiltered(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -128,6 +136,10 @@ func TestAgent_ServicesFiltered(t *testing.T) {
 // This tests that the agent services endpoint (/v1/agent/services) returns
 // Connect proxies.
 func TestAgent_Services_ExternalConnectProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -159,6 +171,10 @@ func TestAgent_Services_ExternalConnectProxy(t *testing.T) {
 
 // Thie tests that a sidecar-registered service is returned as expected.
 func TestAgent_Services_Sidecar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -205,6 +221,10 @@ func TestAgent_Services_Sidecar(t *testing.T) {
 
 // This tests that a mesh gateway service is returned as expected.
 func TestAgent_Services_MeshGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -237,6 +257,10 @@ func TestAgent_Services_MeshGateway(t *testing.T) {
 
 // This tests that a terminating gateway service is returned as expected.
 func TestAgent_Services_TerminatingGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -268,6 +292,10 @@ func TestAgent_Services_TerminatingGateway(t *testing.T) {
 }
 
 func TestAgent_Services_ACLFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -307,6 +335,10 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 }
 
 func TestAgent_Service(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, TestACLConfig()+`
@@ -621,6 +653,10 @@ func TestAgent_Service(t *testing.T) {
 }
 
 func TestAgent_Checks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -649,6 +685,10 @@ func TestAgent_Checks(t *testing.T) {
 }
 
 func TestAgent_ChecksWithFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -680,6 +720,10 @@ func TestAgent_ChecksWithFilter(t *testing.T) {
 }
 
 func TestAgent_HealthServiceByID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -875,6 +919,10 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 }
 
 func TestAgent_HealthServiceByName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1118,6 +1166,10 @@ func TestAgent_HealthServiceByName(t *testing.T) {
 }
 
 func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfigWithParams(nil))
 	defer a.Shutdown()
@@ -1171,6 +1223,10 @@ func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
 }
 
 func TestAgent_Checks_ACLFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -1210,6 +1266,10 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 }
 
 func TestAgent_Self(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := map[string]struct {
@@ -1274,6 +1334,10 @@ func TestAgent_Self(t *testing.T) {
 }
 
 func TestAgent_Self_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -1303,6 +1367,10 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_Metrics_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -1332,6 +1400,10 @@ func TestAgent_Metrics_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_Reload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dc1 := "dc1"
 	a := NewTestAgent(t, `
@@ -1405,6 +1477,10 @@ func TestAgent_Reload(t *testing.T) {
 // TestAgent_ReloadDoesNotTriggerWatch Ensure watches not triggered after reload
 // see https://github.com/hashicorp/consul/issues/7446
 func TestAgent_ReloadDoesNotTriggerWatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dc1 := "dc1"
 	tmpFileRaw, err := ioutil.TempFile("", "rexec")
 	require.NoError(t, err)
@@ -1548,6 +1624,10 @@ func TestAgent_ReloadDoesNotTriggerWatch(t *testing.T) {
 }
 
 func TestAgent_Reload_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -1575,6 +1655,10 @@ func TestAgent_Reload_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_Members(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1596,6 +1680,10 @@ func TestAgent_Members(t *testing.T) {
 }
 
 func TestAgent_Members_WAN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1617,6 +1705,10 @@ func TestAgent_Members_WAN(t *testing.T) {
 }
 
 func TestAgent_Members_ACLFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -1648,6 +1740,10 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 }
 
 func TestAgent_Join(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
@@ -1678,6 +1774,10 @@ func TestAgent_Join(t *testing.T) {
 }
 
 func TestAgent_Join_WAN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
@@ -1708,6 +1808,10 @@ func TestAgent_Join_WAN(t *testing.T) {
 }
 
 func TestAgent_Join_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, TestACLConfig())
 	defer a1.Shutdown()
@@ -1750,6 +1854,10 @@ func (n *mockNotifier) Notify(state string) error {
 }
 
 func TestAgent_JoinLANNotify(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
@@ -1776,6 +1884,10 @@ func TestAgent_JoinLANNotify(t *testing.T) {
 }
 
 func TestAgent_Leave(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
@@ -1812,6 +1924,10 @@ func TestAgent_Leave(t *testing.T) {
 }
 
 func TestAgent_Leave_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -1843,6 +1959,10 @@ func TestAgent_Leave_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_ForceLeave(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
@@ -1901,6 +2021,10 @@ func TestOpenMetricsMimeTypeHeaders(t *testing.T) {
 }
 
 func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -1945,6 +2069,10 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_ForceLeavePrune(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := StartTestAgent(t, TestAgent{Name: "Agent1"})
 	defer a1.Shutdown()
@@ -1993,6 +2121,10 @@ func TestAgent_ForceLeavePrune(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2036,6 +2168,10 @@ func TestAgent_RegisterCheck(t *testing.T) {
 // This verifies all the forms of the new args-style check that we need to
 // support as a result of https://github.com/hashicorp/consul/issues/3587.
 func TestAgent_RegisterCheck_Scripts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		enable_script_checks = true
@@ -2121,6 +2257,10 @@ func TestAgent_RegisterCheck_Scripts(t *testing.T) {
 }
 
 func TestAgent_RegisterCheckScriptsExecDisable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2145,6 +2285,10 @@ func TestAgent_RegisterCheckScriptsExecDisable(t *testing.T) {
 }
 
 func TestAgent_RegisterCheckScriptsExecRemoteDisable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		enable_local_script_checks = true
@@ -2171,6 +2315,10 @@ func TestAgent_RegisterCheckScriptsExecRemoteDisable(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck_Passing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2207,6 +2355,10 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2228,6 +2380,10 @@ func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfigNew())
 	defer a.Shutdown()
@@ -2365,6 +2521,10 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_DeregisterCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2389,6 +2549,10 @@ func TestAgent_DeregisterCheck(t *testing.T) {
 }
 
 func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -2415,6 +2579,10 @@ func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 }
 
 func TestAgent_PassCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2443,6 +2611,10 @@ func TestAgent_PassCheck(t *testing.T) {
 }
 
 func TestAgent_PassCheck_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -2470,6 +2642,10 @@ func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_WarnCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2498,6 +2674,10 @@ func TestAgent_WarnCheck(t *testing.T) {
 }
 
 func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -2525,6 +2705,10 @@ func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_FailCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2553,6 +2737,10 @@ func TestAgent_FailCheck(t *testing.T) {
 }
 
 func TestAgent_FailCheck_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -2580,6 +2768,10 @@ func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_UpdateCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	maxChecksSize := 256
 	a := NewTestAgent(t, fmt.Sprintf("check_output_max_size=%d", maxChecksSize))
@@ -2665,6 +2857,10 @@ func TestAgent_UpdateCheck(t *testing.T) {
 }
 
 func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -2694,6 +2890,10 @@ func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_RegisterService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService(t, "enable_central_service_config = false")
@@ -2780,6 +2980,10 @@ func testAgent_RegisterService(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_RegisterService_ReRegister(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_ReRegister(t, "enable_central_service_config = false")
@@ -2856,6 +3060,10 @@ func testAgent_RegisterService_ReRegister(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_RegisterService_ReRegister_ReplaceExistingChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_ReRegister_ReplaceExistingChecks(t, "enable_central_service_config = false")
@@ -2931,6 +3139,10 @@ func testAgent_RegisterService_ReRegister_ReplaceExistingChecks(t *testing.T, ex
 }
 
 func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_ACLDeny(t, "enable_central_service_config = false")
@@ -3147,6 +3359,10 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_RegisterService_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_ACLDeny(t, "enable_central_service_config = false")
@@ -3197,6 +3413,10 @@ func testAgent_RegisterService_ACLDeny(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_RegisterService_InvalidAddress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_InvalidAddress(t, "enable_central_service_config = false")
@@ -3241,6 +3461,10 @@ func testAgent_RegisterService_InvalidAddress(t *testing.T, extraHCL string) {
 // This verifies that it is put in the local state store properly for syncing
 // later.
 func TestAgent_RegisterService_UnmanagedConnectProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_UnmanagedConnectProxy(t, "enable_central_service_config = false")
@@ -3375,6 +3599,10 @@ func testCreatePolicy(t *testing.T, a *TestAgent, name, rules string) string {
 // TestAgent_sidecarServiceFromNodeService. Note it also tests Deregister
 // explicitly too since setup is identical.
 func TestAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterServiceDeregisterService_Sidecar(t, "enable_central_service_config = false")
@@ -3871,6 +4099,10 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 // registration. This doesn't need to test validation exhaustively since
 // that is done via a table test in the structs package.
 func TestAgent_RegisterService_UnmanagedConnectProxyInvalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_UnmanagedConnectProxyInvalid(t, "enable_central_service_config = false")
@@ -3914,6 +4146,10 @@ func testAgent_RegisterService_UnmanagedConnectProxyInvalid(t *testing.T, extraH
 
 // Tests agent registration of a service that is connect native.
 func TestAgent_RegisterService_ConnectNative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_ConnectNative(t, "enable_central_service_config = false")
@@ -3959,6 +4195,10 @@ func testAgent_RegisterService_ConnectNative(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_RegisterService_ScriptCheck_ExecDisable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_ScriptCheck_ExecDisable(t, "enable_central_service_config = false")
@@ -4005,6 +4245,10 @@ func testAgent_RegisterService_ScriptCheck_ExecDisable(t *testing.T, extraHCL st
 }
 
 func TestAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t, "enable_central_service_config = false")
@@ -4053,6 +4297,10 @@ func testAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T, extra
 }
 
 func TestAgent_DeregisterService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4081,6 +4329,10 @@ func TestAgent_DeregisterService(t *testing.T) {
 }
 
 func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -4110,6 +4362,10 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4150,6 +4406,10 @@ func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
 }
 
 func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4193,6 +4453,10 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 }
 
 func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4230,6 +4494,10 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 }
 
 func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -4260,6 +4528,10 @@ func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4277,6 +4549,10 @@ func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenance_Enable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4310,6 +4586,10 @@ func TestAgent_NodeMaintenance_Enable(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenance_Disable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4335,6 +4615,10 @@ func TestAgent_NodeMaintenance_Disable(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -4356,6 +4640,10 @@ func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck_Service(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4407,6 +4695,10 @@ func TestAgent_RegisterCheck_Service(t *testing.T) {
 }
 
 func TestAgent_Monitor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4599,6 +4891,10 @@ func TestAgent_Monitor(t *testing.T) {
 }
 
 func TestAgent_Monitor_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -4617,6 +4913,10 @@ func TestAgent_Monitor_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_TokenTriggersFullSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	body := func(token string) io.Reader {
@@ -4724,6 +5024,10 @@ func TestAgent_TokenTriggersFullSync(t *testing.T) {
 }
 
 func TestAgent_Token(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// The behavior of this handler when ACLs are disabled is vetted over
@@ -4988,6 +5292,10 @@ func TestAgent_Token(t *testing.T) {
 }
 
 func TestAgentConnectCARoots_empty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -5003,6 +5311,10 @@ func TestAgentConnectCARoots_empty(t *testing.T) {
 }
 
 func TestAgentConnectCARoots_list(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5081,6 +5393,10 @@ func TestAgentConnectCARoots_list(t *testing.T) {
 }
 
 func TestAgentConnectCALeafCert_aclDefaultDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -5117,6 +5433,10 @@ func TestAgentConnectCALeafCert_aclDefaultDeny(t *testing.T) {
 }
 
 func TestAgentConnectCALeafCert_aclServiceWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -5174,6 +5494,10 @@ func TestAgentConnectCALeafCert_aclServiceWrite(t *testing.T) {
 }
 
 func TestAgentConnectCALeafCert_aclServiceReadDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -5228,6 +5552,10 @@ func TestAgentConnectCALeafCert_aclServiceReadDeny(t *testing.T) {
 }
 
 func TestAgentConnectCALeafCert_good(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5323,6 +5651,10 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 // Test we can request a leaf cert for a service we have permission for
 // but is not local to this agent.
 func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5447,6 +5779,10 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 }
 
 func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5673,6 +6009,10 @@ func makeTelemetryDefaults(targetID string) lib.TelemetryConfig {
 }
 
 func TestAgentConnectAuthorize_badBody(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5693,6 +6033,10 @@ func TestAgentConnectAuthorize_badBody(t *testing.T) {
 }
 
 func TestAgentConnectAuthorize_noTarget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5714,6 +6058,10 @@ func TestAgentConnectAuthorize_noTarget(t *testing.T) {
 
 // Client ID is not in the valid URI format
 func TestAgentConnectAuthorize_idInvalidFormat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5738,6 +6086,10 @@ func TestAgentConnectAuthorize_idInvalidFormat(t *testing.T) {
 
 // Client ID is a valid URI but its not a service URI
 func TestAgentConnectAuthorize_idNotService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5762,6 +6114,10 @@ func TestAgentConnectAuthorize_idNotService(t *testing.T) {
 
 // Test when there is an intention allowing the connection
 func TestAgentConnectAuthorize_allow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -5859,6 +6215,10 @@ func TestAgentConnectAuthorize_allow(t *testing.T) {
 
 // Test when there is an intention denying the connection
 func TestAgentConnectAuthorize_deny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5908,6 +6268,10 @@ func TestAgentConnectAuthorize_deny(t *testing.T) {
 // only issue certs that are valid for the specific cluster trust domain at x509
 // level which is enforced by TLS handshake.
 func TestAgentConnectAuthorize_allowTrustDomain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5953,6 +6317,10 @@ func TestAgentConnectAuthorize_allowTrustDomain(t *testing.T) {
 }
 
 func TestAgentConnectAuthorize_denyWildcard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -6034,6 +6402,10 @@ func TestAgentConnectAuthorize_denyWildcard(t *testing.T) {
 
 // Test that authorize fails without service:write for the target service.
 func TestAgentConnectAuthorize_serviceWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -6072,6 +6444,10 @@ func TestAgentConnectAuthorize_serviceWrite(t *testing.T) {
 
 // Test when no intentions match w/ a default deny policy
 func TestAgentConnectAuthorize_defaultDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -6096,6 +6472,10 @@ func TestAgentConnectAuthorize_defaultDeny(t *testing.T) {
 
 // Test when no intentions match w/ a default allow policy
 func TestAgentConnectAuthorize_defaultAllow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -6127,6 +6507,10 @@ func TestAgentConnectAuthorize_defaultAllow(t *testing.T) {
 }
 
 func TestAgent_Host(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 
@@ -6154,6 +6538,10 @@ func TestAgent_Host(t *testing.T) {
 }
 
 func TestAgent_HostBadACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 
@@ -6178,6 +6566,10 @@ func TestAgent_HostBadACL(t *testing.T) {
 
 // Thie tests that a proxy with an ExposeConfig is returned as expected.
 func TestAgent_Services_ExposeConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -97,6 +97,10 @@ func requireCheckMissingMap(t *testing.T, m interface{}, id types.CheckID) {
 }
 
 func TestAgent_MultiStartStop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	for i := 0; i < 10; i++ {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
@@ -108,6 +112,10 @@ func TestAgent_MultiStartStop(t *testing.T) {
 }
 
 func TestAgent_ConnectClusterIDConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	tests := []struct {
 		name          string
 		hcl           string
@@ -159,6 +167,10 @@ func TestAgent_ConnectClusterIDConfig(t *testing.T) {
 }
 
 func TestAgent_StartStop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -178,6 +190,10 @@ func TestAgent_StartStop(t *testing.T) {
 }
 
 func TestAgent_RPCPing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -190,6 +206,10 @@ func TestAgent_RPCPing(t *testing.T) {
 }
 
 func TestAgent_TokenStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, `
@@ -211,6 +231,10 @@ func TestAgent_TokenStore(t *testing.T) {
 }
 
 func TestAgent_ReconnectConfigSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	func() {
 		a := NewTestAgent(t, "")
@@ -247,6 +271,10 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 }
 
 func TestAgent_ReconnectConfigWanDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, `
@@ -260,6 +288,10 @@ func TestAgent_ReconnectConfigWanDisabled(t *testing.T) {
 }
 
 func TestAgent_AddService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_AddService(t, "enable_central_service_config = false")
@@ -456,6 +488,10 @@ func testAgent_AddService(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_AddServices_AliasUpdateCheckNotReverted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_AddServices_AliasUpdateCheckNotReverted(t, "enable_central_service_config = false")
@@ -571,6 +607,10 @@ func test_createAlias(t *testing.T, agent *TestAgent, chk *structs.CheckType, ex
 // in CheckAlias.runQuery() waits for 1 min, so Shutdoww the agent might take time
 // So, we ensure the agent will update regularilly the index
 func TestAgent_CheckAliasRPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Helper()
 
 	a := NewTestAgent(t, `
@@ -674,6 +714,10 @@ func TestAgent_CheckAliasRPC(t *testing.T) {
 }
 
 func TestAgent_AddServiceNoExec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_AddServiceNoExec(t, "enable_central_service_config = false")
@@ -716,6 +760,10 @@ func testAgent_AddServiceNoExec(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_AddServiceNoRemoteExec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_AddServiceNoRemoteExec(t, "enable_central_service_config = false")
@@ -753,8 +801,12 @@ func testAgent_AddServiceNoRemoteExec(t *testing.T, extraHCL string) {
 	}
 }
 
-func TestCacheRateLimit(test *testing.T) {
-	test.Parallel()
+func TestCacheRateLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
 	tests := []struct {
 		// count := number of updates performed (1 every 10ms)
 		count int
@@ -770,7 +822,7 @@ func TestCacheRateLimit(test *testing.T) {
 		{300, 2, 2},
 	}
 	for _, currentTest := range tests {
-		test.Run(fmt.Sprintf("rate_limit_at_%v", currentTest.rateLimit), func(t *testing.T) {
+		t.Run(fmt.Sprintf("rate_limit_at_%v", currentTest.rateLimit), func(t *testing.T) {
 			tt := currentTest
 			t.Parallel()
 			a := NewTestAgent(t, "cache = { entry_fetch_rate = 1, entry_fetch_max_burst = 100 }")
@@ -854,6 +906,10 @@ func TestCacheRateLimit(test *testing.T) {
 }
 
 func TestAddServiceIPv4TaggedDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Helper()
 
 	a := NewTestAgent(t, "")
@@ -883,6 +939,10 @@ func TestAddServiceIPv4TaggedDefault(t *testing.T) {
 }
 
 func TestAddServiceIPv6TaggedDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Helper()
 
 	a := NewTestAgent(t, "")
@@ -912,6 +972,10 @@ func TestAddServiceIPv6TaggedDefault(t *testing.T) {
 }
 
 func TestAddServiceIPv4TaggedSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Helper()
 
 	a := NewTestAgent(t, "")
@@ -947,6 +1011,10 @@ func TestAddServiceIPv4TaggedSet(t *testing.T) {
 }
 
 func TestAddServiceIPv6TaggedSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Helper()
 
 	a := NewTestAgent(t, "")
@@ -982,6 +1050,10 @@ func TestAddServiceIPv6TaggedSet(t *testing.T) {
 }
 
 func TestAgent_RemoveService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RemoveService(t, "enable_central_service_config = false")
@@ -1093,6 +1165,10 @@ func testAgent_RemoveService(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_RemoveServiceRemovesAllChecks(t, "enable_central_service_config = false")
@@ -1164,6 +1240,10 @@ func testAgent_RemoveServiceRemovesAllChecks(t *testing.T, extraHCL string) {
 // we would have unnecessary catalog churn from anti-entropy. See issues
 // #3259, #3642, #3845, and #3866.
 func TestAgent_IndexChurn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	t.Run("no tags", func(t *testing.T) {
@@ -1269,6 +1349,10 @@ func verifyIndexChurn(t *testing.T, tags []string) {
 }
 
 func TestAgent_AddCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		enable_script_checks = true
@@ -1303,6 +1387,10 @@ func TestAgent_AddCheck(t *testing.T) {
 }
 
 func TestAgent_AddCheck_StartPassing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		enable_script_checks = true
@@ -1337,6 +1425,10 @@ func TestAgent_AddCheck_StartPassing(t *testing.T) {
 }
 
 func TestAgent_AddCheck_MinInterval(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		enable_script_checks = true
@@ -1370,6 +1462,10 @@ func TestAgent_AddCheck_MinInterval(t *testing.T) {
 }
 
 func TestAgent_AddCheck_MissingService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		enable_script_checks = true
@@ -1393,6 +1489,10 @@ func TestAgent_AddCheck_MissingService(t *testing.T) {
 }
 
 func TestAgent_AddCheck_RestoreState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1432,6 +1532,10 @@ func TestAgent_AddCheck_RestoreState(t *testing.T) {
 }
 
 func TestAgent_AddCheck_ExecDisable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -1465,6 +1569,10 @@ func TestAgent_AddCheck_ExecDisable(t *testing.T) {
 }
 
 func TestAgent_AddCheck_ExecRemoteDisable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, `
@@ -1493,6 +1601,10 @@ func TestAgent_AddCheck_ExecRemoteDisable(t *testing.T) {
 }
 
 func TestAgent_AddCheck_GRPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1696,6 +1808,10 @@ func launchHTTPCheckServer(t *testing.T, ctx context.Context) (srv *httptest.Ser
 }
 
 func TestAgent_AddCheck_Alias(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1728,6 +1844,10 @@ func TestAgent_AddCheck_Alias(t *testing.T) {
 }
 
 func TestAgent_AddCheck_Alias_setToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1756,6 +1876,10 @@ func TestAgent_AddCheck_Alias_setToken(t *testing.T) {
 }
 
 func TestAgent_AddCheck_Alias_userToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1786,6 +1910,10 @@ acl_token = "hello"
 }
 
 func TestAgent_AddCheck_Alias_userAndSetToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1816,6 +1944,10 @@ acl_token = "hello"
 }
 
 func TestAgent_RemoveCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		enable_script_checks = true
@@ -1860,6 +1992,10 @@ func TestAgent_RemoveCheck(t *testing.T) {
 }
 
 func TestAgent_HTTPCheck_TLSSkipVerify(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1901,6 +2037,10 @@ func TestAgent_HTTPCheck_TLSSkipVerify(t *testing.T) {
 }
 
 func TestAgent_HTTPCheck_EnableAgentTLSForChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	run := func(t *testing.T, ca string) {
@@ -1966,6 +2106,10 @@ func TestAgent_HTTPCheck_EnableAgentTLSForChecks(t *testing.T) {
 }
 
 func TestAgent_updateTTLCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2014,6 +2158,10 @@ func TestAgent_updateTTLCheck(t *testing.T) {
 }
 
 func TestAgent_PersistService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_PersistService(t, "enable_central_service_config = false")
@@ -2113,6 +2261,10 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_persistedService_compat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_persistedService_compat(t, "enable_central_service_config = false")
@@ -2167,6 +2319,10 @@ func testAgent_persistedService_compat(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_PurgeService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_PurgeService(t, "enable_central_service_config = false")
@@ -2222,6 +2378,10 @@ func testAgent_PurgeService(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_PurgeServiceOnDuplicate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_PurgeServiceOnDuplicate(t, "enable_central_service_config = false")
@@ -2275,6 +2435,10 @@ func testAgent_PurgeServiceOnDuplicate(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_PersistCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	cfg := `
 		server = false
@@ -2352,6 +2516,10 @@ func TestAgent_PersistCheck(t *testing.T) {
 }
 
 func TestAgent_PurgeCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2386,6 +2554,10 @@ func TestAgent_PurgeCheck(t *testing.T) {
 }
 
 func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	nodeID := NodeID()
 	a := StartTestAgent(t, TestAgent{
@@ -2450,6 +2622,10 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 }
 
 func TestAgent_DeregisterPersistedSidecarAfterRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	nodeID := NodeID()
 	a := StartTestAgent(t, TestAgent{
@@ -2519,6 +2695,10 @@ func TestAgent_DeregisterPersistedSidecarAfterRestart(t *testing.T) {
 }
 
 func TestAgent_loadChecks_token(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		check = {
@@ -2535,6 +2715,10 @@ func TestAgent_loadChecks_token(t *testing.T) {
 }
 
 func TestAgent_unloadChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2575,6 +2759,10 @@ func TestAgent_unloadChecks(t *testing.T) {
 }
 
 func TestAgent_loadServices_token(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_loadServices_token(t, "enable_central_service_config = false")
@@ -2605,6 +2793,10 @@ func testAgent_loadServices_token(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_loadServices_sidecar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_loadServices_sidecar(t, "enable_central_service_config = false")
@@ -2646,6 +2838,10 @@ func testAgent_loadServices_sidecar(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_loadServices_sidecarSeparateToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_loadServices_sidecarSeparateToken(t, "enable_central_service_config = false")
@@ -2685,6 +2881,10 @@ func testAgent_loadServices_sidecarSeparateToken(t *testing.T, extraHCL string) 
 }
 
 func TestAgent_loadServices_sidecarInheritMeta(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_loadServices_sidecarInheritMeta(t, "enable_central_service_config = false")
@@ -2729,6 +2929,10 @@ func testAgent_loadServices_sidecarInheritMeta(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_loadServices_sidecarOverrideMeta(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_loadServices_sidecarOverrideMeta(t, "enable_central_service_config = false")
@@ -2777,6 +2981,10 @@ func testAgent_loadServices_sidecarOverrideMeta(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_unloadServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_unloadServices(t, "enable_central_service_config = false")
@@ -2817,6 +3025,10 @@ func testAgent_unloadServices(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_Service_MaintenanceMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2883,6 +3095,10 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 }
 
 func TestAgent_Service_Reap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// t.Parallel() // timing test. no parallel
 	a := StartTestAgent(t, TestAgent{Overrides: `
 		check_reap_interval = "50ms"
@@ -2938,6 +3154,10 @@ func TestAgent_Service_Reap(t *testing.T) {
 }
 
 func TestAgent_Service_NoReap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// t.Parallel() // timing test. no parallel
 	a := StartTestAgent(t, TestAgent{Overrides: `
 		check_reap_interval = "50ms"
@@ -2979,6 +3199,10 @@ func TestAgent_Service_NoReap(t *testing.T) {
 }
 
 func TestAgent_AddService_restoresSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_AddService_restoresSnapshot(t, "enable_central_service_config = false")
@@ -3023,6 +3247,10 @@ func testAgent_AddService_restoresSnapshot(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_AddCheck_restoresSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3063,6 +3291,10 @@ func TestAgent_AddCheck_restoresSnapshot(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenanceMode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3100,6 +3332,10 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 }
 
 func TestAgent_checkStateSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3151,6 +3387,10 @@ func TestAgent_checkStateSnapshot(t *testing.T) {
 }
 
 func TestAgent_loadChecks_checkFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3186,6 +3426,10 @@ func TestAgent_loadChecks_checkFails(t *testing.T) {
 }
 
 func TestAgent_persistCheckState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3234,6 +3478,10 @@ func TestAgent_persistCheckState(t *testing.T) {
 }
 
 func TestAgent_loadCheckState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3295,6 +3543,10 @@ func TestAgent_loadCheckState(t *testing.T) {
 }
 
 func TestAgent_purgeCheckState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3328,6 +3580,10 @@ func TestAgent_purgeCheckState(t *testing.T) {
 }
 
 func TestAgent_GetCoordinate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, ``)
 	defer a.Shutdown()
 
@@ -3344,6 +3600,10 @@ func TestAgent_GetCoordinate(t *testing.T) {
 }
 
 func TestAgent_reloadWatches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3402,6 +3662,10 @@ func TestAgent_reloadWatches(t *testing.T) {
 }
 
 func TestAgent_reloadWatchesHTTPS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := TestAgent{UseTLS: true}
 	if err := a.Start(t); err != nil {
@@ -3424,6 +3688,10 @@ func TestAgent_reloadWatchesHTTPS(t *testing.T) {
 }
 
 func TestAgent_SecurityChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	hcl := `
 		enable_script_checks = true
@@ -3439,6 +3707,10 @@ func TestAgent_SecurityChecks(t *testing.T) {
 }
 
 func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	hcl := `
@@ -3473,6 +3745,10 @@ func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 }
 
 func TestAgent_ReloadConfigAndKeepChecksStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
 		testAgent_ReloadConfigAndKeepChecksStatus(t, "enable_central_service_config = false")
@@ -3513,6 +3789,10 @@ func testAgent_ReloadConfigAndKeepChecksStatus(t *testing.T, extraHCL string) {
 }
 
 func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	hcl := `
@@ -3552,6 +3832,10 @@ func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 }
 
 func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	hcl := `
@@ -3580,6 +3864,10 @@ func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 }
 
 func TestAgent_consulConfig_AutoEncryptAllowTLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	hcl := `
@@ -3596,6 +3884,10 @@ func TestAgent_consulConfig_AutoEncryptAllowTLS(t *testing.T) {
 }
 
 func TestAgent_consulConfig_RaftTrailingLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	hcl := `
 		raft_trailing_logs = 812345
@@ -3842,6 +4134,10 @@ func TestConfigSourceFromName(t *testing.T) {
 }
 
 func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -3971,6 +4267,10 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 }
 
 func TestAgent_RerouteNewHTTPChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -4080,6 +4380,10 @@ func TestAgent_RerouteNewHTTPChecks(t *testing.T) {
 }
 
 func TestAgentCache_serviceInConfigFile_initialFetchErrors_Issue6521(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// Ensure that initial failures to fetch the discovery chain via the agent
@@ -4177,6 +4481,10 @@ LOOP:
 
 // This is a mirror of a similar test in agent/consul/server_test.go
 func TestAgent_JoinWAN_viaMeshGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	gwPort := freeport.MustTake(1)
@@ -4446,6 +4754,10 @@ func TestAgent_JoinWAN_viaMeshGateway(t *testing.T) {
 }
 
 func TestAutoConfig_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// eventually this test should really live with integration tests
 	// the goal here is to have one test server and another test client
 	// spin up both agents and allow the server to authorize the auto config
@@ -4609,6 +4921,10 @@ func TestAutoConfig_Integration(t *testing.T) {
 }
 
 func TestAgent_AutoEncrypt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// eventually this test should really live with integration tests
 	// the goal here is to have one test server and another test client
 	// spin up both agents and allow the server to authorize the auto encrypt
@@ -4684,6 +5000,10 @@ func TestAgent_AutoEncrypt(t *testing.T) {
 }
 
 func TestSharedRPCRouter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// this test runs both a server and client and ensures that the shared
 	// router is being used. It would be possible for the Client and Server
 	// types to create and use their own routers and for RPCs such as the
@@ -4714,6 +5034,10 @@ func TestSharedRPCRouter(t *testing.T) {
 }
 
 func TestAgent_ListenHTTP_MultipleAddresses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ports, err := freeport.Take(2)
 	require.NoError(t, err)
 	t.Cleanup(func() { freeport.Return(ports) })

--- a/agent/auto-config/auto_config_test.go
+++ b/agent/auto-config/auto_config_test.go
@@ -229,6 +229,10 @@ func TestInitialConfiguration_disabled(t *testing.T) {
 }
 
 func TestInitialConfiguration_cancelled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	mcfg := newMockedConfig(t)
 
 	loader := setupRuntimeConfig(t)

--- a/agent/cache-types/catalog_list_services_test.go
+++ b/agent/cache-types/catalog_list_services_test.go
@@ -63,6 +63,10 @@ func TestCatalogListServices_badReqType(t *testing.T) {
 }
 
 func TestCatalogListServices_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	rpc := &MockRPC{}
 	typ := &CatalogListServices{RPC: rpc}
 

--- a/agent/cache-types/connect_ca_leaf_test.go
+++ b/agent/cache-types/connect_ca_leaf_test.go
@@ -147,6 +147,10 @@ func TestCalculateSoftExpire(t *testing.T) {
 // Test that after an initial signing, new CA roots (new ID) will
 // trigger a blocking query to execute.
 func TestConnectCALeaf_changingRoots(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	if testingRace {
 		t.Skip("fails with -race because caRoot.Active is modified concurrently")
 	}
@@ -515,6 +519,10 @@ func TestConnectCALeaf_changingRootsBetweenBlockingCalls(t *testing.T) {
 }
 
 func TestConnectCALeaf_CSRRateLimiting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -696,6 +704,10 @@ func TestConnectCALeaf_CSRRateLimiting(t *testing.T) {
 // This test runs multiple concurrent callers watching different leaf certs and
 // tries to ensure that the background root watch activity behaves correctly.
 func TestConnectCALeaf_watchRootsDedupingMultipleCallers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	if testingRace {
 		t.Skip("fails with -race because caRoot.Active is modified concurrently")
 	}
@@ -891,6 +903,10 @@ func mustFetchResult(t *testing.T, result interface{}) cache.FetchResult {
 // Test that after an initial signing, an expiringLeaf will trigger a
 // blocking query to resign.
 func TestConnectCALeaf_expiringLeaf(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -21,6 +21,10 @@ import (
 )
 
 func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	namespace := pbcommon.DefaultEnterpriseMeta.Namespace
 	client := NewTestStreamingClient(namespace)
 	typ := StreamingHealthServices{deps: MaterializerDeps{
@@ -279,6 +283,10 @@ func TestOrderingConsistentWithMemDb(t *testing.T) {
 }
 
 func TestStreamingHealthServices_FullSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	namespace := getNamespace("ns2")
 	client := NewTestStreamingClient(namespace)
 	typ := StreamingHealthServices{deps: MaterializerDeps{

--- a/agent/cache/cache_test.go
+++ b/agent/cache/cache_test.go
@@ -89,6 +89,10 @@ func TestCacheGet_initError(t *testing.T) {
 // Test a cached error is replaced by a successful result. See
 // https://github.com/hashicorp/consul/issues/4480
 func TestCacheGet_cachedErrorsDontStick(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -324,6 +328,10 @@ func TestCacheGet_cancellation(t *testing.T) {
 // Test a get with an index set will timeout if the fetch doesn't return
 // anything.
 func TestCacheGet_blockingIndexTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := TestType(t)
@@ -360,6 +368,10 @@ func TestCacheGet_blockingIndexTimeout(t *testing.T) {
 // Test a get with an index set with requests returning an error
 // will return that error.
 func TestCacheGet_blockingIndexError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := TestType(t)
@@ -395,6 +407,10 @@ func TestCacheGet_blockingIndexError(t *testing.T) {
 // Test that if a Type returns an empty value on Fetch that the previous
 // value is preserved.
 func TestCacheGet_emptyFetchResult(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -463,6 +479,10 @@ func TestCacheGet_emptyFetchResult(t *testing.T) {
 // Test that a type registered with a periodic refresh will perform
 // that refresh after the timer is up.
 func TestCacheGet_periodicRefresh(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := &MockType{}
@@ -503,6 +523,10 @@ func TestCacheGet_periodicRefresh(t *testing.T) {
 // Test that a type registered with a periodic refresh will perform
 // that refresh after the timer is up.
 func TestCacheGet_periodicRefreshMultiple(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := &MockType{}
@@ -552,6 +576,10 @@ func TestCacheGet_periodicRefreshMultiple(t *testing.T) {
 
 // Test that a refresh performs a backoff.
 func TestCacheGet_periodicRefreshErrorBackoff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := &MockType{}
@@ -594,6 +622,10 @@ func TestCacheGet_periodicRefreshErrorBackoff(t *testing.T) {
 
 // Test that a badly behaved RPC that returns 0 index will perform a backoff.
 func TestCacheGet_periodicRefreshBadRPCZeroIndexErrorBackoff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := &MockType{}
@@ -638,6 +670,10 @@ func TestCacheGet_periodicRefreshBadRPCZeroIndexErrorBackoff(t *testing.T) {
 // immediately on the initial request if there is no data written to that table
 // yet.
 func TestCacheGet_noIndexSetsOne(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := &MockType{}
@@ -734,6 +770,10 @@ func TestCacheGet_fetchTimeout(t *testing.T) {
 
 // Test that entries expire
 func TestCacheGet_expire(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -790,6 +830,10 @@ func TestCacheGet_expire(t *testing.T) {
 
 // Test that entries reset their TTL on Get
 func TestCacheGet_expireResetGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -845,6 +889,10 @@ func TestCacheGet_expireResetGet(t *testing.T) {
 
 // Test that entries with state that satisfies io.Closer get cleaned up
 func TestCacheGet_expireClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1002,6 +1050,10 @@ func (t *testPartitionType) RegisterOptions() RegisterOptions {
 // states.
 func TestCacheGet_refreshAge(t *testing.T) {
 	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	if testing.Short() {
 		t.Skip("too slow for -short run")
 	}
 	t.Parallel()
@@ -1122,6 +1174,10 @@ func TestCacheGet_refreshAge(t *testing.T) {
 }
 
 func TestCacheGet_nonRefreshAge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1352,6 +1408,10 @@ func TestCacheReload(t *testing.T) {
 // are arriving at similar times, which wouldn't be the case if they use a
 // shared limiter.
 func TestCacheThrottle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ1 := TestType(t)

--- a/agent/cache/watch_test.go
+++ b/agent/cache/watch_test.go
@@ -161,6 +161,10 @@ func TestCacheNotify(t *testing.T) {
 }
 
 func TestCacheNotifyPolling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := TestTypeNonBlocking(t)
@@ -274,6 +278,10 @@ func TestCacheNotifyPolling(t *testing.T) {
 
 // Test that a refresh performs a backoff.
 func TestCacheWatch_ErrorBackoff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := TestType(t)
@@ -336,6 +344,10 @@ OUT:
 
 // Test that a refresh performs a backoff.
 func TestCacheWatch_ErrorBackoffNonBlocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	typ := TestTypeNonBlocking(t)

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -43,6 +47,10 @@ func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {
 }
 
 func TestCatalogDeregister(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -62,6 +70,10 @@ func TestCatalogDeregister(t *testing.T) {
 }
 
 func TestCatalogDatacenters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -81,6 +93,10 @@ func TestCatalogDatacenters(t *testing.T) {
 }
 
 func TestCatalogNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -115,6 +131,10 @@ func TestCatalogNodes(t *testing.T) {
 }
 
 func TestCatalogNodes_MetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -156,6 +176,10 @@ func TestCatalogNodes_MetaFilter(t *testing.T) {
 }
 
 func TestCatalogNodes_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -192,6 +216,10 @@ func TestCatalogNodes_Filter(t *testing.T) {
 }
 
 func TestCatalogNodes_WanTranslation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
@@ -290,6 +318,10 @@ func TestCatalogNodes_WanTranslation(t *testing.T) {
 }
 
 func TestCatalogNodes_Blocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -364,6 +396,10 @@ RUN_BLOCKING_QUERY:
 }
 
 func TestCatalogNodes_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -449,6 +485,10 @@ func TestCatalogNodes_DistanceSort(t *testing.T) {
 }
 
 func TestCatalogServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -485,6 +525,10 @@ func TestCatalogServices(t *testing.T) {
 }
 
 func TestCatalogServices_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -526,6 +570,10 @@ func TestCatalogServices_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalogRegister_checkRegistration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -579,6 +627,10 @@ func TestCatalogRegister_checkRegistration(t *testing.T) {
 }
 
 func TestCatalogServiceNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -692,6 +744,10 @@ func TestCatalogServiceNodes(t *testing.T) {
 }
 
 func TestCatalogServiceNodes_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -747,6 +803,10 @@ func TestCatalogServiceNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalogServiceNodes_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -810,6 +870,10 @@ func TestCatalogServiceNodes_Filter(t *testing.T) {
 }
 
 func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
@@ -892,6 +956,10 @@ func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 }
 
 func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -983,6 +1051,10 @@ func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
 // Test that connect proxies can be queried via /v1/catalog/service/:service
 // directly and that their results contain the proxy fields.
 func TestCatalogServiceNodes_ConnectProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -1011,6 +1083,10 @@ func TestCatalogServiceNodes_ConnectProxy(t *testing.T) {
 // Test that the Connect-compatible endpoints can be queried for a
 // service via /v1/catalog/connect/:service.
 func TestCatalogConnectServiceNodes_good(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -1039,6 +1115,10 @@ func TestCatalogConnectServiceNodes_good(t *testing.T) {
 }
 
 func TestCatalogConnectServiceNodes_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -1077,6 +1157,10 @@ func TestCatalogConnectServiceNodes_Filter(t *testing.T) {
 }
 
 func TestCatalogNodeServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1120,6 +1204,10 @@ func TestCatalogNodeServices(t *testing.T) {
 }
 
 func TestCatalogNodeServiceList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1170,6 +1258,10 @@ func TestCatalogNodeServiceList(t *testing.T) {
 }
 
 func TestCatalogNodeServices_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1209,6 +1301,10 @@ func TestCatalogNodeServices_Filter(t *testing.T) {
 // Test that the services on a node contain all the Connect proxies on
 // the node as well with their fields properly populated.
 func TestCatalogNodeServices_ConnectProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -1235,6 +1331,10 @@ func TestCatalogNodeServices_ConnectProxy(t *testing.T) {
 }
 
 func TestCatalogNodeServices_WanTranslation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
@@ -1323,6 +1423,10 @@ func TestCatalogNodeServices_WanTranslation(t *testing.T) {
 }
 
 func TestCatalog_GatewayServices_Terminating(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1412,6 +1516,10 @@ func TestCatalog_GatewayServices_Terminating(t *testing.T) {
 }
 
 func TestCatalog_GatewayServices_Ingress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()

--- a/agent/checks/alias_test.go
+++ b/agent/checks/alias_test.go
@@ -17,6 +17,10 @@ import (
 
 // Test that we do a backoff on error.
 func TestCheckAlias_remoteErrBackoff(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	notify := newMockAliasNotify()
@@ -49,6 +53,10 @@ func TestCheckAlias_remoteErrBackoff(t *testing.T) {
 
 // No remote health checks should result in passing on the check.
 func TestCheckAlias_remoteNoChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	notify := newMockAliasNotify()
@@ -75,6 +83,10 @@ func TestCheckAlias_remoteNoChecks(t *testing.T) {
 
 // If the node is critical then the check is critical
 func TestCheckAlias_remoteNodeFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	notify := newMockAliasNotify()

--- a/agent/checks/check_test.go
+++ b/agent/checks/check_test.go
@@ -31,6 +31,10 @@ func uniqueID() string {
 }
 
 func TestCheckMonitor_Script(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	tests := []struct {
 		script, status string
 	}{
@@ -71,6 +75,10 @@ func TestCheckMonitor_Script(t *testing.T) {
 }
 
 func TestCheckMonitor_Args(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	tests := []struct {
 		args   []string
 		status string
@@ -112,6 +120,10 @@ func TestCheckMonitor_Args(t *testing.T) {
 }
 
 func TestCheckMonitor_Timeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
 	logger := testutil.Logger(t)
@@ -143,6 +155,10 @@ func TestCheckMonitor_Timeout(t *testing.T) {
 }
 
 func TestCheckMonitor_RandomStagger(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
 	logger := testutil.Logger(t)
@@ -202,6 +218,10 @@ func TestCheckMonitor_LimitOutput(t *testing.T) {
 }
 
 func TestCheckTTL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
 	logger := testutil.Logger(t)
@@ -250,6 +270,10 @@ func TestCheckTTL(t *testing.T) {
 }
 
 func TestCheckHTTP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tests := []struct {
@@ -727,6 +751,10 @@ func TestCheckHTTP_TLS_SkipVerify(t *testing.T) {
 }
 
 func TestCheckHTTP_TLS_BadVerify(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	server := httptest.NewTLSServer(largeBodyHandler(200))
 	defer server.Close()
@@ -937,6 +965,10 @@ func TestCheckTCPPassing(t *testing.T) {
 }
 
 func TestCheck_Docker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	tests := []struct {
 		desc     string
 		handlers map[string]http.HandlerFunc

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -55,6 +55,10 @@ type configTest struct {
 // values, e.g. 'a' or 1 instead of 'servicex' or 3306.
 
 func TestBuilder_BuildAndValidate_ConfigFlagsAndEdgecases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dataDir := testutil.TempDir(t, "consul")
 
 	defaultEntMeta := structs.DefaultEnterpriseMeta()

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestConfig_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -94,6 +98,10 @@ func TestConfig_Get(t *testing.T) {
 }
 
 func TestConfig_Delete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -144,6 +152,10 @@ func TestConfig_Delete(t *testing.T) {
 }
 
 func TestConfig_Apply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -183,6 +195,10 @@ func TestConfig_Apply(t *testing.T) {
 }
 
 func TestConfig_Apply_TerminatingGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -243,6 +259,10 @@ func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 }
 
 func TestConfig_Apply_IngressGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -308,6 +328,10 @@ func TestConfig_Apply_IngressGateway(t *testing.T) {
 }
 
 func TestConfig_Apply_ProxyDefaultsMeshGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -346,6 +370,10 @@ func TestConfig_Apply_ProxyDefaultsMeshGateway(t *testing.T) {
 }
 
 func TestConfig_Apply_CAS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -428,6 +456,10 @@ func TestConfig_Apply_CAS(t *testing.T) {
 }
 
 func TestConfig_Apply_Decoding(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -500,6 +532,10 @@ func TestConfig_Apply_Decoding(t *testing.T) {
 }
 
 func TestConfig_Apply_ProxyDefaultsExpose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -113,6 +113,10 @@ func TestConsulCAProvider_Bootstrap_WithCert(t *testing.T) {
 }
 
 func TestConsulCAProvider_SignLeaf(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	for _, tc := range KeyTestCases {
@@ -221,6 +225,10 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 }
 
 func TestConsulCAProvider_CrossSignCA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tests := CASigningKeyTypeCases()
@@ -339,6 +347,10 @@ func testCrossSignProviders(t *testing.T, provider1, provider2 Provider) {
 }
 
 func TestConsulProvider_SignIntermediate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tests := CASigningKeyTypeCases()

--- a/agent/connect/generate_test.go
+++ b/agent/connect/generate_test.go
@@ -76,6 +76,10 @@ func testGenerateECDSAKey(t *testing.T, bits int) {
 
 // Tests to make sure we are able to generate every type of private key supported by the x509 lib.
 func TestGenerateKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	for _, params := range goodParams {
 		t.Run(fmt.Sprintf("TestGenerateKeys-%s-%d", params.keyType, params.keyBits),
@@ -121,6 +125,10 @@ func TestValidateBadConfigs(t *testing.T) {
 // Tests the ability of a CA to sign a CSR using a different key type. This is
 // allowed by TLS 1.2 and should succeed in all combinations.
 func TestSignatureMismatches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	r := require.New(t)
 	for _, p1 := range goodParams {

--- a/agent/connect/testing_ca_test.go
+++ b/agent/connect/testing_ca_test.go
@@ -104,6 +104,10 @@ func testCAAndLeaf_xc(t *testing.T, keyType string, keyBits int) {
 }
 
 func TestTestCAAndLeaf(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	for _, params := range goodParams {
 		t.Run(fmt.Sprintf("TestTestCAAndLeaf-%s-%d", params.keyType, params.keyBits),
@@ -114,6 +118,10 @@ func TestTestCAAndLeaf(t *testing.T) {
 }
 
 func TestTestCAAndLeaf_xc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	for _, params := range goodParams {
 		t.Run(fmt.Sprintf("TestTestCAAndLeaf_xc-%s-%d", params.keyType, params.keyBits),

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestConnectCARoots_empty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -33,6 +37,10 @@ func TestConnectCARoots_empty(t *testing.T) {
 }
 
 func TestConnectCARoots_list(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -62,6 +70,10 @@ func TestConnectCARoots_list(t *testing.T) {
 }
 
 func TestConnectCAConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tests := []struct {
@@ -262,6 +274,10 @@ func TestConnectCAConfig(t *testing.T) {
 }
 
 func TestConnectCARoots_PEMEncoding(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	primary := NewTestAgent(t, "")
 	defer primary.Shutdown()
 	testrpc.WaitForActiveCARoot(t, primary.RPC, "dc1", nil)

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -25,6 +25,10 @@ import (
 )
 
 func TestACLEndpoint_Bootstrap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
 		c.Build = "0.8.0" // Too low for auto init of bootstrap.
@@ -57,6 +61,10 @@ func TestACLEndpoint_Bootstrap(t *testing.T) {
 }
 
 func TestACLEndpoint_BootstrapTokens(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, srv, codec := testACLServerWithConfig(t, func(c *Config) {
 		// remove this as we are bootstrapping
@@ -102,6 +110,10 @@ func TestACLEndpoint_BootstrapTokens(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -141,6 +153,10 @@ func TestACLEndpoint_Apply(t *testing.T) {
 }
 
 func TestACLEndpoint_Update_PurgeCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -192,6 +208,10 @@ func TestACLEndpoint_Update_PurgeCache(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply_CustomID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -221,6 +241,10 @@ func TestACLEndpoint_Apply_CustomID(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply_Denied(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -239,6 +263,10 @@ func TestACLEndpoint_Apply_Denied(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply_DeleteAnon(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -259,6 +287,10 @@ func TestACLEndpoint_Apply_DeleteAnon(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply_RootChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -279,6 +311,10 @@ func TestACLEndpoint_Apply_RootChange(t *testing.T) {
 }
 
 func TestACLEndpoint_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -309,6 +345,10 @@ func TestACLEndpoint_Get(t *testing.T) {
 }
 
 func TestACLEndpoint_GetPolicy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -350,6 +390,10 @@ func TestACLEndpoint_GetPolicy(t *testing.T) {
 }
 
 func TestACLEndpoint_GetPolicy_Management(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 
@@ -370,6 +414,10 @@ func TestACLEndpoint_GetPolicy_Management(t *testing.T) {
 }
 
 func TestACLEndpoint_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -418,6 +466,10 @@ func TestACLEndpoint_List(t *testing.T) {
 }
 
 func TestACLEndpoint_List_Denied(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -431,6 +483,10 @@ func TestACLEndpoint_List_Denied(t *testing.T) {
 }
 
 func TestACLEndpoint_ReplicationStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc2"
@@ -456,6 +512,10 @@ func TestACLEndpoint_ReplicationStatus(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
 		c.ACLTokenMinExpirationTTL = 10 * time.Millisecond
@@ -558,6 +618,10 @@ func TestACLEndpoint_TokenRead(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenClone(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
@@ -637,6 +701,10 @@ func TestACLEndpoint_TokenClone(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
@@ -1402,6 +1470,10 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenSet_CustomID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -1664,6 +1736,10 @@ func TestACLEndpoint_TokenSet_CustomID(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenSet_anon(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -1700,6 +1776,10 @@ func TestACLEndpoint_TokenSet_anon(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, s1, codec := testACLServerWithConfig(t, func(c *Config) {
@@ -1882,6 +1962,10 @@ func TestACLEndpoint_TokenDelete(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenDelete_anon(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -1907,6 +1991,10 @@ func TestACLEndpoint_TokenDelete_anon(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
@@ -1980,6 +2068,10 @@ func TestACLEndpoint_TokenList(t *testing.T) {
 }
 
 func TestACLEndpoint_TokenBatchRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
@@ -2037,6 +2129,10 @@ func TestACLEndpoint_TokenBatchRead(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicyRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -2060,6 +2156,10 @@ func TestACLEndpoint_PolicyRead(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicyReadByName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -2083,6 +2183,10 @@ func TestACLEndpoint_PolicyReadByName(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicyBatchRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2111,6 +2215,10 @@ func TestACLEndpoint_PolicyBatchRead(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicySet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2194,6 +2302,10 @@ func TestACLEndpoint_PolicySet(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicySet_CustomID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, _ := testACLServerWithConfig(t, nil, false)
@@ -2219,6 +2331,10 @@ func TestACLEndpoint_PolicySet_CustomID(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicySet_globalManagement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2271,6 +2387,10 @@ func TestACLEndpoint_PolicySet_globalManagement(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicyDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2299,6 +2419,10 @@ func TestACLEndpoint_PolicyDelete(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicyDelete_globalManagement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, _ := testACLServerWithConfig(t, nil, false)
@@ -2318,6 +2442,10 @@ func TestACLEndpoint_PolicyDelete_globalManagement(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicyList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2350,6 +2478,10 @@ func TestACLEndpoint_PolicyList(t *testing.T) {
 }
 
 func TestACLEndpoint_PolicyResolve(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2397,6 +2529,10 @@ func TestACLEndpoint_PolicyResolve(t *testing.T) {
 }
 
 func TestACLEndpoint_RoleRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 	waitForLeaderEstablishment(t, srv)
@@ -2420,6 +2556,10 @@ func TestACLEndpoint_RoleRead(t *testing.T) {
 }
 
 func TestACLEndpoint_RoleBatchRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2448,6 +2588,10 @@ func TestACLEndpoint_RoleBatchRead(t *testing.T) {
 }
 
 func TestACLEndpoint_RoleSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2806,6 +2950,10 @@ func TestACLEndpoint_RoleSet(t *testing.T) {
 }
 
 func TestACLEndpoint_RoleSet_names(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2884,6 +3032,10 @@ func TestACLEndpoint_RoleSet_names(t *testing.T) {
 }
 
 func TestACLEndpoint_RoleDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2912,6 +3064,10 @@ func TestACLEndpoint_RoleDelete(t *testing.T) {
 }
 
 func TestACLEndpoint_RoleList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2938,6 +3094,10 @@ func TestACLEndpoint_RoleList(t *testing.T) {
 }
 
 func TestACLEndpoint_RoleResolve(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -2985,6 +3145,10 @@ func TestACLEndpoint_RoleResolve(t *testing.T) {
 }
 
 func TestACLEndpoint_AuthMethodSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tempDir, err := ioutil.TempDir("", "consul")
@@ -3262,6 +3426,10 @@ func TestACLEndpoint_AuthMethodSet(t *testing.T) {
 }
 
 func TestACLEndpoint_AuthMethodDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -3307,6 +3475,10 @@ func TestACLEndpoint_AuthMethodDelete(t *testing.T) {
 
 // Deleting an auth method atomically deletes all rules and tokens as well.
 func TestACLEndpoint_AuthMethodDelete_RuleAndTokenCascade(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -3421,6 +3593,10 @@ func TestACLEndpoint_AuthMethodDelete_RuleAndTokenCascade(t *testing.T) {
 }
 
 func TestACLEndpoint_AuthMethodList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -3447,6 +3623,10 @@ func TestACLEndpoint_AuthMethodList(t *testing.T) {
 }
 
 func TestACLEndpoint_BindingRuleSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -3704,6 +3884,10 @@ func TestACLEndpoint_BindingRuleSet(t *testing.T) {
 }
 
 func TestACLEndpoint_BindingRuleDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -3757,6 +3941,10 @@ func TestACLEndpoint_BindingRuleDelete(t *testing.T) {
 }
 
 func TestACLEndpoint_BindingRuleList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -3798,6 +3986,10 @@ func TestACLEndpoint_BindingRuleList(t *testing.T) {
 }
 
 func TestACLEndpoint_SecureIntroEndpoints_LocalTokensDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, s1, _ := testACLServerWithConfig(t, func(c *Config) {
@@ -3898,6 +4090,10 @@ func TestACLEndpoint_SecureIntroEndpoints_LocalTokensDisabled(t *testing.T) {
 }
 
 func TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, s1, codec1 := testACLServerWithConfig(t, func(c *Config) {
@@ -4320,6 +4516,10 @@ func TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData(t *testing.T) {
 }
 
 func TestACLEndpoint_Login(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -4704,6 +4904,10 @@ func TestACLEndpoint_Login(t *testing.T) {
 }
 
 func TestACLEndpoint_Login_with_MaxTokenTTL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -4773,6 +4977,10 @@ func TestACLEndpoint_Login_with_MaxTokenTTL(t *testing.T) {
 }
 
 func TestACLEndpoint_Login_with_TokenLocality(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	go t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -4875,6 +5083,10 @@ func TestACLEndpoint_Login_with_TokenLocality(t *testing.T) {
 }
 
 func TestACLEndpoint_Login_k8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -4996,6 +5208,10 @@ func TestACLEndpoint_Login_k8s(t *testing.T) {
 }
 
 func TestACLEndpoint_Login_jwt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -5148,6 +5364,10 @@ func startSSOTestServer(t *testing.T) *oidcauthtest.Server {
 }
 
 func TestACLEndpoint_Logout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)

--- a/agent/consul/acl_replication_legacy_test.go
+++ b/agent/consul/acl_replication_legacy_test.go
@@ -227,6 +227,10 @@ func TestACLReplication_reconcileACLs(t *testing.T) {
 }
 
 func TestACLReplication_updateLocalACLs_RateLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
@@ -278,6 +282,10 @@ func TestACLReplication_updateLocalACLs_RateLimit(t *testing.T) {
 }
 
 func TestACLReplication_IsACLReplicationEnabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// ACLs not enabled.
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -340,6 +348,10 @@ func TestACLReplication_IsACLReplicationEnabled(t *testing.T) {
 //
 // Actually testing legacy replication is difficult to do without old binaries.
 func TestACLReplication_LegacyTokens(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -291,6 +291,10 @@ func TestACLReplication_diffACLTokens(t *testing.T) {
 }
 
 func TestACLReplication_Tokens(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -473,6 +477,10 @@ func TestACLReplication_Tokens(t *testing.T) {
 }
 
 func TestACLReplication_Policies(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -594,6 +602,10 @@ func TestACLReplication_Policies(t *testing.T) {
 }
 
 func TestACLReplication_TokensRedacted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -740,6 +752,10 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 }
 
 func TestACLReplication_AllTypes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -1426,6 +1426,10 @@ func TestACLResolver_DatacenterScoping(t *testing.T) {
 
 // TODO(rb): replicate this sort of test but for roles
 func TestACLResolver_Client(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	t.Run("Racey-Token-Mod-Policy-Resolve", func(t *testing.T) {
@@ -3376,6 +3380,10 @@ func TestACL_filterPreparedQueries(t *testing.T) {
 }
 
 func TestACL_unhandledFilterType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	defer func(t *testing.T) {
 		if recover() == nil {

--- a/agent/consul/acl_token_exp_test.go
+++ b/agent/consul/acl_token_exp_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestACLTokenReap_Primary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	t.Run("global", func(t *testing.T) {

--- a/agent/consul/auto_config_endpoint_test.go
+++ b/agent/consul/auto_config_endpoint_test.go
@@ -92,6 +92,10 @@ func signJWTWithStandardClaims(t *testing.T, privKey string, claims interface{})
 //  * Each of the individual config generation functions. These can be unit tested separately and should NOT
 //    require running test servers
 func TestAutoConfigInitialConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	gossipKey := make([]byte, 32)
 	// this is not cryptographic randomness and is not secure but for the sake of this test its all we need.
 	n, err := rand.Read(gossipKey)

--- a/agent/consul/auto_encrypt_endpoint_test.go
+++ b/agent/consul/auto_encrypt_endpoint_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestAutoEncryptSign(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	type test struct {

--- a/agent/consul/autopilot_test.go
+++ b/agent/consul/autopilot_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestAutopilot_IdempotentShutdown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir1, s1 := testServerWithConfig(t, nil)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -29,6 +33,10 @@ func TestAutopilot_IdempotentShutdown(t *testing.T) {
 }
 
 func TestAutopilot_CleanupDeadServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dc := "dc1"
 	conf := func(c *Config) {
 		c.Datacenter = dc
@@ -113,6 +121,10 @@ func TestAutopilot_CleanupDeadServer(t *testing.T) {
 }
 
 func TestAutopilot_CleanupDeadNonvoter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.AutopilotConfig = &structs.AutopilotConfig{
 			CleanupDeadServers:      true,
@@ -146,6 +158,10 @@ func TestAutopilot_CleanupDeadNonvoter(t *testing.T) {
 }
 
 func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
@@ -203,6 +219,10 @@ func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 }
 
 func TestAutopilot_RollingUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
@@ -282,6 +302,10 @@ func TestAutopilot_RollingUpdate(t *testing.T) {
 }
 
 func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerDCBootstrap(t, "dc1", true)
 	defer os.RemoveAll(dir1)
@@ -334,6 +358,10 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 }
 
 func TestAutopilot_PromoteNonVoter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
@@ -406,6 +434,10 @@ func TestAutopilot_PromoteNonVoter(t *testing.T) {
 }
 
 func TestAutopilot_MinQuorum(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dc := "dc1"
 	conf := func(c *Config) {
 		c.Datacenter = dc

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -22,6 +22,10 @@ import (
 )
 
 func TestCatalog_Register(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -52,6 +56,10 @@ func TestCatalog_Register(t *testing.T) {
 }
 
 func TestCatalog_RegisterService_InvalidAddress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -82,6 +90,10 @@ func TestCatalog_RegisterService_InvalidAddress(t *testing.T) {
 }
 
 func TestCatalog_RegisterService_SkipNodeUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -121,6 +133,10 @@ func TestCatalog_RegisterService_SkipNodeUpdate(t *testing.T) {
 }
 
 func TestCatalog_Register_NodeID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -157,6 +173,10 @@ func TestCatalog_Register_NodeID(t *testing.T) {
 }
 
 func TestCatalog_Register_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -252,6 +272,10 @@ node "foo" {
 }
 
 func TestCatalog_Register_ForwardLeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -296,6 +320,10 @@ func TestCatalog_Register_ForwardLeader(t *testing.T) {
 }
 
 func TestCatalog_Register_ForwardDC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -329,6 +357,10 @@ func TestCatalog_Register_ForwardDC(t *testing.T) {
 }
 
 func TestCatalog_Register_ConnectProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -360,6 +392,10 @@ func TestCatalog_Register_ConnectProxy(t *testing.T) {
 // Test an invalid ConnectProxy. We don't need to exhaustively test because
 // this is all tested in structs on the Validate method.
 func TestCatalog_Register_ConnectProxy_invalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -381,6 +417,10 @@ func TestCatalog_Register_ConnectProxy_invalid(t *testing.T) {
 
 // Test that write is required for the proxy destination to register a proxy.
 func TestCatalog_Register_ConnectProxy_ACLDestinationServiceName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -444,6 +484,10 @@ node "foo" {
 }
 
 func TestCatalog_Register_ConnectNative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -474,6 +518,10 @@ func TestCatalog_Register_ConnectNative(t *testing.T) {
 }
 
 func TestCatalog_Deregister(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -500,6 +548,10 @@ func TestCatalog_Deregister(t *testing.T) {
 }
 
 func TestCatalog_Deregister_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -671,6 +723,10 @@ service "service" {
 }
 
 func TestCatalog_ListDatacenters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -705,6 +761,10 @@ func TestCatalog_ListDatacenters(t *testing.T) {
 }
 
 func TestCatalog_ListDatacenters_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -744,6 +804,10 @@ func TestCatalog_ListDatacenters_DistanceSort(t *testing.T) {
 }
 
 func TestCatalog_ListNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -801,6 +865,10 @@ func TestCatalog_ListNodes(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -864,6 +932,10 @@ func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalog_RPC_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -940,6 +1012,10 @@ func TestCatalog_RPC_Filter(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_StaleRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1008,6 +1084,10 @@ func TestCatalog_ListNodes_StaleRead(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_ConsistentRead_Fail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1064,6 +1144,10 @@ func TestCatalog_ListNodes_ConsistentRead_Fail(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_ConsistentRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1109,6 +1193,10 @@ func TestCatalog_ListNodes_ConsistentRead(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1200,6 +1288,10 @@ func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_ACLFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -1289,6 +1381,10 @@ func Benchmark_Catalog_ListNodes(t *testing.B) {
 }
 
 func TestCatalog_ListServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1355,6 +1451,10 @@ func TestCatalog_ListServices(t *testing.T) {
 }
 
 func TestCatalog_ListServices_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1419,6 +1519,10 @@ func TestCatalog_ListServices_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalog_ListServices_Blocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1479,6 +1583,10 @@ func TestCatalog_ListServices_Blocking(t *testing.T) {
 }
 
 func TestCatalog_ListServices_Timeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1521,6 +1629,10 @@ func TestCatalog_ListServices_Timeout(t *testing.T) {
 }
 
 func TestCatalog_ListServices_Stale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -1605,6 +1717,10 @@ func TestCatalog_ListServices_Stale(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1655,6 +1771,10 @@ func TestCatalog_ListServiceNodes(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes_ByAddress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1738,6 +1858,10 @@ func TestCatalog_ListServiceNodes_ByAddress(t *testing.T) {
 // TestCatalog_ListServiceNodes_ServiceTags_V1_2_3Compat asserts the compatibility between <=v1.2.3 agents and >=v1.3.0 servers
 // see https://github.com/hashicorp/consul/issues/4922
 func TestCatalog_ListServiceNodes_ServiceTags_V1_2_3Compat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1815,6 +1939,10 @@ func TestCatalog_ListServiceNodes_ServiceTags_V1_2_3Compat(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1926,6 +2054,10 @@ func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -2014,6 +2146,10 @@ func TestCatalog_ListServiceNodes_DistanceSort(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes_ConnectProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -2045,6 +2181,10 @@ func TestCatalog_ListServiceNodes_ConnectProxy(t *testing.T) {
 }
 
 func TestCatalog_ServiceNodes_Gateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -2161,6 +2301,10 @@ func TestCatalog_ServiceNodes_Gateway(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes_ConnectDestination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -2214,6 +2358,10 @@ func TestCatalog_ListServiceNodes_ConnectDestination(t *testing.T) {
 // Test that calling ServiceNodes with Connect: true will return
 // Connect native services.
 func TestCatalog_ListServiceNodes_ConnectDestinationNative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -2255,6 +2403,10 @@ func TestCatalog_ListServiceNodes_ConnectDestinationNative(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes_ConnectProxy_ACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -2341,6 +2493,10 @@ node "" { policy = "read" }
 }
 
 func TestCatalog_ListServiceNodes_ConnectNative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -2372,6 +2528,10 @@ func TestCatalog_ListServiceNodes_ConnectNative(t *testing.T) {
 }
 
 func TestCatalog_NodeServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -2423,6 +2583,10 @@ func TestCatalog_NodeServices(t *testing.T) {
 }
 
 func TestCatalog_NodeServices_ConnectProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -2454,6 +2618,10 @@ func TestCatalog_NodeServices_ConnectProxy(t *testing.T) {
 }
 
 func TestCatalog_NodeServices_ConnectNative(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -2485,6 +2653,10 @@ func TestCatalog_NodeServices_ConnectNative(t *testing.T) {
 
 // Used to check for a regression against a known bug
 func TestCatalog_Register_FailedCase1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -2608,6 +2780,10 @@ node "" {
 }
 
 func TestCatalog_ListServices_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -2632,6 +2808,10 @@ func TestCatalog_ListServices_FilterACL(t *testing.T) {
 }
 
 func TestCatalog_ServiceNodes_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -2682,6 +2862,10 @@ func TestCatalog_ServiceNodes_FilterACL(t *testing.T) {
 }
 
 func TestCatalog_NodeServices_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -2749,6 +2933,10 @@ node "%s" {
 }
 
 func TestCatalog_NodeServices_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -2774,6 +2962,10 @@ func TestCatalog_NodeServices_FilterACL(t *testing.T) {
 }
 
 func TestCatalog_GatewayServices_TerminatingGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -2915,6 +3107,10 @@ func TestCatalog_GatewayServices_TerminatingGateway(t *testing.T) {
 }
 
 func TestCatalog_GatewayServices_BothGateways(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -3078,6 +3274,10 @@ func TestCatalog_GatewayServices_BothGateways(t *testing.T) {
 }
 
 func TestCatalog_GatewayServices_ACLFiltering(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -92,6 +92,10 @@ func TestClient_StartStop(t *testing.T) {
 }
 
 func TestClient_JoinLAN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -119,6 +123,10 @@ func TestClient_JoinLAN(t *testing.T) {
 }
 
 func TestClient_LANReap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -267,6 +275,10 @@ func (l *leaderFailer) Once(args struct{}, reply *struct{}) error {
 }
 
 func TestClient_RPC_Retry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -356,6 +368,10 @@ func TestClient_RPC_Pool(t *testing.T) {
 }
 
 func TestClient_RPC_ConsulServerPing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	var servers []*Server
 	const numServers = 5
@@ -502,6 +518,10 @@ func newDefaultDeps(t *testing.T, c *Config) Deps {
 }
 
 func TestClient_RPC_RateLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, conf1 := testServerConfig(t)
 	s1, err := newServer(t, conf1)
@@ -526,6 +546,10 @@ func TestClient_RPC_RateLimit(t *testing.T) {
 }
 
 func TestClient_SnapshotRPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -567,6 +591,10 @@ func TestClient_SnapshotRPC(t *testing.T) {
 }
 
 func TestClient_SnapshotRPC_RateLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, s1 := testServer(t)
 	defer s1.Shutdown()
@@ -597,6 +625,10 @@ func TestClient_SnapshotRPC_RateLimit(t *testing.T) {
 }
 
 func TestClient_SnapshotRPC_TLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, conf1 := testServerConfig(t)
 	conf1.VerifyIncoming = true
@@ -650,6 +682,10 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 }
 
 func TestClientServer_UserEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	clientOut := make(chan serf.UserEvent, 2)
 	dir1, c1 := testClientWithConfig(t, func(conf *Config) {
@@ -749,6 +785,10 @@ func TestClient_Reload(t *testing.T) {
 }
 
 func TestClient_ShortReconnectTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	cluster := newTestCluster(t, &testClusterConfig{
 		Datacenter: "dc1",
 		Servers:    1,

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestConfigEntry_Apply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -103,6 +107,10 @@ func TestConfigEntry_Apply(t *testing.T) {
 }
 
 func TestConfigEntry_ProxyDefaultsMeshGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -133,6 +141,10 @@ func TestConfigEntry_ProxyDefaultsMeshGateway(t *testing.T) {
 }
 
 func TestConfigEntry_Apply_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -221,6 +233,10 @@ operator = "write"
 }
 
 func TestConfigEntry_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -254,6 +270,10 @@ func TestConfigEntry_Get(t *testing.T) {
 }
 
 func TestConfigEntry_Get_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -326,6 +346,10 @@ operator = "read"
 }
 
 func TestConfigEntry_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -366,6 +390,10 @@ func TestConfigEntry_List(t *testing.T) {
 }
 
 func TestConfigEntry_ListAll(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -455,6 +483,10 @@ func TestConfigEntry_ListAll(t *testing.T) {
 }
 
 func TestConfigEntry_List_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -536,6 +568,10 @@ operator = "read"
 }
 
 func TestConfigEntry_ListAll_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -617,6 +653,10 @@ operator = "read"
 }
 
 func TestConfigEntry_Delete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -687,6 +727,10 @@ func TestConfigEntry_Delete(t *testing.T) {
 }
 
 func TestConfigEntry_Delete_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -782,6 +826,10 @@ operator = "write"
 }
 
 func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -844,6 +892,10 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 }
 
 func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1010,6 +1062,10 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 }
 
 func TestConfigEntry_ResolveServiceConfig_UpstreamProxyDefaultsProtocol(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1080,6 +1136,10 @@ func TestConfigEntry_ResolveServiceConfig_UpstreamProxyDefaultsProtocol(t *testi
 }
 
 func TestConfigEntry_ResolveServiceConfig_ProxyDefaultsProtocol_UsedForAllUpstreams(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1124,6 +1184,10 @@ func TestConfigEntry_ResolveServiceConfig_ProxyDefaultsProtocol_UsedForAllUpstre
 }
 
 func TestConfigEntry_ResolveServiceConfigNoConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1154,6 +1218,10 @@ func TestConfigEntry_ResolveServiceConfigNoConfig(t *testing.T) {
 }
 
 func TestConfigEntry_ResolveServiceConfig_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1225,6 +1293,10 @@ operator = "write"
 }
 
 func TestConfigEntry_ProxyDefaultsExposeConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)

--- a/agent/consul/config_replication_test.go
+++ b/agent/consul/config_replication_test.go
@@ -92,6 +92,10 @@ func TestReplication_ConfigSort(t *testing.T) {
 }
 
 func TestReplication_ConfigEntries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -30,6 +30,10 @@ func testParseCert(t *testing.T, pemValue string) *x509.Certificate {
 
 // Test listing root CAs.
 func TestConnectCARoots(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -74,6 +78,10 @@ func TestConnectCARoots(t *testing.T) {
 }
 
 func TestConnectCAConfig_GetSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -145,6 +153,10 @@ func TestConnectCAConfig_GetSet(t *testing.T) {
 }
 
 func TestConnectCAConfig_GetSet_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -235,6 +247,10 @@ pY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=
 // signing works when requested (and is denied when not requested). This occurs
 // if the current CA is not able to cross sign external CA certificates.
 func TestConnectCAConfig_GetSetForceNoCrossSigning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -338,6 +354,10 @@ func TestConnectCAConfig_GetSetForceNoCrossSigning(t *testing.T) {
 }
 
 func TestConnectCAConfig_TriggerRotation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -493,6 +513,10 @@ func TestConnectCAConfig_TriggerRotation(t *testing.T) {
 }
 
 func TestConnectCAConfig_UpdateSecondary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -649,6 +673,10 @@ func TestConnectCAConfig_UpdateSecondary(t *testing.T) {
 
 // Test CA signing
 func TestConnectCASign(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tests := []struct {
@@ -751,6 +779,10 @@ func BenchmarkConnectCASign(b *testing.B) {
 }
 
 func TestConnectCASign_rateLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -812,6 +844,10 @@ func TestConnectCASign_rateLimit(t *testing.T) {
 }
 
 func TestConnectCASign_concurrencyLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -916,6 +952,10 @@ func TestConnectCASign_concurrencyLimit(t *testing.T) {
 }
 
 func TestConnectCASignValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {

--- a/agent/consul/coordinate_endpoint_test.go
+++ b/agent/consul/coordinate_endpoint_test.go
@@ -36,6 +36,10 @@ func generateRandomCoordinate() *coordinate.Coordinate {
 }
 
 func TestCoordinate_Update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.CoordinateUpdatePeriod = 500 * time.Millisecond
@@ -178,6 +182,10 @@ func TestCoordinate_Update(t *testing.T) {
 }
 
 func TestCoordinate_Update_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -246,6 +254,10 @@ node "node1" {
 }
 
 func TestCoordinate_ListDatacenters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -277,6 +289,10 @@ func TestCoordinate_ListDatacenters(t *testing.T) {
 }
 
 func TestCoordinate_ListNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -342,6 +358,10 @@ func TestCoordinate_ListNodes(t *testing.T) {
 }
 
 func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -472,6 +492,10 @@ node "foo" {
 }
 
 func TestCoordinate_Node(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -526,6 +550,10 @@ func TestCoordinate_Node(t *testing.T) {
 }
 
 func TestCoordinate_Node_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"

--- a/agent/consul/discovery_chain_endpoint_test.go
+++ b/agent/consul/discovery_chain_endpoint_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestDiscoveryChainEndpoint_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {

--- a/agent/consul/federation_state_endpoint_test.go
+++ b/agent/consul/federation_state_endpoint_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestFederationState_Apply_Upsert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -100,6 +104,10 @@ func TestFederationState_Apply_Upsert(t *testing.T) {
 }
 
 func TestFederationState_Apply_Upsert_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -173,6 +181,10 @@ func TestFederationState_Apply_Upsert_ACLDeny(t *testing.T) {
 }
 
 func TestFederationState_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -212,6 +224,10 @@ func TestFederationState_Get(t *testing.T) {
 }
 
 func TestFederationState_Get_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -281,6 +297,10 @@ func TestFederationState_Get_ACLDeny(t *testing.T) {
 }
 
 func TestFederationState_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -373,6 +393,10 @@ func TestFederationState_List(t *testing.T) {
 }
 
 func TestFederationState_List_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -563,6 +587,10 @@ func TestFederationState_List_ACLDeny(t *testing.T) {
 }
 
 func TestFederationState_Apply_Delete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -642,6 +670,10 @@ func TestFederationState_Apply_Delete(t *testing.T) {
 }
 
 func TestFederationState_Apply_Delete_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {

--- a/agent/consul/federation_state_replication_test.go
+++ b/agent/consul/federation_state_replication_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestReplication_FederationStates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -1477,6 +1477,10 @@ func TestFSM_ConfigEntry(t *testing.T) {
 // FSM, and applies the rest. The goal is to verify that chunking snapshotting
 // works as expected.
 func TestFSM_Chunking_Lifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 	assert := assert.New(t)

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestHealth_ChecksInState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -65,6 +69,10 @@ func TestHealth_ChecksInState(t *testing.T) {
 }
 
 func TestHealth_ChecksInState_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -161,6 +169,10 @@ func TestHealth_ChecksInState_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealth_ChecksInState_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -239,6 +251,10 @@ func TestHealth_ChecksInState_DistanceSort(t *testing.T) {
 }
 
 func TestHealth_NodeChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -281,6 +297,10 @@ func TestHealth_NodeChecks(t *testing.T) {
 }
 
 func TestHealth_ServiceChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -328,6 +348,10 @@ func TestHealth_ServiceChecks(t *testing.T) {
 }
 
 func TestHealth_ServiceChecks_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -434,6 +458,10 @@ func TestHealth_ServiceChecks_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealth_ServiceChecks_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -523,6 +551,10 @@ func TestHealth_ServiceChecks_DistanceSort(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -646,6 +678,10 @@ func TestHealth_ServiceNodes(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -708,6 +744,10 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -839,6 +879,10 @@ func TestHealth_ServiceNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -928,6 +972,10 @@ func TestHealth_ServiceNodes_DistanceSort(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_ConnectProxy_ACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -1031,6 +1079,10 @@ node "foo" {
 }
 
 func TestHealth_ServiceNodes_Gateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -1146,6 +1198,10 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 	})
 }
 func TestHealth_ServiceNodes_Ingress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1232,6 +1288,10 @@ func TestHealth_ServiceNodes_Ingress(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -1373,6 +1433,10 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 }
 
 func TestHealth_NodeChecks_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -1409,6 +1473,10 @@ func TestHealth_NodeChecks_FilterACL(t *testing.T) {
 }
 
 func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -1452,6 +1520,10 @@ func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -1488,6 +1560,10 @@ func TestHealth_ServiceNodes_FilterACL(t *testing.T) {
 }
 
 func TestHealth_ChecksInState_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -1525,6 +1601,10 @@ func TestHealth_ChecksInState_FilterACL(t *testing.T) {
 }
 
 func TestHealth_RPC_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -15,6 +15,10 @@ import (
 
 // Test basic creation
 func TestIntentionApply_new(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -98,6 +102,10 @@ func TestIntentionApply_new(t *testing.T) {
 
 // Test the source type defaults
 func TestIntentionApply_defaultSourceType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -144,6 +152,10 @@ func TestIntentionApply_defaultSourceType(t *testing.T) {
 
 // Shouldn't be able to create with an ID set
 func TestIntentionApply_createWithID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -174,6 +186,10 @@ func TestIntentionApply_createWithID(t *testing.T) {
 
 // Test basic updating
 func TestIntentionApply_updateGood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -254,6 +270,10 @@ func TestIntentionApply_updateGood(t *testing.T) {
 
 // Shouldn't be able to update a non-existent intention
 func TestIntentionApply_updateNonExist(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -284,6 +304,10 @@ func TestIntentionApply_updateNonExist(t *testing.T) {
 
 // Test basic deleting
 func TestIntentionApply_deleteGood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -339,6 +363,10 @@ func TestIntentionApply_deleteGood(t *testing.T) {
 }
 
 func TestIntentionApply_WithoutIDs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -823,6 +851,10 @@ func TestIntentionApply_WithoutIDs(t *testing.T) {
 
 // Test apply with a deny ACL
 func TestIntentionApply_aclDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -903,6 +935,10 @@ service "foo" {
 }
 
 func TestIntention_WildcardACLEnforcement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -1220,6 +1256,10 @@ func TestIntention_WildcardACLEnforcement(t *testing.T) {
 
 // Test apply with delete and a default deny ACL
 func TestIntentionApply_aclDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1297,6 +1337,10 @@ service "foo" {
 
 // Test apply with update and a default deny ACL
 func TestIntentionApply_aclUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1362,6 +1406,10 @@ service "foo" {
 
 // Test apply with a management token
 func TestIntentionApply_aclManagement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1403,6 +1451,10 @@ func TestIntentionApply_aclManagement(t *testing.T) {
 
 // Test update changing the name where an ACL won't allow it
 func TestIntentionApply_aclUpdateChange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1465,6 +1517,10 @@ service "foo" {
 
 // Test reading with ACLs
 func TestIntentionGet_acl(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -1562,6 +1618,10 @@ func TestIntentionGet_acl(t *testing.T) {
 }
 
 func TestIntentionList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1587,6 +1647,10 @@ func TestIntentionList(t *testing.T) {
 
 // Test listing with ACLs
 func TestIntentionList_acl(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, testServerACLConfig(nil))
@@ -1668,6 +1732,10 @@ func TestIntentionList_acl(t *testing.T) {
 // Test basic matching. We don't need to exhaustively test inputs since this
 // is tested in the agent/consul/state package.
 func TestIntentionMatch_good(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -1737,6 +1805,10 @@ func TestIntentionMatch_good(t *testing.T) {
 
 // Test matching with ACLs
 func TestIntentionMatch_acl(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
@@ -1819,6 +1891,10 @@ func TestIntentionMatch_acl(t *testing.T) {
 
 // Test the Check method defaults to allow with no ACL set.
 func TestIntentionCheck_defaultNoACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServer(t)
@@ -1845,6 +1921,10 @@ func TestIntentionCheck_defaultNoACL(t *testing.T) {
 
 // Test the Check method defaults to deny with allowlist ACLs.
 func TestIntentionCheck_defaultACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -1877,6 +1957,10 @@ func TestIntentionCheck_defaultACLDeny(t *testing.T) {
 
 // Test the Check method defaults to deny with denylist ACLs.
 func TestIntentionCheck_defaultACLAllow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -1909,6 +1993,10 @@ func TestIntentionCheck_defaultACLAllow(t *testing.T) {
 
 // Test the Check method requires service:read permission.
 func TestIntentionCheck_aclDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -1962,6 +2050,10 @@ service "bar" {
 
 // Test the Check method returns allow/deny properly.
 func TestIntentionCheck_match(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, srv, codec := testACLServerWithConfig(t, nil, false)

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestInternal_NodeInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -73,6 +77,10 @@ func TestInternal_NodeInfo(t *testing.T) {
 }
 
 func TestInternal_NodeDump(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -165,6 +173,10 @@ func TestInternal_NodeDump(t *testing.T) {
 }
 
 func TestInternal_NodeDump_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -223,6 +235,10 @@ func TestInternal_NodeDump_Filter(t *testing.T) {
 }
 
 func TestInternal_KeyringOperation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key1 := "H1dfkSZOVnP/JUnaBfTzXg=="
 	keyBytes1, err := base64.StdEncoding.DecodeString(key1)
@@ -306,6 +322,10 @@ func TestInternal_KeyringOperation(t *testing.T) {
 }
 
 func TestInternal_KeyringOperationList_LocalOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key1 := "H1dfkSZOVnP/JUnaBfTzXg=="
 	keyBytes1, err := base64.StdEncoding.DecodeString(key1)
@@ -387,6 +407,10 @@ func TestInternal_KeyringOperationList_LocalOnly(t *testing.T) {
 }
 
 func TestInternal_KeyringOperationWrite_LocalOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key1 := "H1dfkSZOVnP/JUnaBfTzXg=="
 	keyBytes1, err := base64.StdEncoding.DecodeString(key1)
@@ -420,6 +444,10 @@ func TestInternal_KeyringOperationWrite_LocalOnly(t *testing.T) {
 }
 
 func TestInternal_NodeInfo_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -471,6 +499,10 @@ func TestInternal_NodeInfo_FilterACL(t *testing.T) {
 }
 
 func TestInternal_NodeDump_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
@@ -521,6 +553,10 @@ func TestInternal_NodeDump_FilterACL(t *testing.T) {
 }
 
 func TestInternal_EventFire_Token(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, srv := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -557,6 +593,10 @@ func TestInternal_EventFire_Token(t *testing.T) {
 }
 
 func TestInternal_ServiceDump(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -650,6 +690,10 @@ func TestInternal_ServiceDump(t *testing.T) {
 }
 
 func TestInternal_ServiceDump_Kind(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -706,6 +750,10 @@ func TestInternal_ServiceDump_Kind(t *testing.T) {
 }
 
 func TestInternal_GatewayServiceDump_Terminating(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -904,6 +952,10 @@ func TestInternal_GatewayServiceDump_Terminating(t *testing.T) {
 }
 
 func TestInternal_GatewayServiceDump_Terminating_ACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -1030,6 +1082,10 @@ func TestInternal_GatewayServiceDump_Terminating_ACL(t *testing.T) {
 }
 
 func TestInternal_GatewayServiceDump_Ingress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1239,6 +1295,10 @@ func TestInternal_GatewayServiceDump_Ingress(t *testing.T) {
 }
 
 func TestInternal_GatewayServiceDump_Ingress_ACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -1380,6 +1440,10 @@ func TestInternal_GatewayServiceDump_Ingress_ACL(t *testing.T) {
 }
 
 func TestInternal_GatewayIntentions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1490,6 +1554,10 @@ func TestInternal_GatewayIntentions(t *testing.T) {
 }
 
 func TestInternal_GatewayIntentions_aclDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir1, s1 := testServerWithConfig(t, testServerACLConfig(nil))
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1608,6 +1676,10 @@ service_prefix "terminating-gateway" { policy = "read" }
 }
 
 func TestInternal_ServiceTopology(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1730,6 +1802,10 @@ func TestInternal_ServiceTopology(t *testing.T) {
 }
 
 func TestInternal_ServiceTopology_ACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"

--- a/agent/consul/kvs_endpoint_test.go
+++ b/agent/consul/kvs_endpoint_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestKVS_Apply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -71,6 +75,10 @@ func TestKVS_Apply(t *testing.T) {
 }
 
 func TestKVS_Apply_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -135,6 +143,10 @@ func TestKVS_Apply_ACLDeny(t *testing.T) {
 }
 
 func TestKVS_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -183,6 +195,10 @@ func TestKVS_Get(t *testing.T) {
 }
 
 func TestKVS_Get_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -224,6 +240,10 @@ func TestKVS_Get_ACLDeny(t *testing.T) {
 }
 
 func TestKVSEndpoint_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -296,6 +316,10 @@ func TestKVSEndpoint_List(t *testing.T) {
 }
 
 func TestKVSEndpoint_List_Blocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -392,6 +416,10 @@ func TestKVSEndpoint_List_Blocking(t *testing.T) {
 }
 
 func TestKVSEndpoint_List_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -478,6 +506,10 @@ func TestKVSEndpoint_List_ACLDeny(t *testing.T) {
 }
 
 func TestKVSEndpoint_List_ACLEnableKeyListPolicy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -603,6 +635,10 @@ key "zip" {
 }
 
 func TestKVSEndpoint_ListKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -673,6 +709,10 @@ func TestKVSEndpoint_ListKeys(t *testing.T) {
 }
 
 func TestKVSEndpoint_ListKeys_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -753,6 +793,10 @@ func TestKVSEndpoint_ListKeys_ACLDeny(t *testing.T) {
 }
 
 func TestKVS_Apply_LockDelay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -825,6 +869,10 @@ func TestKVS_Apply_LockDelay(t *testing.T) {
 }
 
 func TestKVS_Issue_1626(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -193,6 +193,10 @@ func initTestManager(t *testing.T, manager *CAManager, delegate *mockCAServerDel
 }
 
 func TestCAManager_Initialize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	conf := DefaultConfig()
 	conf.ConnectEnabled = true
 	conf.PrimaryDatacenter = "dc1"
@@ -228,6 +232,10 @@ func TestCAManager_Initialize(t *testing.T) {
 }
 
 func TestCAManager_UpdateConfigWhileRenewIntermediate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// No parallel execution because we change globals
 	// Set the interval and drift buffer low for renewing the cert.
 	origInterval := structs.IntermediateCertRenewInterval

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -25,6 +25,10 @@ import (
 )
 
 func TestLeader_SecondaryCA_Initialize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tests := []struct {
@@ -292,6 +296,10 @@ func TestLeader_Vault_PrimaryCA_IntermediateRenew(t *testing.T) {
 }
 
 func TestLeader_SecondaryCA_IntermediateRenew(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// no parallel execution because we change globals
 	origInterval := structs.IntermediateCertRenewInterval
 	origMinTTL := structs.MinLeafCertTTL
@@ -420,6 +428,10 @@ func TestLeader_SecondaryCA_IntermediateRenew(t *testing.T) {
 }
 
 func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -567,6 +579,10 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 }
 
 func TestLeader_SecondaryCA_FixSigningKeyID_via_IntermediateRefresh(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -666,6 +682,10 @@ func TestLeader_SecondaryCA_FixSigningKeyID_via_IntermediateRefresh(t *testing.T
 }
 
 func TestLeader_SecondaryCA_TransitionFromPrimary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// Initialize dc1 as the primary DC
@@ -754,6 +774,10 @@ func TestLeader_SecondaryCA_TransitionFromPrimary(t *testing.T) {
 }
 
 func TestLeader_SecondaryCA_UpgradeBeforePrimary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// Initialize dc1 as the primary DC
@@ -895,6 +919,10 @@ func TestLeader_GenerateCASignRequest(t *testing.T) {
 }
 
 func TestLeader_CARootPruning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	caRootPruneInterval = 200 * time.Millisecond
@@ -957,6 +985,10 @@ func TestLeader_CARootPruning(t *testing.T) {
 }
 
 func TestLeader_PersistIntermediateCAs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -1130,6 +1162,10 @@ func TestLeader_lessThanHalfTimePassed(t *testing.T) {
 }
 
 func TestLeader_retryLoopBackoffHandleSuccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	type test struct {
 		desc     string
 		loopFn   func() error

--- a/agent/consul/leader_federation_state_ae_test.go
+++ b/agent/consul/leader_federation_state_ae_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestLeader_FederationStateAntiEntropy_BlockingQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -190,6 +194,10 @@ func TestLeader_FederationStateAntiEntropy_BlockingQuery(t *testing.T) {
 }
 
 func TestLeader_FederationStateAntiEntropyPruning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -263,6 +271,10 @@ func TestLeader_FederationStateAntiEntropyPruning(t *testing.T) {
 }
 
 func TestLeader_FederationStateAntiEntropyPruning_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {

--- a/agent/consul/leader_intentions_test.go
+++ b/agent/consul/leader_intentions_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestLeader_ReplicateIntentions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This setup is a little hacky, but should work. We spin up BOTH servers with
 	// no intentions and force them to think they're not eligible for intentions
 	// config entries yet by overriding serf tags.
@@ -361,6 +365,10 @@ func TestLeader_batchLegacyIntentionUpdates(t *testing.T) {
 }
 
 func TestLeader_LegacyIntentionMigration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This setup is a little hacky, but should work. We spin up a server with
 	// no intentions and force it to think it's not eligible for intentions
 	// config entries yet by overriding serf tags.

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -21,6 +21,10 @@ import (
 )
 
 func TestLeader_RegisterMember(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -92,6 +96,10 @@ func TestLeader_RegisterMember(t *testing.T) {
 }
 
 func TestLeader_FailedMember(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -153,6 +161,10 @@ func TestLeader_FailedMember(t *testing.T) {
 }
 
 func TestLeader_LeftMember(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -199,6 +211,10 @@ func TestLeader_LeftMember(t *testing.T) {
 	})
 }
 func TestLeader_ReapMember(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -260,6 +276,10 @@ func TestLeader_ReapMember(t *testing.T) {
 }
 
 func TestLeader_CheckServersMeta(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -364,6 +384,10 @@ func TestLeader_CheckServersMeta(t *testing.T) {
 }
 
 func TestLeader_ReapServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -439,6 +463,10 @@ func TestLeader_ReapServer(t *testing.T) {
 }
 
 func TestLeader_Reconcile_ReapMember(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -488,6 +516,10 @@ func TestLeader_Reconcile_ReapMember(t *testing.T) {
 }
 
 func TestLeader_Reconcile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -528,6 +560,10 @@ func TestLeader_Reconcile(t *testing.T) {
 }
 
 func TestLeader_Reconcile_Races(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -618,6 +654,10 @@ func TestLeader_Reconcile_Races(t *testing.T) {
 }
 
 func TestLeader_LeftServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -657,6 +697,10 @@ func TestLeader_LeftServer(t *testing.T) {
 }
 
 func TestLeader_LeftLeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -755,6 +799,10 @@ func TestLeader_MultiBootstrap(t *testing.T) {
 }
 
 func TestLeader_TombstoneGC_Reset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -817,6 +865,10 @@ func TestLeader_TombstoneGC_Reset(t *testing.T) {
 }
 
 func TestLeader_ReapTombstones(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -888,6 +940,10 @@ func TestLeader_ReapTombstones(t *testing.T) {
 }
 
 func TestLeader_RollRaftServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Bootstrap = true
@@ -949,6 +1005,10 @@ func TestLeader_RollRaftServer(t *testing.T) {
 }
 
 func TestLeader_ChangeServerID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	conf := func(c *Config) {
 		c.Bootstrap = false
 		c.BootstrapExpect = 3
@@ -1026,6 +1086,10 @@ func TestLeader_ChangeServerID(t *testing.T) {
 }
 
 func TestLeader_ChangeNodeID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1089,6 +1153,10 @@ func TestLeader_ChangeNodeID(t *testing.T) {
 }
 
 func TestLeader_ACL_Initialization(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	tests := []struct {
@@ -1139,6 +1207,10 @@ func TestLeader_ACL_Initialization(t *testing.T) {
 }
 
 func TestLeader_ACLUpgrade(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLsEnabled = true
@@ -1201,6 +1273,10 @@ func TestLeader_ACLUpgrade(t *testing.T) {
 }
 
 func TestLeader_ConfigEntryBootstrap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	global_entry_init := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
@@ -1234,6 +1310,10 @@ func TestLeader_ConfigEntryBootstrap(t *testing.T) {
 }
 
 func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	type testcase struct {
@@ -1367,6 +1447,10 @@ func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
 }
 
 func TestLeader_ACLLegacyReplication(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// This test relies on configuring a secondary DC with no route to the primary DC
@@ -1387,6 +1471,10 @@ func TestLeader_ACLLegacyReplication(t *testing.T) {
 }
 
 func TestDatacenterSupportsFederationStates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	addGateway := func(t *testing.T, srv *Server, dc, node string) {
 		t.Helper()
 		arg := structs.RegisterRequest{
@@ -1683,6 +1771,10 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 }
 
 func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	addLegacyIntention := func(srv *Server, dc, src, dest string, allow bool) error {
 		ixn := &structs.Intention{
 			SourceNS:        structs.IntentionDefaultNamespace,

--- a/agent/consul/operator_autopilot_endpoint_test.go
+++ b/agent/consul/operator_autopilot_endpoint_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestOperator_Autopilot_GetConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.AutopilotConfig.CleanupDeadServers = false
@@ -41,6 +45,10 @@ func TestOperator_Autopilot_GetConfiguration(t *testing.T) {
 }
 
 func TestOperator_Autopilot_GetConfiguration_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -100,6 +108,10 @@ func TestOperator_Autopilot_GetConfiguration_ACLDeny(t *testing.T) {
 }
 
 func TestOperator_Autopilot_SetConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.AutopilotConfig.CleanupDeadServers = false
@@ -137,6 +149,10 @@ func TestOperator_Autopilot_SetConfiguration(t *testing.T) {
 }
 
 func TestOperator_Autopilot_SetConfiguration_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -206,6 +222,10 @@ func TestOperator_Autopilot_SetConfiguration_ACLDeny(t *testing.T) {
 }
 
 func TestOperator_ServerHealth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	conf := func(c *Config) {
 		c.Datacenter = "dc1"
@@ -264,6 +284,10 @@ func TestOperator_ServerHealth(t *testing.T) {
 }
 
 func TestOperator_AutopilotState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	conf := func(c *Config) {
 		c.Datacenter = "dc1"

--- a/agent/consul/operator_raft_endpoint_test.go
+++ b/agent/consul/operator_raft_endpoint_test.go
@@ -17,6 +17,10 @@ import (
 )
 
 func TestOperator_RaftGetConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -59,6 +63,10 @@ func TestOperator_RaftGetConfiguration(t *testing.T) {
 }
 
 func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -136,6 +144,10 @@ func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -199,6 +211,10 @@ func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByAddress_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -256,6 +272,10 @@ func TestOperator_RaftRemovePeerByAddress_ACLDeny(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
@@ -320,6 +340,10 @@ func TestOperator_RaftRemovePeerByID(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByID_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -26,6 +26,10 @@ import (
 )
 
 func TestPreparedQuery_Apply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -187,6 +191,10 @@ func TestPreparedQuery_Apply(t *testing.T) {
 }
 
 func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -470,6 +478,10 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 }
 
 func TestPreparedQuery_Apply_ForwardLeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Bootstrap = false
@@ -625,6 +637,10 @@ func TestPreparedQuery_parseQuery(t *testing.T) {
 }
 
 func TestPreparedQuery_ACLDeny_Catchall_Template(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -840,6 +856,10 @@ func TestPreparedQuery_ACLDeny_Catchall_Template(t *testing.T) {
 }
 
 func TestPreparedQuery_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -1094,6 +1114,10 @@ func TestPreparedQuery_Get(t *testing.T) {
 }
 
 func TestPreparedQuery_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -1303,6 +1327,10 @@ func TestPreparedQuery_List(t *testing.T) {
 }
 
 func TestPreparedQuery_Explain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -1440,6 +1468,10 @@ func TestPreparedQuery_Explain(t *testing.T) {
 // walk through the different cases once we have it up. This is broken into
 // sections so it's still pretty easy to read.
 func TestPreparedQuery_Execute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -2360,6 +2392,10 @@ func TestPreparedQuery_Execute(t *testing.T) {
 }
 
 func TestPreparedQuery_Execute_ForwardLeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -2489,6 +2525,10 @@ func TestPreparedQuery_Execute_ForwardLeader(t *testing.T) {
 }
 
 func TestPreparedQuery_Execute_ConnectExact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -2734,6 +2774,10 @@ func TestPreparedQuery_tagFilter(t *testing.T) {
 }
 
 func TestPreparedQuery_Wrapper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -26,6 +26,10 @@ import (
 )
 
 func TestRPC_NoLeader_Fail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.RPCHoldTimeout = 1 * time.Millisecond
@@ -58,6 +62,10 @@ func TestRPC_NoLeader_Fail(t *testing.T) {
 }
 
 func TestRPC_NoLeader_Fail_on_stale_read(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.RPCHoldTimeout = 1 * time.Millisecond
@@ -100,6 +108,10 @@ func TestRPC_NoLeader_Fail_on_stale_read(t *testing.T) {
 }
 
 func TestRPC_NoLeader_Retry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.RPCHoldTimeout = 10 * time.Second
@@ -294,6 +306,10 @@ func TestRPC_blockingQuery(t *testing.T) {
 }
 
 func TestRPC_ReadyForConsistentReads(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, s := testServerWithConfig(t, func(c *Config) {
 		c.RPCHoldTimeout = 2 * time.Millisecond
@@ -326,6 +342,10 @@ func TestRPC_ReadyForConsistentReads(t *testing.T) {
 }
 
 func TestRPC_MagicByteTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.RPCHandshakeTimeout = 10 * time.Millisecond
@@ -362,6 +382,10 @@ func TestRPC_MagicByteTimeout(t *testing.T) {
 }
 
 func TestRPC_TLSHandshakeTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -411,6 +435,10 @@ func TestRPC_TLSHandshakeTimeout(t *testing.T) {
 }
 
 func TestRPC_PreventsTLSNesting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := []struct {
@@ -592,6 +620,10 @@ func connectClient(t *testing.T, s1 *Server, mb pool.RPCType, useTLS, wantOpen b
 }
 
 func TestRPC_RPCMaxConnsPerClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := []struct {
@@ -737,6 +769,10 @@ func TestRPC_readUint32(t *testing.T) {
 }
 
 func TestRPC_LocalTokenStrippedOnForward(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"

--- a/agent/consul/rtt_test.go
+++ b/agent/consul/rtt_test.go
@@ -131,6 +131,10 @@ func seedCoordinates(t *testing.T, codec rpc.ClientCodec, server *Server) {
 }
 
 func TestRTT_sortNodesByDistanceFrom(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
@@ -184,6 +188,10 @@ func TestRTT_sortNodesByDistanceFrom(t *testing.T) {
 }
 
 func TestRTT_sortNodesByDistanceFrom_Nodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
@@ -234,6 +242,10 @@ func TestRTT_sortNodesByDistanceFrom_Nodes(t *testing.T) {
 }
 
 func TestRTT_sortNodesByDistanceFrom_ServiceNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
@@ -284,6 +296,10 @@ func TestRTT_sortNodesByDistanceFrom_ServiceNodes(t *testing.T) {
 }
 
 func TestRTT_sortNodesByDistanceFrom_HealthChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
@@ -334,6 +350,10 @@ func TestRTT_sortNodesByDistanceFrom_HealthChecks(t *testing.T) {
 }
 
 func TestRTT_sortNodesByDistanceFrom_CheckServiceNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -328,6 +328,10 @@ func TestServer_StartStop(t *testing.T) {
 }
 
 func TestServer_fixupACLDatacenter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	_, s1 := testServerWithConfig(t, func(c *Config) {
@@ -452,6 +456,10 @@ func TestServer_JoinLAN_SerfAllowedCIDRs(t *testing.T) {
 }
 
 func TestServer_LANReap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	configureServer := func(c *Config) {
@@ -549,6 +557,10 @@ func TestServer_JoinWAN(t *testing.T) {
 }
 
 func TestServer_WANReap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
@@ -590,6 +602,10 @@ func TestServer_WANReap(t *testing.T) {
 }
 
 func TestServer_JoinWAN_Flood(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Set up two servers in a WAN.
 	dir1, s1 := testServerDCBootstrap(t, "dc1", true)
@@ -629,6 +645,10 @@ func TestServer_JoinWAN_Flood(t *testing.T) {
 
 // This is a mirror of a similar test in agent/agent_test.go
 func TestServer_JoinWAN_viaMeshGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	gwPort := freeport.MustTake(1)
@@ -861,6 +881,10 @@ func TestServer_JoinWAN_viaMeshGateway(t *testing.T) {
 }
 
 func TestServer_JoinSeparateLanAndWanAddresses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.NodeName = t.Name() + "-s1"
@@ -955,6 +979,10 @@ func TestServer_JoinSeparateLanAndWanAddresses(t *testing.T) {
 }
 
 func TestServer_LeaveLeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1001,6 +1029,10 @@ func TestServer_LeaveLeader(t *testing.T) {
 }
 
 func TestServer_Leave(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1051,6 +1083,10 @@ func TestServer_RPC(t *testing.T) {
 }
 
 func TestServer_JoinLAN_TLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, conf1 := testServerConfig(t)
 	conf1.VerifyIncoming = true
@@ -1085,6 +1121,10 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 }
 
 func TestServer_Expect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// All test servers should be in expect=3 mode, except for the 3rd one,
 	// but one with expect=0 can cause a bootstrap to occur from the other
 	// servers as currently implemented.
@@ -1134,6 +1174,10 @@ func TestServer_Expect(t *testing.T) {
 
 // Should not trigger bootstrap and new election when s3 joins, since cluster exists
 func TestServer_AvoidReBootstrap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir1, s1 := testServerDCExpect(t, "dc1", 2)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1170,6 +1214,10 @@ func TestServer_AvoidReBootstrap(t *testing.T) {
 }
 
 func TestServer_Expect_NonVoters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerDCExpectNonVoter(t, "dc1", 2)
 	defer os.RemoveAll(dir1)
@@ -1296,6 +1344,10 @@ func testVerifyRPC(s1, s2 *Server, t *testing.T) (bool, error) {
 }
 
 func TestServer_TLSToNoTLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Set up a server with no TLS configured
 	dir1, s1 := testServer(t)
@@ -1324,6 +1376,10 @@ func TestServer_TLSToNoTLS(t *testing.T) {
 }
 
 func TestServer_TLSForceOutgoingToNoTLS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Set up a server with no TLS configured
 	dir1, s1 := testServer(t)
@@ -1350,6 +1406,10 @@ func TestServer_TLSForceOutgoingToNoTLS(t *testing.T) {
 }
 
 func TestServer_TLSToFullVerify(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Set up a server with TLS and VerifyIncoming set
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -1383,6 +1443,10 @@ func TestServer_TLSToFullVerify(t *testing.T) {
 }
 
 func TestServer_RevokeLeadershipIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -1395,6 +1459,10 @@ func TestServer_RevokeLeadershipIdempotent(t *testing.T) {
 }
 
 func TestServer_Reload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	global_entry_init := &structs.ProxyConfigEntry{
@@ -1448,6 +1516,10 @@ func TestServer_Reload(t *testing.T) {
 }
 
 func TestServer_RPC_RateLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, conf1 := testServerConfig(t)
 	conf1.RPCRate = 2
@@ -1468,6 +1540,10 @@ func TestServer_RPC_RateLimit(t *testing.T) {
 }
 
 func TestServer_CALogging(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	_, conf1 := testServerConfig(t)
 
@@ -1499,6 +1575,10 @@ func TestServer_CALogging(t *testing.T) {
 }
 
 func TestServer_DatacenterJoinAddresses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	conf := testClusterConfig{
 		Datacenter: "primary",
 		Servers:    3,
@@ -1517,6 +1597,10 @@ func TestServer_DatacenterJoinAddresses(t *testing.T) {
 }
 
 func TestServer_CreateACLToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	_, srv, codec := testACLServerWithConfig(t, nil, false)
 
 	waitForLeaderEstablishment(t, srv)

--- a/agent/consul/session_endpoint_test.go
+++ b/agent/consul/session_endpoint_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestSession_Apply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -74,6 +78,10 @@ func TestSession_Apply(t *testing.T) {
 }
 
 func TestSession_DeleteApply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -139,6 +147,10 @@ func TestSession_DeleteApply(t *testing.T) {
 }
 
 func TestSession_Apply_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -217,6 +229,10 @@ session "foo" {
 }
 
 func TestSession_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -262,6 +278,10 @@ func TestSession_Get(t *testing.T) {
 }
 
 func TestSession_Get_Compat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -308,6 +328,10 @@ func TestSession_Get_Compat(t *testing.T) {
 }
 
 func TestSession_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -361,6 +385,10 @@ func TestSession_List(t *testing.T) {
 }
 
 func TestSession_Get_List_NodeSessions_ACLFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -500,6 +528,10 @@ session "foo" {
 }
 
 func TestSession_ApplyTimers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -543,6 +575,10 @@ func TestSession_ApplyTimers(t *testing.T) {
 }
 
 func TestSession_Renew(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This method is timing sensitive, disable Parallel
 	//t.Parallel()
 	ttl := 1 * time.Second
@@ -708,6 +744,10 @@ func TestSession_Renew(t *testing.T) {
 }
 
 func TestSession_Renew_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -781,6 +821,10 @@ session "foo" {
 }
 
 func TestSession_Renew_Compat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This method is timing sensitive, disable Parallel
 	//t.Parallel()
 	ttl := 5 * time.Second
@@ -838,6 +882,10 @@ func TestSession_Renew_Compat(t *testing.T) {
 }
 
 func TestSession_NodeSessions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -898,6 +946,10 @@ func TestSession_NodeSessions(t *testing.T) {
 }
 
 func TestSession_Apply_BadTTL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)

--- a/agent/consul/session_timers_test.go
+++ b/agent/consul/session_timers_test.go
@@ -6,6 +6,10 @@ import (
 )
 
 func TestSessionTimers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	m := NewSessionTimers()
 	ch := make(chan int)
 	newTm := func(d time.Duration) *time.Timer {

--- a/agent/consul/session_ttl_test.go
+++ b/agent/consul/session_ttl_test.go
@@ -23,6 +23,10 @@ func generateUUID() (ret string) {
 }
 
 func TestInitializeSessionTimers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -56,6 +60,10 @@ func TestInitializeSessionTimers(t *testing.T) {
 }
 
 func TestResetSessionTimer_Fault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -96,6 +104,10 @@ func TestResetSessionTimer_Fault(t *testing.T) {
 }
 
 func TestResetSessionTimer_NoTTL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -150,6 +162,10 @@ func TestResetSessionTimer_InvalidTTL(t *testing.T) {
 }
 
 func TestResetSessionTimerLocked(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -170,6 +186,10 @@ func TestResetSessionTimerLocked(t *testing.T) {
 }
 
 func TestResetSessionTimerLocked_Renew(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -219,6 +239,10 @@ func TestResetSessionTimerLocked_Renew(t *testing.T) {
 }
 
 func TestInvalidateSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -291,6 +315,10 @@ func TestClearAllSessionTimers(t *testing.T) {
 }
 
 func TestServer_SessionTTL_Failover(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)

--- a/agent/consul/snapshot_endpoint_test.go
+++ b/agent/consul/snapshot_endpoint_test.go
@@ -154,6 +154,10 @@ func verifySnapshot(t *testing.T, s *Server, dc, token string) {
 }
 
 func TestSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -164,6 +168,10 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestSnapshot_LeaderState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -247,6 +255,10 @@ func TestSnapshot_LeaderState(t *testing.T) {
 }
 
 func TestSnapshot_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
@@ -294,6 +306,10 @@ func TestSnapshot_ACLDeny(t *testing.T) {
 }
 
 func TestSnapshot_Forward_Leader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Bootstrap = true
 		c.SerfWANConfig = nil
@@ -340,6 +356,10 @@ func TestSnapshot_Forward_Leader(t *testing.T) {
 }
 
 func TestSnapshot_Forward_Datacenter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerDC(t, "dc1")
 	defer os.RemoveAll(dir1)

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1374,6 +1374,10 @@ func TestStateStore_Node_Snapshot(t *testing.T) {
 }
 
 func TestStateStore_EnsureService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	s := testStateStore(t)
 
 	// Fetching services for a node with none returns nil.
@@ -2564,6 +2568,10 @@ func TestStateStore_ServiceChecks(t *testing.T) {
 }
 
 func TestStateStore_ServiceChecksByNodeMeta(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	s := testStateStore(t)
 
 	// Querying with no results returns nil.
@@ -2671,6 +2679,10 @@ func TestStateStore_ServiceChecksByNodeMeta(t *testing.T) {
 }
 
 func TestStateStore_ChecksInState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	s := testStateStore(t)
 
 	// Querying with no results returns nil
@@ -2734,6 +2746,10 @@ func TestStateStore_ChecksInState(t *testing.T) {
 }
 
 func TestStateStore_ChecksInStateByNodeMeta(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	s := testStateStore(t)
 
 	// Querying with no results returns nil.
@@ -3036,6 +3052,10 @@ func TestStateStore_IndexIndependence(t *testing.T) {
 }
 
 func TestStateStore_ConnectQueryBlocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	tests := []struct {
 		name                   string
 		setupFn                func(s *Store)
@@ -3585,6 +3605,10 @@ func TestStateStore_CheckConnectServiceNodes(t *testing.T) {
 }
 
 func TestStateStore_CheckConnectServiceNodes_Gateways(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	assert := assert.New(t)
 	s := testStateStore(t)
 
@@ -5331,6 +5355,10 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 }
 
 func TestStateStore_GatewayServices_WildcardAssociation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	s := testStateStore(t)
 	setupIngressState(t, s)
 	require := require.New(t)

--- a/agent/consul/state/coordinate_test.go
+++ b/agent/consul/state/coordinate_test.go
@@ -28,6 +28,10 @@ func generateRandomCoordinate() *coordinate.Coordinate {
 }
 
 func TestStateStore_Coordinate_Updates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	s := testStateStore(t)
 
 	// Make sure the coordinates list starts out empty, and that a query for

--- a/agent/consul/state/delay_test.go
+++ b/agent/consul/state/delay_test.go
@@ -6,6 +6,10 @@ import (
 )
 
 func TestDelay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	d := NewDelay()
 
 	// An unknown key should have a time in the past.

--- a/agent/consul/state/graveyard_test.go
+++ b/agent/consul/state/graveyard_test.go
@@ -103,6 +103,10 @@ func TestGraveyard_Lifecycle(t *testing.T) {
 }
 
 func TestGraveyard_GC_Trigger(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// Set up a fast-expiring GC.
 	ttl, granularity := 100*time.Millisecond, 20*time.Millisecond
 	gc, err := NewTombstoneGC(ttl, granularity)

--- a/agent/consul/state/prepared_query_test.go
+++ b/agent/consul/state/prepared_query_test.go
@@ -35,6 +35,10 @@ func TestStateStore_PreparedQuery_isUUID(t *testing.T) {
 }
 
 func TestStateStore_PreparedQuerySet_PreparedQueryGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	s := testStateStore(t)
 
 	// Querying with no results returns nil.

--- a/agent/consul/state/session_test.go
+++ b/agent/consul/state/session_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestStateStore_SessionCreate_SessionGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	s := testStateStore(t)
 
 	// SessionGet returns nil if the session doesn't exist

--- a/agent/consul/state/store_integration_test.go
+++ b/agent/consul/state/store_integration_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestStore_IntegrationWithEventPublisher_ACLTokenUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 	s := testACLTokensStateStore(t)
@@ -97,6 +101,10 @@ func TestStore_IntegrationWithEventPublisher_ACLTokenUpdate(t *testing.T) {
 }
 
 func TestStore_IntegrationWithEventPublisher_ACLPolicyUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 	s := testACLTokensStateStore(t)
@@ -215,6 +223,10 @@ func TestStore_IntegrationWithEventPublisher_ACLPolicyUpdate(t *testing.T) {
 }
 
 func TestStore_IntegrationWithEventPublisher_ACLRoleUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 	s := testACLTokensStateStore(t)

--- a/agent/consul/stats_fetcher_test.go
+++ b/agent/consul/stats_fetcher_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestStatsFetcher(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir1, s1 := testServerDCExpect(t, "dc1", 3)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/status_endpoint_test.go
+++ b/agent/consul/status_endpoint_test.go
@@ -60,6 +60,10 @@ func insecureRPCClient(s *Server, c tlsutil.Config) (rpc.ClientCodec, error) {
 }
 
 func TestStatusLeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -87,6 +91,10 @@ func TestStatusLeader(t *testing.T) {
 }
 
 func TestStatusLeader_ForwardDC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerDC(t, "primary")
 	defer os.RemoveAll(dir1)
@@ -131,6 +139,10 @@ func TestStatusPeers(t *testing.T) {
 }
 
 func TestStatusPeers_ForwardDC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServerDC(t, "primary")
 	defer os.RemoveAll(dir1)

--- a/agent/consul/stream/event_buffer_test.go
+++ b/agent/consul/stream/event_buffer_test.go
@@ -14,6 +14,10 @@ import (
 // correctness properties are not violated (and that -race doesn't complain).
 func TestEventBufferFuzz(t *testing.T) {
 	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	if testing.Short() {
 		t.Skip("too slow for short run")
 	}
 

--- a/agent/consul/stream/subscription_test.go
+++ b/agent/consul/stream/subscription_test.go
@@ -11,6 +11,10 @@ import (
 func noopUnSub() {}
 
 func TestSubscription(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	eb := newEventBuffer()
 
 	index := uint64(100)
@@ -87,6 +91,10 @@ func TestSubscription(t *testing.T) {
 }
 
 func TestSubscription_Close(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	eb := newEventBuffer()
 	index := uint64(100)
 	startHead := eb.Head()

--- a/agent/consul/system_metadata_test.go
+++ b/agent/consul/system_metadata_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestLeader_SystemMetadata_CRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This test is a little strange because it is testing behavior that
 	// doesn't have an exposed RPC. We're just testing the full round trip of
 	// raft+fsm For now,

--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -55,6 +55,10 @@ node "test-node" {
 var testNodeID = "9749a7df-fac5-46b4-8078-32a3d96c59f3"
 
 func TestTxn_CheckNotExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -107,6 +111,10 @@ func TestTxn_CheckNotExists(t *testing.T) {
 }
 
 func TestTxn_Apply(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -300,6 +308,10 @@ func TestTxn_Apply(t *testing.T) {
 }
 
 func TestTxn_Apply_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -614,6 +626,10 @@ func TestTxn_Apply_ACLDeny(t *testing.T) {
 }
 
 func TestTxn_Apply_LockDelay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -701,6 +717,10 @@ func TestTxn_Apply_LockDelay(t *testing.T) {
 }
 
 func TestTxn_Read(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -823,6 +843,10 @@ func TestTxn_Read(t *testing.T) {
 }
 
 func TestTxn_Read_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)

--- a/agent/coordinate_endpoint_test.go
+++ b/agent/coordinate_endpoint_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestCoordinate_Disabled_Response(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		disable_coordinates = true
@@ -51,6 +55,10 @@ func TestCoordinate_Disabled_Response(t *testing.T) {
 }
 
 func TestCoordinate_Datacenters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -77,6 +85,10 @@ func TestCoordinate_Datacenters(t *testing.T) {
 }
 
 func TestCoordinate_Nodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -228,6 +240,10 @@ func TestCoordinate_Nodes(t *testing.T) {
 }
 
 func TestCoordinate_Node(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -341,6 +357,10 @@ func TestCoordinate_Node(t *testing.T) {
 }
 
 func TestCoordinate_Update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -393,6 +413,10 @@ func TestCoordinate_Update(t *testing.T) {
 }
 
 func TestCoordinate_Update_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()

--- a/agent/discovery_chain_endpoint_test.go
+++ b/agent/discovery_chain_endpoint_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func TestDiscoveryChainRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -156,6 +156,10 @@ func TestEncodeKVasRFC1464(t *testing.T) {
 }
 
 func TestDNS_Over_TCP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -189,6 +193,10 @@ func TestDNS_Over_TCP(t *testing.T) {
 }
 
 func TestDNS_EmptyAltDomain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -204,6 +212,10 @@ func TestDNS_EmptyAltDomain(t *testing.T) {
 }
 
 func TestDNS_NodeLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -299,6 +311,10 @@ func TestDNS_NodeLookup(t *testing.T) {
 }
 
 func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -331,6 +347,10 @@ func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_PeriodName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -371,6 +391,10 @@ func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_AAAA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -414,6 +438,10 @@ func TestDNS_NodeLookup_AAAA(t *testing.T) {
 }
 
 func TestDNSCycleRecursorCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Start a DNS recursor that returns a SERVFAIL
 	server1 := makeRecursor(t, dns.Msg{
@@ -448,6 +476,10 @@ func TestDNSCycleRecursorCheck(t *testing.T) {
 	require.Equal(t, wantAnswer, in.Answer)
 }
 func TestDNSCycleRecursorCheckAllFail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Start 3 DNS recursors that returns a REFUSED status
 	server1 := makeRecursor(t, dns.Msg{
@@ -477,6 +509,10 @@ func TestDNSCycleRecursorCheckAllFail(t *testing.T) {
 	require.Equal(t, dns.RcodeServerFailure, in.Rcode)
 }
 func TestDNS_NodeLookup_CNAME(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	recursor := makeRecursor(t, dns.Msg{
 		Answer: []dns.RR{
@@ -536,6 +572,10 @@ func TestDNS_NodeLookup_CNAME(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_TXT(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -582,6 +622,10 @@ func TestDNS_NodeLookup_TXT(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_TXT_DontSuppress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -628,6 +672,10 @@ func TestDNS_NodeLookup_TXT_DontSuppress(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_ANY(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -669,6 +717,10 @@ func TestDNS_NodeLookup_ANY(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -710,6 +762,10 @@ func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -746,6 +802,10 @@ func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
 }
 
 func TestDNS_EDNS0(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -786,6 +846,10 @@ func TestDNS_EDNS0(t *testing.T) {
 }
 
 func TestDNS_EDNS0_ECS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -878,6 +942,10 @@ func TestDNS_EDNS0_ECS(t *testing.T) {
 }
 
 func TestDNS_ReverseLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -918,6 +986,10 @@ func TestDNS_ReverseLookup(t *testing.T) {
 }
 
 func TestDNS_ReverseLookup_CustomDomain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		domain = "custom"
@@ -960,6 +1032,10 @@ func TestDNS_ReverseLookup_CustomDomain(t *testing.T) {
 }
 
 func TestDNS_ReverseLookup_IPV6(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1000,6 +1076,10 @@ func TestDNS_ReverseLookup_IPV6(t *testing.T) {
 }
 
 func TestDNS_ServiceReverseLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1048,6 +1128,10 @@ func TestDNS_ServiceReverseLookup(t *testing.T) {
 }
 
 func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1096,6 +1180,10 @@ func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 }
 
 func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		domain = "custom"
@@ -1146,6 +1234,10 @@ func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 }
 
 func TestDNS_SOA_Settings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testSoaWithConfig := func(config string, ttl, expire, refresh, retry uint) {
 		a := NewTestAgent(t, config)
@@ -1179,6 +1271,10 @@ func TestDNS_SOA_Settings(t *testing.T) {
 }
 
 func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1227,6 +1323,10 @@ func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
 }
 
 func TestDNS_ServiceLookupNoMultiCNAME(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1282,6 +1382,10 @@ func TestDNS_ServiceLookupNoMultiCNAME(t *testing.T) {
 }
 
 func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1340,6 +1444,10 @@ func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
 }
 
 func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1414,6 +1522,10 @@ func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1535,6 +1647,10 @@ func TestDNS_ServiceLookup(t *testing.T) {
 }
 
 func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		node_name = "my.test-node"
@@ -1592,6 +1708,10 @@ func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 }
 
 func TestDNS_ConnectServiceLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -1637,6 +1757,10 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 }
 
 func TestDNS_IngressServiceLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -1740,6 +1864,10 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 }
 
 func TestDNS_ExternalServiceLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1798,6 +1926,10 @@ func TestDNS_ExternalServiceLookup(t *testing.T) {
 }
 
 func TestDNS_InifiniteRecursion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This test should not create an infinite recursion
 	t.Parallel()
 	a := NewTestAgent(t, `
@@ -1853,6 +1985,10 @@ func TestDNS_InifiniteRecursion(t *testing.T) {
 }
 
 func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		domain = "CONSUL."
@@ -1952,6 +2088,10 @@ func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
 }
 
 func TestDNS_NSRecords(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		domain = "CONSUL."
@@ -1987,6 +2127,10 @@ func TestDNS_NSRecords(t *testing.T) {
 }
 
 func TestDNS_NSRecords_IPV6(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
  		domain = "CONSUL."
@@ -2024,6 +2168,10 @@ func TestDNS_NSRecords_IPV6(t *testing.T) {
 }
 
 func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		node_name = "test-node"
@@ -2151,6 +2299,10 @@ func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2244,6 +2396,10 @@ func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	recursor := makeRecursor(t, dns.Msg{
 		Answer: []dns.RR{
@@ -2351,6 +2507,10 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2444,6 +2604,10 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
@@ -2652,6 +2816,10 @@ func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 }
 
 func TestDNS_Lookup_TaggedIPAddresses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2842,6 +3010,10 @@ func TestDNS_Lookup_TaggedIPAddresses(t *testing.T) {
 }
 
 func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2913,6 +3085,10 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -2985,6 +3161,10 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 }
 
 func TestDNS_PreparedQueryNearIPEDNS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ipCoord := lib.GenerateCoordinate(1 * time.Millisecond)
 	serviceNodes := []struct {
 		name    string
@@ -3112,6 +3292,10 @@ func TestDNS_PreparedQueryNearIPEDNS(t *testing.T) {
 }
 
 func TestDNS_PreparedQueryNearIP(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ipCoord := lib.GenerateCoordinate(1 * time.Millisecond)
 	serviceNodes := []struct {
 		name    string
@@ -3228,6 +3412,10 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3307,6 +3495,10 @@ func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Dedup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3410,6 +3602,10 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3541,6 +3737,10 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 }
 
 func TestDNS_Recurse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	recursor := makeRecursor(t, dns.Msg{
 		Answer: []dns.RR{dnsA("apple.com", "1.2.3.4")},
@@ -3571,6 +3771,10 @@ func TestDNS_Recurse(t *testing.T) {
 }
 
 func TestDNS_Recurse_Truncation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	recursor := makeRecursor(t, dns.Msg{
@@ -3605,6 +3809,10 @@ func TestDNS_Recurse_Truncation(t *testing.T) {
 }
 
 func TestDNS_RecursorTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	serverClientTimeout := 3 * time.Second
 	testClientTimeout := serverClientTimeout + 5*time.Second
@@ -3658,6 +3866,10 @@ func TestDNS_RecursorTimeout(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3814,6 +4026,10 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -3927,6 +4143,10 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		dns_config {
@@ -4070,6 +4290,10 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Randomize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -4201,6 +4425,10 @@ func TestBinarySearch(t *testing.T) {
 }
 
 func TestDNS_TCP_and_UDP_Truncate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		dns_config {
@@ -4306,6 +4534,10 @@ func TestDNS_TCP_and_UDP_Truncate(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Truncate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		dns_config {
@@ -4375,6 +4607,10 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		dns_config {
@@ -4651,6 +4887,10 @@ func checkDNSService(t *testing.T, generateNumNodes int, aRecordLimit int, qType
 }
 
 func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	tests := []struct {
 		name                string
@@ -4729,6 +4969,10 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_AnswerLimits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Build a matrix of config parameters (udpAnswerLimit), and the
 	// length of the response per query type and question.  Negative
@@ -4795,6 +5039,10 @@ func TestDNS_ServiceLookup_AnswerLimits(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_CNAME(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	recursor := makeRecursor(t, dns.Msg{
 		Answer: []dns.RR{
@@ -4892,6 +5140,10 @@ func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	recursor := makeRecursor(t, dns.Msg{
 		Answer: []dns.RR{
@@ -4990,6 +5242,10 @@ func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_TTL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	recursor := makeRecursor(t, dns.Msg{
 		Answer: []dns.RR{
@@ -5116,6 +5372,10 @@ func TestDNS_NodeLookup_TTL(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_TTL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		dns_config {
@@ -5194,6 +5454,10 @@ func TestDNS_ServiceLookup_TTL(t *testing.T) {
 }
 
 func TestDNS_PreparedQuery_TTL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		dns_config {
@@ -5314,6 +5578,10 @@ func TestDNS_PreparedQuery_TTL(t *testing.T) {
 }
 
 func TestDNS_PreparedQuery_Failover(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
@@ -5426,6 +5694,10 @@ func TestDNS_PreparedQuery_Failover(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -5501,6 +5773,10 @@ func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_SRV_RFC_TCP_Default(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -5576,6 +5852,10 @@ func TestDNS_ServiceLookup_SRV_RFC_TCP_Default(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	tests := []struct {
 		token   string
@@ -5628,6 +5908,10 @@ func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
 	}
 }
 func TestDNS_ServiceLookup_MetaTXT(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = true }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -5674,6 +5958,10 @@ func TestDNS_ServiceLookup_MetaTXT(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_SuppressTXT(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -5717,6 +6005,10 @@ func TestDNS_ServiceLookup_SuppressTXT(t *testing.T) {
 }
 
 func TestDNS_AddressLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -5754,6 +6046,10 @@ func TestDNS_AddressLookup(t *testing.T) {
 }
 
 func TestDNS_AddressLookupIPV6(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -5795,6 +6091,10 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 // Consul server agent is queried for a service in a non-existent
 // domain.
 func TestDNS_NonExistentDC_Server(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -5818,6 +6118,10 @@ func TestDNS_NonExistentDC_Server(t *testing.T) {
 // Consul server agent is queried over RPC by a non-server agent
 // for a service in a non-existent domain
 func TestDNS_NonExistentDC_RPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	s := NewTestAgent(t, `
 		node_name = "test-server"
@@ -5852,6 +6156,10 @@ func TestDNS_NonExistentDC_RPC(t *testing.T) {
 }
 
 func TestDNS_NonExistingLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -5881,6 +6189,10 @@ func TestDNS_NonExistingLookup(t *testing.T) {
 }
 
 func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -6020,6 +6332,10 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 }
 
 func TestDNS_AltDomains_Service(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		alt_domain = "test-domain."
@@ -6092,6 +6408,10 @@ func TestDNS_AltDomains_Service(t *testing.T) {
 }
 
 func TestDNS_AltDomains_SOA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		node_name = "test-node"
@@ -6134,6 +6454,10 @@ func TestDNS_AltDomains_SOA(t *testing.T) {
 }
 
 func TestDNS_AltDomains_Overlap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// this tests the domain matching logic in DNSServer when encountering more
 	// than one potential match (i.e. ambiguous match)
 	// it should select the longer matching domain when dispatching
@@ -6178,6 +6502,10 @@ func TestDNS_AltDomains_Overlap(t *testing.T) {
 }
 
 func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		dns_config {
@@ -6228,6 +6556,10 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 }
 
 func TestDNS_InvalidQueries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -6270,6 +6602,10 @@ func TestDNS_InvalidQueries(t *testing.T) {
 }
 
 func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -6776,6 +7112,10 @@ func TestDNS_Compression_trimUDPResponse(t *testing.T) {
 }
 
 func TestDNS_Compression_Query(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -6863,6 +7203,10 @@ func TestDNS_Compression_Query(t *testing.T) {
 }
 
 func TestDNS_Compression_ReverseLookup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -6915,6 +7259,10 @@ func TestDNS_Compression_ReverseLookup(t *testing.T) {
 }
 
 func TestDNS_Compression_Recurse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	recursor := makeRecursor(t, dns.Msg{
 		Answer: []dns.RR{dnsA("apple.com", "1.2.3.4")},
@@ -6986,6 +7334,10 @@ func TestDNSInvalidRegex(t *testing.T) {
 }
 
 func TestDNS_ConfigReload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, `
@@ -7088,6 +7440,10 @@ func TestDNS_ConfigReload(t *testing.T) {
 }
 
 func TestDNS_ReloadConfig_DuringQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -17,6 +17,10 @@ import (
 )
 
 func TestEventFire(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -57,6 +61,10 @@ func TestEventFire(t *testing.T) {
 }
 
 func TestEventFire_token(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig()+`
 		acl_default_policy = "deny"
@@ -119,6 +127,10 @@ func TestEventFire_token(t *testing.T) {
 }
 
 func TestEventList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -152,6 +164,10 @@ func TestEventList(t *testing.T) {
 }
 
 func TestEventList_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -190,6 +206,10 @@ func TestEventList_Filter(t *testing.T) {
 }
 
 func TestEventList_ACLFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
@@ -241,6 +261,10 @@ func TestEventList_ACLFilter(t *testing.T) {
 }
 
 func TestEventList_Blocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -293,6 +317,10 @@ func TestEventList_Blocking(t *testing.T) {
 }
 
 func TestEventList_EventBufOrder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -20,6 +20,10 @@ import (
 )
 
 func TestHealthChecksInState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("warning", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -69,6 +73,10 @@ func TestHealthChecksInState(t *testing.T) {
 }
 
 func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -109,6 +117,10 @@ func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealthChecksInState_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -155,6 +167,10 @@ func TestHealthChecksInState_Filter(t *testing.T) {
 }
 
 func TestHealthChecksInState_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -229,6 +245,10 @@ func TestHealthChecksInState_DistanceSort(t *testing.T) {
 }
 
 func TestHealthNodeChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -264,6 +284,10 @@ func TestHealthNodeChecks(t *testing.T) {
 }
 
 func TestHealthNodeChecks_Filtering(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -308,6 +332,10 @@ func TestHealthNodeChecks_Filtering(t *testing.T) {
 }
 
 func TestHealthServiceChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -364,6 +392,10 @@ func TestHealthServiceChecks(t *testing.T) {
 }
 
 func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -417,6 +449,10 @@ func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealthServiceChecks_Filtering(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -478,6 +514,10 @@ func TestHealthServiceChecks_Filtering(t *testing.T) {
 }
 
 func TestHealthServiceChecks_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -558,6 +598,10 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 }
 
 func TestHealthServiceNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -684,6 +728,10 @@ func TestHealthServiceNodes(t *testing.T) {
 }
 
 func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -737,6 +785,10 @@ func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealthServiceNodes_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -799,6 +851,10 @@ func TestHealthServiceNodes_Filter(t *testing.T) {
 }
 
 func TestHealthServiceNodes_DistanceSort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -878,6 +934,10 @@ func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 }
 
 func TestHealthServiceNodes_PassingFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -975,6 +1035,10 @@ func TestHealthServiceNodes_PassingFilter(t *testing.T) {
 }
 
 func TestHealthServiceNodes_CheckType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1028,6 +1092,10 @@ func TestHealthServiceNodes_CheckType(t *testing.T) {
 }
 
 func TestHealthServiceNodes_WanTranslation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
@@ -1114,6 +1182,10 @@ func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 }
 
 func TestHealthConnectServiceNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -1140,6 +1212,10 @@ func TestHealthConnectServiceNodes(t *testing.T) {
 }
 
 func TestHealthIngressServiceNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -1210,6 +1286,10 @@ func TestHealthIngressServiceNodes(t *testing.T) {
 }
 
 func TestHealthConnectServiceNodes_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -1248,6 +1328,10 @@ func TestHealthConnectServiceNodes_Filter(t *testing.T) {
 }
 
 func TestHealthConnectServiceNodes_PassingFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")

--- a/agent/http_oss_test.go
+++ b/agent/http_oss_test.go
@@ -60,6 +60,10 @@ func newHttpClient(timeout time.Duration) *http.Client {
 }
 
 func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// To avoid actually triggering RPCs that are allowed, lock everything down
 	// with default-deny ACLs. This drops the test runtime from 11s to 0.6s.
 	a := NewTestAgent(t, `
@@ -124,6 +128,10 @@ func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
 }
 
 func TestHTTPAPI_OptionMethod_OSS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, `acl_datacenter = "dc1"`)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -160,6 +168,10 @@ func TestHTTPAPI_OptionMethod_OSS(t *testing.T) {
 }
 
 func TestHTTPAPI_AllowedNets_OSS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, `
 		acl_datacenter = "dc1"
 		http_config {

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -34,6 +34,10 @@ import (
 )
 
 func TestHTTPServer_UnixSocket(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
@@ -92,6 +96,10 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 }
 
 func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
@@ -130,6 +138,10 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 }
 
 func TestSetupHTTPServer_HTTP2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// Fire up an agent with TLS enabled.
@@ -299,6 +311,10 @@ func TestSetMeta(t *testing.T) {
 }
 
 func TestHTTPAPI_BlockEndpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, `
@@ -334,6 +350,10 @@ func TestHTTPAPI_BlockEndpoints(t *testing.T) {
 }
 
 func TestHTTPAPI_Ban_Nonprintable_Characters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
@@ -353,6 +373,10 @@ func TestHTTPAPI_Ban_Nonprintable_Characters(t *testing.T) {
 }
 
 func TestHTTPAPI_Allow_Nonprintable_Characters_With_Flag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, "disable_http_unprintable_char_filter = true")
 	defer a.Shutdown()
 
@@ -373,6 +397,10 @@ func TestHTTPAPI_Allow_Nonprintable_Characters_With_Flag(t *testing.T) {
 }
 
 func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Header should not be present if address translation is off.
 	{
@@ -416,6 +444,10 @@ func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
 }
 
 func TestHTTPAPI_DefaultACLPolicy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	type testcase struct {
@@ -464,6 +496,10 @@ func TestHTTPAPI_DefaultACLPolicy(t *testing.T) {
 }
 
 func TestHTTPAPIResponseHeaders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		ui_config {
@@ -503,6 +539,10 @@ func requireHasHeadersSet(t *testing.T, a *TestAgent, path string) {
 }
 
 func TestUIResponseHeaders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		http_config {
@@ -519,6 +559,10 @@ func TestUIResponseHeaders(t *testing.T) {
 }
 
 func TestAcceptEncodingGzip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -558,6 +602,10 @@ func TestAcceptEncodingGzip(t *testing.T) {
 }
 
 func TestContentTypeIsJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -579,6 +627,10 @@ func TestContentTypeIsJSON(t *testing.T) {
 }
 
 func TestHTTP_wrap_obfuscateLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	buf := new(bytes.Buffer)
 	a := StartTestAgent(t, TestAgent{LogOutput: buf})
@@ -632,11 +684,19 @@ func TestHTTP_wrap_obfuscateLog(t *testing.T) {
 }
 
 func TestPrettyPrint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testPrettyPrint("pretty=1", t)
 }
 
 func TestPrettyPrintBare(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testPrettyPrint("pretty", t)
 }
@@ -669,6 +729,10 @@ func testPrettyPrint(pretty string, t *testing.T) {
 }
 
 func TestParseSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -867,6 +931,10 @@ func TestParseWait(t *testing.T) {
 }
 
 func TestHTTPServer_PProfHandlers_EnableDebug(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -881,6 +949,10 @@ func TestHTTPServer_PProfHandlers_EnableDebug(t *testing.T) {
 }
 
 func TestHTTPServer_PProfHandlers_DisableDebugNoACLs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -895,6 +967,10 @@ func TestHTTPServer_PProfHandlers_DisableDebugNoACLs(t *testing.T) {
 }
 
 func TestHTTPServer_PProfHandlers_ACLs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 	dc1 := "dc1"
@@ -996,6 +1072,10 @@ func TestParseWait_InvalidIndex(t *testing.T) {
 }
 
 func TestParseConsistency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
@@ -1053,6 +1133,10 @@ func ensureConsistency(t *testing.T, a *TestAgent, path string, maxStale time.Du
 }
 
 func TestParseConsistencyAndMaxStale(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
@@ -1084,6 +1168,10 @@ func TestParseConsistencyAndMaxStale(t *testing.T) {
 }
 
 func TestParseConsistency_Invalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
@@ -1102,6 +1190,10 @@ func TestParseConsistency_Invalid(t *testing.T) {
 
 // Test ACL token is resolved in correct order
 func TestACLResolution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	var token string
 	// Request without token
@@ -1239,6 +1331,10 @@ func TestACLResolution(t *testing.T) {
 }
 
 func TestEnableWebUI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		ui_config {
@@ -1286,6 +1382,10 @@ func TestEnableWebUI(t *testing.T) {
 }
 
 func TestAllowedNets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	type testVal struct {
 		nets     []string
 		ip       string
@@ -1409,6 +1509,10 @@ func jsonReader(v interface{}) io.Reader {
 }
 
 func TestHTTPServer_HandshakeTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	// Fire up an agent with TLS enabled.
@@ -1456,6 +1560,10 @@ func TestHTTPServer_HandshakeTimeout(t *testing.T) {
 }
 
 func TestRPC_HTTPSMaxConnsPerClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := []struct {

--- a/agent/intentions_endpoint_oss_test.go
+++ b/agent/intentions_endpoint_oss_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestOSS_IntentionsCreate_failure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestIntentionList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -85,6 +89,10 @@ func TestIntentionList(t *testing.T) {
 }
 
 func TestIntentionMatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -221,6 +229,10 @@ func TestIntentionMatch(t *testing.T) {
 }
 
 func TestIntentionCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -301,6 +313,10 @@ func TestIntentionCheck(t *testing.T) {
 }
 
 func TestIntentionPutExact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -368,6 +384,10 @@ func TestIntentionPutExact(t *testing.T) {
 }
 
 func TestIntentionCreate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -410,6 +430,10 @@ func TestIntentionCreate(t *testing.T) {
 }
 
 func TestIntentionSpecificGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -460,6 +484,10 @@ func TestIntentionSpecificGet(t *testing.T) {
 }
 
 func TestIntentionSpecificUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -506,6 +534,10 @@ func TestIntentionSpecificUpdate(t *testing.T) {
 }
 
 func TestIntentionDeleteExact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -597,6 +629,10 @@ func TestIntentionDeleteExact(t *testing.T) {
 }
 
 func TestIntentionSpecificDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -28,6 +28,10 @@ func checkForKey(key string, keyring *memberlist.Keyring) error {
 }
 
 func TestAgent_LoadKeyrings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key := "tbLJg26ZJyJ9pK3qhc9jig=="
 
@@ -124,6 +128,10 @@ func writeKeyRings(t *testing.T, key string, dataDir string) {
 }
 
 func TestAgent_InmemKeyrings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key := "tbLJg26ZJyJ9pK3qhc9jig=="
 
@@ -283,6 +291,10 @@ func TestAgent_InitKeyring(t *testing.T) {
 }
 
 func TestAgentKeyring_ACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key1 := "tbLJg26ZJyJ9pK3qhc9jig=="
 	key2 := "4leC33rgtXKIVUr9Nr0snQ=="

--- a/agent/kvs_endpoint_test.go
+++ b/agent/kvs_endpoint_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestKVSEndpoint_PUT_GET_DELETE(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -73,6 +77,10 @@ func TestKVSEndpoint_PUT_GET_DELETE(t *testing.T) {
 }
 
 func TestKVSEndpoint_Recurse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -149,6 +157,10 @@ func TestKVSEndpoint_Recurse(t *testing.T) {
 }
 
 func TestKVSEndpoint_DELETE_CAS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -215,6 +227,10 @@ func TestKVSEndpoint_DELETE_CAS(t *testing.T) {
 }
 
 func TestKVSEndpoint_CAS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -291,6 +307,10 @@ func TestKVSEndpoint_CAS(t *testing.T) {
 }
 
 func TestKVSEndpoint_ListKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -340,6 +360,10 @@ func TestKVSEndpoint_ListKeys(t *testing.T) {
 }
 
 func TestKVSEndpoint_AcquireRelease(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -399,6 +423,10 @@ func TestKVSEndpoint_AcquireRelease(t *testing.T) {
 }
 
 func TestKVSEndpoint_GET_Raw(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -429,6 +457,10 @@ func TestKVSEndpoint_GET_Raw(t *testing.T) {
 }
 
 func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -448,6 +480,10 @@ func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
 }
 
 func TestKVSEndpoint_DELETE_ConflictingFlags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -30,6 +30,10 @@ func unNilMap(in map[string]string) map[string]string {
 }
 
 func TestAgentAntiEntropy_Services(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -250,6 +254,10 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -414,6 +422,10 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 }
 
 func TestAgent_ServiceWatchCh(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -498,6 +510,10 @@ func TestAgent_ServiceWatchCh(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -629,6 +645,10 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -759,6 +779,10 @@ var testRegisterRules = `
  `
 
 func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		acl_datacenter = "dc1"
@@ -906,6 +930,10 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1098,6 +1126,10 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_RemovingServiceAndCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -1173,6 +1205,10 @@ func TestAgentAntiEntropy_RemovingServiceAndCheck(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dc := "dc1"
 	a := &agent.TestAgent{HCL: `
@@ -1392,6 +1428,10 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		discard_check_output = true
@@ -1443,6 +1483,10 @@ func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := &agent.TestAgent{HCL: `
 		check_update_interval = "500ms"
@@ -1647,6 +1691,10 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	nodeID := types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5")
 	nodeMeta := map[string]string{
@@ -1967,6 +2015,10 @@ func TestAgent_AliasCheck_ServiceNotification(t *testing.T) {
 }
 
 func TestAgent_sendCoordinate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.StartTestAgent(t, agent.TestAgent{Overrides: `
 		sync_coordinate_interval_min = "1ms"
@@ -2098,6 +2150,10 @@ func TestState_Notify(t *testing.T) {
 
 // Test that alias check is updated after AddCheck, UpdateCheck, and RemoveCheck for the same service id
 func TestAliasNotifications_local(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, "")

--- a/agent/operator_endpoint_test.go
+++ b/agent/operator_endpoint_test.go
@@ -20,6 +20,10 @@ import (
 )
 
 func TestOperator_RaftConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -46,6 +50,10 @@ func TestOperator_RaftConfiguration(t *testing.T) {
 }
 
 func TestOperator_RaftPeer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -81,6 +89,10 @@ func TestOperator_RaftPeer(t *testing.T) {
 }
 
 func TestOperator_KeyringInstall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	oldKey := "H3/9gBxcKKRf45CaI2DlRg=="
 	newKey := "z90lFx3sZZLtTOkutXcwYg=="
@@ -117,6 +129,10 @@ func TestOperator_KeyringInstall(t *testing.T) {
 }
 
 func TestOperator_KeyringList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	a := NewTestAgent(t, `
@@ -164,6 +180,10 @@ func TestOperator_KeyringList(t *testing.T) {
 	}
 }
 func TestOperator_KeyringListLocalOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	a := NewTestAgent(t, `
@@ -203,6 +223,10 @@ func TestOperator_KeyringListLocalOnly(t *testing.T) {
 }
 
 func TestOperator_KeyringRemove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	tempKey := "z90lFx3sZZLtTOkutXcwYg=="
@@ -261,6 +285,10 @@ func TestOperator_KeyringRemove(t *testing.T) {
 }
 
 func TestOperator_KeyringUse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	oldKey := "H3/9gBxcKKRf45CaI2DlRg=="
 	newKey := "z90lFx3sZZLtTOkutXcwYg=="
@@ -305,6 +333,10 @@ func TestOperator_KeyringUse(t *testing.T) {
 }
 
 func TestOperator_Keyring_InvalidRelayFactor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	a := NewTestAgent(t, `
@@ -327,6 +359,10 @@ func TestOperator_Keyring_InvalidRelayFactor(t *testing.T) {
 }
 
 func TestOperator_Keyring_LocalOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	a := NewTestAgent(t, `
@@ -362,6 +398,10 @@ func TestOperator_Keyring_LocalOnly(t *testing.T) {
 }
 
 func TestOperator_AutopilotGetConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -387,6 +427,10 @@ func TestOperator_AutopilotGetConfiguration(t *testing.T) {
 }
 
 func TestOperator_AutopilotSetConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -415,6 +459,10 @@ func TestOperator_AutopilotSetConfiguration(t *testing.T) {
 }
 
 func TestOperator_AutopilotCASConfiguration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -483,6 +531,10 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 }
 
 func TestOperator_ServerHealth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		raft_protocol = 3
@@ -515,6 +567,10 @@ func TestOperator_ServerHealth(t *testing.T) {
 }
 
 func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, `
 		raft_protocol = 3
@@ -548,6 +604,10 @@ func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
 }
 
 func TestOperator_AutopilotState(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -74,6 +74,10 @@ func (m *MockPreparedQuery) Explain(args *structs.PreparedQueryExecuteRequest,
 }
 
 func TestPreparedQuery_Create(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -162,6 +166,10 @@ func TestPreparedQuery_Create(t *testing.T) {
 }
 
 func TestPreparedQuery_List(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -245,6 +253,10 @@ func TestPreparedQuery_List(t *testing.T) {
 }
 
 func TestPreparedQuery_Execute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -618,6 +630,10 @@ func TestPreparedQuery_Execute(t *testing.T) {
 }
 
 func TestPreparedQuery_ExecuteCached(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -675,6 +691,10 @@ func TestPreparedQuery_ExecuteCached(t *testing.T) {
 }
 
 func TestPreparedQuery_Explain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -770,6 +790,10 @@ func TestPreparedQuery_Explain(t *testing.T) {
 }
 
 func TestPreparedQuery_Get(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -836,6 +860,10 @@ func TestPreparedQuery_Get(t *testing.T) {
 }
 
 func TestPreparedQuery_Update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -914,6 +942,10 @@ func TestPreparedQuery_Update(t *testing.T) {
 }
 
 func TestPreparedQuery_Delete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -991,6 +1023,10 @@ func TestPreparedQuery_parseLimit(t *testing.T) {
 // this is just a basic end-to-end sanity check to make sure things are wired
 // correctly when calling through to the real endpoints.
 func TestPreparedQuery_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -49,6 +49,10 @@ func assertLastReqArgs(t *testing.T, types *TestCacheTypes, token string, source
 }
 
 func TestManager_BasicLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// Create a bunch of common data for the various test cases.
 	roots, leaf := TestCerts(t)
 

--- a/agent/remote_exec_test.go
+++ b/agent/remote_exec_test.go
@@ -25,6 +25,10 @@ func generateUUID() (ret string) {
 }
 
 func TestRexecWriter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// t.Parallel() // timing test. no parallel
 	writer := &rexecWriter{
 		BufCh:    make(chan []byte, 16),
@@ -97,11 +101,19 @@ func TestRexecWriter(t *testing.T) {
 }
 
 func TestRemoteExecGetSpec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testRemoteExecGetSpec(t, "", "", true, "")
 }
 
 func TestRemoteExecGetSpec_ACLToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecGetSpec(t, `
@@ -113,6 +125,10 @@ func TestRemoteExecGetSpec_ACLToken(t *testing.T) {
 }
 
 func TestRemoteExecGetSpec_ACLAgentToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecGetSpec(t, `
@@ -124,6 +140,10 @@ func TestRemoteExecGetSpec_ACLAgentToken(t *testing.T) {
 }
 
 func TestRemoteExecGetSpec_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecGetSpec(t, `
@@ -171,11 +191,19 @@ func testRemoteExecGetSpec(t *testing.T, hcl string, token string, shouldSucceed
 }
 
 func TestRemoteExecWrites(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testRemoteExecWrites(t, "", "", true, "")
 }
 
 func TestRemoteExecWrites_ACLToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecWrites(t, `
@@ -187,6 +215,10 @@ func TestRemoteExecWrites_ACLToken(t *testing.T) {
 }
 
 func TestRemoteExecWrites_ACLAgentToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecWrites(t, `
@@ -198,6 +230,10 @@ func TestRemoteExecWrites_ACLAgentToken(t *testing.T) {
 }
 
 func TestRemoteExecWrites_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecWrites(t, `
@@ -330,11 +366,19 @@ func testHandleRemoteExec(t *testing.T, command string, expectedSubstring string
 }
 
 func TestHandleRemoteExec(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testHandleRemoteExec(t, "uptime", "load", "0")
 }
 
 func TestHandleRemoteExecFailed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testHandleRemoteExec(t, "echo failing;exit 2", "failing", "2")
 }

--- a/agent/retry_join_test.go
+++ b/agent/retry_join_test.go
@@ -20,6 +20,10 @@ func TestAgentRetryNewDiscover(t *testing.T) {
 }
 
 func TestAgentRetryJoinAddrs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	d, err := newDiscover()
 	require.NoError(t, err)
 

--- a/agent/router/manager_test.go
+++ b/agent/router/manager_test.go
@@ -275,6 +275,10 @@ func TestServers_NumServers(t *testing.T) {
 
 // func (m *Manager) RebalanceServers() {
 func TestServers_RebalanceServers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	const failPct = 0.5
 	m := testManagerFailProb(t, failPct)
 	const maxServers = 100

--- a/agent/routine-leak-checker/leak_test.go
+++ b/agent/routine-leak-checker/leak_test.go
@@ -96,6 +96,10 @@ func setupPrimaryServer(t *testing.T) *agent.TestAgent {
 }
 
 func TestTestAgentLeaks_Server(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	/*
 		Eventually go routine leak checking should be moved into other packages such as the agent
 		and agent/consul packages. However there are too many leaks for the test to run properly.

--- a/agent/rpc/subscribe/subscribe_test.go
+++ b/agent/rpc/subscribe/subscribe_test.go
@@ -584,6 +584,10 @@ func TestServer_Subscribe_IntegrationWithBackend_ForwardToDC(t *testing.T) {
 
 func TestServer_Subscribe_IntegrationWithBackend_FilterEventsByACLToken(t *testing.T) {
 	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	if testing.Short() {
 		t.Skip("too slow for -short run")
 	}
 

--- a/agent/service_checks_test.go
+++ b/agent/service_checks_test.go
@@ -16,6 +16,10 @@ import (
 // Integration test for ServiceHTTPBasedChecks cache-type
 // Placed in agent pkg rather than cache-types to avoid circular dependency when importing agent.TestAgent
 func TestAgent_ServiceHTTPChecksNotification(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestServiceManager_RegisterService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	a := NewTestAgent(t, "")
@@ -62,6 +66,10 @@ func TestServiceManager_RegisterService(t *testing.T) {
 }
 
 func TestServiceManager_RegisterSidecar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	a := NewTestAgent(t, "")
@@ -149,6 +157,10 @@ func TestServiceManager_RegisterSidecar(t *testing.T) {
 }
 
 func TestServiceManager_RegisterMeshGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	a := NewTestAgent(t, "")
@@ -205,6 +217,10 @@ func TestServiceManager_RegisterMeshGateway(t *testing.T) {
 }
 
 func TestServiceManager_RegisterTerminatingGateway(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	a := NewTestAgent(t, "")
@@ -261,6 +277,10 @@ func TestServiceManager_RegisterTerminatingGateway(t *testing.T) {
 }
 
 func TestServiceManager_PersistService_API(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This is the ServiceManager version of TestAgent_PersistService  and
 	// TestAgent_PurgeService.
 	t.Parallel()
@@ -475,6 +495,10 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 }
 
 func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// This is the ServiceManager version of TestAgent_PersistService  and
 	// TestAgent_PurgeService but for config files.
 	t.Parallel()
@@ -644,6 +668,10 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 }
 
 func TestServiceManager_Disabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	a := NewTestAgent(t, "enable_central_service_config = false")

--- a/agent/session_endpoint_test.go
+++ b/agent/session_endpoint_test.go
@@ -62,6 +62,10 @@ func verifySession(t *testing.T, r *retry.R, a *TestAgent, want structs.Session)
 }
 
 func TestSessionCreate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -120,6 +124,10 @@ func TestSessionCreate(t *testing.T) {
 }
 
 func TestSessionCreate_NodeChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -181,6 +189,10 @@ func TestSessionCreate_NodeChecks(t *testing.T) {
 }
 
 func TestSessionCreate_Delete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -239,6 +251,10 @@ func TestSessionCreate_Delete(t *testing.T) {
 }
 
 func TestSessionCreate_DefaultCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -273,6 +289,10 @@ func TestSessionCreate_DefaultCheck(t *testing.T) {
 }
 
 func TestSessionCreate_NoCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -428,6 +448,10 @@ func makeTestSessionTTL(t *testing.T, srv *HTTPHandlers, ttl string) string {
 }
 
 func TestSessionDestroy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -447,6 +471,10 @@ func TestSessionDestroy(t *testing.T) {
 }
 
 func TestSessionCustomTTL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	ttl := 250 * time.Millisecond
 	a := NewTestAgent(t, `
@@ -490,6 +518,10 @@ func TestSessionCustomTTL(t *testing.T) {
 }
 
 func TestSessionTTLRenew(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// t.Parallel() // timing test. no parallel
 	ttl := 250 * time.Millisecond
 	a := NewTestAgent(t, `
@@ -577,6 +609,10 @@ func TestSessionTTLRenew(t *testing.T) {
 }
 
 func TestSessionGet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -624,6 +660,10 @@ func TestSessionGet(t *testing.T) {
 }
 
 func TestSessionList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
 		defer a.Shutdown()
@@ -673,6 +713,10 @@ func TestSessionList(t *testing.T) {
 }
 
 func TestSessionsForNode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -723,6 +767,10 @@ func TestSessionsForNode(t *testing.T) {
 }
 
 func TestSessionDeleteDestroy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	tests := []struct {
 		name              string
 		maxPort           int

--- a/agent/snapshot_endpoint_test.go
+++ b/agent/snapshot_endpoint_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	var snap io.Reader
 	t.Run("create snapshot", func(t *testing.T) {
@@ -56,6 +60,10 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestSnapshot_Options(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	for _, method := range []string{"GET", "PUT"} {
 		t.Run(method, func(t *testing.T) {

--- a/agent/status_endpoint_test.go
+++ b/agent/status_endpoint_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestStatusLeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -28,6 +32,10 @@ func TestStatusLeader(t *testing.T) {
 }
 
 func TestStatusLeaderSecondary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, "datacenter = \"primary\"")
 	defer a1.Shutdown()
@@ -67,6 +75,10 @@ func TestStatusLeaderSecondary(t *testing.T) {
 }
 
 func TestStatusPeers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -84,6 +96,10 @@ func TestStatusPeers(t *testing.T) {
 }
 
 func TestStatusPeersSecondary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := NewTestAgent(t, "datacenter = \"primary\"")
 	defer a1.Shutdown()

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestTxnEndpoint_Bad_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -37,6 +41,10 @@ func TestTxnEndpoint_Bad_JSON(t *testing.T) {
 }
 
 func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testIt := func(t *testing.T, agent *TestAgent, wantPass bool) {
 		value := strings.Repeat("X", 3*raft.SuggestedMaxDataSize)
@@ -95,6 +103,10 @@ limits = {
 }
 
 func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testIt := func(agent *TestAgent, wantPass bool) {
@@ -174,6 +186,10 @@ limits = {
 }
 
 func TestTxnEndpoint_Bad_Size_Ops(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -201,6 +217,10 @@ func TestTxnEndpoint_Bad_Size_Ops(t *testing.T) {
 }
 
 func TestTxnEndpoint_KV_Actions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t, "")
@@ -482,6 +502,10 @@ func TestTxnEndpoint_KV_Actions(t *testing.T) {
 }
 
 func TestTxnEndpoint_UpdateCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()

--- a/agent/ui_endpoint_oss_test.go
+++ b/agent/ui_endpoint_oss_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestUIEndpoint_MetricsProxy_ACLDeny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	var (

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -24,6 +24,10 @@ import (
 )
 
 func TestUiIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	// Make a test dir to serve UI files
 	uiDir := testutil.TempDir(t, "consul")
@@ -70,6 +74,10 @@ func TestUiIndex(t *testing.T) {
 }
 
 func TestUiNodes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -108,6 +116,10 @@ func TestUiNodes(t *testing.T) {
 }
 
 func TestUiNodes_Filter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -150,6 +162,10 @@ func TestUiNodes_Filter(t *testing.T) {
 }
 
 func TestUiNodeInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -198,6 +214,10 @@ func TestUiNodeInfo(t *testing.T) {
 }
 
 func TestUiServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -531,6 +551,10 @@ func TestUiServices(t *testing.T) {
 }
 
 func TestUIGatewayServiceNodes_Terminating(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -654,6 +678,10 @@ func TestUIGatewayServiceNodes_Terminating(t *testing.T) {
 }
 
 func TestUIGatewayServiceNodes_Ingress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, `alt_domain = "alt.consul."`)
@@ -825,6 +853,10 @@ func TestUIGatewayServiceNodes_Ingress(t *testing.T) {
 }
 
 func TestUIGatewayIntentions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -934,6 +966,10 @@ func TestUIEndpoint_modifySummaryForGatewayService_UseRequestedDCInsteadOfConfig
 }
 
 func TestUIServiceTopology(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -1567,6 +1603,10 @@ func TestUIServiceTopology(t *testing.T) {
 }
 
 func TestUIEndpoint_MetricsProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	var lastHeadersSent atomic.Value

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -47,6 +47,10 @@ func TestValidateUserEventParams(t *testing.T) {
 }
 
 func TestShouldProcessUserEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -116,6 +120,10 @@ func TestShouldProcessUserEvent(t *testing.T) {
 }
 
 func TestIngestUserEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -147,6 +155,10 @@ func TestIngestUserEvent(t *testing.T) {
 }
 
 func TestFireReceiveEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -183,6 +195,10 @@ func TestFireReceiveEvent(t *testing.T) {
 }
 
 func TestUserEventToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := NewTestAgent(t, TestACLConfig()+`
 		acl_default_policy = "deny"

--- a/agent/util_test.go
+++ b/agent/util_test.go
@@ -226,6 +226,10 @@ func limitProcessLifetime(dur time.Duration) {
 }
 
 func TestForwardSignals(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	for _, s := range forwardSignals {
 		t.Run("signal-"+s.String(), func(t *testing.T) {
 			testForwardSignal(t, s)

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -19,6 +19,9 @@ import (
 )
 
 func TestClustersFromSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	tests := []struct {
 		name   string

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -218,6 +218,9 @@ func Test_makeLoadAssignment(t *testing.T) {
 }
 
 func Test_endpointsFromSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	tests := []struct {
 		name   string

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -18,6 +18,9 @@ import (
 )
 
 func TestListenersFromSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	tests := []struct {
 		name   string

--- a/agent/xds/server_test.go
+++ b/agent/xds/server_test.go
@@ -595,6 +595,10 @@ func TestServer_StreamAggregatedResources_ACLTokenDeleted_StreamTerminatedDuring
 }
 
 func TestServer_StreamAggregatedResources_ACLTokenDeleted_StreamTerminatedInBackground(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	aclRules := `service "web" { policy = "write" }`
 	token := "service-write-on-web"
 

--- a/command/acl/agenttokens/agent_tokens_test.go
+++ b/command/acl/agenttokens/agent_tokens_test.go
@@ -20,6 +20,10 @@ func TestAgentTokensCommand_noTabs(t *testing.T) {
 }
 
 func TestAgentTokensCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -32,6 +32,10 @@ func TestAuthMethodCreateCommand_noTabs(t *testing.T) {
 }
 
 func TestAuthMethodCreateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -182,6 +186,10 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 }
 
 func TestAuthMethodCreateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -347,6 +355,10 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 }
 
 func TestAuthMethodCreateCommand_k8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
@@ -489,6 +501,10 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 }
 
 func TestAuthMethodCreateCommand_config(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "auth-method")

--- a/command/acl/authmethod/delete/authmethod_delete_test.go
+++ b/command/acl/authmethod/delete/authmethod_delete_test.go
@@ -25,6 +25,10 @@ func TestAuthMethodDeleteCommand_noTabs(t *testing.T) {
 }
 
 func TestAuthMethodDeleteCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/authmethod/list/authmethod_list_test.go
+++ b/command/acl/authmethod/list/authmethod_list_test.go
@@ -26,6 +26,10 @@ func TestAuthMethodListCommand_noTabs(t *testing.T) {
 }
 
 func TestAuthMethodListCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -103,6 +107,10 @@ func TestAuthMethodListCommand(t *testing.T) {
 }
 
 func TestAuthMethodListCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/authmethod/read/authmethod_read_test.go
+++ b/command/acl/authmethod/read/authmethod_read_test.go
@@ -26,6 +26,10 @@ func TestAuthMethodReadCommand_noTabs(t *testing.T) {
 }
 
 func TestAuthMethodReadCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -112,6 +116,10 @@ func TestAuthMethodReadCommand(t *testing.T) {
 }
 
 func TestAuthMethodReadCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/authmethod/update/authmethod_update_test.go
+++ b/command/acl/authmethod/update/authmethod_update_test.go
@@ -31,6 +31,10 @@ func TestAuthMethodUpdateCommand_noTabs(t *testing.T) {
 }
 
 func TestAuthMethodUpdateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -164,6 +168,10 @@ func TestAuthMethodUpdateCommand(t *testing.T) {
 }
 
 func TestAuthMethodUpdateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -251,6 +259,10 @@ func TestAuthMethodUpdateCommand_JSON(t *testing.T) {
 }
 
 func TestAuthMethodUpdateCommand_noMerge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -349,6 +361,10 @@ func TestAuthMethodUpdateCommand_noMerge(t *testing.T) {
 }
 
 func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
@@ -583,6 +599,10 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 }
 
 func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
@@ -770,6 +790,10 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 }
 
 func TestAuthMethodUpdateCommand_config(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	testDir := testutil.TempDir(t, "auth-method")
 

--- a/command/acl/bindingrule/create/bindingrule_create_test.go
+++ b/command/acl/bindingrule/create/bindingrule_create_test.go
@@ -25,6 +25,10 @@ func TestBindingRuleCreateCommand_noTabs(t *testing.T) {
 }
 
 func TestBindingRuleCreateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -172,6 +176,10 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 }
 
 func TestBindingRuleCreateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/bindingrule/delete/bindingrule_delete_test.go
+++ b/command/acl/bindingrule/delete/bindingrule_delete_test.go
@@ -24,6 +24,10 @@ func TestBindingRuleDeleteCommand_noTabs(t *testing.T) {
 }
 
 func TestBindingRuleDeleteCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/bindingrule/list/bindingrule_list_test.go
+++ b/command/acl/bindingrule/list/bindingrule_list_test.go
@@ -26,6 +26,10 @@ func TestBindingRuleListCommand_noTabs(t *testing.T) {
 }
 
 func TestBindingRuleListCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/bindingrule/read/bindingrule_read_test.go
+++ b/command/acl/bindingrule/read/bindingrule_read_test.go
@@ -25,6 +25,10 @@ func TestBindingRuleReadCommand_noTabs(t *testing.T) {
 }
 
 func TestBindingRuleReadCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/bindingrule/update/bindingrule_update_test.go
+++ b/command/acl/bindingrule/update/bindingrule_update_test.go
@@ -26,6 +26,10 @@ func TestBindingRuleUpdateCommand_noTabs(t *testing.T) {
 }
 
 func TestBindingRuleUpdateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -463,6 +467,10 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 }
 
 func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/bootstrap/bootstrap_test.go
+++ b/command/acl/bootstrap/bootstrap_test.go
@@ -22,6 +22,10 @@ func TestBootstrapCommand_noTabs(t *testing.T) {
 }
 
 func TestBootstrapCommand_Pretty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 
@@ -50,6 +54,10 @@ func TestBootstrapCommand_Pretty(t *testing.T) {
 }
 
 func TestBootstrapCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/policy/create/policy_create_test.go
+++ b/command/acl/policy/create/policy_create_test.go
@@ -23,6 +23,10 @@ func TestPolicyCreateCommand_noTabs(t *testing.T) {
 }
 
 func TestPolicyCreateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 
@@ -60,6 +64,10 @@ func TestPolicyCreateCommand(t *testing.T) {
 }
 
 func TestPolicyCreateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 

--- a/command/acl/policy/delete/policy_delete_test.go
+++ b/command/acl/policy/delete/policy_delete_test.go
@@ -21,6 +21,10 @@ func TestPolicyDeleteCommand_noTabs(t *testing.T) {
 }
 
 func TestPolicyDeleteCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/policy/list/policy_list_test.go
+++ b/command/acl/policy/list/policy_list_test.go
@@ -22,6 +22,10 @@ func TestPolicyListCommand_noTabs(t *testing.T) {
 }
 
 func TestPolicyListCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 
@@ -73,6 +77,10 @@ func TestPolicyListCommand(t *testing.T) {
 }
 
 func TestPolicyListCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/policy/read/policy_read_test.go
+++ b/command/acl/policy/read/policy_read_test.go
@@ -22,6 +22,10 @@ func TestPolicyReadCommand_noTabs(t *testing.T) {
 }
 
 func TestPolicyReadCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 
@@ -65,6 +69,10 @@ func TestPolicyReadCommand(t *testing.T) {
 }
 
 func TestPolicyReadCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/policy/update/policy_update_test.go
+++ b/command/acl/policy/update/policy_update_test.go
@@ -23,6 +23,10 @@ func TestPolicyUpdateCommand_noTabs(t *testing.T) {
 }
 
 func TestPolicyUpdateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 
@@ -70,6 +74,10 @@ func TestPolicyUpdateCommand(t *testing.T) {
 }
 
 func TestPolicyUpdateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/role/create/role_create_test.go
+++ b/command/acl/role/create/role_create_test.go
@@ -22,6 +22,10 @@ func TestRoleCreateCommand_noTabs(t *testing.T) {
 }
 
 func TestRoleCreateCommand_Pretty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -111,6 +115,10 @@ func TestRoleCreateCommand_Pretty(t *testing.T) {
 }
 
 func TestRoleCreateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/role/delete/role_delete_test.go
+++ b/command/acl/role/delete/role_delete_test.go
@@ -21,6 +21,10 @@ func TestRoleDeleteCommand_noTabs(t *testing.T) {
 }
 
 func TestRoleDeleteCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/role/list/role_list_test.go
+++ b/command/acl/role/list/role_list_test.go
@@ -23,6 +23,10 @@ func TestRoleListCommand_noTabs(t *testing.T) {
 }
 
 func TestRoleListCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 
@@ -77,6 +81,10 @@ func TestRoleListCommand(t *testing.T) {
 }
 
 func TestRoleListCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 

--- a/command/acl/role/read/role_read_test.go
+++ b/command/acl/role/read/role_read_test.go
@@ -24,6 +24,10 @@ func TestRoleReadCommand_noTabs(t *testing.T) {
 }
 
 func TestRoleReadCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -188,6 +192,10 @@ func TestRoleReadCommand(t *testing.T) {
 }
 
 func TestRoleReadCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/role/update/role_update_test.go
+++ b/command/acl/role/update/role_update_test.go
@@ -24,6 +24,10 @@ func TestRoleUpdateCommand_noTabs(t *testing.T) {
 }
 
 func TestRoleUpdateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -194,6 +198,10 @@ func TestRoleUpdateCommand(t *testing.T) {
 }
 
 func TestRoleUpdateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -273,6 +281,10 @@ func TestRoleUpdateCommand_JSON(t *testing.T) {
 }
 
 func TestRoleUpdateCommand_noMerge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/acl/rules/translate_test.go
+++ b/command/acl/rules/translate_test.go
@@ -22,6 +22,10 @@ func TestRulesTranslateCommand_noTabs(t *testing.T) {
 }
 
 func TestRulesTranslateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")

--- a/command/acl/token/clone/token_clone_test.go
+++ b/command/acl/token/clone/token_clone_test.go
@@ -58,6 +58,10 @@ func TestTokenCloneCommand_noTabs(t *testing.T) {
 }
 
 func TestTokenCloneCommand_Pretty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	req := require.New(t)
 
@@ -162,6 +166,10 @@ func TestTokenCloneCommand_Pretty(t *testing.T) {
 }
 
 func TestTokenCloneCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	req := require.New(t)
 

--- a/command/acl/token/create/token_create_test.go
+++ b/command/acl/token/create/token_create_test.go
@@ -21,6 +21,10 @@ func TestTokenCreateCommand_noTabs(t *testing.T) {
 }
 
 func TestTokenCreateCommand_Pretty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -115,6 +119,10 @@ func TestTokenCreateCommand_Pretty(t *testing.T) {
 }
 
 func TestTokenCreateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 

--- a/command/acl/token/delete/token_delete_test.go
+++ b/command/acl/token/delete/token_delete_test.go
@@ -21,6 +21,10 @@ func TestTokenDeleteCommand_noTabs(t *testing.T) {
 }
 
 func TestTokenDeleteCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/token/list/token_list_test.go
+++ b/command/acl/token/list/token_list_test.go
@@ -23,6 +23,10 @@ func TestTokenListCommand_noTabs(t *testing.T) {
 }
 
 func TestTokenListCommand_Pretty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 
@@ -74,6 +78,10 @@ func TestTokenListCommand_Pretty(t *testing.T) {
 }
 
 func TestTokenListCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/token/read/token_read_test.go
+++ b/command/acl/token/read/token_read_test.go
@@ -23,6 +23,10 @@ func TestTokenReadCommand_noTabs(t *testing.T) {
 }
 
 func TestTokenReadCommand_Pretty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 
@@ -67,6 +71,10 @@ func TestTokenReadCommand_Pretty(t *testing.T) {
 }
 
 func TestTokenReadCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -23,6 +23,10 @@ func TestTokenUpdateCommand_noTabs(t *testing.T) {
 }
 
 func TestTokenUpdateCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -189,6 +193,10 @@ func TestTokenUpdateCommand(t *testing.T) {
 }
 
 func TestTokenUpdateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	assert := assert.New(t)
 	// Alias because we need to access require package in Retry below

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -18,6 +18,10 @@ import (
 
 // TestConfigFail should test command line flags that lead to an immediate error.
 func TestConfigFail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	dataDir := testutil.TempDir(t, "consul")
@@ -79,6 +83,10 @@ func TestConfigFail(t *testing.T) {
 }
 
 func TestRetryJoin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 
@@ -105,6 +113,10 @@ func TestRetryJoin(t *testing.T) {
 }
 
 func TestRetryJoinFail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	tmpDir := testutil.TempDir(t, "consul")
 
@@ -125,6 +137,10 @@ func TestRetryJoinFail(t *testing.T) {
 }
 
 func TestRetryJoinWanFail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	tmpDir := testutil.TempDir(t, "consul")
 

--- a/command/catalog/list/dc/catalog_list_datacenters_test.go
+++ b/command/catalog/list/dc/catalog_list_datacenters_test.go
@@ -52,6 +52,10 @@ func TestCatalogListDatacentersCommand_Validation(t *testing.T) {
 }
 
 func TestCatalogListDatacentersCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/catalog/list/nodes/catalog_list_nodes_test.go
+++ b/command/catalog/list/nodes/catalog_list_nodes_test.go
@@ -31,6 +31,10 @@ func TestCatalogListNodesCommand_Validation(t *testing.T) {
 }
 
 func TestCatalogListNodesCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -165,6 +169,10 @@ func TestCatalogListNodesCommand(t *testing.T) {
 }
 
 func TestCatalogListNodesCommand_verticalBar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	nodeName := "name|with|bars"

--- a/command/catalog/list/services/catalog_list_services_test.go
+++ b/command/catalog/list/services/catalog_list_services_test.go
@@ -33,6 +33,10 @@ func TestCatalogListServicesCommand_Validation(t *testing.T) {
 }
 
 func TestCatalogListServicesCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/config/delete/config_delete_test.go
+++ b/command/config/delete/config_delete_test.go
@@ -16,6 +16,10 @@ func TestConfigDelete_noTabs(t *testing.T) {
 }
 
 func TestConfigDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, ``)

--- a/command/config/list/config_list_test.go
+++ b/command/config/list/config_list_test.go
@@ -17,6 +17,10 @@ func TestConfigList_noTabs(t *testing.T) {
 }
 
 func TestConfigList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()

--- a/command/config/read/config_read_test.go
+++ b/command/config/read/config_read_test.go
@@ -16,6 +16,10 @@ func TestConfigRead_noTabs(t *testing.T) {
 }
 
 func TestConfigRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, ``)

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -22,6 +22,10 @@ func TestConfigWrite_noTabs(t *testing.T) {
 }
 
 func TestConfigWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, ``)

--- a/command/connect/ca/get/connect_ca_get_test.go
+++ b/command/connect/ca/get/connect_ca_get_test.go
@@ -18,6 +18,10 @@ func TestConnectCAGetConfigCommand_noTabs(t *testing.T) {
 }
 
 func TestConnectCAGetConfigCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/connect/ca/set/connect_ca_set_test.go
+++ b/command/connect/ca/set/connect_ca_set_test.go
@@ -22,6 +22,10 @@ func TestConnectCASetConfigCommand_noTabs(t *testing.T) {
 }
 
 func TestConnectCASetConfigCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 	a := agent.NewTestAgent(t, ``)

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -862,6 +862,10 @@ func TestGenerateConfig(t *testing.T) {
 }
 
 func TestEnvoy_GatewayRegistration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func TestExecEnvoy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	cases := []struct {
 		Name     string

--- a/command/connect/expose/expose_test.go
+++ b/command/connect/expose/expose_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestConnectExpose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 	a := agent.NewTestAgent(t, ``)
@@ -141,6 +145,10 @@ func TestConnectExpose(t *testing.T) {
 }
 
 func TestConnectExpose_invalidFlags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 	a := agent.NewTestAgent(t, ``)
@@ -192,6 +200,10 @@ func TestConnectExpose_invalidFlags(t *testing.T) {
 }
 
 func TestConnectExpose_existingConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 	a := agent.NewTestAgent(t, ``)

--- a/command/connect/proxy/proxy_test.go
+++ b/command/connect/proxy/proxy_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestCommandConfigWatcher(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := []struct {

--- a/command/connect/proxy/register_test.go
+++ b/command/connect/proxy/register_test.go
@@ -13,6 +13,10 @@ import (
 )
 
 func TestRegisterMonitor_good(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	require := require.New(t)
 
@@ -37,6 +41,10 @@ func TestRegisterMonitor_good(t *testing.T) {
 }
 
 func TestRegisterMonitor_heartbeat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, ``)

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -25,6 +25,10 @@ func TestDebugCommand_noTabs(t *testing.T) {
 }
 
 func TestDebugCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
@@ -61,6 +65,10 @@ func TestDebugCommand(t *testing.T) {
 }
 
 func TestDebugCommand_Archive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
@@ -142,6 +150,10 @@ func TestDebugCommand_ArgsBad(t *testing.T) {
 }
 
 func TestDebugCommand_OutputPathBad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, "")
@@ -171,6 +183,10 @@ func TestDebugCommand_OutputPathBad(t *testing.T) {
 }
 
 func TestDebugCommand_OutputPathExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
@@ -208,6 +224,10 @@ func TestDebugCommand_OutputPathExists(t *testing.T) {
 }
 
 func TestDebugCommand_CaptureTargets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := map[string]struct {
@@ -316,6 +336,10 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 }
 
 func TestDebugCommand_ProfilesExist(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
@@ -362,6 +386,10 @@ func TestDebugCommand_ProfilesExist(t *testing.T) {
 }
 
 func TestDebugCommand_ValidateTiming(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	cases := map[string]struct {
@@ -422,6 +450,10 @@ func TestDebugCommand_ValidateTiming(t *testing.T) {
 }
 
 func TestDebugCommand_DebugDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")

--- a/command/event/event_test.go
+++ b/command/event/event_test.go
@@ -16,6 +16,10 @@ func TestEventCommand_noTabs(t *testing.T) {
 }
 
 func TestEventCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()

--- a/command/exec/exec_test.go
+++ b/command/exec/exec_test.go
@@ -21,6 +21,10 @@ func TestExecCommand_noTabs(t *testing.T) {
 }
 
 func TestExecCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
@@ -44,6 +48,10 @@ func TestExecCommand(t *testing.T) {
 }
 
 func TestExecCommand_NoShell(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
@@ -67,6 +75,10 @@ func TestExecCommand_NoShell(t *testing.T) {
 }
 
 func TestExecCommand_CrossDC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := agent.NewTestAgent(t, `
 		disable_remote_exec = false
@@ -149,6 +161,10 @@ func TestExecCommand_Validate(t *testing.T) {
 }
 
 func TestExecCommand_Sessions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
@@ -189,6 +205,10 @@ func TestExecCommand_Sessions(t *testing.T) {
 }
 
 func TestExecCommand_Sessions_Foreign(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
@@ -239,6 +259,10 @@ func TestExecCommand_Sessions_Foreign(t *testing.T) {
 }
 
 func TestExecCommand_UploadDestroy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
@@ -296,6 +320,10 @@ func TestExecCommand_UploadDestroy(t *testing.T) {
 }
 
 func TestExecCommand_StreamResults(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false

--- a/command/forceleave/forceleave_test.go
+++ b/command/forceleave/forceleave_test.go
@@ -18,6 +18,10 @@ func TestForceLeaveCommand_noTabs(t *testing.T) {
 }
 
 func TestForceLeaveCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := agent.NewTestAgent(t, ``)
 	a2 := agent.NewTestAgent(t, ``)
@@ -57,6 +61,10 @@ func TestForceLeaveCommand(t *testing.T) {
 }
 
 func TestForceLeaveCommand_NoNodeWithName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()
@@ -75,6 +83,10 @@ func TestForceLeaveCommand_NoNodeWithName(t *testing.T) {
 }
 
 func TestForceLeaveCommand_prune(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := agent.StartTestAgent(t, agent.TestAgent{Name: "Agent1"})
 	defer a1.Shutdown()

--- a/command/info/info_test.go
+++ b/command/info/info_test.go
@@ -16,6 +16,10 @@ func TestInfoCommand_noTabs(t *testing.T) {
 }
 
 func TestInfoCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()

--- a/command/intention/check/check_test.go
+++ b/command/intention/check/check_test.go
@@ -66,6 +66,10 @@ func TestIntentionCheck_Validation(t *testing.T) {
 }
 
 func TestIntentionCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)

--- a/command/intention/create/create_test.go
+++ b/command/intention/create/create_test.go
@@ -57,6 +57,10 @@ func TestIntentionCreate_Validation(t *testing.T) {
 }
 
 func TestIntentionCreate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -84,6 +88,10 @@ func TestIntentionCreate(t *testing.T) {
 }
 
 func TestIntentionCreate_deny(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -112,6 +120,10 @@ func TestIntentionCreate_deny(t *testing.T) {
 }
 
 func TestIntentionCreate_meta(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -140,6 +152,10 @@ func TestIntentionCreate_meta(t *testing.T) {
 }
 
 func TestIntentionCreate_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -175,6 +191,10 @@ func TestIntentionCreate_File(t *testing.T) {
 }
 
 func TestIntentionCreate_File_L7_fails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -216,6 +236,10 @@ func TestIntentionCreate_File_L7_fails(t *testing.T) {
 }
 
 func TestIntentionCreate_FileNoExist(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -238,6 +262,10 @@ func TestIntentionCreate_FileNoExist(t *testing.T) {
 }
 
 func TestIntentionCreate_replace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)

--- a/command/intention/delete/delete_test.go
+++ b/command/intention/delete/delete_test.go
@@ -59,6 +59,10 @@ func TestIntentionDelete_Validation(t *testing.T) {
 }
 
 func TestIntentionDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, ``)

--- a/command/intention/get/get_test.go
+++ b/command/intention/get/get_test.go
@@ -63,6 +63,10 @@ func TestIntentionGet_Validation(t *testing.T) {
 }
 
 func TestIntentionGet_id(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -98,6 +102,10 @@ func TestIntentionGet_id(t *testing.T) {
 }
 
 func TestIntentionGet_srcDst(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -133,6 +141,10 @@ func TestIntentionGet_srcDst(t *testing.T) {
 }
 
 func TestIntentionGet_verticalBar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)

--- a/command/intention/helpers_test.go
+++ b/command/intention/helpers_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestGetFromArgs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, ``)

--- a/command/intention/match/match_test.go
+++ b/command/intention/match/match_test.go
@@ -66,6 +66,10 @@ func TestIntentionMatch_Validation(t *testing.T) {
 }
 
 func TestIntentionMatch_matchDst(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -112,6 +116,10 @@ func TestIntentionMatch_matchDst(t *testing.T) {
 }
 
 func TestIntentionMatch_matchSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)

--- a/command/join/join_test.go
+++ b/command/join/join_test.go
@@ -16,6 +16,10 @@ func TestJoinCommand_noTabs(t *testing.T) {
 }
 
 func TestJoinCommandJoin_lan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := agent.NewTestAgent(t, ``)
 	a2 := agent.NewTestAgent(t, ``)
@@ -40,6 +44,10 @@ func TestJoinCommandJoin_lan(t *testing.T) {
 }
 
 func TestJoinCommand_wan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a1 := agent.NewTestAgent(t, ``)
 	a2 := agent.NewTestAgent(t, ``)

--- a/command/keyring/keyring_test.go
+++ b/command/keyring/keyring_test.go
@@ -18,6 +18,10 @@ func TestKeyringCommand_noTabs(t *testing.T) {
 }
 
 func TestKeyringCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	key1 := "HS5lJ+XuTlYKWaeGYyG+/A=="
 	key2 := "kZyFABeAmc64UMTrm9XuKA=="

--- a/command/kv/del/kv_delete_test.go
+++ b/command/kv/del/kv_delete_test.go
@@ -71,6 +71,10 @@ func TestKVDeleteCommand_Validation(t *testing.T) {
 }
 
 func TestKVDeleteCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -108,6 +112,10 @@ func TestKVDeleteCommand(t *testing.T) {
 }
 
 func TestKVDeleteCommand_Recurse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -152,6 +160,10 @@ func TestKVDeleteCommand_Recurse(t *testing.T) {
 }
 
 func TestKVDeleteCommand_CAS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/kv/exp/kv_export_test.go
+++ b/command/kv/exp/kv_export_test.go
@@ -20,6 +20,10 @@ func TestKVExportCommand_noTabs(t *testing.T) {
 }
 
 func TestKVExportCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/kv/get/kv_get_test.go
+++ b/command/kv/get/kv_get_test.go
@@ -58,6 +58,10 @@ func TestKVGetCommand_Validation(t *testing.T) {
 }
 
 func TestKVGetCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -92,6 +96,10 @@ func TestKVGetCommand(t *testing.T) {
 }
 
 func TestKVGetCommand_Base64(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -127,6 +135,10 @@ func TestKVGetCommand_Base64(t *testing.T) {
 }
 
 func TestKVGetCommand_Missing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -146,6 +158,10 @@ func TestKVGetCommand_Missing(t *testing.T) {
 }
 
 func TestKVGetCommand_Empty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -175,6 +191,10 @@ func TestKVGetCommand_Empty(t *testing.T) {
 }
 
 func TestKVGetCommand_Detailed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -219,6 +239,10 @@ func TestKVGetCommand_Detailed(t *testing.T) {
 }
 
 func TestKVGetCommand_Keys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -254,6 +278,10 @@ func TestKVGetCommand_Keys(t *testing.T) {
 }
 
 func TestKVGetCommand_Recurse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -294,6 +322,10 @@ func TestKVGetCommand_Recurse(t *testing.T) {
 }
 
 func TestKVGetCommand_RecurseBase64(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -335,6 +367,10 @@ func TestKVGetCommand_RecurseBase64(t *testing.T) {
 }
 
 func TestKVGetCommand_DetailedBase64(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/kv/imp/kv_import_test.go
+++ b/command/kv/imp/kv_import_test.go
@@ -16,6 +16,10 @@ func TestKVImportCommand_noTabs(t *testing.T) {
 }
 
 func TestKVImportCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/kv/put/kv_put_test.go
+++ b/command/kv/put/kv_put_test.go
@@ -71,6 +71,10 @@ func TestKVPutCommand_Validation(t *testing.T) {
 }
 
 func TestKVPutCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -100,6 +104,10 @@ func TestKVPutCommand(t *testing.T) {
 }
 
 func TestKVPutCommand_EmptyDataQuoted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -129,6 +137,10 @@ func TestKVPutCommand_EmptyDataQuoted(t *testing.T) {
 }
 
 func TestKVPutCommand_Base64(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -166,6 +178,10 @@ func TestKVPutCommand_Base64(t *testing.T) {
 }
 
 func TestKVPutCommand_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -220,6 +236,10 @@ func TestKVPutCommand_FileNoExist(t *testing.T) {
 }
 
 func TestKVPutCommand_Stdin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -257,6 +277,10 @@ func TestKVPutCommand_Stdin(t *testing.T) {
 }
 
 func TestKVPutCommand_NegativeVal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -286,6 +310,10 @@ func TestKVPutCommand_NegativeVal(t *testing.T) {
 }
 
 func TestKVPutCommand_Flags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -316,6 +344,10 @@ func TestKVPutCommand_Flags(t *testing.T) {
 }
 
 func TestKVPutCommand_CAS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/leave/leave_test.go
+++ b/command/leave/leave_test.go
@@ -16,6 +16,10 @@ func TestLeaveCommand_noTabs(t *testing.T) {
 }
 
 func TestLeaveCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -35,6 +39,10 @@ func TestLeaveCommand(t *testing.T) {
 }
 
 func TestLeaveCommand_FailOnNonFlagArgs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -41,6 +41,10 @@ func TestLockCommand_BadArgs(t *testing.T) {
 }
 
 func TestLockCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -66,6 +70,10 @@ func TestLockCommand(t *testing.T) {
 }
 
 func TestLockCommand_NoShell(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -91,6 +99,10 @@ func TestLockCommand_NoShell(t *testing.T) {
 }
 
 func TestLockCommand_TryLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -125,6 +137,10 @@ func TestLockCommand_TryLock(t *testing.T) {
 }
 
 func TestLockCommand_TrySemaphore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -159,6 +175,10 @@ func TestLockCommand_TrySemaphore(t *testing.T) {
 }
 
 func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -194,6 +214,10 @@ func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
 }
 
 func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -229,6 +253,10 @@ func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
 }
 
 func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -264,6 +292,10 @@ func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
 }
 
 func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -299,6 +331,10 @@ func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 }
 
 func TestLockCommand_ChildExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/login/login_test.go
+++ b/command/login/login_test.go
@@ -31,6 +31,10 @@ func TestLoginCommand_noTabs(t *testing.T) {
 }
 
 func TestLoginCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
@@ -224,6 +228,10 @@ func TestLoginCommand(t *testing.T) {
 }
 
 func TestLoginCommand_k8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
@@ -318,6 +326,10 @@ func TestLoginCommand_k8s(t *testing.T) {
 }
 
 func TestLoginCommand_jwt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")

--- a/command/logout/logout_test.go
+++ b/command/logout/logout_test.go
@@ -24,6 +24,10 @@ func TestLogout_noTabs(t *testing.T) {
 }
 
 func TestLogoutCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `
@@ -150,6 +154,10 @@ func TestLogoutCommand(t *testing.T) {
 }
 
 func TestLogoutCommand_k8s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	a := agent.NewTestAgent(t, `

--- a/command/maint/maint_test.go
+++ b/command/maint/maint_test.go
@@ -40,6 +40,10 @@ func TestMaintCommand_ConflictingArgs(t *testing.T) {
 }
 
 func TestMaintCommand_NoArgs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -89,6 +93,10 @@ func TestMaintCommand_NoArgs(t *testing.T) {
 }
 
 func TestMaintCommand_EnableNodeMaintenance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -113,6 +121,10 @@ func TestMaintCommand_EnableNodeMaintenance(t *testing.T) {
 }
 
 func TestMaintCommand_DisableNodeMaintenance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -136,6 +148,10 @@ func TestMaintCommand_DisableNodeMaintenance(t *testing.T) {
 }
 
 func TestMaintCommand_EnableServiceMaintenance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -170,6 +186,10 @@ func TestMaintCommand_EnableServiceMaintenance(t *testing.T) {
 }
 
 func TestMaintCommand_DisableServiceMaintenance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -203,6 +223,10 @@ func TestMaintCommand_DisableServiceMaintenance(t *testing.T) {
 }
 
 func TestMaintCommand_ServiceMaintenance_NoService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/members/members_test.go
+++ b/command/members/members_test.go
@@ -17,6 +17,10 @@ func TestMembersCommand_noTabs(t *testing.T) {
 }
 
 func TestMembersCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -49,6 +53,10 @@ func TestMembersCommand(t *testing.T) {
 }
 
 func TestMembersCommand_WAN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -70,6 +78,10 @@ func TestMembersCommand_WAN(t *testing.T) {
 }
 
 func TestMembersCommand_statusFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -94,6 +106,10 @@ func TestMembersCommand_statusFilter(t *testing.T) {
 }
 
 func TestMembersCommand_statusFilter_failed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -122,6 +138,10 @@ func TestMembersCommand_statusFilter_failed(t *testing.T) {
 }
 
 func TestMembersCommand_verticalBar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	nodeName := "name|with|bars"

--- a/command/monitor/monitor_test.go
+++ b/command/monitor/monitor_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 func TestMonitorCommand_exitsOnSignalBeforeLinesArrive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.StartTestAgent(t, agent.TestAgent{})
 	defer a.Shutdown()
@@ -63,6 +67,10 @@ func TestMonitorCommand_exitsOnSignalBeforeLinesArrive(t *testing.T) {
 }
 
 func TestMonitorCommand_LogJSONValidFlag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.StartTestAgent(t, agent.TestAgent{})
 	defer a.Shutdown()

--- a/command/operator/autopilot/get/operator_autopilot_get_test.go
+++ b/command/operator/autopilot/get/operator_autopilot_get_test.go
@@ -18,6 +18,10 @@ func TestOperatorAutopilotGetConfigCommand_noTabs(t *testing.T) {
 }
 
 func TestOperatorAutopilotGetConfigCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/operator/autopilot/set/operator_autopilot_set_test.go
+++ b/command/operator/autopilot/set/operator_autopilot_set_test.go
@@ -20,6 +20,10 @@ func TestOperatorAutopilotSetConfigCommand_noTabs(t *testing.T) {
 }
 
 func TestOperatorAutopilotSetConfigCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/operator/autopilot/state/operator_autopilot_state_test.go
+++ b/command/operator/autopilot/state/operator_autopilot_state_test.go
@@ -44,6 +44,10 @@ func TestStateCommand_noTabs(t *testing.T) {
 }
 
 func TestStateCommand_Pretty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		node_id = "f0427127-7531-455a-b651-f1ea1d8451f0"
@@ -71,6 +75,10 @@ func TestStateCommand_Pretty(t *testing.T) {
 }
 
 func TestStateCommand_JSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, "")
 

--- a/command/operator/raft/listpeers/operator_raft_list_test.go
+++ b/command/operator/raft/listpeers/operator_raft_list_test.go
@@ -17,6 +17,10 @@ func TestOperatorRaftListPeersCommand_noTabs(t *testing.T) {
 }
 
 func TestOperatorRaftListPeersCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -40,6 +44,10 @@ func TestOperatorRaftListPeersCommand(t *testing.T) {
 }
 
 func TestOperatorRaftListPeersCommand_verticalBar(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	nodeName := "name|with|bars"

--- a/command/operator/raft/removepeer/operator_raft_remove_test.go
+++ b/command/operator/raft/removepeer/operator_raft_remove_test.go
@@ -16,6 +16,10 @@ func TestOperatorRaftRemovePeerCommand_noTabs(t *testing.T) {
 }
 
 func TestOperatorRaftRemovePeerCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/reload/reload_test.go
+++ b/command/reload/reload_test.go
@@ -16,6 +16,10 @@ func TestReloadCommand_noTabs(t *testing.T) {
 }
 
 func TestReloadCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/rtt/rtt_test.go
+++ b/command/rtt/rtt_test.go
@@ -45,6 +45,10 @@ func TestRTTCommand_BadArgs(t *testing.T) {
 }
 
 func TestRTTCommand_LAN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
 		consul = {
@@ -154,6 +158,10 @@ func TestRTTCommand_LAN(t *testing.T) {
 }
 
 func TestRTTCommand_WAN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/services/deregister/deregister_test.go
+++ b/command/services/deregister/deregister_test.go
@@ -61,6 +61,10 @@ func TestCommand_Validation(t *testing.T) {
 }
 
 func TestCommand_File_id(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -98,6 +102,10 @@ func TestCommand_File_id(t *testing.T) {
 }
 
 func TestCommand_File_nameOnly(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -135,6 +143,10 @@ func TestCommand_File_nameOnly(t *testing.T) {
 }
 
 func TestCommand_Flag(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)

--- a/command/services/register/register_test.go
+++ b/command/services/register/register_test.go
@@ -60,6 +60,10 @@ func TestCommand_Validation(t *testing.T) {
 }
 
 func TestCommand_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -93,6 +97,10 @@ func TestCommand_File(t *testing.T) {
 }
 
 func TestCommand_Flags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -119,6 +127,10 @@ func TestCommand_Flags(t *testing.T) {
 }
 
 func TestCommand_Flags_TaggedAddresses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)
@@ -154,6 +166,10 @@ func TestCommand_Flags_TaggedAddresses(t *testing.T) {
 }
 
 func TestCommand_FileWithUnnamedCheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	require := require.New(t)

--- a/command/snapshot/restore/snapshot_restore_test.go
+++ b/command/snapshot/restore/snapshot_restore_test.go
@@ -65,6 +65,10 @@ func TestSnapshotRestoreCommand_Validation(t *testing.T) {
 }
 
 func TestSnapshotRestoreCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -105,6 +109,10 @@ func TestSnapshotRestoreCommand(t *testing.T) {
 }
 
 func TestSnapshotRestoreCommand_TruncatedSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/snapshot/save/snapshot_save_test.go
+++ b/command/snapshot/save/snapshot_save_test.go
@@ -69,6 +69,10 @@ func TestSnapshotSaveCommand_Validation(t *testing.T) {
 }
 
 func TestSnapshotSaveCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -101,6 +105,10 @@ func TestSnapshotSaveCommand(t *testing.T) {
 }
 
 func TestSnapshotSaveCommand_TruncatedStream(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/command/watch/watch_test.go
+++ b/command/watch/watch_test.go
@@ -22,6 +22,10 @@ func TestWatchCommand_noTabs(t *testing.T) {
 }
 
 func TestWatchCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -42,6 +46,10 @@ func TestWatchCommand(t *testing.T) {
 }
 
 func TestWatchCommand_loadToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := agent.NewTestAgent(t, ` `)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -135,6 +143,10 @@ func TestWatchCommand_loadToken(t *testing.T) {
 }
 
 func TestWatchCommandNoConnect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
@@ -156,6 +168,10 @@ func TestWatchCommandNoConnect(t *testing.T) {
 }
 
 func TestWatchCommandNoAgentService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()

--- a/connect/proxy/config_test.go
+++ b/connect/proxy/config_test.go
@@ -79,6 +79,10 @@ func TestUpstreamResolverFuncFromClient(t *testing.T) {
 }
 
 func TestAgentConfigWatcherSidecarProxy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	a := agent.StartTestAgent(t, agent.TestAgent{Name: "agent_smith"})
 	defer a.Shutdown()
 

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestProxy_public(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	ports := freeport.MustTake(1)

--- a/connect/resolver_test.go
+++ b/connect/resolver_test.go
@@ -41,6 +41,10 @@ func TestStaticResolver_Resolve(t *testing.T) {
 }
 
 func TestConsulResolver_Resolve(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// Setup a local test agent to query
 	agent := agent.StartTestAgent(t, agent.TestAgent{Name: "test-consul"})
 	defer agent.Shutdown()

--- a/connect/service_test.go
+++ b/connect/service_test.go
@@ -33,6 +33,10 @@ func TestService_Name(t *testing.T) {
 }
 
 func TestService_Dial(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ca := connect.TestCA(t, nil)
 
 	tests := []struct {
@@ -125,6 +129,10 @@ func TestService_Dial(t *testing.T) {
 }
 
 func TestService_ServerTLSConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	a := agent.StartTestAgent(t, agent.TestAgent{Name: "007", Overrides: `

--- a/connect/tls_test.go
+++ b/connect/tls_test.go
@@ -135,6 +135,10 @@ func TestClientSideVerifier(t *testing.T) {
 }
 
 func TestServerSideVerifier(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ca1 := connect.TestCA(t, nil)
 	ca2 := connect.TestCA(t, ca1)
 

--- a/internal/go-sso/oidcauth/jwt_test.go
+++ b/internal/go-sso/oidcauth/jwt_test.go
@@ -640,6 +640,10 @@ func setupLogin(t *testing.T, iat, exp, nbf time.Time, issuer string) string {
 }
 
 func TestParsePublicKeyPEM(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	getPublicPEM := func(t *testing.T, pub interface{}) string {
 		derBytes, err := x509.MarshalPKIXPublicKey(pub)
 		require.NoError(t, err)

--- a/lib/retry/retry_test.go
+++ b/lib/retry/retry_test.go
@@ -108,6 +108,10 @@ func TestWaiter_Delay(t *testing.T) {
 }
 
 func TestWaiter_Wait(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	ctx := context.Background()
 
 	t.Run("first failure", func(t *testing.T) {

--- a/lib/semaphore/semaphore_test.go
+++ b/lib/semaphore/semaphore_test.go
@@ -26,6 +26,10 @@ func HammerDynamic(sem *Dynamic, loops int) {
 // TestDynamic hammers the semaphore from all available cores to ensure we don't
 // hit a panic or race detector notice something wonky.
 func TestDynamic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	t.Parallel()
 
 	n := runtime.GOMAXPROCS(0)

--- a/logging/logfile_test.go
+++ b/logging/logfile_test.go
@@ -14,6 +14,10 @@ import (
 )
 
 func TestLogFile_Rotation_MaxDuration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	tempDir := testutil.TempDir(t, "")
 	logFile := LogFile{
 		fileName: "consul.log",

--- a/logging/monitor/monitor_test.go
+++ b/logging/monitor/monitor_test.go
@@ -40,6 +40,10 @@ func TestMonitor_Start(t *testing.T) {
 }
 
 func TestMonitor_Stop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{
@@ -80,6 +84,10 @@ func TestMonitor_Stop(t *testing.T) {
 }
 
 func TestMonitor_DroppedMessages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{
@@ -122,6 +130,10 @@ func TestMonitor_DroppedMessages(t *testing.T) {
 }
 
 func TestMonitor_ZeroBufSizeDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	require := require.New(t)
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -124,6 +124,10 @@ func makeRaft(t *testing.T, dir string) (*raft.Raft, *MockFSM) {
 }
 
 func TestSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir := testutil.TempDir(t, "snapshot")
 
 	// Make a Raft and populate it with some data. We tee everything we
@@ -232,6 +236,10 @@ func TestSnapshot_BadVerify(t *testing.T) {
 }
 
 func TestSnapshot_TruncatedVerify(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir := testutil.TempDir(t, "snapshot")
 
 	// Make a Raft and populate it with some data. We tee everything we
@@ -277,6 +285,10 @@ func TestSnapshot_TruncatedVerify(t *testing.T) {
 }
 
 func TestSnapshot_BadRestore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	dir := testutil.TempDir(t, "snapshot")
 
 	// Make a Raft and populate it with some data.


### PR DESCRIPTION
Add a skip condition when the `-short` flag is used, to all tests slower than 100ms. This allows anyone who is running tests locally to get reasonably fast feedback as they make changes. The default behaviour is still to run all tests so CI will always run every test. The `-short` flag is standard flag on `go test` that sets the `testing.Short` return value to true.

This change was made using `gotestsum tool slowest` with data from the last 3 CI runs of master.
See https://github.com/gotestyourself/gotestsum#finding-and-skipping-slow-tests

With this change:

```
$ time go test -count=1 -short ./agent
ok      github.com/hashicorp/consul/agent       0.743s

real    0m4.791s
# DONE 1377 tests, 495 skipped in 4.465s

$ time go test -count=1 -short ./agent/consul
ok      github.com/hashicorp/consul/agent/consul        4.229s

real    0m8.769s
# DONE 715 tests, 389 skipped in 4.806s
```