### PR TITLE
[1.7.x] xds: deduplicate mesh gateway listeners in a stable way

### DIFF
--- a/.changelog/9650.txt
+++ b/.changelog/9650.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: deduplicate mesh gateway listeners by address in a stable way to prevent some LDS churn
+```


### PR DESCRIPTION
1.7.x backport of #9650

In a situation where the mesh gateway is configured to bind to multiple
network interfaces, we use a feature called 'tagged addresses'.
Sometimes an address is duplicated across multiple tags such as 'lan'
and 'lan_ipv4'.

There is code to deduplicate these things when creating envoy listeners,
but that code doesn't ensure that the same tag wins every time. If the
winning tag flaps between xDS discovery requests it will cause the
listener to be drained and replaced.