### PR TITLE
Backport to release/1.8.x: #9738 - Stop background refresh of cached data for requests that result in ACL not found errors

### DIFF
--- a/.changelog/9738.txt
+++ b/.changelog/9738.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cache: Prevent spamming the logs for days when a cached request encounters an "ACL not found" error.
+```

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -18,11 +18,14 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/armon/go-metrics"
+
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/lib"
 	"golang.org/x/time/rate"
 )
@@ -626,6 +629,8 @@ func (c *Cache) fetch(key string, r getOptions, allowNew bool, attempt uint, ign
 			newEntry.State = result.State
 		}
 
+		preventRefresh := acl.IsErrNotFound(err)
+
 		// Error handling
 		if err == nil {
 			metrics.IncrCounter([]string{"consul", "cache", "fetch_success"}, 1)
@@ -657,8 +662,13 @@ func (c *Cache) fetch(key string, r getOptions, allowNew bool, attempt uint, ign
 				newEntry.RefreshLostContact = time.Time{}
 			}
 		} else {
-			metrics.IncrCounter([]string{"consul", "cache", "fetch_error"}, 1)
-			metrics.IncrCounter([]string{"consul", "cache", tEntry.Name, "fetch_error"}, 1)
+			// TODO (mkeeler) maybe change the name of this label to be more indicative of it just
+			// stopping the background refresh
+			labels := []metrics.Label{{Name: "fatal", Value: strconv.FormatBool(preventRefresh)}}
+
+			// TODO(kit): Add tEntry.Name to label on fetch_error and deprecate second write
+			metrics.IncrCounterWithLabels([]string{"consul", "cache", "fetch_error"}, 1, labels)
+			metrics.IncrCounterWithLabels([]string{"consul", "cache", tEntry.Name, "fetch_error"}, 1, labels)
 
 			// Increment attempt counter
 			attempt++
@@ -695,7 +705,13 @@ func (c *Cache) fetch(key string, r getOptions, allowNew bool, attempt uint, ign
 
 		// If refresh is enabled, run the refresh in due time. The refresh
 		// below might block, but saves us from spawning another goroutine.
-		if tEntry.Opts.Refresh {
+		//
+		// We want to have ACL not found errors stop cache refresh for the cases
+		// where the token used for the query was deleted. If the request
+		// was coming from a cache notification then it will start the
+		// request back up again shortly but in the general case this prevents
+		// spamming the logs with tons of ACL not found errors for days.
+		if tEntry.Opts.Refresh && !preventRefresh {
 			// Check if cache was stopped
 			if atomic.LoadUint32(&c.stopped) == 1 {
 				return

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/consul/logging"
 	"sync/atomic"
 	"time"
 


### PR DESCRIPTION
The first commit is the backport of #9738 which required resolving some conflicts with changes to how the cache is structured. In 1.9.x the expiry heap implementation was moved out of the cache package and into lib/expiry.

The second commit is completely unrelated but fixes up what appears to be a botched auto-merge that resulted in duplicate imports of the logging package in agent/xds/server.go. Regardless I wanted to make the linter happy so its fixed too.