### PR TITLE
ui: Ensure intention form cancel button works

### DIFF
--- a/.changelog/9901.txt
+++ b/.changelog/9901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix intention form cancel button
+```

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.js
@@ -23,6 +23,7 @@ export default class ConsulIntentionForm extends Component {
     this.updateCRDManagement();
   }
 
+  @action
   ondelete() {
     if (this.args.ondelete) {
       this.args.ondelete(...arguments);
@@ -31,6 +32,7 @@ export default class ConsulIntentionForm extends Component {
     }
   }
 
+  @action
   oncancel() {
     if (this.args.oncancel) {
       this.args.oncancel(...arguments);
@@ -39,6 +41,7 @@ export default class ConsulIntentionForm extends Component {
     }
   }
 
+  @action
   onsubmit() {
     if (this.args.onsubmit) {
       this.args.onsubmit(...arguments);
@@ -49,6 +52,7 @@ export default class ConsulIntentionForm extends Component {
   updateCRDManagement() {
     this.isManagedByCRDs = this.repo.isManagedByCRDs();
   }
+
   @action
   submit(item, submit, e) {
     e.preventDefault();
@@ -60,6 +64,7 @@ export default class ConsulIntentionForm extends Component {
       submit();
     }
   }
+
   @action
   createServices(item, e) {
     // Services in the menus should:


### PR DESCRIPTION
By adding `@action` decorators to the actions called form within the
template.

Fixes https://github.com/hashicorp/consul/issues/9764