### PR TITLE
ui: Fix spacing issues in composite row detail section

### DIFF
--- a/.changelog/9930.txt
+++ b/.changelog/9930.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix spacing issues in composite rows
+```

--- a/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/exposed-path/list/index.hbs
@@ -9,15 +9,13 @@
     <li>
       <div class="header">
       {{#let (concat @address ':' path.ListenerPort path.Path) as |combinedAddress|}}
-        <p class="combined-address">
-          <span>
-            {{combinedAddress}}
-          </span>
+        <span>
+          {{combinedAddress}}
           <CopyButton
             @value={{combinedAddress}}
             @name="Address"
           />
-        </p>
+        </span>
       {{/let}}
       </div>
       <div class="detail">

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
@@ -5,15 +5,13 @@
   </BlockSlot>
   <BlockSlot @name="details">
     {{#if item.ID}}
-    <dl>
-      <dt>
-        <CopyButton
-          @value={{item.ID}}
-          @name="ID"
-        />
-      </dt>
-      <dd>{{item.ID}}</dd>
-    </dl>
+    <span>
+      <CopyButton
+        @value={{item.ID}}
+        @name="ID"
+      />
+      {{item.ID}}
+    </span>
     {{/if}}
     {{#if item.LockDelay}}
     <dl class="lock-delay">

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
@@ -4,6 +4,7 @@
     <span>{{item.Name}}</span>
   </BlockSlot>
   <BlockSlot @name="details">
+    {{#if item.ID}}
     <dl>
       <dt>
         <CopyButton
@@ -13,6 +14,8 @@
       </dt>
       <dd>{{item.ID}}</dd>
     </dl>
+    {{/if}}
+    {{#if item.LockDelay}}
     <dl class="lock-delay">
       <dt>
         <Tooltip>
@@ -21,6 +24,8 @@
       </dt>
       <dd data-test-session-delay>{{item.LockDelay}}</dd>
     </dl>
+    {{/if}}
+    {{#if item.TTL}}
     <dl class="ttl">
       <dt>
         <Tooltip>
@@ -29,6 +34,8 @@
       </dt>
       <dd data-test-session-ttl={{item.TTL}}>{{item.TTL}}</dd>
     </dl>
+    {{/if}}
+    {{#if item.Behavior}}
     <dl class="behavior">
       <dt>
         <Tooltip>
@@ -37,6 +44,8 @@
       </dt>
       <dd>{{item.Behavior}}</dd>
     </dl>
+    {{/if}}
+    {{#if (gt item.Checks.length 0)}}
     <dl class="checks">
       <dt>
         <Tooltip>
@@ -49,6 +58,7 @@
       {{/each}}
       </dd>
     </dl>
+    {{/if}}
   </BlockSlot>
 {{#if (can "delete sessions")}}
   <BlockSlot @name="actions">

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
@@ -4,7 +4,6 @@
     <span>{{item.Name}}</span>
   </BlockSlot>
   <BlockSlot @name="details">
-    {{#if item.ID}}
     <span>
       <CopyButton
         @value={{item.ID}}
@@ -12,8 +11,6 @@
       />
       {{item.ID}}
     </span>
-    {{/if}}
-    {{#if item.LockDelay}}
     <dl class="lock-delay">
       <dt>
         <Tooltip>
@@ -22,8 +19,6 @@
       </dt>
       <dd data-test-session-delay>{{item.LockDelay}}</dd>
     </dl>
-    {{/if}}
-    {{#if item.TTL}}
     <dl class="ttl">
       <dt>
         <Tooltip>
@@ -32,8 +27,6 @@
       </dt>
       <dd data-test-session-ttl={{item.TTL}}>{{item.TTL}}</dd>
     </dl>
-    {{/if}}
-    {{#if item.Behavior}}
     <dl class="behavior">
       <dt>
         <Tooltip>
@@ -42,8 +35,6 @@
       </dt>
       <dd>{{item.Behavior}}</dd>
     </dl>
-    {{/if}}
-    {{#if (gt item.Checks.length 0)}}
     <dl class="checks">
       <dt>
         <Tooltip>
@@ -56,7 +47,6 @@
       {{/each}}
       </dd>
     </dl>
-    {{/if}}
   </BlockSlot>
 {{#if (can "delete sessions")}}
   <BlockSlot @name="actions">

--- a/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
@@ -34,13 +34,12 @@ as |item index|>
     </span>
     <dl>
       <dt>
-        <span>Address</span>
-      </dt>
-      <dd>
         <CopyButton
           @value={{item.Address}}
           @name="Address"
         />
+      </dt>
+      <dd>
         {{item.Address}}
       </dd>
     </dl>

--- a/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
@@ -32,16 +32,12 @@ as |item index|>
     <span>
       {{format-number item.MeshServiceInstances.length}} {{pluralize item.MeshServiceInstances.length 'Service' without-count=true}}
     </span>
-    <dl>
-      <dt>
-        <CopyButton
-          @value={{item.Address}}
-          @name="Address"
-        />
-      </dt>
-      <dd>
-        {{item.Address}}
-      </dd>
-    </dl>
+    <span>
+      <CopyButton
+        @value={{item.Address}}
+        @name="Address"
+      />
+      {{item.Address}}
+    </span>
   </BlockSlot>
 </ListCollection>

--- a/ui/packages/consul-ui/app/components/consul/nspace/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/nspace/list/index.hbs
@@ -14,12 +14,9 @@ as |item|>
 {{/if}}
     </BlockSlot>
     <BlockSlot @name="details">
-      <dl>
-        <dt>Description</dt>
-        <dd data-test-description>
-          {{item.Description}}
-        </dd>
-      </dl>
+    {{#if item.Description}}
+      <span data-test-description>{{item.Description}}</span>
+    {{/if}}
   {{#if (env 'CONSUL_ACLS_ENABLED')}}
       <Consul::Token::Ruleset::List @item={{item}} />
   {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
@@ -24,12 +24,7 @@ as |item|>
               {{join ', ' (policy/datacenters item)}}
           </dd>
         </dl>
-        <dl class="description">
-          <dt>Description</dt>
-          <dd data-test-description>
-            {{item.Description}}
-          </dd>
-        </dl>
+        <span data-test-description>{{item.Description}}</span>
     </BlockSlot>
     <BlockSlot @name="actions" as |Actions|>
       <Actions as |Action|>

--- a/ui/packages/consul-ui/app/components/consul/role/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/role/list/index.hbs
@@ -8,12 +8,7 @@ as |item|>
     </BlockSlot>
     <BlockSlot @name="details">
       <Consul::Token::Ruleset::List @item={{item}} />
-      <dl>
-        <dt>Description</dt>
-        <dd data-test-description>
-            {{item.Description}}
-        </dd>
-      </dl>
+      <span data-test-description>{{item.Description}}</span>
     </BlockSlot>
     <BlockSlot @name="actions" as |Actions|>
       <Actions as |Action|>

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
@@ -15,19 +15,9 @@ as |item|>
         <a data-test-token={{item.AccessorID}} href={{href-to 'dc.acls.tokens.edit' item.AccessorID}}>{{substr item.AccessorID -8}}</a>
     </BlockSlot>
     <BlockSlot @name="details">
-        <dl>
-          <dt>Scope</dt>
-          <dd>
-              {{if item.Local 'local' 'global' }}
-          </dd>
-        </dl>
-        <Consul::Token::Ruleset::List @item={{item}} />
-        <dl>
-          <dt>Description</dt>
-          <dd data-test-description>
-              {{or item.Description item.Name}}
-          </dd>
-        </dl>
+      <span>{{if item.Local 'local' 'global' }}</span>
+      <Consul::Token::Ruleset::List @item={{item}} />
+      <span data-test-description>{{or item.Description item.Name}}</span>
     </BlockSlot>
     <BlockSlot @name="actions" as |Actions|>
 

--- a/ui/packages/consul-ui/app/components/consul/token/ruleset/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/ruleset/list/index.hbs
@@ -1,48 +1,26 @@
 {{#let (policy/group (or item.Policies item.ACLs.PolicyDefaults (array))) as |policies|}}
   {{#let (get policies 'management') as |management|}}
     {{#if (gt management.length 0)}}
-        <dl>
-          <dt>
-            Management
-          </dt>
-          <dd>
-              {{#each (get policies 'management') as |item|}}
-                <span data-test-policy class={{policy/typeof item}}>{{item.Name}}</span>
-              {{/each}}
-          </dd>
-        </dl>
+      {{#each (get policies 'management') as |item|}}
+        <span data-test-policy class={{policy/typeof item}}>{{item.Name}}</span>
+      {{/each}}
     {{/if}}
   {{/let}}
   {{#let (get policies 'identities') as |identities|}}
     {{#if (gt identities.length 0)}}
-        <dl>
-          <dt>Identities</dt>
-          <dd>
-              {{#each identities as |item|}}
-                <span data-test-policy class={{policy/typeof item}}>{{item.Name}}</span>
-              {{/each}}
-          </dd>
-        </dl>
+      {{#each identities as |item|}}
+        <span data-test-policy class={{policy/typeof item}}>{{item.Name}}</span>
+      {{/each}}
     {{/if}}
   {{/let}}
   {{#if (token/is-legacy item) }}
-        <dl>
-          <dt>Rules</dt>
-          <dd>
-              Legacy tokens have embedded rules.
-          </dd>
-        </dl>
+    <span>Legacy tokens have embedded rules.</span>
   {{else}}
     {{#let (append (get policies 'policies') (or item.Roles item.ACLs.RoleDefaults (array))) as |policies|}}
       {{#if (gt policies.length 0)}}
-        <dl>
-          <dt>Rules</dt>
-          <dd>
-            {{#each policies as |item|}}
-              <span data-test-policy class={{policy/typeof item}}>{{item.Name}}</span>
-            {{/each}}
-          </dd>
-        </dl>
+        {{#each policies as |item|}}
+          <span data-test-policy class={{policy/typeof item}}>{{item.Name}}</span>
+        {{/each}}
       {{/if}}
     {{/let}}
   {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.hbs
@@ -39,17 +39,13 @@
       {{/if}}
       {{#if (gt item.LocalBindPort 0)}}
 {{#let (concat (or item.LocalBindAddress '127.0.0.1') ':' item.LocalBindPort) as |combinedAddress|}}
-        <dl class="local-bind-address">
-          <dt>
-            <CopyButton
-                @value={{combinedAddress}}
-                @name="Address"
-              />
-          </dt>
-          <dd>
-              {{combinedAddress}}
-          </dd>
-        </dl>
+        <span>
+          <CopyButton
+            @value={{combinedAddress}}
+            @name="Address"
+          />
+          {{combinedAddress}}
+        </span>
 {{/let}}
       {{/if}}
       </div>

--- a/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.hbs
@@ -41,15 +41,12 @@
 {{#let (concat (or item.LocalBindAddress '127.0.0.1') ':' item.LocalBindPort) as |combinedAddress|}}
         <dl class="local-bind-address">
           <dt>
-            <span>
-              Address
-            </span>
+            <CopyButton
+                @value={{combinedAddress}}
+                @name="Address"
+              />
           </dt>
           <dd>
-            <CopyButton
-              @value={{combinedAddress}}
-              @name="Address"
-            />
               {{combinedAddress}}
           </dd>
         </dl>

--- a/ui/packages/consul-ui/app/components/consul/upstream/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream/list/index.hbs
@@ -54,18 +54,13 @@ as |item index|>
     </dl>
   {{/if}}
   {{#each item.GatewayConfig.Addresses as |address|}}
-    <dl>
-      <dt>
-        <span>Address</span>
-      </dt>
-      <dd>
-        <CopyButton
-          @value={{address}}
-          @name="Address"
-        />
-        {{address}}
-      </dd>
-    </dl>
+    <span>
+      <CopyButton
+        @value={{address}}
+        @name="Address"
+      />
+      {{address}}
+    </span>
   {{/each}}
   </BlockSlot>
 </ListCollection>

--- a/ui/packages/consul-ui/app/styles/components/composite-row.scss
+++ b/ui/packages/consul-ui/app/styles/components/composite-row.scss
@@ -33,6 +33,10 @@
 .consul-service-instance-list .detail {
   overflow-x: visible !important;
 }
+.consul-service-list .detail,
+.consul-node-list .detail {
+  padding-left: 31px;
+}
 .consul-intention-permission-list > ul {
   border-top: 1px solid $gray-200;
 }
@@ -51,7 +55,6 @@
   margin-left: 4px;
 }
 %composite-row-detail .copy-button {
-  margin-right: 4px;
   margin-top: 2px;
 }
 %composite-row .copy-button button {

--- a/ui/packages/consul-ui/app/styles/components/composite-row.scss
+++ b/ui/packages/consul-ui/app/styles/components/composite-row.scss
@@ -34,8 +34,9 @@
   overflow-x: visible !important;
 }
 .consul-service-list .detail,
-.consul-node-list .detail {
-  padding-left: 31px;
+.consul-node-list .detail,
+.consul-upstream-list .detail {
+  padding-left: 25px;
 }
 .consul-intention-permission-list > ul {
   border-top: 1px solid $gray-200;
@@ -69,11 +70,6 @@
 }
 %composite-row .copy-button button:hover {
   background-color: transparent !important;
-}
-
-%composite-row-detail > .consul-kind:first-child,
-%composite-row-detail > .consul-external-source:first-child {
-  margin-left: -5px;
 }
 
 %composite-row-detail .policy::before {

--- a/ui/packages/consul-ui/app/styles/components/composite-row.scss
+++ b/ui/packages/consul-ui/app/styles/components/composite-row.scss
@@ -33,11 +33,6 @@
 .consul-service-instance-list .detail {
   overflow-x: visible !important;
 }
-.consul-service-list .detail,
-.consul-node-list .detail,
-.consul-upstream-list .detail {
-  padding-left: 25px;
-}
 .consul-intention-permission-list > ul {
   border-top: 1px solid $gray-200;
 }

--- a/ui/packages/consul-ui/app/styles/components/icon-definition/layout.scss
+++ b/ui/packages/consul-ui/app/styles/components/icon-definition/layout.scss
@@ -13,6 +13,3 @@
   white-space: nowrap;
   margin-left: 4px;
 }
-%icon-definition > dt > * {
-  display: none;
-}


### PR DESCRIPTION
🐛 Fix-ups in all the lists using the %composite-row styling component.

The following fixes were done:
- Replaced definition lists with spans.

NSpace List Before:
<img width="874" alt="npsace_list_before" src="https://user-images.githubusercontent.com/19161242/115257017-b93ec200-a0fd-11eb-8bd7-9817cd550d13.png">

NSpace List After:
<img width="728" alt="nspace_list_after" src="https://user-images.githubusercontent.com/19161242/115256690-75e45380-a0fd-11eb-9882-5c67146cade1.png">

- Show CopyButton if it's the first item in details

Lock Session List Before:
<img width="684" alt="lock_session_before" src="https://user-images.githubusercontent.com/19161242/115258609-20a94180-a0ff-11eb-9986-b4a43195edf4.png">

Lock Session List After: 
<img width="702" alt="lock_session_after" src="https://user-images.githubusercontent.com/19161242/115258644-2b63d680-a0ff-11eb-9041-a67b3c90a65a.png">

- Remove extra spacing from CopyButton

Upstream List Before:
<img width="483" alt="upstream_list_before" src="https://user-images.githubusercontent.com/19161242/115259210-acbb6900-a0ff-11eb-884d-d5a6070a6c96.png">

Upstream List After:
<img width="408" alt="upstream_list_after" src="https://user-images.githubusercontent.com/19161242/115259229-b0e78680-a0ff-11eb-8441-108717d849aa.png">

- Added left padding to the details of lists with health check icon in the header

Node List Before:
<img width="236" alt="node_list_before" src="https://user-images.githubusercontent.com/19161242/115259380-d70d2680-a0ff-11eb-8b22-6e7e0bc47f78.png">

Node List After:

<img width="257" alt="node_list_after" src="https://user-images.githubusercontent.com/19161242/115259454-e7bd9c80-a0ff-11eb-8696-9113085d4087.png">



- Move copy button to be in `span` tag
