### PR TITLE
add consul-haskell to libraries-and-sdks documentation

### DIFF
--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -128,4 +128,8 @@ the community.
     <a href="https://github.com/adaptant-labs/consul-dart">consul-dart</a> -
     Dart client for the Consul HTTP API
   </li>
+  <li>
+    <a href="https://github.com/alphaHeavy/consul-haskell">consul-haskell</a> -
+    Haskell client for the Consul HTTP API
+  </li>
 </ul>


### PR DESCRIPTION
See also https://github.com/alphaHeavy/consul-haskell/issues/40.