### PR TITLE
connect/ca: require new vault mount points when updating the key type/bits for the vault connect CA provider

### DIFF
--- a/.changelog/10331.txt
+++ b/.changelog/10331.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect/ca: require new vault mount points when updating the key type/bits for the vault connect CA provider
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -360,14 +360,14 @@ ifeq ("$(CIRCLECI)","true")
 # Run in CI
 	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -- -cover -coverprofile=coverage.txt ./agent/connect/ca
 # Run leader tests that require Vault
-	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report-leader.xml" -- -cover -coverprofile=coverage-leader.txt -run TestLeader_Vault_ ./agent/consul
+	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report-leader.xml" -- -cover -coverprofile=coverage-leader.txt -run '.*_Vault_' ./agent/consul
 # Run agent tests that require Vault
 	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report-agent.xml" -- -cover -coverprofile=coverage-agent.txt -run '.*_Vault_' ./agent
 else
 # Run locally
 	@echo "Running /agent/connect/ca tests in verbose mode"
 	@go test -v ./agent/connect/ca
-	@go test -v ./agent/consul -run 'TestLeader_Vault_'
+	@go test -v ./agent/consul -run '.*_Vault_'
 	@go test -v ./agent -run '.*_Vault_'
 endif
 

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -537,7 +537,6 @@ func TestConnectCAConfig_Vault_TriggerRotation_Fails(t *testing.T) {
 			},
 		}
 	})
-	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 
 	codec := rpcClient(t, s1)

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -524,7 +524,7 @@ func TestConnectCAConfig_Vault_TriggerRotation_Fails(t *testing.T) {
 	testVault := ca.NewTestVaultServer(t)
 	defer testVault.Stop()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	_, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Build = "1.6.0"
 		c.PrimaryDatacenter = "dc1"
 		c.CAConfig = &structs.CAConfiguration{

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -550,7 +550,6 @@ func TestConnectCAConfig_Vault_TriggerRotation_Fails(t *testing.T) {
 		rootList, _, err := getTestRoots(s1, "dc1")
 		require.NoError(t, err)
 		require.Len(t, rootList.Roots, 1)
-		// originalRoot = activeRoot
 	}
 
 	cases := []struct {

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -546,7 +546,6 @@ func TestConnectCAConfig_Vault_TriggerRotation_Fails(t *testing.T) {
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	// Capture the current root.
-	// var originalRoot *structs.CARoot
 	{
 		rootList, _, err := getTestRoots(s1, "dc1")
 		require.NoError(t, err)


### PR DESCRIPTION
progress on #9572
