### PR TITLE
ui: Adds ability to show a 'partial' list in list-collections

### DIFF
--- a/.changelog/10174.txt
+++ b/.changelog/10174.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Only show a partial list of intention permissions, with the option to show all
+```

--- a/ui/packages/consul-ui/app/components/consul/intention/permission/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/list/index.hbs
@@ -3,6 +3,7 @@
   class="consul-intention-permission-list{{if (not onclick) ' readonly'}}"
   @scroll="native"
   @items={{items}}
+  @partial={{5}}
 as |item|>
   <BlockSlot @name="details">
     <div onclick={{action (optional onclick) item}}>

--- a/ui/packages/consul-ui/app/components/list-collection/index.hbs
+++ b/ui/packages/consul-ui/app/components/list-collection/index.hbs
@@ -42,9 +42,10 @@
     {{~/each~}}
   </EmberNativeScrollable>
 {{else}}
+{{#let (if (and partial (not this.expand)) (slice 0 partial items) items) as |slice|}}
   <ul>
     <li style="display: none;"></li>
-    {{~#each items as |item index|~}}
+    {{~#each slice as |item index|~}}
       <li
         data-test-list-row
         onclick={{action 'click'}}
@@ -67,5 +68,22 @@
       </li>
     {{~/each~}}
   </ul>
+{{#if (and partial (gt items.length partial))}}
+  {{#let (not-eq slice.length items.length) as |more|}}
+  <button
+    class={{if more 'closed'}}
+    type="button"
+    onclick={{action (mut this.expand) more}}
+  >
+    {{#if more}}
+      View {{sub items.length slice.length}} more
+    {{else}}
+      View less
+    {{/if}}
+  </button>
+  {{/let}}
+{{/if}}
+{{/let}}
+
 {{/if}}
 </div>

--- a/ui/packages/consul-ui/app/components/list-collection/index.scss
+++ b/ui/packages/consul-ui/app/components/list-collection/index.scss
@@ -1,0 +1,11 @@
+@import './skin';
+@import './layout';
+.list-collection {
+  @extend %list-collection;
+}
+.list-collection-scroll-virtual {
+  @extend %list-collection-scroll-virtual;
+}
+%list-collection > button {
+  @extend %list-collection-partial-button;
+}

--- a/ui/packages/consul-ui/app/components/list-collection/layout.scss
+++ b/ui/packages/consul-ui/app/components/list-collection/layout.scss
@@ -13,15 +13,3 @@
   width: 100%;
   padding: 15px;
 }
-
-/* ?? */
-%list-collection > ul > li:nth-child(2) .with-feedback p {
-  bottom: auto;
-  top: 24px;
-}
-%list-collection > ul > li:nth-child(2) p::after {
-  bottom: auto;
-  top: -10px !important;
-  border-bottom-width: 18px;
-  border-top-width: 0;
-}

--- a/ui/packages/consul-ui/app/components/list-collection/layout.scss
+++ b/ui/packages/consul-ui/app/components/list-collection/layout.scss
@@ -1,22 +1,20 @@
-.list-collection {
-  @extend %list-collection;
-}
-.list-collection-scroll-virtual {
-  @extend %list-collection-scroll-virtual;
+%list-collection > ul > li,
+%list-collection-scroll-virtual {
+  position: relative;
 }
 %list-collection-scroll-virtual {
   height: 500px;
-  position: relative;
-}
-%list-collection > ul {
-  border-top: 1px solid $gray-200;
-}
-%list-collection > ul > li {
-  position: relative;
 }
 %list-collection-scroll-virtual > ul {
   overflow-x: hidden !important;
 }
+
+%list-collection-partial-button {
+  width: 100%;
+  padding: 15px;
+}
+
+/* ?? */
 %list-collection > ul > li:nth-child(2) .with-feedback p {
   bottom: auto;
   top: 24px;

--- a/ui/packages/consul-ui/app/components/list-collection/skin.scss
+++ b/ui/packages/consul-ui/app/components/list-collection/skin.scss
@@ -1,0 +1,15 @@
+%list-collection > ul {
+  border-top: 1px solid;
+  border-color: var(--gray-200);
+}
+%list-collection-partial-button {
+  cursor: pointer;
+  background-color: var(--gray-050);
+  color: var(--blue-500);
+}
+%list-collection-partial-button::after {
+  @extend %with-chevron-up-mask, %as-pseudo;
+}
+%list-collection-partial-button.closed::after {
+  @extend %with-chevron-down-mask;
+}

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -27,7 +27,6 @@
 @import './components/empty-state';
 @import './components/tabular-details';
 @import './components/tabular-collection';
-@import './components/list-collection';
 @import './components/popover-select';
 @import './components/tooltip-panel';
 @import './components/menu-panel';
@@ -52,6 +51,7 @@
 @import 'consul-ui/components/tooltip';
 @import 'consul-ui/components/notice';
 @import 'consul-ui/components/modal-dialog';
+@import 'consul-ui/components/list-collection';
 @import 'consul-ui/components/filter-bar';
 @import 'consul-ui/components/freetext-filter';
 @import 'consul-ui/components/informed-action';


### PR DESCRIPTION
We have a component that we use quite a lot called `<ListCollection />`, we use it for our 'virtual/DOM-recycling scrolling' and just for normal 'native scrolling' lists.

This PR adds a `@partial` attribute to this component, letting you specify that you only want a certain number of rows to show initially. When this attribute is set, we also render a 'View more' button to let the user expand the list to show all the rows instead of just a 'partial' amount.

![partial-list](https://user-images.githubusercontent.com/554604/117032117-21de8f00-acf9-11eb-82c6-2cfa9474f65c.gif)

We also took the opportunity here to move the `list-collection` styles into the `app/components/list-collection` folder, so everything is co-located in the one folder.