### PR TITLE
ui: Remove ui-staging from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -974,6 +974,8 @@ workflows:
       - ember-test-ent:
           requires:
             - ember-build-ent
+      # ember-coverage in CI uses the dist/ folder to run tests so it requires
+      # either/or ent/oss to be built first
       - ember-coverage:
           requires:
             - ember-build-ent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -875,13 +875,12 @@ workflows:
             - check-vendor
       - build-amd64: *require-check-vendor
       - build-arm: *require-check-vendor
-      # every commit on ui-staging and master will have a rebuilt UI
+      # every commit on master will have a rebuilt UI
       - frontend-cache:
           filters:
             branches:
               only:
                 - master
-                - ui-staging
       - ember-build-prod:
           requires:
             - frontend-cache
@@ -917,7 +916,6 @@ workflows:
               ignore:
                 - /^pull\/.*$/ # only push dev builds from non forks
                 - master # all master dev uploads will include a UI rebuild in build-distros
-                - ui-staging # all ui-staging dev uploads will include a UI rebuild in build-distros
       - dev-upload-docker:
           <<: *dev-upload
           context: consul-ci
@@ -960,7 +958,6 @@ workflows:
             branches:
               only:
                 - master
-                - ui-staging
                 - /^ui\/.*/
       - node-tests:
           requires:


### PR DESCRIPTION
We don't use that branch anymore.

Also while I was futzing around a little, I realised why we depend on building the ui for the coverage, so I added a little comment in there.