### PR TITLE
Remove kube-dns resolution since clusterip will be a tagged addr

### DIFF
--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -192,6 +192,12 @@ func (s *Server) listenersFromSnapshotConnectProxy(cInfo connectionInfo, cfgSnap
 				PrefixLen:     &wrappers.UInt32Value{Value: pfxLen},
 			})
 		}
+
+		// The match rules are stable sorted to avoid draining if the list is provided out of order
+		sort.SliceStable(ranges, func(i, j int) bool {
+			return ranges[i].AddressPrefix < ranges[j].AddressPrefix
+		})
+
 		filterChain.FilterChainMatch = &envoy_listener_v3.FilterChainMatch{
 			PrefixRanges: ranges,
 		}


### PR DESCRIPTION
Upcoming changes to consul-k8s will sync the ClusterIP as a tagged address.

This PR adds every tagged address as a possible address to match on for transparent proxies.