### PR TITLE
docs/nia: enable and disable subcommand

### DIFF
--- a/website/content/docs/nia/cli/cli-overview.mdx
+++ b/website/content/docs/nia/cli/cli-overview.mdx
@@ -8,11 +8,11 @@ description: >-
 
 # Consul-Terraform-Sync Command (CLI)
 
-Consul-Terraform-Sync is controlled via an easy to use command-line interface (CLI). Consul-Terraform-Sync is only a single command-line application: `consul-terraform-sync`. The Consul-Terraform-Sync's main process can be run using additional flags. It also has a subcommands that can be used to interact with Consul-Terraform-Sync when running in daemon mode. The complete list of subcommands is in the navigation to the left. Both the main process and subcommands will return a non-zero exit status on error.
+Consul-Terraform-Sync is controlled via an easy to use command-line interface (CLI). Consul-Terraform-Sync is only a single command-line application: `consul-terraform-sync`. Consul-Terraform-Sync can be run as a daemon and execute CLI commands. When Consul-Terraform-Sync is run as a daemon, it acts as a server to the CLI commands. Users can use the commands to interact and modify the daemon as it is running. The complete list of commands is in the navigation to the left. Both the daemon and commands return a non-zero exit status on error.
 
-## Main Process
+## Daemon
 
-Since there is no default configuration to run Consul-Terraform-Sync in a meaningful way, setting a configuration flag `-config-file` or `-config-dir` is required. For example:
+When running as a daemon, there is no default configuration to run Consul-Terraform-Sync in a meaningful way. Setting a configuration flag `-config-file` or `-config-dir` is required. For example:
 
 ```shell-session
 $ consul-terraform-sync -config-file=config.hcl
@@ -22,13 +22,13 @@ To view a list of available flags, use the `-help` or `-h` flag.
 
 ### Modes
 
-Consul-Terraform-Sync's main process can be run in different modes.
+Consul-Terraform-Sync can be run as a daemon in different modes.
 
-#### Daemon Mode
+#### Long-running Mode
 
 Flag: none
 
-Behavior: This is the default mode in which Consul-Terraform-Sync passes through a once-mode phase and then turns into a long running process. During the once-mode phase, the daemon will exit with a non-zero status if it encounters an error. After successfully passing through once-mode phase, it will begin a long running process in which errors are logged and exiting is not expected behavior.
+Behavior: This is the default mode in which Consul-Terraform-Sync passes through a once-mode phase and then turns into a long running process. During the once-mode phase, the daemon will exit with a non-zero status if it encounters an error. After successfully passing through once-mode phase, it will begin a long-running process in which errors are logged and exiting is not expected behavior. Once beginning the long-running process, the daemon serves any API and command requests.
 
 Usage: Intended to be run as a long running process after running once-mode successfully for given configuration and tasks.
 
@@ -56,22 +56,22 @@ Behavior: Consul-Terraform-Sync will run all tasks once with buffer periods disa
 
 Usage: Intended to be run before daemon-mode in order to confirm configuration is accurate and tasks update network infrastructure as expected.
 
-## Subcommands
+## Commands
 
-In addition to running the main process, Consul-Terraform-Sync features a set of subcommands to provide a user-friendly experience interacting with the main process. This functionality uses the APIs but does not correspond one-to-one with it. Please see the individual subcommands in the left navigation for more details.
+In addition to running the daemon, Consul-Terraform-Sync has a set of commands that act as a client to the daemon server. The commands provide a user-friendly experience interacting with the daemon. The commands use the Consul-Terraform-Sync's APIs but does not correspond one-to-one with it. Please see the individual commands in the left navigation for more details.
 
-To get help for a subcommand, run: `consul-terraform-sync <subcommand> -h`
+To get help for a command, run: `consul-terraform-sync <command> -h`
 
 
 ### CLI Structure
 
-Consul-Terraform-Sync subcommands follow the below structure
+Consul-Terraform-Sync commands follow the below structure
 
 ```shell-session
-consul-terraform-sync <subcommand> [options] [args]
+consul-terraform-sync <command> [options] [args]
 ```
-- `options`: Flags to specify additional settings. There are general options that can be used across all subcommands and subcommand specific options.
-- `args`: Required arguments specific to a subcommand
+- `options`: Flags to specify additional settings. There are general options that can be used across all commands and command-specific options.
+- `args`: Required arguments specific to a commands
 
 Example:
 
@@ -81,6 +81,6 @@ consul-terraform-sync task disable -port=2000 task_a
 
 ### General Options
 
-Below are options that can be used across all subcommands:
+Below are options that can be used across all commands:
 
-- `-port=<port>` - (int: 8558) The port that the Consul-Terraform-Sync main process serves its API.
+- `-port=<port>` - (int: 8558) The port that the Consul-Terraform-Sync daemon serves its API.

--- a/website/content/docs/nia/cli/cli-overview.mdx
+++ b/website/content/docs/nia/cli/cli-overview.mdx
@@ -8,7 +8,9 @@ description: >-
 
 # Consul-Terraform-Sync Command (CLI)
 
-Consul-Terraform-Sync is controlled via an easy to use command-line interface (CLI). Consul-Terraform-Sync is only a single command-line application: `consul-terraform-sync`.
+Consul-Terraform-Sync is controlled via an easy to use command-line interface (CLI). Consul-Terraform-Sync is only a single command-line application: `consul-terraform-sync`. The Consul-Terraform-Sync's main process can be run using additional flags. It also has a subcommands that can be used to interact with Consul-Terraform-Sync when running in daemon mode. The complete list of subcommands is in the navigation to the left. Both the main process and subcommands will return a non-zero exit status on error.
+
+## Main Process
 
 Since there is no default configuration to run Consul-Terraform-Sync in a meaningful way, setting a configuration flag `-config-file` or `-config-dir` is required. For example:
 
@@ -18,11 +20,11 @@ $ consul-terraform-sync -config-file=config.hcl
 
 To view a list of available flags, use the `-help` or `-h` flag.
 
-## Modes
+### Modes
 
-Consul-Terraform-Sync can be run in different modes.
+Consul-Terraform-Sync's main process can be run in different modes.
 
-### Daemon Mode
+#### Daemon Mode
 
 Flag: none
 
@@ -30,7 +32,7 @@ Behavior: This is the default mode in which Consul-Terraform-Sync passes through
 
 Usage: Intended to be run as a long running process after running once-mode successfully for given configuration and tasks.
 
-### Inspect Mode
+#### Inspect Mode
 
 Flag: `-inspect`
 
@@ -46,10 +48,39 @@ Behavior: This has similar behavior as `-inspect` mode for the selected task. Th
 
 Usage: Useful to debug one or more tasks to confirm configuration is accurate and the selected tasks would update network infrastructure as expected.
 
-### Once Mode
+#### Once Mode
 
 Flag: `-once`
 
 Behavior: Consul-Terraform-Sync will run all tasks once with buffer periods disabled and exit. On encountering an error before completing, Consul-Terraform-Sync will exit with a non-zero status.
 
 Usage: Intended to be run before daemon-mode in order to confirm configuration is accurate and tasks update network infrastructure as expected.
+
+## Subcommands
+
+In addition to running the main process, Consul-Terraform-Sync features a set of subcommands to provide a user-friendly experience interacting with the main process. This functionality uses the APIs but does not correspond one-to-one with it. Please see the individual subcommands in the left navigation for more details.
+
+To get help for a subcommand, run: `consul-terraform-sync <subcommand> -h`
+
+
+### CLI Structure
+
+Consul-Terraform-Sync subcommands follow the below structure
+
+```shell-session
+consul-terraform-sync <subcommand> [options] [args]
+```
+- `options`: Flags to specify additional settings. There are general options that can be used across all subcommands and subcommand specific options.
+- `args`: Required arguments specific to a subcommand
+
+Example:
+
+```shell-session
+consul-terraform-sync task disable -port=2000 task_a
+```
+
+### General Options
+
+Below are options that can be used across all subcommands:
+
+- `-port=<port>` - (int: 8558) The port that the Consul-Terraform-Sync main process serves its API.

--- a/website/content/docs/nia/cli/cli-overview.mdx
+++ b/website/content/docs/nia/cli/cli-overview.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: Consul-Terraform-Sync CLI
-sidebar_title: CLI
+sidebar_title: Overview
 description: >-
   How to use the Consul-Terraform-Sync CLI
 ---

--- a/website/content/docs/nia/cli/task.mdx
+++ b/website/content/docs/nia/cli/task.mdx
@@ -1,0 +1,76 @@
+---
+layout: docs
+page_title: Task Subcommands
+sidebar_title: task
+description: >-
+  Consul-Terraform-Sync supports task subcommands for users to modify tasks while the daemon is running
+---
+# task
+
+## task enable
+
+`task enable` subcommand enables an existing task so that it will run and update task resources. If the task is already enabled, it will return a success. The subcommand generates and outputs an inspect plan of how resources will be modified if task becomes enabled. If resources changes are detected, the subcommand will ask for user approval before enabling the task. If no resources are detected, the subcommand will go ahead and enable the task.
+
+### Usage
+`consul-terraform-sync task enable [options] <task_name>`
+
+**Arguments:**
+- `task_name` - (string: required) The name of the task to enable
+
+**Options:** Currently only supporting [general options](/docs/nia/cli/cli-overview#general-options)
+
+
+### Example
+
+```shell-session
+$ consul-terraform-sync task enable task_a
+==> Inspecting changes to resource if enabling 'task_a'...
+
+    Generating plan that Consul Terraform Sync will use Terraform to execute
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+// <diff truncated>
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+
+==> Enabling the task will perform the actions described above.
+    Do you want to perform these actions for 'task_a'?
+     - This action cannot be undone.
+     - Consul Terraform Sync cannot guarantee Terraform will perform
+       these exact actions if monitored services have changed.
+
+    Only 'yes' will be accepted to approve.
+
+Enter a value: yes
+
+==> Enabling and running 'task_a'...
+
+==> 'task_a' enable complete!
+```
+
+## task disable
+
+`task disable` subcommand disables an existing task so that it will no longer run and update task resources. If the task is already disabled, it will return a success.
+
+### Usage
+`consul-terraform-sync task disable [options] <task_name>`
+
+**Arguments:**
+- `task_name` - (string: required) The name of the task to disable
+
+**Options:** Currently only supporting [general options](/docs/nia/cli/cli-overview#general-options)
+
+
+### Example
+
+```shell-session
+$ consul-terraform-sync task disable task_b
+==> Waiting to disable 'task_b'...
+
+==> 'task_b' disable complete!
+```

--- a/website/content/docs/nia/cli/task.mdx
+++ b/website/content/docs/nia/cli/task.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: Task Subcommands
+page_title: Task Command
 sidebar_title: task
 description: >-
-  Consul-Terraform-Sync supports task subcommands for users to modify tasks while the daemon is running
+  Consul-Terraform-Sync supports task commands for users to modify tasks while the daemon is running
 ---
 # task
 
 ## task enable
 
-`task enable` subcommand enables an existing task so that it will run and update task resources. If the task is already enabled, it will return a success. The subcommand generates and outputs an inspect plan of how resources will be modified if task becomes enabled. If resources changes are detected, the subcommand will ask for user approval before enabling the task. If no resources are detected, the subcommand will go ahead and enable the task.
+`task enable` command enables an existing task so that it will run and update task resources. If the task is already enabled, it will return a success. The command generates and outputs a Terraform plan, similar to [inspect-mode](/docs/nia/cli/cli-overview#inspect-mode), of how resources will be modified if task becomes enabled. If resources changes are detected, the command will ask for user approval before enabling the task. If no resources are detected, the command will go ahead and enable the task.
 
 ### Usage
 `consul-terraform-sync task enable [options] <task_name>`
@@ -55,7 +55,7 @@ Enter a value: yes
 
 ## task disable
 
-`task disable` subcommand disables an existing task so that it will no longer run and update task resources. If the task is already disabled, it will return a success.
+`task disable` command disables an existing task so that it will no longer run and update task resources. If the task is already disabled, it will return a success.
 
 ### Usage
 `consul-terraform-sync task disable [options] <task_name>`

--- a/website/content/docs/nia/tasks.mdx
+++ b/website/content/docs/nia/tasks.mdx
@@ -27,7 +27,7 @@ In the example task above, the "fake-firewall" and "null" providers, listed in t
 
 See [task configuration](/docs/nia/configuration#task) for more details on how to configure a task.
 
-A task can be either enabled or disabled. When enabled, tasks are executed and automated as described in sections below. However, disabled tasks do not execute when changes are detected from Consul catalog. Since disabled tasks do not execute, they also do not store [events](/docs/nia/tasks#event) until re-enabled.
+A task can be either enabled or disabled using the [task cli](/docs/nia/cli/task). When enabled, tasks are executed and automated as described in sections below. However, disabled tasks do not execute when changes are detected from Consul catalog. Since disabled tasks do not execute, they also do not store [events](/docs/nia/tasks#event) until re-enabled.
 
 ## Task Execution
 

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -223,7 +223,11 @@ export default [
       },
       'architecture',
       'api',
-      'cli',
+      {
+        category: 'cli',
+        name: 'CLI',
+        content: ['cli-overview'],
+      },
       'configuration',
       'tasks',
       'network-drivers',

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -226,7 +226,7 @@ export default [
       {
         category: 'cli',
         name: 'CLI',
-        content: ['cli-overview'],
+        content: ['cli-overview', 'task'],
       },
       'configuration',
       'tasks',


### PR DESCRIPTION
Commits:
 - Convert exiting CLI page into an 'overview' page and reorganize so that we can have a CLI directory with a page for different subcommands
 - Reorganize 'overview' page into 'main process' vs. 'subcommand' sections. Feedback welcome on 'main process' naming.
 - Add a 'task' subcommand page with details on enable and disable subcommand

Preview
 - [Update cli page => overview](https://consul-pszpn6z7r-hashicorp.vercel.app/docs/nia/cli/cli-overview)
 - [New task subcommand page](https://consul-pszpn6z7r-hashicorp.vercel.app/docs/nia/cli/task)