### PR TITLE
ui: Add 'filtered by' to Healthchecks and ServiceInstance listings

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/health-check/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/health-check/search-bar/index.hbs
@@ -1,140 +1,190 @@
-<form
-  class="consul-health-check-search-bar filter-bar"
+<SearchBar
+  class="consul-healthcheck-search-bar"
   ...attributes
+  @filter={{@filter}}
 >
-  <div class="search">
-    <FreetextFilter
-      @onsearch={{action @onsearch}}
-      @value={{@search}}
-      @placeholder="Search"
-    >
-      <PopoverSelect
-        class="type-search-properties"
-        @position="right"
-        @onchange={{action @onfilter.searchproperty}}
+    <:status as |search|>
+
+{{#let
+
+  (t (concat "components.consul.health-check.search-bar." search.status.key ".name")
+      default=(array
+        (concat "common.search." search.status.key)
+        (concat "common.consul." search.status.key)
+      )
+  )
+
+  (t (concat "components.consul.health-check.search-bar." search.status.key ".options." search.status.value)
+      default=(array
+        (concat "common.search." search.status.value)
+        (concat "common.consul." search.status.value)
+      )
+  )
+
+as |key value|}}
+      <search.RemoveFilter
+        aria-label={{t "common.ui.remove" item=(concat key " " value)}}
+      >
+        <dl>
+          <dt>{{key}}</dt>
+          <dd>{{value}}</dd>
+        </dl>
+      </search.RemoveFilter>
+{{/let}}
+
+    </:status>
+    <:search as |search|>
+      <search.Search
+        @onsearch={{action @onsearch}}
+        @value={{@search}}
+        @placeholder={{t "common.search.search"}}
+      >
+{{#if @filter.searchproperty}}
+        <search.Select
+          class="type-search-properties"
+          @position="right"
+          @onchange={{action @filter.searchproperty.change}}
+          @multiple={{true}}
+          @required={{true}}
+        as |components|>
+          <BlockSlot @name="selected">
+            <span>
+              {{t "common.search.searchproperty"}}
+            </span>
+          </BlockSlot>
+          <BlockSlot @name="options">
+    {{#let components.Optgroup components.Option as |Optgroup Option|}}
+            {{#each @filter.searchproperty.default as |prop|}}
+              <Option @value={{prop}} @selected={{contains prop @filter.searchproperty.value}}>
+                {{t (concat "common.consul." (lowercase prop))}}
+              </Option>
+            {{/each}}
+    {{/let}}
+          </BlockSlot>
+        </search.Select>
+  {{/if}}
+      </search.Search>
+    </:search>
+    <:filter as |search|>
+      <search.Select
+        class="type-status"
+        @position="left"
+        @onchange={{action @filter.status.change}}
         @multiple={{true}}
       as |components|>
         <BlockSlot @name="selected">
           <span>
-            Search across
+            {{t "common.consul.status"}}
           </span>
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
-    {{#each @searchproperties as |prop|}}
-          <Option @value={{prop}} @selected={{contains prop @filter.searchproperties}}>{{prop}}</Option>
+    {{#each (array "passing" "warning" "critical" "empty") as |state|}}
+          <Option class="value-{{state}}" @value={{state}} @selected={{contains state @filter.status.value}}>
+            {{t (concat "common.consul." state)
+                default=(array
+                  (concat "common.search." state)
+                )
+            }}
+          </Option>
     {{/each}}
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
-    </FreetextFilter>
-  </div>
-  <div class="filters">
-    <PopoverSelect
-      class="type-status"
-      @position="left"
-      @onchange={{action @onfilter.status}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Health Status
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
+      </search.Select>
+{{#if @filter.kind}}
+      <search.Select
+        class="type-kind"
+        @position="left"
+        @onchange={{action @filter.kind.change}}
+        @multiple={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{t "components.consul.health-check.search-bar.kind.name"}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+    {{#each (array "service" "node") as |item|}}
+          <Option @value={{item}} @selected={{contains item @filter.kind.value}}>
+            {{t (concat "components.consul.health-check.search-bar.kind.options." item)
+                default=(array
+                  (concat "common.search." item)
+                )
+            }}
+          </Option>
+    {{/each}}
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+{{/if}}
+      <search.Select
+        class="type-check"
+        @position="left"
+        @onchange={{action @filter.check.change}}
+        @multiple={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{t "components.consul.health-check.search-bar.check.name"}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+    {{#each (array "alias" "docker" "grpc" "http" "script" "serf" "tcp" "ttl") as |item|}}
+          <Option @value={{item}} @selected={{contains item @filter.check.value}}>
+            {{t (concat "components.consul.health-check.search-bar.check.options." item)
+                default=(array
+                  (concat "common.search." item)
+                )
+            }}
+          </Option>
+    {{/each}}
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+    </:filter>
+    <:sort as |search|>
+      <search.Select
+        class="type-sort"
+        data-test-sort-control
+        @position="right"
+        @onchange={{action @sort.change}}
+        @multiple={{false}}
+        @required={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{#let (from-entries (array
+                (array "Name:asc" (t "common.sort.alpha.asc"))
+                (array "Name:desc" (t "common.sort.alpha.desc"))
+                (array "Status:asc" (t "common.sort.status.asc"))
+                (array "Status:desc" (t "common.sort.status.desc"))
+                (array "Kind:asc" (t "components.consul.health-check.search-bar.sort.kind.asc"))
+                (array "Kind:desc" (t "components.consul.health-check.search-bar.sort.kind.desc"))
+                ))
+              as |selectable|
+            }}
+              {{get selectable @sort.value}}
+            {{/let}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
 {{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option class="value-passing" @value="passing" @selected={{contains 'passing' @filter.statuses}}>Passing</Option>
-        <Option class="value-warning" @value="warning" @selected={{contains 'warning' @filter.statuses}}>Warning</Option>
-        <Option class="value-critical" @value="critical" @selected={{contains 'critical' @filter.statuses}}>Failing</Option>
-        <Option class="value-empty" @value="empty" @selected={{contains 'empty' @filter.statuses}}>No checks</Option>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-
-    <PopoverSelect
-      class="type-kind"
-      @position="left"
-      @onchange={{action @onfilter.kind}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Kind
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option @value="service" @selected={{contains 'service' @filter.kinds}}>Service Check</Option>
-        <Option @value="node" @selected={{contains 'node' @filter.kinds}}>Node Check</Option>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-
-    <PopoverSelect
-      class="type-check"
-      @position="left"
-      @onchange={{action @onfilter.check}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Type
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option @value="alias" @selected={{contains 'alias' @filter.checks}}>alias</Option>
-        <Option @value="docker" @selected={{contains 'docker' @filter.checks}}>Docker</Option>
-        <Option @value="grpc" @selected={{contains 'grpc' @filter.checks}}>gRPC</Option>
-        <Option @value="http" @selected={{contains 'http' @filter.checks}}>HTTP</Option>
-        <Option @value="serf" @selected={{contains 'serf' @filter.checks}}>Serf</Option>
-        <Option @value="tcp" @selected={{contains 'tcp' @filter.checks}}>TCP</Option>
-        <Option @value="ttl" @selected={{contains 'ttl' @filter.checks}}>TTL</Option>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-
-  </div>
-  <div class="sort">
-    <PopoverSelect
-      class="type-sort"
-      data-test-sort-control
-      @position="right"
-      @onchange={{action @onsort}}
-      @multiple={{false}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          {{#let (from-entries (array
-                (array "Name:asc" "A to Z")
-                (array "Name:desc" "Z to A")
-                (array "Status:asc" "Unhealthy to Healthy")
-                (array "Status:desc" "Healthy to Unhealthy")
-                (array "Kind:asc" "Service to Node")
-                (array "Kind:desc" "Node to Service")
-              ))
-            as |selectable|
-          }}
-            {{get selectable @sort}}
-          {{/let}}
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Optgroup @label="Health Status">
-          <Option @value="Status:asc" @selected={{eq "Status:asc" @sort}}>Unhealthy to Healthy</Option>
-          <Option @value="Status:desc" @selected={{eq "Status:desc" @sort}}>Healthy to Unhealthy</Option>
+        <Optgroup @label={{t "common.consul.status"}}>
+            <Option @value="Status:asc" @selected={{eq "Status:asc" @sort.value}}>{{t "common.sort.status.asc"}}</Option>
+            <Option @value="Status:desc" @selected={{eq "Status:desc" @sort.value}}>{{t "common.sort.status.desc"}}</Option>
         </Optgroup>
-        <Optgroup @label="Check Name">
-          <Option @value="Name:asc" @selected={{eq "Name:asc" @sort}}>A to Z</Option>
-          <Option @value="Name:desc" @selected={{eq "Name:desc" @sort}}>Z to A</Option>
+        <Optgroup @label={{t "components.consul.health-check.search-bar.sort.name.name"}}>
+            <Option @value="Name:asc" @selected={{eq "Name:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+            <Option @value="Name:desc" @selected={{eq "Name:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
         </Optgroup>
-        <Optgroup @label="Check Type">
+        <Optgroup @label={{t "components.consul.health-check.search-bar.sort.kind.name"}}>
           <Option @value="Kind:asc" @selected={{eq "Kind:asc" @sort}}>Service to Node</Option>
           <Option @value="Kind:desc" @selected={{eq "Kind:desc" @sort}}>Node to Service</Option>
         </Optgroup>
 {{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-</form>
+        </BlockSlot>
+      </search.Select>
+    </:sort>
+</SearchBar>

--- a/ui/packages/consul-ui/app/components/consul/service-instance/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service-instance/search-bar/index.hbs
@@ -1,111 +1,155 @@
-<form
-  class="consul-service-instance-search-bar filter-bar"
+<SearchBar
+  class="consul-service-instance-search-bar"
   ...attributes
+  @filter={{@filter}}
 >
-  <div class="search">
-    <FreetextFilter
-      @onsearch={{action @onsearch}}
-      @value={{@search}}
-      @placeholder="Search"
-    >
-      <PopoverSelect
-        class="type-search-properties"
-        @position="right"
-        @onchange={{action @onfilter.searchproperty}}
+    <:status as |search|>
+
+{{#let
+
+  (t (concat "components.consul.service-instance.search-bar." search.status.key ".name")
+      default=(array
+        (concat "common.search." search.status.key)
+        (concat "common.consul." search.status.key)
+      )
+  )
+
+  (t (concat "components.consul.service-instance.search-bar." search.status.key ".options." search.status.value)
+      default=(array
+        (concat "common.search." search.status.value)
+        (concat "common.consul." search.status.value)
+      )
+  )
+
+as |key value|}}
+      <search.RemoveFilter
+        aria-label={{t "common.ui.remove" item=(concat key " " value)}}
+      >
+        <dl>
+          <dt>{{key}}</dt>
+          <dd>{{value}}</dd>
+        </dl>
+      </search.RemoveFilter>
+{{/let}}
+
+    </:status>
+    <:search as |search|>
+      <search.Search
+        @onsearch={{action @onsearch}}
+        @value={{@search}}
+        @placeholder={{t "common.search.search"}}
+      >
+{{#if @filter.searchproperty}}
+        <search.Select
+          class="type-search-properties"
+          @position="right"
+          @onchange={{action @filter.searchproperty.change}}
+          @multiple={{true}}
+          @required={{true}}
+        as |components|>
+          <BlockSlot @name="selected">
+            <span>
+              {{t "common.search.searchproperty"}}
+            </span>
+          </BlockSlot>
+          <BlockSlot @name="options">
+    {{#let components.Optgroup components.Option as |Optgroup Option|}}
+            {{#each @filter.searchproperty.default as |prop|}}
+              <Option @value={{prop}} @selected={{contains prop @filter.searchproperty.value}}>
+                {{t (concat "common.consul." (lowercase prop))}}
+              </Option>
+            {{/each}}
+    {{/let}}
+          </BlockSlot>
+        </search.Select>
+  {{/if}}
+      </search.Search>
+    </:search>
+    <:filter as |search|>
+      <search.Select
+        class="type-status"
+        @position="left"
+        @onchange={{action @filter.status.change}}
         @multiple={{true}}
       as |components|>
         <BlockSlot @name="selected">
           <span>
-            Search across
+            {{t "common.consul.status"}}
           </span>
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
-    {{#each @searchproperties as |prop|}}
-          <Option @value={{prop}} @selected={{contains prop @filter.searchproperties}}>{{string-replace-all prop '\.' ' '}}</Option>
+    {{#each (array "passing" "warning" "critical" "empty") as |state|}}
+          <Option class="value-{{state}}" @value={{state}} @selected={{contains state @filter.status.value}}>
+            {{t (concat "common.consul." state)
+                default=(array
+                  (concat "common.search." state)
+                )
+            }}
+          </Option>
     {{/each}}
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
-    </FreetextFilter>
-  </div>
-  <div class="filters">
-    <PopoverSelect
-      class="type-status"
-      @position="left"
-      @onchange={{action @onfilter.status}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Health Status
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
+      </search.Select>
+  {{#if (gt @sources.length 0)}}
+      <search.Select
+        class="type-source"
+        @position="left"
+        @onchange={{action @filter.source.change}}
+        @multiple={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{t "common.search.source"}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+    {{#each @sources as |source|}}
+          <Option class={{source}} @value={{source}} @selected={{contains source @filter.source.value}}>
+            {{t (concat "common.brand." source)}}
+          </Option>
+    {{/each}}
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+  {{/if}}
+    </:filter>
+    <:sort as |search|>
+      <search.Select
+        class="type-sort"
+        data-test-sort-control
+        @position="right"
+        @onchange={{action @sort.change}}
+        @multiple={{false}}
+        @required={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{#let (from-entries (array
+                (array "Name:asc" (t "common.sort.alpha.asc"))
+                (array "Name:desc" (t "common.sort.alpha.desc"))
+                (array "Status:asc" (t "common.sort.status.asc"))
+                (array "Status:desc" (t "common.sort.status.desc"))
+                ))
+              as |selectable|
+            }}
+              {{get selectable @sort.value}}
+            {{/let}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
 {{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option class="value-passing" @value="passing" @selected={{contains 'passing' @filter.statuses}}>Passing</Option>
-        <Option class="value-warning" @value="warning" @selected={{contains 'warning' @filter.statuses}}>Warning</Option>
-        <Option class="value-critical" @value="critical" @selected={{contains 'critical' @filter.statuses}}>Failing</Option>
-        <Option class="value-empty" @value="empty" @selected={{contains 'empty' @filter.statuses}}>No checks</Option>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-{{#if (gt @sources.length 0)}}
-    <PopoverSelect
-      class="type-source"
-      @position="left"
-      @onchange={{action @onfilter.source}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Source
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-{{#each @sources as |source|}}
-        <Option class={{source}} @value={{source}} @selected={{contains source @filter.sources}}>{{source}}</Option>
-{{/each}}
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-{{/if}}
-  </div>
-  <div class="sort">
-    <PopoverSelect
-      class="type-sort"
-      data-test-sort-control
-      @position="right"
-      @onchange={{action @onsort}}
-      @multiple={{false}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          {{#let (from-entries (array
-                (array "Name:asc" "A to Z")
-                (array "Name:desc" "Z to A")
-                (array "Status:asc" "Unhealthy to Healthy")
-                (array "Status:desc" "Healthy to Unhealthy")
-              ))
-            as |selectable|
-          }}
-            {{get selectable @sort}}
-          {{/let}}
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Optgroup @label="Health Status">
-          <Option @value="Status:asc" @selected={{eq "Status:asc" @sort}}>Unhealthy to Healthy</Option>
-          <Option @value="Status:desc" @selected={{eq "Status:desc" @sort}}>Healthy to Unhealthy</Option>
+        <Optgroup @label={{t "common.consul.status"}}>
+            <Option @value="Status:asc" @selected={{eq "Status:asc" @sort.value}}>{{t "common.sort.status.asc"}}</Option>
+            <Option @value="Status:desc" @selected={{eq "Status:desc" @sort.value}}>{{t "common.sort.status.desc"}}</Option>
         </Optgroup>
-        <Optgroup @label="Service Name">
-          <Option @value="Name:asc" @selected={{eq "Name:asc" @sort}}>A to Z</Option>
-          <Option @value="Name:desc" @selected={{eq "Name:desc" @sort}}>Z to A</Option>
+        <Optgroup @label={{t "components.consul.service-instance.search-bar.sort.name.name"}}>
+            <Option @value="Name:asc" @selected={{eq "Name:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+            <Option @value="Name:desc" @selected={{eq "Name:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
         </Optgroup>
 {{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-</form>
+        </BlockSlot>
+      </search.Select>
+    </:sort>
+</SearchBar>

--- a/ui/packages/consul-ui/app/components/consul/service-instance/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service-instance/search-bar/index.hbs
@@ -18,6 +18,7 @@
       default=(array
         (concat "common.search." search.status.value)
         (concat "common.consul." search.status.value)
+        (concat "common.brand." search.status.value)
       )
   )
 

--- a/ui/packages/consul-ui/app/filter/predicates/health-check.js
+++ b/ui/packages/consul-ui/app/filter/predicates/health-check.js
@@ -1,14 +1,14 @@
 export default {
-  statuses: {
+  status: {
     passing: (item, value) => item.Status === value,
     warning: (item, value) => item.Status === value,
     critical: (item, value) => item.Status === value,
   },
-  kinds: {
+  kind: {
     service: (item, value) => item.Kind === value,
     node: (item, value) => item.Kind === value,
   },
-  checks: {
+  check: {
     serf: (item, value) => item.Type === '',
     script: (item, value) => item.Type === value,
     http: (item, value) => item.Type === value,

--- a/ui/packages/consul-ui/app/filter/predicates/service-instance.js
+++ b/ui/packages/consul-ui/app/filter/predicates/service-instance.js
@@ -1,12 +1,12 @@
 import setHelpers from 'mnemonist/set';
 
 export default {
-  statuses: {
+  status: {
     passing: (item, value) => item.Status === value,
     warning: (item, value) => item.Status === value,
     critical: (item, value) => item.Status === value,
   },
-  sources: (item, values) => {
+  source: (item, values) => {
     return setHelpers.intersectionSize(values, new Set(item.ExternalSources || [])) !== 0;
   },
 };

--- a/ui/packages/consul-ui/app/routes/dc/services/instance/healthchecks.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/instance/healthchecks.js
@@ -4,7 +4,6 @@ export default class HealthchecksRoute extends Route {
   queryParams = {
     sortBy: 'sort',
     status: 'status',
-    kind: 'kind',
     check: 'check',
     searchproperty: {
       as: 'searchproperty',

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show/healthchecks.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show/healthchecks.hbs
@@ -1,40 +1,55 @@
-{{#let (hash
-  statuses=(if status (split status ',') undefined)
-  kinds=(if kind (split kind ',') undefined)
-  checks=(if check (split check ',') undefined)
-  searchproperties=(if (not-eq searchproperty undefined)
-    (split searchproperty ',')
-    searchProperties
+{{#let
+
+  (hash
+    value=(or sortBy "Status:asc")
+    change=(action (mut sortBy) value="target.selected")
   )
-) as |filters|}}
-  {{#let (or sortBy "Status:asc") as |sort|}}
+
+  (hash
+    status=(hash
+      value=(if status (split status ',') undefined)
+      change=(action (mut status) value="target.selectedItems")
+    )
+    kind=(hash
+      value=(if kind (split kind ',') undefined)
+      change=(action (mut kind) value="target.selectedItems")
+    )
+    check=(hash
+      value=(if check (split check ',') undefined)
+      change=(action (mut check) value="target.selectedItems")
+    )
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  item.Checks
+
+as |sort filters items|}}
     <div class="tab-section">
-        {{#if (gt item.Checks.length 0) }}
+        {{#if (gt items.length 0) }}
           <input type="checkbox" id="toolbar-toggle" />
           <Consul::HealthCheck::SearchBar
 
             @search={{search}}
             @onsearch={{action (mut search) value="target.value"}}
-            @searchproperties={{searchProperties}}
 
             @sort={{sort}}
-            @onsort={{action (mut sortBy) value="target.selected"}}
 
             @filter={{filters}}
-            @onfilter={{hash
-              searchproperty=(action (mut searchproperty) value="target.selectedItems")
-              status=(action (mut status) value="target.selectedItems")
-              kind=(action (mut kind) value="target.selectedItems")
-              check=(action (mut check) value="target.selectedItems")
-            }}
           />
         {{/if}}
         <DataCollection
           @type="health-check"
-          @sort={{sort}}
+          @sort={{sort.value}}
           @filters={{filters}}
           @search={{search}}
-          @items={{item.Checks}}
+          @items={{items}}
         as |collection|>
           <collection.Collection>
             <Consul::HealthCheck::List
@@ -45,12 +60,11 @@
             <EmptyState>
               <BlockSlot @name="body">
                 <p>
-                  This node has no health checks{{#if (gt item.Checks.length 0)}} matching that search{{/if}}.
+                  This node has no health checks{{#if (gt items.length 0)}} matching that search{{/if}}.
                 </p>
               </BlockSlot>
             </EmptyState>
             </collection.Empty>
           </DataCollection>
     </div>
-  {{/let}}
 {{/let}}

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show/services.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show/services.hbs
@@ -1,13 +1,32 @@
-{{#let (hash
-  statuses=(if status (split status ',') undefined)
-  sources=(if source (split source ',') undefined)
-  searchproperties=(if (not-eq searchproperty undefined)
-    (split searchproperty ',')
-    searchProperties
+{{#let
+
+  (hash
+    value=(or sortBy "Status:asc")
+    change=(action (mut sortBy) value="target.selected")
   )
-) as |filters|}}
-  {{#let (or sortBy "Status:asc") as |sort|}}
-  {{#let (reject-by 'Service.Kind' 'connect-proxy' item.Services) as |items|}}
+
+  (hash
+    status=(hash
+      value=(if status (split status ',') undefined)
+      change=(action (mut status) value="target.selectedItems")
+    )
+    source=(hash
+      value=(if source (split source ',') undefined)
+      change=(action (mut source) value="target.selectedItems")
+    )
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  (reject-by 'Service.Kind' 'connect-proxy' item.Services)
+
+as |sort filters items|}}
 <div class="tab-section">
   {{#if (gt items.length 0) }}
     <input type="checkbox" id="toolbar-toggle" />
@@ -18,20 +37,14 @@
       @searchproperties={{searchProperties}}
 
       @sort={{sort}}
-      @onsort={{action (mut sortBy) value="target.selected"}}
 
       @filter={{filters}}
-      @onfilter={{hash
-        searchproperty=(action (mut searchproperty) value="target.selectedItems")
-        status=(action (mut status) value="target.selectedItems")
-        source=(action (mut source) value="target.selectedItems")
-      }}
       />
     {{/if}}
     {{! filter out any sidecar proxies }}
     <DataCollection
       @type="service-instance"
-      @sort={{sort}}
+      @sort={{sort.value}}
       @filters={{filters}}
       @search={{search}}
       @items={{items}}
@@ -55,6 +68,4 @@
       </collection.Empty>
     </DataCollection>
 </div>
-    {{/let}}
-  {{/let}}
 {{/let}}

--- a/ui/packages/consul-ui/app/templates/dc/services/instance/healthchecks.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance/healthchecks.hbs
@@ -1,41 +1,52 @@
-{{#let (hash
-  statuses=(if status (split status ',') undefined)
-  kinds=(if kind (split kind ',') undefined)
-  checks=(if check (split check ',') undefined)
-  searchproperties=(if (not-eq searchproperty undefined)
-    (split searchproperty ',')
-    searchProperties
+{{#let
+
+  (hash
+    value=(or sortBy "Status:asc")
+    change=(action (mut sortBy) value="target.selected")
   )
-) as |filters|}}
-  {{#let (or sortBy "Status:asc") as |sort|}}
+
+  (hash
+    status=(hash
+      value=(if status (split status ',') undefined)
+      change=(action (mut status) value="target.selectedItems")
+    )
+    check=(hash
+      value=(if check (split check ',') undefined)
+      change=(action (mut check) value="target.selectedItems")
+    )
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  item.MeshChecks
+
+as |sort filters items|}}
 <div class="tab-section">
 
-    {{#if (gt item.MeshChecks.length 0) }}
+    {{#if (gt items.length 0) }}
       <input type="checkbox" id="toolbar-toggle" />
       <Consul::HealthCheck::SearchBar
         @search={{search}}
         @onsearch={{action (mut search) value="target.value"}}
-        @searchproperties={{searchProperties}}
 
         @sort={{sort}}
-        @onsort={{action (mut sortBy) value="target.selected"}}
 
         @filter={{filters}}
-        @onfilter={{hash
-          searchproperty=(action (mut searchproperty) value="target.selectedItems")
-          status=(action (mut status) value="target.selectedItems")
-          kind=(action (mut kind) value="target.selectedItems")
-          check=(action (mut check) value="target.selectedItems")
-        }}
       />
     {{/if}}
 
     <DataCollection
       @type="health-check"
-      @sort={{sort}}
+      @sort={{sort.value}}
       @filters={{filters}}
       @search={{search}}
-      @items={{item.MeshChecks}}
+      @items={{items}}
     as |collection|>
       <collection.Collection>
         <Consul::HealthCheck::List
@@ -46,7 +57,7 @@
         <EmptyState>
           <BlockSlot @name="body">
             <p>
-              This instance has no health checks{{#if (gt item.MeshChecks.length 0)}} matching that search{{/if}}.
+              This instance has no health checks{{#if (gt items.length 0)}} matching that search{{/if}}.
             </p>
           </BlockSlot>
         </EmptyState>
@@ -54,5 +65,4 @@
       </DataCollection>
 
 </div>
-  {{/let}}
 {{/let}}

--- a/ui/packages/consul-ui/app/templates/dc/services/show/instances.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/instances.hbs
@@ -1,36 +1,49 @@
 <div class="tab-section">
-{{#let (hash
-  statuses=(if status (split status ',') undefined)
-  sources=(if source (split source ',') undefined)
-  searchproperties=(if (not-eq searchproperty undefined)
-    (split searchproperty ',')
-    searchProperties
+{{#let
+
+  (hash
+    value=(or sortBy "Status:asc")
+    change=(action (mut sortBy) value="target.selected")
   )
-) as |filters|}}
-  {{#let (or sortBy "Status:asc") as |sort|}}
+
+  (hash
+    status=(hash
+      value=(if status (split status ',') undefined)
+      change=(action (mut status) value="target.selectedItems")
+    )
+    source=(hash
+      value=(if source (split source ',') undefined)
+      change=(action (mut source) value="target.selectedItems")
+    )
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  items
+
+as |sort filters items|}}
     {{#if (gt items.length 0) }}
     <input type="checkbox" id="toolbar-toggle" />
     <Consul::ServiceInstance::SearchBar
       @sources={{get (collection items) 'ExternalSources'}}
       @search={{search}}
       @onsearch={{action (mut search) value="target.value"}}
-      @searchproperties={{searchProperties}}
 
       @sort={{sort}}
-      @onsort={{action (mut sortBy) value="target.selected"}}
 
       @filter={{filters}}
-      @onfilter={{hash
-        searchproperty=(action (mut searchproperty) value="target.selectedItems")
-        status=(action (mut status) value="target.selectedItems")
-        source=(action (mut source) value="target.selectedItems")
-      }}
       />
     {{/if}}
     {{! Service > Service Instance view doesn't require filtering of proxies }}
     <DataCollection
       @type="service-instance"
-      @sort={{sort}}
+      @sort={{sort.value}}
       @filters={{filters}}
       @search={{search}}
       @items={{items}}
@@ -51,6 +64,5 @@
         </EmptyState>
       </collection.Empty>
     </DataCollection>
-  {{/let}}
 {{/let}}
 </div>

--- a/ui/packages/consul-ui/translations/en-us.yaml
+++ b/ui/packages/consul-ui/translations/en-us.yaml
@@ -57,6 +57,31 @@ components:
         kind: Service Type
         in-mesh: In service mesh
         not-in-mesh: Not in service mesh
+    health-check:
+      search-bar:
+        kind:
+          name: Kind
+          options:
+            service: Service Check
+            node: Node Check
+        check:
+          name: Type
+          options:
+            alias: alias
+            docker: docker
+            grpc: gRPC
+            http: HTTP
+            script: script
+            serf: serf
+            tcp: TCP
+            ttl: TTL
+        sort:
+          name:
+            name: Check Name
+          kind:
+            name: Check Type
+            asc: Service to Node
+            desc: Node to Service
     acl:
       search-bar:
         kind:

--- a/ui/packages/consul-ui/translations/en-us.yaml
+++ b/ui/packages/consul-ui/translations/en-us.yaml
@@ -74,12 +74,12 @@ components:
           options:
             alias: alias
             docker: docker
-            grpc: gRPC
-            http: HTTP
+            grpc: grpc
+            http: http
             script: script
             serf: serf
-            tcp: TCP
-            ttl: TTL
+            tcp: tcp
+            ttl: ttl
         sort:
           name:
             name: Check Name

--- a/ui/packages/consul-ui/translations/en-us.yaml
+++ b/ui/packages/consul-ui/translations/en-us.yaml
@@ -57,6 +57,11 @@ components:
         kind: Service Type
         in-mesh: In service mesh
         not-in-mesh: Not in service mesh
+    service-instance:
+      search-bar:
+        sort:
+          name:
+            name: Service Name
     health-check:
       search-bar:
         kind:


### PR DESCRIPTION
This continues on from #9442 (which is the base branch for this PR), by adding the 'Filtered by' functionality to Healthchecks, and ServiceInstances (sub Node tabs).