### PR TITLE
local: use agent token to deregister services

### DIFF
--- a/.changelog/9683.txt
+++ b/.changelog/9683.txt
@@ -1,0 +1,3 @@
+```release-notes:improvement
+client: when a client agent is attempting to dereigster a service, anddoes not have access to the ACL token used to register a service, attempt to use the agent token instead of the default user token. If no agent token is set, fall back to the default user token.
+```

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -243,7 +243,7 @@ func (l *State) serviceToken(id structs.ServiceID) string {
 		token = s.Token
 	}
 	if token == "" {
-		token = l.tokens.UserToken()
+		token = l.tokens.AgentToken()
 	}
 	return token
 }
@@ -457,7 +457,7 @@ func (l *State) checkToken(id structs.CheckID) string {
 		token = c.Token
 	}
 	if token == "" {
-		token = l.tokens.UserToken()
+		token = l.tokens.AgentToken()
 	}
 	return token
 }


### PR DESCRIPTION
Hopefully improves the issue from #9577 (#7669, #8078).

If an ACL token used to register a service is removed before the service then anti-entropy sync can fail to deregister the service. In those cases the local agent logs are filled with noise from these failures, and it never resolves itself.

Previously it would attempt to fall back to the "default" token, then to the anonymous token. With this change it will first fall back to the "agent" token, then "default", then finally the anonymous.
ref: https://www.consul.io/docs/agent/options#acl_tokens

The agent token seems more appropriate in this case, since this is an "internal operation", not something initiated by the user.