### PR TITLE
ci: change check-vendor to verify git status has no changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,8 +153,9 @@ jobs:
       - run:
           command: make update-vendor
       - run: |
-          if ! git diff --exit-code; then
-            echo "Git directory has vendor changes"
+          if [[ -z $(git status -s) ]]; then
+            echo "Git directory has changes"
+            git status -s
             exit 1
           fi
       - run: *notify-slack-failure


### PR DESCRIPTION
`git diff --exit-code` does not account for untracked files but using a simple `git status -s` and checking for non-zero output will include all varieties of file changes. 