### PR TITLE
sdk/retry: a few small debug improvements

### DIFF
--- a/sdk/testutil/retry/retry_test.go
+++ b/sdk/testutil/retry/retry_test.go
@@ -22,7 +22,7 @@ func TestRetryer(t *testing.T) {
 			var iters, fails int
 			fail := func() { fails++ }
 			start := time.Now()
-			for tt.r.NextOr(fail) {
+			for tt.r.NextOr(t, fail) {
 				iters++
 			}
 			dur := time.Since(start)


### PR DESCRIPTION
On a few occasions I've had to dig through stack traces for tests that timeout
and noticed that `retry.Run` runs the function in a goroutine. This makes
debuging a timeout more difficult because the gourinte of the retryable
function is disconnected from the stack of the actual test. It requires
searching through the entire stack dump to find the other goroutine.

By using panic instead of runtime.Goexit() we remove the need for a
separate goroutine.

Also a few other small improvements:
* add `R.Helper` so that an assertion function can be used with both
  testing.T and retry.R.
* Pass t to `Retryer.NextOr`, and call `t.Helper` in a number of places
  so that the line number reported by `t.Log` is the line in the test
  where `retry.Run` was called, instead of some line in `retry.go` that
  is not relevant to the failure.
* improve the implementation of `dedup` by removing the need to iterate
  twice. Instad track the lines and skip any duplicate when writing to
  the buffer.