### PR TITLE
[1.8.x] local: use agent token to deregister services

### DIFF
--- a/.changelog/9683.txt
+++ b/.changelog/9683.txt
@@ -1,0 +1,3 @@
+```release-notes:improvement
+client: when a client agent is attempting to dereigster a service, anddoes not have access to the ACL token used to register a service, attempt to use the agent token instead of the default user token. If no agent token is set, fall back to the default user token.
+```

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -215,7 +215,7 @@ func (l *State) serviceToken(id structs.ServiceID) string {
 		token = s.Token
 	}
 	if token == "" {
-		token = l.tokens.UserToken()
+		token = l.tokens.AgentToken()
 	}
 	return token
 }
@@ -428,7 +428,7 @@ func (l *State) checkToken(id structs.CheckID) string {
 		token = c.Token
 	}
 	if token == "" {
-		token = l.tokens.UserToken()
+		token = l.tokens.AgentToken()
 	}
 	return token
 }


### PR DESCRIPTION
Manual backport of #9683 because automation no longer works for PRs opened before the SSH key changed.