### PR TITLE
ui: Add all tooltips to the default tabbing order in the page

### DIFF
--- a/ui/packages/consul-ui/app/modifiers/tooltip.js
+++ b/ui/packages/consul-ui/app/modifiers/tooltip.js
@@ -46,6 +46,11 @@ export default modifier(($element, [content], hash = {}) => {
     }
   }
   let $trigger = $anchor;
+  let needsTabIndex = false;
+  if (!$trigger.hasAttribute('tabindex')) {
+    needsTabIndex = true;
+    $trigger.setAttribute('tabindex', '0');
+  }
   const tooltip = tippy($anchor, {
     theme: 'tooltip',
     triggerTarget: $trigger,
@@ -59,6 +64,9 @@ export default modifier(($element, [content], hash = {}) => {
   });
 
   return () => {
+    if (needsTabIndex) {
+      $trigger.removeAttribute('tabindex');
+    }
     clearInterval(interval);
     tooltip.destroy();
   };

--- a/ui/packages/consul-ui/app/modifiers/tooltip.mdx
+++ b/ui/packages/consul-ui/app/modifiers/tooltip.mdx
@@ -1,6 +1,6 @@
 # tooltip
 
-Our tooltip modifier is a thin wrapper around the excellent `tippy.js`. The
+Consul UIs tooltip modifier is a thin wrapper around the excellent `tippy.js`. The
 most common usage will be something like the below:
 
 ```hbs preview-template
@@ -10,6 +10,8 @@ most common usage will be something like the below:
   Hover over me
 </span>
 ```
+
+A `tabindex=0` is automatically added to the element that triggers the tooltip if it doesn't have one already to make sure the tooltip is in the natural tabbing order of the document.
 
 An additional options hash can be passed into the tooltip the contents of
 which are passed along to `tippy.js` [so all of the `tippy.js`


### PR DESCRIPTION
This amends our tooltip modifier to automatically add a `tabindex="0"` to
all of our tooltips (if they don't have a tabindex already).

This means that all tooltips will automatically be
added to the natural tab order of the page. I'm pretty sure we don't
currently require the ability to disable this automatic functionality
but if we do at some point in the future we can add an option to disable
it, meaning all tooltips will be tabbable by default.