### PR TITLE
Add methods to check intention has wildcard src or dst

### DIFF
--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -965,9 +965,7 @@ func (s *Store) IntentionTopology(ws memdb.WatchSet,
 		// Intentions with wildcard source and destination have the lowest precedence, so they are last in the list
 		ixn := intentions[len(intentions)-1]
 
-		// TODO (freddy) This needs an enterprise split to account for (*/* -> */*)
-		//				 Maybe ixn.HasWildcardSource() && ixn.HasWildcardDestination()
-		if ixn.SourceName == structs.WildcardSpecifier && ixn.DestinationName == structs.WildcardSpecifier {
+		if ixn.HasWildcardSource() && ixn.HasWildcardDestination() {
 			defaultDecision = acl.Allow
 			if ixn.Action == structs.IntentionActionDeny {
 				defaultDecision = acl.Deny

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -150,3 +150,11 @@ func (s *Session) CheckIDs() []types.CheckID {
 	}
 	return checks
 }
+
+func (t *Intention) HasWildcardSource() bool {
+	return t.SourceName == WildcardSpecifier
+}
+
+func (t *Intention) HasWildcardDestination() bool {
+	return t.DestinationName == WildcardSpecifier
+}

--- a/agent/structs/structs_oss_test.go
+++ b/agent/structs/structs_oss_test.go
@@ -41,3 +41,35 @@ func TestServiceName_String(t *testing.T) {
 		require.Equal(t, "the-id", fmt.Sprintf("%v", &sn))
 	})
 }
+
+func TestIntention_HasWildcardSource(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		ixn := Intention{
+			SourceName: WildcardSpecifier,
+		}
+		require.True(t, ixn.HasWildcardSource())
+	})
+
+	t.Run("false", func(t *testing.T) {
+		ixn := Intention{
+			SourceName: "web",
+		}
+		require.False(t, ixn.HasWildcardSource())
+	})
+}
+
+func TestIntention_HasWildcardDestination(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		ixn := Intention{
+			DestinationName: WildcardSpecifier,
+		}
+		require.True(t, ixn.HasWildcardDestination())
+	})
+
+	t.Run("false", func(t *testing.T) {
+		ixn := Intention{
+			DestinationName: "web",
+		}
+		require.False(t, ixn.HasWildcardDestination())
+	})
+}


### PR DESCRIPTION
This is needed for an oss/ent split, where the enterprise side checks for wildcard name AND namespace.