### PR TITLE
ui: Show a feedback icon instead of a learn icon in the help menu

### DIFF
--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -152,7 +152,7 @@
                             </MenuItem>
                             <MenuSeparator />
                             <MenuItem
-                              class="learn-link"
+                              class="feedback-link"
                               @href={{env 'CONSUL_REPO_ISSUES_URL'}}
                             >
                               <BlockSlot @name="label">


### PR DESCRIPTION
Before:

<img width="308" alt="Screenshot 2021-01-12 at 11 46 03" src="https://user-images.githubusercontent.com/554604/104310541-c8ddb780-54cb-11eb-82e4-8e913d3ddf0c.png">
