### PR TITLE
ui: [BUGFIX] Use InformedAction for intention confirmation dialogs

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
@@ -66,24 +66,36 @@ as |item index|>
             <li role="none" class="dangerous">
               <label for={{confirm}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Delete</label>
               <div role="menu">
-                <div class="confirmation-alert warning">
-                  <div>
-                    <header>
-                      Confirm Delete
-                    </header>
+                <InformedAction
+                  class="warning"
+                >
+                  <:header>
+                    Confirm Delete
+                  </:header>
+                  <:body>
                     <p>
                       Are you sure you want to delete this intention?
                     </p>
-                  </div>
-                  <ul>
-                    <li class="dangerous">
-                      <button tabindex="-1" type="button" class="type-delete" onclick={{queue (action change) (action @delete item)}}>Delete</button>
-                    </li>
-                    <li>
-                      <label for={{confirm}}>Cancel</label>
-                    </li>
-                  </ul>
-                </div>
+                  </:body>
+                  <:actions as |Actions|>
+                    <Actions.Action class="dangerous">
+                      <Action
+                        class="type-delete"
+                        tabindex="-1"
+                        {{on 'click' (queue (action change) (action @delete item))}}
+                      >
+                        Delete
+                      </Action>
+                    </Actions.Action>
+                    <Actions.Action>
+                      <Action
+                        @for={{confirm}}
+                      >
+                        Cancel
+                      </Action>
+                    </Actions.Action>
+                  </:actions>
+                </InformedAction>
               </div>
             </li>
           {{else}}


### PR DESCRIPTION
During https://github.com/hashicorp/consul/pull/9305 we added an `InformedAction` component 'underneath' our `ConfirmationAlert`s so we could easily use the design for things other than a 'confirmation'

Unfortunately we omitted reimplementing this in our 'snowflake' Intention listing which uses a table instead of a list like all of our other listings - leading to something that looks like this when you try to delete an intention from the listing:

<img width="301" alt="Screenshot 2020-12-15 at 12 21 25" src="https://user-images.githubusercontent.com/554604/102214676-8c209f80-3ed0-11eb-9e53-90a54bcc299f.png">

This PR uses the `InformedAction` for this IntentionListings also and fixes the problem in 1.9.1