### PR TITLE
state: convert remaining checks table indexers to functional pattern

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -1709,13 +1709,18 @@ func checksInStateTxn(tx ReadTxn, ws memdb.WatchSet, state string, entMeta *stru
 	// Get the table index.
 	idx := catalogChecksMaxIndex(tx, entMeta)
 
+	if entMeta == nil {
+		entMeta = structs.DefaultEnterpriseMeta()
+	}
+
 	// Query all checks if HealthAny is passed, otherwise use the index.
 	var iter memdb.ResultIterator
 	var err error
 	if state == api.HealthAny {
 		iter, err = tx.Get(tableChecks, indexID+"_prefix", entMeta)
 	} else {
-		iter, err = catalogListChecksInState(tx, state, entMeta)
+		q := Query{Value: state, EnterpriseMeta: *entMeta}
+		iter, err = tx.Get(tableChecks, indexStatus, q)
 	}
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed check lookup: %s", err)

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -1857,7 +1857,7 @@ func (s *Store) deleteCheckTxn(tx WriteTxn, idx uint64, node string, checkID typ
 	}
 
 	// Delete the check from the DB and update the index.
-	if err := tx.Delete("checks", hc); err != nil {
+	if err := tx.Delete(tableChecks, hc); err != nil {
 		return fmt.Errorf("failed removing check: %s", err)
 	}
 

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -1638,8 +1638,11 @@ func (s *Store) ServiceChecks(ws memdb.WatchSet, serviceName string, entMeta *st
 	// Get the table index.
 	idx := catalogChecksMaxIndex(tx, entMeta)
 
-	// Return the checks.
-	iter, err := catalogListChecksByService(tx, serviceName, entMeta)
+	if entMeta == nil {
+		entMeta = structs.DefaultEnterpriseMeta()
+	}
+	q := Query{Value: serviceName, EnterpriseMeta: *entMeta}
+	iter, err := tx.Get(tableChecks, indexService, q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed check lookup: %s", err)
 	}
@@ -1663,8 +1666,12 @@ func (s *Store) ServiceChecksByNodeMeta(ws memdb.WatchSet, serviceName string,
 
 	// Get the table index.
 	idx := maxIndexForService(tx, serviceName, true, true, entMeta)
-	// Return the checks.
-	iter, err := catalogListChecksByService(tx, serviceName, entMeta)
+
+	if entMeta == nil {
+		entMeta = structs.DefaultEnterpriseMeta()
+	}
+	q := Query{Value: serviceName, EnterpriseMeta: *entMeta}
+	iter, err := tx.Get(tableChecks, indexService, q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed check lookup: %s", err)
 	}

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -175,7 +175,7 @@ func ServiceHealthEventsFromChanges(tx ReadTxn, changes Changes) ([]stream.Event
 			srvChange := serviceChange{changeType: changeTypeFromChange(change), change: change}
 			markService(newNodeServiceTupleFromServiceNode(sn), srvChange)
 
-		case "checks":
+		case tableChecks:
 			// For health we only care about the scope for now to know if it's just
 			// affecting a single service or every service on a node. There is a
 			// subtle edge case where the check with same ID changes from being node

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -139,11 +139,6 @@ func catalogListChecksByService(tx ReadTxn, service string, _ *structs.Enterpris
 	return tx.Get(tableChecks, indexService, service)
 }
 
-func catalogListChecksInState(tx ReadTxn, state string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	// simpler than normal due to the use of the CompoundMultiIndex
-	return tx.Get(tableChecks, indexStatus, state)
-}
-
 func catalogInsertCheck(tx WriteTxn, chk *structs.HealthCheck, idx uint64) error {
 	// Insert the check
 	if err := tx.Insert(tableChecks, chk); err != nil {

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -107,28 +107,28 @@ func catalogServiceLastExtinctionIndex(tx ReadTxn, _ *structs.EnterpriseMeta) (i
 
 func catalogMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta, checks bool) uint64 {
 	if checks {
-		return maxIndexTxn(tx, "nodes", tableServices, "checks")
+		return maxIndexTxn(tx, "nodes", tableServices, tableChecks)
 	}
 	return maxIndexTxn(tx, "nodes", tableServices)
 }
 
 func catalogMaxIndexWatch(tx ReadTxn, ws memdb.WatchSet, _ *structs.EnterpriseMeta, checks bool) uint64 {
 	if checks {
-		return maxIndexWatchTxn(tx, ws, "nodes", tableServices, "checks")
+		return maxIndexWatchTxn(tx, ws, "nodes", tableServices, tableChecks)
 	}
 	return maxIndexWatchTxn(tx, ws, "nodes", tableServices)
 }
 
 func catalogUpdateCheckIndexes(tx WriteTxn, idx uint64, _ *structs.EnterpriseMeta) error {
 	// update the universal index entry
-	if err := tx.Insert(tableIndex, &IndexEntry{"checks", idx}); err != nil {
+	if err := tx.Insert(tableIndex, &IndexEntry{tableChecks, idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 	return nil
 }
 
 func catalogChecksMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta) uint64 {
-	return maxIndexTxn(tx, "checks")
+	return maxIndexTxn(tx, tableChecks)
 }
 
 func catalogListChecksByNode(tx ReadTxn, q Query) (memdb.ResultIterator, error) {
@@ -136,17 +136,17 @@ func catalogListChecksByNode(tx ReadTxn, q Query) (memdb.ResultIterator, error) 
 }
 
 func catalogListChecksByService(tx ReadTxn, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get("checks", "service", service)
+	return tx.Get(tableChecks, indexService, service)
 }
 
 func catalogListChecksInState(tx ReadTxn, state string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	// simpler than normal due to the use of the CompoundMultiIndex
-	return tx.Get("checks", "status", state)
+	return tx.Get(tableChecks, indexStatus, state)
 }
 
 func catalogInsertCheck(tx WriteTxn, chk *structs.HealthCheck, idx uint64) error {
 	// Insert the check
-	if err := tx.Insert("checks", chk); err != nil {
+	if err := tx.Insert(tableChecks, chk); err != nil {
 		return fmt.Errorf("failed inserting check: %s", err)
 	}
 

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -135,10 +135,6 @@ func catalogListChecksByNode(tx ReadTxn, q Query) (memdb.ResultIterator, error) 
 	return tx.Get(tableChecks, indexNode, q)
 }
 
-func catalogListChecksByService(tx ReadTxn, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get(tableChecks, indexService, service)
-}
-
 func catalogInsertCheck(tx WriteTxn, chk *structs.HealthCheck, idx uint64) error {
 	// Insert the check
 	if err := tx.Insert(tableChecks, chk); err != nil {

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -50,9 +50,7 @@ func testIndexerTableChecks() map[string]indexerTestCase {
 		},
 		indexService: {
 			read: indexValue{
-				source: []interface{}{
-					"ServiceName",
-				},
+				source:   Query{Value: "ServiceName"},
 				expected: []byte("servicename\x00"),
 			},
 			write: indexValue{

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -40,14 +40,12 @@ func testIndexerTableChecks() map[string]indexerTestCase {
 		},
 		indexStatus: {
 			read: indexValue{
-				source: []interface{}{
-					"PASSING",
-				},
-				expected: []byte("PASSING\x00"),
+				source:   Query{Value: "PASSING"},
+				expected: []byte("passing\x00"),
 			},
 			write: indexValue{
 				source:   obj,
-				expected: []byte("PASSING\x00"),
+				expected: []byte("passing\x00"),
 			},
 		},
 		indexService: {

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -8,9 +8,11 @@ import (
 
 func testIndexerTableChecks() map[string]indexerTestCase {
 	obj := &structs.HealthCheck{
-		Node:      "NoDe",
-		ServiceID: "SeRvIcE",
-		CheckID:   "CheckID",
+		Node:        "NoDe",
+		ServiceID:   "SeRvIcE",
+		ServiceName: "ServiceName",
+		CheckID:     "CheckID",
+		Status:      "PASSING",
 	}
 	return map[string]indexerTestCase{
 		indexID: {
@@ -34,6 +36,30 @@ func testIndexerTableChecks() map[string]indexerTestCase {
 					source:   Query{Value: "nOdE"},
 					expected: []byte("node\x00"),
 				},
+			},
+		},
+		indexStatus: {
+			read: indexValue{
+				source: []interface{}{
+					"PASSING",
+				},
+				expected: []byte("PASSING\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("PASSING\x00"),
+			},
+		},
+		indexService: {
+			read: indexValue{
+				source: []interface{}{
+					"ServiceName",
+				},
+				expected: []byte("servicename\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("servicename\x00"),
 			},
 		},
 		indexNodeService: {

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1316,7 +1316,7 @@ func TestStateStore_DeleteNode(t *testing.T) {
 	}
 
 	// Indexes were updated.
-	for _, tbl := range []string{"nodes", tableServices, "checks"} {
+	for _, tbl := range []string{"nodes", tableServices, tableChecks} {
 		if idx := s.maxIndex(tbl); idx != 3 {
 			t.Fatalf("bad index: %d (%s)", idx, tbl)
 		}
@@ -2076,7 +2076,7 @@ func TestStateStore_DeleteService(t *testing.T) {
 	if idx := s.maxIndex(tableServices); idx != 4 {
 		t.Fatalf("bad index: %d", idx)
 	}
-	if idx := s.maxIndex("checks"); idx != 4 {
+	if idx := s.maxIndex(tableChecks); idx != 4 {
 		t.Fatalf("bad index: %d", idx)
 	}
 
@@ -2411,7 +2411,7 @@ func TestStateStore_EnsureCheck(t *testing.T) {
 	testCheckOutput(t, 5, 5, "bbbmodified")
 
 	// Index tables were updated
-	if idx := s.maxIndex("checks"); idx != 5 {
+	if idx := s.maxIndex(tableChecks); idx != 5 {
 		t.Fatalf("bad index: %d", idx)
 	}
 }
@@ -2894,7 +2894,7 @@ func TestStateStore_DeleteCheck(t *testing.T) {
 	if idx, check, err := s.NodeCheck("node1", "check1", nil); idx != 3 || err != nil || check != nil {
 		t.Fatalf("Node check should have been deleted idx=%d, node=%v, err=%s", idx, check, err)
 	}
-	if idx := s.maxIndex("checks"); idx != 3 {
+	if idx := s.maxIndex(tableChecks); idx != 3 {
 		t.Fatalf("bad index for checks: %d", idx)
 	}
 	if !watchFired(ws) {
@@ -2914,7 +2914,7 @@ func TestStateStore_DeleteCheck(t *testing.T) {
 	}
 
 	// Index tables were updated.
-	if idx := s.maxIndex("checks"); idx != 3 {
+	if idx := s.maxIndex(tableChecks); idx != 3 {
 		t.Fatalf("bad index: %d", idx)
 	}
 
@@ -2923,7 +2923,7 @@ func TestStateStore_DeleteCheck(t *testing.T) {
 	if err := s.DeleteCheck(4, "node1", "check1", nil); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx := s.maxIndex("checks"); idx != 3 {
+	if idx := s.maxIndex(tableChecks); idx != 3 {
 		t.Fatalf("bad index: %d", idx)
 	}
 	if watchFired(ws) {


### PR DESCRIPTION
Branched from #9948

Same pattern as the rest. The only significant change here is that `checks.status` will now use lowercase out of convenience. Previously all the values were already lowercase so it should be a no-op.