### PR TITLE
Adds `ui_config.refresh"` for turning off UI blocking queries

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1134,11 +1134,12 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 var reBasicName = regexp.MustCompile("^[a-z0-9_-]+$")
 
 func validateUIConfigRefresh(value string) error {
-	if value == "blocking" || value == "off" {
+	switch value {
+	case UIRefreshBlocking, UIRefreshOff:
 		return nil
 	}
-	return fmt.Errorf("ui_config.refresh can only be one of 'blocking' or 'off'."+
-			" received: %q", value)
+	return fmt.Errorf("ui_config.refresh can only be one of either \"%s\" or \"%s\"'."+
+			" received: %q", UIRefreshBlocking, UIRefreshOff, value)
 }
 
 func validateBasicName(field, value string, allowEmpty bool) error {
@@ -1757,11 +1758,16 @@ func (b *Builder) serviceConnectVal(v *ServiceConnect) *structs.ServiceConnect {
 	}
 }
 
+const (
+	UIRefreshBlocking = "blocking"
+	UIRefreshOff      = "off"
+)
+
 func (b *Builder) uiConfigVal(v RawUIConfig) UIConfig {
 	return UIConfig{
 		Enabled:                    b.boolVal(v.Enabled),
 		Dir:                        b.stringVal(v.Dir),
-		Refresh:                    b.stringValWithDefault(v.Refresh, "blocking"),
+		Refresh:                    b.stringValWithDefault(v.Refresh, UIRefreshBlocking),
 		ContentPath:                UIPathBuilder(b.stringVal(v.ContentPath)),
 		MetricsProvider:            b.stringVal(v.MetricsProvider),
 		MetricsProviderFiles:       v.MetricsProviderFiles,

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1138,8 +1138,8 @@ func validateUIConfigRefresh(value string) error {
 	case UIRefreshBlocking, UIRefreshOff:
 		return nil
 	}
-	return fmt.Errorf("ui_config.refresh can only be one of either \"%s\" or \"%s\"'."+
-			" received: %q", UIRefreshBlocking, UIRefreshOff, value)
+	return fmt.Errorf("ui_config.refresh can only be one of either \"%s\" or \"%s\"."+
+		" received: %q", UIRefreshBlocking, UIRefreshOff, value)
 }
 
 func validateBasicName(field, value string, allowEmpty bool) error {
@@ -1776,8 +1776,6 @@ func (b *Builder) uiConfigVal(v RawUIConfig) UIConfig {
 		DashboardURLTemplates:      v.DashboardURLTemplates,
 	}
 }
-
-
 
 func (b *Builder) uiMetricsProxyVal(v RawUIMetricsProxy) UIMetricsProxy {
 	var hdrs []UIMetricsProxyAddHeader

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -173,7 +173,7 @@ func TestBuilder_BuildAndValidate_NodeName(t *testing.T) {
 func TestBuilder_BuildAndValidate_UIRefresh(t *testing.T) {
 	b, err := NewBuilder(BuilderOpts{
 		Config: Config{
-			DataDir:  pString("dir"),
+			DataDir: pString("dir"),
 			UIConfig: RawUIConfig{
 				Refresh: pString("invalid-value"),
 			},

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -170,6 +170,21 @@ func TestBuilder_BuildAndValidate_NodeName(t *testing.T) {
 		})
 	}
 }
+func TestBuilder_BuildAndValidate_UIRefresh(t *testing.T) {
+	b, err := NewBuilder(BuilderOpts{
+		Config: Config{
+			DataDir:  pString("dir"),
+			UIConfig: RawUIConfig{
+				Refresh: pString("invalid-value"),
+			},
+		},
+	})
+	patchBuilderShims(b)
+	require.NoError(t, err)
+	_, err = b.BuildAndValidate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ui_config.refresh can only be one of either")
+}
 
 func patchBuilderShims(b *Builder) {
 	b.hostname = func() (string, error) {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -788,6 +788,7 @@ type AutoConfigAuthorizerRaw struct {
 type RawUIConfig struct {
 	Enabled                    *bool             `json:"enabled,omitempty" hcl:"enabled" mapstructure:"enabled"`
 	Dir                        *string           `json:"dir,omitempty" hcl:"dir" mapstructure:"dir"`
+	Refresh                    *string           `json:"refresh,omitempty" hcl:"refresh" mapstructure:"refresh"`
 	ContentPath                *string           `json:"content_path,omitempty" hcl:"content_path" mapstructure:"content_path"`
 	MetricsProvider            *string           `json:"metrics_provider,omitempty" hcl:"metrics_provider" mapstructure:"metrics_provider"`
 	MetricsProviderFiles       []string          `json:"metrics_provider_files,omitempty" hcl:"metrics_provider_files" mapstructure:"metrics_provider_files"`

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1531,6 +1531,7 @@ type AutoConfigAuthorizer struct {
 type UIConfig struct {
 	Enabled                    bool
 	Dir                        string
+	Refresh                    string
 	ContentPath                string
 	MetricsProvider            string
 	MetricsProviderFiles       []string

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5642,6 +5642,7 @@ func TestFullConfig(t *testing.T) {
 				"enabled": true,
 				"dir": "pVncV4Ey",
 				"content_path": "qp1WRhYH",
+				"refresh": "blocking",
 				"metrics_provider": "sgnaoa_lower_case",
 				"metrics_provider_files": ["sgnaMFoa", "dicnwkTH"],
 				"metrics_provider_options_json": "{\"DIbVQadX\": 1}",
@@ -6333,6 +6334,7 @@ func TestFullConfig(t *testing.T) {
 				enabled = true
 				dir = "pVncV4Ey"
 				content_path = "qp1WRhYH"
+				refresh = "blocking"
 				metrics_provider = "sgnaoa_lower_case"
 				metrics_provider_files = ["sgnaMFoa", "dicnwkTH"]
 				metrics_provider_options_json = "{\"DIbVQadX\": 1}"
@@ -7129,6 +7131,7 @@ func TestFullConfig(t *testing.T) {
 			Enabled:                    true,
 			Dir:                        "pVncV4Ey",
 			ContentPath:                "/qp1WRhYH/", // slashes are added in parsing
+			Refresh:                    "blocking",
 			MetricsProvider:            "sgnaoa_lower_case",
 			MetricsProviderFiles:       []string{"sgnaMFoa", "dicnwkTH"},
 			MetricsProviderOptionsJSON: "{\"DIbVQadX\": 1}",
@@ -7833,6 +7836,7 @@ func TestSanitize(t *testing.T) {
 		"TxnMaxReqLen": 5678000000000000,
 		"UIConfig": {
 			"ContentPath": "",
+			"Refresh": "",
 			"Dir": "",
 			"Enabled": false,
 			"MetricsProvider": "",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5642,7 +5642,7 @@ func TestFullConfig(t *testing.T) {
 				"enabled": true,
 				"dir": "pVncV4Ey",
 				"content_path": "qp1WRhYH",
-				"refresh": "blocking",
+				"refresh": "off",
 				"metrics_provider": "sgnaoa_lower_case",
 				"metrics_provider_files": ["sgnaMFoa", "dicnwkTH"],
 				"metrics_provider_options_json": "{\"DIbVQadX\": 1}",
@@ -6334,7 +6334,7 @@ func TestFullConfig(t *testing.T) {
 				enabled = true
 				dir = "pVncV4Ey"
 				content_path = "qp1WRhYH"
-				refresh = "blocking"
+				refresh = "off"
 				metrics_provider = "sgnaoa_lower_case"
 				metrics_provider_files = ["sgnaMFoa", "dicnwkTH"]
 				metrics_provider_options_json = "{\"DIbVQadX\": 1}"
@@ -7131,7 +7131,7 @@ func TestFullConfig(t *testing.T) {
 			Enabled:                    true,
 			Dir:                        "pVncV4Ey",
 			ContentPath:                "/qp1WRhYH/", // slashes are added in parsing
-			Refresh:                    "blocking",
+			Refresh:                    "off",
 			MetricsProvider:            "sgnaoa_lower_case",
 			MetricsProviderFiles:       []string{"sgnaMFoa", "dicnwkTH"},
 			MetricsProviderOptionsJSON: "{\"DIbVQadX\": 1}",

--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -11,7 +11,7 @@ import (
 func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}, error) {
 
 	uiCfg := map[string]interface{}{
-		"refresh": cfg.UIConfig.Refresh,
+		"refresh":          cfg.UIConfig.Refresh,
 		"metrics_provider": cfg.UIConfig.MetricsProvider,
 		// We explicitly MUST NOT pass the metrics_proxy object since it might
 		// contain add_headers with secrets that the UI shouldn't know e.g. API

--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -11,6 +11,7 @@ import (
 func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}, error) {
 
 	uiCfg := map[string]interface{}{
+		"refresh": cfg.UIConfig.Refresh,
 		"metrics_provider": cfg.UIConfig.MetricsProvider,
 		// We explicitly MUST NOT pass the metrics_proxy object since it might
 		// contain add_headers with secrets that the UI shouldn't know e.g. API

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -81,7 +81,8 @@ func TestUIServerIndex(t *testing.T) {
 					"a-very-unlikely-string":1
 				},
 				"metrics_proxy_enabled": false,
-				"dashboard_url_templates": null
+				"dashboard_url_templates": null,
+				"refresh": "blocking"
 			}`,
 		},
 		{
@@ -116,7 +117,8 @@ func TestUIServerIndex(t *testing.T) {
 			wantUICfgJSON: `{
 				"metrics_provider": "bar",
 				"metrics_proxy_enabled": false,
-				"dashboard_url_templates": null
+				"dashboard_url_templates": null,
+				"refresh": "blocking"
 			}`,
 		},
 		{
@@ -206,6 +208,7 @@ func basicUIEnabledConfig(opts ...cfgFunc) *config.RuntimeConfig {
 		UIConfig: config.UIConfig{
 			Enabled:     true,
 			ContentPath: "/ui/",
+			Refresh:     "blocking",
 		},
 		Datacenter: "dc1",
 	}

--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -2081,6 +2081,11 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     that the web UI should be served from. Defaults to `/ui/`. Equivalent to the
     [`-ui-content-path`](#_ui_content_path) flag.
 
+  - `refresh` ((#ui_config_refresh)) - This specifies how the UI should refresh
+    data. Can be one of `blocking` or `off`. Defaults to `blocking`, meaning the
+    UI will use Consul's blocking query support for immediate updates to the UI.
+    For extremely busy clusters you may want to set this to 'off'.
+
   - `metrics_provider` ((#ui_config_metrics_provider)) - Specifies a named
     metrics provider implementation the UI should use to fetch service metrics.
     By default metrics are disabled. Consul 1.9.0 includes a built-in provider


### PR DESCRIPTION
This adds a `ui_config.refresh` config that can be set to either 'blocking' or 'off' in order to allow operators to configure whether the UI should automatically refresh data in the UI using blocking queries.

```hcl
ui_config {
  refresh = "off" // turn blocking queries off
}
ui_config {
  refresh = "blocking" // the default
}
```
The use case here is for operators with very busy clusters that might not want the UI to be almost streaming data from Consul.

We followed https://github.com/hashicorp/consul/blob/master/contributing/checklist-adding-config-fields.md:

## Adding a Simple Config Field for Client Agents

 - [x] Add the field to the Config struct (or an appropriate sub-struct) in
   `agent/config/config.go`.
 - [x] Add the field to the actual RuntimeConfig struct in
   `agent/config/runtime.go`.
 - [x] Add an appropriate parser/setter in `agent/config/builder.go` to
   translate.
 - [x] Add the new field with a random value to both the JSON and HCL blobs in
   `TestFullConfig` in `agent/config/runtime_test.go`, it should fail now, then
   add the same random value to the expected struct in that test so it passes
   again.
 - [x] Add the new field and it's default value to `TestSanitize` in the same
   file. (Running the test first gives you a nice diff which can save working
   out where etc.)
 - [x] **If** your new config field needed some validation as it's only valid in
   some cases or with some values (often true).
      - [x] Add validation to Validate in `agent/config/builder.go`.
      - [ ] ~Add a test case to the table test `TestConfigFlagsAndEdgeCases` in
        `agent/config/runtime_test.go`.~ I didn't do this as we aren't adding this as a flag
 - [ ] **If** your new config field needs a non-zero-value default. **Not sure if these are needed?**
      - [ ] Add that to `DefaultSource` in `agent/config/defaults.go`.
      - [ ] Add a test case to the table test `TestConfigFlagsAndEdgeCases` in
        `agent/config/runtime_test.go`.
 - [ ] ~**If** your config should take effect on a reload/HUP.~
      - [ ] ~Add necessary code to to trigger a safe (locked or atomic) update to
        any state the feature needs changing. This needs to be added to one or
        more of the following places:~
         - ~`ReloadConfig` in `agent/agent.go` if it needs to affect the local
           client state or another client agent component.~
         - ~`ReloadConfig` in `agent/consul/client.go` if it needs to affect
           state for client agent's RPC client.~
      - [ ] ~Add a test to `agent/agent_test.go` similar to others with prefix
        `TestAgent_reloadConfig*`.~
 - [x] Add documentation to `website/pages/docs/agent/options.mdx`.


Separately, a changelog entry needs adding here when/if approved:

- [ ] Add changelog entry
