### PR TITLE
Upgrades the Stackmenu to latest

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1790,9 +1790,9 @@
       "integrity": "sha512-a2eWgjLwGAC2LjUHE7Xt6sRGGjyTWfrc4N+qVxsyZw4eE0EiNhMIKDYHWjmtb+tGh8r8j+ca3tSjsuOUePVPUw=="
     },
     "@hashicorp/react-hashi-stack-menu": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.1.0.tgz",
-      "integrity": "sha512-WPrMJT64V5y6JPVajCQduAXKTz1ij8OXCOKdvavjhoSpteuA+/xWuQZyeNQaUWnsKCXnNydbBUzuCb2or03vsA==",
+      "version": "1.2.1-canary.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.2.1-canary.0.tgz",
+      "integrity": "sha512-tAghrysfxZrcILFjEFQu1hzlY7d2R/I7N49UkH8n22juVrqd6FlXI/gnXpnJayRbbOGmDKda8f3SEH2Uwq4I3g==",
       "requires": {
         "@hashicorp/react-inline-svg": "^1.0.2",
         "slugify": "1.3.4"

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "@hashicorp/react-callouts": "^7.0.0",
     "@hashicorp/react-docs-page": "10.4.0",
     "@hashicorp/react-featured-slider": "1.1.10",
-    "@hashicorp/react-hashi-stack-menu": "^1.1.0",
+    "@hashicorp/react-hashi-stack-menu": "1.2.1-canary.0",
     "@hashicorp/react-head": "1.1.6",
     "@hashicorp/react-image": "3.0.3",
     "@hashicorp/react-inline-svg": "5.0.0",


### PR DESCRIPTION
Remove the badges from the HCP products on the HashiStackMenu, as they are no longer needed.

[🔍 Preview](https://consul-git-brstackmenu-hashicorp.vercel.app/)

## Before
<img width="825" alt="before" src="https://user-images.githubusercontent.com/2105067/113766078-e341be80-96d1-11eb-828f-8409c2b184b5.png">

## After
<img width="818" alt="after" src="https://user-images.githubusercontent.com/2105067/113766098-e8067280-96d1-11eb-84d1-3d2fc588924f.png">