### PR TITLE
ui: remove old nspace argument from the proxy instance repository

### DIFF
--- a/.changelog/10039.txt
+++ b/.changelog/10039.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: ensure proxy instance API requests perform blocking queries correctly
+```

--- a/ui/packages/consul-ui/app/services/repository/proxy.js
+++ b/ui/packages/consul-ui/app/services/repository/proxy.js
@@ -36,7 +36,7 @@ export default class ProxyService extends RepositoryService {
   }
 
   @dataSource('/:ns/:dc/proxy-instance/:serviceId/:node/:id')
-  findInstanceBySlug(params, nspace, configuration) {
+  findInstanceBySlug(params, configuration) {
     return this.findAllBySlug(params, configuration).then(function(items) {
       let res = {};
       if (get(items, 'length') > 0) {


### PR DESCRIPTION
The extra argument meant that the blocking query configuration wasn't
being read properly, and therefore the correct ?index wasn't being sent
with the request.

The error was introduced after our last 1.9.x release (but it is in the 1.10-0-alpha), hence no backport.

@mikemorris are we adding changelog entries for things which were broken in 1.10.0-alpha and fixed here?