### PR TITLE
testing: slightly better comparison for x509.CertPool

### DIFF
--- a/connect/tls_test.go
+++ b/connect/tls_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent"
@@ -295,11 +294,11 @@ func requireEqualTLSConfig(t *testing.T, expect, got *tls.Config) {
 	require.Equal(expectLeaf, gotLeaf)
 }
 
-// lazyCerts has a func field which can't be compared.
-var cmpCertPool = cmp.Options{
-	cmpopts.IgnoreFields(x509.CertPool{}, "lazyCerts"),
-	cmp.AllowUnexported(x509.CertPool{}),
-}
+// cmpCertPool is a custom comparison for x509.CertPool, because CertPool.lazyCerts
+// has a func field which can't be compared.
+var cmpCertPool = cmp.Comparer(func(x, y *x509.CertPool) bool {
+	return cmp.Equal(x.Subjects(), y.Subjects())
+})
 
 func assertDeepEqual(t *testing.T, x, y interface{}, opts ...cmp.Option) {
 	t.Helper()


### PR DESCRIPTION
Follow up #10004 based on a suggestion in https://github.com/golang/go/issues/45891#issuecomment-830444530

Use the exported function to compare the `x509.CertPool` instead of comparing unexported fields and excluding one. This should be functionally the same (both implementations cared the Subjects, but this one is more future proof.