### PR TITLE
Add fields to the /acl/auth-methods endpoint.

### DIFF
--- a/.changelog/9741.txt
+++ b/.changelog/9741.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: extend the auth-methods list endpoint to include MaxTokenTTL and TokenLocality fields.
+```

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1201,6 +1201,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				Config: map[string]interface{}{
 					"SessionID": testSessionID,
 				},
+				TokenLocality: "global",
+				MaxTokenTTL:   500_000_000_000,
 			}
 
 			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root", jsonBody(methodInput))
@@ -1284,6 +1286,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLAuthMethodList(resp, req)
 			require.NoError(t, err)
+
 			methods, ok := raw.(structs.ACLAuthMethodListStubs)
 			require.True(t, ok)
 
@@ -1297,6 +1300,8 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 						require.Equal(t, expected.Name, actual.Name)
 						require.Equal(t, expected.Type, actual.Type)
 						require.Equal(t, expected.Description, actual.Description)
+						require.Equal(t, expected.MaxTokenTTL, actual.MaxTokenTTL)
+						require.Equal(t, expected.TokenLocality, actual.TokenLocality)
 						require.Equal(t, expected.CreateIndex, actual.CreateIndex)
 						require.Equal(t, expected.ModifyIndex, actual.ModifyIndex)
 						found = true

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1090,13 +1090,16 @@ func (rules ACLBindingRules) Sort() {
 	})
 }
 
+// Note: this is a subset of ACLAuthMethod's fields
 type ACLAuthMethodListStub struct {
-	Name        string
-	Type        string
-	DisplayName string `json:",omitempty"`
-	Description string `json:",omitempty"`
-	CreateIndex uint64
-	ModifyIndex uint64
+	Name          string
+	Type          string
+	DisplayName   string        `json:",omitempty"`
+	Description   string        `json:",omitempty"`
+	MaxTokenTTL   time.Duration `json:",omitempty"`
+	TokenLocality string        `json:",omitempty"`
+	CreateIndex   uint64
+	ModifyIndex   uint64
 	EnterpriseMeta
 }
 
@@ -1106,10 +1109,32 @@ func (p *ACLAuthMethod) Stub() *ACLAuthMethodListStub {
 		Type:           p.Type,
 		DisplayName:    p.DisplayName,
 		Description:    p.Description,
+		MaxTokenTTL:    p.MaxTokenTTL,
+		TokenLocality:  p.TokenLocality,
 		CreateIndex:    p.CreateIndex,
 		ModifyIndex:    p.ModifyIndex,
 		EnterpriseMeta: p.EnterpriseMeta,
 	}
+}
+
+// This is nearly identical to the ACLAuthMethod MarshalJSON
+// Unmarshaling is not implemented because the API is read only
+func (m *ACLAuthMethodListStub) MarshalJSON() ([]byte, error) {
+	type Alias ACLAuthMethodListStub
+	exported := &struct {
+		MaxTokenTTL string `json:",omitempty"`
+		*Alias
+	}{
+		MaxTokenTTL: m.MaxTokenTTL.String(),
+		Alias:       (*Alias)(m),
+	}
+	if m.MaxTokenTTL == 0 {
+		exported.MaxTokenTTL = ""
+	}
+
+	data, err := json.Marshal(exported)
+
+	return data, err
 }
 
 type ACLAuthMethods []*ACLAuthMethod


### PR DESCRIPTION
Add fields to the /acl/auth-methods endpoint.

A GET of the /acl/auth-methods/:name endpoint returns the fieldsMaxTokenTTL and TokenLocality, while a LIST (/acl/auth-methods) does
not.

The list command returns a filtered subset of the full set. This is
somewhat deliberate, so that secrets aren't shown, but the TTL and
Locality fields aren't (IMO) security critical, and it is useful for
the front end to be able to show them.

For consistency these changes mirror the 'omit empty' and string
representation choices made for the GET call.

This includes changes to the gRPC and API code in the client.

The new output looks similar to this
curl 'http://localhost:8500/v1/acl/auth-methods' | jq '.'

  {
    "MaxTokenTTL": "8m20s",
    "Name": "minikube-ttl-local2",
    "Type": "kubernetes",
    "Description": "minikube auth method",
    "TokenLocality": "local",
    "CreateIndex": 530,
    "ModifyIndex": 530,
    "Namespace": "default"
  }
]

Signed-off-by: Mark Anderson <manderson@hashicorp.com>