### PR TITLE
state: use constants and add indexer tests for gateway tables

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2524,7 +2524,7 @@ func updateGatewayNamespace(tx WriteTxn, idx uint64, service *structs.GatewaySer
 			continue
 		}
 
-		existing, err := tx.First(tableGatewayServices, "id", service.Gateway, sn.CompoundServiceName(), service.Port)
+		existing, err := tx.First(tableGatewayServices, indexID, service.Gateway, sn.CompoundServiceName(), service.Port)
 		if err != nil {
 			return fmt.Errorf("gateway service lookup failed: %s", err)
 		}
@@ -2559,7 +2559,7 @@ func updateGatewayNamespace(tx WriteTxn, idx uint64, service *structs.GatewaySer
 func updateGatewayService(tx WriteTxn, idx uint64, mapping *structs.GatewayService) error {
 	// Check if mapping already exists in table if it's already in the table
 	// Avoid insert if nothing changed
-	existing, err := tx.First(tableGatewayServices, "id", mapping.Gateway, mapping.Service, mapping.Port)
+	existing, err := tx.First(tableGatewayServices, indexID, mapping.Gateway, mapping.Service, mapping.Port)
 	if err != nil {
 		return fmt.Errorf("gateway service lookup failed: %s", err)
 	}
@@ -2658,7 +2658,7 @@ func (s *Store) DumpGatewayServices(ws memdb.WatchSet) (uint64, structs.GatewayS
 	tx := s.db.ReadTxn()
 	defer tx.Abort()
 
-	iter, err := tx.Get(tableGatewayServices, "id")
+	iter, err := tx.Get(tableGatewayServices, indexID)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to dump gateway-services: %s", err)
 	}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -3008,7 +3008,7 @@ func linkedFromRegistrationTxn(tx ReadTxn, ws memdb.WatchSet, service structs.Se
 		resp []structs.ServiceName
 	)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		entry := raw.(*structs.UpstreamDownstream)
+		entry := raw.(*upstreamDownstream)
 		if entry.ModifyIndex > idx {
 			idx = entry.ModifyIndex
 		}
@@ -3060,13 +3060,13 @@ func updateMeshTopology(tx WriteTxn, idx uint64, node string, svc *structs.NodeS
 		sid := svc.CompoundServiceID()
 		uid := structs.UniqueID(node, sid.String())
 
-		var mapping *structs.UpstreamDownstream
-		if existing, ok := obj.(*structs.UpstreamDownstream); ok {
+		var mapping *upstreamDownstream
+		if existing, ok := obj.(*upstreamDownstream); ok {
 			rawCopy, err := copystructure.Copy(existing)
 			if err != nil {
 				return fmt.Errorf("failed to copy existing topology mapping: %v", err)
 			}
-			mapping, ok = rawCopy.(*structs.UpstreamDownstream)
+			mapping, ok = rawCopy.(*upstreamDownstream)
 			if !ok {
 				return fmt.Errorf("unexpected topology type %T", rawCopy)
 			}
@@ -3076,7 +3076,7 @@ func updateMeshTopology(tx WriteTxn, idx uint64, node string, svc *structs.NodeS
 			inserted[upstream] = true
 		}
 		if mapping == nil {
-			mapping = &structs.UpstreamDownstream{
+			mapping = &upstreamDownstream{
 				Upstream:   upstream,
 				Downstream: downstream,
 				Refs:       map[string]struct{}{uid: {}},
@@ -3124,9 +3124,9 @@ func cleanupMeshTopology(tx WriteTxn, idx uint64, service *structs.ServiceNode) 
 		return fmt.Errorf("%q lookup failed: %v", tableMeshTopology, err)
 	}
 
-	mappings := make([]*structs.UpstreamDownstream, 0)
+	mappings := make([]*upstreamDownstream, 0)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		mappings = append(mappings, raw.(*structs.UpstreamDownstream))
+		mappings = append(mappings, raw.(*upstreamDownstream))
 	}
 
 	// Do the updates in a separate loop so we don't trash the iterator.
@@ -3135,7 +3135,7 @@ func cleanupMeshTopology(tx WriteTxn, idx uint64, service *structs.ServiceNode) 
 		if err != nil {
 			return fmt.Errorf("failed to copy existing topology mapping: %v", err)
 		}
-		copy, ok := rawCopy.(*structs.UpstreamDownstream)
+		copy, ok := rawCopy.(*upstreamDownstream)
 		if !ok {
 			return fmt.Errorf("unexpected topology type %T", rawCopy)
 		}
@@ -3169,7 +3169,7 @@ func insertGatewayServiceTopologyMapping(tx WriteTxn, idx uint64, gs *structs.Ga
 		return nil
 	}
 
-	mapping := structs.UpstreamDownstream{
+	mapping := upstreamDownstream{
 		Upstream:   gs.Service,
 		Downstream: gs.Gateway,
 		RaftIndex:  gs.RaftIndex,

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -450,7 +450,12 @@ func connectEventsByServiceKind(tx ReadTxn, origEvent stream.Event) ([]stream.Ev
 
 	case structs.ServiceKindTerminatingGateway:
 		var result []stream.Event
-		iter, err := gatewayServices(tx, node.Service.Service, &node.Service.EnterpriseMeta)
+
+		sn := structs.ServiceName{
+			Name:           node.Service.Service,
+			EnterpriseMeta: node.Service.EnterpriseMeta,
+		}
+		iter, err := tx.Get(tableGatewayServices, indexGateway, sn)
 		if err != nil {
 			return nil, err
 		}

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -40,6 +40,51 @@ func testIndexerTableChecks() map[string]indexerTestCase {
 	}
 }
 
+func testIndexerTableMeshTopology() map[string]indexerTestCase {
+	obj := structs.UpstreamDownstream{
+		Upstream:   structs.ServiceName{Name: "UpStReAm"},
+		Downstream: structs.ServiceName{Name: "DownStream"},
+	}
+
+	return map[string]indexerTestCase{
+		indexID: {
+			read: indexValue{
+				source: []interface{}{
+					structs.ServiceName{Name: "UpStReAm"},
+					structs.ServiceName{Name: "DownStream"},
+				},
+				expected: []byte("upstream\x00downstream\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("upstream\x00downstream\x00"),
+			},
+		},
+		indexUpstream: {
+			read: indexValue{
+				source: structs.ServiceName{Name: "UpStReAm"},
+
+				expected: []byte("upstream\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("upstream\x00"),
+			},
+		},
+		indexDownstream: {
+			read: indexValue{
+				source: structs.ServiceName{Name: "DownStream"},
+
+				expected: []byte("downstream\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("downstream\x00"),
+			},
+		},
+	}
+}
+
 func testIndexerTableNodes() map[string]indexerTestCase {
 	return map[string]indexerTestCase{
 		indexID: {

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -41,7 +41,7 @@ func testIndexerTableChecks() map[string]indexerTestCase {
 }
 
 func testIndexerTableMeshTopology() map[string]indexerTestCase {
-	obj := structs.UpstreamDownstream{
+	obj := upstreamDownstream{
 		Upstream:   structs.ServiceName{Name: "UpStReAm"},
 		Downstream: structs.ServiceName{Name: "DownStream"},
 	}

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -62,8 +62,7 @@ func testIndexerTableMeshTopology() map[string]indexerTestCase {
 		},
 		indexUpstream: {
 			read: indexValue{
-				source: structs.ServiceName{Name: "UpStReAm"},
-
+				source:   structs.ServiceName{Name: "UpStReAm"},
 				expected: []byte("upstream\x00"),
 			},
 			write: indexValue{
@@ -73,13 +72,57 @@ func testIndexerTableMeshTopology() map[string]indexerTestCase {
 		},
 		indexDownstream: {
 			read: indexValue{
-				source: structs.ServiceName{Name: "DownStream"},
-
+				source:   structs.ServiceName{Name: "DownStream"},
 				expected: []byte("downstream\x00"),
 			},
 			write: indexValue{
 				source:   obj,
 				expected: []byte("downstream\x00"),
+			},
+		},
+	}
+}
+
+func testIndexerTableGatewayServices() map[string]indexerTestCase {
+	obj := &structs.GatewayService{
+		Gateway: structs.ServiceName{Name: "GateWay"},
+		Service: structs.ServiceName{Name: "SerVice"},
+		Port:    50123,
+	}
+	encodedPort := string([]byte{0x96, 0x8f, 0x06, 0, 0, 0, 0, 0, 0, 0})
+	return map[string]indexerTestCase{
+		indexID: {
+			read: indexValue{
+				source: []interface{}{
+					structs.ServiceName{Name: "GateWay"},
+					structs.ServiceName{Name: "SerVice"},
+					50123,
+				},
+				expected: []byte("gateway\x00service\x00" + encodedPort),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("gateway\x00service\x00" + encodedPort),
+			},
+		},
+		indexGateway: {
+			read: indexValue{
+				source:   structs.ServiceName{Name: "GateWay"},
+				expected: []byte("gateway\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("gateway\x00"),
+			},
+		},
+		indexService: {
+			read: indexValue{
+				source:   structs.ServiceName{Name: "SerVice"},
+				expected: []byte("service\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("service\x00"),
 			},
 		},
 	}

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -18,7 +18,7 @@ const (
 	tableMeshTopology    = "mesh-topology"
 
 	indexID          = "id"
-	indexServiceName = "service"
+	indexService     = "service"
 	indexConnect     = "connect"
 	indexKind        = "kind"
 	indexStatus      = "status"
@@ -26,6 +26,7 @@ const (
 	indexNode        = "node"
 	indexUpstream    = "upstream"
 	indexDownstream  = "downstream"
+	indexGateway     = "gateway"
 )
 
 // nodesTableSchema returns a new table schema used for storing struct.Node.
@@ -93,8 +94,8 @@ func servicesTableSchema() *memdb.TableSchema {
 					writeIndex: writeIndex(indexFromNodeIdentity),
 				},
 			},
-			indexServiceName: {
-				Name:         indexServiceName,
+			indexService: {
+				Name:         indexService,
 				AllowMissing: true,
 				Unique:       false,
 				Indexer: &memdb.StringFieldIndex{
@@ -151,8 +152,8 @@ func checksTableSchema() *memdb.TableSchema {
 					Lowercase: false,
 				},
 			},
-			indexServiceName: {
-				Name:         indexServiceName,
+			indexService: {
+				Name:         indexService,
 				AllowMissing: true,
 				Unique:       false,
 				Indexer: &memdb.StringFieldIndex{
@@ -206,16 +207,16 @@ func gatewayServicesTableSchema() *memdb.TableSchema {
 					},
 				},
 			},
-			"gateway": {
-				Name:         "gateway",
+			indexGateway: {
+				Name:         indexGateway,
 				AllowMissing: false,
 				Unique:       false,
 				Indexer: &ServiceNameIndex{
 					Field: "Gateway",
 				},
 			},
-			"service": {
-				Name:         "service",
+			indexService: {
+				Name:         indexService,
 				AllowMissing: true,
 				Unique:       false,
 				Indexer: &ServiceNameIndex{

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -322,3 +322,18 @@ func (index *ServiceNameIndex) PrefixFromArgs(args ...interface{}) ([]byte, erro
 	}
 	return val, nil
 }
+
+// upstreamDownstream pairs come from individual proxy registrations, which can be updated independently.
+type upstreamDownstream struct {
+	Upstream   structs.ServiceName
+	Downstream structs.ServiceName
+
+	// Refs stores the registrations that contain this pairing.
+	// When there are no remaining Refs, the upstreamDownstream can be deleted.
+	//
+	// Note: This map must be treated as immutable when accessed in MemDB.
+	//       The entire upstreamDownstream structure must be deep copied on updates.
+	Refs map[string]struct{}
+
+	structs.RaftIndex
+}

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -24,6 +24,8 @@ const (
 	indexStatus      = "status"
 	indexNodeService = "node_service"
 	indexNode        = "node"
+	indexUpstream    = "upstream"
+	indexDownstream  = "downstream"
 )
 
 // nodesTableSchema returns a new table schema used for storing struct.Node.
@@ -245,16 +247,16 @@ func meshTopologyTableSchema() *memdb.TableSchema {
 					},
 				},
 			},
-			"upstream": {
-				Name:         "upstream",
+			indexUpstream: {
+				Name:         indexUpstream,
 				AllowMissing: true,
 				Unique:       false,
 				Indexer: &ServiceNameIndex{
 					Field: "Upstream",
 				},
 			},
-			"downstream": {
-				Name:         "downstream",
+			indexDownstream: {
+				Name:         indexDownstream,
 				AllowMissing: false,
 				Unique:       false,
 				Indexer: &ServiceNameIndex{

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -269,7 +269,7 @@ func deleteConfigEntryTxn(tx WriteTxn, idx uint64, kind, name string, entMeta *s
 	sn := structs.NewServiceName(name, entMeta)
 
 	if kind == structs.TerminatingGateway || kind == structs.IngressGateway {
-		if _, err := tx.DeleteAll(tableGatewayServices, "gateway", sn); err != nil {
+		if _, err := tx.DeleteAll(tableGatewayServices, indexGateway, sn); err != nil {
 			return fmt.Errorf("failed to truncate gateway services table: %v", err)
 		}
 		if err := indexUpdateMaxTxn(tx, idx, tableGatewayServices); err != nil {

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -278,7 +278,7 @@ func deleteConfigEntryTxn(tx WriteTxn, idx uint64, kind, name string, entMeta *s
 	}
 	// Also clean up associations in the mesh topology table for ingress gateways
 	if kind == structs.IngressGateway {
-		if _, err := tx.DeleteAll(tableMeshTopology, "downstream", sn); err != nil {
+		if _, err := tx.DeleteAll(tableMeshTopology, indexDownstream, sn); err != nil {
 			return fmt.Errorf("failed to truncate %s table: %v", tableMeshTopology, err)
 		}
 		if err := indexUpdateMaxTxn(tx, idx, tableMeshTopology); err != nil {

--- a/agent/consul/state/schema_test.go
+++ b/agent/consul/state/schema_test.go
@@ -132,6 +132,7 @@ func TestNewDBSchema_Indexers(t *testing.T) {
 		tableServices:      testIndexerTableServices,
 		tableNodes:         testIndexerTableNodes,
 		tableConfigEntries: testIndexerTableConfigEntries,
+		tableMeshTopology:  testIndexerTableMeshTopology,
 	}
 
 	for _, table := range schema.Tables {

--- a/agent/consul/state/schema_test.go
+++ b/agent/consul/state/schema_test.go
@@ -128,11 +128,12 @@ func TestNewDBSchema_Indexers(t *testing.T) {
 	require.NoError(t, schema.Validate())
 
 	var testcases = map[string]func() map[string]indexerTestCase{
-		tableChecks:        testIndexerTableChecks,
-		tableServices:      testIndexerTableServices,
-		tableNodes:         testIndexerTableNodes,
-		tableConfigEntries: testIndexerTableConfigEntries,
-		tableMeshTopology:  testIndexerTableMeshTopology,
+		tableChecks:          testIndexerTableChecks,
+		tableServices:        testIndexerTableServices,
+		tableNodes:           testIndexerTableNodes,
+		tableConfigEntries:   testIndexerTableConfigEntries,
+		tableMeshTopology:    testIndexerTableMeshTopology,
+		tableGatewayServices: testIndexerTableGatewayServices,
 	}
 
 	for _, table := range schema.Tables {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2476,6 +2476,7 @@ func (m MessageType) String() string {
 }
 
 // UpstreamDownstream pairs come from individual proxy registrations, which can be updated independently.
+// TODO: move to state package
 type UpstreamDownstream struct {
 	Upstream   ServiceName
 	Downstream ServiceName

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2474,19 +2474,3 @@ func (m MessageType) String() string {
 	return "Unknown(" + strconv.Itoa(int(m)) + ")"
 
 }
-
-// UpstreamDownstream pairs come from individual proxy registrations, which can be updated independently.
-// TODO: move to state package
-type UpstreamDownstream struct {
-	Upstream   ServiceName
-	Downstream ServiceName
-
-	// Refs stores the registrations that contain this pairing.
-	// When there are no remaining Refs, the UpstreamDownstream can be deleted.
-	//
-	// Note: This map must be treated as immutable when accessed in MemDB.
-	//       The entire UpstreamDownstream structure must be deep copied on updates.
-	Refs map[string]struct{}
-
-	RaftIndex
-}


### PR DESCRIPTION
The mesh-topology and gateway-services tables already use indexers that are pretty close to the new functional index pattern.

Best viewed by individual commit.

This PR doesn't change the indexers, but makes the following changes:
* adds tests for the indexers
* uses the index name constants for all operations
* moves the `UpstreamDownstream` type from `structs` to `state`, and un-exports it. This type is only used to store things, it's not part of any API.
* removes `gatewayServices` and `serviceGateways` functions, and calls the `tx.Get` operations directly. This makes it easier to see what the function is doing from the caller.