### PR TITLE
debug: remove the CLI check for debug_enabled

### DIFF
--- a/.changelog/10273.txt
+++ b/.changelog/10273.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+cli: removes the need to set debug_enabled=true to collect debug data from the CLI. Now
+the CLI behaves the same way as the API and accepts either an ACL token with operator:read, or
+debug_enabled=true.
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -238,18 +238,16 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 			var token string
 			s.parseToken(req, &token)
 
+			// If enableDebug is not set, and ACLs are disabled, write
+			// an unauthorized response
+			if !enableDebug && s.checkACLDisabled(resp, req) {
+				return
+			}
+
 			rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 			if err != nil {
 				resp.WriteHeader(http.StatusForbidden)
 				return
-			}
-
-			// If enableDebug is not set, and ACLs are disabled, write
-			// an unauthorized response
-			if !enableDebug {
-				if s.checkACLDisabled(resp, req) {
-					return
-				}
 			}
 
 			// If the token provided does not have the necessary permissions,

--- a/api/debug.go
+++ b/api/debug.go
@@ -29,6 +29,10 @@ func (d *Debug) Heap() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
+
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
 	body, err := ioutil.ReadAll(resp.Body)
@@ -51,6 +55,10 @@ func (d *Debug) Profile(seconds int) ([]byte, error) {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
@@ -75,6 +83,10 @@ func (d *Debug) Trace(seconds int) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
+
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
 	body, err := ioutil.ReadAll(resp.Body)
@@ -94,6 +106,10 @@ func (d *Debug) Goroutine() ([]byte, error) {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -32,8 +32,6 @@ func TestDebugCommand(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	t.Parallel()
-
 	testDir := testutil.TempDir(t, "debug")
 
 	a := agent.NewTestAgent(t, `
@@ -71,8 +69,6 @@ func TestDebugCommand_Archive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
-
-	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
 
@@ -190,8 +186,6 @@ func TestDebugCommand_OutputPathExists(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	t.Parallel()
-
 	testDir := testutil.TempDir(t, "debug")
 
 	a := agent.NewTestAgent(t, "")
@@ -230,8 +224,6 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
-
-	t.Parallel()
 
 	cases := map[string]struct {
 		// used in -target param
@@ -343,8 +335,6 @@ func TestDebugCommand_ProfilesExist(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	t.Parallel()
-
 	testDir := testutil.TempDir(t, "debug")
 
 	a := agent.NewTestAgent(t, `
@@ -392,8 +382,6 @@ func TestDebugCommand_ValidateTiming(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
-
-	t.Parallel()
 
 	cases := map[string]struct {
 		duration string


### PR DESCRIPTION
Fixes #10208

The API allows collecting profiles even when debug_enabled=false, as long as ACLs are enabled. This PR remove the check for `debug_enabled` from the CLI so that users do not need to set debug_enabled=true for no reason.

Also fixes the API client to return errors on non-200 status codes for debug endpoints and improves the failure messages when pprof data can not be collected.

The fix to the API client exposed the fact that most of these tests were actually failing silently. They were never checking the actual output, and all of these tests were hitting 500 errors on the server (see comment below for why). So this PR also fixes the tests.

