### PR TITLE
ui: Remove any trailing fullstop/period DNS characters from Gateways UI API

### DIFF
--- a/.changelog/9752.txt
+++ b/.changelog/9752.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Remove trailing periods from the gateway internal HTTP API endpoint
+```

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -454,8 +454,11 @@ func (g *GatewayService) Addresses(defaultHosts []string) []string {
 	}
 
 	var addresses []string
+	// loop through the hosts and format that into domain.name:port format,
+	// ensuring we trim any trailing DNS . characters from the domain name as we
+	// go
 	for _, h := range hosts {
-		addresses = append(addresses, fmt.Sprintf("%s:%d", h, g.Port))
+		addresses = append(addresses, fmt.Sprintf("%s:%d", strings.TrimRight(h, "."), g.Port))
 	}
 	return addresses
 }

--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -663,9 +663,11 @@ func TestGatewayService_Addresses(t *testing.T) {
 			argument: []string{
 				"service.ingress.dc.domain",
 				"service.ingress.dc.alt.domain",
+				"service.ingress.dc.alt.domain.",
 			},
 			expected: []string{
 				"service.ingress.dc.domain:8080",
+				"service.ingress.dc.alt.domain:8080",
 				"service.ingress.dc.alt.domain:8080",
 			},
 		},
@@ -673,13 +675,13 @@ func TestGatewayService_Addresses(t *testing.T) {
 			name: "user-defined hosts",
 			input: GatewayService{
 				Port:  8080,
-				Hosts: []string{"*.test.example.com", "other.example.com"},
+				Hosts: []string{"*.test.example.com", "other.example.com", "other.example.com."},
 			},
 			argument: []string{
 				"service.ingress.dc.domain",
 				"service.ingress.alt.domain",
 			},
-			expected: []string{"*.test.example.com:8080", "other.example.com:8080"},
+			expected: []string{"*.test.example.com:8080", "other.example.com:8080", "other.example.com:8080"},
 		},
 	}
 

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -832,11 +832,13 @@ func TestUIGatewayServiceNodes_Ingress(t *testing.T) {
 	require.Nil(t, err)
 	assertIndex(t, resp)
 
-	// Construct expected addresses so that differences between OSS/Ent are handled by code
-	webDNS := serviceIngressDNSName("web", "dc1", "consul.", structs.DefaultEnterpriseMeta())
-	webDNSAlt := serviceIngressDNSName("web", "dc1", "alt.consul.", structs.DefaultEnterpriseMeta())
-	dbDNS := serviceIngressDNSName("db", "dc1", "consul.", structs.DefaultEnterpriseMeta())
-	dbDNSAlt := serviceIngressDNSName("db", "dc1", "alt.consul.", structs.DefaultEnterpriseMeta())
+	// Construct expected addresses so that differences between OSS/Ent are
+	// handled by code. We specifically don't include the trailing DNS . here as
+	// we are constructing what we are expecting, not the actual value
+	webDNS := serviceIngressDNSName("web", "dc1", "consul", structs.DefaultEnterpriseMeta())
+	webDNSAlt := serviceIngressDNSName("web", "dc1", "alt.consul", structs.DefaultEnterpriseMeta())
+	dbDNS := serviceIngressDNSName("db", "dc1", "consul", structs.DefaultEnterpriseMeta())
+	dbDNSAlt := serviceIngressDNSName("db", "dc1", "alt.consul", structs.DefaultEnterpriseMeta())
 
 	dump := obj.([]*ServiceSummary)
 	expect := []*ServiceSummary{


### PR DESCRIPTION
Previous to this commit, the API response for getting information about the upstreams for a gateway (`/v1/internal/ui/gateway-services-nodes/:gateway`) would include Gateway Addresses in the form `domain.name.:8080`, which due to the addition of the port is probably not the expected format (the trailing `.` is DNS not Address:Port URLs).

This commit rightTrims any `.` characters from the end of the domain before formatting the address to include the port resulting in `domain.name:8080`

One thing I'm unsure of, whilst this 'fixes' things for displaying this in the UI, does this effect anything else backend related? I had a quick search to see is the `.Addresses()` method was being used elsewhere, and I couldn't see anything, but would be good to double check.
