### PR TITLE
state: convert services.node and checks.node indexes

### DIFF
--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -491,7 +491,7 @@ func getPayloadCheckServiceNode(payload stream.Payload) *structs.CheckServiceNod
 // parseCheckServiceNodes but is more efficient since we know they are all on
 // the same node.
 func newServiceHealthEventsForNode(tx ReadTxn, idx uint64, node string) ([]stream.Event, error) {
-	services, err := catalogServiceListByNode(tx, node, structs.WildcardEnterpriseMeta(), true)
+	services, err := tx.Get(tableServices, indexNode, Query{Value: node})
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +525,7 @@ func getNodeAndChecks(tx ReadTxn, node string) (*structs.Node, serviceChecksFunc
 	}
 	n := nodeRaw.(*structs.Node)
 
-	iter, err := catalogListChecksByNode(tx, node, structs.WildcardEnterpriseMeta())
+	iter, err := tx.Get(tableChecks, indexNode, Query{Value: node})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -22,6 +22,21 @@ func testIndexerTableChecks() map[string]indexerTestCase {
 				expected: []byte("node\x00service\x00"),
 			},
 		},
+		indexNode: {
+			read: indexValue{
+				source: Query{
+					Value: "NoDe",
+				},
+				expected: []byte("node\x00"),
+			},
+			write: indexValue{
+				source: &structs.HealthCheck{
+					Node:      "NoDe",
+					ServiceID: "SeRvIcE",
+				},
+				expected: []byte("node\x00"),
+			},
+		},
 	}
 }
 
@@ -35,6 +50,26 @@ func testIndexerTableNodes() map[string]indexerTestCase {
 			write: indexValue{
 				source:   &structs.Node{Node: "NoDeId"},
 				expected: []byte("nodeid\x00"),
+			},
+		},
+	}
+}
+
+func testIndexerTableServices() map[string]indexerTestCase {
+	return map[string]indexerTestCase{
+		indexNode: {
+			read: indexValue{
+				source: Query{
+					Value: "NoDe",
+				},
+				expected: []byte("node\x00"),
+			},
+			write: indexValue{
+				source: &structs.ServiceNode{
+					Node:      "NoDe",
+					ServiceID: "SeRvIcE",
+				},
+				expected: []byte("node\x00"),
 			},
 		},
 	}

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -23,6 +23,7 @@ const (
 	indexKind        = "kind"
 	indexStatus      = "status"
 	indexNodeService = "node_service"
+	indexNode        = "node"
 )
 
 // nodesTableSchema returns a new table schema used for storing struct.Node.
@@ -81,13 +82,13 @@ func servicesTableSchema() *memdb.TableSchema {
 					},
 				},
 			},
-			"node": {
-				Name:         "node",
+			indexNode: {
+				Name:         indexNode,
 				AllowMissing: false,
 				Unique:       false,
-				Indexer: &memdb.StringFieldIndex{
-					Field:     "Node",
-					Lowercase: true,
+				Indexer: indexerSingle{
+					readIndex:  readIndex(indexFromNodeQuery),
+					writeIndex: writeIndex(indexFromNodeIdentity),
 				},
 			},
 			indexServiceName: {
@@ -157,13 +158,13 @@ func checksTableSchema() *memdb.TableSchema {
 					Lowercase: true,
 				},
 			},
-			"node": {
-				Name:         "node",
+			indexNode: {
+				Name:         indexNode,
 				AllowMissing: true,
 				Unique:       false,
-				Indexer: &memdb.StringFieldIndex{
-					Field:     "Node",
-					Lowercase: true,
+				Indexer: indexerSingle{
+					readIndex:  readIndex(indexFromNodeQuery),
+					writeIndex: writeIndex(indexFromNodeIdentity),
 				},
 			},
 			indexNodeService: {

--- a/agent/consul/state/schema_test.go
+++ b/agent/consul/state/schema_test.go
@@ -128,8 +128,9 @@ func TestNewDBSchema_Indexers(t *testing.T) {
 	require.NoError(t, schema.Validate())
 
 	var testcases = map[string]func() map[string]indexerTestCase{
-		tableChecks: testIndexerTableChecks,
-		tableNodes:  testIndexerTableNodes,
+		tableChecks:   testIndexerTableChecks,
+		tableServices: testIndexerTableServices,
+		tableNodes:    testIndexerTableNodes,
 	}
 
 	for _, table := range schema.Tables {

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -50,7 +50,7 @@ table=checks
   index=id unique
     indexer=github.com/hashicorp/go-memdb.CompoundIndex Indexes=[github.com/hashicorp/go-memdb.StringFieldIndex Field=Node Lowercase=true, github.com/hashicorp/go-memdb.StringFieldIndex Field=CheckID Lowercase=true] AllowMissing=false
   index=node allow-missing
-    indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=Node Lowercase=true
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromNodeQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexFromNodeIdentity
   index=node_service allow-missing
     indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromNodeServiceQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexNodeServiceFromHealthCheck
   index=service allow-missing
@@ -154,7 +154,7 @@ table=services
   index=kind
     indexer=github.com/hashicorp/consul/agent/consul/state.IndexServiceKind
   index=node
-    indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=Node Lowercase=true
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingle readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromNodeQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexFromNodeIdentity
   index=service allow-missing
     indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=ServiceName Lowercase=true
 

--- a/agent/structs/identity.go
+++ b/agent/structs/identity.go
@@ -1,0 +1,10 @@
+package structs
+
+// Identity of some entity (ex: service, node, check).
+//
+// TODO: this type should replace ServiceID, ServiceName, and CheckID which all
+// have roughly identical implementations.
+type Identity struct {
+	ID string
+	EnterpriseMeta
+}

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -833,6 +833,10 @@ type ServiceNode struct {
 	RaftIndex `bexpr:"-"`
 }
 
+func (s *ServiceNode) NodeIdentity() Identity {
+	return Identity{ID: s.Node}
+}
+
 // PartialClone() returns a clone of the given service node, minus the node-
 // related fields that get filled in later, Address and TaggedAddresses.
 func (s *ServiceNode) PartialClone() *ServiceNode {
@@ -1400,6 +1404,10 @@ type HealthCheck struct {
 	EnterpriseMeta `hcl:",squash" mapstructure:",squash" bexpr:"-"`
 
 	RaftIndex `bexpr:"-"`
+}
+
+func (hc *HealthCheck) NodeIdentity() Identity {
+	return Identity{ID: hc.Node}
 }
 
 func (hc *HealthCheck) CompoundServiceID() ServiceID {


### PR DESCRIPTION
Using NodeIdentity to share the indexes with both.