### PR TITLE
docs/nia: Fix example config block to execute properly

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -141,7 +141,7 @@ driver "terraform" {
   working_dir = ""
 
   backend "consul" {
-    scheme = "https"
+    gzip = true
   }
 
   required_providers {


### PR DESCRIPTION
CTS running with default configuration will communicate over http unless the Consul client is configured with TLS. Having the example set the scheme to https is misleading and will result in an error since TLS is not configured by default:

```
http: server gave HTTP response to HTTPS client
```

PR replaces the example block with a default value for those who do copy the config.

Resolves https://github.com/hashicorp/consul-terraform-sync/issues/163