### PR TITLE
ui: fix mismatched curly brace in mock-api

### DIFF
--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
@@ -56,7 +56,7 @@ ${ fake.random.number({min: 1, max: 10}) > 2 ? `
     "GatewayConfig": {
       "Addresses": [
         ${
-          range(fake.random.number({min: 1, max: 7}).map(
+          range(fake.random.number({min: 1, max: 7})).map(
             function(item, i)
             {
               return `"${fake.random.number({min: 1, max: 10}) > 8 ? `*.`: ``}${fake.internet.domainName()}:${fake.random.number({min: 0, max: 65535})}"`;

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
@@ -56,7 +56,7 @@ ${ fake.random.number({min: 1, max: 10}) > 2 ? `
     "GatewayConfig": {
       "Addresses": [
         ${
-          range(fake.random.number({min: 1, max: 7)).map(
+          range(fake.random.number({min: 1, max: 7}).map(
             function(item, i)
             {
               return `"${fake.random.number({min: 1, max: 10}) > 8 ? `*.`: ``}${fake.internet.domainName()}:${fake.random.number({min: 0, max: 65535})}"`;


### PR DESCRIPTION
Fixes UI test failures introduced in #10035 which didn't run (and so didn't show up as failing) due to a CircleCI authorization issue.