### PR TITLE
Add content type headers to raw KV responses

### DIFF
--- a/.changelog/10023.txt
+++ b/.changelog/10023.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Add content-type headers to raw KV responses to prevent XSS attacks [CVE-2020-25864](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25864)
+```

--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -145,6 +145,10 @@ is instead `text/plain`.
 (Yes, that is intentionally a bunch of gibberish characters to showcase the
 response)
 
+!> **Warning:** Consul versions before 1.9.5, 1.8.10 and 1.7.14 detected the content-type
+of the raw KV data which could be used for cross-site scripting (XSS) attacks. This is 
+identified publicly as CVE-2020-25864.
+
 ## Create/Update Key
 
 This endpoint updates the value of the specified key. If no key exists at the given

--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -136,7 +136,7 @@ flags or want to implement a key-space explorer.
 #### Raw Response
 
 When using the `?raw` endpoint, the response is not `application/json`, but
-rather the content type of the uploaded content.
+is instead `text/plain`.
 
 ```
 )k������z^�-�ɑj�q����#u�-R�r��T�D��٬�Y��l,�ιK��Fm��}�#e��


### PR DESCRIPTION
CVE-2020-25864

A vulnerability was identified in Consul and Consul Enterprise ("Consul") such that a specially crafted KV entry could be used to perform a XSS attack when viewed in the raw mode.

This PR adds content-type headers to raw KV responses to prevent that attack.