### PR TITLE
ui: [BUGFIX] Fix missing or duplicate service instance health checks

### DIFF
--- a/ui/packages/consul-ui/app/services/repository/proxy.js
+++ b/ui/packages/consul-ui/app/services/repository/proxy.js
@@ -41,7 +41,9 @@ export default class ProxyService extends RepositoryService {
     return this.findAllBySlug(slug, dc, nspace, configuration).then(function(items) {
       let res = {};
       if (get(items, 'length') > 0) {
-        let instance = items.filterBy('ServiceProxy.DestinationServiceID', id).findBy('Node', node);
+        let instance = items
+          .filterBy('ServiceProxy.DestinationServiceID', id)
+          .findBy('NodeName', node);
         if (instance) {
           res = instance;
         } else {

--- a/ui/packages/consul-ui/app/services/repository/service-instance.js
+++ b/ui/packages/consul-ui/app/services/repository/service-instance.js
@@ -48,7 +48,7 @@ export default class ServiceInstanceService extends RepositoryService {
     // }
 
     // Copy over all the things to the ProxyServiceInstance
-    ['Service', 'Node'].forEach(prop => {
+    ['Service', 'Node', 'meta'].forEach(prop => {
       set(proxy, prop, instance[prop]);
     });
     ['Checks'].forEach(prop => {

--- a/ui/packages/consul-ui/app/services/repository/service-instance.js
+++ b/ui/packages/consul-ui/app/services/repository/service-instance.js
@@ -52,6 +52,9 @@ export default class ServiceInstanceService extends RepositoryService {
       set(proxy, prop, instance[prop]);
     });
     ['Checks'].forEach(prop => {
+      // completely wipe out any previous values so we don't accumulate things
+      // eternally
+      proxy.set(prop, []);
       instance[prop].forEach(item => {
         if (typeof item !== 'undefined') {
           proxy[prop].addFragment(item.copy());


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/9648

This PR fixes essentially two issue related to the listing of healthchecks correctly.

In https://github.com/hashicorp/consul/pull/9314 we changed our separate Proxy/ServiceInstance models to use a single ServiceInstance model extending from the Proxy model. This meant we had a single model to represent a Service Instance that happened to be a connect sidecar proxy. Unfortunately we didn't realize a clash of property names when we did this, both the Proxy endpoint and the ServiceInstance endpoint contain a `Node` property that are two different shapes. One is a plain string that is the name of the node and one is a map/object containing all the properties of a node (including its name), `"name"` vs `{Name: "name"}`.

In https://github.com/hashicorp/consul/pull/9524 we added a fix that added a `NodeName` property and mapped the string based `Node` property to that instead, meaning these special ProxyServiceInstance models have both `NodeName= "name"` and `Node = {Name: "name"...}`.

Unfortunately we missed that we were using the `Node` property to link our instances and proxy instances together. This updates this code to use the `NodeName` property.

Additionally we noticed that proxy instance healthchecks could potentially accumulate instead of being replaced when blocking queries would respond, eternally adding more and more duplicate healthchecks to a proxy service instance.

The second fix here solves this by resetting the checks array before copying over the healthchecks to the proxy service instance.
