### PR TITLE
Set default enterprise meta in test case

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3316,6 +3316,7 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 					// there worked by inspecting the registered sidecar below.
 					SidecarService: nil,
 				},
+				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			}
 
 			got := a.State.Service(structs.NewServiceID("test", nil))
@@ -3352,6 +3353,7 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 						},
 					},
 				},
+				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			}
 			gotSidecar := a.State.Service(structs.NewServiceID("test-sidecar-proxy", nil))
 			hasNoCorrectTCPCheck := true


### PR DESCRIPTION
I merged #7324, and apparently thet test that had been lying dormant and not running needed an update for enterprise.