### PR TITLE
Add docs for MIME sniffing on metrics endpoint.

### DIFF
--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -246,10 +246,17 @@ In order to enable [Prometheus](https://prometheus.io/) support, you need to use
 configuration directive
 [`prometheus_retention_time`](/docs/agent/options#telemetry-prometheus_retention_time).
 
-Note: If your metric includes labels that use the same key name multiple times
-(i.e. tag=tag2 and tag=tag1), only the sorted last value (tag=tag2) will be visible on
-this endpoint due to a display issue. The complete label set is correctly applied and
-passed to external metrics providers even though it is not visible through this endpoint.
+Since Consul 1.7.2 this endpoint will also automatically switch output format if 
+the request contains an `Accept` header with a compatible MIME type such as 
+`application/openmetrics-text`. This means that recent versions of Prometheus are able to 
+scrape _without_ the `?format` parameter and will still get the correct format results 
+simplifying scrape configuration.
+
+Note: If using the default format and your metric includes labels that use the same key 
+name multiple times (i.e. tag=tag2 and tag=tag1), only the sorted last value (tag=tag2) 
+will be visible on this endpoint due to a display issue. The complete label set is correctly 
+applied and passed to external metrics providers even though it is not visible through this 
+endpoint.
 
 | Method | Path                               | Produces                                   |
 | ------ | ---------------------------------- | ------------------------------------------ |

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -248,8 +248,10 @@ configuration directive
 
 Since Consul 1.7.2 this endpoint will also automatically switch output format if 
 the request contains an `Accept` header with a compatible MIME type such as 
-`application/openmetrics-text`. This means that recent versions of Prometheus are able to 
-scrape _without_ the `?format` parameter and will still get the correct format results 
+`application/openmetrics-text`. Prometheus v2.5.0 and newer pass this header in scraping
+queries, and so will get a compatible format by default. Older versions of Prometheus may 
+work by default as several previously used MIME types are also detected, but the `?format` 
+query parameter may also be used to specify the output format manually if needed.
 simplifying scrape configuration.
 
 Note: If using the default format and your metric includes labels that use the same key 


### PR DESCRIPTION
This was added in 1.7.2 last year but I realised we don't document it so it's kinda surprising Prometheus "just works" now.