### PR TITLE
ci: reset working directory between cherrypick labels

### DIFF
--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -186,6 +186,8 @@ for label in $labels; do
         cherry_pick_with_slack_notification "$branch" "$CIRCLE_SHA1" "$pr_url"
         backport_failures=$((backport_failures + "$?"))
     fi
+    # reset the working directory for the next label
+    git reset --hard
 done
 
 if [ "$backport_failures" -ne 0 ]; then


### PR DESCRIPTION
We have automated cherry-picks that happen on any PRs with `type/docs-cherrypick` to the `stable-website` branch and automatically to the latest `release/1.#.x` branch. However, if the cherry-pick is not clean onto `stable-website`, the working directory is not cleared before attempting to pick into the latest release branch. This PR resets the working directory to allow that cherry-pick to happen regardless of whether the pick to `stable-website` succeeds or fails.