### PR TITLE
website: silence vercel comments. make logs public

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "public": true,
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
in addition to silencing the github bot's PR comments, this also makes the site build logs public - which is best practice across our oss site's hosted on vercel. 