### PR TITLE
ui: Remove extra nspace value from service upstreams

### DIFF
--- a/.changelog/10152.txt
+++ b/.changelog/10152.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Removes the extra rendering of namespace in service upstream list
+```

--- a/ui/packages/consul-ui/app/components/consul/upstream/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream/list/index.hbs
@@ -25,7 +25,6 @@ as |item index|>
       </dd>
     </dl>
     {{#if (and (env 'CONSUL_NSPACES_ENABLED') (not-eq item.Namespace @nspace))}}
-    {{item.Namespace}}
       <a data-test-service-name href={{href-to 'nspace.dc.services.show' (concat '~' item.Namespace) @dc item.Name }}>
         {{item.Name}}
       </a>


### PR DESCRIPTION
Previous to this the namespace was being prefixed to the gateways name (bug introduced in https://github.com/hashicorp/consul/pull/9282).

Before:

<img width="600" alt="Screenshot 2021-04-29 at 14 10 01" src="https://user-images.githubusercontent.com/19161242/115259210-acbb6900-a0ff-11eb-884d-d5a6070a6c96.png">

After:

<img width="600" alt="Screenshot 2021-04-29 at 14 10 01" src="https://user-images.githubusercontent.com/554604/116555758-a5147500-a8f4-11eb-9a15-4a7b5cede726.png">
