### PR TITLE
fix(changelog-checker): remove period to fix broken link

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -29,7 +29,7 @@ jobs:
           # If we do not find a file in .changelog/, we fail the check
           if [ -z "$changelog_files" ]; then
             # Fail status check when no .changelog entry was found on the PR
-            echo "Did not find a .changelog entry and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/consul/pull/8387."
+            echo "Did not find a .changelog entry and the 'pr/no-changelog' label was not applied. Reference - https://github.com/hashicorp/consul/pull/8387"
             exit 1
           else
             echo "Found .changelog entry in PR!"


### PR DESCRIPTION
The `.` immediately following the PR link was being included in the link, causing it to not go to its expected destination.