### PR TITLE
docs: remove a couple deprecations

### DIFF
--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -142,9 +142,7 @@ The table below shows this endpoint's support for
   `?near=_agent` will use the agent's node for the sort. This is specified as
   part of the URL as a query parameter.
 
-- `node-meta` `(string: "")` **Deprecated** - Use `filter` with the `Node.Meta` selector instead.
-  This parameter will be removed in a future version of Consul.
-  Specifies a desired node metadata key/value pair
+- `node-meta` `(string: "")` - Specifies a desired node metadata key/value pair
   of the form `key:value`. This parameter can be specified multiple times, and
   will filter the results to nodes with the specified key/value pairs. This is
   specified as part of the URL as a query parameter.
@@ -250,9 +248,7 @@ The table below shows this endpoint's support for
   will filter the results to nodes with the specified key/value pairs. This is
   specified as part of the URL as a query parameter.
 
-- `passing` `(bool: false)` **Deprecated** - Use `filter` with the `Checks.Status` selector instead.
-  This parameter will be removed in a future version of Consul.
-  Specifies that the server should return only nodes
+- `passing` `(bool: false)` - Specifies that the server should return only nodes
   with all checks in the `passing` state. This can be used to avoid additional
   filtering on the client side.
 


### PR DESCRIPTION
These filters can not be reproduced with bexpr just yet.

Meta is not available from node list, so that can't be used to filter.

`passing` requires all checks are passing, where `Checks.Status` requires only a single check to be passing.

We might be able to extend bexpr to make this work, but removing the deprecation until that is possible seems appropriate.