### PR TITLE
fix(website): docs link text color

### DIFF
--- a/website/pages/style.css
+++ b/website/pages/style.css
@@ -6,6 +6,7 @@
 
 :root {
   --highlight-color: var(--consul);
+  --highlight-color-text: var(--consul-text);
 }
 
 @import '~@hashicorp/react-alert-banner/style.css';


### PR DESCRIPTION
Patches the docs pages link color until the [branding changes](https://github.com/hashicorp/consul/pull/9884) roll out. 

[See the preview](https://consul-d5f33w88c-hashicorp.vercel.app/docs) to test.