### PR TITLE
Fix strings.Replace->strings.ReplaceAll

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -36,5 +36,5 @@ func GetHumanVersion() string {
 	}
 
 	// Strip off any single quotes added by the git information.
-	return strings.Replace(version, "'", "", -1)
+	return strings.ReplaceAll(version, "'", "")
 }


### PR DESCRIPTION
Replaces and closes #10228 

This is a clone of the above community contribution. Tests were not running in their PR, and it needed a rebase anyways.