### PR TITLE
usagemetrics: add cluster members to metrics API (#10340)

### DIFF
--- a/.changelog/10340.txt
+++ b/.changelog/10340.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+telemetry: The usage data in the `metrics` API now includes cluster member counts, reporting clients on a per segment basis.
+```

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -568,7 +568,15 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 			WithStateProvider(s.fsm).
 			WithLogger(s.logger).
 			WithDatacenter(s.config.Datacenter).
-			WithReportingInterval(s.config.MetricsReportingInterval),
+			WithReportingInterval(s.config.MetricsReportingInterval).
+			WithGetMembersFunc(func() []serf.Member {
+				members, err := s.LANMembersAllSegments()
+				if err != nil {
+					return []serf.Member{}
+				}
+
+				return members
+			}),
 	)
 	if err != nil {
 		s.Shutdown()
@@ -1137,7 +1145,7 @@ func (s *Server) LANMembers() []serf.Member {
 	return s.serfLAN.Members()
 }
 
-// WANMembers is used to return the members of the LAN cluster
+// WANMembers is used to return the members of the WAN cluster
 func (s *Server) WANMembers() []serf.Member {
 	if s.serfWAN == nil {
 		return nil

--- a/agent/consul/usagemetrics/usagemetrics_oss_test.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/serf/serf"
 )
 
 func newStateStore() (*state.Store, error) {
@@ -21,6 +22,7 @@ func newStateStore() (*state.Store, error) {
 func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 	type testCase struct {
 		modfiyStateStore func(t *testing.T, s *state.Store)
+		getMembersFunc   getMembersFunc
 		expectedGauges   map[string]metrics.GaugeValue
 	}
 	cases := map[string]testCase{
@@ -45,24 +47,64 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 						{Name: "datacenter", Value: "dc1"},
 					},
 				},
+				"consul.usage.test.consul.members.clients;datacenter=dc1": {
+					Name:  "consul.usage.test.consul.members.clients",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+					},
+				},
+				"consul.usage.test.consul.members.servers;datacenter=dc1": {
+					Name:  "consul.usage.test.consul.members.servers",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+					},
+				},
 			},
+			getMembersFunc: func() []serf.Member { return []serf.Member{} },
 		},
 		"nodes-and-services": {
 			modfiyStateStore: func(t *testing.T, s *state.Store) {
 				require.Nil(t, s.EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"}))
 				require.Nil(t, s.EnsureNode(2, &structs.Node{Node: "bar", Address: "127.0.0.2"}))
 				require.Nil(t, s.EnsureNode(3, &structs.Node{Node: "baz", Address: "127.0.0.2"}))
+				require.Nil(t, s.EnsureNode(4, &structs.Node{Node: "qux", Address: "127.0.0.3"}))
 
 				// Typical services and some consul services spread across two nodes
-				require.Nil(t, s.EnsureService(4, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: nil, Address: "", Port: 5000}))
-				require.Nil(t, s.EnsureService(5, "bar", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}))
-				require.Nil(t, s.EnsureService(6, "foo", &structs.NodeService{ID: "consul", Service: "consul", Tags: nil}))
-				require.Nil(t, s.EnsureService(7, "bar", &structs.NodeService{ID: "consul", Service: "consul", Tags: nil}))
+				require.Nil(t, s.EnsureService(5, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: nil, Address: "", Port: 5000}))
+				require.Nil(t, s.EnsureService(6, "bar", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}))
+				require.Nil(t, s.EnsureService(7, "foo", &structs.NodeService{ID: "consul", Service: "consul", Tags: nil}))
+				require.Nil(t, s.EnsureService(8, "bar", &structs.NodeService{ID: "consul", Service: "consul", Tags: nil}))
+			},
+			getMembersFunc: func() []serf.Member {
+				return []serf.Member{
+					{
+						Name:   "foo",
+						Tags:   map[string]string{"role": "consul"},
+						Status: serf.StatusAlive,
+					},
+					{
+						Name:   "bar",
+						Tags:   map[string]string{"role": "consul"},
+						Status: serf.StatusAlive,
+					},
+					{
+						Name:   "baz",
+						Tags:   map[string]string{"role": "node", "segment": "a"},
+						Status: serf.StatusAlive,
+					},
+					{
+						Name:   "qux",
+						Tags:   map[string]string{"role": "node", "segment": "b"},
+						Status: serf.StatusAlive,
+					},
+				}
 			},
 			expectedGauges: map[string]metrics.GaugeValue{
 				"consul.usage.test.consul.state.nodes;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.nodes",
-					Value:  3,
+					Value:  4,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
 				},
 				"consul.usage.test.consul.state.services;datacenter=dc1": {
@@ -76,6 +118,36 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 					Name:  "consul.usage.test.consul.state.service_instances",
 					Value: 4,
 					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+					},
+				},
+				"consul.usage.test.consul.members.clients;datacenter=dc1": {
+					Name:  "consul.usage.test.consul.members.clients",
+					Value: 2,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+					},
+				},
+				"consul.usage.test.consul.members.servers;datacenter=dc1": {
+					Name:  "consul.usage.test.consul.members.servers",
+					Value: 2,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+					},
+				},
+				"consul.usage.test.consul.members.clients;segment=a;datacenter=dc1": {
+					Name:  "consul.usage.test.consul.members.clients",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "segment", Value: "a"},
+						{Name: "datacenter", Value: "dc1"},
+					},
+				},
+				"consul.usage.test.consul.members.clients;segment=b;datacenter=dc1": {
+					Name:  "consul.usage.test.consul.members.clients",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "segment", Value: "b"},
 						{Name: "datacenter", Value: "dc1"},
 					},
 				},
@@ -102,7 +174,8 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 				new(Config).
 					WithStateProvider(mockStateProvider).
 					WithLogger(testutil.Logger(t)).
-					WithDatacenter("dc1"),
+					WithDatacenter("dc1").
+					WithGetMembersFunc(tcase.getMembersFunc),
 			)
 			require.NoError(t, err)
 

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -11,7 +11,7 @@ description: >-
 
 The Consul agent collects various runtime metrics about the performance of
 different libraries and subsystems. These metrics are aggregated on a ten
-second (10s) interval and are retained for one minute. An _interval_ is the period of time between instances of data being collected and aggregated. 
+second (10s) interval and are retained for one minute. An _interval_ is the period of time between instances of data being collected and aggregated.
 
 When telemetry is being streamed to an external metrics store, the interval is defined to be that store's flush interval.
 
@@ -96,7 +96,7 @@ These are some metrics emitted that can help you understand the health of your c
 
 **Why it's important:** Autopilot can expose the overall health of your cluster with a simple boolean.
 
-**What to look for:** Alert if `healthy` is 0. Some other indicators of an unhealthy cluster would be: 
+**What to look for:** Alert if `healthy` is 0. Some other indicators of an unhealthy cluster would be:
 - `consul.raft.commitTime` - This can help reflect the speed of state store
 changes being performmed by the agent. If this number is rising, the server may
 be experiencing an issue due to degraded resources on the host.
@@ -193,6 +193,8 @@ This is a full list of metrics emitted by Consul.
 | `consul.state.nodes`                                     | Measures the current number of nodes registered with Consul. It is only emitted by Consul servers. Added in v1.9.0.                                                                                                                                                                                                                                                                                            | number of objects    | gauge   |
 | `consul.state.services`                                  | Measures the current number of unique services registered with Consul, based on service name. It is only emitted by Consul servers. Added in v1.9.0.                                                                                                                                                                                                                                                           | number of objects    | gauge   |
 | `consul.state.service_instances`                         | Measures the current number of unique service instances registered with Consul. It is only emitted by Consul servers. Added in v1.9.0.                                                                                                                                                                                                                                                                         | number of objects    | gauge   |
+| `consul.members.clients`                                 | Measures the current number of client agents registered with Consul. It is only emitted by Consul servers. Added in v1.9.6.                                                                                                                                                                                                                                                                                    | number of clients    | gauge   |
+| `consul.members.servers`                                 | Measures the current number of server agents registered with Consul. It is only emitted by Consul servers. Added in v1.9.6.                                                                                                                                                                                                                                                                                    | number of servers    | gauge   |
 | `consul.dns.stale_queries`                               | Increments when an agent serves a query within the allowed stale threshold.                                                                                                                                                                                                                                                                                                                                    | queries              | counter |
 | `consul.dns.ptr_query.`                                  | Measures the time spent handling a reverse DNS query for the given node.                                                                                                                                                                                                                                                                                                                                       | ms                   | timer   |
 | `consul.dns.domain_query.`                               | Measures the time spent handling a domain query for the given node.                                                                                                                                                                                                                                                                                                                                            | ms                   | timer   |


### PR DESCRIPTION
This PR adds cluster members to the metrics API. The number of members per
segment are reported as well as the total number of members.

Tested by running a multi-node cluster locally and ensuring the numbers were
correct. Also added unit test coverage to add the new expected gauges to
existing test cases.