### PR TITLE
Avoid potential proxycfg/xDS deadlock using non-blocking send

### DIFF
--- a/.changelog/9689.txt
+++ b/.changelog/9689.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+proxycfg: avoid potential deadlock in delivering proxy snapshot to watchers.
+```

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -622,7 +622,14 @@ func (s *state) run() {
 				)
 				continue
 			}
-			s.snapCh <- *snapCopy
+
+			select {
+			case s.snapCh <- *snapCopy:
+				// try to send
+			default:
+				// avoid blocking if a snapshot is already buffered
+			}
+
 			// Allow the next change to trigger a send
 			coalesceTimer = nil
 

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -328,7 +328,7 @@ func (s *Server) process(stream ADSStream, reqCh <-chan *envoy.DiscoveryRequest)
 			defer watchCancel()
 
 			logger.Trace("watching proxy, pending initial proxycfg snapshot",
-				"proxy-id", proxyID.String())
+				"service_id", proxyID.String())
 
 			// Now wait for the config so we can check ACL
 			state = statePendingInitialConfig
@@ -342,7 +342,7 @@ func (s *Server) process(stream ADSStream, reqCh <-chan *envoy.DiscoveryRequest)
 			state = stateRunning
 
 			logger.Trace("Got initial config snapshot",
-				"proxy-id", cfgSnap.ProxyID.String())
+				"service_id", cfgSnap.ProxyID.String())
 
 			// Lets actually process the config we just got or we'll mis responding
 			fallthrough
@@ -356,7 +356,7 @@ func (s *Server) process(stream ADSStream, reqCh <-chan *envoy.DiscoveryRequest)
 			extendAuthTimer()
 
 			logger.Trace("Invoking all xDS resource handlers and sending new data if there is any",
-				"proxy-id", cfgSnap.ProxyID.String())
+				"service_id", cfgSnap.ProxyID.String())
 
 			// See if any handlers need to have the current (possibly new) config
 			// sent. Note the order here is actually significant so we can't just

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/consul/logging"
 	"sync/atomic"
 	"time"
 
@@ -164,6 +165,8 @@ const (
 )
 
 func (s *Server) process(stream ADSStream, reqCh <-chan *envoy.DiscoveryRequest) error {
+	logger := s.Logger.Named(logging.XDS)
+
 	// xDS requires a unique nonce to correlate response/request pairs
 	var nonce uint64
 
@@ -324,6 +327,9 @@ func (s *Server) process(stream ADSStream, reqCh <-chan *envoy.DiscoveryRequest)
 			// state machine.
 			defer watchCancel()
 
+			logger.Trace("watching proxy, pending initial proxycfg snapshot",
+				"proxy-id", proxyID.String())
+
 			// Now wait for the config so we can check ACL
 			state = statePendingInitialConfig
 		case statePendingInitialConfig:
@@ -335,6 +341,9 @@ func (s *Server) process(stream ADSStream, reqCh <-chan *envoy.DiscoveryRequest)
 			// Got config, try to authenticate next.
 			state = stateRunning
 
+			logger.Trace("Got initial config snapshot",
+				"proxy-id", cfgSnap.ProxyID.String())
+
 			// Lets actually process the config we just got or we'll mis responding
 			fallthrough
 		case stateRunning:
@@ -345,6 +354,9 @@ func (s *Server) process(stream ADSStream, reqCh <-chan *envoy.DiscoveryRequest)
 			// For the first time through the state machine, this is when the
 			// timer is first started.
 			extendAuthTimer()
+
+			logger.Trace("Invoking all xDS resource handlers and sending new data if there is any",
+				"proxy-id", cfgSnap.ProxyID.String())
 
 			// See if any handlers need to have the current (possibly new) config
 			// sent. Note the order here is actually significant so we can't just

--- a/logging/names.go
+++ b/logging/names.go
@@ -56,5 +56,6 @@ const (
 	UIMetricsProxy     string = "ui_metrics_proxy"
 	WAN                string = "wan"
 	Watch              string = "watch"
+	XDS                string = "xds"
 	Vault              string = "vault"
 )


### PR DESCRIPTION
Deadlock scenario:

    1. Due to scheduling, the state runner sends one snapshot into
    snapCh and then attempts to send a second. The first send succeeds
    because the channel is buffered, but the second blocks.

    2. Separately, Manager.Watch is called by the xDS server after
    getting a discovery request from Envoy. This function acquires the
    manager lock and then blocks on receiving the CurrentSnapshot from
    the state runner.

    3. Separately, there is a Manager goroutine that reads the snapshots
    from the channel in step 1. These reads are done to notify proxy
    watchers, but they require holding the manager lock. This goroutine
    goes to acquire that lock, but can't because it is held by step 2.

Now, the goroutine from step 3 is waiting on the one from step 2 to
release the lock. The goroutine from step 2 won't release the lock until
the goroutine in step 1 advances. But the goroutine in step 1 is waiting
for the one in step 3 to read from the channel it is blocking on. Deadlock.

By making the send in step 1 non-blocking then we can proceed. The coalesce
timer will be reset and a new snapshot (if valid) will be delivered after the
timer elapses or when one is requested by xDS.

**Impact:** This deadlock can block the delivery of proxy configuration to Envoy.

------

Also added some trace logging that would have helped while chasing this down. 