### PR TITLE
[SDK] change all cases of *testing.T to testing.TB

### DIFF
--- a/sdk/testutil/assertions.go
+++ b/sdk/testutil/assertions.go
@@ -8,7 +8,7 @@ import (
 // RequireErrorContains is a test helper for asserting that an error occurred
 // and the error message returned contains the expected error message as a
 // substring.
-func RequireErrorContains(t *testing.T, err error, expectedErrorMessage string) {
+func RequireErrorContains(t testing.TB, err error, expectedErrorMessage string) {
 	t.Helper()
 	if err == nil {
 		t.Fatal("An error is expected but got nil.")

--- a/sdk/testutil/io.go
+++ b/sdk/testutil/io.go
@@ -35,7 +35,7 @@ var noCleanup = strings.ToLower(os.Getenv("TEST_NOCLEANUP")) == "true"
 // If the directory cannot be created t.Fatal is called.
 // The directory will be removed when the test ends. Set TEST_NOCLEANUP env var
 // to prevent the directory from being removed.
-func TempDir(t *testing.T, name string) string {
+func TempDir(t testing.TB, name string) string {
 	if t == nil {
 		panic("argument t must be non-nil")
 	}
@@ -61,7 +61,7 @@ func TempDir(t *testing.T, name string) string {
 // avoid double cleanup.
 // The file will be removed when the test ends.  Set TEST_NOCLEANUP env var
 // to prevent the file from being removed.
-func TempFile(t *testing.T, name string) *os.File {
+func TempFile(t testing.TB, name string) *os.File {
 	if t == nil {
 		panic("argument t must be non-nil")
 	}

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -383,7 +383,7 @@ func (s *TestServer) waitForAPI() error {
 // waitForLeader waits for the Consul server's HTTP API to become
 // available, and then waits for a known leader and an index of
 // 2 or more to be observed to confirm leader election is done.
-func (s *TestServer) WaitForLeader(t *testing.T) {
+func (s *TestServer) WaitForLeader(t testing.TB) {
 	retry.Run(t, func(r *retry.R) {
 		// Query the API and check the status code.
 		url := s.url("/v1/catalog/nodes")
@@ -412,7 +412,7 @@ func (s *TestServer) WaitForLeader(t *testing.T) {
 
 // WaitForActiveCARoot waits until the server can return a Connect CA meaning
 // connect has completed bootstrapping and is ready to use.
-func (s *TestServer) WaitForActiveCARoot(t *testing.T) {
+func (s *TestServer) WaitForActiveCARoot(t testing.TB) {
 	// don't need to fully decode the response
 	type rootsResponse struct {
 		ActiveRootID string
@@ -452,7 +452,7 @@ func (s *TestServer) WaitForActiveCARoot(t *testing.T) {
 // WaitForServiceIntentions waits until the server can accept config entry
 // kinds of service-intentions meaning any migration bootstrapping from pre-1.9
 // intentions has completed.
-func (s *TestServer) WaitForServiceIntentions(t *testing.T) {
+func (s *TestServer) WaitForServiceIntentions(t testing.TB) {
 	const fakeConfigName = "Sa4ohw5raith4si0Ohwuqu3lowiethoh"
 	retry.Run(t, func(r *retry.R) {
 		// Try to delete a non-existent service-intentions config entry. The
@@ -472,7 +472,7 @@ func (s *TestServer) WaitForServiceIntentions(t *testing.T) {
 
 // WaitForSerfCheck ensures we have a node with serfHealth check registered
 // Behavior mirrors testrpc.WaitForTestAgent but avoids the dependency cycle in api pkg
-func (s *TestServer) WaitForSerfCheck(t *testing.T) {
+func (s *TestServer) WaitForSerfCheck(t testing.TB) {
 	retry.Run(t, func(r *retry.R) {
 		// Query the API and check the status code.
 		url := s.url("/v1/catalog/nodes?index=0")

--- a/sdk/testutil/server_methods.go
+++ b/sdk/testutil/server_methods.go
@@ -24,32 +24,32 @@ const (
 )
 
 // JoinLAN is used to join local datacenters together.
-func (s *TestServer) JoinLAN(t *testing.T, addr string) {
+func (s *TestServer) JoinLAN(t testing.TB, addr string) {
 	resp := s.put(t, "/v1/agent/join/"+addr, nil)
 	defer resp.Body.Close()
 }
 
 // JoinWAN is used to join remote datacenters together.
-func (s *TestServer) JoinWAN(t *testing.T, addr string) {
+func (s *TestServer) JoinWAN(t testing.TB, addr string) {
 	resp := s.put(t, "/v1/agent/join/"+addr+"?wan=1", nil)
 	resp.Body.Close()
 }
 
 // SetKV sets an individual key in the K/V store.
-func (s *TestServer) SetKV(t *testing.T, key string, val []byte) {
+func (s *TestServer) SetKV(t testing.TB, key string, val []byte) {
 	resp := s.put(t, "/v1/kv/"+key, bytes.NewBuffer(val))
 	resp.Body.Close()
 }
 
 // SetKVString sets an individual key in the K/V store, but accepts a string
 // instead of []byte.
-func (s *TestServer) SetKVString(t *testing.T, key string, val string) {
+func (s *TestServer) SetKVString(t testing.TB, key string, val string) {
 	resp := s.put(t, "/v1/kv/"+key, bytes.NewBufferString(val))
 	resp.Body.Close()
 }
 
 // GetKV retrieves a single key and returns its value
-func (s *TestServer) GetKV(t *testing.T, key string) []byte {
+func (s *TestServer) GetKV(t testing.TB, key string) []byte {
 	resp := s.get(t, "/v1/kv/"+key)
 	defer resp.Body.Close()
 
@@ -76,12 +76,12 @@ func (s *TestServer) GetKV(t *testing.T, key string) []byte {
 
 // GetKVString retrieves a value from the store, but returns as a string instead
 // of []byte.
-func (s *TestServer) GetKVString(t *testing.T, key string) string {
+func (s *TestServer) GetKVString(t testing.TB, key string) string {
 	return string(s.GetKV(t, key))
 }
 
 // PopulateKV fills the Consul KV with data from a generic map.
-func (s *TestServer) PopulateKV(t *testing.T, data map[string][]byte) {
+func (s *TestServer) PopulateKV(t testing.TB, data map[string][]byte) {
 	for k, v := range data {
 		s.SetKV(t, k, v)
 	}
@@ -89,7 +89,7 @@ func (s *TestServer) PopulateKV(t *testing.T, data map[string][]byte) {
 
 // ListKV returns a list of keys present in the KV store. This will list all
 // keys under the given prefix recursively and return them as a slice.
-func (s *TestServer) ListKV(t *testing.T, prefix string) []string {
+func (s *TestServer) ListKV(t testing.TB, prefix string) []string {
 	resp := s.get(t, "/v1/kv/"+prefix+"?keys")
 	defer resp.Body.Close()
 
@@ -108,7 +108,7 @@ func (s *TestServer) ListKV(t *testing.T, prefix string) []string {
 // AddService adds a new service to the Consul instance. It also
 // automatically adds a health check with the given status, which
 // can be one of "passing", "warning", or "critical".
-func (s *TestServer) AddService(t *testing.T, name, status string, tags []string) {
+func (s *TestServer) AddService(t testing.TB, name, status string, tags []string) {
 	s.AddAddressableService(t, name, status, "", 0, tags) // set empty address and 0 as port for non-accessible service
 }
 
@@ -117,7 +117,7 @@ func (s *TestServer) AddService(t *testing.T, name, status string, tags []string
 // that maybe accessed with in target source code.
 // It also automatically adds a health check with the given status, which
 // can be one of "passing", "warning", or "critical", just like `AddService` does.
-func (s *TestServer) AddAddressableService(t *testing.T, name, status, address string, port int, tags []string) {
+func (s *TestServer) AddAddressableService(t testing.TB, name, status, address string, port int, tags []string) {
 	svc := &TestService{
 		Name:    name,
 		Tags:    tags,
@@ -157,7 +157,7 @@ func (s *TestServer) AddAddressableService(t *testing.T, name, status, address s
 // AddCheck adds a check to the Consul instance. If the serviceID is
 // left empty (""), then the check will be associated with the node.
 // The check status may be "passing", "warning", or "critical".
-func (s *TestServer) AddCheck(t *testing.T, name, serviceID, status string) {
+func (s *TestServer) AddCheck(t testing.TB, name, serviceID, status string) {
 	chk := &TestCheck{
 		ID:   name,
 		Name: name,
@@ -186,7 +186,7 @@ func (s *TestServer) AddCheck(t *testing.T, name, serviceID, status string) {
 }
 
 // put performs a new HTTP PUT request.
-func (s *TestServer) put(t *testing.T, path string, body io.Reader) *http.Response {
+func (s *TestServer) put(t testing.TB, path string, body io.Reader) *http.Response {
 	req, err := http.NewRequest("PUT", s.url(path), body)
 	if err != nil {
 		t.Fatalf("failed to create PUT request: %s", err)
@@ -203,7 +203,7 @@ func (s *TestServer) put(t *testing.T, path string, body io.Reader) *http.Respon
 }
 
 // get performs a new HTTP GET request.
-func (s *TestServer) get(t *testing.T, path string) *http.Response {
+func (s *TestServer) get(t testing.TB, path string) *http.Response {
 	resp, err := s.HTTPClient.Get(s.url(path))
 	if err != nil {
 		t.Fatalf("failed to create GET request: %s", err)

--- a/sdk/testutil/server_wrapper.go
+++ b/sdk/testutil/server_wrapper.go
@@ -4,7 +4,7 @@ import "testing"
 
 type WrappedServer struct {
 	s *TestServer
-	t *testing.T
+	t testing.TB
 }
 
 // Wrap wraps the test server in a `testing.t` for convenience.
@@ -16,7 +16,7 @@ type WrappedServer struct {
 //
 // This is useful when you are calling multiple functions and save the wrapped
 // value as another variable to reduce the inclusion of "t".
-func (s *TestServer) Wrap(t *testing.T) *WrappedServer {
+func (s *TestServer) Wrap(t testing.TB) *WrappedServer {
 	return &WrappedServer{s, t}
 }
 


### PR DESCRIPTION
Using the interface opens up the use of all methods to benchmarks as well as tests.

Should be complete a drop in replacement.

Tested changes manually against both consul-terraform-sync's and consul-template's use of the sdk/testutil's TestServer to validate real-world use cases. 