### PR TITLE
ui: Update not-defined intention popover and banner

### DIFF
--- a/.changelog/10133.txt
+++ b/.changelog/10133.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Updating the wording for the banner and the popover for a service with an upstream that is not explicitly defined.
+```

--- a/ui/packages/consul-ui/app/components/topology-metrics/down-lines/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/down-lines/index.hbs
@@ -93,6 +93,7 @@
   {{else if (and item.Intention.Allowed (not item.TransparentProxy) (eq item.Source 'specific-intention'))}}
     <TopologyMetrics::Popover
       @type='not-defined'
+      @service={{@service}}
       @position={{find-by 'id' (concat this.guid item.Namespace item.Name) this.iconPositions}}
       @item={{item}}
       @oncreate={{action @oncreate item @service}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/popover/index.hbs
@@ -59,7 +59,7 @@
     </:header>
     <:body>
       <p>
-        {{t "components.consul.topology-metrics.popover.not-defined.body"}}
+        {{t "components.consul.topology-metrics.popover.not-defined.body" downstream=@item.Name upstream=@service.Name }}
       </p>
     </:body>
     <:actions as |Actions|>

--- a/ui/packages/consul-ui/translations/components/consul/en-us.yaml
+++ b/ui/packages/consul-ui/translations/components/consul/en-us.yaml
@@ -126,7 +126,7 @@ topology-metrics:
         URL: dc.services.show.intentions
     not-defined-intention:
       header: Connections are not explicitly defined
-      body: There appears to be an Intention defining traffic, but the services are unable to communicate until that connection is explicitly defined as a downstream or Transparent Proxy mode is turned on.
+      body: There appears to be an Intention allowing traffic, but the services are unable to communicate until that connection is enabled by defining an explicit upstream or proxies are set to 'transparent' mode.
       footer: Read the documentation
     wildcard-intention:
       header: Permissive Intention
@@ -149,5 +149,5 @@ topology-metrics:
         notExact: Create
     not-defined:
       header: No traffic
-      body: Add the current service as an explicit upstream or turn on Transparent Proxy mode to initiate traffic.
+      body: Add "{upstream}" as an explicit upstream of "{downstream}" or set the "{downstream}" proxy to "transparent" mode to enable traffic.
       action: Documentation


### PR DESCRIPTION
Update the wording for the banner and the popover for a service with an upstream that is not explicitly defined. 

Before
<img width="1405" alt="Screen Shot 2021-04-27 at 2 41 58 PM" src="https://user-images.githubusercontent.com/19161242/116295760-6dc48d80-a767-11eb-902b-d7e9a03e7e50.png">

After
<img width="1430" alt="Screen Shot 2021-04-27 at 2 42 42 PM" src="https://user-images.githubusercontent.com/19161242/116295792-76b55f00-a767-11eb-816d-48631a50270d.png">
