### PR TITLE
ui: Adds a service for Class based service lookup for dataSource decorator

### DIFF
--- a/ui/packages/consul-ui/app/decorators/data-source.js
+++ b/ui/packages/consul-ui/app/decorators/data-source.js
@@ -1,16 +1,15 @@
+import { runInDebug } from '@ember/debug';
 import wayfarer from 'wayfarer';
-import { singularize } from 'ember-inflector';
 
 const router = wayfarer();
+const routes = {};
 export default path => (target, propertyKey, desc) => {
+  runInDebug(() => {
+    routes[path] = { cls: target, method: propertyKey };
+  });
   router.on(path, function(params, owner) {
-    let name;
-    if (params.modelName) {
-      name = singularize(params.modelName);
-    } else {
-      name = target.getModelName.call();
-    }
-    const instance = owner.lookup(`service:repository/${name}`);
+    const container = owner.lookup('service:container');
+    const instance = container.get(target);
     return configuration => desc.value.apply(instance, [params, configuration]);
   });
   return desc;
@@ -18,3 +17,36 @@ export default path => (target, propertyKey, desc) => {
 export const match = path => {
   return router.match(path);
 };
+
+runInDebug(() => {
+  window.DataSourceRoutes = () => {
+    // debug time only way to access the application and be able to lookup
+    // services, don't use ConsulUi global elsewhere!
+    const container = window.ConsulUi.__container__.lookup('service:container');
+    const win = window.open('', '_blank');
+    win.document.write(`
+<body>
+  <pre>
+${Object.entries(routes)
+  .map(([key, value]) => {
+    let cls = container
+      .keyForClass(value.cls)
+      .split('/')
+      .pop();
+    cls = cls
+      .split('-')
+      .map(item => `${item[0].toUpperCase()}${item.substr(1)}`)
+      .join('');
+    return `${key}
+      ${cls}Repository.${value.method}(params)
+
+`;
+  })
+  .join('')}
+  </pre>
+</body>
+    `);
+    win.focus();
+    return;
+  };
+});

--- a/ui/packages/consul-ui/app/instance-initializers/container.js
+++ b/ui/packages/consul-ui/app/instance-initializers/container.js
@@ -1,0 +1,32 @@
+import { runInDebug } from '@ember/debug';
+
+export default {
+  name: 'container',
+  initialize(application) {
+    const container = application.lookup('service:container');
+    // find all the services and add their classes to the container so we can
+    // look instances up by class afterwards as we then resolve the
+    // registration for each of these further down this means that any top
+    // level code for these services is executed, this is most useful for
+    // making sure any annotation type decorators are executed.
+    // For now we only want repositories, so only look for those for the moment
+    let repositories = container
+      .get('container-debug-adapter:main')
+      .catalogEntriesByType('service')
+      .filter(item => item.startsWith('repository/'));
+
+    // during testing we get -test files in here, filter those out but only in debug envs
+    runInDebug(() => (repositories = repositories.filter(item => !item.endsWith('-test'))));
+
+    // 'service' service is not returned by catalogEntriesByType, possibly
+    // related to pods and the service being called 'service':
+    // https://github.com/ember-cli/ember-resolver/blob/c07287af17766bfd3acf390f867fea17686f77d2/addon/resolvers/classic/container-debug-adapter.js#L80
+    // so push it on the end
+    repositories.push('repository/service');
+    //
+    repositories.forEach(item => {
+      const key = `service:${item}`;
+      container.set(key, container.resolveRegistration(key));
+    });
+  },
+};

--- a/ui/packages/consul-ui/app/services/container.js
+++ b/ui/packages/consul-ui/app/services/container.js
@@ -1,0 +1,36 @@
+import Service from '@ember/service';
+
+export default class ContainerService extends Service {
+  constructor(owner) {
+    super(...arguments);
+    this._owner = owner;
+    this._wm = new WeakMap();
+  }
+
+  set(key, value) {
+    this._wm.set(value, key);
+  }
+
+  // vaguely private, used publicly for debugging purposes
+  keyForClass(cls) {
+    return this._wm.get(cls);
+  }
+
+  get(key) {
+    if (typeof key !== 'string') {
+      key = this.keyForClass(key);
+    }
+    return this.lookup(key);
+  }
+
+  lookup(key) {
+    return this._owner.lookup(key);
+  }
+
+  resolveRegistration(key) {
+    // ember resolveRegistration returns an ember flavoured class extending
+    // from the actual class, access the actual class from the
+    // prototype/parent which is what decorators pass through as target
+    return this._owner.resolveRegistration(key).prototype;
+  }
+}

--- a/ui/packages/consul-ui/app/services/data-source/protocols/http.js
+++ b/ui/packages/consul-ui/app/services/data-source/protocols/http.js
@@ -11,6 +11,7 @@ export default class HttpService extends Service {
   @service('repository/service-instance') 'proxy-service-instance';
   @service('repository/proxy') 'proxy-instance';
   @service('repository/nspace') namespaces;
+  @service('repository/metrics') metrics;
   @service('repository/oidc-provider') oidc;
 
   @service('data-source/protocols/http/blocking') type;

--- a/ui/packages/consul-ui/app/services/data-source/protocols/http.js
+++ b/ui/packages/consul-ui/app/services/data-source/protocols/http.js
@@ -2,94 +2,26 @@ import Service, { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 import { getOwner } from '@ember/application';
 import { match } from 'consul-ui/decorators/data-source';
+import { singularize } from 'ember-inflector';
 
 export default class HttpService extends Service {
-  @service('repository/dc')
-  datacenters;
+  @service('repository/dc') datacenters;
+  @service('repository/node') leader;
+  @service('repository/service') gateways;
+  @service('repository/service-instance') 'proxy-service-instance';
+  @service('repository/proxy') 'proxy-instance';
+  @service('repository/nspace') namespaces;
+  @service('repository/oidc-provider') oidc;
 
-  @service('repository/node')
-  nodes;
-
-  @service('repository/node')
-  node;
-
-  @service('repository/node')
-  leader;
-
-  @service('repository/service')
-  gateways;
-
-  @service('repository/service')
-  services;
-
-  @service('repository/service')
-  service;
-
-  @service('repository/service-instance')
-  'service-instance';
-
-  @service('repository/service-instance')
-  'proxy-service-instance';
-
-  @service('repository/service-instance')
-  'service-instances';
-
-  @service('repository/proxy')
-  proxies;
-
-  @service('repository/proxy')
-  'proxy-instance';
-
-  @service('repository/discovery-chain')
-  'discovery-chain';
-
-  @service('repository/topology')
-  topology;
-
-  @service('repository/coordinate')
-  coordinates;
-
-  @service('repository/session')
-  sessions;
-
-  @service('repository/nspace')
-  namespaces;
-
-  @service('repository/intention')
-  intentions;
-
-  @service('repository/intention')
-  intention;
-
-  @service('repository/kv')
-  kv;
-
-  @service('repository/token')
-  token;
-
-  @service('repository/policy')
-  policies;
-
-  @service('repository/policy')
-  policy;
-
-  @service('repository/role')
-  roles;
-
-  @service('repository/oidc-provider')
-  oidc;
-
-  @service('repository/metrics')
-  metrics;
-
-  @service('data-source/protocols/http/blocking')
-  type;
+  @service('data-source/protocols/http/blocking') type;
 
   source(src, configuration) {
     const [, , , model] = src.split('/');
-    const repo = this[model];
+    const owner = getOwner(this);
     const route = match(src);
-    const find = route.cb(route.params, getOwner(this));
+    const find = route.cb(route.params, owner);
+
+    const repo = this[model] || owner.lookup(`service:repository/${singularize(model)}`);
     configuration.createEvent = function(result = {}, configuration) {
       const event = {
         type: 'message',

--- a/ui/packages/consul-ui/app/services/repository.js
+++ b/ui/packages/consul-ui/app/services/repository.js
@@ -3,7 +3,6 @@ import { assert } from '@ember/debug';
 import { typeOf } from '@ember/utils';
 import { get } from '@ember/object';
 import { isChangeset } from 'validated-changeset';
-import dataSource from 'consul-ui/decorators/data-source';
 
 export default class RepositoryService extends Service {
   getModelName() {
@@ -48,7 +47,6 @@ export default class RepositoryService extends Service {
     return this.store.peekRecord(this.getModelName(), id);
   }
 
-  @dataSource('/:ns/:dc/:modelName')
   findAllByDatacenter(params, configuration = {}) {
     if (typeof configuration.cursor !== 'undefined') {
       params.index = configuration.cursor;
@@ -57,7 +55,6 @@ export default class RepositoryService extends Service {
     return this.store.query(this.getModelName(), params);
   }
 
-  @dataSource('/:ns/:dc/:modelName/:id')
   async findBySlug(params, configuration = {}) {
     if (params.id === '') {
       return this.create({

--- a/ui/packages/consul-ui/app/services/repository/node.js
+++ b/ui/packages/consul-ui/app/services/repository/node.js
@@ -7,6 +7,16 @@ export default class NodeService extends RepositoryService {
     return modelName;
   }
 
+  @dataSource('/:ns/:dc/nodes')
+  async findAllByDatacenter() {
+    return super.findAllByDatacenter(...arguments);
+  }
+
+  @dataSource('/:ns/:dc/node/:id')
+  async findBySlug() {
+    return super.findBySlug(...arguments);
+  }
+
   @dataSource('/:ns/:dc/leader')
   findLeader(params, configuration = {}) {
     if (typeof configuration.refresh !== 'undefined') {

--- a/ui/packages/consul-ui/app/services/repository/nspace.js
+++ b/ui/packages/consul-ui/app/services/repository/nspace.js
@@ -38,6 +38,11 @@ export default class NspaceService extends RepositoryService {
     return res;
   }
 
+  @dataSource('/:ns/:dc/namespace/:id')
+  async findBySlug() {
+    return super.findBySlug(...arguments);
+  }
+
   @dataSource('/:ns/:dc/namespaces')
   findAll(params, configuration = {}) {
     const query = {};

--- a/ui/packages/consul-ui/app/services/repository/policy.js
+++ b/ui/packages/consul-ui/app/services/repository/policy.js
@@ -3,6 +3,7 @@ import { get } from '@ember/object';
 import statusFactory from 'consul-ui/utils/acls-status';
 import isValidServerErrorFactory from 'consul-ui/utils/http/acl/is-valid-server-error';
 import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/policy';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const isValidServerError = isValidServerErrorFactory();
 const status = statusFactory(isValidServerError, Promise);
@@ -19,6 +20,16 @@ export default class PolicyService extends RepositoryService {
 
   getSlugKey() {
     return SLUG_KEY;
+  }
+
+  @dataSource('/:ns/:dc/policies')
+  async findAllByDatacenter() {
+    return super.findAllByDatacenter(...arguments);
+  }
+
+  @dataSource('/:ns/:dc/policy/:id')
+  async findBySlug() {
+    return super.findBySlug(...arguments);
   }
 
   status(obj) {

--- a/ui/packages/consul-ui/app/services/repository/role.js
+++ b/ui/packages/consul-ui/app/services/repository/role.js
@@ -2,6 +2,7 @@ import RepositoryService from 'consul-ui/services/repository';
 import statusFactory from 'consul-ui/utils/acls-status';
 import isValidServerErrorFactory from 'consul-ui/utils/http/acl/is-valid-server-error';
 import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/role';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const isValidServerError = isValidServerErrorFactory();
 const status = statusFactory(isValidServerError, Promise);
@@ -18,6 +19,16 @@ export default class RoleService extends RepositoryService {
 
   getSlugKey() {
     return SLUG_KEY;
+  }
+
+  @dataSource('/:ns/:dc/roles')
+  async findAllByDatacenter() {
+    return super.findAllByDatacenter(...arguments);
+  }
+
+  @dataSource('/:ns/:dc/role/:id')
+  async findBySlug() {
+    return super.findBySlug(...arguments);
   }
 
   status(obj) {

--- a/ui/packages/consul-ui/app/services/repository/service.js
+++ b/ui/packages/consul-ui/app/services/repository/service.js
@@ -2,9 +2,14 @@ import RepositoryService from 'consul-ui/services/repository';
 import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'service';
-export default class _RepositoryService extends RepositoryService {
+export default class ServiceService extends RepositoryService {
   getModelName() {
     return modelName;
+  }
+
+  @dataSource('/:ns/:dc/services')
+  async findAllByDatacenter() {
+    return super.findAllByDatacenter(...arguments);
   }
 
   @dataSource('/:ns/:dc/gateways/for-service/:gateway')


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/9746 we added a new `@dataSource` decorator in order to annotate our `EventSource` functions with a URL for access using our `<DataSource />` component, the data then automatically updates live from the backend using our blocking query support:

```javascript
@dataSource('/:ns/:dc/services')
async findAllByDatacenter({ns, dc}) {
   return fetch(`/somewhere?ns=${ns}&dc=${dc}`)
}
```

```hbs
<DataSource @src="/default/dc1/services" @onchange="" />
```

A few potential improvements we thought we could make with that PR revolved around:

1. Ensuring decorators of 'ember resolved' (and therefore auto imported) classes are executed at app boot up.
2. Being able to lookup instances of a class using a DI container. Ember's default container supports string based identifier lookup. This means that we have to either generate an instance manually (losing singleton guarantees?), or figuring our the string identifier based on 'something'. In https://github.com/hashicorp/consul/pull/9746 we used our `getModelName` which despite working only 'worked by accident' and is really used for providing a centralized getter for model names not service names - accidentally both model and service names are generally the same.
3. Providing some debugging functions to aid development experience with an easy way to get a list of DatSource URLs and the functions they call.

This PR provides those improvements by using a new `container` Service to automatically execute/import certain services yet not execute them. This new service also provides a lookup that supports both standard ember DI lookup plus Class based lookup or these specific services. Lastly we also provide another debug function called `DataSourceRoutes()` which can be called from `console` which gives you a list of URLs and their mappings.

Overall this means the only Services we need to inject statically onto our DataSource service are now only the ones that don't have consistent URL/Service names (for example `oidc/` > `oidc-provider`). A last improvement here would be to remove the need to `reconcile` the data within the DataSource service, and at some point in the future we'll probably look to automatically reconcile the data with the backend from within the repositories themselves.

Notes:

We use an ember service called [ContainerDebugAdapter](https://api.emberjs.com/ember/release/classes/ContainerDebugAdapter) in order to inspect and retrieve classes automatically sourced, yet not executed/imported, by ember. This service has the 'debug' word in its name, so we checked to make sure this service exists during production (which it does), and its also publicly documented without mentioning anything about this being stripped from production builds (similar to other debug utilities). Just incase, we also looked into using the `ModuleRegistry` (which this service uses) that provides similar functionality but there didn't seem to be a public way to get to this class.

If using this `ContainerDebugAdapter` is ever problematic, we can see if theres another way to do this, or just hardcode in a list of the service names we want executing (we currently restrict this to execute only our repository classes)

One other worthwhile comment is that we no longer add a `@dataSource` to the abstract repository class for inherited methods, instead you have to override the inherited methods within the child class in order to decorate them with the correct URL, and in fact this is probably clearer to see what is going on, so is probably a positive here.



