### PR TITLE
Add graceful shutdown of client connection and WaitGroup to H2PING

### DIFF
--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -541,6 +541,7 @@ func (c *CheckH2PING) check() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer cancel()
+	defer clientConn.Shutdown(ctx)
 	err = clientConn.Ping(ctx)
 	if err == nil {
 		c.StatusHandler.updateCheck(c.CheckID, api.HealthPassing, "HTTP2 ping was successful")

--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -519,7 +519,7 @@ type CheckH2PING struct {
 	stop     bool
 	stopCh   chan struct{}
 	stopLock sync.Mutex
-        stopWg   sync.WaitGroup
+	stopWg   sync.WaitGroup
 }
 
 func (c *CheckH2PING) check() {
@@ -560,11 +560,11 @@ func (c *CheckH2PING) Stop() {
 		c.stop = true
 		close(c.stopCh)
 	}
-        c.stopWg.Wait()
+	c.stopWg.Wait()
 }
 
 func (c *CheckH2PING) run() {
-        defer c.stopWg.Done()
+	defer c.stopWg.Done()
 	// Get the randomized initial pause time
 	initialPauseTime := lib.RandomStagger(c.Interval)
 	next := time.After(initialPauseTime)
@@ -587,7 +587,7 @@ func (c *CheckH2PING) Start() {
 	}
 	c.stop = false
 	c.stopCh = make(chan struct{})
-        c.stopWg.Add(1)
+	c.stopWg.Add(1)
 	go c.run()
 }
 

--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -519,6 +519,7 @@ type CheckH2PING struct {
 	stop     bool
 	stopCh   chan struct{}
 	stopLock sync.Mutex
+        stopWg   sync.WaitGroup
 }
 
 func (c *CheckH2PING) check() {
@@ -559,9 +560,11 @@ func (c *CheckH2PING) Stop() {
 		c.stop = true
 		close(c.stopCh)
 	}
+        c.stopWg.Wait()
 }
 
 func (c *CheckH2PING) run() {
+        defer c.stopWg.Done()
 	// Get the randomized initial pause time
 	initialPauseTime := lib.RandomStagger(c.Interval)
 	next := time.After(initialPauseTime)
@@ -584,6 +587,7 @@ func (c *CheckH2PING) Start() {
 	}
 	c.stop = false
 	c.stopCh = make(chan struct{})
+        c.stopWg.Add(1)
 	go c.run()
 }
 


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8431 H2 ping checks were added, but the functionality currently terminates the TCP connection without gracefully shutting down the HTTP2 client connection first (sending a GOAWAY frame). This pull request adds the graceful shutdown and also WaitGroups (as was suggested in the original pull request).