### PR TITLE
Backport 1.8.x 10013: Move static token resolution into the ACLResolver

### DIFF
--- a/.changelog/10013.txt
+++ b/.changelog/10013.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit-logging: (Enterprise only) Fixed an issue that resulted in usage of the agent master token or managed service provider tokens from being resolved properly.
+```

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -104,7 +104,7 @@ func (s *HTTPServer) ACLRulesTranslate(resp http.ResponseWriter, req *http.Reque
 
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1153,7 +1153,7 @@ func (s *HTTPServer) ACLAuthorize(resp http.ResponseWriter, req *http.Request) (
 			return nil, err
 		}
 	} else {
-		authz, err := s.agent.resolveToken(request.Token)
+		authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(request.Token, nil, nil)
 		if err != nil {
 			return nil, err
 		} else if authz == nil {

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -50,7 +50,7 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (s *HTTPServer) AgentMetrics(resp http.ResponseWriter, req *http.Request) (
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (s *HTTPServer) AgentReload(resp http.ResponseWriter, req *http.Request) (i
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (s *HTTPServer) AgentServices(resp http.ResponseWriter, req *http.Request) 
 	var filterExpression string
 	s.parseFilter(req, &filterExpression)
 
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &entMeta, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &entMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func (s *HTTPServer) AgentService(resp http.ResponseWriter, req *http.Request) (
 	}
 
 	// need to resolve to default the meta
-	_, err := s.agent.resolveTokenAndDefaultMeta(token, &entMeta, nil)
+	_, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &entMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (s *HTTPServer) AgentService(resp http.ResponseWriter, req *http.Request) (
 			ws.Add(svcState.WatchCh)
 
 			// Check ACLs.
-			authz, err := s.agent.resolveToken(token)
+			authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 			if err != nil {
 				return "", nil, err
 			}
@@ -363,7 +363,7 @@ func (s *HTTPServer) AgentChecks(resp http.ResponseWriter, req *http.Request) (i
 		return nil, err
 	}
 
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &entMeta, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &entMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -445,7 +445,7 @@ func (s *HTTPServer) AgentJoin(resp http.ResponseWriter, req *http.Request) (int
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -477,7 +477,7 @@ func (s *HTTPServer) AgentLeave(resp http.ResponseWriter, req *http.Request) (in
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -495,7 +495,7 @@ func (s *HTTPServer) AgentForceLeave(resp http.ResponseWriter, req *http.Request
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +547,7 @@ func (s *HTTPServer) AgentRegisterCheck(resp http.ResponseWriter, req *http.Requ
 		return nil, nil
 	}
 
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &args.EnterpriseMeta, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &args.EnterpriseMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -599,7 +599,7 @@ func (s *HTTPServer) AgentDeregisterCheck(resp http.ResponseWriter, req *http.Re
 		return nil, err
 	}
 
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &checkID.EnterpriseMeta, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &checkID.EnterpriseMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -687,7 +687,7 @@ func (s *HTTPServer) agentCheckUpdate(resp http.ResponseWriter, req *http.Reques
 		return nil, err
 	}
 
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &cid.EnterpriseMeta, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &cid.EnterpriseMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -764,7 +764,7 @@ func (s *HTTPServer) AgentHealthServiceByID(resp http.ResponseWriter, req *http.
 
 	// need to resolve to default the meta
 	var authzContext acl.AuthorizerContext
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &entMeta, &authzContext)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &entMeta, &authzContext)
 	if err != nil {
 		return nil, err
 	}
@@ -816,7 +816,7 @@ func (s *HTTPServer) AgentHealthServiceByName(resp http.ResponseWriter, req *htt
 
 	// need to resolve to default the meta
 	var authzContext acl.AuthorizerContext
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &entMeta, &authzContext)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &entMeta, &authzContext)
 	if err != nil {
 		return nil, err
 	}
@@ -892,7 +892,7 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 	var token string
 	s.parseToken(req, &token)
 
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &args.EnterpriseMeta, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &args.EnterpriseMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1021,7 +1021,7 @@ func (s *HTTPServer) AgentDeregisterService(resp http.ResponseWriter, req *http.
 		return nil, err
 	}
 
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &sid.EnterpriseMeta, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &sid.EnterpriseMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1074,7 +1074,7 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 		return nil, err
 	}
 
-	authz, err := s.agent.resolveTokenAndDefaultMeta(token, &sid.EnterpriseMeta, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, &sid.EnterpriseMeta, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1123,7 +1123,7 @@ func (s *HTTPServer) AgentNodeMaintenance(resp http.ResponseWriter, req *http.Re
 	// Get the provided token, if any, and vet against any ACL policies.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1144,7 +1144,7 @@ func (s *HTTPServer) AgentMonitor(resp http.ResponseWriter, req *http.Request) (
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1216,7 +1216,7 @@ func (s *HTTPServer) AgentToken(resp http.ResponseWriter, req *http.Request) (in
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1428,7 +1428,7 @@ func (s *HTTPServer) AgentHost(resp http.ResponseWriter, req *http.Request) (int
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.resolveToken(token)
+	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/connect_auth.go
+++ b/agent/connect_auth.go
@@ -55,7 +55,7 @@ func (a *Agent) ConnectAuthorize(token string,
 	// We do this manually here since the RPC request below only verifies
 	// service:read.
 	var authzContext acl.AuthorizerContext
-	authz, err := a.resolveTokenAndDefaultMeta(token, &req.EnterpriseMeta, &authzContext)
+	authz, err := a.delegate.ResolveTokenAndDefaultMeta(token, &req.EnterpriseMeta, &authzContext)
 	if err != nil {
 		return returnErr(err)
 	}
@@ -109,7 +109,7 @@ func (a *Agent) ConnectAuthorize(token string,
 	// specifying the anonymous token, which will get the default behavior. The
 	// default behavior if ACLs are disabled is to allow connections to mimic the
 	// behavior of Consul itself: everything is allowed if ACLs are disabled.
-	authz, err = a.resolveToken("")
+	authz, err = a.delegate.ResolveToken("")
 	if err != nil {
 		return returnErr(err)
 	}

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -9,6 +9,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/go-hclog"
 	"golang.org/x/sync/singleflight"
@@ -178,6 +179,9 @@ type ACLResolverConfig struct {
 	// ACLConfig is the configuration necessary to pass through to the acl package when creating authorizers
 	// and when authorizing access
 	ACLConfig *acl.Config
+
+	// Tokens is the token store of locally managed tokens
+	Tokens *token.Store
 }
 
 // ACLResolver is the type to handle all your token and policy resolution needs.
@@ -212,6 +216,8 @@ type ACLResolver struct {
 	delegate ACLResolverDelegate
 	aclConf  *acl.Config
 
+	tokens *token.Store
+
 	cache         *structs.ACLCaches
 	identityGroup singleflight.Group
 	policyGroup   singleflight.Group
@@ -223,6 +229,33 @@ type ACLResolver struct {
 	autoDisable  bool
 	disabled     time.Time
 	disabledLock sync.RWMutex
+
+	agentMasterAuthz acl.Authorizer
+}
+
+func agentMasterAuthorizer(nodeName string) (acl.Authorizer, error) {
+	// Build a policy for the agent master token.
+	// The builtin agent master policy allows reading any node information
+	// and allows writes to the agent with the node name of the running agent
+	// only. This used to allow a prefix match on agent names but that seems
+	// entirely unnecessary so it is now using an exact match.
+	policy := &acl.Policy{
+		PolicyRules: acl.PolicyRules{
+			Agents: []*acl.AgentRule{
+				{
+					Node:   nodeName,
+					Policy: acl.PolicyWrite,
+				},
+			},
+			NodePrefixes: []*acl.NodeRule{
+				{
+					Name:   "",
+					Policy: acl.PolicyRead,
+				},
+			},
+		},
+	}
+	return acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
 }
 
 func NewACLResolver(config *ACLResolverConfig) (*ACLResolver, error) {
@@ -259,14 +292,21 @@ func NewACLResolver(config *ACLResolverConfig) (*ACLResolver, error) {
 		return nil, fmt.Errorf("invalid ACL down policy %q", config.Config.ACLDownPolicy)
 	}
 
+	authz, err := agentMasterAuthorizer(config.Config.NodeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize the agent master authorizer")
+	}
+
 	return &ACLResolver{
-		config:      config.Config,
-		logger:      config.Logger.Named(logging.ACL),
-		delegate:    config.Delegate,
-		aclConf:     config.ACLConfig,
-		cache:       cache,
-		autoDisable: config.AutoDisable,
-		down:        down,
+		config:           config.Config,
+		logger:           config.Logger.Named(logging.ACL),
+		delegate:         config.Delegate,
+		aclConf:          config.ACLConfig,
+		cache:            cache,
+		autoDisable:      config.AutoDisable,
+		down:             down,
+		tokens:           config.Tokens,
+		agentMasterAuthz: authz,
 	}, nil
 }
 
@@ -1109,6 +1149,19 @@ func (r *ACLResolver) disableACLsWhenUpstreamDisabled(err error) error {
 	return err
 }
 
+func (r *ACLResolver) resolveLocallyManagedToken(token string) (structs.ACLIdentity, acl.Authorizer, bool) {
+	// can only resolve local tokens if we were given a token store
+	if r.tokens == nil {
+		return nil, nil, false
+	}
+
+	if r.tokens.IsAgentMasterToken(token) {
+		return structs.NewAgentMasterTokenIdentity(r.config.NodeName, token), r.agentMasterAuthz, true
+	}
+
+	return r.resolveLocallyManagedEnterpriseToken(token)
+}
+
 func (r *ACLResolver) ResolveTokenToIdentityAndAuthorizer(token string) (structs.ACLIdentity, acl.Authorizer, error) {
 	if !r.ACLsEnabled() {
 		return nil, nil, nil
@@ -1121,6 +1174,10 @@ func (r *ACLResolver) ResolveTokenToIdentityAndAuthorizer(token string) (structs
 	// handle the anonymous token
 	if token == "" {
 		token = anonymousToken
+	}
+
+	if ident, authz, ok := r.resolveLocallyManagedToken(token); ok {
+		return ident, authz, nil
 	}
 
 	if r.delegate.UseLegacyACLs() {
@@ -1182,6 +1239,10 @@ func (r *ACLResolver) ResolveTokenToIdentity(token string) (structs.ACLIdentity,
 	// handle the anonymous token
 	if token == "" {
 		token = anonymousToken
+	}
+
+	if ident, _, ok := r.resolveLocallyManagedToken(token); ok {
+		return ident, nil
 	}
 
 	if r.delegate.UseLegacyACLs() {

--- a/agent/consul/acl_oss.go
+++ b/agent/consul/acl_oss.go
@@ -36,3 +36,8 @@ func (_ *ACLResolver) resolveEnterpriseIdentityAndPolicies(_ structs.ACLIdentity
 	// this function does nothing in OSS
 	return nil, nil, nil
 }
+
+// resolveLocallyManagedEnterpriseToken will resolve a managed service provider token to an identity and authorizer
+func (_ *ACLResolver) resolveLocallyManagedEnterpriseToken(_ string) (structs.ACLIdentity, acl.Authorizer, bool) {
+	return nil, nil, false
+}

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -230,9 +230,6 @@ func (s *Server) ResolveTokenToIdentity(token string) (structs.ACLIdentity, erro
 }
 
 func (s *Server) ResolveTokenToIdentityAndAuthorizer(token string) (structs.ACLIdentity, acl.Authorizer, error) {
-	if id, authz := s.ResolveEntTokenToIdentityAndAuthorizer(token); id != nil && authz != nil {
-		return id, authz, nil
-	}
 	return s.acls.ResolveTokenToIdentityAndAuthorizer(token)
 }
 
@@ -265,9 +262,6 @@ func (s *Server) ResolveTokenAndDefaultMeta(token string, entMeta *structs.Enter
 }
 
 func (s *Server) filterACL(token string, subj interface{}) error {
-	if id, authz := s.ResolveEntTokenToIdentityAndAuthorizer(token); id != nil && authz != nil {
-		return s.acls.filterACLWithAuthorizer(authz, subj)
-	}
 	return s.acls.filterACL(token, subj)
 }
 

--- a/agent/consul/acl_server_oss.go
+++ b/agent/consul/acl_server_oss.go
@@ -3,14 +3,8 @@
 package consul
 
 import (
-	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 )
-
-// Consul-enterprise only
-func (s *Server) ResolveEntTokenToIdentityAndAuthorizer(token string) (structs.ACLIdentity, acl.Authorizer) {
-	return nil, nil
-}
 
 // Consul-enterprise only
 func (s *Server) validateEnterpriseToken(identity structs.ACLIdentity) error {

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -3848,4 +3849,30 @@ func TestACL_LocalToken(t *testing.T) {
 		_, err := r.fetchAndCacheIdentityFromToken("", nil)
 		require.Equal(t, acl.PermissionDeniedError{Cause: "This is a local token in datacenter \"remote\""}, err)
 	})
+}
+
+func TestACLResolver_AgentMaster(t *testing.T) {
+	var tokens token.Store
+
+	d := &ACLResolverTestDelegate{
+		datacenter: "dc1",
+		enabled:    true,
+	}
+	r := newTestACLResolver(t, d, func(cfg *ACLResolverConfig) {
+		cfg.Tokens = &tokens
+		cfg.Config.NodeName = "foo"
+		cfg.AutoDisable = false
+	})
+
+	tokens.UpdateAgentMasterToken("9a184a11-5599-459e-b71a-550e5f9a5a23", token.TokenSourceConfig)
+
+	ident, authz, err := r.ResolveTokenToIdentityAndAuthorizer("9a184a11-5599-459e-b71a-550e5f9a5a23")
+	require.NoError(t, err)
+	require.NotNil(t, ident)
+	require.Equal(t, "agent-master:foo", ident.ID())
+	require.NotNil(t, authz)
+	require.Equal(t, r.agentMasterAuthz, authz)
+	require.Equal(t, acl.Allow, authz.AgentWrite("foo", nil))
+	require.Equal(t, acl.Allow, authz.NodeRead("bar", nil))
+	require.Equal(t, acl.Deny, authz.NodeWrite("bar", nil))
 }

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -148,6 +148,7 @@ func NewClient(config *Config, options ...ConsulOption) (*Client, error) {
 		AutoDisable: true,
 		CacheConfig: clientACLCacheConfig,
 		ACLConfig:   newACLConfig(c.logger),
+		Tokens:      flat.tokens,
 	}
 	var err error
 	if c.acls, err = NewACLResolver(&aclConfig); err != nil {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -455,6 +455,7 @@ func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
 		AutoDisable: false,
 		Logger:      logger,
 		ACLConfig:   s.aclConfig,
+		Tokens:      flat.tokens,
 	}
 	// Initialize the ACL resolver.
 	if s.acls, err = NewACLResolver(&aclConfig); err != nil {

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -78,7 +78,7 @@ func (s *HTTPServer) EventList(resp http.ResponseWriter, req *http.Request) (int
 	// Fetch the ACL token, if any.
 	var token string
 	s.parseToken(req, &token)
-	authz, err := s.agent.resolveToken(token)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/http.go
+++ b/agent/http.go
@@ -270,7 +270,7 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 			var token string
 			s.parseToken(req, &token)
 
-			rule, err := s.agent.resolveToken(token)
+			rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 			if err != nil {
 				resp.WriteHeader(http.StatusForbidden)
 				return

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1773,3 +1773,55 @@ func CreateACLAuthorizationResponses(authz acl.Authorizer, requests []ACLAuthori
 
 	return responses, nil
 }
+
+type AgentMasterTokenIdentity struct {
+	agent    string
+	secretID string
+}
+
+func NewAgentMasterTokenIdentity(agent string, secretID string) *AgentMasterTokenIdentity {
+	return &AgentMasterTokenIdentity{
+		agent:    agent,
+		secretID: secretID,
+	}
+}
+
+func (id *AgentMasterTokenIdentity) ID() string {
+	return fmt.Sprintf("agent-master:%s", id.agent)
+}
+
+func (id *AgentMasterTokenIdentity) SecretToken() string {
+	return id.secretID
+}
+
+func (id *AgentMasterTokenIdentity) PolicyIDs() []string {
+	return nil
+}
+
+func (id *AgentMasterTokenIdentity) RoleIDs() []string {
+	return nil
+}
+
+func (id *AgentMasterTokenIdentity) EmbeddedPolicy() *ACLPolicy {
+	return nil
+}
+
+func (id *AgentMasterTokenIdentity) ServiceIdentityList() []*ACLServiceIdentity {
+	return nil
+}
+
+func (id *AgentMasterTokenIdentity) NodeIdentityList() []*ACLNodeIdentity {
+	return nil
+}
+
+func (id *AgentMasterTokenIdentity) IsExpired(asOf time.Time) bool {
+	return false
+}
+
+func (id *AgentMasterTokenIdentity) IsLocal() bool {
+	return true
+}
+
+func (id *AgentMasterTokenIdentity) EnterpriseMetadata() *EnterpriseMeta {
+	return nil
+}


### PR DESCRIPTION
Backports #10013 

Conflicts:
* agent/acl.go
* agent/acl_test.go
* agent/agent.go
* agent/ui_endpoint.go

Just superficial conflicts, nothing is functionally different from the original PR