### PR TITLE
updating HCP Consul link

### DIFF
--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -248,7 +248,7 @@ export default function HomePage() {
               description: 'HashiCorp Cloud Platform',
               link: {
                 text: 'Get Started',
-                url: 'https://portal.cloud.hashicorp.com',
+                url: 'https://cloud.hashicorp.com',
                 type: 'outbound',
               },
             },


### PR DESCRIPTION
Changing link to cloud.hashicorp.com instead of the portal.