### PR TITLE
docs: Improve object nesting of ECS routing example

### DIFF
--- a/website/content/docs/ecs/get-started/install.mdx
+++ b/website/content/docs/ecs/get-started/install.mdx
@@ -367,12 +367,19 @@ module "web" {
       local_bind_port  = 8080
     }
   ]
-  environment = [
+  container_definitions = [
     {
-      name  = "BACKEND_URL"
-      value = "http://localhost:8080"
+      name        = "web"
+      environment = [
+        {
+          name  = "BACKEND_URL"
+          value = "http://localhost:8080"
+        }
+      ]
+      ...
     }
   ]
+  ...
 }
 ```
 


### PR DESCRIPTION
The [routing section](https://www.consul.io/docs/ecs/get-started/install#routing) of the ECS "Install" docs is really helpful, but the example terraform shows the `upstreams` and `environment` fields on the same level when the latter is actually [specified within the container definition](https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/examples/dev-server-fargate/main.tf#L58-L78). This change updates the example to reflect this.


### testing
Structured as shown, `terraform plan` throws an error
![image](https://user-images.githubusercontent.com/34254888/120039509-e2365a80-bfb9-11eb-815e-4f080919874a.png)
