### PR TITLE
ui: change coloring of secondary navigation elements

### DIFF
--- a/ui/packages/consul-ui/app/components/tab-nav/README.mdx
+++ b/ui/packages/consul-ui/app/components/tab-nav/README.mdx
@@ -1,3 +1,7 @@
+---
+class: ember
+status: needs-love
+---
 # TabNav
 
 `<TabNav />` renders a list of items as linked tabs (there is also an option

--- a/ui/packages/consul-ui/app/components/tab-nav/README.mdx
+++ b/ui/packages/consul-ui/app/components/tab-nav/README.mdx
@@ -1,0 +1,42 @@
+# TabNav
+
+`<TabNav />` renders a list of items as linked tabs (there is also an option
+to use labels vs anchors for links for radio button based tabs).
+
+Each item in the list should be a hash of `label`, `href` and `selected`.
+
+- `label`: The text to show
+- `href`: a href, probably generated via `href-to`
+- `selected`: whether the item is in the selected state or not, probably
+  generated via `is-href`
+
+**Please note:** This component should probably be rebuilt using contextual
+components and our `Action` component, alternatively this could be hand built
+with native HTML using the same `nav/ul/li/a` pattern and you could just use
+the CSS component to style it. Unless there is a reason to do this, this
+component should be used pending a refactor (please remove this note once
+refactored into contextual components using our `Action` component)
+
+```hbs preview-template
+<figure>
+  <figcaption>A TabNav with a conditional button using `compact` which removes empty values from arrays</figcaption>
+<TabNav @items={{
+  compact
+      (array
+          (hash label="Health Checks" href="#" selected=true)
+          (hash label="Service Instances" href="#" selected=(is-href "docs.something"))
+(if false (hash label="Don't show me" href="#" selected=false) '')
+          (hash label="Lock Sessions" href="#" selected=false)
+          (hash label="Metadata" href="#" selected=false)
+      )
+}}/>
+</figure>
+```
+
+```css
+.tab-nav {
+  @extend %tab-nav;
+}
+```
+
+

--- a/ui/packages/consul-ui/app/components/tab-nav/index.scss
+++ b/ui/packages/consul-ui/app/components/tab-nav/index.scss
@@ -13,7 +13,7 @@
 }
 %with-animated-tab-selection ul::after,
 %tab-button-selected {
-  @extend %frame-brand-300;
+  @extend %frame-blue-300;
 }
 %tab-nav li a {
   @extend %tab-button;

--- a/ui/packages/consul-ui/app/components/tab-nav/skin.scss
+++ b/ui/packages/consul-ui/app/components/tab-nav/skin.scss
@@ -1,7 +1,3 @@
-%tab-nav {
-  border-top: $decor-border-200;
-  border-color: var(--gray-200);
-}
 %tab-nav ul {
   list-style-type: none;
 }
@@ -16,13 +12,13 @@
   /* %frame-transparent-something */
   border-bottom: $decor-border-100;
 }
-%tab-nav {
-  /* %frame-transparent-something */
-  border-color: var(--gray-200);
-}
 %with-animated-tab-selection ul::after,
 %tab-button {
   border-bottom: $decor-border-300;
+}
+%tab-nav {
+  /* %frame-transparent-something */
+  border-color: var(--gray-200);
 }
 %tab-button {
   @extend %with-transition-500;

--- a/ui/packages/consul-ui/app/components/tab-nav/skin.scss
+++ b/ui/packages/consul-ui/app/components/tab-nav/skin.scss
@@ -1,6 +1,6 @@
 %tab-nav {
   border-top: $decor-border-200;
-  border-color: $gray-200;
+  border-color: var(--gray-200);
 }
 %tab-nav ul {
   list-style-type: none;
@@ -18,7 +18,7 @@
 }
 %tab-nav {
   /* %frame-transparent-something */
-  border-color: $gray-200;
+  border-color: var(--gray-200);
 }
 %with-animated-tab-selection ul::after,
 %tab-button {
@@ -26,15 +26,18 @@
 }
 %tab-button {
   @extend %with-transition-500;
-  transition-property: background-color;
-  border-color: $transparent;
-  color: $gray-500;
+  transition-property: background-color, border-color;
+  border-color: var(--transparent);
+  color: var(--gray-500);
 }
 %tab-button-intent,
 %tab-button-active {
   /* %frame-gray-something */
-  background-color: $gray-100;
+  background-color: var(--gray-100);
+}
+%tab-button-intent {
+ border-color: var(--gray-300);
 }
 %tab-nav.animatable .selected a {
-  border-color: $transparent !important;
+  border-color: var(--transparent) !important;
 }

--- a/ui/packages/consul-ui/app/components/tab-nav/skin.scss
+++ b/ui/packages/consul-ui/app/components/tab-nav/skin.scss
@@ -32,7 +32,7 @@
   background-color: var(--gray-100);
 }
 %tab-button-intent {
- border-color: var(--gray-300);
+  border-color: var(--gray-300);
 }
 %tab-nav.animatable .selected a {
   border-color: var(--transparent) !important;


### PR DESCRIPTION
Following our branding update, we noticed that the new `rose` color we use as a highlight on our secondary nav/tabs looked a little weird next to our `red-500` which we use quite a lot. Considering current `structure` uses a `blue-500` for the highlight for the tabs, we took the opportunity to bring our tab coloring into line with that. This was a one line change here https://github.com/hashicorp/consul/pull/10259/files#diff-e0f0d30e1061b08e14e2c0c0ad168b4ce7fc4c638576abbb7893df5777433590L16, but we also:

1. Added a gray bottom border to the tabs whilst hovering (something else I noticed we we differed slightly from current `structure`)
2. Moved all the grays to use CSS properties rather than SASS variables now we have those (confusing _only all our grays_ are currently back to CSS properties)
3. I removed a top border that a realized we no longer need and we overwrite here: https://github.com/hashicorp/consul/blob/7dc78b39c9c5f5120619e70ba168a2d5c12081f2/ui/packages/consul-ui/app/styles/components/app-view/skin.scss#L26-L31 (theres a upcoming PR (https://github.com/hashicorp/consul/pull/10265) to remove that also now we don't need it)
4. Added docs for `TabNav` and noted that it's due for an overhaul since I think it's the first component we ever had.

![tabs](https://user-images.githubusercontent.com/554604/118963278-30b27c00-b95e-11eb-8ff7-1a141e915f7c.gif)
