### PR TITLE
ui: Fix -ui-content-path / ui_config.content_path

### DIFF
--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -132,6 +132,23 @@ func TestUIServerIndex(t *testing.T) {
 				`<script src="/ui/assets/compiled-metrics-providers.js">`,
 			},
 		},
+		{
+			name: "injecting content path",
+			// ember will always pre/append slashes if they don't exist so even if
+			// somebody configures them without our template file will have them
+			cfg: basicUIEnabledConfig(
+				withContentPath("/consul/"),
+			),
+			path:       "/",
+			wantStatus: http.StatusOK,
+			wantNotContains: []string{
+				"__RUNTIME_BOOL_",
+				"__RUNTIME_STRING_",
+			},
+			wantEnv: map[string]interface{}{
+				"rootURL": "/consul/",
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -215,6 +232,11 @@ func basicUIEnabledConfig(opts ...cfgFunc) *config.RuntimeConfig {
 	return cfg
 }
 
+func withContentPath(path string) cfgFunc {
+	return func(cfg *config.RuntimeConfig) {
+		cfg.UIConfig.ContentPath = path
+	}
+}
 func withACLs() cfgFunc {
 	return func(cfg *config.RuntimeConfig) {
 		cfg.ACLDatacenter = "dc1"

--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -169,6 +169,7 @@ module.exports = function(environment, $ = process.env) {
         // __RUNTIME_STRING_Xxxx__ will be replaced with the literal string in
         // the named variable in the data returned from
         // `uiTemplateDataFromConfig`. It may be empty.
+        rootURL: '__RUNTIME_STRING_ContentPath__',
         CONSUL_ACLS_ENABLED: '__RUNTIME_BOOL_ACLsEnabled__',
         CONSUL_SSO_ENABLED: '__RUNTIME_BOOL_SSOEnabled__',
         CONSUL_NSPACES_ENABLED: '__RUNTIME_BOOL_NamespacesEnabled__',


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/9522

Ember's `rootURL` environment var is a little special in that ember will
automatically add slashes around it (`/ui/`) if they don't already exist.

This means our `__RUNTIME_STRING_ContentPath__` placeholder will eventually end up
as `/__RUNTIME_STRING_ContentPath__/`, or once meta/url encoded
`%22%2F__RUNTIME_STRING_ContentPath__%2F%22`. Hurrah!

Typically, this slash-adding only happens to the `rootURL` env var.

The RegExp updates here adds conditional, non-capturing grouping to cope with both
cases and then uses the regexp groups to decide what to do within the
same switch statement as before.

We needed to compile the assetsfs file here in order for the tests to pass, so merging could be fun (It might need a rebase and another `make ui` post-review/pre-merge)

