### PR TITLE
http: error if near is used with streaming

### DIFF
--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -219,11 +219,12 @@ func (s *HTTPHandlers) healthServiceNodes(resp http.ResponseWriter, req *http.Re
 		return nil, nil
 	}
 
-	// useStreaming when a blocking query is requested, but not when the near
-	// query parameter is set, because that requires data only available to the server
-	// to sort the results.
-	useStreaming := s.agent.config.UseStreamingBackend && args.MinQueryIndex > 0 && args.Source.Node == ""
+	useStreaming := s.agent.config.UseStreamingBackend && args.MinQueryIndex > 0
 	args.QueryOptions.UseCache = s.agent.config.HTTPUseCache && (args.QueryOptions.UseCache || useStreaming)
+
+	if args.QueryOptions.UseCache && useStreaming && args.Source.Node != "" {
+		return nil, BadRequestError{Reason: "'near' query param can not be used with streaming"}
+	}
 
 	out, md, err := s.agent.rpcClientHealth.ServiceNodes(req.Context(), args)
 	if err != nil {

--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -232,7 +232,9 @@ The table below shows this endpoint's support for
 - `near` `(string: "")` - Specifies a node name to sort the node list in
   ascending order based on the estimated round trip time from that node. Passing
   `?near=_agent` will use the agent's node for the sort. This is specified as
-  part of the URL as a query parameter.
+  part of the URL as a query parameter. **Note** that `near` can not be used if
+  [`use_streaming_backend`](/docs/agent/options#use_streaming_backend)
+  is enabled, because the data is not available to sort the results.
 
 - `tag` `(string: "")` **Deprecated** - Use `filter` with the `Service.Tags` selector instead.
   This parameter will be removed in a future version of Consul.


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/consul/pull/9745#pullrequestreview-587002996

Error instead of silently falling back to blocking queries, also document the limitation.