### PR TITLE
ui: Miscellaneous Lock Session fixes

### DIFF
--- a/.changelog/10225.txt
+++ b/.changelog/10225.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Reflect the change of Session API response shape for Checks in post 1.7 Consul 
+```

--- a/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
@@ -16,30 +16,32 @@
           <a href="{{env 'CONSUL_DOCS_URL'}}/internals/sessions.html#session-design" rel="help noopener noreferrer" target="_blank">Lock Session</a>
         </h2>
         <dl>
+{{#if api.data.Name}}
           <dt>Name</dt>
           <dd>{{api.data.Name}}</dd>
-          <dt>Agent</dt>
+{{/if}}
+          <dt>ID</dt>
+          <dd>{{api.data.ID}}</dd>
+          <dt>Node</dt>
           <dd>
               <a href={{href-to 'dc.nodes.show' api.data.Node}}>{{api.data.Node}}</a>
           </dd>
-          <dt>ID</dt>
-          <dd>{{api.data.ID}}</dd>
-          <dt>Behavior</dt>
-          <dd>{{api.data.Behavior}}</dd>
-{{#if form.data.Delay }}
           <dt>Delay</dt>
           <dd>{{duration-from api.data.LockDelay}}</dd>
-{{/if}}
-{{#if form.data.TTL }}
           <dt>TTL</dt>
-          <dd>{{api.data.TTL}}</dd>
-{{/if}}
-{{#if (gt api.data.Checks.length 0)}}
+          <dd>{{or api.data.TTL '-'}}</dd>
+          <dt>Behavior</dt>
+          <dd>{{api.data.Behavior}}</dd>
+{{#let (union api.data.NodeChecks api.data.ServiceChecks) as |checks|}}
           <dt>Health Checks</dt>
           <dd>
-              {{ join ', ' api.data.Checks}}
+  {{#if (gt checks.length 0)}}
+              {{ join ', ' checks}}
+  {{else}}
+              -
+  {{/if}}
           </dd>
-{{/if}}
+{{/let}}
         </dl>
 {{#if (can 'delete session' item=api.data)}}
         <ConfirmationDialog @message="Are you sure you want to invalidate this session?">

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
@@ -17,27 +17,26 @@
     {{#if item.Name}}
     <dl>
       <dt>
+        ID
+      </dt>
+      <dd>
         <CopyButton
           @value={{item.ID}}
           @name="ID"
         />
-      </dt>
-      <dd>{{item.ID}}</dd>
+        {{item.ID}}
+      </dd>
     </dl>
     {{/if}}
     <dl class="lock-delay">
-      <dt>
-        <Tooltip>
-          Delay
-        </Tooltip>
+      <dt {{tooltip}}>
+        Delay
       </dt>
       <dd data-test-session-delay>{{duration-from item.LockDelay}}</dd>
     </dl>
     <dl class="ttl">
-      <dt>
-        <Tooltip>
-          TTL
-        </Tooltip>
+      <dt {{tooltip}}>
+        TTL
       </dt>
     {{#if (eq item.TTL "")}}
       <dd data-test-session-ttl={{item.TTL}}>-</dd>
@@ -46,25 +45,27 @@
     {{/if}}
     </dl>
     <dl class="behavior">
-      <dt>
-        <Tooltip>
-          Behavior
-        </Tooltip>
+      <dt {{tooltip}}>
+        Behavior
       </dt>
       <dd>{{item.Behavior}}</dd>
     </dl>
+{{#let (union item.NodeChecks item.ServiceChecks) as |checks|}}
     <dl class="checks">
-      <dt>
-        <Tooltip>
-          Checks
-        </Tooltip>
+      <dt {{tooltip}}>
+        Checks
       </dt>
       <dd>
-      {{#each item.Checks as |item|}}
+{{#if (gt checks.length 0)}}
+      {{#each checks as |item|}}
         <span>{{item}}</span>
       {{/each}}
+{{else}}
+        -
+{{/if}}
       </dd>
     </dl>
+{{/let}}
   </BlockSlot>
 {{#if (can "delete sessions")}}
   <BlockSlot @name="actions">

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.scss
@@ -1,0 +1,11 @@
+.consul-lock-session-list .checks dd {
+  display: inline-flex;
+  flex-wrap: wrap;
+  padding-left: 0px;
+}
+.consul-lock-session-list .checks dd > *:not(:last-child)::after {
+  content: ',';
+  margin-right: 0.3em;
+  display: inline;
+}
+

--- a/ui/packages/consul-ui/app/models/session.js
+++ b/ui/packages/consul-ui/app/models/session.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+import { nullValue } from 'consul-ui/decorators/replace';
 
 export const PRIMARY_KEY = 'uid';
 export const SLUG_KEY = 'ID';
@@ -18,6 +19,8 @@ export default class Session extends Model {
   @attr('number') CreateIndex;
   @attr('number') ModifyIndex;
 
-  @attr({ defaultValue: () => [] }) Checks;
+  @nullValue([]) @attr({ defaultValue: () => [] }) NodeChecks;
+  @nullValue([]) @attr({ defaultValue: () => [] }) ServiceChecks;
+
   @attr({ defaultValue: () => [] }) Resources; // []
 }

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -68,6 +68,7 @@
 @import 'consul-ui/components/consul/external-source';
 @import 'consul-ui/components/consul/kind';
 @import 'consul-ui/components/consul/intention';
+@import 'consul-ui/components/consul/lock-session/list';
 @import 'consul-ui/components/consul/lock-session/form';
 @import 'consul-ui/components/consul/auth-method';
 

--- a/ui/packages/consul-ui/app/styles/components/composite-row.scss
+++ b/ui/packages/consul-ui/app/styles/components/composite-row.scss
@@ -18,6 +18,7 @@
 }
 // TODO: This hides the iconless dt's in the below lists as they don't have
 // tooltips the todo would be to wrap these texts in spans
+.consul-lock-session-list ul > li:not(:first-child) dl:not([class]) dt,
 .consul-nspace-list > ul > li:not(:first-child) dt,
 .consul-token-list > ul > li:not(:first-child) dt,
 .consul-policy-list > ul li:not(:first-child) dl:not(.datacenter) dt,

--- a/ui/packages/consul-ui/mock-api/v1/session/info/_
+++ b/ui/packages/consul-ui/mock-api/v1/session/info/_
@@ -7,7 +7,8 @@
             typeof http.body.Namespace !== 'undefined' ? http.body.Namespace : 'default'
         }",
         "Node":"node-1",
-        "Checks":["serfHealth"],
+        "NodeChecks":["serfHealth"],
+        "ServiceChecks": ["${fake.hacker.noun()}Health"],
         "LockDelay":15000000000,
         "Behavior":"${fake.helpers.randomize(['release', 'delete'])}",
         "TTL":"",

--- a/ui/packages/consul-ui/mock-api/v1/session/node/_
+++ b/ui/packages/consul-ui/mock-api/v1/session/node/_
@@ -19,7 +19,8 @@ ${typeof location.search.ns !== 'undefined' ? `
                 "Namespace": "${location.search.ns}",
 ` : ``}
                 "Node":"${location.pathname.get(3)}",
-                "Checks":["serfHealth"],
+                "NodeChecks":["serfHealth"],
+                "ServiceChecks": ["${fake.hacker.noun()}Health"],
                 "LockDelay":15000000000,
                 "Behavior":"${fake.helpers.randomize(['release', 'delete'])}",
                 "TTL":"",


### PR DESCRIPTION
Whilst reviewing https://github.com/hashicorp/consul/pull/9930 and https://github.com/hashicorp/consul/pull/10121 we noticed a few bugs that required fixing up within Lock Sessions in the UI.

The first and most important was that the Lock Session APIs changed shape back in 1.7 but the documentation doesn't reflect this change (https://www.consul.io/api-docs/session#sample-response-3) so I've already added an issue for this here https://github.com/hashicorp/consul/issues/10095

The UI still expected the JSON response to be in the pre-1.7 shape so primarily this PR alters our mock API and the UI to the shape of the response as it is post-1.7.

Also:

Viewing a Session for a KV:

1. We noticed that the `Name` property is optional, so we only show this row if a Name is set for a session.
2. We noticed that this is the only place in the UI where we refer to a Node as an 'Agent' and is probably just a hangover from the original version of the UI, so we've changed this up here to use the word Node instead to match the rest of the UI.
3. There was a bug where we weren't showing the Delay or TTL here at all, so we fixed that here also.
4. We changed the order of the rows in the table to match the order of the information in our Lock Session listing page.

Lock Session Listing page/component:

1. We moved the CopyButton for the ID out of the `dt` and into the `dd` to make it visible/clickable.
2. Upgraded the tooltips to use a modifier style which we added in https://github.com/hashicorp/consul/pull/9288