### PR TITLE
state: convert acl-policies table to new functional indexer pattern

### DIFF
--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -228,7 +228,7 @@ func (s *Restore) ACLToken(token *structs.ACLToken) error {
 
 // ACLPolicies is used when saving a snapshot
 func (s *Snapshot) ACLPolicies() (memdb.ResultIterator, error) {
-	iter, err := s.tx.Get("acl-policies", "id")
+	iter, err := s.tx.Get(tableACLPolicies, indexID)
 	if err != nil {
 		return nil, err
 	}
@@ -1212,8 +1212,8 @@ func (s *Store) ACLPolicyBatchGet(ws memdb.WatchSet, ids []string) (uint64, stru
 	}
 
 	// We are specifically not wanting to call aclPolicyMaxIndex here as we always want the
-	// index entry for the "acl-policies" table.
-	idx := maxIndexTxn(tx, "acl-policies")
+	// index entry for the tableACLPolicies table.
+	idx := maxIndexTxn(tx, tableACLPolicies)
 
 	return idx, policies, nil
 }

--- a/agent/consul/state/acl_events.go
+++ b/agent/consul/state/acl_events.go
@@ -1,9 +1,10 @@
 package state
 
 import (
+	memdb "github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/agent/consul/stream"
 	"github.com/hashicorp/consul/agent/structs"
-	memdb "github.com/hashicorp/go-memdb"
 )
 
 // aclChangeUnsubscribeEvent creates and returns stream.UnsubscribeEvents that
@@ -27,7 +28,7 @@ func aclChangeUnsubscribeEvent(tx ReadTxn, changes Changes) ([]stream.Event, err
 			}
 			secretIDs = appendSecretIDsFromTokenIterator(secretIDs, tokens)
 
-		case "acl-policies":
+		case tableACLPolicies:
 			policy := changeObject(change).(*structs.ACLPolicy)
 			tokens, err := aclTokenListByPolicy(tx, policy.ID, &policy.EnterpriseMeta)
 			if err != nil {

--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -11,11 +11,11 @@ import (
 )
 
 func aclPolicyInsert(tx *txn, policy *structs.ACLPolicy) error {
-	if err := tx.Insert("acl-policies", policy); err != nil {
+	if err := tx.Insert(tableACLPolicies, policy); err != nil {
 		return fmt.Errorf("failed inserting acl policy: %v", err)
 	}
 
-	if err := indexUpdateMaxTxn(tx, policy.ModifyIndex, "acl-policies"); err != nil {
+	if err := indexUpdateMaxTxn(tx, policy.ModifyIndex, tableACLPolicies); err != nil {
 		return fmt.Errorf("failed updating acl policies index: %v", err)
 	}
 
@@ -23,32 +23,32 @@ func aclPolicyInsert(tx *txn, policy *structs.ACLPolicy) error {
 }
 
 func aclPolicyGetByID(tx ReadTxn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
-	return tx.FirstWatch("acl-policies", "id", id)
+	return tx.FirstWatch(tableACLPolicies, indexID, id)
 }
 
 func aclPolicyGetByName(tx ReadTxn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
-	return tx.FirstWatch("acl-policies", "name", name)
+	return tx.FirstWatch(tableACLPolicies, indexName, name)
 }
 
 func aclPolicyList(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get("acl-policies", "id")
+	return tx.Get(tableACLPolicies, indexID)
 }
 
 func aclPolicyDeleteWithPolicy(tx *txn, policy *structs.ACLPolicy, idx uint64) error {
 	// remove the policy
-	if err := tx.Delete("acl-policies", policy); err != nil {
+	if err := tx.Delete(tableACLPolicies, policy); err != nil {
 		return fmt.Errorf("failed deleting acl policy: %v", err)
 	}
 
 	// update the overall acl-policies index
-	if err := indexUpdateMaxTxn(tx, idx, "acl-policies"); err != nil {
+	if err := indexUpdateMaxTxn(tx, idx, tableACLPolicies); err != nil {
 		return fmt.Errorf("failed updating acl policies index: %v", err)
 	}
 	return nil
 }
 
 func aclPolicyMaxIndex(tx ReadTxn, _ *structs.ACLPolicy, _ *structs.EnterpriseMeta) uint64 {
-	return maxIndexTxn(tx, "acl-policies")
+	return maxIndexTxn(tx, tableACLPolicies)
 }
 
 func aclPolicyUpsertValidateEnterprise(*txn, *structs.ACLPolicy, *structs.ACLPolicy) error {

--- a/agent/consul/state/acl_oss_test.go
+++ b/agent/consul/state/acl_oss_test.go
@@ -23,7 +23,7 @@ func testIndexerTableACLPolicies() map[string]indexerTestCase {
 		},
 		indexName: {
 			read: indexValue{
-				source:   []interface{}{"PolicyName"},
+				source:   Query{Value: "PolicyName"},
 				expected: []byte("policyname\x00"),
 			},
 			write: indexValue{

--- a/agent/consul/state/acl_oss_test.go
+++ b/agent/consul/state/acl_oss_test.go
@@ -1,0 +1,35 @@
+// +build !consulent
+
+package state
+
+import "github.com/hashicorp/consul/agent/structs"
+
+func testIndexerTableACLPolicies() map[string]indexerTestCase {
+	obj := &structs.ACLPolicy{
+		ID:   "123e4567-e89b-12d3-a456-426614174abc",
+		Name: "PoLiCyNaMe",
+	}
+	encodedID := []byte{0x12, 0x3e, 0x45, 0x67, 0xe8, 0x9b, 0x12, 0xd3, 0xa4, 0x56, 0x42, 0x66, 0x14, 0x17, 0x4a, 0xbc}
+	return map[string]indexerTestCase{
+		indexID: {
+			read: indexValue{
+				source:   obj.ID,
+				expected: encodedID,
+			},
+			write: indexValue{
+				source:   obj,
+				expected: encodedID,
+			},
+		},
+		indexName: {
+			read: indexValue{
+				source:   []interface{}{"PolicyName"},
+				expected: []byte("policyname\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("policyname\x00"),
+			},
+		},
+	}
+}

--- a/agent/consul/state/acl_schema.go
+++ b/agent/consul/state/acl_schema.go
@@ -125,10 +125,10 @@ func policiesTableSchema() *memdb.TableSchema {
 				Name:         indexName,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: &memdb.StringFieldIndex{
-					Field: "Name",
-					// TODO (ACL-V2) - should we coerce to lowercase?
-					Lowercase: true,
+				Indexer: indexerSingleWithPrefix{
+					readIndex:   readIndex(indexFromQuery),
+					writeIndex:  writeIndex(indexNameFromACLPolicy),
+					prefixIndex: prefixIndex(prefixIndexFromQuery),
 				},
 			},
 		},

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	pbacl "github.com/hashicorp/consul/proto/pbacl"
-	memdb "github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-uuid"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -3801,7 +3802,7 @@ func TestStateStore_ACLPolicies_Snapshot_Restore(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)
 		require.ElementsMatch(t, policies, res)
-		require.Equal(t, uint64(2), s.maxIndex("acl-policies"))
+		require.Equal(t, uint64(2), s.maxIndex(tableACLPolicies))
 	}()
 }
 

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -103,21 +103,6 @@ func indexFromServiceNode(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func prefixIndexFromQuery(arg interface{}) ([]byte, error) {
-	var b indexBuilder
-	switch v := arg.(type) {
-	case *structs.EnterpriseMeta:
-		return nil, nil
-	case structs.EnterpriseMeta:
-		return nil, nil
-	case Query:
-		b.String(strings.ToLower(v.Value))
-		return b.Bytes(), nil
-	}
-
-	return nil, fmt.Errorf("unexpected type %T for NodeServiceQuery prefix index", arg)
-}
-
 func serviceIndexName(name string, _ *structs.EnterpriseMeta) string {
 	return fmt.Sprintf("service.%s", name)
 }

--- a/agent/consul/state/query_oss.go
+++ b/agent/consul/state/query_oss.go
@@ -1,0 +1,38 @@
+// +build !consulent
+
+package state
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// indexFromQuery builds an index key where Query.Value is lowercase, and is
+// a required value.
+func indexFromQuery(arg interface{}) ([]byte, error) {
+	q, ok := arg.(Query)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type %T for Query index", arg)
+	}
+
+	var b indexBuilder
+	b.String(strings.ToLower(q.Value))
+	return b.Bytes(), nil
+}
+
+func prefixIndexFromQuery(arg interface{}) ([]byte, error) {
+	var b indexBuilder
+	switch v := arg.(type) {
+	case *structs.EnterpriseMeta:
+		return nil, nil
+	case structs.EnterpriseMeta:
+		return nil, nil
+	case Query:
+		b.String(strings.ToLower(v.Value))
+		return b.Bytes(), nil
+	}
+
+	return nil, fmt.Errorf("unexpected type %T for Query prefix index", arg)
+}

--- a/agent/consul/state/schema_test.go
+++ b/agent/consul/state/schema_test.go
@@ -128,6 +128,7 @@ func TestNewDBSchema_Indexers(t *testing.T) {
 	require.NoError(t, schema.Validate())
 
 	var testcases = map[string]func() map[string]indexerTestCase{
+		tableACLPolicies:     testIndexerTableACLPolicies,
 		tableChecks:          testIndexerTableChecks,
 		tableServices:        testIndexerTableServices,
 		tableNodes:           testIndexerTableNodes,

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -12,7 +12,7 @@ table=acl-policies
   index=id unique
     indexer=github.com/hashicorp/go-memdb.UUIDFieldIndex Field=ID
   index=name unique
-    indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=Name Lowercase=true
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingleWithPrefix readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexNameFromACLPolicy prefixIndex=github.com/hashicorp/consul/agent/consul/state.prefixIndexFromQuery
 
 table=acl-roles
   index=id unique


### PR DESCRIPTION
Also adds tests for indexers and uses index and table name constants.