### PR TITLE
ui: Update conditional for topology empty state

### DIFF
--- a/.changelog/10124.txt
+++ b/.changelog/10124.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Update conditional for topology empty state
+```

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -3,7 +3,7 @@
 as |route|>
   <EventSource @src={{topology}} />
   <div class="tab-section">
-    {{#if (and (eq topology.Upstreams.length 0) (eq topology.Downstreams.length 0))}}
+    {{#if (and (eq topology.Upstreams.length 0) (eq topology.Downstreams.length 0) (not topology.DefaultAllow) (not topology.WildcardIntention))}}
       <EmptyState>
         <BlockSlot @name="header">
           <h2>


### PR DESCRIPTION
If there are no upstreams or downstreams but the user has permissive intentions, like wildcard or default allow, then we still need to show banner and *(All Services) card, not empty state.

Before
<img width="1368" alt="Screen Shot 2021-04-27 at 10 00 24 AM" src="https://user-images.githubusercontent.com/19161242/116254920-c2541280-a73f-11eb-809a-1980b7bfb6d9.png">

After
<img width="1581" alt="Screen Shot 2021-04-27 at 10 02 55 AM" src="https://user-images.githubusercontent.com/19161242/116254943-c849f380-a73f-11eb-88f6-98626429cdfd.png">
