### PR TITLE
Move some things around to allow for license updating via config reload

### DIFF
--- a/.changelog/10267.txt
+++ b/.changelog/10267.txt
@@ -1,0 +1,2 @@
+```release-note:improvement
+licensing: **(Enterprise Only)** Consul Enterprise has gained the ability update its license via a configuration reload. The same environment variables and configurations will be used to determine the new license.```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -49,6 +49,7 @@ import (
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/lib/file"
 	"github.com/hashicorp/consul/lib/mutex"
+	"github.com/hashicorp/consul/lib/routine"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
@@ -327,6 +328,10 @@ type Agent struct {
 	// into Agent, which will allow us to remove this field.
 	rpcClientHealth *health.Client
 
+	// routineManager is responsible for managing longer running go routines
+	// run by the Agent
+	routineManager *routine.Manager
+
 	// enterpriseAgent embeds fields that we only access in consul-enterprise builds
 	enterpriseAgent
 }
@@ -371,6 +376,7 @@ func New(bd BaseDeps) (*Agent, error) {
 		tlsConfigurator: bd.TLSConfigurator,
 		config:          bd.RuntimeConfig,
 		cache:           bd.Cache,
+		routineManager:  routine.NewManager(bd.Logger),
 	}
 
 	// TODO: create rpcClientHealth in BaseDeps once NetRPC is available without Agent

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -290,6 +290,12 @@ type Config struct {
 	SegmentName *string `mapstructure:"segment"`
 	// Enterprise Only
 	Segments []Segment `mapstructure:"segments"`
+
+	// Enterprise Only - not user configurable
+	LicensePollBaseTime   *string `mapstructure:"license_poll_base_time"`
+	LicensePollMaxTime    *string `mapstructure:"license_poll_max_time"`
+	LicenseUpdateBaseTime *string `mapstructure:"license_update_base_time"`
+	LicenseUpdateMaxTime  *string `mapstructure:"license_update_max_time"`
 }
 
 type GossipLANConfig struct {

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -30,7 +30,7 @@ func (s *Server) reapExpiredTokens(ctx context.Context) error {
 	}
 }
 
-func (s *Server) startACLTokenReaping() {
+func (s *Server) startACLTokenReaping(ctx context.Context) {
 	// Do a quick check for config settings that would imply the goroutine
 	// below will just spin forever.
 	//
@@ -41,7 +41,7 @@ func (s *Server) startACLTokenReaping() {
 		return
 	}
 
-	s.leaderRoutineManager.Start(aclTokenReapingRoutineName, s.reapExpiredTokens)
+	s.leaderRoutineManager.Start(ctx, aclTokenReapingRoutineName, s.reapExpiredTokens)
 }
 
 func (s *Server) stopACLTokenReaping() {

--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -3,6 +3,7 @@
 package consul
 
 import (
+	"context"
 	"errors"
 	"net"
 	"strings"
@@ -46,7 +47,7 @@ func (s *Server) handleEnterpriseLeave() {
 	return
 }
 
-func (s *Server) establishEnterpriseLeadership() error {
+func (s *Server) establishEnterpriseLeadership(_ context.Context) error {
 	return nil
 }
 

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -29,15 +29,15 @@ var (
 )
 
 // startConnectLeader starts multi-dc connect leader routines.
-func (s *Server) startConnectLeader() error {
+func (s *Server) startConnectLeader(ctx context.Context) error {
 	if !s.config.ConnectEnabled {
 		return nil
 	}
 
-	s.caManager.Start()
-	s.leaderRoutineManager.Start(caRootPruningRoutineName, s.runCARootPruning)
+	s.caManager.Start(ctx)
+	s.leaderRoutineManager.Start(ctx, caRootPruningRoutineName, s.runCARootPruning)
 
-	return s.startIntentionConfigEntryMigration()
+	return s.startIntentionConfigEntryMigration(ctx)
 }
 
 // stopConnectLeader stops connect specific leader functions.

--- a/agent/consul/leader_federation_state_ae.go
+++ b/agent/consul/leader_federation_state_ae.go
@@ -17,7 +17,7 @@ const (
 	federationStatePruneInterval = time.Hour
 )
 
-func (s *Server) startFederationStateAntiEntropy() {
+func (s *Server) startFederationStateAntiEntropy(ctx context.Context) {
 	// Check to see if we can skip waiting for serf feature detection below.
 	if !s.DatacenterSupportsFederationStates() {
 		_, fedStates, err := s.fsm.State().FederationStateList(nil)
@@ -31,12 +31,12 @@ func (s *Server) startFederationStateAntiEntropy() {
 	if s.config.DisableFederationStateAntiEntropy {
 		return
 	}
-	s.leaderRoutineManager.Start(federationStateAntiEntropyRoutineName, s.federationStateAntiEntropySync)
+	s.leaderRoutineManager.Start(ctx, federationStateAntiEntropyRoutineName, s.federationStateAntiEntropySync)
 
 	// If this is the primary, then also prune any stale datacenters from the
 	// list of federation states.
 	if s.config.PrimaryDatacenter == s.config.Datacenter {
-		s.leaderRoutineManager.Start(federationStatePruningRoutineName, s.federationStatePruning)
+		s.leaderRoutineManager.Start(ctx, federationStatePruningRoutineName, s.federationStatePruning)
 	}
 }
 

--- a/agent/consul/leader_intentions.go
+++ b/agent/consul/leader_intentions.go
@@ -15,7 +15,7 @@ const (
 	maxIntentionTxnSize = raftWarnSize / 4
 )
 
-func (s *Server) startIntentionConfigEntryMigration() error {
+func (s *Server) startIntentionConfigEntryMigration(ctx context.Context) error {
 	if !s.config.ConnectEnabled {
 		return nil
 	}
@@ -56,14 +56,14 @@ func (s *Server) startIntentionConfigEntryMigration() error {
 		}
 
 		// When running in the primary we do all of the real work.
-		s.leaderRoutineManager.Start(intentionMigrationRoutineName, s.legacyIntentionMigration)
+		s.leaderRoutineManager.Start(ctx, intentionMigrationRoutineName, s.legacyIntentionMigration)
 	} else {
 		// When running in the secondary we mostly just wait until the
 		// primary finishes, and then wait until we're pretty sure the main
 		// config entry replication thread has seen all of the
 		// migration-related config entry edits before zeroing OUR copy of
 		// the old intentions table.
-		s.leaderRoutineManager.Start(intentionMigrationRoutineName, s.legacyIntentionMigrationInSecondaryDC)
+		s.leaderRoutineManager.Start(ctx, intentionMigrationRoutineName, s.legacyIntentionMigrationInSecondaryDC)
 	}
 
 	return nil

--- a/agent/consul/replication_test.go
+++ b/agent/consul/replication_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/consul/lib/routine"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/mock"
@@ -12,7 +13,7 @@ import (
 )
 
 func TestReplicationRestart(t *testing.T) {
-	mgr := NewLeaderRoutineManager(testutil.Logger(t))
+	mgr := routine.NewManager(testutil.Logger(t))
 
 	config := ReplicatorConfig{
 		Name: "mock",
@@ -30,9 +31,9 @@ func TestReplicationRestart(t *testing.T) {
 	repl, err := NewReplicator(&config)
 	require.NoError(t, err)
 
-	mgr.Start("mock", repl.Run)
+	mgr.Start(context.Background(), "mock", repl.Run)
 	mgr.Stop("mock")
-	mgr.Start("mock", repl.Run)
+	mgr.Start(context.Background(), "mock", repl.Run)
 	// Previously this would have segfaulted
 	mgr.Stop("mock")
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/lib/routine"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/proto/pbsubscribe"
 	"github.com/hashicorp/consul/tlsutil"
@@ -298,7 +299,7 @@ type Server struct {
 	dcSupportsIntentionsAsConfigEntries int32
 
 	// Manager to handle starting/stopping go routines when establishing/revoking raft leadership
-	leaderRoutineManager *LeaderRoutineManager
+	leaderRoutineManager *routine.Manager
 
 	// embedded struct to hold all the enterprise specific data
 	EnterpriseServer
@@ -375,7 +376,7 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 		tombstoneGC:             gc,
 		serverLookup:            NewServerLookup(),
 		shutdownCh:              shutdownCh,
-		leaderRoutineManager:    NewLeaderRoutineManager(logger),
+		leaderRoutineManager:    routine.NewManager(logger.Named(logging.Leader)),
 		aclAuthMethodValidators: authmethod.NewCache(),
 		fsm:                     newFSMFromConfig(flat.Logger, gc, config),
 	}
@@ -1317,6 +1318,10 @@ func (s *Server) SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io
 func (s *Server) RegisterEndpoint(name string, handler interface{}) error {
 	s.logger.Warn("endpoint injected; this should only be used for testing")
 	return s.rpcServer.RegisterName(name, handler)
+}
+
+func (s *Server) FSM() *fsm.FSM {
+	return s.fsm
 }
 
 // Stats is used to return statistics for debugging and insight

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -125,7 +125,7 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer) (BaseDeps, error) 
 		TLSConfigurator:  d.TLSConfigurator,
 		Cache:            d.Cache,
 		Tokens:           d.Tokens,
-		EnterpriseConfig: initEnterpriseAutoConfig(d.EnterpriseDeps),
+		EnterpriseConfig: initEnterpriseAutoConfig(d.EnterpriseDeps, cfg),
 	}
 
 	d.AutoConfig, err = autoconf.New(acConf)

--- a/agent/setup_oss.go
+++ b/agent/setup_oss.go
@@ -15,6 +15,6 @@ func initEnterpriseBaseDeps(d BaseDeps, _ *config.RuntimeConfig) (BaseDeps, erro
 }
 
 // initEnterpriseAutoConfig is responsible for setting up auto-config for enterprise
-func initEnterpriseAutoConfig(_ consul.EnterpriseDeps) autoconf.EnterpriseConfig {
+func initEnterpriseAutoConfig(_ consul.EnterpriseDeps, _ *config.RuntimeConfig) autoconf.EnterpriseConfig {
 	return autoconf.EnterpriseConfig{}
 }

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -86,7 +86,9 @@ type TestAgent struct {
 // The caller is responsible for calling Shutdown() to stop the agent and remove
 // temporary directories.
 func NewTestAgent(t *testing.T, hcl string) *TestAgent {
-	return StartTestAgent(t, TestAgent{HCL: hcl})
+	a := StartTestAgent(t, TestAgent{HCL: hcl})
+	t.Cleanup(func() { a.Shutdown() })
+	return a
 }
 
 // StartTestAgent and wait for it to become available. If the agent fails to

--- a/lib/routine/routine_test.go
+++ b/lib/routine/routine_test.go
@@ -1,4 +1,4 @@
-package consul
+package routine
 
 import (
 	"context"
@@ -10,13 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLeaderRoutineManager(t *testing.T) {
+func TestManager(t *testing.T) {
 	t.Parallel()
 	var runs uint32
 	var running uint32
-	// tlog := testutil.NewCancellableTestLogger(t)
-	// defer tlog.Cancel()
-	mgr := NewLeaderRoutineManager(testutil.Logger(t))
+	mgr := NewManager(testutil.Logger(t))
 
 	run := func(ctx context.Context) error {
 		atomic.StoreUint32(&running, 1)
@@ -30,7 +28,7 @@ func TestLeaderRoutineManager(t *testing.T) {
 	require.False(t, mgr.IsRunning("not-found"))
 
 	// start
-	require.NoError(t, mgr.Start("run", run))
+	require.NoError(t, mgr.Start(context.Background(), "run", run))
 	require.True(t, mgr.IsRunning("run"))
 	retry.Run(t, func(r *retry.R) {
 		require.Equal(r, uint32(1), atomic.LoadUint32(&runs))
@@ -47,7 +45,7 @@ func TestLeaderRoutineManager(t *testing.T) {
 	})
 
 	// restart and stop
-	require.NoError(t, mgr.Start("run", run))
+	require.NoError(t, mgr.Start(context.Background(), "run", run))
 	retry.Run(t, func(r *retry.R) {
 		require.Equal(r, uint32(2), atomic.LoadUint32(&runs))
 		require.Equal(r, uint32(1), atomic.LoadUint32(&running))
@@ -63,7 +61,7 @@ func TestLeaderRoutineManager(t *testing.T) {
 
 	// start with a context
 	ctx, cancel := context.WithCancel(context.Background())
-	require.NoError(t, mgr.StartWithContext(ctx, "run", run))
+	require.NoError(t, mgr.Start(ctx, "run", run))
 	cancel()
 
 	// The function should exit of its own accord due to the parent
@@ -74,5 +72,30 @@ func TestLeaderRoutineManager(t *testing.T) {
 		// the task should automatically set itself to not running if
 		// it exits early
 		require.False(r, mgr.IsRunning("run"))
+	})
+}
+
+func TestManager_StopAll(t *testing.T) {
+	t.Parallel()
+	var runs uint32
+	var running uint32
+	mgr := NewManager(testutil.Logger(t))
+
+	run := func(ctx context.Context) error {
+		atomic.StoreUint32(&running, 1)
+		defer atomic.StoreUint32(&running, 0)
+		atomic.AddUint32(&runs, 1)
+		<-ctx.Done()
+		return nil
+	}
+
+	require.NoError(t, mgr.Start(context.Background(), "run1", run))
+	require.NoError(t, mgr.Start(context.Background(), "run2", run))
+
+	mgr.StopAll()
+
+	retry.Run(t, func(r *retry.R) {
+		require.False(r, mgr.IsRunning("run1"))
+		require.False(r, mgr.IsRunning("run2"))
 	})
 }


### PR DESCRIPTION
The bulk of this commit is moving the LeaderRoutineManager from the agent/consul package into its own package: lib/gort. It also got a renaming and its Start method now requires a context. Requiring that context required updating a whole bunch of other places in the code.