### PR TITLE
[Streaming] Set KnownLeader by default when streaming is activated

### DIFF
--- a/.changelog/9778.txt
+++ b/.changelog/9778.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+streaming: return X-Consul-KnownLeader properly set when using streaming
+```

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -48,7 +48,8 @@ func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
 	empty := &structs.IndexedCheckServiceNodes{
 		Nodes: structs.CheckServiceNodes{},
 		QueryMeta: structs.QueryMeta{
-			Index: 1,
+			Index:       1,
+			KnownLeader: true,
 		},
 	}
 


### PR DESCRIPTION
This is not a real fix but will avoid breaking clients relying on this header

Fix https://github.com/hashicorp/consul/issues/9776

I know the fix is not semantically correct (as we should carry the knowleader with streaming), but don't see how to do it as the data is not carried in anyway with GRPC on updates. Would probably require a refactoring.