### PR TITLE
docs: add note about TMPDIR for snapshots

### DIFF
--- a/website/content/commands/snapshot/save.mdx
+++ b/website/content/commands/snapshot/save.mdx
@@ -16,6 +16,16 @@ the given file.
 If ACLs are enabled, a management token must be supplied in order to perform
 a snapshot save.
 
+-> Note that saving a snapshot involves the server process writing the snapshot to a
+temporary file on-disk before sending that file to the CLI client. The default location
+can vary depending on operating system, but typically is `/tmp`. You can get more detailed
+information on default locations in the Go documentation for [os.TempDir](https://golang.org/pkg/os/#TempDir).
+If you need to change this location, you can do so by setting the `TMPDIR` environment
+variable for the Consul server processes. Keep in mind that setting the environment variable for
+the CLI client attempting to perform a snapshot save will have no effect. It _must_ be set in
+the context of the server process. If you're using Systemd to manage your Consul server
+processes, then adding `Environment=TMPDIR=/path/to/dir` to your Consul unit file will work.
+
 ## Usage
 
 Usage: `consul snapshot save [options] FILE`


### PR DESCRIPTION
Taking a snapshot with `consul snapshot save $FILE` causes a Consul server to write the contents of the snapshot to disk before sending it to the CLI client. By default, this is done on `/tmp` on most systems. There are some situations where the `/tmp` partition isn't large enough for a snapshot though and some other location needs to be specified. To do that, you simply need to set the `TMPDIR` environment variable for the Consul server process. This adds a note to the documentation for `consul snapshot save` that discusses this.