### PR TITLE
ui: Adds human formatting to nanosecond based session durations

### DIFF
--- a/.changelog/10062.txt
+++ b/.changelog/10062.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added humanized formatting to lock session durations
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ references:
     test-results: &TEST_RESULTS_DIR /tmp/test-results
 
   cache:
-    yarn: &YARN_CACHE_KEY consul-ui-v3-{{ checksum "ui/yarn.lock" }}
+    yarn: &YARN_CACHE_KEY consul-ui-v4-{{ checksum "ui/yarn.lock" }}
     rubygem: &RUBYGEM_CACHE_KEY static-site-gems-v1-{{ checksum "Gemfile.lock" }}
 
   environment: &ENVIRONMENT

--- a/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
@@ -28,7 +28,7 @@
           <dd>{{api.data.Behavior}}</dd>
 {{#if form.data.Delay }}
           <dt>Delay</dt>
-          <dd>{{api.data.LockDelay}}</dd>
+          <dd>{{duration-from api.data.LockDelay}}</dd>
 {{/if}}
 {{#if form.data.TTL }}
           <dt>TTL</dt>

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
@@ -19,7 +19,7 @@
           Delay
         </Tooltip>
       </dt>
-      <dd data-test-session-delay>{{item.LockDelay}}</dd>
+      <dd data-test-session-delay>{{duration-from item.LockDelay}}</dd>
     </dl>
     <dl class="ttl">
       <dt>

--- a/ui/packages/consul-ui/app/helpers/duration-from.js
+++ b/ui/packages/consul-ui/app/helpers/duration-from.js
@@ -1,0 +1,10 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+
+export default class DurationFromHelper extends Helper {
+  @service('temporal') temporal;
+
+  compute([value], hash) {
+    return this.temporal.durationFrom(value);
+  }
+}

--- a/ui/packages/consul-ui/app/helpers/duration-from.mdx
+++ b/ui/packages/consul-ui/app/helpers/duration-from.mdx
@@ -1,0 +1,13 @@
+# duration-from
+
+`{{duration-from nanoseconds}}` is used to format a number in nanoseconds to a
+short golang-like human format, for example:
+
+```hbs preview-template
+<p>{{duration-from 15000000000}}</p>
+<p>{{duration-from 15000010001}}</p>
+```
+
+**Note:** The helper only accepts a javascript number primitive currently
+
+Also see the `temporal` service for the implementation.

--- a/ui/packages/consul-ui/app/services/temporal.js
+++ b/ui/packages/consul-ui/app/services/temporal.js
@@ -7,11 +7,15 @@ export default class TemporalService extends Service {
   durationFrom(value, options = {}) {
     switch (true) {
       case typeof value === 'number':
+        // if its zero, don't format just return zero as a string
+        if (value === 0) {
+          return '0';
+        }
         return format(value / 1000000, { formatSubMilliseconds: true })
           .split(' ')
           .join('');
     }
-    assert(`${value} is not a valid type`, true);
+    assert(`${value} is not a valid type`, false);
     return value;
   }
 }

--- a/ui/packages/consul-ui/app/services/temporal.js
+++ b/ui/packages/consul-ui/app/services/temporal.js
@@ -1,0 +1,17 @@
+import format from 'pretty-ms';
+import { assert } from '@ember/debug';
+
+import Service from '@ember/service';
+
+export default class TemporalService extends Service {
+  durationFrom(value, options = {}) {
+    switch (true) {
+      case typeof value === 'number':
+        return format(value / 1000000, { formatSubMilliseconds: true })
+          .split(' ')
+          .join('');
+    }
+    assert(`${value} is not a valid type`, true);
+    return value;
+  }
+}

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -153,6 +153,7 @@
     "parse-duration": "^1.0.0",
     "pretender": "^3.2.0",
     "prettier": "^1.10.2",
+    "pretty-ms": "^7.0.1",
     "qunit-dom": "^1.0.0",
     "react-is": "^17.0.1",
     "refractor": "^3.3.1",

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/sessions/list.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/sessions/list.feature
@@ -26,16 +26,17 @@ Feature: dc / nodes / sessions / list: List Lock Sessions
     - 30s
     - 60m
     ---
-  Scenario: Given 2 session with LockDelay in milliseconds
+  Scenario: Given 3 session with LockDelay in nanoseconds
     Given 1 datacenter model with the value "dc1"
     And 1 node model from yaml
     ---
     ID: node-0
     ---
-    And 2 session models from yaml
+    And 3 session models from yaml
     ---
     - LockDelay: 120000
     - LockDelay: 18000000
+    - LockDelay: 15000000000
     ---
     When I visit the node page for yaml
     ---
@@ -46,6 +47,7 @@ Feature: dc / nodes / sessions / list: List Lock Sessions
     Then I see lockSessionsIsSelected on the tabs
     Then I see delay on the sessions like yaml
     ---
-    - 120000
-    - 18000000
+    - 120µs
+    - 18ms
+    - 15s
     ---

--- a/ui/packages/consul-ui/tests/integration/helpers/duration-from-test.js
+++ b/ui/packages/consul-ui/tests/integration/helpers/duration-from-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | duration-from', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', 15000000000);
+
+    await render(hbs`{{duration-from inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '15s');
+  });
+});

--- a/ui/packages/consul-ui/tests/unit/services/temporal-test.js
+++ b/ui/packages/consul-ui/tests/unit/services/temporal-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | temporal', function(hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:temporal');
+    assert.ok(service);
+  });
+});

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5428,7 +5428,7 @@ ember-auto-import@^1.5.2, ember-auto-import@^1.5.3, ember-auto-import@^1.6.0:
     walk-sync "^0.3.3"
     webpack "^4.43.0"
 
-ember-basic-dropdown@^3.0.10, ember-basic-dropdown@^3.0.16:
+ember-basic-dropdown@^3.0.16:
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.16.tgz#287fcde57b5a37405d89cc65e0a4ad9a2e8e1b0b"
   integrity sha512-ctVQL63nWoZ6+Lvb6aCo70SUA8ieMz5fQa0BuQKeV2LQx8njXDiZZ96gaK0PBn60glNghbIr1ZKU+wmnIT++5w==
@@ -5473,7 +5473,7 @@ ember-changeset-validations@~3.9.0:
     ember-get-config "^0.2.4"
     ember-validators "^2.0.0"
 
-ember-changeset@3.10.1, ember-changeset@^3.9.1:
+ember-changeset@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-3.10.1.tgz#d6f06bc55f867a2c1ac7c5fd780776bd1e5a9b60"
   integrity sha512-4FoGKRcKxixSr+NBQ+ZoiwwbJE0/fuZRULUp9M1RIHejYhst+U8/ni47SsphrMhoRAcZCeyl+JqlBMlwR7v50g==
@@ -13964,7 +13964,7 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validated-changeset@0.10.0, validated-changeset@~0.10.0:
+validated-changeset@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.10.0.tgz#2e8188c089ab282c1b51fba3c289073f6bd14c8b"
   integrity sha512-n8NB3ol6Tbi0O7bnq1wz81m5Wd1gfHw0HUcH4MatOfqO3DyXzWZV+bUaNq6wThXn20rMFB82C8pTNFSWbgXJLA==

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5428,7 +5428,7 @@ ember-auto-import@^1.5.2, ember-auto-import@^1.5.3, ember-auto-import@^1.6.0:
     walk-sync "^0.3.3"
     webpack "^4.43.0"
 
-ember-basic-dropdown@^3.0.16:
+ember-basic-dropdown@^3.0.10, ember-basic-dropdown@^3.0.16:
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.16.tgz#287fcde57b5a37405d89cc65e0a4ad9a2e8e1b0b"
   integrity sha512-ctVQL63nWoZ6+Lvb6aCo70SUA8ieMz5fQa0BuQKeV2LQx8njXDiZZ96gaK0PBn60glNghbIr1ZKU+wmnIT++5w==
@@ -5473,7 +5473,7 @@ ember-changeset-validations@~3.9.0:
     ember-get-config "^0.2.4"
     ember-validators "^2.0.0"
 
-ember-changeset@^3.9.1:
+ember-changeset@3.10.1, ember-changeset@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-3.10.1.tgz#d6f06bc55f867a2c1ac7c5fd780776bd1e5a9b60"
   integrity sha512-4FoGKRcKxixSr+NBQ+ZoiwwbJE0/fuZRULUp9M1RIHejYhst+U8/ni47SsphrMhoRAcZCeyl+JqlBMlwR7v50g==
@@ -11093,6 +11093,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -11335,6 +11340,13 @@ prettier@^1.10.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+pretty-ms@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8"
+  integrity sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==
+  dependencies:
+    parse-ms "^2.1.0"
 
 printf@^0.5.1:
   version "0.5.3"
@@ -13952,7 +13964,7 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validated-changeset@~0.10.0:
+validated-changeset@0.10.0, validated-changeset@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/validated-changeset/-/validated-changeset-0.10.0.tgz#2e8188c089ab282c1b51fba3c289073f6bd14c8b"
   integrity sha512-n8NB3ol6Tbi0O7bnq1wz81m5Wd1gfHw0HUcH4MatOfqO3DyXzWZV+bUaNq6wThXn20rMFB82C8pTNFSWbgXJLA==


### PR DESCRIPTION
This PR adds human formatting to our nanosecond based session duration values.

The functionality makes use of the `pretty-ms` JS package, which also includes an option for formatting 'subMilliseconds' which in our case is useful for formatting to nanosecond precision (used by the session duration values).

We've used a new `temporal` service to do this, which uses the above package to format _numbers only_ for the moment (we can add further types in a central place when needed, and there's a dev warning if you pass anything but a number to the method). The is a tiny bit of extra functionality on top for the above package:

1. `pretty-ms` separates units with a space, so I split-joined the spaces out.
2. I realized that we probably don't want to show a unit if the value is zero, therefore if the value is a zero we return a unit-less zero as a string.

Notes: 

The temporal service (and helper) naming around that is 'inspired' by the t39 temporal proposal which is in Stage 3, which hopefully gives hints to anyone reading the code what it is used for and assumptions on how it could work, its also nice not to have to think about naming things.

If we get to the point that the temporal proposal has a wide enough native support and covers our use cases, we can drop the third-party package and use that from within the service instead.

Helper documentation is also added, which was also handy to use for manual 'get it working' testing, plus I 'filled out' the ember generated automated tests. I also added the default value of the session duration to our acceptance tests.

Changelog to come. I'll try and auto backport to 1.8/1.9/1.10 but off the top of my head it will probably need a little manual intervention to get it down to 1.8.


