### PR TITLE
chore(website): 'overview' nav item links to home page

### DIFF
--- a/website/data/subnav.js
+++ b/website/data/subnav.js
@@ -1,5 +1,5 @@
 export default [
-  { text: 'Overview', url: '/docs/intro' },
+  { text: 'Overview', url: '/' },
   {
     text: 'Use Cases',
     submenu: [
@@ -39,10 +39,10 @@ export default [
     url: '/api-docs',
     type: 'inbound',
   },
-  { 
+  {
     text: 'CLI',
     url: '/commands',
-    type: 'inbound,'
+    type: 'inbound,',
   },
   {
     text: 'Community',


### PR DESCRIPTION
This PR sets the 'overview' tab link to the home page instead of the learn platform.