### PR TITLE
remove reference to docker/ path for old docker mirror

### DIFF
--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,6 +1,6 @@
 FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
 
-FROM docker.mirror.hashicorp.services/docker/bats/bats:latest
+FROM docker.mirror.hashicorp.services/bats/bats:latest
 
 RUN apk add curl
 RUN apk add openssl


### PR DESCRIPTION
Followup to #9782, there was an old lingering `/docker` namespace that we don't need anymore. 