### PR TITLE
Deprecate API driven licensing

### DIFF
--- a/.changelog/10211.txt
+++ b/.changelog/10211.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+licensing: **(Enterprise Only)** Consul Enterprise 1.10 has removed API driven licensing of servers in favor of license loading via configuration. The `PUT` and `DELETE` methods on the `/v1/operator/license` endpoint will now return 405s, the `consul license put` and `consul license reset` CLI commands have been removed and the `LicensePut` and `LicenseReset` methods in the API client have been altered to always return an error.
+```

--- a/api/operator_license.go
+++ b/api/operator_license.go
@@ -1,8 +1,8 @@
 package api
 
 import (
+	"fmt"
 	"io/ioutil"
-	"strings"
 	"time"
 )
 
@@ -78,37 +78,17 @@ func (op *Operator) LicenseGetSigned(q *QueryOptions) (string, error) {
 
 // LicenseReset will reset the license to the builtin one if it is still valid.
 // If the builtin license is invalid, the current license stays active.
-func (op *Operator) LicenseReset(opts *WriteOptions) (*LicenseReply, error) {
-	var reply LicenseReply
-	r := op.c.newRequest("DELETE", "/v1/operator/license")
-	r.setWriteOptions(opts)
-	_, resp, err := requireOK(op.c.doRequest(r))
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := decodeBody(resp, &reply); err != nil {
-		return nil, err
-	}
-
-	return &reply, nil
+//
+// DEPRECATED: Consul 1.10 removes the corresponding HTTP endpoint as licenses
+// are now set via agent configuration instead of through the API
+func (*Operator) LicenseReset(_ *WriteOptions) (*LicenseReply, error) {
+	return nil, fmt.Errorf("Consul 1.10 no longer supports API driven license management.")
 }
 
-func (op *Operator) LicensePut(license string, opts *WriteOptions) (*LicenseReply, error) {
-	var reply LicenseReply
-	r := op.c.newRequest("PUT", "/v1/operator/license")
-	r.setWriteOptions(opts)
-	r.body = strings.NewReader(license)
-	_, resp, err := requireOK(op.c.doRequest(r))
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := decodeBody(resp, &reply); err != nil {
-		return nil, err
-	}
-
-	return &reply, nil
+// LicensePut will configure the Consul Enterprise license for the target datacenter
+//
+// DEPRECATED: Consul 1.10 removes the corresponding HTTP endpoint as licenses
+// are now set via agent configuration instead of through the API
+func (*Operator) LicensePut(_ string, _ *WriteOptions) (*LicenseReply, error) {
+	return nil, fmt.Errorf("Consul 1.10 no longer supports API driven license management.")
 }


### PR DESCRIPTION
The two methods in the API client to Put or Reset a license will now always return an error. These APIs will no longer exist in Consul Enterprise so instead of just getting 405s or removing the methods which would require a v2 of the API for Go module semantic version compatibility, I have chosen to have these return a predefined error noting that the functionality was removed in v1.10.0