### PR TITLE
ui: Add an optional environment variable to control how testem tests start

### DIFF
--- a/ui/packages/consul-ui/testem.js
+++ b/ui/packages/consul-ui/testem.js
@@ -2,7 +2,8 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: ['Chrome'],
-  launch_in_dev: ['Chrome'],
+  launch_in_dev: ['Chrome', 'Firefox', 'Safari'].includes(process.env.TESTEM_AUTOLAUNCH) ?
+    [process.env.TESTEM_AUTOLAUNCH] : typeof process.env.TESTEM_AUTOLAUNCH === 'undefined' ? ['Chrome'] : [],
   browser_start_timeout: 120,
   browser_args: {
     Chrome: {


### PR DESCRIPTION
Here we look for a TESTEM_AUTOLAUNCH environment variable, which can be
set to either Chrome, Firefox or Safari, which will control which
browser to automatically start when running testem tests.

If the variable is set to anything else, then it will not automatically
start a browser in order to run the tests and you will need to visit the
tests manually. e.g.:

TESTEM_AUTOLAUNCH=0 make test-oss-view

Previously we only ever tested in Chrome and therefore there are no
specific settings for Firefox or Safari. If specific settings are
required for these browsers they can be added at a later date.

