### PR TITLE
Document proxy-defaults config for prometheus

### DIFF
--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -84,6 +84,39 @@ spec:
 </Tab>
 </Tabs>
 
+### Prometheus
+
+<Tabs>
+<Tab heading="HCL">
+
+Expose prometheus metrics:
+
+```hcl
+Kind      = "proxy-defaults"
+Name      = "global"
+Config {
+  envoy_prometheus_bind_addr = "0.0.0.0:9102"
+}
+```
+
+</Tab>
+<Tab heading="Kubernetes YAML">
+
+Expose prometheus metrics:
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  config:
+    envoy_prometheus_bind_addr: '0.0.0.0:9102'
+```
+
+</Tab>
+</Tabs>
+
 ### Proxy-specific defaults
 
 <Tabs>


### PR DESCRIPTION
This is a common configuration and some folks (https://discuss.hashicorp.com/t/proxydefaults-for-envoy-kubernetes-with-external-consul-server/20169) had trouble with it.