### PR TITLE
streaming: fix snapshot cache bug

### DIFF
--- a/.changelog/9772.txt
+++ b/.changelog/9772.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+streaming: fixes a bug caused by caching an incorrect snapshot, that would cause clients
+to error until the cache expired.
+```


### PR DESCRIPTION
Previously a snapshot created as part of a resume-stream request could have incorrectly cached the `newSnapshotToFollow` event. When the next subscribe request was received with `Index=0` the returned snapshot would cause clients to error because they received an unexpected framing event.

Fixed the bug by saving a snapshot without the framing event, then creating a new snapshot to prepend the framing event.