### PR TITLE
Support getting nil in testutil.NewTestServerConfigT()

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1078,3 +1078,21 @@ func TestAPI_GenerateEnvHTTPS(t *testing.T) {
 
 	require.Equal(t, expected, c.GenerateEnv())
 }
+
+func TestAPI_NewTestServerConfigT(t *testing.T) {
+	configCallback := func(c *testutil.TestServerConfig) {
+		c.Bootstrap = true
+	}
+
+	// with *testing.T
+	server, err := testutil.NewTestServerConfigT(t, configCallback)
+	require.NoError(t, err)
+	server.WaitForLeader(t)
+	server.Stop()
+
+	// without *testing.T
+	server, err = testutil.NewTestServerConfigT(nil, configCallback)
+	require.NoError(t, err)
+	server.WaitForLeader(t)
+	server.Stop()
+}

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -250,7 +250,9 @@ func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, er
 		return nil, errors.Wrap(err, "failed marshaling json")
 	}
 
-	t.Logf("CONFIG JSON: %s", string(b))
+	if t != nil {
+		t.Logf("CONFIG JSON: %s", string(b))
+	}
 	configFile := filepath.Join(tmpdir, "config.json")
 	if err := ioutil.WriteFile(configFile, b, 0644); err != nil {
 		cfg.ReturnPorts()
@@ -297,7 +299,7 @@ func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, er
 
 	// Wait for the server to be ready
 	if err := server.waitForAPI(); err != nil {
-		if err := server.Stop(); err != nil {
+		if err := server.Stop(); err != nil && t != nil {
 			t.Logf("server stop failed with: %v", err)
 		}
 		return nil, err

--- a/sdk/testutil/testlog.go
+++ b/sdk/testutil/testlog.go
@@ -37,7 +37,7 @@ var testLogOnlyFailed = os.Getenv("TEST_LOGGING_ONLY_FAILED") == "1"
 // will prevent logs being output when the verbose flag is set if the test
 // case is successful.
 func NewLogBuffer(t TestingTB) io.Writer {
-	if sendTestLogsToStdout {
+	if sendTestLogsToStdout || t == nil {
 		return os.Stdout
 	}
 	buf := &logBuffer{buf: new(bytes.Buffer)}


### PR DESCRIPTION
Some Consul Enterprise users have asked the Consul backend of Terraform
to support storing the Terraform state in a Namespace. Since Terraform
uses an old version of the Consul SDK it needs to be updated to be able
to specify a namespace when interacting with the KV store.

Terraform uses testutil.NewTestServerConfig(cb) in the tests to start the
Consul server against it runs the tests at https://github.com/hashicorp/terraform/blob/abf7f3416b45c10f2e62e83d5e223a9fb9d6228b/internal/backend/remote-state/consul/backend_test.go#L21-L54
This functions has been replaced by testutil.NewTestServerConfigT(t, cb)
which takes both a *testing.T interface and a configuration callback.
Since testutil.NewTestServerConfig is called only once in TestMain there
is no *testing.T to give it.

testutil.NewTestServerConfigT has some support to receive nil instead of
the *testing.T object (https://github.com/hashicorp/consul/blob/4c7f5f31c718ea1ee00ef93545177c951376b51f/sdk/testutil/server.go#L231-L234)
but it is incomplete (https://github.com/hashicorp/consul/blob/4c7f5f31c718ea1ee00ef93545177c951376b51f/sdk/testutil/server.go#L253)
making the tests passing if they do this.

This just fixes this code path and add TestAPI_NewTestServerConfigT() to
exercise it so that it continues to work in the future.