### PR TITLE
ui: [BUGFIX] Ensure we show the correct count of instances for each node

### DIFF
--- a/.changelog/9749.txt
+++ b/.changelog/9749.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Exclude proxies when showing the total number of instances on a node.
+```

--- a/ui/packages/consul-ui/app/components/consul/instance-checks/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/instance-checks/index.hbs
@@ -1,4 +1,3 @@
-{{#if (gt @items.length 0)}}
   {{#if (eq this.healthCheck.check 'empty') }}
     <dl class={{this.healthCheck.check}}>
       <dt>
@@ -29,4 +28,3 @@
     </dl>
     {{/if}}
   {{/if}}
-{{/if}}

--- a/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
@@ -30,7 +30,7 @@ as |item index|>
     <span class="leader" data-test-leader={{@leader.Address}}>Leader</span>
   {{/if}}
     <span>
-      {{format-number item.Services.length}} {{pluralize item.Services.length 'Service' without-count=true}}
+      {{format-number item.MeshServiceInstances.length}} {{pluralize item.MeshServiceInstances.length 'Service' without-count=true}}
     </span>
     <dl>
       <dt>

--- a/ui/packages/consul-ui/app/models/node.js
+++ b/ui/packages/consul-ui/app/models/node.js
@@ -1,5 +1,6 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
+import { filter } from '@ember/object/computed';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
 
 export const PRIMARY_KEY = 'uid';
@@ -18,8 +19,13 @@ export default class Node extends Model {
   @attr() meta; // {}
   @attr() Meta; // {}
   @attr() TaggedAddresses; // {lan, wan}
+  // Services are reshaped to a different shape to what you sometimes get from
+  // the response, see models/node.js
   @hasMany('service-instance') Services; // TODO: Rename to ServiceInstances
   @fragmentArray('health-check') Checks;
+  // MeshServiceInstances are all instances that aren't connect-proxies this
+  // currently includes gateways as these need to show up in listings
+  @filter('Services', item => item.Service.Kind !== 'connect-proxy') MeshServiceInstances;
 
   @computed('Checks.[]', 'ChecksCritical', 'ChecksPassing', 'ChecksWarning')
   get Status() {

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show/services.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show/services.hbs
@@ -24,7 +24,7 @@
     )
   )
 
-  (reject-by 'Service.Kind' 'connect-proxy' item.Services)
+  item.MeshServiceInstances
 
 as |sort filters items|}}
 <div class="tab-section">


### PR DESCRIPTION
In our node listing page we show the a number for the amount of Service Instances on each node.

<img width="275" alt="Screenshot 2021-02-10 at 15 22 28" src="https://user-images.githubusercontent.com/554604/107530486-d31ad080-6bb3-11eb-9763-998b01892afe.png">

Before this PR, this count included any proxies on the Node, essentially doubling the service count. This was probably correct in a previous version of the UI when we used to show all the proxies across the catalog as well as the services, but since we merged proxies into the services themselves, essentially making the an implementation detail and therefore invisible in the UI, this count should not include proxies.

This PR adds a `MeshServiceInstances` property to the node model, 'mesh' here meaning 'services that have a proxy assigned to them, and therefore not a proxy itself'. We then use this property to show the instance count, meaning we omit proxy instances from the final count.

We also noticed that we weren't showing an 'empty' icon for services where the check count for either service or node checks was zero. So fixed that here also 🐦 🐦 🥧 

This is how consul looks in the node listing after this fix (the consul service only has node checks, no service checks)

<img width="335" alt="Screenshot 2021-02-10 at 15 25 26" src="https://user-images.githubusercontent.com/554604/107530937-402e6600-6bb4-11eb-962a-abefc24d7383.png">

