### PR TITLE
structs: fix caching of ServiceSpecificRequest when ingress=true

### DIFF
--- a/.changelog/9436.txt
+++ b/.changelog/9436.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cache: Fixed a bug where a DNS or API request for an ingress gateway would incorrectly
+return a cached result for a service request with the same name, and vice versa.
+``

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -617,6 +617,7 @@ func (r *ServiceSpecificRequest) CacheInfo() cache.RequestInfo {
 		r.Connect,
 		r.Filter,
 		r.EnterpriseMeta,
+		r.Ingress,
 	}, nil)
 	if err == nil {
 		// If there is an error, we don't set the key. A blank key forces

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1542,8 +1542,6 @@ func TestServiceSpecificRequestCacheInfoKey(t *testing.T) {
 	ignoredFields := map[string]bool{
 		// TODO: should this filed be included?
 		"ServiceKind": true,
-		// TODO: this filed should be included: github.com/hashicorp/consul/pull/9436
-		"Ingress": true,
 	}
 
 	assertCacheInfoKeyIsComplete(t, &ServiceSpecificRequest{}, ignoredFields)
@@ -1714,6 +1712,16 @@ func TestSpecificServiceRequest_CacheInfo(t *testing.T) {
 				req.ServiceTag = "bar"
 			},
 			wantSame: false,
+		},
+		{
+			name: "with integress=true",
+			req: ServiceSpecificRequest{
+				Datacenter:  "dc1",
+				ServiceName: "my-service",
+			},
+			mutate: func(req *ServiceSpecificRequest) {
+				req.Ingress = true
+			},
 		},
 	}
 


### PR DESCRIPTION
The field was not being included in the cache info key. This would result in a DNS request for
`web.service.consul` returning the same result as `web.ingress.consul`, when those results should
not be the same. The same bug existed in the HTTP api when the cache is enabled.

Issue reported by @blake 

This PR fixes the problem by adding the field to the cache key.