### PR TITLE
docs: Remove beta tag for 1.8 and 1.9 features

### DIFF
--- a/website/content/api-docs/acl/index.mdx
+++ b/website/content/api-docs/acl/index.mdx
@@ -390,7 +390,7 @@ $ curl \
 
 <EnterpriseAlert>
   {' '}
-  This is an enterprise only endpoint. This feature is currently in beta.{' '}
+  This is an enterprise only endpoint.
 </EnterpriseAlert>
 
 This endpoint was added in Consul 1.8.0 and is used to obtain an authorization
@@ -469,7 +469,7 @@ $ curl \
 
 <EnterpriseAlert>
   {' '}
-  This is an enterprise only endpoint. This feature is currently in beta.{' '}
+  This is an enterprise only endpoint.
 </EnterpriseAlert>
 
 This endpoint was added in Consul 1.8.0 and is used to exchange an OIDC

--- a/website/content/api-docs/connect/intentions.mdx
+++ b/website/content/api-docs/connect/intentions.mdx
@@ -17,7 +17,7 @@ migrated to the
 [`service-intentions`](/docs/agent/config-entries/service-intentions)
 config entry kind.
 
-## Upsert Intention by Name ((#upsert-intention-by-name)) <sup>Beta</sup>
+## Upsert Intention by Name ((#upsert-intention-by-name))
 
 -> **1.9.0+:** This API is available in Consul versions 1.9.0 and later.
 
@@ -289,7 +289,7 @@ $ curl \
     http://127.0.0.1:8500/v1/connect/intentions/e9ebc19f-d481-42b1-4871-4d298d3acd5c
 ```
 
-## Read Specific Intention by Name ((##read-specific-intention-by-name)) <sup>Beta</sup>
+## Read Specific Intention by Name ((##read-specific-intention-by-name))
 
 This endpoint reads a specific intention by its unique source and destination.
 
@@ -511,7 +511,7 @@ the following selectors and filter operations being supported:
 | `SourceName`      | Equal, Not Equal, In, Not In, Matches, Not Matches |
 | `SourceType`      | Equal, Not Equal, In, Not In, Matches, Not Matches |
 
-## Delete Intention by Name ((#delete-intention-by-name)) <sup>Beta</sup>
+## Delete Intention by Name ((#delete-intention-by-name))
 
 -> **1.9.0+:** This API is available in Consul versions 1.9.0 and later.
 

--- a/website/content/docs/agent/config-entries/index.mdx
+++ b/website/content/docs/agent/config-entries/index.mdx
@@ -34,7 +34,7 @@ The supported `Kind` names for configuration entries are:
 - [`service-defaults`](/docs/agent/config-entries/service-defaults) - configures
   defaults for all the instances of a given service
 
-- [`service-intentions`](/docs/agent/config-entries/service-intentions) <sup>Beta</sup> - defines
+- [`service-intentions`](/docs/agent/config-entries/service-intentions) - defines
   the [intentions](/docs/connect/intentions) for a destination service
 
 - [`service-resolver`](/docs/agent/config-entries/service-resolver) - matches

--- a/website/content/docs/agent/config-entries/service-intentions.mdx
+++ b/website/content/docs/agent/config-entries/service-intentions.mdx
@@ -1,14 +1,14 @@
 ---
 layout: docs
-page_title: 'Configuration Entry Kind: Service Intentions (beta)'
-sidebar_title: service-intentions <sup>Beta</sup>
+page_title: 'Configuration Entry Kind: Service Intentions'
+sidebar_title: service-intentions
 description: >-
   The service-intentions config entry kind controls Connect traffic
   authorization for both networking layer 4 (e.g. TCP) and networking layer 7
   (e.g. HTTP).
 ---
 
-# Service Intentions ((#service-intentions)) <sup>Beta</sup>
+# Service Intentions ((#service-intentions))
 
 -> **1.9.0+:** This config entry is available in Consul versions 1.9.0 and newer.
 

--- a/website/content/docs/k8s/crds/index.mdx
+++ b/website/content/docs/k8s/crds/index.mdx
@@ -55,7 +55,7 @@ and enable the controller that acts on them:
 ```yaml
 global:
   name: consul
-  image: 'consul:1.9.0-beta1' # consul >= 1.8.4 must be used
+  image: 'consul:1.9.0' # consul >= 1.8.4 must be used
   imageK8S: 'hashicorp/consul-k8s:0.20.0'
 
 controller:
@@ -68,7 +68,7 @@ connectInject:
 Note that:
 
 1. `controller.enabled: true` installs the CRDs and enables the controller.
-1. `global.image` must be a Consul version `>= 1.8.4`, e.g. `consul:1.8.4` or `consul:1.9.0-beta1`.
+1. `global.image` must be a Consul version `>= 1.8.4`, e.g. `consul:1.8.4` or `consul:1.9.0`.
 1. `global.imageK8S` must be `>= 0.20.0`
 1. Configuration entries are used to configure Consul service mesh so it's also
    expected that `connectInject` will be enabled.
@@ -259,7 +259,7 @@ Notes:
 1. See [service-defaults](/docs/agent/config-entries/service-defaults) for full
    documentation on this config entry.
 
-### ServiceIntentions <sup>(Beta)</sup>
+### ServiceIntentions
 
 A [service-intentions](/docs/agent/config-entries/service-intentions)
 entry configures traffic authorization for a destination service.


### PR DESCRIPTION
Remove beta tag for 1.8 and 1.9 features which are now GA.