### PR TITLE
ui: Return empty string  protocol for upstream/downstream metrics request

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/stats/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/stats/index.hbs
@@ -7,7 +7,7 @@
         dc=@dc
         endpoint=@endpoint
         service=@service
-        protocol=@protocol
+        protocol=(or @protocol '')
       )
     }}
     @onchange={{action 'statsUpdate'}}


### PR DESCRIPTION
Protocol is not a required field to make the metrics request for upstream/downstream. Quick fix with empty string.