### PR TITLE
Fix strings.Replace->strings.ReplaceAll

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -36,5 +36,5 @@ func GetHumanVersion() string {
 	}
 
 	// Strip off any single quotes added by the git information.
-	return strings.Replace(version, "'", "", -1)
+	return strings.ReplaceAll(version, "'", "")
 }


### PR DESCRIPTION
Function
`strings.Replace (version, "'", "", -1)`
replaced by
`strings.ReplaceAll (version, "'", "")`