### PR TITLE
ci: fail cherrypick if git push fails

### DIFF
--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -51,8 +51,8 @@ function cherry_pick_with_slack_notification {
     local pr_url="$3"
 
     git checkout "$branch" || exit 1
-    # If git cherry-pick fails, we send a failure notification
-    if ! git cherry-pick --mainline 1 "$commit"; then
+    # If git cherry-pick fails or it fails to push, we send a failure notification
+    if ! (git cherry-pick --mainline 1 "$commit" && git push origin "$branch"); then
         status "🍒❌ Cherry pick of commit ${commit:0:7} from $pr_url onto $branch failed!"
 
         # send slack notification
@@ -85,8 +85,6 @@ function cherry_pick_with_slack_notification {
     # Else we send a success notification
     else
         status "🍒✅ Cherry picking of PR commit ${commit:0:7} from ${pr_url} succeeded!"
-        # push changes to the specified branch
-        git push origin "$branch"
         curl -X POST -H 'Content-type: application/json' \
         --data \
         "{ \


### PR DESCRIPTION
This PR addresses the super rare case in the cherry-picking script where the automation may checkout a branch, cherrypick cleanly, but there may have been a new commit in that branch (either pushed manually or via another CI automated cherry pick job) in that time and the subsequent git push fails since there are new commits. This fix ensures notifying a success/fail when both the `git cherry-pick` and `git push` are both successful rather than when only the cherrypick is successful. 