### PR TITLE
connect: Filter local requests using SourceType=LOCAL

### DIFF
--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -1684,6 +1684,25 @@ func TestConfigSnapshotExposeConfig(t testing.T) *ConfigSnapshot {
 	}
 }
 
+func TestConfigSnapshotExposeConfigChecks(t testing.T) *ConfigSnapshot {
+	return &ConfigSnapshot{
+		Kind:    structs.ServiceKindConnectProxy,
+		Service: "web-proxy",
+		ProxyID: structs.NewServiceID("web-proxy", nil),
+		Address: "1.2.3.4",
+		Port:    8080,
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "web",
+			DestinationServiceID:   "web",
+			LocalServicePort:       8080,
+			Expose: structs.ExposeConfig{
+				Checks: true,
+			},
+		},
+		Datacenter: "dc1",
+	}
+}
+
 func TestConfigSnapshotTerminatingGateway(t testing.T) *ConfigSnapshot {
 	return testConfigSnapshotTerminatingGateway(t, true)
 }

--- a/agent/xds/testdata/listeners/expose-paths-checks.envoy-1-13-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-checks.envoy-1-13-x.golden
@@ -1,0 +1,144 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "exposed_path_health:1.2.3.4:20050",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 20050
+        }
+      },
+      "filterChains": [
+        {
+          "filterChainMatch": {
+            "sourceType": "LOCAL"
+          },
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "route_config": {
+                        "name": "exposed_path_filter_health_20050",
+                        "virtual_hosts": [
+                              {
+                                    "domains": [
+                                          "*"
+                                        ],
+                                    "name": "exposed_path_filter_health_20050",
+                                    "routes": [
+                                          {
+                                                "match": {
+                                                      "path": "/health"
+                                                    },
+                                                "route": {
+                                                      "cluster": "local_app"
+                                                    }
+                                              }
+                                        ]
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "exposed_path_filter_health_20050",
+                  "tracing": {
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        },
+        {
+          "filterChainMatch": {
+            "sourcePrefixRanges": [
+              {
+                "addressPrefix": "1.2.3.4",
+                "prefixLen": 32
+              }
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "route_config": {
+                        "name": "exposed_path_filter_health_20050",
+                        "virtual_hosts": [
+                              {
+                                    "domains": [
+                                          "*"
+                                        ],
+                                    "name": "exposed_path_filter_health_20050",
+                                    "routes": [
+                                          {
+                                                "match": {
+                                                      "path": "/health"
+                                                    },
+                                                "route": {
+                                                      "cluster": "local_app"
+                                                    }
+                                              }
+                                        ]
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "exposed_path_filter_health_20050",
+                  "tracing": {
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "public_listener:1.2.3.4:8080",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "tlsContext": {
+            "requireClientCertificate": true
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "config": {
+                  "rules": {
+                      },
+                  "stat_prefix": "connect_authz"
+                }
+            },
+            {
+              "name": "envoy.tcp_proxy",
+              "config": {
+                  "cluster": "local_app",
+                  "stat_prefix": "public_listener"
+                }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/expose-paths-checks.envoy-1-14-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-checks.envoy-1-14-x.golden
@@ -1,0 +1,144 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "exposed_path_health:1.2.3.4:20050",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 20050
+        }
+      },
+      "filterChains": [
+        {
+          "filterChainMatch": {
+            "sourceType": "LOCAL"
+          },
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "route_config": {
+                        "name": "exposed_path_filter_health_20050",
+                        "virtual_hosts": [
+                              {
+                                    "domains": [
+                                          "*"
+                                        ],
+                                    "name": "exposed_path_filter_health_20050",
+                                    "routes": [
+                                          {
+                                                "match": {
+                                                      "path": "/health"
+                                                    },
+                                                "route": {
+                                                      "cluster": "local_app"
+                                                    }
+                                              }
+                                        ]
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "exposed_path_filter_health_20050",
+                  "tracing": {
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        },
+        {
+          "filterChainMatch": {
+            "sourcePrefixRanges": [
+              {
+                "addressPrefix": "1.2.3.4",
+                "prefixLen": 32
+              }
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "route_config": {
+                        "name": "exposed_path_filter_health_20050",
+                        "virtual_hosts": [
+                              {
+                                    "domains": [
+                                          "*"
+                                        ],
+                                    "name": "exposed_path_filter_health_20050",
+                                    "routes": [
+                                          {
+                                                "match": {
+                                                      "path": "/health"
+                                                    },
+                                                "route": {
+                                                      "cluster": "local_app"
+                                                    }
+                                              }
+                                        ]
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "exposed_path_filter_health_20050",
+                  "tracing": {
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "public_listener:1.2.3.4:8080",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "tlsContext": {
+            "requireClientCertificate": true
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "config": {
+                  "rules": {
+                      },
+                  "stat_prefix": "connect_authz"
+                }
+            },
+            {
+              "name": "envoy.tcp_proxy",
+              "config": {
+                  "cluster": "local_app",
+                  "stat_prefix": "public_listener"
+                }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/expose-paths-checks.envoy-1-15-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-checks.envoy-1-15-x.golden
@@ -1,0 +1,144 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "exposed_path_health:1.2.3.4:20050",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 20050
+        }
+      },
+      "filterChains": [
+        {
+          "filterChainMatch": {
+            "sourceType": "LOCAL"
+          },
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "route_config": {
+                        "name": "exposed_path_filter_health_20050",
+                        "virtual_hosts": [
+                              {
+                                    "domains": [
+                                          "*"
+                                        ],
+                                    "name": "exposed_path_filter_health_20050",
+                                    "routes": [
+                                          {
+                                                "match": {
+                                                      "path": "/health"
+                                                    },
+                                                "route": {
+                                                      "cluster": "local_app"
+                                                    }
+                                              }
+                                        ]
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "exposed_path_filter_health_20050",
+                  "tracing": {
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        },
+        {
+          "filterChainMatch": {
+            "sourcePrefixRanges": [
+              {
+                "addressPrefix": "1.2.3.4",
+                "prefixLen": 32
+              }
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "route_config": {
+                        "name": "exposed_path_filter_health_20050",
+                        "virtual_hosts": [
+                              {
+                                    "domains": [
+                                          "*"
+                                        ],
+                                    "name": "exposed_path_filter_health_20050",
+                                    "routes": [
+                                          {
+                                                "match": {
+                                                      "path": "/health"
+                                                    },
+                                                "route": {
+                                                      "cluster": "local_app"
+                                                    }
+                                              }
+                                        ]
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "exposed_path_filter_health_20050",
+                  "tracing": {
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "public_listener:1.2.3.4:8080",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "tlsContext": {
+            "requireClientCertificate": true
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "config": {
+                  "rules": {
+                      },
+                  "stat_prefix": "connect_authz"
+                }
+            },
+            {
+              "name": "envoy.tcp_proxy",
+              "config": {
+                  "cluster": "local_app",
+                  "stat_prefix": "public_listener"
+                }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/expose-paths-checks.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/expose-paths-checks.envoy-1-16-x.golden
@@ -1,0 +1,144 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "exposed_path_health:1.2.3.4:20050",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 20050
+        }
+      },
+      "filterChains": [
+        {
+          "filterChainMatch": {
+            "sourceType": "LOCAL"
+          },
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "route_config": {
+                        "name": "exposed_path_filter_health_20050",
+                        "virtual_hosts": [
+                              {
+                                    "domains": [
+                                          "*"
+                                        ],
+                                    "name": "exposed_path_filter_health_20050",
+                                    "routes": [
+                                          {
+                                                "match": {
+                                                      "path": "/health"
+                                                    },
+                                                "route": {
+                                                      "cluster": "local_app"
+                                                    }
+                                              }
+                                        ]
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "exposed_path_filter_health_20050",
+                  "tracing": {
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        },
+        {
+          "filterChainMatch": {
+            "sourcePrefixRanges": [
+              {
+                "addressPrefix": "1.2.3.4",
+                "prefixLen": 32
+              }
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "route_config": {
+                        "name": "exposed_path_filter_health_20050",
+                        "virtual_hosts": [
+                              {
+                                    "domains": [
+                                          "*"
+                                        ],
+                                    "name": "exposed_path_filter_health_20050",
+                                    "routes": [
+                                          {
+                                                "match": {
+                                                      "path": "/health"
+                                                    },
+                                                "route": {
+                                                      "cluster": "local_app"
+                                                    }
+                                              }
+                                        ]
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "exposed_path_filter_health_20050",
+                  "tracing": {
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "public_listener:1.2.3.4:8080",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "tlsContext": {
+            "requireClientCertificate": true
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "config": {
+                  "rules": {
+                      },
+                  "stat_prefix": "connect_authz"
+                }
+            },
+            {
+              "name": "envoy.tcp_proxy",
+              "config": {
+                  "cluster": "local_app",
+                  "stat_prefix": "public_listener"
+                }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
If IPv6 is disabled (e.g., with `sysctl net.ipv6.conf.all.disable_ipv6=1`), Envoy will fail to start if configured with an IPv6 address. Consul currently configures Envoy with the IPv6 loopback address when `Expose.Checks` is enabled, even if IPv6 is disabled.

As a result, Envoy will currently fail to start on hosts with IPv6 is disabled if a service uses `Expose.Checks`: https://github.com/hashicorp/consul/issues/9311

Instead of trying to detect if IPv6 is enabled or disabled in Consul, I propose splitting the listener into two filter chains: one for traffic [source type local] (a native Envoy concept) and one for traffic with Consul agent as the source.

[source type local]: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener/listener_components.proto#envoy-api-enum-listener-filterchainmatch-connectionsourcetype