### PR TITLE
envoy: fix deadlock when input is larger than named pipe buffer size

### DIFF
--- a/.changelog/10324.txt
+++ b/.changelog/10324.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+envoy: fixes a bug where a large envoy config could cause the `consul connect envoy` command to deadlock when attempting to start envoy.
+```

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -267,6 +267,9 @@ func limitProcessLifetime(dur time.Duration) {
 // Also sets up a cleanup function to revert the patch when the test exits.
 func patchExecArgs(t *testing.T) {
 	orig := execArgs
+	// go run will run the consul source from the root of the repo. The relative
+	// path is necessary because `go test` always sets the working directory to
+	// the directory of the package being tested.
 	execArgs = func(args ...string) (string, []string, error) {
 		args = append([]string{"run", "../../.."}, args...)
 		return "go", args, nil

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -3,8 +3,10 @@
 package envoy
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -189,11 +191,7 @@ func TestHelperProcess(t *testing.T) {
 
 		limitProcessLifetime(2 * time.Minute)
 
-		// This is another level of gross - we are relying on `consul` being on path
-		// and being the correct version but in general that is true under `make
-		// test`. We already make the same assumption for API package tests.
-		testSelfExecOverride = "consul"
-
+		patchExecArgs(t)
 		err := execEnvoy(
 			os.Args[0],
 			[]string{
@@ -263,4 +261,35 @@ func limitProcessLifetime(dur time.Duration) {
 	go time.AfterFunc(dur, func() {
 		os.Exit(99)
 	})
+}
+
+// patchExecArgs to use a version that will execute the commands using 'go run'.
+// Also sets up a cleanup function to revert the patch when the test exits.
+func patchExecArgs(t *testing.T) {
+	orig := execArgs
+	execArgs = func(args ...string) (string, []string, error) {
+		args = append([]string{"run", "../../.."}, args...)
+		return "go", args, nil
+	}
+	t.Cleanup(func() {
+		execArgs = orig
+	})
+}
+
+func TestMakeBootstrapPipe_DoesNotBlockOnAFullPipe(t *testing.T) {
+	// A named pipe can buffer up to 64k, use a value larger than that
+	bootstrap := bytes.Repeat([]byte("a"), 66000)
+
+	patchExecArgs(t)
+	pipe, err := makeBootstrapPipe(bootstrap)
+	require.NoError(t, err)
+
+	// Read everything from the named pipe, to allow the sub-process to exit
+	f, err := os.Open(pipe)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, f)
+	require.NoError(t, err)
+	require.Equal(t, bootstrap, buf.Bytes())
 }

--- a/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
+++ b/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
@@ -69,11 +69,12 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
+	// Use Warn to send to stderr, because all logs should go to stderr.
+	c.UI.Warn("Bootstrap sent, unlinking named pipe")
+
 	// Removed named pipe now we sent it. Even if Envoy has not yet read it, we
 	// know it has opened it and has the file descriptor since our write above
 	// will block until there is a reader.
-	c.UI.Warn("Bootstrap sent, unlinking named pipe")
-
 	os.RemoveAll(args[0])
 
 	return 0

--- a/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
+++ b/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/hashicorp/consul/command/flags"
 	"github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul/command/flags"
 )
 
 func New(ui cli.Ui) *cmd {
@@ -27,22 +28,20 @@ func (c *cmd) init() {
 }
 
 func (c *cmd) Run(args []string) int {
-	// This should never be alive for very long. In case bad things happen and
-	// Envoy never starts limit how long we live before just exiting so we can't
-	// accumulate tons of these zombie children.
-	time.AfterFunc(10*time.Second, func() {
-		// Force cleanup
-		if len(args) > 0 {
-			os.RemoveAll(args[0])
-		}
-		os.Exit(99)
-	})
-
 	// Read from STDIN, write to the named pipe provided in the only positional arg
 	if len(args) != 1 {
 		c.UI.Error("Expecting named pipe path as argument")
 		return 1
 	}
+
+	// This should never be alive for very long. In case bad things happen and
+	// Envoy never starts limit how long we live before just exiting so we can't
+	// accumulate tons of these zombie children.
+	time.AfterFunc(10*time.Second, func() {
+		// Force cleanup
+		os.RemoveAll(args[0])
+		os.Exit(99)
+	})
 
 	// WRONLY is very important here - the open() call will block until there is a
 	// reader (Envoy) if we open it with RDWR though that counts as an opener and
@@ -60,8 +59,7 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	err = f.Close()
-	if err != nil {
+	if err = f.Close(); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}

--- a/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap_test.go
+++ b/command/connect/envoy/pipe-bootstrap/connect_envoy_pipe-bootstrap_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestConnectEnvoyPipeBootstrapCommand_noTabs(t *testing.T) {
-	t.Parallel()
 	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
 		t.Fatal("help has tabs")
 	}


### PR DESCRIPTION
Fixes #10246

Normally the named pipe would buffer up to 64k, but in some cases when a
soft limit is reached, they will start only buffering up to 4k.
In either case, we should not deadlock.

This commit changes the pipe-bootstrap command to first buffer all of
stdin into the process, before trying to write it to the named pipe.
This allows the process memory to act as the buffer, instead of the
named pipe.

Also changed the order of operations in `makeBootstrapPipe`. The new
test added in this PR showed that simply buffering in the process memory
was not enough to fix the issue. We also need to ensure that the
`pipe-bootstrap` process is started before we try to write to its
stdin. Otherwise the write will still block.

Also set stdout/stderr on the subprocess, so that any errors are visible
to the user.