### PR TITLE
changelog: fixup release-note formatting

### DIFF
--- a/.changelog/9683.txt
+++ b/.changelog/9683.txt
@@ -1,3 +1,3 @@
-```release-notes:improvement
+```release-note:improvement
 client: when a client agent is attempting to dereigster a service, anddoes not have access to the ACL token used to register a service, attempt to use the agent token instead of the default user token. If no agent token is set, fall back to the default user token.
 ```

--- a/.changelog/9923.txt
+++ b/.changelog/9923.txt
@@ -1,3 +1,3 @@
-```release-notes:bug
+```release-note:bug
 http: fix a bug in Consul Enterprise that would cause the UI to believe namespaces were supported, resulting in warning logs and incorrect UI behaviour.
 ```


### PR DESCRIPTION
So these changelog entries will be parsed successfully.

TODO from chatting with @i0rek - could we catch formatting issues like this in the CI changelog check instead of omitting entries silently when running `changelog-build` at release time?