### PR TITLE
ui: Upstreams - Check for a non-existent items argument/attribute

### DIFF
--- a/ui/packages/consul-ui/app/components/data-collection/index.js
+++ b/ui/packages/consul-ui/app/components/data-collection/index.js
@@ -104,10 +104,11 @@ export default class DataCollectionComponent extends Component {
     // TODO: Temporary little hack to ensure we detect DataSource proxy
     // objects but not any other special Ember Proxy object like ember-data
     // things. Remove this once we no longer need the Proxies
-    if (this.args.items.dispatchEvent === 'function') {
-      return this.args.items.content;
+    const items = this.args.items || [];
+    if (typeof items.dispatchEvent === 'function') {
+      return items.content;
     }
-    return this.args.items;
+    return items;
   }
 
   @action


### PR DESCRIPTION
The `@items` attribute of our DataCollection component is not 100% guaranteed to be set, in this specific case `Service.Proxy.Upstreams` could be undefined if there are no Upstreams set for a proxied service. As a consequence of this the Service Instance > Upstreams tab will not error, although it will just show an empty page instead of our 'no upstreams' message.

This guards for an empty `@items` attribute/argument from within the `DataCollection` component.