### PR TITLE
ui: Minor CSS tweaks/layout fixes

### DIFF
--- a/ui/packages/consul-ui/app/components/app-view/layout.scss
+++ b/ui/packages/consul-ui/app/components/app-view/layout.scss
@@ -4,7 +4,7 @@
   align-items: center;
   white-space: nowrap;
   position: relative;
-  z-index: 4;
+  z-index: 5;
 }
 %app-view-actions {
   display: flex;

--- a/ui/packages/consul-ui/app/styles/routes/dc/services/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/services/index.scss
@@ -8,9 +8,18 @@ html[data-route^='dc.services.instance'] .app-view > header dl {
 html[data-route^='dc.services.instance'] .app-view > header dt {
   font-weight: $typo-weight-bold;
 }
+html[data-route^='dc.services.instance'] .tab-nav {
+  border-top: $decor-border-100;
+}
+html[data-route^='dc.services.instance'] .tab-section section:not(:last-child) {
+  border-bottom: $decor-border-100;
+}
+html[data-route^='dc.services.instance'] .tab-nav,
+html[data-route^='dc.services.instance'] .tab-section section:not(:last-child) {
+  border-color: var(--gray-200);
+}
 html[data-route^='dc.services.instance'] .tab-section section:not(:last-child) {
   padding-bottom: 24px;
-  border-bottom: 1px solid $gray-200;
 }
 html[data-route^='dc.services.instance.metadata'] .tab-section section h2 {
   @extend %h300;


### PR DESCRIPTION
This PR includes two minor CSS layout bugfixes:

1. z-Index dancing (+1) for our `<ConsulKind @withInfo=true />`

I quite often work on a very small screen and I noticed we had some z-index clashes between our info popover things and our 'mid-size' search bar, which could happen more often now we have the sidebar navigation. It would be nice to change all over our popover menu type things to use our [`with-overlay` modifier](https://consul-ui-staging-hashicorp.vercel.app/ui/docs/modifiers/with-overlay) so we can pretty much forget about z-index dancing and avoid these types of problems moving forwards.

Before:

<img width="1358" alt="Screenshot 2021-05-26 at 10 23 33" src="https://user-images.githubusercontent.com/554604/119636443-8d091600-be0c-11eb-916a-05273385b067.png">

After:

<img width="1364" alt="Screenshot 2021-05-26 at 10 19 29" src="https://user-images.githubusercontent.com/554604/119636467-92fef700-be0c-11eb-9e4b-c69fbd2d0be9.png">

2. Fix up TabNav top border
During https://github.com/hashicorp/consul/pull/10259 we re-styled our secondary navigation to more closely follow Structures TabNavigation, which doesn't define a top border. I didn't realise that there was still one place in Consul UI which needs a border between the top of the Tab Navigation and the content above it. This fixes that up with some super targeted route level CSS just for that single instance.

Before:

<img width="903" alt="Screenshot 2021-05-26 at 10 32 14" src="https://user-images.githubusercontent.com/554604/119637539-a9598280-be0d-11eb-99b3-59975dbc4fdd.png">

After:

<img width="1185" alt="Screenshot 2021-05-26 at 10 20 07" src="https://user-images.githubusercontent.com/554604/119637559-afe7fa00-be0d-11eb-9098-5d4072f5dee6.png">

