### PR TITLE
ui: Add Admin Partition feature flag

### DIFF
--- a/ui/packages/consul-ui/README.md
+++ b/ui/packages/consul-ui/README.md
@@ -7,6 +7,7 @@
 - [Installation](#installation)
 - [Yarn Commands](#yarn-commands)
 - [Running / Development](#running--development)
+  - [Environment Variables](#environment-variables)
   - [Contributing/Engineering Documentation](#contributingengineering-documentation)
   - [Browser 'Debug Utility' Functions and 'Environment' Variables](#browser-debug-utility-functions-and-environment-variables)
   - [Code Generators](#code-generators)
@@ -86,6 +87,15 @@ Example:
 ```bash
 CONSUL_HTTP_ADDR=http://10.0.0.1:8500 make start-consul
 ```
+
+### Environment Variables
+
+There are various environment variable you can use whilst running `make start` or `make test` to configure various features:
+
+| Variable | Default Value | Description |
+| -------- | ------------- | ----------- |
+| `TESTEM_AUTOLAUNCH` | Chrome | Controls which browser to open tests in. A setting of "" means 'let me manually open the browser' |
+| `EMBER_TEST_REPORT` |  | Output a test report |
 
 ### Contributing/Engineering Documentation
 

--- a/ui/packages/consul-ui/README.md
+++ b/ui/packages/consul-ui/README.md
@@ -3,13 +3,12 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
 - [Yarn Commands](#yarn-commands)
 - [Running / Development](#running--development)
-  - [Browser 'Environment' Variables](#browser-environment-variables)
-  - [Browser 'Debug Utility' Functions](#browser-debug-utility-functions)
+  - [Contributing/Engineering Documentation](#contributingengineering-documentation)
+  - [Browser 'Debug Utility' Functions and 'Environment' Variables](#browser-debug-utility-functions-and-environment-variables)
   - [Code Generators](#code-generators)
   - [Running Tests](#running-tests)
   - [Linting](#linting)
@@ -88,62 +87,17 @@ Example:
 CONSUL_HTTP_ADDR=http://10.0.0.1:8500 make start-consul
 ```
 
+### Contributing/Engineering Documentation
 
-### Browser 'Environment' Variables
+We have an in-app (only during development) component storybook and
+documentation site which can be visited using the [Eng Docs](http://localhost:4200/ui/docs)
+link in the top navigation of the UI.
 
-In order to configure different configurations of Consul you can use Web
-Inspector in your browser to set various cookie which to emulate different
-configurations whislt using the mock API.
+### Browser 'Debug Utility' Functions and 'Environment' Variables
 
-For example: to enable ACLs, use Web Inspector to set a cookie as follows:
-
-```bash
-CONSUL_ACLS_ENABLE=1
-```
-
-This will enable the ACLs login page, to which you can login with any ACL
-token/secret.
-
-| Variable | Default Value | Description |
-| -------- | ------------- | ----------- |
-| `CONSUL_ACLS_ENABLE` | false | Enable/disable ACLs support. |
-| `CONSUL_ACLS_LEGACY` | false | Enable/disable legacy ACLs support. |
-| `CONSUL_NSPACES_ENABLE` | false | Enable/disable Namespace support. |
-| `CONSUL_SSO_ENABLE` | false | Enable/disable SSO support. |
-| `CONSUL_OIDC_PROVIDER_URL` | undefined | Provide a OIDC provider URL for SSO. |
-| `CONSUL_LATENCY` | 0 | Add a latency to network requests (milliseconds) |
-| `CONSUL_METRICS_POLL_INTERVAL` | 10000 | Change the interval between requests to the metrics provider (milliseconds) |
-| `CONSUL_METRICS_PROXY_ENABLE` | false | Enable/disable the metrics proxy |
-| `CONSUL_METRICS_PROVIDER` | | Set the metrics provider to use for the Topology Tab |
-| `CONSUL_SERVICE_DASHBOARD_URL` | | Set the template URL to use for Service Dashboard links |
-| `CONSUL_UI_CONFIG` | | Set the entire `ui_config` for the UI as JSON if you don't want to use the above singular variables |
-| `CONSUL_SERVICE_COUNT` | (random) | Configure the number of services that the API returns. |
-| `CONSUL_NODE_COUNT` | (random) | Configure the number of nodes that the API returns. |
-| `CONSUL_KV_COUNT` | (random) | Configure the number of KV entires that the API returns. |
-| `CONSUL_INTENTION_COUNT` | (random) | Configure the number of intentions that the API returns. |
-| `CONSUL_POLICY_COUNT` | (random) | Configure the number of policies that the API returns. |
-| `CONSUL_ROLE_COUNT` | (random) | Configure the number of roles that the API returns. |
-| `CONSUL_NSPACE_COUNT` | (random) | Configure the number of namespaces that the API returns. |
-| `CONSUL_UPSTREAM_COUNT` | (random) | Configure the number of upstreams that the API returns. |
-| `CONSUL_EXPOSED_COUNT` | (random) | Configure the number of exposed paths that the API returns. |
-| `CONSUL_CHECK_COUNT` | (random) | Configure the number of health checks that the API returns. |
-| `CONSUL_OIDC_PROVIDER_COUNT` | (random) | Configure the number of OIDC providers that the API returns. |
-| `CONSUL_RESOURCE_<singular-resource-name>_<access-type>` | true | Configure permissions e.g `CONSUL_RESOURCE_INTENTION_WRITE=false`. |
-| `DEBUG_ROUTES_ENDPOINT` | undefined | When using the window.Routes() debug utility ([see utility functions](#browser-debug-utility-functions)), use a URL to pass the route DSL to. %s in the URL will be replaced with the route DSL - http://url.com?routes=%s  |
-
-See `./mock-api` for more details.
-
-### Browser 'Debug Utility' Functions
-
-We currently have one 'debug utility', that only exists during development (they
-are removed from the production build using Embers `runInDebug`). You can call
-these either straight from the console in WebInspector, or by using javascript
-URLs i.e. `javascript:Routes()`
-
-| Variable | Arguments | Description |
-| -------- | --------- | ----------- |
-| `Routes(url)` | url: The url to pass the DSL to, if left `undefined` just use a blank tab | Provides a way to easily print out Embers Route DSL for the application or to pass it straight to any third party utility such as ember-diagonal |
-| `Scenario(str)` | str: 'Cookie formatted' string, if left `undefined` open a new tab with a link/bookmarklet to the current Scenario | Provides a way to easily save and reload scenarios of configurations via URLs or bookmarklets |
+Run `make start` then visit http://localhost:4200/ui/docs/bookmarklets for a
+list of debug/engineering utilities you can use to help development of the UI
+under certain scenarios.
 
 ### Code Generators
 

--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -95,6 +95,10 @@ export default function(config = {}, win = window, doc = document) {
         return typeof operatorConfig.ACLsEnabled === 'undefined'
           ? false
           : operatorConfig.ACLsEnabled;
+      case 'CONSUL_PARTITIONS_ENABLED':
+        return typeof operatorConfig.PartitionsEnabled === 'undefined'
+          ? false
+          : operatorConfig.PartitionsEnabled;
       case 'CONSUL_DATACENTER_LOCAL':
         return operatorConfig.LocalDatacenter;
       case 'CONSUL_UI_CONFIG':
@@ -164,6 +168,9 @@ export default function(config = {}, win = window, doc = document) {
             case 'CONSUL_SSO_ENABLE':
               prev['CONSUL_SSO_ENABLED'] = !!JSON.parse(String(value).toLowerCase());
               break;
+            case 'CONSUL_PARTITIONS_ENABLE':
+              prev['CONSUL_PARTITIONS_ENABLED'] = !!JSON.parse(String(value).toLowerCase());
+              break;
             case 'CONSUL_METRICS_PROXY_ENABLE':
               prev['CONSUL_METRICS_PROXY_ENABLED'] = !!JSON.parse(String(value).toLowerCase());
               break;
@@ -199,6 +206,7 @@ export default function(config = {}, win = window, doc = document) {
       case 'CONSUL_ACLS_ENABLED':
       case 'CONSUL_NSPACES_ENABLED':
       case 'CONSUL_SSO_ENABLED':
+      case 'CONSUL_PARTITIONS_ENABLED':
       case 'CONSUL_METRICS_PROVIDER':
       case 'CONSUL_METRICS_PROXY_ENABLE':
       case 'CONSUL_SERVICE_DASHBOARD_URL':

--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -97,6 +97,7 @@ module.exports = function(environment, $ = process.env) {
       ACLsEnabled: false,
       NamespacesEnabled: false,
       SSOEnabled: false,
+      PartitionsEnabled: false,
       LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
     },
 
@@ -118,6 +119,7 @@ module.exports = function(environment, $ = process.env) {
           ACLsEnabled: env('CONSUL_ACLS_ENABLED', true),
           NamespacesEnabled: env('CONSUL_NSPACES_ENABLED', false),
           SSOEnabled: env('CONSUL_SSO_ENABLED', false),
+          PartitionsEnabled: env('CONSUL_PARTITIONS_ENABLED', false),
           LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
         },
 
@@ -148,10 +150,14 @@ module.exports = function(environment, $ = process.env) {
         // different staging sites can be built with certain features disabled
         // by setting an environment variable to 0 during building (e.g.
         // CONSUL_NSPACES_ENABLED=0 make build)
+
+        // TODO: We should be able to remove this now we can link to different
+        // scenarios in staging
         operatorConfig: {
           ACLsEnabled: env('CONSUL_ACLS_ENABLED', true),
           NamespacesEnabled: env('CONSUL_NSPACES_ENABLED', true),
           SSOEnabled: env('CONSUL_SSO_ENABLED', true),
+          PartitionsEnabled: env('CONSUL_PARTITIONS_ENABLED', true),
           LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
         },
 

--- a/ui/packages/consul-ui/docs/bookmarklets.mdx
+++ b/ui/packages/consul-ui/docs/bookmarklets.mdx
@@ -2,7 +2,7 @@
 
 The Consul UI has a set of debug/engineering utility functions that only exist in non-production environments (they are noop'ed from production builds using Ember's `runInDebug`). You can call these either straight from Web Inspectors `console`, or by using `javascript:` URLs i.e. `javascript:Routes()`.
 
-Below is a list of the most commonly used functions as bookmarklets followed by more detailed documentation on these utilities. The bookmarklets can be added to your browser by dragging the bookmarklet link into your browsers Bookmarks Bar.
+Below is a list of the most commonly used functions as bookmarklets followed by more detailed documentation on these utilities. The bookmarklets can be added to your browser by dragging the bookmarklet link into your browsers Bookmarks Bar. Please add any new commonly used environment variables as bookmarklets here for other engineers to use.
 
 | Link/Bookmarklet | Description |
 | ---- | ----------- |
@@ -10,6 +10,7 @@ Below is a list of the most commonly used functions as bookmarklets followed by 
 | [Save Current Scenario](javascript:Scenario()) | Opens a tab with links to allow you to create a bookmarklet or share a URL of your current scenario (your Consul UI relarted development/debug cookies) |
 | [Enable ACLs](javascript:Scenario('CONSUL_ACLS_ENABLE=1')) | Enable ACLs |
 | [Enable Nspaces](javascript:Scenario('CONSUL_NSPACES_ENABLE=1')) | Enable Namespace Support |
+| [Enable Partitions](javascript:Scenario('CONSUL_PARTITIONS_ENABLE=1')) | Enable Admin Partition Support |
 | [Enable SSO ](javascript:Scenario('CONSUL_SSO_ENABLE=1')) | Enable SSO Support |
 | [Enable Metrics](javascript:Scenario('CONSUL_METRICS_PROXY_ENABLE=1;CONSUL_METRICS_PROVIDER=prometheus')) | Enable all configuration required for viewing the full Metrics Visualization |
 
@@ -18,4 +19,42 @@ Below is a list of the most commonly used functions as bookmarklets followed by 
 | `Routes(url)` | url: The url to pass the DSL to, if left `undefined` just use a blank tab | Provides a way to easily print out Embers Route DSL for the application or to pass it straight to any third party utility such as ember-diagonal |
 | `Scenario(str)` | str: 'Cookie formatted' string, if left `undefined` open a new tab with a link/bookmarklet to the current Scenario | Provides a way to easily save and reload scenarios of configurations via URLs or bookmarklets |
 
+
+You can also configure these manually or example using Web Inspector to set a cookie as follows:
+
+```bash
+CONSUL_ACLS_ENABLE=1
+```
+
+This will enable the ACLs login page, to which you can login with any ACL
+token/secret.
+
+| Variable | Default Value | Description |
+| -------- | ------------- | ----------- |
+| `CONSUL_ACLS_ENABLE` | false | Enable/disable ACLs support. |
+| `CONSUL_ACLS_LEGACY` | false | Enable/disable legacy ACLs support. |
+| `CONSUL_NSPACES_ENABLE` | false | Enable/disable Namespace support. |
+| `CONSUL_SSO_ENABLE` | false | Enable/disable SSO support. |
+| `CONSUL_OIDC_PROVIDER_URL` | undefined | Provide a OIDC provider URL for SSO. |
+| `CONSUL_LATENCY` | 0 | Add a latency to network requests (milliseconds) |
+| `CONSUL_METRICS_POLL_INTERVAL` | 10000 | Change the interval between requests to the metrics provider (milliseconds) |
+| `CONSUL_METRICS_PROXY_ENABLE` | false | Enable/disable the metrics proxy |
+| `CONSUL_METRICS_PROVIDER` | | Set the metrics provider to use for the Topology Tab |
+| `CONSUL_SERVICE_DASHBOARD_URL` | | Set the template URL to use for Service Dashboard links |
+| `CONSUL_UI_CONFIG` | | Set the entire `ui_config` for the UI as JSON if you don't want to use the above singular variables |
+| `CONSUL_SERVICE_COUNT` | (random) | Configure the number of services that the API returns. |
+| `CONSUL_NODE_COUNT` | (random) | Configure the number of nodes that the API returns. |
+| `CONSUL_KV_COUNT` | (random) | Configure the number of KV entires that the API returns. |
+| `CONSUL_INTENTION_COUNT` | (random) | Configure the number of intentions that the API returns. |
+| `CONSUL_POLICY_COUNT` | (random) | Configure the number of policies that the API returns. |
+| `CONSUL_ROLE_COUNT` | (random) | Configure the number of roles that the API returns. |
+| `CONSUL_NSPACE_COUNT` | (random) | Configure the number of namespaces that the API returns. |
+| `CONSUL_UPSTREAM_COUNT` | (random) | Configure the number of upstreams that the API returns. |
+| `CONSUL_EXPOSED_COUNT` | (random) | Configure the number of exposed paths that the API returns. |
+| `CONSUL_CHECK_COUNT` | (random) | Configure the number of health checks that the API returns. |
+| `CONSUL_OIDC_PROVIDER_COUNT` | (random) | Configure the number of OIDC providers that the API returns. |
+| `CONSUL_RESOURCE_<singular-resource-name>_<access-type>` | true | Configure permissions e.g `CONSUL_RESOURCE_INTENTION_WRITE=false`. |
+| `DEBUG_ROUTES_ENDPOINT` | undefined | When using the window.Routes() debug utility ([see utility functions](#browser-debug-utility-functions)), use a URL to pass the route DSL to. %s in the URL will be replaced with the route DSL - http://url.com?routes=%s  |
+
+See `./mock-api` for more details.
 

--- a/ui/packages/consul-ui/node-tests/config/environment.js
+++ b/ui/packages/consul-ui/node-tests/config/environment.js
@@ -20,6 +20,7 @@ test(
           ACLsEnabled: true,
           NamespacesEnabled: false,
           SSOEnabled: false,
+          PartitionsEnabled: false,
           LocalDatacenter: 'dc1',
         }
       },
@@ -33,6 +34,7 @@ test(
           ACLsEnabled: true,
           NamespacesEnabled: true,
           SSOEnabled: false,
+          PartitionsEnabled: false,
           LocalDatacenter: 'dc1',
         }
       },
@@ -46,6 +48,7 @@ test(
           ACLsEnabled: true,
           NamespacesEnabled: false,
           SSOEnabled: true,
+          PartitionsEnabled: false,
           LocalDatacenter: 'dc1',
         }
       },
@@ -56,6 +59,7 @@ test(
           ACLsEnabled: true,
           NamespacesEnabled: true,
           SSOEnabled: true,
+          PartitionsEnabled: true,
           LocalDatacenter: 'dc1',
         }
       }


### PR DESCRIPTION
This adds a `PartitionEnabled`/`CONSUL_PARTITIONS_ENABLED` feature flag
that can be set during production form the consul binary, or
additionally during development/testing via cookies.

If this property is not set in the binary at all, then we default to `false`.

Also added this setting to our engineering docs (theres a little more change here just due to me moving that around a little, see commit messages for details)