### PR TITLE
ui: Add filtered by in Nodes, KV and Intentions

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/intention/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/search-bar/index.hbs
@@ -1,102 +1,140 @@
-<form
-  class="consul-intention-search-bar filter-bar"
+<SearchBar
+  class="consul-intention-search-bar"
   ...attributes
+  @filter={{@filter}}
 >
-  <div class="search">
-    <FreetextFilter
-      @onsearch={{action @onsearch}}
-      @value={{@search}}
-      @placeholder="Search"
-    >
-      <PopoverSelect
-        class="type-search-properties"
-        @position="right"
-        @onchange={{action @onfilter.searchproperty}}
+    <:status as |search|>
+
+{{#let
+
+  (t (concat "components.consul.intention.search-bar." search.status.key)
+      default=(array
+        (concat "common.search." search.status.key)
+        (concat "common.consul." search.status.key)
+      )
+  )
+
+  (t (concat "components.consul.intention.search-bar." search.status.value)
+      default=(array
+        (concat "common.search." search.status.value)
+        (concat "common.consul." search.status.value)
+      )
+  )
+
+as |key value|}}
+      <search.RemoveFilter
+        aria-label={{t "common.ui.remove" item=(concat key " " value)}}
+      >
+        <dl>
+          <dt>{{key}}</dt>
+          <dd>{{value}}</dd>
+        </dl>
+      </search.RemoveFilter>
+{{/let}}
+
+    </:status>
+    <:search as |search|>
+      <search.Search
+        @onsearch={{action @onsearch}}
+        @value={{@search}}
+        @placeholder={{t "common.search.search"}}
+      >
+{{#if @filter.searchproperty}}
+        <search.Select
+          class="type-search-properties"
+          @position="right"
+          @onchange={{action @filter.searchproperty.change}}
+          @multiple={{true}}
+          @required={{true}}
+        as |components|>
+          <BlockSlot @name="selected">
+            <span>
+              {{t "common.search.searchproperty"}}
+            </span>
+          </BlockSlot>
+          <BlockSlot @name="options">
+    {{#let components.Optgroup components.Option as |Optgroup Option|}}
+            {{#each @filter.searchproperty.default as |prop|}}
+              <Option @value={{prop}} @selected={{contains prop @filter.searchproperty.value}}>
+                {{t (concat "common.consul." (lowercase prop))}}
+              </Option>
+            {{/each}}
+    {{/let}}
+          </BlockSlot>
+        </search.Select>
+  {{/if}}
+      </search.Search>
+    </:search>
+    <:filter as |search|>
+      <search.Select
+        class="type-access"
+        @position="left"
+        @onchange={{action @filter.access.change}}
         @multiple={{true}}
       as |components|>
         <BlockSlot @name="selected">
           <span>
-            Search across
+            {{t "components.consul.intention.search-bar.access.name"}}
           </span>
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
-          <Option @value="SourceName" @selected={{contains 'SourceName' @filter.searchproperties}}>Source Name</Option>
-          <Option @value="DestinationName" @selected={{contains 'DestinationName' @filter.searchproperties}}>Destination Name</Option>
+    {{#each (array "allow" "deny" "") as |item|}}
+          <Option class={{concat 'value-' item}} @value={{or item 'app-aware'}} @selected={{contains (or item 'app-aware') @filter.access.value}}>
+            <span>{{t (concat "components.consul.intention.search-bar.access.options." (or item 'app-aware'))}}</span>
+          </Option>
+    {{/each}}
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
-    </FreetextFilter>
-  </div>
-  <div class="filters">
-    <PopoverSelect
-      @position="left"
-      @onchange={{action @onfilter.access}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Permission
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option class="value-allow" @value="allow" @selected={{contains 'allow'
-        @filter.accesses}}><span>Allow</span></Option>
-        <Option class="value-deny" @value="deny" @selected={{contains 'deny'
-        @filter.accesses}}><span>Deny</span></Option>
-        <Option class="value-" @value="app-aware" @selected={{contains
-        'app-aware' @filter.accesses}}><span>App aware</span></Option>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-  <div class="sort">
-    <PopoverSelect
-      class="type-sort"
-      data-test-sort-control
-      @position="right"
-      @onchange={{action @onsort}}
-      @multiple={{false}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          {{#let (from-entries (array
-              (array "Action:asc" "Allow to Deny")
-              (array "Action:desc" "Deny to Allow")
-              (array "SourceName:asc" "Source: A to Z")
-              (array "SourceName:desc" "Source: Z to A")
-              (array "DestinationName:asc" "Destination: A to Z")
-              (array "DestinationName:desc" "Destination: Z to A")
-              (array "Precedence:asc" "Precedence: Ascending")
-              (array "Precedence:desc" "Precedence: Descending")
-              ))
-            as |selectable|
-          }}
-            {{get selectable @sort}}
-          {{/let}}
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Optgroup @label="Permission">
-          <Option @value="Action:asc" @selected={{eq "Action:asc" @sort}}>Allow to Deny</Option>
-          <Option @value="Action:desc" @selected={{eq "Action:desc" @sort}}>Deny to Allow</Option>
+      </search.Select>
+    </:filter>
+    <:sort as |search|>
+      <search.Select
+        class="type-sort"
+        data-test-sort-control
+        @position="right"
+        @onchange={{action @sort.change}}
+        @multiple={{false}}
+        @required={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{#let (from-entries (array
+                  (array "Action:asc" (t "components.consul.intention.search-bar.sort.access.asc"))
+                  (array "Action:desc" (t "components.consul.intention.search-bar.sort.access.desc"))
+                  (array "SourceName:asc" (t "components.consul.intention.search-bar.sort.source-name.asc"))
+                  (array "SourceName:desc" (t "components.consul.intention.search-bar.sort.source-name.desc"))
+                  (array "DestinationName:asc" (t "components.consul.intention.search-bar.sort.destination-name.asc"))
+                  (array "DestinationName:desc" (t "components.consul.intention.search-bar.sort.destination-name.desc"))
+                  (array "Precedence:asc" (t "common.sort.numeric.asc"))
+                  (array "Precedence:desc" (t "common.sort.numeric.desc"))
+                ))
+              as |selectable|
+            }}
+              {{get selectable @sort.value}}
+            {{/let}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+        <Optgroup @label={{t "components.consul.intention.search-bar.sort.access.name"}}>
+          <Option @value="Action:asc" @selected={{eq "Action:asc" @sort.value}}>{{t "components.consul.intention.search-bar.sort.access.asc"}}</Option>
+          <Option @value="Action:desc" @selected={{eq "Action:desc" @sort.value}}>{{t "components.consul.intention.search-bar.sort.access.desc"}}</Option>
         </Optgroup>
-        <Optgroup @label="Source">
-          <Option @value="SourceName:asc" @selected={{eq "SourceName:asc" @sort}}>A to Z</Option>
-          <Option @value="SourceName:desc" @selected={{eq "SourceName:desc" @sort}}>Z to A</Option>
+        <Optgroup @label={{t "components.consul.intention.search-bar.sort.source-name.name"}}>
+          <Option @value="SourceName:asc" @selected={{eq "SourceName:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+          <Option @value="SourceName:desc" @selected={{eq "SourceName:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
         </Optgroup>
-        <Optgroup @label="Destination">
-          <Option @value="DestinationName:asc" @selected={{eq "DestinationName:asc" @sort}}>A to Z</Option>
-          <Option @value="DestinationName:desc" @selected={{eq "DestinationName:desc" @sort}}>Z to A</Option>
+        <Optgroup @label={{t "components.consul.intention.search-bar.sort.destination-name.name"}}>
+          <Option @value="DestinationName:asc" @selected={{eq "DestinationName:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+          <Option @value="DestinationName:desc" @selected={{eq "DestinationName:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
         </Optgroup>
-        <Optgroup @label="Precedence">
-          <Option @value="Precedence:asc" @selected={{eq "Precedence:asc" @sort}}>Ascending</Option>
-          <Option @value="Precedence:desc" @selected={{eq "Precedence:desc" @sort}}>Descending</Option>
+        <Optgroup @label={{t "components.consul.intention.search-bar.sort.precedence.name"}}>
+          <Option @value="Precedence:asc" @selected={{eq "Precedence:asc" @sort.value}}>{{t "common.sort.numeric.asc"}}</Option>
+          <Option @value="Precedence:desc" @selected={{eq "Precedence:desc" @sort.value}}>{{t "common.sort.numeric.desc"}}</Option>
         </Optgroup>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-</form>
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+    </:sort>
+</SearchBar>

--- a/ui/packages/consul-ui/app/components/consul/kv/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/search-bar/index.hbs
@@ -1,68 +1,128 @@
-<form
-  class="consul-kv-search-bar filter-bar"
+<SearchBar
+  class="consul-kv-search-bar"
   ...attributes
+  @filter={{@filter}}
 >
-  <div class="search">
-    <FreetextFilter
-      @onsearch={{action @onsearch}}
-      @value={{@search}}
-      @placeholder="Search"
-    />
-  </div>
-  <div class="filters">
-    <PopoverSelect
-      class="type-kind"
-      @position="left"
-      @onchange={{action @onfilter.kind}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Type
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option @value="folder" @selected={{contains 'folder' @filter.kinds}}>Folder</Option>
-        <Option @value="key" @selected={{contains 'key' @filter.kinds}}>Key</Option>
+    <:status as |search|>
+
+{{#let
+
+  (t (concat "components.consul.kv.search-bar." search.status.key)
+      default=(array
+        (concat "common.search." search.status.key)
+        (concat "common.consul." search.status.key)
+      )
+  )
+
+  (t (concat "components.consul.kv.search-bar." search.status.value)
+      default=(array
+        (concat "common.search." search.status.value)
+        (concat "common.consul." search.status.value)
+      )
+  )
+
+as |key value|}}
+      <search.RemoveFilter
+        aria-label={{t "common.ui.remove" item=(concat key " " value)}}
+      >
+        <dl>
+          <dt>{{key}}</dt>
+          <dd>{{value}}</dd>
+        </dl>
+      </search.RemoveFilter>
 {{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-  <div class="sort">
-    <PopoverSelect
-      class="type-sort"
-      data-test-sort-control
-      @position="right"
-      @onchange={{action @onsort}}
-      @multiple={{false}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          {{#let (from-entries (array
-                (array "Key:asc" "A to Z")
-                (array "Key:desc" "Z to A")
-                (array "Kind:asc" "Folders to Keys")
-                (array "Kind:desc" "Keys to Folders")
-              ))
-            as |selectable|
-          }}
-            {{get selectable @sort}}
-          {{/let}}
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Optgroup @label="Name">
-          <Option @value="Key:asc" @selected={{eq "Key:asc" @sort}}>A to Z</Option>
-          <Option @value="Key:desc" @selected={{eq "Key:desc" @sort}}>Z to A</Option>
-        </Optgroup>
-        <Optgroup @label="Type">
-          <Option @value="Kind:asc" @selected={{eq "Kind:asc" @sort}}>Folders to Keys</Option>
-          <Option @value="Kind:desc" @selected={{eq "Kind:desc" @sort}}>Keys to Folders</Option>
-        </Optgroup>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-</form>
+
+    </:status>
+    <:search as |search|>
+      <search.Search
+        @onsearch={{action @onsearch}}
+        @value={{@search}}
+        @placeholder={{t "common.search.search"}}
+      >
+{{#if @filter.searchproperty}}
+        <search.Select
+          class="type-search-properties"
+          @position="right"
+          @onchange={{action @filter.searchproperty.change}}
+          @multiple={{true}}
+          @required={{true}}
+        as |components|>
+          <BlockSlot @name="selected">
+            <span>
+              {{t "common.search.searchproperty"}}
+            </span>
+          </BlockSlot>
+          <BlockSlot @name="options">
+    {{#let components.Optgroup components.Option as |Optgroup Option|}}
+            {{#each @filter.searchproperty.default as |prop|}}
+              <Option @value={{prop}} @selected={{contains prop @filter.searchproperty.value}}>
+                {{t (concat "common.consul." (lowercase prop))}}
+              </Option>
+            {{/each}}
+    {{/let}}
+          </BlockSlot>
+        </search.Select>
+  {{/if}}
+      </search.Search>
+    </:search>
+    <:filter as |search|>
+      <search.Select
+        class="type-kind"
+        @position="left"
+        @onchange={{action @filter.kind.change}}
+        @multiple={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{t "components.consul.kv.search-bar.kind.name"}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+    {{#each (array "folder" "key") as |item|}}
+          <Option class="value-{item}}" @value={{item}} @selected={{contains item @filter.kind.value}}>
+            {{t (concat "components.consul.kv.search-bar.kind.options." item)}}
+          </Option>
+    {{/each}}
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+    </:filter>
+    <:sort as |search|>
+      <search.Select
+        class="type-sort"
+        data-test-sort-control
+        @position="right"
+        @onchange={{action @sort.change}}
+        @multiple={{false}}
+        @required={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{#let (from-entries (array
+                  (array "Key:asc" (t "common.sort.alpha.asc"))
+                  (array "Key:desc" (t "common.sort.alpha.desc"))
+                  (array "Kind:asc" (t "components.consul.kv.search-bar.sort.kind.asc"))
+                  (array "Kind:desc" (t "components.consul.kv.search-bar.sort.kind.desc"))
+                ))
+              as |selectable|
+            }}
+              {{get selectable @sort.value}}
+            {{/let}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+          <Optgroup @label={{t "common.consul.name"}}>
+            <Option @value="Key:asc" @selected={{eq "Key:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+            <Option @value="Key:desc" @selected={{eq "Key:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
+          </Optgroup>
+          <Optgroup @label={{t "components.consul.kv.search-bar.kind.name"}}>
+            <Option @value="Kind:asc" @selected={{eq "Kind:asc" @sort.value}}>{{t "components.consul.kv.search-bar.sort.kind.asc"}}</Option>
+            <Option @value="Kind:desc" @selected={{eq "Kind:desc" @sort.value}}>{{t "components.consul.kv.search-bar.sort.kind.desc"}}</Option>
+          </Optgroup>
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+    </:sort>
+</SearchBar>

--- a/ui/packages/consul-ui/app/components/consul/node/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/search-bar/index.hbs
@@ -1,90 +1,131 @@
-<form
-  class="consul-node-search-bar filter-bar"
+<SearchBar
+  class="consul-node-search-bar"
   ...attributes
+  @filter={{@filter}}
 >
-  <div class="search">
-    <FreetextFilter
-      @onsearch={{action @onsearch}}
-      @value={{@search}}
-      @placeholder="Search"
-    >
-      <PopoverSelect
-        class="type-search-properties"
-        @position="right"
-        @onchange={{action @onfilter.searchproperty}}
+    <:status as |search|>
+
+{{#let
+
+  (t (concat "components.consul.node.search-bar." search.status.key)
+      default=(array
+        (concat "common.search." search.status.key)
+        (concat "common.consul." search.status.key)
+      )
+  )
+
+  (t (concat "components.consul.node.search-bar." search.status.value)
+      default=(array
+        (concat "common.search." search.status.value)
+        (concat "common.consul." search.status.value)
+        (concat "common.brand." search.status.value)
+      )
+  )
+
+as |key value|}}
+      <search.RemoveFilter
+        aria-label={{t "common.ui.remove" item=(concat key " " value)}}
+      >
+        <dl>
+          <dt>{{key}}</dt>
+          <dd>{{value}}</dd>
+        </dl>
+      </search.RemoveFilter>
+{{/let}}
+
+    </:status>
+    <:search as |search|>
+      <search.Search
+        @onsearch={{action @onsearch}}
+        @value={{@search}}
+        @placeholder={{t "common.search.search"}}
+      >
+        <search.Select
+          class="type-search-properties"
+          @position="right"
+          @onchange={{action @filter.searchproperty.change}}
+          @multiple={{true}}
+          @required={{true}}
+        as |components|>
+          <BlockSlot @name="selected">
+            <span>
+              {{t "common.search.searchproperty"}}
+            </span>
+          </BlockSlot>
+          <BlockSlot @name="options">
+    {{#let components.Optgroup components.Option as |Optgroup Option|}}
+            {{#each @filter.searchproperty.default as |prop|}}
+              <Option @value={{prop}} @selected={{contains prop @filter.searchproperty.value}}>
+                {{t (concat "common.consul." (lowercase prop))}}
+              </Option>
+            {{/each}}
+    {{/let}}
+          </BlockSlot>
+        </search.Select>
+      </search.Search>
+    </:search>
+    <:filter as |search|>
+      <search.Select
+        class="type-status"
+        @position="left"
+        @onchange={{action @filter.status.change}}
         @multiple={{true}}
       as |components|>
         <BlockSlot @name="selected">
           <span>
-            Search across
+            {{t "common.consul.status"}}
           </span>
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
-          <Option @value="Node" @selected={{contains 'Node' @filter.searchproperties}}>Node Name</Option>
-          <Option @value="Address" @selected={{contains 'Address' @filter.searchproperties}}>Address</Option>
-          <Option @value="Meta" @selected={{contains 'Meta' @filter.searchproperties}}>Node Meta</Option>
+    {{#each (array "passing" "warning" "critical") as |state|}}
+          <Option class="value-{{state}}" @value={{state}} @selected={{contains state @filter.status.value}}>
+            {{t (concat "common.consul." state)
+                default=(array
+                  (concat "common.search." state)
+                )
+            }}
+          </Option>
+    {{/each}}
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
-    </FreetextFilter>
-  </div>
-  <div class="filters">
-    <PopoverSelect
-      class="type-status"
-      @position="left"
-      @onchange={{action @onfilter.status}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Health Status
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option class="value-passing" @value="passing" @selected={{contains 'passing' @filter.statuses}}>Passing</Option>
-        <Option class="value-warning" @value="warning" @selected={{contains 'warning' @filter.statuses}}>Warning</Option>
-        <Option class="value-critical" @value="critical" @selected={{contains 'critical' @filter.statuses}}>Failing</Option>
-        <Option class="value-empty" @value="empty" @selected={{contains 'empty' @filter.statuses}}>No checks</Option>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-  <div class="sort">
-    <PopoverSelect
-      class="type-sort"
-      data-test-sort-control
-      @position="right"
-      @onchange={{action @onsort}}
-      @multiple={{false}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          {{#let (from-entries (array
-                (array "Node:asc" "A to Z")
-                (array "Node:desc" "Z to A")
-                (array "Status:asc" "Unhealthy to Healthy")
-                (array "Status:desc" "Healthy to Unhealthy")
-              ))
-            as |selectable|
-          }}
-            {{get selectable @sort}}
-          {{/let}}
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Optgroup @label="Health Status">
-          <Option @value="Status:asc" @selected={{eq "Status:asc" @sort}}>Unhealthy to Healthy</Option>
-          <Option @value="Status:desc" @selected={{eq "Status:desc" @sort}}>Healthy to Unhealthy</Option>
-        </Optgroup>
-        <Optgroup @label="Service Name">
-          <Option @value="Node:asc" @selected={{eq "Node:asc" @sort}}>A to Z</Option>
-          <Option @value="Node:desc" @selected={{eq "Node:desc" @sort}}>Z to A</Option>
-        </Optgroup>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-</form>
+      </search.Select>
+    </:filter>
+    <:sort as |search|>
+      <search.Select
+        class="type-sort"
+        data-test-sort-control
+        @position="right"
+        @onchange={{action @sort.change}}
+        @multiple={{false}}
+        @required={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{#let (from-entries (array
+                  (array "Node:asc" (t "common.sort.alpha.asc"))
+                  (array "Node:desc" (t "common.sort.alpha.desc"))
+                  (array "Status:asc" (t "common.sort.status.asc"))
+                  (array "Status:desc" (t "common.sort.status.desc"))
+                ))
+              as |selectable|
+            }}
+              {{get selectable @sort.value}}
+            {{/let}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+          <Optgroup @label={{t "common.consul.status"}}>
+            <Option @value="Status:asc" @selected={{eq "Status:asc" @sort.value}}>{{t "common.sort.status.asc"}}</Option>
+            <Option @value="Status:desc" @selected={{eq "Status:desc" @sort.value}}>{{t "common.sort.status.desc"}}</Option>
+          </Optgroup>
+          <Optgroup @label={{t "common.consul.node-name"}}>
+            <Option @value="Node:asc" @selected={{eq "Name:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+            <Option @value="Node:desc" @selected={{eq "Name:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
+          </Optgroup>
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+    </:sort>
+</SearchBar>

--- a/ui/packages/consul-ui/app/components/consul/node/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/search-bar/index.hbs
@@ -121,8 +121,8 @@ as |key value|}}
             <Option @value="Status:desc" @selected={{eq "Status:desc" @sort.value}}>{{t "common.sort.status.desc"}}</Option>
           </Optgroup>
           <Optgroup @label={{t "common.consul.node-name"}}>
-            <Option @value="Node:asc" @selected={{eq "Name:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
-            <Option @value="Node:desc" @selected={{eq "Name:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
+            <Option @value="Node:asc" @selected={{eq "Node:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+            <Option @value="Node:desc" @selected={{eq "Node:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
           </Optgroup>
   {{/let}}
         </BlockSlot>

--- a/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
@@ -7,14 +7,14 @@
 
 {{#let
 
-  (t (concat "component.consul.service.search-bar." search.status.key)
+  (t (concat "components.consul.service.search-bar." search.status.key)
       default=(array
         (concat "common.search." search.status.key)
         (concat "common.consul." search.status.key)
       )
   )
 
-  (t (concat "component.consul.service.search-bar." search.status.value)
+  (t (concat "components.consul.service.search-bar." search.status.value)
       default=(array
         (concat "common.search." search.status.value)
         (concat "common.consul." search.status.value)
@@ -34,13 +34,13 @@ as |key value|}}
 {{/let}}
 
     </:status>
-    <:search>
-      <FreetextFilter
+    <:search as |search|>
+      <search.Search
         @onsearch={{action @onsearch}}
         @value={{@search}}
         @placeholder={{t "common.search.search"}}
       >
-        <PopoverSelect
+        <search.Select
           class="type-search-properties"
           @position="right"
           @onchange={{action @filter.searchproperty.change}}
@@ -61,11 +61,11 @@ as |key value|}}
             {{/each}}
     {{/let}}
           </BlockSlot>
-        </PopoverSelect>
-      </FreetextFilter>
+        </search.Select>
+      </search.Search>
     </:search>
-    <:filter>
-      <PopoverSelect
+    <:filter as |search|>
+      <search.Select
         class="type-status"
         @position="left"
         @onchange={{action @filter.status.change}}
@@ -89,15 +89,15 @@ as |key value|}}
     {{/each}}
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
-      <PopoverSelect
+      </search.Select>
+      <search.Select
         @position="left"
         @onchange={{action @filter.kind.change}}
         @multiple={{true}}
       as |components|>
         <BlockSlot @name="selected">
           <span>
-            {{t "component.consul.service.search-bar.kind"}}
+            {{t "components.consul.service.search-bar.kind"}}
           </span>
         </BlockSlot>
         <BlockSlot @name="options">
@@ -125,9 +125,9 @@ as |key value|}}
           </Optgroup>
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
+      </search.Select>
   {{#if (gt @sources.length 0)}}
-      <PopoverSelect
+      <search.Select
         class="type-source"
         @position="left"
         @onchange={{action @filter.source.change}}
@@ -147,11 +147,11 @@ as |key value|}}
     {{/each}}
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
+      </search.Select>
   {{/if}}
     </:filter>
-    <:sort>
-      <PopoverSelect
+    <:sort as |search|>
+      <search.Select
         class="type-sort"
         data-test-sort-control
         @position="right"
@@ -162,8 +162,8 @@ as |key value|}}
         <BlockSlot @name="selected">
           <span>
             {{#let (from-entries (array
-                  (array "Name:asc" (t "common.sort.name.asc"))
-                  (array "Name:desc" (t "common.sort.name.desc"))
+                  (array "Name:asc" (t "common.sort.alpha.asc"))
+                  (array "Name:desc" (t "common.sort.alpha.desc"))
                   (array "Status:asc" (t "common.sort.status.asc"))
                   (array "Status:desc" (t "common.sort.status.desc"))
                 ))
@@ -180,11 +180,11 @@ as |key value|}}
             <Option @value="Status:desc" @selected={{eq "Status:desc" @sort.value}}>{{t "common.sort.status.desc"}}</Option>
           </Optgroup>
           <Optgroup @label={{t "common.consul.service-name"}}>
-            <Option @value="Name:asc" @selected={{eq "Name:asc" @sort.value}}>{{t "common.sort.name.asc"}}</Option>
-            <Option @value="Name:desc" @selected={{eq "Name:desc" @sort.value}}>{{t "common.sort.name.desc"}}</Option>
+            <Option @value="Name:asc" @selected={{eq "Name:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+            <Option @value="Name:desc" @selected={{eq "Name:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
           </Optgroup>
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
+      </search.Select>
     </:sort>
 </SearchBar>

--- a/ui/packages/consul-ui/app/components/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/search-bar/index.hbs
@@ -1,15 +1,27 @@
-<div class="search-bar">
+<div
+  class="search-bar"
+  ...attributes
+>
   <form
     class="filter-bar"
   >
     <div class="search">
-      {{yield to="search"}}
+      {{yield (hash
+        Search=(component "freetext-filter")
+        Select=(component "popover-select")
+      ) to="search"}}
     </div>
     <div class="filters">
-      {{yield to="filter"}}
+      {{yield (hash
+        Search=(component "freetext-filter")
+        Select=(component "popover-select")
+      ) to="filter"}}
     </div>
     <div class="sort">
-      {{yield to="sort"}}
+      {{yield (hash
+        Search=(component "freetext-filter")
+        Select=(component "popover-select")
+      ) to="sort"}}
     </div>
   </form>
 {{#if this.isFiltered}}

--- a/ui/packages/consul-ui/app/components/search-bar/index.js
+++ b/ui/packages/consul-ui/app/components/search-bar/index.js
@@ -7,6 +7,9 @@ const diff = (a, b) => {
 export default class SearchBar extends Component {
   get isFiltered() {
     const searchproperty = this.args.filter.searchproperty;
+    if (typeof searchproperty === 'undefined') {
+      return false;
+    }
     return (
       diff(searchproperty.default, searchproperty.value).length > 0 ||
       Object.entries(this.args.filter).some(([key, value]) => {

--- a/ui/packages/consul-ui/app/filter/predicates/intention.js
+++ b/ui/packages/consul-ui/app/filter/predicates/intention.js
@@ -1,5 +1,5 @@
 export default {
-  accesses: {
+  access: {
     allow: (item, value) => item.Action === value,
     deny: (item, value) => item.Action === value,
     'app-aware': (item, value) => typeof item.Action === 'undefined',

--- a/ui/packages/consul-ui/app/filter/predicates/kv.js
+++ b/ui/packages/consul-ui/app/filter/predicates/kv.js
@@ -1,5 +1,5 @@
 export default {
-  kinds: {
+  kind: {
     folder: (item, value) => item.isFolder,
     key: (item, value) => !item.isFolder,
   },

--- a/ui/packages/consul-ui/app/filter/predicates/node.js
+++ b/ui/packages/consul-ui/app/filter/predicates/node.js
@@ -1,5 +1,5 @@
 export default {
-  statuses: {
+  status: {
     passing: (item, value) => item.Status === value,
     warning: (item, value) => item.Status === value,
     critical: (item, value) => item.Status === value,

--- a/ui/packages/consul-ui/app/routes/dc/intentions/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/intentions/index.js
@@ -14,10 +14,11 @@ export default class IndexRoute extends Route {
     },
   };
 
-  model(params) {
+  async model(params) {
     return {
       dc: this.modelFor('dc').dc.Name,
       nspace: this.modelFor('nspace').nspace.substr(1),
+      searchProperties: this.queryParams.searchproperty.empty[0],
     };
   }
 

--- a/ui/packages/consul-ui/app/routes/dc/nodes/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/nodes/index.js
@@ -1,6 +1,5 @@
 import { inject as service } from '@ember/service';
 import Route from 'consul-ui/routing/route';
-import { hash } from 'rsvp';
 
 export default class IndexRoute extends Route {
   @service('data-source/service') data;

--- a/ui/packages/consul-ui/app/routes/dc/nodes/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/nodes/index.js
@@ -18,13 +18,16 @@ export default class IndexRoute extends Route {
     },
   };
 
-  model(params) {
+  async model(params) {
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
-    return hash({
-      items: this.data.source(uri => uri`/${nspace}/${dc}/nodes`),
-      leader: this.data.source(uri => uri`/${nspace}/${dc}/leader`),
-    });
+    const items = this.data.source(uri => uri`/${nspace}/${dc}/nodes`);
+    const leader = this.data.source(uri => uri`/${nspace}/${dc}/leader`);
+    return {
+      items: await items,
+      leader: await leader,
+      searchProperties: this.queryParams.searchproperty.empty[0],
+    };
   }
 
   setupController(controller, model) {

--- a/ui/packages/consul-ui/app/routes/dc/services/show/intentions/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/intentions/index.js
@@ -14,11 +14,12 @@ export default class IndexRoute extends Route {
     },
   };
 
-  model(params) {
+  async model(params) {
     return {
       dc: this.modelFor('dc').dc.Name,
       nspace: this.modelFor('nspace').nspace.substr(1) || 'default',
       slug: this.paramsFor('dc.services.show').name,
+      searchProperties: this.queryParams.searchproperty.empty[0],
     };
   }
 

--- a/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
@@ -6,104 +6,115 @@
   </BlockSlot>
 
   <BlockSlot @name="loaded">
-{{#let api.data as |items|}}
-  {{#let (hash
-    accesses=(if access (split access ',') undefined)
-    searchproperties=(if (not-eq searchproperty undefined)
-      (split searchproperty ',')
-      (array 'SourceName' 'DestinationName')
+{{#let
+
+  (hash
+    value=(or sortBy "Action:asc")
+    change=(action (mut sortBy) value="target.selected")
+  )
+
+  (hash
+    access=(hash
+      value=(if access (split access ',') undefined)
+      change=(action (mut access) value="target.selectedItems")
     )
-  ) as |filters|}}
-    {{#let (or sortBy "Action:asc") as |sort|}}
-      <AppView>
-        <BlockSlot @name="header">
-            <h1>
-                Intentions <em>{{format-number items.length}} total</em>
-            </h1>
-            <label for="toolbar-toggle"></label>
-        </BlockSlot>
-        <BlockSlot @name="actions">
-            <a data-test-create href="{{href-to 'dc.intentions.create'}}" class="type-create">Create</a>
-        </BlockSlot>
-        <BlockSlot @name="toolbar">
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
 
-  {{#if (gt items.length 0) }}
-          <Consul::Intention::SearchBar
-            @search={{search}}
-            @onsearch={{action (mut search) value="target.value"}}
+  api.data
 
-            @sort={{sort}}
-            @onsort={{action (mut sortBy) value="target.selected"}}
+as |sort filters items|}}
 
-            @filter={{filters}}
-            @onfilter={{hash
-              searchproperty=(action (mut searchproperty) value="target.selectedItems")
-              access=(action (mut access) value="target.selectedItems")
-            }}
-          />
-  {{/if}}
+  <AppView>
+    <BlockSlot @name="header">
+        <h1>
+            Intentions <em>{{format-number items.length}} total</em>
+        </h1>
+        <label for="toolbar-toggle"></label>
+    </BlockSlot>
+    <BlockSlot @name="actions">
+        <a data-test-create href="{{href-to 'dc.intentions.create'}}" class="type-create">Create</a>
+    </BlockSlot>
+    <BlockSlot @name="toolbar">
 
-        </BlockSlot>
+{{#if (gt items.length 0) }}
+      <Consul::Intention::SearchBar
+        @search={{search}}
+        @onsearch={{action (mut search) value="target.value"}}
+
+        @sort={{sort}}
+
+        @filter={{filters}}
+      />
+{{/if}}
+
+    </BlockSlot>
+    <BlockSlot @name="content">
+      <DataWriter
+        @sink={{concat '/' dc '/' nspace '/intention/'}}
+        @type="intention"
+        @ondelete={{refresh-route}}
+      as |writer|>
         <BlockSlot @name="content">
-          <DataWriter
-            @sink={{concat '/' dc '/' nspace '/intention/'}}
+          <DataCollection
             @type="intention"
-            @ondelete={{refresh-route}}
-          as |writer|>
-            <BlockSlot @name="content">
-              <DataCollection
-                @type="intention"
-                @sort={{sort}}
-                @filters={{filters}}
-                @search={{search}}
-                @items={{items}}
-              as |collection|>
-                <collection.Collection>
-                  <Consul::Intention::List
-                    @items={{collection.items}}
-                    @delete={{writer.delete}}
-                  as |list|>
-                      <list.CustomResourceNotice />
-                      <list.Table />
-                  </Consul::Intention::List>
-                </collection.Collection>
-                <collection.Empty>
-                  <EmptyState @allowLogin={{true}}>
-                    <BlockSlot @name="header">
-                      <h2>
-                        {{#if (gt items.length 0)}}
-                          No intentions found
-                        {{else}}
-                          Welcome to Intentions
-                        {{/if}}
-                      </h2>
-                    </BlockSlot>
-                    <BlockSlot @name="body">
-                      <p>
-                        {{#if (gt items.length 0)}}
-                          No intentions where found matching that search, or you may not have access to view the intentions you are searching for.
-                        {{else}}
-                          There don't seem to be any intentions, or you may not have access to view intentions yet.
-                        {{/if}}
-                      </p>
-                    </BlockSlot>
-                    <BlockSlot @name="actions">
-                      <li class="docs-link">
-                        <a href="{{env 'CONSUL_DOCS_URL'}}/commands/intention" rel="noopener noreferrer" target="_blank">Documentation on intentions</a>
-                      </li>
-                      <li class="learn-link">
-                        <a href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/getting-started/connect" rel="noopener noreferrer" target="_blank">Read the guide</a>
-                      </li>
-                    </BlockSlot>
-                  </EmptyState>
-                </collection.Empty>
-              </DataCollection>
-            </BlockSlot>
-          </DataWriter>
+            @sort={{sort.value}}
+            @filters={{filters}}
+            @search={{search}}
+            @items={{items}}
+          as |collection|>
+            <collection.Collection>
+              <Consul::Intention::List
+                @items={{collection.items}}
+                @delete={{writer.delete}}
+              as |list|>
+                  <list.CustomResourceNotice />
+                  <list.Table />
+              </Consul::Intention::List>
+            </collection.Collection>
+            <collection.Empty>
+              <EmptyState @allowLogin={{true}}>
+                <BlockSlot @name="header">
+                  <h2>
+                    {{#if (gt items.length 0)}}
+                      No intentions found
+                    {{else}}
+                      Welcome to Intentions
+                    {{/if}}
+                  </h2>
+                </BlockSlot>
+                <BlockSlot @name="body">
+                  <p>
+                    {{#if (gt items.length 0)}}
+                      No intentions where found matching that search, or you may not have access to view the intentions you are searching for.
+                    {{else}}
+                      There don't seem to be any intentions, or you may not have access to view intentions yet.
+                    {{/if}}
+                  </p>
+                </BlockSlot>
+                <BlockSlot @name="actions">
+                  <li class="docs-link">
+                    <a href="{{env 'CONSUL_DOCS_URL'}}/commands/intention" rel="noopener noreferrer" target="_blank">Documentation on intentions</a>
+                  </li>
+                  <li class="learn-link">
+                    <a href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/getting-started/connect" rel="noopener noreferrer" target="_blank">Read the guide</a>
+                  </li>
+                </BlockSlot>
+              </EmptyState>
+            </collection.Empty>
+          </DataCollection>
         </BlockSlot>
-      </AppView>
-    {{/let}}
-  {{/let}}
+      </DataWriter>
+    </BlockSlot>
+  </AppView>
+
 {{/let}}
   </BlockSlot>
 </DataLoader>

--- a/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
@@ -1,8 +1,21 @@
 {{page-title 'Key/Value'}}
-{{#let (hash
-  kinds=(if kind (split kind ',') undefined)
-) as |filters|}}
-  {{#let (or sortBy "Kind:asc") as |sort|}}
+{{#let
+
+  (hash
+    value=(or sortBy "Kind:asc")
+    change=(action (mut sortBy) value="target.selected")
+  )
+
+  (hash
+    kind=(hash
+      value=(if kind (split kind ',') undefined)
+      change=(action (mut kind) value="target.selectedItems")
+    )
+  )
+
+  items
+
+as |sort filters items|}}
     <AppView>
     {{#if (not-eq parent.Key '/') }}
       <BlockSlot @name="breadcrumbs">
@@ -31,12 +44,8 @@
           @onsearch={{action (mut search) value="target.value"}}
 
           @sort={{sort}}
-          @onsort={{action (mut sortBy) value="target.selected"}}
 
           @filter={{filters}}
-          @onfilter={{hash
-            kind=(action (mut kind) value="target.selectedItems")
-          }}
         />
     {{/if}}
       </BlockSlot>
@@ -57,7 +66,7 @@
           <BlockSlot @name="content">
             <DataCollection
               @type="kv"
-              @sort={{sort}}
+              @sort={{sort.value}}
               @filters={{filters}}
               @search={{search}}
               @items={{items}}
@@ -104,5 +113,4 @@
         </DataWriter>
       </BlockSlot>
     </AppView>
-  {{/let}}
 {{/let}}

--- a/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
@@ -1,14 +1,31 @@
 {{page-title 'Nodes'}}
 <EventSource @src={{items}} />
 <EventSource @src={{leader}} />
-{{#let (hash
-  statuses=(if status (split status ',') undefined)
-  searchproperties=(if (not-eq searchproperty undefined)
-    (split searchproperty ',')
-    (array 'Node' 'Address' 'Meta')
+{{#let
+
+  (hash
+    value=(or sortBy "Status:asc")
+    change=(action (mut sortBy) value="target.selected")
   )
-) as |filters|}}
-{{#let (or sortBy "Status:asc") as |sort|}}
+
+  (hash
+    status=(hash
+      value=(if status (split status ',') undefined)
+      change=(action (mut status) value="target.selectedItems")
+    )
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  items
+
+as |sort filters items|}}
   <AppView>
     <BlockSlot @name="header">
       <h1>
@@ -23,20 +40,15 @@
           @onsearch={{action (mut search) value="target.value"}}
 
           @sort={{sort}}
-          @onsort={{action (mut sortBy) value="target.selected"}}
 
           @filter={{filters}}
-          @onfilter={{hash
-            searchproperty=(action (mut searchproperty) value="target.selectedItems")
-            status=(action (mut status) value="target.selectedItems")
-          }}
         />
     {{/if}}
     </BlockSlot>
     <BlockSlot @name="content">
       <DataCollection
         @type="node"
-        @sort={{sort}}
+        @sort={{sort.value}}
         @filters={{filters}}
         @search={{search}}
         @items={{items}}
@@ -59,5 +71,4 @@
       </DataCollection>
     </BlockSlot>
   </AppView>
-  {{/let}}
 {{/let}}

--- a/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
@@ -12,74 +12,83 @@ as |api|>
     <ErrorState @error={{api.error}} />
   </BlockSlot>
   <BlockSlot @name="loaded">
-{{#let api.data as |items|}}
-  {{#let (hash
-    accesses=(if access (split access ',') undefined)
-    searchproperties=(if (not-eq searchproperty undefined)
-      (split searchproperty ',')
-      (array 'SourceName' 'DestinationName')
+{{#let
+
+  (hash
+    value=(or sortBy "Action:asc")
+    change=(action (mut sortBy) value="target.selected")
+  )
+
+  (hash
+    access=(hash
+      value=(if access (split access ',') undefined)
+      change=(action (mut access) value="target.selectedItems")
     )
-  ) as |filters|}}
-    {{#let (or sortBy "Action:asc") as |sort|}}
-      <div class="tab-section">
-          <Portal @target="app-view-actions">
-            <a data-test-create href={{href-to 'dc.services.show.intentions.create'}} class="type-create">Create</a>
-          </Portal>
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  api.data
+
+as |sort filters items|}}
+  <div class="tab-section">
+      <Portal @target="app-view-actions">
+        <a data-test-create href={{href-to 'dc.services.show.intentions.create'}} class="type-create">Create</a>
+      </Portal>
 {{#if (gt items.length 0) }}
-          <Consul::Intention::SearchBar
-            @search={{search}}
-            @onsearch={{action (mut search) value="target.value"}}
+      <Consul::Intention::SearchBar
+        @search={{search}}
+        @onsearch={{action (mut search) value="target.value"}}
 
-            @sort={{sort}}
-            @onsort={{action (mut sortBy) value="target.selected"}}
+        @sort={{sort}}
 
-            @filter={{filters}}
-            @onfilter={{hash
-              searchproperty=(action (mut searchproperty) value="target.selectedItems")
-              access=(action (mut access) value="target.selectedItems")
-            }}
-            />
+        @filter={{filters}}
+      />
 {{/if}}
 
-          <DataWriter
-            @sink={{concat '/' dc '/' nspace '/intention/'}}
+      <DataWriter
+        @sink={{concat '/' dc '/' nspace '/intention/'}}
+        @type="intention"
+        @ondelete={{refresh-route}}
+      as |writer|>
+        <BlockSlot @name="content">
+          <DataCollection
             @type="intention"
-            @ondelete={{refresh-route}}
-          as |writer|>
-            <BlockSlot @name="content">
-              <DataCollection
-                @type="intention"
-                @sort={{sort}}
-                @filters={{filters}}
-                @search={{search}}
-                @items={{items}}
-              as |collection|>
-                <collection.Collection>
-                  <Consul::Intention::List
-                    @items={{collection.items}}
-                    @check={{search}}
-                    @delete={{writer.delete}}
-                  as |list|>
-                    <list.CustomResourceNotice />
-                    <list.CheckNotice />
-                    <list.Table @routeName="dc.services.show.intentions.edit" />
-                  </Consul::Intention::List>
-                </collection.Collection>
-                <collection.Empty>
-                  <EmptyState>
-                    <BlockSlot @name="body">
-                      <p>
-                          There are no intentions {{if (gt items.length 0) 'found '}} for this service.
-                      </p>
-                    </BlockSlot>
-                  </EmptyState>
-                </collection.Empty>
-              </DataCollection>
-            </BlockSlot>
-          </DataWriter>
-      </div>
-    {{/let}}
-  {{/let}}
+            @sort={{sort.value}}
+            @filters={{filters}}
+            @search={{search}}
+            @items={{items}}
+          as |collection|>
+            <collection.Collection>
+              <Consul::Intention::List
+                @items={{collection.items}}
+                @check={{search}}
+                @delete={{writer.delete}}
+              as |list|>
+                <list.CustomResourceNotice />
+                <list.CheckNotice />
+                <list.Table @routeName="dc.services.show.intentions.edit" />
+              </Consul::Intention::List>
+            </collection.Collection>
+            <collection.Empty>
+              <EmptyState>
+                <BlockSlot @name="body">
+                  <p>
+                      There are no intentions {{if (gt items.length 0) 'found '}} for this service.
+                  </p>
+                </BlockSlot>
+              </EmptyState>
+            </collection.Empty>
+          </DataCollection>
+        </BlockSlot>
+      </DataWriter>
+  </div>
 {{/let}}
   </BlockSlot>
 </DataLoader>

--- a/ui/packages/consul-ui/tests/unit/filter/predicates/intention-test.js
+++ b/ui/packages/consul-ui/tests/unit/filter/predicates/intention-test.js
@@ -20,7 +20,7 @@ module('Unit | Filter | Predicates | intention', function() {
     expected = [items[0]];
     actual = items.filter(
       predicate({
-        accesses: ['allow'],
+        access: ['allow'],
       })
     );
     assert.deepEqual(actual, expected);
@@ -28,7 +28,7 @@ module('Unit | Filter | Predicates | intention', function() {
     expected = [items[1]];
     actual = items.filter(
       predicate({
-        accesses: ['deny'],
+        access: ['deny'],
       })
     );
     assert.deepEqual(actual, expected);
@@ -36,7 +36,7 @@ module('Unit | Filter | Predicates | intention', function() {
     expected = items;
     actual = items.filter(
       predicate({
-        accesses: ['allow', 'deny'],
+        access: ['allow', 'deny'],
       })
     );
     assert.deepEqual(actual, expected);

--- a/ui/packages/consul-ui/translations/en-us.yaml
+++ b/ui/packages/consul-ui/translations/en-us.yaml
@@ -24,6 +24,7 @@ common:
     mesh-gateway: Mesh Gateway
     status: Health Status
     service-name: Service Name
+    node-name: Node Name
   search:
     search: Search
     searchproperty: Search Across
@@ -32,17 +33,57 @@ common:
     in-mesh: In service mesh
     not-in-mesh: Not in service mesh
   sort:
-    name:
+    alpha:
       asc: A to Z
       desc: Z to A
+    numeric:
+      asc: Ascending
+      desc: Descending
     status:
       asc: Unhealthy to Healthy
       desc: Healthy to Unhealthy
 
-component:
+components:
   consul:
     service:
       search-bar:
         kind: Service Type
         in-mesh: In service mesh
-        not-in-mesh: In service mesh
+        not-in-mesh: Not in service mesh
+    kv:
+      search-bar:
+        kind:
+          name: Type
+          options:
+            folder: Folder
+            key: Key
+        sort:
+          kind:
+            asc: Folders to Keys
+            desc: Keys to Folders
+    intention:
+      search-bar:
+        access:
+          name: Permission
+          options:
+            allow: Allow
+            deny: Deny
+            app-aware: App aware
+        sort:
+          access:
+            name: Permission
+            asc: Allow to Deny
+            desc: Deny to Allow
+          source-name:
+            name: Source
+            asc: "Source: A to Z"
+            desc: "Source: Z to A"
+          destination-name:
+            name: Destination
+            asc: "Destination: A to Z"
+            desc: "Destination: Z to A"
+          precedence:
+            name: Precedence
+            asc: Ascending
+            desc: Descending
+


### PR DESCRIPTION
This continues on from https://github.com/hashicorp/consul/pull/9442 (which is the base branch for this PR), by adding the 'Filtered by' functionality to Nodes, KVs and Intentions (the top level, non-restricted areas), plus per service Intentions.

Additional notes:

1. Moved a top level i18n key: `component` > `components` to mirror the ember `components` directory.
2. Exported the generic search and menu components from the SearchBar component and used those for if we need to switch this up slightly at some point.
3. Moved a few `model` hooks to `async` (only was is actually async)

Apart from that its mainly 'copy/pasta, tweak, tweak, tweak' three times.