### PR TITLE
website(style): Update gray brand colors

### DIFF
--- a/website/components/basic-hero/style.css
+++ b/website/components/basic-hero/style.css
@@ -11,7 +11,7 @@
   }
 
   & .g-type-body-large {
-    color: var(--gray-3);
+    color: var(--gray-2);
     margin: 0 auto 0 auto;
     text-align: center;
     max-width: 40em;
@@ -50,7 +50,7 @@
     justify-content: center;
     margin-top: 32px;
     & a {
-      color: var(--gray-3);
+      color: var(--gray-2);
     }
     & svg * {
       stroke: var(--gray-2) !important;
@@ -59,7 +59,7 @@
 
   &.has-background {
     background-repeat: no-repeat;
-    background-color: var(--gray-7);
+    background-color: var(--gray-6);
     background-image: url(/img/hero/pattern-desktop.svg);
     width: 100%;
     background-size: cover;
@@ -70,7 +70,7 @@
     }
 
     & .g-btn {
-      background: var(--gray-7);
+      background: var(--gray-6);
     }
   }
 }

--- a/website/components/case-study-carousel/style.css
+++ b/website/components/case-study-carousel/style.css
@@ -32,11 +32,11 @@
   &.has-background {
     &::after {
       content: '';
-      background: var(--gray-7);
+      background: var(--gray-6);
     }
 
     & .background-section {
-      background: var(--gray-7);
+      background: var(--gray-6);
     }
   }
 
@@ -142,7 +142,7 @@
     }
 
     &:disabled svg path {
-      stroke: var(--gray-5);
+      stroke: var(--gray-4);
     }
   }
 
@@ -156,7 +156,7 @@
 
     @media (max-width: 800px) {
       box-shadow: none;
-      border: 1px solid var(--gray-6);
+      border: 1px solid var(--gray-5);
       padding: 48px;
     }
 
@@ -257,7 +257,7 @@
     }
 
     & .case {
-      color: var(--gray-5);
+      color: var(--gray-4);
       font-size: 24px;
       line-height: 31px; /* Called for within the design, no custom property seemed appropriate */
     }

--- a/website/components/cloud-offerings-list/style.css
+++ b/website/components/cloud-offerings-list/style.css
@@ -12,7 +12,7 @@ ul.g-cloud-offerings-list {
     flex-grow: 1;
     margin: 16px;
     background: var(--white);
-    border: 1px solid var(--gray-6);
+    border: 1px solid var(--gray-5);
     border-radius: 2px;
     text-align: center;
     transition: box-shadow 0.25s, transform 0.25s, -webkit-transform 0.25s;
@@ -38,7 +38,7 @@ ul.g-cloud-offerings-list {
       }
 
       & > span {
-        color: var(--gray-4);
+        color: var(--gray-3);
       }
 
       & > h4 {

--- a/website/components/enterprise-comparison/style.css
+++ b/website/components/enterprise-comparison/style.css
@@ -1,7 +1,7 @@
 .g-enterprise-comparison {
   padding-top: 128px;
   padding-bottom: 128px;
-  background: var(--gray-7);
+  background: var(--gray-6);
 
   & h2 {
     text-align: center;

--- a/website/components/footer/style.css
+++ b/website/components/footer/style.css
@@ -2,7 +2,7 @@
   padding: 25px 0 17px 0;
   flex-shrink: 0;
   display: flex;
-  border-top: 1px solid var(--gray-6);
+  border-top: 1px solid var(--gray-5);
 
   & .g-container {
     display: flex;

--- a/website/components/hcp-callout-section/HCPCalloutSection.module.css
+++ b/website/components/hcp-callout-section/HCPCalloutSection.module.css
@@ -39,10 +39,10 @@
         margin-bottom: 8px;
       }
       & .chin {
-        color: var(--gray-4);
+        color: var(--gray-3);
       }
       & .description {
-        color: var(--gray-4);
+        color: var(--gray-3);
         margin-top: 28px;
         margin-bottom: 0;
 

--- a/website/components/learn-callout/style.css
+++ b/website/components/learn-callout/style.css
@@ -87,7 +87,7 @@
       }
 
       & .course {
-        border: 1px solid var(--gray-6);
+        border: 1px solid var(--gray-5);
         display: flex;
         flex-direction: column;
         width: 100%;
@@ -98,7 +98,7 @@
         }
 
         & .image {
-          background: var(--gray-7);
+          background: var(--gray-6);
           position: relative;
           display: flex;
           justify-content: center;
@@ -116,7 +116,7 @@
         }
 
         & .time {
-          color: var(--gray-4);
+          color: var(--gray-3);
           position: absolute;
           top: 10px;
           right: 10px;

--- a/website/components/mini-cta/style.css
+++ b/website/components/mini-cta/style.css
@@ -1,12 +1,12 @@
 .g-mini-cta {
-  background: var(--gray-7);
+  background: var(--gray-6);
   text-align: center;
   padding-bottom: 64px;
   padding-top: 48px;
 
   & hr {
     width: 64px;
-    color: var(--gray-5);
+    color: var(--gray-4);
     margin: 0 auto 64px auto;
 
     @media (max-width: 800px) {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1352,9 +1352,9 @@
       "integrity": "sha512-59AS4kK3EURCTU9ibJmk8MVT8i3qc5tEHv985dxECZrWTL4+3kKr45u/13OPpcRlpUSIKeWEsN9FL1f5/ztHww=="
     },
     "@hashicorp/mktg-global-styles": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.0.tgz",
-      "integrity": "sha512-REr07tPJDKpyTh/u9tUS3sf29LnkDrWFVgY7FTvDJfbJ60IJ/R1TYNmcE7QKREGJ8j0p43QWEDabqVWOWvOXFA=="
+      "version": "2.1.1-canary.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/mktg-global-styles/-/mktg-global-styles-2.1.1-canary.0.tgz",
+      "integrity": "sha512-P/PtJNKU8SQPwiVM4FAXT28D3IQqQCtm1CuyP/5uJvZCljzHQ8bTWqQuoV0wVw5ceAPbYoQyACB9fait9eCm7Q=="
     },
     "@hashicorp/nextjs-scripts": {
       "version": "16.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "author": "HashiCorp",
   "dependencies": {
-    "@hashicorp/mktg-global-styles": "2.1.0",
+    "@hashicorp/mktg-global-styles": "2.1.1-canary.0",
     "@hashicorp/nextjs-scripts": "16.0.1",
     "@hashicorp/react-alert-banner": "5.0.0",
     "@hashicorp/react-button": "4.0.0",


### PR DESCRIPTION
Removes references to deprecated gray CSS properties and maps all gray colors to new brand values.

[_Created by Sourcegraph campaign `kstraut/product-sites-migrate-v3-gray-colors`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/product-sites-migrate-v3-gray-colors)

## **Important**
Due to old imports of `react-global-styles` within `react-components`, the proper gray values will not show until we update `react-components` later on because the old style sheets are taking precedent.

## The Map
```
// v2 gray css properties to new v3 values
"--gray-3" --> "--gray-2" 
 
"--gray-4" --> "--gray-3" 
 
"--gray-5" --> "--gray-4" 
 
"--gray-6" --> "--gray-5" 
 
"--gray-7" --> "--gray-6" 
 

// Replace Deprecated Gray Value references
"DEPRECATED-gray-:[~1|2]" --> "gray-1" 
 
"DEPRECATED-gray-:[~3|4]" --> "gray-2" 
 
"DEPRECATED-gray-:[~5|6]" --> "gray-3" 
 
"DEPRECATED-gray-7" --> "gray-4" 
 
"DEPRECATED-gray-:[~8|9]" --> "gray-5" 
 
"DEPRECATED-gray-10" --> "gray-6" 
```