### PR TITLE
ui: Add 'filtered by' to Upstreams and UpstreamInstance listings

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/upstream-instance/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream-instance/search-bar/index.hbs
@@ -1,63 +1,96 @@
-<form
-  class="consul-upstream-instance-search-bar filter-bar"
+<SearchBar
+  class="consul-upstream-instance-search-bar"
   ...attributes
+  @filter={{@filter}}
 >
-  <div class="search">
-    <FreetextFilter
-      @onsearch={{action @onsearch}}
-      @value={{@search}}
-      @placeholder="Search"
-    >
-      <PopoverSelect
-        class="type-search-properties"
+    <:status as |search|>
+
+{{#let
+
+  (t (concat "components.consul.upstream-instance.search-bar." search.status.key ".name")
+      default=(array
+        (concat "common.search." search.status.key)
+        (concat "common.consul." search.status.key)
+      )
+  )
+
+  (t (concat "components.consul.upstream-instance.search-bar." search.status.value ".name")
+      default=(array
+        (concat "common.search." search.status.value)
+        (concat "common.consul." search.status.value)
+        (concat "common.brand." search.status.value)
+      )
+  )
+
+as |key value|}}
+      <search.RemoveFilter
+        aria-label={{t "common.ui.remove" item=(concat key " " value)}}
+      >
+        <dl>
+          <dt>{{key}}</dt>
+          <dd>{{value}}</dd>
+        </dl>
+      </search.RemoveFilter>
+{{/let}}
+
+    </:status>
+    <:search as |search|>
+      <search.Search
+        @onsearch={{action @onsearch}}
+        @value={{@search}}
+        @placeholder={{t "common.search.search"}}
+      >
+        <search.Select
+          class="type-search-properties"
+          @position="right"
+          @onchange={{action @filter.searchproperty.change}}
+          @multiple={{true}}
+          @required={{true}}
+        as |components|>
+          <BlockSlot @name="selected">
+            <span>
+              {{t "common.search.searchproperty"}}
+            </span>
+          </BlockSlot>
+          <BlockSlot @name="options">
+    {{#let components.Optgroup components.Option as |Optgroup Option|}}
+            {{#each @filter.searchproperty.default as |prop|}}
+              <Option @value={{prop}} @selected={{contains prop @filter.searchproperty.value}}>
+                {{t (concat "common.consul." (lowercase prop))}}
+              </Option>
+            {{/each}}
+    {{/let}}
+          </BlockSlot>
+        </search.Select>
+      </search.Search>
+    </:search>
+    <:sort as |search|>
+      <search.Select
+        class="type-sort"
+        data-test-sort-control
         @position="right"
-        @onchange={{action @onfilter.searchproperty}}
-        @multiple={{true}}
+        @onchange={{action @sort.change}}
+        @multiple={{false}}
+        @required={{true}}
       as |components|>
         <BlockSlot @name="selected">
           <span>
-            Search across
+            {{#let (from-entries (array
+                  (array "DestinationName:asc" (t "common.sort.alpha.asc"))
+                  (array "DestinationName:desc" (t "common.sort.alpha.desc"))
+                ))
+              as |selectable|
+            }}
+              {{get selectable @sort.value}}
+            {{/let}}
           </span>
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
-    {{#each @searchproperties as |prop|}}
-          <Option @value={{prop}} @selected={{contains prop @filter.searchproperties}}>{{prop}}</Option>
-    {{/each}}
+            <Option @value="DestinationName:asc" @selected={{eq "DestinationName:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+            <Option @value="DestinationName:desc" @selected={{eq "DestinationName:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
-    </FreetextFilter>
-  </div>
-  <div class="sort">
-{{#let (or @sort 'DestinationName:asc') as |sort|}}
-    <PopoverSelect
-      class="type-sort"
-      data-test-sort-control
-      @position="right"
-      @onchange={{action @onsort}}
-      @multiple={{false}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          {{#let (from-entries (array
-              (array "DestinationName:asc" "A to Z")
-              (array "DestinationName:desc" "Z to A")
-            ))
-          as |selectable|}}
-            {{get selectable sort}}
-          {{/let}}
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Optgroup @label="Service Name">
-          <Option @value="DestinationName:asc" @selected={{eq "DestinationName:asc" sort}}>A to Z</Option>
-          <Option @value="DestinationName:desc" @selected={{eq "DestinationName:desc" sort}}>Z to A</Option>
-        </Optgroup>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-{{/let}}
-  </div>
-</form>
+      </search.Select>
+    </:sort>
+</SearchBar>

--- a/ui/packages/consul-ui/app/components/consul/upstream/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream/search-bar/index.hbs
@@ -1,86 +1,126 @@
-<form
-  class="consul-upstream-search-bar filter-bar"
+<SearchBar
+  class="consul-upstream-search-bar"
   ...attributes
+  @filter={{@filter}}
 >
-  <div class="search">
-    <FreetextFilter
-      @onsearch={{action @onsearch}}
-      @value={{@search}}
-      @placeholder="Search"
-    >
-      <PopoverSelect
-        class="type-search-properties"
-        @position="right"
-        @onchange={{action @onfilter.searchproperty}}
+    <:status as |search|>
+
+{{#let
+
+  (t (concat "components.consul.upstream.search-bar." search.status.key ".name")
+      default=(array
+        (concat "common.search." search.status.key)
+        (concat "common.consul." search.status.key)
+      )
+  )
+
+  (t (concat "components.consul.upstream.search-bar." search.status.value ".name")
+      default=(array
+        (concat "common.search." search.status.value)
+        (concat "common.consul." search.status.value)
+        (concat "common.brand." search.status.value)
+      )
+  )
+
+as |key value|}}
+      <search.RemoveFilter
+        aria-label={{t "common.ui.remove" item=(concat key " " value)}}
+      >
+        <dl>
+          <dt>{{key}}</dt>
+          <dd>{{value}}</dd>
+        </dl>
+      </search.RemoveFilter>
+{{/let}}
+
+    </:status>
+    <:search as |search|>
+      <search.Search
+        @onsearch={{action @onsearch}}
+        @value={{@search}}
+        @placeholder={{t "common.search.search"}}
+      >
+        <search.Select
+          class="type-search-properties"
+          @position="right"
+          @onchange={{action @filter.searchproperty.change}}
+          @multiple={{true}}
+          @required={{true}}
+        as |components|>
+          <BlockSlot @name="selected">
+            <span>
+              {{t "common.search.searchproperty"}}
+            </span>
+          </BlockSlot>
+          <BlockSlot @name="options">
+    {{#let components.Optgroup components.Option as |Optgroup Option|}}
+            {{#each @filter.searchproperty.default as |prop|}}
+              <Option @value={{prop}} @selected={{contains prop @filter.searchproperty.value}}>
+                {{t (concat "common.consul." (lowercase prop))}}
+              </Option>
+            {{/each}}
+    {{/let}}
+          </BlockSlot>
+        </search.Select>
+      </search.Search>
+    </:search>
+    <:filter as |search|>
+      <search.Select
+        @position="left"
+        @onchange={{action @filter.instance.change}}
         @multiple={{true}}
       as |components|>
         <BlockSlot @name="selected">
           <span>
-            Search across
+            {{t "components.consul.upstream.search-bar.instance.name"}}
           </span>
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
-          <Option @value="Name" @selected={{contains 'Name' @filter.searchproperties}}>Name</Option>
-          <Option @value="Tags" @selected={{contains 'Tags' @filter.searchproperties}}>Tags</Option>
+      {{#each (array "registered" "not-registered") as |item|}}
+            <Option @value={{item}} @selected={{contains item @filter.instance.value}}>
+              {{t (concat "common.consul." item)}}
+            </Option>
+      {{/each}}
   {{/let}}
         </BlockSlot>
-      </PopoverSelect>
-    </FreetextFilter>
-  </div>
-  <div class="filters">
-    <PopoverSelect
-      @position="left"
-      @onchange={{action @onfilter.instance}}
-      @multiple={{true}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          Type
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Option @value="registered" @selected={{contains 'registered' @filter.instances}}>Registered</Option>
-        <Option @value="not-registered" @selected={{contains 'not-registered' @filter.instances}}>Not Registered</Option>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-  <div class="sort">
-    <PopoverSelect
-      class="type-sort"
-      data-test-sort-control
-      @position="right"
-      @onchange={{action @onsort}}
-      @multiple={{false}}
-    as |components|>
-      <BlockSlot @name="selected">
-        <span>
-          {{#let (from-entries (array
-                (array "Name:asc" "A to Z")
-                (array "Name:desc" "Z to A")
-                (array "Status:asc" "Unhealthy to Healthy")
-                (array "Status:desc" "Healthy to Unhealthy")
-              ))
-            as |selectable|
-          }}
-            {{get selectable @sort}}
-          {{/let}}
-        </span>
-      </BlockSlot>
-      <BlockSlot @name="options">
-{{#let components.Optgroup components.Option as |Optgroup Option|}}
-        <Optgroup @label="Health Status">
-          <Option @value="Status:asc" @selected={{eq "Status:asc" @sort}}>Unhealthy to Healthy</Option>
-          <Option @value="Status:desc" @selected={{eq "Status:desc" @sort}}>Healthy to Unhealthy</Option>
-        </Optgroup>
-        <Optgroup @label="Service Name">
-          <Option @value="Name:asc" @selected={{eq "Name:asc" @sort}}>A to Z</Option>
-          <Option @value="Name:desc" @selected={{eq "Name:desc" @sort}}>Z to A</Option>
-        </Optgroup>
-{{/let}}
-      </BlockSlot>
-    </PopoverSelect>
-  </div>
-</form>
+      </search.Select>
+    </:filter>
+    <:sort as |search|>
+      <search.Select
+        class="type-sort"
+        data-test-sort-control
+        @position="right"
+        @onchange={{action @sort.change}}
+        @multiple={{false}}
+        @required={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{#let (from-entries (array
+                  (array "Name:asc" (t "common.sort.alpha.asc"))
+                  (array "Name:desc" (t "common.sort.alpha.desc"))
+                  (array "Status:asc" (t "common.sort.status.asc"))
+                  (array "Status:desc" (t "common.sort.status.desc"))
+                ))
+              as |selectable|
+            }}
+              {{get selectable @sort.value}}
+            {{/let}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+          <Optgroup @label={{t "common.consul.status"}}>
+            <Option @value="Status:asc" @selected={{eq "Status:asc" @sort.value}}>{{t "common.sort.status.asc"}}</Option>
+            <Option @value="Status:desc" @selected={{eq "Status:desc" @sort.value}}>{{t "common.sort.status.desc"}}</Option>
+          </Optgroup>
+          <Optgroup @label={{t "common.consul.service-name"}}>
+            <Option @value="Name:asc" @selected={{eq "Name:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
+            <Option @value="Name:desc" @selected={{eq "Name:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
+          </Optgroup>
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+    </:sort>
+</SearchBar>

--- a/ui/packages/consul-ui/app/filter/predicates/service-instance.js
+++ b/ui/packages/consul-ui/app/filter/predicates/service-instance.js
@@ -5,6 +5,7 @@ export default {
     passing: (item, value) => item.Status === value,
     warning: (item, value) => item.Status === value,
     critical: (item, value) => item.Status === value,
+    empty: (item, value) => item.MeshChecks.length === 0,
   },
   source: (item, values) => {
     return setHelpers.intersectionSize(values, new Set(item.ExternalSources || [])) !== 0;

--- a/ui/packages/consul-ui/app/filter/predicates/service.js
+++ b/ui/packages/consul-ui/app/filter/predicates/service.js
@@ -13,6 +13,7 @@ export default {
     passing: (item, value) => item.MeshStatus === value,
     warning: (item, value) => item.MeshStatus === value,
     critical: (item, value) => item.MeshStatus === value,
+    empty: (item, value) => item.MeshChecksTotal === 0,
   },
   instance: {
     registered: (item, value) => item.InstanceCount > 0,

--- a/ui/packages/consul-ui/app/models/service.js
+++ b/ui/packages/consul-ui/app/models/service.js
@@ -48,6 +48,16 @@ export default class Service extends Model {
 
   @attr() meta; // {}
 
+  @computed('ChecksPassing', 'ChecksWarning', 'ChecksCritical')
+  get ChecksTotal() {
+    return this.ChecksPassing + this.ChecksWarning + this.ChecksCritical;
+  }
+
+  @computed('MeshChecksPassing', 'MeshChecksWarning', 'MeshChecksCritical')
+  get MeshChecksTotal() {
+    return this.MeshChecksPassing + this.MeshChecksWarning + this.MeshChecksCritical;
+  }
+
   /* Mesh properties involve both the service and the associated proxy */
   @computed('ConnectedWithProxy', 'ConnectedWithGateway')
   get MeshEnabled() {

--- a/ui/packages/consul-ui/app/routes/dc/services/show/services.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/services.js
@@ -25,13 +25,12 @@ export default class ServicesRoute extends Route {
       .slice(0, -1)
       .join('.');
     const name = this.modelFor(parent).slug;
-    const gatewayServices = await this.data.source(
-      uri => uri`/${nspace}/${dc}/gateways/for-service/${name}`
-    );
+    const items = await this.data.source(uri => uri`/${nspace}/${dc}/gateways/for-service/${name}`);
     return {
       dc,
       nspace,
-      gatewayServices,
+      items,
+      searchProperties: this.queryParams.searchproperty.empty[0],
     };
   }
 

--- a/ui/packages/consul-ui/app/styles/layout.scss
+++ b/ui/packages/consul-ui/app/styles/layout.scss
@@ -18,7 +18,7 @@ html[data-route$='edit'] .app-view > header + div > *:first-child {
 /* if it is a filter bar and the thing after the filter bar is a p then it also */
 /* needs a top margun :S */
 %app-view-content .tab-section > *:first-child:not(.filter-bar):not(table),
-%app-view-content .tab-section > .filter-bar + p,
+%app-view-content .tab-section > .search-bar + p,
 %app-view-content .tab-section .consul-health-check-list {
   margin-top: 1.25em;
 }

--- a/ui/packages/consul-ui/app/styles/typography.scss
+++ b/ui/packages/consul-ui/app/styles/typography.scss
@@ -17,7 +17,7 @@ h3 {
 %radio-card header,
 fieldset > header,
 %main-nav-horizontal-action,
-%app-view-content div > dl > dt,
+%definition-table dt,
 %table caption,
 %tbody-th,
 %form-element > span {

--- a/ui/packages/consul-ui/app/templates/dc/services/instance/upstreams.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance/upstreams.hbs
@@ -1,12 +1,26 @@
 <div class="tab-section">
-{{#let (hash
-  searchproperties=(if (not-eq searchproperty undefined)
-    (split searchproperty ',')
-    searchProperties
+{{#let
+
+  (hash
+    value=(or sortBy "DestinationName:asc")
+    change=(action (mut sortBy) value="target.selected")
   )
-) as |filters|}}
-  {{#let (or sortBy "DestinationName:asc") as |sort|}}
-    {{#if (gt proxy.Service.Proxy.Upstreams.length 0)}}
+
+  (hash
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  proxy.Service.Proxy.Upstreams
+
+as |sort filters items|}}
+    {{#if (gt items.length 0)}}
       <input type="checkbox" id="toolbar-toggle" />
       <Consul::UpstreamInstance::SearchBar
         @search={{search}}
@@ -14,20 +28,16 @@
         @searchproperties={{searchProperties}}
 
         @sort={{sort}}
-        @onsort={{action (mut sortBy) value="target.selected"}}
 
         @filter={{filters}}
-        @onfilter={{hash
-          searchproperty=(action (mut searchproperty) value="target.selectedItems")
-        }}
       />
     {{/if}}
     <DataCollection
       @type="upstream-instance"
-      @sort={{sort}}
+      @sort={{sort.value}}
       @filters={{filters}}
       @search={{search}}
-      @items={{proxy.Service.Proxy.Upstreams}}
+      @items={{items}}
     as |collection|>
       <collection.Collection>
         <Consul::UpstreamInstance::List
@@ -40,12 +50,11 @@
         <EmptyState>
           <BlockSlot @name="body">
             <p>
-              This service has no upstreams{{#if (gt proxy.Service.Proxy.Upstreams.length 0)}} matching that search{{/if}}.
+              This service has no upstreams{{#if (gt items.length 0)}} matching that search{{/if}}.
             </p>
           </BlockSlot>
         </EmptyState>
       </collection.Empty>
     </DataCollection>
-  {{/let}}
 {{/let}}
 </div>

--- a/ui/packages/consul-ui/app/templates/dc/services/show/services.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/services.hbs
@@ -1,27 +1,39 @@
-<EventSource @src={{gatewayServices}} />
+<EventSource @src={{items}} />
 <div class="tab-section">
-{{#let (hash
-  instances=(if instance (split instance ',') undefined)
-  searchproperties=(if (not-eq searchproperty undefined)
-    (split searchproperty ',')
-    (array 'Name' 'Tags')
+{{#let
+
+  (hash
+    value=(or sortBy "Status:asc")
+    change=(action (mut sortBy) value="target.selected")
   )
-) as |filters|}}
-  {{#let (or sortBy "Name:asc") as |sort|}}
-{{#if (gt gatewayServices.length 0)}}
+
+  (hash
+    instance=(hash
+      value=(if instance (split instance ',') undefined)
+      change=(action (mut instance) value="target.selectedItems")
+    )
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  items
+
+as |sort filters items|}}
+{{#if (gt items.length 0)}}
     <input type="checkbox" id="toolbar-toggle" />
     <Consul::Upstream::SearchBar
       @search={{search}}
       @onsearch={{action (mut search) value="target.value"}}
 
       @sort={{sort}}
-      @onsort={{action (mut sortBy) value="target.selected"}}
 
       @filter={{filters}}
-      @onfilter={{hash
-        searchproperty=(action (mut searchproperty) value="target.selectedItems")
-        instance=(action (mut instance) value="target.selectedItems")
-      }}
       />
 {{/if}}
     <p>
@@ -30,10 +42,10 @@
     </p>
     <DataCollection
       @type="service"
-      @sort={{sort}}
+      @sort={{sort.value}}
       @filters={{filters}}
       @search={{search}}
-      @items={{gatewayServices}}
+      @items={{items}}
     as |collection|>
       <collection.Collection>
         <Consul::Service::List
@@ -46,12 +58,11 @@
         <EmptyState>
           <BlockSlot @name="body">
             <p>
-              There are no linked services{{#if (gt gatewayServices.length 0)}} matching that search{{/if}}.
+              There are no linked services{{#if (gt items.length 0)}} matching that search{{/if}}.
             </p>
           </BlockSlot>
         </EmptyState>
       </collection.Empty>
     </DataCollection>
-  {{/let}}
 {{/let}}
 </div>

--- a/ui/packages/consul-ui/app/templates/dc/services/show/upstreams.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/upstreams.hbs
@@ -1,27 +1,39 @@
-<EventSource @src={{gatewayServices}} />
+<EventSource @src={{items}} />
 <div class="tab-section">
-{{#let (hash
-  instances=(if instance (split instance ',') undefined)
-  searchproperties=(if (not-eq searchproperty undefined)
-    (split searchproperty ',')
-    (array 'Name' 'Tags')
+{{#let
+
+  (hash
+    value=(or sortBy "Status:asc")
+    change=(action (mut sortBy) value="target.selected")
   )
-) as |filters|}}
-  {{#let (or sortBy "Status:asc") as |sort|}}
-{{#if (gt gatewayServices.length 0)}}
+
+  (hash
+    instance=(hash
+      value=(if instance (split instance ',') undefined)
+      change=(action (mut instance) value="target.selectedItems")
+    )
+    searchproperty=(hash
+      value=(if (not-eq searchproperty undefined)
+        (split searchproperty ',')
+        searchProperties
+      )
+      change=(action (mut searchproperty) value="target.selectedItems")
+      default=searchProperties
+    )
+  )
+
+  items
+
+as |sort filters items|}}
+{{#if (gt items.length 0)}}
     <input type="checkbox" id="toolbar-toggle" />
     <Consul::Upstream::SearchBar
       @search={{search}}
       @onsearch={{action (mut search) value="target.value"}}
 
       @sort={{sort}}
-      @onsort={{action (mut sortBy) value="target.selected"}}
 
       @filter={{filters}}
-      @onfilter={{hash
-        searchproperty=(action (mut searchproperty) value="target.selectedItems")
-        instance=(action (mut instance) value="target.selectedItems")
-      }}
       />
 {{/if}}
       <p>
@@ -29,10 +41,10 @@
       </p>
       <DataCollection
         @type="service"
-        @sort={{sort}}
+        @sort={{sort.value}}
         @filters={{filters}}
         @search={{search}}
-        @items={{gatewayServices}}
+        @items={{items}}
       as |collection|>
         <collection.Collection>
           <Consul::Upstream::List
@@ -46,12 +58,11 @@
           <EmptyState>
             <BlockSlot @name="body">
               <p>
-                There are no upstreams{{#if (gt gatewayServices.length 0)}} matching that search{{/if}}.
+                There are no upstreams{{#if (gt items.length 0)}} matching that search{{/if}}.
               </p>
             </BlockSlot>
           </EmptyState>
         </collection.Empty>
       </DataCollection>
-  {{/let}}
 {{/let}}
 </div>

--- a/ui/packages/consul-ui/translations/en-us.yaml
+++ b/ui/packages/consul-ui/translations/en-us.yaml
@@ -31,6 +31,9 @@ common:
     node-name: Node Name
     accessorid: AccessorID
     datacenter: Datacenter
+    localbindaddress: LocalBindAddress
+    localbindport: LocalBindPort
+    destinationname: DestinationName
   search:
     search: Search
     searchproperty: Search Across

--- a/ui/packages/consul-ui/translations/en-us.yaml
+++ b/ui/packages/consul-ui/translations/en-us.yaml
@@ -31,9 +31,10 @@ common:
     node-name: Node Name
     accessorid: AccessorID
     datacenter: Datacenter
-    localbindaddress: LocalBindAddress
-    localbindport: LocalBindPort
-    destinationname: DestinationName
+    localbindaddress: Local Bind Address
+    localbindport: Local Bind Port
+    destinationname: Destination Name
+    sourcename: Source Name
   search:
     search: Search
     searchproperty: Search Across

--- a/ui/packages/consul-ui/translations/en-us.yaml
+++ b/ui/packages/consul-ui/translations/en-us.yaml
@@ -16,6 +16,8 @@ common:
     passing: Passing
     warning: Warning
     critical: Critical
+    registered: Registered
+    not-registered: Not Registered
     empty: No checks
     tags: Tags
     service: Service
@@ -57,6 +59,10 @@ components:
         kind: Service Type
         in-mesh: In service mesh
         not-in-mesh: Not in service mesh
+    upstream:
+      search-bar:
+        instance:
+          name: Type
     service-instance:
       search-bar:
         sort:


### PR DESCRIPTION
This continues on from #9442 (which is the base branch for this PR), by adding the 'Filtered by' functionality to Upstreams, Linked Services and Upstream Instances tabs (remaining sub Service/Service Instance tabs)

Additionally, I noticed our filter for Services with no healthchecks at all was not configured, so I added that on the end here.