### PR TITLE
grpc: fix resolver data race

### DIFF
--- a/agent/grpc/client.go
+++ b/agent/grpc/client.go
@@ -25,10 +25,10 @@ type ClientConnPool struct {
 type ServerLocator interface {
 	// ServerForAddr is used to look up server metadata from an address.
 	ServerForAddr(addr string) (*metadata.Server, error)
-	// Scheme returns the url scheme to use to dial the server. This is primarily
+	// Authority returns the target authority to use to dial the server. This is primarily
 	// needed for testing multiple agents in parallel, because gRPC requires the
 	// resolver to be registered globally.
-	Scheme() string
+	Authority() string
 }
 
 // TLSWrapper wraps a non-TLS connection and returns a connection with TLS
@@ -58,7 +58,7 @@ func (c *ClientConnPool) ClientConn(datacenter string) (*grpc.ClientConn, error)
 	}
 
 	conn, err := grpc.Dial(
-		fmt.Sprintf("%s:///server.%s", c.servers.Scheme(), datacenter),
+		fmt.Sprintf("consul://%s/server.%s", c.servers.Authority(), datacenter),
 		// use WithInsecure mode here because we handle the TLS wrapping in the
 		// custom dialer based on logic around whether the server has TLS enabled.
 		grpc.WithInsecure(),

--- a/agent/grpc/client_test.go
+++ b/agent/grpc/client_test.go
@@ -117,7 +117,7 @@ func newConfig(t *testing.T) resolver.Config {
 	n := t.Name()
 	s := strings.Replace(n, "/", "", -1)
 	s = strings.Replace(s, "_", "", -1)
-	return resolver.Config{Scheme: strings.ToLower(s)}
+	return resolver.Config{Authority: strings.ToLower(s)}
 }
 
 func TestClientConnPool_IntegrationWithGRPCResolver_Rebalance(t *testing.T) {
@@ -194,4 +194,11 @@ func TestClientConnPool_IntegrationWithGRPCResolver_MultiDC(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, resp.Datacenter, dc)
 	}
+}
+
+func registerWithGRPC(t *testing.T, b *resolver.ServerResolverBuilder) {
+	resolver.Register(b)
+	t.Cleanup(func() {
+		resolver.Deregister(b.Authority())
+	})
 }

--- a/agent/grpc/resolver/registry.go
+++ b/agent/grpc/resolver/registry.go
@@ -1,0 +1,54 @@
+package resolver
+
+import (
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc/resolver"
+)
+
+// registry of ServerResolverBuilder. This type exists because grpc requires that
+// resolvers are registered globally before any requests are made. This is
+// incompatible with our resolver implementation and testing strategy, which
+// requires a different Resolver for each test.
+type registry struct {
+	lock        sync.RWMutex
+	byAuthority map[string]*ServerResolverBuilder
+}
+
+func (r *registry) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOption) (resolver.Resolver, error) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	res, ok := r.byAuthority[target.Authority]
+	if !ok {
+		return nil, fmt.Errorf("no resolver registered for %v", target.Authority)
+	}
+	return res.Build(target, cc, opts)
+}
+
+func (r *registry) Scheme() string {
+	return "consul"
+}
+
+var _ resolver.Builder = (*registry)(nil)
+
+var reg = &registry{byAuthority: make(map[string]*ServerResolverBuilder)}
+
+func init() {
+	resolver.Register(reg)
+}
+
+// Register a ServerResolverBuilder with the global registry.
+func Register(res *ServerResolverBuilder) {
+	reg.lock.Lock()
+	defer reg.lock.Unlock()
+	reg.byAuthority[res.Authority()] = res
+}
+
+// Deregister the ServerResolverBuilder associated with the authority. Only used
+// for testing.
+func Deregister(authority string) {
+	reg.lock.Lock()
+	defer reg.lock.Unlock()
+	delete(reg.byAuthority, authority)
+}

--- a/agent/grpc/server_test.go
+++ b/agent/grpc/server_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/resolver"
 
 	"github.com/hashicorp/consul/agent/grpc/internal/testservice"
 	"github.com/hashicorp/consul/agent/metadata"
@@ -166,11 +165,4 @@ func (f *fakeRPCListener) handleConn(conn net.Conn) {
 		fmt.Println("ERROR: unexpected byte", typ)
 		conn.Close()
 	}
-}
-
-func registerWithGRPC(t *testing.T, b resolver.Builder) {
-	resolver.Register(b)
-	t.Cleanup(func() {
-		resolver.UnregisterForTesting(b.Scheme())
-	})
 }

--- a/agent/submatview/store.go
+++ b/agent/submatview/store.go
@@ -30,7 +30,7 @@ type Store struct {
 
 	// idleTTL is the duration of time an entry should remain in the Store after the
 	// last request for that entry has been terminated. It is a field on the struct
-	// so that it can be patched in tests without need a lock.
+	// so that it can be patched in tests without needing a global lock.
 	idleTTL time.Duration
 }
 
@@ -122,8 +122,8 @@ func (s *Store) Get(ctx context.Context, req Request) (Result, error) {
 	defer cancel()
 
 	result, err := materializer.getFromView(ctx, info.MinIndex)
-	// context.DeadlineExceeded is translated to nil to match the behaviour of
-	// agent/cache.Cache.Get.
+	// context.DeadlineExceeded is translated to nil to match the timeout
+	// behaviour of agent/cache.Cache.Get.
 	if err == nil || errors.Is(err, context.DeadlineExceeded) {
 		return result, nil
 	}


### PR DESCRIPTION
We have seen test flakes caused by 'concurrent map read and map write', and the race detector reports the problem as well (prevent us from running some tests with -race).

The root of the problem is the grpc expects resolvers to be registered at init time before any requests are made, but we were using a separate resolver for each test.

This commit introduces a resolver registry. The registry is registered as the single grpc resolver for the `consul` scheme. Each test uses the Authority section of the target (instead of the scheme) to identify the resolver that should be used for the test. The scheme is used for lookup, which is why it can no longer be used as the unique key.

This allows us to use a lock around the map of resolvers, preventing the data race.


<details>
<summary>data race stack</summary>

```
WARNING: DATA RACE
Write at 0x00c000117470 by goroutine 25:
  runtime.mapassign_faststr()
      /usr/lib/go/src/runtime/map_faststr.go:202 +0x0
  google.golang.org/grpc/resolver.Register()
      /home/daniel/go/pkg/mod/google.golang.org/grpc@v1.25.1/resolver/resolver.go:47 +0x104
  github.com/hashicorp/consul/agent.registerWithGRPC()
      /home/daniel/pers/code/consul/agent/setup.go:182 +0x8d
  github.com/hashicorp/consul/agent.NewBaseDeps()
      /home/daniel/pers/code/consul/agent/setup.go:108 +0x10d0
  github.com/hashicorp/consul/agent.(*TestAgent).Start()
      /home/daniel/pers/code/consul/agent/testagent.go:190 +0x555
  github.com/hashicorp/consul/agent.StartTestAgent.func1()
      /home/daniel/pers/code/consul/agent/testagent.go:103 +0x6d
  github.com/hashicorp/consul/sdk/testutil/retry.run.func2()
      /home/daniel/pers/code/consul/sdk/testutil/retry/retry.go:148 +0x67
  github.com/hashicorp/consul/sdk/testutil/retry.run()
      /home/daniel/pers/code/consul/sdk/testutil/retry/retry.go:149 +0x112
  github.com/hashicorp/consul/sdk/testutil/retry.RunWith()
      /home/daniel/pers/code/consul/sdk/testutil/retry/retry.go:108 +0x74
  github.com/hashicorp/consul/agent.StartTestAgent()
      /home/daniel/pers/code/consul/agent/testagent.go:101 +0x173
  github.com/hashicorp/consul/command/monitor.TestMonitorCommand_exitsOnSignalBeforeLinesArrive()
      /home/daniel/pers/code/consul/command/monitor/monitor_test.go:18 +0x177
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202

Previous read at 0x00c000117470 by goroutine 26:
  runtime.mapaccess2_faststr()
      /usr/lib/go/src/runtime/map_faststr.go:107 +0x0
  google.golang.org/grpc/resolver.Get()
      /home/daniel/go/pkg/mod/google.golang.org/grpc@v1.25.1/resolver/resolver.go:54 +0x1c17
  google.golang.org/grpc.DialContext()
      /home/daniel/go/pkg/mod/google.golang.org/grpc@v1.25.1/clientconn.go:246 +0x1ba2
  google.golang.org/grpc.Dial()
      /home/daniel/go/pkg/mod/google.golang.org/grpc@v1.25.1/clientconn.go:106 +0x530
  github.com/hashicorp/consul/agent/grpc.(*ClientConnPool).ClientConn()
      /home/daniel/pers/code/consul/agent/grpc/client.go:60 +0x24f
  github.com/hashicorp/consul/agent.New()
      /home/daniel/pers/code/consul/agent/agent.go:383 +0x52e
  github.com/hashicorp/consul/agent.(*TestAgent).Start()
      /home/daniel/pers/code/consul/agent/testagent.go:199 +0x938
  github.com/hashicorp/consul/agent.StartTestAgent.func1()
      /home/daniel/pers/code/consul/agent/testagent.go:103 +0x6d
  github.com/hashicorp/consul/sdk/testutil/retry.run.func2()
      /home/daniel/pers/code/consul/sdk/testutil/retry/retry.go:148 +0x67
  github.com/hashicorp/consul/sdk/testutil/retry.run()
      /home/daniel/pers/code/consul/sdk/testutil/retry/retry.go:149 +0x112
  github.com/hashicorp/consul/sdk/testutil/retry.RunWith()
      /home/daniel/pers/code/consul/sdk/testutil/retry/retry.go:108 +0x74
  github.com/hashicorp/consul/agent.StartTestAgent()
      /home/daniel/pers/code/consul/agent/testagent.go:101 +0x173
  github.com/hashicorp/consul/command/monitor.TestMonitorCommand_LogJSONValidFlag()
      /home/daniel/pers/code/consul/command/monitor/monitor_test.go:75 +0x177
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202

Goroutine 25 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /usr/lib/go/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /usr/lib/go/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:1417 +0x3b3
  main.main()
      _testmain.go:45 +0x236

Goroutine 26 (running) created at:
  testing.(*T).Run()
      /usr/lib/go/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /usr/lib/go/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /usr/lib/go/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /usr/lib/go/src/testing/testing.go:1417 +0x3b3
  main.main()
      _testmain.go:45 +0x236
```
</details>