### PR TITLE
ui: Change URI helper to a template based approach

### DIFF
--- a/ui/packages/consul-ui/app/components/data-form/index.hbs
+++ b/ui/packages/consul-ui/app/components/data-form/index.hbs
@@ -1,8 +1,28 @@
-<DataLoader @items={{item}} @src={{uri nspace dc type src}} @onchange={{action "setData"}} @once={{true}}>
+<DataLoader
+  @items={{item}}
+  @src={{uri
+    '/${nspace}/${dc}/${type}/${src}'
+    (hash
+      nspace=nspace
+      dc=dc
+      type=type
+      src=src
+    )
+  }}
+  @onchange={{action "setData"}}
+  @once={{true}}
+>
   <BlockSlot @name="loaded">
 
     <DataWriter
-      @sink={{uri nspace (or data.Datacenter dc) type}}
+      @sink={{uri
+        '/${nspace}/${dc}/${type}'
+        (hash
+          nspace=nspace
+          dc=(or data.Datacenter dc)
+          type=type
+        )
+      }}
       @type={{type}}
       @label={{label}}
       @ondelete={{action ondelete}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/series/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/series/index.hbs
@@ -1,6 +1,14 @@
 {{#unless @noMetricsReason}}
   <DataSource
-    @src={{uri @nspace @dc 'metrics' 'summary-for-service' @service @protocol}}
+    @src={{uri
+      '/${nspace}/${dc}/metrics/summary-for-service/${service}/${protocol}'
+      (hash
+        nspace=@nspace
+        dc=@dc
+        service=@service
+        protocol=@protocol
+      )
+    }}
     @onchange={{action 'change'}}
     @onerror={{action (mut error) value="error"}}
   />

--- a/ui/packages/consul-ui/app/components/topology-metrics/stats/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/stats/index.hbs
@@ -1,6 +1,15 @@
 {{#unless @noMetricsReason}}
   <DataSource
-    @src={{uri @nspace @dc 'metrics' @endpoint @service @protocol}}
+    @src={{uri
+      '/${nspace}/${dc}/metrics/${endpoint}/${service}/${protocol}'
+      (hash
+        nspace=@nspace
+        dc=@dc
+        endpoint=@endpoint
+        service=@service
+        protocol=@protocol
+      )
+    }}
     @onchange={{action 'statsUpdate'}}
     @onerror={{action (mut error) value="error"}}
   />

--- a/ui/packages/consul-ui/app/helpers/render-template.js
+++ b/ui/packages/consul-ui/app/helpers/render-template.js
@@ -1,18 +1,19 @@
-import { helper } from '@ember/component/helper';
-import { get } from '@ember/object';
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
 
-// Covers alpha-capitalized dot separated API keys such as
-// `{{Name}}`, `{{Service.Name}}` etc. but not `{{}}`
+// simple mustache regexp `/{{item.Name}}/`
 const templateRe = /{{([A-Za-z.0-9_-]+)}}/g;
-export default helper(function renderTemplate([template, vars]) {
-  if (typeof vars !== 'undefined' && typeof template !== 'undefined') {
-    return template.replace(templateRe, function(match, group) {
-      try {
-        return encodeURIComponent(get(vars, group) || '');
-      } catch (e) {
-        return '';
-      }
-    });
+let render;
+export default class RenderTemplateHelper extends Helper {
+  @service('encoder') encoder;
+  constructor() {
+    super(...arguments);
+    if (typeof render !== 'function') {
+      render = this.encoder.createRegExpEncoder(templateRe, encodeURIComponent, false);
+    }
   }
-  return '';
-});
+
+  compute([template, vars]) {
+    return render(template, vars);
+  }
+}

--- a/ui/packages/consul-ui/app/helpers/uri.js
+++ b/ui/packages/consul-ui/app/helpers/uri.js
@@ -1,10 +1,18 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
+const templateRe = /\${([A-Za-z.0-9_-]+)}/g;
+let render;
 export default class UriHelper extends Helper {
   @service('encoder') encoder;
+  constructor() {
+    super(...arguments);
+    if (typeof render !== 'function') {
+      render = this.encoder.createRegExpEncoder(templateRe, encodeURIComponent);
+    }
+  }
 
-  compute(params, hash) {
-    return this.encoder.uriJoin(params);
+  compute([template, vars]) {
+    return render(template, vars);
   }
 }

--- a/ui/packages/consul-ui/app/services/encoder.js
+++ b/ui/packages/consul-ui/app/services/encoder.js
@@ -1,9 +1,31 @@
 import Service from '@ember/service';
+import { get } from '@ember/object';
+import { runInDebug } from '@ember/debug';
 import atob from 'consul-ui/utils/atob';
 import btoa from 'consul-ui/utils/btoa';
 
+const createRegExpEncoder = function(re, encoder = str => str, strict = true) {
+  return (template = '', vars = {}) => {
+    if (template !== '') {
+      return template.replace(re, (match, group) => {
+        const value = get(vars, group);
+        runInDebug(() => {
+          if (strict && typeof value === 'undefined') {
+            console.error(new Error(`${group} is undefined in ${template}`));
+          }
+        });
+        return encoder(value || '');
+      });
+    }
+    return '';
+  };
+};
 export default class EncoderService extends Service {
   uriComponent = encodeURIComponent;
+
+  createRegExpEncoder(re, encoder) {
+    return createRegExpEncoder(re, encoder);
+  }
 
   atob() {
     return atob(...arguments);

--- a/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
@@ -1,4 +1,13 @@
-<DataLoader @src={{uri nspace dc 'intentions' 'for-service' slug}} as |api|>
+<DataLoader
+  @src={{uri
+    '/${nspace}/${dc}/intentions/for-service/${slug}'
+    (hash
+      nspace=nspace
+      dc=dc
+      slug=slug
+    )
+  }}
+as |api|>
   <BlockSlot @name="error">
     <ErrorState @error={{api.error}} />
   </BlockSlot>


### PR DESCRIPTION
This moves our `uri` helper to use a the template renderer we already have for rendering URLs.

Reasons behind this:

1. We had a bug a while ago where we were trying to construct a URL with an undefined nspace, this was resulting in a URL like `//dc/something`. This approach has a strict mode that will warn you whilst in development with a clear error if any values are `undefined`. This should prevent any such bugs in the future (we re-use the functionality we already had for rendering URLs without a strict mode).
2. Our template based datasources now look pretty much exactly the same as our javascript based ones, which additionally means it's easy to find places where we are using a specific data sources by searching through the project. This approach generally just looks easier to see whats happening rather than our previous concat approach.

Right now, there are dev time errors being thrown for a missing `@protocol` argument within the topology tab, so would be good to catch up to see what the 'default' value would be for a protocol before just assuming its an empty string.