### PR TITLE
ui: Update browser targets

### DIFF
--- a/.changelog/9729.txt
+++ b/.changelog/9729.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Use older (~2016) native ES6 features to reduce transpilation and UI JS payload
+```

--- a/ui/packages/consul-ui/config/targets.js
+++ b/ui/packages/consul-ui/config/targets.js
@@ -1,14 +1,13 @@
 'use strict';
-
-const browsers = ['last 1 Chrome versions', 'last 1 Firefox versions', 'last 1 Safari versions'];
-
-const isCI = !!process.env.CI;
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
+// async/await support came with the below specified versions for Chrome,
+// Firefox and Edge. Async/await is is the newest ES6 feature we are not
+// transpiling. Safari's template literal support is a little problematic during
+// v12 in that it has a GC bug for tagged template literals. We don't currently
+// rely on this functionality so the bug wouldn't effect us, but in order to use
+// browser versions as a measure for ES6 features we need to specify Safari 13
+// for native, non-transpiled template literals. In reality template literals
+// came in Safari 9.1. Safari's async/await support came in Safari 10, so thats
+// the earliest Safari we cover in reality here.
 module.exports = {
-  browsers,
+  browsers: ['Chrome 55', 'Firefox 53', 'Safari 13', 'Edge 15'],
 };

--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -58,11 +58,6 @@ module.exports = function(defaults) {
         implementation: require('sass'),
         sourceMapEmbed: sourcemaps,
       },
-      autoprefixer: {
-        sourcemap: sourcemaps,
-        grid: true,
-        browsers: ['defaults', 'ie 11'],
-      },
     }
   );
   // Use `app.import` to add additional libraries to the generated

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -92,7 +92,6 @@
     "ember-changeset-validations": "^3.9.0",
     "ember-cli": "~3.20.2",
     "ember-cli-app-version": "^3.2.0",
-    "ember-cli-autoprefixer": "^0.8.1",
     "ember-cli-babel": "^7.17.2",
     "ember-cli-code-coverage": "^1.0.0-beta.4",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3985,18 +3985,6 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@^7.0.0:
-  version "7.2.6"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.6.tgz#256672f86f7c735da849c4f07d008abb056067dc"
-  integrity sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==
-  dependencies:
-    browserslist "^2.11.3"
-    caniuse-lite "^1.0.30000805"
-    normalize-range "^0.1.2"
-    num2fraction "^1.2.2"
-    postcss "^6.0.17"
-    postcss-value-parser "^3.2.3"
-
 autoprefixer@^9.7.2:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
@@ -5209,15 +5197,6 @@ broccoli-asset-rewrite@^2.0.0:
   dependencies:
     broccoli-filter "^1.2.3"
 
-broccoli-autoprefixer@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-autoprefixer/-/broccoli-autoprefixer-5.0.0.tgz#68c9f3bfdfff9df2d39e46545b9cf9d4443d6a16"
-  integrity sha1-aMnzv9//nfLTnkZUW5z51EQ9ahY=
-  dependencies:
-    autoprefixer "^7.0.0"
-    broccoli-persistent-filter "^1.1.6"
-    postcss "^6.0.1"
-
 broccoli-babel-transpiler@^6.5.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz#a4afc8d3b59b441518eb9a07bd44149476e30738"
@@ -5893,14 +5872,6 @@ browserslist@4.10.0:
     node-releases "^1.1.52"
     pkg-up "^3.1.0"
 
-browserslist@^2.11.3:
-  version "2.11.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
-  integrity sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==
-  dependencies:
-    caniuse-lite "^1.0.30000792"
-    electron-to-chromium "^1.3.30"
-
 browserslist@^3.2.6:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
@@ -6115,7 +6086,7 @@ can-symlink@^1.0.0:
   dependencies:
     tmp "0.0.28"
 
-caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001135:
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001135:
   version "1.0.30001148"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz#dc97c7ed918ab33bf8706ddd5e387287e015d637"
   integrity sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==
@@ -7620,15 +7591,15 @@ ejs@^3.1.2:
   dependencies:
     jake "^10.6.1"
 
-electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.571:
-  version "1.3.582"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.582.tgz#1adfac5affce84d85b3d7b3dfbc4ade293a6ffc4"
-  integrity sha512-0nCJ7cSqnkMC+kUuPs0YgklFHraWGl/xHqtZWWtOeVtyi+YqkoAOMGuZQad43DscXCQI/yizcTa3u6B5r+BLww==
-
 electron-to-chromium@^1.3.378:
   version "1.3.584"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.584.tgz#506cf7ba5895aafa8241876ab028654b61fd9ceb"
   integrity sha512-NB3DzrTzJFhWkUp+nl2KtUtoFzrfGXTir2S+BU4tXGyXH9vlluPuFpE3pTKeH7+PY460tHLjKzh6K2+TWwW+Ww==
+
+electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.571:
+  version "1.3.582"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.582.tgz#1adfac5affce84d85b3d7b3dfbc4ade293a6ffc4"
+  integrity sha512-0nCJ7cSqnkMC+kUuPs0YgklFHraWGl/xHqtZWWtOeVtyi+YqkoAOMGuZQad43DscXCQI/yizcTa3u6B5r+BLww==
 
 element-resize-detector@^1.2.1:
   version "1.2.1"
@@ -7796,14 +7767,6 @@ ember-cli-app-version@^3.2.0:
   dependencies:
     ember-cli-babel "^6.12.0"
     git-repo-version "^1.0.2"
-
-ember-cli-autoprefixer@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-autoprefixer/-/ember-cli-autoprefixer-0.8.1.tgz#071dd9574451057b03dcc03b71f5bd9cb07ef332"
-  integrity sha1-Bx3ZV0RRBXsD3MA7cfW9nLB+8zI=
-  dependencies:
-    broccoli-autoprefixer "^5.0.0"
-    lodash "^4.0.0"
 
 ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.0, ember-cli-babel-plugin-helpers@^1.1.1:
   version "1.1.1"
@@ -12724,7 +12687,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.5.1:
+lodash@^4.0.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.5.1:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -14430,24 +14393,10 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
     uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^3.2.3:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
-  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
-
 postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
-
-postcss@^6.0.1, postcss@^6.0.17:
-  version "6.0.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
-  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
-  dependencies:
-    chalk "^2.4.1"
-    source-map "^0.6.1"
-    supports-color "^5.4.0"
 
 postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.35"
@@ -16647,7 +16596,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
Consul UI pre 1.9 used a mainly ES5 style of javascript, this meant that the majority of the code did not need any ES6 to ES5 babel transpilation or shim code, and our javascript payload was roughly:

Consul UI: 116KB gzipped
Dependencies: 374KB gzipped

As of 1.9 we started moving towards using Ember's new Octane edition, which felt much more ES6-y. So as well as beginning to update all of our components to use glimmer components, we also updated the style of how we write the UI to use ES6 javascript rather than ES5. This meant that (with our existing browser targets file), much of this was being transpiled using babel into ES5 javascript, giving a rough javascript payload of:

Consul UI: 229KB gzipped
Dependencies: 460KB gzipped

That's roughly **200KB gzipped** of payload difference between Consul UI 1.8 and 1.9 split roughly 50/50 between app and dependencies, mainly due to moving to a ES6 style of writing javascript.

This PR alters our browser targets file to target newer browsers and transpile less.

We took a good while looking into this, basing the following on the fact that we generally use these ES6 features:

1. Template literals
2. Native classes
3. Arrow functions
4. Async/await
5. Default arguments/parameters
6. Destructuring
7. The odd generator

We found the newest feature here (surprisingly) was async/await, which landed in Chrome 55, FF 53, Safari 10, Edge 15, which "release date wise" takes us to around the end of 2016 for all of these 'evergreen' browsers, probably a reasonable date.

The slight caveat here is a garbage collection bug for tagged Template Literals in Safari 12, which considering our current usage of template literals wouldn't affect us.

This brings us to a browserlist of: (bumped Safari version to get non-transpiled template literals)

```
'Chrome 55', 'Firefox 53', 'Safari 13', 'Edge 15'
```

This brings us back down to:

Consul UI: 184KB gzipped
Dependencies: 431KB gzipped

A ~71KB reduction on 1.9, not close to the 200KB between 1.8 and 1.9 but a good reduction (although I'm still confused as to where we gained 130KB 🤷 )

We also took the opportunity to remove `ember-cli-autoprefixer` here as the above browserlist supports all the things that autoprefixer was prefixing for us (mainly MS flavoured grid and flexbox).

There's probably a little more we can do here but nothing quite like a 70KB reduction, so we'll probably leave that for future PRs.

Overall this frees us up to make use of some other nice JS dependencies for upcoming features with a clear conscience 😄 

### Consul UI 1.8

<img width="833" alt="1 8" src="https://user-images.githubusercontent.com/554604/107223119-b5136b80-6a0d-11eb-9c0a-375305c1ff02.png">

### Consul UI 1.9

<img width="819" alt="1 9" src="https://user-images.githubusercontent.com/554604/107223158-bfce0080-6a0d-11eb-9d73-fa16665ce491.png">

### Consul UI this PR

<img width="890" alt="now" src="https://user-images.githubusercontent.com/554604/107223209-cf4d4980-6a0d-11eb-94f6-428b59650946.png">





