### PR TITLE
docs: Fix code tag displaying on ACL binding rules

### DIFF
--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -56,37 +56,37 @@ The table below shows this endpoint's support for
   - `BindType=service` - The computed bind name value is used as an
     `ACLServiceIdentity.ServiceName` field in the token that is created.
 
-        ```json
-        { ...other fields...
-            "ServiceIdentities": [
-                { "ServiceName": "<computed BindName>" }
-            ]
-        }
-        ```
+    ```json
+    { ...other fields...
+        "ServiceIdentities": [
+            { "ServiceName": "<computed BindName>" }
+        ]
+    }
+    ```
 
   - `BindType=node` - The computed bind name value is used as an
     `ACLNodeIdentity.NodeName` field in the token that is created.
 
-        ```json
-        { ...other fields...
-            "NodeIdentities": [
-                { "NodeName": "<computed BindName>", "Datacenter": "<local datacenter>" }
-            ]
-        }
-        ```
+    ```json
+    { ...other fields...
+        "NodeIdentities": [
+            { "NodeName": "<computed BindName>", "Datacenter": "<local datacenter>" }
+        ]
+    }
+    ```
 
   - `BindType=role` - The computed bind name value is used as a `RoleLink.Name`
     field in the token that is created. This binding rule will only apply if a
     role with the given name exists at login-time. If it does not then this
     rule is ignored.
 
-        ```json
-        { ...other fields...
-            "Roles": [
-                { "Name": "<computed BindName>" }
-            ]
-        }
-        ```
+    ```json
+    { ...other fields...
+        "Roles": [
+            { "Name": "<computed BindName>" }
+        ]
+    }
+    ```
 
 - `BindName` `(string: <required>)` - The name to bind to a token at
   login-time. What it binds to can be adjusted with different values of the
@@ -236,37 +236,37 @@ The table below shows this endpoint's support for
   - `BindType=service` - The computed bind name value is used as an
     `ACLServiceIdentity.ServiceName` field in the token that is created.
 
-        ```json
-        { ...other fields...
-            "ServiceIdentities": [
-                { "ServiceName": "<computed BindName>" }
-            ]
-        }
-        ```
+    ```json
+    { ...other fields...
+        "ServiceIdentities": [
+            { "ServiceName": "<computed BindName>" }
+        ]
+    }
+    ```
 
   - `BindType=node` - The computed bind name value is used as an
     `ACLNodeIdentity.NodeName` field in the token that is created.
 
-        ```json
-        { ...other fields...
-            "NodeIdentities": [
-                { "NodeName": "<computed BindName>", "Datacenter": "<local datacenter>" }
-            ]
-        }
-        ```
+    ```json
+    { ...other fields...
+        "NodeIdentities": [
+            { "NodeName": "<computed BindName>", "Datacenter": "<local datacenter>" }
+        ]
+    }
+    ```
 
   - `BindType=role` - The computed bind name value is used as a `RoleLink.Name`
     field in the token that is created. This binding rule will only apply if a
     role with the given name exists at login-time. If it does not then this
     rule is ignored.
 
-        ```json
-        { ...other fields...
-            "Roles": [
-                { "Name": "<computed BindName>" }
-            ]
-        }
-        ```
+    ```json
+    { ...other fields...
+        "Roles": [
+            { "Name": "<computed BindName>" }
+        ]
+    }
+    ```
 
 - `BindName` `(string: <required>)` - The name to bind to a token at
   login-time. What it binds to can be adjusted with different values of the


### PR DESCRIPTION
Fix indentation of code blocks on ACL binding rules page so that code fence does not display in JSON output.