### PR TITLE
ui: Fix broken link format in ECS install page

### DIFF
--- a/website/content/docs/ecs/get-started/install.mdx
+++ b/website/content/docs/ecs/get-started/install.mdx
@@ -142,8 +142,7 @@ The specific permissions needed are:
 1. `ecs:ListTasks` on resource `*`.
 1. `ecs:DescribeTasks` on all tasks in this account and region. You can either
    use `*` for simplicity or scope it to the region and account, e.g. `arn:aws:ecs:us-east-1:1111111111111:task/*`. If 
-   your account is configured to use the new, [longer ECS task ARN format] 
-  (https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-account-settings.html#ecs-resource-ids)
+   your account is configured to use the new, [longer ECS task ARN format](https://docs.aws.amazon.com/AmazonECS/latest/userguide/ecs-account-settings.html#ecs-resource-ids)
    then you can further scope `ecs:DescribeTasks` down to tasks in a specific cluster, e.g. `arn:aws:ecs:us-east-1:1111111111111:task/MY_CLUSTER_NAME/*`.
 
 The IAM role's ARN will be passed into the `mesh-task` module in the next step


### PR DESCRIPTION
Fixes markdown syntax of ECS ARN link. Currently, line break between link text & url is causing a display issue [here](https://www.consul.io/docs/ecs/get-started/install#task-iam-role) :
![image](https://user-images.githubusercontent.com/34254888/119893423-307f2700-bef0-11eb-8d08-4d325b0ffb81.png)

### Edit
Change appears fixed in [preview](https://consul-e6luoni7g-hashicorp.vercel.app/docs/ecs/get-started/install#task-iam-role)
