### PR TITLE
docs: Add intentions to ACL System docs

### DIFF
--- a/website/content/docs/security/acl/acl-rules.mdx
+++ b/website/content/docs/security/acl/acl-rules.mdx
@@ -512,7 +512,19 @@ In addition to ACLs, in Consul 0.9.0 and later, the agent must be configured wit
 [`enable_local_script_checks`](/docs/agent/options#_enable_local_script_checks)
 set to `true` in order to enable script checks.
 
--> Note: [Intention privileges](/docs/connect/intentions#intention-management-permissions) are managed with service rules.
+Service rules are also used to grant read or write access to intentions. The
+following policy provides read-write access to the "app" service, and explicitly
+grants `intention:read` access to view intentions associated with the "app" service.
+
+```hcl
+service "app" {
+  policy = "write"
+  intention = "read"
+}
+```
+
+Refer to [Intention Management Permissions](/docs/connect/intentions#intention-management-permissions)
+for more information about managing intentions with service rules.
 
 #### Session Rules
 

--- a/website/content/docs/security/acl/acl-rules.mdx
+++ b/website/content/docs/security/acl/acl-rules.mdx
@@ -514,17 +514,17 @@ set to `true` in order to enable script checks.
 
 Service rules are also used to grant read or write access to intentions. The
 following policy provides read-write access to the "app" service, and explicitly
-grants `intention:read` access to view intentions associated with the "app" service.
+grants `intentions:read` access to view intentions associated with the "app" service.
 
 ```hcl
 service "app" {
   policy = "write"
-  intention = "read"
+  intentions = "read"
 }
 ```
 
 Refer to [Intention Management Permissions](/docs/connect/intentions#intention-management-permissions)
-for more information about managing intentions with service rules.
+for more information about managing intentions access with service rules.
 
 #### Session Rules
 

--- a/website/content/docs/security/acl/acl-system.mdx
+++ b/website/content/docs/security/acl/acl-system.mdx
@@ -246,7 +246,7 @@ rules:
 | [`node`](/docs/acl/acl-rules#node-rules)            | Node-level catalog operations in the [Catalog API](/api/catalog), [Health API](/api/health), [Prepared Query API](/api/query), [Network Coordinate API](/api/coordinate), and [Agent API](/api/agent) |
 | [`operator`](/docs/acl/acl-rules#operator-rules)    | Cluster-level operations in the [Operator API](/api/operator), other than the [Keyring API](/api/operator/keyring)                                                                                    |
 | [`query`](/docs/acl/acl-rules#prepared-query-rules) | Prepared query operations in the [Prepared Query API](/api/query)                                                                                                                                     |
-| [`service`](/docs/acl/acl-rules#service-rules)      | Service-level catalog operations in the [Catalog API](/api/catalog), [Health API](/api/health), [Prepared Query API](/api/query), and [Agent API](/api/agent)                                         |
+| [`service`](/docs/acl/acl-rules#service-rules)      | Service-level catalog operations in the [Catalog API](/api/catalog), [Health API](/api/health), [Intentions API](/api/connect/intentions), [Prepared Query API](/api/query), and [Agent API](/api/agent)                                         |
 | [`session`](/docs/acl/acl-rules#session-rules)      | Session operations in the [Session API](/api/session)                                                                                                                                                 |
 
 Since Consul snapshots actually contain ACL tokens, the [Snapshot API](/api/snapshot)


### PR DESCRIPTION
Adds mention of `intentions` rules to ACL System and ACL Rules pages.

Resolves #9790