### PR TITLE
ui: [BUGFIX] Replace all replaceAll with split.join for older browsers without replaceAll

### DIFF
--- a/.changelog/9715.txt
+++ b/.changelog/9715.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug in older browsers relating to String.replaceAll and fieldset w/flexbox usage
+```

--- a/ui/packages/consul-ui/app/components/form-group/element/index.js
+++ b/ui/packages/consul-ui/app/components/form-group/element/index.js
@@ -21,7 +21,10 @@ export default class Element extends Component {
     }
   }
   get prop() {
-    return `${this.args.name.toLowerCase().replaceAll('.', '-')}`;
+    return `${this.args.name
+      .toLowerCase()
+      .split('.')
+      .join('-')}`;
   }
   get state() {
     const error = this.touched && this.args.error;

--- a/ui/packages/consul-ui/app/components/freetext-filter/index.hbs
+++ b/ui/packages/consul-ui/app/components/freetext-filter/index.hbs
@@ -1,4 +1,4 @@
-<fieldset
+<div
   class="freetext-filter"
   ...attributes
 >
@@ -16,4 +16,4 @@
     />
   </label>
   {{yield}}
-</fieldset>
+</div>

--- a/ui/packages/consul-ui/app/components/freetext-filter/layout.scss
+++ b/ui/packages/consul-ui/app/components/freetext-filter/layout.scss
@@ -4,6 +4,7 @@
     display: flex;
     position: relative;
     height: var(--height);
+    width: 100%;
   }
   &_input,
   & > label {

--- a/ui/packages/consul-ui/app/utils/intl/missing-message.js
+++ b/ui/packages/consul-ui/app/utils/intl/missing-message.js
@@ -4,6 +4,7 @@ export default function missingMessage(key, locales) {
   const last = key
     .split('.')
     .pop()
-    .replaceAll('-', ' ');
+    .split('-')
+    .join(' ');
   return `${last.substr(0, 1).toUpperCase()}${last.substr(1)}`;
 }


### PR DESCRIPTION
`String.replaceAll` is only available in newer browsers (for example after Chrome 85), so here we revert to using `split(find).join(replace)` instead of `replaceAll`.

A related CSS problem here was support for defining flex-box on fieldsets in older browsers. As this PR is a bugfix for 'older browsers' we added the fix for that here too.

Previous:

<img width="989" alt="Screenshot 2021-02-05 at 11 09 23" src="https://user-images.githubusercontent.com/554604/107026476-a8d7a600-67a2-11eb-9c9c-f751687fb7cf.png">


Fixes https://github.com/hashicorp/consul/issues/9714

Thanks @r3knit !