### PR TITLE
(WIP) Add a add completeness test for all types with CacheInfo method

### DIFF
--- a/agent/structs/structs_oss_test.go
+++ b/agent/structs/structs_oss_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var enterpriseMetaField = "EnterpriseMeta"
+
 func TestServiceID_String(t *testing.T) {
 	t.Run("value", func(t *testing.T) {
 		sid := NewServiceID("the-id", &EnterpriseMeta{})


### PR DESCRIPTION
Five types seems to have a CacheInfo() method. The cache Key for one of them (`DatacentersRequest`) is a constant. Therefore, I didn't add a test for that type. Please let me know what can be improved on this PR. 