### PR TITLE
ui: DataSource Decorator

### DIFF
--- a/ui/packages/consul-ui/app/decorators/data-source.js
+++ b/ui/packages/consul-ui/app/decorators/data-source.js
@@ -1,0 +1,20 @@
+import wayfarer from 'wayfarer';
+import { singularize } from 'ember-inflector';
+
+const router = wayfarer();
+export default path => (target, propertyKey, desc) => {
+  router.on(path, function(params, owner) {
+    let name;
+    if (params.modelName) {
+      name = singularize(params.modelName);
+    } else {
+      name = target.getModelName.call();
+    }
+    const instance = owner.lookup(`service:repository/${name}`);
+    return configuration => desc.value.apply(instance, [params, configuration]);
+  });
+  return desc;
+};
+export const match = path => {
+  return router.match(path);
+};

--- a/ui/packages/consul-ui/app/mixins/token/with-actions.js
+++ b/ui/packages/consul-ui/app/mixins/token/with-actions.js
@@ -8,11 +8,11 @@ export default Mixin.create(WithBlockingActions, {
   actions: {
     use: function(item) {
       return this.repo
-        .findBySlug(
-          get(item, 'AccessorID'),
-          this.modelFor('dc').dc.Name,
-          this.modelFor('nspace').nspace.substr(1)
-        )
+        .findBySlug({
+          ns: this.modelFor('nspace').nspace.substr(1),
+          dc: this.modelFor('dc').dc.Name,
+          id: get(item, 'AccessorID'),
+        })
         .then(item => {
           return this.settings.persist({
             token: {

--- a/ui/packages/consul-ui/app/routes/dc/acls/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/edit.js
@@ -13,7 +13,10 @@ export default class EditRoute extends Route.extend(WithAclActions) {
 
   model(params) {
     return hash({
-      item: this.repo.findBySlug(params.id, this.modelFor('dc').dc.Name),
+      item: this.repo.findBySlug({
+        dc: this.modelFor('dc').dc.Name,
+        id: params.id,
+      }),
       types: ['management', 'client'],
     });
   }

--- a/ui/packages/consul-ui/app/routes/dc/acls/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/index.js
@@ -30,7 +30,7 @@ export default class IndexRoute extends Route.extend(WithAclActions) {
   }
 
   async model(params) {
-    const _items = this.repo.findAllByDatacenter(this.modelFor('dc').dc.Name);
+    const _items = this.repo.findAllByDatacenter({ dc: this.modelFor('dc').dc.Name });
     const _token = this.settings.findBySlug('token');
     return {
       items: await _items,

--- a/ui/packages/consul-ui/app/routes/dc/acls/policies/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/policies/edit.js
@@ -21,15 +21,21 @@ export default class EditRoute extends SingleRoute.extend(WithPolicyActions) {
         ...model,
         ...{
           routeName: this.routeName,
-          items: tokenRepo.findByPolicy(get(model.item, 'ID'), dc, nspace).catch(function(e) {
-            switch (get(e, 'errors.firstObject.status')) {
-              case '403':
-              case '401':
-                // do nothing the SingleRoute will have caught it already
-                return;
-            }
-            throw e;
-          }),
+          items: tokenRepo
+            .findByPolicy({
+              ns: nspace,
+              dc: dc,
+              id: get(model.item, 'ID'),
+            })
+            .catch(function(e) {
+              switch (get(e, 'errors.firstObject.status')) {
+                case '403':
+                case '401':
+                  // do nothing the SingleRoute will have caught it already
+                  return;
+              }
+              throw e;
+            }),
         },
       });
     });

--- a/ui/packages/consul-ui/app/routes/dc/acls/policies/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/policies/index.js
@@ -26,10 +26,10 @@ export default class IndexRoute extends Route.extend(WithPolicyActions) {
   model(params) {
     return hash({
       ...this.repo.status({
-        items: this.repo.findAllByDatacenter(
-          this.modelFor('dc').dc.Name,
-          this.modelFor('nspace').nspace.substr(1)
-        ),
+        items: this.repo.findAllByDatacenter({
+          ns: this.modelFor('nspace').nspace.substr(1),
+          dc: this.modelFor('dc').dc.Name,
+        }),
       }),
       searchProperties: this.queryParams.searchproperty.empty[0],
     });

--- a/ui/packages/consul-ui/app/routes/dc/acls/roles/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/roles/edit.js
@@ -20,15 +20,21 @@ export default class EditRoute extends SingleRoute.extend(WithRoleActions) {
       return hash({
         ...model,
         ...{
-          items: tokenRepo.findByRole(get(model.item, 'ID'), dc, nspace).catch(function(e) {
-            switch (get(e, 'errors.firstObject.status')) {
-              case '403':
-              case '401':
-                // do nothing the SingleRoute will have caught it already
-                return;
-            }
-            throw e;
-          }),
+          items: tokenRepo
+            .findByRole({
+              ns: nspace,
+              dc: dc,
+              id: get(model.item, 'ID'),
+            })
+            .catch(function(e) {
+              switch (get(e, 'errors.firstObject.status')) {
+                case '403':
+                case '401':
+                  // do nothing the SingleRoute will have caught it already
+                  return;
+              }
+              throw e;
+            }),
         },
       });
     });

--- a/ui/packages/consul-ui/app/routes/dc/acls/roles/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/roles/index.js
@@ -22,10 +22,10 @@ export default class IndexRoute extends Route.extend(WithRoleActions) {
   model(params) {
     return hash({
       ...this.repo.status({
-        items: this.repo.findAllByDatacenter(
-          this.modelFor('dc').dc.Name,
-          this.modelFor('nspace').nspace.substr(1)
-        ),
+        items: this.repo.findAllByDatacenter({
+          ns: this.modelFor('nspace').nspace.substr(1),
+          dc: this.modelFor('dc').dc.Name,
+        }),
       }),
       searchProperties: this.queryParams.searchproperty.empty[0],
     });

--- a/ui/packages/consul-ui/app/routes/dc/acls/tokens/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/tokens/index.js
@@ -35,10 +35,10 @@ export default class IndexRoute extends Route.extend(WithTokenActions) {
   model(params) {
     return hash({
       ...this.repo.status({
-        items: this.repo.findAllByDatacenter(
-          this.modelFor('dc').dc.Name,
-          this.modelFor('nspace').nspace.substr(1)
-        ),
+        items: this.repo.findAllByDatacenter({
+          ns: this.modelFor('nspace').nspace.substr(1),
+          dc: this.modelFor('dc').dc.Name,
+        }),
       }),
       nspace: this.modelFor('nspace').nspace.substr(1),
       token: this.settings.findBySlug('token'),

--- a/ui/packages/consul-ui/app/routes/dc/intentions/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/intentions/edit.js
@@ -11,7 +11,11 @@ export default class EditRoute extends Route {
 
     let item;
     if (typeof intention_id !== 'undefined') {
-      item = await this.repo.findBySlug(intention_id, dc, nspace);
+      item = await this.repo.findBySlug({
+        ns: nspace,
+        dc: dc,
+        id: intention_id,
+      });
     } else {
       const defaultNspace = this.env.var('CONSUL_NSPACES_ENABLED') ? '*' : 'default';
       item = await this.repo.create({

--- a/ui/packages/consul-ui/app/routes/dc/kv/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/kv/edit.js
@@ -26,14 +26,26 @@ export default class EditRoute extends Route {
       nspace: nspace || 'default',
       parent:
         typeof key !== 'undefined'
-          ? this.repo.findBySlug(ascend(key, 1) || '/', dc, nspace)
-          : this.repo.findBySlug('/', dc, nspace),
+          ? this.repo.findBySlug({
+              ns: nspace,
+              dc: dc,
+              id: ascend(key, 1) || '/',
+            })
+          : this.repo.findBySlug({
+              ns: nspace,
+              dc: dc,
+              id: '/',
+            }),
       item: create
         ? this.repo.create({
             Datacenter: dc,
             Namespace: nspace,
           })
-        : this.repo.findBySlug(key, dc, nspace),
+        : this.repo.findBySlug({
+            ns: nspace,
+            dc: dc,
+            id: key,
+          }),
       session: null,
     }).then(model => {
       // TODO: Consider loading this after initial page load
@@ -43,7 +55,11 @@ export default class EditRoute extends Route {
           return hash({
             ...model,
             ...{
-              session: this.sessionRepo.findByKey(session, dc, nspace),
+              session: this.sessionRepo.findByKey({
+                ns: nspace,
+                dc: dc,
+                id: session,
+              }),
             },
           });
         }

--- a/ui/packages/consul-ui/app/routes/dc/kv/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/kv/index.js
@@ -31,20 +31,30 @@ export default class IndexRoute extends Route {
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
-      parent: this.repo.findBySlug(key, dc, nspace),
+      parent: this.repo.findBySlug({
+        ns: nspace,
+        dc: dc,
+        id: key,
+      }),
     }).then(model => {
       return hash({
         ...model,
         ...{
-          items: this.repo.findAllBySlug(get(model.parent, 'Key'), dc, nspace).catch(e => {
-            const status = get(e, 'errors.firstObject.status');
-            switch (status) {
-              case '403':
-                return this.transitionTo('dc.acls.tokens');
-              default:
-                return this.transitionTo('dc.kv.index');
-            }
-          }),
+          items: this.repo
+            .findAllBySlug({
+              ns: nspace,
+              dc: dc,
+              id: get(model.parent, 'Key'),
+            })
+            .catch(e => {
+              const status = get(e, 'errors.firstObject.status');
+              switch (status) {
+                case '403':
+                  return this.transitionTo('dc.acls.tokens');
+                default:
+                  return this.transitionTo('dc.kv.index');
+              }
+            }),
         },
       });
     });

--- a/ui/packages/consul-ui/app/routes/dc/nspaces/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/nspaces/edit.js
@@ -28,7 +28,7 @@ export default class EditRoute extends Route.extend(WithNspaceActions) {
               },
             })
           )
-        : repo.findBySlug(params.name),
+        : repo.findBySlug({ id: params.name }),
     });
   }
 

--- a/ui/packages/consul-ui/app/routing/single.js
+++ b/ui/packages/consul-ui/app/routing/single.js
@@ -27,7 +27,11 @@ export default Route.extend({
                 Namespace: nspace,
               })
             )
-          : repo.findBySlug(params.id, dc, nspace),
+          : repo.findBySlug({
+              ns: nspace,
+              dc: dc,
+              id: params.id,
+            }),
       }),
     });
   },

--- a/ui/packages/consul-ui/app/services/data-source/protocols/http.js
+++ b/ui/packages/consul-ui/app/services/data-source/protocols/http.js
@@ -1,5 +1,7 @@
 import Service, { inject as service } from '@ember/service';
 import { get } from '@ember/object';
+import { getOwner } from '@ember/application';
+import { match } from 'consul-ui/decorators/data-source';
 
 export default class HttpService extends Service {
   @service('repository/dc')
@@ -84,12 +86,10 @@ export default class HttpService extends Service {
   type;
 
   source(src, configuration) {
-    // TODO: Consider adding/requiring 'action': nspace, dc, model, action, ...rest
-    const [, nspace, dc, model, ...rest] = src.split('/').map(decodeURIComponent);
-    // nspaces can be filled, blank or *
-    // so we might get urls like //dc/services
-    let find;
+    const [, , , model] = src.split('/');
     const repo = this[model];
+    const route = match(src);
+    const find = route.cb(route.params, getOwner(this));
     configuration.createEvent = function(result = {}, configuration) {
       const event = {
         type: 'message',
@@ -101,141 +101,6 @@ export default class HttpService extends Service {
       }
       return event;
     };
-    let method, slug, more, protocol;
-    switch (model) {
-      case 'metrics':
-        [method, slug, ...more] = rest;
-        switch (method) {
-          case 'summary-for-service':
-            [protocol, ...more] = more;
-            find = configuration =>
-              repo.findServiceSummary(protocol, slug, dc, nspace, configuration);
-            break;
-          case 'upstream-summary-for-service':
-            find = configuration => repo.findUpstreamSummary(slug, dc, nspace, configuration);
-            break;
-          case 'downstream-summary-for-service':
-            find = configuration => repo.findDownstreamSummary(slug, dc, nspace, configuration);
-            break;
-        }
-        break;
-      case 'datacenters':
-      case 'namespaces':
-        find = configuration => repo.findAll(configuration);
-        break;
-      case 'services':
-      case 'nodes':
-      case 'roles':
-      case 'policies':
-        find = configuration => repo.findAllByDatacenter(dc, nspace, configuration);
-        break;
-      case 'leader':
-        find = configuration => repo.findLeader(dc, configuration);
-        break;
-      case 'intentions':
-        [method, ...slug] = rest;
-        switch (method) {
-          case 'for-service':
-            find = configuration => repo.findByService(slug, dc, nspace, configuration);
-            break;
-          default:
-            find = configuration => repo.findAllByDatacenter(dc, nspace, configuration);
-            break;
-        }
-        break;
-      case 'service-instances':
-        [method, ...slug] = rest;
-        switch (method) {
-          case 'for-service':
-            find = configuration => repo.findByService(slug, dc, nspace, configuration);
-            break;
-        }
-        break;
-      case 'coordinates':
-        [method, ...slug] = rest;
-        switch (method) {
-          case 'for-node':
-            find = configuration => repo.findAllByNode(slug, dc, configuration);
-            break;
-        }
-        break;
-      case 'proxies':
-        [method, ...slug] = rest;
-        switch (method) {
-          case 'for-service':
-            find = configuration => repo.findAllBySlug(slug, dc, nspace, configuration);
-            break;
-        }
-        break;
-      case 'gateways':
-        [method, ...slug] = rest;
-        switch (method) {
-          case 'for-service':
-            find = configuration => repo.findGatewayBySlug(slug, dc, nspace, configuration);
-            break;
-        }
-        break;
-      case 'sessions':
-        [method, ...slug] = rest;
-        switch (method) {
-          case 'for-node':
-            find = configuration => repo.findByNode(slug, dc, nspace, configuration);
-            break;
-        }
-        break;
-      case 'token':
-        find = configuration => repo.self(rest[1], dc);
-        break;
-      case 'discovery-chain':
-      case 'node':
-        find = configuration => repo.findBySlug(rest[0], dc, nspace, configuration);
-        break;
-      case 'service-instance':
-        // id, node, service
-        find = configuration =>
-          repo.findBySlug(rest[0], rest[1], rest[2], dc, nspace, configuration);
-        break;
-      case 'proxy-service-instance':
-        // id, node, service
-        find = configuration =>
-          repo.findProxyBySlug(rest[0], rest[1], rest[2], dc, nspace, configuration);
-        break;
-      case 'proxy-instance':
-        // id, node, service
-        find = configuration =>
-          repo.findInstanceBySlug(rest[0], rest[1], rest[2], dc, nspace, configuration);
-        break;
-      case 'topology':
-        // id, service kind
-        find = configuration => repo.findBySlug(rest[0], rest[1], dc, nspace, configuration);
-        break;
-      case 'policy':
-      case 'kv':
-      case 'intention':
-        slug = rest[0];
-        if (slug) {
-          find = configuration => repo.findBySlug(slug, dc, nspace, configuration);
-        } else {
-          find = configuration =>
-            Promise.resolve(repo.create({ Datacenter: dc, Namespace: nspace }));
-        }
-        break;
-      case 'oidc':
-        [method, ...slug] = rest;
-        switch (method) {
-          case 'providers':
-            find = configuration => repo.findAllByDatacenter(dc, nspace, configuration);
-            break;
-          case 'provider':
-            find = configuration => repo.findBySlug(slug[0], dc, nspace);
-            break;
-          case 'authorize':
-            find = configuration =>
-              repo.authorize(slug[0], slug[1], slug[2], dc, nspace, configuration);
-            break;
-        }
-        break;
-    }
     return this.type.source(find, configuration);
   }
 }

--- a/ui/packages/consul-ui/app/services/repository.js
+++ b/ui/packages/consul-ui/app/services/repository.js
@@ -3,6 +3,7 @@ import { assert } from '@ember/debug';
 import { typeOf } from '@ember/utils';
 import { get } from '@ember/object';
 import { isChangeset } from 'validated-changeset';
+import dataSource from 'consul-ui/decorators/data-source';
 
 export default class RepositoryService extends Service {
   getModelName() {
@@ -47,29 +48,28 @@ export default class RepositoryService extends Service {
     return this.store.peekRecord(this.getModelName(), id);
   }
 
-  findAllByDatacenter(dc, nspace, configuration = {}) {
-    const query = {
-      dc: dc,
-      ns: nspace,
-    };
+  @dataSource('/:ns/:dc/:modelName')
+  findAllByDatacenter(params, configuration = {}) {
     if (typeof configuration.cursor !== 'undefined') {
-      query.index = configuration.cursor;
-      query.uri = configuration.uri;
+      params.index = configuration.cursor;
+      params.uri = configuration.uri;
     }
-    return this.store.query(this.getModelName(), query);
+    return this.store.query(this.getModelName(), params);
   }
 
-  findBySlug(slug, dc, nspace, configuration = {}) {
-    const query = {
-      dc: dc,
-      ns: nspace,
-      id: slug,
-    };
-    if (typeof configuration.cursor !== 'undefined') {
-      query.index = configuration.cursor;
-      query.uri = configuration.uri;
+  @dataSource('/:ns/:dc/:modelName/:id')
+  async findBySlug(params, configuration = {}) {
+    if (params.id === '') {
+      return this.create({
+        Datacenter: params.dc,
+        Namespace: params.ns,
+      });
     }
-    return this.store.queryRecord(this.getModelName(), query);
+    if (typeof configuration.cursor !== 'undefined') {
+      params.index = configuration.cursor;
+      params.uri = configuration.uri;
+    }
+    return this.store.queryRecord(this.getModelName(), params);
   }
 
   create(obj) {

--- a/ui/packages/consul-ui/app/services/repository/coordinate.js
+++ b/ui/packages/consul-ui/app/services/repository/coordinate.js
@@ -4,6 +4,7 @@ import RepositoryService from 'consul-ui/services/repository';
 import tomographyFactory from 'consul-ui/utils/tomography';
 import distance from 'consul-ui/utils/distance';
 const tomography = tomographyFactory(distance);
+import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'coordinate';
 export default class CoordinateService extends RepositoryService {
@@ -13,25 +14,21 @@ export default class CoordinateService extends RepositoryService {
 
   // Coordinates don't need nspaces so we have a custom method here
   // that doesn't accept nspaces
-  findAllByDatacenter(dc, configuration = {}) {
-    const query = {
-      dc: dc,
-    };
+  @dataSource('/:ns/:dc/coordinates')
+  findAllByDatacenter(params, configuration = {}) {
     if (typeof configuration.cursor !== 'undefined') {
-      query.index = configuration.cursor;
-      query.uri = configuration.uri;
+      params.index = configuration.cursor;
+      params.uri = configuration.uri;
     }
-    return this.store.query(this.getModelName(), query);
+    return this.store.query(this.getModelName(), params);
   }
 
-  findAllByNode(node, dc, configuration) {
-    return this.findAllByDatacenter(dc, configuration).then(function(coordinates) {
+  @dataSource('/:ns/:dc/coordinates/for-node/:id')
+  findAllByNode(params, configuration) {
+    return this.findAllByDatacenter(params, configuration).then(function(coordinates) {
       let results = {};
       if (get(coordinates, 'length') > 1) {
-        results = tomography(
-          node,
-          coordinates
-        );
+        results = tomography(params.id, coordinates);
       }
       results.meta = get(coordinates, 'meta');
       return results;

--- a/ui/packages/consul-ui/app/services/repository/dc.js
+++ b/ui/packages/consul-ui/app/services/repository/dc.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import RepositoryService from 'consul-ui/services/repository';
 import { get } from '@ember/object';
 import Error from '@ember/error';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'dc';
 export default class DcService extends RepositoryService {
@@ -12,7 +13,8 @@ export default class DcService extends RepositoryService {
     return modelName;
   }
 
-  async findAll() {
+  @dataSource('/:ns/:dc/datacenters')
+  async findAll(params, configuration = {}) {
     return this.store.query(this.getModelName(), {});
   }
 

--- a/ui/packages/consul-ui/app/services/repository/intention.js
+++ b/ui/packages/consul-ui/app/services/repository/intention.js
@@ -1,6 +1,7 @@
 import { set, get } from '@ember/object';
 import RepositoryService from 'consul-ui/services/repository';
 import { PRIMARY_KEY } from 'consul-ui/models/intention';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'intention';
 export default class IntentionRepository extends RepositoryService {
@@ -45,11 +46,22 @@ export default class IntentionRepository extends RepositoryService {
     return res;
   }
 
-  async findByService(slug, dc, nspace, configuration = {}) {
+  @dataSource('/:ns/:dc/intentions')
+  async findAllByDatacenter() {
+    return super.findAllByDatacenter(...arguments);
+  }
+
+  @dataSource('/:ns/:dc/intention/:id')
+  async findBySlug() {
+    return super.findBySlug(...arguments);
+  }
+
+  @dataSource('/:ns/:dc/intentions/for-service/:slug')
+  async findByService(params, configuration = {}) {
     const query = {
-      dc,
-      nspace,
-      filter: `SourceName == "${slug}" or DestinationName == "${slug}" or SourceName == "*" or DestinationName == "*"`,
+      dc: params.dc,
+      nspace: params.nspace,
+      filter: `SourceName == "${params.slug}" or DestinationName == "${params.slug}" or SourceName == "*" or DestinationName == "*"`,
     };
     if (typeof configuration.cursor !== 'undefined') {
       query.index = configuration.cursor;

--- a/ui/packages/consul-ui/app/services/repository/node.js
+++ b/ui/packages/consul-ui/app/services/repository/node.js
@@ -1,4 +1,5 @@
 import RepositoryService from 'consul-ui/services/repository';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'node';
 export default class NodeService extends RepositoryService {
@@ -6,13 +7,11 @@ export default class NodeService extends RepositoryService {
     return modelName;
   }
 
-  findLeader(dc, configuration = {}) {
-    const query = {
-      dc: dc,
-    };
+  @dataSource('/:ns/:dc/leader')
+  findLeader(params, configuration = {}) {
     if (typeof configuration.refresh !== 'undefined') {
-      query.uri = configuration.uri;
+      params.uri = configuration.uri;
     }
-    return this.store.queryLeader(this.getModelName(), query);
+    return this.store.queryLeader(this.getModelName(), params);
   }
 }

--- a/ui/packages/consul-ui/app/services/repository/nspace.js
+++ b/ui/packages/consul-ui/app/services/repository/nspace.js
@@ -1,5 +1,6 @@
 import RepositoryService from 'consul-ui/services/repository';
 import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/nspace';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'nspace';
 export default class NspaceService extends RepositoryService {
@@ -37,7 +38,8 @@ export default class NspaceService extends RepositoryService {
     return res;
   }
 
-  findAll(configuration = {}) {
+  @dataSource('/:ns/:dc/namespaces')
+  findAll(params, configuration = {}) {
     const query = {};
     if (typeof configuration.cursor !== 'undefined') {
       query.index = configuration.cursor;

--- a/ui/packages/consul-ui/app/services/repository/nspace/enabled.js
+++ b/ui/packages/consul-ui/app/services/repository/nspace/enabled.js
@@ -24,7 +24,7 @@ export default class EnabledService extends RepositoryService {
     return modelName;
   }
 
-  findAll(configuration = {}) {
+  findAll(params, configuration = {}) {
     const query = {};
     if (typeof configuration.cursor !== 'undefined') {
       query.index = configuration.cursor;

--- a/ui/packages/consul-ui/app/services/repository/oidc-provider.js
+++ b/ui/packages/consul-ui/app/services/repository/oidc-provider.js
@@ -2,6 +2,7 @@ import { inject as service } from '@ember/service';
 import RepositoryService from 'consul-ui/services/repository';
 import { getOwner } from '@ember/application';
 import { set } from '@ember/object';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'oidc-provider';
 const OAUTH_PROVIDER_NAME = 'oidc-with-url';
@@ -18,15 +19,19 @@ export default class OidcProviderService extends RepositoryService {
     return modelName;
   }
 
-  authorize(id, code, state, dc, nspace, configuration = {}) {
-    const query = {
-      id: id,
-      code: code,
-      state: state,
-      dc: dc,
-      ns: nspace,
-    };
-    return this.store.authorize(this.getModelName(), query);
+  @dataSource('/:ns/:dc/oidc/providers')
+  async findAllByDatacenter() {
+    return super.findAllByDatacenter(...arguments);
+  }
+
+  @dataSource('/:ns/:dc/oidc/provider/:id')
+  async findBySlug() {
+    return super.findBySlug(...arguments);
+  }
+
+  @dataSource('/:ns/:dc/oidc/authorize/:id/:code/:state')
+  authorize(params, configuration = {}) {
+    return this.store.authorize(this.getModelName(), params);
   }
 
   logout(id, code, state, dc, nspace, configuration = {}) {

--- a/ui/packages/consul-ui/app/services/repository/service-instance.js
+++ b/ui/packages/consul-ui/app/services/repository/service-instance.js
@@ -1,6 +1,7 @@
 import RepositoryService from 'consul-ui/services/repository';
 import { inject as service } from '@ember/service';
 import { set } from '@ember/object';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'service-instance';
 export default class ServiceInstanceService extends RepositoryService {
@@ -9,35 +10,26 @@ export default class ServiceInstanceService extends RepositoryService {
     return modelName;
   }
 
-  async findByService(slug, dc, nspace, configuration = {}) {
-    const query = {
-      dc: dc,
-      ns: nspace,
-      id: slug,
-    };
+  @dataSource('/:ns/:dc/service-instances/for-service/:id')
+  async findByService(params, configuration = {}) {
     if (typeof configuration.cursor !== 'undefined') {
-      query.index = configuration.cursor;
-      query.uri = configuration.uri;
+      params.index = configuration.cursor;
+      params.uri = configuration.uri;
     }
-    return this.store.query(this.getModelName(), query);
+    return this.store.query(this.getModelName(), params);
   }
 
-  async findBySlug(serviceId, node, service, dc, nspace, configuration = {}) {
-    const query = {
-      dc: dc,
-      ns: nspace,
-      serviceId: serviceId,
-      node: node,
-      id: service,
-    };
+  @dataSource('/:ns/:dc/service-instance/:serviceId/:node/:id')
+  async findBySlug(params, configuration = {}) {
     if (typeof configuration.cursor !== 'undefined') {
-      query.index = configuration.cursor;
-      query.uri = configuration.uri;
+      params.index = configuration.cursor;
+      params.uri = configuration.uri;
     }
-    return this.store.queryRecord(this.getModelName(), query);
+    return this.store.queryRecord(this.getModelName(), params);
   }
 
-  async findProxyBySlug(serviceId, node, service, dc, nspace, configuration = {}) {
+  @dataSource('/:ns/:dc/proxy-service-instance/:serviceId/:node/:id')
+  async findProxyBySlug(params, configuration = {}) {
     const instance = await this.findBySlug(...arguments);
     let proxy = this.store.peekRecord('proxy', instance.uid);
     // Currently, we call the proxy endpoint before this endpoint

--- a/ui/packages/consul-ui/app/services/repository/service.js
+++ b/ui/packages/consul-ui/app/services/repository/service.js
@@ -1,20 +1,18 @@
 import RepositoryService from 'consul-ui/services/repository';
+import dataSource from 'consul-ui/decorators/data-source';
+
 const modelName = 'service';
 export default class _RepositoryService extends RepositoryService {
   getModelName() {
     return modelName;
   }
 
-  findGatewayBySlug(slug, dc, nspace, configuration = {}) {
-    const query = {
-      dc: dc,
-      ns: nspace,
-      gateway: slug,
-    };
+  @dataSource('/:ns/:dc/gateways/for-service/:gateway')
+  findGatewayBySlug(params, configuration = {}) {
     if (typeof configuration.cursor !== 'undefined') {
-      query.index = configuration.cursor;
-      query.uri = configuration.uri;
+      params.index = configuration.cursor;
+      params.uri = configuration.uri;
     }
-    return this.store.query(this.getModelName(), query);
+    return this.store.query(this.getModelName(), params);
   }
 }

--- a/ui/packages/consul-ui/app/services/repository/session.js
+++ b/ui/packages/consul-ui/app/services/repository/session.js
@@ -1,5 +1,6 @@
 import { inject as service } from '@ember/service';
 import RepositoryService from 'consul-ui/services/repository';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'session';
 export default class SessionService extends RepositoryService {
@@ -10,21 +11,18 @@ export default class SessionService extends RepositoryService {
     return modelName;
   }
 
-  findByNode(node, dc, nspace, configuration = {}) {
-    const query = {
-      id: node,
-      dc: dc,
-      ns: nspace,
-    };
+  @dataSource('/:ns/:dc/sessions/for-node/:id')
+  findByNode(params, configuration = {}) {
     if (typeof configuration.cursor !== 'undefined') {
-      query.index = configuration.cursor;
-      query.uri = configuration.uri;
+      params.index = configuration.cursor;
+      params.uri = configuration.uri;
     }
-    return this.store.query(this.getModelName(), query);
+    return this.store.query(this.getModelName(), params);
   }
 
   // TODO: Why Key? Probably should be findBySlug like the others
-  findByKey(slug, dc, nspace) {
+  @dataSource('/:ns/:dc/sessions/for-key/:id')
+  findByKey(params, configuration = {}) {
     return this.findBySlug(...arguments);
   }
 }

--- a/ui/packages/consul-ui/app/services/repository/token.js
+++ b/ui/packages/consul-ui/app/services/repository/token.js
@@ -3,6 +3,7 @@ import { get } from '@ember/object';
 import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/token';
 import statusFactory from 'consul-ui/utils/acls-status';
 import isValidServerErrorFactory from 'consul-ui/utils/http/acl/is-valid-server-error';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const isValidServerError = isValidServerErrorFactory();
 const status = statusFactory(isValidServerError, Promise);
@@ -25,11 +26,13 @@ export default class TokenService extends RepositoryService {
     return status(obj);
   }
 
-  self(secret, dc) {
+  @dataSource('/:ns/:dc/token/self/:secret')
+  self(params) {
+    // TODO: Does this need ns passing through?
     return this.store
       .self(this.getModelName(), {
-        secret: secret,
-        dc: dc,
+        secret: params.secret,
+        dc: params.dc,
       })
       .catch(e => {
         // If we get this 500 RPC error, it means we are a legacy ACL cluster
@@ -37,7 +40,7 @@ export default class TokenService extends RepositoryService {
         if (isValidServerError(e)) {
           return {
             AccessorID: null,
-            SecretID: secret,
+            SecretID: params.secret,
           };
         }
         return Promise.reject(e);
@@ -48,19 +51,19 @@ export default class TokenService extends RepositoryService {
     return this.store.clone(this.getModelName(), get(item, PRIMARY_KEY));
   }
 
-  findByPolicy(id, dc, nspace) {
+  findByPolicy(params) {
     return this.store.query(this.getModelName(), {
-      policy: id,
-      dc: dc,
-      ns: nspace,
+      policy: params.id,
+      dc: params.dc,
+      ns: params.ns,
     });
   }
 
-  findByRole(id, dc, nspace) {
+  findByRole(params) {
     return this.store.query(this.getModelName(), {
-      role: id,
-      dc: dc,
-      ns: nspace,
+      role: params.id,
+      dc: params.dc,
+      ns: params.ns,
     });
   }
 }

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -160,7 +160,8 @@
     "tape": "^5.0.1",
     "text-encoding": "^0.7.0",
     "tippy.js": "^6.2.7",
-    "torii": "^0.10.1"
+    "torii": "^0.10.1",
+    "wayfarer": "^7.0.1"
   },
   "resolutions": {
     "ember-basic-dropdown": "^3.0.10"

--- a/ui/packages/consul-ui/tests/integration/services/repository/acl-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/acl-test.js
@@ -19,7 +19,7 @@ test('findByDatacenter returns the correct data for list endpoint', function(ass
       });
     },
     function performTest(service) {
-      return service.findAllByDatacenter(dc);
+      return service.findAllByDatacenter({ dc });
     },
     function performAssertion(actual, expected) {
       assert.deepEqual(
@@ -47,7 +47,7 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
       return stub(`/v1/acl/info/${id}?dc=${dc}`);
     },
     function performTest(service) {
-      return service.findBySlug(id, dc);
+      return service.findBySlug({ id, dc });
     },
     function performAssertion(actual, expected) {
       assert.deepEqual(

--- a/ui/packages/consul-ui/tests/integration/services/repository/coordinate-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/coordinate-test.js
@@ -24,7 +24,7 @@ test('findAllByDatacenter returns the correct data for list endpoint', function(
       });
     },
     function performTest(service) {
-      return service.findAllByDatacenter(dc);
+      return service.findAllByDatacenter({ dc });
     },
     function performAssertion(actual, expected) {
       assert.deepEqual(
@@ -51,11 +51,11 @@ test('findAllByNode calls findAllByDatacenter with the correct arguments', funct
     cursor: 1,
   };
   const service = this.subject();
-  service.findAllByDatacenter = function(dc, configuration) {
+  service.findAllByDatacenter = function(params, configuration) {
     assert.equal(arguments.length, 2, 'Expected to be called with the correct number of arguments');
-    assert.equal(dc, datacenter);
+    assert.equal(params.dc, datacenter);
     assert.deepEqual(configuration, conf);
     return Promise.resolve([]);
   };
-  return service.findAllByNode('node-name', datacenter, conf);
+  return service.findAllByNode({ node: 'node-name', dc: datacenter }, conf);
 });

--- a/ui/packages/consul-ui/tests/integration/services/repository/discovery-chain-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/discovery-chain-test.js
@@ -18,7 +18,7 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
       });
     },
     function performTest(service) {
-      return service.findBySlug(id, dc);
+      return service.findBySlug({ id, dc });
     },
     function performAssertion(actual, expected) {
       const result = expected(function(payload) {

--- a/ui/packages/consul-ui/tests/integration/services/repository/kv-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/kv-test.js
@@ -23,7 +23,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findAllBySlug(id, dc, nspace || undefinedNspace);
+        return service.findAllBySlug({ id, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(
@@ -51,7 +51,7 @@ const undefinedNspace = 'default';
         return stub(`/v1/kv/${id}?dc=${dc}${typeof nspace !== 'undefined' ? `&ns=${nspace}` : ``}`);
       },
       function(service) {
-        return service.findBySlug(id, dc, nspace || undefinedNspace);
+        return service.findBySlug({ id, dc, ns: nspace || undefinedNspace });
       },
       function(actual, expected) {
         assert.deepEqual(

--- a/ui/packages/consul-ui/tests/integration/services/repository/node-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/node-test.js
@@ -25,7 +25,7 @@ test('findByDatacenter returns the correct data for list endpoint', function(ass
       });
     },
     function performTest(service) {
-      return service.findAllByDatacenter(dc);
+      return service.findAllByDatacenter({ dc });
     },
     function performAssertion(actual, expected) {
       actual.forEach(item => {
@@ -44,7 +44,7 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
       return stub(`/v1/internal/ui/node/${id}?dc=${dc}`);
     },
     function(service) {
-      return service.findBySlug(id, dc);
+      return service.findBySlug({ id, dc });
     },
     function(actual, expected) {
       assert.equal(actual.uid, `["${nspace}","${dc}","${actual.ID}"]`);

--- a/ui/packages/consul-ui/tests/integration/services/repository/policy-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/policy-test.js
@@ -29,7 +29,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findAllByDatacenter(dc, nspace || undefinedNspace);
+        return service.findAllByDatacenter({ dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(
@@ -59,7 +59,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findBySlug(id, dc, nspace || undefinedNspace);
+        return service.findBySlug({ id, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(

--- a/ui/packages/consul-ui/tests/integration/services/repository/role-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/role-test.js
@@ -30,7 +30,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findAllByDatacenter(dc, nspace || undefinedNspace);
+        return service.findAllByDatacenter({ dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(
@@ -61,7 +61,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findBySlug(id, dc, nspace || undefinedNspace);
+        return service.findBySlug({ id, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(

--- a/ui/packages/consul-ui/tests/integration/services/repository/service-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/service-test.js
@@ -33,7 +33,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findGatewayBySlug(gateway, dc, nspace || undefinedNspace, conf);
+        return service.findGatewayBySlug({ gateway, dc, ns: nspace || undefinedNspace }, conf);
       },
       function performAssertion(actual, expected) {
         const result = expected(function(payload) {

--- a/ui/packages/consul-ui/tests/integration/services/repository/session-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/session-test.js
@@ -29,7 +29,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findByNode(id, dc, nspace || undefinedNspace);
+        return service.findByNode({ id, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(
@@ -59,7 +59,7 @@ const undefinedNspace = 'default';
         );
       },
       function(service) {
-        return service.findByKey(id, dc, nspace || undefinedNspace);
+        return service.findByKey({ id, dc, ns: nspace || undefinedNspace });
       },
       function(actual, expected) {
         assert.deepEqual(

--- a/ui/packages/consul-ui/tests/integration/services/repository/token-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/token-test.js
@@ -26,7 +26,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findAllByDatacenter(dc, nspace || undefinedNspace);
+        return service.findAllByDatacenter({ dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(
@@ -57,7 +57,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findBySlug(id, dc, nspace || undefinedNspace);
+        return service.findBySlug({ id, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(
@@ -99,7 +99,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findByPolicy(policy, dc, nspace || undefinedNspace);
+        return service.findByPolicy({ id: policy, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(
@@ -136,7 +136,7 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findByRole(role, dc, nspace || undefinedNspace);
+        return service.findByRole({ id: role, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(

--- a/ui/packages/consul-ui/tests/integration/services/repository/topology-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/topology-test.js
@@ -19,7 +19,7 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
       });
     },
     function performTest(service) {
-      return service.findBySlug(id, kind, dc);
+      return service.findBySlug({ id, kind, dc });
     },
     function performAssertion(actual, expected) {
       const result = expected(function(payload) {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -13354,6 +13354,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
+nanoassert@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-1.1.0.tgz#4f3152e09540fde28c76f44b19bbcd1d5a42478d"
+  integrity sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40=
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -17879,6 +17884,13 @@ watchpack@^1.5.0, watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
+
+wayfarer@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/wayfarer/-/wayfarer-7.0.1.tgz#17a64d351d49f9d3d6c508155867df7658184ce3"
+  integrity sha512-yf+kAlOYnJRjLxflLy+1+xEclb6222EAVvAjSY+Yz2qAIDrXeN5wLl/G302Mwv3E0KMg1HT/WDGsvSymX0U7Rw==
+  dependencies:
+    nanoassert "^1.1.0"
 
 wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
We use a `<DataSource @src={{url}} />` component throughout our UI for when we want to load data from within our components. The URL specified as the `@src` is used to map/lookup what is used in to retrieve data, for example we mostly use our repository methods wrapped with our Promise backed `EventSource` implementation, but DataSource URLs can also be mapped to EventTarget backed `EventSource`s and native `EventSource`s or `WebSockets` if we ever need to use those (for example these are options for potential streaming support with the Consul backend).

The URL to function/method mapping previous to this PR used a very naive humongous `switch` statement which was a temporary 'this is fine for the moment' solution, although we'd always wanted to replace with something more manageable.

Here we add `wayfarer` as a dependency - a very small (1kb), very fast, radix trie based router, and use that to perform the URL to function/method mapping.

This essentially turns every `DataSource` into a very small SPA - change its URL and the view of data changes. When the data itself changes, either the yielded view of data changes or the `onchange` event is fired with the changed data, making the externally sourced view of data completely reactive.

```javascript
// use the new decorator a service somewhere to annotate/decorate
// a method with the URL that can be used to access this method
@dataSource('/:ns/:dc/services')
async findAllByDatacenter(params) {
  // get the data
}

// can use with JS in a route somewhere
async model() {
  return this.data.source(uri => uri`/${nspace}/${dc}/services`)
}
```

```hbs
{{!-- or just straight in a template using the component --}}
<DataSource @src="/default/dc1/services" @onchange="" />
```

We did some investigation as to whether we could use Ember's router/route-recognizer for this but we hit a couple of problems:

1. We need to allow empty URL segments/params, for example for an empty namespace (`//dc-1/services`), it doesn't seem like Ember's Router supports this.
2. There doesn't seem to be a public way to get to Ember's router microlib (route-recognizer), we tried getting to it via private methods and then accessing the constructor of the instantiated instance of Ember's Router, which was all a bit ugh. We also briefly looked at separately depending on `route-recognizer` but this adds 4kb to our dependencies vs 1kb for `wayfarer` which also supports empty segments (see point 1)

Lastly, this probably isn't the final version of this:

We found that as Ember Services aren't statically imported using `import` but instead sourced by ember-cli and only executed on demand, the decorators used in the service aren't executed until you first access the service. So, we have a little bit of a chicken and egg problem - the decorator needs to be executed so we know which Service needs to be accessed, but the decorator isn't executed until you access the Service!

So, for the moment we still require a large list of services injecting into our datasource service in order to execute the decorators. I'm not entirely sure the best way to work around this as yet, but potentially we may still move away from the decorators and end up with a centralized place to configure these, similar to Ember's `router.js` file we use to configure our Ember Routes.

Whichever way we go the overall approach using a router to map URLs to methods will remain the same. 
