### PR TITLE
Remove unmaintained python-consul reference

### DIFF
--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -24,10 +24,6 @@ the community.
     the Consul HTTP API
   </li>
   <li>
-    <a href="https://github.com/cablehead/python-consul">python-consul</a> -
-    Python client for the Consul HTTP API
-  </li>
-  <li>
     <a href="https://github.com/poppyred/python-consul2">python-consul2</a> -
     Python client for the Consul HTTP API
   </li>


### PR DESCRIPTION
The last commit on python-consul is from 2018 with no activity since.
This can be misleading for users as they will eventually stumble up bugs
and/or missing features. python-consul2 is also listed and should be
recommended as a replacement.