### PR TITLE
Display a warning when rpc.enable_streaming = true is set on a client

### DIFF
--- a/.changelog/9530.txt
+++ b/.changelog/9530.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-streaming: display a warning on agent when rpc.enable_streaming is set on a non-server since not used.
+streaming: display a warning on agent(s) when incompatible streaming parameters are used
 ```

--- a/.changelog/9530.txt
+++ b/.changelog/9530.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+streaming: display a warning on agent when rpc.enable_streaming is set on a non-server since not used.
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1426,7 +1426,11 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 		b.warn("bootstrap_expect > 0: expecting %d servers", rt.BootstrapExpect)
 	}
 
-	if rt.RPCConfig.EnableStreaming && !rt.ServerMode {
+	if rt.ServerMode {
+		if rt.UseStreamingBackend && !rt.RPCConfig.EnableStreaming {
+			b.warn("use_streaming_backend = true requires rpc.enable_streaming on servers to work properly")
+		}
+	} else if rt.RPCConfig.EnableStreaming {
 		b.warn("rpc.enable_streaming = true has no effect when not running in server mode")
 	}
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1426,6 +1426,10 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 		b.warn("bootstrap_expect > 0: expecting %d servers", rt.BootstrapExpect)
 	}
 
+	if rt.RPCConfig.EnableStreaming && !rt.ServerMode {
+		b.warn("rpc.enable_streaming = true has no effect when not running in server mode")
+	}
+
 	if rt.AutoEncryptAllowTLS {
 		if !rt.VerifyIncoming && !rt.VerifyIncomingRPC {
 			b.warn("if auto_encrypt.allow_tls is turned on, either verify_incoming or verify_incoming_rpc should be enabled. It is necessary to turn it off during a migration to TLS, but it should definitely be turned on afterwards.")

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2899,6 +2899,48 @@ func TestBuilder_BuildAndValidate_ConfigFlagsAndEdgecases(t *testing.T) {
 			},
 		},
 		{
+			desc: "rpc.enable_streaming = true has no effect when not running in server mode",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{`{
+			  "rpc": { "enable_streaming": true }
+			}`},
+			hcl: []string{`
+			  rpc { enable_streaming = true }
+			`},
+			warns: []string{"rpc.enable_streaming = true has no effect when not running in server mode"},
+			patch: func(rt *RuntimeConfig) {
+				rt.DataDir = dataDir
+				// rpc.enable_streaming make no sense in not-server mode
+				rt.RPCConfig.EnableStreaming = true
+				rt.ServerMode = false
+			},
+		},
+		{
+			desc: "use_streaming_backend = true requires rpc.enable_streaming on servers to work properly",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{`{
+			  "use_streaming_backend": true,
+			  "server": true
+			}`},
+			hcl: []string{`
+			  use_streaming_backend = true
+			  server = true
+			`},
+			warns: []string{"use_streaming_backend = true requires rpc.enable_streaming on servers to work properly"},
+			patch: func(rt *RuntimeConfig) {
+				rt.DataDir = dataDir
+				rt.UseStreamingBackend = true
+				// server things
+				rt.ServerMode = true
+				rt.LeaveOnTerm = false
+				rt.SkipLeaveOnInt = true
+			},
+		},
+		{
 			desc: "auto_encrypt.allow_tls errors in client mode",
 			args: []string{
 				`-data-dir=` + dataDir,


### PR DESCRIPTION
This option has no effect when running as an agent.