### PR TITLE
Docs: Update terminating-gateway-config-entry

### DIFF
--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -9,7 +9,7 @@ description: >-
 
 # Terminating Gateway
 
--> **v1.8.4+:** On Kubernetes, the `ServiceSplitter` custom resource is supported in Consul versions 1.8.4+.<br />
+-> **v1.8.4+:** On Kubernetes, the `TerminatingGateway` custom resource is supported in Consul versions 1.8.4+.<br />
 **v1.8.0+:** On other platforms, this config entry is supported in Consul versions 1.8.0+.
 
 The `terminating-gateway` config entry kind (`TerminatingGateway` on Kubernetes) allows you to configure terminating gateways
@@ -651,10 +651,11 @@ and configure default certificates for mutual TLS. Also override the SNI and CA 
     {
       name: 'Services',
       type: 'array<LinkedService>: <optional>',
-      description: `A list of services to link
+      description: 'A list of services to link
                       with the gateway. The gateway will proxy traffic to these services. These linked services
                       must be registered with Consul for the gateway to discover their addresses. They must also
-                      be registered in the same Consul datacenter as the terminating gateway.`,
+                      be registered in the same Consul datacenter as the terminating gateway. If Consul ACLs are
+                      enabled, the Terminatig Gateway's ACL token must grant `service:write` for all linked services.',
       children: [
         {
           name: 'Name',


### PR DESCRIPTION
fix crds support reference and adding ACL clarification for linked services.