### PR TITLE
Document agent token policy requirement for rexec

### DIFF
--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -41,6 +41,8 @@ execute this command.
 | `key:write`     | `"_rexec"` prefix |
 | `event:write`   | `"_rexec"` prefix |
 
+In addition to the above, the policy associated with the [agent token](https://www.consul.io/docs/security/acl/acl-system#acl-agent-token) should have `write` on `"_rexec"` key prefix. This is for the agents to read the `exec` command and write its output back to the KV store.
+
 ## Usage
 
 Usage: `consul exec [options] [-|command...]`


### PR DESCRIPTION
The Agent token policy when using rexec should have `write` on "_rexec" key prefix. Updated the exec command documentation to explicitly state this requirement.