### PR TITLE
restore(1.8.x): Serf tag refactor

### DIFF
--- a/.changelog/_917.txt
+++ b/.changelog/_917.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+namespaces: **(Enterprise only)** fixes a problem where the logs would contain many warnings about namespaces not being licensed.
+``` 

--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -5,13 +5,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/serf/serf"
+
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/serf/serf"
 )
 
 // setupSerf is used to setup and initialize a Serf
@@ -63,7 +64,7 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 		return nil, err
 	}
 
-	c.addEnterpriseSerfTags(conf.Tags)
+	addEnterpriseSerfTags(conf.Tags)
 
 	return serf.Create(conf)
 }

--- a/agent/consul/enterprise_client_oss.go
+++ b/agent/consul/enterprise_client_oss.go
@@ -23,7 +23,3 @@ func (c *Client) handleEnterpriseUserEvents(event serf.UserEvent) bool {
 func (c *Client) enterpriseStats() map[string]map[string]string {
 	return nil
 }
-
-func (_ *Client) addEnterpriseSerfTags(_ map[string]string) {
-	// do nothing
-}

--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -5,10 +5,11 @@ package consul
 import (
 	"net"
 
-	"github.com/hashicorp/consul/agent/pool"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/serf/serf"
+
+	"github.com/hashicorp/consul/agent/pool"
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 var (
@@ -59,7 +60,7 @@ func (s *Server) validateEnterpriseRequest(entMeta *structs.EnterpriseMeta, writ
 	return nil
 }
 
-func (_ *Server) addEnterpriseSerfTags(_ map[string]string) {
+func addEnterpriseSerfTags(_ map[string]string) {
 	// do nothing
 }
 

--- a/agent/consul/replication.go
+++ b/agent/consul/replication.go
@@ -205,9 +205,7 @@ func (r *IndexReplicator) Replicate(ctx context.Context, lastRemoteIndex uint64,
 		return 0, false, fmt.Errorf("failed to retrieve %s: %w", r.Delegate.PluralNoun(), err)
 	}
 
-	r.Logger.Debug("finished fetching remote objects",
-		"amount", lenRemote,
-	)
+	r.Logger.Debug("finished fetching remote objects", "amount", lenRemote)
 
 	// Need to check if we should be stopping. This will be common as the fetching process is a blocking
 	// RPC which could have been hanging around for a long time and during that time leadership could

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -7,15 +7,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/memberlist"
+	"github.com/hashicorp/raft"
+	"github.com/hashicorp/serf/serf"
+
 	"github.com/hashicorp/consul/agent/consul/wanfed"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/memberlist"
-	"github.com/hashicorp/raft"
-	"github.com/hashicorp/serf/serf"
 )
 
 const (
@@ -165,7 +166,7 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 		return nil, err
 	}
 
-	s.addEnterpriseSerfTags(conf.Tags)
+	addEnterpriseSerfTags(conf.Tags)
 
 	return serf.Create(conf)
 }

--- a/agent/metadata/server.go
+++ b/agent/metadata/server.go
@@ -7,9 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/serf/serf"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 // Key is used in maps and for equality tests.  A key is based on endpoints.
@@ -120,8 +121,8 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 			segmentName := strings.TrimPrefix(name, "sl_")
 			segmentAddrs[segmentName] = addr
 			segmentPorts[segmentName] = segmentPort
-		} else if strings.HasPrefix(name, "ft_") {
-			featureName := strings.TrimPrefix(name, "ft_")
+		} else if strings.HasPrefix(name, featureFlagPrefix) {
+			featureName := strings.TrimPrefix(name, featureFlagPrefix)
 			featureState, err := strconv.Atoi(value)
 			if err != nil {
 				return false, nil
@@ -187,4 +188,15 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 		FeatureFlags: featureFlags,
 	}
 	return true, parts
+}
+
+const featureFlagPrefix = "ft_"
+
+// AddFeatureFlags to the tags. The tags map is expected to be a serf.Config.Tags.
+// The feature flags are encoded in the tags so that IsConsulServer can decode them
+// and populate the Server.FeatureFlags map.
+func AddFeatureFlags(tags map[string]string, flags ...string) {
+	for _, flag := range flags {
+		tags[featureFlagPrefix+flag] = "1"
+	}
 }

--- a/agent/metadata/server_test.go
+++ b/agent/metadata/server_test.go
@@ -4,9 +4,10 @@ import (
 	"net"
 	"testing"
 
-	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/metadata"
 )
 
 func TestServer_Key_params(t *testing.T) {
@@ -181,8 +182,10 @@ func TestIsConsulServer_Optional(t *testing.T) {
 	if parts.RaftVersion != 0 {
 		t.Fatalf("bad: %v", parts.RaftVersion)
 	}
+
 	m.Tags["bootstrap"] = "1"
 	m.Tags["disabled"] = "1"
+	m.Tags["ft_ns"] = "1"
 	ok, parts = metadata.IsConsulServer(m)
 	if !ok {
 		t.Fatalf("expected a valid consul server")
@@ -196,6 +199,9 @@ func TestIsConsulServer_Optional(t *testing.T) {
 	if parts.Version != 1 {
 		t.Fatalf("bad: %v", parts)
 	}
+	expectedFlags := map[string]int{"ns": 1}
+	require.Equal(t, expectedFlags, parts.FeatureFlags)
+
 	m.Tags["expect"] = "3"
 	delete(m.Tags, "bootstrap")
 	delete(m.Tags, "disabled")


### PR DESCRIPTION
Restores the backport of https://github.com/hashicorp/consul/pull/10277 to `release/1.8.x`

This reverts commit 442a8efc7fc7eb0121e27339e5322efef5ea6418.