### PR TITLE
Add a CLI tool for "Client Libraries & SDKs" page

### DIFF
--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -128,4 +128,8 @@ the community.
     <a href="https://github.com/adaptant-labs/consul-dart">consul-dart</a> -
     Dart client for the Consul HTTP API
   </li>
+  <li>
+    <a href="https://github.com/sadedil/kvit">kvit</a> - A command line
+    utility for synchronizing key value pairs between Consul and file system
+  </li>
 </ul>

--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -128,8 +128,4 @@ the community.
     <a href="https://github.com/adaptant-labs/consul-dart">consul-dart</a> -
     Dart client for the Consul HTTP API
   </li>
-  <li>
-    <a href="https://github.com/sadedil/kvit">kvit</a> - A command line
-    utility for synchronizing key value pairs between Consul and file system
-  </li>
 </ul>

--- a/website/content/docs/download-tools.mdx
+++ b/website/content/docs/download-tools.mdx
@@ -61,5 +61,6 @@ These Consul tools are created and managed by the amazing members of the Consul 
 - [Spring Cloud Consul](https://github.com/spring-cloud/spring-cloud-consul) - Service discovery, configuration and events for Spring Cloud
 - [IntelliJ IDEA Consul K/V Support](https://plugins.jetbrains.com/plugin/10511-consul-k-v-support) - editor for K/V store
 - [git2consul-go](https://github.com/KohlsTechnology/git2consul-go) - Data feeder for Consul K/V store
+- [kvit](https://github.com/sadedil/kvit) - A command line utility for synchronizing key value pairs between Consul and file system
 
 Are you the author of a tool and you would like to be featured on this page? The Consul website is open source and is embedded inside the [Consul repository](https://github.com/hashicorp/consul) on GitHub. You can submit a Pull Request to add your tool to the list and we will gladly review it.


### PR DESCRIPTION
Hi everyone,

I'm developing an open source CLI tool for easily editing Consul KV values from your favorite text editor. I've added to Client Libraries & SDKs page on website.

Repository: https://github.com/sadedil/kvit

Kind regards,
Mustafa