### PR TITLE
Use full names for cfg entries in sidebar

### DIFF
--- a/website/content/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/agent/config-entries/ingress-gateway.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Configuration Entry Kind: Ingress Gateway'
-sidebar_title: ingress-gateway
+sidebar_title: Ingress Gateway
 description: >-
   The `ingress-gateway` config entry kind allows for configuring Ingress gateways
   with listeners that expose a set of services outside the Consul service mesh.

--- a/website/content/docs/agent/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/agent/config-entries/proxy-defaults.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Configuration Entry Kind: Proxy Defaults'
-sidebar_title: proxy-defaults
+sidebar_title: Proxy Defaults
 description: >-
   The proxy-defaults config entry kind allows for configuring global config
   defaults across all services for Connect proxy configuration. Currently, only

--- a/website/content/docs/agent/config-entries/service-defaults.mdx
+++ b/website/content/docs/agent/config-entries/service-defaults.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Configuration Entry Kind: Service Defaults'
-sidebar_title: service-defaults
+sidebar_title: Service Defaults
 description: >-
   The service-defaults config entry kind controls default global values for a
   service, such as its protocol.

--- a/website/content/docs/agent/config-entries/service-intentions.mdx
+++ b/website/content/docs/agent/config-entries/service-intentions.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Configuration Entry Kind: Service Intentions'
-sidebar_title: service-intentions
+sidebar_title: Service Intentions
 description: >-
   The service-intentions config entry kind controls Connect traffic
   authorization for both networking layer 4 (e.g. TCP) and networking layer 7

--- a/website/content/docs/agent/config-entries/service-resolver.mdx
+++ b/website/content/docs/agent/config-entries/service-resolver.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Configuration Entry Kind: Service Resolver'
-sidebar_title: service-resolver
+sidebar_title: Service Resolver
 description: >-
   The `service-resolver` config entry kind controls which service instances
   should satisfy Connect upstream discovery requests for a given service name.

--- a/website/content/docs/agent/config-entries/service-router.mdx
+++ b/website/content/docs/agent/config-entries/service-router.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Configuration Entry Kind: Service Router'
-sidebar_title: service-router
+sidebar_title: Service Router
 description: >-
   The service-router config entry kind controls Connect traffic routing and
   manipulation at networking layer 7 (e.g. HTTP).

--- a/website/content/docs/agent/config-entries/service-splitter.mdx
+++ b/website/content/docs/agent/config-entries/service-splitter.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Configuration Entry Kind: Service Splitter'
-sidebar_title: service-splitter
+sidebar_title: Service Splitter
 description: >-
   The service-splitter config entry kind controls how to split incoming Connect
   requests across different subsets of a single service (like during staged

--- a/website/content/docs/agent/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/agent/config-entries/terminating-gateway.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Configuration Entry Kind: Terminating Gateway'
-sidebar_title: terminating-gateway
+sidebar_title: Terminating Gateway
 description: >-
   The `terminating-gateway` config entry kind allows for configuring terminating gateways
   to proxy traffic from services in the Consul service mesh to services outside the mesh.


### PR DESCRIPTION
With the addition of Kube CRD docs alongside the HCL config entry docs, it makes sense for the sidebar to use the name for the config entry (e.g. `Ingress Gateway` instead of `ingress-gateway`) because the CRD name is `IngressGateway`.