### PR TITLE
docs: rename SourceAddress to SourceIP

### DIFF
--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -431,9 +431,9 @@ spec:
               type: 'string: ""',
               description: {
                 hcl:
-                  'The attribute type to hash on. Must be one of `header`, `cookie`, or `query_parameter`. Cannot be specified along with `SourceAddress`.',
+                  'The attribute type to hash on. Must be one of `header`, `cookie`, or `query_parameter`. Cannot be specified along with `SourceIP`.',
                 yaml:
-                  'The attribute type to hash on. Must be one of `header`, `cookie`, or `query_parameter`. Cannot be specified along with `sourceAddress`.',
+                  'The attribute type to hash on. Must be one of `header`, `cookie`, or `query_parameter`. Cannot be specified along with `sourceIP`.',
               },
             },
             {
@@ -441,9 +441,9 @@ spec:
               type: 'string: ""',
               description: {
                 hcl:
-                  'The value to hash. ie. header name, cookie name, URL query parameter name. Cannot be specified along with `SourceAddress`.',
+                  'The value to hash. ie. header name, cookie name, URL query parameter name. Cannot be specified along with `SourceIP`.',
                 yaml:
-                  'The value to hash. ie. header name, cookie name, URL query parameter name. Cannot be specified along with `sourceAddress`.',
+                  'The value to hash. ie. header name, cookie name, URL query parameter name. Cannot be specified along with `sourceIP`.',
               },
             },
             {


### PR DESCRIPTION
SourceAddress was probably renamed to SourceIP but the docs weren't
updated.