### PR TITLE
structs: Add more cache key completeness tests

### DIFF
--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -639,15 +639,21 @@ func (r *ServiceConfigRequest) CacheInfo() cache.RequestInfo {
 	// the slice would affect cache keys if we ever persist between agent restarts
 	// and change it.
 	v, err := hashstructure.Hash(struct {
-		Name           string
-		EnterpriseMeta EnterpriseMeta
-		Upstreams      []string    `hash:"set"`
-		UpstreamIDs    []ServiceID `hash:"set"`
+		Name              string
+		EnterpriseMeta    EnterpriseMeta
+		Upstreams         []string    `hash:"set"`
+		UpstreamIDs       []ServiceID `hash:"set"`
+		MeshGatewayConfig MeshGatewayConfig
+		ProxyMode         ProxyMode
+		Filter            string
 	}{
-		Name:           r.Name,
-		EnterpriseMeta: r.EnterpriseMeta,
-		Upstreams:      r.Upstreams,
-		UpstreamIDs:    r.UpstreamIDs,
+		Name:              r.Name,
+		EnterpriseMeta:    r.EnterpriseMeta,
+		Upstreams:         r.Upstreams,
+		UpstreamIDs:       r.UpstreamIDs,
+		ProxyMode:         r.Mode,
+		MeshGatewayConfig: r.MeshGateway,
+		Filter:            r.QueryOptions.Filter,
 	}, nil)
 	if err == nil {
 		// If there is an error, we don't set the key. A blank key forces

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -11,10 +11,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mitchellh/hashstructure"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/lib"
-	"github.com/mitchellh/hashstructure"
 )
 
 const (
@@ -1378,6 +1379,7 @@ func (r *DiscoveryChainRequest) CacheInfo() cache.RequestInfo {
 		OverrideMeshGateway    MeshGatewayConfig
 		OverrideProtocol       string
 		OverrideConnectTimeout time.Duration
+		Filter                 string
 	}{
 		Name:                   r.Name,
 		EvaluateInDatacenter:   r.EvaluateInDatacenter,
@@ -1385,6 +1387,7 @@ func (r *DiscoveryChainRequest) CacheInfo() cache.RequestInfo {
 		OverrideMeshGateway:    r.OverrideMeshGateway,
 		OverrideProtocol:       r.OverrideProtocol,
 		OverrideConnectTimeout: r.OverrideConnectTimeout,
+		Filter:                 r.QueryOptions.Filter,
 	}, nil)
 	if err == nil {
 		// If there is an error, we don't set the key. A blank key forces

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -2222,18 +2222,9 @@ func TestConfigEntryQuery_CacheInfoKey(t *testing.T) {
 }
 
 func TestServiceConfigRequest_CacheInfoKey(t *testing.T) {
-	ignoredFields := []string{
-		// TODO: should QueryOptions.Filter be included in the key?
-		"QueryOptions",
-		// TODO: should this be included in the key?
-		"MeshGateway",
-		// TODO: should this be included in the key?
-		"Mode",
-	}
-	assertCacheInfoKeyIsComplete(t, &ServiceConfigRequest{}, ignoredFields...)
+	assertCacheInfoKeyIsComplete(t, &ServiceConfigRequest{})
 }
 
 func TestDiscoveryChainRequest_CacheInfoKey(t *testing.T) {
-	// TODO: should QueryOptions.Filter be included in the key?
-	assertCacheInfoKeyIsComplete(t, &DiscoveryChainRequest{}, "QueryOptions")
+	assertCacheInfoKeyIsComplete(t, &DiscoveryChainRequest{})
 }

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -2216,3 +2216,25 @@ func requireContainsLower(t *testing.T, haystack, needle string) {
 func intPointer(i int) *int {
 	return &i
 }
+
+func TestConfigEntryQuery_CacheInfoKey(t *testing.T) {
+	assertCacheInfoKeyIsComplete(t, &ConfigEntryQuery{}, nil)
+}
+
+func TestServiceConfigRequest_CacheInfoKey(t *testing.T) {
+	ignoredFields := map[string]bool{
+		"QueryOptions": true,
+		// TODO: should this be included in the key?
+		"MeshGateway": true,
+		// TODO: should this be included in the key?
+		"Mode": true,
+	}
+	assertCacheInfoKeyIsComplete(t, &ServiceConfigRequest{}, ignoredFields)
+}
+
+func TestDiscoveryChainRequest_CacheInfoKey(t *testing.T) {
+	ignoredFields := map[string]bool{
+		"QueryOptions": true,
+	}
+	assertCacheInfoKeyIsComplete(t, &DiscoveryChainRequest{}, ignoredFields)
+}

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -2218,23 +2218,22 @@ func intPointer(i int) *int {
 }
 
 func TestConfigEntryQuery_CacheInfoKey(t *testing.T) {
-	assertCacheInfoKeyIsComplete(t, &ConfigEntryQuery{}, nil)
+	assertCacheInfoKeyIsComplete(t, &ConfigEntryQuery{})
 }
 
 func TestServiceConfigRequest_CacheInfoKey(t *testing.T) {
-	ignoredFields := map[string]bool{
-		"QueryOptions": true,
+	ignoredFields := []string{
+		// TODO: should QueryOptions.Filter be included in the key?
+		"QueryOptions",
 		// TODO: should this be included in the key?
-		"MeshGateway": true,
+		"MeshGateway",
 		// TODO: should this be included in the key?
-		"Mode": true,
+		"Mode",
 	}
-	assertCacheInfoKeyIsComplete(t, &ServiceConfigRequest{}, ignoredFields)
+	assertCacheInfoKeyIsComplete(t, &ServiceConfigRequest{}, ignoredFields...)
 }
 
 func TestDiscoveryChainRequest_CacheInfoKey(t *testing.T) {
-	ignoredFields := map[string]bool{
-		"QueryOptions": true,
-	}
-	assertCacheInfoKeyIsComplete(t, &DiscoveryChainRequest{}, ignoredFields)
+	// TODO: should QueryOptions.Filter be included in the key?
+	assertCacheInfoKeyIsComplete(t, &DiscoveryChainRequest{}, "QueryOptions")
 }

--- a/agent/structs/intention_test.go
+++ b/agent/structs/intention_test.go
@@ -5,9 +5,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/acl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/acl"
 )
 
 func TestIntention_ACLs(t *testing.T) {
@@ -452,4 +453,10 @@ func TestIntention_String(t *testing.T) {
 			require.Equal(t, tc.expect, got)
 		})
 	}
+}
+
+func TestIntentionQueryRequest_CacheInfoKey(t *testing.T) {
+	// TODO: should these fields be included in the key?
+	ignored := []string{"IntentionID", "Check", "Exact", "QueryOptions"}
+	assertCacheInfoKeyIsComplete(t, &IntentionQueryRequest{}, ignored...)
 }

--- a/agent/structs/intention_test.go
+++ b/agent/structs/intention_test.go
@@ -456,7 +456,5 @@ func TestIntention_String(t *testing.T) {
 }
 
 func TestIntentionQueryRequest_CacheInfoKey(t *testing.T) {
-	// TODO: should these fields be included in the key?
-	ignored := []string{"IntentionID", "Check", "Exact", "QueryOptions"}
-	assertCacheInfoKeyIsComplete(t, &IntentionQueryRequest{}, ignored...)
+	assertCacheInfoKeyIsComplete(t, &IntentionQueryRequest{})
 }

--- a/agent/structs/prepared_query_test.go
+++ b/agent/structs/prepared_query_test.go
@@ -27,3 +27,9 @@ func TestStructs_PreparedQuery_GetACLPrefix(t *testing.T) {
 		t.Fatalf("bad: ok=%v prefix=%#v", ok, prefix)
 	}
 }
+
+func TestPreparedQueryExecuteRequest_CacheInfoKey(t *testing.T) {
+	// TODO: should these fields be included in the key?
+	ignored := []string{"Agent", "QueryOptions"}
+	assertCacheInfoKeyIsComplete(t, &PreparedQueryExecuteRequest{}, ignored...)
+}

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -642,6 +642,7 @@ func (r *ServiceSpecificRequest) CacheInfo() cache.RequestInfo {
 		r.Filter,
 		r.EnterpriseMeta,
 		r.Ingress,
+		r.ServiceKind,
 	}, nil)
 	if err == nil {
 		// If there is an error, we don't set the key. A blank key forces

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1597,8 +1597,7 @@ func TestNodeSpecificRequest_CacheInfoKey(t *testing.T) {
 }
 
 func TestServiceSpecificRequest_CacheInfoKey(t *testing.T) {
-	// TODO: should ServiceKind filed be included in the key?
-	assertCacheInfoKeyIsComplete(t, &ServiceSpecificRequest{}, "ServiceKind")
+	assertCacheInfoKeyIsComplete(t, &ServiceSpecificRequest{})
 }
 
 func TestServiceDumpRequest_CacheInfoKey(t *testing.T) {
@@ -1613,7 +1612,7 @@ func TestServiceDumpRequest_CacheInfoKey(t *testing.T) {
 var cacheInfoIgnoredFields = map[string]bool{
 	// Datacenter is part of the cache key added by the cache itself.
 	"Datacenter": true,
-	// QuerySource is always the same for every request from  a single agent, so it
+	// QuerySource is always the same for every request from a single agent, so it
 	// is excluded from the key.
 	"Source": true,
 	// EnterpriseMeta is an empty struct, so can not be included.
@@ -1654,10 +1653,11 @@ func assertCacheInfoKeyIsComplete(t *testing.T, request cache.Request, ignoredFi
 
 		key := request.CacheInfo().Key
 		if originalKey == key {
-			t.Fatalf("expected field %v to be represented in the CacheInfo.Key, %v change to %v",
+			t.Fatalf("expected field %v to be represented in the CacheInfo.Key, %v change to %v (key: %v)",
 				fieldName,
 				originalValue,
-				field.Interface())
+				field.Interface(),
+				key)
 		}
 	}
 }

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1588,15 +1588,15 @@ func TestStructs_validateMetaPair(t *testing.T) {
 	}
 }
 
-func TestDCSpecificRequestCacheInfoKey(t *testing.T) {
+func TestDCSpecificRequest_CacheInfoKey(t *testing.T) {
 	assertCacheInfoKeyIsComplete(t, &DCSpecificRequest{}, nil)
 }
 
-func TestNodeSpecificRequestCacheInfoKey(t *testing.T) {
+func TestNodeSpecificRequest_CacheInfoKey(t *testing.T) {
 	assertCacheInfoKeyIsComplete(t, &NodeSpecificRequest{}, nil)
 }
 
-func TestServiceSpecificRequestCacheInfoKey(t *testing.T) {
+func TestServiceSpecificRequest_CacheInfoKey(t *testing.T) {
 	ignoredFields := map[string]bool{
 		// TODO: should this filed be included?
 		"ServiceKind": true,
@@ -1605,7 +1605,7 @@ func TestServiceSpecificRequestCacheInfoKey(t *testing.T) {
 	assertCacheInfoKeyIsComplete(t, &ServiceSpecificRequest{}, ignoredFields)
 }
 
-func TestServiceDumpRequestCacheInfoKey(t *testing.T) {
+func TestServiceDumpRequest_CacheInfoKey(t *testing.T) {
 	ignoredFields := map[string]bool{
 		// ServiceKind is only included when UseServiceKind=true
 		"ServiceKind": true,
@@ -1629,6 +1629,7 @@ var cacheInfoIgnoredFields = map[string]bool{
 }
 
 func assertCacheInfoKeyIsComplete(t *testing.T, request cache.Request, ignoredFields map[string]bool) {
+	t.Helper()
 	fuzzer := fuzz.NewWithSeed(time.Now().UnixNano())
 	fuzzer.Funcs(randQueryOptions)
 	fuzzer.Fuzz(request)


### PR DESCRIPTION
related issue: #9437, this PR builds on #9480

This PR adds cache key completeness tests for the remaining types in `structs`. See the comment on `assertCacheInfoKeyIsComplete`, or the description in the linked issue, for how this works.

There are 2 or 3 structs outside of the `structs` package that also implement the `cache.Request` interface, but to test those we'll need to extract this assertion function to an `internal/testing/` helper package so we can export it.