### PR TITLE
Stop background refresh of cached data for requests that result in ACL not found errors

### DIFF
--- a/.changelog/9738.txt
+++ b/.changelog/9738.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cache: Prevent spamming the logs for days when a cached request encounters an "ACL not found" error.
+```


### PR DESCRIPTION
Backport of #9738 to release/1.7.x

There were conflicts in cache.go and cache_test.go. Lots of improvements have been made to the cache code structure since 1.7.x so I had to change the impl accordingly. However these were just superficial changes for this fix.
