### PR TITLE
Avoid nil panic when cluster config doesn't exist

### DIFF
--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -59,6 +59,7 @@ func (s *Server) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnapsh
 	// In transparent proxy mode there needs to be a passthrough cluster for traffic going to destinations
 	// that aren't in Consul's catalog.
 	if cfgSnap.Proxy.Mode == structs.ProxyModeTransparent &&
+		cfgSnap.ConnectProxy.ClusterConfig != nil &&
 		!cfgSnap.ConnectProxy.ClusterConfig.TransparentProxy.CatalogDestinationsOnly {
 
 		clusters = append(clusters, &envoy_cluster_v3.Cluster{

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -76,7 +76,6 @@ func (s *Server) listenersFromSnapshotConnectProxy(cInfo connectionInfo, cfgSnap
 			port = cfgSnap.Proxy.TransparentProxy.OutboundListenerPort
 		}
 
-		// TODO (freddy) Make DefaultTProxyOutboundPort configurable
 		outboundListener = makeListener(OutboundListenerName, "127.0.0.1", port, envoy_core_v3.TrafficDirection_OUTBOUND)
 		outboundListener.FilterChains = make([]*envoy_listener_v3.FilterChain, 0)
 		outboundListener.ListenerFilters = []*envoy_listener_v3.ListenerFilter{


### PR DESCRIPTION
Also removes a deja-do todo.