### PR TITLE
[1.8.x] Fix advertise_addr_wan_ipv6 configuration key

### DIFF
--- a/.changelog/9851.txt
+++ b/.changelog/9851.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+config: correct config key from `advertise_addr_ipv6` to `advertise_addr_wan_ipv6`
+```

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hashicorp/consul/lib/decode"
 	"github.com/hashicorp/hcl"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/consul/lib/decode"
 )
 
 const (
@@ -141,7 +142,7 @@ type Config struct {
 	AdvertiseAddrLANIPv6             *string                  `json:"advertise_addr_ipv6,omitempty" hcl:"advertise_addr_ipv6" mapstructure:"advertise_addr_ipv6"`
 	AdvertiseAddrWAN                 *string                  `json:"advertise_addr_wan,omitempty" hcl:"advertise_addr_wan" mapstructure:"advertise_addr_wan"`
 	AdvertiseAddrWANIPv4             *string                  `json:"advertise_addr_wan_ipv4,omitempty" hcl:"advertise_addr_wan_ipv4" mapstructure:"advertise_addr_wan_ipv4"`
-	AdvertiseAddrWANIPv6             *string                  `json:"advertise_addr_wan_ipv6,omitempty" hcl:"advertise_addr_wan_ipv6" mapstructure:"advertise_addr_ipv6"`
+	AdvertiseAddrWANIPv6             *string                  `json:"advertise_addr_wan_ipv6,omitempty" hcl:"advertise_addr_wan_ipv6" mapstructure:"advertise_addr_wan_ipv6"`
 	AutoConfig                       AutoConfigRaw            `json:"auto_config,omitempty" hcl:"auto_config" mapstructure:"auto_config"`
 	Autopilot                        Autopilot                `json:"autopilot,omitempty" hcl:"autopilot" mapstructure:"autopilot"`
 	BindAddr                         *string                  `json:"bind_addr,omitempty" hcl:"bind_addr" mapstructure:"bind_addr"`


### PR DESCRIPTION
backport of  #9851 to 1.8.x