### PR TITLE
Remove jfrog references

### DIFF
--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,6 +1,6 @@
-FROM hashicorp.jfrog.io/docker/fortio/fortio AS fortio
+FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
 
-FROM hashicorp.jfrog.io/docker/bats/bats:latest
+FROM docker.mirror.hashicorp.services/docker/bats/bats:latest
 
 RUN apk add curl
 RUN apk add openssl

--- a/test/integration/connect/envoy/Dockerfile-consul-envoy
+++ b/test/integration/connect/envoy/Dockerfile-consul-envoy
@@ -3,5 +3,5 @@ ARG ENVOY_VERSION
 
 FROM consul-dev as consul
 
-FROM hashicorp.jfrog.io/docker/envoyproxy/envoy:v${ENVOY_VERSION}
+FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
 COPY --from=consul /bin/consul /bin/consul


### PR DESCRIPTION
This removes all references to `hashicorp.jfrog.io` which has been replaced with a self-hosted registry, `docker.mirror.hashicorp.services`