### PR TITLE
Handle FSM.Apply errors in raftApply

### DIFF
--- a/agent/consul/acl_replication_types.go
+++ b/agent/consul/acl_replication_types.go
@@ -86,14 +86,8 @@ func (r *aclTokenReplicator) DeleteLocalBatch(srv *Server, batch []string) error
 		TokenIDs: batch,
 	}
 
-	resp, err := srv.raftApply(structs.ACLTokenDeleteRequestType, &req)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-	return nil
+	_, err := srv.raftApply(structs.ACLTokenDeleteRequestType, &req)
+	return err
 }
 
 func (r *aclTokenReplicator) LenPendingUpdates() int {
@@ -116,15 +110,8 @@ func (r *aclTokenReplicator) UpdateLocalBatch(ctx context.Context, srv *Server, 
 		FromReplication:   true,
 	}
 
-	resp, err := srv.raftApply(structs.ACLTokenSetRequestType, &req)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
+	_, err := srv.raftApply(structs.ACLTokenSetRequestType, &req)
+	return err
 }
 
 ///////////////////////
@@ -199,14 +186,8 @@ func (r *aclPolicyReplicator) DeleteLocalBatch(srv *Server, batch []string) erro
 		PolicyIDs: batch,
 	}
 
-	resp, err := srv.raftApply(structs.ACLPolicyDeleteRequestType, &req)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-	return nil
+	_, err := srv.raftApply(structs.ACLPolicyDeleteRequestType, &req)
+	return err
 }
 
 func (r *aclPolicyReplicator) LenPendingUpdates() int {
@@ -226,16 +207,8 @@ func (r *aclPolicyReplicator) UpdateLocalBatch(ctx context.Context, srv *Server,
 		Policies: r.updated[start:end],
 	}
 
-	resp, err := srv.raftApply(structs.ACLPolicySetRequestType, &req)
-	if err != nil {
-		return err
-	}
-
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
+	_, err := srv.raftApply(structs.ACLPolicySetRequestType, &req)
+	return err
 }
 
 ////////////////////////////////
@@ -334,16 +307,8 @@ func (r *aclRoleReplicator) DeleteLocalBatch(srv *Server, batch []string) error 
 		RoleIDs: batch,
 	}
 
-	resp, err := srv.raftApply(structs.ACLRoleDeleteRequestType, &req)
-	if err != nil {
-		return err
-	}
-
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
+	_, err := srv.raftApply(structs.ACLRoleDeleteRequestType, &req)
+	return err
 }
 
 func (r *aclRoleReplicator) LenPendingUpdates() int {
@@ -364,14 +329,6 @@ func (r *aclRoleReplicator) UpdateLocalBatch(ctx context.Context, srv *Server, s
 		AllowMissingLinks: true,
 	}
 
-	resp, err := srv.raftApply(structs.ACLRoleSetRequestType, &req)
-	if err != nil {
-		return err
-	}
-
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
+	_, err := srv.raftApply(structs.ACLRoleSetRequestType, &req)
+	return err
 }

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"golang.org/x/time/rate"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func (s *Server) reapExpiredTokens(ctx context.Context) error {
@@ -102,7 +103,7 @@ func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
 		"amount", len(req.TokenIDs),
 		"locality", locality,
 	)
-	resp, err := s.raftApply(structs.ACLTokenDeleteRequestType, &req)
+	_, err = s.raftApply(structs.ACLTokenDeleteRequestType, &req)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to apply token expiration deletions: %v", err)
 	}
@@ -110,10 +111,6 @@ func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
 	// Purge the identities from the cache
 	for _, secretID := range secretIDs {
 		s.acls.cache.RemoveIdentity(tokenSecretCacheID(secretID))
-	}
-
-	if respErr, ok := resp.(error); ok {
-		return 0, respErr
 	}
 
 	return len(req.TokenIDs), nil

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -7,15 +7,16 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	bexpr "github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/types"
-	bexpr "github.com/hashicorp/go-bexpr"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-uuid"
 )
 
 var CatalogCounters = []prometheus.CounterDefinition{
@@ -210,14 +211,8 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 		}
 	}
 
-	resp, err := c.srv.raftApply(structs.RegisterRequestType, args)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-	return nil
+	_, err = c.srv.raftApply(structs.RegisterRequestType, args)
+	return err
 }
 
 // Deregister is used to remove a service registration for a given node.
@@ -268,10 +263,8 @@ func (c *Catalog) Deregister(args *structs.DeregisterRequest, reply *struct{}) e
 
 	}
 
-	if _, err := c.srv.raftApply(structs.DeregisterRequestType, args); err != nil {
-		return err
-	}
-	return nil
+	_, err = c.srv.raftApply(structs.DeregisterRequestType, args)
+	return err
 }
 
 // ListDatacenters is used to query for the list of known datacenters

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -92,9 +92,6 @@ func (c *ConfigEntry) Apply(args *structs.ConfigEntryRequest, reply *bool) error
 	if err != nil {
 		return err
 	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
 	if respBool, ok := resp.(bool); ok {
 		*reply = respBool
 	}
@@ -296,14 +293,8 @@ func (c *ConfigEntry) Delete(args *structs.ConfigEntryRequest, reply *struct{}) 
 	}
 
 	args.Op = structs.ConfigEntryDelete
-	resp, err := c.srv.raftApply(structs.ConfigEntryRequestType, args)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-	return nil
+	_, err = c.srv.raftApply(structs.ConfigEntryRequestType, args)
+	return err
 }
 
 // ResolveServiceConfig

--- a/agent/consul/config_replication.go
+++ b/agent/consul/config_replication.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func configSort(configs []structs.ConfigEntry) {
@@ -97,13 +98,9 @@ func (s *Server) reconcileLocalConfig(ctx context.Context, configs []structs.Con
 			Entry:      entry,
 		}
 
-		resp, err := s.raftApply(structs.ConfigEntryRequestType, &req)
+		_, err := s.raftApply(structs.ConfigEntryRequestType, &req)
 		if err != nil {
 			return false, fmt.Errorf("Failed to apply config %s: %v", op, err)
-		}
-
-		if respErr, ok := resp.(error); ok {
-			return false, fmt.Errorf("Failed to apply config %s: %v", op, respErr)
 		}
 
 		if i < len(configs)-1 {

--- a/agent/consul/consul_ca_delegate.go
+++ b/agent/consul/consul_ca_delegate.go
@@ -16,13 +16,5 @@ func (c *consulCADelegate) State() *state.Store {
 }
 
 func (c *consulCADelegate) ApplyCARequest(req *structs.CARequest) (interface{}, error) {
-	resp, err := c.srv.raftApply(structs.ConnectCARequestType, req)
-	if err != nil {
-		return nil, err
-	}
-	if respErr, ok := resp.(error); ok {
-		return nil, respErr
-	}
-
-	return resp, nil
+	return c.srv.raftApply(structs.ConnectCARequestType, req)
 }

--- a/agent/consul/coordinate_endpoint.go
+++ b/agent/consul/coordinate_endpoint.go
@@ -6,13 +6,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
 )
 
 // Coordinate manages queries and updates for network coordinates.
@@ -105,12 +106,9 @@ func (c *Coordinate) batchApplyUpdates() error {
 		t := structs.CoordinateBatchUpdateType | structs.IgnoreUnknownTypeFlag
 
 		slice := updates[start:end]
-		resp, err := c.srv.raftApply(t, slice)
+		_, err := c.srv.raftApply(t, slice)
 		if err != nil {
 			return err
-		}
-		if respErr, ok := resp.(error); ok {
-			return respErr
 		}
 	}
 	return nil

--- a/agent/consul/federation_state_endpoint.go
+++ b/agent/consul/federation_state_endpoint.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	memdb "github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
-	memdb "github.com/hashicorp/go-memdb"
 )
 
 var FederationStateSummaries = []prometheus.SummaryDefinition{
@@ -84,9 +85,6 @@ func (c *FederationState) Apply(args *structs.FederationStateRequest, reply *boo
 	resp, err := c.srv.raftApply(structs.FederationStateRequestType, args)
 	if err != nil {
 		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
 	}
 	if respBool, ok := resp.(bool); ok {
 		*reply = respBool

--- a/agent/consul/federation_state_replication.go
+++ b/agent/consul/federation_state_replication.go
@@ -154,13 +154,9 @@ func (r *FederationStateReplicator) PerformDeletions(ctx context.Context, deleti
 			State:      state,
 		}
 
-		resp, err := r.srv.raftApply(structs.FederationStateRequestType, &req)
+		_, err := r.srv.raftApply(structs.FederationStateRequestType, &req)
 		if err != nil {
 			return false, err
-		}
-
-		if respErr, ok := resp.(error); ok {
-			return false, respErr
 		}
 
 		if i < len(deletions)-1 {
@@ -199,13 +195,9 @@ func (r *FederationStateReplicator) PerformUpdates(ctx context.Context, updatesR
 			State:      state2,
 		}
 
-		resp, err := r.srv.raftApply(structs.FederationStateRequestType, &req)
+		_, err := r.srv.raftApply(structs.FederationStateRequestType, &req)
 		if err != nil {
 			return false, err
-		}
-
-		if respErr, ok := resp.(error); ok {
-			return false, respErr
 		}
 
 		if i < len(updates)-1 {

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/go-bexpr"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
 )
 
 var IntentionSummaries = []prometheus.SummaryDefinition{
@@ -157,15 +158,8 @@ func (s *Intention) Apply(args *structs.IntentionRequest, reply *string) error {
 	args.Mutation = mut
 	args.Intention = nil
 
-	resp, err := s.srv.raftApply(structs.IntentionRequestType, args)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
+	_, err = s.srv.raftApply(structs.IntentionRequestType, args)
+	return err
 }
 
 func (s *Intention) computeApplyChangesLegacyCreate(

--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
 )
 
 var KVSummaries = []prometheus.SummaryDefinition{
@@ -122,11 +123,7 @@ func (k *KVS) Apply(args *structs.KVSRequest, reply *bool) error {
 	// Apply the update.
 	resp, err := k.srv.raftApply(structs.KVSRequestType, args)
 	if err != nil {
-		k.logger.Error("Raft apply failed", "error", err)
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
+		return fmt.Errorf("raft apply failed: %w", err)
 	}
 
 	// Check if the return type is a bool.

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -135,15 +135,8 @@ func (s *Server) pruneCARoots() error {
 	args.Op = structs.CAOpSetRoots
 	args.Index = idx
 	args.Roots = newRoots
-	resp, err := s.raftApply(structs.ConnectCARequestType, args)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
+	_, err = s.raftApply(structs.ConnectCARequestType, args)
+	return err
 }
 
 // retryLoopBackoff loops a given function indefinitely, backing off exponentially

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -628,15 +628,12 @@ func TestLeader_Vault_PrimaryCA_FixSigningKeyID_OnRestart(t *testing.T) {
 		activePrimaryRoot.SigningKeyID = primaryRootSigningKeyID
 
 		// Store the root cert in raft
-		resp, err := s1pre.raftApply(structs.ConnectCARequestType, &structs.CARequest{
+		_, err = s1pre.raftApply(structs.ConnectCARequestType, &structs.CARequest{
 			Op:    structs.CAOpSetRoots,
 			Index: idx,
 			Roots: []*structs.CARoot{activePrimaryRoot},
 		})
 		require.NoError(t, err)
-		if respErr, ok := resp.(error); ok {
-			t.Fatalf("respErr: %v", respErr)
-		}
 	}
 
 	// Shutdown s1pre and restart it to trigger the secondary CA init to correct
@@ -731,15 +728,12 @@ func TestLeader_SecondaryCA_FixSigningKeyID_via_IntermediateRefresh(t *testing.T
 		activeSecondaryRoot.SigningKeyID = secondaryRootSigningKeyID
 
 		// Store the root cert in raft
-		resp, err := s2pre.raftApply(structs.ConnectCARequestType, &structs.CARequest{
+		_, err = s2pre.raftApply(structs.ConnectCARequestType, &structs.CARequest{
 			Op:    structs.CAOpSetRoots,
 			Index: idx,
 			Roots: []*structs.CARoot{activeSecondaryRoot},
 		})
 		require.NoError(t, err)
-		if respErr, ok := resp.(error); ok {
-			t.Fatalf("respErr: %v", respErr)
-		}
 	}
 
 	// Shutdown s2pre and restart it to trigger the secondary CA init to correct

--- a/agent/consul/leader_federation_state_ae.go
+++ b/agent/consul/leader_federation_state_ae.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"time"
 
+	memdb "github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
-	memdb "github.com/hashicorp/go-memdb"
 )
 
 const (
@@ -117,12 +118,9 @@ func (s *Server) updateOurFederationState(curr *structs.FederationState) error {
 
 	if s.config.Datacenter == s.config.PrimaryDatacenter {
 		// We are the primary, so we can't do an RPC as we don't have a replication token.
-		resp, err := s.raftApply(structs.FederationStateRequestType, args)
+		_, err := s.raftApply(structs.FederationStateRequestType, args)
 		if err != nil {
 			return err
-		}
-		if respErr, ok := resp.(error); ok {
-			return respErr
 		}
 	} else {
 		args.WriteRequest = structs.WriteRequest{
@@ -225,12 +223,9 @@ func (s *Server) pruneStaleFederationStates() error {
 				Datacenter: dc,
 			},
 		}
-		resp, err := s.raftApply(structs.FederationStateRequestType, &req)
+		_, err := s.raftApply(structs.FederationStateRequestType, &req)
 		if err != nil {
 			return fmt.Errorf("Failed to delete federation state %s: %v", dc, err)
-		}
-		if respErr, ok := resp.(error); ok {
-			return fmt.Errorf("Failed to delete federation state %s: %v", dc, respErr)
 		}
 	}
 

--- a/agent/consul/leader_intentions.go
+++ b/agent/consul/leader_intentions.go
@@ -164,10 +164,8 @@ func (s *Server) legacyIntentionsMigrationCleanupPhase(quiet bool) error {
 	req := structs.IntentionRequest{
 		Op: structs.IntentionOpDeleteAll,
 	}
-	if resp, err := s.raftApply(structs.IntentionRequestType, req); err != nil {
+	if _, err := s.raftApply(structs.IntentionRequestType, req); err != nil {
 		return err
-	} else if respErr, ok := resp.(error); ok {
-		return respErr
 	}
 
 	// Bypass the serf component and jump right to the final state.
@@ -409,9 +407,6 @@ func (s *Server) replicateLegacyIntentionsOnce(ctx context.Context, lastFetchInd
 		resp, err := s.raftApply(structs.TxnRequestType, &txnReq)
 		if err != nil {
 			return 0, false, err
-		}
-		if respErr, ok := resp.(error); ok {
-			return 0, false, respErr
 		}
 
 		if txnResp, ok := resp.(structs.TxnResponse); ok {

--- a/agent/consul/leader_intentions_test.go
+++ b/agent/consul/leader_intentions_test.go
@@ -108,14 +108,8 @@ func TestLeader_ReplicateIntentions(t *testing.T) {
 		if req.Op != structs.IntentionOpDelete {
 			req2.Intention.Hash = req.Intention.Hash // not part of Clone
 		}
-		resp, err := s.raftApply(structs.IntentionRequestType, req2)
-		if err != nil {
-			return err
-		}
-		if respErr, ok := resp.(error); ok {
-			return respErr
-		}
-		return nil
+		_, err := s.raftApply(structs.IntentionRequestType, req2)
+		return err
 	}
 
 	// Directly insert legacy intentions into raft in dc1.
@@ -442,14 +436,11 @@ func TestLeader_LegacyIntentionMigration(t *testing.T) {
 	var retained []*structs.Intention
 	for _, ixn := range ixns {
 		ixn2 := *ixn
-		resp, err := s1pre.raftApply(structs.IntentionRequestType, &structs.IntentionRequest{
+		_, err := s1pre.raftApply(structs.IntentionRequestType, &structs.IntentionRequest{
 			Op:        structs.IntentionOpCreate,
 			Intention: &ixn2,
 		})
 		require.NoError(t, err)
-		if respErr, ok := resp.(error); ok {
-			t.Fatalf("respErr: %v", respErr)
-		}
 
 		if _, present := ixn.Meta["unit-test-discarded"]; !present {
 			retained = append(retained, ixn)

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -3,10 +3,11 @@ package consul
 import (
 	"fmt"
 
-	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/structs"
 	autopilot "github.com/hashicorp/raft-autopilot"
 	"github.com/hashicorp/serf/serf"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 // AutopilotGetConfiguration is used to retrieve the current Autopilot configuration.
@@ -62,11 +63,7 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 	// Apply the update
 	resp, err := op.srv.raftApply(structs.AutopilotRequestType, args)
 	if err != nil {
-		op.logger.Error("Raft apply failed", "error", err)
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
+		return fmt.Errorf("raft apply failed: %w", err)
 	}
 
 	// Check if the return type is a bool.

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/logging"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-uuid"
 )
 
 var PreparedQuerySummaries = []prometheus.SummaryDefinition{
@@ -128,15 +129,10 @@ func (p *PreparedQuery) Apply(args *structs.PreparedQueryRequest, reply *string)
 	}
 
 	// Commit the query to the state store.
-	resp, err := p.srv.raftApply(structs.PreparedQueryRequestType, args)
+	_, err = p.srv.raftApply(structs.PreparedQueryRequestType, args)
 	if err != nil {
-		p.logger.Error("Raft apply failed", "error", err)
-		return err
+		return fmt.Errorf("raft apply failed: %w", err)
 	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
 	return nil
 }
 

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -535,9 +535,8 @@ func canRetry(args interface{}, err error) bool {
 		return true
 	}
 
-	// If we are chunking and it doesn't seem to have completed, try again
-	intErr, ok := args.(error)
-	if ok && strings.Contains(intErr.Error(), ErrChunkingResubmit.Error()) {
+	// If we are chunking and it doesn't seem to have completed, try again.
+	if err != nil && strings.Contains(err.Error(), ErrChunkingResubmit.Error()) {
 		return true
 	}
 

--- a/agent/consul/system_metadata.go
+++ b/agent/consul/system_metadata.go
@@ -22,15 +22,8 @@ func (s *Server) setSystemMetadataKey(key, val string) error {
 		Entry: &structs.SystemMetadataEntry{Key: key, Value: val},
 	}
 
-	resp, err := s.raftApply(structs.SystemMetadataRequestType, args)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
+	_, err := s.raftApply(structs.SystemMetadataRequestType, args)
+	return err
 }
 
 func (s *Server) deleteSystemMetadataKey(key string) error {
@@ -39,13 +32,6 @@ func (s *Server) deleteSystemMetadataKey(key string) error {
 		Entry: &structs.SystemMetadataEntry{Key: key},
 	}
 
-	resp, err := s.raftApply(structs.SystemMetadataRequestType, args)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
+	_, err := s.raftApply(structs.SystemMetadataRequestType, args)
+	return err
 }

--- a/agent/consul/txn_endpoint.go
+++ b/agent/consul/txn_endpoint.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/go-hclog"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-hclog"
 )
 
 var TxnSummaries = []prometheus.SummaryDefinition{
@@ -138,11 +139,7 @@ func (t *Txn) Apply(args *structs.TxnRequest, reply *structs.TxnResponse) error 
 	// Apply the update.
 	resp, err := t.srv.raftApply(structs.TxnRequestType, args)
 	if err != nil {
-		t.logger.Error("Raft apply failed", "error", err)
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
+		return fmt.Errorf("raft apply failed: %w", err)
 	}
 
 	// Convert the return type. This should be a cheap copy since we are


### PR DESCRIPTION
Fixes #9970

Previously we were inconsistently checking the response for errors. This
PR moves the response-is-error check into `raftApply`, so that all callers
can look at only the error response, instead of having to know that
errors could come from two places.

This should expose a few more errors that were previously hidden because
some calls to `raftApply` were ignoring the response return value.

Also handle errors more consistently. In some cases we would log the
error before returning it. This can be very confusing because it can
result in the same error being logged multiple times. Instead return
a wrapped error.

Also fixes a bug with `canRetry` and chunking errors. Previously it never would
have retried on those errors because it was looking at the wrong arg.