### PR TITLE
ci: Explicitly specify a default Makefile target, don't default to the first target

### DIFF
--- a/ui/GNUmakefile
+++ b/ui/GNUmakefile
@@ -1,5 +1,9 @@
 .PHONY: clean dist dist-docker dist-netlify test-workspace
 
+# make is run with no target from the consul root Makefile ui target but from
+# within docker during release, so that we keep that as the default target
+.DEFAULT_GOAL := dist-docker
+
 # Run from CI, should run any checks/tests for the workspace that we'd like to
 # be run for every PR
 test-workspace:


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/9507 we added a new target to the top of our Makefile, which of course redefines the default Makefile target ... 🤦 

This uses `.DEFAULT_GOAL` to explicitly set the default target instead.