### PR TITLE
Fixup enterprise tests from tproxy changes

### DIFF
--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -1664,7 +1664,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				{
 					requiredWatches: map[string]verifyWatchRequest{
 						"discovery-chain:" + dbStr: genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
-							Name:                 dbStr,
+							Name:                 "db",
 							EvaluateInDatacenter: "dc1",
 							EvaluateInNamespace:  "default",
 							Datacenter:           "dc1",
@@ -1686,11 +1686,11 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				},
 				{
 					requiredWatches: map[string]verifyWatchRequest{
-						"upstream-target:db.default.dc1:db": genVerifyServiceWatch("db", "", "dc1", true),
+						"upstream-target:db.default.dc1:" + dbStr: genVerifyServiceWatch("db", "", "dc1", true),
 					},
 					events: []cache.UpdateEvent{
 						{
-							CorrelationID: "upstream-target:db.default.dc1:db",
+							CorrelationID: "upstream-target:db.default.dc1:" + dbStr,
 							Result: &structs.IndexedCheckServiceNodes{
 								Nodes: structs.CheckServiceNodes{
 									{

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -112,8 +112,9 @@ func TestServiceManager_RegisterSidecar(t *testing.T) {
 			LocalServicePort:       8000,
 			Upstreams: structs.Upstreams{
 				{
-					DestinationName: "redis",
-					LocalBindPort:   5000,
+					DestinationName:      "redis",
+					DestinationNamespace: "default",
+					LocalBindPort:        5000,
 				},
 			},
 		},
@@ -141,8 +142,9 @@ func TestServiceManager_RegisterSidecar(t *testing.T) {
 			},
 			Upstreams: structs.Upstreams{
 				{
-					DestinationName: "redis",
-					LocalBindPort:   5000,
+					DestinationName:      "redis",
+					DestinationNamespace: "default",
+					LocalBindPort:        5000,
 					Config: map[string]interface{}{
 						"protocol": "tcp",
 					},
@@ -341,8 +343,9 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 			LocalServicePort:       8000,
 			Upstreams: structs.Upstreams{
 				{
-					DestinationName: "redis",
-					LocalBindPort:   5000,
+					DestinationName:      "redis",
+					DestinationNamespace: "default",
+					LocalBindPort:        5000,
 				},
 			},
 		},
@@ -366,8 +369,9 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 			},
 			Upstreams: structs.Upstreams{
 				{
-					DestinationName: "redis",
-					LocalBindPort:   5000,
+					DestinationName:      "redis",
+					DestinationNamespace: "default",
+					LocalBindPort:        5000,
 					Config: map[string]interface{}{
 						"protocol": "tcp",
 					},
@@ -550,6 +554,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 			local_service_port       = 8000
 			upstreams = [{
 			  destination_name = "redis"
+			  destination_namespace = "default"
 			  local_bind_port  = 5000
 			}]
 		  }
@@ -592,9 +597,10 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 			},
 			Upstreams: structs.Upstreams{
 				{
-					DestinationType: "service",
-					DestinationName: "redis",
-					LocalBindPort:   5000,
+					DestinationType:      "service",
+					DestinationName:      "redis",
+					DestinationNamespace: "default",
+					LocalBindPort:        5000,
 					Config: map[string]interface{}{
 						"protocol": "tcp",
 					},

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1531,8 +1531,9 @@ func TestServiceConfigEntry_Normalize(t *testing.T) {
 				Name: "web",
 			},
 			expect: ServiceConfigEntry{
-				Kind: ServiceDefaults,
-				Name: "web",
+				Kind:           ServiceDefaults,
+				Name:           "web",
+				EnterpriseMeta: *DefaultEnterpriseMeta(),
 			},
 		},
 		{
@@ -1543,9 +1544,10 @@ func TestServiceConfigEntry_Normalize(t *testing.T) {
 				Protocol: "PrOtoCoL",
 			},
 			expect: ServiceConfigEntry{
-				Kind:     ServiceDefaults,
-				Name:     "web",
-				Protocol: "protocol",
+				Kind:           ServiceDefaults,
+				Name:           "web",
+				Protocol:       "protocol",
+				EnterpriseMeta: *DefaultEnterpriseMeta(),
 			},
 		},
 		{
@@ -1564,6 +1566,7 @@ func TestServiceConfigEntry_Normalize(t *testing.T) {
 					},
 					UpstreamDefaults: &UpstreamConfig{ConnectTimeoutMs: -20},
 				},
+				EnterpriseMeta: *DefaultEnterpriseMeta(),
 			},
 			expect: ServiceConfigEntry{
 				Kind: ServiceDefaults,
@@ -1582,6 +1585,7 @@ func TestServiceConfigEntry_Normalize(t *testing.T) {
 						ConnectTimeoutMs: 0,
 					},
 				},
+				EnterpriseMeta: *DefaultEnterpriseMeta(),
 			},
 		},
 	}


### PR DESCRIPTION
Some enterprise test fixes were needed from the tproxy changes. These are the OSS side of those.