### PR TITLE
Remove zero-value validation of upstream cfg structs

### DIFF
--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -795,8 +795,8 @@ func (chk *PassiveHealthCheck) IsZero() bool {
 }
 
 func (chk PassiveHealthCheck) Validate() error {
-	if chk.Interval <= 0*time.Second {
-		return fmt.Errorf("passive health check interval must be greater than 0s")
+	if chk.Interval < 0*time.Second {
+		return fmt.Errorf("passive health check interval cannot be negative")
 	}
 	return nil
 }
@@ -826,14 +826,14 @@ func (ul *UpstreamLimits) IsZero() bool {
 }
 
 func (ul UpstreamLimits) Validate() error {
-	if ul.MaxConnections != nil && *ul.MaxConnections <= 0 {
-		return fmt.Errorf("max connections must be at least 0")
+	if ul.MaxConnections != nil && *ul.MaxConnections < 0 {
+		return fmt.Errorf("max connections cannot be negative")
 	}
-	if ul.MaxPendingRequests != nil && *ul.MaxPendingRequests <= 0 {
-		return fmt.Errorf("max pending requests must be at least 0")
+	if ul.MaxPendingRequests != nil && *ul.MaxPendingRequests < 0 {
+		return fmt.Errorf("max pending requests cannot be negative")
 	}
-	if ul.MaxConcurrentRequests != nil && *ul.MaxConcurrentRequests <= 0 {
-		return fmt.Errorf("max concurrent requests must be at least 0")
+	if ul.MaxConcurrentRequests != nil && *ul.MaxConcurrentRequests < 0 {
+		return fmt.Errorf("max concurrent requests cannot be negative")
 	}
 	return nil
 }

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1453,21 +1453,15 @@ func TestPassiveHealthCheck_Validate(t *testing.T) {
 		wantMsg string
 	}{
 		{
-			name:    "valid-interval",
-			input:   PassiveHealthCheck{Interval: 2 * time.Second},
+			name:    "valid interval",
+			input:   PassiveHealthCheck{Interval: 0 * time.Second},
 			wantErr: false,
 		},
 		{
-			name:    "negative-interval",
+			name:    "negative interval",
 			input:   PassiveHealthCheck{Interval: -1 * time.Second},
 			wantErr: true,
-			wantMsg: "greater than 0s",
-		},
-		{
-			name:    "zero-interval",
-			input:   PassiveHealthCheck{Interval: 0 * time.Second},
-			wantErr: true,
-			wantMsg: "greater than 0s",
+			wantMsg: "cannot be negative",
 		},
 	}
 
@@ -1492,54 +1486,36 @@ func TestUpstreamLimits_Validate(t *testing.T) {
 	}{
 		{
 			name:    "valid-max-conns",
-			input:   UpstreamLimits{MaxConnections: intPointer(1)},
-			wantErr: false,
-		},
-		{
-			name:    "zero-max-conns",
 			input:   UpstreamLimits{MaxConnections: intPointer(0)},
-			wantErr: true,
-			wantMsg: "at least 0",
+			wantErr: false,
 		},
 		{
 			name:    "negative-max-conns",
 			input:   UpstreamLimits{MaxConnections: intPointer(-1)},
 			wantErr: true,
-			wantMsg: "at least 0",
+			wantMsg: "cannot be negative",
 		},
 		{
 			name:    "valid-max-concurrent",
-			input:   UpstreamLimits{MaxConcurrentRequests: intPointer(1)},
-			wantErr: false,
-		},
-		{
-			name:    "zero-max-concurrent",
 			input:   UpstreamLimits{MaxConcurrentRequests: intPointer(0)},
-			wantErr: true,
-			wantMsg: "at least 0",
+			wantErr: false,
 		},
 		{
 			name:    "negative-max-concurrent",
 			input:   UpstreamLimits{MaxConcurrentRequests: intPointer(-1)},
 			wantErr: true,
-			wantMsg: "at least 0",
+			wantMsg: "cannot be negative",
 		},
 		{
 			name:    "valid-max-pending",
-			input:   UpstreamLimits{MaxPendingRequests: intPointer(1)},
-			wantErr: false,
-		},
-		{
-			name:    "zero-max-pending",
 			input:   UpstreamLimits{MaxPendingRequests: intPointer(0)},
-			wantErr: true,
-			wantMsg: "at least 0",
+			wantErr: false,
 		},
 		{
 			name:    "negative-max-pending",
 			input:   UpstreamLimits{MaxPendingRequests: intPointer(-1)},
 			wantErr: true,
-			wantMsg: "at least 0",
+			wantMsg: "cannot be negative",
 		},
 	}
 


### PR DESCRIPTION
The zero value of these flags was already being excluded in the xDS
generation of circuit breaker/outlier detection config.

See: `makeThresholdsIfNeeded` and `ToOutlierDetection`.

This validation actually leads to users having to specify every field 
in the structs if any one of them is defined.