### PR TITLE
docs: fix api-docs namespace descriptions

### DIFF
--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -13,7 +13,7 @@ The functionality described here is available only in
 
 ## Create a Namespace
 
-This endpoint creates a new ACL token.
+This endpoint creates a new Namespace.
 
 | Method | Path         | Produces           |
 | ------ | ------------ | ------------------ |
@@ -207,7 +207,7 @@ $ curl -H "X-Consul-Token: b23b3cad-5ea1-4413-919e-c76884b9ad60" \
 
 ## Update a Namespace
 
-This endpoint updates a new ACL token.
+This endpoint updates a Namespace.
 
 | Method | Path               | Produces           |
 | ------ | ------------------ | ------------------ |


### PR DESCRIPTION
Looks like some copy/paste from ACL docs.