### PR TITLE
Fix missing agent/sentinel page

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -651,6 +651,10 @@
       {
         "title": "Telemetry",
         "path": "agent/telemetry"
+      },
+      {
+        "title": "Sentinel",
+        "path": "agent/sentinel"
       }
     ]
   },


### PR DESCRIPTION
This page wasn't present in navigation and therefore not rendering due to recent nav infrastructure changes - this gets the page back in the nav and rendering again. We will be running a wider scan for other pages that have this same issue shortly!