### PR TITLE
ui: Fix 'filter by' removal and provide more tests/docs around it

### DIFF
--- a/ui/packages/consul-ui/app/components/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/search-bar/index.hbs
@@ -55,7 +55,7 @@
 {{/each}}
           <li class="remove-all">
             <Action
-              {{on "click" this.removeFilters}}
+              {{on "click" this.removeAllFilters}}
             >
               Remove filters
             </Action>

--- a/ui/packages/consul-ui/app/components/search-bar/utils.js
+++ b/ui/packages/consul-ui/app/components/search-bar/utils.js
@@ -1,0 +1,38 @@
+export const diff = (a, b) => {
+  return a.filter(item => !b.includes(item));
+};
+/**
+ * filters accepts the args.filter @attribute which is shaped like
+ * {filterName: {default: ['Node', 'Address'], value: ['Address']}, ...}
+ * It will turn this into an array of 'filters' shaped like
+ * [{key: 'filterName', value: 'Address', selected: ["Node"]}]
+ * importantly 'selected' isn't what is currently 'selected' it is what selected
+ * will be once you remove this filter
+ * There is more explanation in the unit tests for this function so thats worthwhile
+ * checking if you are in amongst this
+ */
+export const filters = filters => {
+  return Object.entries(filters)
+    .filter(([key, value]) => {
+      if (key === 'searchproperty') {
+        return diff(value.default, value.value).length > 0;
+      }
+      return (value.value || []).length > 0;
+    })
+    .reduce((prev, [key, value]) => {
+      return prev.concat(
+        value.value.map(item => {
+          const obj = {
+            key: key,
+            value: item,
+          };
+          if (key !== 'searchproperty') {
+            obj.selected = diff(value.value, [item]);
+          } else {
+            obj.selected = value.value.length === 1 ? value.default : diff(value.value, [item]);
+          }
+          return obj;
+        })
+      );
+    }, []);
+};

--- a/ui/packages/consul-ui/tests/unit/components/search-bar/filters-test.js
+++ b/ui/packages/consul-ui/tests/unit/components/search-bar/filters-test.js
@@ -1,0 +1,154 @@
+import { filters } from 'consul-ui/components/search-bar/utils';
+import { module, test } from 'qunit';
+
+module('Unit | Component | search-bar/filters', function() {
+  test('it correctly reshapes the filter data', function(assert) {
+    [
+      // basic filter, returns a single filter button when clicked
+      // resets selected/queryparam to empty
+      {
+        filters: {
+          status: {
+            value: ['passing'],
+          },
+        },
+        expected: [
+          {
+            key: 'status',
+            value: 'passing',
+            selected: [],
+          },
+        ],
+      },
+      // basic filters, returns multiple filter button when clicked
+      // sets selected/queryparam to the left over single filter
+      {
+        filters: {
+          status: {
+            value: ['passing', 'warning'],
+          },
+        },
+        expected: [
+          {
+            key: 'status',
+            value: 'passing',
+            selected: ['warning'],
+          },
+          {
+            key: 'status',
+            value: 'warning',
+            selected: ['passing'],
+          },
+        ],
+      },
+      // basic filters, returns multiple filter button when clicked
+      // sets selected/queryparam to the left over multiple filters
+      {
+        filters: {
+          status: {
+            value: ['passing', 'warning', 'critical'],
+          },
+        },
+        expected: [
+          {
+            key: 'status',
+            value: 'passing',
+            selected: ['warning', 'critical'],
+          },
+          {
+            key: 'status',
+            value: 'warning',
+            selected: ['passing', 'critical'],
+          },
+          {
+            key: 'status',
+            value: 'critical',
+            selected: ['passing', 'warning'],
+          },
+        ],
+      },
+      // basic filters, returns multiple filter button when clicked
+      // sets selected/queryparam to the left over multiple filters
+      // also search property multiple filter, sets the selected/queryparam to
+      // the left of single searchproperty filter
+      {
+        filters: {
+          status: {
+            value: ['passing', 'warning', 'critical'],
+          },
+          searchproperties: {
+            default: ['Node', 'Address', 'Meta'],
+            value: ['Node', 'Address'],
+          },
+        },
+        expected: [
+          {
+            key: 'status',
+            value: 'passing',
+            selected: ['warning', 'critical'],
+          },
+          {
+            key: 'status',
+            value: 'warning',
+            selected: ['passing', 'critical'],
+          },
+          {
+            key: 'status',
+            value: 'critical',
+            selected: ['passing', 'warning'],
+          },
+          {
+            key: 'searchproperties',
+            value: 'Node',
+            selected: ['Address'],
+          },
+          {
+            key: 'searchproperties',
+            value: 'Address',
+            selected: ['Node'],
+          },
+        ],
+      },
+      // basic filters, returns multiple filter button when clicked
+      // sets selected/queryparam to the left over multiple filters
+      // also search property single filter, resets the selected/queryparam to
+      // empty
+      {
+        filters: {
+          status: {
+            value: ['passing', 'warning', 'critical'],
+          },
+          searchproperties: {
+            default: ['Node', 'Address', 'Meta'],
+            value: ['Node'],
+          },
+        },
+        expected: [
+          {
+            key: 'status',
+            value: 'passing',
+            selected: ['warning', 'critical'],
+          },
+          {
+            key: 'status',
+            value: 'warning',
+            selected: ['passing', 'critical'],
+          },
+          {
+            key: 'status',
+            value: 'critical',
+            selected: ['passing', 'warning'],
+          },
+          {
+            key: 'searchproperties',
+            value: 'Node',
+            selected: [],
+          },
+        ],
+      },
+    ].forEach(item => {
+      const actual = filters(item.filters);
+      assert.deepEqual(actual, item.expected);
+    });
+  });
+});


### PR DESCRIPTION
This PR is part of https://github.com/hashicorp/consul/pull/9442 and the base branch of this is that PR.

Previously when removing a special 'searchproperty' filter, it would
remove all the search property filters instead of only the one you had
clicked.

This fixes that up, adds unit tests and adds copious amounts of documentation
around the filter data reshaping function for future self/somebody.