### PR TITLE
ui: Use babel plugin to strip calls to runInDebug

### DIFF
--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -8,13 +8,19 @@ module.exports = function(defaults) {
 
   const env = EmberApp.env();
   const prodlike = ['production', 'staging'];
+  const sourcemaps = !['production'].includes(env);
 
   const trees = {};
   const addons = {};
   const outputPaths = {};
   let excludeFiles = [];
 
-  const sourcemaps = !['production'].includes(env);
+  const babel = {
+    plugins: [
+      '@babel/plugin-proposal-object-rest-spread',
+    ],
+    sourceMaps: sourcemaps ? 'inline' : false,
+  }
 
   // setup up different build configuration depending on environment
   if(!['test'].includes(env)) {
@@ -38,6 +44,9 @@ module.exports = function(defaults) {
       // exclude docfy
       '@docfy/ember'
     ];
+    babel.plugins.push(
+      ['strip-function-call', {'strip': ['Ember.runInDebug']}]
+    )
   } else {
     // add debug css is we are not in test or production environments
     outputPaths.app = {
@@ -69,10 +78,7 @@ module.exports = function(defaults) {
       'ember-cli-math-helpers': {
         only: ['div'],
       },
-      babel: {
-        plugins: ['@babel/plugin-proposal-object-rest-spread'],
-        sourceMaps: sourcemaps ? 'inline' : false,
-      },
+      babel: babel,
       autoImport: {
         // allows use of a CSP without 'unsafe-eval' directive
         forbidEval: true,

--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -44,9 +44,6 @@ module.exports = function(defaults) {
       // exclude docfy
       '@docfy/ember'
     ];
-    babel.plugins.push(
-      ['strip-function-call', {'strip': ['Ember.runInDebug']}]
-    )
   } else {
     // add debug css is we are not in test or production environments
     outputPaths.app = {
@@ -54,6 +51,13 @@ module.exports = function(defaults) {
         'debug': '/assets/debug.css'
       }
     }
+  }
+  if(['production'].includes(env)) {
+    // everything apart from production is 'debug', including test
+    // which means this and everything it affects is never tested
+    babel.plugins.push(
+      ['strip-function-call', {'strip': ['Ember.runInDebug']}]
+    )
   }
   //
 

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -71,6 +71,7 @@
     "babel-loader": "^8.1.0",
     "babel-plugin-ember-modules-api-polyfill": "^3.2.0",
     "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
+    "babel-plugin-strip-function-call": "^1.0.2",
     "base64-js": "^1.3.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-funnel": "^3.0.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2746,6 +2746,11 @@ babel-plugin-polyfill-regenerator@^0.1.2:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.1.5"
 
+babel-plugin-strip-function-call@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-strip-function-call/-/babel-plugin-strip-function-call-1.0.2.tgz#374a68b5648e16e2b6d1effd280c3abc88648e3a"
+  integrity sha1-N0potWSOFuK20e/9KAw6vIhkjjo=
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"


### PR DESCRIPTION
A while ago we discovered `runInDebug` imported from `@ember/debug` and started using it to be able to add engineering utilities to the UI to help other engineers without compiling the required debug code into the final production build.

For example:

https://github.com/hashicorp/consul/pull/8658
https://github.com/hashicorp/consul/pull/9675
https://github.com/hashicorp/consul/pull/9666
https://github.com/hashicorp/consul/pull/9831
https://github.com/hashicorp/consul/pull/9771


During https://github.com/hashicorp/consul/pull/9831 we found out there was a change at some point in the ember docs that changed the documented behaviour of `runInDebug` from being 'stripped' to being a 'noop' instead.

> We also noticed whilst we were doing this that although the older ember documentation for runInDebug states `Uses of this method in Ember itself are stripped from the ember.prod.js build.`, but that is not actually the case 😬 (or at least not in later versions).

Here we use an additional babel plugin to strip any calls to `runInDebug` from the final production source code.

P.S. Be aware that GitHubs diff here is a little confusing by default (unless you expand the code), the stripping is only performed during ~`test` and~ `production`.

As we can't strip this for test runs (I'm assuming runInDebug is used deep down for test setup or something), that means anything that is affected by the removal/stripping of `runInDebug` is never tested fully.

Worth noting that as `runInDebug` is noop-ed in default ember usage, so even without this addition, anything that `runInDebug` affects is never tested fully either.

The only addition here is to strip it instead of turning it into a noop so we don't ship dead code that is never run.

