### PR TITLE
Exclude node addresses when using tproxy on k8s

### DIFF
--- a/agent/xds/testdata/listeners/transparent-proxy-k8s.envoy-1-17-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-k8s.envoy-1-17-x.golden
@@ -40,14 +40,6 @@
           "filterChainMatch": {
             "prefixRanges": [
               {
-                "addressPrefix": "8.8.8.8",
-                "prefixLen": 32
-              },
-              {
-                "addressPrefix": "8.8.8.9",
-                "prefixLen": 32
-              },
-              {
                 "addressPrefix": "9.9.9.10",
                 "prefixLen": 32
               },

--- a/agent/xds/testdata/listeners/transparent-proxy-k8s.v2compat.envoy-1-17-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-k8s.v2compat.envoy-1-17-x.golden
@@ -2,7 +2,7 @@
   "versionInfo": "00000001",
   "resources": [
     {
-      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
       "name": "db:127.0.0.1:9191",
       "address": {
         "socketAddress": {
@@ -16,7 +16,7 @@
             {
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
                 "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
@@ -27,7 +27,7 @@
       "trafficDirection": "OUTBOUND"
     },
     {
-      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
       "name": "outbound_listener:127.0.0.1:15001",
       "address": {
         "socketAddress": {
@@ -39,14 +39,6 @@
         {
           "filterChainMatch": {
             "prefixRanges": [
-              {
-                "addressPrefix": "8.8.8.8",
-                "prefixLen": 32
-              },
-              {
-                "addressPrefix": "8.8.8.9",
-                "prefixLen": 32
-              },
               {
                 "addressPrefix": "9.9.9.10",
                 "prefixLen": 32
@@ -61,7 +53,7 @@
             {
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
                 "statPrefix": "upstream.google.default.dc1",
                 "cluster": "google.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
@@ -73,7 +65,7 @@
             {
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
                 "statPrefix": "upstream.original-destination",
                 "cluster": "original-destination"
               }
@@ -89,7 +81,7 @@
       "trafficDirection": "OUTBOUND"
     },
     {
-      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
       "name": "prepared_query:geo-cache:127.10.10.10:8181",
       "address": {
         "socketAddress": {
@@ -103,7 +95,7 @@
             {
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
                 "statPrefix": "upstream.prepared_query_geo-cache",
                 "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
               }
@@ -114,7 +106,7 @@
       "trafficDirection": "OUTBOUND"
     },
     {
-      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
       "name": "public_listener:0.0.0.0:9999",
       "address": {
         "socketAddress": {
@@ -128,7 +120,7 @@
             {
               "name": "envoy.filters.network.rbac",
               "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
                 "rules": {
 
                 },
@@ -138,7 +130,7 @@
             {
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
                 "statPrefix": "public_listener",
                 "cluster": "local_app"
               }
@@ -147,7 +139,7 @@
           "transportSocket": {
             "name": "tls",
             "typedConfig": {
-              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "@type": "type.googleapis.com/envoy.api.v2.auth.DownstreamTlsContext",
               "commonTlsContext": {
                 "tlsParams": {
 
@@ -176,6 +168,6 @@
       "trafficDirection": "INBOUND"
     }
   ],
-  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
   "nonce": "00000001"
 }

--- a/agent/xds/testdata/listeners/transparent-proxy.v2compat.envoy-1-17-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy.v2compat.envoy-1-17-x.golden
@@ -42,6 +42,18 @@
               {
                 "addressPrefix": "8.8.8.8",
                 "prefixLen": 32
+              },
+              {
+                "addressPrefix": "8.8.8.9",
+                "prefixLen": 32
+              },
+              {
+                "addressPrefix": "9.9.9.10",
+                "prefixLen": 32
+              },
+              {
+                "addressPrefix": "9.9.9.9",
+                "prefixLen": 32
               }
             ]
           },


### PR DESCRIPTION
Each filter chain on the tproxy outbound listener needs unique addresses
to match on. However, if multiple upstream services are hosted on the
same node, then their node address would be duplicated across filter
chain matches. If the local node were to dial that upstream IP then
Envoy would not know how to disambiguate it.

In Kubernetes we do not expect services in the mesh to dial upstreams in
the mesh using the node's address.