### PR TITLE
Backport #9487 to release/1.7.x

### DIFF
--- a/agent/consul/cluster_test.go
+++ b/agent/consul/cluster_test.go
@@ -1,0 +1,100 @@
+package consul
+
+import (
+	"net/rpc"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/stretchr/testify/require"
+)
+
+type testClusterConfig struct {
+	Datacenter string
+	Servers    int
+	Clients    int
+	ServerConf func(*Config)
+	ClientConf func(*Config)
+
+	ServerWait func(*testing.T, *Server)
+	ClientWait func(*testing.T, *Client)
+}
+
+type testCluster struct {
+	Servers      []*Server
+	ServerCodecs []rpc.ClientCodec
+	Clients      []*Client
+}
+
+func newTestCluster(t *testing.T, conf *testClusterConfig) *testCluster {
+	t.Helper()
+
+	require.NotNil(t, conf)
+	cluster := testCluster{}
+
+	// create the servers
+	for i := 0; i < conf.Servers; i++ {
+		dir, srv := testServerWithConfig(t, func(c *Config) {
+			if conf.Datacenter != "" {
+				c.Datacenter = conf.Datacenter
+			}
+			c.Bootstrap = false
+			c.BootstrapExpect = conf.Servers
+
+			if conf.ServerConf != nil {
+				conf.ServerConf(c)
+			}
+		})
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		t.Cleanup(func() { srv.Shutdown() })
+
+		cluster.Servers = append(cluster.Servers, srv)
+
+		codec := rpcClient(t, srv)
+
+		cluster.ServerCodecs = append(cluster.ServerCodecs, codec)
+		t.Cleanup(func() { codec.Close() })
+
+		if i > 0 {
+			joinLAN(t, srv, cluster.Servers[0])
+		}
+	}
+
+	waitForLeaderEstablishment(t, cluster.Servers...)
+	if conf.ServerWait != nil {
+		for _, srv := range cluster.Servers {
+			conf.ServerWait(t, srv)
+		}
+	}
+
+	// create the clients
+	for i := 0; i < conf.Clients; i++ {
+		dir, client := testClientWithConfig(t, func(c *Config) {
+			if conf.Datacenter != "" {
+				c.Datacenter = conf.Datacenter
+			}
+			if conf.ClientConf != nil {
+				conf.ClientConf(c)
+			}
+		})
+
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		t.Cleanup(func() { client.Shutdown() })
+
+		if len(cluster.Servers) > 0 {
+			joinLAN(t, client, cluster.Servers[0])
+		}
+
+		cluster.Clients = append(cluster.Clients, client)
+	}
+
+	for _, client := range cluster.Clients {
+		if conf.ClientWait != nil {
+			conf.ClientWait(t, client)
+		} else {
+			testrpc.WaitForTestAgent(t, client.RPC, client.config.Datacenter)
+		}
+	}
+
+	return &cluster
+}

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -112,7 +112,7 @@ func TestRPC_NoLeader_Retry(t *testing.T) {
 
 	// This isn't sure-fire but tries to check that we don't have a
 	// leader going into the RPC, so we exercise the retry logic.
-	if ok, _ := s1.getLeader(); ok {
+	if ok, _, _ := s1.getLeader(); ok {
 		t.Fatalf("should not have a leader yet")
 	}
 
@@ -122,6 +122,53 @@ func TestRPC_NoLeader_Retry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bad: %v", err)
 	}
+}
+
+func TestRPC_getLeader_ErrLeaderNotTracked(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	cluster := newTestCluster(t, &testClusterConfig{
+		Datacenter: "dc1",
+		Servers:    3,
+		ServerWait: func(t *testing.T, srv *Server) {
+			// The test cluster waits for a leader to be established
+			// but not for all the RPC tracking of all servers to be updated
+			// so we also want to wait for that here
+			retry.Run(t, func(r *retry.R) {
+				if !srv.IsLeader() {
+					_, _, err := srv.getLeader()
+					require.NoError(r, err)
+				}
+			})
+
+		},
+	})
+
+	// At this point we know we have a cluster with a leader and all followers are tracking that
+	// leader in the serverLookup struct. We need to find a follower to hack its server lookup
+	// to force the error we desire
+
+	var follower *Server
+	for _, srv := range cluster.Servers {
+		if !srv.IsLeader() {
+			follower = srv
+			break
+		}
+	}
+
+	_, leaderMeta, err := follower.getLeader()
+	require.NoError(t, err)
+
+	// now do some behind the scenes trickery on the followers server lookup
+	// to remove the leader from it so that we can force a ErrLeaderNotTracked error
+	follower.serverLookup.RemoveServer(leaderMeta)
+
+	isLeader, meta, err := follower.getLeader()
+	require.Equal(t, structs.ErrLeaderNotTracked, err)
+	require.Nil(t, meta)
+	require.False(t, isLeader)
 }
 
 type MockSink struct {

--- a/agent/consul/snapshot_endpoint.go
+++ b/agent/consul/snapshot_endpoint.go
@@ -48,9 +48,9 @@ func (s *Server) dispatchSnapshotRequest(args *structs.SnapshotRequest, in io.Re
 
 	// Perform leader forwarding if required.
 	if !args.AllowStale {
-		if isLeader, server := s.getLeader(); !isLeader {
-			if server == nil {
-				return nil, structs.ErrNoLeader
+		if isLeader, server, err := s.getLeader(); !isLeader {
+			if err != nil {
+				return nil, err
 			}
 			return SnapshotRPC(s.connPool, args.Datacenter, server.Addr, server.UseTLS, args, in, reply)
 		}

--- a/agent/structs/errors.go
+++ b/agent/structs/errors.go
@@ -14,6 +14,7 @@ const (
 	errSegmentsNotSupported       = "Network segments are not supported in this version of Consul"
 	errRPCRateExceeded            = "RPC rate limit exceeded"
 	errServiceNotFound            = "Service not found: "
+	errLeaderNotTracked           = "Raft leader not found in server lookup mapping"
 )
 
 var (
@@ -24,6 +25,7 @@ var (
 	ErrSegmentsNotSupported       = errors.New(errSegmentsNotSupported)
 	ErrRPCRateExceeded            = errors.New(errRPCRateExceeded)
 	ErrDCNotAvailable             = errors.New(errDCNotAvailable)
+	ErrLeaderNotTracked           = errors.New(errLeaderNotTracked)
 )
 
 func IsErrNoLeader(err error) bool {


### PR DESCRIPTION
There were conflicts in:
* agent/structs/errors.go related to the ErrQueryNotFound not existing in 1.7.x
* agent/consul/rpc_test.go related to import differences between 1.7.x and 1.8.x

I also pulled in the cluster_test.go file from a later release so I wouldn't have to rewrite the test. ~I did have to modify how a test cluster gets torn down as 1.7.x isn't compiled with Go 1.14. Now the cluster has a shutdown method which will do all the necessary steps to undo what it created.~