### PR TITLE
ui: Routlet Params

### DIFF
--- a/ui/packages/consul-ui/app/components/route/README.mdx
+++ b/ui/packages/consul-ui/app/components/route/README.mdx
@@ -20,6 +20,7 @@ routes.
 | export | Type | Default | Description |
 | --- | --- | --- | --- |
 | `model` | `Object` | `undefined` | Arbitrary hash of data passed down from the parent route/outlet |
+| `params` | `Object` | `undefined` | An object/merge of **all** optional route params and normal route params |
 
 ```hbs
 <Route

--- a/ui/packages/consul-ui/app/components/route/index.hbs
+++ b/ui/packages/consul-ui/app/components/route/index.hbs
@@ -6,5 +6,6 @@
 {{/if}}
 
 {{yield (hash
-  model=model
+  model=this.model
+  params=this.params
 )}}

--- a/ui/packages/consul-ui/app/components/route/index.js
+++ b/ui/packages/consul-ui/app/components/route/index.js
@@ -12,6 +12,10 @@ export default class RouteComponent extends Component {
     return this.args.title;
   }
 
+  get params() {
+    return this.routlet.paramsFor(this.args.name);
+  }
+
   @action
   connect() {
     this.routlet.addRoute(this.args.name, this);

--- a/ui/packages/consul-ui/app/utils/routing/transitionable.js
+++ b/ui/packages/consul-ui/app/utils/routing/transitionable.js
@@ -24,7 +24,7 @@ export default function(route, params = {}, container) {
     atts = atts.concat(replaceRouteParams(parent, params));
     current = parent;
   }
-  // Reverse atts here so it doen't get confusing whilst debugging
+  // Reverse atts here so it doesn't get confusing whilst debugging
   // (.reverse is destructive)
   atts.reverse();
   return filter(route.name || 'application', atts, params);


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/10212 we found that:

> Ideally we would have liked to have used paramsFor and the various params arguments in model hooks to access these 'optional' parameters. They are just 'params' just like all our other parameters in URLs, they just happen to be optional. Unfortunately this proved to be a little difficult to integrate into ember, so we (hopefully temporarily) went with a new optionalParams method that is available on all routes. optionalParams returns a hash/object of the configured optionalParams, defaulting each of them to an empty string (this decision was based on the experience of what we needed for our namespace support and felt like it made sense)

This PR adds a new exported `params` property to our Route components (the base branch is the above PR but I did this separately incase anyone has looked at https://github.com/hashicorp/consul/pull/10212 already).

This property is slightly different from embers `paramsFor` in that:

1. It is a merge of both 'normal' URL parameters and our 'optional' parameters. This is the primary usecase (see above), and if you access the routes params from this component you don't need to know whether something is optional or not, they are all just 'params'.
2. We add all the params form the entire URL, not just for the current route. That means `<Route @name="dc.services.index" as |route| />` will have a `route.params.dc` property. This means you can get any parameter from any Route no matter where it is in the URL, or where you are in the Route hierarchy. This means that for this to be useful, you shouldn't use two identifiers of the same name in the same URL (pretty sure we don't do this)
3. You could overwrite the Route params if you wanted to by using a yet undocumented attribute of our Outlet component, i.e. you could force certain route params if you wanted the params to be independent of URL, say for testing the route in isolation.

Notes:

1. We stopped short of adding queryParams into the params object, but we left the code commented in there to do that if we choose to. QueryParams are just 'params' like other params, really we don't care where they come from, they are all just parameters. The only thing different with queryParams is, they 'mirror' the actual queryParams in the URL without having to use `<a href="">` or `transitionTo` to change them - you can just set them and the URL changes. As we haven't replicated this functionality I didn't add them in, but I'm thinking we could and just make a note that they are read only if you access them from here - I know that ember core are considering changes to queryParams anyway so I may read up on that and think/discuss it some more before we finally decide.
2. I've ordered the merging in a way that seems to make the most sense. Optional parameters are overwriten by 'normal parameters' and 'normal parameters' are overwritten by 'outlet parameters'.

All in all this will be really useful when we come to add admin partitions to the UI.


