### PR TITLE
changelog: add entry for network areas WAN config fix

### DIFF
--- a/.changelog/_923.txt
+++ b/.changelog/_923.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+areas: **(Enterprise only)** Selectively merge gossip_wan config for network areas to avoid attempting to enable gossip encryption where it was not intended or necessary.
+```


### PR DESCRIPTION
Was already manually added to the `release/1.8.x` branch during the 1.8.11-beta2 release