### PR TITLE
ui: Fuzzy and Regex searching

### DIFF
--- a/ui/packages/consul-ui/app/components/data-collection/index.js
+++ b/ui/packages/consul-ui/app/components/data-collection/index.js
@@ -95,7 +95,7 @@ export default class DataCollectionComponent extends Component {
     return this.content.filter(predicate(this.args.filters));
   }
 
-  @computed('args{items,items.content}')
+  @computed('args.{items.[],items.content.[]}')
   get content() {
     // TODO: Temporary little hack to ensure we detect DataSource proxy
     // objects but not any other special Ember Proxy object like ember-data

--- a/ui/packages/consul-ui/app/components/data-collection/index.js
+++ b/ui/packages/consul-ui/app/components/data-collection/index.js
@@ -23,7 +23,7 @@ export default class DataCollectionComponent extends Component {
   }
 
   get searchMethod() {
-    return this.args.searchable || 'fuzzy';
+    return this.args.searchable || 'exact';
   }
 
   get searchProperties() {

--- a/ui/packages/consul-ui/app/components/data-collection/index.js
+++ b/ui/packages/consul-ui/app/components/data-collection/index.js
@@ -4,7 +4,75 @@ import { computed, get, action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { sort } from '@ember/object/computed';
 import { defineProperty } from '@ember/object';
+import Fuse from 'fuse.js';
 
+class FuzzySearch {
+  constructor(items, options) {
+    this.fuse = new Fuse(items, {
+      shouldSort: false, // use our own sorting for the moment
+      threshold: 0.4,
+      keys: Object.keys(options.finders) || [],
+      getFn(item, key) {
+        return (options.finders[key](item) || []).toString();
+      },
+    });
+  }
+
+  search(s) {
+    return this.fuse.search(s).map(item => item.item);
+  }
+}
+
+class PredicateSearch {
+  constructor(items, options) {
+    this.items = items;
+    this.options = options;
+  }
+
+  search(s) {
+    const predicate = this.predicate(s);
+    // Test the value of each key for each object against the regex
+    // All that match are returned.
+    return this.items.filter(item => {
+      return Object.entries(this.options.finders).some(([key, finder]) => {
+        const val = finder(item);
+        if (Array.isArray(val)) {
+          return val.some(predicate);
+        } else {
+          return predicate(val);
+        }
+      });
+    });
+  }
+}
+class ExactSearch extends PredicateSearch {
+  predicate(s) {
+    s = s.toLowerCase();
+    return item =>
+      item
+        .toString()
+        .toLowerCase()
+        .indexOf(s) !== -1;
+  }
+}
+class RegExpSearch extends PredicateSearch {
+  predicate(s) {
+    let regex;
+    try {
+      regex = new RegExp(s, 'i');
+    } catch (e) {
+      // Return a predicate that excludes everything; most likely due to an
+      // eager search of an incomplete regex
+      return () => false;
+    }
+    return item => regex.test(item);
+  }
+}
+const searchables = {
+  fuzzy: FuzzySearch,
+  exact: ExactSearch,
+  regex: RegExpSearch,
+};
 export default class DataCollectionComponent extends Component {
   @service('filter') filter;
   @service('sort') sort;
@@ -12,7 +80,7 @@ export default class DataCollectionComponent extends Component {
 
   @tracked term = '';
 
-  get type() {
+  get kind() {
     return this.args.type;
   }
 
@@ -27,7 +95,15 @@ export default class DataCollectionComponent extends Component {
     return this.items;
   }
 
-  @computed('args{items,.items.content}')
+  get searchMethod() {
+    return this.args.searchable || 'fuzzy';
+  }
+
+  get searchProperties() {
+    return this.args.filters.searchproperties;
+  }
+
+  @computed('args{items,items.content}')
   get content() {
     // TODO: Temporary little hack to ensure we detect DataSource proxy
     // objects but not any other special Ember Proxy object like ember-data
@@ -51,36 +127,46 @@ export default class DataCollectionComponent extends Component {
     return this.sorted;
   }
 
-  @computed('type', 'filtered', 'args.filters.searchproperties', 'searchTerm')
+  @computed('filtered', 'searchTerm', 'searchable')
   get searched() {
     if (this.searchTerm === '') {
       return this.filtered;
     }
-    const predicate = this.searchService.predicate(this.type);
-    const options = {};
-    if (typeof get(this, 'args.filters.searchproperties') !== 'undefined') {
-      options.properties = this.args.filters.searchproperties;
-    }
-    return this.filtered.filter(predicate(this.searchTerm, options));
+    return this.searchable.search(this.searchTerm);
   }
 
-  @computed('type', 'content', 'args.filters')
+  @computed('kind', 'searchMethod', 'filtered', 'searchProperties')
+  get searchable() {
+    const searchable =
+      typeof this.searchMethod === 'string' ? searchables[this.searchMethod] : this.args.searchable;
+    return new searchable(this.filtered, {
+      finders: Object.fromEntries(
+        Object.entries(this.search.predicate(this.kind)).filter(([key, value]) => {
+          return typeof this.searchProperties === 'undefined'
+            ? true
+            : this.searchProperties.includes(key);
+        })
+      ),
+    });
+  }
+
+  @computed('kind', 'content', 'args.filters')
   get filtered() {
     if (typeof this.args.filters === 'undefined') {
       return this.content;
     }
-    const predicate = this.filter.predicate(this.type);
+    const predicate = this.filter.predicate(this.kind);
     if (typeof predicate === 'undefined') {
       return this.content;
     }
     return this.content.filter(predicate(this.args.filters));
   }
 
-  @computed('type', 'args.sort')
+  @computed('kind', 'args.sort')
   get comparator() {
     if (typeof this.args.sort === 'undefined') {
       return [];
     }
-    return this.sort.comparator(this.type)(this.args.sort);
+    return this.sort.comparator(this.kind)(this.args.sort);
   }
 }

--- a/ui/packages/consul-ui/app/components/data-collection/index.js
+++ b/ui/packages/consul-ui/app/components/data-collection/index.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { computed, get, action } from '@ember/object';
+import { computed, action } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
 import { sort } from '@ember/object/computed';
@@ -13,12 +13,9 @@ export default class DataCollectionComponent extends Component {
 
   @tracked term = '';
 
-  constructor() {
-    super(...arguments);
-    this.searchableMap = this.searchService.searchables;
-  }
+  @alias('searchService.searchables') searchableMap;
 
-  get kind() {
+  get type() {
     return this.args.type;
   }
 
@@ -35,7 +32,7 @@ export default class DataCollectionComponent extends Component {
     return this.term || this.args.search || '';
   }
 
-  @computed('kind', 'searchMethod', 'filtered', 'searchProperties')
+  @computed('type', 'searchMethod', 'filtered', 'searchProperties')
   get searchable() {
     const Searchable =
       typeof this.searchMethod === 'string'
@@ -43,7 +40,7 @@ export default class DataCollectionComponent extends Component {
         : this.args.searchable;
     return new Searchable(this.filtered, {
       finders: Object.fromEntries(
-        Object.entries(this.searchService.predicate(this.kind)).filter(([key, value]) => {
+        Object.entries(this.searchService.predicate(this.type)).filter(([key, value]) => {
           return typeof this.searchProperties === 'undefined'
             ? true
             : this.searchProperties.includes(key);
@@ -52,12 +49,12 @@ export default class DataCollectionComponent extends Component {
     });
   }
 
-  @computed('kind', 'args.sort')
+  @computed('type', 'args.sort')
   get comparator() {
     if (typeof this.args.sort === 'undefined') {
       return [];
     }
-    return this.sort.comparator(this.kind)(this.args.sort);
+    return this.sort.comparator(this.type)(this.args.sort);
   }
 
   @computed('comparator', 'searched')
@@ -81,14 +78,14 @@ export default class DataCollectionComponent extends Component {
     return this.searchable.search(this.searchTerm);
   }
 
-  @computed('kind', 'content', 'args.filters')
+  @computed('type', 'content', 'args.filters')
   get filtered() {
     // if we don't filter, return a copy of the content so we end up with what
     // filter will return when filtering ED recordsets
     if (typeof this.args.filters === 'undefined') {
       return this.content.slice();
     }
-    const predicate = this.filter.predicate(this.kind);
+    const predicate = this.filter.predicate(this.type);
     if (typeof predicate === 'undefined') {
       return this.content.slice();
     }

--- a/ui/packages/consul-ui/app/search/predicates/acl.js
+++ b/ui/packages/consul-ui/app/search/predicates/acl.js
@@ -1,4 +1,4 @@
 export default {
-  ID: (item, value) => item.ID.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Name: (item, value) => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1,
+  ID: item => item.ID,
+  Name: item => item.Name,
 };

--- a/ui/packages/consul-ui/app/search/predicates/health-check.js
+++ b/ui/packages/consul-ui/app/search/predicates/health-check.js
@@ -16,6 +16,7 @@ export default {
     );
   },
   CheckID: (item, value) => (item.CheckID || '').toLowerCase().indexOf(value.toLowerCase()) !== -1,
+  ID: (item, value) => (item.Service.ID || '').toLowerCase().indexOf(value.toLowerCase()) !== -1,
   Notes: (item, value) =>
     item.Notes.toString()
       .toLowerCase()

--- a/ui/packages/consul-ui/app/search/predicates/health-check.js
+++ b/ui/packages/consul-ui/app/search/predicates/health-check.js
@@ -2,32 +2,12 @@ const asArray = function(arr) {
   return Array.isArray(arr) ? arr : arr.toArray();
 };
 export default {
-  Name: (item, value) => {
-    return item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1;
-  },
-  Node: (item, value) => {
-    return item.Node.toLowerCase().indexOf(value.toLowerCase()) !== -1;
-  },
-  Service: (item, value) => {
-    const lower = value.toLowerCase();
-    return (
-      item.ServiceName.toLowerCase().indexOf(lower) !== -1 ||
-      item.ServiceID.toLowerCase().indexOf(lower) !== -1
-    );
-  },
-  CheckID: (item, value) => (item.CheckID || '').toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  ID: (item, value) => (item.Service.ID || '').toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Notes: (item, value) =>
-    item.Notes.toString()
-      .toLowerCase()
-      .indexOf(value.toLowerCase()) !== -1,
-  Output: (item, value) =>
-    item.Output.toString()
-      .toLowerCase()
-      .indexOf(value.toLowerCase()) !== -1,
-  ServiceTags: (item, value) => {
-    return asArray(item.ServiceTags || []).some(
-      item => item.toLowerCase().indexOf(value.toLowerCase()) !== -1
-    );
-  },
+  Name: (item, value) => item.Name,
+  Node: (item, value) => item.Node,
+  Service: (item, value) => item.ServiceName,
+  CheckID: (item, value) => item.CheckID || '',
+  ID: (item, value) => item.Service.ID || '',
+  Notes: (item, value) => item.Notes,
+  Output: (item, value) => item.Output,
+  ServiceTags: (item, value) => asArray(item.ServiceTags || []),
 };

--- a/ui/packages/consul-ui/app/search/predicates/intention.js
+++ b/ui/packages/consul-ui/app/search/predicates/intention.js
@@ -1,9 +1,7 @@
-const allLabel = 'All Services (*)'.toLowerCase();
+const allLabel = 'All Services (*)';
 export default {
-  SourceName: (item, value) =>
-    item.SourceName.toLowerCase().indexOf(value.toLowerCase()) !== -1 ||
-    (item.SourceName === '*' && allLabel.indexOf(value.toLowerCase()) !== -1),
-  DestinationName: (item, value) =>
-    item.DestinationName.toLowerCase().indexOf(value.toLowerCase()) !== -1 ||
-    (item.DestinationName === '*' && allLabel.indexOf(value.toLowerCase()) !== -1),
+  SourceName: item =>
+    [item.SourceName, item.SourceName === '*' ? allLabel : undefined].filter(item => Boolean),
+  DestinationName: item =>
+    [item.SourceName, item.DestinationName === '*' ? allLabel : undefined].filter(item => Boolean),
 };

--- a/ui/packages/consul-ui/app/search/predicates/intention.js
+++ b/ui/packages/consul-ui/app/search/predicates/intention.js
@@ -1,7 +1,7 @@
 const allLabel = 'All Services (*)';
 export default {
   SourceName: item =>
-    [item.SourceName, item.SourceName === '*' ? allLabel : undefined].filter(item => Boolean),
+    [item.SourceName, item.SourceName === '*' ? allLabel : undefined].filter(Boolean),
   DestinationName: item =>
-    [item.SourceName, item.DestinationName === '*' ? allLabel : undefined].filter(item => Boolean),
+    [item.DestinationName, item.DestinationName === '*' ? allLabel : undefined].filter(Boolean),
 };

--- a/ui/packages/consul-ui/app/search/predicates/kv.js
+++ b/ui/packages/consul-ui/app/search/predicates/kv.js
@@ -1,9 +1,8 @@
 import rightTrim from 'consul-ui/utils/right-trim';
 export default {
-  Key: (item, value) =>
+  Key: item =>
     rightTrim(item.Key.toLowerCase())
       .split('/')
       .filter(item => Boolean(item))
-      .pop()
-      .indexOf(value.toLowerCase()) !== -1,
+      .pop(),
 };

--- a/ui/packages/consul-ui/app/search/predicates/node.js
+++ b/ui/packages/consul-ui/app/search/predicates/node.js
@@ -1,8 +1,5 @@
 export default {
-  Node: (item, value) => item.Node.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Address: (item, value) => item.Address.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Meta: (item, value) =>
-    Object.entries(item.Meta || {}).some(entry =>
-      entry.some(item => item.toLowerCase().indexOf(value.toLowerCase()) !== -1)
-    ),
+  Node: item => item.Node,
+  Address: item => item.Address,
+  Meta: item => Object.entries(item.Meta || {}).reduce((prev, entry) => prev.concat(entry), []),
 };

--- a/ui/packages/consul-ui/app/search/predicates/nspace.js
+++ b/ui/packages/consul-ui/app/search/predicates/nspace.js
@@ -1,16 +1,12 @@
 export default {
-  Name: (item, value) => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Description: (item, value) => item.Description.toLowerCase().indexOf(value.toLowerCase()) !== -1,
+  Name: (item, value) => item.Name,
+  Description: (item, value) => item.Description,
   Role: (item, value) => {
     const acls = item.ACLs || {};
-    return (acls.RoleDefaults || []).some(
-      item => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1
-    );
+    return (acls.RoleDefaults || []).map(item => item.Name);
   },
   Policy: (item, value) => {
     const acls = item.ACLs || {};
-    return (acls.PolicyDefaults || []).some(
-      item => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1
-    );
+    return (acls.PolicyDefaults || []).map(item => item.Name);
   },
 };

--- a/ui/packages/consul-ui/app/search/predicates/policy.js
+++ b/ui/packages/consul-ui/app/search/predicates/policy.js
@@ -1,4 +1,4 @@
 export default {
-  Name: (item, value) => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Description: (item, value) => item.Description.toLowerCase().indexOf(value.toLowerCase()) !== -1,
+  Name: item => item.Name,
+  Description: item => item.Description,
 };

--- a/ui/packages/consul-ui/app/search/predicates/role.js
+++ b/ui/packages/consul-ui/app/search/predicates/role.js
@@ -1,17 +1,10 @@
 export default {
-  Name: (item, value) => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Description: (item, value) => item.Description.toLowerCase().indexOf(value.toLowerCase()) !== -1,
+  Name: (item, value) => item.Name,
+  Description: (item, value) => item.Description,
   Policy: (item, value) => {
-    return (
-      (item.Policies || []).some(
-        item => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1
-      ) ||
-      (item.ServiceIdentities || []).some(
-        item => item.ServiceName.toLowerCase().indexOf(value.toLowerCase()) !== -1
-      ) ||
-      (item.NodeIdentities || []).some(
-        item => item.NodeName.toLowerCase().indexOf(value.toLowerCase()) !== -1
-      )
-    );
+    return (item.Policies || [])
+      .map(item => item.Name)
+      .concat((item.ServiceIdentities || []).map(item => item.ServiceName))
+      .concat((item.NodeIdentities || []).map(item => item.NodeName));
   },
 };

--- a/ui/packages/consul-ui/app/search/predicates/service-instance.js
+++ b/ui/packages/consul-ui/app/search/predicates/service-instance.js
@@ -1,24 +1,11 @@
 export default {
-  Name: (item, value) => {
-    return item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1;
-  },
-  Tags: (item, value) =>
-    (item.Service.Tags || []).some(item => item.toLowerCase().indexOf(value.toLowerCase()) !== -1),
-  ID: (item, value) => (item.Service.ID || '').toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Address: (item, value) =>
-    item.Address.toString()
-      .toLowerCase()
-      .indexOf(value.toLowerCase()) !== -1,
-  Port: (item, value) =>
-    item.Service.Port.toString()
-      .toLowerCase()
-      .indexOf(value.toLowerCase()) !== -1,
-  ['Service.Meta']: (item, value) =>
-    Object.entries(item.Meta || item.Service.Meta || {}).some(entry =>
-      entry.some(item => item.toLowerCase().indexOf(value.toLowerCase()) !== -1)
-    ),
-  ['Node.Meta']: (item, value) =>
-    Object.entries(item.Node.Meta || {}).some(entry =>
-      entry.some(item => item.toLowerCase().indexOf(value.toLowerCase()) !== -1)
-    ),
+  Name: item => item.Name,
+  Tags: item => item.Service.Tags || [],
+  ID: (item, value) => item.Service.ID || '',
+  Address: item => item.Address || '',
+  Port: item => (item.Service.Port || '').toString(),
+  ['Service.Meta']: item =>
+    Object.entries(item.Service.Meta || {}).reduce((prev, entry) => prev.concat(entry), []),
+  ['Node.Meta']: item =>
+    Object.entries(item.Node.Meta || {}).reduce((prev, entry) => prev.concat(entry), []),
 };

--- a/ui/packages/consul-ui/app/search/predicates/service.js
+++ b/ui/packages/consul-ui/app/search/predicates/service.js
@@ -1,4 +1,4 @@
 export default {
-  Name: (item, value) => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Tags: (item, value) => (item.Tags || []).some(item => item.toLowerCase().indexOf(value.toLowerCase()) !== -1)
+  Name: item => item.Name,
+  Tags: item => item.Tags || [],
 };

--- a/ui/packages/consul-ui/app/search/predicates/token.js
+++ b/ui/packages/consul-ui/app/search/predicates/token.js
@@ -1,20 +1,12 @@
 export default {
-  Name: (item, value) => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Description: (item, value) => item.Description.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  AccessorID: (item, value) => item.AccessorID.toLowerCase().indexOf(value.toLowerCase()) !== -1,
-  Role: (item, value) =>
-    (item.Roles || []).some(item => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1),
+  Name: (item, value) => item.Name,
+  Description: (item, value) => item.Description,
+  AccessorID: (item, value) => item.AccessorID,
+  Role: (item, value) => (item.Roles || []).map(item => item.Name),
   Policy: (item, value) => {
-    return (
-      (item.Policies || []).some(
-        item => item.Name.toLowerCase().indexOf(value.toLowerCase()) !== -1
-      ) ||
-      (item.ServiceIdentities || []).some(
-        item => item.ServiceName.toLowerCase().indexOf(value.toLowerCase()) !== -1
-      ) ||
-      (item.NodeIdentities || []).some(
-        item => item.NodeName.toLowerCase().indexOf(value.toLowerCase()) !== -1
-      )
-    );
+    return (item.Policies || [])
+      .map(item => item.Name)
+      .concat((item.ServiceIdentities || []).map(item => item.ServiceName))
+      .concat((item.NodeIdentities || []).map(item => item.NodeName));
   },
 };

--- a/ui/packages/consul-ui/app/services/search.js
+++ b/ui/packages/consul-ui/app/services/search.js
@@ -1,5 +1,4 @@
 import Service from '@ember/service';
-import setHelpers from 'mnemonist/set';
 
 import intention from 'consul-ui/search/predicates/intention';
 import upstreamInstance from 'consul-ui/search/predicates/upstream-instance';
@@ -14,21 +13,7 @@ import role from 'consul-ui/search/predicates/role';
 import policy from 'consul-ui/search/predicates/policy';
 import nspace from 'consul-ui/search/predicates/nspace';
 
-export const search = spec => {
-  let possible = Object.keys(spec);
-  return (term, options = {}) => {
-    const actual = [
-      ...setHelpers.intersection(new Set(possible), new Set(options.properties || possible)),
-    ];
-    return item => {
-      return (
-        typeof actual.find(key => {
-          return spec[key](item, term);
-        }) !== 'undefined'
-      );
-    };
-  };
-};
+const search = spec => spec;
 const predicates = {
   intention: search(intention),
   service: search(service),

--- a/ui/packages/consul-ui/app/services/search.js
+++ b/ui/packages/consul-ui/app/services/search.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
-import Fuse from 'fuse.js';
+
+import ExactSearch from 'consul-ui/utils/search/exact';
 
 import intention from 'consul-ui/search/predicates/intention';
 import upstreamInstance from 'consul-ui/search/predicates/upstream-instance';
@@ -29,75 +30,11 @@ const predicates = {
   nspace: nspace,
 };
 
-class FuzzySearch {
-  constructor(items, options) {
-    this.fuse = new Fuse(items, {
-      includeMatches: true,
-
-      shouldSort: false, // use our own sorting for the moment
-      threshold: 0.4,
-      keys: Object.keys(options.finders) || [],
-      getFn(item, key) {
-        return (options.finders[key[0]](item) || []).toString();
-      },
-    });
-  }
-
-  search(s) {
-    return this.fuse.search(s).map(item => item.item);
-  }
-}
-
-class PredicateSearch {
-  constructor(items, options) {
-    this.items = items;
-    this.options = options;
-  }
-
-  search(s) {
-    const predicate = this.predicate(s);
-    // Test the value of each key for each object against the regex
-    // All that match are returned.
-    return this.items.filter(item => {
-      return Object.entries(this.options.finders).some(([key, finder]) => {
-        const val = finder(item);
-        if (Array.isArray(val)) {
-          return val.some(predicate);
-        } else {
-          return predicate(val);
-        }
-      });
-    });
-  }
-}
-class ExactSearch extends PredicateSearch {
-  predicate(s) {
-    s = s.toLowerCase();
-    return item =>
-      item
-        .toString()
-        .toLowerCase()
-        .indexOf(s) !== -1;
-  }
-}
-class RegExpSearch extends PredicateSearch {
-  predicate(s) {
-    let regex;
-    try {
-      regex = new RegExp(s, 'i');
-    } catch (e) {
-      // Return a predicate that excludes everything; most likely due to an
-      // eager search of an incomplete regex
-      return () => false;
-    }
-    return item => regex.test(item);
-  }
-}
 export default class SearchService extends Service {
   searchables = {
-    fuzzy: FuzzySearch,
     exact: ExactSearch,
-    regex: RegExpSearch,
+    // regex: RegExpSearch,
+    // fuzzy: FuzzySearch,
   };
   predicate(name) {
     return predicates[name];

--- a/ui/packages/consul-ui/app/services/search.js
+++ b/ui/packages/consul-ui/app/services/search.js
@@ -14,20 +14,19 @@ import role from 'consul-ui/search/predicates/role';
 import policy from 'consul-ui/search/predicates/policy';
 import nspace from 'consul-ui/search/predicates/nspace';
 
-const search = spec => spec;
 const predicates = {
-  intention: search(intention),
-  service: search(service),
-  ['service-instance']: search(serviceInstance),
-  ['upstream-instance']: search(upstreamInstance),
-  ['health-check']: search(healthCheck),
-  node: search(node),
-  kv: search(kv),
-  acl: search(acl),
-  token: search(token),
-  role: search(role),
-  policy: search(policy),
-  nspace: search(nspace),
+  intention: intention,
+  service: service,
+  ['service-instance']: serviceInstance,
+  ['upstream-instance']: upstreamInstance,
+  ['health-check']: healthCheck,
+  node: node,
+  kv: kv,
+  acl: acl,
+  token: token,
+  role: role,
+  policy: policy,
+  nspace: nspace,
 };
 
 class FuzzySearch {
@@ -47,7 +46,6 @@ class FuzzySearch {
   search(s) {
     return this.fuse.search(s).map(item => item.item);
   }
-
 }
 
 class PredicateSearch {

--- a/ui/packages/consul-ui/app/services/search.js
+++ b/ui/packages/consul-ui/app/services/search.js
@@ -1,4 +1,5 @@
 import Service from '@ember/service';
+import Fuse from 'fuse.js';
 
 import intention from 'consul-ui/search/predicates/intention';
 import upstreamInstance from 'consul-ui/search/predicates/upstream-instance';
@@ -28,7 +29,78 @@ const predicates = {
   policy: search(policy),
   nspace: search(nspace),
 };
+
+class FuzzySearch {
+  constructor(items, options) {
+    this.fuse = new Fuse(items, {
+      includeMatches: true,
+
+      shouldSort: false, // use our own sorting for the moment
+      threshold: 0.4,
+      keys: Object.keys(options.finders) || [],
+      getFn(item, key) {
+        return (options.finders[key[0]](item) || []).toString();
+      },
+    });
+  }
+
+  search(s) {
+    return this.fuse.search(s).map(item => item.item);
+  }
+
+}
+
+class PredicateSearch {
+  constructor(items, options) {
+    this.items = items;
+    this.options = options;
+  }
+
+  search(s) {
+    const predicate = this.predicate(s);
+    // Test the value of each key for each object against the regex
+    // All that match are returned.
+    return this.items.filter(item => {
+      return Object.entries(this.options.finders).some(([key, finder]) => {
+        const val = finder(item);
+        if (Array.isArray(val)) {
+          return val.some(predicate);
+        } else {
+          return predicate(val);
+        }
+      });
+    });
+  }
+}
+class ExactSearch extends PredicateSearch {
+  predicate(s) {
+    s = s.toLowerCase();
+    return item =>
+      item
+        .toString()
+        .toLowerCase()
+        .indexOf(s) !== -1;
+  }
+}
+class RegExpSearch extends PredicateSearch {
+  predicate(s) {
+    let regex;
+    try {
+      regex = new RegExp(s, 'i');
+    } catch (e) {
+      // Return a predicate that excludes everything; most likely due to an
+      // eager search of an incomplete regex
+      return () => false;
+    }
+    return item => regex.test(item);
+  }
+}
 export default class SearchService extends Service {
+  searchables = {
+    fuzzy: FuzzySearch,
+    exact: ExactSearch,
+    regex: RegExpSearch,
+  };
   predicate(name) {
     return predicates[name];
   }

--- a/ui/packages/consul-ui/app/utils/search/exact.js
+++ b/ui/packages/consul-ui/app/utils/search/exact.js
@@ -1,0 +1,12 @@
+import PredicateSearch from './predicate';
+
+export default class ExactSearch extends PredicateSearch {
+  predicate(s) {
+    s = s.toLowerCase();
+    return (item = '') =>
+      item
+        .toString()
+        .toLowerCase()
+        .indexOf(s) !== -1;
+  }
+}

--- a/ui/packages/consul-ui/app/utils/search/fuzzy.js
+++ b/ui/packages/consul-ui/app/utils/search/fuzzy.js
@@ -1,0 +1,20 @@
+import Fuse from 'fuse.js';
+
+export default class FuzzySearch {
+  constructor(items, options) {
+    this.fuse = new Fuse(items, {
+      includeMatches: true,
+
+      shouldSort: false, // use our own sorting for the moment
+      threshold: 0.4,
+      keys: Object.keys(options.finders) || [],
+      getFn(item, key) {
+        return (options.finders[key[0]](item) || []).toString();
+      },
+    });
+  }
+
+  search(s) {
+    return this.fuse.search(s).map(item => item.item);
+  }
+}

--- a/ui/packages/consul-ui/app/utils/search/predicate.js
+++ b/ui/packages/consul-ui/app/utils/search/predicate.js
@@ -1,0 +1,22 @@
+export default class PredicateSearch {
+  constructor(items, options) {
+    this.items = items;
+    this.options = options;
+  }
+
+  search(s) {
+    const predicate = this.predicate(s);
+    // Test the value of each key for each object against the regex
+    // All that match are returned.
+    return this.items.filter(item => {
+      return Object.entries(this.options.finders).some(([key, finder]) => {
+        const val = finder(item);
+        if (Array.isArray(val)) {
+          return val.some(predicate);
+        } else {
+          return predicate(val);
+        }
+      });
+    });
+  }
+}

--- a/ui/packages/consul-ui/app/utils/search/regexp.js
+++ b/ui/packages/consul-ui/app/utils/search/regexp.js
@@ -1,0 +1,15 @@
+import PredicateSearch from './predicate';
+
+export default class RegExpSearch extends PredicateSearch {
+  predicate(s) {
+    let regex;
+    try {
+      regex = new RegExp(s, 'i');
+    } catch (e) {
+      // Return a predicate that excludes everything; most likely due to an
+      // eager search of an incomplete regex
+      return () => false;
+    }
+    return item => regex.test(item);
+  }
+}

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -143,7 +143,6 @@
     "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-node": "^11.0.0",
     "flat": "^5.0.0",
-    "fuse.js": "^6.4.3",
     "husky": "^4.2.5",
     "ivy-codemirror": "^2.1.0",
     "js-yaml": "^3.13.1",

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -143,6 +143,7 @@
     "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-node": "^11.0.0",
     "flat": "^5.0.0",
+    "fuse.js": "^6.4.3",
     "husky": "^4.2.5",
     "ivy-codemirror": "^2.1.0",
     "js-yaml": "^3.13.1",

--- a/ui/packages/consul-ui/tests/unit/search/predicates/acl-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/acl-test.js
@@ -1,33 +1,43 @@
-import predicates from 'consul-ui/search/predicates/acl';
-import { search as create } from 'consul-ui/services/search';
 import { module, test } from 'qunit';
 
+import ExactSearch from 'consul-ui/utils/search/exact';
+import predicates from 'consul-ui/search/predicates/acl';
+
 module('Unit | Search | Predicate | acl', function() {
-  const search = create(predicates);
   test('items are found by properties', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          ID: 'HIT-id',
+          Name: 'name',
+        },
+        {
+          ID: 'id',
+          Name: 'name',
+        },
+        {
+          ID: 'id',
+          Name: 'name-HIT',
+        },
+      ],
       {
-        ID: 'HIT-id',
-        Name: 'name',
-      },
-      {
-        ID: 'id',
-        Name: 'name',
-      },
-      {
-        ID: 'id',
-        Name: 'name-HIT',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 2);
   });
   test('items are not found', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          ID: 'id',
+          Name: 'name',
+        },
+      ],
       {
-        ID: 'id',
-        Name: 'name',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
 });

--- a/ui/packages/consul-ui/tests/unit/search/predicates/intention-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/intention-test.js
@@ -1,51 +1,48 @@
-import predicates from 'consul-ui/search/predicates/intention';
-import { search as create } from 'consul-ui/services/search';
 import { module, test } from 'qunit';
 
+import ExactSearch from 'consul-ui/utils/search/exact';
+import predicates from 'consul-ui/search/predicates/intention';
+
 module('Unit | Search | Predicate | intention', function() {
-  const search = create(predicates);
   test('items are found by properties', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          SourceName: 'Hit',
+          DestinationName: 'destination',
+        },
+        {
+          SourceName: 'source',
+          DestinationName: 'destination',
+        },
+        {
+          SourceName: 'source',
+          DestinationName: 'hiT',
+        },
+      ],
       {
-        SourceName: 'Hit',
-        DestinationName: 'destination',
-      },
-      {
-        SourceName: 'source',
-        DestinationName: 'destination',
-      },
-      {
-        SourceName: 'source',
-        DestinationName: 'hiT',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 2);
   });
   test('items are not found', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          SourceName: 'source',
+          DestinationName: 'destination',
+        },
+      ],
       {
-        SourceName: 'source',
-        DestinationName: 'destination',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
   test('items are found by *', function(assert) {
-    const actual = [
-      {
-        SourceName: '*',
-        DestinationName: 'destination',
-      },
-      {
-        SourceName: 'source',
-        DestinationName: '*',
-      },
-    ].filter(search('*'));
-    assert.equal(actual.length, 2);
-  });
-  test("* items are found by searching anything in 'All Services (*)'", function(assert) {
-    ['All Services (*)', 'SerVices', '(*)', '*', 'vIces', 'lL Ser'].forEach(term => {
-      const actual = [
+    const actual = new ExactSearch(
+      [
         {
           SourceName: '*',
           DestinationName: 'destination',
@@ -54,8 +51,31 @@ module('Unit | Search | Predicate | intention', function() {
           SourceName: 'source',
           DestinationName: '*',
         },
-      ].filter(search(term));
-      assert.equal(actual.length, 2);
+      ],
+      {
+        finders: predicates,
+      }
+    ).search('*');
+    assert.equal(actual.length, 2);
+  });
+  test("* items are found by searching anything in 'All Services (*)'", function(assert) {
+    const actual = new ExactSearch(
+      [
+        {
+          SourceName: '*',
+          DestinationName: 'destination',
+        },
+        {
+          SourceName: 'source',
+          DestinationName: '*',
+        },
+      ],
+      {
+        finders: predicates,
+      }
+    );
+    ['All Services (*)', 'SerVices', '(*)', '*', 'vIces', 'lL Ser'].forEach(term => {
+      assert.equal(actual.search(term).length, 2);
     });
   });
 });

--- a/ui/packages/consul-ui/tests/unit/search/predicates/kv-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/kv-test.js
@@ -1,32 +1,42 @@
-import predicates from 'consul-ui/search/predicates/kv';
-import { search as create } from 'consul-ui/services/search';
 import { module, test } from 'qunit';
 
+import ExactSearch from 'consul-ui/utils/search/exact';
+import predicates from 'consul-ui/search/predicates/kv';
+
 module('Unit | Search | Predicate | kv', function() {
-  const search = create(predicates);
   test('items are found by properties', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Key: 'HIT-here',
+        },
+        {
+          Key: 'folder-HIT/',
+        },
+        {
+          Key: 'excluded',
+        },
+        {
+          Key: 'really/long/path/HIT-here',
+        },
+      ],
       {
-        Key: 'HIT-here',
-      },
-      {
-        Key: 'folder-HIT/',
-      },
-      {
-        Key: 'excluded',
-      },
-      {
-        Key: 'really/long/path/HIT-here',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 3);
   });
   test('items are not found', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Key: 'key',
+        },
+      ],
       {
-        Key: 'key',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
 });

--- a/ui/packages/consul-ui/tests/unit/search/predicates/node-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/node-test.js
@@ -1,47 +1,67 @@
-import predicates from 'consul-ui/search/predicates/node';
-import { search as create } from 'consul-ui/services/search';
 import { module, test } from 'qunit';
 
+import ExactSearch from 'consul-ui/utils/search/exact';
+import predicates from 'consul-ui/search/predicates/node';
+
 module('Unit | Search | Predicate | node', function() {
-  const search = create(predicates);
   test('items are found by name', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Node: 'node-HIT',
+          Address: '10.0.0.0',
+        },
+        {
+          Node: 'node',
+          Address: '10.0.0.0',
+        },
+      ],
       {
-        Node: 'node-HIT',
-        Address: '10.0.0.0',
-      },
-      {
-        Node: 'node',
-        Address: '10.0.0.0',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 1);
   });
   test('items are found by IP address', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Node: 'node-HIT',
+          Address: '10.0.0.0',
+        },
+      ],
       {
-        Node: 'node-HIT',
-        Address: '10.0.0.0',
-      },
-    ].filter(search('10'));
+        finders: predicates,
+      }
+    ).search('10');
     assert.equal(actual.length, 1);
   });
   test('items are not found by name', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Node: 'name',
+          Address: '10.0.0.0',
+        },
+      ],
       {
-        Node: 'name',
-        Address: '10.0.0.0',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
   test('items are not found by IP address', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Node: 'name',
+          Address: '10.0.0.0',
+        },
+      ],
       {
-        Node: 'name',
-        Address: '10.0.0.0',
-      },
-    ].filter(search('9'));
+        finders: predicates,
+      }
+    ).search('9');
     assert.equal(actual.length, 0);
   });
 });

--- a/ui/packages/consul-ui/tests/unit/search/predicates/policy-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/policy-test.js
@@ -1,29 +1,39 @@
-import predicates from 'consul-ui/search/predicates/policy';
-import { search as create } from 'consul-ui/services/search';
 import { module, test } from 'qunit';
 
+import ExactSearch from 'consul-ui/utils/search/exact';
+import predicates from 'consul-ui/search/predicates/policy';
+
 module('Unit | Search | Predicate | policy', function() {
-  const search = create(predicates);
   test('items are found by properties', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Name: 'name-HIT',
+          Description: 'description',
+        },
+        {
+          Name: 'name',
+          Description: 'desc-HIT-ription',
+        },
+      ],
       {
-        Name: 'name-HIT',
-        Description: 'description',
-      },
-      {
-        Name: 'name',
-        Description: 'desc-HIT-ription',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 2);
   });
   test('items are not found', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Name: 'name',
+          Description: 'description',
+        },
+      ],
       {
-        Name: 'name',
-        Description: 'description',
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
 });

--- a/ui/packages/consul-ui/tests/unit/search/predicates/role-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/role-test.js
@@ -1,78 +1,93 @@
-import predicates from 'consul-ui/search/predicates/role';
-import { search as create } from 'consul-ui/services/search';
 import { module, test } from 'qunit';
 
+import ExactSearch from 'consul-ui/utils/search/exact';
+import predicates from 'consul-ui/search/predicates/role';
+
 module('Unit | Search | Predicate | role', function() {
-  const search = create(predicates);
   test('items are found by properties', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Name: 'name-HIT',
+          Description: 'description',
+          Policies: [],
+        },
+        {
+          Name: 'name',
+          Description: 'desc-HIT-ription',
+          Policies: [],
+        },
+        {
+          Name: 'name',
+          Description: 'description',
+          Policies: [{ Name: 'policy' }, { Name: 'policy-HIT' }],
+        },
+        {
+          Name: 'name',
+          Description: 'description',
+          ServiceIdentities: [
+            { ServiceName: 'service-identity' },
+            { ServiceName: 'service-identity-HIT' },
+          ],
+        },
+      ],
       {
-        Name: 'name-HIT',
-        Description: 'description',
-        Policies: [],
-      },
-      {
-        Name: 'name',
-        Description: 'desc-HIT-ription',
-        Policies: [],
-      },
-      {
-        Name: 'name',
-        Description: 'description',
-        Policies: [{ Name: 'policy' }, { Name: 'policy-HIT' }],
-      },
-      {
-        Name: 'name',
-        Description: 'description',
-        ServiceIdentities: [
-          { ServiceName: 'service-identity' },
-          { ServiceName: 'service-identity-HIT' },
-        ],
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 4);
   });
   test('items are not found', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Name: 'name',
+          Description: 'description',
+          Policies: [],
+        },
+        {
+          Name: 'name',
+          Description: 'description',
+          Policies: [{ Name: 'policy' }, { Name: 'policy-second' }],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          ServiceIdenitities: [{ ServiceName: 'si' }, { ServiceName: 'si-second' }],
+        },
+      ],
       {
-        Name: 'name',
-        Description: 'description',
-        Policies: [],
-      },
-      {
-        Name: 'name',
-        Description: 'description',
-        Policies: [{ Name: 'policy' }, { Name: 'policy-second' }],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        ServiceIdenitities: [{ ServiceName: 'si' }, { ServiceName: 'si-second' }],
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
   test('arraylike things can be empty', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          Name: 'name',
+          Description: 'description',
+        },
+        {
+          Name: 'name',
+          Description: 'description',
+          Policies: null,
+          ServiceIdentities: null,
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Policies: [],
+          ServiceIdentities: [],
+        },
+      ],
       {
-        Name: 'name',
-        Description: 'description',
-      },
-      {
-        Name: 'name',
-        Description: 'description',
-        Policies: null,
-        ServiceIdentities: null,
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Policies: [],
-        ServiceIdentities: [],
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
 });

--- a/ui/packages/consul-ui/tests/unit/search/predicates/service-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/service-test.js
@@ -1,54 +1,63 @@
-import { search } from 'consul-ui/services/search';
-import spec from 'consul-ui/search/predicates/service';
 import { module, test } from 'qunit';
 
-module('Unit | Search | Filter | service', function() {
-  const predicate = search(spec);
+import ExactSearch from 'consul-ui/utils/search/exact';
+import predicates from 'consul-ui/search/predicates/service';
+
+module('Unit | Search | Predicate | service', function() {
   test('items are found by properties', function(assert) {
-    [
+    const actual = new ExactSearch(
+      [
+        {
+          Name: 'name-HIT',
+          Tags: [],
+        },
+        {
+          Name: 'name',
+          Tags: ['tag', 'tag-withHiT'],
+        },
+      ],
       {
-        Name: 'name-HIT',
-        Tags: [],
-      },
-      {
-        Name: 'name',
-        Tags: ['tag', 'tag-withHiT'],
-      },
-    ].forEach(function(item) {
-      const actual = predicate('hit')(item);
-      assert.ok(actual);
-    });
+        finders: predicates,
+      }
+    ).search('hit');
+    assert.equal(actual.length, 2);
   });
   test('items are not found', function(assert) {
-    [
+    const actual = new ExactSearch(
+      [
+        {
+          Name: 'name',
+        },
+        {
+          Name: 'name',
+          Tags: ['one', 'two'],
+        },
+      ],
       {
-        Name: 'name',
-      },
-      {
-        Name: 'name',
-        Tags: ['one', 'two'],
-      },
-    ].forEach(function(item) {
-      const actual = predicate('hit')(item);
-      assert.notOk(actual);
-    });
+        finders: predicates,
+      }
+    ).search('hit');
+    assert.equal(actual.length, 0);
   });
   test('tags can be empty', function(assert) {
-    [
+    const actual = new ExactSearch(
+      [
+        {
+          Name: 'name',
+        },
+        {
+          Name: 'name',
+          Tags: null,
+        },
+        {
+          Name: 'name',
+          Tags: [],
+        },
+      ],
       {
-        Name: 'name',
-      },
-      {
-        Name: 'name',
-        Tags: null,
-      },
-      {
-        Name: 'name',
-        Tags: [],
-      },
-    ].forEach(function(item) {
-      const actual = predicate('hit')(item);
-      assert.notOk(actual);
-    });
+        finders: predicates,
+      }
+    ).search('hit');
+    assert.equal(actual.length, 0);
   });
 });

--- a/ui/packages/consul-ui/tests/unit/search/predicates/token-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/token-test.js
@@ -1,126 +1,141 @@
-import predicates from 'consul-ui/search/predicates/token';
-import { search as create } from 'consul-ui/services/search';
 import { module, test } from 'qunit';
 
-module('Unit | Search | Filter | token', function() {
-  const search = create(predicates);
+import ExactSearch from 'consul-ui/utils/search/exact';
+import predicates from 'consul-ui/search/predicates/token';
+
+module('Unit | Search | Predicate | token', function() {
   test('items are found by properties', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Policies: [],
+        },
+        {
+          AccessorID: 'HIT-id',
+          Name: 'name',
+          Description: 'description',
+          Policies: [],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name-HIT',
+          Description: 'description',
+          Policies: [],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'desc-HIT-ription',
+          Policies: [],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Policies: [{ Name: 'policy' }, { Name: 'policy-HIT' }],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Roles: [{ Name: 'role' }, { Name: 'role-HIT' }],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          ServiceIdentities: [
+            { ServiceName: 'service-identity' },
+            { ServiceName: 'service-identity-HIT' },
+          ],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          NodeIdentities: [{ NodeName: 'node-identity' }, { NodeName: 'node-identity-HIT' }],
+        },
+      ],
       {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Policies: [],
-      },
-      {
-        AccessorID: 'HIT-id',
-        Name: 'name',
-        Description: 'description',
-        Policies: [],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name-HIT',
-        Description: 'description',
-        Policies: [],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'desc-HIT-ription',
-        Policies: [],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Policies: [{ Name: 'policy' }, { Name: 'policy-HIT' }],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Roles: [{ Name: 'role' }, { Name: 'role-HIT' }],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        ServiceIdentities: [
-          { ServiceName: 'service-identity' },
-          { ServiceName: 'service-identity-HIT' },
-        ],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        NodeIdentities: [{ NodeName: 'node-identity' }, { NodeName: 'node-identity-HIT' }],
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 7);
   });
   test('items are not found', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Policies: [],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Policies: [{ Name: 'policy' }, { Name: 'policy-second' }],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Roles: [{ Name: 'role' }, { Name: 'role-second' }],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          ServiceIdentities: [{ ServiceName: 'si' }, { ServiceName: 'si-second' }],
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          NodeIdentities: [{ NodeName: 'si' }, { NodeName: 'si-second' }],
+        },
+      ],
       {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Policies: [],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Policies: [{ Name: 'policy' }, { Name: 'policy-second' }],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Roles: [{ Name: 'role' }, { Name: 'role-second' }],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        ServiceIdentities: [{ ServiceName: 'si' }, { ServiceName: 'si-second' }],
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        NodeIdentities: [{ NodeName: 'si' }, { NodeName: 'si-second' }],
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
   test('arraylike things can be empty', function(assert) {
-    const actual = [
+    const actual = new ExactSearch(
+      [
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Policies: null,
+          Roles: null,
+          ServiceIdentities: null,
+          NodeIdentities: null,
+        },
+        {
+          AccessorID: 'id',
+          Name: 'name',
+          Description: 'description',
+          Policies: [],
+          Roles: [],
+          ServiceIdentities: [],
+          NodeIdentities: [],
+        },
+      ],
       {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Policies: null,
-        Roles: null,
-        ServiceIdentities: null,
-        NodeIdentities: null,
-      },
-      {
-        AccessorID: 'id',
-        Name: 'name',
-        Description: 'description',
-        Policies: [],
-        Roles: [],
-        ServiceIdentities: [],
-        NodeIdentities: [],
-      },
-    ].filter(search('hit'));
+        finders: predicates,
+      }
+    ).search('hit');
     assert.equal(actual.length, 0);
   });
 });

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9869,11 +9869,6 @@ fuse.js@^3.6.1:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.6.1.tgz#7de85fdd6e1b3377c23ce010892656385fd9b10c"
   integrity sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==
 
-fuse.js@^6.4.3:
-  version "6.4.3"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.3.tgz#aadd6ac34aab5b1d6e6c60462fcb4d1c3f53bb01"
-  integrity sha512-JNgngolukIrqwayWnvy6NLH63hmwKPhm63o0uyBg51jPD0j09IvAzlV1rTXfAsgxpghI7khAo6Mv+EmvjDWXig==
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9869,6 +9869,11 @@ fuse.js@^3.6.1:
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.6.1.tgz#7de85fdd6e1b3377c23ce010892656385fd9b10c"
   integrity sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==
 
+fuse.js@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.3.tgz#aadd6ac34aab5b1d6e6c60462fcb4d1c3f53bb01"
+  integrity sha512-JNgngolukIrqwayWnvy6NLH63hmwKPhm63o0uyBg51jPD0j09IvAzlV1rTXfAsgxpghI7khAo6Mv+EmvjDWXig==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
This PR unfortunately moves search things around yet again to match an interface that can be switched in and out of fuzzy searching using fuse.js. We add both fuzzy searching and regex based searching to the codebase here, but it is not yet compiled in.

Once we have some sort of UI widget designed to enable you to select the type of searching you want to use (and store it in local storage), we'll add these into the build.

Unfortunately, there is a little more movement to come in a future PR in order to add a visual status for the filters.