### PR TITLE
Convert new tproxy structs in api module into ptrs

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3519,6 +3519,10 @@ func testAgent_RegisterService_UnmanagedConnectProxy(t *testing.T, extraHCL stri
 					LocalBindPort:   1235,
 				},
 			},
+			Mode: api.ProxyModeTransparent,
+			TransparentProxy: &api.TransparentProxyConfig{
+				OutboundListenerPort: 808,
+			},
 		},
 	}
 

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -110,8 +110,8 @@ type TransparentProxyConfig struct {
 	OutboundListenerPort int `json:",omitempty" alias:"outbound_listener_port"`
 }
 
-func (c TransparentProxyConfig) ToAPI() api.TransparentProxyConfig {
-	return api.TransparentProxyConfig{OutboundListenerPort: c.OutboundListenerPort}
+func (c TransparentProxyConfig) ToAPI() *api.TransparentProxyConfig {
+	return &api.TransparentProxyConfig{OutboundListenerPort: c.OutboundListenerPort}
 }
 
 // ConnectProxyConfig describes the configuration needed for any proxy managed

--- a/agent/structs/connect_proxy_config_test.go
+++ b/agent/structs/connect_proxy_config_test.go
@@ -46,6 +46,10 @@ func TestConnectProxyConfig_ToAPI(t *testing.T) {
 						LocalBindAddress: "127.10.10.10",
 					},
 				},
+				Mode: ProxyModeTransparent,
+				TransparentProxy: TransparentProxyConfig{
+					OutboundListenerPort: 808,
+				},
 			},
 			want: &api.AgentServiceConnectProxyConfig{
 				DestinationServiceName: "web",
@@ -75,6 +79,10 @@ func TestConnectProxyConfig_ToAPI(t *testing.T) {
 						LocalBindPort:    2345,
 						LocalBindAddress: "127.10.10.10",
 					},
+				},
+				Mode: api.ProxyModeTransparent,
+				TransparentProxy: &api.TransparentProxyConfig{
+					OutboundListenerPort: 808,
 				},
 			},
 		},

--- a/api/agent.go
+++ b/api/agent.go
@@ -114,16 +114,16 @@ type AgentServiceConnect struct {
 // AgentServiceConnectProxyConfig is the proxy configuration in a connect-proxy
 // ServiceDefinition or response.
 type AgentServiceConnectProxyConfig struct {
-	DestinationServiceName string                 `json:",omitempty"`
-	DestinationServiceID   string                 `json:",omitempty"`
-	LocalServiceAddress    string                 `json:",omitempty"`
-	LocalServicePort       int                    `json:",omitempty"`
-	Mode                   ProxyMode              `json:",omitempty"`
-	TransparentProxy       TransparentProxyConfig `json:",omitempty"`
-	Config                 map[string]interface{} `json:",omitempty" bexpr:"-"`
-	Upstreams              []Upstream             `json:",omitempty"`
-	MeshGateway            MeshGatewayConfig      `json:",omitempty"`
-	Expose                 ExposeConfig           `json:",omitempty"`
+	DestinationServiceName string                  `json:",omitempty"`
+	DestinationServiceID   string                  `json:",omitempty"`
+	LocalServiceAddress    string                  `json:",omitempty"`
+	LocalServicePort       int                     `json:",omitempty"`
+	Mode                   ProxyMode               `json:",omitempty"`
+	TransparentProxy       *TransparentProxyConfig `json:",omitempty"`
+	Config                 map[string]interface{}  `json:",omitempty" bexpr:"-"`
+	Upstreams              []Upstream              `json:",omitempty"`
+	MeshGateway            MeshGatewayConfig       `json:",omitempty"`
+	Expose                 ExposeConfig            `json:",omitempty"`
 }
 
 const (

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -505,6 +505,10 @@ func testUnmanagedProxy(t *testing.T) *AgentService {
 			LocalServiceAddress:    "127.0.0.2",
 			LocalServicePort:       8080,
 			Upstreams:              testUpstreams(t),
+			Mode:                   ProxyModeTransparent,
+			TransparentProxy: &TransparentProxyConfig{
+				OutboundListenerPort: 808,
+			},
 		},
 		ID:      "web-proxy1",
 		Service: "web-proxy",

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -193,15 +193,15 @@ type UpstreamLimits struct {
 type ServiceConfigEntry struct {
 	Kind             string
 	Name             string
-	Namespace        string                 `json:",omitempty"`
-	Protocol         string                 `json:",omitempty"`
-	Mode             ProxyMode              `json:",omitempty"`
-	TransparentProxy TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
-	MeshGateway      MeshGatewayConfig      `json:",omitempty" alias:"mesh_gateway"`
-	Connect          ConnectConfiguration   `json:",omitempty"`
-	Expose           ExposeConfig           `json:",omitempty"`
-	ExternalSNI      string                 `json:",omitempty" alias:"external_sni"`
-	Meta             map[string]string      `json:",omitempty"`
+	Namespace        string                  `json:",omitempty"`
+	Protocol         string                  `json:",omitempty"`
+	Mode             ProxyMode               `json:",omitempty"`
+	TransparentProxy *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
+	MeshGateway      MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
+	Connect          *ConnectConfiguration   `json:",omitempty"`
+	Expose           ExposeConfig            `json:",omitempty"`
+	ExternalSNI      string                  `json:",omitempty" alias:"external_sni"`
+	Meta             map[string]string       `json:",omitempty"`
 	CreateIndex      uint64
 	ModifyIndex      uint64
 }
@@ -233,13 +233,13 @@ func (s *ServiceConfigEntry) GetModifyIndex() uint64 {
 type ProxyConfigEntry struct {
 	Kind             string
 	Name             string
-	Namespace        string                 `json:",omitempty"`
-	Mode             ProxyMode              `json:",omitempty"`
-	TransparentProxy TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
-	Config           map[string]interface{} `json:",omitempty"`
-	MeshGateway      MeshGatewayConfig      `json:",omitempty" alias:"mesh_gateway"`
-	Expose           ExposeConfig           `json:",omitempty"`
-	Meta             map[string]string      `json:",omitempty"`
+	Namespace        string                  `json:",omitempty"`
+	Mode             ProxyMode               `json:",omitempty"`
+	TransparentProxy *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
+	Config           map[string]interface{}  `json:",omitempty"`
+	MeshGateway      MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
+	Expose           ExposeConfig            `json:",omitempty"`
+	Meta             map[string]string       `json:",omitempty"`
 	CreateIndex      uint64
 	ModifyIndex      uint64
 }

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -321,7 +321,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					Mode: MeshGatewayModeRemote,
 				},
 				Mode:             ProxyModeTransparent,
-				TransparentProxy: TransparentProxyConfig{OutboundListenerPort: 808},
+				TransparentProxy: &TransparentProxyConfig{OutboundListenerPort: 808},
 			},
 		},
 		{
@@ -388,8 +388,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 					Mode: MeshGatewayModeRemote,
 				},
 				Mode:             ProxyModeTransparent,
-				TransparentProxy: TransparentProxyConfig{OutboundListenerPort: 808},
-				Connect: ConnectConfiguration{
+				TransparentProxy: &TransparentProxyConfig{OutboundListenerPort: 808},
+				Connect: &ConnectConfiguration{
 					UpstreamConfigs: map[string]UpstreamConfig{
 						"redis": {
 							PassiveHealthCheck: &PassiveHealthCheck{

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -275,7 +275,7 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode: api.MeshGatewayModeRemote,
 				},
 				Mode: api.ProxyModeDirect,
-				TransparentProxy: api.TransparentProxyConfig{
+				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 				},
 			},
@@ -297,7 +297,7 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode: api.MeshGatewayModeRemote,
 				},
 				Mode: api.ProxyModeDirect,
-				TransparentProxy: api.TransparentProxyConfig{
+				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 				},
 			},
@@ -654,10 +654,10 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode: api.MeshGatewayModeRemote,
 				},
 				Mode: api.ProxyModeDirect,
-				TransparentProxy: api.TransparentProxyConfig{
+				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 				},
-				Connect: api.ConnectConfiguration{
+				Connect: &api.ConnectConfiguration{
 					UpstreamConfigs: map[string]api.UpstreamConfig{
 						"redis": {
 							PassiveHealthCheck: &api.PassiveHealthCheck{

--- a/command/services/config_test.go
+++ b/command/services/config_test.go
@@ -122,6 +122,10 @@ func TestStructsToAgentService(t *testing.T) {
 					LocalServiceAddress:    "127.0.0.1",
 					LocalServicePort:       8181,
 					Upstreams:              structs.TestUpstreams(t),
+					Mode:                   structs.ProxyModeTransparent,
+					TransparentProxy: structs.TransparentProxyConfig{
+						OutboundListenerPort: 808,
+					},
 					Config: map[string]interface{}{
 						"foo": "bar",
 					},
@@ -138,6 +142,10 @@ func TestStructsToAgentService(t *testing.T) {
 					LocalServiceAddress:    "127.0.0.1",
 					LocalServicePort:       8181,
 					Upstreams:              structs.TestUpstreams(t).ToAPI(),
+					Mode:                   api.ProxyModeTransparent,
+					TransparentProxy: &api.TransparentProxyConfig{
+						OutboundListenerPort: 808,
+					},
 					Config: map[string]interface{}{
 						"foo": "bar",
 					},


### PR DESCRIPTION
This way we avoid serializing these when empty. Otherwise users of the
latest version of the api submodule cannot interact with older versions
of Consul, because the api client would send keys that Consul doesn't
recognize yet.

Related: https://github.com/golang/go/issues/11939