### PR TITLE
api: Ensure internal/ui/gateway-service-nodes responds with array

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -261,7 +261,12 @@ RPC:
 	}
 
 	summaries, _ := summarizeServices(out.Dump, s.agent.config, args.Datacenter)
-	return prepSummaryOutput(summaries, false), nil
+
+	prepped := prepSummaryOutput(summaries, false)
+	if prepped == nil {
+		prepped = make([]*ServiceSummary, 0)
+	}
+	return prepped, nil
 }
 
 // UIServiceTopology returns the list of upstreams and downstreams for a Connect enabled service.
@@ -449,6 +454,8 @@ func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig, dc s
 
 func prepSummaryOutput(summaries map[structs.ServiceName]*ServiceSummary, excludeSidecars bool) []*ServiceSummary {
 	var resp []*ServiceSummary
+	// Ensure at least a zero length slice
+	resp = make([]*ServiceSummary, 0)
 
 	// Collect and sort resp for display
 	for _, sum := range summaries {

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -629,7 +629,18 @@ func TestUIGatewayServiceNodes_Terminating(t *testing.T) {
 			},
 		}
 		require.NoError(t, a.RPC("Catalog.Register", &arg, &regOutput))
+	}
 
+	{
+		// Request without having registered the config-entry, shouldn't respond with null
+		req, _ := http.NewRequest("GET", "/v1/internal/ui/gateway-services-nodes/terminating-gateway", nil)
+		resp := httptest.NewRecorder()
+		obj, err := a.srv.UIGatewayServicesNodes(resp, req)
+		require.Nil(t, err)
+		require.NotNil(t, obj)
+	}
+
+	{
 		// Register terminating-gateway config entry, linking it to db and redis (does not exist)
 		args := &structs.TerminatingGatewayConfigEntry{
 			Name: "terminating-gateway",


### PR DESCRIPTION
A continuation of https://github.com/hashicorp/consul/pull/9397 fixes https://github.com/hashicorp/consul/issues/9535

In some circumstances endpoints that use this function will have no
results in them (due to ACLs, Namespaces, filtering or incorrect/missing
central config registration).

This ensures that the response is at least an empty array (`[]`) rather
than `null`.
