### PR TITLE
api: Ensure the internal/ui/service endpoint responds with an array

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -205,7 +205,8 @@ RPC:
 	summaries, hasProxy := summarizeServices(out.Nodes.ToServiceDump(), nil, "")
 	sorted := prepSummaryOutput(summaries, false)
 
-	var result []*ServiceListingSummary
+	// Ensure at least a zero length slice
+	result := make([]*ServiceListingSummary, 0)
 	for _, svc := range sorted {
 		sum := ServiceListingSummary{ServiceSummary: *svc}
 

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -548,6 +548,21 @@ func TestUiServices(t *testing.T) {
 		}
 		require.ElementsMatch(t, expected, summary)
 	})
+	t.Run("Filtered without results", func(t *testing.T) {
+		filterQuery := url.QueryEscape("Service.Service == absent")
+		req, _ := http.NewRequest("GET", "/v1/internal/ui/services?filter="+filterQuery, nil)
+		resp := httptest.NewRecorder()
+		obj, err := a.srv.UIServices(resp, req)
+		require.NoError(t, err)
+		assertIndex(t, resp)
+
+		// Ensure the ServiceSummary doesn't output a `null` response when there
+		// are no matching summaries
+		require.NotNil(t, obj)
+
+		summary := obj.([]*ServiceListingSummary)
+		require.Len(t, summary, 0)
+	})
 }
 
 func TestUIGatewayServiceNodes_Terminating(t *testing.T) {


### PR DESCRIPTION
In some circumstances this endpoint will have no results in it (due to ACLs, Namespaces or filtering).

This ensures that the HTTP response is at least an empty array (`[]`) rather than `null`

