### PR TITLE
ui: Add 'Scenario' debug function for easy saving debug scenarios

### DIFF
--- a/ui/packages/consul-ui/README.md
+++ b/ui/packages/consul-ui/README.md
@@ -144,6 +144,7 @@ URLs i.e. `javascript:Routes()`
 | Variable | Arguments | Description |
 | -------- | --------- | ----------- |
 | `Routes(url)` | url: The url to pass the DSL to, if left `undefined` just use a blank tab | Provides a way to easily print out Embers Route DSL for the application or to pass it straight to any third party utility such as ember-diagonal |
+| `Scenario(str)` | str: 'Cookie formatted' string, if left `undefined` open a new tab with a lonk to the current Scenario | Provides a way to easily save and reload scenarios of configurations via URLs or bookmarklets |
 
 ### Code Generators
 

--- a/ui/packages/consul-ui/README.md
+++ b/ui/packages/consul-ui/README.md
@@ -128,9 +128,7 @@ token/secret.
 | `CONSUL_EXPOSED_COUNT` | (random) | Configure the number of exposed paths that the API returns. |
 | `CONSUL_CHECK_COUNT` | (random) | Configure the number of health checks that the API returns. |
 | `CONSUL_OIDC_PROVIDER_COUNT` | (random) | Configure the number of OIDC providers that the API returns. |
-| `DEBUG_ROUTES_ENDPOINT` | undefined | When using the window.Routes() debug
-utility ([see utility functions](#browser-debug-utility-functions)), use a URL to pass the route DSL to. %s in the URL will be replaced
-with the route DSL - http://url.com?routes=%s  |
+| `DEBUG_ROUTES_ENDPOINT` | undefined | When using the window.Routes() debug utility ([see utility functions](#browser-debug-utility-functions)), use a URL to pass the route DSL to. %s in the URL will be replaced with the route DSL - http://url.com?routes=%s  |
 
 See `./mock-api` for more details.
 
@@ -144,7 +142,7 @@ URLs i.e. `javascript:Routes()`
 | Variable | Arguments | Description |
 | -------- | --------- | ----------- |
 | `Routes(url)` | url: The url to pass the DSL to, if left `undefined` just use a blank tab | Provides a way to easily print out Embers Route DSL for the application or to pass it straight to any third party utility such as ember-diagonal |
-| `Scenario(str)` | str: 'Cookie formatted' string, if left `undefined` open a new tab with a lonk to the current Scenario | Provides a way to easily save and reload scenarios of configurations via URLs or bookmarklets |
+| `Scenario(str)` | str: 'Cookie formatted' string, if left `undefined` open a new tab with a link/bookmarklet to the current Scenario | Provides a way to easily save and reload scenarios of configurations via URLs or bookmarklets |
 
 ### Code Generators
 

--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -11,12 +11,37 @@ export default function(config = {}, win = window, doc = document) {
   // look at the hash in the URL and transfer anything after the hash into
   // cookies to enable linking of the UI with various settings enabled
   runInDebug(() => {
+    const cookies = function(str) {
+      return str
+        .split(';')
+        .map(item => item.trim())
+        .filter(item => item !== '')
+        .filter(item =>
+          item
+            .split('=')
+            .shift()
+            .startsWith('CONSUL_')
+        );
+    };
+    window.Scenario = function(str = '') {
+      if (str.length > 0) {
+        cookies(str).forEach(item => (doc.cookie = `${item};Path=/`));
+        win.location.hash = '';
+        location.reload();
+      } else {
+        str = cookies(doc.cookie).join(';');
+        const tab = window.open('', '_blank');
+        tab.document.write(
+          `<body><pre>${location.href}#${str}</pre><br /><a href="javascript:Scenario('${str}')">Scenario</a></body>`
+        );
+      }
+    };
     if (
       typeof win.location !== 'undefined' &&
       typeof win.location.hash === 'string' &&
       win.location.hash.length > 0
     ) {
-      doc.cookie = win.location.hash.substr(1);
+      Scenario(win.location.hash.substr(1));
     }
   });
   const dev = function(str = doc.cookie) {

--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -23,14 +23,14 @@ export default function(config = {}, win = window, doc = document) {
             .startsWith('CONSUL_')
         );
     };
-    window.Scenario = function(str = '') {
+    win.Scenario = function(str = '') {
       if (str.length > 0) {
         cookies(str).forEach(item => (doc.cookie = `${item};Path=/`));
         win.location.hash = '';
         location.reload();
       } else {
         str = cookies(doc.cookie).join(';');
-        const tab = window.open('', '_blank');
+        const tab = win.open('', '_blank');
         tab.document.write(
           `<body><pre>${location.href}#${str}</pre><br /><a href="javascript:Scenario('${str}')">Scenario</a></body>`
         );
@@ -41,7 +41,7 @@ export default function(config = {}, win = window, doc = document) {
       typeof win.location.hash === 'string' &&
       win.location.hash.length > 0
     ) {
-      Scenario(win.location.hash.substr(1));
+      win.Scenario(win.location.hash.substr(1));
     }
   });
   const dev = function(str = doc.cookie) {


### PR DESCRIPTION
Following on from https://github.com/hashicorp/consul/pull/9666, this PR adds a `Scenario()` debug function to allow you to easily save off 'scenarios' for easy debugging or demoing purposes.

When called with no arguments (using WebInspector's `console`, or via a bookmarklet), the function will open a new tab with an easily copy/pastable URL (for sharing preview sites) and a draggable bookmarklet link containing the configuration for your current development/debug configuration settings (which we can set via the cookies panel in the WebInspector). Whilst this function only exists in non-production environments we also only emit cookies that begin with `CONSUL_` which we know are our own debug/dev cookies.

Scenarios are composable, so instead of having lots of multiple bookmarklets, you can save say one for enabling nspace/acls another for metrics - clicking one after the other will give you nspaces/acls plus metrics.

We haven't added this to the README as yet , we'll wait until https://github.com/hashicorp/consul/pull/9666 has been merged and also possibly decide a more central place for all these types of functions to live.

Directions below:

```
data:text/html,<a href="javascript:Scenario()">Save Current Scenario</a>
```

![scenario](https://user-images.githubusercontent.com/554604/106454791-335a9580-6483-11eb-80c7-aac82104ac3e.gif)

