### PR TITLE
remove a race condition in sdk testutil server stop

### DIFF
--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -342,7 +342,6 @@ func (s *TestServer) Stop() error {
 		return err
 	case <-time.After(10 * time.Second):
 		s.cmd.Process.Signal(syscall.SIGABRT)
-		s.cmd.Wait()
 		return fmt.Errorf("timeout waiting for server to stop gracefully")
 	}
 }

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -342,6 +342,7 @@ func (s *TestServer) Stop() error {
 		return err
 	case <-time.After(10 * time.Second):
 		s.cmd.Process.Signal(syscall.SIGABRT)
+		<-waitDone
 		return fmt.Errorf("timeout waiting for server to stop gracefully")
 	}
 }


### PR DESCRIPTION
We have 2 threads calling `exec.Cmd.Wait` which is not reentrant. It causes some test case failure at our side when running the test suite with the `-race` flag.

I've just removed the `cmd.Wait` which looks useless.

Related to #8329