### PR TITLE
docs: Clarify set-agent-token token persistence behavior

### DIFF
--- a/website/content/commands/acl/set-agent-token.mdx
+++ b/website/content/commands/acl/set-agent-token.mdx
@@ -9,8 +9,10 @@ Command: `consul acl set-agent-token`
 
 This command updates the ACL tokens currently in use by the agent. It can be used to introduce
 ACL tokens to the agent for the first time, or to update tokens that were initially loaded from
-the agent's configuration. Tokens are not persisted, so will need to be updated again if the
-agent is restarted.
+the agent's configuration. Tokens are not persisted unless
+[`acl.enable_token_persistence`](/docs/agent/options#acl_enable_token_persistence)
+is `true`, so tokens will need to be updated again if that option is `false` and
+the agent is restarted.
 
 ## Usage
 


### PR DESCRIPTION
Clarify that tokens configured via `set-agent-token` will not be persisted if `acl.enable_token_persistence` is `false`.