### PR TITLE
ci: fix logic for check-vendor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - run:
           command: make update-vendor
       - run: |
-          if [[ -z $(git status -s) ]]; then
+          if [[ -n $(git status -s) ]]; then
             echo "Git directory has changes"
             git status -s
             exit 1


### PR DESCRIPTION
The check should error for non-zero rather than zero output. 