### PR TITLE
Avoid adding original_dst filter when not needed

### DIFF
--- a/.changelog/10302.txt
+++ b/.changelog/10302.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+connect: Avoid adding original_dst listener filter when it won't be used.
+```
+

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -78,12 +78,6 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 
 		outboundListener = makePortListener(OutboundListenerName, "127.0.0.1", port, envoy_core_v3.TrafficDirection_OUTBOUND)
 		outboundListener.FilterChains = make([]*envoy_listener_v3.FilterChain, 0)
-		outboundListener.ListenerFilters = []*envoy_listener_v3.ListenerFilter{
-			{
-				// TODO (freddy): Hard-coded until we upgrade the go-control-plane library
-				Name: "envoy.filters.listener.original_dst",
-			},
-		}
 	}
 
 	var hasFilterChains bool
@@ -206,6 +200,13 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		// Add a catch-all filter chain that acts as a TCP proxy to non-catalog destinations
 		if cfgSnap.ConnectProxy.MeshConfig == nil ||
 			!cfgSnap.ConnectProxy.MeshConfig.TransparentProxy.CatalogDestinationsOnly {
+
+			outboundListener.ListenerFilters = []*envoy_listener_v3.ListenerFilter{
+				{
+					// TODO (freddy): Hard-coded until we upgrade the go-control-plane library
+					Name: "envoy.filters.listener.original_dst",
+				},
+			}
 
 			filterChain, err := s.makeUpstreamFilterChainForDiscoveryChain(
 				"passthrough",

--- a/agent/xds/testdata/listeners/transparent-proxy-catalog-destinations-only.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-catalog-destinations-only.envoy-1-18-x.golden
@@ -57,11 +57,6 @@
           ]
         }
       ],
-      "listenerFilters": [
-        {
-          "name": "envoy.filters.listener.original_dst"
-        }
-      ],
       "trafficDirection": "OUTBOUND"
     },
     {

--- a/agent/xds/testdata/listeners/transparent-proxy-catalog-destinations-only.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-catalog-destinations-only.v2compat.envoy-1-16-x.golden
@@ -57,11 +57,6 @@
           ]
         }
       ],
-      "listenerFilters": [
-        {
-          "name": "envoy.filters.listener.original_dst"
-        }
-      ],
       "trafficDirection": "OUTBOUND"
     },
     {


### PR DESCRIPTION
Including it shouldn't hurt functionally, since no filter chain would
reference it, but it likely adds overhead.