### PR TITLE
fix(website): update node version to latest LTS for website

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/node:10.16.3-alpine
+FROM docker.mirror.hashicorp.services/node:14.17.0-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json


### PR DESCRIPTION
Update the node version in the website's `Dockerfile` to the latest LTS version, which is 14.17.0.