### PR TITLE
docs: Small change to fix broken link to k8s upgrade from k8s tls certs page

### DIFF
--- a/website/content/docs/k8s/operations/certificate-rotation.mdx
+++ b/website/content/docs/k8s/operations/certificate-rotation.mdx
@@ -25,4 +25,4 @@ To explicitly perform server certificate rotation, follow these steps:
 
    This should run the `tls-init` job that will generate new Server certificates.
 
-1. Restart the Server pods following the steps [here](/docs/k8s/operations/upgrade#upgrading-consul-servers).
+1. Restart the Server pods following the steps [here](/docs/k8s/upgrade#upgrading-consul-servers).


### PR DESCRIPTION
Broken link to k8s server upgrade from tls certs page