### PR TITLE
state: Remove extra entMeta arg to EnsureConfigEntry

### DIFF
--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConfigEntry_Apply(t *testing.T) {
@@ -253,7 +254,7 @@ func TestConfigEntry_Get(t *testing.T) {
 		Name: "foo",
 	}
 	state := s1.fsm.State()
-	require.NoError(state.EnsureConfigEntry(1, entry, nil))
+	require.NoError(state.EnsureConfigEntry(1, entry))
 
 	args := structs.ConfigEntryQuery{
 		Kind:       structs.ServiceDefaults,
@@ -316,11 +317,11 @@ operator = "read"
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
 		Name: structs.ProxyConfigGlobal,
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "foo",
-	}, nil))
+	}))
 
 	// This should fail since we don't have write perms for the "db" service.
 	args := structs.ConfigEntryQuery{
@@ -374,8 +375,8 @@ func TestConfigEntry_List(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(state.EnsureConfigEntry(1, expected.Entries[0], nil))
-	require.NoError(state.EnsureConfigEntry(2, expected.Entries[1], nil))
+	require.NoError(state.EnsureConfigEntry(1, expected.Entries[0]))
+	require.NoError(state.EnsureConfigEntry(2, expected.Entries[1]))
 
 	args := structs.ConfigEntryQuery{
 		Kind:       structs.ServiceDefaults,
@@ -428,10 +429,10 @@ func TestConfigEntry_ListAll(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, state.EnsureConfigEntry(1, entries[0], nil))
-	require.NoError(t, state.EnsureConfigEntry(2, entries[1], nil))
-	require.NoError(t, state.EnsureConfigEntry(3, entries[2], nil))
-	require.NoError(t, state.EnsureConfigEntry(4, entries[3], nil))
+	require.NoError(t, state.EnsureConfigEntry(1, entries[0]))
+	require.NoError(t, state.EnsureConfigEntry(2, entries[1]))
+	require.NoError(t, state.EnsureConfigEntry(3, entries[2]))
+	require.NoError(t, state.EnsureConfigEntry(4, entries[3]))
 
 	t.Run("all kinds", func(t *testing.T) {
 		args := structs.ConfigEntryListAllRequest{
@@ -529,15 +530,15 @@ operator = "read"
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
 		Name: structs.ProxyConfigGlobal,
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "foo",
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(3, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "db",
-	}, nil))
+	}))
 
 	// This should filter out the "db" service since we don't have permissions for it.
 	args := structs.ConfigEntryQuery{
@@ -614,15 +615,15 @@ operator = "read"
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
 		Name: structs.ProxyConfigGlobal,
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "foo",
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(3, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "db",
-	}, nil))
+	}))
 
 	// This should filter out the "db" service since we don't have permissions for it.
 	args := structs.ConfigEntryListAllRequest{
@@ -687,7 +688,7 @@ func TestConfigEntry_Delete(t *testing.T) {
 		Name: "foo",
 	}
 	state := s1.fsm.State()
-	require.NoError(t, state.EnsureConfigEntry(1, entry, nil))
+	require.NoError(t, state.EnsureConfigEntry(1, entry))
 
 	// Verify it's there.
 	_, existing, err := state.ConfigEntry(nil, structs.ServiceDefaults, "foo", nil)
@@ -773,11 +774,11 @@ operator = "write"
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
 		Name: structs.ProxyConfigGlobal,
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "foo",
-	}, nil))
+	}))
 
 	// This should fail since we don't have write perms for the "db" service.
 	args := structs.ConfigEntryRequest{
@@ -848,17 +849,17 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 		Config: map[string]interface{}{
 			"foo": 1,
 		},
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
 		Name:     "foo",
 		Protocol: "http",
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
 		Name:     "bar",
 		Protocol: "grpc",
-	}, nil))
+	}))
 
 	args := structs.ServiceConfigRequest{
 		Name:       "foo",
@@ -918,17 +919,17 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 		Config: map[string]interface{}{
 			"global": 1,
 		},
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
 		Name:     "foo",
 		Protocol: "grpc",
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(3, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
 		Name:     "bar",
 		Protocol: "http",
-	}, nil))
+	}))
 
 	var index uint64
 
@@ -1084,24 +1085,24 @@ func TestConfigEntry_ResolveServiceConfig_UpstreamProxyDefaultsProtocol(t *testi
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "foo",
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "bar",
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "other",
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
 		Name:     "alreadyprotocol",
 		Protocol: "grpc",
-	}, nil))
+	}))
 
 	args := structs.ServiceConfigRequest{
 		Name:       "foo",
@@ -1158,7 +1159,7 @@ func TestConfigEntry_ResolveServiceConfig_ProxyDefaultsProtocol_UsedForAllUpstre
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},
-	}, nil))
+	}))
 
 	args := structs.ServiceConfigRequest{
 		Name:       "foo",
@@ -1264,15 +1265,15 @@ operator = "write"
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
 		Name: structs.ProxyConfigGlobal,
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "foo",
-	}, nil))
+	}))
 	require.NoError(state.EnsureConfigEntry(3, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
 		Name: "db",
-	}, nil))
+	}))
 
 	// This should fail since we don't have write perms for the "db" service.
 	args := structs.ServiceConfigRequest{

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
@@ -575,7 +576,7 @@ func (c *FSM) applyConfigEntryOperation(buf []byte, index uint64) interface{} {
 	case structs.ConfigEntryUpsertCAS:
 		defer metrics.MeasureSinceWithLabels([]string{"fsm", "config_entry", req.Entry.GetKind()}, time.Now(),
 			[]metrics.Label{{Name: "op", Value: "upsert"}})
-		updated, err := c.state.EnsureConfigEntryCAS(index, req.Entry.GetRaftIndex().ModifyIndex, req.Entry, req.Entry.GetEnterpriseMeta())
+		updated, err := c.state.EnsureConfigEntryCAS(index, req.Entry.GetRaftIndex().ModifyIndex, req.Entry)
 		if err != nil {
 			return err
 		}
@@ -583,7 +584,7 @@ func (c *FSM) applyConfigEntryOperation(buf []byte, index uint64) interface{} {
 	case structs.ConfigEntryUpsert:
 		defer metrics.MeasureSinceWithLabels([]string{"fsm", "config_entry", req.Entry.GetKind()}, time.Now(),
 			[]metrics.Label{{Name: "op", Value: "upsert"}})
-		if err := c.state.EnsureConfigEntry(index, req.Entry, req.Entry.GetEnterpriseMeta()); err != nil {
+		if err := c.state.EnsureConfigEntry(index, req.Entry); err != nil {
 			return err
 		}
 		return true

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-msgpack/codec"
+	"github.com/hashicorp/go-raftchunking"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/state"
@@ -12,9 +16,6 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib/stringslice"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/go-msgpack/codec"
-	"github.com/hashicorp/go-raftchunking"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFSM_SnapshotRestore_OSS(t *testing.T) {
@@ -226,8 +227,8 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		Kind: structs.ProxyDefaults,
 		Name: "global",
 	}
-	require.NoError(t, fsm.state.EnsureConfigEntry(18, serviceConfig, structs.DefaultEnterpriseMeta()))
-	require.NoError(t, fsm.state.EnsureConfigEntry(19, proxyConfig, structs.DefaultEnterpriseMeta()))
+	require.NoError(t, fsm.state.EnsureConfigEntry(18, serviceConfig))
+	require.NoError(t, fsm.state.EnsureConfigEntry(19, proxyConfig))
 
 	ingress := &structs.IngressGatewayConfigEntry{
 		Kind: structs.IngressGateway,
@@ -244,7 +245,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, fsm.state.EnsureConfigEntry(20, ingress, structs.DefaultEnterpriseMeta()))
+	require.NoError(t, fsm.state.EnsureConfigEntry(20, ingress))
 	_, gatewayServices, err := fsm.state.GatewayServices(nil, "ingress", structs.DefaultEnterpriseMeta())
 	require.NoError(t, err)
 
@@ -416,7 +417,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, fsm.state.EnsureConfigEntry(26, serviceIxn, structs.DefaultEnterpriseMeta()))
+	require.NoError(t, fsm.state.EnsureConfigEntry(26, serviceIxn))
 
 	// Snapshot
 	snap, err := fsm.Snapshot()

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -2178,7 +2178,7 @@ func TestStateStore_ConnectServiceNodes_Gateways(t *testing.T) {
 				Name: "db",
 			},
 		},
-	}, nil))
+	}))
 	assert.True(watchFired(ws))
 
 	// Read everything back.
@@ -3644,7 +3644,7 @@ func TestStateStore_CheckConnectServiceNodes_Gateways(t *testing.T) {
 				Name: "db",
 			},
 		},
-	}, nil))
+	}))
 	assert.True(watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -4528,7 +4528,7 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 				Name: "api",
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	// Read everything back.
@@ -4572,7 +4572,7 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 				Name: "api",
 			},
 		},
-	}, nil))
+	}))
 	assert.False(t, watchFired(ws))
 
 	idx, out, err = s.GatewayServices(ws, "gateway", nil)
@@ -4625,7 +4625,7 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 				SNI:      "my-alt-domain",
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	// Read everything back.
@@ -4756,7 +4756,7 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 				Name: "db",
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	idx, out, err = s.GatewayServices(ws, "gateway", nil)
@@ -4787,7 +4787,7 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 				Name: "*",
 			},
 		},
-	}, nil))
+	}))
 
 	ws = memdb.NewWatchSet()
 	idx, out, err = s.GatewayServices(ws, "gateway2", nil)
@@ -4862,7 +4862,7 @@ func TestStateStore_GatewayServices_ServiceDeletion(t *testing.T) {
 				CAFile: "my_ca.pem",
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	// Listing with no results returns an empty list.
@@ -4881,7 +4881,7 @@ func TestStateStore_GatewayServices_ServiceDeletion(t *testing.T) {
 				Name: "*",
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	// Read everything back for first gateway.
@@ -5299,7 +5299,7 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 		_, _, err := s.GatewayServices(ws, "ingress1", nil)
 		require.NoError(t, err)
 
-		require.Nil(t, s.EnsureConfigEntry(20, ingress1, nil))
+		require.Nil(t, s.EnsureConfigEntry(20, ingress1))
 		require.False(t, watchFired(ws))
 
 		expected := structs.GatewayServices{
@@ -5344,7 +5344,7 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 		_, _, err := s.GatewayServices(ws, "ingress1", nil)
 		require.NoError(t, err)
 
-		require.Nil(t, s.EnsureConfigEntry(20, ingress1, nil))
+		require.Nil(t, s.EnsureConfigEntry(20, ingress1))
 		require.True(t, watchFired(ws))
 
 		idx, results, err := s.GatewayServices(ws, "ingress1", nil)
@@ -5437,7 +5437,7 @@ func TestStateStore_GatewayServices_IngressProtocolFiltering(t *testing.T) {
 		testRegisterNode(t, s, 0, "node1")
 		testRegisterService(t, s, 1, "node1", "service1")
 		testRegisterService(t, s, 2, "node1", "service2")
-		assert.NoError(t, s.EnsureConfigEntry(4, ingress1, nil))
+		assert.NoError(t, s.EnsureConfigEntry(4, ingress1))
 	})
 
 	t.Run("no services from default tcp protocol", func(t *testing.T) {
@@ -5470,7 +5470,7 @@ func TestStateStore_GatewayServices_IngressProtocolFiltering(t *testing.T) {
 			Kind:     structs.ServiceDefaults,
 			Protocol: "http",
 		}
-		assert.NoError(t, s.EnsureConfigEntry(5, svcDefaults, nil))
+		assert.NoError(t, s.EnsureConfigEntry(5, svcDefaults))
 		idx, results, err := s.GatewayServices(nil, "ingress1", nil)
 		require.NoError(err)
 		require.Equal(uint64(5), idx)
@@ -5513,7 +5513,7 @@ func TestStateStore_GatewayServices_IngressProtocolFiltering(t *testing.T) {
 				"protocol": "http",
 			},
 		}
-		assert.NoError(t, s.EnsureConfigEntry(6, proxyDefaults, nil))
+		assert.NoError(t, s.EnsureConfigEntry(6, proxyDefaults))
 
 		idx, results, err := s.GatewayServices(nil, "ingress1", nil)
 		require.NoError(err)
@@ -5543,7 +5543,7 @@ func TestStateStore_GatewayServices_IngressProtocolFiltering(t *testing.T) {
 			Kind:     structs.ServiceDefaults,
 			Protocol: "grpc",
 		}
-		assert.NoError(t, s.EnsureConfigEntry(7, svcDefaults, nil))
+		assert.NoError(t, s.EnsureConfigEntry(7, svcDefaults))
 
 		idx, results, err := s.GatewayServices(nil, "ingress1", nil)
 		require.NoError(err)
@@ -5583,7 +5583,7 @@ func TestStateStore_GatewayServices_IngressProtocolFiltering(t *testing.T) {
 				},
 			},
 		}
-		assert.NoError(t, s.EnsureConfigEntry(8, ingress1, nil))
+		assert.NoError(t, s.EnsureConfigEntry(8, ingress1))
 
 		idx, results, err := s.GatewayServices(nil, "ingress1", nil)
 		require.NoError(err)
@@ -5622,7 +5622,7 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 			"protocol": "http",
 		},
 	}
-	assert.NoError(t, s.EnsureConfigEntry(11, proxyDefaults, nil))
+	assert.NoError(t, s.EnsureConfigEntry(11, proxyDefaults))
 
 	// Register some ingress config entries.
 	wildcardIngress := &structs.IngressGatewayConfigEntry{
@@ -5640,7 +5640,7 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 			},
 		},
 	}
-	assert.NoError(t, s.EnsureConfigEntry(12, wildcardIngress, nil))
+	assert.NoError(t, s.EnsureConfigEntry(12, wildcardIngress))
 
 	ingress1 := &structs.IngressGatewayConfigEntry{
 		Kind: "ingress-gateway",
@@ -5667,7 +5667,7 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 			},
 		},
 	}
-	assert.NoError(t, s.EnsureConfigEntry(13, ingress1, nil))
+	assert.NoError(t, s.EnsureConfigEntry(13, ingress1))
 	assert.True(t, watchFired(ws))
 
 	ingress2 := &structs.IngressGatewayConfigEntry{
@@ -5685,7 +5685,7 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 			},
 		},
 	}
-	assert.NoError(t, s.EnsureConfigEntry(14, ingress2, nil))
+	assert.NoError(t, s.EnsureConfigEntry(14, ingress2))
 	assert.True(t, watchFired(ws))
 
 	ingress3 := &structs.IngressGatewayConfigEntry{
@@ -5712,7 +5712,7 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 			},
 		},
 	}
-	assert.NoError(t, s.EnsureConfigEntry(15, ingress3, nil))
+	assert.NoError(t, s.EnsureConfigEntry(15, ingress3))
 	assert.True(t, watchFired(ws))
 
 	nothingIngress := &structs.IngressGatewayConfigEntry{
@@ -5720,7 +5720,7 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 		Name:      "nothingIngress",
 		Listeners: []structs.IngressListener{},
 	}
-	assert.NoError(t, s.EnsureConfigEntry(16, nothingIngress, nil))
+	assert.NoError(t, s.EnsureConfigEntry(16, nothingIngress))
 	assert.True(t, watchFired(ws))
 
 	return ws
@@ -5788,7 +5788,7 @@ func TestStateStore_DumpGatewayServices(t *testing.T) {
 					SNI:      "my-alt-domain",
 				},
 			},
-		}, nil))
+		}))
 		assert.True(t, watchFired(ws))
 
 		// Read everything back.
@@ -5849,7 +5849,7 @@ func TestStateStore_DumpGatewayServices(t *testing.T) {
 					SNI:      "my-alt-domain",
 				},
 			},
-		}, nil))
+		}))
 		assert.False(t, watchFired(ws))
 
 		idx, out, err := s.DumpGatewayServices(ws)
@@ -5984,7 +5984,7 @@ func TestStateStore_DumpGatewayServices(t *testing.T) {
 					Name: "db",
 				},
 			},
-		}, nil))
+		}))
 		assert.True(t, watchFired(ws))
 
 		idx, out, err := s.DumpGatewayServices(ws)
@@ -6013,7 +6013,7 @@ func TestStateStore_DumpGatewayServices(t *testing.T) {
 			Kind:     structs.ServiceDefaults,
 			Protocol: "http",
 		}
-		assert.NoError(t, s.EnsureConfigEntry(25, svcDefault, nil))
+		assert.NoError(t, s.EnsureConfigEntry(25, svcDefault))
 
 		// Associate gateway with db and api
 		assert.Nil(t, s.EnsureConfigEntry(26, &structs.IngressGatewayConfigEntry{
@@ -6040,7 +6040,7 @@ func TestStateStore_DumpGatewayServices(t *testing.T) {
 					},
 				},
 			},
-		}, nil))
+		}))
 		assert.True(t, watchFired(ws))
 
 		// Read everything back.
@@ -6814,7 +6814,7 @@ func TestCatalog_upstreamsFromRegistration_Ingress(t *testing.T) {
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},
-	}, nil))
+	}))
 
 	defaultMeta := structs.DefaultEnterpriseMeta()
 	ingress := structs.NewServiceName("ingress", defaultMeta)
@@ -6846,7 +6846,7 @@ func TestCatalog_upstreamsFromRegistration_Ingress(t *testing.T) {
 				},
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -6881,7 +6881,7 @@ func TestCatalog_upstreamsFromRegistration_Ingress(t *testing.T) {
 				},
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -6915,7 +6915,7 @@ func TestCatalog_upstreamsFromRegistration_Ingress(t *testing.T) {
 				},
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -6978,7 +6978,7 @@ func TestCatalog_upstreamsFromRegistration_Ingress(t *testing.T) {
 				},
 			},
 		},
-	}, nil))
+	}))
 	assert.True(t, watchFired(ws))
 
 	ws = memdb.NewWatchSet()
@@ -7021,7 +7021,7 @@ func TestCatalog_cleanupGatewayWildcards_panic(t *testing.T) {
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},
-	}, nil))
+	}))
 
 	defaultMeta := structs.DefaultEnterpriseMeta()
 
@@ -7035,7 +7035,7 @@ func TestCatalog_cleanupGatewayWildcards_panic(t *testing.T) {
 				EnterpriseMeta: *defaultMeta,
 			},
 		},
-	}, nil))
+	}))
 
 	require.NoError(t, s.EnsureConfigEntry(3, &structs.IngressGatewayConfigEntry{
 		Kind: "ingress-gateway",
@@ -7052,7 +7052,7 @@ func TestCatalog_cleanupGatewayWildcards_panic(t *testing.T) {
 				},
 			},
 		},
-	}, nil))
+	}))
 
 	// Register two services that share a prefix, both will be covered by gateway wildcards above
 	api := structs.NodeService{
@@ -7195,7 +7195,7 @@ func TestCatalog_DownstreamsForService(t *testing.T) {
 
 			for _, entry := range tc.entries {
 				require.NoError(t, entry.Normalize())
-				require.NoError(t, s.EnsureConfigEntry(i, entry, nil))
+				require.NoError(t, s.EnsureConfigEntry(i, entry))
 				i++
 			}
 
@@ -7300,7 +7300,7 @@ func TestCatalog_DownstreamsForService_Updates(t *testing.T) {
 		},
 	}
 	require.NoError(t, defaults.Normalize())
-	require.NoError(t, s.EnsureConfigEntry(5, &defaults, nil))
+	require.NoError(t, s.EnsureConfigEntry(5, &defaults))
 
 	router := structs.ServiceRouterConfigEntry{
 		Kind: structs.ServiceRouter,
@@ -7319,7 +7319,7 @@ func TestCatalog_DownstreamsForService_Updates(t *testing.T) {
 		},
 	}
 	require.NoError(t, router.Normalize())
-	require.NoError(t, s.EnsureConfigEntry(6, &router, nil))
+	require.NoError(t, s.EnsureConfigEntry(6, &router))
 
 	// We updated a relevant config entry
 	require.True(t, watchFired(ws))
@@ -7502,7 +7502,7 @@ func TestProtocolForIngressGateway(t *testing.T) {
 				require.NoError(t, entry.Normalize())
 				require.NoError(t, entry.Validate())
 
-				require.NoError(t, s.EnsureConfigEntry(tc.idx, entry, structs.DefaultEnterpriseMeta()))
+				require.NoError(t, s.EnsureConfigEntry(tc.idx, entry))
 			}
 
 			tx := s.db.ReadTxn()

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/sdk/testutil"
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func TestStore_ConfigEntry(t *testing.T) {
@@ -23,7 +24,7 @@ func TestStore_ConfigEntry(t *testing.T) {
 	}
 
 	// Create
-	require.NoError(s.EnsureConfigEntry(0, expected, nil))
+	require.NoError(s.EnsureConfigEntry(0, expected))
 
 	idx, config, err := s.ConfigEntry(nil, structs.ProxyDefaults, "global", nil)
 	require.NoError(err)
@@ -38,7 +39,7 @@ func TestStore_ConfigEntry(t *testing.T) {
 			"DestinationServiceName": "bar",
 		},
 	}
-	require.NoError(s.EnsureConfigEntry(1, updated, nil))
+	require.NoError(s.EnsureConfigEntry(1, updated))
 
 	idx, config, err = s.ConfigEntry(nil, structs.ProxyDefaults, "global", nil)
 	require.NoError(err)
@@ -58,19 +59,19 @@ func TestStore_ConfigEntry(t *testing.T) {
 		Kind: structs.ServiceDefaults,
 		Name: "foo",
 	}
-	require.NoError(s.EnsureConfigEntry(3, serviceConf, nil))
+	require.NoError(s.EnsureConfigEntry(3, serviceConf))
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.ConfigEntry(ws, structs.ServiceDefaults, "foo", nil)
 	require.NoError(err)
 
 	// Make an unrelated modification and make sure the watch doesn't fire.
-	require.NoError(s.EnsureConfigEntry(4, updated, nil))
+	require.NoError(s.EnsureConfigEntry(4, updated))
 	require.False(watchFired(ws))
 
 	// Update the watched config and make sure it fires.
 	serviceConf.Protocol = "http"
-	require.NoError(s.EnsureConfigEntry(5, serviceConf, nil))
+	require.NoError(s.EnsureConfigEntry(5, serviceConf))
 	require.True(watchFired(ws))
 }
 
@@ -87,7 +88,7 @@ func TestStore_ConfigEntryCAS(t *testing.T) {
 	}
 
 	// Create
-	require.NoError(s.EnsureConfigEntry(1, expected, nil))
+	require.NoError(s.EnsureConfigEntry(1, expected))
 
 	idx, config, err := s.ConfigEntry(nil, structs.ProxyDefaults, "global", nil)
 	require.NoError(err)
@@ -102,7 +103,7 @@ func TestStore_ConfigEntryCAS(t *testing.T) {
 			"DestinationServiceName": "bar",
 		},
 	}
-	ok, err := s.EnsureConfigEntryCAS(2, 99, updated, nil)
+	ok, err := s.EnsureConfigEntryCAS(2, 99, updated)
 	require.False(ok)
 	require.NoError(err)
 
@@ -113,7 +114,7 @@ func TestStore_ConfigEntryCAS(t *testing.T) {
 	require.Equal(expected, config)
 
 	// Update with a valid index
-	ok, err = s.EnsureConfigEntryCAS(2, 1, updated, nil)
+	ok, err = s.EnsureConfigEntryCAS(2, 1, updated)
 	require.True(ok)
 	require.NoError(err)
 
@@ -156,7 +157,7 @@ func TestStore_ConfigEntry_UpdateOver(t *testing.T) {
 
 	// Create
 	nextIndex := uint64(1)
-	require.NoError(t, s.EnsureConfigEntry(nextIndex, initial.Clone(), nil))
+	require.NoError(t, s.EnsureConfigEntry(nextIndex, initial.Clone()))
 
 	idx, raw, err := s.ConfigEntry(nil, structs.ServiceIntentions, "api", nil)
 	require.NoError(t, err)
@@ -184,7 +185,7 @@ func TestStore_ConfigEntry_UpdateOver(t *testing.T) {
 		}
 
 		nextIndex++
-		err := s.EnsureConfigEntry(nextIndex, updated.Clone(), nil)
+		err := s.EnsureConfigEntry(nextIndex, updated.Clone())
 		testutil.RequireErrorContains(t, err, "cannot set this field to a different value")
 	})
 
@@ -205,7 +206,7 @@ func TestStore_ConfigEntry_UpdateOver(t *testing.T) {
 		}
 
 		nextIndex++
-		require.NoError(t, s.EnsureConfigEntry(nextIndex, updated.Clone(), nil))
+		require.NoError(t, s.EnsureConfigEntry(nextIndex, updated.Clone()))
 
 		// check
 		idx, raw, err = s.ConfigEntry(nil, structs.ServiceIntentions, "api", nil)
@@ -238,9 +239,9 @@ func TestStore_ConfigEntries(t *testing.T) {
 		Name: "test3",
 	}
 
-	require.NoError(s.EnsureConfigEntry(0, entry1, nil))
-	require.NoError(s.EnsureConfigEntry(1, entry2, nil))
-	require.NoError(s.EnsureConfigEntry(2, entry3, nil))
+	require.NoError(s.EnsureConfigEntry(0, entry1))
+	require.NoError(s.EnsureConfigEntry(1, entry2))
+	require.NoError(s.EnsureConfigEntry(2, entry3))
 
 	// Get all entries
 	idx, entries, err := s.ConfigEntries(nil, nil)
@@ -269,7 +270,7 @@ func TestStore_ConfigEntries(t *testing.T) {
 		Kind:     structs.ServiceDefaults,
 		Name:     "test2",
 		Protocol: "tcp",
-	}, nil))
+	}))
 	require.True(watchFired(ws))
 }
 
@@ -291,7 +292,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						{Weight: 100},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -312,7 +313,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						{Weight: 100},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -355,7 +356,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 					EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 		},
 		"splitter works with http protocol (from proxy-defaults)": {
@@ -389,7 +390,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						{Weight: 10, ServiceSubset: "v2"},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 		},
 		"router fails with tcp protocol": {
@@ -426,7 +427,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -460,7 +461,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -609,7 +610,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					Name:     "main",
 					Protocol: "tcp",
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -692,7 +693,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					Name:     "main",
 					Protocol: "tcp",
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -720,7 +721,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						{Weight: 10, Service: "other"},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "uses inconsistent protocols",
 			expectGraphErr: true,
@@ -755,7 +756,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "uses inconsistent protocols",
 			expectGraphErr: true,
@@ -789,7 +790,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "uses inconsistent protocols",
 			expectGraphErr: true,
@@ -820,7 +821,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						Service: "other",
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      "uses inconsistent protocols",
 			expectGraphErr: true,
@@ -848,7 +849,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						ServiceSubset: "v1",
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 		},
 		"cannot redirect to a subset that does not exist": {
@@ -868,7 +869,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						ServiceSubset: "v1",
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      `does not have a subset named "v1"`,
 			expectGraphErr: true,
@@ -892,7 +893,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						Service: "other",
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      `detected circular resolver redirect`,
 			expectGraphErr: true,
@@ -922,7 +923,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 						{Weight: 100, Service: "other"},
 					},
 				}
-				return s.EnsureConfigEntry(0, entry, nil)
+				return s.EnsureConfigEntry(0, entry)
 			},
 			expectErr:      `detected circular reference`,
 			expectGraphErr: true,
@@ -937,7 +938,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 			s := testConfigStateStore(t)
 			for _, entry := range tc.entries {
 				require.NoError(t, entry.Normalize())
-				require.NoError(t, s.EnsureConfigEntry(0, entry, nil))
+				require.NoError(t, s.EnsureConfigEntry(0, entry))
 			}
 
 			err := tc.op(t, s)
@@ -1245,7 +1246,7 @@ func TestStore_ReadDiscoveryChainConfigEntries_Overrides(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := testConfigStateStore(t)
 			for _, entry := range tc.entries {
-				require.NoError(t, s.EnsureConfigEntry(0, entry, nil))
+				require.NoError(t, s.EnsureConfigEntry(0, entry))
 			}
 
 			t.Run("without override", func(t *testing.T) {
@@ -1340,7 +1341,7 @@ func TestStore_ReadDiscoveryChainConfigEntries_SubsetSplit(t *testing.T) {
 	}
 
 	for _, entry := range entries {
-		require.NoError(t, s.EnsureConfigEntry(0, entry, nil))
+		require.NoError(t, s.EnsureConfigEntry(0, entry))
 	}
 
 	_, entrySet, err := s.readDiscoveryChainConfigEntries(nil, "main", nil, nil)
@@ -1361,14 +1362,14 @@ func TestStore_ValidateGatewayNamesCannotBeShared(t *testing.T) {
 		Kind: structs.IngressGateway,
 		Name: "gateway",
 	}
-	require.NoError(t, s.EnsureConfigEntry(0, ingress, nil))
+	require.NoError(t, s.EnsureConfigEntry(0, ingress))
 
 	terminating := &structs.TerminatingGatewayConfigEntry{
 		Kind: structs.TerminatingGateway,
 		Name: "gateway",
 	}
 	// Cannot have 2 gateways with same service name
-	require.Error(t, s.EnsureConfigEntry(1, terminating, nil))
+	require.Error(t, s.EnsureConfigEntry(1, terminating))
 
 	ingress = &structs.IngressGatewayConfigEntry{
 		Kind: structs.IngressGateway,
@@ -1377,14 +1378,14 @@ func TestStore_ValidateGatewayNamesCannotBeShared(t *testing.T) {
 			{Port: 8080},
 		},
 	}
-	require.NoError(t, s.EnsureConfigEntry(2, ingress, nil))
+	require.NoError(t, s.EnsureConfigEntry(2, ingress))
 	require.NoError(t, s.DeleteConfigEntry(3, structs.IngressGateway, "gateway", nil))
 
 	// Adding the terminating gateway with same name should now work
-	require.NoError(t, s.EnsureConfigEntry(4, terminating, nil))
+	require.NoError(t, s.EnsureConfigEntry(4, terminating))
 
 	// Cannot have 2 gateways with same service name
-	require.Error(t, s.EnsureConfigEntry(5, ingress, nil))
+	require.Error(t, s.EnsureConfigEntry(5, ingress))
 }
 
 func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
@@ -1413,10 +1414,10 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 			Name:     "web",
 			Protocol: "http",
 		}
-		require.NoError(t, s.EnsureConfigEntry(0, expected, nil))
+		require.NoError(t, s.EnsureConfigEntry(0, expected))
 
 		// Next configure http ingress to route to the http service
-		require.NoError(t, s.EnsureConfigEntry(1, newIngress("http", "web"), nil))
+		require.NoError(t, s.EnsureConfigEntry(1, newIngress("http", "web")))
 
 		t.Run("via modification", func(t *testing.T) {
 			// Now redefine the target service as tcp
@@ -1426,7 +1427,7 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 				Protocol: "tcp",
 			}
 
-			err := s.EnsureConfigEntry(2, expected, nil)
+			err := s.EnsureConfigEntry(2, expected)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), `has protocol "tcp"`)
 		})
@@ -1442,7 +1443,7 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 		s := testConfigStateStore(t)
 
 		// First configure tcp ingress to route to a defaulted tcp service
-		require.NoError(t, s.EnsureConfigEntry(0, newIngress("tcp", "web"), nil))
+		require.NoError(t, s.EnsureConfigEntry(0, newIngress("tcp", "web")))
 
 		// Now redefine the target service as http
 		expected := &structs.ServiceConfigEntry{
@@ -1450,14 +1451,14 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 			Name:     "web",
 			Protocol: "http",
 		}
-		require.NoError(t, s.EnsureConfigEntry(1, expected, nil))
+		require.NoError(t, s.EnsureConfigEntry(1, expected))
 	})
 
 	t.Run("tcp ingress fails with tcp upstream (defaulted) later changed to http", func(t *testing.T) {
 		s := testConfigStateStore(t)
 
 		// First configure tcp ingress to route to a defaulted tcp service
-		require.NoError(t, s.EnsureConfigEntry(0, newIngress("tcp", "web"), nil))
+		require.NoError(t, s.EnsureConfigEntry(0, newIngress("tcp", "web")))
 
 		// Now redefine the target service as http
 		expected := &structs.ServiceConfigEntry{
@@ -1465,7 +1466,7 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 			Name:     "web",
 			Protocol: "http",
 		}
-		require.NoError(t, s.EnsureConfigEntry(1, expected, nil))
+		require.NoError(t, s.EnsureConfigEntry(1, expected))
 
 		t.Run("and a router defined", func(t *testing.T) {
 			// This part should fail.
@@ -1473,7 +1474,7 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 				Kind: structs.ServiceRouter,
 				Name: "web",
 			}
-			err := s.EnsureConfigEntry(2, expected2, nil)
+			err := s.EnsureConfigEntry(2, expected2)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), `has protocol "http"`)
 		})
@@ -1487,7 +1488,7 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 					{Weight: 100},
 				},
 			}
-			err := s.EnsureConfigEntry(2, expected2, nil)
+			err := s.EnsureConfigEntry(2, expected2)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), `has protocol "http"`)
 		})
@@ -1495,7 +1496,7 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 
 	t.Run("http ingress fails with tcp upstream (defaulted)", func(t *testing.T) {
 		s := testConfigStateStore(t)
-		err := s.EnsureConfigEntry(0, newIngress("http", "web"), nil)
+		err := s.EnsureConfigEntry(0, newIngress("http", "web"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `has protocol "tcp"`)
 	})
@@ -1509,9 +1510,9 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 				"protocol": "http2",
 			},
 		}
-		require.NoError(t, s.EnsureConfigEntry(0, expected, nil))
+		require.NoError(t, s.EnsureConfigEntry(0, expected))
 
-		err := s.EnsureConfigEntry(1, newIngress("http", "web"), nil)
+		err := s.EnsureConfigEntry(1, newIngress("http", "web"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `has protocol "http2"`)
 	})
@@ -1523,8 +1524,8 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 			Name:     "web",
 			Protocol: "grpc",
 		}
-		require.NoError(t, s.EnsureConfigEntry(1, expected, nil))
-		err := s.EnsureConfigEntry(2, newIngress("http", "web"), nil)
+		require.NoError(t, s.EnsureConfigEntry(1, expected))
+		err := s.EnsureConfigEntry(2, newIngress("http", "web"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), `has protocol "grpc"`)
 	})
@@ -1536,18 +1537,18 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 			Name:     "web",
 			Protocol: "http",
 		}
-		require.NoError(t, s.EnsureConfigEntry(2, expected, nil))
-		require.NoError(t, s.EnsureConfigEntry(3, newIngress("http", "web"), nil))
+		require.NoError(t, s.EnsureConfigEntry(2, expected))
+		require.NoError(t, s.EnsureConfigEntry(3, newIngress("http", "web")))
 	})
 
 	t.Run("http ingress ignores wildcard specifier", func(t *testing.T) {
 		s := testConfigStateStore(t)
-		require.NoError(t, s.EnsureConfigEntry(4, newIngress("http", "*"), nil))
+		require.NoError(t, s.EnsureConfigEntry(4, newIngress("http", "*")))
 	})
 
 	t.Run("deleting ingress config entry ok", func(t *testing.T) {
 		s := testConfigStateStore(t)
-		require.NoError(t, s.EnsureConfigEntry(1, newIngress("tcp", "web"), nil))
+		require.NoError(t, s.EnsureConfigEntry(1, newIngress("tcp", "web")))
 		require.NoError(t, s.DeleteConfigEntry(5, structs.IngressGateway, "gateway", nil))
 	})
 }
@@ -1821,7 +1822,7 @@ func TestSourcesForTarget(t *testing.T) {
 			var i uint64 = 1
 			for _, entry := range tc.entries {
 				require.NoError(t, entry.Normalize())
-				require.NoError(t, s.EnsureConfigEntry(i, entry, nil))
+				require.NoError(t, s.EnsureConfigEntry(i, entry))
 				i++
 			}
 
@@ -2023,7 +2024,7 @@ func TestTargetsForSource(t *testing.T) {
 			var i uint64 = 1
 			for _, entry := range tc.entries {
 				require.NoError(t, entry.Normalize())
-				require.NoError(t, s.EnsureConfigEntry(i, entry, nil))
+				require.NoError(t, s.EnsureConfigEntry(i, entry))
 				i++
 			}
 
@@ -2258,7 +2259,7 @@ func TestStore_ValidateServiceIntentionsErrorOnIncompatibleProtocols(t *testing.
 				if op.deletion {
 					err = s.DeleteConfigEntry(nextIndex, op.entry.GetKind(), op.entry.GetName(), nil)
 				} else {
-					err = s.EnsureConfigEntry(nextIndex, op.entry, nil)
+					err = s.EnsureConfigEntry(nextIndex, op.entry)
 				}
 
 				if isLast && tc.expectLastErr != "" {

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -290,7 +290,7 @@ func (s *Store) intentionMutationLegacyCreate(
 		return err
 	}
 
-	if err := ensureConfigEntryTxn(tx, idx, upsertEntry, upsertEntry.GetEnterpriseMeta()); err != nil {
+	if err := ensureConfigEntryTxn(tx, idx, upsertEntry); err != nil {
 		return err
 	}
 
@@ -334,7 +334,7 @@ func (s *Store) intentionMutationLegacyUpdate(
 		return err
 	}
 
-	if err := ensureConfigEntryTxn(tx, idx, upsertEntry, upsertEntry.GetEnterpriseMeta()); err != nil {
+	if err := ensureConfigEntryTxn(tx, idx, upsertEntry); err != nil {
 		return err
 	}
 
@@ -380,7 +380,7 @@ func (s *Store) intentionMutationDelete(
 		return err
 	}
 
-	if err := ensureConfigEntryTxn(tx, idx, upsertEntry, upsertEntry.GetEnterpriseMeta()); err != nil {
+	if err := ensureConfigEntryTxn(tx, idx, upsertEntry); err != nil {
 		return err
 	}
 
@@ -428,7 +428,7 @@ func (s *Store) intentionMutationLegacyDelete(
 		return err
 	}
 
-	if err := ensureConfigEntryTxn(tx, idx, upsertEntry, upsertEntry.GetEnterpriseMeta()); err != nil {
+	if err := ensureConfigEntryTxn(tx, idx, upsertEntry); err != nil {
 		return err
 	}
 
@@ -476,7 +476,7 @@ func (s *Store) intentionMutationUpsert(
 		return err
 	}
 
-	if err := ensureConfigEntryTxn(tx, idx, upsertEntry, upsertEntry.GetEnterpriseMeta()); err != nil {
+	if err := ensureConfigEntryTxn(tx, idx, upsertEntry); err != nil {
 		return err
 	}
 

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-memdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/go-memdb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -128,7 +129,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 			lastIndex++
 			require.NoError(t, configEntry.LegacyNormalize())
 			require.NoError(t, configEntry.LegacyValidate())
-			require.NoError(t, s.EnsureConfigEntry(lastIndex, configEntry.Clone(), nil))
+			require.NoError(t, s.EnsureConfigEntry(lastIndex, configEntry.Clone()))
 
 			// Make sure the config entry index got updated instead of the old intentions one
 			require.Equal(t, lastIndex, s.maxIndex(configTableName))
@@ -190,7 +191,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 			lastIndex++
 			require.NoError(t, configEntry.LegacyNormalize())
 			require.NoError(t, configEntry.LegacyValidate())
-			require.NoError(t, s.EnsureConfigEntry(lastIndex, configEntry.Clone(), nil))
+			require.NoError(t, s.EnsureConfigEntry(lastIndex, configEntry.Clone()))
 
 			// Change a value that isn't in the unique 4 tuple and check we don't
 			// incorrectly consider this a duplicate when updating.
@@ -198,7 +199,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 			lastIndex++
 			require.NoError(t, configEntry.LegacyNormalize())
 			require.NoError(t, configEntry.LegacyValidate())
-			require.NoError(t, s.EnsureConfigEntry(lastIndex, configEntry.Clone(), nil))
+			require.NoError(t, s.EnsureConfigEntry(lastIndex, configEntry.Clone()))
 
 			// Make sure the config entry index got updated instead of the old intentions one
 			require.Equal(t, lastIndex, s.maxIndex(configTableName))
@@ -783,7 +784,7 @@ func testStore_IntentionMutation(t *testing.T, s *Store) {
 					Type:           structs.IntentionSourceConsul,
 				},
 			},
-		}, nil))
+		}))
 
 		lastIndex++
 
@@ -867,7 +868,7 @@ func TestStore_IntentionSet_updateCreatedAt(t *testing.T) {
 
 			require.NoError(t, conf.LegacyNormalize())
 			require.NoError(t, conf.LegacyValidate())
-			require.NoError(t, s.EnsureConfigEntry(1, conf.Clone(), nil))
+			require.NoError(t, s.EnsureConfigEntry(1, conf.Clone()))
 		}
 
 		// Read it back and verify
@@ -915,7 +916,7 @@ func TestStore_IntentionSet_metaNil(t *testing.T) {
 			// Insert
 			require.NoError(t, conf.LegacyNormalize())
 			require.NoError(t, conf.LegacyValidate())
-			require.NoError(t, s.EnsureConfigEntry(1, conf.Clone(), nil))
+			require.NoError(t, s.EnsureConfigEntry(1, conf.Clone()))
 		}
 
 		// Read it back and verify
@@ -968,7 +969,7 @@ func TestStore_IntentionSet_metaSet(t *testing.T) {
 			// Insert
 			require.NoError(t, conf.LegacyNormalize())
 			require.NoError(t, conf.LegacyValidate())
-			require.NoError(t, s.EnsureConfigEntry(1, conf.Clone(), nil))
+			require.NoError(t, s.EnsureConfigEntry(1, conf.Clone()))
 		}
 
 		// Read it back and verify
@@ -1024,7 +1025,7 @@ func TestStore_IntentionDelete(t *testing.T) {
 			// Insert
 			require.NoError(t, conf.LegacyNormalize())
 			require.NoError(t, conf.LegacyValidate())
-			require.NoError(t, s.EnsureConfigEntry(1, conf.Clone(), nil))
+			require.NoError(t, s.EnsureConfigEntry(1, conf.Clone()))
 
 			// Make sure the index got updated.
 			require.Equal(t, s.maxIndex(configTableName), lastIndex)
@@ -1163,7 +1164,7 @@ func TestStore_IntentionsList(t *testing.T) {
 				require.NoError(t, conf.LegacyNormalize())
 				require.NoError(t, conf.LegacyValidate())
 				lastIndex++
-				require.NoError(t, s.EnsureConfigEntry(lastIndex, conf, nil))
+				require.NoError(t, s.EnsureConfigEntry(lastIndex, conf))
 			}
 
 			expectIDs = []string{
@@ -1315,7 +1316,7 @@ func TestStore_IntentionMatch_table(t *testing.T) {
 				require.NoError(t, conf.LegacyNormalize())
 				require.NoError(t, conf.LegacyValidate())
 				lastIndex++
-				require.NoError(t, s.EnsureConfigEntry(lastIndex, conf, &conf.EnterpriseMeta))
+				require.NoError(t, s.EnsureConfigEntry(lastIndex, conf))
 			}
 		}
 
@@ -1503,7 +1504,7 @@ func TestStore_IntentionMatchOne_table(t *testing.T) {
 				require.NoError(t, conf.LegacyNormalize())
 				require.NoError(t, conf.LegacyValidate())
 				lastIndex++
-				require.NoError(t, s.EnsureConfigEntry(lastIndex, conf, &conf.EnterpriseMeta))
+				require.NoError(t, s.EnsureConfigEntry(lastIndex, conf))
 			}
 		}
 
@@ -1590,7 +1591,7 @@ func TestStore_IntentionMatch_WatchesDuringUpgrade(t *testing.T) {
 			{Name: "web", Action: structs.IntentionActionAllow},
 		},
 	}
-	require.NoError(t, s.EnsureConfigEntry(1, conf, &conf.EnterpriseMeta))
+	require.NoError(t, s.EnsureConfigEntry(1, conf))
 
 	require.True(t, watchFired(ws))
 }
@@ -1755,7 +1756,7 @@ func TestStore_IntentionDecision(t *testing.T) {
 
 	s := testConfigStateStore(t)
 	for _, entry := range entries {
-		require.NoError(t, s.EnsureConfigEntry(1, entry, nil))
+		require.NoError(t, s.EnsureConfigEntry(1, entry))
 	}
 
 	tt := []struct {


### PR DESCRIPTION
In every case we would pass in the value from the proceeding arg. The extra arg is an opportunity for introducing a bug, so I think we should remove it to avoid that bug.