### PR TITLE
state: convert ACLRoles policies index to new functional indexer pattern

### DIFF
--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -237,7 +237,7 @@ func (s *Restore) ACLPolicy(policy *structs.ACLPolicy) error {
 
 // ACLRoles is used when saving a snapshot
 func (s *Snapshot) ACLRoles() (memdb.ResultIterator, error) {
-	iter, err := s.tx.Get("acl-roles", "id")
+	iter, err := s.tx.Get(tableACLRoles, indexID)
 	if err != nil {
 		return nil, err
 	}
@@ -1440,7 +1440,7 @@ func (s *Store) ACLRoleBatchGet(ws memdb.WatchSet, ids []string) (uint64, struct
 		}
 	}
 
-	idx := maxIndexTxn(tx, "acl-roles")
+	idx := maxIndexTxn(tx, tableACLRoles)
 
 	return idx, roles, nil
 }

--- a/agent/consul/state/acl_events.go
+++ b/agent/consul/state/acl_events.go
@@ -36,7 +36,8 @@ func aclChangeUnsubscribeEvent(tx ReadTxn, changes Changes) ([]stream.Event, err
 			}
 			secretIDs = appendSecretIDsFromTokenIterator(secretIDs, tokens)
 
-			roles, err := aclRoleListByPolicy(tx, policy.ID, &policy.EnterpriseMeta)
+			q := Query{Value: policy.ID, EnterpriseMeta: policy.EnterpriseMeta}
+			roles, err := tx.Get(tableACLRoles, indexPolicies, q)
 			if err != nil {
 				return nil, err
 			}

--- a/agent/consul/state/acl_events.go
+++ b/agent/consul/state/acl_events.go
@@ -20,7 +20,7 @@ func aclChangeUnsubscribeEvent(tx ReadTxn, changes Changes) ([]stream.Event, err
 			token := changeObject(change).(*structs.ACLToken)
 			secretIDs = append(secretIDs, token.SecretID)
 
-		case "acl-roles":
+		case tableACLRoles:
 			role := changeObject(change).(*structs.ACLRole)
 			tokens, err := aclTokenListByRole(tx, role.ID, &role.EnterpriseMeta)
 			if err != nil {

--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -38,6 +38,21 @@ func indexNameFromACLPolicy(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+func indexNameFromACLRole(raw interface{}) ([]byte, error) {
+	p, ok := raw.(*structs.ACLRole)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type %T for structs.ACLRole index", raw)
+	}
+
+	if p.Name == "" {
+		return nil, errMissingValueForIndex
+	}
+
+	var b indexBuilder
+	b.String(strings.ToLower(p.Name))
+	return b.Bytes(), nil
+}
+
 func aclPolicyGetByID(tx ReadTxn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch(tableACLPolicies, indexID, id)
 }
@@ -157,14 +172,6 @@ func aclRoleInsert(tx *txn, role *structs.ACLRole) error {
 
 func aclRoleGetByID(tx ReadTxn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch(tableACLRoles, indexID, id)
-}
-
-func aclRoleGetByName(tx ReadTxn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
-	return tx.FirstWatch(tableACLRoles, indexName, name)
-}
-
-func aclRoleList(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get(tableACLRoles, indexID)
 }
 
 func aclRoleListByPolicy(tx ReadTxn, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {

--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -144,48 +144,48 @@ func (s *Store) ACLTokenUpsertValidateEnterprise(token *structs.ACLToken, existi
 
 func aclRoleInsert(tx *txn, role *structs.ACLRole) error {
 	// insert the role into memdb
-	if err := tx.Insert("acl-roles", role); err != nil {
+	if err := tx.Insert(tableACLRoles, role); err != nil {
 		return fmt.Errorf("failed inserting acl role: %v", err)
 	}
 
 	// update the overall acl-roles index
-	if err := indexUpdateMaxTxn(tx, role.ModifyIndex, "acl-roles"); err != nil {
+	if err := indexUpdateMaxTxn(tx, role.ModifyIndex, tableACLRoles); err != nil {
 		return fmt.Errorf("failed updating acl roles index: %v", err)
 	}
 	return nil
 }
 
 func aclRoleGetByID(tx ReadTxn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
-	return tx.FirstWatch("acl-roles", "id", id)
+	return tx.FirstWatch(tableACLRoles, indexID, id)
 }
 
 func aclRoleGetByName(tx ReadTxn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
-	return tx.FirstWatch("acl-roles", "name", name)
+	return tx.FirstWatch(tableACLRoles, indexName, name)
 }
 
 func aclRoleList(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get("acl-roles", "id")
+	return tx.Get(tableACLRoles, indexID)
 }
 
 func aclRoleListByPolicy(tx ReadTxn, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get("acl-roles", "policies", policy)
+	return tx.Get(tableACLRoles, indexPolicies, policy)
 }
 
 func aclRoleDeleteWithRole(tx *txn, role *structs.ACLRole, idx uint64) error {
 	// remove the role
-	if err := tx.Delete("acl-roles", role); err != nil {
+	if err := tx.Delete(tableACLRoles, role); err != nil {
 		return fmt.Errorf("failed deleting acl role: %v", err)
 	}
 
 	// update the overall acl-roles index
-	if err := indexUpdateMaxTxn(tx, idx, "acl-roles"); err != nil {
+	if err := indexUpdateMaxTxn(tx, idx, tableACLRoles); err != nil {
 		return fmt.Errorf("failed updating acl policies index: %v", err)
 	}
 	return nil
 }
 
 func aclRoleMaxIndex(tx ReadTxn, _ *structs.ACLRole, _ *structs.EnterpriseMeta) uint64 {
-	return maxIndexTxn(tx, "acl-roles")
+	return maxIndexTxn(tx, tableACLRoles)
 }
 
 func aclRoleUpsertValidateEnterprise(tx *txn, role *structs.ACLRole, existing *structs.ACLRole) error {

--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -66,7 +66,11 @@ func multiIndexPolicyFromACLRole(raw interface{}) ([][]byte, error) {
 
 	vals := make([][]byte, 0, count)
 	for _, link := range role.Policies {
-		vals = append(vals, []byte(strings.ToLower(link.ID)+"\x00"))
+		v, err := uuidStringToBytes(link.ID)
+		if err != nil {
+			return nil, err
+		}
+		vals = append(vals, v)
 	}
 
 	return vals, nil

--- a/agent/consul/state/acl_oss_test.go
+++ b/agent/consul/state/acl_oss_test.go
@@ -33,3 +33,49 @@ func testIndexerTableACLPolicies() map[string]indexerTestCase {
 		},
 	}
 }
+
+func testIndexerTableACLRoles() map[string]indexerTestCase {
+	obj := &structs.ACLRole{
+		ID:   "123e4567-e89a-12d7-a456-426614174abc",
+		Name: "RoLe",
+		Policies: []structs.ACLRolePolicyLink{
+			{ID: "PolicyId1"}, {ID: "PolicyId2"},
+		},
+	}
+	encodedID := []byte{0x12, 0x3e, 0x45, 0x67, 0xe8, 0x9a, 0x12, 0xd7, 0xa4, 0x56, 0x42, 0x66, 0x14, 0x17, 0x4a, 0xbc}
+	return map[string]indexerTestCase{
+		indexID: {
+			read: indexValue{
+				source:   obj.ID,
+				expected: encodedID,
+			},
+			write: indexValue{
+				source:   obj,
+				expected: encodedID,
+			},
+		},
+		indexName: {
+			read: indexValue{
+				source:   "RoLe",
+				expected: []byte("role\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("role\x00"),
+			},
+		},
+		indexPolicies: {
+			read: indexValue{
+				source:   "PolicyId1",
+				expected: []byte("PolicyId1\x00"),
+			},
+			writeMulti: indexValueMulti{
+				source: obj,
+				expected: [][]byte{
+					[]byte("PolicyId1\x00"),
+					[]byte("PolicyId2\x00"),
+				},
+			},
+		},
+	}
+}

--- a/agent/consul/state/acl_oss_test.go
+++ b/agent/consul/state/acl_oss_test.go
@@ -56,7 +56,7 @@ func testIndexerTableACLRoles() map[string]indexerTestCase {
 		},
 		indexName: {
 			read: indexValue{
-				source:   "RoLe",
+				source:   Query{Value: "RoLe"},
 				expected: []byte("role\x00"),
 			},
 			write: indexValue{

--- a/agent/consul/state/acl_oss_test.go
+++ b/agent/consul/state/acl_oss_test.go
@@ -66,14 +66,14 @@ func testIndexerTableACLRoles() map[string]indexerTestCase {
 		},
 		indexPolicies: {
 			read: indexValue{
-				source:   "PolicyId1",
-				expected: []byte("PolicyId1\x00"),
+				source:   Query{Value: "PolicyId1"},
+				expected: []byte("policyid1\x00"),
 			},
 			writeMulti: indexValueMulti{
 				source: obj,
 				expected: [][]byte{
-					[]byte("PolicyId1\x00"),
-					[]byte("PolicyId2\x00"),
+					[]byte("policyid1\x00"),
+					[]byte("policyid2\x00"),
 				},
 			},
 		},

--- a/agent/consul/state/acl_oss_test.go
+++ b/agent/consul/state/acl_oss_test.go
@@ -35,14 +35,18 @@ func testIndexerTableACLPolicies() map[string]indexerTestCase {
 }
 
 func testIndexerTableACLRoles() map[string]indexerTestCase {
+	policyID1 := "123e4567-e89a-12d7-a456-426614174001"
+	policyID2 := "123e4567-e89a-12d7-a456-426614174002"
 	obj := &structs.ACLRole{
 		ID:   "123e4567-e89a-12d7-a456-426614174abc",
 		Name: "RoLe",
 		Policies: []structs.ACLRolePolicyLink{
-			{ID: "PolicyId1"}, {ID: "PolicyId2"},
+			{ID: policyID1}, {ID: policyID2},
 		},
 	}
 	encodedID := []byte{0x12, 0x3e, 0x45, 0x67, 0xe8, 0x9a, 0x12, 0xd7, 0xa4, 0x56, 0x42, 0x66, 0x14, 0x17, 0x4a, 0xbc}
+	encodedPID1 := []byte{0x12, 0x3e, 0x45, 0x67, 0xe8, 0x9a, 0x12, 0xd7, 0xa4, 0x56, 0x42, 0x66, 0x14, 0x17, 0x40, 0x01}
+	encodedPID2 := []byte{0x12, 0x3e, 0x45, 0x67, 0xe8, 0x9a, 0x12, 0xd7, 0xa4, 0x56, 0x42, 0x66, 0x14, 0x17, 0x40, 0x02}
 	return map[string]indexerTestCase{
 		indexID: {
 			read: indexValue{
@@ -66,15 +70,12 @@ func testIndexerTableACLRoles() map[string]indexerTestCase {
 		},
 		indexPolicies: {
 			read: indexValue{
-				source:   Query{Value: "PolicyId1"},
-				expected: []byte("policyid1\x00"),
+				source:   Query{Value: policyID1},
+				expected: encodedPID1,
 			},
 			writeMulti: indexValueMulti{
-				source: obj,
-				expected: [][]byte{
-					[]byte("policyid1\x00"),
-					[]byte("policyid2\x00"),
-				},
+				source:   obj,
+				expected: [][]byte{encodedPID1, encodedPID2},
 			},
 		},
 	}

--- a/agent/consul/state/acl_schema.go
+++ b/agent/consul/state/acl_schema.go
@@ -151,9 +151,10 @@ func rolesTableSchema() *memdb.TableSchema {
 				Name:         indexName,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: &memdb.StringFieldIndex{
-					Field:     "Name",
-					Lowercase: true,
+				Indexer: indexerSingleWithPrefix{
+					readIndex:   readIndex(indexFromQuery),
+					writeIndex:  writeIndex(indexNameFromACLRole),
+					prefixIndex: prefixIndex(prefixIndexFromQuery),
 				},
 			},
 			indexPolicies: {

--- a/agent/consul/state/acl_schema.go
+++ b/agent/consul/state/acl_schema.go
@@ -163,7 +163,7 @@ func rolesTableSchema() *memdb.TableSchema {
 				AllowMissing: true,
 				Unique:       false,
 				Indexer: indexerMulti{
-					readIndex:       readIndex(indexFromQuery),
+					readIndex:       readIndex(indexFromUUIDQuery),
 					writeIndexMulti: writeIndexMulti(multiIndexPolicyFromACLRole),
 				},
 			},

--- a/agent/consul/state/acl_schema.go
+++ b/agent/consul/state/acl_schema.go
@@ -162,7 +162,10 @@ func rolesTableSchema() *memdb.TableSchema {
 				// Need to allow missing for the anonymous token
 				AllowMissing: true,
 				Unique:       false,
-				Indexer:      &RolePoliciesIndex{},
+				Indexer: indexerMulti{
+					readIndex:       readIndex(indexFromQuery),
+					writeIndexMulti: writeIndexMulti(multiIndexPolicyFromACLRole),
+				},
 			},
 		},
 	}

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -4082,7 +4082,7 @@ func TestStateStore_ACLRoles_Snapshot_Restore(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)
 		require.ElementsMatch(t, roles, res)
-		require.Equal(t, uint64(2), s.maxIndex("acl-roles"))
+		require.Equal(t, uint64(2), s.maxIndex(tableACLRoles))
 	}()
 }
 

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -28,13 +28,6 @@ const (
 	minUUIDLookupLen = 2
 )
 
-// Query is a type used to query any single value index that may include an
-// enterprise identifier.
-type Query struct {
-	Value string
-	structs.EnterpriseMeta
-}
-
 func resizeNodeLookupKey(s string) string {
 	l := len(s)
 

--- a/agent/consul/state/indexer.go
+++ b/agent/consul/state/indexer.go
@@ -107,6 +107,13 @@ func (b *indexBuilder) String(v string) {
 	(*bytes.Buffer)(b).WriteString(null)
 }
 
+// Raw appends the bytes without a null terminator to the buffer. Raw should
+// only be used when v has a fixed length, or when building the last segment of
+// a prefix index.
+func (b *indexBuilder) Raw(v []byte) {
+	(*bytes.Buffer)(b).Write(v)
+}
+
 func (b *indexBuilder) Bytes() []byte {
 	return (*bytes.Buffer)(b).Bytes()
 }

--- a/agent/consul/state/query.go
+++ b/agent/consul/state/query.go
@@ -1,0 +1,42 @@
+package state
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// Query is a type used to query any single value index that may include an
+// enterprise identifier.
+type Query struct {
+	Value string
+	structs.EnterpriseMeta
+}
+
+// uuidStringToBytes is a modified version of memdb.UUIDFieldIndex.parseString
+func uuidStringToBytes(uuid string) ([]byte, error) {
+	l := len(uuid)
+	if l != 36 {
+		return nil, fmt.Errorf("UUID must be 36 characters")
+	}
+
+	hyphens := strings.Count(uuid, "-")
+	if hyphens > 4 {
+		return nil, fmt.Errorf(`UUID should have maximum of 4 "-"; got %d`, hyphens)
+	}
+
+	// The sanitized length is the length of the original string without the "-".
+	sanitized := strings.Replace(uuid, "-", "", -1)
+	sanitizedLength := len(sanitized)
+	if sanitizedLength%2 != 0 {
+		return nil, fmt.Errorf("UUID (without hyphens) must be even length")
+	}
+
+	dec, err := hex.DecodeString(sanitized)
+	if err != nil {
+		return nil, fmt.Errorf("invalid UUID: %w", err)
+	}
+	return dec, nil
+}

--- a/agent/consul/state/query_oss.go
+++ b/agent/consul/state/query_oss.go
@@ -36,3 +36,11 @@ func prefixIndexFromQuery(arg interface{}) ([]byte, error) {
 
 	return nil, fmt.Errorf("unexpected type %T for Query prefix index", arg)
 }
+
+func indexFromUUIDQuery(raw interface{}) ([]byte, error) {
+	q, ok := raw.(Query)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type %T for UUIDQuery index", raw)
+	}
+	return uuidStringToBytes(q.Value)
+}

--- a/agent/consul/state/schema_test.go
+++ b/agent/consul/state/schema_test.go
@@ -129,6 +129,7 @@ func TestNewDBSchema_Indexers(t *testing.T) {
 
 	var testcases = map[string]func() map[string]indexerTestCase{
 		tableACLPolicies:     testIndexerTableACLPolicies,
+		tableACLRoles:        testIndexerTableACLRoles,
 		tableChecks:          testIndexerTableChecks,
 		tableServices:        testIndexerTableServices,
 		tableNodes:           testIndexerTableNodes,

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -18,7 +18,7 @@ table=acl-roles
   index=id unique
     indexer=github.com/hashicorp/go-memdb.UUIDFieldIndex Field=ID
   index=name unique
-    indexer=github.com/hashicorp/go-memdb.StringFieldIndex Field=Name Lowercase=true
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingleWithPrefix readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexNameFromACLRole prefixIndex=github.com/hashicorp/consul/agent/consul/state.prefixIndexFromQuery
   index=policies allow-missing
     indexer=github.com/hashicorp/consul/agent/consul/state.RolePoliciesIndex
 

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -20,7 +20,7 @@ table=acl-roles
   index=name unique
     indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingleWithPrefix readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexNameFromACLRole prefixIndex=github.com/hashicorp/consul/agent/consul/state.prefixIndexFromQuery
   index=policies allow-missing
-    indexer=github.com/hashicorp/consul/agent/consul/state.RolePoliciesIndex
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerMulti readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromQuery writeIndexMulti=github.com/hashicorp/consul/agent/consul/state.multiIndexPolicyFromACLRole
 
 table=acl-tokens
   index=accessor unique allow-missing

--- a/agent/consul/state/testdata/TestStateStoreSchema.golden
+++ b/agent/consul/state/testdata/TestStateStoreSchema.golden
@@ -20,7 +20,7 @@ table=acl-roles
   index=name unique
     indexer=github.com/hashicorp/consul/agent/consul/state.indexerSingleWithPrefix readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromQuery writeIndex=github.com/hashicorp/consul/agent/consul/state.indexNameFromACLRole prefixIndex=github.com/hashicorp/consul/agent/consul/state.prefixIndexFromQuery
   index=policies allow-missing
-    indexer=github.com/hashicorp/consul/agent/consul/state.indexerMulti readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromQuery writeIndexMulti=github.com/hashicorp/consul/agent/consul/state.multiIndexPolicyFromACLRole
+    indexer=github.com/hashicorp/consul/agent/consul/state.indexerMulti readIndex=github.com/hashicorp/consul/agent/consul/state.indexFromUUIDQuery writeIndexMulti=github.com/hashicorp/consul/agent/consul/state.multiIndexPolicyFromACLRole
 
 table=acl-tokens
   index=accessor unique allow-missing


### PR DESCRIPTION
Just like all the others.

This also changes the `acl-roles.polcies` index to use an encoded UUID, where as previously it used a string. This should save a bit of memory for each linked policy.