### PR TITLE
[1.8.x] remove Codecov from CI runs (#10145)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,12 +215,6 @@ jobs:
           path: *TEST_RESULTS_DIR
       - store_artifacts:
           path: *TEST_RESULTS_DIR
-      - run: &codecov_upload
-          name: codecov upload
-          when: always
-          # The -C flag shouldn't be necessary, but it fails to find the commit
-          # without it.
-          command: bash <(curl -s https://codecov.io/bash) -C "$CIRCLE_SHA1"
 
   # split off a job for the API package since it is separate
   go-test-api:
@@ -252,7 +246,6 @@ jobs:
           path: *TEST_RESULTS_DIR
       - store_artifacts:
           path: *TEST_RESULTS_DIR
-      - run: *codecov_upload
 
   # split off a job for the SDK package since it is separate
   go-test-sdk:
@@ -284,7 +277,6 @@ jobs:
           path: *TEST_RESULTS_DIR
       - store_artifacts:
           path: *TEST_RESULTS_DIR
-      - run: *codecov_upload
 
   # build all distros
   build-distros: &build-distros
@@ -648,10 +640,6 @@ jobs:
       - run:
           working_directory: ui-v2
           command: make test-coverage-ci
-      - run:
-          name: codecov ui upload
-          working_directory: ui-v2
-          command: bash <(curl -s https://codecov.io/bash) -v -c -C $CIRCLE_SHA1 -F ui
 
   envoy-integration-test-1_11_2:
     docker:
@@ -730,7 +718,6 @@ jobs:
             make test-connect-ca-providers
       - store_test_results:
           path: *TEST_RESULTS_DIR
-      - run: *codecov_upload
 
   # only runs on master: checks latest commit to see if the PR associated has a backport/* or docs* label to cherry-pick
   cherry-picker:


### PR DESCRIPTION
manual backport of https://github.com/hashicorp/consul/pull/10145 to 1.8.x