### PR TITLE
ui: Show the No Dependencies message when a Topology has no streams

### DIFF
--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -15,7 +15,7 @@
       </BlockSlot>
       <BlockSlot @name="actions">
         <li class="docs-link">
-          <a href="{{env 'CONSUL_DOCS_URL'}}/connect/registration/service-registration#upstream-configuration-reference" rel="noopener noreferrer" target="_blank">Documentation on upstreams</a>
+          <a href="{{env 'CONSUL_DOCS_URL'}}/connect/registration/service-registration#complete-configuration-example" rel="noopener noreferrer" target="_blank">Documentation on upstreams</a>
         </li>
       </BlockSlot>
     </EmptyState>

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -1,24 +1,7 @@
 <EventSource @src={{topology}} />
-<div id="topology" class="tab-section">
+<div class="tab-section">
   <div role="tabpanel">
-  {{#if topology.FilteredByACLs}}
-    <TopologyMetrics::Notice::LimitedAccess />
-  {{/if}}
-  {{#if topology}}
-    <TopologyMetrics
-      @nspace={{nspace}}
-      @dc={{dc.Name}}
-      @service={{items.firstObject}}
-      @topology={{topology}}
-      @metricsHref={{render-template urls.service (hash
-        Datacenter=dc.Name
-        Service=items.firstObject
-      )}}
-      @isRemoteDC={{isRemoteDC}}
-      @hasMetricsProvider={{hasMetricsProvider}}
-      @oncreate={{route-action 'createIntention'}}
-    />
-  {{else}}
+  {{#if (and (eq topology.Upstreams.length 0) (eq topology.Downstreams.length 0))}}
     <EmptyState>
       <BlockSlot @name="header">
         <h2>
@@ -36,6 +19,23 @@
         </li>
       </BlockSlot>
     </EmptyState>
+  {{else}}
+    {{#if topology.FilteredByACLs}}
+      <TopologyMetrics::Notice::LimitedAccess />
+    {{/if}}
+    <TopologyMetrics
+      @nspace={{nspace}}
+      @dc={{dc.Name}}
+      @service={{items.firstObject}}
+      @topology={{topology}}
+      @metricsHref={{render-template urls.service (hash
+        Datacenter=dc.Name
+        Service=items.firstObject
+      )}}
+      @isRemoteDC={{isRemoteDC}}
+      @hasMetricsProvider={{hasMetricsProvider}}
+      @oncreate={{route-action 'createIntention'}}
+    />
   {{/if}}
   </div>
 </div>


### PR DESCRIPTION
Previously this checked for the existence of `topology` in order to decide whether to show a topology visualization or not. `topology` is always truthy so we change the conditional here to look for the existence of Downstreams and Upstreams. We also change the order of the conditional to make it slightly easier to read.

~(Awaiting a question offline on which link to use in the No Dependencies empty state)~