### PR TITLE
[1.9.x ]Fix merge conflict

### DIFF
--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"


### PR DESCRIPTION
I think the backport cherry-pick introduced this duplicate import. 

Fixes #9839