### PR TITLE
streaming: default rpc.enable_streaming to true

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -822,6 +822,8 @@ func (b *builder) Build() (rt RuntimeConfig, err error) {
 		}
 	}
 
+	serverMode := boolVal(c.ServerMode)
+
 	// ----------------------------------------------------------------
 	// build runtime config
 	//
@@ -1050,7 +1052,7 @@ func (b *builder) Build() (rt RuntimeConfig, err error) {
 		RPCMaxConnsPerClient:        intVal(c.Limits.RPCMaxConnsPerClient),
 		RPCProtocol:                 intVal(c.RPCProtocol),
 		RPCRateLimit:                rate.Limit(float64Val(c.Limits.RPCRate)),
-		RPCConfig:                   consul.RPCConfig{EnableStreaming: boolVal(c.RPC.EnableStreaming)},
+		RPCConfig:                   consul.RPCConfig{EnableStreaming: boolValWithDefault(c.RPC.EnableStreaming, serverMode)},
 		RaftProtocol:                intVal(c.RaftProtocol),
 		RaftSnapshotThreshold:       intVal(c.RaftSnapshotThreshold),
 		RaftSnapshotInterval:        b.durationVal("raft_snapshot_interval", c.RaftSnapshotInterval),
@@ -1074,7 +1076,7 @@ func (b *builder) Build() (rt RuntimeConfig, err error) {
 		SerfBindAddrWAN:             serfBindAddrWAN,
 		SerfPortLAN:                 serfPortLAN,
 		SerfPortWAN:                 serfPortWAN,
-		ServerMode:                  boolVal(c.ServerMode),
+		ServerMode:                  serverMode,
 		ServerName:                  stringVal(c.ServerName),
 		ServerPort:                  serverPort,
 		Services:                    services,

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -179,6 +179,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
 			rt.DataDir = dataDir
+			rt.RPCConfig.EnableStreaming = true
 		},
 		expectedWarnings: []string{"bootstrap = true: do not enable unless necessary"},
 	})
@@ -195,6 +196,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
 			rt.DataDir = dataDir
+			rt.RPCConfig.EnableStreaming = true
 		},
 		expectedWarnings: []string{"bootstrap_expect > 0: expecting 3 servers"},
 	})
@@ -342,6 +344,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ConsulServerHealthInterval = 10 * time.Millisecond
 			rt.GRPCPort = 8502
 			rt.GRPCAddrs = []net.Addr{tcpAddr("127.0.0.1:8502")}
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 	run(t, testCase{
@@ -663,6 +666,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 	run(t, testCase{
@@ -845,6 +849,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
 			rt.DataDir = dataDir
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 	run(t, testCase{
@@ -1851,6 +1856,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.SkipLeaveOnInt = true
 			rt.DataDir = dataDir
+			rt.RPCConfig.EnableStreaming = true
 		},
 		expectedWarnings: []string{"BootstrapExpect is set to 1; this is the same as Bootstrap mode.", "bootstrap = true: do not enable unless necessary"},
 	})
@@ -1867,6 +1873,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.SkipLeaveOnInt = true
 			rt.DataDir = dataDir
+			rt.RPCConfig.EnableStreaming = true
 		},
 		expectedWarnings: []string{
 			`bootstrap_expect = 2: A cluster with 2 servers will provide no failure tolerance. See https://www.consul.io/docs/internals/consensus.html#deployment-table`,
@@ -1886,6 +1893,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.SkipLeaveOnInt = true
 			rt.DataDir = dataDir
+			rt.RPCConfig.EnableStreaming = true
 		},
 		expectedWarnings: []string{
 			`bootstrap_expect is even number: A cluster with an even number of servers does not achieve optimum fault tolerance. See https://www.consul.io/docs/internals/consensus.html#deployment-table`,
@@ -2843,6 +2851,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 	run(t, testCase{
@@ -2870,6 +2879,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 	run(t, testCase{
@@ -2897,6 +2907,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 	run(t, testCase{
@@ -2921,6 +2932,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 	run(t, testCase{
@@ -2949,10 +2961,12 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		json: []string{`{
 			  "use_streaming_backend": true,
+              "rpc": {"enable_streaming": false},
 			  "server": true
 			}`},
 		hcl: []string{`
 			  use_streaming_backend = true
+              rpc { enable_streaming = false }
 			  server = true
 			`},
 		expectedWarnings: []string{"use_streaming_backend = true requires rpc.enable_streaming on servers to work properly"},
@@ -3322,6 +3336,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.LeaveOnTerm = false
 			rt.SkipLeaveOnInt = true
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 
@@ -4497,6 +4512,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ServerMode = true
 			rt.SkipLeaveOnInt = true
 			rt.CertFile = "foo"
+			rt.RPCConfig.EnableStreaming = true
 		},
 	})
 	// UI Config tests

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1832,10 +1832,10 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
 
 - `rpc` configuration for Consul servers.
 
-  - `enable_streaming` ((#rpc_enable_streaming)) (experimental) enables the gRPC subscribe endpoint on a Consul Server. All
+  - `enable_streaming` ((#rpc_enable_streaming)) defaults to true. If set to false it will disable
+    the gRPC subscribe endpoint on a Consul Server. All
     servers in all federated datacenters must have this enabled before any client can use
     [`use_streaming_backend`](#use_streaming_backend).
-    This setting will default to true in a future version of Consul.
 
 - `segment` <EnterpriseAlert inline /> - Equivalent to the [`-segment` command-line flag](#_segment).
 


### PR DESCRIPTION
So that all servers will start the grpc server used by streaming.

Not backporting this, it should only be included in the next release.