### PR TITLE
docs/nia: omit zero-value defaults

### DIFF
--- a/website/pages/docs/nia/installation/configuration.mdx
+++ b/website/pages/docs/nia/installation/configuration.mdx
@@ -70,12 +70,12 @@ buffer_period {
 
 * `buffer_period` - Configures the default buffer period for all [tasks](#task) to dampen the affects of flapping services to downstream network devices. It defines the minimum and maximum amount of time to wait for the cluster to reach a consistent state and accumulate changes before triggering task executions. The default is enabled to reduce the number of times downstream infrastructure is updated within a short period of time. This is useful to enable in systems that have a lot of flapping.
   * `enabled` - (bool: true) Enable or disable buffer periods globally. Specifying `min` will also enable it.
-  * `min` - (string: 5s) The minimum period of time to wait after changes are detected before triggering related tasks.
-  * `max` - (string: 20s) The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
+  * `min` - (string: "5s") The minimum period of time to wait after changes are detected before triggering related tasks.
+  * `max` - (string: "20s") The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
 * `log_level` - (string: "WARN") The log level to use for Consul-Terraform-Sync logging.
 * `port` - (int: 8501) The port for Consul-Terraform-Sync to use to serve API requests.
 * `syslog` - Specifies the syslog server for logging.
-  * `enabled` - (bool: false) Enable syslog logging. Specifying other option also enables syslog logging.
+  * `enabled` - (bool) Enable syslog logging. Specifying other option also enables syslog logging.
   * `facility` - (string) Name of the syslog facility to log to.
   * `name` - (string: "consul-terraform-sync") Name to use for the daemon process when logging to syslog.
 
@@ -97,11 +97,11 @@ consul {
 
 * `address` - (string: "localhost:8500") Address is the address of the Consul agent. It may be an IP or FQDN.
 * `auth` - Auth is the HTTP basic authentication for communicating with Consul.
-  * `enabled` - (bool: false)
+  * `enabled` - (bool)
   * `username` - (string)
   * `password` - (string)
 * `tls` - Configure TLS to use a secure client connection with Consul. This option is required for Consul-Terraform-Sync when connecting to a [Consul agent with TLS verification enabled for HTTPS connections](/docs/agent/options#verify_incoming).
-  * `enabled` - (bool: false) Enable TLS. Specifying any option for TLS will also enable it.
+  * `enabled` - (bool) Enable TLS. Specifying any option for TLS will also enable it.
   * `verify` - (bool: true) Enables TLS peer verification. The default is enabled, which will check the global CA chain to make sure the given certificates are valid. If you are using a self-signed certificate that you have not added to the CA chain, you may want to disable SSL verification. However, please understand this is a potential security vulnerability.
   * `key` - (string) The client key file to use for talking to Consul over TLS. The key also be provided through the `CONSUL_CLIENT_KEY` environment variable.
   * `ca_cert` - (string) The CA file to use for talking to Consul over TLS. Can also be provided though the `CONSUL_CACERT` environment variable.
@@ -112,7 +112,7 @@ consul {
 * `transport` - Transport configures the low-level network connection details.
   * `dial_keep_alive` - (string: "30s") The amount of time for keep-alives.
   * `dial_timeout` - (string: "30s") The amount of time to wait to establish a connection.
-  * `disable_keep_alives` - (bool: false) Determines if keep-alives should be used. Disabling this significantly decreases performance.
+  * `disable_keep_alives` - (bool) Determines if keep-alives should be used. Disabling this significantly decreases performance.
   * `idle_conn_timeout` - (string: "90s") The timeout for idle connections.
   * `max_idle_conns` - (int: 100) The maximum number of total idle connections.
   * `max_idle_conns_per_host` - (int: 1) The maximum number of idle connections per remote host.
@@ -133,7 +133,7 @@ service {
 * `datacenter` - (string) The datacenter the service is deployed in.
 * `description` - (string) The human readable text to describe the service.
 * `id` - (string) ID identifies the service for Consul-Terraform-Sync. This is used to explicitly identify the service config for a task to use. If no ID is provided, the service is identified by the service name within a [task definition](#task).
-* `name` - (string: <required\>) The Consul logical name of the service (required).
+* `name` - (string: required) The Consul logical name of the service (required).
 * `namespace` <EnterpriseAlert inline /> - (string: "default") The namespace of the service. If not provided, the namespace will be inferred from the Consul-Terraform-Sync ACL token, or default to the `default` namespace.
 * `tag` - (string) Tag is used to filter nodes based on the tag for the service.
 
@@ -154,11 +154,11 @@ task {
 ```
 
 * `description` - (string) The human readable text to describe the service.
-* `name` - (string: <required\>) Name is the unique name of the task (required). A task name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.
-* `providers` - (list[string]: []) Providers is the list of provider names the task is dependent on. This is used to map [Terraform provider configuration](#terraform-provider) to the task.
-* `services` - (list[string]: []) Services is the list of logical service names or service IDs the task executes on. Consul-Terraform-Sync monitors the Consul Catalog for changes to these services and triggers the task to run. Any service value not explicitly defined by a `service` block with a matching ID is assumed to be a logical service name in the default namespace.
-* `source` - (string: <required\>) Source is the location the driver uses to fetch task dependencies. The source format is dependent on the driver. For the [Terraform driver](#terraform-driver), the source is the module path (local or remote). Read more on [Terraform module source here](https://www.terraform.io/docs/modules/sources.html).
-* `variable_files` - (list[string]: []) A list of paths to files containing variables for the task. For the [Terraform driver](#terraform-driver), these are used as Terraform [variable defintion (`.tfvars`) files](https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files) and consists of only variable name assignments. The variable assignments must match the corresponding variable declarations available by the Terraform module for the task. Consul-Terraform-Sync will generate the intermediate variable declarations to pass as arguments from the auto-generated root module to the task's module. Variables are loaded in the same order as they appear in the order of the files. Duplicate variables are overwritten with the later value. *Note: unless specified by the module, configure arguments for Terraform providers using [`terraform_provider` blocks](#terraform-provider).*
+* `name` - (string: required) Name is the unique name of the task (required). A task name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.
+* `providers` - (list[string]) Providers is the list of provider names the task is dependent on. This is used to map [Terraform provider configuration](#terraform-provider) to the task.
+* `services` - (list[string]: required) Services is the list of logical service names or service IDs the task executes on. Consul-Terraform-Sync monitors the Consul Catalog for changes to these services and triggers the task to run. Any service value not explicitly defined by a `service` block with a matching ID is assumed to be a logical service name in the default namespace.
+* `source` - (string: required) Source is the location the driver uses to fetch task dependencies. The source format is dependent on the driver. For the [Terraform driver](#terraform-driver), the source is the module path (local or remote). Read more on [Terraform module source here](https://www.terraform.io/docs/modules/sources.html).
+* `variable_files` - (list[string]) A list of paths to files containing variables for the task. For the [Terraform driver](#terraform-driver), these are used as Terraform [variable defintion (`.tfvars`) files](https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files) and consists of only variable name assignments. The variable assignments must match the corresponding variable declarations available by the Terraform module for the task. Consul-Terraform-Sync will generate the intermediate variable declarations to pass as arguments from the auto-generated root module to the task's module. Variables are loaded in the same order as they appear in the order of the files. Duplicate variables are overwritten with the later value. *Note: unless specified by the module, configure arguments for Terraform providers using [`terraform_provider` blocks](#terraform-provider).*
   ```hcl
   address_group = "consul-services"
   tags = [
@@ -168,9 +168,9 @@ task {
   ```
 * `version` - (string) The version of the provided source the task will use. For the [Terraform driver](#terraform-driver), this is the module version. The latest version will be used as the default if omitted.
 * `buffer_period` - Configures the buffer period for the task to dampen the affects of flapping services to downstream network devices. It defines the minimum and maximum amount of time to wait for the cluster to reach a consistent state and accumulate changes before triggering task execution. The default is inherited from the top level [`buffer_period` block](#global-config-options). If configured, these values will take precedence over the global buffer period. This is useful to enable for a task that is dependent on services that have a lot of flapping.
-  * `enabled` - (bool: false) Enable or disable buffer periods for this task. Specifying `min` will also enable it.
-  * `min` - (string: 5s) The minimum period of time to wait after changes are detected before triggering related tasks.
-  * `max` - (string: 20s) The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
+  * `enabled` - (bool) Enable or disable buffer periods for this task. Specifying `min` will also enable it.
+  * `min` - (string: "5s") The minimum period of time to wait after changes are detected before triggering related tasks.
+  * `max` - (string: "20s") The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
 
 ## Terraform Driver
 
@@ -196,12 +196,12 @@ driver "terraform" {
 }
 ```
 
-* `backend` - (obj: optional) The backend stores [Terraform state files](https://www.terraform.io/docs/state/index.html) for each task. This option is similar to the [Terraform backend configuration](https://www.terraform.io/docs/backends/types/consul.html). Consul backend is the only supported backend at this time. If omitted, Consul-Terraform-Sync will generate default values and use configuration from the [`consul` block](#consul). The Consul KV path is the base path to store state files for tasks. The full path of each state file will have the task identifer appended to the end of the path, e.g. `consul-terraform-sync/terraform-env:task-name`.
-* `log` - (bool: false) Enable all Terraform output (stderr and stdout) to be included in the Consul-Terraform-Sync log. This is useful for debugging and development purposes. It may be difficult to work with log aggregators that expect uniform log format.
-* `path` - (string: optional) The file path to install Terraform or discover an existing Terraform binary. If omitted, Terraform will be installed in the same directory as the Consul-Terraform-Sync daemon. To resolve an incompatible Terraform version or to change versions will require removing the existing binary or change to a different path.
-* `persist_log` - (bool: false) Enable trace logging for each Terraform client to disk per task. This is equivalent to setting `TF_LOG_PATH=<work_dir>/terraform.log`. Trace log level results in verbose logging and may be useful for debugging and development purposes. We do not recommend enabling this for production. There is no log rotation and may quickly result in large files.
+* `backend` - (obj) The backend stores [Terraform state files](https://www.terraform.io/docs/state/index.html) for each task. This option is similar to the [Terraform backend configuration](https://www.terraform.io/docs/backends/types/consul.html). Consul backend is the only supported backend at this time. If omitted, Consul-Terraform-Sync will generate default values and use configuration from the [`consul` block](#consul). The Consul KV path is the base path to store state files for tasks. The full path of each state file will have the task identifer appended to the end of the path, e.g. `consul-terraform-sync/terraform-env:task-name`.
+* `log` - (bool) Enable all Terraform output (stderr and stdout) to be included in the Consul-Terraform-Sync log. This is useful for debugging and development purposes. It may be difficult to work with log aggregators that expect uniform log format.
+* `path` - (string) The file path to install Terraform or discover an existing Terraform binary. If omitted, Terraform will be installed in the same directory as the Consul-Terraform-Sync daemon. To resolve an incompatible Terraform version or to change versions will require removing the existing binary or change to a different path.
+* `persist_log` - (bool) Enable trace logging for each Terraform client to disk per task. This is equivalent to setting `TF_LOG_PATH=<work_dir>/terraform.log`. Trace log level results in verbose logging and may be useful for debugging and development purposes. We do not recommend enabling this for production. There is no log rotation and may quickly result in large files.
 * `required_providers` - (obj: required) Declare each Terraform provider used across all tasks. This is similar to the [Terraform `terraform.required_providers`](https://www.terraform.io/docs/configuration/provider-requirements.html#requiring-providers) field to specify the source and version for each provider. Consul-Terraform-Sync will process these requirements when preparing each task that uses the provider.
-* `version` - (string: optional) The Terraform version to install and run in automation for task execution. If omittied, the driver will install the latest official release of Terraform. To change versions, remove the existing binary or change the path to install the desired version. Verify that the desired Terraform version is compatible across all Terraform modules used for Consul-Terraform-Sync automation.
+* `version` - (string) The Terraform version to install and run in automation for task execution. If omittied, the driver will install the latest official release of Terraform. To change versions, remove the existing binary or change the path to install the desired version. Verify that the desired Terraform version is compatible across all Terraform modules used for Consul-Terraform-Sync automation.
 * `working_dir` - (string: "sync-tasks") The base working directory to manage Terraform configurations all tasks. The full path of each working directory will have the task identifier appended to the end of the path, e.g. `./sync-tasks/task-name`.
 
 ## Terraform Provider
@@ -261,7 +261,7 @@ terraform_provider "example" {
 
 #### Vault
 
-`with secret` queries Vault secrets. Vault is an optional source that will require operators to configure the Vault client.
+`with secret` queries the [Vault KV secrets engine](https://www.vaultproject.io/api-docs/secret/kv). Vault is an optional source that will require operators to configure the Vault client. Access the secret using template dot notation `Data.data.<secret_key>`.
 
 ```hcl
 vault {
@@ -273,15 +273,13 @@ terraform_provider "example" {
 }
 ```
 
-Access the secret using template dot notation `Data.data.<secret>`. To use the Vault KV Secrets Engine version 1 use the `secret/<path>` prefix, and `secret/data/<path>` prefix for version 2.
-
 ##### Vault Configuration
 
 * `address` - (string) The URI of the Vault server. This can also be set via the `VAULT_ADDR` environment variable.
-* `enabled` - (bool: false) Enabled controls whether the Vault integration is active.
+* `enabled` - (bool) Enabled controls whether the Vault integration is active.
 * `namespace` - (string) Namespace is the Vault namespace to use for reading secrets. This can also be set via the `VAULT_NAMESPACE` environment variable.
-* `renew_token` - (bool: false) Renews the Vault token. This can also be set via the `VAULT_RENEW_TOKEN` environment variable.
-* `tls` - [(tls)](#tls) TLS indicates the client should use a secure connection while talking to Vault. Supports the environment variables:
+* `renew_token` - (bool) Renews the Vault token. This can also be set via the `VAULT_RENEW_TOKEN` environment variable.
+* `tls` - [(tls block)](#tls) TLS indicates the client should use a secure connection while talking to Vault. Supports the environment variables:
   * `VAULT_CACERT`
   * `VAULT_CAPATH`
   * `VAULT_CLIENT_CERT`
@@ -290,8 +288,8 @@ Access the secret using template dot notation `Data.data.<secret>`. To use the V
   * `VAULT_TLS_SERVER_NAME`
 * `token` - (string) Token is the Vault token to communicate with for requests. It may be a wrapped token or a real token. This can also be set via the `VAULT_TOKEN` environment variable, or via the `VaultAgentTokenFile`.
 * `vault_agent_token_file` - (string) The path of the file that contains a Vault Agent token. If this is specified, Consul-Terraform-Sync will not try to renew the Vault token.
-* `transport` - [(transport)](#transport) Transport configures the low-level network connection details.
-* `unwrap_token` - (bool: false) Unwraps the provided Vault token as a wrapped token.
+* `transport` - [(transport block)](#transport) Transport configures the low-level network connection details.
+* `unwrap_token` - (bool) Unwraps the provided Vault token as a wrapped token.
 
 ~> Note: Vault credentials are not accessible by tasks and the associated Terraform configurations, including automated Terraform modules. If the task requires Vault, you will need to seprately configure the Vault provider and explicitly include it in the `task.providers` list.
 


### PR DESCRIPTION
The config docs were inconsistently including "optional" or the default zero-value, like false or `[]` for empty list. The changes remove them completely and assumes default zero if `required` or a default value is not explicitly documented.