### PR TITLE
Fixup discovery chain handling in transparent mode

### DIFF
--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -1020,12 +1020,12 @@ func (s *state) resetWatchesFromChain(
 	}
 
 	var (
-		watchedChainSource bool
-		needGateways       = make(map[string]struct{})
+		watchedChainEndpoints bool
+		needGateways          = make(map[string]struct{})
 	)
 	for _, target := range chain.Targets {
 		if target.ID == chain.ID() {
-			watchedChainSource = true
+			watchedChainEndpoints = true
 		}
 
 		s.logger.Trace("initializing watch of target",
@@ -1069,7 +1069,7 @@ func (s *state) resetWatchesFromChain(
 	//
 	// Outside of transparent mode we only watch the chain target, B,
 	// since A is a virtual service and traffic will not be sent to it.
-	if !watchedChainSource && s.proxyCfg.Mode == structs.ProxyModeTransparent {
+	if !watchedChainEndpoints && s.proxyCfg.Mode == structs.ProxyModeTransparent {
 		s.logger.Trace("initializing watch of chain source",
 			"upstream", id,
 			"chain", chain.ServiceName,

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -1023,8 +1023,10 @@ func (s *state) resetWatchesFromChain(
 		watchedChainEndpoints bool
 		needGateways          = make(map[string]struct{})
 	)
+
+	chainID := chain.ID()
 	for _, target := range chain.Targets {
-		if target.ID == chain.ID() {
+		if target.ID == chainID {
 			watchedChainEndpoints = true
 		}
 

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -88,7 +88,7 @@ func (c *CompiledDiscoveryChain) IsDefault() bool {
 	return target.Service == c.ServiceName && target.Namespace == c.Namespace
 }
 
-// ID returns an ID that endoces the service, namespace, and datacenter.
+// ID returns an ID that encodes the service, namespace, and datacenter.
 // This ID allows us to compare a discovery chain target to the chain upstream itself.
 func (c *CompiledDiscoveryChain) ID() string {
 	return chainID("", c.ServiceName, c.Namespace, c.Datacenter)

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -88,6 +88,12 @@ func (c *CompiledDiscoveryChain) IsDefault() bool {
 	return target.Service == c.ServiceName && target.Namespace == c.Namespace
 }
 
+// ID returns an ID that endoces the service, namespace, and datacenter.
+// This ID allows us to compare a discovery chain target to the chain upstream itself.
+func (c *CompiledDiscoveryChain) ID() string {
+	return chainID("", c.ServiceName, c.Namespace, c.Datacenter)
+}
+
 const (
 	DiscoveryGraphNodeTypeRouter   = "router"
 	DiscoveryGraphNodeTypeSplitter = "splitter"
@@ -229,13 +235,16 @@ func NewDiscoveryTarget(service, serviceSubset, namespace, datacenter string) *D
 	return t
 }
 
-func (t *DiscoveryTarget) setID() {
+func chainID(subset, service, namespace, dc string) string {
 	// NOTE: this format is similar to the SNI syntax for simplicity
-	if t.ServiceSubset == "" {
-		t.ID = fmt.Sprintf("%s.%s.%s", t.Service, t.Namespace, t.Datacenter)
-	} else {
-		t.ID = fmt.Sprintf("%s.%s.%s.%s", t.ServiceSubset, t.Service, t.Namespace, t.Datacenter)
+	if subset == "" {
+		return fmt.Sprintf("%s.%s.%s", service, namespace, dc)
 	}
+	return fmt.Sprintf("%s.%s.%s.%s", subset, service, namespace, dc)
+}
+
+func (t *DiscoveryTarget) setID() {
+	t.ID = fmt.Sprintf("%s.%s.%s.%s", t.ServiceSubset, t.Service, t.Namespace, t.Datacenter)
 }
 
 func (t *DiscoveryTarget) String() string {

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -244,7 +244,7 @@ func chainID(subset, service, namespace, dc string) string {
 }
 
 func (t *DiscoveryTarget) setID() {
-	t.ID = fmt.Sprintf("%s.%s.%s.%s", t.ServiceSubset, t.Service, t.Namespace, t.Datacenter)
+	t.ID = chainID(t.ServiceSubset, t.Service, t.Namespace, t.Datacenter)
 }
 
 func (t *DiscoveryTarget) String() string {

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -133,6 +133,9 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			continue
 		}
 
+		// The rest of this loop is used exclusively for transparent proxies.
+		// Below we create a filter chain per upstream, rather than a listener per upstream
+		// as we do for explicit upstreams above.
 		filterChain, err := s.makeUpstreamFilterChainForDiscoveryChain(
 			id,
 			"",

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -146,18 +146,20 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			return nil, err
 		}
 
-		endpoints := cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[id]
+		endpoints := cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[id][chain.ID()]
 		uniqueAddrs := make(map[string]struct{})
 
-		for _, t := range chain.Targets {
-			// Match on the virtual IP for the upstream service.
-			// We do not match on all endpoints here since it would lead to load balancing across
-			// all instances when any instance address is dialed.
-			for _, e := range endpoints[t.ID] {
-				if vip := e.Service.TaggedAddresses[virtualIPTag]; vip.Address != "" {
-					uniqueAddrs[vip.Address] = struct{}{}
-				}
+		// Match on the virtual IP for the upstream service (identified by the chain's ID).
+		// We do not match on all endpoints here since it would lead to load balancing across
+		// all instances when any instance address is dialed.
+		for _, e := range endpoints {
+			if vip := e.Service.TaggedAddresses[virtualIPTag]; vip.Address != "" {
+				uniqueAddrs[vip.Address] = struct{}{}
 			}
+		}
+		if len(uniqueAddrs) > 1 {
+			s.Logger.Warn("detected multiple virtual IPs for an upstream, all will be used to match traffic",
+				"upstream", id)
 		}
 
 		// For every potential address we collected, create the appropriate address prefix to match on.

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -508,6 +508,22 @@ func TestListenersFromSnapshot(t *testing.T) {
 							},
 						},
 					},
+					// Other targets of the discovery chain should be ignored.
+					// We only match on the upstream's virtual IP, not the IPs of other targets.
+					"google-v2.default.dc1": {
+						structs.CheckServiceNode{
+							Node: &structs.Node{
+								Address:    "7.7.7.7",
+								Datacenter: "dc1",
+							},
+							Service: &structs.NodeService{
+								Service: "google-v2",
+								TaggedAddresses: map[string]structs.ServiceAddress{
+									"virtual": {Address: "10.10.10.10"},
+								},
+							},
+						},
+					},
 				}
 
 				// DiscoveryChains without endpoints do not get a filter chain because there are no addresses to match on.


### PR DESCRIPTION
Previously we would associate the address of a discovery chain target
with the discovery chain's filter chain. This was broken for a few reasons:

- If the upstream is a virtual service, the client proxy has no way of
dialing it because virtual services are not targets of their discovery
chains. The targets are distinct services. This is addressed by watching
the endpoints of all upstream services, not just their discovery chain
targets.

- If multiple discovery chains resolve to the same target, that would
lead to multiple filter chains attempting to match on the target's
virtual IP. This is addressed by only matching on the upstream's virtual
IP.

**NOTE:** this implementation requires an intention to the redirecting 
virtual service and not just to the final destination. This is how 
we can know that the virtual service is an upstream to watch.

A later PR will look into traversing discovery chains when computing 
upstreams so that intentions are only required to the discovery chain 
targets.

TODO:
- [x] Add proxycfg/state tests
- [x] Add xds/listeners tests

Fixes: #10053