### PR TITLE
ui: Rearrange Service > Show to load Topology and Routing tabs separately

### DIFF
--- a/ui/packages/consul-ui/app/controllers/dc/services/show.js
+++ b/ui/packages/consul-ui/app/controllers/dc/services/show.js
@@ -1,11 +1,9 @@
 import { inject as service } from '@ember/service';
-import { alias } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { get, action } from '@ember/object';
+
 export default class ShowController extends Controller {
   @service('flashMessages') notify;
-
-  @alias('items.firstObject') item;
 
   @action
   error(e) {
@@ -19,14 +17,7 @@ export default class ShowController extends Controller {
           action: 'update',
         });
       }
-      [
-        e.target,
-        this.intentions,
-        this.chain,
-        this.proxies,
-        this.gatewayServices,
-        this.topology,
-      ].forEach(function(item) {
+      [e.target, this.proxies].forEach(function(item) {
         if (item && typeof item.close === 'function') {
           item.close();
         }

--- a/ui/packages/consul-ui/app/routes/dc.js
+++ b/ui/packages/consul-ui/app/routes/dc.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import Route from 'consul-ui/routing/route';
-import { hash, Promise } from 'rsvp';
 import { get, action } from '@ember/object';
 
 // TODO: We should potentially move all these nspace related things
@@ -24,49 +23,35 @@ const findActiveNspace = function(nspaces, nspace) {
   return found;
 };
 export default class DcRoute extends Route {
-  @service('repository/dc')
-  repo;
+  @service('repository/dc') repo;
+  @service('repository/nspace/disabled') nspacesRepo;
+  @service('settings') settingsRepo;
 
-  @service('repository/nspace/disabled')
-  nspacesRepo;
-
-  @service('settings')
-  settingsRepo;
-
-  model(params) {
+  async model(params) {
     const app = this.modelFor('application');
-    return hash({
-      nspace: this.nspacesRepo.getActive(),
-      token: this.settingsRepo.findBySlug('token'),
-      dc: this.repo.findBySlug(params.dc, app.dcs),
-    })
-      .then(function(model) {
-        return hash({
-          ...model,
-          ...{
-            // if there is only 1 namespace then use that
-            // otherwise find the namespace object that corresponds
-            // to the active one
-            nspace:
-              app.nspaces.length > 1
-                ? findActiveNspace(app.nspaces, model.nspace)
-                : app.nspaces.firstObject,
-          },
-        });
-      })
-      .then(model => {
-        if (get(model, 'token.SecretID')) {
-          return hash({
-            ...model,
-            ...{
-              // When disabled nspaces is [], so nspace is undefined
-              permissions: this.nspacesRepo.authorize(params.dc, get(model, 'nspace.Name')),
-            },
-          });
-        } else {
-          return model;
-        }
-      });
+
+    let [token, nspace, dc] = await Promise.all([
+      this.settingsRepo.findBySlug('token'),
+      this.nspacesRepo.getActive(),
+      this.repo.findBySlug(params.dc, app.dcs),
+    ]);
+    // if there is only 1 namespace then use that
+    // otherwise find the namespace object that corresponds
+    // to the active one
+    nspace =
+      app.nspaces.length > 1 ? findActiveNspace(app.nspaces, nspace) : app.nspaces.firstObject;
+
+    let permissions;
+    if (get(token, 'SecretID')) {
+      // When disabled nspaces is [], so nspace is undefined
+      permissions = await this.nspacesRepo.authorize(params.dc, get(nspace || {}, 'Name'));
+    }
+    return {
+      dc,
+      nspace,
+      token,
+      permissions,
+    };
   }
 
   setupController(controller, model) {

--- a/ui/packages/consul-ui/app/routes/dc/services/show/instances.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/instances.js
@@ -15,7 +15,7 @@ export default class InstancesRoute extends Route {
     },
   };
 
-  model() {
+  async model() {
     const parent = this.routeName
       .split('.')
       .slice(0, -1)

--- a/ui/packages/consul-ui/app/routes/dc/services/show/routing.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/routing.js
@@ -1,16 +1,25 @@
 import Route from 'consul-ui/routing/route';
+import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 
 export default class RoutingRoute extends Route {
-  model() {
+  @service('data-source/service') data;
+
+  async model(params, transition) {
     const parent = this.routeName
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    const model = this.modelFor(parent);
+    return {
+      ...model,
+      chain: await this.data.source(
+        uri => uri`/${model.nspace}/${model.dc.Name}/discovery-chain/${model.slug}`
+      ),
+    };
   }
 
-  afterModel(model, transition) {
+  async afterModel(model, transition) {
     if (!get(model, 'chain')) {
       const parent = this.routeName
         .split('.')

--- a/ui/packages/consul-ui/app/routes/dc/services/show/topology.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/topology.js
@@ -1,18 +1,48 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { get, action } from '@ember/object';
 
 export default class TopologyRoute extends Route {
   @service('ui-config') config;
   @service('env') env;
+  @service('data-source/service') data;
+  @service('repository/intention') repo;
 
-  model() {
+  @action
+  async createIntention(source, destination) {
+    const model = this.repo.create({
+      Datacenter: source.Datacenter,
+      SourceName: source.Name,
+      SourceNS: source.Namespace || 'default',
+      DestinationName: destination.Name,
+      DestinationNS: destination.Namespace || 'default',
+      Action: 'allow',
+    });
+    await this.repo.persist(model);
+    this.refresh();
+  }
+
+  async model() {
     const parent = this.routeName
       .split('.')
       .slice(0, -1)
       .join('.');
+    const model = this.modelFor(parent);
+    const dc = get(model, 'dc');
+    const nspace = get(model, 'nspace');
 
+    const item = get(model, 'items.firstObject');
+    if (get(item, 'IsMeshOrigin')) {
+      let kind = get(item, 'Service.Kind');
+      if (typeof kind === 'undefined') {
+        kind = '';
+      }
+      model.topology = await this.data.source(
+        uri => uri`/${nspace}/${dc.Name}/topology/${model.slug}/${kind}`
+      );
+    }
     return {
-      ...this.modelFor(parent),
+      ...model,
       hasMetricsProvider: !!this.config.get().metrics_provider,
       isRemoteDC: this.env.var('CONSUL_DATACENTER_LOCAL') !== this.modelFor('dc').dc.Name,
     };

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -1,75 +1,73 @@
 <EventSource @src={{items}} @onerror={{action "error"}} />
-<EventSource @src={{chain}} />
-<EventSource @src={{intentions}} />
 <EventSource @src={{proxies}} />
-<EventSource @src={{gatewayServices}} />
-<EventSource @src={{topology}} />
-{{page-title item.Service.Service}}
-<AppView>
-  <BlockSlot @name="notification" as |status type|>
-    <Consul::Service::Notifications
-      @type={{type}}
-      @status={{status}}
-    />
-  </BlockSlot>
-  <BlockSlot @name="breadcrumbs">
-    <ol>
-        <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
-    </ol>
-  </BlockSlot>
-  <BlockSlot @name="header">
-      <h1>
-        {{item.Service.Service}}
-      </h1>
-      <Consul::ExternalSource @item={{item.Service}} />
-      <Consul::Kind @item={{item.Service}} @withInfo={{true}} />
-  </BlockSlot>
-  <BlockSlot @name="nav">
-  {{#if (not-eq item.Service.Kind 'mesh-gateway')}}
-    <TabNav @items={{
-      compact
-          (array
-(if (and topology.Datacenter (or (gt proxies.length 0) (eq item.Service.Kind 'ingress-gateway')))
-            (hash label="Topology" href=(href-to "dc.services.show.topology") selected=(is-href "dc.services.show.topology"))
-'')
-(if (eq item.Service.Kind 'terminating-gateway')
-            (hash label="Linked Services" href=(href-to "dc.services.show.services") selected=(is-href "dc.services.show.services"))
-'')
-(if (eq item.Service.Kind 'ingress-gateway')
-            (hash label="Upstreams" href=(href-to "dc.services.show.upstreams") selected=(is-href "dc.services.show.upstreams"))
-'')
-            (hash label="Instances" href=(href-to "dc.services.show.instances") selected=(is-href "dc.services.show.instances"))
-(if (not-eq item.Service.Kind 'terminating-gateway')
-            (hash label="Intentions" href=(href-to "dc.services.show.intentions") selected=(is-href "dc.services.show.intentions"))
-'')
-(if chain.Chain
-            (hash label="Routing" href=(href-to "dc.services.show.routing") selected=(is-href "dc.services.show.routing"))
-'')
-(if (not item.Service.Kind)
-            (hash label="Tags" href=(href-to "dc.services.show.tags") selected=(is-href "dc.services.show.tags"))
-'')
-          )
-    }}/>
-  {{/if}}
-  </BlockSlot>
-  <BlockSlot @name="actions">
-    {{#if urls.service}}
-      <a href={{render-template urls.service (hash
-        Datacenter=dc
-        Service=(hash Name=item.Service.Service)
-      )}}
-        target="_blank"
-        rel="noopener noreferrer"
-        data-test-dashboard-anchor>
-        Open Dashboard
-      </a>
+{{#let items.firstObject as |item|}}
+  {{page-title item.Service.Service}}
+  <AppView>
+    <BlockSlot @name="notification" as |status type|>
+      <Consul::Service::Notifications
+        @type={{type}}
+        @status={{status}}
+      />
+    </BlockSlot>
+    <BlockSlot @name="breadcrumbs">
+      <ol>
+          <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
+      </ol>
+    </BlockSlot>
+    <BlockSlot @name="header">
+        <h1>
+          {{item.Service.Service}}
+        </h1>
+        <Consul::ExternalSource @item={{item.Service}} />
+        <Consul::Kind @item={{item.Service}} @withInfo={{true}} />
+    </BlockSlot>
+    <BlockSlot @name="nav">
+    {{#if (not-eq item.Service.Kind 'mesh-gateway')}}
+      <TabNav @items={{
+        compact
+            (array
+  (if (and dc.MeshEnabled item.IsMeshOrigin (or (gt proxies.length 0) (eq item.Service.Kind 'ingress-gateway')))
+              (hash label="Topology" href=(href-to "dc.services.show.topology") selected=(is-href "dc.services.show.topology"))
+  '')
+  (if (eq item.Service.Kind 'terminating-gateway')
+              (hash label="Linked Services" href=(href-to "dc.services.show.services") selected=(is-href "dc.services.show.services"))
+  '')
+  (if (eq item.Service.Kind 'ingress-gateway')
+              (hash label="Upstreams" href=(href-to "dc.services.show.upstreams") selected=(is-href "dc.services.show.upstreams"))
+  '')
+              (hash label="Instances" href=(href-to "dc.services.show.instances") selected=(is-href "dc.services.show.instances"))
+  (if (not-eq item.Service.Kind 'terminating-gateway')
+              (hash label="Intentions" href=(href-to "dc.services.show.intentions") selected=(is-href "dc.services.show.intentions"))
+  '')
+  (if (and dc.MeshEnabled item.IsOrigin)
+              (hash label="Routing" href=(href-to "dc.services.show.routing") selected=(is-href "dc.services.show.routing"))
+  '')
+  (if (not item.Service.Kind)
+              (hash label="Tags" href=(href-to "dc.services.show.tags") selected=(is-href "dc.services.show.tags"))
+  '')
+            )
+      }}/>
     {{/if}}
-  </BlockSlot>
-  <BlockSlot @name="content">
-    <Outlet
-      @name={{routeName}}
-    as |o|>
-      {{outlet}}
-    </Outlet>
-  </BlockSlot>
-</AppView>
+    </BlockSlot>
+    <BlockSlot @name="actions">
+      {{#if urls.service}}
+        <a href={{render-template urls.service (hash
+          Datacenter=dc.Name
+          Service=(hash Name=item.Service.Service)
+        )}}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-test-dashboard-anchor>
+          Open Dashboard
+        </a>
+      {{/if}}
+    </BlockSlot>
+    <BlockSlot @name="content">
+      <Outlet
+        @name={{routeName}}
+      as |o|>
+        {{outlet}}
+      </Outlet>
+    </BlockSlot>
+  </AppView>
+{{/let}}

--- a/ui/packages/consul-ui/app/templates/dc/services/show/routing.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/routing.hbs
@@ -1,3 +1,4 @@
+<EventSource @src={{chain}} />
 <div id="routing" class="tab-section">
   <div role="tabpanel">
     <Consul::DiscoveryChain

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -1,3 +1,4 @@
+<EventSource @src={{topology}} />
 <div id="topology" class="tab-section">
   <div role="tabpanel">
   {{#if topology.FilteredByACLs}}
@@ -6,11 +7,11 @@
   {{#if topology}}
     <TopologyMetrics
       @nspace={{nspace}}
-      @dc={{dc}}
+      @dc={{dc.Name}}
       @service={{items.firstObject}}
       @topology={{topology}}
       @metricsHref={{render-template urls.service (hash
-        Datacenter=dc
+        Datacenter=dc.Name
         Service=items.firstObject
       )}}
       @isRemoteDC={{isRemoteDC}}


### PR DESCRIPTION
This PR continues to split up the once slightly complicated Service > Show Route into separate routes.

We use the new `IsOrigin` and `IsMeshOrigin` properties of services, along with DC.MeshEnabled, to decide whether to show certain tabs, the data for those tabs is only loaded when you visit them, instead of loading it all upfront in Services > Show.

In order to figure out id a DC is `MeshEnabled` we still do one extra HTTP request in order to figure this out, but this is a request that we are likely to reuse if it comes back successful. If we ever end up with a `/v1/catalog/datacenter/:dc-name` to gather data for a specific DC, we can replace this fuether up the Route hierarchy. I added some comments to that effect in the code.

Lastly, one super important thing to point out here is that this is the first time we are passing `dc` into the template as an ember data object rather than just a string (the name of the DC). Eventually we should do this everywhere now we are adding more properties to DCs but in the meantime this is something to be very mindful of.