### PR TITLE
state: use runCase pattern for large test

### DIFF
--- a/agent/consul/state/catalog_events_oss_test.go
+++ b/agent/consul/state/catalog_events_oss_test.go
@@ -1,7 +1,0 @@
-// +build !consulent
-
-package state
-
-func withServiceHealthEnterpriseCases(cases []serviceHealthTestCase) []serviceHealthTestCase {
-	return cases
-}


### PR DESCRIPTION
Best viewed with whitespace off. This same pattern was used in #9452 for a large `agent/config` test.

This pattern is temporarily broken (see https://github.com/golang/go/issues/44887), but should be fixed in 1.16.x.

----

The TestServiceHealthEventsFromChanges function was over 1400 lines.
Attempting to debug test failures in test functions this large is
difficult. It requires scrolling to the line which defines the testcase
because the failure message only includes the line number of the
assertion, not the line number of the test case.

This is an excellent example of where test tables stop working well, and
start being a problem. To mitigate this problem, the runCase pattern can
be used. When one of these tests fails, a failure message will print the
line number of both the test case and the assertion. This allows a
developer to quickly jump to both of the relevant lines, signficantly
reducing the time it takes to debug test failures.

For example, one such failure could look like this:

    catalog_events_test.go:1610: case: service reg, new node
    catalog_events_test.go:1605: assertion failed: values are not equal