### PR TITLE
state: remove duplicate tableCheck indexes

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -1317,7 +1317,7 @@ func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID st
 
 	// Delete any checks associated with the service. This will invalidate
 	// sessions as necessary.
-	checks, err := catalogChecksForNodeService(tx, nodeName, serviceID, entMeta)
+	checks, err := catalogListServiceChecks(tx, nodeName, serviceID, entMeta)
 	if err != nil {
 		return fmt.Errorf("failed service check lookup: %s", err)
 	}

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -157,11 +157,11 @@ func catalogListChecks(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultItera
 }
 
 func catalogListNodeChecks(tx ReadTxn, node string) (memdb.ResultIterator, error) {
-	return tx.Get("checks", "node_service_check", node, false)
+	return tx.Get("checks", indexNodeServiceCheck, node, false)
 }
 
 func catalogListServiceChecks(tx ReadTxn, node string, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get("checks", "node_service", node, service)
+	return tx.Get("checks", indexNodeService, node, service)
 }
 
 func catalogInsertCheck(tx WriteTxn, chk *structs.HealthCheck, idx uint64) error {
@@ -175,10 +175,6 @@ func catalogInsertCheck(tx WriteTxn, chk *structs.HealthCheck, idx uint64) error
 	}
 
 	return nil
-}
-
-func catalogChecksForNodeService(tx ReadTxn, node string, service string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get("checks", "node_service", node, service)
 }
 
 func validateRegisterRequestTxn(_ ReadTxn, _ *structs.RegisterRequest, _ bool) (*structs.EnterpriseMeta, error) {

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -1,0 +1,26 @@
+// +build !consulent
+
+package state
+
+import "github.com/hashicorp/consul/agent/structs"
+
+func testIndexerTableChecks() map[string]indexerTestCase {
+	return map[string]indexerTestCase{
+		indexNodeService: {
+			read: indexValue{
+				source: NodeServiceQuery{
+					Node:    "NoDe",
+					Service: "SeRvIcE",
+				},
+				expected: []byte("node\x00service\x00"),
+			},
+			write: indexValue{
+				source: &structs.HealthCheck{
+					Node:      "NoDe",
+					ServiceID: "SeRvIcE",
+				},
+				expected: []byte("node\x00service\x00"),
+			},
+		},
+	}
+}

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -17,13 +17,12 @@ const (
 	tableGatewayServices = "gateway-services"
 	tableMeshTopology    = "mesh-topology"
 
-	indexID               = "id"
-	indexServiceName      = "service"
-	indexConnect          = "connect"
-	indexKind             = "kind"
-	indexStatus           = "status"
-	indexNodeServiceCheck = "node_service_check"
-	indexNodeService      = "node_service"
+	indexID          = "id"
+	indexServiceName = "service"
+	indexConnect     = "connect"
+	indexKind        = "kind"
+	indexStatus      = "status"
+	indexNodeService = "node_service"
 )
 
 // nodesTableSchema returns a new table schema used for storing node
@@ -170,37 +169,13 @@ func checksTableSchema() *memdb.TableSchema {
 					Lowercase: true,
 				},
 			},
-			indexNodeServiceCheck: {
-				Name:         indexNodeServiceCheck,
-				AllowMissing: true,
-				Unique:       false,
-				Indexer: &memdb.CompoundIndex{
-					Indexes: []memdb.Indexer{
-						&memdb.StringFieldIndex{
-							Field:     "Node",
-							Lowercase: true,
-						},
-						&memdb.FieldSetIndex{
-							Field: "ServiceID",
-						},
-					},
-				},
-			},
 			indexNodeService: {
 				Name:         indexNodeService,
 				AllowMissing: true,
 				Unique:       false,
-				Indexer: &memdb.CompoundIndex{
-					Indexes: []memdb.Indexer{
-						&memdb.StringFieldIndex{
-							Field:     "Node",
-							Lowercase: true,
-						},
-						&memdb.StringFieldIndex{
-							Field:     "ServiceID",
-							Lowercase: true,
-						},
-					},
+				Indexer: indexerSingle{
+					fromArgsIndexer:   indexFromSingleArg(indexFromNodeServiceQuery),
+					fromObjectIndexer: indexFromObject(indexNodeServiceFromHealthCheck),
 				},
 			},
 		},

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -174,8 +174,8 @@ func checksTableSchema() *memdb.TableSchema {
 				AllowMissing: true,
 				Unique:       false,
 				Indexer: indexerSingle{
-					fromArgsIndexer:   indexFromSingleArg(indexFromNodeServiceQuery),
-					fromObjectIndexer: indexFromObject(indexNodeServiceFromHealthCheck),
+					readIndex:  readIndex(indexFromNodeServiceQuery),
+					writeIndex: writeIndex(indexNodeServiceFromHealthCheck),
 				},
 			},
 		},

--- a/agent/consul/state/indexer.go
+++ b/agent/consul/state/indexer.go
@@ -1,0 +1,94 @@
+package state
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// indexerSingle implements both memdb.Indexer and memdb.SingleIndexer. It may
+// be used in a memdb.IndexSchema to specify functions that generate the index
+// value for memdb.Txn operations.
+type indexerSingle struct {
+	// readIndex is used by memdb for Txn.Get, Txn.First, and other operations
+	// that read data.
+	readIndex
+	// writeIndex is used by memdb for Txn.Insert, Txn.Delete, for operations
+	// that write data to the index.
+	writeIndex
+}
+
+// indexerMulti implements both memdb.Indexer and memdb.MultiIndexer. It may
+// be used in a memdb.IndexSchema to specify functions that generate the index
+// value for memdb.Txn operations.
+type indexerMulti struct {
+	// readIndex is used by memdb for Txn.Get, Txn.First, and other operations
+	// that read data.
+	readIndex
+	// writeIndexMulti is used by memdb for Txn.Insert, Txn.Delete, for operations
+	// that write data to the index.
+	writeIndexMulti
+}
+
+// readIndex implements memdb.Indexer. It exists so that a function can be used
+// to provide the interface.
+//
+// Unlike memdb.Indexer, a readIndex function accepts only a single argument. To
+// generate an index from multiple values, use a struct type with multiple fields.
+type readIndex func(arg interface{}) ([]byte, error)
+
+func (f readIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("index supports only a single arg")
+	}
+	return f(args[0])
+}
+
+var errMissingValueForIndex = fmt.Errorf("object is missing a value for this index")
+
+// writeIndex implements memdb.SingleIndexer. It is used so that a function
+// can be used to provide this interface.
+//
+// Instead of a bool return value, writeIndex expects errMissingValueForIndex to
+// indicate that an index could not be build for the object. It will translate
+// this error into a false value to satisfy the memdb.SingleIndexer interface.
+type writeIndex func(raw interface{}) ([]byte, error)
+
+func (f writeIndex) FromObject(raw interface{}) (bool, []byte, error) {
+	v, err := f(raw)
+	if errors.Is(err, errMissingValueForIndex) {
+		return false, nil, nil
+	}
+	return err == nil, v, err
+}
+
+// writeIndexMulti implements memdb.MultiIndexer. It is used so that a function
+// can be used to provide this interface.
+//
+// Instead of a bool return value, writeIndexMulti expects errMissingValueForIndex to
+// indicate that an index could not be build for the object. It will translate
+// this error into a false value to satisfy the memdb.MultiIndexer interface.
+type writeIndexMulti func(raw interface{}) ([][]byte, error)
+
+func (f writeIndexMulti) FromObject(raw interface{}) (bool, [][]byte, error) {
+	v, err := f(raw)
+	if errors.Is(err, errMissingValueForIndex) {
+		return false, nil, nil
+	}
+	return err == nil, v, err
+}
+
+const null = "\x00"
+
+// indexBuilder is a buffer used to construct memdb index values.
+type indexBuilder bytes.Buffer
+
+// String appends the string and a null terminator to the buffer.
+func (b *indexBuilder) String(v string) {
+	(*bytes.Buffer)(b).WriteString(v)
+	(*bytes.Buffer)(b).WriteString(null)
+}
+
+func (b *indexBuilder) Bytes() []byte {
+	return (*bytes.Buffer)(b).Bytes()
+}

--- a/agent/consul/state/schema_test.go
+++ b/agent/consul/state/schema_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/hashicorp/consul/internal/testing/golden"
 )
 
-func TestStateStoreSchema(t *testing.T) {
+// TODO: once TestNewDBSchema_Indexers has test cases for all tables and indexes
+// it is probably safe to remove this test
+func TestNewDBSchema(t *testing.T) {
 	schema := newDBSchema()
 	require.NoError(t, schema.Validate())
 
@@ -102,4 +104,83 @@ func indexNames(table *memdb.TableSchema) []string {
 
 	sort.Strings(indexes)
 	return indexes
+}
+
+type indexerTestCase struct {
+	read       indexValue
+	write      indexValue
+	prefix     []indexValue
+	writeMulti indexValueMulti
+}
+
+type indexValue struct {
+	source   interface{}
+	expected []byte
+}
+
+type indexValueMulti struct {
+	source   interface{}
+	expected [][]byte
+}
+
+func TestNewDBSchema_Indexers(t *testing.T) {
+	schema := newDBSchema()
+	require.NoError(t, schema.Validate())
+
+	var testcases = map[string]func() map[string]indexerTestCase{
+		tableChecks: testIndexerTableChecks,
+	}
+
+	for _, table := range schema.Tables {
+		if testcases[table.Name] == nil {
+			continue
+		}
+		t.Run(table.Name, func(t *testing.T) {
+			tableTCs := testcases[table.Name]()
+
+			for _, index := range table.Indexes {
+				t.Run(index.Name, func(t *testing.T) {
+					indexer := index.Indexer
+					tc, ok := tableTCs[index.Name]
+					if !ok {
+						t.Skip("TODO: missing test case")
+					}
+
+					args := []interface{}{tc.read.source}
+					if s, ok := tc.read.source.([]interface{}); ok {
+						// Indexes using memdb.CompoundIndex must be expanded to multiple args
+						args = s
+					}
+
+					actual, err := indexer.FromArgs(args...)
+					require.NoError(t, err)
+					require.Equal(t, tc.read.expected, actual)
+
+					if i, ok := indexer.(memdb.SingleIndexer); ok {
+						valid, actual, err := i.FromObject(tc.write.source)
+						require.NoError(t, err)
+						require.True(t, valid)
+						require.Equal(t, tc.write.expected, actual)
+					}
+
+					if i, ok := indexer.(memdb.PrefixIndexer); ok {
+						for _, c := range tc.prefix {
+							t.Run("", func(t *testing.T) {
+								actual, err := i.PrefixFromArgs(c.source)
+								require.NoError(t, err)
+								require.Equal(t, c.expected, actual)
+							})
+						}
+					}
+
+					if i, ok := indexer.(memdb.MultiIndexer); ok {
+						valid, actual, err := i.FromObject(tc.writeMulti.source)
+						require.NoError(t, err)
+						require.True(t, valid)
+						require.Equal(t, tc.writeMulti.expected, actual)
+					}
+				})
+			}
+		})
+	}
 }

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -52,9 +52,7 @@ table=checks
   index=node allow-missing
     indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=Node Lowercase=true
   index=node_service allow-missing
-    indexer=github.com/hashicorp/go-memdb.CompoundIndex Indexes=[github.com/hashicorp/go-memdb.StringFieldIndex Field=Node Lowercase=true, github.com/hashicorp/go-memdb.StringFieldIndex Field=ServiceID Lowercase=true] AllowMissing=false
-  index=node_service_check allow-missing
-    indexer=github.com/hashicorp/go-memdb.CompoundIndex Indexes=[github.com/hashicorp/go-memdb.StringFieldIndex Field=Node Lowercase=true, github.com/hashicorp/go-memdb.FieldSetIndex Field=ServiceID] AllowMissing=false
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle fromArgsIndexer=github.com/hashicorp/consul/agent/consul/state.indexFromSingleArg.func1 fromObjectIndexer=github.com/hashicorp/consul/agent/consul/state.indexNodeServiceFromHealthCheck
   index=service allow-missing
     indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=ServiceName Lowercase=true
   index=status

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -52,7 +52,7 @@ table=checks
   index=node allow-missing
     indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=Node Lowercase=true
   index=node_service allow-missing
-    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle fromArgsIndexer=github.com/hashicorp/consul/agent/consul/state.indexFromSingleArg.func1 fromObjectIndexer=github.com/hashicorp/consul/agent/consul/state.indexNodeServiceFromHealthCheck
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromNodeServiceQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexNodeServiceFromHealthCheck
   index=service allow-missing
     indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=ServiceName Lowercase=true
   index=status


### PR DESCRIPTION
This PR uses a new pattern (see `agent/consul/state/indexer.go`) for defining memdb indexes in the state store.

By using this pattern we are able to remove one of the indexes on the check table. The generic index did not behave the way we wanted, which forced us to create a second index. Now we can use a single index because we add the blank string value as part of the index.

Since each section of the index is null terminated, there is no ambiguity. Node checks will have two sequential null bytes at the end, but that is ok.

This PR also makes the new function signature for indexFromObject match that of indexFromQuery by using errors as values. This will allow us to use the same function for both sets of operations (queries and insert/delete).

It also adds an indexBuilder which can be used instead of a bytes.Buffer to add null terminators, and makes the index building a little less verbose.