### PR TITLE
Fixes issue where success before passing and failures before critical were not being honoured

### DIFF
--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	http2 "golang.org/x/net/http2"
 	"io"
 	"io/ioutil"
 	"net"
@@ -15,6 +14,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	http2 "golang.org/x/net/http2"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-hclog"
@@ -917,9 +918,9 @@ func NewStatusHandler(inner CheckNotifier, logger hclog.Logger, successBeforePas
 		logger:                 logger,
 		inner:                  inner,
 		successBeforePassing:   successBeforePassing,
-		successCounter:         successBeforePassing,
+		successCounter:         0,
 		failuresBeforeCritical: failuresBeforeCritical,
-		failuresCounter:        failuresBeforeCritical,
+		failuresCounter:        0,
 	}
 }
 


### PR DESCRIPTION
This PR fixes an issue where the health check features `success_before_passing` and `failures_before_critical` were not being honoured and status was changed immediately.

This is probably also the cause of the Nomad bug listed in this issue.
https://github.com/hashicorp/nomad/issues/9189

Co-authored-by: Erik Veld <eveld@hashicorp.com>

Previously given the following service config where the destination service http://localhost:9090 always returns a 500 or no response for the /health and /ready endpoints. Consul would immediately set the check status to critical.

```json
{
  "service": {
    "id": "api-v1",
    "name": "api",
    "tags": ["primary"],
    "address": "127.0.0.1",
    "meta": {
      "meta": "for my service"
    },
    "port": 9090,
    "checks": [
      {
        "name": "HTTP API Ready",
        "http": "http://localhost:9090/ready",
        "interval": "10s",
        "timeout": "5s",
        "status": "warning",
        "success_before_passing": 1,
        "failures_before_critical": 10
      },
      {
        "name": "HTTP API Health",
        "http": "http://localhost:9090/health",
        "interval": "10s",
        "timeout": "5s",
        "status": "warning",
        "success_before_passing": 3,
        "failures_before_critical": 10
      }
    ]
  }
}
```

This was tested by running Consul locally.

```
consul agent -dev
```

Registering the service.

```
consul services register ./service.json
```

And checking the logs and output from the /agent/checks endpoint

```
curl localhost:8500/v1/agent/checks | jq '. | map(. | {check_id: .CheckID, name: .Name, status: .Status})'
```

Before the first health check, the status correctly reported as `warning`, however, after the first check the status immediately moved to `critical`.

```json
[
  {
    "check_id": "service:api-v1:1",
    "name": "HTTP API Ready",
    "status": "critical"
  },
  {
    "check_id": "service:api-v1:2",
    "name": "HTTP API Health",
    "status": "critical"
  }
]
```

After the code changes, the service correctly stays in warning until the number of consecutive failures defined in the config has been reached.

We have also tested the happy path using fake-service and the behaviour is as expected. 


