### PR TITLE
Update Kubernetes docs to point to install pages.

### DIFF
--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -30,8 +30,9 @@ all the necessary components to run Consul. The configuration enables you
 to run just a server cluster, just a client cluster, or both. Using the Helm
 chart, you can have a full Consul deployment up and running in minutes.
 
-A step-by-step beginner tutorial and accompanying video can be found at the
-[Minikube with Consul guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs).
+Step-by-step tutorials for how to deploy Consul to Kubernetes, please see
+our [Deploy to Kubernetes](https://learn.hashicorp.com/collections/consul/kubernetes-deploy)
+collection. This collection includes configuration caveats for single node deployments.
 
 While the Helm chart exposes dozens of useful configurations and automatically
 sets up complex resources, it **does not automatically operate Consul.**


### PR DESCRIPTION
Adds more clear indicators that the collections on the learn.hashicorp.com sites have specific instructions for single node deployments.

Closes  #8260 as the docs pages have since been moved.
Co-Authored by: soonoo <qpseh2m7@gmail.com>