### PR TITLE
docs: rename enterprise to Consul enterprise

### DIFF
--- a/website/content/docs/enterprise/index.mdx
+++ b/website/content/docs/enterprise/index.mdx
@@ -1,6 +1,6 @@
 ---
 layout: docs
-page_title: Enterprise Features
+page_title: Consul Enterprise
 description: >-
   Consul Enterprise features a number of capabilities beyond the open source
   offering that may be beneficial in certain workflows.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -755,7 +755,7 @@
     ]
   },
   {
-    "title": "Enterprise Features",
+    "title": "Consul Enterprise",
     "routes": [
       {
         "title": "Overview",


### PR DESCRIPTION
This PR renames the documentation sidebar collection name `Enterprise Features` to `Consul Enterprise`. This is to follow the same pattern as the other products (Nomad, and Vault). 