### PR TITLE
Bump raft-autopilot version to the latest.

### DIFF
--- a/.changelog/10306.txt
+++ b/.changelog/10306.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+autopilot: **(Enterprise only)** Fixed an issue where autopilot could cause a new leader to demote the wrong voter when redundancy zones are in use and the previous leader failed.
+```
+

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/hashicorp/memberlist v0.2.4
 	github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69
 	github.com/hashicorp/raft v1.3.1
-	github.com/hashicorp/raft-autopilot v0.1.2
+	github.com/hashicorp/raft-autopilot v0.1.5
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/hashicorp/serf v0.9.5
 	github.com/hashicorp/vault/api v1.0.5-0.20200717191844-f687267c8086

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/hashicorp/raft v1.1.1/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7
 github.com/hashicorp/raft v1.2.0/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
 github.com/hashicorp/raft v1.3.1 h1:zDT8ke8y2aP4wf9zPTB2uSIeavJ3Hx/ceY4jxI2JxuY=
 github.com/hashicorp/raft v1.3.1/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
-github.com/hashicorp/raft-autopilot v0.1.2 h1:yeqdUjWLjVJkBM+mcVxqwxi+w+aHsb9cEON2dz69OCs=
-github.com/hashicorp/raft-autopilot v0.1.2/go.mod h1:Af4jZBwaNOI+tXfIqIdbcAnh/UyyqIMj/pOISIfhArw=
+github.com/hashicorp/raft-autopilot v0.1.5 h1:onEfMH5uHVdXQqtas36zXUHEZxLdsJVu/nXHLcLdL1I=
+github.com/hashicorp/raft-autopilot v0.1.5/go.mod h1:Af4jZBwaNOI+tXfIqIdbcAnh/UyyqIMj/pOISIfhArw=
 github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea h1:xykPFhrBAS2J0VBzVa5e80b5ZtYuNQtgXjN40qBZlD4=
 github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pNv7Wc3ycL6F5oOWn+tPGo2gWD4a5X+yp/ntwdKLjRk=
 github.com/hashicorp/serf v0.9.5 h1:EBWvyu9tcRszt3Bxp3KNssBMP1KuHWyO51lz9+786iM=

--- a/vendor/github.com/hashicorp/raft-autopilot/autopilot.go
+++ b/vendor/github.com/hashicorp/raft-autopilot/autopilot.go
@@ -147,16 +147,6 @@ type Autopilot struct {
 	// racing.
 	stateLock sync.RWMutex
 
-	// startTime is recorded so that we can make better determinations about server
-	// stability during the initial period of time after autopilot first starts.
-	// If autopilot has just started the default behavior to check if a server is
-	// stable will not work as it will ensure the server has been healthy for
-	// the configured server stabilization time. If that configure time is longer
-	// than the amount of time autopilot has been running you can run into issues
-	// with leadership flapping during some scenarios where a cluster is being
-	// brought up.
-	startTime time.Time
-
 	// removeDeadCh is used to trigger the running autopilot go routines to
 	// find and remove any dead/failed servers
 	removeDeadCh chan struct{}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -483,7 +483,7 @@ github.com/hashicorp/memberlist
 github.com/hashicorp/net-rpc-msgpackrpc
 # github.com/hashicorp/raft v1.3.1
 github.com/hashicorp/raft
-# github.com/hashicorp/raft-autopilot v0.1.2
+# github.com/hashicorp/raft-autopilot v0.1.5
 github.com/hashicorp/raft-autopilot
 # github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 github.com/hashicorp/raft-boltdb


### PR DESCRIPTION
This is a pretty simple dependency bump. Mainly we are wanting to pull in this fix: https://github.com/hashicorp/raft-autopilot/pull/9