### PR TITLE
http: set consistency header properly for health endpoint

### DIFF
--- a/.changelog/10189.txt
+++ b/.changelog/10189.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+http: fix a bug that caused the `X-Consul-Effective-Consistency` header to be missing on
+request for service health
+```

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -227,8 +227,8 @@ func (s *HTTPHandlers) healthServiceNodes(resp http.ResponseWriter, req *http.Re
 	if args.QueryOptions.UseCache {
 		setCacheMeta(resp, &md)
 	}
+	out.QueryMeta.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
 	setMeta(resp, &out.QueryMeta)
-	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
 
 	// FIXME: argument parsing should be done before performing the rpc
 	// Filter to only passing if specified


### PR DESCRIPTION
A recent change in 1.9.x inverted the order of these two lines, which caused the `X-Consul-Effective-Consistency` header to be missing for the service health endpoints.