### PR TITLE
ci: add script to check for .changelog file in PRs

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Trigger CircleCI Load Test Pipeline
+      - name: Check for changelog entry in diff
         run: |
           # check if there is a diff in the .changelog directory
           changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "${{ github.event.pull_request.base.ref }}")" -- .changelog/)

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -2,6 +2,9 @@
 # here: https://securitylab.github.com/research/github-actions-preventing-pwn-requests. But
 # due to this workflow only running a git diff check and not building or publishing anything,
 # there is no harm in checking out the PR HEAD code.
+#
+# All the code checked out in this workflow should be considered untrusted. This workflow must 
+# never call any makefiles or scripts. It must never be changed to run any code from the checkout.
 on:
   pull_request_target:
     # Runs on PRs to master and all release branches

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,39 @@
+# The outline of this workflow is something that the GitHub Security team warns against
+# here: https://securitylab.github.com/research/github-actions-preventing-pwn-requests. But
+# due to this workflow only running a git diff check and not building or publishing anything,
+# there is no harm in checking out the PR HEAD code.
+on:
+  pull_request_target:
+    # Runs on PRs to master and all release branches
+    # By default it triggers on opened, synchronize, or reopened PRs
+    branches:
+      - master
+      - release/*
+
+jobs:
+  changelog-check:
+    # If there  a `pr/no-changelog` label we ignore this check
+    if: "!${{ contains(github.event.pull_request.label.*.name, 'pr/no-changelog')}}"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Trigger CircleCI Load Test Pipeline
+        run: |
+          # check if there is a diff in the .changelog directory
+          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "${{ github.event.pull_request.base.ref }}")" -- .changelog/)
+
+          # If we do not find a file in .changelog/, we post a comment to the PR
+          if [ -z "$changelog_files" ]; then
+            # post PR comment to GitHub when no .changelog entry was found on PR
+            echo "changelog-check: Did not find a .changelog entry, posting a reminder in the PR"
+            github_message="🤔 Double check that this PR does not require a changelog entry in the .changelog directory. [Reference](https://github.com/hashicorp/consul/pull/8387)"
+            curl -f -s -H "Authorization: token ${{ secrets.PR_COMMENT_TOKEN }}" \
+                -X POST \
+                -d "{ \"body\": \"${github_message}\"}" \
+                "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"
+          else
+            echo "changelog-check: Found .changelog entry in PR!"
+          fi


### PR DESCRIPTION
https://github.com/hashicorp/consul/pull/8387 added go-changelog which generates changelog entries from the `.changelog` directory. This PR adds a small CI check to add a comment to any PR that does not have the `pr/no-changelog` label to remind the author to double check that the PR does not require a changelog entry. 