### PR TITLE
state: do not delete from inside an iteration (coordinates)

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -740,7 +740,11 @@ func (s *Store) deleteNodeTxn(tx WriteTxn, idx uint64, nodeName string) error {
 	if err != nil {
 		return fmt.Errorf("failed coordinate lookup: %s", err)
 	}
+	var coordsToDelete []interface{}
 	for coord := coords.Next(); coord != nil; coord = coords.Next() {
+		coordsToDelete = append(coordsToDelete, coord)
+	}
+	for _, coord := range coordsToDelete {
 		if err := tx.Delete("coordinates", coord); err != nil {
 			return fmt.Errorf("failed deleting coordinate: %s", err)
 		}


### PR DESCRIPTION
Deleting from memdb inside an interation can cause a panic from Iterator.Next. This
case is technically safe (for now) because the iterator is using the root radix tree
not a modified one.

However this could break at any time if someone adds an insert or delete to the coordinates table
before this place in the function.

It also sets a bad example, because generally deletes in an interator are not safe. So this
commit uses the pattern we have in other places to move the deletes out of the iteration.

There's no test for this because nothing has really changed. This is "future proofing".

This was found while investigating #9566. I don't think this one can cause a panic, but still good to fix.