### PR TITLE
ui: Adds localStorage to <html class=""> mapping for user controlled theming

### DIFF
--- a/ui/packages/consul-ui/app/templates/application.hbs
+++ b/ui/packages/consul-ui/app/templates/application.hbs
@@ -1,11 +1,23 @@
 <HeadLayout />
 {{page-title 'Consul' separator=' - '}}
+
 {{#if (env 'CONSUL_ACLS_ENABLED')}}
   {{document-attrs class="has-acls"}}
 {{/if}}
 {{#if (env 'CONSUL_NSPACES_ENABLED')}}
   {{document-attrs class="has-nspaces"}}
 {{/if}}
+
+<DataSource
+  @src="settings://consul:theme"
+as |source|>
+{{#each-in source.data as |key value|}}
+  {{#if (and value (contains key (array "color-scheme" "contrast")))}}
+    {{document-attrs class=(concat 'prefers-' key '-' value)}}
+  {{/if}}
+{{/each-in}}
+</DataSource>
+
 {{#if (not-eq router.currentRouteName 'application')}}
   <HashicorpConsul
     id="wrapper"


### PR DESCRIPTION
This PR adds localStorage (synced across browser tabs) based theme settings that are mapped to the root class of the app. Theming options are currently based on:

1. `prefers-contrast`: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast
2. `prefers-color-scheme`: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

This allows us to move forwards to incrementally add support for 'dark-mode' and 'low/high' contrast themes little by little, but purposefully not giving a user facing knob for this just yet. 

Eventually we will probably want to add support for the user to choose/change these themes via an in app toggle/menu as well as via browser configured `@media` queries when they are more widely supported, hence the use of localStorage here rather than our dev-time only cookies.

Just a note here, I've made it possible to add multiple individual settings (so a dark scheme and low contrast), which is how I would imagine the media queries can be configured. If we don't want to do this and make them either/or instead we can do that at some point in the future seeing as we aren't exposing this to users just yet.

 
![theming](https://user-images.githubusercontent.com/554604/103637956-27db8380-4f44-11eb-8f86-ecb6728eb407.gif)
