### PR TITLE
dns: properly trim response when EDNS is used

### DIFF
--- a/.changelog/10009.txt
+++ b/.changelog/10009.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dns: fixes a bug with edns truncation where the response could exceed the size limit in some cases.
+```

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -507,7 +507,7 @@ func (d *DNSServer) handleQuery(resp dns.ResponseWriter, req *dns.Msg) {
 
 	setEDNS(req, m, !errors.Is(err, errECSNotGlobal))
 
-	//d.trimDNSResponse(cfg, network, req, m)
+	d.trimDNSResponse(cfg, network, req, m)
 
 	if err := resp.WriteMsg(m); err != nil {
 		d.logger.Warn("failed to respond", "error", err)
@@ -1270,10 +1270,8 @@ func (d *DNSServer) serviceLookup(cfg *dnsConfig, lookup serviceLookup, req, res
 		d.serviceNodeRecords(cfg, lookup.Datacenter, out.Nodes, req, resp, ttl, lookup.MaxRecursionLevel)
 	}
 
-	d.trimDNSResponse(cfg, lookup.Network, req, resp)
-
 	// If the answer is empty and the response isn't truncated, return not found
-	if len(resp.Answer) == 0 && !resp.Truncated {
+	if len(resp.Answer) == 0 {
 		return errNoAnswer
 	}
 	return nil
@@ -1378,10 +1376,8 @@ func (d *DNSServer) preparedQueryLookup(cfg *dnsConfig, network, datacenter, que
 		d.serviceNodeRecords(cfg, out.Datacenter, out.Nodes, req, resp, ttl, maxRecursionLevel)
 	}
 
-	d.trimDNSResponse(cfg, network, req, resp)
-
 	// If the answer is empty and the response isn't truncated, return not found
-	if len(resp.Answer) == 0 && !resp.Truncated {
+	if len(resp.Answer) == 0 {
 		return errNoAnswer
 	}
 	return nil

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -587,12 +587,6 @@ func (d *DNSServer) nameservers(cfg *dnsConfig, maxRecursionLevel int) (ns []dns
 	return
 }
 
-func (d *DNSServer) invalidQuery(req, resp *dns.Msg, cfg *dnsConfig, qName string) {
-	d.logger.Warn("QName invalid", "qname", qName)
-	d.addSOA(cfg, resp)
-	resp.SetRcode(req, dns.RcodeNameError)
-}
-
 func (d *DNSServer) parseDatacenter(labels []string, datacenter *string) bool {
 	switch len(labels) {
 	case 1:

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -545,6 +545,7 @@ func TestDNS_NodeLookup_CNAME(t *testing.T) {
 
 	m := new(dns.Msg)
 	m.SetQuestion("google.node.consul.", dns.TypeANY)
+	m.SetEdns0(8192, true)
 
 	c := new(dns.Client)
 	in, _, err := c.Exchange(m, a.DNSAddr())

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6779,17 +6779,15 @@ func TestDNS_EDNS_Truncate_AgentSource(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	{
-		m := new(dns.Msg)
-		m.SetQuestion("foo.query.consul.", dns.TypeSRV)
-		m.SetEdns0(2048, true)
-		m.Compress = false
+	req := new(dns.Msg)
+	req.SetQuestion("foo.query.consul.", dns.TypeSRV)
+	req.SetEdns0(2048, true)
+	req.Compress = false
 
-		c := new(dns.Client)
-		r, _, err := c.Exchange(m, a.DNSAddr())
-		require.NoError(t, err)
-		require.True(t, r.Len() < 2048)
-	}
+	c := new(dns.Client)
+	resp, _, err := c.Exchange(req, a.DNSAddr())
+	require.NoError(t, err)
+	require.True(t, resp.Len() < 2048)
 }
 
 func TestDNS_trimUDPResponse_NoTrim(t *testing.T) {


### PR DESCRIPTION
Fixes #9945

Best viewed by individual commit.

This PR refactors parts of the `DNSServer` to allow us to set the response code and trim the response in a single place. This fixes the problem of the DNS response exceeding the max size.

I notice we never called trim in `handlePtr` or `handleRecurse`. I wonder if we should be.

TODO:
* [x] changelog
* [x] add a new test specifically for this case
* [x] figure out if the last remaining TODO needs to be resolved, which might require returning the error down through the calls