### PR TITLE
ui:  Reformat MaxTokenTTL to sortBy as an integer

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/auth-method/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/search-bar/index.hbs
@@ -122,8 +122,8 @@ as |key value|}}
             {{#let (from-entries (array
                   (array "MethodName:asc" (t "common.sort.alpha.asc"))
                   (array "MethodName:desc" (t "common.sort.alpha.desc"))
-                  (array "MaxTokenTTL:desc" (t "common.sort.duration.asc"))
-                  (array "MaxTokenTTL:asc" (t "common.sort.duration.desc"))
+                  (array "TokenTTL:desc" (t "common.sort.duration.asc"))
+                  (array "TokenTTL:asc" (t "common.sort.duration.desc"))
                 ))
               as |selectable|
             }}
@@ -138,8 +138,8 @@ as |key value|}}
           <Option @value="MethodName:desc" @selected={{eq "MethodName:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>
         </Optgroup>
         <Optgroup @label={{t "common.ui.maxttl"}}>
-          <Option @value="MaxTokenTTL:desc" @selected={{eq "MaxTokenTTL:desc" @sort.value}}>{{t "common.sort.duration.asc"}}</Option>
-          <Option @value="MaxTokenTTL:asc" @selected={{eq "MaxTokenTTL:asc" @sort.value}}>{{t "common.sort.duration.desc"}}</Option>
+          <Option @value="TokenTTL:desc" @selected={{eq "TokenTTL:desc" @sort.value}}>{{t "common.sort.duration.asc"}}</Option>
+          <Option @value="TokenTTL:asc" @selected={{eq "TokenTTL:asc" @sort.value}}>{{t "common.sort.duration.desc"}}</Option>
         </Optgroup>
   {{/let}}
         </BlockSlot>

--- a/ui/packages/consul-ui/app/models/auth-method.js
+++ b/ui/packages/consul-ui/app/models/auth-method.js
@@ -1,5 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 import { or } from '@ember/object/computed';
+import Duration from '@icholy/duration';
+import { computed } from '@ember/object';
 
 export const PRIMARY_KEY = 'uid';
 export const SLUG_KEY = 'Name';
@@ -22,4 +24,10 @@ export default class AuthMethod extends Model {
   @attr('number') ModifyIndex;
   @attr() Datacenters; // string[]
   @attr() meta; // {}
+
+  @computed('MaxTokenTTL')
+  get TokenTTL() {
+    const d = new Duration(this.MaxTokenTTL);
+    return d.milliseconds();
+  }
 }

--- a/ui/packages/consul-ui/app/models/auth-method.js
+++ b/ui/packages/consul-ui/app/models/auth-method.js
@@ -1,6 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 import { or } from '@ember/object/computed';
-import Duration from '@icholy/duration';
+import parse from 'parse-duration';
 import { computed } from '@ember/object';
 
 export const PRIMARY_KEY = 'uid';
@@ -27,7 +27,6 @@ export default class AuthMethod extends Model {
 
   @computed('MaxTokenTTL')
   get TokenTTL() {
-    const d = new Duration(this.MaxTokenTTL);
-    return d.milliseconds();
+    return parse(this.MaxTokenTTL);
   }
 }

--- a/ui/packages/consul-ui/app/sort/comparators/auth-method.js
+++ b/ui/packages/consul-ui/app/sort/comparators/auth-method.js
@@ -1,3 +1,3 @@
 export default ({ properties }) => (key = 'MethodName:asc') => {
-  return properties(['MethodName', 'MaxTokenTTL'])(key);
+  return properties(['MethodName', 'TokenTTL'])(key);
 };

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -150,6 +150,7 @@
     "loader.js": "^4.7.0",
     "mnemonist": "^0.38.0",
     "ngraph.graph": "^19.1.0",
+    "parse-duration": "^1.0.0",
     "pretender": "^3.2.0",
     "prettier": "^1.10.2",
     "qunit-dom": "^1.0.0",

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -64,6 +64,7 @@
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
     "@hashicorp/ember-cli-api-double": "^3.1.0",
+    "@icholy/duration": "^5.1.0",
     "@mapbox/rehype-prism": "^0.6.0",
     "@xstate/fsm": "^1.4.0",
     "a11y-dialog": "^6.0.1",

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -64,7 +64,6 @@
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
     "@hashicorp/ember-cli-api-double": "^3.1.0",
-    "@icholy/duration": "^5.1.0",
     "@mapbox/rehype-prism": "^0.6.0",
     "@xstate/fsm": "^1.4.0",
     "a11y-dialog": "^6.0.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1528,11 +1528,6 @@
     pretender "^3.2.0"
     recursive-readdir-sync "^1.0.6"
 
-"@icholy/duration@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@icholy/duration/-/duration-5.1.0.tgz#da193379e3a1b3107984c8bf22b4aa4ee7af1ef8"
-  integrity sha512-I/zdjC6qYdwWJ2H1/PZbI3g58pPIiI/eOe5XDTtQ/v36d0ogcvAylqwOIWj/teY1rBnIMzUyWfX7PMm9I67WWg==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -11046,6 +11046,11 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-duration@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-1.0.0.tgz#8605651745f61088f6fb14045c887526c291858c"
+  integrity sha512-X4kUkCTHU1N/kEbwK9FpUJ0UZQa90VzeczfS704frR30gljxDG0pSziws06XlK+CGRSo/1wtG1mFIdBFQTMQNw==
+
 parse-entities@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1528,6 +1528,11 @@
     pretender "^3.2.0"
     recursive-readdir-sync "^1.0.6"
 
+"@icholy/duration@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@icholy/duration/-/duration-5.1.0.tgz#da193379e3a1b3107984c8bf22b4aa4ee7af1ef8"
+  integrity sha512-I/zdjC6qYdwWJ2H1/PZbI3g58pPIiI/eOe5XDTtQ/v36d0ogcvAylqwOIWj/teY1rBnIMzUyWfX7PMm9I67WWg==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
🐛 MaxTokenTTL comes in as a string from endpoint. We installed Duration.js package to reformat MaxTokenTTL as an integer and use the integer format to sortBy.

* No changelog since this feature has not been released.