### PR TITLE
ui: Fix empty SVG height

### DIFF
--- a/.changelog/10122.txt
+++ b/.changelog/10122.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: Adding conditional to prevent SVG drawing from breaking
+ui: Adding conditional to prevent Service Mesh from breaking when there are no Upstreams
 ```

--- a/.changelog/10122.txt
+++ b/.changelog/10122.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Adding conditional to prevent SVG drawing from breaking
+```

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -108,9 +108,8 @@ export default class TopologyMetrics extends Component {
     // Calculate viewBox dimensions
     this.downView = document.getElementById('downstream-lines').getBoundingClientRect();
     const upstreamLines = document.getElementById('upstream-lines').getBoundingClientRect();
-    if (document.getElementById('upstream-column')) {
-      const upstreamColumn = document.getElementById('upstream-column').getBoundingClientRect();
-
+    const upstreamColumn = document.getElementById('upstream-column').getBoundingClientRect();
+    if (upstreamColumn) {
       this.upView = {
         x: upstreamLines.x,
         y: upstreamLines.y,

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -108,14 +108,16 @@ export default class TopologyMetrics extends Component {
     // Calculate viewBox dimensions
     this.downView = document.getElementById('downstream-lines').getBoundingClientRect();
     const upstreamLines = document.getElementById('upstream-lines').getBoundingClientRect();
-    const upstreamColumn = document.getElementById('upstream-column').getBoundingClientRect();
+    if (document.getElementById('upstream-column')) {
+      const upstreamColumn = document.getElementById('upstream-column').getBoundingClientRect();
 
-    this.upView = {
-      x: upstreamLines.x,
-      y: upstreamLines.y,
-      width: upstreamLines.width,
-      height: upstreamColumn.height,
-    };
+      this.upView = {
+        x: upstreamLines.x,
+        y: upstreamLines.y,
+        width: upstreamLines.width,
+        height: upstreamColumn.height + 10,
+      };
+    }
 
     // Get Card elements positions
     const downCards = [

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -108,13 +108,14 @@ export default class TopologyMetrics extends Component {
     // Calculate viewBox dimensions
     this.downView = document.getElementById('downstream-lines').getBoundingClientRect();
     const upstreamLines = document.getElementById('upstream-lines').getBoundingClientRect();
-    const upstreamColumn = document.getElementById('upstream-column').getBoundingClientRect();
+    const upstreamColumn = document.getElementById('upstream-column');
+
     if (upstreamColumn) {
       this.upView = {
         x: upstreamLines.x,
         y: upstreamLines.y,
         width: upstreamLines.width,
-        height: upstreamColumn.height + 10,
+        height: upstreamColumn.getBoundingClientRect().height + 10,
       };
     }
 


### PR DESCRIPTION
Adding a conditional that prevents the Topology view from breaking when there are no upstreams in the upstream column.

Before
<img width="1519" alt="Screen Shot 2021-04-27 at 9 57 52 AM" src="https://user-images.githubusercontent.com/19161242/116254229-2aeebf80-a73f-11eb-9583-30abae7c3b69.png">

After
<img width="1566" alt="Screen Shot 2021-04-27 at 9 58 34 AM" src="https://user-images.githubusercontent.com/19161242/116254243-2f1add00-a73f-11eb-885c-ae345fd3a4f8.png">
