### PR TITLE
ui: [BUGFIX] Role/Policy selector default sort

### DIFF
--- a/ui/packages/consul-ui/app/components/child-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/child-selector/index.hbs
@@ -23,7 +23,7 @@
       <PowerSelect
         @searchEnabled={{true}}
         @search={{action collection.search}}
-        @options={{options}}
+        @options={{sort-by 'Name:asc' options}}
         @loadingMessage="Loading..."
         @searchMessage="No possible options"
         @searchPlaceholder={{placeholder}}

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
@@ -10,10 +10,10 @@ Feature: dc / acls / policies / as many / add existing: Add existing policy
     ---
     And 2 policy models from yaml
     ---
-    - ID: policy-1
-      Name: Policy 1
     - ID: policy-2
       Name: Policy 2
+    - ID: policy-1
+      Name: Policy 1
     ---
     When I visit the [Model] page for yaml
     ---
@@ -22,6 +22,7 @@ Feature: dc / acls / policies / as many / add existing: Add existing policy
     ---
     Then the url should be /datacenter/acls/[Model]s/key
     And I click "form > #policies .ember-power-select-trigger"
+    And I see the text "Policy 1" in ".ember-power-select-option:first-child"
     And I type "Policy 1" into ".ember-power-select-search-input"
     And I click ".ember-power-select-option:first-child"
     And I see 1 policy model on the policies component

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
@@ -10,10 +10,10 @@ Feature: dc / acls / roles / as many / add existing: Add existing
     ---
     And 2 role models from yaml
     ---
-    - ID: role-1
-      Name: Role 1
     - ID: role-2
       Name: Role 2
+    - ID: role-1
+      Name: Role 1
     ---
     When I visit the token page for yaml
     ---
@@ -22,6 +22,7 @@ Feature: dc / acls / roles / as many / add existing: Add existing
     ---
     Then the url should be /datacenter/acls/tokens/key
     And I click "form > #roles .ember-power-select-trigger"
+    And I see the text "Role 1" in ".ember-power-select-option:first-child"
     And I type "Role 1" into ".ember-power-select-search-input"
     And I click ".ember-power-select-option:first-child"
     And I see 1 role model on the roles component


### PR DESCRIPTION
`ember-power-select` seems to have a somewhat interesting search API in that makes for a strange search/sort implementation.

1. The `options=""` attribute that the select will use for its options **is only when you are not searching using ember-power-select, or the search field is blank**
2. The `search=""` attribute (along with the `searchEnabled={{true}}` attribute) which accepts a function to which the search term is passed that should return a set of options as a result of the search. **If the search field is empty the function is not called and the menu instead uses `options` again**

So when the search is blank the menu will use the `options=""` for its options, not the result of the `search=""` function even when `searchEnabled={{true}}`.

We revisited our power-select related search and sort here https://github.com/hashicorp/consul/pull/9236, where we provided an additional interface to our `DataCollection` component in order for the search functionality to be callable by ember-power-selects `search=""` function. This was fine when searching as it returns the searched and sorted dataset, but when you are not searching/search is empty this means the options aren't sorted :S.

Moreover, we cannot just set `options={{collection.items}}` in order to provide a sorted collection when not searching or searching is blank, as when the search field is emptied after searching, the menu will revert back to using the `options=""` attribute for its dataset without clearing the last call to its search function/recalling the search function with a blank value. This means `collection.items` keeps the result of the last non-blank search i.e. if you search 'role' and then remove the search by deleting each letter one by one, `collection.items` will contain the results of a search for 'r'.

We could have used a second `DataCollection` component here, using one for the result of `search={{action collection1.search}}` and one for `options={{collection2.items}}`, but as we only need to sort here we just use ember-composable-helpers `{{sort-by}}`. If the sorting becomes more complicated for such an interaction, we can move to use 2 `DataCollection` components.

Tests added here for a simple check for the correct sorting in these menus.



