### PR TITLE
ci: allow bash_env in load-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -893,6 +893,8 @@ jobs:
     environment:
       AWS_DEFAULT_REGION: us-east-2
       BUCKET: consul-ci-load-tests
+      BASH_ENV: /etc/profile
+    shell: /bin/sh -leo pipefail
     steps:
       - checkout
       - run: apk add jq curl bash
@@ -924,7 +926,6 @@ jobs:
             echo "export TF_VAR_consul_download_url=https://${S3_ARTIFACT_BUCKET}.s3.${AWS_DEFAULT_REGION}.amazonaws.com/${S3_ARTIFACT_PATH}/${LOCAL_COMMIT_SHA}.zip" >> $BASH_ENV
       - run:
           name: wait for dev build from test-integrations workflow
-          shell: /usr/bin/env bash -euo pipefail -c
           command: |
             echo "curl-ing https://${S3_ARTIFACT_BUCKET}.s3.${AWS_DEFAULT_REGION}.amazonaws.com/${S3_ARTIFACT_PATH}/${LOCAL_COMMIT_SHA}.zip"
             until [ $SECONDS -ge 300 ] && exit 1; do
@@ -935,7 +936,6 @@ jobs:
       - run:
           working_directory: .circleci/terraform/load-test
           name: terraform init
-          shell: /usr/bin/env bash -euo pipefail -c
           command: |
             echo "commit is ${LOCAL_COMMIT_SHA}"
             terraform init \
@@ -946,14 +946,12 @@ jobs:
       - run:
           working_directory: .circleci/terraform/load-test
           name: run terraform apply
-          shell: /usr/bin/env bash -euo pipefail -c
           command: |
             terraform apply -auto-approve
       - run:
           working_directory: .circleci/terraform/load-test
           when: always
           name: terraform destroy
-          shell: /usr/bin/env bash -euo pipefail -c
           command: |
             terraform destroy -auto-approve
       - run: *notify-slack-failure
@@ -964,7 +962,7 @@ jobs:
     docker:
       - image: docker.mirror.hashicorp.services/alpine:latest
     steps:
-      - run: 'echo ok'
+      - run: "echo ok"
 
 workflows:
   version: 2

--- a/.circleci/terraform/load-test/main.tf
+++ b/.circleci/terraform/load-test/main.tf
@@ -20,4 +20,5 @@ module "load-test" {
   test_public_ip       = true
   ami_owners           = var.ami_owners
   consul_download_url  = var.consul_download_url
+  cluster_name         = var.cluster_name
 }

--- a/.circleci/terraform/load-test/variables.tf
+++ b/.circleci/terraform/load-test/variables.tf
@@ -17,3 +17,8 @@ variable "consul_download_url" {
   description = "URL to download the Consul binary from"
   default     = ""
 }
+variable "cluster_name" {
+  description = "What to name the Consul cluster and all of its associated resources"
+  type        = string
+  default     = "consul-example"
+}


### PR DESCRIPTION
This PR allows `BASH_ENV` to be used within the `hashicorp/terraform` image which is alpine based. 

I also fixed the cluster_name uniqueness. The variable was set in the CI run but the variable was never declared in TF config and passed to the module so it was never used 🤦 . Now each cluster should be uniquely named with the shortref