### PR TITLE
Add replication metrics

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -806,10 +806,19 @@ func (s *Server) runLegacyACLReplication(ctx context.Context) error {
 		}
 
 		if err != nil {
+			metrics.SetGauge([]string{"leader", "replication", "acl-legacy", "status"},
+				0,
+			)
 			lastRemoteIndex = 0
 			s.updateACLReplicationStatusError()
 			legacyACLLogger.Warn("Legacy ACL replication error (will retry if still leader)", "error", err)
 		} else {
+			metrics.SetGauge([]string{"leader", "replication", "acl-legacy", "status"},
+				1,
+			)
+			metrics.SetGauge([]string{"leader", "replication", "acl-legacy", "index"},
+				float32(index),
+			)
 			lastRemoteIndex = index
 			s.updateACLReplicationStatusIndex(structs.ACLReplicateLegacy, index)
 			legacyACLLogger.Debug("Legacy ACL replication completed through remote index", "index", index)
@@ -867,7 +876,7 @@ type replicateFunc func(ctx context.Context, logger hclog.Logger, lastRemoteInde
 func (s *Server) runACLPolicyReplicator(ctx context.Context) error {
 	policyLogger := s.aclReplicationLogger(structs.ACLReplicatePolicies.SingularNoun())
 	policyLogger.Info("started ACL Policy replication")
-	return s.runACLReplicator(ctx, policyLogger, structs.ACLReplicatePolicies, s.replicateACLPolicies)
+	return s.runACLReplicator(ctx, policyLogger, structs.ACLReplicatePolicies, s.replicateACLPolicies, "acl-policies")
 }
 
 // This function is only intended to be run as a managed go routine, it will block until
@@ -875,7 +884,7 @@ func (s *Server) runACLPolicyReplicator(ctx context.Context) error {
 func (s *Server) runACLRoleReplicator(ctx context.Context) error {
 	roleLogger := s.aclReplicationLogger(structs.ACLReplicateRoles.SingularNoun())
 	roleLogger.Info("started ACL Role replication")
-	return s.runACLReplicator(ctx, roleLogger, structs.ACLReplicateRoles, s.replicateACLRoles)
+	return s.runACLReplicator(ctx, roleLogger, structs.ACLReplicateRoles, s.replicateACLRoles, "acl-roles")
 }
 
 // This function is only intended to be run as a managed go routine, it will block until
@@ -883,7 +892,7 @@ func (s *Server) runACLRoleReplicator(ctx context.Context) error {
 func (s *Server) runACLTokenReplicator(ctx context.Context) error {
 	tokenLogger := s.aclReplicationLogger(structs.ACLReplicateTokens.SingularNoun())
 	tokenLogger.Info("started ACL Token replication")
-	return s.runACLReplicator(ctx, tokenLogger, structs.ACLReplicateTokens, s.replicateACLTokens)
+	return s.runACLReplicator(ctx, tokenLogger, structs.ACLReplicateTokens, s.replicateACLTokens, "acl-tokens")
 }
 
 // This function is only intended to be run as a managed go routine, it will block until
@@ -893,6 +902,7 @@ func (s *Server) runACLReplicator(
 	logger hclog.Logger,
 	replicationType structs.ACLReplicationType,
 	replicateFunc replicateFunc,
+	metricName string,
 ) error {
 	var failedAttempts uint
 	limiter := rate.NewLimiter(rate.Limit(s.config.ACLReplicationRate), s.config.ACLReplicationBurst)
@@ -913,6 +923,9 @@ func (s *Server) runACLReplicator(
 		}
 
 		if err != nil {
+			metrics.SetGauge([]string{"leader", "replication", metricName, "status"},
+				0,
+			)
 			lastRemoteIndex = 0
 			s.updateACLReplicationStatusError()
 			logger.Warn("ACL replication error (will retry if still leader)",
@@ -929,6 +942,12 @@ func (s *Server) runACLReplicator(
 				// do nothing
 			}
 		} else {
+			metrics.SetGauge([]string{"leader", "replication", metricName, "status"},
+				1,
+			)
+			metrics.SetGauge([]string{"leader", "replication", metricName, "index"},
+				float32(index),
+			)
 			lastRemoteIndex = index
 			s.updateACLReplicationStatusIndex(replicationType, index)
 			logger.Debug("ACL replication completed through remote index",

--- a/agent/consul/replication_test.go
+++ b/agent/consul/replication_test.go
@@ -20,6 +20,7 @@ func TestReplicationRestart(t *testing.T) {
 			ReplicateFn: func(ctx context.Context, lastRemoteIndex uint64, logger hclog.Logger) (uint64, bool, error) {
 				return 1, false, nil
 			},
+			Name: "foo",
 		},
 
 		Rate:  1,

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -400,7 +400,7 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 
 	configReplicatorConfig := ReplicatorConfig{
 		Name:     logging.ConfigEntry,
-		Delegate: &FunctionReplicator{ReplicateFn: s.replicateConfig, Name: "config"},
+		Delegate: &FunctionReplicator{ReplicateFn: s.replicateConfig, Name: "config-entries"},
 		Rate:     s.config.ConfigReplicationRate,
 		Burst:    s.config.ConfigReplicationBurst,
 		Logger:   s.logger,

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -400,7 +400,7 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 
 	configReplicatorConfig := ReplicatorConfig{
 		Name:     logging.ConfigEntry,
-		Delegate: &FunctionReplicator{ReplicateFn: s.replicateConfig},
+		Delegate: &FunctionReplicator{ReplicateFn: s.replicateConfig, Name: "config"},
 		Rate:     s.config.ConfigReplicationRate,
 		Burst:    s.config.ConfigReplicationBurst,
 		Logger:   s.logger,


### PR DESCRIPTION
This adds metrics around replication status and latest replicated index to be emitted for:

* ACL Tokens
* ACL Policies
* ACL Roles
* Legacy ACLs
* Federation States
* Config Entries
* Namespaces

The metrics will be emitted with the name: `consul.leader.replication.<type>.status` and `consul.leader.replication.<type>.index`

The `status` one is 0 if the last round of replication errored and 1 if it didn't. The `index` one is updated with the last replicated index.

As we don't have unit tests to ensure metrics were emitted correctly I tested this manually like so:

1. `make dev-docker` for this branch
2. `git clone github.com/mkeeler/consul-docker-test`
3. `cd acls` within the `consul-docker-test` source
4. `terraform init`
5. `terraform apply -var consul_image=consul-dev`
   * This will bring up a multi-dc setup with ACLs enabled with token replication and connect enabled which is enough to cause all the various replicators to be running.
6. In a browser go to http://localhost:3000/d/FanxUjuGk/replication?orgId=1
7. Alternatively navigate to http://localhost:9090 (prometheus ui) and search for the metrics:
   * `consul_leader_replication_acl_tokens_status`
   * `consul_leader_replication_acl_tokens_index`
   * `consul_leader_replication_acl_policies_status`
   * `consul_leader_replication_acl_policies_index`
   * `consul_leader_replication_acl_roles_status`
   * `consul_leader_replication_acl_roles_index`
   * `consul_leader_replication_config_entries_status`
   * `consul_leader_replication_config_entries_index`
   * `consul_leader_replication_federation_state_status`
   * `consul_leader_replication_federation_state_index`