### PR TITLE
structs: rename EnterpriseMeta constructor

### DIFF
--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -43,7 +43,7 @@ func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
 	req := &structs.ServiceSpecificRequest{
 		Datacenter:     "dc1",
 		ServiceName:    "web",
-		EnterpriseMeta: structs.EnterpriseMetaInitializer(namespace),
+		EnterpriseMeta: structs.NewEnterpriseMeta(namespace),
 	}
 	empty := &structs.IndexedCheckServiceNodes{
 		Nodes: structs.CheckServiceNodes{},
@@ -228,7 +228,7 @@ func requireResultsSame(t *testing.T, want, got *structs.IndexedCheckServiceNode
 // returns the empty string. It allows the same tests to work in both oss and ent
 // without duplicating the tests.
 func getNamespace(ns string) string {
-	meta := structs.EnterpriseMetaInitializer(ns)
+	meta := structs.NewEnterpriseMeta(ns)
 	return meta.GetNamespace()
 }
 
@@ -312,7 +312,7 @@ func TestStreamingHealthServices_FullSnapshot(t *testing.T) {
 	req := &structs.ServiceSpecificRequest{
 		Datacenter:     "dc1",
 		ServiceName:    "web",
-		EnterpriseMeta: structs.EnterpriseMetaInitializer(namespace),
+		EnterpriseMeta: structs.NewEnterpriseMeta(namespace),
 	}
 
 	gatherNodes := func(res interface{}) []string {
@@ -442,7 +442,7 @@ func TestStreamingHealthServices_EventBatches(t *testing.T) {
 	req := &structs.ServiceSpecificRequest{
 		Datacenter:     "dc1",
 		ServiceName:    "web",
-		EnterpriseMeta: structs.EnterpriseMetaInitializer(namespace),
+		EnterpriseMeta: structs.NewEnterpriseMeta(namespace),
 	}
 
 	gatherNodes := func(res interface{}) []string {
@@ -514,7 +514,7 @@ func TestStreamingHealthServices_Filtering(t *testing.T) {
 	req := &structs.ServiceSpecificRequest{
 		Datacenter:     "dc1",
 		ServiceName:    "web",
-		EnterpriseMeta: structs.EnterpriseMetaInitializer(namespace),
+		EnterpriseMeta: structs.NewEnterpriseMeta(namespace),
 		QueryOptions: structs.QueryOptions{
 			Filter: `Node.Node == "node2"`,
 		},

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2999,7 +2999,7 @@ func updateMeshTopology(tx WriteTxn, idx uint64, node string, svc *structs.NodeS
 	oldUpstreams := make(map[structs.ServiceName]bool)
 	if e, ok := existing.(*structs.ServiceNode); ok {
 		for _, u := range e.ServiceProxy.Upstreams {
-			upstreamMeta := structs.EnterpriseMetaInitializer(u.DestinationNamespace)
+			upstreamMeta := structs.NewEnterpriseMeta(u.DestinationNamespace)
 			sn := structs.NewServiceName(u.DestinationName, &upstreamMeta)
 
 			oldUpstreams[sn] = true
@@ -3015,7 +3015,7 @@ func updateMeshTopology(tx WriteTxn, idx uint64, node string, svc *structs.NodeS
 		}
 
 		// TODO (freddy): Account for upstream datacenter
-		upstreamMeta := structs.EnterpriseMetaInitializer(u.DestinationNamespace)
+		upstreamMeta := structs.NewEnterpriseMeta(u.DestinationNamespace)
 		upstream := structs.NewServiceName(u.DestinationName, &upstreamMeta)
 
 		obj, err := tx.First(tableMeshTopology, "id", upstream, downstream)

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -55,7 +55,7 @@ func serviceHealthSnapshot(db ReadDB, topic stream.Topic) stream.SnapshotFunc {
 		defer tx.Abort()
 
 		connect := topic == topicServiceHealthConnect
-		entMeta := structs.EnterpriseMetaInitializer(req.Namespace)
+		entMeta := structs.NewEnterpriseMeta(req.Namespace)
 		idx, nodes, err := checkServiceNodesTxn(tx, nil, req.Key, connect, &entMeta)
 		if err != nil {
 			return 0, err

--- a/agent/consul/state/catalog_events_test.go
+++ b/agent/consul/state/catalog_events_test.go
@@ -1539,7 +1539,7 @@ func newPayloadCheckServiceNode(service, namespace string) EventPayloadCheckServ
 		Value: &structs.CheckServiceNode{
 			Service: &structs.NodeService{
 				Service:        service,
-				EnterpriseMeta: structs.EnterpriseMetaInitializer(namespace),
+				EnterpriseMeta: structs.NewEnterpriseMeta(namespace),
 			},
 		},
 	}
@@ -1550,7 +1550,7 @@ func newPayloadCheckServiceNodeWithKey(service, namespace, key string) EventPayl
 		Value: &structs.CheckServiceNode{
 			Service: &structs.NodeService{
 				Service:        service,
-				EnterpriseMeta: structs.EnterpriseMetaInitializer(namespace),
+				EnterpriseMeta: structs.NewEnterpriseMeta(namespace),
 			},
 		},
 		key: key,

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -407,7 +407,7 @@ func (s *Store) discoveryChainTargetsTxn(tx ReadTxn, ws memdb.WatchSet, dc, serv
 
 	var resp []structs.ServiceName
 	for _, t := range chain.Targets {
-		em := structs.EnterpriseMetaInitializer(t.Namespace)
+		em := structs.NewEnterpriseMeta(t.Namespace)
 		target := structs.NewServiceName(t.Service, &em)
 
 		// TODO (freddy): Allow upstream DC and encode in response
@@ -463,7 +463,7 @@ func (s *Store) discoveryChainSourcesTxn(tx ReadTxn, ws memdb.WatchSet, dc strin
 		}
 
 		for _, t := range chain.Targets {
-			em := structs.EnterpriseMetaInitializer(t.Namespace)
+			em := structs.NewEnterpriseMeta(t.Namespace)
 			candidate := structs.NewServiceName(t.Service, &em)
 
 			if !candidate.Matches(destination) {

--- a/agent/rpc/subscribe/subscribe.go
+++ b/agent/rpc/subscribe/subscribe.go
@@ -51,7 +51,7 @@ func (h *Server) Subscribe(req *pbsubscribe.SubscribeRequest, serverStream pbsub
 	logger.Trace("new subscription")
 	defer logger.Trace("subscription closed")
 
-	entMeta := structs.EnterpriseMetaInitializer(req.Namespace)
+	entMeta := structs.NewEnterpriseMeta(req.Namespace)
 	authz, err := h.Backend.ResolveTokenAndDefaultMeta(req.Token, &entMeta, nil)
 	if err != nil {
 		return err

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -50,7 +50,7 @@ func (m *EnterpriseMeta) NamespaceOrEmpty() string {
 	return ""
 }
 
-func EnterpriseMetaInitializer(_ string) EnterpriseMeta {
+func NewEnterpriseMeta(_ string) EnterpriseMeta {
 	return emptyEnterpriseMeta
 }
 

--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -156,7 +156,7 @@ func (s *HTTPHandlers) convertOps(resp http.ResponseWriter, req *http.Request) (
 						Value:          in.KV.Value,
 						Flags:          in.KV.Flags,
 						Session:        in.KV.Session,
-						EnterpriseMeta: structs.EnterpriseMetaInitializer(in.KV.Namespace),
+						EnterpriseMeta: structs.NewEnterpriseMeta(in.KV.Namespace),
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: in.KV.Index,
 						},
@@ -216,7 +216,7 @@ func (s *HTTPHandlers) convertOps(resp http.ResponseWriter, req *http.Request) (
 							Warning: svc.Weights.Warning,
 						},
 						EnableTagOverride: svc.EnableTagOverride,
-						EnterpriseMeta:    structs.EnterpriseMetaInitializer(svc.Namespace),
+						EnterpriseMeta:    structs.NewEnterpriseMeta(svc.Namespace),
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: svc.ModifyIndex,
 						},
@@ -273,7 +273,7 @@ func (s *HTTPHandlers) convertOps(resp http.ResponseWriter, req *http.Request) (
 							Timeout:                        timeout,
 							DeregisterCriticalServiceAfter: deregisterCriticalServiceAfter,
 						},
-						EnterpriseMeta: structs.EnterpriseMetaInitializer(check.Namespace),
+						EnterpriseMeta: structs.NewEnterpriseMeta(check.Namespace),
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: check.ModifyIndex,
 						},


### PR DESCRIPTION
To match the Go convention.