### PR TITLE
ui: Adds a `Routes()` router DSL dumping function only in dev mode

### DIFF
--- a/ui/packages/consul-ui/README.md
+++ b/ui/packages/consul-ui/README.md
@@ -9,6 +9,7 @@
 - [Yarn Commands](#yarn-commands)
 - [Running / Development](#running--development)
   - [Browser 'Environment' Variables](#browser-environment-variables)
+  - [Browser 'Debug Utility' Functions](#browser-debug-utility-functions)
   - [Code Generators](#code-generators)
   - [Running Tests](#running-tests)
   - [Linting](#linting)
@@ -127,8 +128,22 @@ token/secret.
 | `CONSUL_EXPOSED_COUNT` | (random) | Configure the number of exposed paths that the API returns. |
 | `CONSUL_CHECK_COUNT` | (random) | Configure the number of health checks that the API returns. |
 | `CONSUL_OIDC_PROVIDER_COUNT` | (random) | Configure the number of OIDC providers that the API returns. |
+| `DEBUG_ROUTES_ENDPOINT` | undefined | When using the window.Routes() debug
+utility ([see utility functions](#browser-debug-utility-functions)), use a URL to pass the route DSL to. %s in the URL will be replaced
+with the route DSL - http://url.com?routes=%s  |
 
 See `./mock-api` for more details.
+
+### Browser 'Debug Utility' Functions
+
+We currently have one 'debug utility', that only exists during development (they
+are removed from the production build using Embers `runInDebug`). You can call
+these either straight from the console in WebInspector, or by using javascript
+URLs i.e. `javascript:Routes()`
+
+| Variable | Arguments | Description |
+| -------- | --------- | ----------- |
+| `Routes(url)` | url: The url to pass the DSL to, if left `undefined` just use a blank tab | Provides a way to easily print out Embers Route DSL for the application or to pass it straight to any third party utility such as ember-diagonal |
 
 ### Code Generators
 

--- a/ui/packages/consul-ui/app/router.js
+++ b/ui/packages/consul-ui/app/router.js
@@ -1,6 +1,7 @@
 import EmberRouter from '@ember/routing/router';
+import { runInDebug } from '@ember/debug';
 import { env } from 'consul-ui/env';
-import walk from 'consul-ui/utils/routing/walk';
+import walk, { dump } from 'consul-ui/utils/routing/walk';
 
 export const routes = {
   // Our parent datacenter resource sets the namespace
@@ -184,3 +185,23 @@ export default class Router extends EmberRouter {
 }
 
 Router.map(walk(routes));
+
+// To print the Ember route DSL use `Routes()` in Web Inspectors console
+// or `javascript:Routes()` in the location bar of your browser
+runInDebug(() => {
+  window.Routes = (endpoint = env('DEBUG_ROUTES_ENDPOINT')) => {
+    if (!endpoint) {
+      endpoint = 'data:,%s';
+    }
+    let win;
+    const str = dump(routes);
+    if (endpoint.startsWith('data:,')) {
+      win = window.open('', '_blank');
+      win.document.write(`<body><pre>${str}</pre></body>`);
+    } else {
+      win = window.open(endpoint.replace('%s', encodeURIComponent(str)), '_blank');
+    }
+    win.focus();
+    return;
+  };
+});

--- a/ui/packages/consul-ui/app/utils/routing/walk.js
+++ b/ui/packages/consul-ui/app/utils/routing/walk.js
@@ -1,3 +1,5 @@
+import { runInDebug } from '@ember/debug';
+
 export const walk = function(routes) {
   const keys = Object.keys(routes);
   keys.forEach((item, i) => {
@@ -35,46 +37,48 @@ export default function(routes) {
   };
 }
 
-// The following code is purposefully commented out to prevent it from ending up
-// in the production codebase. In future it would be good to figure out how to do this
-// without having to use comments.
+export let dump = () => {};
 
-// const indent = function(num) {
-//   return Array(num).fill('  ', 0, num).join('')
-// }
-// /**
-//  * String dumper to produce Router.map code
-//  * Uses { walk } to recursively walk through a JSON object of routes
-//  * to produce the code necessary to define your routes for your ember application
-//  *
-//  * @param {object} routes - JSON representation of routes
-//  * @example `console.log(dump(routes));`
-//  */
-// export const dump = function(routes) {
-//   let level = 2;
-//   const obj = {
-//     out: '',
-//     route: function(name, options, cb) {
-//       this.out += `${indent(level)}this.route('${name}', ${JSON.stringify(options)}`;
-//       if(cb) {
-//         level ++;
-//         this.out += `, function() {
-// `;
-//         cb.apply(this, []);
-//         level --;
-//         this.out += `${indent(level)}});
-// `;
-//       } else {
-//         this.out += ');';
-//       }
-//       this.out += `
-// `;
-//     }
-//   };
-//   walk.apply(obj, [routes])
-//   return `Router.map(
-//   function() {
-// ${obj.out}
-//   }
-// );`;
-// }
+runInDebug(() => {
+  const indent = function(num) {
+    return Array(num)
+      .fill('  ', 0, num)
+      .join('');
+  };
+  /**
+   * String dumper to produce Router.map code
+   * Uses { walk } to recursively walk through a JSON object of routes
+   * to produce the code necessary to define your routes for your ember application
+   *
+   * @param {object} routes - JSON representation of routes
+   * @example `console.log(dump(routes));`
+   */
+  dump = function(routes) {
+    let level = 2;
+    const obj = {
+      out: '',
+      route: function(name, options, cb) {
+        this.out += `${indent(level)}this.route('${name}', ${JSON.stringify(options)}`;
+        if (cb) {
+          level++;
+          this.out += `, function() {
+`;
+          cb.apply(this, []);
+          level--;
+          this.out += `${indent(level)}});
+`;
+        } else {
+          this.out += ');';
+        }
+        this.out += `
+`;
+      },
+    };
+    walk.apply(obj, [routes]);
+    return `Router.map(
+  function() {
+${obj.out}
+  }
+);`;
+  };
+});


### PR DESCRIPTION
Back in https://github.com/hashicorp/consul/pull/5206 we fixed a URL encoding/decoding issues with URLs for wildcarded routes by extracting our routing configuration to a JSON-like JS pojo, before feeding this in Embers `Route.map`. This meant we could inspect the routing configuration from elsewhere to provide support for URL encoding/decoding. The one downside in doing this was that we were not using Embers Route DSL to code our Routing configuration.

At the time we wrote a little `dump` util in order to easily convert the JSON-like configuration back to Ember's Router DSL should we ever need to, but commented it out as we didn't want it ending up in the production source code.

We've since discovered `runInDebug`, which lets you specify inline code to be stripped from production builds.

This PR uses `runInDebug` to wrap the a utility function called `Routes()`, which will print out Embers Route DSL in a new tab should we need to. Passing a URL with a `%s` marker will pass the Route DSL to the URL, for example `http://url.com?routes=%s`, this lets you easily use tools like `ember-diagonal`. Additionally we've added a `DEBUG_ROUTES_ENDPOINT` development environment variable (set via cookies), so you can set this URL semi-permanently if you always want the DSL passed to a URL instead of opening in a new tab. We named it `Routes()` for now and hung it off of `window` for easy usage - we shouldn't have any problems with clashes and its only a development function so we feel this is ok.

To call this `Routes()` function, you can either type `Routes()` into your WebInspector console and hit enter, or make some bookmarklets if you find yourself wanting to do this often - see below for directions:

```
data:text/html,<a href="javascript:Routes()">Print Routing DSL</a><br /><a href="javascript:Routes('https://alexspeller.com/ember-diagonal/?routesInput=%s')">Show Routing DSL in Ember Diagonal</a>
```

![bookmarklets](https://user-images.githubusercontent.com/554604/106265988-c4c9cd80-621f-11eb-89e8-35aa7ebb8fd2.gif)


Lastly, there are probably a few other debug/dev functions I sometimes use that I could add in also, so I've added a new section in the README file to document this one and any future debug/dev functions.

