### PR TITLE
ui: Implement read-only KV/Session and Intention views based on ACLs

### DIFF
--- a/ui/packages/consul-ui/README.md
+++ b/ui/packages/consul-ui/README.md
@@ -128,6 +128,7 @@ token/secret.
 | `CONSUL_EXPOSED_COUNT` | (random) | Configure the number of exposed paths that the API returns. |
 | `CONSUL_CHECK_COUNT` | (random) | Configure the number of health checks that the API returns. |
 | `CONSUL_OIDC_PROVIDER_COUNT` | (random) | Configure the number of OIDC providers that the API returns. |
+| `CONSUL_RESOURCE_<singular-resource-name>_<access-type>` | true | Configure permissions e.g `CONSUL_RESOURCE_INTENTION_WRITE=false`. |
 | `DEBUG_ROUTES_ENDPOINT` | undefined | When using the window.Routes() debug utility ([see utility functions](#browser-debug-utility-functions)), use a URL to pass the route DSL to. %s in the URL will be replaced with the route DSL - http://url.com?routes=%s  |
 
 See `./mock-api` for more details.

--- a/ui/packages/consul-ui/app/abilities/base.js
+++ b/ui/packages/consul-ui/app/abilities/base.js
@@ -14,23 +14,27 @@ export default class BaseAbility extends Ability {
     return this.permissions.generate(this.resource, action);
   }
 
-  get canCreate() {
-    return this.permissions.has(this.generate(ACCESS_WRITE));
-  }
-
-  get canDelete() {
-    return this.permissions.has(this.generate(ACCESS_WRITE));
-  }
-
   get canRead() {
     return this.permissions.has(this.generate(ACCESS_READ));
   }
 
   get canList() {
-    return this.permissions.has(this.generate(ACCESS_LIST));
+    return this.canRead;
+  }
+
+  get canWrite() {
+    return this.permissions.has(this.generate(ACCESS_WRITE));
+  }
+
+  get canCreate() {
+    return this.canWrite;
+  }
+
+  get canDelete() {
+    return this.canWrite;
   }
 
   get canUpdate() {
-    return this.permissions.has(this.generate(ACCESS_WRITE));
+    return this.canWrite;
   }
 }

--- a/ui/packages/consul-ui/app/abilities/base.js
+++ b/ui/packages/consul-ui/app/abilities/base.js
@@ -19,7 +19,7 @@ export default class BaseAbility extends Ability {
   }
 
   get canList() {
-    return this.canRead;
+    return this.permissions.has(this.generate(ACCESS_LIST));
   }
 
   get canWrite() {

--- a/ui/packages/consul-ui/app/abilities/intention.js
+++ b/ui/packages/consul-ui/app/abilities/intention.js
@@ -2,4 +2,8 @@ import BaseAbility from './base';
 
 export default class IntentionAbility extends BaseAbility {
   resource = 'intention';
+
+  get canWrite() {
+    return super.canWrite && (typeof this.item === 'undefined' || this.item.IsEditable);
+  }
 }

--- a/ui/packages/consul-ui/app/abilities/session.js
+++ b/ui/packages/consul-ui/app/abilities/session.js
@@ -1,0 +1,5 @@
+import BaseAbility from './base';
+
+export default class SessionAbility extends BaseAbility {
+  resource = 'session';
+}

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -32,7 +32,7 @@ as |api|>
 
     <BlockSlot @name="form">
 {{#let api.data as |item|}}
-  {{#if item.IsEditable}}
+{{#if (can 'write intention' item=item)}}
 
 {{#if this.warn}}
   {{#let (changeset-get item 'Action') as |newAction|}}

--- a/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
@@ -59,7 +59,7 @@ as |item index|>
           More
         </BlockSlot>
         <BlockSlot @name="menu" as |confirm send keypressClick change|>
-        {{#if item.IsEditable}}
+        {{#if (can "write intention" item=item)}}
             <li role="none">
               <a role="menuitem" tabindex="-1" href={{href-to (or routeName 'dc.intentions.edit') item.ID}}>Edit</a>
             </li>

--- a/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
@@ -11,8 +11,11 @@
   as |api|
 >
   <BlockSlot @name="content">
+{{#let (cannot 'write kv' item=api.data) as |disabld|}}
     <form onsubmit={{action api.submit}}>
-      <fieldset disabled={{api.disabled}}>
+      <fieldset
+        {{disabled (or disabld api.disabled)}}
+      >
 {{#if api.isCreate}}
         <label class="type-text{{if api.data.error.Key ' has-error'}}">
             <span>Key or folder</span>
@@ -24,27 +27,47 @@
         <div>
             <div class="type-toggle">
               <label>
-                  <input type="checkbox" name="json" checked={{if json 'checked'}} onchange={{action api.change}} />
+                  <input
+                    type="checkbox"
+                    name="json"
+                    {{disabled false}}
+                    checked={{if json 'checked'}}
+                    onchange={{action api.change}}
+                  />
                   <span>Code</span>
               </label>
             </div>
             <label for="" class="type-text{{if api.data.error.Value ' has-error'}}">
                 <span>Value</span>
 {{#if json}}
-                <CodeEditor @name="value" @value={{atob api.data.Value}} @onkeyup={{action api.change "value"}} />
+                <CodeEditor
+                  @name="value"
+                  @readonly={{or disabld api.disabled}}
+                  @value={{atob api.data.Value}}
+                  @onkeyup={{action api.change "value"}}
+                />
 {{else}}
-                <textarea autofocus={{not api.isCreate}} name="value" oninput={{action api.change}}>{{atob api.data.Value}}</textarea>
+                <textarea
+                  {{disabled (or disabld api.disabled)}}
+                  autofocus={{not api.isCreate}}
+                  name="value"
+                  oninput={{action api.change}}>{{atob api.data.Value}}</textarea>
 {{/if}}
             </label>
         </div>
 {{/if}}
     </fieldset>
     {{#if api.isCreate}}
+{{#if (not disabld)}}
         <button type="submit" disabled={{or api.data.isPristine api.data.isInvalid api.disabled}}>Save</button>
+{{/if}}
         <button type="reset" onclick={{action oncancel api.data}} disabled={{api.disabled}}>Cancel</button>
     {{else}}
+{{#if (not disabld)}}
         <button type="submit" disabled={{or api.data.isInvalid api.disabled}}>Save</button>
+{{/if}}
         <button type="reset" onclick={{action oncancel api.data}} disabled={{api.disabled}}>Cancel</button>
+{{#if (not disabld)}}
         <ConfirmationDialog @message="Are you sure you want to delete this key?">
           <BlockSlot @name="action" as |confirm|>
             <button data-test-delete type="button" class="type-delete" {{action confirm api.delete}} disabled={{api.disabled}}>Delete</button>
@@ -54,6 +77,8 @@
           </BlockSlot>
         </ConfirmationDialog>
     {{/if}}
+{{/if}}
       </form>
+{{/let}}
     </BlockSlot>
 </DataForm>

--- a/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
@@ -17,6 +17,7 @@ as |item index|>
         More
       </BlockSlot>
       <BlockSlot @name="menu" as |confirm send keypressClick|>
+      {{#if (can 'write kv' item=item)}}
           <li role="none">
             <a data-test-edit role="menuitem" tabindex="-1" href={{href-to (if item.isFolder 'dc.kv.folder' 'dc.kv.edit') item.Key}}>{{if item.isFolder 'View' 'Edit'}}</a>
           </li>
@@ -55,6 +56,11 @@ as |item index|>
               </InformedAction>
             </div>
           </li>
+        {{else}}
+          <li role="none">
+            <a data-test-edit role="menuitem" tabindex="-1" href={{href-to (if item.isFolder 'dc.kv.folder' 'dc.kv.edit') item.Key}}>View</a>
+          </li>
+        {{/if}}
       </BlockSlot>
     </PopoverMenu>
   </BlockSlot>

--- a/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
@@ -41,6 +41,7 @@
           </dd>
 {{/if}}
         </dl>
+{{#if (can 'delete session' item=api.data)}}
         <ConfirmationDialog @message="Are you sure you want to invalidate this session?">
           <BlockSlot @name="action" as |confirm|>
             <button type="button" data-test-delete class="type-delete" {{action confirm api.delete session}} disabled={{api.disabled}}>Invalidate Session</button>
@@ -53,6 +54,7 @@
             <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
           </BlockSlot>
         </ConfirmationDialog>
+{{/if}}
       </div>
     </BlockSlot>
 </DataForm>

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
@@ -50,6 +50,7 @@
       </dd>
     </dl>
   </BlockSlot>
+{{#if (can "delete sessions")}}
   <BlockSlot @name="actions">
     <ConfirmationDialog @message="Are you sure you want to invalidate this session?">
       <BlockSlot @name="action" as |confirm|>
@@ -70,5 +71,6 @@
       </BlockSlot>
     </ConfirmationDialog>
   </BlockSlot>
+{{/if}}
 </ListCollection>
 {{/if}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
@@ -96,6 +96,7 @@
       returns=(set this 'popoverController')
     }}
     {{on 'click' (fn (optional this.popoverController.show))}}
+    {{disabled (cannot 'update intention' item=item.Intention)}}
     type="button"
     style={{{concat 'top:' @position.y 'px;left:' @position.x 'px;'}}}
     aria-label={{if (eq @type 'deny') 'Add intention' 'View intention'}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/popover/index.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/popover/index.scss
@@ -5,10 +5,13 @@
     background-color: $white;
     padding: 1px 1px;
     &:hover {
-      cursor:pointer;
+      cursor: pointer;
     }
     &:active, &:focus {
       outline: none;
+    }
+    &:disabled {
+      cursor: default;
     }
   }
   &.deny .informed-action header::before {

--- a/ui/packages/consul-ui/app/instance-initializers/nspace.js
+++ b/ui/packages/consul-ui/app/instance-initializers/nspace.js
@@ -80,6 +80,9 @@ export function initialize(container) {
       .filter(function(item) {
         return item.startsWith('dc');
       })
+      .filter(function(item) {
+        return item.endsWith('path');
+      })
       .map(function(item) {
         return item.replace('._options.path', '').replace(dotRe, '/');
       })

--- a/ui/packages/consul-ui/app/modifiers/disabled.js
+++ b/ui/packages/consul-ui/app/modifiers/disabled.js
@@ -1,0 +1,17 @@
+import { modifier } from 'ember-modifier';
+
+export default modifier(function enabled($element, [bool], hash) {
+  if (['input', 'textarea', 'select', 'button'].includes($element.nodeName.toLowerCase())) {
+    if (bool) {
+      $element.disabled = bool;
+    } else {
+      $element.dataset.disabled = false;
+    }
+    return;
+  }
+  for (const $el of $element.querySelectorAll('input,textarea')) {
+    if ($el.dataset.disabled !== 'false') {
+      $el.disabled = bool;
+    }
+  }
+});

--- a/ui/packages/consul-ui/app/router.js
+++ b/ui/packages/consul-ui/app/router.js
@@ -91,10 +91,16 @@ export const routes = {
     intentions: {
       _options: { path: '/intentions' },
       edit: {
-        _options: { path: '/:intention_id' },
+        _options: {
+          path: '/:intention_id',
+          abilities: ['read intentions'],
+        },
       },
       create: {
-        _options: { path: '/create' },
+        _options: {
+          path: '/create',
+          abilities: ['create intentions'],
+        },
       },
     },
     // Key/Value
@@ -107,10 +113,16 @@ export const routes = {
         _options: { path: '/*key/edit' },
       },
       create: {
-        _options: { path: '/*key/create' },
+        _options: {
+          path: '/*key/create',
+          abilities: ['create kvs'],
+        },
       },
       'root-create': {
-        _options: { path: '/create' },
+        _options: {
+          path: '/create',
+          abilities: ['create kvs'],
+        },
       },
     },
     // ACLs

--- a/ui/packages/consul-ui/app/routes/application.js
+++ b/ui/packages/consul-ui/app/routes/application.js
@@ -36,7 +36,7 @@ export default Route.extend(WithBlockingActions, {
     error: function(e, transition) {
       // TODO: Normalize all this better
       let error = {
-        status: e.code || '',
+        status: e.code || e.statusCode || '',
         message: e.message || e.detail || 'Error',
       };
       if (e.errors && e.errors[0]) {

--- a/ui/packages/consul-ui/app/routes/dc/kv/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/kv/edit.js
@@ -6,11 +6,9 @@ import { get } from '@ember/object';
 import ascend from 'consul-ui/utils/ascend';
 
 export default class EditRoute extends Route {
-  @service('repository/kv')
-  repo;
-
-  @service('repository/session')
-  sessionRepo;
+  @service('repository/kv') repo;
+  @service('repository/session') sessionRepo;
+  @service('repository/permission') permissions;
 
   model(params) {
     const create =
@@ -39,7 +37,7 @@ export default class EditRoute extends Route {
       // TODO: Consider loading this after initial page load
       if (typeof model.item !== 'undefined') {
         const session = get(model.item, 'Session');
-        if (session) {
+        if (session && this.permissions.can('read sessions')) {
           return hash({
             ...model,
             ...{

--- a/ui/packages/consul-ui/app/routing/route.js
+++ b/ui/packages/consul-ui/app/routing/route.js
@@ -1,12 +1,33 @@
 import Route from '@ember/routing/route';
 import { get, setProperties } from '@ember/object';
+import { inject as service } from '@ember/service';
+import HTTPError from 'consul-ui/utils/http/error';
 
 // paramsFor
 import { routes } from 'consul-ui/router';
 import wildcard from 'consul-ui/utils/routing/wildcard';
+
 const isWildcard = wildcard(routes);
 
 export default class BaseRoute extends Route {
+  @service('repository/permission') permissions;
+
+  /**
+   * Inspects a custom `abilities` array on the router for this route. Every
+   * abililty needs to 'pass' for the route not to throw a 403 error. Anything
+   * more complex then this (say ORs) should use a single ability and perform
+   * the OR lgic in the test for the ability. Note, this ability check happens
+   * before any calls to the backend for this model/route.
+   */
+  async beforeModel() {
+    const abilities = get(routes, `${this.routeName}._options.abilities`) || [];
+    if (abilities.length > 0) {
+      if (!abilities.every(ability => this.permissions.can(ability))) {
+        throw new HTTPError(403);
+      }
+    }
+  }
+
   /**
    * By default any empty string query parameters should remove the query
    * parameter from the URL. This is the most common behavior if you don't
@@ -16,28 +37,29 @@ export default class BaseRoute extends Route {
    * queryParameter configuration to configure what is deemed 'empty'
    */
   serializeQueryParam(value, key, type) {
-    if(typeof value !== 'undefined') {
+    if (typeof value !== 'undefined') {
       const empty = get(this, `queryParams.${key}.empty`);
-      if(typeof empty === 'undefined') {
+      if (typeof empty === 'undefined') {
         // by default any queryParams when an empty string mean undefined,
         // therefore remove the queryParam from the URL
-        if(value === '') {
+        if (value === '') {
           value = undefined;
         }
       } else {
         const possible = empty[0];
         let actual = value;
-        if(Array.isArray(actual)) {
+        if (Array.isArray(actual)) {
           actual = actual.split(',');
         }
-        const diff = possible.filter(item => !actual.includes(item))
-        if(diff.length === 0) {
+        const diff = possible.filter(item => !actual.includes(item));
+        if (diff.length === 0) {
           value = undefined;
         }
       }
     }
     return value;
   }
+
   /**
    * Set the routeName for the controller so that it is available in the template
    * for the route/controller.. This is mainly used to give a route name to the
@@ -49,6 +71,7 @@ export default class BaseRoute extends Route {
     });
     super.setupController(...arguments);
   }
+
   /**
    * Adds urldecoding to any wildcard route `params` passed into ember `model`
    * hooks, plus of course anywhere else where `paramsFor` is used. This means

--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 const modelName = 'permission';
 export default class PermissionService extends RepositoryService {
   @service('env') env;
-
+  @service('can') _can;
   // move this to the store
   @tracked permissions = [];
 
@@ -18,6 +18,10 @@ export default class PermissionService extends RepositoryService {
     return this.permissions.some(item => {
       return keys.every(key => item[key] === permission[key]) && item.Allow === true;
     });
+  }
+
+  can(can) {
+    return this._can.can(can);
   }
 
   generate(resource, action, segment) {
@@ -43,16 +47,36 @@ export default class PermissionService extends RepositoryService {
         Access: 'read',
       },
       {
+        Resource: 'session',
+        Access: 'read',
+      },
+      {
+        Resource: 'session',
+        Access: 'write',
+      },
+      {
         Resource: 'key',
         Access: 'read',
+      },
+      {
+        Resource: 'key',
+        Access: 'write',
       },
       {
         Resource: 'intention',
         Access: 'read',
       },
       {
+        Resource: 'intention',
+        Access: 'write',
+      },
+      {
         Resource: 'acl',
         Access: 'read',
+      },
+      {
+        Resource: 'acl',
+        Access: 'write',
       },
     ];
     if (!this.env.var('CONSUL_ACLS_ENABLED')) {

--- a/ui/packages/consul-ui/app/styles/base/components/form-elements/skin.scss
+++ b/ui/packages/consul-ui/app/styles/base/components/form-elements/skin.scss
@@ -6,6 +6,11 @@
   border: $decor-border-100;
   outline: none;
 }
+textarea:disabled + .CodeMirror,
+%form-element-text-input:disabled,
+%form-element-text-input:read-only {
+  cursor: not-allowed;
+}
 %form h2 {
   @extend %h200;
 }

--- a/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
@@ -40,7 +40,9 @@ as |sort filters items|}}
         <label for="toolbar-toggle"></label>
     </BlockSlot>
     <BlockSlot @name="actions">
+{{#if (can 'create intentions')}}
         <a data-test-create href="{{href-to 'dc.intentions.create'}}" class="type-create">Create</a>
+{{/if}}
     </BlockSlot>
     <BlockSlot @name="toolbar">
 

--- a/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
@@ -24,7 +24,8 @@
       </h1>
   </BlockSlot>
   <BlockSlot @name="content">
-  {{#if session}}
+  {{! if a KV has a session `Session` will always be populated despite any specific session permissions }}
+  {{#if item.Session}}
     <Notice
       @type="warning"
     as |notice|>
@@ -42,7 +43,7 @@
       @onsubmit={{if (eq parent.Key '/') (transition-to 'dc.kv.index') (transition-to 'dc.kv.folder' parent.Key)}}
       @parent={{parent}}
     />
-  {{! we only have session data if you have read perms}}
+  {{! session is slightly different to item.Session as we only have session if you have session:read perms}}
   {{#if session}}
     <Consul::LockSession::Form
       @item={{session}}

--- a/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
@@ -42,6 +42,7 @@
       @onsubmit={{if (eq parent.Key '/') (transition-to 'dc.kv.index') (transition-to 'dc.kv.folder' parent.Key)}}
       @parent={{parent}}
     />
+  {{! we only have session data if you have read perms}}
   {{#if session}}
     <Consul::LockSession::Form
       @item={{session}}

--- a/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
@@ -28,6 +28,7 @@
   {{#if item.Session}}
     <Notice
       @type="warning"
+      data-test-session-warning
     as |notice|>
       <notice.Body>
         <p>

--- a/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
@@ -50,11 +50,13 @@ as |sort filters items|}}
     {{/if}}
       </BlockSlot>
       <BlockSlot @name="actions">
+{{#if (can 'create kvs')}}
     {{#if (not-eq parent.Key '/') }}
           <a data-test-create href="{{href-to 'dc.kv.create' parent.Key}}" class="type-create">Create</a>
     {{else}}
           <a data-test-create href="{{href-to 'dc.kv.root-create'}}" class="type-create">Create</a>
     {{/if}}
+{{/if}}
       </BlockSlot>
       <BlockSlot @name="content">
         <DataWriter

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show/sessions.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show/sessions.hbs
@@ -1,13 +1,29 @@
 <EventSource @src={{sessions}} />
 <div class="tab-section">
 {{#if (gt sessions.length 0)}}
-    <Consul::LockSession::List @items={{sessions}} @onInvalidate={{action send 'invalidateSession'}}/>
+    <Consul::LockSession::List
+      @items={{sessions}}
+      @onInvalidate={{action send 'invalidateSession'}}
+    />
 {{else}}
-    <EmptyState>
+    <EmptyState @allowLogin={{true}}>
+      <BlockSlot @name="header">
+        <h2>
+            Welcome to Lock Sessions
+        </h2>
+      </BlockSlot>
       <BlockSlot @name="body">
         <p>
-          There are no Lock Sessions for this Node. For more information, view <a href="{{ env 'CONSUL_DOCS_URL'}}/internals/sessions.html" rel="noopener noreferrer" target="_blank">our documentation</a>
+          Consul provides a session mechanism which can be used to build distributed locks. Sessions act as a binding layer between nodes, health checks, and key/value data. There are currently no lock sessions present, or you may not have permission to view lock sessions.
         </p>
+      </BlockSlot>
+      <BlockSlot @name="actions">
+        <li class="docs-link">
+          <a href="{{env 'CONSUL_DOCS_URL'}}/internals/sessions.html" rel="noopener noreferrer" target="_blank">Documentation on sessions</a>
+        </li>
+        <li class="learn-link">
+          <a href="{{env 'CONSUL_DOCS_LEARN_URL'}}/tutorials/consul/distributed-semaphore" rel="noopener noreferrer" target="_blank">Read the guide</a>
+        </li>
       </BlockSlot>
     </EmptyState>
 {{/if}}

--- a/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
@@ -38,9 +38,11 @@ as |api|>
 
 as |sort filters items|}}
   <div class="tab-section">
+{{#if (can 'create intentions')}}
       <Portal @target="app-view-actions">
         <a data-test-create href={{href-to 'dc.services.show.intentions.create'}} class="type-create">Create</a>
       </Portal>
+{{/if}}
 {{#if (gt items.length 0) }}
       <Consul::Intention::SearchBar
         @search={{search}}

--- a/ui/packages/consul-ui/mock-api/v1/internal/acl/authorize
+++ b/ui/packages/consul-ui/mock-api/v1/internal/acl/authorize
@@ -1,32 +1,14 @@
 [
-  {
-    "Resource": "operator",
-    "Access": "write",
-    "Allow": true
-  },
-  {
-    "Resource": "service",
-    "Access": "read",
-    "Allow": true
-  },
-  {
-    "Resource": "node",
-    "Access": "read",
-    "Allow": true
-  },
-  {
-    "Resource": "key",
-    "Access": "read",
-    "Allow": true
-  },
-  {
-    "Resource": "intention",
-    "Access": "read",
-    "Allow": true
-  },
-  {
-    "Resource": "acl",
-    "Access": "read",
-    "Allow": true
-  }
+${
+  http.body.map(item => {
+    return JSON.stringify(
+      Object.assign(
+        item,
+        {
+          Allow: !!JSON.parse(env(`CONSUL_RESOURCE_${item.Resource.toUpperCase()}_${item.Access.toUpperCase()}`, 'true'))
+        }
+      )
+    );
+  })
+}
 ]

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/index.feature
@@ -10,6 +10,20 @@ Feature: dc / intentions / index
     Then the url should be /dc-1/intentions
     And the title should be "Intentions - Consul"
     Then I see 3 intention models on the intentionList component
+  Scenario: Viewing intentions with no write access
+    Given 1 datacenter model with the value "dc-1"
+    And 3 intention models
+    And permissions from yaml
+    ---
+    intention:
+      write: false
+    ---
+    When I visit the intentions page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/intentions
+    And I don't see create
   Scenario: Viewing intentions in the listing live updates
     Given 1 datacenter model with the value "dc-1"
     Given 3 intention models

--- a/ui/packages/consul-ui/tests/acceptance/dc/kvs/edit.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/kvs/edit.feature
@@ -25,6 +25,29 @@ Feature: dc / kvs / edit: KV Viewing
       kv: another-key
     ---
     Then I don't see ID on the session
+  Scenario: Viewing a kv with no write access
+    Given 1 datacenter model with the value "datacenter"
+    And 1 kv model from yaml
+    ---
+      Key: key
+      Session: session-id
+    ---
+    And permissions from yaml
+    ---
+    key:
+      write: false
+    session:
+      read: false
+    ---
+    When I visit the kv page for yaml
+    ---
+      dc: datacenter
+      kv: key
+    ---
+    Then the url should be /datacenter/kv/key/edit
+    And I don't see create
+    And I don't see ID on the session
+    And I see warning on the session
   # Make sure we can view KVs that have similar names to sections in the UI
   Scenario: I have KV called [Page]
     Given 1 datacenter model with the value "datacenter"

--- a/ui/packages/consul-ui/tests/acceptance/dc/kvs/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/kvs/index.feature
@@ -1,0 +1,27 @@
+@setupApplicationTest
+Feature: dc / kvs / index
+  Scenario: Viewing kvs in the listing
+    Given 1 datacenter model with the value "dc-1"
+    And 3 kv models
+    When I visit the kvs page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/kv
+    And the title should be "Key/Value - Consul"
+    Then I see 3 kv models
+  Scenario: Viewing kvs with no write access
+    Given 1 datacenter model with the value "dc-1"
+    And 3 kv models
+    And permissions from yaml
+    ---
+    key:
+      write: false
+    ---
+    When I visit the kvs page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/kv
+    And I don't see create
+

--- a/ui/packages/consul-ui/tests/acceptance/steps/dc/kvs/index-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/dc/kvs/index-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui/packages/consul-ui/tests/pages.js
+++ b/ui/packages/consul-ui/tests/pages.js
@@ -152,7 +152,9 @@ export default {
       radiogroup
     )
   ),
-  service: create(service(visitable, clickable, attribute, collection, text, consulIntentionList, tabgroup)),
+  service: create(
+    service(visitable, clickable, attribute, collection, text, consulIntentionList, tabgroup)
+  ),
   instance: create(
     instance(
       visitable,
@@ -179,7 +181,7 @@ export default {
     )
   ),
   kvs: create(kvs(visitable, creatable, consulKvList)),
-  kv: create(kv(visitable, attribute, submitable, deletable, cancelable, clickable)),
+  kv: create(kv(visitable, attribute, isPresent, submitable, deletable, cancelable, clickable)),
   acls: create(acls(visitable, deletable, creatable, clickable, attribute, collection)),
   acl: create(acl(visitable, submitable, deletable, cancelable, clickable)),
   policies: create(policies(visitable, creatable, consulPolicyList, popoverSelect)),

--- a/ui/packages/consul-ui/tests/pages/dc/kv/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/kv/edit.js
@@ -1,4 +1,4 @@
-export default function(visitable, attribute, submitable, deletable, cancelable) {
+export default function(visitable, attribute, present, submitable, deletable, cancelable) {
   return {
     visit: visitable(['/:dc/kv/:kv/edit', '/:dc/kv/create'], function(str) {
       // this will encode the parts of the key path but means you can no longer
@@ -12,6 +12,7 @@ export default function(visitable, attribute, submitable, deletable, cancelable)
     ...cancelable(),
     ...deletable(),
     session: {
+      warning: present('[data-test-session-warning]'),
       ID: attribute('data-test-session', '[data-test-session]'),
       ...deletable({}, '[data-test-session]'),
     },

--- a/ui/packages/consul-ui/tests/steps.js
+++ b/ui/packages/consul-ui/tests/steps.js
@@ -97,7 +97,7 @@ export default function({
   const clipboard = function() {
     return window.localStorage.getItem('clipboard');
   };
-  models(library, create);
+  models(library, create, setCookie);
   http(library, respondWith, setCookie);
   visit(library, pages, utils.setCurrentPage, reset);
   click(library, utils.find, helpers.click);

--- a/ui/packages/consul-ui/tests/steps/doubles/model.js
+++ b/ui/packages/consul-ui/tests/steps/doubles/model.js
@@ -27,7 +27,6 @@ export default function(scenario, create, set, win = window, doc = document) {
       doc.cookie = `CONSUL_UI_CONFIG=${JSON.stringify(data)}`;
     })
     .given(['permissions from yaml\n$yaml'], function(data) {
-      const resources = [];
       Object.entries(data).forEach(([key, value]) => {
         const resource = `CONSUL_RESOURCE_${key.toUpperCase()}`;
         Object.entries(value).forEach(([key, value]) => {

--- a/ui/packages/consul-ui/tests/steps/doubles/model.js
+++ b/ui/packages/consul-ui/tests/steps/doubles/model.js
@@ -1,4 +1,4 @@
-export default function(scenario, create, win = window, doc = document) {
+export default function(scenario, create, set, win = window, doc = document) {
   scenario
     .given(['an external edit results in $number $model model[s]?'], function(number, model) {
       return create(number, model);
@@ -21,6 +21,18 @@ export default function(scenario, create, win = window, doc = document) {
       });
     })
     .given(['ui_config from yaml\n$yaml'], function(data) {
+      // this one doesn't interact with the api therefore you don't need to use
+      // setCookie/set. Ideally setCookie should probably use doc.cookie also so
+      // there is no difference between these
       doc.cookie = `CONSUL_UI_CONFIG=${JSON.stringify(data)}`;
+    })
+    .given(['permissions from yaml\n$yaml'], function(data) {
+      const resources = [];
+      Object.entries(data).forEach(([key, value]) => {
+        const resource = `CONSUL_RESOURCE_${key.toUpperCase()}`;
+        Object.entries(value).forEach(([key, value]) => {
+          set(`${resource}_${key.toUpperCase()}`, value);
+        });
+      });
     });
 }


### PR DESCRIPTION
This PR is a continuation of https://github.com/hashicorp/consul/pull/9687.

Here we implement read-only views for KVs, Sessions and Intentions based on your ACL Tokens policies.

This means you can assign ACLs to users in the UI giving certain users read only access to areas like KV. This is currently at a global level using something like:

```hcl
key_prefix "" {
  policy = "read"
}
```

which would give the user with a token with the above policy read only access to all KVs.

Being able to configure this more finely per KV will be added in a further PR.

Further notes:

1. `{{disabled}}` modifier f0cc8cb938ed0aa0d24750c06dd1446b6d7314fa. `<fieldset>`s have a nice feature that lets you set a `<fieldset disabled>` on them which means all of the form elements within the fieldset are in a disabled state, meaning you only have to set the disabled-ness in one place. The downside is, if you want everything disabled apart from one form element, there doesn't seem to be a native way to do that. Using a modifier instead means we can add the functionality we want here. This is currently not super reactive (if you add further elements to the parent element after insertion these will not be set to the correct value for disabled). In order to improve this we'll probably require some `MutationObserver` work. As and when we need that we can look at that then.
2. Global configuration of protected routes 66c8cc94d453b728b471969d0bf5e3caa8c8d4c2 and e66c220302d67385116cba1870a1ade9b81f8406. We currently have a JSON-like object which is then used by `Router` in order to create embers routes. This means we can also use this information for other things, for example knowing whether a route is a wildcard route in order to add further url de/encoding logic to the params for this route. These commits further add to this configuration with an `abilities: []` property. The `abilities` property allows you to use `ember-can`s DSL to specify what abilities a user requires in order to access a route. If the user doesn't have all of the specified abilities then they see a 403 page instead. Using the central configuration means we can add the logic required for this to our Consul specific base `Route`, then its super simple to see all in one place, what routes have additional ability based restrictions.
3. Acceptance tests where added, along with a new step to allow us to set a users permissions during testing. Worthwhile noting that in order to set permissions during development the cookie names to use in WebInspector takes the form `CONSUL_RESOURCE_{singular-resource-name}_{access_type}`, so for example setting the cookie `CONSUL_RESOURCE_INTENTION_WRITE=false` will give you readonly intentions.


