### PR TITLE
state: convert config-entries table to the new pattern of functional indexers

### DIFF
--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -1246,3 +1246,9 @@ func NewConfigEntryKindName(kind, name string, entMeta *structs.EnterpriseMeta) 
 func newConfigEntryQuery(c structs.ConfigEntry) ConfigEntryKindName {
 	return NewConfigEntryKindName(c.GetKind(), c.GetName(), c.GetEnterpriseMeta())
 }
+
+// ConfigEntryKindQuery is used to lookup config entries by their kind.
+type ConfigEntryKindQuery struct {
+	Kind string
+	structs.EnterpriseMeta
+}

--- a/agent/consul/state/config_entry_intention.go
+++ b/agent/consul/state/config_entry_intention.go
@@ -123,7 +123,7 @@ func (s *ServiceIntentionSourceIndex) FromArgs(args ...interface{}) ([]byte, err
 	return []byte(arg.String() + "\x00"), nil
 }
 
-func (s *Store) configIntentionsListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.Intentions, bool, error) {
+func configIntentionsListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.Intentions, bool, error) {
 	// unrolled part of configEntriesByKindTxn
 
 	idx := maxIndexTxn(tx, tableConfigEntries)
@@ -144,7 +144,7 @@ func (s *Store) configIntentionsListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *
 	return idx, results, true, nil
 }
 
-func (s *Store) configIntentionGetTxn(tx ReadTxn, ws memdb.WatchSet, id string) (uint64, *structs.ServiceIntentionsConfigEntry, *structs.Intention, error) {
+func configIntentionGetTxn(tx ReadTxn, ws memdb.WatchSet, id string) (uint64, *structs.ServiceIntentionsConfigEntry, *structs.Intention, error) {
 	idx := maxIndexTxn(tx, tableConfigEntries)
 	if idx < 1 {
 		idx = 1

--- a/agent/consul/state/config_entry_oss.go
+++ b/agent/consul/state/config_entry_oss.go
@@ -44,11 +44,11 @@ func validateConfigEntryEnterprise(_ ReadTxn, _ structs.ConfigEntry) error {
 }
 
 func getAllConfigEntriesWithTxn(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get(tableConfigEntries, "id")
+	return tx.Get(tableConfigEntries, indexID)
 }
 
 func getConfigEntryKindsWithTxn(tx ReadTxn, kind string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get(tableConfigEntries, "kind", kind)
+	return tx.Get(tableConfigEntries, indexKind, kind)
 }
 
 func configIntentionsConvertToList(iter memdb.ResultIterator, _ *structs.EnterpriseMeta) structs.Intentions {

--- a/agent/consul/state/config_entry_oss_test.go
+++ b/agent/consul/state/config_entry_oss_test.go
@@ -1,0 +1,35 @@
+// +build !consulent
+
+package state
+
+import "github.com/hashicorp/consul/agent/structs"
+
+func testIndexerTableConfigEntries() map[string]indexerTestCase {
+	return map[string]indexerTestCase{
+		indexID: {
+			read: indexValue{
+				source: ConfigEntryKindName{
+					Kind: "Proxy-Defaults",
+					Name: "NaMe",
+				},
+				expected: []byte("proxy-defaults\x00name\x00"),
+			},
+			write: indexValue{
+				source:   &structs.ProxyConfigEntry{Name: "NaMe"},
+				expected: []byte("proxy-defaults\x00name\x00"),
+			},
+		},
+		indexKind: {
+			read: indexValue{
+				source: ConfigEntryKindQuery{
+					Kind: "Service-Defaults",
+				},
+				expected: []byte("service-defaults\x00"),
+			},
+			write: indexValue{
+				source:   &structs.ServiceConfigEntry{},
+				expected: []byte("service-defaults\x00"),
+			},
+		},
+	}
+}

--- a/agent/consul/state/config_entry_schema.go
+++ b/agent/consul/state/config_entry_schema.go
@@ -32,9 +32,9 @@ func configTableSchema() *memdb.TableSchema {
 				Name:         indexKind,
 				AllowMissing: false,
 				Unique:       false,
-				Indexer: &memdb.StringFieldIndex{
-					Field:     "Kind",
-					Lowercase: true,
+				Indexer: indexerSingle{
+					readIndex:  readIndex(indexFromConfigEntryKindQuery),
+					writeIndex: writeIndex(indexKindFromConfigEntry),
 				},
 			},
 			indexLink: {

--- a/agent/consul/state/config_entry_schema.go
+++ b/agent/consul/state/config_entry_schema.go
@@ -1,6 +1,8 @@
 package state
 
-import "github.com/hashicorp/go-memdb"
+import (
+	"github.com/hashicorp/go-memdb"
+)
 
 const (
 	tableConfigEntries = "config-entries"
@@ -20,17 +22,9 @@ func configTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: &memdb.CompoundIndex{
-					Indexes: []memdb.Indexer{
-						&memdb.StringFieldIndex{
-							Field:     "Kind",
-							Lowercase: true,
-						},
-						&memdb.StringFieldIndex{
-							Field:     "Name",
-							Lowercase: true,
-						},
-					},
+				Indexer: indexerSingle{
+					readIndex:  readIndex(indexFromConfigEntryKindName),
+					writeIndex: writeIndex(indexFromConfigEntry),
 				},
 			},
 			indexKind: {

--- a/agent/consul/state/config_entry_schema.go
+++ b/agent/consul/state/config_entry_schema.go
@@ -22,9 +22,10 @@ func configTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingle{
-					readIndex:  readIndex(indexFromConfigEntryKindName),
-					writeIndex: writeIndex(indexFromConfigEntry),
+				Indexer: indexerSingleWithPrefix{
+					readIndex:   readIndex(indexFromConfigEntryKindName),
+					writeIndex:  writeIndex(indexFromConfigEntry),
+					prefixIndex: prefixIndex(indexFromConfigEntryKindName),
 				},
 			},
 			indexKind: {

--- a/agent/consul/state/indexer.go
+++ b/agent/consul/state/indexer.go
@@ -30,6 +30,13 @@ type indexerMulti struct {
 	writeIndexMulti
 }
 
+// indexerSingleWithPrefix is a indexerSingle which also supports prefix queries.
+type indexerSingleWithPrefix struct {
+	readIndex
+	writeIndex
+	prefixIndex
+}
+
 // readIndex implements memdb.Indexer. It exists so that a function can be used
 // to provide the interface.
 //
@@ -76,6 +83,17 @@ func (f writeIndexMulti) FromObject(raw interface{}) (bool, [][]byte, error) {
 		return false, nil, nil
 	}
 	return err == nil, v, err
+}
+
+// prefixIndex implements memdb.PrefixIndexer. It exists so that a function
+// can be used to provide this interface.
+type prefixIndex func(args interface{}) ([]byte, error)
+
+func (f prefixIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("index supports only a single arg")
+	}
+	return f(args[0])
 }
 
 const null = "\x00"

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -154,7 +154,7 @@ func (s *Store) LegacyIntentions(ws memdb.WatchSet, entMeta *structs.EnterpriseM
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	idx, results, _, err := s.legacyIntentionsListTxn(tx, ws, entMeta)
+	idx, results, _, err := legacyIntentionsListTxn(tx, ws, entMeta)
 	return idx, results, err
 }
 
@@ -168,12 +168,12 @@ func (s *Store) Intentions(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (
 		return 0, nil, false, err
 	}
 	if !usingConfigEntries {
-		return s.legacyIntentionsListTxn(tx, ws, entMeta)
+		return legacyIntentionsListTxn(tx, ws, entMeta)
 	}
-	return s.configIntentionsListTxn(tx, ws, entMeta)
+	return configIntentionsListTxn(tx, ws, entMeta)
 }
 
-func (s *Store) legacyIntentionsListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.Intentions, bool, error) {
+func legacyIntentionsListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.Intentions, bool, error) {
 	// Get the index
 	idx := maxIndexTxn(tx, tableConnectIntentions)
 	if idx < 1 {
@@ -578,13 +578,13 @@ func (s *Store) IntentionGet(ws memdb.WatchSet, id string) (uint64, *structs.Ser
 		return 0, nil, nil, err
 	}
 	if !usingConfigEntries {
-		idx, ixn, err := s.legacyIntentionGetTxn(tx, ws, id)
+		idx, ixn, err := legacyIntentionGetTxn(tx, ws, id)
 		return idx, nil, ixn, err
 	}
-	return s.configIntentionGetTxn(tx, ws, id)
+	return configIntentionGetTxn(tx, ws, id)
 }
 
-func (s *Store) legacyIntentionGetTxn(tx ReadTxn, ws memdb.WatchSet, id string) (uint64, *structs.Intention, error) {
+func legacyIntentionGetTxn(tx ReadTxn, ws memdb.WatchSet, id string) (uint64, *structs.Intention, error) {
 	// Get the table index.
 	idx := maxIndexTxn(tx, tableConnectIntentions)
 	if idx < 1 {

--- a/agent/consul/state/schema_test.go
+++ b/agent/consul/state/schema_test.go
@@ -128,9 +128,10 @@ func TestNewDBSchema_Indexers(t *testing.T) {
 	require.NoError(t, schema.Validate())
 
 	var testcases = map[string]func() map[string]indexerTestCase{
-		tableChecks:   testIndexerTableChecks,
-		tableServices: testIndexerTableServices,
-		tableNodes:    testIndexerTableNodes,
+		tableChecks:        testIndexerTableChecks,
+		tableServices:      testIndexerTableServices,
+		tableNodes:         testIndexerTableNodes,
+		tableConfigEntries: testIndexerTableConfigEntries,
 	}
 
 	for _, table := range schema.Tables {

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -60,7 +60,7 @@ table=checks
 
 table=config-entries
   index=id unique
-    indexer=github.com/hashicorp/go-memdb.CompoundIndex Indexes=[github.com/hashicorp/go-memdb.StringFieldIndex Field=Kind Lowercase=true, github.com/hashicorp/go-memdb.StringFieldIndex Field=Name Lowercase=true] AllowMissing=false
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromConfigEntryKindName writeIndex=github.com/hashicorp/consul/agent/consul/state.indexFromConfigEntry
   index=intention-legacy-id unique allow-missing
     indexer=github.com/hashicorp/consul/agent/consul/state.ServiceIntentionLegacyIDIndex uuidFieldIndex={}
   index=intention-source allow-missing

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -66,7 +66,7 @@ table=config-entries
   index=intention-source allow-missing
     indexer=github.com/hashicorp/consul/agent/consul/state.ServiceIntentionSourceIndex
   index=kind
-    indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=Kind Lowercase=true
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromConfigEntryKindQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexKindFromConfigEntry
   index=link allow-missing
     indexer=github.com/hashicorp/consul/agent/consul/state.ConfigEntryLinkIndex
 

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -60,7 +60,7 @@ table=checks
 
 table=config-entries
   index=id unique
-    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromConfigEntryKindName writeIndex=github.com/hashicorp/consul/agent/consul/state.indexFromConfigEntry
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingleWithPrefix readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromConfigEntryKindName writeIndex=github.com/hashicorp/consul/agent/consul/state.indexFromConfigEntry prefixIndex=github.com/hashicorp/consul/agent/consul/state.indexFromConfigEntryKindName
   index=intention-legacy-id unique allow-missing
     indexer=github.com/hashicorp/consul/agent/consul/state.ServiceIntentionLegacyIDIndex uuidFieldIndex={}
   index=intention-source allow-missing


### PR DESCRIPTION
Branched from #9863

This PR converts the id and kind indexes to the new pattern.