### PR TITLE
docs: fix another broken link to upgrading k8s servers from token rot…

### DIFF
--- a/website/content/docs/k8s/operations/certificate-rotation.mdx
+++ b/website/content/docs/k8s/operations/certificate-rotation.mdx
@@ -12,7 +12,7 @@ are issued every time the Helm chart is upgraded. These certificates are signed 
 continue to work as expected in the existing cluster.
 
 Consul servers read the certificates from Kubernetes secrets during start-up and keep them in memory. In order to ensure the
-servers use the newer certificate, the server pods need to be [restarted explicitly](/docs/k8s/operations/upgrade#upgrading-consul-servers) in
+servers use the newer certificate, the server pods need to be [restarted explicitly](/docs/k8s/upgrade#upgrading-consul-servers) in
 a situation where `helm upgrade` does not restart the server pods.
 
 To explicitly perform server certificate rotation, follow these steps:


### PR DESCRIPTION
fix another broken link to upgrading k8s servers from token rotation page