### PR TITLE
connect/ca: Allow ForceWithoutCrossSigning for all providers

### DIFF
--- a/.changelog/9672.txt
+++ b/.changelog/9672.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+cli: added a `-force-without-cross-signing` flag to the `ca set-config` command.
+connect/ca: The ForceWithoutCrossSigning field will now work as expected for CA providers that support cross signing.
+```

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -873,12 +873,13 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 				"You can try again with ForceWithoutCrossSigningSet but this may cause " +
 				"disruption - see documentation for more.")
 		}
-		if !canXSign && args.Config.ForceWithoutCrossSigning {
-			c.logger.Warn("current CA doesn't support cross signing but " +
-				"CA reconfiguration forced anyway with ForceWithoutCrossSigning")
+		if args.Config.ForceWithoutCrossSigning {
+			c.logger.Warn("ForceWithoutCrossSigning set, CA reconfiguration skipping cross-signing")
 		}
 
-		if canXSign {
+		// If ForceWithoutCrossSigning wasn't set, attempt to have the old CA generate a
+		// cross-signed intermediate.
+		if canXSign && !args.Config.ForceWithoutCrossSigning {
 			// Have the old provider cross-sign the new root
 			xcCert, err := oldProvider.CrossSignCA(newRoot)
 			if err != nil {

--- a/api/connect_ca.go
+++ b/api/connect_ca.go
@@ -23,6 +23,14 @@ type CAConfig struct {
 	// configuration is an error.
 	State map[string]string
 
+	// ForceWithoutCrossSigning indicates that the CA reconfiguration should go
+	// ahead even if the current CA is unable to cross sign certificates. This
+	// risks temporary connection failures during the rollout as new leafs will be
+	// rejected by proxies that have not yet observed the new root cert but is the
+	// only option if a CA that doesn't support cross signing needs to be
+	// reconfigured or mirated away from.
+	ForceWithoutCrossSigning bool
+
 	CreateIndex uint64
 	ModifyIndex uint64
 }

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -176,7 +176,7 @@ The table below shows this endpoint's support for
   providers, see [Provider Config](/docs/connect/ca).
 
 - `ForceWithoutCrossSigning` `(bool: <optional>)` - Indicates that the CA change
-  should be force to complete even if the current CA doesn't support cross
+  should be forced to complete even if the current CA doesn't support cross
   signing. Changing root without cross-signing may cause temporary connection
   failures until the rollout completes. See [Forced Rotation Without
   Cross-Signing](/docs/connect/ca#forced-rotation-without-cross-signing)

--- a/website/content/commands/connect/ca.mdx
+++ b/website/content/commands/connect/ca.mdx
@@ -82,6 +82,13 @@ Usage: `consul connect ca set-config [options]`
   The format of this config file matches the request payload documented in the
   [Update CA Configuration API](/api/connect/ca#update-ca-configuration).
 
+- `-force-without-cross-signing` `(bool: <optional>)` - Indicates that the CA change
+  should be forced to complete even if the current CA doesn't support cross
+  signing. Changing root without cross-signing may cause temporary connection
+  failures until the rollout completes. See [Forced Rotation Without
+  Cross-Signing](/docs/connect/ca#forced-rotation-without-cross-signing)
+  for more detail.
+
 The output looks like this:
 
 ```


### PR DESCRIPTION
This allows setting ForceWithoutCrossSigning when reconfiguring the CA for any provider, in order to forcibly move to a new root in cases where the old provider isn't reachable or able to cross-sign for whatever reason. 

Previously this was ignored for the Consul/Vault providers, so it was possible to get stuck with an unusable CA.