### PR TITLE
Update Docs nav for deprecated proxies

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -193,6 +193,10 @@
           {
             "title": "Proxy Integration",
             "path": "connect/proxies/integrate"
+          },
+          {
+            "title": "Deprecated Proxies",
+            "path": "connect/proxies/managed-deprecated"
           }
         ]
       },


### PR DESCRIPTION
Fixes #9990

This adds the deprecated proxies field to the nav resource, allowing for the page to be accessed in other links. Tested locally by building the image, verifying the presence of the new field in the sidebar, and checking that I can access the managed-deprecated page from another page. 