### PR TITLE
make h2ping changelog entry conform with changelog template

### DIFF
--- a/.changelog/8431.txt
+++ b/.changelog/8431.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
-health-checks: add H2 ping health checks.
+```release-note:feature
+checks: add H2 ping health checks.
 ```


### PR DESCRIPTION
I noticed that the H2 ping checks were released as part of the most recent beta but didn't see a changelog entry. After doing some investigating, I noticed that the changelog file I wrote used `enhancements` as its type, which is not supported by the template. I fixed the entry to use `feature` instead. I am sorry for the mistake and hope it does not cause too much trouble.