### PR TITLE
snapshot: fix saving of auth methods

### DIFF
--- a/.changelog/10025.txt
+++ b/.changelog/10025.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+snapshot: fixes a bug that would cause snapshots to be missing all but the first ACL Auth Method.
+```

--- a/agent/consul/fsm/snapshot_oss.go
+++ b/agent/consul/fsm/snapshot_oss.go
@@ -1,10 +1,11 @@
 package fsm
 
 import (
-	"github.com/hashicorp/consul/agent/consul/state"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/raft"
+
+	"github.com/hashicorp/consul/agent/consul/state"
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func init() {
@@ -247,7 +248,7 @@ func (s *snapshot) persistACLs(sink raft.SnapshotSink,
 		return err
 	}
 
-	for method := methods.Next(); method != nil; method = rules.Next() {
+	for method := methods.Next(); method != nil; method = methods.Next() {
 		if _, err := sink.Write([]byte{byte(structs.ACLAuthMethodSetRequestType)}); err != nil {
 			return err
 		}

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -125,6 +125,13 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}
 	require.NoError(t, fsm.state.ACLAuthMethodSet(1, method))
 
+	method = &structs.ACLAuthMethod{
+		Name:        "some-method2",
+		Type:        "testing",
+		Description: "test snapshot auth method",
+	}
+	require.NoError(t, fsm.state.ACLAuthMethodSet(1, method))
+
 	bindingRule := &structs.ACLBindingRule{
 		ID:          "85184c52-5997-4a84-9817-5945f2632a17",
 		Description: "test snapshot binding rule",
@@ -549,10 +556,12 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, bindingRule, bindingRule2)
 
-	// Verify ACL Auth Method is restored
-	_, method2, err := fsm2.state.ACLAuthMethodGetByName(nil, method.Name, nil)
+	// Verify ACL Auth Methods are restored
+	_, authMethods, err := fsm2.state.ACLAuthMethodList(nil, nil)
 	require.NoError(t, err)
-	require.Equal(t, method, method2)
+	require.Len(t, authMethods, 2)
+	require.Equal(t, "some-method", authMethods[0].Name)
+	require.Equal(t, "some-method2", authMethods[1].Name)
 
 	// Verify ACL Token is restored
 	_, rtoken, err := fsm2.state.ACLTokenGetByAccessor(nil, token.AccessorID, nil)


### PR DESCRIPTION
Fixes #9784

Previously only a single auth method would be saved to the snapshot. This commit fixes the typo and adds to the test, to show that all auth methods are now saved.