### PR TITLE
testing: attempt to fix some test flakes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ steps:
   install-gotestsum: &install-gotestsum
     name: install gotestsum
     environment:
-      GOTESTSUM_RELEASE: 0.6.0
+      GOTESTSUM_RELEASE: 1.6.4
     command: |
       url=https://github.com/gotestyourself/gotestsum/releases/download
       curl -sSL "${url}/v${GOTESTSUM_RELEASE}/gotestsum_${GOTESTSUM_RELEASE}_linux_amd64.tar.gz" | \

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -10,6 +10,11 @@ import (
 	"testing"
 	"time"
 
+	uuid "github.com/hashicorp/go-uuid"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2/jwt"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/authmethod/kubeauth"
 	"github.com/hashicorp/consul/agent/consul/authmethod/testauth"
@@ -18,10 +23,6 @@ import (
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	uuid "github.com/hashicorp/go-uuid"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func TestACLEndpoint_Bootstrap(t *testing.T) {
@@ -4981,7 +4982,7 @@ func TestACLEndpoint_Login_with_TokenLocality(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	go t.Parallel()
+	t.Parallel()
 
 	_, s1, codec := testACLServerWithConfig(t, func(c *Config) {
 		c.ACLTokenMinExpirationTTL = 10 * time.Millisecond

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2
 	github.com/hashicorp/consul/api v1.8.0
 	github.com/hashicorp/consul/sdk v0.7.0
-	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-bexpr v0.1.2
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.1

--- a/sdk/testutil/retry/retry.go
+++ b/sdk/testutil/retry/retry.go
@@ -99,6 +99,7 @@ func decorate(s string) string {
 }
 
 func Run(t Failer, f func(r *R)) {
+	t.Helper()
 	run(DefaultFailer(), t, f)
 }
 


### PR DESCRIPTION
I've noticed a few more test flakes lately ([ex](https://app.circleci.com/pipelines/github/hashicorp/consul/18450/workflows/29b09269-d2f6-4564-a73c-ac4a2bcb5bad/jobs/366684/tests#failed-test-2)).

One common one is "TestAgent already started" which is fixed by this PR, by properly setting `a.Agent = nil` in the error case.

The rest of these changes are to try and make the failures easier to debug by reporting the right line number.

Also updates `gotestsum` to pickup some bug fixes.

Also fixed a long standing issue with `TestACLEndpoint_Login_with_TokenLocality` where it was being reported as failing, even thought it had not failed (see the last commit).