### PR TITLE
ui: Service Instance forwards/backwards/forwards navigation test

### DIFF
--- a/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
@@ -35,7 +35,7 @@
       <AppView>
           <BlockSlot @name="breadcrumbs">
               <ol>
-                  <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
+                  <li><a href={{href-to 'dc.services'}}>All Services</a></li>
                   <li><a data-test-back href={{href-to 'dc.services.show'}}>Service ({{item.Service.Service}})</a></li>
               </ol>
           </BlockSlot>

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/instances/navigation.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/instances/navigation.feature
@@ -2,21 +2,40 @@
 Feature: dc / services / instances / navigation
   Background:
     Given 1 datacenter model with the value "dc-1"
-    And 2 instance models from yaml
+    And 1 proxy model from yaml
+    ---
+    ServiceName: service-0-proxy
+    Node: node-0
+    ServiceID: service-a-proxy
+    ---
+    And 3 instance models from yaml
     ---
     - Service:
-        Service: service-0
+        Name: service-0
         ID: service-a
       Node:
         Node: node-0
+      Checks:
+      - Status: critical
     - Service:
-        Service: service-0
+        Name: service-0
         ID: service-b
       Node:
-        Node: another-node
+        Node: node-0
+      Checks:
+      - Status: passing
+    # A listing of instances from 2 services would never happen in consul but
+    # this satisfies our mocking needs for the moment, until we have a 'And 1
+    # proxy on request.0 from yaml', 'And 1 proxy on request.1 from yaml' or
+    # similar
+    - Service:
+        Name: service-0-proxy
+        ID: service-a-proxy
+      Node:
+        Node: node-0
+      Checks:
+      - Status: passing
     ---
-  // TODO: Improve mock data to get proper service instance data
-  @ignore
   Scenario: Clicking a instance in the listing and back again
     When I visit the service page for yaml
     ---
@@ -25,9 +44,15 @@ Feature: dc / services / instances / navigation
     ---
     And I click instances on the tabs
     Then the url should be /dc-1/services/service-0/instances
-    Then I see 2 instance models on the instanceList component
-    When I click instance on the instanceList.instances component
-    Then a GET request was made to "/v1/catalog/connect/service-0?dc=dc-1"
+    Then I see 3 instance models
+    When I click instance on the instances component
+    Then a GET request was made to "/v1/catalog/connect/service-0?dc=dc-1&ns=@namespace"
+    Then a GET request was made to "/v1/health/service/service-0-proxy?dc=dc-1&ns=@namespace"
     Then the url should be /dc-1/services/service-0/instances/node-0/service-a/health-checks
     And I click "[data-test-back]"
-    Then the url should be /dc1/services/service-0/topology
+    Then the url should be /dc-1/services/service-0/topology
+    And I click instances on the tabs
+    When I click instance on the instances component
+    Then a GET request was made to "/v1/catalog/connect/service-0?dc=dc-1&ns=@namespace"
+    Then a GET request was made to "/v1/health/service/service-0-proxy?dc=dc-1&ns=@namespace"
+    Then the url should be /dc-1/services/service-0/instances/node-0/service-a/health-checks

--- a/ui/packages/consul-ui/tests/pages.js
+++ b/ui/packages/consul-ui/tests/pages.js
@@ -161,7 +161,16 @@ export default {
     )
   ),
   service: create(
-    service(visitable, attribute, collection, text, consulIntentionList, catalogToolbar, tabgroup)
+    service(
+      visitable,
+      clickable,
+      attribute,
+      collection,
+      text,
+      consulIntentionList,
+      catalogToolbar,
+      tabgroup
+    )
   ),
   instance: create(
     instance(

--- a/ui/packages/consul-ui/tests/pages/dc/services/show.js
+++ b/ui/packages/consul-ui/tests/pages/dc/services/show.js
@@ -1,4 +1,13 @@
-export default function(visitable, attribute, collection, text, intentions, filter, tabs) {
+export default function(
+  visitable,
+  clickable,
+  attribute,
+  collection,
+  text,
+  intentions,
+  filter,
+  tabs
+) {
   const page = {
     visit: visitable('/:dc/services/:service'),
     externalSource: attribute('data-test-external-source', '[data-test-external-source]', {
@@ -23,6 +32,7 @@ export default function(visitable, attribute, collection, text, intentions, filt
     // TODO: These need to somehow move to subpages
     instances: collection('.consul-service-instance-list > ul > li:not(:first-child)', {
       address: text('[data-test-address]'),
+      instance: clickable('a'),
     }),
     intentionList: intentions(),
   };


### PR DESCRIPTION
aka the 'in/out/in' test, aka 'The Hokey Cokey Test ™️ '

This PR is additional to https://github.com/hashicorp/consul/pull/9524 and is the base branch for this PR.

Here we add a test for clicking forwards and backwards, and then forwards again between the Service Detail page and the Service Instance detail page, to prove that the fix in https://github.com/hashicorp/consul/pull/9524 works.

I undid the fix to verify that this was failing with a 404 before the fix, redoing the fix makes the tests pass.

Notes:

We cheated a little here as in the app we call the same endpoint in quick succession one after the other and we have no generic way of mocking this absolutely realistically from within our acceptance tests. We rely on the fact that the list of instances from consul are then filtered by the UI to only give us the instance we are interested in. This means we can put as many different instances in the mocked response as we like, with all different ids, from all different services (which would never happen in Consul), and this will then satisfy the mocks we need for the test.

Alternatively we could have included some conditionals in the mock-api template, but this I'm not sure how generically we would have done that.

Longer term some sort of 'Given 1 instance model on request.0 from yaml', 'Given 2 instance models on request.1 from yaml' or similar might be a nice addition.

