### PR TITLE
[1.8.x] connect: update supported envoy versions to 1.14.7, 1.13.7, 1.12.7, 1.11.2

### DIFF
--- a/.changelog/10106.txt
+++ b/.changelog/10106.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-connect: update supported envoy versions to 1.14.7, 1.13.8, 1.12.7, 1.11.2
+connect: update supported envoy versions to 1.14.7, 1.13.7, 1.12.7, 1.11.2
 ```

--- a/.changelog/10106.txt
+++ b/.changelog/10106.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: update supported envoy versions to 1.14.7, 1.13.8, 1.12.7, 1.11.2
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,11 +694,11 @@ jobs:
       ENVOY_VERSION: "1.12.7"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
-  envoy-integration-test-1_13_8:
+  envoy-integration-test-1_13_7:
     docker:
       - image: *GOLANG_IMAGE
     environment:
-      ENVOY_VERSION: "1.13.8"
+      ENVOY_VERSION: "1.13.7"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
   envoy-integration-test-1_14_7:
@@ -846,7 +846,7 @@ workflows:
       - envoy-integration-test-1_12_7:
           requires:
             - dev-build
-      - envoy-integration-test-1_13_8:
+      - envoy-integration-test-1_13_7:
           requires:
             - dev-build
       - envoy-integration-test-1_14_7:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,18 +694,18 @@ jobs:
       ENVOY_VERSION: "1.12.7"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
-  envoy-integration-test-1_13_7:
+  envoy-integration-test-1_13_8:
     docker:
       - image: *GOLANG_IMAGE
     environment:
-      ENVOY_VERSION: "1.13.7"
+      ENVOY_VERSION: "1.13.8"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
-  envoy-integration-test-1_14_6:
+  envoy-integration-test-1_14_7:
     docker:
       - image: *GOLANG_IMAGE
     environment:
-      ENVOY_VERSION: "1.14.6"
+      ENVOY_VERSION: "1.14.7"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
   # run integration tests for the connect ca providers
@@ -846,10 +846,10 @@ workflows:
       - envoy-integration-test-1_12_7:
           requires:
             - dev-build
-      - envoy-integration-test-1_13_7:
+      - envoy-integration-test-1_13_8:
           requires:
             - dev-build
-      - envoy-integration-test-1_14_6:
+      - envoy-integration-test-1_14_7:
           requires:
             - dev-build
   website:

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -7,8 +7,8 @@ package proxysupport
 //
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
-	"1.14.6",
-	"1.13.7",
+	"1.14.7",
+	"1.13.8",
 	"1.12.7",
 	"1.11.2",
 }

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -8,7 +8,7 @@ package proxysupport
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
 	"1.14.7",
-	"1.13.8",
+	"1.13.7",
 	"1.12.7",
 	"1.11.2",
 }

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-addr-config.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -13,7 +13,7 @@
     "id": "ingress-gateway",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -13,7 +13,7 @@
     "id": "ingress-gateway",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -13,7 +13,7 @@
     "id": "my-gateway-123",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -13,7 +13,7 @@
     "id": "my-gateway",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -13,7 +13,7 @@
     "id": "ingress-gateway-1",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.14.6"
+      "envoy_version": "1.14.7"
     }
   },
   "static_resources": {

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -6,7 +6,7 @@ set -eEuo pipefail
 DEBUG=${DEBUG:-}
 
 # ENVOY_VERSION to run each test against
-ENVOY_VERSION=${ENVOY_VERSION:-"1.14.6"}
+ENVOY_VERSION=${ENVOY_VERSION:-"1.14.7"}
 export ENVOY_VERSION
 
 if [ ! -z "$DEBUG" ] ; then


### PR DESCRIPTION
Manual, modified backport of #10101 to 1.8.x