### PR TITLE
ci: add load test automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,16 @@
 ---
 version: 2.1
 
+parameters:
+  commit:
+    type: string
+    default: ""
+    description: "Commit to run load tests against"
+  trigger-load-test:
+    type: boolean
+    default: false
+    description: "Boolean whether to run the load test workflow"
+
 references:
   images:
     go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.15.6
@@ -876,9 +886,72 @@ jobs:
                     "https://circleci.com/api/v1.1/project/github/hashicorp/consul-enterprise/tree/${CIRCLE_BRANCH}" | jq -r '.build_url'
       - run: *notify-slack-failure
 
+  # Run load tests against a commit
+  load-test:
+    docker:
+      - image: hashicorp/terraform:latest
+    environment:
+      AWS_DEFAULT_REGION: us-east-2
+      BUCKET: consul-ci-load-tests
+    steps:
+      - checkout
+      - run: apk add jq curl bash
+      - run:
+          name: export load-test credentials
+          command: |
+            echo "export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID_LOAD_TEST" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY_LOAD_TEST" >> $BASH_ENV
+      - run:
+          name: export role arn
+          command: |
+            echo "export TF_VAR_role_arn=$ROLE_ARN_LOAD_TEST" >> $BASH_ENV
+      - run:
+          name: setup TF_VARs
+          command: |
+            short_ref=$(git rev-parse --short << pipeline.parameters.commit>>)
+            echo "export TF_VAR_ami_owners=$LOAD_TEST_AMI_OWNERS" >> $BASH_ENV
+            echo "export TF_VAR_vpc_name=$short_ref" >> $BASH_ENV
+            echo "export TF_VAR_cluster_name=$short_ref" >> $BASH_ENV
+            echo "export TF_VAR_consul_download_url=https://${S3_ARTIFACT_BUCKET}.s3.${AWS_DEFAULT_REGION}.amazonaws.com/${S3_ARTIFACT_PATH}/<< pipeline.parameters.commit>>.zip" >> $BASH_ENV
+      - run:
+          name: wait for dev build from test-integrations workflow
+          shell: /usr/bin/env bash -euo pipefail -c
+          command: |
+            echo "curl-ing https://${S3_ARTIFACT_BUCKET}.s3.${AWS_DEFAULT_REGION}.amazonaws.com/${S3_ARTIFACT_PATH}/<< pipeline.parameters.commit>>.zip"
+            until [ $SECONDS -ge 300 ] && exit 1; do
+              curl -o /dev/null --fail --silent "https://${S3_ARTIFACT_BUCKET}.s3.${AWS_DEFAULT_REGION}.amazonaws.com/${S3_ARTIFACT_PATH}/<< pipeline.parameters.commit>>.zip" && exit
+              echo -n "."
+              sleep 2
+            done
+      - run:
+          working_directory: .circleci/terraform/load-test
+          name: terraform init
+          command: |
+            source $BASH_ENV
+            echo "commit is << pipeline.parameters.commit >>"
+            terraform init \
+            -backend-config="bucket=${BUCKET}" \
+            -backend-config="key=<< pipeline.parameters.commit >>" \
+            -backend-config="region=${AWS_DEFAULT_REGION}" \
+            -backend-config="role_arn=${ROLE_ARN_LOAD_TEST}"
+      - run:
+          working_directory: .circleci/terraform/load-test
+          name: run terraform apply
+          command: |
+            source $BASH_ENV
+            terraform apply -auto-approve
+      - run:
+          working_directory: .circleci/terraform/load-test
+          when: always
+          name: terraform destroy
+          command: |
+            source $BASH_ENV
+            terraform destroy -auto-approve
+
 workflows:
   version: 2
   go-tests:
+    unless: << pipeline.parameters.trigger-load-test >>
     jobs:
       - check-vendor: &filter-ignore-non-go-branches
           filters:
@@ -899,6 +972,7 @@ workflows:
       - go-test-race: *filter-ignore-non-go-branches
       - go-test-sdk: *filter-ignore-non-go-branches
   build-distros:
+    unless: << pipeline.parameters.trigger-load-test >>
     jobs:
       - check-vendor: *filter-ignore-non-go-branches
       - build-386: &require-check-vendor
@@ -937,6 +1011,7 @@ workflows:
             - dev-build
           context: consul-ci
   test-integrations:
+    unless: << pipeline.parameters.trigger-load-test >>
     jobs:
       - dev-build: *filter-ignore-non-go-branches
       - dev-upload-s3: &dev-upload
@@ -969,6 +1044,7 @@ workflows:
           requires:
             - dev-build
   website:
+    unless: << pipeline.parameters.trigger-load-test >>
     jobs:
       - build-website-docker-image:
           context: website-docker-image
@@ -983,6 +1059,7 @@ workflows:
               only:
                 - stable-website
   frontend:
+    unless: << pipeline.parameters.trigger-load-test >>
     jobs:
       - frontend-cache:
           filters:
@@ -1014,6 +1091,7 @@ workflows:
           requires:
             - ember-build-ent
   workflow-automation:
+    unless: << pipeline.parameters.trigger-load-test >>
     jobs:
       - trigger-oss-merge:
           context: team-consul
@@ -1028,3 +1106,7 @@ workflows:
             branches:
               only:
                 - master
+  load-test:
+    when: << pipeline.parameters.trigger-load-test >>
+    jobs:
+      - load-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 references:
   images:
@@ -43,16 +43,6 @@ steps:
         unzip awscliv2.zip
         sudo ./aws/install
 
-  aws-assume-role: &aws-assume-role
-    run:
-      name: assume-role aws creds
-      command: |
-        # assume role has duration of 15 min (the minimum allowed)
-        CREDENTIALS="$(aws sts assume-role --duration-seconds 900 --role-arn ${ROLE_ARN} --role-session-name build-${CIRCLE_SHA1} | jq '.Credentials')"
-        echo "export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')" >> $BASH_ENV
-        echo "export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')" >> $BASH_ENV
-        echo "export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.SessionToken')" >> $BASH_ENV
-
   # This step MUST be at the end of any set of steps due to the 'when' condition
   notify-slack-failure: &notify-slack-failure
     name: notify-slack-failure
@@ -79,6 +69,30 @@ steps:
       else
         echo "Not posting slack failure notifications for non-master branch"
       fi
+
+commands:
+  assume-role:
+    description: "Assume role to an ARN"
+    parameters:
+      access-key:
+        type: env_var_name
+        default: AWS_ACCESS_KEY_ID
+      secret-key:
+        type: env_var_name
+        default: AWS_SECRET_ACCESS_KEY
+      role-arn:
+        type: env_var_name
+        default: ROLE_ARN
+    steps:
+      - run: |
+          export AWS_ACCESS_KEY_ID="${<< parameters.access-key >>}"
+          export AWS_SECRET_ACCESS_KEY="${<< parameters.secret-key >>}"
+          export ROLE_ARN="${<< parameters.role-arn >>}"
+          # assume role has duration of 15 min (the minimum allowed)
+          CREDENTIALS="$(aws sts assume-role --duration-seconds 900 --role-arn ${ROLE_ARN} --role-session-name build-${CIRCLE_SHA1} | jq '.Credentials')"
+          echo "export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')" >> $BASH_ENV
+          echo "export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')" >> $BASH_ENV
+          echo "export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.SessionToken')" >> $BASH_ENV
 
 jobs:
   # lint consul tests
@@ -415,7 +429,10 @@ jobs:
     steps:
       - checkout
       - *get-aws-cli
-      - *aws-assume-role
+      - assume-role:
+          access-key: AWS_ACCESS_KEY_ID_S3_UPLOAD
+          secret-key: AWS_SECRET_ACCESS_KEY_S3_UPLOAD
+          role-arn: ROLE_ARN_S3_UPLOAD
       # get consul binary
       - attach_workspace:
           at: bin/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -778,7 +778,7 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash) -v -c -C $CIRCLE_SHA1 -F ui
       - run: *notify-slack-failure
 
-  envoy-integration-test-1.13.6: &ENVOY_TESTS
+  envoy-integration-test-1_13_6: &ENVOY_TESTS
     docker:
       # We only really need bash and docker-compose which is installed on all
       # Circle images but pick Go since we have to pick one of them.
@@ -818,17 +818,17 @@ jobs:
           path: *TEST_RESULTS_DIR
       - run: *notify-slack-failure
 
-  envoy-integration-test-1.14.5:
+  envoy-integration-test-1_14_5:
     <<: *ENVOY_TESTS
     environment:
       ENVOY_VERSION: "1.14.5"
 
-  envoy-integration-test-1.15.2:
+  envoy-integration-test-1_15_2:
     <<: *ENVOY_TESTS
     environment:
       ENVOY_VERSION: "1.15.2"
 
-  envoy-integration-test-1.16.0:
+  envoy-integration-test-1_16_0:
     <<: *ENVOY_TESTS
     environment:
       ENVOY_VERSION: "1.16.0"
@@ -1031,16 +1031,16 @@ workflows:
       - nomad-integration-0_8:
           requires:
             - dev-build
-      - envoy-integration-test-1.13.6:
+      - envoy-integration-test-1_13_6:
           requires:
             - dev-build
-      - envoy-integration-test-1.14.5:
+      - envoy-integration-test-1_14_5:
           requires:
             - dev-build
-      - envoy-integration-test-1.15.2:
+      - envoy-integration-test-1_15_2:
           requires:
             - dev-build
-      - envoy-integration-test-1.16.0:
+      - envoy-integration-test-1_16_0:
           requires:
             - dev-build
   website:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,14 +438,14 @@ jobs:
           at: bin/
       - run:
           name: package binary
-          command: tar -czf consul.tar.gz -C bin/ consul
+          command: zip -j consul.zip bin/consul
       - run:
           name: Upload to s3
           command: |
             if [ -n "${S3_ARTIFACT_PATH}" ]; then
               aws s3 cp \
               --metadata "CIRCLECI=${CIRCLECI},CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL},CIRCLE_BRANCH=${CIRCLE_BRANCH}" \
-              "consul.tar.gz" "s3://${S3_ARTIFACT_BUCKET}/${S3_ARTIFACT_PATH}/${CIRCLE_SHA1}.tar.gz"
+              "consul.zip" "s3://${S3_ARTIFACT_BUCKET}/${S3_ARTIFACT_PATH}/${CIRCLE_SHA1}.zip" --acl public-read
             else
               echo "CircleCI - S3_ARTIFACT_PATH was not set"
               exit 1

--- a/.circleci/terraform/load-test/.terraform.lock.hcl
+++ b/.circleci/terraform/load-test/.terraform.lock.hcl
@@ -1,0 +1,105 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.23.0"
+  constraints = ">= 2.54.0, ~> 3.0"
+  hashes = [
+    "h1:tSznQxPJvolDnmqqaTK9SsJ0bluTws7OAWcnc1t0ABs=",
+    "zh:30b0733027c00472618da998bc77967c692e238ae117c07e046fdd7336b83fa3",
+    "zh:3677550a8bef8e01c67cb615407dc8a69d32f4e36017033cd6f71a831c99d5de",
+    "zh:3c2fb4c14bfd43cf20ee25d0068ce09f1d48758408b8f1c88a096cea243612b3",
+    "zh:5577543322003693c4fe24a69ed0d47e58f867426fd704fac94cf5c16d3d6153",
+    "zh:6771f09d76ad01ffc04baa3bce7a3eed09f6a8a949274ffbd9d11756a58a4329",
+    "zh:7a57b79d304d17cf52ee3ddce91679f6b4289c5bdda2e31b763bf7d512e542d9",
+    "zh:815fb027e17bfe754b05367d20bd0694726a95a99b81e8d939ddd44e2b1f05a9",
+    "zh:a3d67db5ec0f4e9750eb19676a9a1aff36b0721e276a4ba789f42b991bf5951c",
+    "zh:cd67ff33860ad578172c19412ce608ba818e7590083197df2b793f870d6f50a3",
+    "zh:fbe0835055d1260fb77ad19a32a8726248ba7ac187f6c463ded90737b4cea8e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.0.0"
+  hashes = [
+    "h1:pO1ANXtOCRfecKsY9Hn4UsXoPBLv6LFiDIEiS1MZ09E=",
+    "zh:34ce8b79493ace8333d094752b579ccc907fa9392a2c1d6933a6c95d0786d3f1",
+    "zh:5c5a19c4f614a4ffb68bae0b0563f3860115cf7539b8adc21108324cfdc10092",
+    "zh:67ddb1ca2cd3e1a8f948302597ceb967f19d2eeb2d125303493667388fe6330e",
+    "zh:68e6b16f3a8e180fcba1a99754118deb2d82331b51f6cca39f04518339bfdfa6",
+    "zh:8393a12eb11598b2799d51c9b0a922a3d9fadda5a626b94a1b4914086d53120e",
+    "zh:90daea4b2010a86f2aca1e3a9590e0b3ddcab229c2bd3685fae76a832e9e836f",
+    "zh:99308edc734a0ac9149b44f8e316ca879b2670a1cae387a8ae754c180b57cdb4",
+    "zh:c76594db07a9d1a73372a073888b672df64adb455d483c2426cc220eda7e092e",
+    "zh:dc09c1fb36c6a706bdac96cce338952888c8423978426a09f5df93031aa88b84",
+    "zh:deda88134e9780319e8de91b3745520be48ead6ec38cb662694d09185c3dac70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.0.0"
+  hashes = [
+    "h1:V1tzrSG6t3e7zWvUwRbGbhsWU2Jd/anrJpOl9XM+R/8=",
+    "zh:05fb7eab469324c97e9b73a61d2ece6f91de4e9b493e573bfeda0f2077bc3a4c",
+    "zh:1688aa91885a395c4ae67636d411475d0b831e422e005dcf02eedacaafac3bb4",
+    "zh:24a0b1292e3a474f57c483a7a4512d797e041bc9c2fbaac42fe12e86a7fb5a3c",
+    "zh:2fc951bd0d1b9b23427acc93be09b6909d72871e464088171da60fbee4fdde03",
+    "zh:6db825759425599a326385a68acc6be2d9ba0d7d6ef587191d0cdc6daef9ac63",
+    "zh:85985763d02618993c32c294072cc6ec51f1692b803cb506fcfedca9d40eaec9",
+    "zh:a53186599c57058be1509f904da512342cfdc5d808efdaf02dec15f0f3cb039a",
+    "zh:c2e07b49b6efa676bdc7b00c06333ea1792a983a5720f9e2233db27323d2707c",
+    "zh:cdc8fe1096103cf5374751e2e8408ec4abd2eb67d5a1c5151fe2c7ecfd525bef",
+    "zh:dbdef21df0c012b0d08776f3d4f34eb0f2f229adfde07ff252a119e52c0f65b7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.0.1"
+  hashes = [
+    "h1:0QaSbRBgBi8vI/8IRwec1INdOqBxXbgsSFElx1O4k4g=",
+    "zh:0d4f683868324af056a9eb2b06306feef7c202c88dbbe6a4ad7517146a22fb50",
+    "zh:4824b3c7914b77d41dfe90f6f333c7ac9860afb83e2a344d91fbe46e5dfbec26",
+    "zh:4b82e43712f3cf0d0cbc95b2cbcd409ba8f0dc7848fdfb7c13633c27468ed04a",
+    "zh:78b3a2b860c3ebc973a794000015f5946eb59b82705d701d487475406b2612f1",
+    "zh:88bc65197bd74ff408d147b32f0045372ae3a3f2a2fdd7f734f315d988c0e4a2",
+    "zh:91bd3c9f625f177f3a5d641a64e54d4b4540cb071070ecda060a8261fb6eb2ef",
+    "zh:a6818842b28d800f784e0c93284ff602b0c4022f407e4750da03f50b853a9a2c",
+    "zh:c4a1a2b52abd05687e6cfded4a789dcd7b43e7a746e4d02dd1055370cf9a994d",
+    "zh:cf65041bf12fc3bde709c1d267dbe94142bc05adcabc4feb17da3b12249132ac",
+    "zh:e385e00e7425dda9d30b74ab4ffa4636f4b8eb23918c0b763f0ffab84ece0c5c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.0.0"
+  hashes = [
+    "h1:AcQGOAD5xa4KE9gYw5g7R6UU8a77Yn/afPvch4N86lQ=",
+    "zh:05eac573a1fe53227bcc6b01daf6ddf0b73456f97f56f316f1b3114a4771e175",
+    "zh:09390dad764c76f0fd59cae4dad296e3e39487e06de3a4bc0df73916c6bb2f17",
+    "zh:142d0bc4722ab088b7ca124b0eb44206b9d100f51035c162d50ef552e09813d0",
+    "zh:2c391743dd20f43329c0d0d49dec7827970d788115593c0e32a57050c0a85337",
+    "zh:525b12fc87369c0e6d347afe6c77668aebf56cfa078bb0f1f01cc2ee01ac7016",
+    "zh:5583d81b7a05c6d49a4c445e1ee62e82facb07bb9204998a836b7b522a51db8d",
+    "zh:925e3acc70e18ed1cd296d337fc3e0ca43ac6f5bf2e660f24de750c7754f91aa",
+    "zh:a291457d25b207fd28fb4fad9209ebb591e25cfc507ca1cb0fb8b2e255be1969",
+    "zh:bbf9e2718752aebfbd7c6b8e196eb2e52730b66befed2ea1954f9ff1c199295e",
+    "zh:f4b333c467ae02c1a238ac57465fe66405f6e2a6cfeb4eded9bc321c5652a1bf",
+  ]
+}

--- a/.circleci/terraform/load-test/main.tf
+++ b/.circleci/terraform/load-test/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  assume_role {
+    role_arn = var.role_arn
+  }
+}
+
+module "load-test" {
+  source = "github.com/hashicorp/consul/test/load/terraform"
+
+  vpc_az               = ["us-east-2a", "us-east-2b"]
+  vpc_name             = var.vpc_name
+  vpc_cidr             = "10.0.0.0/16"
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.3.0/24"]
+  test_public_ip       = true
+  ami_owners           = var.ami_owners
+  consul_download_url  = var.consul_download_url
+}

--- a/.circleci/terraform/load-test/variables.tf
+++ b/.circleci/terraform/load-test/variables.tf
@@ -1,0 +1,19 @@
+variable "vpc_name" {
+  description = "Name of the VPC"
+}
+
+variable "ami_owners" {
+  type        = list(string)
+  description = "The account owner number which the desired AMI is in"
+}
+
+variable "role_arn" {
+  type        = string
+  description = "Role ARN for assume role"
+}
+
+variable "consul_download_url" {
+  type        = string
+  description = "URL to download the Consul binary from"
+  default     = ""
+}

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   trigger-load-test:
-    if: ${{ github.event.label.name == 'test/load' }}
+    if: ${{ github.event.label.name == 'pr/load-test' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,63 @@
+on:
+  pull_request:
+    branches:
+      - master
+    types: [labeled]
+
+jobs:
+  trigger-load-test:
+    if: ${{ github.event.label.name == 'test/load' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Trigger CircleCI Load Test Pipeline
+        run: |
+          # build json payload to trigger CircleCI Load Test Pipeline
+          # This only runs the load test pipeline on the 'master' branch
+          jsonData=$(jq --null-input -r --arg commit ${{ github.event.pull_request.head.sha }} \
+            '{branch:"master", parameters: {"commit": $commit, "trigger-load-test": true}}')
+          echo "Passing JSON data to CircleCI API: $jsonData"
+          load_test_pipeline_id=$(curl -X POST \
+               -H "Circle-Token: ${{ secrets.CIRCLE_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               -d "$jsonData" \
+              "https://circleci.com/api/v2/project/gh/${GITHUB_REPOSITORY}/pipeline" | jq -r '.id')
+          echo "LOAD_TEST_PIPELINE_ID=$load_test_pipeline_id" >> $GITHUB_ENV
+      - name: Post Load Test URL to PR
+        env:
+          PR_COMMENT_URL: ${{ github.event.pull_request.comments_url }}
+        run: |
+          echo "LOAD_TEST_PIPELINE_ID is: $LOAD_TEST_PIPELINE_ID"
+          # get load-test workflow
+          workflow=
+          # wait up to a minute for load-test workflow to start
+          until [ $SECONDS -ge 60 ] && exit 1; do
+            workflow=$(curl -s -X GET \
+                -H "Circle-Token: ${{ secrets.CIRCLE_TOKEN }}" \
+                -H "Content-Type: application/json" \
+                "https://circleci.com/api/v2/pipeline/${LOAD_TEST_PIPELINE_ID}/workflow" | jq '.items[] | select(.name=="load-test")')
+            # if we found a workflow we exit
+            if [ -n "$workflow" ]; then
+              break
+            fi
+            echo -n "."
+            sleep 5
+          done
+          echo "$workflow"
+          # get pipeline number
+          pipeline_number=$(echo "$workflow" | jq -r '.pipeline_number')
+          # get workflow id
+          workflow_id=$(echo "$workflow" | jq -r '.id')
+          # get project slug
+          project_slug=$(echo "$workflow" | jq -r '.project_slug')
+          # build load test URL
+          load_test_url="https://app.circleci.com/pipelines/${project_slug}/${pipeline_number}/workflows/${workflow_id}"
+          # comment URL to pull request
+          curl -X POST \
+               -H "Authorization: token ${{ secrets.PR_COMMENT_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               -d "{\"body\": \"Load Test Pipeline Started at: $load_test_url\"}" \
+              "$PR_COMMENT_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,39 @@ website/.bundle
 website/build/
 website/npm-debug.log
 website/vendor
+
+### Terraform gitignore ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc


### PR DESCRIPTION
This PR adds automation to run load tests against PRs. Currently this only supports PRs made internally (on a branch and not a fork) since we only publish dev builds to s3 from non-forks. 

To trigger load tests, you apply the `pr/load-test` GitHub label to a specific PR. This will trigger a GitHub action that passes the commit SHA of the PR, and a boolean to signal load tests to run, to CircleCI which triggers a pipeline that just runs the `load-test` workflow. It will also post the URL of the CircleCI workflow to the PR since API triggered runs do not show up in GitHub checks. If you make subsequent commits to the PR and want to run load tests again, you would remove the label and readd it to retrigger the GitHub Action again. 

**Note:** I had to modify the AWS credential environment variable names since we used to have one set of credentials to do the s3 dev build uploading, but because I use S3 as a backend for the load test, there are two sets of credentials that are namespaced in the environment. **This means that I will need to backport b5560b04d8710bb04301287ae41d01a5b4770fd1 to the release branches and any current dev branches will need to be rebased off of master to pull in this config.** If not, the `dev-upload-s3` step will fail. Not a huge deal if you don't care about getting that s3 build for your branch though, so YMMV if you need to actually rebase. 