### PR TITLE
ui: Move intention form description field

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -102,6 +102,12 @@
 {{/if}}
       </fieldset>
     </div>
+  <fieldset>
+    <label class="type-text{{if item.error.Description ' has-error'}}">
+      <span>Description (Optional)</span>
+      <input type="text" name="Description" value={{item.Description}} placeholder="Description (Optional)" onchange={{action onchange}} />
+    </label>
+  </fieldset>
     <div>
       <span class="label">Should this source connect to the destination?</span>
       <div role="radiogroup" class={{if item.error.Action ' has-error'}}>
@@ -183,12 +189,6 @@
 {{/if}}
   </fieldset>
 {{/if}}
-  <fieldset>
-    <label class="type-text{{if item.error.Description ' has-error'}}">
-      <span>Description (Optional)</span>
-      <input type="text" name="Description" value={{item.Description}} placeholder="Description (Optional)" onchange={{action onchange}} />
-    </label>
-  </fieldset>
 
   <ModalDialog
     class="consul-intention-permission-modal"


### PR DESCRIPTION
We decided that the description field for intentions should be above the 'Allow/deny/app-aware' widget rather than below it.

Before:

<img width="1366" alt="Screenshot 2021-05-27 at 11 45 05" src="https://user-images.githubusercontent.com/554604/119813800-9dd78b80-bee1-11eb-860c-4a6596b97ce4.png">

After:

<img width="1370" alt="Screenshot 2021-05-27 at 11 48 53" src="https://user-images.githubusercontent.com/554604/119813819-a334d600-bee1-11eb-82e9-1114e6b7b023.png">


