### PR TITLE
ui: Update authorization things to use new DataSource decorator/params interface

### DIFF
--- a/ui/packages/consul-ui/app/adapters/permission.js
+++ b/ui/packages/consul-ui/app/adapters/permission.js
@@ -4,20 +4,20 @@ import { inject as service } from '@ember/service';
 export default class PermissionAdapter extends Adapter {
   @service('env') env;
 
-  requestForAuthorize(request, { dc, ns, permissions = [], index }) {
+  requestForAuthorize(request, { dc, ns, resources = [], index }) {
     // the authorize endpoint is slightly different to all others in that it
     // ignores an ns parameter, but accepts a Namespace property on each
     // resource. Here we hide this different from the rest of the app as
-    // currently we never need to ask for permissions/resources for mutiple
+    // currently we never need to ask for permissions/resources for multiple
     // different namespaces in one call so here we use the ns param and add
     // this to the resources instead of passing through on the queryParameter
     if (this.env.var('CONSUL_NSPACES_ENABLED')) {
-      permissions = permissions.map(item => ({ ...item, Namespace: ns }));
+      resources = resources.map(item => ({ ...item, Namespace: ns }));
     }
     return request`
       POST /v1/internal/acl/authorize?${{ dc, index }}
 
-      ${permissions}
+      ${resources}
     `;
   }
 

--- a/ui/packages/consul-ui/app/routes/dc.js
+++ b/ui/packages/consul-ui/app/routes/dc.js
@@ -43,7 +43,10 @@ export default class DcRoute extends Route {
       app.nspaces.length > 1 ? findActiveNspace(app.nspaces, nspace) : app.nspaces.firstObject;
 
     // When disabled nspaces is [], so nspace is undefined
-    const permissions = await this.permissionsRepo.findAll(params.dc, get(nspace || {}, 'Name'));
+    const permissions = await this.permissionsRepo.findAll({
+      dc: params.dc,
+      nspace: get(nspace || {}, 'Name'),
+    });
     return {
       dc,
       nspace,
@@ -79,7 +82,10 @@ export default class DcRoute extends Route {
       const controller = this.controllerFor('application');
       Promise.all([
         this.nspacesRepo.findAll(),
-        this.permissionsRepo.findAll(get(controller, 'dc.Name'), get(controller, 'nspace.Name')),
+        this.permissionsRepo.findAll({
+          dc: get(controller, 'dc.Name'),
+          nspace: get(controller, 'nspace.Name'),
+        }),
       ]).then(([nspaces, permissions]) => {
         if (typeof controller !== 'undefined') {
           controller.setProperties({

--- a/ui/packages/consul-ui/app/routes/dc/acls/auth-methods/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/auth-methods/index.js
@@ -22,10 +22,10 @@ export default class IndexRoute extends Route {
   model(params) {
     return hash({
       ...this.repo.status({
-        items: this.repo.findAllByDatacenter(
-          this.modelFor('dc').dc.Name,
-          this.modelFor('nspace').nspace.substr(1)
-        ),
+        items: this.repo.findAllByDatacenter({
+          dc: this.modelFor('dc').dc.Name,
+          ns: this.modelFor('nspace').nspace.substr(1),
+        }),
       }),
       searchProperties: this.queryParams.searchproperty.empty[0],
     });

--- a/ui/packages/consul-ui/app/services/repository/auth-method.js
+++ b/ui/packages/consul-ui/app/services/repository/auth-method.js
@@ -2,6 +2,7 @@ import RepositoryService from 'consul-ui/services/repository';
 import statusFactory from 'consul-ui/utils/acls-status';
 import isValidServerErrorFactory from 'consul-ui/utils/http/acl/is-valid-server-error';
 import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/auth-method';
+import dataSource from 'consul-ui/decorators/data-source';
 
 const isValidServerError = isValidServerErrorFactory();
 const status = statusFactory(isValidServerError, Promise);
@@ -18,6 +19,16 @@ export default class AuthMethodService extends RepositoryService {
 
   getSlugKey() {
     return SLUG_KEY;
+  }
+
+  @dataSource('/:ns/:dc/auth-methods')
+  async findAllByDatacenter() {
+    return super.findAllByDatacenter(...arguments);
+  }
+
+  @dataSource('/:ns/:dc/auth-method/:id')
+  async findBySlug() {
+    return super.findBySlug(...arguments);
   }
 
   status(obj) {

--- a/ui/packages/consul-ui/app/services/repository/intention.js
+++ b/ui/packages/consul-ui/app/services/repository/intention.js
@@ -35,13 +35,13 @@ export default class IntentionRepository extends RepositoryService {
 
   // legacy intentions are strange that in order to read/write you need access
   // to either/or the destination or source
-  async authorizeBySlug(cb, access, slug, dc, nspace) {
-    const [, source, , destination] = slug.split(':');
+  async authorizeBySlug(cb, access, params) {
+    const [, source, , destination] = params.id.split(':');
     const ability = this.permissions.abilityFor(this.getModelName());
-    const permissions = ability
+    params.resources = ability
       .generateForSegment(source)
       .concat(ability.generateForSegment(destination));
-    return this.authorizeByPermissions(cb, permissions, access, dc, nspace);
+    return this.authorizeByPermissions(cb, access, params);
   }
 
   async persist(obj) {
@@ -67,12 +67,12 @@ export default class IntentionRepository extends RepositoryService {
     return super.findBySlug(...arguments);
   }
 
-  @dataSource('/:ns/:dc/intentions/for-service/:slug')
+  @dataSource('/:ns/:dc/intentions/for-service/:id')
   async findByService(params, configuration = {}) {
     const query = {
       dc: params.dc,
       nspace: params.nspace,
-      filter: `SourceName == "${params.slug}" or DestinationName == "${params.slug}" or SourceName == "*" or DestinationName == "*"`,
+      filter: `SourceName == "${params.id}" or DestinationName == "${params.id}" or SourceName == "*" or DestinationName == "*"`,
     };
     if (typeof configuration.cursor !== 'undefined') {
       query.index = configuration.cursor;

--- a/ui/packages/consul-ui/app/services/repository/kv.js
+++ b/ui/packages/consul-ui/app/services/repository/kv.js
@@ -22,7 +22,7 @@ export default class KvService extends RepositoryService {
       // we only use findBySlug for a folder when we are looking to create a
       // parent for a key for retriveing something Model shaped. Therefore we
       // only use existing records or a fake record with the correct Key,
-      // which means we don't need to inpsect permissions as its an already
+      // which means we don't need to inspect permissions as its an already
       // existing KV or a fake one
 
       // TODO: This very much shouldn't be here,
@@ -38,11 +38,9 @@ export default class KvService extends RepositoryService {
         });
       }
       return item;
+    } else {
+      return super.findBySlug(...arguments);
     }
-    if (typeof configuration.cursor !== 'undefined') {
-      params.index = configuration.cursor;
-    }
-    return this.store.queryRecord(this.getModelName(), params);
   }
 
   // this one only gives you keys
@@ -76,9 +74,7 @@ export default class KvService extends RepositoryService {
         return items.filter(item => params.id !== get(item, 'Key'));
       },
       ACCESS_LIST,
-      params.id,
-      params.dc,
-      params.nspace
+      params
     );
   }
 }

--- a/ui/packages/consul-ui/app/services/repository/service-instance.js
+++ b/ui/packages/consul-ui/app/services/repository/service-instance.js
@@ -20,9 +20,7 @@ export default class ServiceInstanceService extends RepositoryService {
     return this.authorizeBySlug(
       async () => this.store.query(this.getModelName(), params),
       ACCESS_READ,
-      params.id,
-      params.dc,
-      params.nspace
+      params
     );
   }
 
@@ -35,9 +33,7 @@ export default class ServiceInstanceService extends RepositoryService {
     return this.authorizeBySlug(
       async () => this.store.queryRecord(this.getModelName(), params),
       ACCESS_READ,
-      params.id,
-      params.dc,
-      params.nspace
+      params
     );
   }
 

--- a/ui/packages/consul-ui/tests/integration/services/repository/auth-method-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/auth-method-test.js
@@ -25,7 +25,10 @@ const undefinedNspace = 'default';
         );
       },
       function performTest(service) {
-        return service.findAllByDatacenter(dc, nspace || undefinedNspace);
+        return service.findAllByDatacenter({
+          dc: dc,
+          nspace: nspace || undefinedNspace,
+        });
       },
       function performAssertion(actual, expected) {
         assert.deepEqual(


### PR DESCRIPTION
In a parallel timescale to https://github.com/hashicorp/consul/pull/9746 we added auth-methods and a new set of methods for authorization within repositories. Now that work is merged we've added the changes required to bring that work up to date with https://github.com/hashicorp/consul/pull/9746 here in a separate PR for keeping things easy to see those specific changes.

Few notes:

1. This mainly moves everything from using multiple arguments to using a params object. Previously we'd preferred multiple arguments to avoid having to remember the names of params/object properties when using the repository methods. Now we have our `@dataSource` decorator, the names of the properties of the `params` object are defined right alongside where they are used, and DataSource usage now uses URIs to 'call' specific methods (along with automatically generated documentation for these URLs). So this now gives us the best of both worlds.
2. The names of methods on repositories are now completely unimportant to the end user, seeing as you call them via URIs.  Additionally now we pass a params object through to the method, names like 'findBySlug' don't quite match up as this could just be 'findOne' or `findById`, the names are now almost unimportant apart from for documentation purposes. So there's likely to be some renaming at some point in the near future.
3. The `repository` approach that we've used from the very beginning of the rebuild of the UI to provide some abstraction over `ember-data` is now completely decoupled from the rest of the app. Our self-documenting DataSource usage and their URI based data/resource identification/retrieval means that the app could be completely unaware of the concept of 'repositories' and the method names used in order to retrieve data. There is still a little work to move over to DataSources everywhere (mainly within the ACLs area) but this is also likely to be updated to use DataSources in the near future.