### PR TITLE
Fix crash from deleting objects while stepping through iterator

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2780,6 +2780,7 @@ func cleanupGatewayWildcards(tx WriteTxn, idx uint64, svc *structs.ServiceNode) 
 	if err != nil {
 		return fmt.Errorf("failed gateway lookup for %q: %s", svc.ServiceName, err)
 	}
+
 	for mapping := gateways.Next(); mapping != nil; mapping = gateways.Next() {
 		if gs, ok := mapping.(*structs.GatewayService); ok && gs != nil {
 			// Only delete if association was created by a wildcard specifier.
@@ -3268,9 +3269,15 @@ func cleanupMeshTopology(tx WriteTxn, idx uint64, service *structs.ServiceNode) 
 	if err != nil {
 		return fmt.Errorf("%q lookup failed: %v", topologyTableName, err)
 	}
+
+	mappings := make([]*structs.UpstreamDownstream, 0)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		entry := raw.(*structs.UpstreamDownstream)
-		rawCopy, err := copystructure.Copy(entry)
+		mappings = append(mappings, raw.(*structs.UpstreamDownstream))
+	}
+
+	// Do the updates in a separate loop so we don't trash the iterator.
+	for _, m := range mappings {
+		rawCopy, err := copystructure.Copy(m)
 		if err != nil {
 			return fmt.Errorf("failed to copy existing topology mapping: %v", err)
 		}
@@ -3278,13 +3285,15 @@ func cleanupMeshTopology(tx WriteTxn, idx uint64, service *structs.ServiceNode) 
 		if !ok {
 			return fmt.Errorf("unexpected topology type %T", rawCopy)
 		}
+
+		// Bail early if there's no reference to the proxy ID we're deleting
 		if _, ok := copy.Refs[uid]; !ok {
 			continue
 		}
 
 		delete(copy.Refs, uid)
 		if len(copy.Refs) == 0 {
-			if err := tx.Delete(topologyTableName, entry); err != nil {
+			if err := tx.Delete(topologyTableName, m); err != nil {
 				return fmt.Errorf("failed to truncate %s table: %v", topologyTableName, err)
 			}
 			if err := indexUpdateMaxTxn(tx, idx, topologyTableName); err != nil {

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2781,21 +2781,27 @@ func cleanupGatewayWildcards(tx WriteTxn, idx uint64, svc *structs.ServiceNode) 
 		return fmt.Errorf("failed gateway lookup for %q: %s", svc.ServiceName, err)
 	}
 
+	mappings := make([]*structs.GatewayService, 0)
 	for mapping := gateways.Next(); mapping != nil; mapping = gateways.Next() {
 		if gs, ok := mapping.(*structs.GatewayService); ok && gs != nil {
-			// Only delete if association was created by a wildcard specifier.
-			// Otherwise the service was specified in the config entry, and the association should be maintained
-			// for when the service is re-registered
-			if gs.FromWildcard {
-				if err := tx.Delete(gatewayServicesTableName, gs); err != nil {
-					return fmt.Errorf("failed to truncate gateway services table: %v", err)
-				}
-				if err := indexUpdateMaxTxn(tx, idx, gatewayServicesTableName); err != nil {
-					return fmt.Errorf("failed updating gateway-services index: %v", err)
-				}
-				if err := deleteGatewayServiceTopologyMapping(tx, idx, gs); err != nil {
-					return fmt.Errorf("failed to reconcile mesh topology for gateway: %v", err)
-				}
+			mappings = append(mappings, gs)
+		}
+	}
+
+	// Do the updates in a separate loop so we don't trash the iterator.
+	for _, m := range mappings {
+		// Only delete if association was created by a wildcard specifier.
+		// Otherwise the service was specified in the config entry, and the association should be maintained
+		// for when the service is re-registered
+		if m.FromWildcard {
+			if err := tx.Delete(gatewayServicesTableName, m); err != nil {
+				return fmt.Errorf("failed to truncate gateway services table: %v", err)
+			}
+			if err := indexUpdateMaxTxn(tx, idx, gatewayServicesTableName); err != nil {
+				return fmt.Errorf("failed updating gateway-services index: %v", err)
+			}
+			if err := deleteGatewayServiceTopologyMapping(tx, idx, m); err != nil {
+				return fmt.Errorf("failed to reconcile mesh topology for gateway: %v", err)
 			}
 		}
 	}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -6790,7 +6790,7 @@ func TestCatalog_topologyCleanupPanic(t *testing.T) {
 	require.NoError(t, s.EnsureService(2, "foo", &svc))
 	assert.True(t, watchFired(ws))
 
-	// Now delete the node Foo, and this would panic because the deletion within an iterator
+	// Now delete the node Foo, and this would panic because of the deletion within an iterator
 	require.NoError(t, s.DeleteNode(3, "foo"))
 	assert.True(t, watchFired(ws))
 
@@ -7006,6 +7006,75 @@ func TestCatalog_upstreamsFromRegistration_Ingress(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(8), idx)
 	require.Len(t, names, 0)
+}
+
+func TestCatalog_cleanupGatewayWildcards_panic(t *testing.T) {
+	s := testStateStore(t)
+
+	require.NoError(t, s.EnsureNode(0, &structs.Node{
+		ID:   "c73b8fdf-4ef8-4e43-9aa2-59e85cc6a70c",
+		Node: "foo",
+	}))
+	require.NoError(t, s.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
+		Kind: structs.ProxyDefaults,
+		Name: structs.ProxyConfigGlobal,
+		Config: map[string]interface{}{
+			"protocol": "http",
+		},
+	}, nil))
+
+	defaultMeta := structs.DefaultEnterpriseMeta()
+
+	// Register two different gateways that target services via wildcard
+	require.NoError(t, s.EnsureConfigEntry(2, &structs.TerminatingGatewayConfigEntry{
+		Kind: "terminating-gateway",
+		Name: "my-gateway-1-terminating",
+		Services: []structs.LinkedService{
+			{
+				Name:           "*",
+				EnterpriseMeta: *defaultMeta,
+			},
+		},
+	}, nil))
+
+	require.NoError(t, s.EnsureConfigEntry(3, &structs.IngressGatewayConfigEntry{
+		Kind: "ingress-gateway",
+		Name: "my-gateway-2-ingress",
+		Listeners: []structs.IngressListener{
+			{
+				Port:     1111,
+				Protocol: "http",
+				Services: []structs.IngressService{
+					{
+						Name:           "*",
+						EnterpriseMeta: *defaultMeta,
+					},
+				},
+			},
+		},
+	}, nil))
+
+	// Register two services that share a prefix, both will be covered by gateway wildcards above
+	api := structs.NodeService{
+		ID:             "api",
+		Service:        "api",
+		Address:        "127.0.0.2",
+		Port:           443,
+		EnterpriseMeta: *defaultMeta,
+	}
+	require.NoError(t, s.EnsureService(4, "foo", &api))
+
+	api2 := structs.NodeService{
+		ID:             "api-2",
+		Service:        "api-2",
+		Address:        "127.0.0.2",
+		Port:           443,
+		EnterpriseMeta: *defaultMeta,
+	}
+	require.NoError(t, s.EnsureService(5, "foo", &api2))
+
+	// Now delete the node "foo", and this would panic because of the deletion within an iterator
+	require.NoError(t, s.DeleteNode(6, "foo"))
 }
 
 func TestCatalog_DownstreamsForService(t *testing.T) {


### PR DESCRIPTION
Fixes: #9566

There is a panic that can be triggered with go-memdb when within a write transaction:

1. An index is modified with an insert/delete.
2. An object referenced by that index is deleted from inside an iterator while there are remaining elements to iterate through.

Memdb would benefit from some changes to prevent this foot-gun scenario, but that's left as future work for now.

This PR avoids the panic by collecting objects from the iterator before doing any of the deletions.
