### PR TITLE
catalog: add option to v1/health/service/:service endpoint to prefer returning connect capable nodes over underlying nodes if some are present

### DIFF
--- a/.changelog/9959.txt
+++ b/.changelog/9959.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+catalog: add option to v1/health/service/:service endpoint to prefer returning connect capable nodes over underlying nodes if some are present
+```

--- a/agent/cache-types/streaming_health_services.go
+++ b/agent/cache-types/streaming_health_services.go
@@ -200,7 +200,19 @@ func (c *StreamingHealthServices) preferConnectFetch(
 			if !ok {
 				return cache.FetchResult{}, fmt.Errorf("invalid streaming service health response type: %T", e.Result)
 			}
-			state.PlainResults = result
+
+			// only return typical results here
+			dup := &structs.IndexedCheckServiceNodes{
+				Nodes:     make(structs.CheckServiceNodes, 0, len(result.Nodes)),
+				QueryMeta: result.QueryMeta,
+			}
+			for _, node := range result.Nodes {
+				if node.Service.Kind == structs.ServiceKindTypical {
+					dup.Nodes = append(dup.Nodes, node)
+				}
+			}
+
+			state.PlainResults = dup
 		default:
 			return cache.FetchResult{}, fmt.Errorf("unexpected correlation id: %s", e.CorrelationID)
 		}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2001,6 +2001,7 @@ func checkServiceNodesTxn(
 	preferConnect bool,
 	entMeta *structs.EnterpriseMeta,
 ) (uint64, structs.CheckServiceNodes, error) {
+	onlyReturnTypicalKinds := false
 	if preferConnect {
 		connect = true // temporarily flip this flag for the first pass
 	}
@@ -2041,6 +2042,9 @@ START_OVER:
 	serviceNames := make(map[structs.ServiceName]struct{}, 2)
 	for service := iter.Next(); service != nil; service = iter.Next() {
 		sn := service.(*structs.ServiceNode)
+		if onlyReturnTypicalKinds && sn.ServiceKind != structs.ServiceKindTypical {
+			continue // skip it
+		}
 		results = append(results, sn)
 
 		name := structs.NewServiceName(sn.ServiceName, &sn.EnterpriseMeta)
@@ -2137,6 +2141,7 @@ START_OVER:
 	if preferConnect && len(results) == 0 {
 		connect = false
 		preferConnect = false
+		onlyReturnTypicalKinds = true
 		goto START_OVER
 	}
 

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -60,8 +60,9 @@ func serviceHealthSnapshot(db ReadDB, topic stream.Topic) stream.SnapshotFunc {
 		defer tx.Abort()
 
 		connect := topic == topicServiceHealthConnect
+
 		entMeta := structs.NewEnterpriseMeta(req.Namespace)
-		idx, nodes, err := checkServiceNodesTxn(tx, nil, req.Key, connect, &entMeta)
+		idx, nodes, err := checkServiceNodesTxn(tx, nil, req.Key, connect, false, &entMeta)
 		if err != nil {
 			return 0, err
 		}

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -209,6 +209,9 @@ func (s *HTTPHandlers) healthServiceNodes(resp http.ResponseWriter, req *http.Re
 	default:
 		// serviceHealth is the default type
 		prefix = "/v1/health/service/"
+		if _, ok := params["prefer-connect"]; ok {
+			args.PreferConnect = true
+		}
 	}
 
 	// Pull out the service name

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -144,7 +144,7 @@ func registerCacheTypes(bd BaseDeps) error {
 			Client: pbsubscribe.NewStateChangeSubscriptionClient(conn),
 			Logger: bd.Logger,
 		}
-		bd.Cache.RegisterType(cachetype.StreamingHealthServicesName, cachetype.NewStreamingHealthServices(matDeps))
+		bd.Cache.RegisterType(cachetype.StreamingHealthServicesName, cachetype.NewStreamingHealthServices(matDeps, bd.Cache))
 	}
 	return nil
 }

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -568,6 +568,10 @@ type ServiceSpecificRequest struct {
 	TagFilter      bool // Controls tag filtering
 	Source         QuerySource
 
+	// PreferConnect if true will default to returning Connect-compatible
+	// services, but if none are found it will return standard services.
+	PreferConnect bool
+
 	// Connect if true will only search for Connect-compatible services.
 	Connect bool
 
@@ -618,6 +622,7 @@ func (r *ServiceSpecificRequest) CacheInfo() cache.RequestInfo {
 		r.Filter,
 		r.EnterpriseMeta,
 		r.Ingress,
+		r.PreferConnect,
 	}, nil)
 	if err == nil {
 		// If there is an error, we don't set the key. A blank key forces

--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -257,7 +257,8 @@ The table below shows this endpoint's support for
 
 - `prefer-connect` `(bool: false)` - If any [Connect-capable service](#list-nodes-for-connect-capable-service)
   exists for this service, nodes for those are returned in lieu of the nodes
-  for the underlying service. This is specified as part of the URL as a query parameter.
+  for the underlying service. Attempts to resolve anything other than a typical service name will return no results.
+  This is specified as part of the URL as a query parameter.
   Added in Consul 1.10.0.
 
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of the service.

--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -255,6 +255,11 @@ The table below shows this endpoint's support for
 - `filter` `(string: "")` - Specifies the expression used to filter the
   queries results prior to returning the data.
 
+- `prefer-connect` `(bool: false)` - If any [Connect-capable service](#list-nodes-for-connect-capable-service)
+  exists for this service, nodes for those are returned in lieu of the nodes
+  for the underlying service. This is specified as part of the URL as a query parameter.
+  Added in Consul 1.10.0.
+
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of the service.
   This value may be provided by either the `ns` URL query parameter or in the
   `X-Consul-Namespace` header. If not provided, the namespace will be inherited


### PR DESCRIPTION
Adds a new parameter `?prefer-connect` to the existing endpoint `/v1/health/service/:service`

Fixes #9744

Ordinarily a request to `/v1/health/service/:service` will return standard catalog data for instances of `:service` (including the node each runs on, the definition of each, and their checks and check states). There is a similar API endpoint `/v1/health/connect/:service` that does something very similar, except it returns just connect-enabled endpoints for `:service`.

The former is what you would normally do for standard service discovery when you are not using Connect. The latter is what you do if you need to locate the ports of the proxies that front the real services when Connect is enabled.

If you run a mix of Connect and non-Connect workloads and wish to do some sort of general query to list all of your services and _figure out_ which ones are using Connect today you have to do both of these queries serially.

This PR handles doing this sort of operation under the covers so the caller only has to call `/v1/health/service/:service?prefer-connect` and the results will EITHER be those you would have gotten from `/v1/health/connect/:service` OR those you would have gotten from `/v1/health/service/:service`. You can tell the difference by checking the inner `Service.Kind` values. If they are unset that represents a "typical" service which is a plain service. If they are set to something like `connect-proxy` or `terminating-gateway` then you know that the results represent Connect enabled endpoints.