### PR TITLE
docs/nia decodify field type

### DIFF
--- a/website/pages/docs/nia/api.mdx
+++ b/website/pages/docs/nia/api.mdx
@@ -61,7 +61,7 @@ Currently no request parameters are offered for the overall status API.
 
 #### Response Fields
 
-* `status` - `(string)` Values are "healthy", "degraded", "critical", or "undetermined". This is determined by the health status values of all individual tasks, as described above.
+* `status` - (string) Values are "healthy", "degraded", "critical", or "undetermined". This is determined by the health status values of all individual tasks, as described above.
 
 
 #### Example
@@ -94,36 +94,36 @@ Task health status value is determined by the success or failure of all stored [
 
 #### Request Parameters
 
-* `task` - `(string)` Option to specify the name of the task to return in the response. If not specified, all tasks are returned in the response.
-* `include` - `(string)` Only accepts the value "events". Use to include stored event information in response.
-* `status` - `(string)` Only accepts health status values "healthy", "degraded", "critical", or "undetermined". Use to filter response by tasks that have the specified health status value. Recommend setting this parameter when requesting all tasks i.e. no `task` parameter is set.
+* `task` - (string) Option to specify the name of the task to return in the response. If not specified, all tasks are returned in the response.
+* `include` - (string) Only accepts the value "events". Use to include stored event information in response.
+* `status` - (string) Only accepts health status values "healthy", "degraded", "critical", or "undetermined". Use to filter response by tasks that have the specified health status value. Recommend setting this parameter when requesting all tasks i.e. no `task` parameter is set.
 
 #### Response Fields
 
 The response is a JSON map of task name to a status information structure with the following fields.
 
-* `task_name` - `(string)` Name that task is configured with in Consul-Terraform-Sync.
-* `status` - `(string)` Values are "healthy", "degraded", "critical", or "undetermined". This is determined by the success or failure of all stored events on the network infrastructure update process for the task, as described earlier.
-* `services` - `(list[string])` List of the services configured for the task.
-* `providers` - `(list[string])` List of the providers configured for the task.
-* `events_url` - `(string)` Relative URL to retrieve the event data stored for the task.
-* `events` - [`(list[Event])`](/docs/nia/api#event) - List of stored events that inform the task's status. See section below for information on event data. This field is only included in the response upon request by setting the `?include=events` parameter. The relative URL for the request to include events can be retrieved from the `events_url` field.
+* `task_name` - (string) Name that task is configured with in Consul-Terraform-Sync.
+* `status` - (string) Values are "healthy", "degraded", "critical", or "undetermined". This is determined by the success or failure of all stored events on the network infrastructure update process for the task, as described earlier.
+* `services` - (list[string]) List of the services configured for the task.
+* `providers` - (list[string]) List of the providers configured for the task.
+* `events_url` - (string) Relative URL to retrieve the event data stored for the task.
+* `events` - [(list[Event])](/docs/nia/api#event) - List of stored events that inform the task's status. See section below for information on event data. This field is only included in the response upon request by setting the `?include=events` parameter. The relative URL for the request to include events can be retrieved from the `events_url` field.
 
 ##### Event
 
 Event represents the process of updating network infrastructure of a task. The data is captured in a JSON structure. For more details on the scope of an event, see [Event](/docs/nia/tasks#event).
 
-* `id` - `(string)` UUID to uniquely identify the event.
-* `success` - `(bool)` Indication of whether the event was successful or not.
-* `start_time` - `(time)` Time when the event started.
-* `end_time` - `(time)` Time when the event ended.
-* `task_name` - `(string)` Name that task is configured with in Consul-Terraform-Sync.
+* `id` - (string) UUID to uniquely identify the event.
+* `success` - (bool) Indication of whether the event was successful or not.
+* `start_time` - (time) Time when the event started.
+* `end_time` - (time) Time when the event ended.
+* `task_name` - (string) Name that task is configured with in Consul-Terraform-Sync.
 * `error` Information when the event fails. Null when successful.
-  * `message` - `(string)` Error message that is returned on failure.
+  * `message` - (string) Error message that is returned on failure.
 * `config`
-  * `services` - `(list[string])` List of the services configured for the task.
-  * `source` - `(string)` Source configured for the task.
-  * `providers` - `(list[string])` List of the providers configured for the task.
+  * `services` - (list[string]) List of the services configured for the task.
+  * `source` - (string) Source configured for the task.
+  * `providers` - (list[string]) List of the providers configured for the task.
 
 #### Example: All Task Statuses
 

--- a/website/pages/docs/nia/installation/configuration.mdx
+++ b/website/pages/docs/nia/installation/configuration.mdx
@@ -69,15 +69,15 @@ buffer_period {
 ```
 
 * `buffer_period` - Configures the default buffer period for all [tasks](#task) to dampen the affects of flapping services to downstream network devices. It defines the minimum and maximum amount of time to wait for the cluster to reach a consistent state and accumulate changes before triggering task executions. The default is enabled to reduce the number of times downstream infrastructure is updated within a short period of time. This is useful to enable in systems that have a lot of flapping.
-  * `enabled` - `(bool: true)` Enable or disable buffer periods globally. Specifying `min` will also enable it.
-  * `min` - `(string: 5s)` The minimum period of time to wait after changes are detected before triggering related tasks.
-  * `max` - `(string: 20s)` The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
-* `log_level` - `(string: "WARN")` The log level to use for Consul-Terraform-Sync logging.
-* `port` - `(int: 8501)` The port for Consul-Terraform-Sync to use to serve API requests.
+  * `enabled` - (bool: true) Enable or disable buffer periods globally. Specifying `min` will also enable it.
+  * `min` - (string: 5s) The minimum period of time to wait after changes are detected before triggering related tasks.
+  * `max` - (string: 20s) The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
+* `log_level` - (string: "WARN") The log level to use for Consul-Terraform-Sync logging.
+* `port` - (int: 8501) The port for Consul-Terraform-Sync to use to serve API requests.
 * `syslog` - Specifies the syslog server for logging.
-  * `enabled` - `(bool: false)` Enable syslog logging. Specifying other option also enables syslog logging.
-  * `facility` - `(string: <none>)` Name of the syslog facility to log to.
-  * `name` - `(string: "consul-terraform-sync")` Name to use for the daemon process when logging to syslog.
+  * `enabled` - (bool: false) Enable syslog logging. Specifying other option also enables syslog logging.
+  * `facility` - (string: <none\>) Name of the syslog facility to log to.
+  * `name` - (string: "consul-terraform-sync") Name to use for the daemon process when logging to syslog.
 
 ## Consul
 
@@ -95,28 +95,28 @@ consul {
 }
 ```
 
-* `address` - `(string: "localhost:8500")` Address is the address of the Consul agent. It may be an IP or FQDN.
+* `address` - (string: "localhost:8500") Address is the address of the Consul agent. It may be an IP or FQDN.
 * `auth` - Auth is the HTTP basic authentication for communicating with Consul.
-  * `enabled` - `(bool: false)`
-  * `username` - `(string: <none>)`
-  * `password` - `(string: <none>)`
+  * `enabled` - (bool: false)
+  * `username` - (string: <none\>)
+  * `password` - (string: <none\>)
 * `tls` - Configure TLS to use a secure client connection with Consul. This option is required for Consul-Terraform-Sync when connecting to a [Consul agent with TLS verification enabled for HTTPS connections](/docs/agent/options#verify_incoming).
-  * `enabled` - `(bool: false)` Enable TLS. Specifying any option for TLS will also enable it.
-  * `verify` - `(bool: true)` Enables TLS peer verification. The default is enabled, which will check the global CA chain to make sure the given certificates are valid. If you are using a self-signed certificate that you have not added to the CA chain, you may want to disable SSL verification. However, please understand this is a potential security vulnerability.
-  * `key` - `(string: <none>)` The client key file to use for talking to Consul over TLS. The key also be provided through the `CONSUL_CLIENT_KEY` environment variable.
-  * `ca_cert` - `(string: <none>)` The CA file to use for talking to Consul over TLS. Can also be provided though the `CONSUL_CACERT` environment variable.
-  * `ca_path` - `(string: <none>)` The path to a directory of CA certs to use for talking to Consul over TLS. Can also be provided through the `CONSUL_CAPATH` environment variable.
-  * `cert` - `(string: <none>)` The client cert file to use for talking to Consul over TLS. Can also be provided through the `CONSUL_CLIENT_CERT` environment variable.
-  * `server_name` - `(string: <none>)` The server name to use as the SNI host when connecting via TLS. Can also be provided through the `CONSUL_TLS_SERVER_NAME` environment variable.
-* `token` - `(string: <none>)` The ACL token to use for client communication with the local Consul agent. The token can also be provided through the `CONSUL_TOKEN` or `CONSUL_HTTP_TOKEN` environment variables.
+  * `enabled` - (bool: false) Enable TLS. Specifying any option for TLS will also enable it.
+  * `verify` - (bool: true) Enables TLS peer verification. The default is enabled, which will check the global CA chain to make sure the given certificates are valid. If you are using a self-signed certificate that you have not added to the CA chain, you may want to disable SSL verification. However, please understand this is a potential security vulnerability.
+  * `key` - (string: <none\>) The client key file to use for talking to Consul over TLS. The key also be provided through the `CONSUL_CLIENT_KEY` environment variable.
+  * `ca_cert` - (string: <none\>) The CA file to use for talking to Consul over TLS. Can also be provided though the `CONSUL_CACERT` environment variable.
+  * `ca_path` - (string: <none\>) The path to a directory of CA certs to use for talking to Consul over TLS. Can also be provided through the `CONSUL_CAPATH` environment variable.
+  * `cert` - (string: <none\>) The client cert file to use for talking to Consul over TLS. Can also be provided through the `CONSUL_CLIENT_CERT` environment variable.
+  * `server_name` - (string: <none\>) The server name to use as the SNI host when connecting via TLS. Can also be provided through the `CONSUL_TLS_SERVER_NAME` environment variable.
+* `token` - (string: <none\>) The ACL token to use for client communication with the local Consul agent. The token can also be provided through the `CONSUL_TOKEN` or `CONSUL_HTTP_TOKEN` environment variables.
 * `transport` - Transport configures the low-level network connection details.
-  * `dial_keep_alive` - `(string: "30s")` The amount of time for keep-alives.
-  * `dial_timeout` - `(string: "30s")` The amount of time to wait to establish a connection.
-  * `disable_keep_alives` - `(bool: false)` Determines if keep-alives should be used. Disabling this significantly decreases performance.
-  * `idle_conn_timeout` - `(string: "90s")` The timeout for idle connections.
-  * `max_idle_conns` - `(int: 100)` The maximum number of total idle connections.
-  * `max_idle_conns_per_host` - `(int: 1)` The maximum number of idle connections per remote host.
-  * `tls_handshake_timeout` - `(string: "10s")` amount of time to wait to complete the TLS handshake.
+  * `dial_keep_alive` - (string: "30s") The amount of time for keep-alives.
+  * `dial_timeout` - (string: "30s") The amount of time to wait to establish a connection.
+  * `disable_keep_alives` - (bool: false) Determines if keep-alives should be used. Disabling this significantly decreases performance.
+  * `idle_conn_timeout` - (string: "90s") The timeout for idle connections.
+  * `max_idle_conns` - (int: 100) The maximum number of total idle connections.
+  * `max_idle_conns_per_host` - (int: 1) The maximum number of idle connections per remote host.
+  * `tls_handshake_timeout` - (string: "10s") amount of time to wait to complete the TLS handshake.
 
 ## Service
 
@@ -130,12 +130,12 @@ service {
 }
 ```
 
-* `datacenter` - `(string: <none>)` The datacenter the service is deployed in.
-* `description` - `(string: <none>)` The human readable text to describe the service.
-* `id` - `(string: <none>)` ID identifies the service for Consul-Terraform-Sync. This is used to explicitly identify the service config for a task to use. If no ID is provided, the service is identified by the service name within a [task definition](#task).
-* `name` - `(string: <required>)` The Consul logical name of the service (required).
-* `namespace` <EnterpriseAlert inline /> - `(string: "default")` The namespace of the service. If not provided, the namespace will be inferred from the Consul-Terraform-Sync ACL token, or default to the `default` namespace.
-* `tag` - `(string: <none>)` Tag is used to filter nodes based on the tag for the service.
+* `datacenter` - (string: <none\>) The datacenter the service is deployed in.
+* `description` - (string: <none\>) The human readable text to describe the service.
+* `id` - (string: <none\>) ID identifies the service for Consul-Terraform-Sync. This is used to explicitly identify the service config for a task to use. If no ID is provided, the service is identified by the service name within a [task definition](#task).
+* `name` - (string: <required\>) The Consul logical name of the service (required).
+* `namespace` <EnterpriseAlert inline /> - (string: "default") The namespace of the service. If not provided, the namespace will be inferred from the Consul-Terraform-Sync ACL token, or default to the `default` namespace.
+* `tag` - (string: <none\>) Tag is used to filter nodes based on the tag for the service.
 
 ## Task
 
@@ -153,12 +153,12 @@ task {
 }
 ```
 
-* `description` - `(string: <none>)` The human readable text to describe the service.
-* `name` - `(string: <required>)` Name is the unique name of the task (required). A task name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.
-* `providers` - `(list[string]: [])` Providers is the list of provider names the task is dependent on. This is used to map [Terraform provider configuration](#terraform-provider) to the task.
-* `services` - `(list[string]: [])` Services is the list of logical service names or service IDs the task executes on. Consul-Terraform-Sync monitors the Consul Catalog for changes to these services and triggers the task to run. Any service value not explicitly defined by a `service` block with a matching ID is assumed to be a logical service name in the default namespace.
-* `source` - `(string: <required>)` Source is the location the driver uses to fetch task dependencies. The source format is dependent on the driver. For the [Terraform driver](#terraform-driver), the source is the module path (local or remote). Read more on [Terraform module source here](https://www.terraform.io/docs/modules/sources.html).
-* `variable_files` - `(list[string]: [])` A list of paths to files containing variables for the task. For the [Terraform driver](#terraform-driver), these are used as Terraform [variable defintion (`.tfvars`) files](https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files) and consists of only variable name assignments. The variable assignments must match the corresponding variable declarations available by the Terraform module for the task. Consul-Terraform-Sync will generate the intermediate variable declarations to pass as arguments from the auto-generated root module to the task's module. Variables are loaded in the same order as they appear in the order of the files. Duplicate variables are overwritten with the later value. *Note: unless specified by the module, configure arguments for Terraform providers using [`terraform_provider` blocks](#terraform-provider).*
+* `description` - (string: <none\>) The human readable text to describe the service.
+* `name` - (string: <required\>) Name is the unique name of the task (required). A task name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.
+* `providers` - (list[string]: []) Providers is the list of provider names the task is dependent on. This is used to map [Terraform provider configuration](#terraform-provider) to the task.
+* `services` - (list[string]: []) Services is the list of logical service names or service IDs the task executes on. Consul-Terraform-Sync monitors the Consul Catalog for changes to these services and triggers the task to run. Any service value not explicitly defined by a `service` block with a matching ID is assumed to be a logical service name in the default namespace.
+* `source` - (string: <required\>) Source is the location the driver uses to fetch task dependencies. The source format is dependent on the driver. For the [Terraform driver](#terraform-driver), the source is the module path (local or remote). Read more on [Terraform module source here](https://www.terraform.io/docs/modules/sources.html).
+* `variable_files` - (list[string]: []) A list of paths to files containing variables for the task. For the [Terraform driver](#terraform-driver), these are used as Terraform [variable defintion (`.tfvars`) files](https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files) and consists of only variable name assignments. The variable assignments must match the corresponding variable declarations available by the Terraform module for the task. Consul-Terraform-Sync will generate the intermediate variable declarations to pass as arguments from the auto-generated root module to the task's module. Variables are loaded in the same order as they appear in the order of the files. Duplicate variables are overwritten with the later value. *Note: unless specified by the module, configure arguments for Terraform providers using [`terraform_provider` blocks](#terraform-provider).*
   ```hcl
   address_group = "consul-services"
   tags = [
@@ -166,11 +166,11 @@ task {
     "terraform"
   ]
   ```
-* `version` - `(string: <none>)` The version of the provided source the task will use. For the [Terraform driver](#terraform-driver), this is the module version. The latest version will be used as the default if omitted.
+* `version` - (string: <none\>) The version of the provided source the task will use. For the [Terraform driver](#terraform-driver), this is the module version. The latest version will be used as the default if omitted.
 * `buffer_period` - Configures the buffer period for the task to dampen the affects of flapping services to downstream network devices. It defines the minimum and maximum amount of time to wait for the cluster to reach a consistent state and accumulate changes before triggering task execution. The default is inherited from the top level [`buffer_period` block](#global-config-options). If configured, these values will take precedence over the global buffer period. This is useful to enable for a task that is dependent on services that have a lot of flapping.
-  * `enabled` - `(bool: false)` Enable or disable buffer periods for this task. Specifying `min` will also enable it.
-  * `min` - `(string: 5s)` The minimum period of time to wait after changes are detected before triggering related tasks.
-  * `max` - `(string: 20s)` The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
+  * `enabled` - (bool: false) Enable or disable buffer periods for this task. Specifying `min` will also enable it.
+  * `min` - (string: 5s) The minimum period of time to wait after changes are detected before triggering related tasks.
+  * `max` - (string: 20s) The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
 
 ## Terraform Driver
 
@@ -196,13 +196,13 @@ driver "terraform" {
 }
 ```
 
-* `backend` - `(obj: optional)` The backend stores [Terraform state files](https://www.terraform.io/docs/state/index.html) for each task. This option is similar to the [Terraform backend configuration](https://www.terraform.io/docs/backends/types/consul.html). Consul backend is the only supported backend at this time. If omitted, Consul-Terraform-Sync will generate default values and use configuration from the [`consul` block](#consul). The Consul KV path is the base path to store state files for tasks. The full path of each state file will have the task identifer appended to the end of the path, e.g. `consul-terraform-sync/terraform-env:task-name`.
-* `log` - `(bool: false)` Enable all Terraform output (stderr and stdout) to be included in the Consul-Terraform-Sync log. This is useful for debugging and development purposes. It may be difficult to work with log aggregators that expect uniform log format.
-* `path` - `(string: optional)` The file path to install Terraform or discover an existing Terraform binary. If omitted, Terraform will be installed in the same directory as the Consul-Terraform-Sync daemon. To resolve an incompatible Terraform version or to change versions will require removing the existing binary or change to a different path.
-* `persist_log` - `(bool: false)` Enable trace logging for each Terraform client to disk per task. This is equivalent to setting `TF_LOG_PATH=<work_dir>/terraform.log`. Trace log level results in verbose logging and may be useful for debugging and development purposes. We do not recommend enabling this for production. There is no log rotation and may quickly result in large files.
-* `required_providers` - `(obj: required)` Declare each Terraform provider used across all tasks. This is similar to the [Terraform `terraform.required_providers`](https://www.terraform.io/docs/configuration/provider-requirements.html#requiring-providers) field to specify the source and version for each provider. Consul-Terraform-Sync will process these requirements when preparing each task that uses the provider.
-* `version` - `(string: optional)` The Terraform version to install and run in automation for task execution. If omittied, the driver will install the latest official release of Terraform. To change versions, remove the existing binary or change the path to install the desired version. Verify that the desired Terraform version is compatible across all Terraform modules used for Consul-Terraform-Sync automation.
-* `working_dir` - `(string: "sync-tasks")` The base working directory to manage Terraform configurations all tasks. The full path of each working directory will have the task identifier appended to the end of the path, e.g. `./sync-tasks/task-name`.
+* `backend` - (obj: optional) The backend stores [Terraform state files](https://www.terraform.io/docs/state/index.html) for each task. This option is similar to the [Terraform backend configuration](https://www.terraform.io/docs/backends/types/consul.html). Consul backend is the only supported backend at this time. If omitted, Consul-Terraform-Sync will generate default values and use configuration from the [`consul` block](#consul). The Consul KV path is the base path to store state files for tasks. The full path of each state file will have the task identifer appended to the end of the path, e.g. `consul-terraform-sync/terraform-env:task-name`.
+* `log` - (bool: false) Enable all Terraform output (stderr and stdout) to be included in the Consul-Terraform-Sync log. This is useful for debugging and development purposes. It may be difficult to work with log aggregators that expect uniform log format.
+* `path` - (string: optional) The file path to install Terraform or discover an existing Terraform binary. If omitted, Terraform will be installed in the same directory as the Consul-Terraform-Sync daemon. To resolve an incompatible Terraform version or to change versions will require removing the existing binary or change to a different path.
+* `persist_log` - (bool: false) Enable trace logging for each Terraform client to disk per task. This is equivalent to setting `TF_LOG_PATH=<work_dir>/terraform.log`. Trace log level results in verbose logging and may be useful for debugging and development purposes. We do not recommend enabling this for production. There is no log rotation and may quickly result in large files.
+* `required_providers` - (obj: required) Declare each Terraform provider used across all tasks. This is similar to the [Terraform `terraform.required_providers`](https://www.terraform.io/docs/configuration/provider-requirements.html#requiring-providers) field to specify the source and version for each provider. Consul-Terraform-Sync will process these requirements when preparing each task that uses the provider.
+* `version` - (string: optional) The Terraform version to install and run in automation for task execution. If omittied, the driver will install the latest official release of Terraform. To change versions, remove the existing binary or change the path to install the desired version. Verify that the desired Terraform version is compatible across all Terraform modules used for Consul-Terraform-Sync automation.
+* `working_dir` - (string: "sync-tasks") The base working directory to manage Terraform configurations all tasks. The full path of each working directory will have the task identifier appended to the end of the path, e.g. `./sync-tasks/task-name`.
 
 ## Terraform Provider
 
@@ -274,21 +274,21 @@ terraform_provider "example" {
 Access the secret using template dot notation `Data.data.<secret>`. To use the Vault KV Secrets Engine version 1 use the `secret/<path>` prefix, and `secret/data/<path>` prefix for version 2.
 
 ##### Vault Configuration
-* `address` - `(string)` The URI of the Vault server. This can also be set via the `VAULT_ADDR` environment variable.
-* `enabled` - `(bool: false)` Enabled controls whether the Vault integration is active.
-* `namespace` - `(string)` Namespace is the Vault namespace to use for reading secrets. This can also be set via the `VAULT_NAMESPACE` environment variable.
-* `renew_token` - `(bool: false)` Renews the Vault token. This can also be set via the `VAULT_RENEW_TOKEN` environment variable.
-* `tls` - [`(tls)`](#tls) TLS indicates the client should use a secure connection while talking to Vault. Supports the environment variables:
+* `address` - (string) The URI of the Vault server. This can also be set via the `VAULT_ADDR` environment variable.
+* `enabled` - (bool: false) Enabled controls whether the Vault integration is active.
+* `namespace` - (string) Namespace is the Vault namespace to use for reading secrets. This can also be set via the `VAULT_NAMESPACE` environment variable.
+* `renew_token` - (bool: false) Renews the Vault token. This can also be set via the `VAULT_RENEW_TOKEN` environment variable.
+* `tls` - [(tls)](#tls) TLS indicates the client should use a secure connection while talking to Vault. Supports the environment variables:
   * `VAULT_CACERT`
   * `VAULT_CAPATH`
   * `VAULT_CLIENT_CERT`
   * `VAULT_CLIENT_KEY`
   * `VAULT_SKIP_VERIFY`
   * `VAULT_TLS_SERVER_NAME`
-* `token` - `(string)` Token is the Vault token to communicate with for requests. It may be a wrapped token or a real token. This can also be set via the `VAULT_TOKEN` environment variable, or via the `VaultAgentTokenFile`.
-* `vault_agent_token_file` - `(string)` The path of the file that contains a Vault Agent token. If this is specified, Consul-Terraform-Sync will not try to renew the Vault token.
-* `transport` - [`(transport)`](#transport) Transport configures the low-level network connection details.
-* `unwrap_token` - `(bool: false)` Unwraps the provided Vault token as a wrapped token.
+* `token` - (string) Token is the Vault token to communicate with for requests. It may be a wrapped token or a real token. This can also be set via the `VAULT_TOKEN` environment variable, or via the `VaultAgentTokenFile`.
+* `vault_agent_token_file` - (string) The path of the file that contains a Vault Agent token. If this is specified, Consul-Terraform-Sync will not try to renew the Vault token.
+* `transport` - [(transport)](#transport) Transport configures the low-level network connection details.
+* `unwrap_token` - (bool: false) Unwraps the provided Vault token as a wrapped token.
 
 ~> Note: Vault credentials are not accessible by tasks and the associated Terraform configurations, including automated Terraform modules. If the task requires Vault, you will need to seprately configure the Vault provider and explicitly include it in the `task.providers` list.
 


### PR DESCRIPTION
 - decodify parameters/field/config’s type information such that
 '`token` - `string`' => '`token` - string'
 - decodifying types that have angle brackets require escaping the close angle
 bracket e.g. '<none\>' => '<none\\>'

Preview links:
 - [config](https://deploy-preview-9376--consul-docs-preview.netlify.app/docs/nia/installation/configuration)
 - [api](https://deploy-preview-9376--consul-docs-preview.netlify.app/docs/nia/api)

**Previous:**
<img width="509" alt="Screen Shot 2020-12-10 at 5 20 58 PM" src="https://user-images.githubusercontent.com/6819378/101836848-2026eb80-3b0c-11eb-820d-3a827000ad3c.png">


**With change:**
<img width="499" alt="Screen Shot 2020-12-10 at 5 21 04 PM" src="https://user-images.githubusercontent.com/6819378/101836855-2321dc00-3b0c-11eb-920c-4229937e8bf4.png">

**Error when close angle bracket isn't escaped:**
<img width="714" alt="Screen Shot 2020-12-10 at 4 51 29 PM" src="https://user-images.githubusercontent.com/6819378/101836746-f53c9780-3b0b-11eb-99eb-9e328f1012d6.png">
