### PR TITLE
update changelog and website checks

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -1,0 +1,36 @@
+# This workflow checks that there is either a 'pr/no-changelog' label applied to a PR
+# or there is a .changelog/<pr number>.txt file associated with a PR for a changelog entry
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+    # Runs on PRs to master and all release branches
+    branches:
+      - master
+      - release/*
+
+jobs:
+  # checks that a .changelog entry is present for a PR
+  changelog-check:
+    # If there  a `pr/no-changelog` label we ignore this check
+    if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-changelog')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # by default the checkout action doesn't checkout all branches
+      - name: Check for changelog entry in diff
+        run: |
+          # check if there is a diff in the .changelog directory
+          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" -- .changelog/${{ github.event.pull_request.number }}.txt)
+
+          # If we do not find a file in .changelog/, we fail the check
+          if [ -z "$changelog_files" ]; then
+            # Fail status check when no .changelog entry was found on the PR
+            echo "Did not find a .changelog entry and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/consul/pull/8387."
+            exit 1
+          else
+            echo "Found .changelog entry in PR!"
+          fi

--- a/.github/workflows/pr-file-checker.yml
+++ b/.github/workflows/pr-file-checker.yml
@@ -7,7 +7,7 @@
 # never call any makefiles or scripts. It must never be changed to run any code from the checkout.
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, synchronize, labeled]
     # Runs on PRs to master and all release branches
     branches:
       - master
@@ -17,7 +17,7 @@ jobs:
   # checks that a .changelog entry is present for a PR
   changelog-check:
     # If there  a `pr/no-changelog` label we ignore this check
-    if: "!${{ contains(github.event.pull_request.labels.*.name, 'pr/no-changelog')}}"
+    if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-changelog')"
     runs-on: ubuntu-latest
 
     steps:
@@ -46,7 +46,7 @@ jobs:
   # checks that a 'type/docs-cherrypick' label is attached to PRs with website/ changes
   website-check:
     # If there's a `type/docs-cherrypick` label we ignore this check
-    if: "!${{ contains(github.event.pull_request.labels.*.name, 'type/docs-cherrypick')}}"
+    if: "!contains(github.event.pull_request.labels.*.name, 'type/docs-cherrypick')"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/website-checker.yml
+++ b/.github/workflows/website-checker.yml
@@ -5,44 +5,20 @@
 #
 # All the code checked out in this workflow should be considered untrusted. This workflow must
 # never call any makefiles or scripts. It must never be changed to run any code from the checkout.
+
+# This workflow posts a message to a PR to remind maintainers that there are website/ changes
+# in the PR and if they need to be cherry-picked to the stable-website branch, the
+# 'type/docs-cherrypick' label needs to be applied.
+
 on:
   pull_request_target:
-    types: [opened, synchronize, labeled]
+    types: [opened]
     # Runs on PRs to master and all release branches
     branches:
       - master
       - release/*
 
 jobs:
-  # checks that a .changelog entry is present for a PR
-  changelog-check:
-    # If there  a `pr/no-changelog` label we ignore this check
-    if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-changelog')"
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 # by default the checkout action doesn't checkout all branches
-      - name: Check for changelog entry in diff
-        run: |
-          # check if there is a diff in the .changelog directory
-          changelog_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/${{ github.event.pull_request.base.ref }}")" -- .changelog/)
-
-          # If we do not find a file in .changelog/, we post a comment to the PR
-          if [ -z "$changelog_files" ]; then
-            # post PR comment to GitHub when no .changelog entry was found on PR
-            echo "changelog-check: Did not find a .changelog entry, posting a reminder in the PR"
-            github_message="🤔 Double check that this PR does not require a changelog entry in the \`.changelog\` directory. [Reference](https://github.com/hashicorp/consul/pull/8387)"
-            curl -f -s -H "Authorization: token ${{ secrets.PR_COMMENT_TOKEN }}" \
-                -X POST \
-                -d "{ \"body\": \"${github_message}\"}" \
-                "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"
-          else
-            echo "changelog-check: Found .changelog entry in PR!"
-          fi
-
   # checks that a 'type/docs-cherrypick' label is attached to PRs with website/ changes
   website-check:
     # If there's a `type/docs-cherrypick` label we ignore this check


### PR DESCRIPTION
This PR splits out the `website/` check to only run on PR `opened` while the changelog check runs on `opened`, `synchronize` (new commits) and `labeled` and also changes it to a status check that fails when there is no `pr/no-changelog` label applied nor is there a `.changelog/$pr_number.txt` file. 

I also changed the `on` trigger to be `pull_request` for the changelog check because it no longer needs a token secret to post to the PR so it doesn't need to only run on `pull_request_target`