### PR TITLE
Dynamic reload of consul agent name

### DIFF
--- a/.changelog/9525.txt
+++ b/.changelog/9525.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+config reload: dynamically reload node name of consul agents.
+```

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -974,6 +974,11 @@ func (s *Server) Shutdown() error {
 	return nil
 }
 
+// ReconnectSerfWithNewNodeName change of node name is not yet supported for servers
+func (s *Server) ReconnectSerfWithNewNodeName(oldNodeName string) error {
+	return nil
+}
+
 // Leave is used to prepare for a graceful shutdown of the server
 func (s *Server) Leave() error {
 	s.logger.Info("server starting leave")

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -227,6 +227,10 @@ func (l *State) SetDiscardCheckOutput(b bool) {
 	l.discardCheckOutput.Store(b)
 }
 
+func (l *State) SetConfig(config Config) {
+	l.config = config
+}
+
 // ServiceToken returns the configured ACL token for the given
 // service ID. If none is present, the agent's token is returned.
 func (l *State) ServiceToken(id structs.ServiceID) string {


### PR DESCRIPTION
This commit allows to dynamically rename consul agents in client mode using consul reload.

When a reload with name change is triggered, the agent leaves the serf cluster and join it back with its new name using a subset of IPs of the previously known peers as start addresses. This commit does not handle server being renamed to mitigate potential risks on the cluster.