### PR TITLE
[1.7.x] connect: connect CA Roots in the primary datacenter should use a SigningKeyID derived from their local intermediate

### DIFF
--- a/.changelog/9428.txt
+++ b/.changelog/9428.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: connect CA Roots in the primary datacenter should use a SigningKeyID derived from their local intermediate
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -385,10 +385,14 @@ test-vault-ca-provider:
 ifeq ("$(CIRCLECI)","true")
 # Run in CI
 	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -- $(CURDIR)/agent/connect/ca/* -run 'TestVault(CA)?Provider'
+	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report-leader.xml" -- $(CURDIR)/agent/consul -run 'TestLeader_Vault_'
+	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report-agent.xml" -- $(CURDIR)/agent -run '.*_Vault_'
 else
 # Run locally
 	@echo "Running /agent/connect/ca TestVault(CA)?Provider tests in verbose mode"
 	@go test $(CURDIR)/agent/connect/ca/* -run 'TestVault(CA)?Provider' -v
+	@go test $(CURDIR)/agent/consul -run 'TestLeader_Vault_' -v
+	@go test $(CURDIR)/agent -run '.*_Vault_' -v
 endif
 
 proto-delete:

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/connect/ca"
 	"github.com/hashicorp/consul/agent/debug"
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
@@ -5221,6 +5222,130 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 				r.Fatalf("should be a cache hit")
 			}
 		})
+	}
+}
+
+func TestAgentConnectCALeafCert_Vault_doesNotChurnLeafCertsAtIdle(t *testing.T) {
+	ca.SkipIfVaultNotPresent(t)
+
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	testVault := ca.NewTestVaultServer(t)
+	defer testVault.Stop()
+
+	assert := assert.New(t)
+	require := require.New(t)
+	a := NewTestAgent(t, t.Name(), fmt.Sprintf(`
+		connect {
+			ca_provider = "vault"
+			ca_config {
+				address = %[1]q
+				token = %[2]q
+				root_pki_path = "pki-root/"
+				intermediate_pki_path = "pki-intermediate/"
+			}
+		}
+	`, testVault.Addr, testVault.RootToken))
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+	testrpc.WaitForActiveCARoot(t, a.RPC, "dc1", nil)
+
+	var ca1 *structs.CARoot
+	{
+		args := &structs.DCSpecificRequest{Datacenter: "dc1"}
+		var reply structs.IndexedCARoots
+		require.NoError(a.RPC("ConnectCA.Roots", args, &reply))
+		for _, r := range reply.Roots {
+			if r.ID == reply.ActiveRootID {
+				ca1 = r
+				break
+			}
+		}
+		require.NotNil(ca1)
+	}
+
+	{
+		// Register a local service
+		args := &structs.ServiceDefinition{
+			ID:      "foo",
+			Name:    "test",
+			Address: "127.0.0.1",
+			Port:    8000,
+			Check: structs.CheckType{
+				TTL: 15 * time.Second,
+			},
+		}
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+		resp := httptest.NewRecorder()
+		_, err := a.srv.AgentRegisterService(resp, req)
+		require.NoError(err)
+		if !assert.Equal(200, resp.Code) {
+			t.Log("Body: ", resp.Body.String())
+		}
+	}
+
+	// List
+	req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test", nil)
+	resp := httptest.NewRecorder()
+	obj, err := a.srv.AgentConnectCALeafCert(resp, req)
+	require.NoError(err)
+	require.Equal("MISS", resp.Header().Get("X-Cache"))
+
+	// Get the issued cert
+	issued, ok := obj.(*structs.IssuedCert)
+	assert.True(ok)
+
+	// Verify that the cert is signed by the CA
+	requireLeafValidUnderCA(t, issued, ca1)
+
+	// Verify blocking index
+	assert.True(issued.ModifyIndex > 0)
+	assert.Equal(fmt.Sprintf("%d", issued.ModifyIndex),
+		resp.Header().Get("X-Consul-Index"))
+
+	// Test caching
+	{
+		// Fetch it again
+		resp := httptest.NewRecorder()
+		obj2, err := a.srv.AgentConnectCALeafCert(resp, req)
+		require.NoError(err)
+		require.Equal(obj, obj2)
+
+		// Should cache hit this time and not make request
+		require.Equal("HIT", resp.Header().Get("X-Cache"))
+	}
+
+	// Test that we aren't churning leaves for no reason at idle.
+	{
+		ch := make(chan error, 1)
+		go func() {
+			req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test?index="+strconv.Itoa(int(issued.ModifyIndex)), nil)
+			resp := httptest.NewRecorder()
+			obj, err := a.srv.AgentConnectCALeafCert(resp, req)
+			if err != nil {
+				ch <- err
+			} else {
+				issued2 := obj.(*structs.IssuedCert)
+				if issued.CertPEM == issued2.CertPEM {
+					ch <- fmt.Errorf("leaf woke up unexpectedly with same cert")
+				} else {
+					ch <- fmt.Errorf("leaf woke up unexpectedly with new cert")
+				}
+			}
+		}()
+
+		start := time.Now()
+
+		select {
+		case <-time.After(5 * time.Second):
+		case err := <-ch:
+			dur := time.Since(start)
+			t.Fatalf("unexpected return from blocking query; leaf churned during idle period, took %s: %v", dur, err)
+		}
 	}
 }
 

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -3,9 +3,15 @@ package ca
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"os/exec"
+	"sync"
 
 	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/go-hclog"
+	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/mitchellh/go-testing-interface"
 )
 
@@ -75,4 +81,152 @@ func TestConsulProvider(t testing.T, d ConsulProviderStateDelegate) *ConsulProvi
 	})
 	provider.SetLogger(logger)
 	return provider
+}
+
+// SkipIfVaultNotPresent skips the test if the vault binary is not in PATH.
+//
+// These tests may be skipped in CI. They are run as part of a separate
+// integration test suite.
+func SkipIfVaultNotPresent(t testing.T) {
+	vaultBinaryName := os.Getenv("VAULT_BINARY_NAME")
+	if vaultBinaryName == "" {
+		vaultBinaryName = "vault"
+	}
+
+	path, err := exec.LookPath(vaultBinaryName)
+	if err != nil || path == "" {
+		t.Skipf("%q not found on $PATH - download and install to run this test", vaultBinaryName)
+	}
+}
+
+func NewTestVaultServer(t testing.T) *TestVaultServer {
+	testVault, err := runTestVault()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	testVault.WaitUntilReady(t)
+
+	return testVault
+}
+
+func runTestVault() (*TestVaultServer, error) {
+	vaultBinaryName := os.Getenv("VAULT_BINARY_NAME")
+	if vaultBinaryName == "" {
+		vaultBinaryName = "vault"
+	}
+
+	path, err := exec.LookPath(vaultBinaryName)
+	if err != nil || path == "" {
+		return nil, fmt.Errorf("%q not found on $PATH", vaultBinaryName)
+	}
+
+	ports := freeport.MustTake(2)
+	returnPortsFn := func() {
+		freeport.Return(ports)
+	}
+
+	var (
+		clientAddr  = fmt.Sprintf("127.0.0.1:%d", ports[0])
+		clusterAddr = fmt.Sprintf("127.0.0.1:%d", ports[1])
+	)
+
+	const token = "root"
+
+	client, err := vaultapi.NewClient(&vaultapi.Config{
+		Address: "http://" + clientAddr,
+	})
+	if err != nil {
+		returnPortsFn()
+		return nil, err
+	}
+	client.SetToken(token)
+
+	args := []string{
+		"server",
+		"-dev",
+		"-dev-root-token-id",
+		token,
+		"-dev-listen-address",
+		clientAddr,
+		"-address",
+		clusterAddr,
+	}
+
+	cmd := exec.Command(vaultBinaryName, args...)
+	cmd.Stdout = ioutil.Discard
+	cmd.Stderr = ioutil.Discard
+	if err := cmd.Start(); err != nil {
+		returnPortsFn()
+		return nil, err
+	}
+
+	return &TestVaultServer{
+		RootToken:     token,
+		Addr:          "http://" + clientAddr,
+		cmd:           cmd,
+		client:        client,
+		returnPortsFn: returnPortsFn,
+	}, nil
+}
+
+type TestVaultServer struct {
+	RootToken string
+	Addr      string
+	cmd       *exec.Cmd
+	client    *vaultapi.Client
+
+	// returnPortsFn will put the ports claimed for the test back into the
+	returnPortsFn func()
+}
+
+var printedVaultVersion sync.Once
+
+func (v *TestVaultServer) Client() *vaultapi.Client {
+	return v.client
+}
+
+func (v *TestVaultServer) WaitUntilReady(t testing.T) {
+	var version string
+	retry.Run(t, func(r *retry.R) {
+		resp, err := v.client.Sys().Health()
+		if err != nil {
+			r.Fatalf("err: %v", err)
+		}
+		if !resp.Initialized {
+			r.Fatalf("vault server is not initialized")
+		}
+		if resp.Sealed {
+			r.Fatalf("vault server is sealed")
+		}
+		version = resp.Version
+	})
+	printedVaultVersion.Do(func() {
+		fmt.Fprintf(os.Stderr, "[INFO] agent/connect/ca: testing with vault server version: %s\n", version)
+	})
+}
+
+func (v *TestVaultServer) Stop() error {
+	// There was no process
+	if v.cmd == nil {
+		return nil
+	}
+
+	if v.cmd.Process != nil {
+		if err := v.cmd.Process.Signal(os.Interrupt); err != nil {
+			return fmt.Errorf("failed to kill vault server: %v", err)
+		}
+	}
+
+	// wait for the process to exit to be sure that the data dir can be
+	// deleted on all platforms.
+	if err := v.cmd.Wait(); err != nil {
+		return err
+	}
+
+	if v.returnPortsFn != nil {
+		v.returnPortsFn()
+	}
+
+	return nil
 }

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -448,6 +448,111 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 	require.NoError(err)
 }
 
+func TestLeader_Vault_PrimaryCA_FixSigningKeyID_OnRestart(t *testing.T) {
+	ca.SkipIfVaultNotPresent(t)
+
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	testVault := ca.NewTestVaultServer(t)
+	defer testVault.Stop()
+
+	dir1pre, s1pre := testServerWithConfig(t, func(c *Config) {
+		c.Build = "1.6.0"
+		c.PrimaryDatacenter = "dc1"
+		c.CAConfig = &structs.CAConfiguration{
+			Provider: "vault",
+			Config: map[string]interface{}{
+				"Address":             testVault.Addr,
+				"Token":               testVault.RootToken,
+				"RootPKIPath":         "pki-root/",
+				"IntermediatePKIPath": "pki-intermediate/",
+			},
+		}
+	})
+	defer os.RemoveAll(dir1pre)
+	defer s1pre.Shutdown()
+
+	testrpc.WaitForLeader(t, s1pre.RPC, "dc1")
+
+	// Restore the pre-1.9.3/1.8.8/1.7.12 behavior of the SigningKeyID not being derived
+	// from the intermediates in the primary (which only matters for provider=vault).
+	var primaryRootSigningKeyID string
+	{
+		state := s1pre.fsm.State()
+
+		// Get the highest index
+		idx, activePrimaryRoot, err := state.CARootActive(nil)
+		require.NoError(t, err)
+		require.NotNil(t, activePrimaryRoot)
+
+		rootCert, err := connect.ParseCert(activePrimaryRoot.RootCert)
+		require.NoError(t, err)
+
+		// Force this to be derived just from the root, not the intermediate.
+		primaryRootSigningKeyID = connect.EncodeSigningKeyID(rootCert.SubjectKeyId)
+		activePrimaryRoot.SigningKeyID = primaryRootSigningKeyID
+
+		// Store the root cert in raft
+		resp, err := s1pre.raftApply(structs.ConnectCARequestType, &structs.CARequest{
+			Op:    structs.CAOpSetRoots,
+			Index: idx,
+			Roots: []*structs.CARoot{activePrimaryRoot},
+		})
+		require.NoError(t, err)
+		if respErr, ok := resp.(error); ok {
+			t.Fatalf("respErr: %v", respErr)
+		}
+	}
+
+	// Shutdown s1pre and restart it to trigger the secondary CA init to correct
+	// the SigningKeyID.
+	s1pre.Shutdown()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.DataDir = s1pre.config.DataDir
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.NodeName = s1pre.config.NodeName
+		c.NodeID = s1pre.config.NodeID
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Retry since it will take some time to init the primary CA fully and there
+	// isn't a super clean way to watch specifically until it's done than polling
+	// the CA provider anyway.
+	retry.Run(t, func(r *retry.R) {
+		// verify that the root is now corrected
+		provider, activeRoot := s1.getCAProvider()
+		require.NotNil(r, provider)
+		require.NotNil(r, activeRoot)
+
+		activeIntermediate, err := provider.ActiveIntermediate()
+		require.NoError(r, err)
+
+		intermediateCert, err := connect.ParseCert(activeIntermediate)
+		require.NoError(r, err)
+
+		// Force this to be derived just from the root, not the intermediate.
+		expect := connect.EncodeSigningKeyID(intermediateCert.SubjectKeyId)
+
+		// The in-memory representation was saw the correction via a setCAProvider call.
+		require.Equal(r, expect, activeRoot.SigningKeyID)
+
+		// The state store saw the correction, too.
+		_, activePrimaryRoot, err := s1.fsm.State().CARootActive(nil)
+		require.NoError(r, err)
+		require.NotNil(r, activePrimaryRoot)
+		require.Equal(r, expect, activePrimaryRoot.SigningKeyID)
+	})
+}
+
 func TestLeader_SecondaryCA_FixSigningKeyID_via_IntermediateRefresh(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
1.7.x backport of #9428