### PR TITLE
ui: Backport of #9488: Make sure we pass the nspace through to the API for nodes

### DIFF
--- a/.changelog/9488.txt
+++ b/.changelog/9488.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: ensure namespace is used for node API requests
+```

--- a/ui-v2/app/adapters/node.js
+++ b/ui-v2/app/adapters/node.js
@@ -1,21 +1,35 @@
 import Adapter from './application';
 // TODO: Update to use this.formatDatacenter()
+
+// Node and Namespaces are a little strange in that Nodes don't belong in a
+// namespace whereas things that belong to a Node do (Health Checks and
+// Service Instances). So even though Nodes themselves don't require a
+// namespace filter, you sill needs to pass the namespace through to API
+// requests in order to get the correct information for the things that belong
+// to the node.
+
 export default Adapter.extend({
-  requestForQuery: function(request, { dc, index, id }) {
+  requestForQuery: function(request, { dc, ns, index, id }) {
     return request`
       GET /v1/internal/ui/nodes?${{ dc }}
 
-      ${{ index }}
+      ${{
+        ...this.formatNspace(ns),
+        index,
+      }}
     `;
   },
-  requestForQueryRecord: function(request, { dc, index, id }) {
+  requestForQueryRecord: function(request, { dc, ns, index, id }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
     return request`
       GET /v1/internal/ui/node/${id}?${{ dc }}
 
-      ${{ index }}
+      ${{
+        ...this.formatNspace(ns),
+        index,
+      }}
     `;
   },
   requestForQueryLeader: function(request, { dc }) {

--- a/ui-v2/tests/acceptance/page-navigation.feature
+++ b/ui-v2/tests/acceptance/page-navigation.feature
@@ -23,7 +23,7 @@ Feature: page-navigation
   Where:
     -------------------------------------------------------------------------------------
     | Link       | URL               | Endpoint                                         |
-    | nodes      | /dc-1/nodes       | /v1/internal/ui/nodes?dc=dc-1                    |
+    | nodes      | /dc-1/nodes       | /v1/internal/ui/nodes?dc=dc-1&ns=@namespace      |
     | kvs        | /dc-1/kv          | /v1/kv/?keys&dc=dc-1&separator=%2F&ns=@namespace |
     | acls       | /dc-1/acls/tokens | /v1/acl/tokens?dc=dc-1&ns=@namespace             |
     | intentions | /dc-1/intentions  | /v1/connect/intentions?dc=dc-1                   |
@@ -64,7 +64,7 @@ Feature: page-navigation
     ---
       - /v1/catalog/datacenters
       - /v1/namespaces
-      - /v1/internal/ui/node/node-0?dc=dc-1
+      - /v1/internal/ui/node/node-0?dc=dc-1&ns=@namespace
       - /v1/coordinate/nodes?dc=dc-1
       - /v1/session/node/node-0?dc=dc-1&ns=@namespace
     ---


### PR DESCRIPTION
This is a backport of #9488 to 1.7.x

Nodes themselves are not namespaced, so we'd originally assumed we did not need to pass through the ns query parameter when listing or viewing nodes.

As it turns out the API endpoints we use to list and view nodes (and related things) return things that are namespaced, therefore any API requests for nodes do require a the ns query parameter to be passed through to the request.

This PR adds the necessary ns query param to all things Node, apart from the querying for the leader which only returns node related information.