### PR TITLE
state: move config-entries table definition to config_entries_schema.go

### DIFF
--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -80,7 +80,7 @@ func init() {
 
 // ConfigEntries is used to pull all the config entries for the snapshot.
 func (s *Snapshot) ConfigEntries() ([]structs.ConfigEntry, error) {
-	entries, err := s.tx.Get(configTableName, "id")
+	entries, err := s.tx.Get(tableConfigEntries, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (s *Store) ConfigEntry(ws memdb.WatchSet, kind, name string, entMeta *struc
 
 func configEntryTxn(tx ReadTxn, ws memdb.WatchSet, kind, name string, entMeta *structs.EnterpriseMeta) (uint64, structs.ConfigEntry, error) {
 	// Get the index
-	idx := maxIndexTxn(tx, configTableName)
+	idx := maxIndexTxn(tx, tableConfigEntries)
 
 	// Get the existing config entry.
 	watchCh, existing, err := firstWatchConfigEntryWithTxn(tx, kind, name, entMeta)
@@ -142,7 +142,7 @@ func (s *Store) ConfigEntriesByKind(ws memdb.WatchSet, kind string, entMeta *str
 
 func configEntriesByKindTxn(tx ReadTxn, ws memdb.WatchSet, kind string, entMeta *structs.EnterpriseMeta) (uint64, []structs.ConfigEntry, error) {
 	// Get the index and watch for updates
-	idx := maxIndexWatchTxn(tx, ws, configTableName)
+	idx := maxIndexWatchTxn(tx, ws, tableConfigEntries)
 
 	// Lookup by kind, or all if kind is empty
 	var iter memdb.ResultIterator
@@ -296,10 +296,10 @@ func deleteConfigEntryTxn(tx WriteTxn, idx uint64, kind, name string, entMeta *s
 	}
 
 	// Delete the config entry from the DB and update the index.
-	if err := tx.Delete(configTableName, existing); err != nil {
+	if err := tx.Delete(tableConfigEntries, existing); err != nil {
 		return fmt.Errorf("failed removing config entry: %s", err)
 	}
-	if err := tx.Insert("index", &IndexEntry{configTableName, idx}); err != nil {
+	if err := tx.Insert("index", &IndexEntry{tableConfigEntries, idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
@@ -320,10 +320,10 @@ func insertConfigEntryWithTxn(tx WriteTxn, idx uint64, conf structs.ConfigEntry)
 	}
 
 	// Insert the config entry and update the index
-	if err := tx.Insert(configTableName, conf); err != nil {
+	if err := tx.Insert(tableConfigEntries, conf); err != nil {
 		return fmt.Errorf("failed inserting config entry: %s", err)
 	}
-	if err := indexUpdateMaxTxn(tx, idx, configTableName); err != nil {
+	if err := indexUpdateMaxTxn(tx, idx, tableConfigEntries); err != nil {
 		return fmt.Errorf("failed updating index: %v", err)
 	}
 
@@ -429,7 +429,7 @@ func (s *Store) discoveryChainSourcesTxn(tx ReadTxn, ws memdb.WatchSet, dc strin
 	queue := []structs.ServiceName{destination}
 	for len(queue) > 0 {
 		// The "link" index returns config entries that reference a service
-		iter, err := tx.Get(configTableName, "link", queue[0].ToServiceID())
+		iter, err := tx.Get(tableConfigEntries, "link", queue[0].ToServiceID())
 		if err != nil {
 			return 0, nil, err
 		}
@@ -601,7 +601,7 @@ func validateProposedConfigEntryInServiceGraph(
 		sid := structs.NewServiceID(name, entMeta)
 		checkChains[sid] = struct{}{}
 
-		iter, err := tx.Get(configTableName, "link", sid)
+		iter, err := tx.Get(tableConfigEntries, "link", sid)
 		if err != nil {
 			return err
 		}

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -12,10 +12,6 @@ import (
 	"github.com/hashicorp/consul/lib"
 )
 
-const (
-	configTableName = "config-entries"
-)
-
 type ConfigEntryLinkIndex struct {
 }
 

--- a/agent/consul/state/config_entry_intention.go
+++ b/agent/consul/state/config_entry_intention.go
@@ -126,7 +126,7 @@ func (s *ServiceIntentionSourceIndex) FromArgs(args ...interface{}) ([]byte, err
 func (s *Store) configIntentionsListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.Intentions, bool, error) {
 	// unrolled part of configEntriesByKindTxn
 
-	idx := maxIndexTxn(tx, configTableName)
+	idx := maxIndexTxn(tx, tableConfigEntries)
 
 	iter, err := getConfigEntryKindsWithTxn(tx, structs.ServiceIntentions, structs.WildcardEnterpriseMeta())
 	if err != nil {
@@ -145,12 +145,12 @@ func (s *Store) configIntentionsListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *
 }
 
 func (s *Store) configIntentionGetTxn(tx ReadTxn, ws memdb.WatchSet, id string) (uint64, *structs.ServiceIntentionsConfigEntry, *structs.Intention, error) {
-	idx := maxIndexTxn(tx, configTableName)
+	idx := maxIndexTxn(tx, tableConfigEntries)
 	if idx < 1 {
 		idx = 1
 	}
 
-	watchCh, existing, err := tx.FirstWatch(configTableName, "intention-legacy-id", id)
+	watchCh, existing, err := tx.FirstWatch(tableConfigEntries, "intention-legacy-id", id)
 	if err != nil {
 		return 0, nil, nil, fmt.Errorf("failed config entry lookup: %s", err)
 	}
@@ -239,7 +239,7 @@ func configIntentionMatchOneTxn(
 }
 
 func readSourceIntentionsFromConfigEntriesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta) (uint64, structs.Intentions, error) {
-	idx := maxIndexTxn(tx, configTableName)
+	idx := maxIndexTxn(tx, tableConfigEntries)
 
 	var (
 		results structs.Intentions
@@ -265,7 +265,7 @@ func readSourceIntentionsFromConfigEntriesTxn(tx ReadTxn, ws memdb.WatchSet, ser
 func readSourceIntentionsFromConfigEntriesForServiceTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta, results structs.Intentions) (structs.Intentions, error) {
 	sn := structs.NewServiceName(serviceName, entMeta)
 
-	iter, err := tx.Get(configTableName, "intention-source", sn)
+	iter, err := tx.Get(tableConfigEntries, "intention-source", sn)
 	if err != nil {
 		return nil, fmt.Errorf("failed config entry lookup: %s", err)
 	}
@@ -284,7 +284,7 @@ func readSourceIntentionsFromConfigEntriesForServiceTxn(tx ReadTxn, ws memdb.Wat
 }
 
 func readDestinationIntentionsFromConfigEntriesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta) (uint64, structs.Intentions, error) {
-	idx := maxIndexTxn(tx, configTableName)
+	idx := maxIndexTxn(tx, tableConfigEntries)
 
 	var results structs.Intentions
 

--- a/agent/consul/state/config_entry_oss.go
+++ b/agent/consul/state/config_entry_oss.go
@@ -9,7 +9,7 @@ import (
 )
 
 func firstConfigEntryWithTxn(tx ReadTxn, kind, name string, _ *structs.EnterpriseMeta) (interface{}, error) {
-	return tx.First(configTableName, "id", kind, name)
+	return tx.First(tableConfigEntries, "id", kind, name)
 }
 
 func firstWatchConfigEntryWithTxn(
@@ -18,7 +18,7 @@ func firstWatchConfigEntryWithTxn(
 	name string,
 	_ *structs.EnterpriseMeta,
 ) (<-chan struct{}, interface{}, error) {
-	return tx.FirstWatch(configTableName, "id", kind, name)
+	return tx.FirstWatch(tableConfigEntries, "id", kind, name)
 }
 
 func validateConfigEntryEnterprise(_ ReadTxn, _ structs.ConfigEntry) error {
@@ -26,11 +26,11 @@ func validateConfigEntryEnterprise(_ ReadTxn, _ structs.ConfigEntry) error {
 }
 
 func getAllConfigEntriesWithTxn(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get(configTableName, "id")
+	return tx.Get(tableConfigEntries, "id")
 }
 
 func getConfigEntryKindsWithTxn(tx ReadTxn, kind string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get(configTableName, "kind", kind)
+	return tx.Get(tableConfigEntries, "kind", kind)
 }
 
 func configIntentionsConvertToList(iter memdb.ResultIterator, _ *structs.EnterpriseMeta) structs.Intentions {

--- a/agent/consul/state/config_entry_oss.go
+++ b/agent/consul/state/config_entry_oss.go
@@ -3,63 +3,10 @@
 package state
 
 import (
-	"github.com/hashicorp/consul/agent/structs"
 	memdb "github.com/hashicorp/go-memdb"
-)
 
-// configTableSchema returns a new table schema used to store global
-// config entries.
-func configTableSchema() *memdb.TableSchema {
-	return &memdb.TableSchema{
-		Name: configTableName,
-		Indexes: map[string]*memdb.IndexSchema{
-			"id": {
-				Name:         "id",
-				AllowMissing: false,
-				Unique:       true,
-				Indexer: &memdb.CompoundIndex{
-					Indexes: []memdb.Indexer{
-						&memdb.StringFieldIndex{
-							Field:     "Kind",
-							Lowercase: true,
-						},
-						&memdb.StringFieldIndex{
-							Field:     "Name",
-							Lowercase: true,
-						},
-					},
-				},
-			},
-			"kind": {
-				Name:         "kind",
-				AllowMissing: false,
-				Unique:       false,
-				Indexer: &memdb.StringFieldIndex{
-					Field:     "Kind",
-					Lowercase: true,
-				},
-			},
-			"link": {
-				Name:         "link",
-				AllowMissing: true,
-				Unique:       false,
-				Indexer:      &ConfigEntryLinkIndex{},
-			},
-			"intention-legacy-id": {
-				Name:         "intention-legacy-id",
-				AllowMissing: true,
-				Unique:       true,
-				Indexer:      &ServiceIntentionLegacyIDIndex{},
-			},
-			"intention-source": {
-				Name:         "intention-source",
-				AllowMissing: true,
-				Unique:       false,
-				Indexer:      &ServiceIntentionSourceIndex{},
-			},
-		},
-	}
-}
+	"github.com/hashicorp/consul/agent/structs"
+)
 
 func firstConfigEntryWithTxn(tx ReadTxn, kind, name string, _ *structs.EnterpriseMeta) (interface{}, error) {
 	return tx.First(configTableName, "id", kind, name)

--- a/agent/consul/state/config_entry_schema.go
+++ b/agent/consul/state/config_entry_schema.go
@@ -1,0 +1,65 @@
+package state
+
+import "github.com/hashicorp/go-memdb"
+
+const (
+	configTableName = "config-entries"
+
+	indexLink              = "link"
+	indexIntentionLegacyID = "intention-legacy-id"
+	indexSource            = "intention-source"
+)
+
+// configTableSchema returns a new table schema used to store global
+// config entries.
+func configTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: configTableName,
+		Indexes: map[string]*memdb.IndexSchema{
+			indexID: {
+				Name:         indexID,
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.StringFieldIndex{
+							Field:     "Kind",
+							Lowercase: true,
+						},
+						&memdb.StringFieldIndex{
+							Field:     "Name",
+							Lowercase: true,
+						},
+					},
+				},
+			},
+			indexKind: {
+				Name:         indexKind,
+				AllowMissing: false,
+				Unique:       false,
+				Indexer: &memdb.StringFieldIndex{
+					Field:     "Kind",
+					Lowercase: true,
+				},
+			},
+			indexLink: {
+				Name:         indexLink,
+				AllowMissing: true,
+				Unique:       false,
+				Indexer:      &ConfigEntryLinkIndex{},
+			},
+			indexIntentionLegacyID: {
+				Name:         indexIntentionLegacyID,
+				AllowMissing: true,
+				Unique:       true,
+				Indexer:      &ServiceIntentionLegacyIDIndex{},
+			},
+			indexSource: {
+				Name:         indexSource,
+				AllowMissing: true,
+				Unique:       false,
+				Indexer:      &ServiceIntentionSourceIndex{},
+			},
+		},
+	}
+}

--- a/agent/consul/state/config_entry_schema.go
+++ b/agent/consul/state/config_entry_schema.go
@@ -3,7 +3,7 @@ package state
 import "github.com/hashicorp/go-memdb"
 
 const (
-	configTableName = "config-entries"
+	tableConfigEntries = "config-entries"
 
 	indexLink              = "link"
 	indexIntentionLegacyID = "intention-legacy-id"
@@ -14,7 +14,7 @@ const (
 // config entries.
 func configTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: configTableName,
+		Name: tableConfigEntries,
 		Indexes: map[string]*memdb.IndexSchema{
 			indexID: {
 				Name:         indexID,

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -718,7 +718,7 @@ func (s *Store) LegacyIntentionDeleteAll(idx uint64) error {
 	// Also bump the index for the config entry table so that
 	// secondaries can correctly know when they've replicated all of the service-intentions
 	// config entries that USED to exist in the old intentions table.
-	if err := tx.Insert("index", &IndexEntry{configTableName, idx}); err != nil {
+	if err := tx.Insert("index", &IndexEntry{tableConfigEntries, idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 


### PR DESCRIPTION
Branched from #9664

Move the indexes so they are shared with enterprise and use constants for table and index names.