### PR TITLE
ui: Fix nspace spacing issue

### DIFF
--- a/.changelog/10157.txt
+++ b/.changelog/10157.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Don't render a DOM element for empty namespace descriptions
+```

--- a/ui/packages/consul-ui/app/components/consul/nspace/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/nspace/list/index.hbs
@@ -14,12 +14,14 @@ as |item|>
 {{/if}}
     </BlockSlot>
     <BlockSlot @name="details">
+{{#if item.Description}}
       <dl>
         <dt>Description</dt>
         <dd data-test-description>
           {{item.Description}}
         </dd>
       </dl>
+{{/if}}
   {{#if (env 'CONSUL_ACLS_ENABLED')}}
       <Consul::Token::Ruleset::List @item={{item}} />
   {{/if}}

--- a/ui/packages/consul-ui/app/styles/components/composite-row.scss
+++ b/ui/packages/consul-ui/app/styles/components/composite-row.scss
@@ -16,13 +16,19 @@
 .consul-lock-session-list ul > li:not(:first-child) {
   @extend %with-one-action-row;
 }
-// TODO: This hides the icons-less dt's in the below lists as they don't have
+// TODO: This hides the iconless dt's in the below lists as they don't have
 // tooltips the todo would be to wrap these texts in spans
 .consul-nspace-list > ul > li:not(:first-child) dt,
 .consul-token-list > ul > li:not(:first-child) dt,
 .consul-policy-list > ul li:not(:first-child) dl:not(.datacenter) dt,
 .consul-role-list > ul > li:not(:first-child) dt {
+  @extend %iconless-dt;
+}
+%iconless-dt {
   display: none;
+}
+%iconless-dt + dd {
+  margin-left: 0 !important;
 }
 /* TODO: the service list has a 1px offset */
 .consul-policy-list dl.datacenter dt,


### PR DESCRIPTION
PRed as a potential alternative approach to https://github.com/hashicorp/consul/pull/9930. ~, therefore in draft for the moment.~

This fixes the spacing bug in nspaces only by only showing `Description` if the namespace has one, and removing the extra 2 pixel margin of `dd`s for when `dt`s aren't rendered/don't exist.

If this is approved, there is still the outstanding design question of what to do for the various mixtures of lists containing icons/no-icons/mixture of icons/no-icons. But once we've decided what we want to do there, we can PR whatever the decision is separately.

Before:

<img width="441" alt="Screenshot 2021-04-30 at 13 57 45" src="https://user-images.githubusercontent.com/19161242/115257017-b93ec200-a0fd-11eb-8bd7-9817cd550d13.png">

After:

<img width="441" alt="Screenshot 2021-04-30 at 13 57 45" src="https://user-images.githubusercontent.com/554604/116698534-63e79800-a9bc-11eb-9862-b9d742855c49.png">
