### PR TITLE
connect/proxy: fix a few problems with tests

### DIFF
--- a/connect/proxy/config_test.go
+++ b/connect/proxy/config_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestUpstreamResolverFuncFromClient(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name string
 		cfg  UpstreamConfig

--- a/connect/proxy/conn_test.go
+++ b/connect/proxy/conn_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 
 // Assert io.Closer implementation
@@ -65,8 +66,6 @@ func testConnPipelineSetup(t *testing.T) (net.Conn, net.Conn, *Conn, func()) {
 }
 
 func TestConn(t *testing.T) {
-	t.Parallel()
-
 	src, dst, c, stop := testConnPipelineSetup(t)
 	defer stop()
 
@@ -124,8 +123,6 @@ func TestConn(t *testing.T) {
 }
 
 func TestConnSrcClosing(t *testing.T) {
-	t.Parallel()
-
 	src, dst, c, stop := testConnPipelineSetup(t)
 	defer stop()
 
@@ -164,8 +161,6 @@ func TestConnSrcClosing(t *testing.T) {
 }
 
 func TestConnDstClosing(t *testing.T) {
-	t.Parallel()
-
 	src, dst, c, stop := testConnPipelineSetup(t)
 	defer stop()
 


### PR DESCRIPTION
We noticed that `TestUpstreamListener` would deadlock sometimes when run
with the race detector ([example](https://app.circleci.com/pipelines/github/hashicorp/consul/18113/workflows/d9d32c2f-9adb-4171-8957-734f50786d70/jobs/358395/tests)). While debugging this issue I found and fixed the
following problems.

1. the net.Listener was not being closed properly when Listener.Stop was
   called. This caused the Listener.Serve goroutine to run forever.
   Fixed by storing a reference to net.Listener and closing it properly
   when Listener.Stop is called.
2. call connWG.Add in the correct place. WaitGroup.Add must be called
   before starting a goroutine, not from inside the goroutine.
3. Set metrics config EnableRuntimeMetrics to `false` so that we don't
   start a background goroutine in each test for no reason. There is no
   way to shutdown this goroutine, and it was an added distraction while
   debugging these timeouts.
5. two tests were calling require.NoError from a goroutine.
   require.NoError calls t.FailNow, which MUST be called from the main
   test goroutine. Instead use t.Errorf, which can be called from other
   goroutines and will still fail the test.
6. `assertCurrentGaugeValue` was breaking out of a for loop, which
   would cause the `RWMutex.RUnlock` to be missed. Fixed by calling
   unlock before `break`.

The core issue of a deadlock  was fixed by armon/go-metrics#124. If that merges soon I will include the vendor update in this PR.