### PR TITLE
ci: allow cherry-picking a manual backport to other release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1123,6 +1123,7 @@ workflows:
             branches:
               only:
                 - master
+                - /release\/\d+\.\d+\.x$/
   load-test:
     when: << pipeline.parameters.trigger-load-test >>
     jobs:

--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -165,11 +165,12 @@ if echo "$resp" | jq -e '.items[].labels[] | select(.name | contains("docs-cherr
     fi
 fi
 
+git config --local user.email "github-team-consul-core@hashicorp.com"
+git config --local user.name "hc-github-team-consul-core"
+
 backport_failures=0
 # loop through all labels on the PR
 for label in $labels; do
-    git config --local user.email "github-team-consul-core@hashicorp.com"
-    git config --local user.name "hc-github-team-consul-core"
     status "checking label: $label"
     # if the label matches docs-cherrypick, it will attempt to cherry-pick to stable-website
     if [[ $label =~ docs-cherrypick ]]; then


### PR DESCRIPTION
If an automatic backport fails to more than one release branch we need to crate a PR to backport it. So far we've had to create a backport PR for each target release branch.

With this change, we may be able to create only a single PR, and then run the backport automation to cherry-pick it into other release branches.

The idea is that if a change introduced in version n-1 caused a conflict, and there are no other changes, then the backport automation should be able to use the new commit for version n-2 and n-3.