### PR TITLE
ui: Fix up erroneously placed conditional in Upstreams listing

### DIFF
--- a/ui/packages/consul-ui/app/templates/dc/services/instance/upstreams.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance/upstreams.hbs
@@ -22,31 +22,31 @@
           searchproperty=(action (mut searchproperty) value="target.selectedItems")
         }}
       />
-      <DataCollection
-        @type="upstream-instance"
-        @sort={{sort}}
-        @filters={{filters}}
-        @search={{search}}
-        @items={{proxy.Service.Proxy.Upstreams}}
-      as |collection|>
-        <collection.Collection>
-          <Consul::UpstreamInstance::List
-            @items={{collection.items}}
-            @dc={{dc}}
-            @nspace={{nspace}}
-          />
-        </collection.Collection>
-        <collection.Empty>
-          <EmptyState>
-            <BlockSlot @name="body">
-              <p>
-                This service has no upstreams{{#if (gt proxy.Service.Proxy.Upstreams.length 0)}} matching that search{{/if}}.
-              </p>
-            </BlockSlot>
-          </EmptyState>
-        </collection.Empty>
-      </DataCollection>
     {{/if}}
+    <DataCollection
+      @type="upstream-instance"
+      @sort={{sort}}
+      @filters={{filters}}
+      @search={{search}}
+      @items={{proxy.Service.Proxy.Upstreams}}
+    as |collection|>
+      <collection.Collection>
+        <Consul::UpstreamInstance::List
+          @items={{collection.items}}
+          @dc={{dc}}
+          @nspace={{nspace}}
+        />
+      </collection.Collection>
+      <collection.Empty>
+        <EmptyState>
+          <BlockSlot @name="body">
+            <p>
+              This service has no upstreams{{#if (gt proxy.Service.Proxy.Upstreams.length 0)}} matching that search{{/if}}.
+            </p>
+          </BlockSlot>
+        </EmptyState>
+      </collection.Empty>
+    </DataCollection>
   {{/let}}
 {{/let}}
   </div>


### PR DESCRIPTION
This meant that when where were no upstreams, no message would show
telling you of that fact, you'd just get whitespace underneath the selected tab.