### PR TITLE
submatview: fix a bug with Store.Get

### DIFF
--- a/agent/submatview/store.go
+++ b/agent/submatview/store.go
@@ -118,8 +118,11 @@ func (s *Store) Get(ctx context.Context, req Request) (Result, error) {
 	}
 	defer s.releaseEntry(key)
 
-	ctx, cancel := context.WithTimeout(ctx, info.Timeout)
-	defer cancel()
+	if info.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, info.Timeout)
+		defer cancel()
+	}
 
 	result, err := materializer.getFromView(ctx, info.MinIndex)
 	// context.DeadlineExceeded is translated to nil to match the timeout

--- a/agent/submatview/store_test.go
+++ b/agent/submatview/store_test.go
@@ -160,7 +160,6 @@ func (r *fakeRequest) CacheInfo() cache.RequestInfo {
 		Key:        key,
 		Token:      "abcd",
 		Datacenter: "dc1",
-		Timeout:    4 * time.Second,
 		MinIndex:   r.index,
 	}
 }


### PR DESCRIPTION
When info.Timeout is 0, it should have no timeout. Previously it was using a 0 duration timeout which caused it to return without waiting.

This bug was masked by using a timeout in the tests. Removing the timeout caused the tests to fail.

This bug only exists in the latest 1.10 beta release, so I guess no need for a changelog entry.