### PR TITLE
docs: update upgrade guide to use 1.8.10

### DIFF
--- a/website/content/docs/upgrading/instructions/index.mdx
+++ b/website/content/docs/upgrading/instructions/index.mdx
@@ -9,7 +9,7 @@ description: >-
 # Upgrade Instructions
 
 This document is intended to help users who find themselves many versions behind to upgrade safely.
-Our recommended upgrade path is moving from version 0.8.5 to 1.2.4 to 1.6.9 to the current version. To get
+Our recommended upgrade path is moving from version 0.8.5 to 1.2.4 to 1.6.9 to 1.8.10 to the current version. To get
 started, you will want to choose the version you are currently on below and then follow the instructions
 until you are on the latest version. The upgrade guides will mention notable changes and link to relevant
 changelogs – we recommend reviewing the changelog for versions between the one you are on and the

--- a/website/content/docs/upgrading/instructions/upgrade-to-1-8-x.mdx
+++ b/website/content/docs/upgrading/instructions/upgrade-to-1-8-x.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: Upgrading to 1.8.4
+page_title: Upgrading to 1.8.10
 description: >-
   Specific versions of Consul may have additional information about the upgrade
   process beyond the standard flow.
 ---
 
-# Upgrading to 1.8.4
+# Upgrading to 1.8.10
 
 ## Introduction
 
 This guide explains how to best upgrade a multi-datacenter Consul deployment that is using
-a version of Consul >= 1.6.9 and < 1.8.4 while maintaining replication. If you are on a version
+a version of Consul >= 1.6.9 and < 1.8.10 while maintaining replication. If you are on a version
 older than 1.6.9, please follow the link for the version you are on from [here](/docs/upgrading/instructions).
 
 In this guide, we will be using an example with two datacenters (DCs) and will be
@@ -19,7 +19,7 @@ referring to them as DC1 and DC2. DC1 will be the primary datacenter.
 
 ## Requirements
 
-- All Consul servers should be on a version of Consul >= 1.6.9 and < 1.8.4.
+- All Consul servers should be on a version of Consul >= 1.6.9 and < 1.8.10.
 
 ## Assumptions
 
@@ -87,7 +87,7 @@ You should receive output similar to this:
 }
 ```
 
-**3.** Upgrade the Consul agents in all DCs to version 1.8.4 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process).
+**3.** Upgrade the Consul agents in all DCs to version 1.8.10 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process).
 
 **4.** Confirm that replication is still working in DC2 by issuing the following curl command from a
 consul server in that DC:

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -860,7 +860,7 @@
             "path": "upgrading/instructions/upgrade-to-1-6-x"
           },
           {
-            "title": "Upgrading to 1.8.4",
+            "title": "Upgrading to 1.8.10",
             "path": "upgrading/instructions/upgrade-to-1-8-x"
           }
         ]


### PR DESCRIPTION
At the time the guide was created, 1.8.4 was the most recent release. This updates that to reflect the new most recent release in the 1.8.x series.