### PR TITLE
structs: remove EnterpriseMeta.GetNamespace

### DIFF
--- a/agent/cache-types/streaming_health_services.go
+++ b/agent/cache-types/streaming_health_services.go
@@ -75,7 +75,7 @@ func (c *StreamingHealthServices) Fetch(opts cache.FetchOptions, req cache.Reque
 			Token:      srvReq.Token,
 			Datacenter: srvReq.Datacenter,
 			Index:      index,
-			Namespace:  srvReq.EnterpriseMeta.GetNamespace(),
+			Namespace:  srvReq.EnterpriseMeta.NamespaceOrEmpty(),
 		}
 		if srvReq.Connect {
 			req.Topic = pbsubscribe.Topic_ServiceHealthConnect

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -229,7 +229,7 @@ func requireResultsSame(t *testing.T, want, got *structs.IndexedCheckServiceNode
 // without duplicating the tests.
 func getNamespace(ns string) string {
 	meta := structs.NewEnterpriseMeta(ns)
-	return meta.GetNamespace()
+	return meta.NamespaceOrEmpty()
 }
 
 func TestOrderingConsistentWithMemDb(t *testing.T) {

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -44,7 +44,7 @@ func (e EventPayloadCheckServiceNode) MatchesKey(key, namespace string) bool {
 	if e.overrideKey != "" {
 		name = e.overrideKey
 	}
-	ns := e.Value.Service.EnterpriseMeta.GetNamespace()
+	ns := e.Value.Service.EnterpriseMeta.NamespaceOrDefault()
 	if e.overrideNamespace != "" {
 		ns = e.overrideNamespace
 	}
@@ -315,8 +315,8 @@ func ServiceHealthEventsFromChanges(tx ReadTxn, changes Changes) ([]stream.Event
 					e.Topic = topicServiceHealthConnect
 					payload := e.Payload.(EventPayloadCheckServiceNode)
 					payload.overrideKey = serviceName.Name
-					if gatewayName.EnterpriseMeta.GetNamespace() != serviceName.EnterpriseMeta.GetNamespace() {
-						payload.overrideNamespace = serviceName.EnterpriseMeta.GetNamespace()
+					if gatewayName.EnterpriseMeta.NamespaceOrDefault() != serviceName.EnterpriseMeta.NamespaceOrDefault() {
+						payload.overrideNamespace = serviceName.EnterpriseMeta.NamespaceOrDefault()
 					}
 					e.Payload = payload
 
@@ -339,8 +339,8 @@ func ServiceHealthEventsFromChanges(tx ReadTxn, changes Changes) ([]stream.Event
 				e.Topic = topicServiceHealthConnect
 				payload := e.Payload.(EventPayloadCheckServiceNode)
 				payload.overrideKey = serviceName.Name
-				if gatewayName.EnterpriseMeta.GetNamespace() != serviceName.EnterpriseMeta.GetNamespace() {
-					payload.overrideNamespace = serviceName.EnterpriseMeta.GetNamespace()
+				if gatewayName.EnterpriseMeta.NamespaceOrDefault() != serviceName.EnterpriseMeta.NamespaceOrDefault() {
+					payload.overrideNamespace = serviceName.EnterpriseMeta.NamespaceOrDefault()
 				}
 				e.Payload = payload
 
@@ -470,8 +470,8 @@ func copyEventForService(event stream.Event, service structs.ServiceName) stream
 	event.Topic = topicServiceHealthConnect
 	payload := event.Payload.(EventPayloadCheckServiceNode)
 	payload.overrideKey = service.Name
-	if payload.Value.Service.EnterpriseMeta.GetNamespace() != service.EnterpriseMeta.GetNamespace() {
-		payload.overrideNamespace = service.EnterpriseMeta.GetNamespace()
+	if payload.Value.Service.EnterpriseMeta.NamespaceOrDefault() != service.EnterpriseMeta.NamespaceOrDefault() {
+		payload.overrideNamespace = service.EnterpriseMeta.NamespaceOrDefault()
 	}
 
 	event.Payload = payload

--- a/agent/consul/state/catalog_events_test.go
+++ b/agent/consul/state/catalog_events_test.go
@@ -1666,7 +1666,7 @@ var cmpPartialOrderEvents = cmp.Options{
 			if payload.overrideKey != "" {
 				name = payload.overrideKey
 			}
-			ns := csn.Service.EnterpriseMeta.GetNamespace()
+			ns := csn.Service.EnterpriseMeta.NamespaceOrDefault()
 			if payload.overrideNamespace != "" {
 				ns = payload.overrideNamespace
 			}

--- a/agent/rpc/subscribe/subscribe.go
+++ b/agent/rpc/subscribe/subscribe.go
@@ -95,7 +95,7 @@ func toStreamSubscribeRequest(req *pbsubscribe.SubscribeRequest, entMeta structs
 		Key:       req.Key,
 		Token:     req.Token,
 		Index:     req.Index,
-		Namespace: entMeta.GetNamespace(),
+		Namespace: entMeta.NamespaceOrEmpty(),
 	}
 }
 

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -74,11 +74,6 @@ func (_ *EnterpriseMeta) FillAuthzContext(_ *acl.AuthorizerContext) {}
 
 func (_ *EnterpriseMeta) Normalize() {}
 
-// GetNamespace always returns the empty string.
-func (_ *EnterpriseMeta) GetNamespace() string {
-	return ""
-}
-
 // FillAuthzContext stub
 func (_ *DirEntry) FillAuthzContext(_ *acl.AuthorizerContext) {}
 


### PR DESCRIPTION
I added this recently without realizing that the method already existed and was named NamespaceOrEmpty. Replace all calls to GetNamespace with NamespaceOrEmpty or NamespaceOrDefault as appropriate.