### PR TITLE
ui: Adds QUnit toggle bookmarklet to our docs

### DIFF
--- a/ui/packages/consul-ui/docs/bookmarklets.mdx
+++ b/ui/packages/consul-ui/docs/bookmarklets.mdx
@@ -13,6 +13,7 @@ Below is a list of the most commonly used functions as bookmarklets followed by 
 | [Enable Partitions](javascript:Scenario('CONSUL_PARTITIONS_ENABLE=1')) | Enable Admin Partition Support |
 | [Enable SSO ](javascript:Scenario('CONSUL_SSO_ENABLE=1')) | Enable SSO Support |
 | [Enable Metrics](javascript:Scenario('CONSUL_METRICS_PROXY_ENABLE=1;CONSUL_METRICS_PROVIDER=prometheus')) | Enable all configuration required for viewing the full Metrics Visualization |
+| [Toggle QUnit Display](javascript:(function()%7B(function()%7Bconst%20s%20%3D%20document.getElementById(%22ember-testing-container%22).style%3Bs.display%20%3D%20s.display%20%3D%3D%3D%20%22none%22%20%3F%20%22block%22%20%3A%20%22none%22%3B%7D)()%3B%7D)()%3B) | Toggle the QUnit display on or off during browser testing |
 
 | Function | Arguments | Description |
 | -------- | --------- | ----------- |


### PR DESCRIPTION
Adds a bookmarklet to our docs for folks to toggle the QUnit preview during testing so you can see the things behind it easily:

![qunit](https://user-images.githubusercontent.com/554604/119000519-18088d00-b983-11eb-83f3-0a00137ae208.gif)

I think this is only temporarily needed as I vaguely remember trying an upgrade of something and this seemed to have been fixed before I backed out of the upgrade I was doing. I might be misremembering though.