### PR TITLE
Split Upstream.Identifier() so non-empty namespace is always prepended in ent

### DIFF
--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -190,6 +190,8 @@ func TestManager_BasicLifecycle(t *testing.T) {
 		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 	})
 
+	db := structs.NewServiceName("db", nil)
+
 	// Create test cases using some of the common data above.
 	tests := []*testcase_BasicLifecycle{
 		{
@@ -217,18 +219,18 @@ func TestManager_BasicLifecycle(t *testing.T) {
 					ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
 						Leaf: leaf,
 						DiscoveryChain: map[string]*structs.CompiledDiscoveryChain{
-							"db": dbDefaultChain(),
+							db.String(): dbDefaultChain(),
 						},
 						WatchedDiscoveryChains: map[string]context.CancelFunc{},
 						WatchedUpstreams:       nil, // Clone() clears this out
 						WatchedUpstreamEndpoints: map[string]map[string]structs.CheckServiceNodes{
-							"db": {
+							db.String(): {
 								"db.default.dc1": TestUpstreamNodes(t),
 							},
 						},
 						WatchedGateways: nil, // Clone() clears this out
 						WatchedGatewayEndpoints: map[string]map[string]structs.CheckServiceNodes{
-							"db": {},
+							db.String(): {},
 						},
 						UpstreamConfig: map[string]*structs.Upstream{
 							upstreams[0].Identifier(): &upstreams[0],
@@ -271,19 +273,19 @@ func TestManager_BasicLifecycle(t *testing.T) {
 					ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
 						Leaf: leaf,
 						DiscoveryChain: map[string]*structs.CompiledDiscoveryChain{
-							"db": dbSplitChain(),
+							db.String(): dbSplitChain(),
 						},
 						WatchedDiscoveryChains: map[string]context.CancelFunc{},
 						WatchedUpstreams:       nil, // Clone() clears this out
 						WatchedUpstreamEndpoints: map[string]map[string]structs.CheckServiceNodes{
-							"db": {
+							db.String(): {
 								"v1.db.default.dc1": TestUpstreamNodes(t),
 								"v2.db.default.dc1": TestUpstreamNodesAlternate(t),
 							},
 						},
 						WatchedGateways: nil, // Clone() clears this out
 						WatchedGatewayEndpoints: map[string]map[string]structs.CheckServiceNodes{
-							"db": {},
+							db.String(): {},
 						},
 						UpstreamConfig: map[string]*structs.Upstream{
 							upstreams[0].Identifier(): &upstreams[0],

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -435,28 +435,6 @@ func (k UpstreamKey) String() string {
 	)
 }
 
-// Identifier returns a string representation that uniquely identifies the
-// upstream in a canonical but human readable way.
-func (u *Upstream) Identifier() string {
-	name := u.DestinationName
-	typ := u.DestinationType
-
-	if typ != UpstreamDestTypePreparedQuery && u.DestinationNamespace != "" && u.DestinationNamespace != IntentionDefaultNamespace {
-		name = u.DestinationNamespace + "/" + u.DestinationName
-	}
-	if u.Datacenter != "" {
-		name += "?dc=" + u.Datacenter
-	}
-
-	// Service is default type so never prefix it. This is more readable and long
-	// term it is the only type that matters so we can drop the prefix and have
-	// nicer naming in metrics etc.
-	if typ == "" || typ == UpstreamDestTypeService {
-		return name
-	}
-	return typ + ":" + name
-}
-
 // String implements Stringer by returning the Identifier.
 func (u *Upstream) String() string {
 	return u.Identifier()

--- a/agent/structs/connect_proxy_config_oss.go
+++ b/agent/structs/connect_proxy_config_oss.go
@@ -11,3 +11,25 @@ func (us *Upstream) DestinationID() ServiceID {
 		ID: us.DestinationName,
 	}
 }
+
+// Identifier returns a string representation that uniquely identifies the
+// upstream in a canonical but human readable way.
+func (us *Upstream) Identifier() string {
+	name := us.DestinationName
+	typ := us.DestinationType
+
+	if typ != UpstreamDestTypePreparedQuery && us.DestinationNamespace != "" && us.DestinationNamespace != IntentionDefaultNamespace {
+		name = us.DestinationNamespace + "/" + us.DestinationName
+	}
+	if us.Datacenter != "" {
+		name += "?dc=" + us.Datacenter
+	}
+
+	// Service is default type so never prefix it. This is more readable and long
+	// term it is the only type that matters so we can drop the prefix and have
+	// nicer naming in metrics etc.
+	if typ == "" || typ == UpstreamDestTypeService {
+		return name
+	}
+	return typ + ":" + name
+}

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -472,7 +472,7 @@ func (s *Server) makeUpstreamClustersForDiscoveryChain(
 	if err != nil {
 		// Don't hard fail on a config typo, just warn. The parse func returns
 		// default config if there is an error so it's safe to continue.
-		s.Logger.Warn("failed to parse", "upstream", upstream.Identifier(),
+		s.Logger.Warn("failed to parse", "upstream", id,
 			"error", err)
 	}
 
@@ -487,7 +487,7 @@ func (s *Server) makeUpstreamClustersForDiscoveryChain(
 			}
 		} else {
 			s.Logger.Warn("ignoring escape hatch setting, because a discovery chain is configured for",
-				"discovery chain", chain.ServiceName, "upstream", upstream.Identifier(),
+				"discovery chain", chain.ServiceName, "upstream", id,
 				"envoy_cluster_json", chain.ServiceName)
 		}
 	}


### PR DESCRIPTION
Previously the Upstream.Identifier() key would not prepend the namespace
if it was the default namespace. On the other hand, elements in the
DiscoveryChain map always have the namespace prepended in enterprise.
This mismatch leads to not being able to fetch UpstreamConfig for a
given upstream's DiscoveryChain.

This PR preserves the original behavior in OSS, and adapts some
tests to account for the oss/ent split.