### PR TITLE
http: fix a bug that would cause runtimeConfig to be cached

### DIFF
--- a/.changelog/9923.txt
+++ b/.changelog/9923.txt
@@ -1,0 +1,3 @@
+```release-notes:bug
+http: fix a bug in Consul Enterprise that would cause the UI to believe namespaces were supported, resulting in warning logs and incorrect UI behaviour.
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -288,7 +288,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 		uiHandler := uiserver.NewHandler(
 			s.agent.config,
 			s.agent.logger.Named(logging.HTTP),
-			s.uiTemplateDataTransform(),
+			s.uiTemplateDataTransform,
 		)
 		s.configReloaders = append(s.configReloaders, uiHandler.ReloadConfig)
 
@@ -298,10 +298,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 			uiHandler,
 			s.agent.config.HTTPResponseHeaders,
 		)
-		mux.Handle(
-			"/robots.txt",
-			uiHandlerWithHeaders,
-		)
+		mux.Handle("/robots.txt", uiHandlerWithHeaders)
 		mux.Handle(
 			s.agent.config.UIConfig.ContentPath,
 			http.StripPrefix(

--- a/agent/http_oss.go
+++ b/agent/http_oss.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/agent/uiserver"
 )
 
 func (s *HTTPHandlers) parseEntMeta(req *http.Request, entMeta *structs.EnterpriseMeta) error {
@@ -71,6 +70,6 @@ func (s *HTTPHandlers) enterpriseHandler(next http.Handler) http.Handler {
 
 // uiTemplateDataTransform returns an optional uiserver.UIDataTransform to allow
 // altering UI data in enterprise.
-func (s *HTTPHandlers) uiTemplateDataTransform() uiserver.UIDataTransform {
+func (s *HTTPHandlers) uiTemplateDataTransform(data map[string]interface{}) error {
 	return nil
 }

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -13,9 +13,10 @@ import (
 
 	"golang.org/x/net/html"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUIServerIndex(t *testing.T) {
@@ -105,7 +106,7 @@ func TestUIServerIndex(t *testing.T) {
 				withMetricsProvider("foo"),
 			),
 			path: "/",
-			tx: func(cfg *config.RuntimeConfig, data map[string]interface{}) error {
+			tx: func(data map[string]interface{}) error {
 				data["SSOEnabled"] = true
 				o := data["UIConfig"].(map[string]interface{})
 				o["metrics_provider"] = "bar"

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/html"
-
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/html"
 
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -359,4 +359,57 @@ func TestCompiledJS(t *testing.T) {
 		})
 	}
 
+}
+
+func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
+	cfg := basicUIEnabledConfig()
+
+	value := "seeds"
+	transform := func(data map[string]interface{}) error {
+		data["apple"] = value
+		return nil
+	}
+	h := NewHandler(cfg, hclog.New(nil), transform)
+
+	t.Run("initial request", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		expected := `{
+		"ACLsEnabled": false,
+		"LocalDatacenter": "dc1",
+		"ContentPath": "/ui/",
+		"UIConfig": {
+			"metrics_provider": "",
+			"metrics_proxy_enabled": false,
+			"dashboard_url_templates": null
+		},
+		"apple": "seeds"
+	}`
+		require.JSONEq(t, expected, extractUIConfig(t, rec.Body.String()))
+	})
+
+	t.Run("transform value has changed", func(t *testing.T) {
+
+		value = "plant"
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		expected := `{
+			"ACLsEnabled": false,
+			"LocalDatacenter": "dc1",
+			"ContentPath": "/ui/",
+			"UIConfig": {
+				"metrics_provider": "",
+				"metrics_proxy_enabled": false,
+				"dashboard_url_templates": null
+			},
+			"apple": "plant"
+		}`
+		require.JSONEq(t, expected, extractUIConfig(t, rec.Body.String()))
+	})
 }


### PR DESCRIPTION
This bug would result in the UI not having the correct settings in Consul enterprise, which could produce many warnings in the logs.

This bug occurred because the index page, which includes a map of configuration was rendered when the HTTPHandler is first created. This PR changes the UIServer to instead render the index page when the page is requested.

The rendering does not appear to be all that expensive, so rendering it when requested should not cause much extra latency.

Also includes a bit of cleanup to remove some unnecessary args, and unnecessary function wrapping.

This bug only exists in 1.9.x, so I think we only need one backport.