### PR TITLE
docs/nia: consul compatibilty

### DIFF
--- a/website/content/docs/nia/compatibility.mdx
+++ b/website/content/docs/nia/compatibility.mdx
@@ -1,0 +1,18 @@
+---
+layout: docs
+page_title: Consul-Terraform-Sync Compatibility
+sidebar_title: Compatibility
+description: >-
+  Consul-Terraform-Sync Compatibility
+---
+# Compatibility
+
+## Consul
+
+Below are the supported Consul versions with compatible Consul-Terraform-Sync versions. The latest Consul-Terraform-Sync binary targets supporting the latest patch version of the three most recent Consul minor versions.
+
+| Consul Version                       | Compatible Consul-Terraform-Sync Version |
+| ------------------------------------ | ---------------------------------------- |
+| Latest patch version of 1.9          | 0.1.0                                    |
+| Latest patch version of 1.8 (1.8.9)  | 0.1.0                                    |
+| Latest patch version of 1.7 (1.7.13) | 0.1.0                                    |

--- a/website/content/docs/nia/installation/requirements.mdx
+++ b/website/content/docs/nia/installation/requirements.mdx
@@ -20,6 +20,8 @@ Consul-Terraform-Sync is a daemon that runs alongside Consul, similar to other C
 
 To install a local Consul agent, refer to the [Getting Started: Install Consul Tutorial](https://learn.hashicorp.com/tutorials/consul/get-started-install).
 
+For information on compatible Consul versions, refer to the [Consul compatibility matrix](/docs/nia/compatibility#consul).
+
 ### Run an Agent
 
 The Consul agent must be running in order to dynamically update network devices. To run the local Consul agent, you can run Consul in development mode which can be started with `consul agent -dev` for simplicity. For more details on running Consul agent, refer to the [Getting Started: Run the Consul Agent Tutorial](https://learn.hashicorp.com/tutorials/consul/get-started-agent?in=consul/getting-started).

--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -237,6 +237,7 @@ export default [
       'tasks',
       'terraform-modules',
       'network-drivers',
+      'compatibility',
     ],
   },
 


### PR DESCRIPTION
Added a 'compatibility' page with a Consul compatibility matrix

Changes:
 - [New compatibility page](https://consul-lnpwex284-hashicorp.vercel.app/docs/nia/compatibility)
 - Link to compatibility page from the ['getting started: install consul' page](https://consul-lnpwex284-hashicorp.vercel.app/docs/nia/installation/requirements#install-consul)