### PR TITLE
ui: Improves the 'you must provide ... to `generate`' error from href-to

### DIFF
--- a/ui/packages/consul-ui/app/helpers/href-to.js
+++ b/ui/packages/consul-ui/app/helpers/href-to.js
@@ -42,7 +42,14 @@ export default class HrefToHelper extends Helper {
   @service('router') router;
 
   compute(params, hash) {
-    return hrefTo(this, this.router, params, hash);
+    let href;
+    try {
+      href = hrefTo(this, this.router, params, hash);
+    } catch (e) {
+      e.message = `${e.message} For "${params[0]}:${JSON.stringify(params.slice(1))}"`;
+      throw e;
+    }
+    return href;
   }
 
   @observes('router.currentURL')


### PR DESCRIPTION
This originally comes from the ember-href-to helper and is one of those
errors that when I see it I think ... hmmm

This gives a little bit more of a clue as to what is wrong by logging
the route name you asked for plus the params you passed to it so you:

1. Have more help finding the href-to that is problematic in the
template/component
2. Can see all the parameters you passed (including a potential null
parameter for the thing you are missing)

After:

<img width="534" alt="Screenshot 2021-01-06 at 17 00 16" src="https://user-images.githubusercontent.com/554604/103798002-10ce8b80-5041-11eb-997a-c5a55c4e65f8.png">
