### PR TITLE
nia docs: add status api

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -180,6 +180,7 @@ export default [
         content: ['install', 'requirements', 'configuration', 'run'],
       },
       'architecture',
+      'api',
       'cli',
       'tasks',
       'network-drivers',

--- a/website/pages/docs/nia/api.mdx
+++ b/website/pages/docs/nia/api.mdx
@@ -1,0 +1,223 @@
+---
+layout: docs
+page_title: Consul-Terraform-Sync API
+sidebar_title: API
+description: >-
+  How to use the Consul-Terraform-Sync API
+---
+
+# Consul-Terraform-Sync API
+
+When running in [daemon mode](/docs/nia/cli#daemon-mode), Consul-Terraform-Sync serves an HTTP API interface.
+
+### Port
+
+The API is served at the default port `8501` or a different port if set with [`port` configuration](/docs/nia/installation/configuration#port)
+
+### Version Prefix
+
+All API routes are prefixed with `/v1/`. This documentation is for v1 of the API, which is the only version currently.
+
+Example: `curl localhost:8501/v1/status`
+
+### Error
+
+Successful API requests will receive a 2XX success status code. For other unsuccessful status codes, when possible, more details will be provided in a response body. The response will be a JSON map with an "error" key.
+
+Example: Status 400 Bad Request
+```json
+{
+  "error": "example error message: unsupported status parameter value"
+}
+```
+
+## Status
+
+The `/status` endpoints share status-related information for tasks. This information is available for understanding the status of individuals tasks and across tasks. The health status value is determined by aggregating the success or failure of the event of a task detecting changes in Consul services and then updating network infrastructure. Currently, only the 5 most recent events are stored in Consul-Terraform-Sync. For more information on the hierarchy of status information and how it is collected, see [Status Information](/docs/nia/tasks#status-information).
+
+Below are all possible values for health status. See individual endpoints below for details on how each health status value is determined:
+ - Healthy
+ - Degraded
+ - Critical
+ - Undetermined
+
+### Overall Status
+
+This endpoint returns the overall status information across all tasks.
+
+Overall health status value is determined by the [health status values of all individual tasks](/docs/nia/api#task-status)
+ - Healthy: All tasks have health status "healthy".
+ - Degraded: At least one task has health status "degraded" but none are "critical".
+ - Critical: At least one task has health status "critical".
+ - Undetermined: No tasks have health status information at the moment.
+
+
+| Method | Path                | Produces           |
+| ------ | ------------------- | ------------------ |
+| `GET`  | `/status` | `application/json` |
+
+#### Request Parameters
+Currently no request parameters are offered for the overall status API.
+
+#### Response Fields
+
+* `status` - `(string)` Values are "healthy", "degraded", "critical", or "undetermined". This is determined by the health status values of all individual tasks, as described above.
+
+
+#### Example
+
+Request:
+```shell-session
+curl localhost:8501/v1/status
+```
+
+Response:
+```json
+{
+  "status": "healthy"
+}
+```
+
+### Task Status
+
+This endpoint returns the individual task status information for a single specified task or for all tasks.
+
+Task health status value is determined by the success or failure of all stored [event data](/docs/nia/tasks#event) on the process of updating network infrastructure for a task. Currently only the 5 most recent events are stored per task.
+ - Healthy: All stored events of the task are successful.
+ - Degraded: More than half of the stored events are successful _or_ less than half of the stored events are successful but the most recent event is successful.
+ - Critical: Half or less of the stored events are successful and the most recent event is not successful.
+ - Undetermined: No event data is stored for the task.
+
+| Method | Path                | Produces           |
+| ------ | ------------------- | ------------------ |
+| `GET`  | `/status/tasks/:task` | `application/json` |
+
+#### Request Parameters
+
+* `task` - `(string)` Option to specify the name of the task to return in the response. If not specified, all tasks are returned in the response.
+* `include` - `(string)` Only accepts the value "events". Use to include stored event information in response.
+* `status` - `(string)` Only accepts health status values "healthy", "degraded", "critical", or "undetermined". Use to filter response by tasks that have the specified health status value. Recommend setting this parameter when requesting all tasks i.e. no `task` parameter is set.
+
+#### Response Fields
+
+The response is a JSON map of task name to a status information structure with the following fields.
+
+* `task_name` - `(string)` Name that task is configured with in Consul-Terraform-Sync.
+* `status` - `(string)` Values are "healthy", "degraded", "critical", or "undetermined". This is determined by the success or failure of all stored events on the network infrastructure update process for the task, as described earlier.
+* `services` - `(list[string])` List of the services configured for the task.
+* `providers` - `(list[string])` List of the providers configured for the task.
+* `events_url` - `(string)` Relative URL to retrieve the event data stored for the task.
+* `events` - [`(list[Event])`](/docs/nia/api#event) - List of stored events that inform the task's status. See section below for information on event data. This field is only included in the response upon request by setting the `?include=events` parameter. The relative URL for the request to include events can be retrieved from the `events_url` field.
+
+##### Event
+
+Event represents the process of updating network infrastructure of a task. The data is captured in a JSON structure. For more details on the scope of an event, see [Event](/docs/nia/tasks#event).
+
+* `id` - `(string)` UUID to uniquely identify the event.
+* `success` - `(bool)` Indication of whether the event was successful or not.
+* `start_time` - `(time)` Time when the event started.
+* `end_time` - `(time)` Time when the event ended.
+* `task_name` - `(string)` Name that task is configured with in Consul-Terraform-Sync.
+* `error` Information when the event fails. Null when successful.
+  * `message` - `(string)` Error message that is returned on failure.
+* `config`
+  * `services` - `(list[string])` List of the services configured for the task.
+  * `source` - `(string)` Source configured for the task.
+  * `providers` - `(list[string])` List of the providers configured for the task.
+
+#### Example: All Task Statuses
+
+Request:
+```shell-session
+curl localhost:8501/v1/status/tasks
+```
+
+Response:
+```json
+{
+  "task_a": {
+    "task_name": "task_a",
+    "status": "healthy",
+    "providers": [
+      "local"
+    ],
+    "services": [
+      "api"
+    ],
+    "events_url": "/v1/status/tasks/task_a?include=events"
+  },
+  "task_b": {
+    "task_name": "task_b",
+    "status": "degraded",
+    "providers": [
+      "null"
+    ],
+    "services": [
+      "web"
+    ],
+    "events_url": "/v1/status/tasks/task_b?include=events"
+  }
+}
+```
+
+#### Example: Individual Task Status with Events
+
+Request:
+```shell-session
+curl localhost:8501/v1/status/tasks/task_b?include=events
+```
+
+Response:
+```json
+{
+  "task_b": {
+    "task_name": "task_b",
+    "status": "degraded",
+    "providers": [
+      "null"
+    ],
+    "services": [
+      "web",
+    ],
+    "events_url": "/v1/status/tasks/task_b?include=events",
+    "events": [
+      {
+        "id": "44137ba2-8fc9-6cbe-0e0e-e9305ee4f7f9",
+        "success": true,
+        "start_time": "2020-11-24T12:06:51.858292-05:00",
+        "end_time": "2020-11-24T12:06:52.770165-05:00",
+        "task_name": "task_b",
+        "error": null,
+        "config": {
+          "providers": [
+            "null"
+          ],
+          "services": [
+            "web",
+          ],
+          "source": "../modules/test_task"
+        }
+      },
+      {
+        "id": "ef202675-502f-431f-b133-ed64d15b0e0e",
+        "success": false,
+        "start_time": "2020-11-24T12:04:18.651231-05:00",
+        "end_time": "2020-11-24T12:04:20.900115-05:00",
+        "task_name": "task_b",
+        "error": {
+          "message": "example error: terraform-apply error"
+        },
+        "config": {
+          "providers": [
+            "null"
+          ],
+          "services": [
+            "web",
+          ],
+          "source": "../modules/test_task"
+        }
+      }
+    ]
+  }
+}
+```

--- a/website/pages/docs/nia/installation/configuration.mdx
+++ b/website/pages/docs/nia/installation/configuration.mdx
@@ -16,6 +16,7 @@ An example HCL configuration is shown below to automate a task to execute a Terr
 
 ```hcl
 log_level = "info"
+port = 8505
 
 consul {
   address = "consul.example.com"
@@ -58,6 +59,7 @@ Top level options are reserved for configuring Consul-Terraform-Sync.
 
 ```hcl
 log_level = "INFO"
+port = 8505
 syslog {}
 buffer_period {
   enabled = true
@@ -66,15 +68,16 @@ buffer_period {
 }
 ```
 
-* `log_level` - `(string: "WARN")` The log level to use for Consul-Terraform-Sync logging.
-* `syslog` - Specifies the syslog server for logging.
-  * `enabled` - `(bool: false)` Enable syslog logging. Specifying other option also enables syslog logging.
-  * `facility` - `(string: <none>)` Name of the syslog facility to log to.
-  * `name` - `(string: "consul-terraform-sync")` Name to use for the daemon process when logging to syslog.
 * `buffer_period` - Configures the default buffer period for all [tasks](#task) to dampen the affects of flapping services to downstream network devices. It defines the minimum and maximum amount of time to wait for the cluster to reach a consistent state and accumulate changes before triggering task executions. The default is enabled to reduce the number of times downstream infrastructure is updated within a short period of time. This is useful to enable in systems that have a lot of flapping.
   * `enabled` - `(bool: true)` Enable or disable buffer periods globally. Specifying `min` will also enable it.
   * `min` - `(string: 5s)` The minimum period of time to wait after changes are detected before triggering related tasks.
   * `max` - `(string: 20s)` The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
+* `log_level` - `(string: "WARN")` The log level to use for Consul-Terraform-Sync logging.
+* `port` - `(int: 8501)` The port for Consul-Terraform-Sync to use to serve API requests.
+* `syslog` - Specifies the syslog server for logging.
+  * `enabled` - `(bool: false)` Enable syslog logging. Specifying other option also enables syslog logging.
+  * `facility` - `(string: <none>)` Name of the syslog facility to log to.
+  * `name` - `(string: "consul-terraform-sync")` Name to use for the daemon process when logging to syslog.
 
 ## Consul
 

--- a/website/pages/docs/nia/tasks.mdx
+++ b/website/pages/docs/nia/tasks.mdx
@@ -55,3 +55,67 @@ Consul-Terraform-Sync automatically generates any files needed to execute the ne
 Consul-Terraform-Sync will attempt to execute each task once upon startup to synchronize infrastructure with the current state of Consul. The daemon will stop and exit if any error occurs while preparing the automation environment or executing a task for the first time. This helps ensure all tasks have proper configuration and are executable before the daemon transitions into running tasks in full automation as service changes are discovered over time. After all tasks have successfully executed once, task failures during automation will be logged and retried or attempted again after a subsequent change.
 
 Tasks are executed near-real time when service changes are detected. For services or environments that are prone to flapping, it may be useful to configure a [buffer period](/docs/nia/installation/configuration#buffer_period-1) for a task to accumulate changes before it is executed. The buffer period would reduce the number of consecutive network calls to infrastructure by batching changes for a task over a short duration of time.
+
+## Status Information
+
+Status-related information is collected and offered via [status API](/docs/nia/api#status) to provide visibility into what and how the tasks are running. Information is offered in three-levels (lowest to highest):
+ - Event data
+ - Task status
+ - Overall status
+
+These three levels form a hierarchy where each level of data informs the one higher. The lowest-level, event data, is collected each time a task runs to update network infrastructure. This event data is then aggregated to inform individual task statuses. The aggregation of all the task statuses inform the overall status.
+
+### Event
+
+Each time a task's services has an update, Consul-Terraform-Sync takes a series of steps in order to update network infrastructure. This process starts with updating the task's templates to fetch new service data from Consul and ends with any post-actions after modifying network infrastructure. An event is a data structure that captures information on this process of updating network infrastructure. It stores information to help understand if the update to network infrastructure was successful or not, and it stores any errors that occurred.
+
+Sample event:
+```json
+{
+  "id": "ef202675-502f-431f-b133-ed64d15b0e0e",
+  "success": false,
+  "start_time": "2020-11-24T12:05:18.651231-05:00",
+  "end_time": "2020-11-24T12:05:20.900115-05:00",
+  "task_name": "task_b",
+  "error": {
+    "message": "example error: error while doing terraform-apply"
+  },
+  ...
+}
+```
+
+For complete information on the event structure, see [events in our API documentation](/docs/nia/api#event). Event information can be retrieved by using the [`include=events` parameter](/docs/nia/api#include) with the [task status API](/docs/nia/api#task-status).
+
+### Task Status
+
+Each time a task runs to update network infrastructure, event data is stored for that run. Currently, only the 5 most recent events are stored for each task. The stored events are used to determine the task status. For example, if a task has 5 events stored and 3 are success and 2 are not, then the task's health status is "degraded".
+
+Sample task status:
+```json
+{
+    "task_name": "task_b",
+    "status": "degraded",
+    "providers": [
+      "null"
+    ],
+    "services": [
+      "web",
+    ],
+    "events_url": "/v1/status/tasks/task_b?include=events",
+}
+```
+
+Task status information can be retrieved with [task status API](/docs/nia/api#task-status). The API documentation includes details on what health statuses are available and how it is calculated based on events' success/failure information.
+
+### Overall Status
+
+Overall status is determined by looking at the health status of all task statuses. For example, if Consul-Terraform-Sync is configured with 10 tasks and 8 are critical and 2 are degraded, then the overall health status is "critical".
+
+Sample overall status:
+```json
+{
+  "status": "critical"
+}
+```
+
+Overall status information can be retrieved with [overall status API](/docs/nia/api#overall-status). The API documentation includes details on what health statuses are available and how it is calculated based on task statuses' health status information.


### PR DESCRIPTION
 - Configuration page: port config
 - API page covering endpoints and parameters
 - Tasks page: additional details on event, task status, overall status hierarchy

Links to changes:
 - Port config: https://deploy-preview-9362--consul-docs-preview.netlify.app/docs/nia/installation/configuration#port
 - New API page: https://deploy-preview-9362--consul-docs-preview.netlify.app/docs/nia/api
 - Task page status content: https://deploy-preview-9362--consul-docs-preview.netlify.app/docs/nia/tasks#status-information