### PR TITLE
config: Use DeprecatedConfig struct for deprecated config fields

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -346,10 +346,12 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		for _, err := range validateEnterpriseConfigKeys(&c2) {
 			b.warn("%s", err)
 		}
+		b.Warnings = append(b.Warnings, md.Warnings...)
 
 		// if we have a single 'check' or 'service' we need to add them to the
 		// list of checks and services first since we cannot merge them
 		// generically and later values would clobber earlier ones.
+		// TODO: move to applyDeprecatedConfig
 		if c2.Check != nil {
 			c2.Checks = append(c2.Checks, *c2.Check)
 			c2.Check = nil
@@ -733,16 +735,6 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 
 	aclsEnabled := false
 	primaryDatacenter := strings.ToLower(stringVal(c.PrimaryDatacenter))
-	if c.ACLDatacenter != nil {
-		b.warn("The 'acl_datacenter' field is deprecated. Use the 'primary_datacenter' field instead.")
-
-		if primaryDatacenter == "" {
-			primaryDatacenter = strings.ToLower(stringVal(c.ACLDatacenter))
-		}
-
-		// when the acl_datacenter config is used it implicitly enables acls
-		aclsEnabled = true
-	}
 
 	if c.ACL.Enabled != nil {
 		aclsEnabled = boolVal(c.ACL.Enabled)
@@ -887,7 +879,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 			EnablePersistence:   boolValWithDefault(c.ACL.EnableTokenPersistence, false),
 			ACLDefaultToken:     stringValWithDefault(c.ACL.Tokens.Default, stringVal(c.ACLToken)),
 			ACLAgentToken:       stringValWithDefault(c.ACL.Tokens.Agent, stringVal(c.ACLAgentToken)),
-			ACLAgentMasterToken: stringValWithDefault(c.ACL.Tokens.AgentMaster, stringVal(c.ACLAgentMasterToken)),
+			ACLAgentMasterToken: stringVal(c.ACL.Tokens.AgentMaster),
 			ACLReplicationToken: stringValWithDefault(c.ACL.Tokens.Replication, stringVal(c.ACLReplicationToken)),
 		},
 

--- a/agent/config/deprecated.go
+++ b/agent/config/deprecated.go
@@ -1,0 +1,42 @@
+package config
+
+import "fmt"
+
+type DeprecatedConfig struct {
+	// DEPRECATED (ACL-Legacy-Compat) - moved into the "acl.tokens" stanza
+	ACLAgentMasterToken *string `mapstructure:"acl_agent_master_token"`
+	// DEPRECATED (ACL-Legacy-Compat) - moved to "primary_datacenter"
+	ACLDatacenter *string `mapstructure:"acl_datacenter"`
+}
+
+func applyDeprecatedConfig(d *decodeTarget) (Config, []string) {
+	dep := d.DeprecatedConfig
+	var warns []string
+
+	if dep.ACLAgentMasterToken != nil {
+		if d.Config.ACL.Tokens.AgentMaster == nil {
+			d.Config.ACL.Tokens.AgentMaster = dep.ACLAgentMasterToken
+		}
+		warns = append(warns, deprecationWarning("acl_agent_master_token", "acl.tokens.agent_master"))
+	}
+
+	if dep.ACLDatacenter != nil {
+		if d.Config.PrimaryDatacenter == nil {
+			d.Config.PrimaryDatacenter = dep.ACLDatacenter
+		}
+
+		// when the acl_datacenter config is used it implicitly enables acls
+		d.Config.ACL.Enabled = pBool(true)
+		warns = append(warns, deprecationWarning("acl_datacenter", "primary_datacenter"))
+	}
+
+	return d.Config, warns
+}
+
+func deprecationWarning(old, new string) string {
+	return fmt.Sprintf("The '%v' field is deprecated. Use the '%v' field instead.", old, new)
+}
+
+func pBool(v bool) *bool {
+	return &v
+}

--- a/agent/config/merge_test.go
+++ b/agent/config/merge_test.go
@@ -52,7 +52,6 @@ func TestMerge(t *testing.T) {
 	}
 }
 
-func pBool(v bool) *bool                { return &v }
 func pInt(v int) *int                   { return &v }
 func pString(v string) *string          { return &v }
 func pDuration(v time.Duration) *string { s := v.String(); return &s }

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5903,6 +5903,7 @@ func TestLoad_FullConfig(t *testing.T) {
 
 	expectedWarns := []string{
 		`The 'acl_datacenter' field is deprecated. Use the 'primary_datacenter' field instead.`,
+		`The 'acl_agent_master_token' field is deprecated. Use the 'acl.tokens.agent_master' field instead.`,
 		`bootstrap_expect > 0: expecting 53 servers`,
 	}
 	expectedWarns = append(expectedWarns, enterpriseConfigKeyWarnings...)


### PR DESCRIPTION
We have deprecated config fields in the past, but I believe this approach has a number of advantages.

1. All of the deprecation logic (copying the value to the new location, and creating a warning) is together in the same place. Previously it was scattered in 3 or more places, which resulting in a lot of inconsistency.
2. Deprecated fields no longer need to be part of the `Config`. The `Config` struct can be used exclusively as an intermediate for merging. The new `DeprecatedConfig` and `decodeTarget` structs allow us to decode into `DeprecatedConfig` and immediately copy to the new config location.
3. Building a `RuntimeConfig` from a `Config` is more straightforward because deprecated config is handled before that step.