### PR TITLE
ui: Set overflow: auto on the tab nav

### DIFF
--- a/ui/packages/consul-ui/app/components/tab-nav/layout.scss
+++ b/ui/packages/consul-ui/app/components/tab-nav/layout.scss
@@ -1,6 +1,6 @@
 %tab-nav {
   clear: both;
-  overflow: scroll;
+  overflow: auto;
 }
 %tab-nav ul {
   display: inline-flex;


### PR DESCRIPTION
This ensures scroll bars are mainly hidden, yet visible on small screens
if the tabs are large enough for there to be an overflow