### PR TITLE
ui: Topology intention saving improvements

### DIFF
--- a/.changelog/9513.txt
+++ b/.changelog/9513.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes an issue where intention description or metadata could be overwritten if saved from the topology view.
+```

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -3,7 +3,7 @@
 <div
   {{did-insert (action this.calculate)}}
   {{did-update (action this.calculate) @topology.Upstreams @topology.Downstreams}}
-  class="topology-container"
+  class="topology-container consul-topology-metrics"
 >
 {{#if (gt @topology.Downstreams.length 0)}}
   <div id="downstream-container">

--- a/ui/packages/consul-ui/app/components/topology-metrics/notifications/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/notifications/index.hbs
@@ -1,0 +1,19 @@
+{{#if (eq @type 'create')}}
+  {{#if (eq @status 'success') }}
+    Your intention has been added.
+  {{else}}
+    There was an error adding your intention.
+  {{/if}}
+{{else if (eq @type 'update') }}
+  {{#if (eq @status 'success') }}
+    Your intention has been saved.
+  {{else}}
+    There was an error saving your intention.
+  {{/if}}
+{{/if}}
+{{#let @error.errors.firstObject as |error|}}
+  {{#if error.detail }}
+    <br />{{concat '(' (if error.status (concat error.status ': ')) error.detail ')'}}
+  {{/if}}
+{{/let}}
+

--- a/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
@@ -16,7 +16,11 @@
     </:header>
     <:body>
       <p>
-        Add an intention that allows these two services to connect.
+        {{#if @item.Intention.HasExact}}
+          Change the action of this intention to allow.
+        {{else}}
+          Add an intention that allows these two services to connect.
+        {{/if}}
       </p>
     </:body>
     <:actions as |Actions|>
@@ -25,7 +29,11 @@
           {{on "click" @oncreate}}
           type="button"
         >
-          Create
+          {{#if @item.Intention.HasExact}}
+            Allow
+          {{else}}
+            Create
+          {{/if}}
         </button>
       </Actions.Action>
       <Actions.Action>

--- a/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
@@ -27,6 +27,7 @@
       <Actions.Action class="action">
         <button
           {{on "click" @oncreate}}
+          data-test-confirm
           type="button"
         >
           {{#if @item.Intention.HasExact}}
@@ -94,10 +95,11 @@
       )
       returns=(set this 'popoverController')
     }}
-    type="button"
     {{on 'click' (fn (optional this.popoverController.show))}}
+    type="button"
     style={{{concat 'top:' @position.y 'px;left:' @position.x 'px;'}}}
     aria-label={{if (eq @type 'deny') 'Add intention' 'View intention'}}
+    data-test-action
   >
   </button>
 </div>

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -34,6 +34,13 @@
 
     <BlockSlot @name="loaded">
       <AppView>
+        <BlockSlot @name="notification" as |status type item error|>
+          <TopologyMetrics::Notifications
+            @type={{type}}
+            @status={{status}}
+            @error={{error}}
+          />
+        </BlockSlot>
         <BlockSlot @name="breadcrumbs">
           <ol>
               <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/topology.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/topology.feature
@@ -1,0 +1,43 @@
+@setupApplicationTest
+Feature: dc / services / show / topology: Intention Create
+  Background:
+    Given 1 datacenter model with the value "datacenter"
+    And 1 intention model from yaml
+    ---
+      SourceNS: default
+      SourceName: web
+      DestinationNS: default
+      DestinationName: db
+      ID: intention-id
+    ---
+    And 1 node model
+    And 1 service model from yaml
+    ---
+    - Service:
+        Name: web
+        Kind: ~
+    ---
+    And 1 topology model from yaml
+    ---
+      Downstreams: []
+      Upstreams:
+        - Name: db
+          Namespace: default
+          Datacenter: datacenter
+          Intention: {}
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: datacenter
+      service: web
+    ---
+  Scenario: Allow a connection between service and upstream by saving an intention
+    When I click ".consul-topology-metrics [data-test-action]"
+    And I click ".consul-topology-metrics [data-test-confirm]"
+    And "[data-notification]" has the "success" class
+  Scenario: There was an error saving the intention
+    Given the url "/v1/connect/intentions/exact?source=default%2Fweb&destination=default%2Fdb&dc=datacenter" responds with a 500 status
+    When I click ".consul-topology-metrics [data-test-action]"
+    And I click ".consul-topology-metrics [data-test-confirm]"
+    And "[data-notification]" has the "error" class
+

--- a/ui/packages/consul-ui/tests/acceptance/steps/dc/services/show/topology-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/dc/services/show/topology-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui/packages/consul-ui/tests/helpers/type-to-url.js
+++ b/ui/packages/consul-ui/tests/helpers/type-to-url.js
@@ -38,6 +38,9 @@ export default function(type) {
     case 'nspace':
       requests = ['/v1/namespaces', '/v1/namespace/'];
       break;
+    case 'topology':
+      requests = ['/v1/internal/ui/service-topology'];
+      break;
   }
   // TODO: An instance of URL should come in here (instead of 2 args)
   return function(url, method) {


### PR DESCRIPTION
This PR adds various things:

### Save existing intention

Previously (in 1.9.0) if an intention already existed for an upstream, we would link to the intention save form in order for you to save it. Once saved this would push you back to the intention listing page, rather than back to the topology page. The user flow is much nicer when an upstream doesn't have an existing intention, in which case we simply created/saved the intention in-place within the topology view.

In 1.9.1 we accidentally updated things to not distinguish different flows between an upstream with an existing intention and a non-existent intention. This meant that an intention description or metadata could potentially be overwritten if saved from the topology view page.

This PR adds the user flow we actually want, i.e. there is no difference between an upstream with an existing intention and a non-existent intention - we always keep you in the topology view. But crucially here we also check for and use an intention to save if one already exists for the upstream, if not we create a new one for you. I actually wanted to do this slightly differently using a `<DataSource />` component instead of the in-route `data.source`, but that didn't quite work out.

### Notifications on saving/failing to save an intention from the topology view

We also add our standard notifications for performing the above actions from within the topology view, which is also a bit of a long story!

From the beginning of time (i.e. back in Ember 2 days) we've used an ember Mixin to reuse our notification functionality across the app. We are moving away from Mixins as they are now deprecated.

A while back we made a `<DataForm />` which we can use to save full forms in a composable manner that includes auto notifications for saving and erroring. Whilst this avoids Mixins, its currently still very heavyweight and its innards aren't really split enough as yet - but it does still use our 'from the beginning of time' `feedback` service.

I wanted to do something with a smaller scope than `<DataForm />` for our notifications to help us move away from Mixins even further. I kinda of reluctantly took a look at adding a decorator (I'm not super keen on writing custom decorators as yet), as our old implementation was basically wrapping a function in a `try/catch` in order to notify, which kinda feels the same as a decorator, but I realised that as decorators wrap an entire method, you can use them to wrap functions that you use within the method:

```javascript
@notify
@action 
async save() {
  // I only want this line wrapped in try/catch
  await this.repo.persist()
  // not this line
  this.refresh()
}
```

which led me to just splitting up our notification service so we can use it differently if we need to:

```javascript
@action
async save() {
  const notification= this.feedback.notification(type)
  try {
   // I only want this line wrapped in try/catch
    let thing = await this.repo.persist()
    notification.success(thing)
  } catch(e) {
   notification.error(e)
  }
  // not this line
  this.refresh()
}
```
The old style `execute` still works as before:

```javascript
this.feedback.execute(() => this.repo.persist())
```

and both interfaces use the same innards.

### Testing

I added some basic tests around this, but purposefully didn't use page-objects. The more I use them the more I wonder if we could do page-objects differently, and more and more as we add more nested components. I played with a different approach but ended up going down a bit of a rabbit hole with it all and stopped before things got too weird.




