### PR TITLE
ui: Add EmptyState for exposed paths, plus additional details

### DIFF
--- a/ui/packages/consul-ui/app/components/action/index.hbs
+++ b/ui/packages/consul-ui/app/components/action/index.hbs
@@ -1,35 +1,27 @@
-{{#if @for}}
+{{#if @for~}}
   <label
     for={{@for}}
     ...attributes
-  >
-    {{yield}}
-  </label>
-{{else if @href}}
-  {{#if @external}}
+  >{{yield}}</label>
+{{~else if @href~}}
+  {{~#if @external~}}
     <a
       href={{@href}}
       target="_blank"
       rel="noopener noreferrer"
       ...attributes
-    >
-      {{yield}}
-    </a>
-  {{else}}
+    >{{yield}}</a>
+  {{~else~}}
     <a
       href={{@href}}
       ...attributes
-    >
-      {{yield}}
-    </a>
-  {{/if}}
-{{else}}
+    >{{yield}}</a>
+  {{~/if~}}
+{{~else~}}
   <button
     tabindex="-1"
     type="button"
     {{on 'click' (optional @onclick)}}
     ...attributes
-  >
-    {{yield}}
-  </button>
-{{/if}}
+  >{{yield}}</button>
+{{~/if}}

--- a/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.hbs
@@ -37,7 +37,7 @@
         <dl class="port">
           <dt>
             <Tooltip>
-              ListenerPort
+              Listener Port
             </Tooltip>
           </dt>
           <dd>
@@ -49,7 +49,7 @@
         <dl class="port">
           <dt>
             <Tooltip>
-              LocalPathPort
+              Local Path Port
             </Tooltip>
           </dt>
           <dd>

--- a/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.hbs
@@ -8,7 +8,7 @@
   {{#each @items as |path|}}
     <li>
       <div class="header">
-      {{#let (concat address ':' path.Path) as |combinedAddress|}}
+      {{#let (concat address ':' path.ListenerPort path.Path) as |combinedAddress|}}
         <p class="combined-address">
           <span>
             {{combinedAddress}}
@@ -37,7 +37,7 @@
         <dl class="port">
           <dt>
             <Tooltip>
-                Port
+              ListenerPort
             </Tooltip>
           </dt>
           <dd>
@@ -49,7 +49,7 @@
         <dl class="port">
           <dt>
             <Tooltip>
-                Port
+              LocalPathPort
             </Tooltip>
           </dt>
           <dd>
@@ -61,7 +61,7 @@
         <dl class="path">
           <dt>
             <Tooltip>
-                Path
+              Path
             </Tooltip>
           </dt>
           <dd>

--- a/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.hbs
@@ -8,7 +8,7 @@
   {{#each @items as |path|}}
     <li>
       <div class="header">
-      {{#let (concat address ':' path.ListenerPort path.Path) as |combinedAddress|}}
+      {{#let (concat @address ':' path.ListenerPort path.Path) as |combinedAddress|}}
         <p class="combined-address">
           <span>
             {{combinedAddress}}

--- a/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.js
+++ b/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui/packages/consul-ui/app/templates/dc/services/instance/exposedpaths.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance/exposedpaths.hbs
@@ -2,9 +2,21 @@
   <div role="tabpanel">
   {{#if (gt proxy.Service.Proxy.Expose.Paths.length 0)}}
     <p>
-      The following list shows individual HTTP paths exposed through Envoy for external services like Prometheus. Read more about this in our documentation.
+      The following list shows individual HTTP paths exposed through Envoy for external services like Prometheus. Read more about this in our <Action @href={{concat (env 'CONSUL_DOCS_URL') '/connect/registration/service-registration#expose-paths-configuration-reference'}} @external={{true}}>documentation</Action>.
     </p>
-    <Consul::ExposedPath::List @items={{proxy.Service.Proxy.Expose.Paths}} @address={{item.Address}} />
+    {{! Uses the IP address of the proxy, not the service }}
+    <Consul::ExposedPath::List
+      @items={{proxy.Service.Proxy.Expose.Paths}}
+      @address={{proxy.Address}}
+    />
+  {{else}}
+    <EmptyState>
+      <BlockSlot @name="body">
+        <p>
+          There are no individual HTTP paths exposed through Envoy for external services like Prometheus. Read more about this in our <Action @href={{concat (env 'CONSUL_DOCS_URL') '/connect/registration/service-registration#expose-paths-configuration-reference'}} @external={{true}}>documentation</Action>.
+        </p>
+      </BlockSlot>
+    </EmptyState>
   {{/if}}
   </div>
 </div>


### PR DESCRIPTION
1. Add the port to the combined address
2. Use the proxy address for the ip address used in the combined address.
3. Add an empty state for when you don't have any ExposedPaths with some info plus a docs link.

Note: We started using our `Action` component a bit more here (our 'you can click on this to do something' component), we had to add some ember related whitespace ignoring here hence the `~`s