### PR TITLE
Disallow * as service-defaults name

### DIFF
--- a/.changelog/10069.txt
+++ b/.changelog/10069.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+connect: Disallow wildcard as name for service-defaults. 
+```

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -157,6 +157,9 @@ func (e *ServiceConfigEntry) Validate() error {
 	if e.Name == "" {
 		return fmt.Errorf("Name is required")
 	}
+	if e.Name == WildcardSpecifier {
+		return fmt.Errorf("service-defaults name must be the name of a service, and not a wildcard")
+	}
 
 	validationErr := validateConfigEntryMeta(e.Meta)
 

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1700,6 +1700,13 @@ func TestServiceConfigEntry_Validate(t *testing.T) {
 		expectErr string
 	}{
 		{
+			name: "wildcard name is not allowed",
+			input: &ServiceConfigEntry{
+				Name: WildcardSpecifier,
+			},
+			expectErr: `must be the name of a service, and not a wildcard`,
+		},
+		{
 			name: "upstream config override no name",
 			input: &ServiceConfigEntry{
 				Name: "web",


### PR DESCRIPTION
This PR disallows wildcards as the name for a `service-defaults` config entry. Using wildcards as service names clashes with how they're used by intentions.

Note that the wildcard specifier is already disallowed as the destination name of connect proxies.