### PR TITLE
Fixup centralized upstream config resolution

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -410,13 +410,14 @@ func (c *ConfigEntry) ResolveServiceConfig(args *structs.ServiceConfigRequest, r
 			upstreamIDs := args.UpstreamIDs
 			legacyUpstreams := false
 
-			// Before Consul namespaces were released, the Upstreams provided to the endpoint did not contain the namespace.
-			// Because of this we attach the enterprise meta of the request, which will just be the default namespace.
-			if len(upstreamIDs) == 0 {
+			// The request is considered legacy if the deprecated args.Upstream was used
+			if len(upstreamIDs) == 0 && len(args.Upstreams) > 0 {
 				legacyUpstreams = true
 
 				upstreamIDs = make([]structs.ServiceID, 0)
 				for _, upstream := range args.Upstreams {
+					// Before Consul namespaces were released, the Upstreams provided to the endpoint did not contain the namespace.
+					// Because of this we attach the enterprise meta of the request, which will just be the default namespace.
 					sid := structs.NewServiceID(upstream, &args.EnterpriseMeta)
 					upstreamIDs = append(upstreamIDs, sid)
 				}

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -336,6 +336,7 @@ func (s *state) initWatchesConnectProxy(snap *ConfigSnapshot) error {
 		// Store defaults keyed under wildcard so they can be applied to centrally configured upstreams
 		if u.DestinationName == structs.WildcardSpecifier {
 			snap.ConnectProxy.UpstreamConfig[u.DestinationID().String()] = &u
+			continue
 		}
 
 		// This can be true if the upstream is a synthetic entry populated from centralized upstream config.

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -1606,6 +1607,16 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				Proxy: structs.ConnectProxyConfig{
 					DestinationServiceName: "api",
 					TransparentProxy:       true,
+					Upstreams: structs.Upstreams{
+						{
+							CentrallyConfigured:  true,
+							DestinationName:      structs.WildcardSpecifier,
+							DestinationNamespace: structs.WildcardSpecifier,
+							Config: map[string]interface{}{
+								"connect_timeout_ms": 6000,
+							},
+						},
+					},
 				},
 			},
 			sourceDC: "dc1",
@@ -1622,10 +1633,13 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.False(t, snap.Valid(), "proxy without roots/leaf/intentions is not valid")
-						require.True(t, snap.ConnectProxy.IsEmpty())
 						require.True(t, snap.MeshGateway.IsEmpty())
 						require.True(t, snap.IngressGateway.IsEmpty())
 						require.True(t, snap.TerminatingGateway.IsEmpty())
+
+						// Centrally configured upstream defaults should be stored so that upstreams from intentions can inherit them
+						require.Len(t, snap.ConnectProxy.UpstreamConfig, 1)
+						require.Contains(t, snap.ConnectProxy.UpstreamConfig, "*")
 					},
 				},
 				// Valid snapshot after roots, leaf, and intentions
@@ -1694,16 +1708,24 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 
 						// Should not have results yet
 						require.Empty(t, snap.ConnectProxy.DiscoveryChain)
+
+						require.Len(t, snap.ConnectProxy.UpstreamConfig, 2)
+						cfg, ok := snap.ConnectProxy.UpstreamConfig[db.String()]
+						require.True(t, ok)
+
+						// Upstream config should have been inherited from defaults under wildcard key
+						require.Equal(t, cfg.Config["connect_timeout_ms"], 6000)
 					},
 				},
 				// Discovery chain updates should be stored
 				{
 					requiredWatches: map[string]verifyWatchRequest{
 						"discovery-chain:" + dbStr: genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
-							Name:                 "db",
-							EvaluateInDatacenter: "dc1",
-							EvaluateInNamespace:  "default",
-							Datacenter:           "dc1",
+							Name:                   "db",
+							EvaluateInDatacenter:   "dc1",
+							EvaluateInNamespace:    "default",
+							Datacenter:             "dc1",
+							OverrideConnectTimeout: 6 * time.Second,
 						}),
 					},
 					events: []cache.UpdateEvent{

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -1615,6 +1615,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							Config: map[string]interface{}{
 								"connect_timeout_ms": 6000,
 							},
+							MeshGateway: structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeRemote},
 						},
 					},
 				},
@@ -1726,6 +1727,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							EvaluateInNamespace:    "default",
 							Datacenter:             "dc1",
 							OverrideConnectTimeout: 6 * time.Second,
+							OverrideMeshGateway:    structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeRemote},
 						}),
 					},
 					events: []cache.UpdateEvent{

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -335,12 +335,13 @@ func makeConfigRequest(bd BaseDeps, addReq AddServiceRequest) *structs.ServiceCo
 	}
 
 	req := &structs.ServiceConfigRequest{
-		Name:           name,
-		Datacenter:     bd.RuntimeConfig.Datacenter,
-		QueryOptions:   structs.QueryOptions{Token: addReq.token},
-		MeshGateway:    ns.Proxy.MeshGateway,
-		UpstreamIDs:    upstreams,
-		EnterpriseMeta: ns.EnterpriseMeta,
+		Name:             name,
+		Datacenter:       bd.RuntimeConfig.Datacenter,
+		QueryOptions:     structs.QueryOptions{Token: addReq.token},
+		MeshGateway:      ns.Proxy.MeshGateway,
+		TransparentProxy: ns.Proxy.TransparentProxy,
+		UpstreamIDs:      upstreams,
+		EnterpriseMeta:   ns.EnterpriseMeta,
 	}
 	if req.QueryOptions.Token == "" {
 		req.QueryOptions.Token = bd.Tokens.AgentToken()
@@ -436,8 +437,8 @@ func mergeServiceConfig(defaults *structs.ServiceConfigResponse, service *struct
 	}
 
 	// Ensure upstreams present in central config are represented in the local configuration.
-	// This does not apply outside of TransparentProxy mode because in that situation every upstream needs to be defined
-	// explicitly and locally with a local bind port.
+	// This does not apply outside of TransparentProxy mode because in that situation every possible upstream already exists
+	// inside of ns.Proxy.Upstreams.
 	if ns.Proxy.TransparentProxy {
 		for id, remote := range remoteUpstreams {
 			if _, ok := localUpstreams[id]; ok {

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -250,7 +250,7 @@ func (w *serviceConfigWatch) runWatch(ctx context.Context, wg *sync.WaitGroup, u
 	}
 }
 
-// handleUpdate receives an update event the global config defaults, updates
+// handleUpdate receives an update event from the global config defaults, updates
 // the local state and re-registers the service with the newly merged config.
 //
 // NOTE: the caller must NOT hold the Agent.stateLock!

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -326,7 +326,7 @@ func makeConfigRequest(bd BaseDeps, addReq AddServiceRequest) *structs.ServiceCo
 		// Also if we have any upstreams defined, add them to the request so we can
 		// learn about their configs.
 		for _, us := range ns.Proxy.Upstreams {
-			if us.DestinationType == "" || us.DestinationType == structs.UpstreamDestTypeService {
+			if us.DestinationType == "" || us.DestinationType == structs.UpstreamDestTypeService && !us.CentrallyConfigured {
 				sid := us.DestinationID()
 				sid.EnterpriseMeta.Merge(&ns.EnterpriseMeta)
 				upstreams = append(upstreams, sid)
@@ -440,14 +440,25 @@ func mergeServiceConfig(defaults *structs.ServiceConfigResponse, service *struct
 	// This does not apply outside of TransparentProxy mode because in that situation every possible upstream already exists
 	// inside of ns.Proxy.Upstreams.
 	if ns.Proxy.TransparentProxy {
+		var upstreams structs.Upstreams
+
+		for _, us := range ns.Proxy.Upstreams {
+			if _, ok := remoteUpstreams[us.DestinationID()]; !ok && us.CentrallyConfigured {
+				// If a centrally configured upstream is only present locally then that means it was
+				// removed from central config and should be removed from the local list as well.
+				continue
+			}
+			upstreams = append(upstreams, us)
+		}
+
 		for id, remote := range remoteUpstreams {
 			if _, ok := localUpstreams[id]; ok {
 				// Remote upstream is already present locally
 				continue
 			}
-
-			ns.Proxy.Upstreams = append(ns.Proxy.Upstreams, remote)
+			upstreams = append(upstreams, remote)
 		}
+		ns.Proxy.Upstreams = upstreams
 	}
 
 	return ns, err

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -1048,64 +1048,6 @@ func Test_mergeServiceConfig_UpstreamOverrides(t *testing.T) {
 			},
 		},
 		{
-			name: "synthetic local upstream is cleaned up if not in config response",
-			args: args{
-				defaults: &structs.ServiceConfigResponse{
-					UpstreamIDConfigs: structs.OpaqueUpstreamConfigs{
-						{
-							Upstream: structs.ServiceID{
-								ID:             "zap",
-								EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
-							},
-							Config: map[string]interface{}{
-								"protocol": "grpc",
-							},
-						},
-					},
-				},
-				service: &structs.NodeService{
-					ID:      "foo-proxy",
-					Service: "foo-proxy",
-					Proxy: structs.ConnectProxyConfig{
-						DestinationServiceName: "foo",
-						DestinationServiceID:   "foo",
-						TransparentProxy:       true,
-						Upstreams: structs.Upstreams{
-							structs.Upstream{
-								DestinationNamespace: "default",
-								DestinationName:      "zip",
-								LocalBindPort:        8080,
-								Config: map[string]interface{}{
-									"protocol": "http",
-								},
-								// Should get zip cleaned up
-								CentrallyConfigured: true,
-							},
-						},
-					},
-				},
-			},
-			want: &structs.NodeService{
-				ID:      "foo-proxy",
-				Service: "foo-proxy",
-				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "foo",
-					DestinationServiceID:   "foo",
-					TransparentProxy:       true,
-					Upstreams: structs.Upstreams{
-						structs.Upstream{
-							DestinationNamespace: "default",
-							DestinationName:      "zap",
-							Config: map[string]interface{}{
-								"protocol": "grpc",
-							},
-							CentrallyConfigured: true,
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "upstream mode from remote defaults overrides local default",
 			args: args{
 				defaults: &structs.ServiceConfigResponse{

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -590,6 +590,9 @@ type ServiceConfigRequest struct {
 	// MeshGateway contains the mesh gateway configuration from the requesting proxy's registration
 	MeshGateway MeshGatewayConfig
 
+	// TransparentProxy indicates whether the requesting proxy is in transparent proxy mode
+	TransparentProxy bool
+
 	UpstreamIDs []ServiceID
 
 	// DEPRECATED

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -194,7 +194,9 @@ func (cfg *ConnectConfiguration) Normalize() {
 		v.Normalize()
 	}
 
-	cfg.UpstreamDefaults.Normalize()
+	if cfg.UpstreamDefaults != nil {
+		cfg.UpstreamDefaults.Normalize()
+	}
 }
 
 func (cfg ConnectConfiguration) Validate() error {
@@ -206,8 +208,11 @@ func (cfg ConnectConfiguration) Validate() error {
 		}
 	}
 
-	if err := cfg.UpstreamDefaults.Validate(); err != nil {
-		validationErr = multierror.Append(validationErr, fmt.Errorf("error in upstream defaults %v", err))
+	if cfg.UpstreamDefaults != nil {
+		err := cfg.UpstreamDefaults.Validate()
+		if err != nil {
+			validationErr = multierror.Append(validationErr, fmt.Errorf("error in upstream defaults %v", err))
+		}
 	}
 
 	return validationErr

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -333,6 +333,9 @@ func (u *Upstream) Validate() error {
 	if u.DestinationName == "" {
 		return fmt.Errorf("upstream destination name cannot be empty")
 	}
+	if u.DestinationName == WildcardSpecifier && !u.CentrallyConfigured {
+		return fmt.Errorf("upstream destination name cannot be a wildcard")
+	}
 
 	if u.LocalBindPort == 0 && !u.CentrallyConfigured {
 		return fmt.Errorf("upstream local bind port cannot be zero")

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1153,7 +1153,7 @@ func (s *NodeService) Validate() error {
 				"Proxy.DestinationServiceName must be non-empty for Connect proxy "+
 					"services"))
 		}
-		if strings.TrimSpace(s.Proxy.DestinationServiceName) == WildcardSpecifier {
+		if s.Proxy.DestinationServiceName == WildcardSpecifier {
 			result = multierror.Append(result, fmt.Errorf(
 				"Proxy.DestinationServiceName must not be a wildcard for Connect proxy "+
 					"services"))

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1153,6 +1153,11 @@ func (s *NodeService) Validate() error {
 				"Proxy.DestinationServiceName must be non-empty for Connect proxy "+
 					"services"))
 		}
+		if strings.TrimSpace(s.Proxy.DestinationServiceName) == WildcardSpecifier {
+			result = multierror.Append(result, fmt.Errorf(
+				"Proxy.DestinationServiceName must not be a wildcard for Connect proxy "+
+					"services"))
+		}
 
 		if s.Port == 0 {
 			result = multierror.Append(result, fmt.Errorf(

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1189,7 +1189,9 @@ func (s *NodeService) Validate() error {
 			}
 			addr = net.JoinHostPort(addr, fmt.Sprintf("%d", u.LocalBindPort))
 
-			if _, ok := bindAddrs[addr]; ok {
+			// Centrally configured upstreams will fail this check if there are multiple because they do not have an address/port.
+			// Only consider non-centrally configured upstreams in this check since those are the ones we create listeners for.
+			if _, ok := bindAddrs[addr]; ok && !u.CentrallyConfigured {
 				result = multierror.Append(result, fmt.Errorf(
 					"upstreams cannot contain duplicates by local bind address and port; %q is specified twice", addr))
 				continue

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -769,6 +769,24 @@ func TestStructs_NodeService_ValidateConnectProxy(t *testing.T) {
 			"upstreams cannot contain duplicates",
 		},
 		{
+			"connect-proxy: Centrally configured upstreams can have duplicate ip/port",
+			func(x *NodeService) {
+				x.Proxy.Upstreams = Upstreams{
+					{
+						DestinationType:     UpstreamDestTypeService,
+						DestinationName:     "foo",
+						CentrallyConfigured: true,
+					},
+					{
+						DestinationType:     UpstreamDestTypeService,
+						DestinationName:     "bar",
+						CentrallyConfigured: true,
+					},
+				}
+			},
+			"",
+		},
+		{
 			"connect-proxy: Upstreams duplicated by ip and port",
 			func(x *NodeService) {
 				x.Proxy.Upstreams = Upstreams{

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -649,6 +649,12 @@ func TestStructs_NodeService_ValidateConnectProxy(t *testing.T) {
 		},
 
 		{
+			"connect-proxy: wildcard Proxy.DestinationServiceName",
+			func(x *NodeService) { x.Proxy.DestinationServiceName = "*" },
+			"Proxy.DestinationServiceName must not be",
+		},
+
+		{
 			"connect-proxy: valid Proxy.DestinationServiceName",
 			func(x *NodeService) { x.Proxy.DestinationServiceName = "hello" },
 			"",
@@ -696,6 +702,28 @@ func TestStructs_NodeService_ValidateConnectProxy(t *testing.T) {
 				}}
 			},
 			"upstream destination name cannot be empty",
+		},
+		{
+			"connect-proxy: upstream wildcard name",
+			func(x *NodeService) {
+				x.Proxy.Upstreams = Upstreams{{
+					DestinationType: UpstreamDestTypeService,
+					DestinationName: WildcardSpecifier,
+					LocalBindPort:   5000,
+				}}
+			},
+			"upstream destination name cannot be a wildcard",
+		},
+		{
+			"connect-proxy: upstream can have wildcard name when centrally configured",
+			func(x *NodeService) {
+				x.Proxy.Upstreams = Upstreams{{
+					DestinationType:     UpstreamDestTypeService,
+					DestinationName:     WildcardSpecifier,
+					CentrallyConfigured: true,
+				}}
+			},
+			"",
 		},
 		{
 			"connect-proxy: upstream empty bind port",

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -98,7 +98,7 @@ type ConnectConfiguration struct {
 	UpstreamConfigs map[string]UpstreamConfig `json:",omitempty" alias:"upstream_configs"`
 
 	// UpstreamDefaults contains default configuration for all upstreams of a given service
-	UpstreamDefaults UpstreamConfig `json:",omitempty" alias:"upstream_defaults"`
+	UpstreamDefaults *UpstreamConfig `json:",omitempty" alias:"upstream_defaults"`
 }
 
 type UpstreamConfig struct {

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -393,7 +393,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 							MeshGateway: MeshGatewayConfig{Mode: "remote"},
 						},
 					},
-					UpstreamDefaults: UpstreamConfig{
+					UpstreamDefaults: &UpstreamConfig{
 						EnvoyClusterJSON:  "zip",
 						EnvoyListenerJSON: "zop",
 						Protocol:          "http",

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -638,7 +638,7 @@ func TestParseConfigEntry(t *testing.T) {
 							},
 						},
 					},
-					UpstreamDefaults: api.UpstreamConfig{
+					UpstreamDefaults: &api.UpstreamConfig{
 						EnvoyClusterJSON:  "zip",
 						EnvoyListenerJSON: "zop",
 						Protocol:          "http",


### PR DESCRIPTION
This is a bit of an omnibus PR fixing primarily these issues:

- Centrally configured upstreams should not have ports validated, since the port will be empty.
- Update how we know whether the request was from an old client, since checking for explicit upstreamIDs won't be correct in transparent proxy mode when no explicit upstreams are configured.
- Ensure that upstream defaults can be applied to all upstreams from intentions, rather than only merging them against explicit upstreams.
- Ensure that overriding mesh gateway mode for disco chain watches works in transparent proxy mode.
- Ensure synthetic upstreams get cleaned up in local registrations