### PR TITLE
Pin alpine/socat image to a version

### DIFF
--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -531,7 +531,7 @@ function run_container_fake-statsd {
   docker run -d --name $(container_name) \
     $WORKDIR_SNIPPET \
     $(network_snippet primary) \
-    "${HASHICORP_DOCKER_PROXY}/alpine/socat" \
+    "${HASHICORP_DOCKER_PROXY}/alpine/socat:1.7.3.4-r1" \
     -u UDP-RECVFROM:8125,fork,reuseaddr \
     SYSTEM:'xargs -0 echo >> /workdir/primary/statsd/statsd.log'
 }


### PR DESCRIPTION
To fix failing integration tests. The latest version (`1.7.4.0-r0`) appears to not be catting all the bytes, so the expected metrics are missing in the output.

Reported the issue here: https://github.com/alpine-docker/socat/issues/11

Test failures can be seen here: https://app.circleci.com/pipelines/github/hashicorp/consul/15747/workflows/1c42c50d-eaeb-49c8-8ee6-eddf18895b52