### PR TITLE
streaming: Grpc tuning

### DIFF
--- a/agent/cache-types/streaming_health_services.go
+++ b/agent/cache-types/streaming_health_services.go
@@ -113,9 +113,13 @@ func newMaterializer(
 		Logger: deps.Logger,
 		Waiter: &retry.Waiter{
 			MinFailures: 1,
-			MinWait:     0,
-			MaxWait:     60 * time.Second,
-			Jitter:      retry.NewJitter(100),
+			// Start backing off with small increments (200-400ms) which will double
+			// each attempt. (200-400, 400-800, 800-1600, 1600-3200, 3200-6000, 6000
+			// after that). (retry.Wait applies Max limit after jitter right now).
+			Factor:  200 * time.Millisecond,
+			MinWait: 0,
+			MaxWait: 60 * time.Second,
+			Jitter:  retry.NewJitter(100),
 		},
 		Request: newRequestFn,
 	}), nil

--- a/agent/grpc/handler.go
+++ b/agent/grpc/handler.go
@@ -6,8 +6,10 @@ package grpc
 import (
 	"fmt"
 	"net"
+	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 // NewHandler returns a gRPC server that accepts connections from Handle(conn).
@@ -20,6 +22,9 @@ func NewHandler(addr net.Addr, register func(server *grpc.Server)) *Handler {
 	srv := grpc.NewServer(
 		grpc.StatsHandler(newStatsHandler(metrics)),
 		grpc.StreamInterceptor((&activeStreamCounter{metrics: metrics}).Intercept),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime: 15 * time.Second,
+		}),
 	)
 	register(srv)
 


### PR DESCRIPTION
These tuning parameters match the gRPC transport used by streaming to have the same keepalive behaviour our Yamux-based RPCs do.

While doing scaling experiments we saw issues with TCP connections dropping and not being detected until an event delivery is attempted since the default keepalive is only sent every 2 hours in gRPC.

This also tunes the retry backoff during streaming materializer failures. These parameters may have improved recovery times after TCP drops some, but in fact gRPC itself has it's own backoff policy that comes into play here too which was not investigated further. These settings seem reasonable though, especially given that gRPC is already doing backoff on reconnections lower down in the stack for the vast majority of cases where streaming clients would error.