### PR TITLE
structs: remove unnecessary name field from proxy-defaults

### DIFF
--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3486,7 +3486,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ConfigEntryBootstrap = []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind:           structs.ProxyDefaults,
-					Name:           structs.ProxyConfigGlobal,
 					EnterpriseMeta: *defaultEntMeta,
 					Config: map[string]interface{}{
 						"bar": "abc",
@@ -3556,7 +3555,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.ConfigEntryBootstrap = []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind:           structs.ProxyDefaults,
-					Name:           structs.ProxyConfigGlobal,
 					EnterpriseMeta: *defaultEntMeta,
 					Config: map[string]interface{}{
 						"bar": "abc",
@@ -5330,7 +5328,6 @@ func TestLoad_FullConfig(t *testing.T) {
 		ConfigEntryBootstrap: []structs.ConfigEntry{
 			&structs.ProxyConfigEntry{
 				Kind:           structs.ProxyDefaults,
-				Name:           structs.ProxyConfigGlobal,
 				EnterpriseMeta: *defaultEntMeta,
 				Config: map[string]interface{}{
 					"foo": "bar",

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -7,10 +7,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/testrpc"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/testrpc"
 )
 
 func TestConfig_Get(t *testing.T) {
@@ -41,7 +42,6 @@ func TestConfig_Get(t *testing.T) {
 		{
 			Datacenter: "dc1",
 			Entry: &structs.ProxyConfigEntry{
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"foo": "bar",
 					"bar": 1,
@@ -85,7 +85,6 @@ func TestConfig_Get(t *testing.T) {
 		value := obj.(structs.ConfigEntry)
 		require.Equal(t, value.GetKind(), structs.ProxyDefaults)
 		entry := value.(*structs.ProxyConfigEntry)
-		require.Equal(t, structs.ProxyConfigGlobal, entry.Name)
 		require.Contains(t, entry.Config, "foo")
 		require.Equal(t, "bar", entry.Config["foo"])
 	})

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -125,7 +125,6 @@ func TestConfigEntry_ProxyDefaultsMeshGateway(t *testing.T) {
 		Datacenter: "dc1",
 		Entry: &structs.ProxyConfigEntry{
 			Kind:        "proxy-defaults",
-			Name:        "global",
 			MeshGateway: structs.MeshGatewayConfig{Mode: "local"},
 		},
 	}
@@ -317,7 +316,6 @@ operator = "read"
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
@@ -409,7 +407,6 @@ func TestConfigEntry_ListAll(t *testing.T) {
 	entries := []structs.ConfigEntry{
 		&structs.ProxyConfigEntry{
 			Kind: structs.ProxyDefaults,
-			Name: "global",
 		},
 		&structs.ServiceConfigEntry{
 			Kind: structs.ServiceDefaults,
@@ -530,7 +527,6 @@ operator = "read"
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
@@ -565,7 +561,6 @@ operator = "read"
 	proxyConf, ok := out.Entries[0].(*structs.ProxyConfigEntry)
 	require.Len(out.Entries, 1)
 	require.True(ok)
-	require.Equal(structs.ProxyConfigGlobal, proxyConf.Name)
 	require.Equal(structs.ProxyDefaults, proxyConf.Kind)
 }
 
@@ -615,7 +610,6 @@ operator = "read"
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
@@ -650,7 +644,6 @@ operator = "read"
 
 	require.Equal("foo", svcConf.Name)
 	require.Equal(structs.ServiceDefaults, svcConf.Kind)
-	require.Equal(structs.ProxyConfigGlobal, proxyConf.Name)
 	require.Equal(structs.ProxyDefaults, proxyConf.Kind)
 }
 
@@ -774,7 +767,6 @@ operator = "write"
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
@@ -809,9 +801,7 @@ operator = "write"
 	// Try to delete the global proxy config without a token.
 	args = structs.ConfigEntryRequest{
 		Datacenter: s1.config.Datacenter,
-		Entry: &structs.ProxyConfigEntry{
-			Name: structs.ProxyConfigGlobal,
-		},
+		Entry:      &structs.ProxyConfigEntry{},
 	}
 	err = msgpackrpc.CallWithCodec(codec, "ConfigEntry.Delete", &args, &out)
 	if !acl.IsErrPermissionDenied(err) {
@@ -846,7 +836,6 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"foo": 1,
 		},
@@ -912,7 +901,6 @@ func TestConfigEntry_ResolveServiceConfig_TransparentProxy(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind:             structs.ProxyDefaults,
-					Name:             structs.ProxyConfigGlobal,
 					Mode:             structs.ProxyModeTransparent,
 					TransparentProxy: structs.TransparentProxyConfig{OutboundListenerPort: 10101},
 				},
@@ -950,7 +938,6 @@ func TestConfigEntry_ResolveServiceConfig_TransparentProxy(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind:             structs.ProxyDefaults,
-					Name:             structs.ProxyConfigGlobal,
 					Mode:             structs.ProxyModeDirect,
 					TransparentProxy: structs.TransparentProxyConfig{OutboundListenerPort: 10101},
 				},
@@ -1021,7 +1008,6 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "grpc",
 					},
@@ -1063,7 +1049,6 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "grpc",
 					},
@@ -1160,7 +1145,6 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "udp",
 					},
@@ -1424,7 +1408,6 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"global": 1,
 		},
@@ -1590,7 +1573,6 @@ func TestConfigEntry_ResolveServiceConfig_UpstreamProxyDefaultsProtocol(t *testi
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},
@@ -1664,7 +1646,6 @@ func TestConfigEntry_ResolveServiceConfig_ProxyDefaultsProtocol_UsedForAllUpstre
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},
@@ -1773,7 +1754,6 @@ operator = "write"
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 	}))
 	require.NoError(state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
@@ -1831,7 +1811,6 @@ func TestConfigEntry_ProxyDefaultsExposeConfig(t *testing.T) {
 		Datacenter: "dc1",
 		Entry: &structs.ProxyConfigEntry{
 			Kind:   "proxy-defaults",
-			Name:   "global",
 			Expose: expose,
 		},
 	}

--- a/agent/consul/config_replication_test.go
+++ b/agent/consul/config_replication_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestReplication_ConfigSort(t *testing.T) {
@@ -145,7 +146,6 @@ func TestReplication_ConfigEntries(t *testing.T) {
 		Op:         structs.ConfigEntryUpsert,
 		Entry: &structs.ProxyConfigEntry{
 			Kind: structs.ProxyDefaults,
-			Name: "global",
 			Config: map[string]interface{}{
 				"foo": "bar",
 				"bar": 1,
@@ -215,7 +215,6 @@ func TestReplication_ConfigEntries(t *testing.T) {
 		Op:         structs.ConfigEntryUpsert,
 		Entry: &structs.ProxyConfigEntry{
 			Kind: structs.ProxyDefaults,
-			Name: "global",
 			Config: map[string]interface{}{
 				"foo": "baz",
 				"baz": 2,

--- a/agent/consul/discoverychain/compile_test.go
+++ b/agent/consul/discoverychain/compile_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/stretchr/testify/require"
 )
 
 type compileTestCase struct {
@@ -1018,7 +1019,6 @@ func testcase_DatacenterRedirect_WithMeshGateways() compileTestCase {
 	entries := newEntries()
 	entries.GlobalProxy = &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		MeshGateway: structs.MeshGatewayConfig{
 			Mode: structs.MeshGatewayModeRemote,
 		},
@@ -1265,7 +1265,6 @@ func testcase_DatacenterFailover_WithMeshGateways() compileTestCase {
 	entries := newEntries()
 	entries.GlobalProxy = &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		MeshGateway: structs.MeshGatewayConfig{
 			Mode: structs.MeshGatewayModeRemote,
 		},
@@ -1404,7 +1403,6 @@ func testcase_DefaultResolver_WithProxyDefaults() compileTestCase {
 	entries := newEntries()
 	entries.GlobalProxy = &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"protocol": "grpc",
 		},
@@ -2497,7 +2495,6 @@ func newSimpleRoute(name string, muts ...func(*structs.ServiceRoute)) structs.Se
 func setGlobalProxyProtocol(entries *structs.DiscoveryChainConfigEntries, protocol string) {
 	entries.GlobalProxy = &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"protocol": protocol,
 		},

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -9,11 +9,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/hashicorp/consul/agent/connect"
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-raftchunking"
 	raftchunkingtypes "github.com/hashicorp/go-raftchunking/types"
 	"github.com/hashicorp/go-uuid"
@@ -22,6 +17,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/types"
 )
 
 func generateUUID() (ret string) {
@@ -1440,7 +1441,6 @@ func TestFSM_ConfigEntry(t *testing.T) {
 	// Create a simple config entry
 	entry := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: "global",
 		Config: map[string]interface{}{
 			"foo": "bar",
 		},

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -232,7 +232,6 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}
 	proxyConfig := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: "global",
 	}
 	require.NoError(t, fsm.state.EnsureConfigEntry(18, serviceConfig))
 	require.NoError(t, fsm.state.EnsureConfigEntry(19, proxyConfig))

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -12,9 +16,6 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/types"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestHealth_ChecksInState(t *testing.T) {
@@ -1355,7 +1356,6 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 			Datacenter: "dc1",
 			Entry: &structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
 				},

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -7,14 +7,15 @@ import (
 	"net/rpc"
 	"testing"
 
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/hashicorp/consul/types"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/types"
 )
 
 func waitForLeader(servers ...*Server) error {
@@ -893,7 +894,6 @@ func registerTestTopologyEntries(t *testing.T, codec rpc.ClientCodec, token stri
 			Datacenter: "dc1",
 			Entry: &structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
 				},

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -9,16 +9,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/serf/serf"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	tokenStore "github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/hashicorp/go-hclog"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/hashicorp/serf/serf"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLeader_RegisterMember(t *testing.T) {
@@ -1374,7 +1375,6 @@ func TestLeader_ConfigEntryBootstrap(t *testing.T) {
 	t.Parallel()
 	global_entry_init := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"foo": "bar",
 			"bar": int64(1),
@@ -1398,7 +1398,6 @@ func TestLeader_ConfigEntryBootstrap(t *testing.T) {
 		global, ok := entry.(*structs.ProxyConfigEntry)
 		require.True(t, ok)
 		require.Equal(t, global_entry_init.Kind, global.Kind)
-		require.Equal(t, global_entry_init.Name, global.Name)
 		require.Equal(t, global_entry_init.Config, global.Config)
 	})
 }

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -1453,7 +1453,6 @@ func TestServer_ReloadConfig(t *testing.T) {
 
 	entryInit := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			// these are made a []uint8 and a int64 to allow the Equals test to pass
 			// otherwise it will fail complaining about data types
@@ -1489,7 +1488,6 @@ func TestServer_ReloadConfig(t *testing.T) {
 	global, ok := entry.(*structs.ProxyConfigEntry)
 	require.True(t, ok)
 	require.Equal(t, entryInit.Kind, global.Kind)
-	require.Equal(t, entryInit.Name, global.Name)
 	require.Equal(t, entryInit.Config, global.Config)
 
 	// Check rate limiter got updated

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -5507,7 +5507,6 @@ func TestStateStore_GatewayServices_IngressProtocolFiltering(t *testing.T) {
 		}
 
 		proxyDefaults := &structs.ProxyConfigEntry{
-			Name: structs.ProxyConfigGlobal,
 			Kind: structs.ProxyDefaults,
 			Config: map[string]interface{}{
 				"protocol": "http",
@@ -5616,7 +5615,6 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 
 	// Default protocol to http
 	proxyDefaults := &structs.ProxyConfigEntry{
-		Name: structs.ProxyConfigGlobal,
 		Kind: structs.ProxyDefaults,
 		Config: map[string]interface{}{
 			"protocol": "http",
@@ -6810,7 +6808,6 @@ func TestCatalog_upstreamsFromRegistration_Ingress(t *testing.T) {
 	}))
 	require.NoError(t, s.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},
@@ -7017,7 +7014,6 @@ func TestCatalog_cleanupGatewayWildcards_panic(t *testing.T) {
 	}))
 	require.NoError(t, s.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},
@@ -7138,7 +7134,6 @@ func TestCatalog_DownstreamsForService(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -7294,7 +7289,6 @@ func TestCatalog_DownstreamsForService_Updates(t *testing.T) {
 	// Update the routing so that api's upstream routes to our target and watches should fire
 	defaults := structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: structs.ProxyConfigGlobal,
 		Config: map[string]interface{}{
 			"protocol": "http",
 		},

--- a/agent/consul/state/config_entry_oss_test.go
+++ b/agent/consul/state/config_entry_oss_test.go
@@ -15,8 +15,16 @@ func testIndexerTableConfigEntries() map[string]indexerTestCase {
 				expected: []byte("proxy-defaults\x00name\x00"),
 			},
 			write: indexValue{
-				source:   &structs.ProxyConfigEntry{Name: "NaMe"},
-				expected: []byte("proxy-defaults\x00name\x00"),
+				source:   &structs.ProxyConfigEntry{},
+				expected: []byte("proxy-defaults\x00global\x00"),
+			},
+			extra: []indexerTestCase{
+				{
+					write: indexValue{
+						source:   &structs.ServiceConfigEntry{Name: "NaMe"},
+						expected: []byte("service-defaults\x00name\x00"),
+					},
+				},
 			},
 		},
 		indexKind: {

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -17,7 +17,6 @@ func TestStore_ConfigEntry(t *testing.T) {
 
 	expected := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: "global",
 		Config: map[string]interface{}{
 			"DestinationServiceName": "foo",
 		},
@@ -34,7 +33,6 @@ func TestStore_ConfigEntry(t *testing.T) {
 	// Update
 	updated := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: "global",
 		Config: map[string]interface{}{
 			"DestinationServiceName": "bar",
 		},
@@ -81,7 +79,6 @@ func TestStore_ConfigEntryCAS(t *testing.T) {
 
 	expected := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: "global",
 		Config: map[string]interface{}{
 			"DestinationServiceName": "foo",
 		},
@@ -98,7 +95,6 @@ func TestStore_ConfigEntryCAS(t *testing.T) {
 	// Update with invalid index
 	updated := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: "global",
 		Config: map[string]interface{}{
 			"DestinationServiceName": "bar",
 		},
@@ -228,7 +224,6 @@ func TestStore_ConfigEntries(t *testing.T) {
 	// Create some config entries.
 	entry1 := &structs.ProxyConfigEntry{
 		Kind: structs.ProxyDefaults,
-		Name: "test1",
 	}
 	entry2 := &structs.ServiceConfigEntry{
 		Kind: structs.ServiceDefaults,
@@ -322,7 +317,6 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "tcp", // loses
 					},
@@ -363,7 +357,6 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -505,7 +498,6 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -541,7 +533,6 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -902,7 +893,6 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1505,7 +1495,6 @@ func TestStore_ValidateIngressGatewayErrorOnMismatchedProtocols(t *testing.T) {
 		s := testConfigStateStore(t)
 		expected := &structs.ProxyConfigEntry{
 			Kind: structs.ProxyDefaults,
-			Name: "global",
 			Config: map[string]interface{}{
 				"protocol": "http2",
 			},
@@ -1580,7 +1569,6 @@ func TestSourcesForTarget(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1615,7 +1603,6 @@ func TestSourcesForTarget(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1641,7 +1628,6 @@ func TestSourcesForTarget(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1670,7 +1656,6 @@ func TestSourcesForTarget(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1697,7 +1682,6 @@ func TestSourcesForTarget(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1740,7 +1724,6 @@ func TestSourcesForTarget(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1856,7 +1839,6 @@ func TestTargetsForSource(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1891,7 +1873,6 @@ func TestTargetsForSource(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1916,7 +1897,6 @@ func TestTargetsForSource(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1944,7 +1924,6 @@ func TestTargetsForSource(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -1971,7 +1950,6 @@ func TestTargetsForSource(t *testing.T) {
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},
@@ -2061,7 +2039,6 @@ func TestStore_ValidateServiceIntentionsErrorOnIncompatibleProtocols(t *testing.
 	proxyDefaults := func(protocol string) *structs.ProxyConfigEntry {
 		return &structs.ProxyConfigEntry{
 			Kind: structs.ProxyDefaults,
-			Name: structs.ProxyConfigGlobal,
 			Config: map[string]interface{}{
 				"protocol": protocol,
 			},

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -1705,7 +1705,6 @@ func TestStore_IntentionDecision(t *testing.T) {
 	entries := []structs.ConfigEntry{
 		&structs.ProxyConfigEntry{
 			Kind: structs.ProxyDefaults,
-			Name: structs.ProxyConfigGlobal,
 			Config: map[string]interface{}{
 				"protocol": "http",
 			},

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -1799,7 +1799,6 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 			Datacenter: "dc1",
 			Entry: &structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
 				},

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -80,7 +80,6 @@ func TestManager_BasicLifecycle(t *testing.T) {
 			},
 			&structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
 				},

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -10,14 +10,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/mitchellh/go-testing-interface"
-	"github.com/stretchr/testify/require"
 )
 
 // TestCacheTypes encapsulates all the different cache types proxycfg.State will
@@ -951,7 +952,6 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		entries = append(entries,
 			&structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
 				},
@@ -1004,7 +1004,6 @@ func setupTestVariationConfigEntriesAndSnapshot(
 			},
 			&structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
 				},
@@ -1028,7 +1027,6 @@ func setupTestVariationConfigEntriesAndSnapshot(
 			},
 			&structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "grpc",
 				},
@@ -1059,7 +1057,6 @@ func setupTestVariationConfigEntriesAndSnapshot(
 			},
 			&structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
 				},
@@ -1261,7 +1258,6 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		entries = append(entries,
 			&structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
-				Name: structs.ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"protocol": "http",
 				},

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -48,7 +48,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 			name: "proxy-defaults",
 			snake: `
 				kind = "proxy-defaults"
-				name = "main"
 				meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -66,7 +65,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 			`,
 			camel: `
 				Kind = "proxy-defaults"
-				Name = "main"
 				Meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -84,7 +82,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 			`,
 			expect: &ProxyConfigEntry{
 				Kind: "proxy-defaults",
-				Name: "main",
 				Meta: map[string]string{
 					"foo": "bar",
 					"gir": "zim",
@@ -1418,7 +1415,6 @@ func TestConfigEntryResponseMarshalling(t *testing.T) {
 		"proxy-default entry": {
 			Entry: &ProxyConfigEntry{
 				Kind: ProxyDefaults,
-				Name: ProxyConfigGlobal,
 				Config: map[string]interface{}{
 					"foo": "bar",
 				},

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -12,15 +12,16 @@ import (
 	"sync/atomic"
 	"testing"
 
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUiIndex(t *testing.T) {
@@ -1297,7 +1298,6 @@ func TestUIServiceTopology(t *testing.T) {
 				Datacenter: "dc1",
 				Entry: &structs.ProxyConfigEntry{
 					Kind: structs.ProxyDefaults,
-					Name: structs.ProxyConfigGlobal,
 					Config: map[string]interface{}{
 						"protocol": "http",
 					},

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -179,7 +179,6 @@ func TestListenersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshotDiscoveryChainWithEntries(t,
 					&structs.ProxyConfigEntry{
 						Kind: structs.ProxyDefaults,
-						Name: structs.ProxyConfigGlobal,
 						Config: map[string]interface{}{
 							"protocol": "http",
 						},
@@ -194,7 +193,6 @@ func TestListenersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshotDiscoveryChainWithEntries(t,
 					&structs.ProxyConfigEntry{
 						Kind: structs.ProxyDefaults,
-						Name: structs.ProxyConfigGlobal,
 						Config: map[string]interface{}{
 							"protocol": "http2",
 						},
@@ -209,7 +207,6 @@ func TestListenersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshotDiscoveryChainWithEntries(t,
 					&structs.ProxyConfigEntry{
 						Kind: structs.ProxyDefaults,
-						Name: structs.ProxyConfigGlobal,
 						Config: map[string]interface{}{
 							"protocol": "grpc",
 						},

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -159,7 +159,6 @@ func TestRoutesFromSnapshot(t *testing.T) {
 				entries := []structs.ConfigEntry{
 					&structs.ProxyConfigEntry{
 						Kind: structs.ProxyDefaults,
-						Name: structs.ProxyConfigGlobal,
 						Config: map[string]interface{}{
 							"protocol": "http",
 						},


### PR DESCRIPTION
The `ProxyConfigEntry.Name` field should always be `global`. So instead of having to set that everywhere, and write code that checks that constraint everywhere, we can remove the field. It likely has to stay around for backwards compatibility, but making it an `interface{}` and deprecating it should indicate that it's not supposed to be used.