### PR TITLE
lib/ttlcache: never decrease the expiry on update

### DIFF
--- a/lib/ttlcache/eviction_test.go
+++ b/lib/ttlcache/eviction_test.go
@@ -47,8 +47,8 @@ func TestExpiryHeap(t *testing.T) {
 		testNoMessage(t, ch)
 	})
 
-	runStep(t, "update entry3 to expire first", func(t *testing.T) {
-		h.Update(entry3.heapIndex, 10*time.Millisecond)
+	runStep(t, "update so that entry3 expires first", func(t *testing.T) {
+		h.Update(entry.heapIndex, 2000*time.Millisecond)
 		assert.Equal(t, 1, entry.heapIndex)
 		assert.Equal(t, 0, entry3.heapIndex)
 		testMessage(t, ch)
@@ -56,11 +56,18 @@ func TestExpiryHeap(t *testing.T) {
 	})
 
 	runStep(t, "0th element change triggers a notify", func(t *testing.T) {
-		h.Update(entry3.heapIndex, 20)
+		h.Update(entry3.heapIndex, 1500*time.Millisecond)
 		assert.Equal(t, 1, entry.heapIndex) // no move
 		assert.Equal(t, 0, entry3.heapIndex)
 		testMessage(t, ch)
 		testNoMessage(t, ch) // one message
+	})
+
+	runStep(t, "update can not decrease expiry time", func(t *testing.T) {
+		h.Update(entry.heapIndex, 100*time.Millisecond)
+		assert.Equal(t, 1, entry.heapIndex) // no move
+		assert.Equal(t, 0, entry3.heapIndex)
+		testNoMessage(t, ch) // no notify, because no change in the heap
 	})
 }
 


### PR DESCRIPTION
I ran into this while working on a larger change.  This was not actually causing a bug, but it seems like it would have the potential to cause a bug if we ever had different sources use a different TTL value for the same entry.


Previously we allowed `Update` to decrease the expiry value. With this change the expiry must always increase.