### PR TITLE
Give descriptive error if auth method not found

### DIFF
--- a/.changelog/10163.txt
+++ b/.changelog/10163.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: Give more descriptive error if auth method not found.
+```

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -2380,7 +2380,7 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLToken) erro
 	if err != nil {
 		return err
 	} else if method == nil {
-		return fmt.Errorf("auth method %q not found", auth.AuthMethod)
+		return fmt.Errorf("%w: auth method %q not found", acl.ErrNotFound, auth.AuthMethod)
 	}
 
 	if err := a.enterpriseAuthMethodTypeValidation(method.Type); err != nil {

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -2380,7 +2380,7 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLToken) erro
 	if err != nil {
 		return err
 	} else if method == nil {
-		return acl.ErrNotFound
+		return fmt.Errorf("auth method %q not found", auth.AuthMethod)
 	}
 
 	if err := a.enterpriseAuthMethodTypeValidation(method.Type); err != nil {

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -4628,7 +4628,7 @@ func TestACLEndpoint_Login(t *testing.T) {
 		}
 		resp := structs.ACLToken{}
 
-		testutil.RequireErrorContains(t, acl.Login(&req, &resp), "ACL not found")
+		testutil.RequireErrorContains(t, acl.Login(&req, &resp), fmt.Sprintf("auth method %q not found", method.Name+"-notexist"))
 	})
 
 	t.Run("invalid method token", func(t *testing.T) {

--- a/command/login/login_test.go
+++ b/command/login/login_test.go
@@ -143,7 +143,7 @@ func TestLoginCommand(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
-		require.Contains(t, ui.ErrorWriter.String(), "403 (ACL not found)")
+		require.Contains(t, ui.ErrorWriter.String(), "500 (auth method \"test\" not found)")
 	})
 
 	testSessionID := testauth.StartSession()

--- a/command/login/login_test.go
+++ b/command/login/login_test.go
@@ -143,7 +143,7 @@ func TestLoginCommand(t *testing.T) {
 
 		code := cmd.Run(args)
 		require.Equal(t, code, 1, "err: %s", ui.ErrorWriter.String())
-		require.Contains(t, ui.ErrorWriter.String(), "500 (auth method \"test\" not found)")
+		require.Contains(t, ui.ErrorWriter.String(), "403 (ACL not found: auth method \"test\" not found")
 	})
 
 	testSessionID := testauth.StartSession()


### PR DESCRIPTION
Previously during a `consul login -method=blah`, if the auth method was not found, the
error returned would be "ACL not found". This is potentially confusing
because there may be many different ACLs involved in a login: the ACL of
the Consul client, perhaps the binding rule or the auth method.

Now the error will be "auth method blah not found", which is much easier
to debug.