### PR TITLE
ui: Use pill/badge components for intention filter options

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/intention/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/search-bar/index.hbs
@@ -41,9 +41,12 @@
       </BlockSlot>
       <BlockSlot @name="options">
 {{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option class="value-allow" @value="allow" @selected={{contains 'allow' @filter.accesses}}>Allow</Option>
-        <Option class="value-deny" @value="deny" @selected={{contains 'deny' @filter.accesses}}>Deny</Option>
-        <Option class="value-" @value="app-aware" @selected={{contains 'app-aware' @filter.accesses}}>App aware</Option>
+        <Option class="value-allow" @value="allow" @selected={{contains 'allow'
+        @filter.accesses}}><span>Allow</span></Option>
+        <Option class="value-deny" @value="deny" @selected={{contains 'deny'
+        @filter.accesses}}><span>Deny</span></Option>
+        <Option class="value-" @value="app-aware" @selected={{contains
+        'app-aware' @filter.accesses}}><span>App aware</span></Option>
 {{/let}}
       </BlockSlot>
     </PopoverSelect>

--- a/ui/packages/consul-ui/app/components/consul/intention/search-bar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/search-bar/index.scss
@@ -1,12 +1,14 @@
 .consul-intention-search-bar {
-  .value-allow button::before {
-    @extend %with-arrow-right-mask, %as-pseudo;
-    color: $green-500;
+  li button span {
+    @extend %pill-700;
   }
-  .value-deny button::before {
-    @extend %with-deny-color-icon, %as-pseudo;
+  .value-allow span {
+    @extend %pill-allow;
   }
-  .value- button::before {
-    @extend %with-layers-mask, %as-pseudo;
+  .value-deny span {
+    @extend %pill-deny;
+  }
+  .value- span {
+    @extend %pill-l7;
   }
 }


### PR DESCRIPTION
Before:

<img width="650" alt="Screenshot 2020-12-09 at 14 26 28" src="https://user-images.githubusercontent.com/554604/101642145-8c312300-3a2a-11eb-823c-2c5d1df4b240.png">

After:

<img width="665" alt="Screenshot 2020-12-09 at 14 24 54" src="https://user-images.githubusercontent.com/554604/101642154-905d4080-3a2a-11eb-9ecc-4415dc546104.png">

cc @jnwright 
