### PR TITLE
Update topology mapping Refs on all proxy instance deletions

### DIFF
--- a/.changelog/9589.txt
+++ b/.changelog/9589.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Fixes a panic introduced in 1.9.0 where servers in a specific state may crash during node de-registration.
+```

--- a/.changelog/9589.txt
+++ b/.changelog/9589.txt
@@ -1,3 +1,5 @@
 ```release-note:bug
-server: Fixes a panic introduced in 1.9.0 where servers in a specific state may crash during node de-registration.
+server: Fixes a server panic introduced in 1.9.0 where Connect service mesh is
+being used. Node de-registration could panic if it hosted services with
+multiple upstreams.
 ```

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -3287,6 +3287,11 @@ func cleanupMeshTopology(tx WriteTxn, idx uint64, service *structs.ServiceNode) 
 			if err := indexUpdateMaxTxn(tx, idx, topologyTableName); err != nil {
 				return fmt.Errorf("failed updating %s index: %v", topologyTableName, err)
 			}
+			continue
+
+		}
+		if err := tx.Insert(topologyTableName, copy); err != nil {
+			return fmt.Errorf("failed inserting %s mapping: %s", topologyTableName, err)
 		}
 	}
 	return nil

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -3278,8 +3278,11 @@ func cleanupMeshTopology(tx WriteTxn, idx uint64, service *structs.ServiceNode) 
 		if !ok {
 			return fmt.Errorf("unexpected topology type %T", rawCopy)
 		}
-		delete(copy.Refs, uid)
+		if _, ok := copy.Refs[uid]; !ok {
+			continue
+		}
 
+		delete(copy.Refs, uid)
 		if len(copy.Refs) == 0 {
 			if err := tx.Delete(topologyTableName, entry); err != nil {
 				return fmt.Errorf("failed to truncate %s table: %v", topologyTableName, err)

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -6719,7 +6719,7 @@ func TestCatalog_upstreamsFromRegistration_Watches(t *testing.T) {
 
 	ws = memdb.NewWatchSet()
 	tx = s.db.ReadTxn()
-	idx, _, err = upstreamsFromRegistrationTxn(tx, ws, web)
+	idx, names, err = upstreamsFromRegistrationTxn(tx, ws, web)
 
 	require.NoError(t, err)
 
@@ -6728,7 +6728,7 @@ func TestCatalog_upstreamsFromRegistration_Watches(t *testing.T) {
 		idx: 5,
 	}
 	require.Equal(t, exp.idx, idx)
-	require.Empty(t, exp.names)
+	require.Equal(t, exp.names, names)
 }
 
 func TestCatalog_upstreamsFromRegistration_Ingress(t *testing.T) {


### PR DESCRIPTION
To keep track of upstream/downstream pairings for the mesh topology visualization we keep the mapping stored in memdb. This pairing mapping contains a map with a reference to every proxy ID that contains this pair in its service definition.

As proxy instances are deregistered, this map needs to be updated to remove that reference for the pairing.

Currently that map is not being updated on deletions when the proxy ID being registered **is not** the last instance for that proxy **name**.

This PR ensures we persist the new reference map when proxy IDs are deregistered, and fixes the broken assertion in the relevant test.

Fixes: #9566