### PR TITLE
server: ensure that central service config flattening properly resets the state each time

### DIFF
--- a/.changelog/10239.txt
+++ b/.changelog/10239.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: ensure that central service config flattening properly resets the state each time
+```

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1420,6 +1420,9 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 	// of the blocking query does NOT bleed over into the next run. Concretely
 	// in this test the data present in the initial proxy-defaults should not
 	// be present when we are woken up due to proxy-defaults being deleted.
+	//
+	// This test does not pertain to upstreams, see:
+	// TestConfigEntry_ResolveServiceConfig_Upstreams_Blocking
 
 	state := s1.fsm.State()
 	require.NoError(state.EnsureConfigEntry(1, &structs.ProxyConfigEntry{
@@ -1569,6 +1572,205 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 		}
 		require.Equal(expected, out)
 	}
+}
+
+func TestConfigEntry_ResolveServiceConfig_Upstreams_Blocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	// The main thing this should test is that information from one iteration
+	// of the blocking query does NOT bleed over into the next run. Concretely
+	// in this test the data present in the initial proxy-defaults should not
+	// be present when we are woken up due to proxy-defaults being deleted.
+	//
+	// This test is about fields in upstreams, see:
+	// TestConfigEntry_ResolveServiceConfig_Blocking
+
+	state := s1.fsm.State()
+	require.NoError(t, state.EnsureConfigEntry(1, &structs.ServiceConfigEntry{
+		Kind:     structs.ServiceDefaults,
+		Name:     "foo",
+		Protocol: "http",
+	}))
+	require.NoError(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
+		Kind:     structs.ServiceDefaults,
+		Name:     "bar",
+		Protocol: "http",
+	}))
+
+	var index uint64
+
+	runStep(t, "foo and bar should be both http", func(t *testing.T) {
+		// Verify that we get the results of service-defaults for 'foo' and 'bar'.
+		var out structs.ServiceConfigResponse
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.ResolveServiceConfig",
+			&structs.ServiceConfigRequest{
+				Name:       "foo",
+				Datacenter: "dc1",
+				UpstreamIDs: []structs.ServiceID{
+					structs.NewServiceID("bar", nil),
+					structs.NewServiceID("other", nil),
+				},
+			},
+			&out,
+		))
+
+		expected := structs.ServiceConfigResponse{
+			ProxyConfig: map[string]interface{}{
+				"protocol": "http",
+			},
+			UpstreamIDConfigs: []structs.OpaqueUpstreamConfig{
+				{
+					Upstream: structs.NewServiceID("bar", nil),
+					Config: map[string]interface{}{
+						"protocol": "http",
+					},
+				},
+			},
+			QueryMeta: out.QueryMeta, // don't care
+		}
+
+		require.Equal(t, expected, out)
+		index = out.Index
+	})
+
+	runStep(t, "blocking query for foo wakes on bar entry delete", func(t *testing.T) {
+		// Now setup a blocking query for 'foo' while we erase the
+		// service-defaults for bar.
+
+		// Async cause a change
+		start := time.Now()
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			err := state.DeleteConfigEntry(index+1,
+				structs.ServiceDefaults,
+				"bar",
+				nil,
+			)
+			if err != nil {
+				t.Errorf("delete config entry failed: %v", err)
+			}
+		}()
+
+		// Re-run the query
+		var out structs.ServiceConfigResponse
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.ResolveServiceConfig",
+			&structs.ServiceConfigRequest{
+				Name:       "foo",
+				Datacenter: "dc1",
+				UpstreamIDs: []structs.ServiceID{
+					structs.NewServiceID("bar", nil),
+					structs.NewServiceID("other", nil),
+				},
+				QueryOptions: structs.QueryOptions{
+					MinQueryIndex: index,
+					MaxQueryTime:  time.Second,
+				},
+			},
+			&out,
+		))
+
+		// Should block at least 100ms
+		require.True(t, time.Since(start) >= 100*time.Millisecond, "too fast")
+
+		// Check the indexes
+		require.Equal(t, out.Index, index+1)
+
+		expected := structs.ServiceConfigResponse{
+			ProxyConfig: map[string]interface{}{
+				"protocol": "http",
+			},
+			QueryMeta: out.QueryMeta, // don't care
+		}
+
+		require.Equal(t, expected, out)
+		index = out.Index
+	})
+
+	runStep(t, "foo should be http and bar should be unset", func(t *testing.T) {
+		// Verify that we get the results of service-defaults for just 'foo'.
+		var out structs.ServiceConfigResponse
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.ResolveServiceConfig",
+			&structs.ServiceConfigRequest{
+				Name:       "foo",
+				Datacenter: "dc1",
+				UpstreamIDs: []structs.ServiceID{
+					structs.NewServiceID("bar", nil),
+					structs.NewServiceID("other", nil),
+				},
+			},
+			&out,
+		))
+
+		expected := structs.ServiceConfigResponse{
+			ProxyConfig: map[string]interface{}{
+				"protocol": "http",
+			},
+			QueryMeta: out.QueryMeta, // don't care
+		}
+
+		require.Equal(t, expected, out)
+		index = out.Index
+	})
+
+	runStep(t, "blocking query for foo wakes on foo entry delete", func(t *testing.T) {
+		// Now setup a blocking query for 'foo' while we erase the
+		// service-defaults for foo.
+
+		// Async cause a change
+		start := time.Now()
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			err := state.DeleteConfigEntry(index+1,
+				structs.ServiceDefaults,
+				"foo",
+				nil,
+			)
+			if err != nil {
+				t.Errorf("delete config entry failed: %v", err)
+			}
+		}()
+
+		// Re-run the query
+		var out structs.ServiceConfigResponse
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.ResolveServiceConfig",
+			&structs.ServiceConfigRequest{
+				Name:       "foo",
+				Datacenter: "dc1",
+				UpstreamIDs: []structs.ServiceID{
+					structs.NewServiceID("bar", nil),
+					structs.NewServiceID("other", nil),
+				},
+				QueryOptions: structs.QueryOptions{
+					MinQueryIndex: index,
+					MaxQueryTime:  time.Second,
+				},
+			},
+			&out,
+		))
+
+		// Should block at least 100ms
+		require.True(t, time.Since(start) >= 100*time.Millisecond, "too fast")
+
+		// Check the indexes
+		require.Equal(t, out.Index, index+1)
+
+		expected := structs.ServiceConfigResponse{
+			QueryMeta: out.QueryMeta, // don't care
+		}
+
+		require.Equal(t, expected, out)
+		index = out.Index
+	})
 }
 
 func TestConfigEntry_ResolveServiceConfig_UpstreamProxyDefaultsProtocol(t *testing.T) {
@@ -1847,4 +2049,11 @@ func TestConfigEntry_ProxyDefaultsExposeConfig(t *testing.T) {
 	proxyConf, ok := entry.(*structs.ProxyConfigEntry)
 	require.True(t, ok)
 	require.Equal(t, expose, proxyConf.Expose)
+}
+
+func runStep(t *testing.T, name string, fn func(t *testing.T)) {
+	t.Helper()
+	if !t.Run(name, fn) {
+		t.FailNow()
+	}
 }

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -966,12 +966,6 @@ type ServiceConfigResponse struct {
 	QueryMeta
 }
 
-func (r *ServiceConfigResponse) Reset() {
-	r.ProxyConfig = nil
-	r.UpstreamConfigs = nil
-	r.MeshGateway = MeshGatewayConfig{}
-}
-
 // MarshalBinary writes ServiceConfigResponse as msgpack encoded. It's only here
 // because we need custom decoding of the raw interface{} values.
 func (r *ServiceConfigResponse) MarshalBinary() (data []byte, err error) {


### PR DESCRIPTION
The prior solution to call reply.Reset() aged poorly since newer fields
were added to the reply, but not added to Reset() leading serial
blocking query loops on the server to blend replies.

This could manifest as a service-defaults protocol change from
default=>http not reverting back to default after the config entry
reponsible was deleted.