### PR TITLE
acl: use the presence of a management policy in the state store as a sign that we already migrated to v2 acls

### DIFF
--- a/.changelog/9505.txt
+++ b/.changelog/9505.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: use the presence of a management policy in the state store as a sign that we already migrated to v2 acls
+```

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1278,7 +1278,7 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	// t.Parallel()
+	t.Parallel()
 
 	// We test this by having two datacenters with one server each. They
 	// initially come up and complete the migration, then we power them both


### PR DESCRIPTION
This way we only have to wait for the serf barrier to pass once before
we can upgrade to v2 acls. Without this patch every restart needs to
re-compute the change, and potentially if a stray older node joins after
a migration it might regress back to v1 mode which would be problematic.