### PR TITLE
Rename "cluster" config entry to "mesh"

### DIFF
--- a/.changelog/10127.txt
+++ b/.changelog/10127.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: rename cluster config entry to mesh.
+```

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4156,8 +4156,8 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 				"config_entries": {
 					"bootstrap": [
 						{
-							"kind": "cluster",
-							"name": "cluster",
+							"kind": "mesh",
+							"name": "mesh",
 							"meta" : {
 								"foo": "bar",
 								"gir": "zim"
@@ -4173,8 +4173,8 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		hcl: []string{`
 				config_entries {
 				  bootstrap {
-					kind = "cluster"
-					name = "cluster"
+					kind = "mesh"
+					name = "mesh"
 					meta {
 						"foo" = "bar"
 						"gir" = "zim"
@@ -4189,15 +4189,15 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		expected: func(rt *RuntimeConfig) {
 			rt.DataDir = dataDir
 			rt.ConfigEntryBootstrap = []structs.ConfigEntry{
-				&structs.ClusterConfigEntry{
-					Kind: "cluster",
-					Name: "cluster",
+				&structs.MeshConfigEntry{
+					Kind: structs.MeshConfig,
+					Name: structs.MeshConfigMesh,
 					Meta: map[string]string{
 						"foo": "bar",
 						"gir": "zim",
 					},
 					EnterpriseMeta: *defaultEntMeta,
-					TransparentProxy: structs.TransparentProxyClusterConfig{
+					TransparentProxy: structs.TransparentProxyMeshConfig{
 						CatalogDestinationsOnly: true,
 					},
 				},
@@ -4211,8 +4211,8 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 				"config_entries": {
 					"bootstrap": [
 						{
-							"Kind": "cluster",
-							"Name": "cluster",
+							"Kind": "mesh",
+							"Name": "mesh",
 							"Meta" : {
 								"foo": "bar",
 								"gir": "zim"
@@ -4228,8 +4228,8 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		hcl: []string{`
 				config_entries {
 				  bootstrap {
-					Kind = "cluster"
-					Name = "cluster"
+					Kind = "mesh"
+					Name = "mesh"
 					Meta {
 						"foo" = "bar"
 						"gir" = "zim"
@@ -4244,15 +4244,15 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		expected: func(rt *RuntimeConfig) {
 			rt.DataDir = dataDir
 			rt.ConfigEntryBootstrap = []structs.ConfigEntry{
-				&structs.ClusterConfigEntry{
-					Kind: "cluster",
-					Name: "cluster",
+				&structs.MeshConfigEntry{
+					Kind: structs.MeshConfig,
+					Name: structs.MeshConfigMesh,
 					Meta: map[string]string{
 						"foo": "bar",
 						"gir": "zim",
 					},
 					EnterpriseMeta: *defaultEntMeta,
-					TransparentProxy: structs.TransparentProxyClusterConfig{
+					TransparentProxy: structs.TransparentProxyMeshConfig{
 						CatalogDestinationsOnly: true,
 					},
 				},

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -426,15 +426,15 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}
 	require.NoError(t, fsm.state.EnsureConfigEntry(26, serviceIxn))
 
-	// cluster config entry
-	clusterConfig := &structs.ClusterConfigEntry{
-		Kind: structs.ClusterConfig,
-		Name: structs.ClusterConfigCluster,
-		TransparentProxy: structs.TransparentProxyClusterConfig{
+	// mesh config entry
+	meshConfig := &structs.MeshConfigEntry{
+		Kind: structs.MeshConfig,
+		Name: structs.MeshConfigMesh,
+		TransparentProxy: structs.TransparentProxyMeshConfig{
 			CatalogDestinationsOnly: true,
 		},
 	}
-	require.NoError(t, fsm.state.EnsureConfigEntry(27, clusterConfig))
+	require.NoError(t, fsm.state.EnsureConfigEntry(27, meshConfig))
 
 	// Snapshot
 	snap, err := fsm.Snapshot()
@@ -710,10 +710,10 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, serviceIxn, serviceIxnEntry)
 
-	// Verify cluster config entry is restored
-	_, clusterConfigEntry, err := fsm2.state.ConfigEntry(nil, structs.ClusterConfig, structs.ClusterConfigCluster, structs.DefaultEnterpriseMeta())
+	// Verify mesh config entry is restored
+	_, meshConfigEntry, err := fsm2.state.ConfigEntry(nil, structs.MeshConfig, structs.MeshConfigMesh, structs.DefaultEnterpriseMeta())
 	require.NoError(t, err)
-	require.Equal(t, clusterConfig, clusterConfigEntry)
+	require.Equal(t, meshConfig, meshConfigEntry)
 
 	// Snapshot
 	snap, err = fsm2.Snapshot()

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -361,7 +361,7 @@ func validateProposedConfigEntryInGraph(
 			return err
 		}
 	case structs.ServiceIntentions:
-	case structs.ClusterConfig:
+	case structs.MeshConfig:
 	default:
 		return fmt.Errorf("unhandled kind %q during validation of %q", kind, name)
 	}

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -61,8 +61,8 @@ type configSnapshotConnectProxy struct {
 	Intentions    structs.Intentions
 	IntentionsSet bool
 
-	ClusterConfig    *structs.ClusterConfigEntry
-	ClusterConfigSet bool
+	MeshConfig    *structs.MeshConfigEntry
+	MeshConfigSet bool
 }
 
 func (c *configSnapshotConnectProxy) IsEmpty() bool {
@@ -80,7 +80,7 @@ func (c *configSnapshotConnectProxy) IsEmpty() bool {
 		len(c.WatchedServiceChecks) == 0 &&
 		len(c.PreparedQueryEndpoints) == 0 &&
 		len(c.UpstreamConfig) == 0 &&
-		!c.ClusterConfigSet
+		!c.MeshConfigSet
 }
 
 type configSnapshotTerminatingGateway struct {
@@ -360,7 +360,7 @@ type ConfigSnapshot struct {
 func (s *ConfigSnapshot) Valid() bool {
 	switch s.Kind {
 	case structs.ServiceKindConnectProxy:
-		if s.Proxy.Mode == structs.ProxyModeTransparent && !s.ConnectProxy.ClusterConfigSet {
+		if s.Proxy.Mode == structs.ProxyModeTransparent && !s.ConnectProxy.MeshConfigSet {
 			return false
 		}
 		return s.Roots != nil &&

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -46,7 +46,7 @@ const (
 	serviceResolverIDPrefix            = "service-resolver:"
 	serviceIntentionsIDPrefix          = "service-intentions:"
 	intentionUpstreamsID               = "intention-upstreams"
-	clusterConfigEntryID               = "cluster-config"
+	meshConfigEntryID                  = "mesh"
 	svcChecksWatchIDPrefix             = cachetype.ServiceHTTPChecksName + ":"
 	serviceIDPrefix                    = string(structs.UpstreamDestTypeService) + ":"
 	preparedQueryIDPrefix              = string(structs.UpstreamDestTypePreparedQuery) + ":"
@@ -318,12 +318,12 @@ func (s *state) initWatchesConnectProxy(snap *ConfigSnapshot) error {
 		}
 
 		err = s.cache.Notify(s.ctx, cachetype.ConfigEntryName, &structs.ConfigEntryQuery{
-			Kind:           structs.ClusterConfig,
-			Name:           structs.ClusterConfigCluster,
+			Kind:           structs.MeshConfig,
+			Name:           structs.MeshConfigMesh,
 			Datacenter:     s.source.Datacenter,
 			QueryOptions:   structs.QueryOptions{Token: s.token},
 			EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
-		}, clusterConfigEntryID, s.ch)
+		}, meshConfigEntryID, s.ch)
 		if err != nil {
 			return err
 		}
@@ -887,22 +887,22 @@ func (s *state) handleUpdateConnectProxy(u cache.UpdateEvent, snap *ConfigSnapsh
 		svcID := structs.ServiceIDFromString(strings.TrimPrefix(u.CorrelationID, svcChecksWatchIDPrefix))
 		snap.ConnectProxy.WatchedServiceChecks[svcID] = resp
 
-	case u.CorrelationID == clusterConfigEntryID:
+	case u.CorrelationID == meshConfigEntryID:
 		resp, ok := u.Result.(*structs.ConfigEntryResponse)
 		if !ok {
 			return fmt.Errorf("invalid type for response: %T", u.Result)
 		}
 
 		if resp.Entry != nil {
-			clusterConf, ok := resp.Entry.(*structs.ClusterConfigEntry)
+			meshConf, ok := resp.Entry.(*structs.MeshConfigEntry)
 			if !ok {
 				return fmt.Errorf("invalid type for config entry: %T", resp.Entry)
 			}
-			snap.ConnectProxy.ClusterConfig = clusterConf
+			snap.ConnectProxy.MeshConfig = meshConf
 		} else {
-			snap.ConnectProxy.ClusterConfig = nil
+			snap.ConnectProxy.MeshConfig = nil
 		}
-		snap.ConnectProxy.ClusterConfigSet = true
+		snap.ConnectProxy.MeshConfigSet = true
 
 	default:
 		return s.handleUpdateUpstreams(u, &snap.ConnectProxy.ConfigSnapshotUpstreams)

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -289,15 +289,15 @@ func genVerifyDiscoveryChainWatch(expected *structs.DiscoveryChainRequest) verif
 	}
 }
 
-func genVerifyClusterConfigWatch(expectedDatacenter string) verifyWatchRequest {
+func genVerifyMeshConfigWatch(expectedDatacenter string) verifyWatchRequest {
 	return func(t testing.TB, cacheType string, request cache.Request) {
 		require.Equal(t, cachetype.ConfigEntryName, cacheType)
 
 		reqReal, ok := request.(*structs.ConfigEntryQuery)
 		require.True(t, ok)
 		require.Equal(t, expectedDatacenter, reqReal.Datacenter)
-		require.Equal(t, structs.ClusterConfigCluster, reqReal.Name)
-		require.Equal(t, structs.ClusterConfig, reqReal.Kind)
+		require.Equal(t, structs.MeshConfigMesh, reqReal.Name)
+		require.Equal(t, structs.MeshConfig, reqReal.Kind)
 	}
 }
 
@@ -1554,9 +1554,9 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						rootsWatchID: genVerifyRootsWatch("dc1"),
 						intentionUpstreamsID: genVerifyServiceSpecificRequest(intentionUpstreamsID,
 							"api", "", "dc1", false),
-						leafWatchID:          genVerifyLeafWatch("api", "dc1"),
-						intentionsWatchID:    genVerifyIntentionWatch("api", "dc1"),
-						clusterConfigEntryID: genVerifyClusterConfigWatch("dc1"),
+						leafWatchID:       genVerifyLeafWatch("api", "dc1"),
+						intentionsWatchID: genVerifyIntentionWatch("api", "dc1"),
+						meshConfigEntryID: genVerifyMeshConfigWatch("dc1"),
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.False(t, snap.Valid(), "proxy without roots/leaf/intentions is not valid")
@@ -1588,7 +1588,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							Err:           nil,
 						},
 						{
-							CorrelationID: clusterConfigEntryID,
+							CorrelationID: meshConfigEntryID,
 							Result: &structs.ConfigEntryResponse{
 								Entry: nil, // no explicit config
 							},
@@ -1603,8 +1603,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.True(t, snap.MeshGateway.IsEmpty())
 						require.True(t, snap.IngressGateway.IsEmpty())
 						require.True(t, snap.TerminatingGateway.IsEmpty())
-						require.True(t, snap.ConnectProxy.ClusterConfigSet)
-						require.Nil(t, snap.ConnectProxy.ClusterConfig)
+						require.True(t, snap.ConnectProxy.MeshConfigSet)
+						require.Nil(t, snap.ConnectProxy.MeshConfig)
 					},
 				},
 			},
@@ -1639,9 +1639,9 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						rootsWatchID: genVerifyRootsWatch("dc1"),
 						intentionUpstreamsID: genVerifyServiceSpecificRequest(intentionUpstreamsID,
 							"api", "", "dc1", false),
-						leafWatchID:          genVerifyLeafWatch("api", "dc1"),
-						intentionsWatchID:    genVerifyIntentionWatch("api", "dc1"),
-						clusterConfigEntryID: genVerifyClusterConfigWatch("dc1"),
+						leafWatchID:       genVerifyLeafWatch("api", "dc1"),
+						intentionsWatchID: genVerifyIntentionWatch("api", "dc1"),
+						meshConfigEntryID: genVerifyMeshConfigWatch("dc1"),
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.False(t, snap.Valid(), "proxy without roots/leaf/intentions is not valid")
@@ -1671,12 +1671,12 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							Err:           nil,
 						},
 						{
-							CorrelationID: clusterConfigEntryID,
+							CorrelationID: meshConfigEntryID,
 							Result: &structs.ConfigEntryResponse{
-								Entry: &structs.ClusterConfigEntry{
-									Kind:             structs.ClusterConfig,
-									Name:             structs.ClusterConfigCluster,
-									TransparentProxy: structs.TransparentProxyClusterConfig{},
+								Entry: &structs.MeshConfigEntry{
+									Kind:             structs.MeshConfig,
+									Name:             structs.MeshConfigMesh,
+									TransparentProxy: structs.TransparentProxyMeshConfig{},
 								},
 							},
 							Err: nil,
@@ -1690,8 +1690,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.True(t, snap.MeshGateway.IsEmpty())
 						require.True(t, snap.IngressGateway.IsEmpty())
 						require.True(t, snap.TerminatingGateway.IsEmpty())
-						require.True(t, snap.ConnectProxy.ClusterConfigSet)
-						require.NotNil(t, snap.ConnectProxy.ClusterConfig)
+						require.True(t, snap.ConnectProxy.MeshConfigSet)
+						require.NotNil(t, snap.ConnectProxy.MeshConfig)
 					},
 				},
 				// Receiving an intention should lead to spinning up a discovery chain watch

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -26,10 +26,10 @@ const (
 	IngressGateway     string = "ingress-gateway"
 	TerminatingGateway string = "terminating-gateway"
 	ServiceIntentions  string = "service-intentions"
-	ClusterConfig      string = "cluster"
+	MeshConfig         string = "mesh"
 
-	ProxyConfigGlobal    string = "global"
-	ClusterConfigCluster string = "cluster"
+	ProxyConfigGlobal string = "global"
+	MeshConfigMesh    string = "mesh"
 
 	DefaultServiceProtocol = "tcp"
 )
@@ -43,7 +43,7 @@ var AllConfigEntryKinds = []string{
 	IngressGateway,
 	TerminatingGateway,
 	ServiceIntentions,
-	ClusterConfig,
+	MeshConfig,
 }
 
 // ConfigEntry is the interface for centralized configuration stored in Raft.
@@ -528,8 +528,8 @@ func MakeConfigEntry(kind, name string) (ConfigEntry, error) {
 		return &TerminatingGatewayConfigEntry{Name: name}, nil
 	case ServiceIntentions:
 		return &ServiceIntentionsConfigEntry{Name: name}, nil
-	case ClusterConfig:
-		return &ClusterConfigEntry{Name: name}, nil
+	case MeshConfig:
+		return &MeshConfigEntry{Name: name}, nil
 	default:
 		return nil, fmt.Errorf("invalid config entry kind: %s", kind)
 	}

--- a/agent/structs/config_entry_cluster.go
+++ b/agent/structs/config_entry_cluster.go
@@ -6,32 +6,32 @@ import (
 	"github.com/hashicorp/consul/acl"
 )
 
-type ClusterConfigEntry struct {
+type MeshConfigEntry struct {
 	Kind string
 	Name string
 
 	// TransparentProxy contains cluster-wide options pertaining to TPROXY mode
 	// when enabled.
-	TransparentProxy TransparentProxyClusterConfig `alias:"transparent_proxy"`
+	TransparentProxy TransparentProxyMeshConfig `alias:"transparent_proxy"`
 
 	Meta           map[string]string `json:",omitempty"`
 	EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 	RaftIndex
 }
 
-// TransparentProxyClusterConfig contains cluster-wide options pertaining to
+// TransparentProxyMeshConfig contains cluster-wide options pertaining to
 // TPROXY mode when enabled.
-type TransparentProxyClusterConfig struct {
+type TransparentProxyMeshConfig struct {
 	// CatalogDestinationsOnly can be used to disable the pass-through that
 	// allows traffic to destinations outside of the mesh.
 	CatalogDestinationsOnly bool `alias:"catalog_destinations_only"`
 }
 
-func (e *ClusterConfigEntry) GetKind() string {
-	return ClusterConfig
+func (e *MeshConfigEntry) GetKind() string {
+	return MeshConfig
 }
 
-func (e *ClusterConfigEntry) GetName() string {
+func (e *MeshConfigEntry) GetName() string {
 	if e == nil {
 		return ""
 	}
@@ -39,33 +39,33 @@ func (e *ClusterConfigEntry) GetName() string {
 	return e.Name
 }
 
-func (e *ClusterConfigEntry) GetMeta() map[string]string {
+func (e *MeshConfigEntry) GetMeta() map[string]string {
 	if e == nil {
 		return nil
 	}
 	return e.Meta
 }
 
-func (e *ClusterConfigEntry) Normalize() error {
+func (e *MeshConfigEntry) Normalize() error {
 	if e == nil {
 		return fmt.Errorf("config entry is nil")
 	}
 
-	e.Kind = ClusterConfig
-	e.Name = ClusterConfigCluster
+	e.Kind = MeshConfig
+	e.Name = MeshConfigMesh
 
 	e.EnterpriseMeta.Normalize()
 
 	return nil
 }
 
-func (e *ClusterConfigEntry) Validate() error {
+func (e *MeshConfigEntry) Validate() error {
 	if e == nil {
 		return fmt.Errorf("config entry is nil")
 	}
 
-	if e.Name != ClusterConfigCluster {
-		return fmt.Errorf("invalid name (%q), only %q is supported", e.Name, ClusterConfigCluster)
+	if e.Name != MeshConfigMesh {
+		return fmt.Errorf("invalid name (%q), only %q is supported", e.Name, MeshConfigMesh)
 	}
 
 	if err := validateConfigEntryMeta(e.Meta); err != nil {
@@ -75,17 +75,17 @@ func (e *ClusterConfigEntry) Validate() error {
 	return e.validateEnterpriseMeta()
 }
 
-func (e *ClusterConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *MeshConfigEntry) CanRead(authz acl.Authorizer) bool {
 	return true
 }
 
-func (e *ClusterConfigEntry) CanWrite(authz acl.Authorizer) bool {
+func (e *MeshConfigEntry) CanWrite(authz acl.Authorizer) bool {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
 	return authz.OperatorWrite(&authzContext) == acl.Allow
 }
 
-func (e *ClusterConfigEntry) GetRaftIndex() *RaftIndex {
+func (e *MeshConfigEntry) GetRaftIndex() *RaftIndex {
 	if e == nil {
 		return &RaftIndex{}
 	}
@@ -93,7 +93,7 @@ func (e *ClusterConfigEntry) GetRaftIndex() *RaftIndex {
 	return &e.RaftIndex
 }
 
-func (e *ClusterConfigEntry) GetEnterpriseMeta() *EnterpriseMeta {
+func (e *MeshConfigEntry) GetEnterpriseMeta() *EnterpriseMeta {
 	if e == nil {
 		return nil
 	}

--- a/agent/structs/config_entry_cluster_oss.go
+++ b/agent/structs/config_entry_cluster_oss.go
@@ -2,6 +2,6 @@
 
 package structs
 
-func (e *ClusterConfigEntry) validateEnterpriseMeta() error {
+func (e *MeshConfigEntry) validateEnterpriseMeta() error {
 	return nil
 }

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1307,10 +1307,10 @@ func TestDecodeConfigEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "cluster",
+			name: "mesh",
 			snake: `
-				kind = "cluster"
-				name = "cluster"
+				kind = "mesh"
+				name = "mesh"
 				meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -1320,8 +1320,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 				}
 			`,
 			camel: `
-				Kind = "cluster"
-				Name = "cluster"
+				Kind = "mesh"
+				Name = "mesh"
 				Meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -1330,14 +1330,14 @@ func TestDecodeConfigEntry(t *testing.T) {
 					CatalogDestinationsOnly = true
 				}
 			`,
-			expect: &ClusterConfigEntry{
-				Kind: "cluster",
-				Name: "cluster",
+			expect: &MeshConfigEntry{
+				Kind: MeshConfig,
+				Name: MeshConfigMesh,
 				Meta: map[string]string{
 					"foo": "bar",
 					"gir": "zim",
 				},
-				TransparentProxy: TransparentProxyClusterConfig{
+				TransparentProxy: TransparentProxyMeshConfig{
 					CatalogDestinationsOnly: true,
 				},
 			},

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -59,8 +59,8 @@ func (s *Server) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnapsh
 	// In transparent proxy mode there needs to be a passthrough cluster for traffic going to destinations
 	// that aren't in Consul's catalog.
 	if cfgSnap.Proxy.Mode == structs.ProxyModeTransparent &&
-		cfgSnap.ConnectProxy.ClusterConfig != nil &&
-		!cfgSnap.ConnectProxy.ClusterConfig.TransparentProxy.CatalogDestinationsOnly {
+		cfgSnap.ConnectProxy.MeshConfig != nil &&
+		!cfgSnap.ConnectProxy.MeshConfig.TransparentProxy.CatalogDestinationsOnly {
 
 		clusters = append(clusters, &envoy_cluster_v3.Cluster{
 			Name: OriginalDestinationClusterName,

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -631,9 +631,9 @@ func TestClustersFromSnapshot(t *testing.T) {
 			setup: func(snap *proxycfg.ConfigSnapshot) {
 				snap.Proxy.Mode = structs.ProxyModeTransparent
 
-				snap.ConnectProxy.ClusterConfigSet = true
-				snap.ConnectProxy.ClusterConfig = &structs.ClusterConfigEntry{
-					TransparentProxy: structs.TransparentProxyClusterConfig{
+				snap.ConnectProxy.MeshConfigSet = true
+				snap.ConnectProxy.MeshConfig = &structs.MeshConfigEntry{
+					TransparentProxy: structs.TransparentProxyMeshConfig{
 						CatalogDestinationsOnly: false,
 					},
 				}

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -218,8 +218,8 @@ func (s *Server) listenersFromSnapshotConnectProxy(cInfo connectionInfo, cfgSnap
 		})
 
 		// Add a catch-all filter chain that acts as a TCP proxy to non-catalog destinations
-		if cfgSnap.ConnectProxy.ClusterConfig == nil ||
-			!cfgSnap.ConnectProxy.ClusterConfig.TransparentProxy.CatalogDestinationsOnly {
+		if cfgSnap.ConnectProxy.MeshConfig == nil ||
+			!cfgSnap.ConnectProxy.MeshConfig.TransparentProxy.CatalogDestinationsOnly {
 
 			filterChain, err := s.makeUpstreamFilterChainForDiscoveryChain(
 				"passthrough",

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -483,7 +483,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			setup: func(snap *proxycfg.ConfigSnapshot) {
 				snap.Proxy.Mode = structs.ProxyModeTransparent
 
-				snap.ConnectProxy.ClusterConfigSet = true
+				snap.ConnectProxy.MeshConfigSet = true
 
 				// DiscoveryChain without an UpstreamConfig should yield a filter chain when in transparent proxy mode
 				snap.ConnectProxy.DiscoveryChain["google"] = discoverychain.TestCompileConfigEntries(
@@ -516,11 +516,11 @@ func TestListenersFromSnapshot(t *testing.T) {
 			setup: func(snap *proxycfg.ConfigSnapshot) {
 				snap.Proxy.Mode = structs.ProxyModeTransparent
 
-				snap.ConnectProxy.ClusterConfigSet = true
-				snap.ConnectProxy.ClusterConfig = &structs.ClusterConfigEntry{
-					Kind: structs.ClusterConfig,
-					Name: structs.ClusterConfigCluster,
-					TransparentProxy: structs.TransparentProxyClusterConfig{
+				snap.ConnectProxy.MeshConfigSet = true
+				snap.ConnectProxy.MeshConfig = &structs.MeshConfigEntry{
+					Kind: structs.MeshConfig,
+					Name: structs.MeshConfigMesh,
+					TransparentProxy: structs.TransparentProxyMeshConfig{
 						CatalogDestinationsOnly: true,
 					},
 				}

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -21,10 +21,10 @@ const (
 	IngressGateway     string = "ingress-gateway"
 	TerminatingGateway string = "terminating-gateway"
 	ServiceIntentions  string = "service-intentions"
-	ClusterConfig      string = "cluster"
+	MeshConfig         string = "mesh"
 
-	ProxyConfigGlobal    string = "global"
-	ClusterConfigCluster string = "cluster"
+	ProxyConfigGlobal string = "global"
+	MeshConfigMesh    string = "mesh"
 )
 
 type ConfigEntry interface {
@@ -294,8 +294,8 @@ func makeConfigEntry(kind, name string) (ConfigEntry, error) {
 		return &TerminatingGatewayConfigEntry{Kind: kind, Name: name}, nil
 	case ServiceIntentions:
 		return &ServiceIntentionsConfigEntry{Kind: kind, Name: name}, nil
-	case ClusterConfig:
-		return &ClusterConfigEntry{Kind: kind, Name: name}, nil
+	case MeshConfig:
+		return &MeshConfigEntry{Kind: kind, Name: name}, nil
 	default:
 		return nil, fmt.Errorf("invalid config entry kind: %s", kind)
 	}

--- a/api/config_entry_cluster.go
+++ b/api/config_entry_cluster.go
@@ -1,39 +1,39 @@
 package api
 
-type ClusterConfigEntry struct {
+type MeshConfigEntry struct {
 	Kind             string
 	Name             string
-	Namespace        string                        `json:",omitempty"`
-	TransparentProxy TransparentProxyClusterConfig `alias:"transparent_proxy"`
-	Meta             map[string]string             `json:",omitempty"`
+	Namespace        string                     `json:",omitempty"`
+	TransparentProxy TransparentProxyMeshConfig `alias:"transparent_proxy"`
+	Meta             map[string]string          `json:",omitempty"`
 	CreateIndex      uint64
 	ModifyIndex      uint64
 }
 
-type TransparentProxyClusterConfig struct {
+type TransparentProxyMeshConfig struct {
 	CatalogDestinationsOnly bool `alias:"catalog_destinations_only"`
 }
 
-func (e *ClusterConfigEntry) GetKind() string {
+func (e *MeshConfigEntry) GetKind() string {
 	return e.Kind
 }
 
-func (e *ClusterConfigEntry) GetName() string {
+func (e *MeshConfigEntry) GetName() string {
 	return e.Name
 }
 
-func (e *ClusterConfigEntry) GetNamespace() string {
+func (e *MeshConfigEntry) GetNamespace() string {
 	return e.Namespace
 }
 
-func (e *ClusterConfigEntry) GetMeta() map[string]string {
+func (e *MeshConfigEntry) GetMeta() map[string]string {
 	return e.Meta
 }
 
-func (e *ClusterConfigEntry) GetCreateIndex() uint64 {
+func (e *MeshConfigEntry) GetCreateIndex() uint64 {
 	return e.CreateIndex
 }
 
-func (e *ClusterConfigEntry) GetModifyIndex() uint64 {
+func (e *MeshConfigEntry) GetModifyIndex() uint64 {
 	return e.ModifyIndex
 }

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -1137,11 +1137,11 @@ func TestDecodeConfigEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "cluster",
+			name: "mesh",
 			body: `
 			{
-				"Kind": "cluster",
-				"Name": "cluster",
+				"Kind": "mesh",
+				"Name": "mesh",
 				"Meta" : {
 					"foo": "bar",
 					"gir": "zim"
@@ -1151,14 +1151,14 @@ func TestDecodeConfigEntry(t *testing.T) {
 				}
 			}
 			`,
-			expect: &ClusterConfigEntry{
-				Kind: "cluster",
-				Name: "cluster",
+			expect: &MeshConfigEntry{
+				Kind: "mesh",
+				Name: "mesh",
 				Meta: map[string]string{
 					"foo": "bar",
 					"gir": "zim",
 				},
-				TransparentProxy: TransparentProxyClusterConfig{
+				TransparentProxy: TransparentProxyMeshConfig{
 					CatalogDestinationsOnly: true,
 				},
 			},

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -2624,10 +2624,10 @@ func TestParseConfigEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "cluster",
+			name: "mesh",
 			snake: `
-				kind = "cluster"
-				name = "cluster"
+				kind = "mesh"
+				name = "mesh"
 				meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -2637,8 +2637,8 @@ func TestParseConfigEntry(t *testing.T) {
 				}
 			`,
 			camel: `
-				Kind = "cluster"
-				Name = "cluster"
+				Kind = "mesh"
+				Name = "mesh"
 				Meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -2649,8 +2649,8 @@ func TestParseConfigEntry(t *testing.T) {
 			`,
 			snakeJSON: `
 			{
-				"kind": "cluster",
-				"name": "cluster",
+				"kind": "mesh",
+				"name": "mesh",
 				"meta" : {
 					"foo": "bar",
 					"gir": "zim"
@@ -2662,8 +2662,8 @@ func TestParseConfigEntry(t *testing.T) {
 			`,
 			camelJSON: `
 			{
-				"Kind": "cluster",
-				"Name": "cluster",
+				"Kind": "mesh",
+				"Name": "mesh",
 				"Meta" : {
 					"foo": "bar",
 					"gir": "zim"
@@ -2673,14 +2673,14 @@ func TestParseConfigEntry(t *testing.T) {
 				}
 			}
 			`,
-			expect: &api.ClusterConfigEntry{
-				Kind: "cluster",
-				Name: "cluster",
+			expect: &api.MeshConfigEntry{
+				Kind: api.MeshConfig,
+				Name: api.MeshConfigMesh,
 				Meta: map[string]string{
 					"foo": "bar",
 					"gir": "zim",
 				},
-				TransparentProxy: api.TransparentProxyClusterConfig{
+				TransparentProxy: api.TransparentProxyMeshConfig{
 					CatalogDestinationsOnly: true,
 				},
 			},

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -1,18 +1,18 @@
 ---
 layout: docs
-page_title: 'Configuration Entry Kind: Cluster'
+page_title: 'Configuration Entry Kind: Mesh'
 description: >-
-  The cluster config entry kind allows for globally defining default
+  The mesh config entry kind allows for globally defining default
   configuration across all services mesh proxies.
   Settings in this config entry apply across all namespaces and federated datacenters.
-  Currently, only one cluster entry is supported.
+  Currently, only one mesh entry is supported.
 ---
 
-# Cluster <sup>Beta</sup>
+# Mesh <sup>Beta</sup>
 
 -> **v1.10.0+:** This config entry is supported in Consul versions 1.10.0+.
 
-The `cluster` config entry kind allows for globally defining
+The `mesh` config entry kind allows for globally defining
 default configuration that applies to all service mesh proxies.
 Settings in this config entry apply across all namespaces and federated datacenters.
 
@@ -24,8 +24,9 @@ Settings in this config entry apply across all namespaces and federated datacent
 <Tab heading="HCL">
 
 ```hcl
-Kind      = "cluster"
-Name      = "cluster"
+Kind      = "mesh"
+Name      = "mesh"
+
 TransparentProxy {
   CatalogDestinationsOnly = true
 }
@@ -34,13 +35,14 @@ TransparentProxy {
 </Tab>
 <Tab heading="HCL (Consul Enterprise)">
 
-**NOTE:** The `cluster` config entry can only be created in the `default`
+**NOTE:** The `mesh` config entry can only be created in the `default`
 namespace and it will apply to proxies across **all** namespaces.
 
 ```hcl
-Kind      = "cluster"
-Name      = "cluster"
+Kind      = "mesh"
+Name      = "mesh"
 Namespace = "default" # Can only be set to "default".
+
 TransparentProxy {
   CatalogDestinationsOnly = true
 }
@@ -51,9 +53,9 @@ TransparentProxy {
 
 ## Available Fields
 
-- `Kind` - Must be set to `cluster`
+- `Kind` - Must be set to `mesh`
 
-- `Name` `(string: <required>)` - Must be set to `cluster`
+- `Name` `(string: <required>)` - Must be set to `mesh`
 
 - `Namespace` `(string: "default")` <EnterpriseAlert inline /> - Specifies the namespace the config entry will apply to.
   Must be set to `default`
@@ -71,7 +73,7 @@ TransparentProxy {
 
 Configuration entries may be protected by [ACLs](/docs/security/acl).
 
-Reading a `cluster` config entry requires no specific privileges.
+Reading a `mesh` config entry requires no specific privileges.
 
-Creating, updating, or deleting a `cluster` config entry requires
+Creating, updating, or deleting a `mesh` config entry requires
 `operator:write`.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -142,12 +142,12 @@
             "path": "connect/config-entries"
           },
           {
-            "title": "Cluster",
-            "path": "connect/config-entries/cluster"
-          },
-          {
             "title": "Ingress Gateway",
             "path": "connect/config-entries/ingress-gateway"
+          },
+          {
+            "title": "Mesh",
+            "path": "connect/config-entries/mesh"
           },
           {
             "title": "Proxy Defaults",


### PR DESCRIPTION
This config entry is being renamed primarily because in k8s the name
cluster could be confusing given that the config entry applies across
federated datacenters.

Additionally, this config entry will only apply to Consul as a service
mesh, so the more generic "cluster" name is not needed.