### PR TITLE
agent: remove leading whitespace from agent log lines

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -270,7 +270,7 @@ func (c *cmd) run(args []string) int {
 	// Let the agent know we've finished registration
 	agent.StartSync()
 
-	cli.output("Consul agent running!")
+	c.logger.Info("Consul agent running!")
 
 	// wait for signal
 	signalCh = make(chan os.Signal, 10)

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/testrpc"
+	"github.com/mitchellh/cli"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/mitchellh/cli"
+	"github.com/hashicorp/consul/testrpc"
 )
 
 // TestConfigFail should test command line flags that lead to an immediate error.
@@ -121,7 +121,7 @@ func TestRetryJoinFail(t *testing.T) {
 	tmpDir := testutil.TempDir(t, "consul")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, "", "", "", "", nil)
+	cmd := New(ui)
 
 	args := []string{
 		"-bind", "127.0.0.1",
@@ -145,7 +145,7 @@ func TestRetryJoinWanFail(t *testing.T) {
 	tmpDir := testutil.TempDir(t, "consul")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, "", "", "", "", nil)
+	cmd := New(ui)
 
 	args := []string{
 		"-server",
@@ -184,7 +184,7 @@ func TestProtectDataDir(t *testing.T) {
 	}
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, "", "", "", "", nil)
+	cmd := New(ui)
 	args := []string{"-config-file=" + cfgFile.Name()}
 	if code := cmd.Run(args); code == 0 {
 		t.Fatalf("should fail")
@@ -203,7 +203,7 @@ func TestBadDataDirPermissions(t *testing.T) {
 	}
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, "", "", "", "", nil)
+	cmd := New(ui)
 	args := []string{"-data-dir=" + dataDir, "-server=true", "-bind=10.0.0.1"}
 	if code := cmd.Run(args); code == 0 {
 		t.Fatalf("Should fail with bad data directory permissions")

--- a/command/cli/cli.go
+++ b/command/cli/cli.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"io"
+
+	mcli "github.com/mitchellh/cli"
+)
+
+// Ui implements the mitchellh/cli.Ui interface, while exposing the underlying
+// io.Writer used for stdout and stderr.
+// TODO: rename to UI to match golang style guide
+type Ui interface {
+	mcli.Ui
+	Stdout() io.Writer
+	Stderr() io.Writer
+}
+
+// BasicUI augments mitchellh/cli.BasicUi by exposing the underlying io.Writer.
+type BasicUI struct {
+	mcli.BasicUi
+}
+
+func (b *BasicUI) Stdout() io.Writer {
+	return b.BasicUi.Writer
+}
+
+func (b *BasicUI) Stderr() io.Writer {
+	return b.BasicUi.ErrorWriter
+}
+
+// Command is an alias to reduce the diff. It can be removed at any time.
+type Command mcli.Command

--- a/command/commands_oss.go
+++ b/command/commands_oss.go
@@ -108,17 +108,11 @@ import (
 	"github.com/hashicorp/consul/command/validate"
 	"github.com/hashicorp/consul/command/version"
 	"github.com/hashicorp/consul/command/watch"
-	consulversion "github.com/hashicorp/consul/version"
 
 	"github.com/mitchellh/cli"
 )
 
 func init() {
-	rev := consulversion.GitCommit
-	ver := consulversion.Version
-	verPre := consulversion.VersionPrerelease
-	verHuman := consulversion.GetHumanVersion()
-
 	Register("acl", func(cli.Ui) (cli.Command, error) { return acl.New(), nil })
 	Register("acl bootstrap", func(ui cli.Ui) (cli.Command, error) { return aclbootstrap.New(ui), nil })
 	Register("acl policy", func(cli.Ui) (cli.Command, error) { return aclpolicy.New(), nil })
@@ -154,9 +148,7 @@ func init() {
 	Register("acl binding-rule read", func(ui cli.Ui) (cli.Command, error) { return aclbrread.New(ui), nil })
 	Register("acl binding-rule update", func(ui cli.Ui) (cli.Command, error) { return aclbrupdate.New(ui), nil })
 	Register("acl binding-rule delete", func(ui cli.Ui) (cli.Command, error) { return aclbrdelete.New(ui), nil })
-	Register("agent", func(ui cli.Ui) (cli.Command, error) {
-		return agent.New(ui, rev, ver, verPre, verHuman, make(chan struct{})), nil
-	})
+	Register("agent", func(ui cli.Ui) (cli.Command, error) { return agent.New(ui), nil })
 	Register("catalog", func(cli.Ui) (cli.Command, error) { return catalog.New(), nil })
 	Register("catalog datacenters", func(ui cli.Ui) (cli.Command, error) { return catlistdc.New(ui), nil })
 	Register("catalog nodes", func(ui cli.Ui) (cli.Command, error) { return catlistnodes.New(ui), nil })

--- a/command/commands_oss.go
+++ b/command/commands_oss.go
@@ -41,6 +41,7 @@ import (
 	catlistdc "github.com/hashicorp/consul/command/catalog/list/dc"
 	catlistnodes "github.com/hashicorp/consul/command/catalog/list/nodes"
 	catlistsvc "github.com/hashicorp/consul/command/catalog/list/services"
+	"github.com/hashicorp/consul/command/cli"
 	"github.com/hashicorp/consul/command/config"
 	configdelete "github.com/hashicorp/consul/command/config/delete"
 	configlist "github.com/hashicorp/consul/command/config/list"
@@ -108,8 +109,6 @@ import (
 	"github.com/hashicorp/consul/command/validate"
 	"github.com/hashicorp/consul/command/version"
 	"github.com/hashicorp/consul/command/watch"
-
-	"github.com/mitchellh/cli"
 )
 
 func init() {

--- a/command/registry.go
+++ b/command/registry.go
@@ -6,7 +6,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/mitchellh/cli"
+	mcli "github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul/command/cli"
 )
 
 // Factory is a function that returns a new instance of a CLI-sub command.
@@ -24,14 +26,14 @@ func Register(name string, fn Factory) {
 	registry[name] = fn
 }
 
-// Map returns a realized mapping of available CLI commands in a format that
+// CommandsFromRegistry returns a realized mapping of available CLI commands in a format that
 // the CLI class can consume. This should be called after all registration is
 // complete.
-func Map(ui cli.Ui) map[string]cli.CommandFactory {
-	m := make(map[string]cli.CommandFactory)
+func CommandsFromRegistry(ui cli.Ui) map[string]mcli.CommandFactory {
+	m := make(map[string]mcli.CommandFactory)
 	for name, fn := range registry {
 		thisFn := fn
-		m[name] = func() (cli.Command, error) {
+		m[name] = func() (mcli.Command, error) {
 			return thisFn(ui)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -6,11 +6,13 @@ import (
 	"log"
 	"os"
 
+	mcli "github.com/mitchellh/cli"
+
 	"github.com/hashicorp/consul/command"
+	"github.com/hashicorp/consul/command/cli"
 	"github.com/hashicorp/consul/command/version"
 	"github.com/hashicorp/consul/lib"
 	_ "github.com/hashicorp/consul/service_os"
-	"github.com/mitchellh/cli"
 )
 
 func init() {
@@ -24,19 +26,21 @@ func main() {
 func realMain() int {
 	log.SetOutput(ioutil.Discard)
 
-	ui := &cli.BasicUi{Writer: os.Stdout, ErrorWriter: os.Stderr}
-	cmds := command.Map(ui)
+	ui := &cli.BasicUI{
+		BasicUi: mcli.BasicUi{Writer: os.Stdout, ErrorWriter: os.Stderr},
+	}
+	cmds := command.CommandsFromRegistry(ui)
 	var names []string
 	for c := range cmds {
 		names = append(names, c)
 	}
 
-	cli := &cli.CLI{
+	cli := &mcli.CLI{
 		Args:         os.Args[1:],
 		Commands:     cmds,
 		Autocomplete: true,
 		Name:         "consul",
-		HelpFunc:     cli.FilteredHelpFunc(names, cli.BasicHelpFunc("consul")),
+		HelpFunc:     mcli.FilteredHelpFunc(names, mcli.BasicHelpFunc("consul")),
 		HelpWriter:   os.Stdout,
 		ErrorWriter:  os.Stderr,
 	}


### PR DESCRIPTION
This PR fixes a problem reported by a user:

> fluentd is considering the logs (rom Consul pods as multiline and results in combining (all) the logs.

Every log line had 4 spaces prepended. This was caused by the `UI` interface that is used in the CLI. We have encountered a number of problems with the `UI` interface. This PR takes the first step to fix the interface by exposing the underlying Stdout/Stderr streams as `io.Writer`.

The PR includes some other cleanup, and is best viewed by individual commit.

I tested this by running `consul agent -dev` and `consul agent -dev -log-json` to verify it worked as it did before, with the exception of the leading spaces.