### PR TITLE
connect: connect CA Roots in the primary datacenter should use a SigningKeyID derived from their local intermediate

### DIFF
--- a/.changelog/9428.txt
+++ b/.changelog/9428.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: connect CA Roots in the primary datacenter should use a SigningKeyID derived from their local intermediate
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -359,10 +359,14 @@ ifeq ("$(CIRCLECI)","true")
 	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -- -cover -coverprofile=coverage.txt ./agent/connect/ca
 # Run leader tests that require Vault
 	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report-leader.xml" -- -cover -coverprofile=coverage-leader.txt -run TestLeader_Vault_ ./agent/consul
+# Run agent tests that require Vault
+	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report-agent.xml" -- -cover -coverprofile=coverage-agent.txt -run '.*_Vault_' ./agent
 else
 # Run locally
 	@echo "Running /agent/connect/ca tests in verbose mode"
 	@go test -v ./agent/connect/ca
+	@go test -v ./agent/consul -run 'TestLeader_Vault_'
+	@go test -v ./agent -run '.*_Vault_'
 endif
 
 proto: $(PROTOGOFILES) $(PROTOGOBINFILES)

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -458,7 +458,6 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 	}
 	if activeRoot != nil && needsSigningKeyUpdate {
 		c.logger.Info("Correcting stored SigningKeyID value", "previous", rootCA.SigningKeyID, "updated", expectedSigningKeyID)
-		rootCA.SigningKeyID = expectedSigningKeyID
 
 	} else if activeRoot != nil && !needsSigningKeyUpdate {
 		// This state shouldn't be possible to get into because we update the root and
@@ -471,6 +470,10 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 		c.setCAProvider(provider, rootCA)
 
 		return nil
+	}
+
+	if needsSigningKeyUpdate {
+		rootCA.SigningKeyID = expectedSigningKeyID
 	}
 
 	// Get the highest index

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -416,7 +416,7 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 	if err != nil {
 		return fmt.Errorf("error generating intermediate cert: %v", err)
 	}
-	_, err = connect.ParseCert(interPEM)
+	intermediateCert, err := connect.ParseCert(interPEM)
 	if err != nil {
 		return fmt.Errorf("error getting intermediate cert: %v", err)
 	}
@@ -439,6 +439,13 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 		}
 	}
 
+	// Versions prior to 1.9.2, 1.8.8, and 1.7.12 incorrectly used the primary
+	// rootCA's subjectKeyID here instead of the intermediate. For
+	// provider=consul this didn't matter since there are no intermediates in
+	// the primaryDC, but for vault it does matter.
+	expectedSigningKeyID := connect.EncodeSigningKeyID(intermediateCert.SubjectKeyId)
+	needsSigningKeyUpdate := (rootCA.SigningKeyID != expectedSigningKeyID)
+
 	// Check if the CA root is already initialized and exit if it is,
 	// adding on any existing intermediate certs since they aren't directly
 	// tied to the provider.
@@ -449,7 +456,10 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 	if err != nil {
 		return err
 	}
-	if activeRoot != nil {
+	if activeRoot != nil && needsSigningKeyUpdate {
+		c.logger.Info("Correcting stored SigningKeyID value", "previous", rootCA.SigningKeyID, "updated", expectedSigningKeyID)
+
+	} else if activeRoot != nil && !needsSigningKeyUpdate {
 		// This state shouldn't be possible to get into because we update the root and
 		// CA config in the same FSM operation.
 		if activeRoot.ID != rootCA.ID {
@@ -460,6 +470,10 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 		c.setCAProvider(provider, rootCA)
 
 		return nil
+	}
+
+	if needsSigningKeyUpdate {
+		rootCA.SigningKeyID = expectedSigningKeyID
 	}
 
 	// Get the highest index

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -439,7 +439,7 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 		}
 	}
 
-	// Versions prior to 1.9.2, 1.8.8, and 1.7.12 incorrectly used the primary
+	// Versions prior to 1.9.3, 1.8.8, and 1.7.12 incorrectly used the primary
 	// rootCA's subjectKeyID here instead of the intermediate. For
 	// provider=consul this didn't matter since there are no intermediates in
 	// the primaryDC, but for vault it does matter.

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -458,6 +458,7 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 	}
 	if activeRoot != nil && needsSigningKeyUpdate {
 		c.logger.Info("Correcting stored SigningKeyID value", "previous", rootCA.SigningKeyID, "updated", expectedSigningKeyID)
+		rootCA.SigningKeyID = expectedSigningKeyID
 
 	} else if activeRoot != nil && !needsSigningKeyUpdate {
 		// This state shouldn't be possible to get into because we update the root and
@@ -470,10 +471,6 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 		c.setCAProvider(provider, rootCA)
 
 		return nil
-	}
-
-	if needsSigningKeyUpdate {
-		rootCA.SigningKeyID = expectedSigningKeyID
 	}
 
 	// Get the highest index

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -609,7 +609,7 @@ func TestLeader_Vault_PrimaryCA_FixSigningKeyID_OnRestart(t *testing.T) {
 
 	testrpc.WaitForLeader(t, s1pre.RPC, "dc1")
 
-	// Restore the pre-1.9.2/1.8.8/1.7.12 behavior of the SigningKeyID not being derived
+	// Restore the pre-1.9.3/1.8.8/1.7.12 behavior of the SigningKeyID not being derived
 	// from the intermediates in the primary (which only matters for provider=vault).
 	var primaryRootSigningKeyID string
 	{

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -639,7 +639,7 @@ func TestLeader_Vault_PrimaryCA_FixSigningKeyID_OnRestart(t *testing.T) {
 		}
 	}
 
-	// Shutdown s2pre and restart it to trigger the secondary CA init to correct
+	// Shutdown s1pre and restart it to trigger the secondary CA init to correct
 	// the SigningKeyID.
 	s1pre.Shutdown()
 

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -671,6 +671,12 @@ func (s *state) run() {
 }
 
 func (s *state) handleUpdate(u cache.UpdateEvent, snap *ConfigSnapshot) error {
+	s.logger.Trace("handleUpdate saw cache event",
+		"correlationID", u.CorrelationID,
+		"kind", s.kind,
+		"error", u.Err,
+	)
+
 	switch s.kind {
 	case structs.ServiceKindConnectProxy:
 		return s.handleUpdateConnectProxy(u, snap)

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -671,12 +671,6 @@ func (s *state) run() {
 }
 
 func (s *state) handleUpdate(u cache.UpdateEvent, snap *ConfigSnapshot) error {
-	s.logger.Trace("handleUpdate saw cache event",
-		"correlationID", u.CorrelationID,
-		"kind", s.kind,
-		"error", u.Err,
-	)
-
 	switch s.kind {
 	case structs.ServiceKindConnectProxy:
 		return s.handleUpdateConnectProxy(u, snap)


### PR DESCRIPTION
This fixes an issue where leaf certificates issued in primary
datacenters using Vault as a Connect CA would be reissued very
frequently (every ~20 seconds) because the logic meant to detect root
rotation was errantly triggering.

The hash of the rootCA was being compared against a hash of the
intermediateCA and always failing. This doesn't apply to the Consul
built-in CA provider because there is no intermediate in use in the
primary DC.

This is reminiscent of #6513.