### PR TITLE
ui: Remove random undefined from codemod run

### DIFF
--- a/ui/packages/consul-ui/app/routes/dc.js
+++ b/ui/packages/consul-ui/app/routes/dc.js
@@ -82,7 +82,6 @@ export default class DcRoute extends Route {
   // https://deprecations.emberjs.com/v3.x/#toc_deprecate-router-events
   @action
   willTransition(transition) {
-    undefined;
     if (
       typeof transition !== 'undefined' &&
       (transition.from.name.endsWith('nspaces.create') ||


### PR DESCRIPTION
An Ember codemod for translating old style Ember classes to JS native class syntax that we ran in https://github.com/hashicorp/consul/pull/9093 added a random `undefined` in the code, this PR removes it.

