### PR TITLE
ui: Use ember-on-resize-modifier to fix bug with sidebar

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/down-lines/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/down-lines/index.hbs
@@ -1,6 +1,5 @@
 {{#if (gt @lines.length 0)}}
   <svg
-    {{on-resize this.getIconPositions }}
     {{did-insert this.getIconPositions}}
     {{did-update this.getIconPositions @lines}}
     viewBox={{concat @view.x ' ' @view.y ' ' @view.width ' ' @view.height}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/down-lines/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/down-lines/index.hbs
@@ -1,7 +1,6 @@
-{{on-window 'resize' (action this.getIconPositions)}}
-
 {{#if (gt @lines.length 0)}}
   <svg
+    {{on-resize this.getIconPositions }}
     {{did-insert this.getIconPositions}}
     {{did-update this.getIconPositions @lines}}
     viewBox={{concat @view.x ' ' @view.y ' ' @view.width ' ' @view.height}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -1,8 +1,7 @@
-{{on-window 'resize' (action this.calculate)}}
-
 <div
-  {{did-insert (action this.calculate)}}
-  {{did-update (action this.calculate) @topology.Upstreams @topology.Downstreams}}
+  {{on-resize this.calculate}}
+  {{did-insert this.calculate}}
+  {{did-update this.calculate @topology.Upstreams @topology.Downstreams}}
   class="topology-container consul-topology-metrics"
 >
 {{#if (gt @topology.Downstreams.length 0)}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -1,7 +1,7 @@
 <div
   {{on-resize this.calculate}}
-  {{did-insert this.calculate}}
-  {{did-update this.calculate @topology.Upstreams @topology.Downstreams}}
+  {{did-insert this.setHeight}}
+  {{did-update this.setHeight @topology.Upstreams @topology.Downstreams}}
   class="topology-container consul-topology-metrics"
 >
 {{#if (gt @topology.Downstreams.length 0)}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -1,11 +1,13 @@
 <div
   {{on-resize this.calculate}}
-  {{did-insert this.setHeight}}
-  {{did-update this.setHeight @topology.Upstreams @topology.Downstreams}}
   class="topology-container consul-topology-metrics"
 >
 {{#if (gt @topology.Downstreams.length 0)}}
-  <div id="downstream-container">
+  <div
+    id="downstream-container"
+    {{did-insert this.setHeight 'downstream-lines'}}
+    {{did-update this.setHeight 'downstream-lines' @topology.Downstreams}}
+  >
     <div>
       <p>{{@dc}}</p>
       <span>
@@ -82,7 +84,11 @@
 {{#if (gt @topology.Upstreams.length 0)}}
   <div id="upstream-column">
   {{#each-in (group-by "Datacenter" @topology.Upstreams) as |dc upstreams|}}
-    <div id="upstream-container">
+    <div
+      id="upstream-container"
+      {{did-insert this.setHeight 'upstream-lines'}}
+      {{did-update this.setHeight 'upstream-lines' @topology.Upstreams}}
+    >
       <p>{{dc}}</p>
     {{#each upstreams as |item|}}
       <TopologyMetrics::Card

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -68,21 +68,10 @@ export default class TopologyMetrics extends Component {
 
   // =actions
   @action
-  setHeight() {
-    if (document.querySelector('#downstream-container')) {
-      const downContainer = document.querySelector('#downstream-container').getBoundingClientRect();
-
-      document
-        .querySelector('#downstream-lines')
-        .setAttribute('style', `height:${downContainer.height}px`);
-    }
-
-    if (document.querySelector('#upstream-container')) {
-      const upContainer = document.querySelector('#upstream-container').getBoundingClientRect();
-
-      document
-        .querySelector('#upstream-lines')
-        .setAttribute('style', `height:${upContainer.height}px`);
+  setHeight(el, item) {
+    if (el) {
+      const container = el.getBoundingClientRect();
+      document.getElementById(`${item[0]}`).setAttribute('style', `height:${container.height}px`);
     }
 
     this.calculate();
@@ -99,8 +88,8 @@ export default class TopologyMetrics extends Component {
     }
 
     // Calculate viewBox dimensions
-    this.downView = document.querySelector('#downstream-lines').getBoundingClientRect();
-    this.upView = document.querySelector('#upstream-lines').getBoundingClientRect();
+    this.downView = document.getElementById('downstream-lines').getBoundingClientRect();
+    this.upView = document.getElementById('upstream-lines').getBoundingClientRect();
 
     // Get Card elements positions
     const downCards = [...document.querySelectorAll('#downstream-container .card')];

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -68,6 +68,27 @@ export default class TopologyMetrics extends Component {
 
   // =actions
   @action
+  setHeight() {
+    if (document.querySelector('#downstream-container')) {
+      const downContainer = document.querySelector('#downstream-container').getBoundingClientRect();
+
+      document
+        .querySelector('#downstream-lines')
+        .setAttribute('style', `height:${downContainer.height}px`);
+    }
+
+    if (document.querySelector('#upstream-container')) {
+      const upContainer = document.querySelector('#upstream-container').getBoundingClientRect();
+
+      document
+        .querySelector('#upstream-lines')
+        .setAttribute('style', `height:${upContainer.height}px`);
+    }
+
+    this.calculate();
+  }
+
+  @action
   calculate() {
     if (this.args.isRemoteDC) {
       this.noMetricsReason = 'Unable to fetch metrics for a remote datacenter';

--- a/ui/packages/consul-ui/app/components/topology-metrics/layout.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/layout.scss
@@ -28,7 +28,6 @@
 #downstream-lines,
 #upstream-lines {
   position: relative;
-  height: 100%;
 }
 #downstream-lines {
   margin-left: -20px;

--- a/ui/packages/consul-ui/app/components/topology-metrics/up-lines/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/up-lines/index.hbs
@@ -1,7 +1,6 @@
-{{on-window 'resize' (action this.getIconPositions)}}
-
 {{#if (gt @lines.length 0)}}
   <svg
+    {{on-resize this.getIconPositions }}
     {{did-insert this.getIconPositions}}
     {{did-update this.getIconPositions @lines}}
     viewBox={{concat @center.x ' ' @view.y ' ' @view.width ' ' @view.height}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/up-lines/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/up-lines/index.hbs
@@ -1,6 +1,5 @@
 {{#if (gt @lines.length 0)}}
   <svg
-    {{on-resize this.getIconPositions }}
     {{did-insert this.getIconPositions}}
     {{did-update this.getIconPositions @lines}}
     viewBox={{concat @center.x ' ' @view.y ' ' @view.width ' ' @view.height}}


### PR DESCRIPTION
🐛 The icons in the Topology View were not positioning themselves in the right place with the sidebar close/open action.

🔧 Use ember-on-resize-modifier to recalculate the positioning of the icons.

