### PR TITLE
Convert new tproxy structs in api module into ptrs

### DIFF
--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -110,8 +110,8 @@ type TransparentProxyConfig struct {
 	OutboundListenerPort int `json:",omitempty" alias:"outbound_listener_port"`
 }
 
-func (c TransparentProxyConfig) ToAPI() api.TransparentProxyConfig {
-	return api.TransparentProxyConfig{OutboundListenerPort: c.OutboundListenerPort}
+func (c TransparentProxyConfig) ToAPI() *api.TransparentProxyConfig {
+	return &api.TransparentProxyConfig{OutboundListenerPort: c.OutboundListenerPort}
 }
 
 // ConnectProxyConfig describes the configuration needed for any proxy managed

--- a/api/agent.go
+++ b/api/agent.go
@@ -114,16 +114,16 @@ type AgentServiceConnect struct {
 // AgentServiceConnectProxyConfig is the proxy configuration in a connect-proxy
 // ServiceDefinition or response.
 type AgentServiceConnectProxyConfig struct {
-	DestinationServiceName string                 `json:",omitempty"`
-	DestinationServiceID   string                 `json:",omitempty"`
-	LocalServiceAddress    string                 `json:",omitempty"`
-	LocalServicePort       int                    `json:",omitempty"`
-	Mode                   ProxyMode              `json:",omitempty"`
-	TransparentProxy       TransparentProxyConfig `json:",omitempty"`
-	Config                 map[string]interface{} `json:",omitempty" bexpr:"-"`
-	Upstreams              []Upstream             `json:",omitempty"`
-	MeshGateway            MeshGatewayConfig      `json:",omitempty"`
-	Expose                 ExposeConfig           `json:",omitempty"`
+	DestinationServiceName string                  `json:",omitempty"`
+	DestinationServiceID   string                  `json:",omitempty"`
+	LocalServiceAddress    string                  `json:",omitempty"`
+	LocalServicePort       int                     `json:",omitempty"`
+	Mode                   ProxyMode               `json:",omitempty"`
+	TransparentProxy       *TransparentProxyConfig `json:",omitempty"`
+	Config                 map[string]interface{}  `json:",omitempty" bexpr:"-"`
+	Upstreams              []Upstream              `json:",omitempty"`
+	MeshGateway            MeshGatewayConfig       `json:",omitempty"`
+	Expose                 ExposeConfig            `json:",omitempty"`
 }
 
 const (

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -505,6 +505,10 @@ func testUnmanagedProxy(t *testing.T) *AgentService {
 			LocalServiceAddress:    "127.0.0.2",
 			LocalServicePort:       8080,
 			Upstreams:              testUpstreams(t),
+			Mode:                   ProxyModeTransparent,
+			TransparentProxy: &TransparentProxyConfig{
+				OutboundListenerPort: 808,
+			},
 		},
 		ID:      "web-proxy1",
 		Service: "web-proxy",

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -193,15 +193,15 @@ type UpstreamLimits struct {
 type ServiceConfigEntry struct {
 	Kind             string
 	Name             string
-	Namespace        string                 `json:",omitempty"`
-	Protocol         string                 `json:",omitempty"`
-	Mode             ProxyMode              `json:",omitempty"`
-	TransparentProxy TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
-	MeshGateway      MeshGatewayConfig      `json:",omitempty" alias:"mesh_gateway"`
-	Connect          ConnectConfiguration   `json:",omitempty"`
-	Expose           ExposeConfig           `json:",omitempty"`
-	ExternalSNI      string                 `json:",omitempty" alias:"external_sni"`
-	Meta             map[string]string      `json:",omitempty"`
+	Namespace        string                  `json:",omitempty"`
+	Protocol         string                  `json:",omitempty"`
+	Mode             ProxyMode               `json:",omitempty"`
+	TransparentProxy *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
+	MeshGateway      MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
+	Connect          *ConnectConfiguration   `json:",omitempty"`
+	Expose           ExposeConfig            `json:",omitempty"`
+	ExternalSNI      string                  `json:",omitempty" alias:"external_sni"`
+	Meta             map[string]string       `json:",omitempty"`
 	CreateIndex      uint64
 	ModifyIndex      uint64
 }
@@ -233,13 +233,13 @@ func (s *ServiceConfigEntry) GetModifyIndex() uint64 {
 type ProxyConfigEntry struct {
 	Kind             string
 	Name             string
-	Namespace        string                 `json:",omitempty"`
-	Mode             ProxyMode              `json:",omitempty"`
-	TransparentProxy TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
-	Config           map[string]interface{} `json:",omitempty"`
-	MeshGateway      MeshGatewayConfig      `json:",omitempty" alias:"mesh_gateway"`
-	Expose           ExposeConfig           `json:",omitempty"`
-	Meta             map[string]string      `json:",omitempty"`
+	Namespace        string                  `json:",omitempty"`
+	Mode             ProxyMode               `json:",omitempty"`
+	TransparentProxy *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
+	Config           map[string]interface{}  `json:",omitempty"`
+	MeshGateway      MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
+	Expose           ExposeConfig            `json:",omitempty"`
+	Meta             map[string]string       `json:",omitempty"`
 	CreateIndex      uint64
 	ModifyIndex      uint64
 }

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -321,7 +321,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					Mode: MeshGatewayModeRemote,
 				},
 				Mode:             ProxyModeTransparent,
-				TransparentProxy: TransparentProxyConfig{OutboundListenerPort: 808},
+				TransparentProxy: &TransparentProxyConfig{OutboundListenerPort: 808},
 			},
 		},
 		{
@@ -388,8 +388,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 					Mode: MeshGatewayModeRemote,
 				},
 				Mode:             ProxyModeTransparent,
-				TransparentProxy: TransparentProxyConfig{OutboundListenerPort: 808},
-				Connect: ConnectConfiguration{
+				TransparentProxy: &TransparentProxyConfig{OutboundListenerPort: 808},
+				Connect: &ConnectConfiguration{
 					UpstreamConfigs: map[string]UpstreamConfig{
 						"redis": {
 							PassiveHealthCheck: &PassiveHealthCheck{

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -275,7 +275,7 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode: api.MeshGatewayModeRemote,
 				},
 				Mode: api.ProxyModeDirect,
-				TransparentProxy: api.TransparentProxyConfig{
+				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 				},
 			},
@@ -297,7 +297,7 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode: api.MeshGatewayModeRemote,
 				},
 				Mode: api.ProxyModeDirect,
-				TransparentProxy: api.TransparentProxyConfig{
+				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 				},
 			},
@@ -654,10 +654,10 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode: api.MeshGatewayModeRemote,
 				},
 				Mode: api.ProxyModeDirect,
-				TransparentProxy: api.TransparentProxyConfig{
+				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 				},
-				Connect: api.ConnectConfiguration{
+				Connect: &api.ConnectConfiguration{
 					UpstreamConfigs: map[string]api.UpstreamConfig{
 						"redis": {
 							PassiveHealthCheck: &api.PassiveHealthCheck{


### PR DESCRIPTION
This way we avoid serializing these when empty. Otherwise users of the
latest version of the api submodule cannot interact with older versions
of Consul, because a new api client would send keys that the older Consul
doesn't recognize yet.


New PR, since old PR didn't run test suite in CI.