### PR TITLE
Fix bug in usage metrics when multiple service instances are changed in a single transaction

### DIFF
--- a/.changelog/9440.txt
+++ b/.changelog/9440.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+state: fix computation of usage metrics to account for various places that can modify multiple services in a single transaction.
+```

--- a/agent/consul/state/usage_oss.go
+++ b/agent/consul/state/usage_oss.go
@@ -3,12 +3,15 @@
 package state
 
 import (
+	"github.com/hashicorp/consul/agent/structs"
 	memdb "github.com/hashicorp/go-memdb"
 )
 
 type EnterpriseServiceUsage struct{}
 
-func addEnterpriseServiceUsage(map[string]int, memdb.Change, uniqueServiceState) {}
+func addEnterpriseServiceInstanceUsage(map[string]int, memdb.Change) {}
+
+func addEnterpriseServiceUsage(map[string]int, map[structs.ServiceName]uniqueServiceState) {}
 
 func compileEnterpriseUsage(tx ReadTxn, usage ServiceUsage) (ServiceUsage, error) {
 	return usage, nil

--- a/agent/consul/state/usage_test.go
+++ b/agent/consul/state/usage_test.go
@@ -55,6 +55,43 @@ func TestStateStore_Usage_ServiceUsageEmpty(t *testing.T) {
 	require.Equal(t, usage.ServiceInstances, 0)
 }
 
+func TestStateStore_Usage_ServiceUsage_DeleteNode(t *testing.T) {
+	s := testStateStore(t)
+	testRegisterNode(t, s, 1, "node1")
+
+	svc1 := &structs.NodeService{
+		ID:      "service1",
+		Service: "test",
+		Address: "1.1.1.1",
+		Port:    1111,
+	}
+	svc2 := &structs.NodeService{
+		ID:      "service2",
+		Service: "test",
+		Address: "1.1.1.1",
+		Port:    1111,
+	}
+
+	// Register multiple instances on a single node to test that we do not
+	// double count deletions within the same transaction.
+	require.NoError(t, s.EnsureService(1, "node1", svc1))
+	require.NoError(t, s.EnsureService(2, "node1", svc2))
+
+	idx, usage, err := s.ServiceUsage()
+	require.NoError(t, err)
+	require.Equal(t, idx, uint64(2))
+	require.Equal(t, usage.Services, 1)
+	require.Equal(t, usage.ServiceInstances, 2)
+
+	require.NoError(t, s.DeleteNode(3, "node1"))
+
+	idx, usage, err = s.ServiceUsage()
+	require.NoError(t, err)
+	require.Equal(t, idx, uint64(3))
+	require.Equal(t, usage.Services, 0)
+	require.Equal(t, usage.ServiceInstances, 0)
+}
+
 func TestStateStore_Usage_Restore(t *testing.T) {
 	s := testStateStore(t)
 	restore := s.Restore()
@@ -67,12 +104,27 @@ func TestStateStore_Usage_Restore(t *testing.T) {
 			Address: "198.18.0.2",
 		},
 	})
+	restore.Registration(9, &structs.RegisterRequest{
+		Node: "test-node",
+		Service: &structs.NodeService{
+			ID:      "mysql1",
+			Service: "mysql",
+			Port:    8081,
+			Address: "198.18.0.2",
+		},
+	})
 	require.NoError(t, restore.Commit())
 
 	idx, count, err := s.NodeCount()
 	require.NoError(t, err)
 	require.Equal(t, idx, uint64(9))
 	require.Equal(t, count, 1)
+
+	idx, usage, err := s.ServiceUsage()
+	require.NoError(t, err)
+	require.Equal(t, idx, uint64(9))
+	require.Equal(t, usage.Services, 1)
+	require.Equal(t, usage.ServiceInstances, 2)
 }
 
 func TestStateStore_Usage_updateUsage_Underflow(t *testing.T) {
@@ -92,8 +144,12 @@ func TestStateStore_Usage_updateUsage_Underflow(t *testing.T) {
 	}
 
 	err := updateUsage(txn, changes)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "negative count")
+	require.NoError(t, err)
+
+	// Check that we do not underflow
+	u, err := txn.First("usage", "id", "nodes")
+	require.NoError(t, err)
+	require.Equal(t, 0, u.(*UsageEntry).Count)
 
 	// A insert a change to create a usage entry
 	changes = Changes{
@@ -128,8 +184,12 @@ func TestStateStore_Usage_updateUsage_Underflow(t *testing.T) {
 	}
 
 	err = updateUsage(txn, changes)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "negative count")
+	require.NoError(t, err)
+
+	// Check that we do not underflow
+	u, err = txn.First("usage", "id", "nodes")
+	require.NoError(t, err)
+	require.Equal(t, 0, u.(*UsageEntry).Count)
 }
 
 func TestStateStore_Usage_ServiceUsage_updatingServiceName(t *testing.T) {


### PR DESCRIPTION
## Symptom

A log line like so:
```
2020-12-18T20:39:41.784Z [WARN]  agent.fsm: DeleteNode failed: error="failed to insert usage entry for "service-names": delta will cause a negative count"
```

### Cause
When multiple service instances are registered/deregistered at once, usage metrics of service names would be computed incorrectly, eventually leading to state store errors like the above. This could happen on `DeleteNode` RPCs, and also when Consul does a restore.

To fix, we collect all of the memdb changes and then do a pass through the updated memdb state to reconcile, instead of dealing with the memdb changes one at a time.

Unfortunately it might not error out immediately, if you have enough services that the count does not go negative. Instead, the usage metrics will be subtly wrong until another service deletion forces the count negative.

### Testing

I have tested out reproduction cases involving both
```
curl -s -XPUT -H"X-Consul-Token: $CONSUL_HTTP_TOKEN" $CONSUL_HTTP_ADDR/v1/catalog/deregister -d '{"Node": "consul-dc1-client0"}'
```

and 

```
$ consul snapshot save testing.snap
Saved and verified snapshot to index 161
$ consul snapshot restore testing.snap
Restored snapshot
```

while watching:
```
$ curl -s -H"X-Consul-Token: $CONSUL_HTTP_TOKEN" $CONSUL_HTTP_ADDR/v1/agent/metrics | jq '.Gauges[] | select(.Name | contains("state"))'
```
and this PR does fix the issues and correctly computes usage metrics.