### PR TITLE
ci: fix pr file checker

### DIFF
--- a/.github/workflows/pr-file-checker.yml
+++ b/.github/workflows/pr-file-checker.yml
@@ -7,8 +7,8 @@
 # never call any makefiles or scripts. It must never be changed to run any code from the checkout.
 on:
   pull_request_target:
+    types: [opened]
     # Runs on PRs to master and all release branches
-    # By default it triggers on opened, synchronize, or reopened PRs
     branches:
       - master
       - release/*

--- a/.github/workflows/pr-file-checker.yml
+++ b/.github/workflows/pr-file-checker.yml
@@ -17,7 +17,7 @@ jobs:
   # checks that a .changelog entry is present for a PR
   changelog-check:
     # If there  a `pr/no-changelog` label we ignore this check
-    if: "!${{ contains(github.event.pull_request.label.*.name, 'pr/no-changelog')}}"
+    if: "!${{ contains(github.event.pull_request.labels.*.name, 'pr/no-changelog')}}"
     runs-on: ubuntu-latest
 
     steps:
@@ -46,7 +46,7 @@ jobs:
   # checks that a 'type/docs-cherrypick' label is attached to PRs with website/ changes
   website-check:
     # If there's a `type/docs-cherrypick` label we ignore this check
-    if: "!${{ contains(github.event.pull_request.label.*.name, 'type/docs-cherrypick')}}"
+    if: "!${{ contains(github.event.pull_request.labels.*.name, 'type/docs-cherrypick')}}"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This fixes the trigger conditional using the wrong key (`label`->`labels`) and also sets the checks  to only run when PRs are opened. The case this doesn't cover is if you forget to add docs to your PR but then add docs in the `website/` directory afterward opening the PR, the check won't rerun to remind you to check if `type/docs-cherrypick` needs to be added. I think this is a good enough compromise for now and we can refactor in the future depending on how helpful this is. 