### PR TITLE
health: use blocking queries for near query parameter

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -378,10 +378,10 @@ func New(bd BaseDeps) (*Agent, error) {
 		cacheName = cachetype.StreamingHealthServicesName
 	}
 	a.rpcClientHealth = &health.Client{
-		Cache:            bd.Cache,
-		NetRPC:           &a,
-		CacheName:        cacheName,
-		CacheNameIngress: cachetype.HealthServicesName,
+		Cache:                 bd.Cache,
+		NetRPC:                &a,
+		CacheName:             cacheName,
+		CacheNameNotStreaming: cachetype.HealthServicesName,
 	}
 
 	a.serviceManager = NewServiceManager(&a)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -540,7 +540,6 @@ func (a *Agent) Start(ctx context.Context) error {
 		Logger: a.logger.Named(logging.ProxyConfig),
 		State:  a.State,
 		Source: &structs.QuerySource{
-			Node:       a.config.NodeName,
 			Datacenter: a.config.Datacenter,
 			Segment:    a.config.SegmentName,
 		},

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -219,12 +219,8 @@ func (s *HTTPHandlers) healthServiceNodes(resp http.ResponseWriter, req *http.Re
 		return nil, nil
 	}
 
-	useStreaming := s.agent.config.UseStreamingBackend && args.MinQueryIndex > 0 && !args.Ingress
+	useStreaming := s.agent.config.UseStreamingBackend && args.MinQueryIndex > 0 && !args.Ingress && args.Source.Node == ""
 	args.QueryOptions.UseCache = s.agent.config.HTTPUseCache && (args.QueryOptions.UseCache || useStreaming)
-
-	if args.QueryOptions.UseCache && useStreaming && args.Source.Node != "" {
-		return nil, BadRequestError{Reason: "'near' query param can not be used with streaming"}
-	}
 
 	out, md, err := s.agent.rpcClientHealth.ServiceNodes(req.Context(), args)
 	if err != nil {

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -219,7 +219,7 @@ func (s *HTTPHandlers) healthServiceNodes(resp http.ResponseWriter, req *http.Re
 		return nil, nil
 	}
 
-	useStreaming := s.agent.config.UseStreamingBackend && args.MinQueryIndex > 0 && !args.Ingress && args.Source.Node == ""
+	useStreaming := s.agent.config.UseStreamingBackend && s.agent.rpcClientHealth.UseStreaming(args)
 	args.QueryOptions.UseCache = s.agent.config.HTTPUseCache && (args.QueryOptions.UseCache || useStreaming)
 
 	out, md, err := s.agent.rpcClientHealth.ServiceNodes(req.Context(), args)

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -352,10 +352,7 @@ func testManager_BasicLifecycle(
 	require := require.New(t)
 	logger := testutil.Logger(t)
 	state := local.NewState(local.Config{}, logger, &token.Store{})
-	source := &structs.QuerySource{
-		Node:       "node1",
-		Datacenter: "dc1",
-	}
+	source := &structs.QuerySource{Datacenter: "dc1"}
 
 	// Stub state syncing
 	state.TriggerSyncChanges = func() {}

--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -86,3 +86,11 @@ func (c *Client) Notify(
 	}
 	return c.Cache.Notify(ctx, cacheName, &req, correlationID, ch)
 }
+
+func (c *Client) UseStreaming(req structs.ServiceSpecificRequest) bool {
+	if req.Ingress || req.Source.Node != "" {
+		return false
+	}
+
+	return req.QueryOptions.UseCache || req.QueryOptions.MinQueryIndex > 0
+}

--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -12,9 +12,9 @@ type Client struct {
 	Cache  CacheGetter
 	// CacheName to use for service health.
 	CacheName string
-	// CacheNameIngress is the name of the cache type to use for ingress
-	// service health.
-	CacheNameIngress string
+	// CacheNameNotStreaming is the name of the cache type to use for any requests
+	// that are not supported by the streaming backend (ex: Ingress=true).
+	CacheNameNotStreaming string
 }
 
 type NetRPC interface {
@@ -57,8 +57,8 @@ func (c *Client) getServiceNodes(
 	}
 
 	cacheName := c.CacheName
-	if req.Ingress {
-		cacheName = c.CacheNameIngress
+	if req.Ingress || req.Source.Node != "" {
+		cacheName = c.CacheNameNotStreaming
 	}
 
 	raw, md, err := c.Cache.Get(ctx, cacheName, &req)
@@ -81,8 +81,8 @@ func (c *Client) Notify(
 	ch chan<- cache.UpdateEvent,
 ) error {
 	cacheName := c.CacheName
-	if req.Ingress {
-		cacheName = c.CacheNameIngress
+	if req.Ingress || req.Source.Node != "" {
+		cacheName = c.CacheNameNotStreaming
 	}
 	return c.Cache.Notify(ctx, cacheName, &req, correlationID, ch)
 }

--- a/agent/rpcclient/health/health_test.go
+++ b/agent/rpcclient/health/health_test.go
@@ -1,0 +1,91 @@
+package health
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/cache"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func TestClient_ServiceNodes_BackendRouting(t *testing.T) {
+	type testCase struct {
+		name     string
+		req      structs.ServiceSpecificRequest
+		expected func(t *testing.T, c *Client)
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		c := &Client{
+			NetRPC:                &fakeNetRPC{},
+			Cache:                 &fakeCache{},
+			CacheName:             "cache-with-streaming",
+			CacheNameNotStreaming: "cache-no-streaming",
+		}
+
+		_, _, err := c.ServiceNodes(context.Background(), tc.req)
+		require.NoError(t, err)
+		tc.expected(t, c)
+	}
+
+	var testCases = []testCase{
+		{
+			name: "rpc by default",
+			req: structs.ServiceSpecificRequest{
+				Datacenter:  "dc1",
+				ServiceName: "web1",
+			},
+			expected: useRPC,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func useRPC(t *testing.T, c *Client) {
+	t.Helper()
+
+	rpc, ok := c.NetRPC.(*fakeNetRPC)
+	if !ok {
+		t.Fatalf("test setup error, expected *fakeNetRPC, got %T", c.NetRPC)
+	}
+
+	cache, ok := c.Cache.(*fakeCache)
+	if !ok {
+		t.Fatalf("test setup error, expected *fakeCache, got %T", c.Cache)
+	}
+
+	require.Len(t, cache.callsGet, 0)
+	require.Equal(t, []string{"Health.ServiceNodes"}, rpc.calls)
+}
+
+type fakeCache struct {
+	callsGet []string
+}
+
+func (f *fakeCache) Get(_ context.Context, t string, _ cache.Request) (interface{}, cache.ResultMeta, error) {
+	f.callsGet = append(f.callsGet, t)
+	return nil, cache.ResultMeta{}, nil
+}
+
+func (f *fakeCache) Notify(_ context.Context, _ string, _ cache.Request, _ string, _ chan<- cache.UpdateEvent) error {
+	panic("implement me")
+}
+
+type fakeNetRPC struct {
+	calls []string
+}
+
+func (f *fakeNetRPC) RPC(method string, _ interface{}, _ interface{}) error {
+	f.calls = append(f.calls, method)
+	return nil
+}
+
+// TODO: test Notify routing

--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -229,9 +229,10 @@ The table below shows this endpoint's support for
 - `near` `(string: "")` - Specifies a node name to sort the node list in
   ascending order based on the estimated round trip time from that node. Passing
   `?near=_agent` will use the agent's node for the sort. This is specified as
-  part of the URL as a query parameter. **Note** that `near` can not be used if
-  [`use_streaming_backend`](/docs/agent/options#use_streaming_backend)
-  is enabled, because the data is not available to sort the results.
+  part of the URL as a query parameter. **Note** that using `near` will ignore 
+  [`use_streaming_backend`](/docs/agent/options#use_streaming_backend) and always
+  use blocking queries, because the data required to sort the results is not available
+  to the streaming backend.
 
 - `tag` `(string: "")` **Deprecated** - Use `filter` with the `Service.Tags` selector instead.
   This parameter will be removed in a future version of Consul.


### PR DESCRIPTION
Effectively reverts the changes in #9758

There's no reason to error here. We can still satisfy the request using blocking queries.