### PR TITLE
ui: Implement fine grained read-only views based on ACLs

### DIFF
--- a/ui/packages/consul-ui/app/abilities/acl.js
+++ b/ui/packages/consul-ui/app/abilities/acl.js
@@ -8,6 +8,7 @@ export default class ACLAbility extends BaseAbility {
   @service('env') env;
 
   resource = 'acl';
+  segmented = false;
 
   get canRead() {
     return this.env.var('CONSUL_ACLS_ENABLED') && super.canRead;

--- a/ui/packages/consul-ui/app/abilities/base.js
+++ b/ui/packages/consul-ui/app/abilities/base.js
@@ -24,7 +24,7 @@ export default class BaseAbility extends Ability {
 
   get canRead() {
     if (typeof this.item !== 'undefined') {
-      const perm = get(this, 'item.Resources').find(item => item.Access === ACCESS_READ);
+      const perm = (get(this, 'item.Resources') || []).find(item => item.Access === ACCESS_READ);
       if (perm) {
         return perm.Allow;
       }
@@ -34,7 +34,7 @@ export default class BaseAbility extends Ability {
 
   get canList() {
     if (typeof this.item !== 'undefined') {
-      const perm = get(this, 'item.Resources').find(item => item.Access === ACCESS_LIST);
+      const perm = (get(this, 'item.Resources') || []).find(item => item.Access === ACCESS_LIST);
       if (perm) {
         return perm.Allow;
       }
@@ -44,7 +44,7 @@ export default class BaseAbility extends Ability {
 
   get canWrite() {
     if (typeof this.item !== 'undefined') {
-      const perm = get(this, 'item.Resources').find(item => item.Access === ACCESS_WRITE);
+      const perm = (get(this, 'item.Resources') || []).find(item => item.Access === ACCESS_WRITE);
       if (perm) {
         return perm.Allow;
       }

--- a/ui/packages/consul-ui/app/abilities/base.js
+++ b/ui/packages/consul-ui/app/abilities/base.js
@@ -1,9 +1,10 @@
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 import { Ability } from 'ember-can';
 
-const ACCESS_READ = 'read';
-const ACCESS_WRITE = 'write';
-const ACCESS_LIST = 'list';
+export const ACCESS_READ = 'read';
+export const ACCESS_WRITE = 'write';
+export const ACCESS_LIST = 'list';
 
 export default class BaseAbility extends Ability {
   @service('repository/permission') permissions;
@@ -14,15 +15,40 @@ export default class BaseAbility extends Ability {
     return this.permissions.generate(this.resource, action);
   }
 
+  generateForSegment(segment) {
+    return [
+      this.permissions.generate(this.resource, ACCESS_READ, segment),
+      this.permissions.generate(this.resource, ACCESS_WRITE, segment),
+    ];
+  }
+
   get canRead() {
+    if (typeof this.item !== 'undefined') {
+      const perm = get(this, 'item.Resources').find(item => item.Access === ACCESS_READ);
+      if (perm) {
+        return perm.Allow;
+      }
+    }
     return this.permissions.has(this.generate(ACCESS_READ));
   }
 
   get canList() {
+    if (typeof this.item !== 'undefined') {
+      const perm = get(this, 'item.Resources').find(item => item.Access === ACCESS_LIST);
+      if (perm) {
+        return perm.Allow;
+      }
+    }
     return this.permissions.has(this.generate(ACCESS_LIST));
   }
 
   get canWrite() {
+    if (typeof this.item !== 'undefined') {
+      const perm = get(this, 'item.Resources').find(item => item.Access === ACCESS_WRITE);
+      if (perm) {
+        return perm.Allow;
+      }
+    }
     return this.permissions.has(this.generate(ACCESS_WRITE));
   }
 

--- a/ui/packages/consul-ui/app/abilities/base.js
+++ b/ui/packages/consul-ui/app/abilities/base.js
@@ -6,6 +6,13 @@ export const ACCESS_READ = 'read';
 export const ACCESS_WRITE = 'write';
 export const ACCESS_LIST = 'list';
 
+// None of the permission inspection here is namespace aware, this is due to
+// the fact that we only have one set of permission from one namespace at one
+// time, therefore all the permissions are relevant to the namespace you are
+// currently in, when you choose a different namespace we refresh the
+// permissions list. This is also fine for permission inspection for single
+// items/models as we only request the permissions for the namespace you are
+// in, we don't need to recheck that namespace here
 export default class BaseAbility extends Ability {
   @service('repository/permission') permissions;
 

--- a/ui/packages/consul-ui/app/abilities/base.js
+++ b/ui/packages/consul-ui/app/abilities/base.js
@@ -16,13 +16,23 @@ export const ACCESS_LIST = 'list';
 export default class BaseAbility extends Ability {
   @service('repository/permission') permissions;
 
+  // the name of the resource used for this ability in the backend, e.g
+  // service, key, operator, node
   resource = '';
+  // whether you can ask the backend for a segment for this resource, e.g. you
+  // can ask for a specific service or KV, but not a specific nspace or token
+  segmented = true;
 
   generate(action) {
     return this.permissions.generate(this.resource, action);
   }
 
   generateForSegment(segment) {
+    // if this ability isn't segmentable just return empty which means we
+    // won't request the permissions/resources form the backend
+    if (!this.segmented) {
+      return [];
+    }
     return [
       this.permissions.generate(this.resource, ACCESS_READ, segment),
       this.permissions.generate(this.resource, ACCESS_WRITE, segment),

--- a/ui/packages/consul-ui/app/abilities/intention.js
+++ b/ui/packages/consul-ui/app/abilities/intention.js
@@ -1,4 +1,5 @@
 import BaseAbility from './base';
+import { get } from '@ember/object';
 
 export default class IntentionAbility extends BaseAbility {
   resource = 'intention';

--- a/ui/packages/consul-ui/app/abilities/intention.js
+++ b/ui/packages/consul-ui/app/abilities/intention.js
@@ -1,5 +1,4 @@
 import BaseAbility from './base';
-import { get } from '@ember/object';
 
 export default class IntentionAbility extends BaseAbility {
   resource = 'intention';

--- a/ui/packages/consul-ui/app/abilities/kv.js
+++ b/ui/packages/consul-ui/app/abilities/kv.js
@@ -1,5 +1,13 @@
-import BaseAbility from './base';
+import BaseAbility, { ACCESS_LIST } from './base';
 
 export default class KVAbility extends BaseAbility {
   resource = 'key';
+
+  generateForSegment(segment) {
+    let resources = super.generateForSegment(segment);
+    if (segment.endsWith('/')) {
+      resources = resources.concat(this.permissions.generate(this.resource, ACCESS_LIST, segment));
+    }
+    return resources;
+  }
 }

--- a/ui/packages/consul-ui/app/abilities/nspace.js
+++ b/ui/packages/consul-ui/app/abilities/nspace.js
@@ -5,6 +5,7 @@ export default class NspaceAbility extends BaseAbility {
   @service('env') env;
 
   resource = 'operator';
+  segmented = false;
 
   get canManage() {
     return this.canCreate;

--- a/ui/packages/consul-ui/app/abilities/service-instance.js
+++ b/ui/packages/consul-ui/app/abilities/service-instance.js
@@ -1,0 +1,5 @@
+import BaseAbility from './base';
+
+export default class ServiceInstanceAbility extends BaseAbility {
+  resource = 'service';
+}

--- a/ui/packages/consul-ui/app/adapters/application.js
+++ b/ui/packages/consul-ui/app/adapters/application.js
@@ -9,7 +9,7 @@ export default class ApplicationAdapter extends Adapter {
   @service('env') env;
 
   formatNspace(nspace) {
-    if (this.env.env('CONSUL_NSPACES_ENABLED')) {
+    if (this.env.var('CONSUL_NSPACES_ENABLED')) {
       return nspace !== '' ? { [NSPACE_QUERY_PARAM]: nspace } : undefined;
     }
   }

--- a/ui/packages/consul-ui/app/adapters/nspace.js
+++ b/ui/packages/consul-ui/app/adapters/nspace.js
@@ -57,28 +57,4 @@ export default class NspaceAdapter extends Adapter {
       DELETE /v1/namespace/${data[SLUG_KEY]}
     `;
   }
-
-  requestForAuthorize(request, { dc, ns, permissions, index }) {
-    return request`
-      POST /v1/internal/acl/authorize?${{ dc, ...this.formatNspace(ns), index }}
-
-      ${permissions}
-    `;
-  }
-
-  authorize(store, type, id, snapshot) {
-    return this.rpc(
-      function(adapter, request, serialized, unserialized) {
-        return adapter.requestForAuthorize(request, serialized, unserialized);
-      },
-      function(serializer, respond, serialized, unserialized) {
-        // Completely skip the serializer here
-        return respond(function(headers, body) {
-          return body;
-        });
-      },
-      snapshot,
-      type.modelName
-    );
-  }
 }

--- a/ui/packages/consul-ui/app/adapters/nspace.js
+++ b/ui/packages/consul-ui/app/adapters/nspace.js
@@ -60,7 +60,7 @@ export default class NspaceAdapter extends Adapter {
 
   requestForAuthorize(request, { dc, ns, permissions, index }) {
     return request`
-      POST /v1/internal/acl/authorize?${{ dc, ns, index }}
+      POST /v1/internal/acl/authorize?${{ dc, ...this.formatNspace(ns), index }}
 
       ${permissions}
     `;

--- a/ui/packages/consul-ui/app/adapters/permission.js
+++ b/ui/packages/consul-ui/app/adapters/permission.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 export default class PermissionAdapter extends Adapter {
   @service('env') env;
 
-  requestForAuthorize(request, { dc, ns, permissions, index }) {
+  requestForAuthorize(request, { dc, ns, permissions = [], index }) {
     // the authorize endpoint is slightly different to all others in that it
     // ignores an ns parameter, but accepts a Namespace property on each
     // resource. Here we hide this different from the rest of the app as

--- a/ui/packages/consul-ui/app/adapters/permission.js
+++ b/ui/packages/consul-ui/app/adapters/permission.js
@@ -1,9 +1,21 @@
 import Adapter from './application';
+import { inject as service } from '@ember/service';
 
 export default class PermissionAdapter extends Adapter {
+  @service('env') env;
+
   requestForAuthorize(request, { dc, ns, permissions, index }) {
+    // the authorize endpoint is slightly different to all others in that it
+    // ignores an ns parameter, but accepts a Namespace property on each
+    // resource. Here we hide this different from the rest of the app as
+    // currently we never need to ask for permissions/resources for mutiple
+    // different namespaces in one call so here we use the ns param and add
+    // this to the resources instead of passing through on the queryParameter
+    if (this.env.var('CONSUL_NSPACES_ENABLED')) {
+      permissions = permissions.map(item => ({ ...item, Namespace: ns }));
+    }
     return request`
-      POST /v1/internal/acl/authorize?${{ dc, ...this.formatNspace(ns), index }}
+      POST /v1/internal/acl/authorize?${{ dc, index }}
 
       ${permissions}
     `;

--- a/ui/packages/consul-ui/app/adapters/permission.js
+++ b/ui/packages/consul-ui/app/adapters/permission.js
@@ -1,0 +1,27 @@
+import Adapter from './application';
+
+export default class PermissionAdapter extends Adapter {
+  requestForAuthorize(request, { dc, ns, permissions, index }) {
+    return request`
+      POST /v1/internal/acl/authorize?${{ dc, ...this.formatNspace(ns), index }}
+
+      ${permissions}
+    `;
+  }
+
+  authorize(store, type, id, snapshot) {
+    return this.rpc(
+      function(adapter, request, serialized, unserialized) {
+        return adapter.requestForAuthorize(request, serialized, unserialized);
+      },
+      function(serializer, respond, serialized, unserialized) {
+        // Completely skip the serializer here
+        return respond(function(headers, body) {
+          return body;
+        });
+      },
+      snapshot,
+      type.modelName
+    );
+  }
+}

--- a/ui/packages/consul-ui/app/components/app-error/index.hbs
+++ b/ui/packages/consul-ui/app/components/app-error/index.hbs
@@ -5,6 +5,6 @@
     </h1>
   </BlockSlot>
   <BlockSlot @name="content">
-    <ErrorState @error={{@error}} @allowLogin={{eq @error.status 403}} />
+    <ErrorState @error={{@error}} @allowLogin={{eq @error.status "403"}} />
   </BlockSlot>
 </AppView>

--- a/ui/packages/consul-ui/app/components/app-error/index.hbs
+++ b/ui/packages/consul-ui/app/components/app-error/index.hbs
@@ -5,6 +5,6 @@
     </h1>
   </BlockSlot>
   <BlockSlot @name="content">
-    <ErrorState @error={{@error}} />
+    <ErrorState @error={{@error}} @allowLogin={{eq @error.status 403}} />
   </BlockSlot>
 </AppView>

--- a/ui/packages/consul-ui/app/components/data-loader/index.hbs
+++ b/ui/packages/consul-ui/app/components/data-loader/index.hbs
@@ -62,10 +62,17 @@
           </Notification>
         {{/yield-slot}}
     </State>
-
-    <YieldSlot @name="loaded">
-      {{yield api}}
-    </YieldSlot>
+    {{#if (eq error.status "403")}}
+      {{#yield-slot name="error"}}
+        {{yield api}}
+      {{else}}
+        <ErrorState @error={{error}} />
+      {{/yield-slot}}
+    {{else}}
+      <YieldSlot @name="loaded">
+        {{yield api}}
+      </YieldSlot>
+    {{/if}}
 
   </State>
 

--- a/ui/packages/consul-ui/app/models/intention.js
+++ b/ui/packages/consul-ui/app/models/intention.js
@@ -27,6 +27,7 @@ export default class Intention extends Model {
   @attr('number') CreateIndex;
   @attr('number') ModifyIndex;
   @attr() Meta; // {}
+  @attr({ defaultValue: () => [] }) Resources; // []
   @fragmentArray('intention-permission') Permissions;
 
   @computed('Meta')

--- a/ui/packages/consul-ui/app/models/kv.js
+++ b/ui/packages/consul-ui/app/models/kv.js
@@ -20,6 +20,7 @@ export default class Kv extends Model {
   @attr('number') CreateIndex;
   @attr('number') ModifyIndex;
   @attr('string') Session;
+  @attr({ defaultValue: () => [] }) Resources; // []
 
   @computed('isFolder')
   get Kind() {

--- a/ui/packages/consul-ui/app/models/node.js
+++ b/ui/packages/consul-ui/app/models/node.js
@@ -18,6 +18,7 @@ export default class Node extends Model {
   @attr() meta; // {}
   @attr() Meta; // {}
   @attr() TaggedAddresses; // {lan, wan}
+  @attr({ defaultValue: () => [] }) Resources; // []
   @hasMany('service-instance') Services; // TODO: Rename to ServiceInstances
   @fragmentArray('health-check') Checks;
 

--- a/ui/packages/consul-ui/app/models/nspace.js
+++ b/ui/packages/consul-ui/app/models/nspace.js
@@ -10,6 +10,7 @@ export default class Nspace extends Model {
 
   @attr('number') SyncTime;
   @attr('string', { defaultValue: () => '' }) Description;
+  @attr({ defaultValue: () => [] }) Resources; // []
   // TODO: Is there some sort of date we can use here
   @attr('string') DeletedAt;
   @attr({

--- a/ui/packages/consul-ui/app/models/permission.js
+++ b/ui/packages/consul-ui/app/models/permission.js
@@ -1,0 +1,8 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Permission extends Model {
+  @attr('string') Resource;
+  @attr('string') Segment;
+  @attr('string') Access;
+  @attr('boolean') Allow;
+}

--- a/ui/packages/consul-ui/app/models/service-instance.js
+++ b/ui/packages/consul-ui/app/models/service-instance.js
@@ -37,6 +37,7 @@ export default class ServiceInstance extends Model {
   @fragmentArray('health-check') Checks;
   @attr('number') SyncTime;
   @attr() meta;
+  @attr({ defaultValue: () => [] }) Resources; // []
 
   // The name is the Name of the Service (the grouping of instances)
   @alias('Service.Service') Name;

--- a/ui/packages/consul-ui/app/models/service.js
+++ b/ui/packages/consul-ui/app/models/service.js
@@ -35,6 +35,7 @@ export default class Service extends Model {
   @attr('number') InstanceCount;
   @attr('boolean') ConnectedWithGateway;
   @attr('boolean') ConnectedWithProxy;
+  @attr({ defaultValue: () => [] }) Resources; // []
   @attr('number') SyncTime;
   @attr('number') CreateIndex;
   @attr('number') ModifyIndex;

--- a/ui/packages/consul-ui/app/models/session.js
+++ b/ui/packages/consul-ui/app/models/session.js
@@ -19,4 +19,5 @@ export default class Session extends Model {
   @attr('number') ModifyIndex;
 
   @attr({ defaultValue: () => [] }) Checks;
+  @attr({ defaultValue: () => [] }) Resources; // []
 }

--- a/ui/packages/consul-ui/app/routes/dc/kv/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/kv/index.js
@@ -36,15 +36,7 @@ export default class IndexRoute extends Route {
       return hash({
         ...model,
         ...{
-          items: this.repo.findAllBySlug(get(model.parent, 'Key'), dc, nspace).catch(e => {
-            const status = get(e, 'errors.firstObject.status');
-            switch (status) {
-              case '403':
-                return this.transitionTo('dc.acls.tokens');
-              default:
-                return this.transitionTo('dc.kv.index');
-            }
-          }),
+          items: this.repo.findAllBySlug(get(model.parent, 'Key'), dc, nspace),
         },
       });
     });
@@ -55,7 +47,8 @@ export default class IndexRoute extends Route {
     if (e.errors && e.errors[0] && e.errors[0].status == '404') {
       return this.transitionTo('dc.kv.index');
     }
-    throw e;
+    // let the route above handle the error
+    return true;
   }
 
   setupController(controller, model) {

--- a/ui/packages/consul-ui/app/serializers/permission.js
+++ b/ui/packages/consul-ui/app/serializers/permission.js
@@ -1,0 +1,3 @@
+import Serializer from './application';
+
+export default class PermissionSerializer extends Serializer {}

--- a/ui/packages/consul-ui/app/services/repository/discovery-chain.js
+++ b/ui/packages/consul-ui/app/services/repository/discovery-chain.js
@@ -19,7 +19,7 @@ export default class DiscoveryChainService extends RepositoryService {
     }
     return super.findBySlug(...arguments).catch(e => {
       const code = get(e, 'errors.firstObject.status');
-      const body = get(e, 'errors.firstObject.detail').trim();
+      const body = (get(e, 'errors.firstObject.detail') || '').trim();
       switch (code) {
         case '500':
           if (datacenter !== null && body.endsWith(ERROR_MESH_DISABLED)) {

--- a/ui/packages/consul-ui/app/services/repository/intention.js
+++ b/ui/packages/consul-ui/app/services/repository/intention.js
@@ -32,6 +32,17 @@ export default class IntentionRepository extends RepositoryService {
     return this.managedByCRDs;
   }
 
+  // legacy intentions are strange that in order to read/write you need access
+  // to either/or the destination or source
+  async authorizeBySlug(cb, access, slug, dc, nspace) {
+    const [, source, , destination] = slug.split(':');
+    const ability = this.permissions.abilityFor(this.getModelName());
+    const permissions = ability
+      .generateForSegment(source)
+      .concat(ability.generateForSegment(destination));
+    return this.authorizeByPermissions(cb, permissions, access, dc, nspace);
+  }
+
   async persist(obj) {
     const res = await super.persist(...arguments);
     // if Action is set it means we are an l4 type intention

--- a/ui/packages/consul-ui/app/services/repository/kv.js
+++ b/ui/packages/consul-ui/app/services/repository/kv.js
@@ -2,8 +2,7 @@ import RepositoryService from 'consul-ui/services/repository';
 import isFolder from 'consul-ui/utils/isFolder';
 import { get } from '@ember/object';
 import { PRIMARY_KEY } from 'consul-ui/models/kv';
-import HTTPError from 'consul-ui/utils/http/error';
-import { ACCESS_READ, ACCESS_LIST } from 'consul-ui/abilities/base';
+import { ACCESS_LIST } from 'consul-ui/abilities/base';
 
 const modelName = 'kv';
 export default class KvService extends RepositoryService {

--- a/ui/packages/consul-ui/app/services/repository/kv.js
+++ b/ui/packages/consul-ui/app/services/repository/kv.js
@@ -2,6 +2,7 @@ import RepositoryService from 'consul-ui/services/repository';
 import isFolder from 'consul-ui/utils/isFolder';
 import { get } from '@ember/object';
 import { PRIMARY_KEY } from 'consul-ui/models/kv';
+import HTTPError from 'consul-ui/utils/http/error';
 
 const modelName = 'kv';
 export default class KvService extends RepositoryService {

--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -130,6 +130,11 @@ export default class PermissionService extends RepositoryService {
     }
 
     const resources = ability.generateForSegment(segment.toString());
+    // if we get no resources for a segment it means that this
+    // ability/permission isn't segmentable
+    if (resources.length === 0) {
+      return [];
+    }
     return this.authorize(resources, dc, nspace);
   }
 

--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -1,6 +1,7 @@
 import RepositoryService from 'consul-ui/services/repository';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { runInDebug } from '@ember/debug';
 
 const modelName = 'permission';
 // The set of permissions/resources required globally by the UI in order to
@@ -76,6 +77,10 @@ export default class PermissionService extends RepositoryService {
     return this._can.can(can);
   }
 
+  abilityFor(str) {
+    return this._can.abilityFor(str);
+  }
+
   generate(resource, action, segment) {
     const req = {
       Resource: resource,
@@ -109,6 +114,7 @@ export default class PermissionService extends RepositoryService {
           permissions: resources,
         });
       } catch (e) {
+        runInDebug(() => console.error(e));
         // passthrough
       }
       return permissions;
@@ -127,8 +133,12 @@ export default class PermissionService extends RepositoryService {
     return this.authorize(resources, dc, nspace);
   }
 
+  async findByPermissions(resources, dc, nspace) {
+    return this.authorize(resources, dc, nspace);
+  }
+
   async findAll(dc, nspace) {
-    this.permissions = await this.authorize(REQUIRED_PERMISSIONS, dc, nspace);
+    this.permissions = await this.findByPermissions(REQUIRED_PERMISSIONS, dc, nspace);
     return this.permissions;
   }
 }

--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -115,7 +115,7 @@ export default class PermissionService extends RepositoryService {
     }
   }
 
-  async findBySlug(dc, nspace, model, segment) {
+  async findBySlug(segment, model, dc, nspace) {
     let ability;
     try {
       ability = this._can.abilityFor(model);

--- a/ui/packages/consul-ui/app/services/repository/service-instance.js
+++ b/ui/packages/consul-ui/app/services/repository/service-instance.js
@@ -19,7 +19,7 @@ export default class ServiceInstanceService extends RepositoryService {
       query.index = configuration.cursor;
       query.uri = configuration.uri;
     }
-    return this.store.query(this.getModelName(), query);
+    return this.addResources(() => this.store.query(this.getModelName(), query), slug, dc, nspace);
   }
 
   async findBySlug(serviceId, node, service, dc, nspace, configuration = {}) {
@@ -34,7 +34,12 @@ export default class ServiceInstanceService extends RepositoryService {
       query.index = configuration.cursor;
       query.uri = configuration.uri;
     }
-    return this.store.queryRecord(this.getModelName(), query);
+    return this.addResources(
+      () => this.store.queryRecord(this.getModelName(), query),
+      service,
+      dc,
+      nspace
+    );
   }
 
   async findProxyBySlug(serviceId, node, service, dc, nspace, configuration = {}) {

--- a/ui/packages/consul-ui/app/services/repository/service-instance.js
+++ b/ui/packages/consul-ui/app/services/repository/service-instance.js
@@ -1,6 +1,7 @@
 import RepositoryService from 'consul-ui/services/repository';
 import { inject as service } from '@ember/service';
 import { set } from '@ember/object';
+import { ACCESS_READ } from 'consul-ui/abilities/base';
 
 const modelName = 'service-instance';
 export default class ServiceInstanceService extends RepositoryService {
@@ -19,7 +20,13 @@ export default class ServiceInstanceService extends RepositoryService {
       query.index = configuration.cursor;
       query.uri = configuration.uri;
     }
-    return this.addResources(() => this.store.query(this.getModelName(), query), slug, dc, nspace);
+    return this.authorizeBySlug(
+      async () => this.store.query(this.getModelName(), query),
+      ACCESS_READ,
+      slug,
+      dc,
+      nspace
+    );
   }
 
   async findBySlug(serviceId, node, service, dc, nspace, configuration = {}) {
@@ -34,8 +41,9 @@ export default class ServiceInstanceService extends RepositoryService {
       query.index = configuration.cursor;
       query.uri = configuration.uri;
     }
-    return this.addResources(
-      () => this.store.queryRecord(this.getModelName(), query),
+    return this.authorizeBySlug(
+      async () => this.store.queryRecord(this.getModelName(), query),
+      ACCESS_READ,
       service,
       dc,
       nspace

--- a/ui/packages/consul-ui/app/services/store.js
+++ b/ui/packages/consul-ui/app/services/store.js
@@ -63,8 +63,8 @@ export default class StoreService extends Store {
     });
   }
 
-  // TODO: This one is only for nspaces and OIDC, should fail nicely if you call it
-  // for anything other than nspaces/OIDC for good DX
+  // TODO: This one is only for permissions and OIDC, should fail nicely if you call it
+  // for anything other than permissions/OIDC for good DX
   authorize(modelName, query = {}) {
     const adapter = this.adapterFor(modelName);
     const serializer = this.serializerFor(modelName);

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
@@ -18,6 +18,13 @@
           This node no longer exists in the catalog.
         </p>
       </Notification>
+    {{else if (eq loader.error.status "403")}}
+      <Notification @sticky={{true}}>
+        <p data-notification role="alert" class="error notification-update">
+          <strong>Error!</strong>
+          You no longer have access to this service
+        </p>
+      </Notification>
     {{else}}
       <Notification @sticky={{true}}>
         <p data-notification role="alert" class="warning notification-update">

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
@@ -22,7 +22,7 @@
       <Notification @sticky={{true}}>
         <p data-notification role="alert" class="error notification-update">
           <strong>Error!</strong>
-          You no longer have access to this service
+          You no longer have access to this node
         </p>
       </Notification>
     {{else}}

--- a/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
@@ -21,6 +21,13 @@
             This service has been deregistered and no longer exists in the catalog.
           </p>
         </Notification>
+      {{else if (eq loader.error.status "403")}}
+        <Notification @sticky={{true}}>
+          <p data-notification role="alert" class="error notification-update">
+            <strong>Error!</strong>
+            You no longer have access to this service
+          </p>
+        </Notification>
       {{else}}
         <Notification @sticky={{true}}>
           <p data-notification role="alert" class="warning notification-update">

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -22,6 +22,13 @@
             This service has been deregistered and no longer exists in the catalog.
           </p>
         </Notification>
+      {{else if (eq loader.error.status "403")}}
+        <Notification @sticky={{true}}>
+          <p data-notification role="alert" class="error notification-update">
+            <strong>Error!</strong>
+            You no longer have access to this service
+          </p>
+        </Notification>
       {{else}}
         <Notification @sticky={{true}}>
           <p data-notification role="alert" class="warning notification-update">

--- a/ui/packages/consul-ui/tests/acceptance/dc/kvs/edit.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/kvs/edit.feature
@@ -48,6 +48,26 @@ Feature: dc / kvs / edit: KV Viewing
     And I don't see create
     And I don't see ID on the session
     And I see warning on the session
+  Scenario: Viewing a kv with no read access
+    Given 1 datacenter model with the value "datacenter"
+    And 1 kv model from yaml
+    ---
+      Key: key
+    ---
+    And permissions from yaml
+    ---
+    key:
+      write: false
+      read: false
+    ---
+    When I visit the kv page for yaml
+    ---
+      dc: datacenter
+      kv: key
+    ---
+    Then the url should be /datacenter/kv/key/edit
+    And I see status on the error like "403"
+    And a GET request wasn't made to "/v1/kv/key?dc=datacenter"
   # Make sure we can view KVs that have similar names to sections in the UI
   Scenario: I have KV called [Page]
     Given 1 datacenter model with the value "datacenter"

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show.feature
@@ -119,3 +119,44 @@ Feature: dc / services / show: Show Service
     ---
     # The Metrics dashboard should use the Service.Name not the ID
     And I see href on the metricsAnchor like "https://something.com?service-0&dc1"
+  Scenario: With no access to service
+    Given 1 datacenter model with the value "dc1"
+    And permissions from yaml
+    ---
+    service:
+      read: false
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    Then I see status on the error like "403"
+  Scenario: When access is removed from a service
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    And a network latency of 100
+    And permissions from yaml
+    ---
+    service:
+      read: true
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    And I click instances on the tabs
+    And I see 1 instance model
+    Given permissions from yaml
+    ---
+    service:
+      read: false
+    ---
+    # authorization requests are not blocking so we just wait until the next
+    # service blocking query responds
+    Then pause until I see the text "no longer have access" in "[data-notification]"
+    And "[data-notification]" has the "error" class
+    And I see status on the error like "403"
+

--- a/ui/packages/consul-ui/tests/integration/adapters/permission-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/permission-test.js
@@ -13,8 +13,9 @@ module('Integration | Adapter | permission', function(hooks) {
     test('requestForAuthorize returns the correct url/method', function(assert) {
       const adapter = this.owner.lookup('adapter:permission');
       const client = this.owner.lookup('service:client/http');
+      // authorize endpoint doesn't need an ns sending on the query param
       const expected = `POST /v1/internal/acl/authorize?dc=${dc}${
-        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+        shouldHaveNspace(nspace) ? `` : ``
       }`;
       const actual = adapter.requestForAuthorize(client.requestParams.bind(client), {
         dc: dc,

--- a/ui/packages/consul-ui/tests/integration/adapters/permission-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/permission-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { env } from '../../../env';
+const shouldHaveNspace = function(nspace) {
+  return typeof nspace !== 'undefined' && env('CONSUL_NSPACES_ENABLED');
+};
+
+module('Integration | Adapter | permission', function(hooks) {
+  setupTest(hooks);
+  const dc = 'dc-1';
+  const undefinedNspace = 'default';
+  [undefinedNspace, 'team-1', undefined].forEach(nspace => {
+    test('requestForAuthorize returns the correct url/method', function(assert) {
+      const adapter = this.owner.lookup('adapter:permission');
+      const client = this.owner.lookup('service:client/http');
+      const expected = `POST /v1/internal/acl/authorize?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
+      const actual = adapter.requestForAuthorize(client.requestParams.bind(client), {
+        dc: dc,
+        ns: nspace,
+      });
+      assert.equal(`${actual.method} ${actual.url}`, expected);
+    });
+  });
+});

--- a/ui/packages/consul-ui/tests/unit/adapters/permission-test.js
+++ b/ui/packages/consul-ui/tests/unit/adapters/permission-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | permission', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let adapter = this.owner.lookup('adapter:permission');
+    assert.ok(adapter);
+  });
+});

--- a/ui/packages/consul-ui/tests/unit/models/permission-test.js
+++ b/ui/packages/consul-ui/tests/unit/models/permission-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Model | permission', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = run(() => store.createRecord('permission', {}));
+    assert.ok(model);
+  });
+});

--- a/ui/packages/consul-ui/tests/unit/serializers/permission-test.js
+++ b/ui/packages/consul-ui/tests/unit/serializers/permission-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Serializer | permission', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('permission');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let record = store.createRecord('permission', {});
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});

--- a/ui/packages/consul-ui/tests/unit/services/repository/permission-test.js
+++ b/ui/packages/consul-ui/tests/unit/services/repository/permission-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | permission', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:repository/permission');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
This is a continuation of https://github.com/hashicorp/consul/pull/9687 and https://github.com/hashicorp/consul/pull/9706.

This PR performs a pre-request when viewing individual models that may be restricted via `service_prefix`/`key_prefix` etc. If the request tells us that the user doesn't have access to view the individual model, then we don't even make the request to try to fetch it (which would result in a 403 anyway).

If your access is restricted whilst you are viewing a model and we are told that during our blocking queries, then we show a message (similar to when a service is deregistered) but instead of keeping the information in the page, we wipe the page and show you our standard 403 error page (including a link to re-authenticate)

As only certain models require this pre-request check, we've added a `segmented` property to all of our `abilities`, if this property is `false` no check is ever made as the model cannot be 'segmented'/used with `_prefix` (such as ACLs).