### PR TITLE
Check for optionally prepended namespace in upstream assertion

### DIFF
--- a/test/integration/connect/envoy/case-basic/verify.bats
+++ b/test/integration/connect/envoy/case-basic/verify.bats
@@ -39,7 +39,7 @@ load helpers
 @test "s1 proxy should have been configured with one rbac listener filter at L4" {
   LISTEN_FILTERS=$(get_envoy_listener_filters localhost:19000)
   PUB=$(echo "$LISTEN_FILTERS" | grep -E "^public_listener:" | cut -f 2 -d ' ' )
-  UPS=$(echo "$LISTEN_FILTERS" | grep -E "^s2:" | cut -f 2 -d ' ' )
+  UPS=$(echo "$LISTEN_FILTERS" | grep -E "^(default\/)?s2:" | cut -f 2 -d ' ' )
 
   echo "LISTEN_FILTERS = $LISTEN_FILTERS"
   echo "PUB = $PUB"

--- a/test/integration/connect/envoy/case-http/verify.bats
+++ b/test/integration/connect/envoy/case-http/verify.bats
@@ -36,7 +36,7 @@ load helpers
 @test "s1 proxy should have been configured with http connection managers" {
   LISTEN_FILTERS=$(get_envoy_listener_filters localhost:19000)
   PUB=$(echo "$LISTEN_FILTERS" | grep -E "^public_listener:" | cut -f 2 -d ' ' )
-  UPS=$(echo "$LISTEN_FILTERS" | grep -E "^s2:" | cut -f 2 -d ' ' )
+  UPS=$(echo "$LISTEN_FILTERS" | grep -E "^(default\/)?s2:" | cut -f 2 -d ' ' )
 
   echo "LISTEN_FILTERS = $LISTEN_FILTERS"
   echo "PUB = $PUB"
@@ -59,7 +59,7 @@ load helpers
 @test "s1 proxy should have been configured with http rbac filters" {
   HTTP_FILTERS=$(get_envoy_http_filters localhost:19000)
   PUB=$(echo "$HTTP_FILTERS" | grep -E "^public_listener:" | cut -f 2 -d ' ' )
-  UPS=$(echo "$HTTP_FILTERS" | grep -E "^s2:" | cut -f 2 -d ' ' )
+  UPS=$(echo "$HTTP_FILTERS" | grep -E "^(default\/)?s2:" | cut -f 2 -d ' ' )
 
   echo "HTTP_FILTERS = $HTTP_FILTERS"
   echo "PUB = $PUB"


### PR DESCRIPTION
Previously the Upstream identifier in enterprise avoided prepending the namespace if the upstream was in the default namespace. 

This changed in #10031, so this PR updates integration test assertions to account for a potential `default/` prefix.