### PR TITLE
Removing unnecessary comment

### DIFF
--- a/website/content/api-docs/agent/connect.mdx
+++ b/website/content/api-docs/agent/connect.mdx
@@ -63,8 +63,7 @@ The table below shows this endpoint's support for
   certificate.
 
 - `ClientCertSerial` `(string: <required>)` - The colon-hex-encoded serial
-  number for the requesting client cert. This is used to check against
-  revocation lists.
+  number for the requesting client cert.
 
 - `Namespace` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of
   the target service. If not provided in the JSON body, the value of


### PR DESCRIPTION
Removing unnecessary comment around CRL to avoid confusion, as discussed with @banks