### PR TITLE
fix render error on autopilot docs page

### DIFF
--- a/website/content/api-docs/operator/autopilot.mdx
+++ b/website/content/api-docs/operator/autopilot.mdx
@@ -426,7 +426,7 @@ Each zone in the responses `RedundancyZones` mapping will have this structure.
 - `FailureTolerance` is the number of servers in this zone that could fail without causing a total zone failure
   and subsequent promotion of a server from another zone as a fallback.
 
-### Upgrade Information Response Format <Enterprise Alert inline />
+### Upgrade Information Response Format <EnterpriseAlert inline />
 
 ```json
 {


### PR DESCRIPTION
There was a minor error using a component on this page which caused the entire page not to render. This fixes that situation.