### PR TITLE
Cross linking Learn tutorials

### DIFF
--- a/website/content/docs/nia/architecture.mdx
+++ b/website/content/docs/nia/architecture.mdx
@@ -50,3 +50,9 @@ A driver encapsulates the resources required to communicate the updates to the
 network infrastructure. Terraform is the initial supported driver. It comes
 with a set of providers that [enables supporting](/docs/nia/terraform-modules) a wide variety of
 infrastructure applications.
+
+## Security Guidelines
+
+The [Secure Consul-Terraform-Sync for Production](https://learn.hashicorp.com/tutorials/consul/consul-terraform-sync-secure?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) 
+tutorial contains a checklist of best practices to secure your 
+Consul-Terraform-Sync installation for a production environment.

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -69,7 +69,7 @@ consul {
   - `ca_path` - (string) The path to a directory of CA certs to use for talking to Consul over TLS. Can also be provided through the `CONSUL_CAPATH` environment variable.
   - `cert` - (string) The client cert file to use for talking to Consul over TLS. Can also be provided through the `CONSUL_CLIENT_CERT` environment variable.
   - `server_name` - (string) The server name to use as the SNI host when connecting via TLS. Can also be provided through the `CONSUL_TLS_SERVER_NAME` environment variable.
-- `token` - (string) The ACL token to use for client communication with the local Consul agent. The token can also be provided through the `CONSUL_TOKEN` or `CONSUL_HTTP_TOKEN` environment variables.
+- `token` - (string) The ACL token to use for client communication with the local Consul agent. The token can also be provided through the `CONSUL_TOKEN` or `CONSUL_HTTP_TOKEN` environment variables. More information on the required privileges required by Consul-Terraform-Sync are available in the [Secure Consul-Terraform-Sync for Production](https://learn.hashicorp.com/tutorials/consul/consul-terraform-sync-secure?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS#configure-acl-privileges-for-consul-terraform-sync) tutorial 
 - `transport` - Transport configures the low-level network connection details.
   - `dial_keep_alive` - (string: "30s") The amount of time for keep-alives.
   - `dial_timeout` - (string: "30s") The amount of time to wait to establish a connection.

--- a/website/content/docs/nia/index.mdx
+++ b/website/content/docs/nia/index.mdx
@@ -34,7 +34,7 @@ Consul-Terraform-Sync executes one or more automation tasks with the most recent
 
 ## Getting Started With Network Infrastructure Automation
 
-The [Network Infrastructure Automation (NIA)](https://learn.hashicorp.com/collections/consul/network-infrastructure-automationutm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) 
+The [Network Infrastructure Automation (NIA)](https://learn.hashicorp.com/collections/consul/network-infrastructure-automation?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) 
 collection contains examples on how to configure Consul-Terraform-Sync to 
 perform Network Infrastructure Automation. The collection contains also a 
 tutorial to secure your Consul-Terraform-Sync configuration for a production 

--- a/website/content/docs/nia/index.mdx
+++ b/website/content/docs/nia/index.mdx
@@ -32,6 +32,15 @@ Consul-Terraform-Sync executes one or more automation tasks with the most recent
 
 **Terraform Provider** - A [Terraform provider](https://www.terraform.io/docs/providers/index.html) is responsible for understanding API interactions and exposing resources for an infrastructure type.
 
+## Getting Started With Network Infrastructure Automation
+
+The [Network Infrastructure Automation (NIA)](https://learn.hashicorp.com/collections/consul/network-infrastructure-automationutm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) 
+collection contains examples on how to configure Consul-Terraform-Sync to 
+perform Network Infrastructure Automation. The collection contains also a 
+tutorial to secure your Consul-Terraform-Sync configuration for a production 
+environment and one to help you build you own Consul-Terraform-Sync compatible 
+module.
+
 ## Community
 
 - [Contribute](https://github.com/hashicorp/consul-terraform-sync) to the open source project

--- a/website/content/docs/nia/installation/install.mdx
+++ b/website/content/docs/nia/installation/install.mdx
@@ -8,6 +8,9 @@ description: >-
 
 # Install Consul-Terraform-Sync
 
+The [introduction](https://learn.hashicorp.com/tutorials/consul/consul-terraform-sync-secure#configure-acl-privileges-for-consul-terraform-sync?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial provides a quick walkthrough of installing, configuring, and running 
+Consul-Terraform-Sync on your local machine.
+
 ## Installing Consul-Terraform-Sync
 
 To install Consul-Terraform-Sync, find the [appropriate package](https://releases.hashicorp.com/consul-terraform-sync/) for your system and download it as a zip archive. Unzip the package to extract the binary named consul-terraform-sync. Move the consul-terraform-sync binary to a location available on your PATH.

--- a/website/content/docs/nia/installation/install.mdx
+++ b/website/content/docs/nia/installation/install.mdx
@@ -8,7 +8,7 @@ description: >-
 
 # Install Consul-Terraform-Sync
 
-The [introduction](https://learn.hashicorp.com/tutorials/consul/consul-terraform-sync-secure#configure-acl-privileges-for-consul-terraform-sync?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial provides a quick walkthrough of installing, configuring, and running 
+The [introduction](https://learn.hashicorp.com/tutorials/consul/consul-terraform-sync-intro?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial provides a quick walkthrough of installing, configuring, and running 
 Consul-Terraform-Sync on your local machine.
 
 ## Installing Consul-Terraform-Sync

--- a/website/content/docs/nia/installation/run.mdx
+++ b/website/content/docs/nia/installation/run.mdx
@@ -27,3 +27,12 @@ description: >-
   ```shell-session
   $ curl localhost:8558/status/tasks
   ```
+
+## Other Run modes
+
+Consul-Terraform-Sync allows you to inspect your configuration before applying 
+any change and to run in once mode, meaning that you can verify the changes are 
+correctly applied in a test run before running it in unsupervised daemon mode.
+
+To learn more on these options check the 
+[Consul-Terraform-Sync Run Modes and Status Inspection](https://learn.hashicorp.com/tutorials/consul/consul-terraform-sync-run-and-inspect?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial.

--- a/website/content/docs/security/security-models/nia.mdx
+++ b/website/content/docs/security/security-models/nia.mdx
@@ -10,6 +10,10 @@ description: >-
 
 Network Infrastructure Automation (NIA) enables dynamic updates to network infrastructure devices triggered by service changes using the [Consul Terraform Sync](https://github.com/hashicorp/consul-terraform-sync) (`consul-terraform-sync`) daemon. This daemon uses Consul's catalog to monitor networking information about services along with [Terraform](https://www.terraform.io/)'s provider ecosystem to apply relevant changes to network infrastructure.
 
+The [Secure Consul-Terraform-Sync for Production](https://learn.hashicorp.com/tutorials/consul/consul-terraform-sync-secure?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) 
+tutorial contains a checklist of best practices to secure your 
+Consul-Terraform-Sync installation for a production environment.
+
 ### Personas
 
 When considering Consul NIA's security model, it helps to think of the following personas.


### PR DESCRIPTION
Here the first changes to the documentation to cross link the Learn tutorials.

I am not sure if we want to add links in other pages but, once https://github.com/hashicorp/learn/pull/3096 is merged we might want to change the first link in https://www.consul.io/docs/nia/terraform-modules#how-to-create-a-compatible-terraform-module to the new specific CTS tutorial or add an extra one.

Comments or changes are welcome.