### PR TITLE
config-entry: remove Kind and Name field from Mesh config entry

### DIFF
--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4157,7 +4157,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 					"bootstrap": [
 						{
 							"kind": "mesh",
-							"name": "mesh",
 							"meta" : {
 								"foo": "bar",
 								"gir": "zim"
@@ -4174,7 +4173,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 				config_entries {
 				  bootstrap {
 					kind = "mesh"
-					name = "mesh"
 					meta {
 						"foo" = "bar"
 						"gir" = "zim"
@@ -4190,8 +4188,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.DataDir = dataDir
 			rt.ConfigEntryBootstrap = []structs.ConfigEntry{
 				&structs.MeshConfigEntry{
-					Kind: structs.MeshConfig,
-					Name: structs.MeshConfigMesh,
 					Meta: map[string]string{
 						"foo": "bar",
 						"gir": "zim",
@@ -4212,7 +4208,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 					"bootstrap": [
 						{
 							"Kind": "mesh",
-							"Name": "mesh",
 							"Meta" : {
 								"foo": "bar",
 								"gir": "zim"
@@ -4229,7 +4224,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 				config_entries {
 				  bootstrap {
 					Kind = "mesh"
-					Name = "mesh"
 					Meta {
 						"foo" = "bar"
 						"gir" = "zim"
@@ -4245,8 +4239,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.DataDir = dataDir
 			rt.ConfigEntryBootstrap = []structs.ConfigEntry{
 				&structs.MeshConfigEntry{
-					Kind: structs.MeshConfig,
-					Name: structs.MeshConfigMesh,
 					Meta: map[string]string{
 						"foo": "bar",
 						"gir": "zim",

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -162,8 +162,10 @@ func (c *ConfigEntry) List(args *structs.ConfigEntryQuery, reply *structs.Indexe
 		return err
 	}
 
-	if args.Kind != "" && !structs.ValidateConfigEntryKind(args.Kind) {
-		return fmt.Errorf("invalid config entry kind: %s", args.Kind)
+	if args.Kind != "" {
+		if _, err := structs.MakeConfigEntry(args.Kind, ""); err != nil {
+			return fmt.Errorf("invalid config entry kind: %s", args.Kind)
+		}
 	}
 
 	return c.srv.blockingQuery(

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -428,8 +428,6 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 
 	// mesh config entry
 	meshConfig := &structs.MeshConfigEntry{
-		Kind: structs.MeshConfig,
-		Name: structs.MeshConfigMesh,
 		TransparentProxy: structs.TransparentProxyMeshConfig{
 			CatalogDestinationsOnly: true,
 		},

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -1674,8 +1674,6 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							CorrelationID: meshConfigEntryID,
 							Result: &structs.ConfigEntryResponse{
 								Entry: &structs.MeshConfigEntry{
-									Kind:             structs.MeshConfig,
-									Name:             structs.MeshConfigMesh,
 									TransparentProxy: structs.TransparentProxyMeshConfig{},
 								},
 							},

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -529,7 +529,7 @@ func MakeConfigEntry(kind, name string) (ConfigEntry, error) {
 	case ServiceIntentions:
 		return &ServiceIntentionsConfigEntry{Name: name}, nil
 	case MeshConfig:
-		return &MeshConfigEntry{Name: name}, nil
+		return &MeshConfigEntry{}, nil
 	default:
 		return nil, fmt.Errorf("invalid config entry kind: %s", kind)
 	}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -535,21 +535,6 @@ func MakeConfigEntry(kind, name string) (ConfigEntry, error) {
 	}
 }
 
-func ValidateConfigEntryKind(kind string) bool {
-	switch kind {
-	case ServiceDefaults, ProxyDefaults:
-		return true
-	case ServiceRouter, ServiceSplitter, ServiceResolver:
-		return true
-	case IngressGateway, TerminatingGateway:
-		return true
-	case ServiceIntentions:
-		return true
-	default:
-		return false
-	}
-}
-
 // ConfigEntryQuery is used when requesting info about a config entry.
 type ConfigEntryQuery struct {
 	Kind       string

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -7,9 +7,6 @@ import (
 )
 
 type MeshConfigEntry struct {
-	Kind string
-	Name string
-
 	// TransparentProxy contains cluster-wide options pertaining to TPROXY mode
 	// when enabled.
 	TransparentProxy TransparentProxyMeshConfig `alias:"transparent_proxy"`
@@ -36,7 +33,7 @@ func (e *MeshConfigEntry) GetName() string {
 		return ""
 	}
 
-	return e.Name
+	return MeshConfigMesh
 }
 
 func (e *MeshConfigEntry) GetMeta() map[string]string {
@@ -51,11 +48,7 @@ func (e *MeshConfigEntry) Normalize() error {
 		return fmt.Errorf("config entry is nil")
 	}
 
-	e.Kind = MeshConfig
-	e.Name = MeshConfigMesh
-
 	e.EnterpriseMeta.Normalize()
-
 	return nil
 }
 
@@ -63,11 +56,6 @@ func (e *MeshConfigEntry) Validate() error {
 	if e == nil {
 		return fmt.Errorf("config entry is nil")
 	}
-
-	if e.Name != MeshConfigMesh {
-		return fmt.Errorf("invalid name (%q), only %q is supported", e.Name, MeshConfigMesh)
-	}
-
 	if err := validateConfigEntryMeta(e.Meta); err != nil {
 		return err
 	}

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -1,6 +1,7 @@
 package structs
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/consul/acl"
@@ -87,4 +88,20 @@ func (e *MeshConfigEntry) GetEnterpriseMeta() *EnterpriseMeta {
 	}
 
 	return &e.EnterpriseMeta
+}
+
+// MarshalJSON adds the Kind field so that the JSON can be decoded back into the
+// correct type.
+// This method is implemented on the structs type (as apposed to the api type)
+// because that is what the API currently uses to return a response.
+func (e *MeshConfigEntry) MarshalJSON() ([]byte, error) {
+	type Alias MeshConfigEntry
+	source := &struct {
+		Kind string
+		*Alias
+	}{
+		Kind:  MeshConfig,
+		Alias: (*Alias)(e),
+	}
+	return json.Marshal(source)
 }

--- a/agent/structs/config_entry_oss.go
+++ b/agent/structs/config_entry_oss.go
@@ -19,6 +19,9 @@ func validateUnusedKeys(unused []string) error {
 	for _, k := range unused {
 		switch {
 		case k == "CreateIndex" || k == "ModifyIndex":
+		case k == "kind" || k == "Kind":
+			// The kind field is used to determine the target, but doesn't need
+			// to exist on the target.
 		case strings.HasSuffix(strings.ToLower(k), "namespace"):
 			err = multierror.Append(err, fmt.Errorf("invalid config key %q, namespaces are a consul enterprise feature", k))
 		default:

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1310,7 +1310,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 			name: "mesh",
 			snake: `
 				kind = "mesh"
-				name = "mesh"
 				meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -1321,7 +1320,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 			`,
 			camel: `
 				Kind = "mesh"
-				Name = "mesh"
 				Meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -1331,8 +1329,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 				}
 			`,
 			expect: &MeshConfigEntry{
-				Kind: MeshConfig,
-				Name: MeshConfigMesh,
 				Meta: map[string]string{
 					"foo": "bar",
 					"gir": "zim",

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -519,8 +519,6 @@ func TestListenersFromSnapshot(t *testing.T) {
 
 				snap.ConnectProxy.MeshConfigSet = true
 				snap.ConnectProxy.MeshConfig = &structs.MeshConfigEntry{
-					Kind: structs.MeshConfig,
-					Name: structs.MeshConfigMesh,
 					TransparentProxy: structs.TransparentProxyMeshConfig{
 						CatalogDestinationsOnly: true,
 					},

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -295,7 +295,7 @@ func makeConfigEntry(kind, name string) (ConfigEntry, error) {
 	case ServiceIntentions:
 		return &ServiceIntentionsConfigEntry{Kind: kind, Name: name}, nil
 	case MeshConfig:
-		return &MeshConfigEntry{Kind: kind, Name: name}, nil
+		return &MeshConfigEntry{}, nil
 	default:
 		return nil, fmt.Errorf("invalid config entry kind: %s", kind)
 	}

--- a/api/config_entry_cluster.go
+++ b/api/config_entry_cluster.go
@@ -1,7 +1,8 @@
 package api
 
+import "encoding/json"
+
 type MeshConfigEntry struct {
-	Name             string
 	Namespace        string                     `json:",omitempty"`
 	TransparentProxy TransparentProxyMeshConfig `alias:"transparent_proxy"`
 	Meta             map[string]string          `json:",omitempty"`
@@ -35,4 +36,18 @@ func (e *MeshConfigEntry) GetCreateIndex() uint64 {
 
 func (e *MeshConfigEntry) GetModifyIndex() uint64 {
 	return e.ModifyIndex
+}
+
+// MarshalJSON adds the Kind field so that the JSON can be decoded back into the
+// correct type.
+func (e *MeshConfigEntry) MarshalJSON() ([]byte, error) {
+	type Alias MeshConfigEntry
+	source := &struct {
+		Kind string
+		*Alias
+	}{
+		Kind:  MeshConfig,
+		Alias: (*Alias)(e),
+	}
+	return json.Marshal(source)
 }

--- a/api/config_entry_cluster.go
+++ b/api/config_entry_cluster.go
@@ -1,7 +1,6 @@
 package api
 
 type MeshConfigEntry struct {
-	Kind             string
 	Name             string
 	Namespace        string                     `json:",omitempty"`
 	TransparentProxy TransparentProxyMeshConfig `alias:"transparent_proxy"`
@@ -15,11 +14,11 @@ type TransparentProxyMeshConfig struct {
 }
 
 func (e *MeshConfigEntry) GetKind() string {
-	return e.Kind
+	return MeshConfig
 }
 
 func (e *MeshConfigEntry) GetName() string {
-	return e.Name
+	return MeshConfigMesh
 }
 
 func (e *MeshConfigEntry) GetNamespace() string {

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -196,6 +196,64 @@ func TestAPI_ConfigEntries(t *testing.T) {
 		_, _, err = config_entries.Get(ServiceDefaults, "foo", nil)
 		require.Error(t, err)
 	})
+
+	t.Run("Mesh", func(t *testing.T) {
+		mesh := &MeshConfigEntry{
+			TransparentProxy: TransparentProxyMeshConfig{CatalogDestinationsOnly: true},
+			Meta: map[string]string{
+				"foo": "bar",
+				"gir": "zim",
+			},
+		}
+		ce := c.ConfigEntries()
+
+		runStep(t, "set and get", func(t *testing.T) {
+			_, wm, err := ce.Set(mesh, nil)
+			require.NoError(t, err)
+			require.NotNil(t, wm)
+			require.NotEqual(t, 0, wm.RequestTime)
+
+			entry, qm, err := ce.Get(MeshConfig, MeshConfigMesh, nil)
+			require.NoError(t, err)
+			require.NotNil(t, qm)
+			require.NotEqual(t, 0, qm.RequestTime)
+
+			result, ok := entry.(*MeshConfigEntry)
+			require.True(t, ok)
+
+			// ignore indexes
+			result.CreateIndex = 0
+			result.ModifyIndex = 0
+			require.Equal(t, mesh, result)
+		})
+
+		runStep(t, "list", func(t *testing.T) {
+			entries, qm, err := ce.List(MeshConfig, nil)
+			require.NoError(t, err)
+			require.NotNil(t, qm)
+			require.NotEqual(t, 0, qm.RequestTime)
+			require.Len(t, entries, 1)
+		})
+
+		runStep(t, "delete", func(t *testing.T) {
+			wm, err := ce.Delete(MeshConfig, MeshConfigMesh, nil)
+			require.NoError(t, err)
+			require.NotNil(t, wm)
+			require.NotEqual(t, 0, wm.RequestTime)
+
+			// verify deletion
+			_, _, err = ce.Get(MeshConfig, MeshConfigMesh, nil)
+			require.Error(t, err)
+		})
+	})
+
+}
+
+func runStep(t *testing.T, name string, fn func(t *testing.T)) {
+	t.Helper()
+	if !t.Run(name, fn) {
+		t.FailNow()
+	}
 }
 
 func TestDecodeConfigEntry(t *testing.T) {

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -1141,7 +1141,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 			body: `
 			{
 				"Kind": "mesh",
-				"Name": "mesh",
 				"Meta" : {
 					"foo": "bar",
 					"gir": "zim"
@@ -1152,8 +1151,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 			}
 			`,
 			expect: &MeshConfigEntry{
-				Kind: "mesh",
-				Name: "mesh",
 				Meta: map[string]string{
 					"foo": "bar",
 					"gir": "zim",

--- a/command/config/write/config_write.go
+++ b/command/config/write/config_write.go
@@ -6,13 +6,14 @@ import (
 	"io"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/mapstructure"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/hashicorp/consul/command/helpers"
 	"github.com/hashicorp/consul/lib/decode"
-	"github.com/hashicorp/go-multierror"
-	"github.com/mitchellh/cli"
-	"github.com/mitchellh/mapstructure"
 )
 
 func New(ui cli.Ui) *cmd {
@@ -155,6 +156,12 @@ func newDecodeConfigEntry(raw map[string]interface{}) (api.ConfigEntry, error) {
 	}
 
 	for _, k := range md.Unused {
+		switch k {
+		case "kind", "Kind":
+			// The kind field is used to determine the target, but doesn't need
+			// to exist on the target.
+			continue
+		}
 		err = multierror.Append(err, fmt.Errorf("invalid config key %q", k))
 	}
 	if err != nil {

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -2627,7 +2627,6 @@ func TestParseConfigEntry(t *testing.T) {
 			name: "mesh",
 			snake: `
 				kind = "mesh"
-				name = "mesh"
 				meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -2638,7 +2637,6 @@ func TestParseConfigEntry(t *testing.T) {
 			`,
 			camel: `
 				Kind = "mesh"
-				Name = "mesh"
 				Meta {
 					"foo" = "bar"
 					"gir" = "zim"
@@ -2650,7 +2648,6 @@ func TestParseConfigEntry(t *testing.T) {
 			snakeJSON: `
 			{
 				"kind": "mesh",
-				"name": "mesh",
 				"meta" : {
 					"foo": "bar",
 					"gir": "zim"
@@ -2663,7 +2660,6 @@ func TestParseConfigEntry(t *testing.T) {
 			camelJSON: `
 			{
 				"Kind": "mesh",
-				"Name": "mesh",
 				"Meta" : {
 					"foo": "bar",
 					"gir": "zim"
@@ -2674,8 +2670,6 @@ func TestParseConfigEntry(t *testing.T) {
 			}
 			`,
 			expect: &api.MeshConfigEntry{
-				Kind: api.MeshConfig,
-				Name: api.MeshConfigMesh,
 				Meta: map[string]string{
 					"foo": "bar",
 					"gir": "zim",


### PR DESCRIPTION
Related to #10067, making this change to the new config entry before it is released makes it much easier to remove these fields.

No config entry needs a Kind field. It is only used to determine the Go type to target. As we introduce new config entries (like this one) we can remove the kind field and have the `GetKind` method return the single supported value.

In this case (similar to proxy-defaults) the Name field is also unnecessary. We always use the same value. So we can omit the name field entirely. In the future if we want to support separate names, we can introduce the field in a backwards compatible way, where empty string means the old default name.

TODO:
* [x] test marshalling the value to the HTTP API. I guess with this change we no longer have a `kind` field in the output. Marshaling will need to add the kind field based on the type.