### PR TITLE
state: convert all table name constants to the new prefix pattern

### DIFF
--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -54,7 +54,7 @@ func catalogUpdateServiceIndexes(tx WriteTxn, serviceName string, idx uint64, _ 
 }
 
 func catalogUpdateServiceExtinctionIndex(tx WriteTxn, idx uint64, _ *structs.EnterpriseMeta) error {
-	if err := tx.Insert("index", &IndexEntry{serviceLastExtinctionIndexName, idx}); err != nil {
+	if err := tx.Insert("index", &IndexEntry{indexServiceExtinction, idx}); err != nil {
 		return fmt.Errorf("failed updating missing service extinction index: %s", err)
 	}
 	return nil
@@ -110,7 +110,7 @@ func catalogServiceNodeList(tx ReadTxn, name string, index string, _ *structs.En
 }
 
 func catalogServiceLastExtinctionIndex(tx ReadTxn, _ *structs.EnterpriseMeta) (interface{}, error) {
-	return tx.First("index", "id", serviceLastExtinctionIndexName)
+	return tx.First("index", "id", indexServiceExtinction)
 }
 
 func catalogMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta, checks bool) uint64 {

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	tableNodes    = "nodes"
-	tableServices = "services"
-	tableChecks   = "checks"
+	tableNodes           = "nodes"
+	tableServices        = "services"
+	tableChecks          = "checks"
+	tableGatewayServices = "gateway-services"
+	tableMeshTopology    = "mesh-topology"
 
 	indexID               = "id"
 	indexServiceName      = "service"
@@ -205,11 +207,11 @@ func checksTableSchema() *memdb.TableSchema {
 	}
 }
 
-//  gatewayServicesTableNameSchema returns a new table schema used to store information
+//  gatewayServicesTableSchema returns a new table schema used to store information
 // about services associated with terminating gateways.
-func gatewayServicesTableNameSchema() *memdb.TableSchema {
+func gatewayServicesTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: gatewayServicesTableName,
+		Name: tableGatewayServices,
 		Indexes: map[string]*memdb.IndexSchema{
 			indexID: {
 				Name:         indexID,
@@ -249,11 +251,11 @@ func gatewayServicesTableNameSchema() *memdb.TableSchema {
 	}
 }
 
-// topologyTableNameSchema returns a new table schema used to store information
+// meshTopologyTableSchema returns a new table schema used to store information
 // relating upstream and downstream services
-func topologyTableNameSchema() *memdb.TableSchema {
+func meshTopologyTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: topologyTableName,
+		Name: tableMeshTopology,
 		Indexes: map[string]*memdb.IndexSchema{
 			indexID: {
 				Name:         indexID,
@@ -350,6 +352,6 @@ func init() {
 	registerSchema(nodesTableSchema)
 	registerSchema(servicesTableSchema)
 	registerSchema(checksTableSchema)
-	registerSchema(gatewayServicesTableNameSchema)
-	registerSchema(topologyTableNameSchema)
+	registerSchema(gatewayServicesTableSchema)
+	registerSchema(meshTopologyTableSchema)
 }

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -273,20 +273,20 @@ func deleteConfigEntryTxn(tx WriteTxn, idx uint64, kind, name string, entMeta *s
 	sn := structs.NewServiceName(name, entMeta)
 
 	if kind == structs.TerminatingGateway || kind == structs.IngressGateway {
-		if _, err := tx.DeleteAll(gatewayServicesTableName, "gateway", sn); err != nil {
+		if _, err := tx.DeleteAll(tableGatewayServices, "gateway", sn); err != nil {
 			return fmt.Errorf("failed to truncate gateway services table: %v", err)
 		}
-		if err := indexUpdateMaxTxn(tx, idx, gatewayServicesTableName); err != nil {
+		if err := indexUpdateMaxTxn(tx, idx, tableGatewayServices); err != nil {
 			return fmt.Errorf("failed updating gateway-services index: %v", err)
 		}
 	}
 	// Also clean up associations in the mesh topology table for ingress gateways
 	if kind == structs.IngressGateway {
-		if _, err := tx.DeleteAll(topologyTableName, "downstream", sn); err != nil {
-			return fmt.Errorf("failed to truncate %s table: %v", topologyTableName, err)
+		if _, err := tx.DeleteAll(tableMeshTopology, "downstream", sn); err != nil {
+			return fmt.Errorf("failed to truncate %s table: %v", tableMeshTopology, err)
 		}
-		if err := indexUpdateMaxTxn(tx, idx, topologyTableName); err != nil {
-			return fmt.Errorf("failed updating %s index: %v", topologyTableName, err)
+		if err := indexUpdateMaxTxn(tx, idx, tableMeshTopology); err != nil {
+			return fmt.Errorf("failed updating %s index: %v", tableMeshTopology, err)
 		}
 	}
 

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/connect"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func TestStore_CAConfig(t *testing.T) {
@@ -201,7 +202,7 @@ func TestStore_CARootSetList(t *testing.T) {
 	assert.True(ok)
 
 	// Make sure the index got updated.
-	assert.Equal(s.maxIndex(caRootTableName), uint64(1))
+	assert.Equal(s.maxIndex(tableConnectCARoots), uint64(1))
 	assert.True(watchFired(ws), "watch fired")
 
 	// Read it back out and verify it.
@@ -239,7 +240,7 @@ func TestStore_CARootSet_emptyID(t *testing.T) {
 	assert.False(ok)
 
 	// Make sure the index got updated.
-	assert.Equal(s.maxIndex(caRootTableName), uint64(0))
+	assert.Equal(s.maxIndex(tableConnectCARoots), uint64(0))
 	assert.False(watchFired(ws), "watch fired")
 
 	// Read it back out and verify it.

--- a/agent/consul/state/federation_state.go
+++ b/agent/consul/state/federation_state.go
@@ -3,18 +3,19 @@ package state
 import (
 	"fmt"
 
-	"github.com/hashicorp/consul/agent/structs"
 	memdb "github.com/hashicorp/go-memdb"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
-const federationStateTableName = "federation-states"
+const tableFederationStates = "federation-states"
 
 func federationStateTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: federationStateTableName,
+		Name: tableFederationStates,
 		Indexes: map[string]*memdb.IndexSchema{
-			"id": {
-				Name:         "id",
+			indexID: {
+				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
 				Indexer: &memdb.StringFieldIndex{
@@ -32,7 +33,7 @@ func init() {
 
 // FederationStates is used to pull all the federation states for the snapshot.
 func (s *Snapshot) FederationStates() ([]*structs.FederationState, error) {
-	configs, err := s.tx.Get(federationStateTableName, "id")
+	configs, err := s.tx.Get(tableFederationStates, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -48,10 +49,10 @@ func (s *Snapshot) FederationStates() ([]*structs.FederationState, error) {
 // FederationState is used when restoring from a snapshot.
 func (s *Restore) FederationState(g *structs.FederationState) error {
 	// Insert
-	if err := s.tx.Insert(federationStateTableName, g); err != nil {
+	if err := s.tx.Insert(tableFederationStates, g); err != nil {
 		return fmt.Errorf("failed restoring federation state object: %s", err)
 	}
-	if err := indexUpdateMaxTxn(s.tx, g.ModifyIndex, federationStateTableName); err != nil {
+	if err := indexUpdateMaxTxn(s.tx, g.ModifyIndex, tableFederationStates); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
@@ -91,7 +92,7 @@ func federationStateSetTxn(tx *txn, idx uint64, config *structs.FederationState)
 
 	// Check for existing.
 	var existing *structs.FederationState
-	existingRaw, err := tx.First(federationStateTableName, "id", config.Datacenter)
+	existingRaw, err := tx.First(tableFederationStates, "id", config.Datacenter)
 	if err != nil {
 		return fmt.Errorf("failed federation state lookup: %s", err)
 	}
@@ -117,10 +118,10 @@ func federationStateSetTxn(tx *txn, idx uint64, config *structs.FederationState)
 	}
 
 	// Insert the federation state and update the index
-	if err := tx.Insert(federationStateTableName, config); err != nil {
+	if err := tx.Insert(tableFederationStates, config); err != nil {
 		return fmt.Errorf("failed inserting federation state: %s", err)
 	}
-	if err := tx.Insert("index", &IndexEntry{federationStateTableName, idx}); err != nil {
+	if err := tx.Insert("index", &IndexEntry{tableFederationStates, idx}); err != nil {
 		return fmt.Errorf("failed updating index: %v", err)
 	}
 
@@ -136,10 +137,10 @@ func (s *Store) FederationStateGet(ws memdb.WatchSet, datacenter string) (uint64
 
 func federationStateGetTxn(tx ReadTxn, ws memdb.WatchSet, datacenter string) (uint64, *structs.FederationState, error) {
 	// Get the index
-	idx := maxIndexTxn(tx, federationStateTableName)
+	idx := maxIndexTxn(tx, tableFederationStates)
 
 	// Get the existing contents.
-	watchCh, existing, err := tx.FirstWatch(federationStateTableName, "id", datacenter)
+	watchCh, existing, err := tx.FirstWatch(tableFederationStates, "id", datacenter)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed federation state lookup: %s", err)
 	}
@@ -166,9 +167,9 @@ func (s *Store) FederationStateList(ws memdb.WatchSet) (uint64, []*structs.Feder
 
 func federationStateListTxn(tx ReadTxn, ws memdb.WatchSet) (uint64, []*structs.FederationState, error) {
 	// Get the index
-	idx := maxIndexTxn(tx, federationStateTableName)
+	idx := maxIndexTxn(tx, tableFederationStates)
 
-	iter, err := tx.Get(federationStateTableName, "id")
+	iter, err := tx.Get(tableFederationStates, "id")
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed federation state lookup: %s", err)
 	}
@@ -207,7 +208,7 @@ func (s *Store) FederationStateBatchDelete(idx uint64, datacenters []string) err
 
 func federationStateDeleteTxn(tx *txn, idx uint64, datacenter string) error {
 	// Try to retrieve the existing federation state.
-	existing, err := tx.First(federationStateTableName, "id", datacenter)
+	existing, err := tx.First(tableFederationStates, "id", datacenter)
 	if err != nil {
 		return fmt.Errorf("failed federation state lookup: %s", err)
 	}
@@ -216,10 +217,10 @@ func federationStateDeleteTxn(tx *txn, idx uint64, datacenter string) error {
 	}
 
 	// Delete the federation state from the DB and update the index.
-	if err := tx.Delete(federationStateTableName, existing); err != nil {
+	if err := tx.Delete(tableFederationStates, existing); err != nil {
 		return fmt.Errorf("failed removing federation state: %s", err)
 	}
-	if err := tx.Insert("index", &IndexEntry{federationStateTableName, idx}); err != nil {
+	if err := tx.Insert("index", &IndexEntry{tableFederationStates, idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 	return nil

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -12,18 +12,16 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-const (
-	intentionsTableName = "connect-intentions"
-)
+const tableConnectIntentions = "connect-intentions"
 
 // intentionsTableSchema returns a new table schema used for storing
 // intentions for Connect.
 func intentionsTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: intentionsTableName,
+		Name: tableConnectIntentions,
 		Indexes: map[string]*memdb.IndexSchema{
-			"id": {
-				Name:         "id",
+			indexID: {
+				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
 				Indexer: &memdb.UUIDFieldIndex{
@@ -106,7 +104,7 @@ func init() {
 // Deprecated: service-intentions config entries are handled as config entries
 // in the snapshot.
 func (s *Snapshot) LegacyIntentions() (structs.Intentions, error) {
-	ixns, err := s.tx.Get(intentionsTableName, "id")
+	ixns, err := s.tx.Get(tableConnectIntentions, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -125,10 +123,10 @@ func (s *Snapshot) LegacyIntentions() (structs.Intentions, error) {
 // in the snapshot.
 func (s *Restore) LegacyIntention(ixn *structs.Intention) error {
 	// Insert the intention
-	if err := s.tx.Insert(intentionsTableName, ixn); err != nil {
+	if err := s.tx.Insert(tableConnectIntentions, ixn); err != nil {
 		return fmt.Errorf("failed restoring intention: %s", err)
 	}
-	if err := indexUpdateMaxTxn(s.tx, ixn.ModifyIndex, intentionsTableName); err != nil {
+	if err := indexUpdateMaxTxn(s.tx, ixn.ModifyIndex, tableConnectIntentions); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
@@ -181,7 +179,7 @@ func (s *Store) Intentions(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (
 
 func (s *Store) legacyIntentionsListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.Intentions, bool, error) {
 	// Get the index
-	idx := maxIndexTxn(tx, intentionsTableName)
+	idx := maxIndexTxn(tx, tableConnectIntentions)
 	if idx < 1 {
 		idx = 1
 	}
@@ -530,7 +528,7 @@ func legacyIntentionSetTxn(tx WriteTxn, idx uint64, ixn *structs.Intention) erro
 	ixn.UpdatePrecedence()
 
 	// Check for an existing intention
-	existing, err := tx.First(intentionsTableName, "id", ixn.ID)
+	existing, err := tx.First(tableConnectIntentions, "id", ixn.ID)
 	if err != nil {
 		return fmt.Errorf("failed intention lookup: %s", err)
 	}
@@ -544,7 +542,7 @@ func legacyIntentionSetTxn(tx WriteTxn, idx uint64, ixn *structs.Intention) erro
 	ixn.ModifyIndex = idx
 
 	// Check for duplicates on the 4-tuple.
-	duplicate, err := tx.First(intentionsTableName, "source_destination",
+	duplicate, err := tx.First(tableConnectIntentions, "source_destination",
 		ixn.SourceNS, ixn.SourceName, ixn.DestinationNS, ixn.DestinationName)
 	if err != nil {
 		return fmt.Errorf("failed intention lookup: %s", err)
@@ -564,10 +562,10 @@ func legacyIntentionSetTxn(tx WriteTxn, idx uint64, ixn *structs.Intention) erro
 	}
 
 	// Insert
-	if err := tx.Insert(intentionsTableName, ixn); err != nil {
+	if err := tx.Insert(tableConnectIntentions, ixn); err != nil {
 		return err
 	}
-	if err := tx.Insert("index", &IndexEntry{intentionsTableName, idx}); err != nil {
+	if err := tx.Insert("index", &IndexEntry{tableConnectIntentions, idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
@@ -592,13 +590,13 @@ func (s *Store) IntentionGet(ws memdb.WatchSet, id string) (uint64, *structs.Ser
 
 func (s *Store) legacyIntentionGetTxn(tx ReadTxn, ws memdb.WatchSet, id string) (uint64, *structs.Intention, error) {
 	// Get the table index.
-	idx := maxIndexTxn(tx, intentionsTableName)
+	idx := maxIndexTxn(tx, tableConnectIntentions)
 	if idx < 1 {
 		idx = 1
 	}
 
 	// Look up by its ID.
-	watchCh, intention, err := tx.FirstWatch(intentionsTableName, "id", id)
+	watchCh, intention, err := tx.FirstWatch(tableConnectIntentions, "id", id)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed intention lookup: %s", err)
 	}
@@ -635,13 +633,13 @@ func (s *Store) legacyIntentionGetExactTxn(tx ReadTxn, ws memdb.WatchSet, args *
 	}
 
 	// Get the table index.
-	idx := maxIndexTxn(tx, intentionsTableName)
+	idx := maxIndexTxn(tx, tableConnectIntentions)
 	if idx < 1 {
 		idx = 1
 	}
 
 	// Look up by its full name.
-	watchCh, intention, err := tx.FirstWatch(intentionsTableName, "source_destination",
+	watchCh, intention, err := tx.FirstWatch(tableConnectIntentions, "source_destination",
 		args.SourceNS, args.SourceName, args.DestinationNS, args.DestinationName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed intention lookup: %s", err)
@@ -683,7 +681,7 @@ func (s *Store) LegacyIntentionDelete(idx uint64, id string) error {
 // with the proper indexes into the state store.
 func legacyIntentionDeleteTxn(tx WriteTxn, idx uint64, queryID string) error {
 	// Pull the query.
-	wrapped, err := tx.First(intentionsTableName, "id", queryID)
+	wrapped, err := tx.First(tableConnectIntentions, "id", queryID)
 	if err != nil {
 		return fmt.Errorf("failed intention lookup: %s", err)
 	}
@@ -692,10 +690,10 @@ func legacyIntentionDeleteTxn(tx WriteTxn, idx uint64, queryID string) error {
 	}
 
 	// Delete the query and update the index.
-	if err := tx.Delete(intentionsTableName, wrapped); err != nil {
+	if err := tx.Delete(tableConnectIntentions, wrapped); err != nil {
 		return fmt.Errorf("failed intention delete: %s", err)
 	}
-	if err := tx.Insert("index", &IndexEntry{intentionsTableName, idx}); err != nil {
+	if err := tx.Insert("index", &IndexEntry{tableConnectIntentions, idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
@@ -709,10 +707,10 @@ func (s *Store) LegacyIntentionDeleteAll(idx uint64) error {
 	defer tx.Abort()
 
 	// Delete the table and update the index.
-	if _, err := tx.DeleteAll(intentionsTableName, "id"); err != nil {
+	if _, err := tx.DeleteAll(tableConnectIntentions, "id"); err != nil {
 		return fmt.Errorf("failed intention delete-all: %s", err)
 	}
-	if err := tx.Insert("index", &IndexEntry{intentionsTableName, idx}); err != nil {
+	if err := tx.Insert("index", &IndexEntry{tableConnectIntentions, idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 	// Also bump the index for the config entry table so that
@@ -822,7 +820,7 @@ func (s *Store) IntentionMatch(ws memdb.WatchSet, args *structs.IntentionQueryMa
 
 func (s *Store) legacyIntentionMatchTxn(tx ReadTxn, ws memdb.WatchSet, args *structs.IntentionQueryMatch) (uint64, []structs.Intentions, error) {
 	// Get the table index.
-	idx := maxIndexTxn(tx, intentionsTableName)
+	idx := maxIndexTxn(tx, tableConnectIntentions)
 	if idx < 1 {
 		idx = 1
 	}
@@ -876,7 +874,7 @@ func legacyIntentionMatchOneTxn(
 	matchType structs.IntentionMatchType,
 ) (uint64, structs.Intentions, error) {
 	// Get the table index.
-	idx := maxIndexTxn(tx, intentionsTableName)
+	idx := maxIndexTxn(tx, tableConnectIntentions)
 	if idx < 1 {
 		idx = 1
 	}
@@ -907,7 +905,7 @@ func intentionMatchOneTxn(tx ReadTxn, ws memdb.WatchSet,
 	// Perform each call and accumulate the result.
 	var result structs.Intentions
 	for _, params := range getParams {
-		iter, err := tx.Get(intentionsTableName, string(matchType), params...)
+		iter, err := tx.Get(tableConnectIntentions, string(matchType), params...)
 		if err != nil {
 			return nil, fmt.Errorf("failed intention lookup: %s", err)
 		}

--- a/agent/consul/state/intention_oss.go
+++ b/agent/consul/state/intention_oss.go
@@ -3,11 +3,12 @@
 package state
 
 import (
-	"github.com/hashicorp/consul/agent/structs"
 	memdb "github.com/hashicorp/go-memdb"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func intentionListTxn(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	// Get all intentions
-	return tx.Get(intentionsTableName, "id")
+	return tx.Get(tableConnectIntentions, "id")
 }

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -90,7 +90,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 			require.NoError(t, s.LegacyIntentionSet(lastIndex, legacyIxn))
 
 			// Make sure the right index got updated.
-			require.Equal(t, lastIndex, s.maxIndex(intentionsTableName))
+			require.Equal(t, lastIndex, s.maxIndex(tableConnectIntentions))
 			require.Equal(t, uint64(0), s.maxIndex(tableConfigEntries))
 
 			expected = &structs.Intention{
@@ -133,7 +133,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 
 			// Make sure the config entry index got updated instead of the old intentions one
 			require.Equal(t, lastIndex, s.maxIndex(tableConfigEntries))
-			require.Equal(t, uint64(0), s.maxIndex(intentionsTableName))
+			require.Equal(t, uint64(0), s.maxIndex(tableConnectIntentions))
 
 			expected = &structs.Intention{
 				ID:              srcID,
@@ -178,7 +178,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 			require.NoError(t, s.LegacyIntentionSet(lastIndex, legacyIxn))
 
 			// Make sure the index got updated.
-			require.Equal(t, lastIndex, s.maxIndex(intentionsTableName))
+			require.Equal(t, lastIndex, s.maxIndex(tableConnectIntentions))
 			require.Equal(t, uint64(0), s.maxIndex(tableConfigEntries))
 
 			expected.SourceNS = legacyIxn.SourceNS
@@ -203,7 +203,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 
 			// Make sure the config entry index got updated instead of the old intentions one
 			require.Equal(t, lastIndex, s.maxIndex(tableConfigEntries))
-			require.Equal(t, uint64(0), s.maxIndex(intentionsTableName))
+			require.Equal(t, uint64(0), s.maxIndex(tableConnectIntentions))
 
 			expected.Description = configEntry.Sources[0].Description
 			expected.Action = structs.IntentionActionDeny
@@ -240,7 +240,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 			require.Error(t, s.LegacyIntentionSet(lastIndex, legacyIxn))
 
 			// Make sure the index did NOT get updated.
-			require.Equal(t, lastIndex-1, s.maxIndex(intentionsTableName))
+			require.Equal(t, lastIndex-1, s.maxIndex(tableConnectIntentions))
 			require.Equal(t, uint64(0), s.maxIndex(tableConfigEntries))
 			require.False(t, watchFired(ws), "watch not fired")
 		}
@@ -815,7 +815,7 @@ func TestStore_LegacyIntentionSet_emptyId(t *testing.T) {
 	require.Contains(t, err.Error(), ErrMissingIntentionID.Error())
 
 	// Index is not updated if nothing is saved.
-	require.Equal(t, s.maxIndex(intentionsTableName), uint64(0))
+	require.Equal(t, s.maxIndex(tableConnectIntentions), uint64(0))
 	require.Equal(t, uint64(0), s.maxIndex(tableConfigEntries))
 
 	require.False(t, watchFired(ws), "watch fired")
@@ -1005,7 +1005,7 @@ func TestStore_IntentionDelete(t *testing.T) {
 			require.NoError(t, s.LegacyIntentionSet(lastIndex, ixn))
 
 			// Make sure the index got updated.
-			require.Equal(t, s.maxIndex(intentionsTableName), lastIndex)
+			require.Equal(t, s.maxIndex(tableConnectIntentions), lastIndex)
 			require.Equal(t, uint64(0), s.maxIndex(tableConfigEntries))
 		} else {
 			conf := &structs.ServiceIntentionsConfigEntry{
@@ -1029,7 +1029,7 @@ func TestStore_IntentionDelete(t *testing.T) {
 
 			// Make sure the index got updated.
 			require.Equal(t, s.maxIndex(tableConfigEntries), lastIndex)
-			require.Equal(t, uint64(0), s.maxIndex(intentionsTableName))
+			require.Equal(t, uint64(0), s.maxIndex(tableConnectIntentions))
 		}
 		require.True(t, watchFired(ws), "watch fired")
 
@@ -1045,7 +1045,7 @@ func TestStore_IntentionDelete(t *testing.T) {
 			require.NoError(t, s.LegacyIntentionDelete(lastIndex, id))
 
 			// Make sure the index got updated.
-			require.Equal(t, s.maxIndex(intentionsTableName), lastIndex)
+			require.Equal(t, s.maxIndex(tableConnectIntentions), lastIndex)
 			require.Equal(t, uint64(0), s.maxIndex(tableConfigEntries))
 		} else {
 			lastIndex++
@@ -1053,7 +1053,7 @@ func TestStore_IntentionDelete(t *testing.T) {
 
 			// Make sure the index got updated.
 			require.Equal(t, s.maxIndex(tableConfigEntries), lastIndex)
-			require.Equal(t, uint64(0), s.maxIndex(intentionsTableName))
+			require.Equal(t, uint64(0), s.maxIndex(tableConnectIntentions))
 		}
 		require.True(t, watchFired(ws), "watch fired")
 

--- a/agent/consul/state/usage.go
+++ b/agent/consul/state/usage.go
@@ -3,8 +3,9 @@ package state
 import (
 	"fmt"
 
-	"github.com/hashicorp/consul/agent/structs"
 	memdb "github.com/hashicorp/go-memdb"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 const (
@@ -101,7 +102,7 @@ func updateUsage(tx WriteTxn, changes Changes) error {
 	// This will happen when restoring from a snapshot, just take the max index
 	// of the tables we are tracking.
 	if idx == 0 {
-		idx = maxIndexTxn(tx, "nodes", servicesTableName)
+		idx = maxIndexTxn(tx, "nodes", tableServices)
 	}
 
 	return writeUsageDeltas(tx, idx, usageDeltas)
@@ -110,7 +111,7 @@ func updateUsage(tx WriteTxn, changes Changes) error {
 func updateServiceNameUsage(tx WriteTxn, usageDeltas map[string]int, serviceNameChanges map[structs.ServiceName]int) (map[structs.ServiceName]uniqueServiceState, error) {
 	serviceStates := make(map[structs.ServiceName]uniqueServiceState, len(serviceNameChanges))
 	for svc, delta := range serviceNameChanges {
-		serviceIter, err := getWithTxn(tx, servicesTableName, "service", svc.Name, &svc.EnterpriseMeta)
+		serviceIter, err := getWithTxn(tx, tableServices, "service", svc.Name, &svc.EnterpriseMeta)
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +227,7 @@ func (s *Store) ServiceUsage() (uint64, ServiceUsage, error) {
 	tx := s.db.ReadTxn()
 	defer tx.Abort()
 
-	serviceInstances, err := firstUsageEntry(tx, servicesTableName)
+	serviceInstances, err := firstUsageEntry(tx, tableServices)
 	if err != nil {
 		return 0, ServiceUsage{}, fmt.Errorf("failed services lookup: %s", err)
 	}


### PR DESCRIPTION
Branched from #9665

Best viewed by commit.

Renames table name constants to the new prefix pattern.

