### PR TITLE
docs/nia: update api default port

### DIFF
--- a/website/pages/docs/nia/api.mdx
+++ b/website/pages/docs/nia/api.mdx
@@ -12,13 +12,13 @@ When running in [daemon mode](/docs/nia/cli#daemon-mode), Consul-Terraform-Sync 
 
 ### Port
 
-The API is served at the default port `8501` or a different port if set with [`port` configuration](/docs/nia/installation/configuration#port)
+The API is served at the default port `8558` or a different port if set with [`port` configuration](/docs/nia/installation/configuration#port)
 
 ### Version Prefix
 
 All API routes are prefixed with `/v1/`. This documentation is for v1 of the API, which is the only version currently.
 
-Example: `curl localhost:8501/v1/status`
+Example: `localhost:8558/v1/status`
 
 ### Error
 
@@ -68,7 +68,7 @@ Currently no request parameters are offered for the overall status API.
 
 Request:
 ```shell-session
-curl localhost:8501/v1/status
+$ curl localhost:8558/v1/status
 ```
 
 Response:
@@ -129,7 +129,7 @@ Event represents the process of updating network infrastructure of a task. The d
 
 Request:
 ```shell-session
-curl localhost:8501/v1/status/tasks
+$ curl localhost:8558/v1/status/tasks
 ```
 
 Response:
@@ -164,7 +164,7 @@ Response:
 
 Request:
 ```shell-session
-curl localhost:8501/v1/status/tasks/task_b?include=events
+$ curl localhost:8558/v1/status/tasks/task_b?include=events
 ```
 
 Response:

--- a/website/pages/docs/nia/installation/configuration.mdx
+++ b/website/pages/docs/nia/installation/configuration.mdx
@@ -16,7 +16,7 @@ An example HCL configuration is shown below to automate a task to execute a Terr
 
 ```hcl
 log_level = "info"
-port = 8505
+port = 8558
 
 consul {
   address = "consul.example.com"
@@ -59,7 +59,7 @@ Top level options are reserved for configuring Consul-Terraform-Sync.
 
 ```hcl
 log_level = "INFO"
-port = 8505
+port = 8558
 syslog {}
 buffer_period {
   enabled = true
@@ -73,7 +73,7 @@ buffer_period {
   * `min` - (string: 5s) The minimum period of time to wait after changes are detected before triggering related tasks.
   * `max` - (string: 20s) The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
 * `log_level` - (string: "WARN") The log level to use for Consul-Terraform-Sync logging.
-* `port` - (int: 8501) The port for Consul-Terraform-Sync to use to serve API requests.
+* `port` - (int: 8558) The port for Consul-Terraform-Sync to use to serve API requests.
 * `syslog` - Specifies the syslog server for logging.
   * `enabled` - (bool: false) Enable syslog logging. Specifying other option also enables syslog logging.
   * `facility` - (string) Name of the syslog facility to log to.


### PR DESCRIPTION
Related change: https://github.com/hashicorp/consul-terraform-sync/pull/158

[Api page change](https://deploy-preview-9391--consul-docs-preview.netlify.app/docs/nia/api)
[Config page](https://deploy-preview-9391--consul-docs-preview.netlify.app/docs/nia/installation/configuration)