### PR TITLE
ui: Never respond with empty gateway addresses (mock-api)

### DIFF
--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
@@ -56,7 +56,7 @@ ${ fake.random.number({min: 1, max: 10}) > 2 ? `
     "GatewayConfig": {
       "Addresses": [
         ${
-          range(fake.random.number(6)).map(
+          range(fake.random.number({min: 1, max: 7)).map(
             function(item, i)
             {
               return `"${fake.random.number({min: 1, max: 10}) > 8 ? `*.`: ``}${fake.internet.domainName()}:${fake.random.number({min: 0, max: 65535})}"`;


### PR DESCRIPTION
We noticed that our mock API would sometimes respond with an empty array
of addresses - which resulted in an empty space in the gateway upstream
listing which looked as though it could be broken.

I checked with backend, and as this will never happen, I made the change
here also so the gateway upstream list is always fully populated with
addresses.