### PR TITLE
Allow passing ALPN next protocols down to connect services. Fixes #4466.

### DIFF
--- a/.changelog/9920.txt
+++ b/.changelog/9920.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: The builtin connect proxy no longer advertises support for h2 via ALPN. [[GH-4466](https://github.com/hashicorp/consul/issues/4466)].
+```

--- a/connect/proxy/config.go
+++ b/connect/proxy/config.go
@@ -46,7 +46,7 @@ type Config struct {
 
 // Service returns the *connect.Service structure represented by this config.
 func (c *Config) Service(client *api.Client, logger hclog.Logger) (*connect.Service, error) {
-	return connect.NewServiceWithLogger(c.ProxiedServiceName, client, logger)
+	return connect.NewServiceWithConfig(c.ProxiedServiceName, connect.Config{Client: client, Logger: logger, ServerNextProtos: []string{}})
 }
 
 // PublicListenerConfig contains the parameters needed for the incoming mTLS

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"testing"
 
@@ -60,12 +61,15 @@ func TestProxy_public(t *testing.T) {
 	defer p.Close()
 	go p.Serve()
 
+	// We create this client with an explicit ServerNextProtos here for safety, so
+	// we can properly verify that h2 was not accepted below
+	svc, err := connect.NewServiceWithConfig("echo", connect.Config{Client: client, ServerNextProtos: []string{"h2"}})
+	require.NoError(err)
+
 	// Create a test connection to the proxy. We retry here a few times
 	// since this is dependent on the agent actually starting up and setting
 	// up the CA.
 	var conn net.Conn
-	svc, err := connect.NewService("echo", client)
-	require.NoError(err)
 	retry.Run(t, func(r *retry.R) {
 		conn, err = svc.Dial(context.Background(), &connect.StaticResolver{
 			Addr:    TestLocalAddr(ports[0]),
@@ -75,6 +79,10 @@ func TestProxy_public(t *testing.T) {
 			r.Fatalf("err: %s", err)
 		}
 	})
+
+	// Verify that we did not select h2 via ALPN since the proxy is layer 4 only
+	tlsConn := conn.(*tls.Conn)
+	require.Equal("", tlsConn.ConnectionState().NegotiatedProtocol)
 
 	// Connection works, test it is the right one
 	TestEchoConn(t, conn, "")

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -61,8 +61,9 @@ func TestProxy_public(t *testing.T) {
 	defer p.Close()
 	go p.Serve()
 
-	// We create this client with an explicit ServerNextProtos here for safety, so
-	// we can properly verify that h2 was not accepted below
+	// We create this client with an explicit ServerNextProtos here which will use `h2`
+	// if the proxy supports it. This is so we can verify below that the proxy _doesn't_
+	// advertise `h2` support as it's only a L4 proxy.
 	svc, err := connect.NewServiceWithConfig("echo", connect.Config{Client: client, ServerNextProtos: []string{"h2"}})
 	require.NoError(err)
 


### PR DESCRIPTION
@banks This should cover the technical aspects of the PR. I am not to happy with the pointer to the nextProto array, but I am not sure how we could pass the default nicely otherwise…