### PR TITLE
[Streaming][bugfix] handle TLS signalisation when TLS is disabled on client side

### DIFF
--- a/.changelog/9494.txt
+++ b/.changelog/9494.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: properly set GRPC over RPC magic numbers when encryption was not set or partially set in the cluster with streaming enabled
+```

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -560,7 +560,9 @@ func TestRPC_PreventsTLSNesting(t *testing.T) {
 
 			// Start tls client
 			tlsWrap := s1.tlsConfigurator.OutgoingRPCWrapper()
-			tlsConn, err := tlsWrap("dc1", conn)
+			tlsConnWrapper, useTLS := tlsWrap("dc1", conn)
+			require.True(t, useTLS)
+			tlsConn, err := tlsConnWrapper(conn)
 			require.NoError(t, err)
 
 			// Write Inner magic byte
@@ -617,7 +619,9 @@ func connectClient(t *testing.T, s1 *Server, mb pool.RPCType, useTLS, wantOpen b
 	require.NoError(t, err)
 
 	if useTLS {
-		tlsConn, err := tlsWrap(s1.config.Datacenter, conn)
+		tlsConnW, useTLS := tlsWrap(s1.config.Datacenter, conn)
+		require.Equal(t, useTLS, useTLS)
+		tlsConn, err := tlsConnW(conn)
 		// Subtly, tlsWrap will NOT actually do a handshake in this case - it only
 		// does so for some configs, so even if the server closed the conn before
 		// handshake this won't fail and it's only when we attempt to read or write

--- a/agent/consul/status_endpoint_test.go
+++ b/agent/consul/status_endpoint_test.go
@@ -49,7 +49,8 @@ func insecureRPCClient(s *Server, c tlsutil.Config) (rpc.ClientCodec, error) {
 	}
 
 	// Wrap the connection in a TLS client
-	tlsConn, err := wrapper(s.config.Datacenter, conn)
+	tlsConnW, _ := wrapper(s.config.Datacenter, conn)
+	tlsConn, err := tlsConnW(conn)
 	if err != nil {
 		conn.Close()
 		return nil, err

--- a/agent/grpc/server_test.go
+++ b/agent/grpc/server_test.go
@@ -163,7 +163,7 @@ func (f *fakeRPCListener) handleConn(conn net.Conn) {
 		f.handleConn(conn)
 
 	default:
-		fmt.Println("ERROR: unexpected byte", typ)
+		fmt.Println("server_test ERROR: unexpected byte", typ)
 		conn.Close()
 	}
 }

--- a/agent/pool/pool.go
+++ b/agent/pool/pool.go
@@ -345,7 +345,8 @@ func (p *ConnPool) dial(
 		}
 
 		// Wrap the connection in a TLS client
-		tlsConn, err := wrapper(dc, conn)
+		tlsConnBuilder, _ := wrapper(dc, conn)
+		tlsConn, err := tlsConnBuilder(conn)
 		if err != nil {
 			conn.Close()
 			return nil, nil, err


### PR DESCRIPTION
This will fix #9474

`wrapper(server.Datacenter, conn)` could return the same connection. In such case, Consul client were incorrectly marking connection as RPCTLS while the connection was not encrypted.

This cause messages like:
```
[ERROR] agent.server.rpc: failed to read byte: conn=from=10.236.195.48:51572 error="tls: first record does not look like a TLS handshake"
```

The bug can be highlighted very easily by running Consul in dev mode with this config:
```
consul agent -dev -hcl 'rpc{enable_streaming=true}' -hcl use_streaming_backend=true -hcl 'ca_file="/etc/consul/ca.pem", cert_file="/etc/consul/cert.pem", key_file="/etc/consul/key.pem"'
```
Then, the bug is triggered with:
```
curl http://localhost:8500/v1/health/service/consul?index=2&stale
```

After this fix, such configuration works well.