### PR TITLE
ui: Create and use collapsible notices component

### DIFF
--- a/ui/packages/consul-ui/app/components/notice/layout.scss
+++ b/ui/packages/consul-ui/app/components/notice/layout.scss
@@ -22,3 +22,6 @@
   left: 0.6rem;
   font-size: 1rem;
 }
+%notice p.hide {
+  display: none;
+}

--- a/ui/packages/consul-ui/app/components/notice/layout.scss
+++ b/ui/packages/consul-ui/app/components/notice/layout.scss
@@ -22,6 +22,3 @@
   left: 0.6rem;
   font-size: 1rem;
 }
-%notice p.hide {
-  display: none;
-}

--- a/ui/packages/consul-ui/tests/acceptance/steps/dc/acls/auth-methods/index-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/dc/acls/auth-methods/index-steps.js
@@ -1,4 +1,4 @@
-import steps from '../../../steps';
+import steps from '../../../../steps';
 
 // step definitions that are shared between features should be moved to the
 // tests/acceptance/steps/steps.js file


### PR DESCRIPTION
![collapsible_banner](https://user-images.githubusercontent.com/19161242/119000584-3c4f7400-b959-11eb-837f-28f23d73e807.gif)

- Creates `CollapsibleNotices` component
- Restructure the acceptance tests folder for topology
- Adds testing for TProxy notices in Topology tab
- Use of `CollapsibleNotices` in Toplogy route when there are more than 2 `Notices`.