### PR TITLE
ui: [BUGFIX] Use InformedAction for KV confirmation dialogs

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
@@ -23,31 +23,36 @@ as |item index|>
           <li role="none" class="dangerous">
             <label for={{confirm}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Delete</label>
             <div role="menu">
-              <div class="confirmation-alert warning">
-                <div>
-                  <header>
-                    Confirm Delete
-                  </header>
+              <InformedAction
+                class="warning"
+              >
+                <:header>
+                  Confirm Delete
+                </:header>
+                <:body>
                   <p>
-                    Are you sure you want to delete this key?
+                    Are you sure you want to delete this KV entry?
                   </p>
-                </div>
-                <ul>
-                  <li class="dangerous">
-                    <button
-                      tabindex="-1"
-                      type="button"
+                </:body>
+                <:actions as |Actions|>
+                  <Actions.Action class="dangerous">
+                    <Action
                       class="type-delete"
-                      onclick={{queue (action change) (action @delete item)}}
+                      tabindex="-1"
+                      {{on 'click' (queue (action change) (action @delete item))}}
                     >
                       Delete
-                    </button>
-                  </li>
-                  <li>
-                    <label for={{confirm}}>Cancel</label>
-                  </li>
-                </ul>
-              </div>
+                    </Action>
+                  </Actions.Action>
+                  <Actions.Action>
+                    <Action
+                      @for={{confirm}}
+                    >
+                      Cancel
+                    </Action>
+                  </Actions.Action>
+                </:actions>
+              </InformedAction>
             </div>
           </li>
       </BlockSlot>


### PR DESCRIPTION
Similar to #9398:

During #9305 we added an InformedAction component 'underneath' our ConfirmationAlerts so we could easily use the design for things other than a 'confirmation'

Unfortunately we omitted reimplementing this in our KV listing which uses a table instead of a list like most of our other listings.

This PR uses the InformedAction for KVListings also and fixes the problem in 1.9.1

Fixes https://github.com/hashicorp/consul/issues/9423