### PR TITLE
Add OSS bits for supporting specifying the enterprise license via config

### DIFF
--- a/.changelog/10210.txt
+++ b/.changelog/10210.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+licensing: **(Enterprise Only)** Consul Enterprise has gained the ability to autoload a license via configuration. This can be specified with the `license_path` configuration, the `CONSUL_LICENSE` environment variable or the `CONSUL_LICENSE_PATH` environment variable
+```

--- a/agent/config/builder_oss.go
+++ b/agent/config/builder_oss.go
@@ -49,6 +49,10 @@ func validateEnterpriseConfigKeys(config *Config) []error {
 	if boolVal(config.Audit.Enabled) || len(config.Audit.Sinks) > 0 {
 		add("audit")
 	}
+	if config.LicensePath != nil {
+		add("license_path")
+		config.LicensePath = nil
+	}
 
 	return result
 }

--- a/agent/config/builder_oss_test.go
+++ b/agent/config/builder_oss_test.go
@@ -97,6 +97,15 @@ func TestValidateEnterpriseConfigKeys(t *testing.T) {
 				require.Nil(t, c.ACL.Tokens.ManagedServiceProvider)
 			},
 		},
+		"license_path": {
+			config: Config{
+				LicensePath: &stringVal,
+			},
+			badKeys: []string{"license_path"},
+			check: func(t *testing.T, c *Config) {
+				require.Empty(t, c.LicensePath)
+			},
+		},
 		"multi": {
 			config: Config{
 				ReadReplica: &boolVal,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -187,6 +187,7 @@ type Config struct {
 	HTTPConfig                       HTTPConfig          `mapstructure:"http_config"`
 	KeyFile                          *string             `mapstructure:"key_file"`
 	LeaveOnTerm                      *bool               `mapstructure:"leave_on_terminate"`
+	LicensePath                      *string             `mapstructure:"license_path"`
 	Limits                           Limits              `mapstructure:"limits"`
 	LogLevel                         *string             `mapstructure:"log_level"`
 	LogJSON                          *bool               `mapstructure:"log_json"`

--- a/agent/config/runtime_oss_test.go
+++ b/agent/config/runtime_oss_test.go
@@ -9,6 +9,7 @@ func entFullRuntimeConfig(rt *RuntimeConfig) {}
 var enterpriseReadReplicaWarnings = []string{enterpriseConfigKeyError{key: "read_replica (or the deprecated non_voting_server)"}.Error()}
 
 var enterpriseConfigKeyWarnings = []string{
+	enterpriseConfigKeyError{key: "license_path"}.Error(),
 	enterpriseConfigKeyError{key: "read_replica (or the deprecated non_voting_server)"}.Error(),
 	enterpriseConfigKeyError{key: "autopilot.redundancy_zone_tag"}.Error(),
 	enterpriseConfigKeyError{key: "autopilot.upgrade_version_tag"}.Error(),

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -277,6 +277,7 @@ http_config {
 }
 key_file = "IEkkwgIA"
 leave_on_terminate = true
+license_path = "/path/to/license.lic"
 limits {
     http_max_conns_per_client = 100
     https_handshake_timeout = "2391ms"

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -277,6 +277,7 @@
   },
   "key_file": "IEkkwgIA",
   "leave_on_terminate": true,
+  "license_path": "/path/to/license.lic",
   "limits": {
     "http_max_conns_per_client": 100,
     "https_handshake_timeout": "2391ms",


### PR DESCRIPTION
Consul Enterprise is getting the ability to load licenses via configuration. This PR includes the necessary bits to allow that to happen.