### PR TITLE
[1.7.x] debug: remove the CLI check for debug_enabled

### DIFF
--- a/.changelog/10273.txt
+++ b/.changelog/10273.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+cli: removes the need to set debug_enabled=true to collect debug data from the CLI. Now
+the CLI behaves the same way as the API and accepts either an ACL token with operator:read, or
+debug_enabled=true.
+```

--- a/api/debug.go
+++ b/api/debug.go
@@ -29,6 +29,10 @@ func (d *Debug) Heap() ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
+
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
 	body, err := ioutil.ReadAll(resp.Body)
@@ -51,6 +55,10 @@ func (d *Debug) Profile(seconds int) ([]byte, error) {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
@@ -75,6 +83,10 @@ func (d *Debug) Trace(seconds int) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
+
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
 	body, err := ioutil.ReadAll(resp.Body)
@@ -94,6 +106,10 @@ func (d *Debug) Goroutine() ([]byte, error) {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, generateUnexpectedResponseCodeError(resp)
+	}
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -5,15 +5,18 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/mitchellh/cli"
 )
 
 func TestDebugCommand_noTabs(t *testing.T) {
@@ -25,7 +28,9 @@ func TestDebugCommand_noTabs(t *testing.T) {
 }
 
 func TestDebugCommand(t *testing.T) {
-	t.Parallel()
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
@@ -62,7 +67,9 @@ func TestDebugCommand(t *testing.T) {
 }
 
 func TestDebugCommand_Archive(t *testing.T) {
-	t.Parallel()
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
@@ -179,7 +186,9 @@ func TestDebugCommand_OutputPathBad(t *testing.T) {
 }
 
 func TestDebugCommand_OutputPathExists(t *testing.T) {
-	t.Parallel()
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
@@ -217,7 +226,9 @@ func TestDebugCommand_OutputPathExists(t *testing.T) {
 }
 
 func TestDebugCommand_CaptureTargets(t *testing.T) {
-	t.Parallel()
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	cases := map[string]struct {
 		// used in -target param
@@ -326,7 +337,9 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 }
 
 func TestDebugCommand_ProfilesExist(t *testing.T) {
-	t.Parallel()
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
@@ -373,7 +386,9 @@ func TestDebugCommand_ProfilesExist(t *testing.T) {
 }
 
 func TestDebugCommand_ValidateTiming(t *testing.T) {
-	t.Parallel()
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	cases := map[string]struct {
 		duration string
@@ -469,13 +484,16 @@ func TestDebugCommand_DebugDisabled(t *testing.T) {
 	// Glob ignores file system errors
 	for _, v := range profiles {
 		fs, _ := filepath.Glob(fmt.Sprintf("%s/*/%s", outputPath, v))
-		if len(fs) > 0 {
-			t.Errorf("output data should not exist for %s", v)
-		}
+		// TODO: make this always one
+		require.True(t, len(fs) >= 1)
+		content, err := ioutil.ReadFile(fs[0])
+		require.NoError(t, err)
+		require.Len(t, content, 0)
 	}
 
 	errOutput := ui.ErrorWriter.String()
-	if !strings.Contains(errOutput, "Unable to capture pprof") {
-		t.Errorf("expected warn output, got %s", errOutput)
+	for _, prof := range []string{"heap", "cpu", "goroutine", "trace"} {
+		expected := fmt.Sprintf("failed to collect %v", prof)
+		require.Contains(t, errOutput, expected)
 	}
 }


### PR DESCRIPTION
Backport of #10273

Conflict was in `http.go`