### PR TITLE
xds: prevent LDS flaps in mesh gateways due to unstable datacenter lists

### DIFF
--- a/.changelog/9651.txt
+++ b/.changelog/9651.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: prevent LDS flaps in mesh gateways due to unstable datacenter lists; also prevent some flaps in terminating gateways as well
+```

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -3,6 +3,7 @@ package proxycfg
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/mitchellh/copystructure"
@@ -245,6 +246,10 @@ func (c *configSnapshotMeshGateway) Datacenters() []string {
 			dcs = append(dcs, dc)
 		}
 	}
+
+	// Always sort the results to ensure we generate deterministic things over
+	// xDS, such as mesh-gateway listener filter chains.
+	sort.Strings(dcs)
 	return dcs
 }
 

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -777,7 +777,12 @@ func (s *Server) makeTerminatingGatewayListener(
 		}
 	}
 
-	// Before we add the fallback, sort these chains by the matched name.
+	// Before we add the fallback, sort these chains by the matched name. All
+	// of these filter chains are independent, but envoy requires them to be in
+	// some order. If we put them in a random order then every xDS iteration
+	// envoy will force the listener to be replaced. Sorting these has no
+	// effect on how they operate, but it does mean that we won't churn
+	// listeners at idle.
 	sort.Slice(l.FilterChains, func(i, j int) bool {
 		return l.FilterChains[i].FilterChainMatch.ServerNames[0] < l.FilterChains[j].FilterChainMatch.ServerNames[0]
 	})

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -777,6 +777,11 @@ func (s *Server) makeTerminatingGatewayListener(
 		}
 	}
 
+	// Before we add the fallback, sort these chains by the matched name.
+	sort.Slice(l.FilterChains, func(i, j int) bool {
+		return l.FilterChains[i].FilterChainMatch.ServerNames[0] < l.FilterChains[j].FilterChainMatch.ServerNames[0]
+	})
+
 	// This fallback catch-all filter ensures a listener will be present for health checks to pass
 	// Envoy will reset these connections since known endpoints are caught by filter chain matches above
 	tcpProxy, err := makeTCPProxyFilter(name, "", "terminating_gateway.")


### PR DESCRIPTION
Also fix a similar issue in Terminating Gateways that was masked by an
overzealous test.

(chained on #9650)

I suspect the 1.7.x backport will need to be manual.