### PR TITLE
Update topology endpoint to account for transparent proxy

### DIFF
--- a/.changelog/10016.txt
+++ b/.changelog/10016.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Update the service mesh visualization to account for transparent proxies.
+```

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -573,11 +573,50 @@ func registerTestCatalogEntriesMap(t *testing.T, codec rpc.ClientCodec, registra
 func registerTestTopologyEntries(t *testing.T, codec rpc.ClientCodec, token string) {
 	t.Helper()
 
-	// api and api-proxy on node foo - upstream: web
+	// ingress-gateway on node edge - upstream: api
+	// api and api-proxy on node foo - transparent proxy
 	// web and web-proxy on node bar - upstream: redis
-	// web and web-proxy on node baz - upstream: redis
+	// web and web-proxy on node baz - transparent proxy
 	// redis and redis-proxy on node zip
 	registrations := map[string]*structs.RegisterRequest{
+		"Node edge": {
+			Datacenter: "dc1",
+			Node:       "edge",
+			ID:         types.NodeID("8e3481c0-760e-4b5f-a3b8-6c8c559e8a15"),
+			Address:    "127.0.0.1",
+			Checks: structs.HealthChecks{
+				&structs.HealthCheck{
+					Node:    "edge",
+					CheckID: "edge:alive",
+					Name:    "edge-liveness",
+					Status:  api.HealthPassing,
+				},
+			},
+			WriteRequest: structs.WriteRequest{Token: token},
+		},
+		"Service ingress on edge": {
+			Datacenter:     "dc1",
+			Node:           "edge",
+			SkipNodeUpdate: true,
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindIngressGateway,
+				ID:      "ingress",
+				Service: "ingress",
+				Port:    8443,
+				Address: "198.18.1.1",
+			},
+			Checks: structs.HealthChecks{
+				&structs.HealthCheck{
+					Node:        "edge",
+					CheckID:     "edge:ingress",
+					Name:        "ingress-liveness",
+					Status:      api.HealthPassing,
+					ServiceID:   "ingress",
+					ServiceName: "ingress",
+				},
+			},
+			WriteRequest: structs.WriteRequest{Token: token},
+		},
 		"Node foo": {
 			Datacenter: "dc1",
 			Node:       "foo",
@@ -627,13 +666,8 @@ func registerTestTopologyEntries(t *testing.T, codec rpc.ClientCodec, token stri
 				Port:    8443,
 				Address: "198.18.1.2",
 				Proxy: structs.ConnectProxyConfig{
+					Mode:                   structs.ProxyModeTransparent,
 					DestinationServiceName: "api",
-					Upstreams: structs.Upstreams{
-						{
-							DestinationName: "web",
-							LocalBindPort:   8080,
-						},
-					},
 				},
 			},
 			Checks: structs.HealthChecks{
@@ -767,13 +801,8 @@ func registerTestTopologyEntries(t *testing.T, codec rpc.ClientCodec, token stri
 				Port:    8443,
 				Address: "198.18.1.40",
 				Proxy: structs.ConnectProxyConfig{
+					Mode:                   structs.ProxyModeTransparent,
 					DestinationServiceName: "web",
-					Upstreams: structs.Upstreams{
-						{
-							DestinationName: "redis",
-							LocalBindPort:   123,
-						},
-					},
 				},
 			},
 			Checks: structs.HealthChecks{
@@ -855,7 +884,10 @@ func registerTestTopologyEntries(t *testing.T, codec rpc.ClientCodec, token stri
 	}
 	registerTestCatalogEntriesMap(t, codec, registrations)
 
-	// Add intentions: deny all, web -> redis with L7 perms, but omit intention for api -> web
+	// ingress -> api gateway config entry (but no intention)
+	// wildcard deny intention
+	// api -> web exact intention
+	// web -> redis exact intention
 	entries := []structs.ConfigEntryRequest{
 		{
 			Datacenter: "dc1",
@@ -864,6 +896,39 @@ func registerTestTopologyEntries(t *testing.T, codec rpc.ClientCodec, token stri
 				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
+				},
+			},
+			WriteRequest: structs.WriteRequest{Token: token},
+		},
+		{
+			Datacenter: "dc1",
+			Entry: &structs.IngressGatewayConfigEntry{
+				Kind: structs.IngressGateway,
+				Name: "ingress",
+				Listeners: []structs.IngressListener{
+					{
+						Port:     8443,
+						Protocol: "http",
+						Services: []structs.IngressService{
+							{
+								Name: "api",
+							},
+						},
+					},
+				},
+			},
+			WriteRequest: structs.WriteRequest{Token: token},
+		},
+		{
+			Datacenter: "dc1",
+			Entry: &structs.ServiceIntentionsConfigEntry{
+				Kind: structs.ServiceIntentions,
+				Name: "web",
+				Sources: []*structs.SourceIntention{
+					{
+						Action: structs.IntentionActionAllow,
+						Name:   "api",
+					},
 				},
 			},
 			WriteRequest: structs.WriteRequest{Token: token},

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -1721,6 +1721,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 
 			expectUp := map[string]structs.IntentionDecisionSummary{
 				web.String(): {
+					DefaultAllow:   true,
 					Allowed:        false,
 					HasPermissions: false,
 					ExternalSource: "nomad",
@@ -1749,6 +1750,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 
 			expectDown := map[string]structs.IntentionDecisionSummary{
 				api.String(): {
+					DefaultAllow:   true,
 					Allowed:        false,
 					HasPermissions: false,
 					ExternalSource: "nomad",
@@ -1764,6 +1766,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 
 			expectUp := map[string]structs.IntentionDecisionSummary{
 				redis.String(): {
+					DefaultAllow:   true,
 					Allowed:        false,
 					HasPermissions: true,
 					HasExact:       true,
@@ -1791,6 +1794,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 
 			expectDown := map[string]structs.IntentionDecisionSummary{
 				web.String(): {
+					DefaultAllow:   true,
 					Allowed:        false,
 					HasPermissions: true,
 					HasExact:       true,

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -955,7 +955,7 @@ func (s *Store) IntentionTopology(ws memdb.WatchSet,
 		return 0, nil, fmt.Errorf("failed to fetch %s for %s: %v", requested, target.String(), err)
 	}
 
-	var resp structs.ServiceList
+	resp := make(structs.ServiceList, 0)
 	for _, svc := range services {
 		resp = append(resp, svc.Name)
 	}

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -750,10 +750,12 @@ func (s *Store) IntentionDecision(
 		}
 	}
 
-	var resp structs.IntentionDecisionSummary
+	resp := structs.IntentionDecisionSummary{
+		DefaultAllow: defaultDecision == acl.Allow,
+	}
 	if ixnMatch == nil {
 		// No intention found, fall back to default
-		resp.Allowed = defaultDecision == acl.Allow
+		resp.Allowed = resp.DefaultAllow
 		return resp, nil
 	}
 

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -1774,7 +1774,10 @@ func TestStore_IntentionDecision(t *testing.T) {
 			dst:             "ditto",
 			matchType:       structs.IntentionMatchDestination,
 			defaultDecision: acl.Deny,
-			expect:          structs.IntentionDecisionSummary{Allowed: false},
+			expect: structs.IntentionDecisionSummary{
+				Allowed:      false,
+				DefaultAllow: false,
+			},
 		},
 		{
 			name:            "no matching intention and default allow",
@@ -1782,7 +1785,10 @@ func TestStore_IntentionDecision(t *testing.T) {
 			dst:             "ditto",
 			matchType:       structs.IntentionMatchDestination,
 			defaultDecision: acl.Allow,
-			expect:          structs.IntentionDecisionSummary{Allowed: true},
+			expect: structs.IntentionDecisionSummary{
+				Allowed:      true,
+				DefaultAllow: true,
+			},
 		},
 		{
 			name:      "denied with permissions",

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -35,6 +35,22 @@ const (
 	MeshGatewayModeRemote MeshGatewayMode = "remote"
 )
 
+const (
+	// TODO (freddy) Should we have a TopologySourceMixed when there is a mix of proxy reg and tproxy?
+	//				 Currently we label as proxy-registration if ANY instance has the explicit upstream definition.
+	// TopologySourceRegistration is used to label upstreams or downstreams from explicit upstream definitions
+	TopologySourceRegistration = "proxy-registration"
+
+	// TopologySourceSpecificIntention is used to label upstreams or downstreams from specific intentions
+	TopologySourceSpecificIntention = "specific-intention"
+
+	// TopologySourceWildcardIntention is used to label upstreams or downstreams from wildcard intentions
+	TopologySourceWildcardIntention = "wildcard-intention"
+
+	// TopologySourceDefaultAllow is used to label upstreams or downstreams from default allow ACL policy
+	TopologySourceDefaultAllow = "default-allow"
+)
+
 // MeshGatewayConfig controls how Mesh Gateways are configured and used
 // This is a struct to allow for future additions without having more free-hanging
 // configuration items all over the place

--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -666,12 +666,14 @@ type IntentionQueryCheckResponse struct {
 // - Whether all actions are allowed
 // - Whether the matching intention has L7 permissions attached
 // - Whether the intention is managed by an external source like k8s
-// - Whether there is an exact, on-wildcard, intention referencing the two services
+// - Whether there is an exact, or wildcard, intention referencing the two services
+// - Whether ACLs are in DefaultAllow mode
 type IntentionDecisionSummary struct {
 	Allowed        bool
 	HasPermissions bool
 	ExternalSource string
 	HasExact       bool
+	DefaultAllow   bool
 }
 
 // IntentionQueryExact holds the parameters for performing a lookup of an

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1924,6 +1924,17 @@ type ServiceTopology struct {
 
 	// MetricsProtocol is the protocol of the service being queried
 	MetricsProtocol string
+
+	// TransparentProxy describes whether all instances of the proxy
+	// service are in transparent mode.
+	TransparentProxy bool
+
+	// (Up|Down)streamSources are maps with labels for why each service is being
+	// returned. Services can be upstreams or downstreams due to
+	// explicit upstream definition or various types of intention policies:
+	// specific, wildcard, or default allow.
+	UpstreamSources   map[string]string
+	DownstreamSources map[string]string
 }
 
 // IndexedConfigEntries has its own encoding logic which differs from

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -396,6 +396,7 @@ func TestUiServices(t *testing.T) {
 
 		// internal accounting that users don't see can be blown away
 		for _, sum := range summary {
+			sum.transparentProxySet = false
 			sum.externalSourceSet = nil
 			sum.checks = nil
 		}
@@ -1078,12 +1079,7 @@ func TestUIServiceTopology(t *testing.T) {
 					Address: "198.18.1.2",
 					Proxy: structs.ConnectProxyConfig{
 						DestinationServiceName: "api",
-						Upstreams: structs.Upstreams{
-							{
-								DestinationName: "web",
-								LocalBindPort:   8080,
-							},
-						},
+						Mode:                   structs.ProxyModeTransparent,
 					},
 				},
 				Checks: structs.HealthChecks{
@@ -1210,12 +1206,7 @@ func TestUIServiceTopology(t *testing.T) {
 					Address: "198.18.1.40",
 					Proxy: structs.ConnectProxyConfig{
 						DestinationServiceName: "web",
-						Upstreams: structs.Upstreams{
-							{
-								DestinationName: "redis",
-								LocalBindPort:   123,
-							},
-						},
+						Mode:                   structs.ProxyModeTransparent,
 					},
 				},
 				Checks: structs.HealthChecks{
@@ -1296,8 +1287,10 @@ func TestUIServiceTopology(t *testing.T) {
 		}
 	}
 
-	// Add intentions: deny all, ingress -> api, web -> redis with L7 perms, but omit intention for api -> web
-	// Add ingress config: ingress -> api
+	// ingress -> api gateway config entry (but no intention)
+	// wildcard deny intention
+	// api -> web exact intention
+	// web -> redis exact intention
 	{
 		entries := []structs.ConfigEntryRequest{
 			{
@@ -1316,6 +1309,20 @@ func TestUIServiceTopology(t *testing.T) {
 					Kind:     structs.ServiceDefaults,
 					Name:     "api",
 					Protocol: "tcp",
+				},
+			},
+			{
+				Datacenter: "dc1",
+				Entry: &structs.ServiceIntentionsConfigEntry{
+					Kind: structs.ServiceIntentions,
+					Name: "*",
+					Meta: map[string]string{structs.MetaExternalSource: "nomad"},
+					Sources: []*structs.SourceIntention{
+						{
+							Name:   "*",
+							Action: structs.IntentionActionDeny,
+						},
+					},
 				},
 			},
 			{
@@ -1342,12 +1349,11 @@ func TestUIServiceTopology(t *testing.T) {
 				Datacenter: "dc1",
 				Entry: &structs.ServiceIntentionsConfigEntry{
 					Kind: structs.ServiceIntentions,
-					Name: "*",
-					Meta: map[string]string{structs.MetaExternalSource: "nomad"},
+					Name: "web",
 					Sources: []*structs.SourceIntention{
 						{
-							Name:   "*",
-							Action: structs.IntentionActionDeny,
+							Action: structs.IntentionActionAllow,
+							Name:   "api",
 						},
 					},
 				},
@@ -1419,16 +1425,18 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
-				Protocol: "tcp",
+				Protocol:         "tcp",
+				TransparentProxy: false,
 				Upstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
-							Name:           "api",
-							Datacenter:     "dc1",
-							Nodes:          []string{"foo"},
-							InstanceCount:  1,
-							ChecksPassing:  3,
-							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+							Name:             "api",
+							Datacenter:       "dc1",
+							Nodes:            []string{"foo"},
+							InstanceCount:    1,
+							ChecksPassing:    3,
+							EnterpriseMeta:   *structs.DefaultEnterpriseMeta(),
+							TransparentProxy: true,
 						},
 						Intention: structs.IntentionDecisionSummary{
 							DefaultAllow:   true,
@@ -1436,6 +1444,7 @@ func TestUIServiceTopology(t *testing.T) {
 							HasPermissions: false,
 							HasExact:       true,
 						},
+						Source: structs.TopologySourceRegistration,
 					},
 				},
 				Downstreams:    []*ServiceTopologySummary{},
@@ -1447,6 +1456,7 @@ func TestUIServiceTopology(t *testing.T) {
 			for _, u := range result.Upstreams {
 				u.externalSourceSet = nil
 				u.checks = nil
+				u.transparentProxySet = false
 			}
 			require.Equal(r, expect, result)
 		})
@@ -1462,17 +1472,19 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
-				Protocol: "tcp",
+				Protocol:         "tcp",
+				TransparentProxy: true,
 				Downstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
-							Name:           "ingress",
-							Kind:           structs.ServiceKindIngressGateway,
-							Datacenter:     "dc1",
-							Nodes:          []string{"edge"},
-							InstanceCount:  1,
-							ChecksPassing:  1,
-							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+							Name:             "ingress",
+							Kind:             structs.ServiceKindIngressGateway,
+							Datacenter:       "dc1",
+							Nodes:            []string{"edge"},
+							InstanceCount:    1,
+							ChecksPassing:    1,
+							EnterpriseMeta:   *structs.DefaultEnterpriseMeta(),
+							TransparentProxy: false,
 						},
 						Intention: structs.IntentionDecisionSummary{
 							DefaultAllow:   true,
@@ -1480,29 +1492,29 @@ func TestUIServiceTopology(t *testing.T) {
 							HasPermissions: false,
 							HasExact:       true,
 						},
+						Source: structs.TopologySourceRegistration,
 					},
 				},
 				Upstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
-							Name:           "web",
-							Datacenter:     "dc1",
-							Nodes:          []string{"bar", "baz"},
-							InstanceCount:  2,
-							ChecksPassing:  3,
-							ChecksWarning:  1,
-							ChecksCritical: 2,
-							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+							Name:             "web",
+							Datacenter:       "dc1",
+							Nodes:            []string{"bar", "baz"},
+							InstanceCount:    2,
+							ChecksPassing:    3,
+							ChecksWarning:    1,
+							ChecksCritical:   2,
+							EnterpriseMeta:   *structs.DefaultEnterpriseMeta(),
+							TransparentProxy: false,
 						},
 						Intention: structs.IntentionDecisionSummary{
 							DefaultAllow:   true,
-							Allowed:        false,
+							Allowed:        true,
 							HasPermissions: false,
-							ExternalSource: "nomad",
-
-							// From wildcard deny
-							HasExact: false,
+							HasExact:       true,
 						},
+						Source: structs.TopologySourceSpecificIntention,
 					},
 				},
 				FilteredByACLs: false,
@@ -1511,10 +1523,12 @@ func TestUIServiceTopology(t *testing.T) {
 
 			// Internal accounting that is not returned in JSON response
 			for _, u := range result.Upstreams {
+				u.transparentProxySet = false
 				u.externalSourceSet = nil
 				u.checks = nil
 			}
 			for _, d := range result.Downstreams {
+				d.transparentProxySet = false
 				d.externalSourceSet = nil
 				d.checks = nil
 			}
@@ -1532,17 +1546,19 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
-				Protocol: "http",
+				Protocol:         "http",
+				TransparentProxy: false,
 				Upstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
-							Name:           "redis",
-							Datacenter:     "dc1",
-							Nodes:          []string{"zip"},
-							InstanceCount:  1,
-							ChecksPassing:  2,
-							ChecksCritical: 1,
-							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+							Name:             "redis",
+							Datacenter:       "dc1",
+							Nodes:            []string{"zip"},
+							InstanceCount:    1,
+							ChecksPassing:    2,
+							ChecksCritical:   1,
+							EnterpriseMeta:   *structs.DefaultEnterpriseMeta(),
+							TransparentProxy: false,
 						},
 						Intention: structs.IntentionDecisionSummary{
 							DefaultAllow:   true,
@@ -1550,27 +1566,27 @@ func TestUIServiceTopology(t *testing.T) {
 							HasPermissions: true,
 							HasExact:       true,
 						},
+						Source: structs.TopologySourceRegistration,
 					},
 				},
 				Downstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
-							Name:           "api",
-							Datacenter:     "dc1",
-							Nodes:          []string{"foo"},
-							InstanceCount:  1,
-							ChecksPassing:  3,
-							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+							Name:             "api",
+							Datacenter:       "dc1",
+							Nodes:            []string{"foo"},
+							InstanceCount:    1,
+							ChecksPassing:    3,
+							EnterpriseMeta:   *structs.DefaultEnterpriseMeta(),
+							TransparentProxy: true,
 						},
 						Intention: structs.IntentionDecisionSummary{
 							DefaultAllow:   true,
-							Allowed:        false,
+							Allowed:        true,
 							HasPermissions: false,
-							ExternalSource: "nomad",
-
-							// From wildcard deny
-							HasExact: false,
+							HasExact:       true,
 						},
+						Source: structs.TopologySourceSpecificIntention,
 					},
 				},
 				FilteredByACLs: false,
@@ -1579,10 +1595,12 @@ func TestUIServiceTopology(t *testing.T) {
 
 			// Internal accounting that is not returned in JSON response
 			for _, u := range result.Upstreams {
+				u.transparentProxySet = false
 				u.externalSourceSet = nil
 				u.checks = nil
 			}
 			for _, d := range result.Downstreams {
+				d.transparentProxySet = false
 				d.externalSourceSet = nil
 				d.checks = nil
 			}
@@ -1620,6 +1638,7 @@ func TestUIServiceTopology(t *testing.T) {
 							HasPermissions: true,
 							HasExact:       true,
 						},
+						Source: structs.TopologySourceRegistration,
 					},
 				},
 				FilteredByACLs: false,
@@ -1628,6 +1647,7 @@ func TestUIServiceTopology(t *testing.T) {
 
 			// Internal accounting that is not returned in JSON response
 			for _, d := range result.Downstreams {
+				d.transparentProxySet = false
 				d.externalSourceSet = nil
 				d.checks = nil
 			}

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1431,6 +1431,7 @@ func TestUIServiceTopology(t *testing.T) {
 							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 						},
 						Intention: structs.IntentionDecisionSummary{
+							DefaultAllow:   true,
 							Allowed:        true,
 							HasPermissions: false,
 							HasExact:       true,
@@ -1474,6 +1475,7 @@ func TestUIServiceTopology(t *testing.T) {
 							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 						},
 						Intention: structs.IntentionDecisionSummary{
+							DefaultAllow:   true,
 							Allowed:        true,
 							HasPermissions: false,
 							HasExact:       true,
@@ -1493,6 +1495,7 @@ func TestUIServiceTopology(t *testing.T) {
 							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 						},
 						Intention: structs.IntentionDecisionSummary{
+							DefaultAllow:   true,
 							Allowed:        false,
 							HasPermissions: false,
 							ExternalSource: "nomad",
@@ -1542,6 +1545,7 @@ func TestUIServiceTopology(t *testing.T) {
 							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 						},
 						Intention: structs.IntentionDecisionSummary{
+							DefaultAllow:   true,
 							Allowed:        false,
 							HasPermissions: true,
 							HasExact:       true,
@@ -1559,6 +1563,7 @@ func TestUIServiceTopology(t *testing.T) {
 							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 						},
 						Intention: structs.IntentionDecisionSummary{
+							DefaultAllow:   true,
 							Allowed:        false,
 							HasPermissions: false,
 							ExternalSource: "nomad",
@@ -1610,6 +1615,7 @@ func TestUIServiceTopology(t *testing.T) {
 							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 						},
 						Intention: structs.IntentionDecisionSummary{
+							DefaultAllow:   true,
 							Allowed:        false,
 							HasPermissions: true,
 							HasExact:       true,


### PR DESCRIPTION
This PR ensures that we return:
- Upstreams and downstreams from intentions
- Whether all instances of a service's proxies are in transparent mode
- The default allow policy

TODO after beta:

- Refactor/break up the catalog function