### PR TITLE
stream: fix a bug with subscriptions and the latest item in the topic buffers.

### DIFF
--- a/agent/consul/stream/event_buffer_test.go
+++ b/agent/consul/stream/event_buffer_test.go
@@ -17,10 +17,6 @@ func TestEventBufferFuzz(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	if testing.Short() {
-		t.Skip("too slow for short run")
-	}
-
 	nReaders := 1000
 	nMessages := 1000
 

--- a/agent/consul/stream/event_publisher.go
+++ b/agent/consul/stream/event_publisher.go
@@ -171,7 +171,8 @@ func (e *EventPublisher) Subscribe(req *SubscribeRequest) (*Subscription, error)
 		subscriptionHead := buf.Head()
 		// splice the rest of the topic buffer onto the subscription buffer so
 		// the subscription will receive new events.
-		buf.AppendItem(topicHead.NextLink())
+		next, _ := topicHead.NextNoBlock()
+		buf.AppendItem(next)
 		return e.subscriptions.add(req, subscriptionHead), nil
 	}
 

--- a/agent/consul/stream/event_snapshot.go
+++ b/agent/consul/stream/event_snapshot.go
@@ -67,12 +67,12 @@ func (s *eventSnapshot) spliceFromTopicBuffer(topicBufferHead *bufferItem, idx u
 			return
 		}
 
-		next := item.NextNoBlock()
-		if next == nil {
+		next, ok := item.NextNoBlock()
+		if !ok {
 			// We reached the head of the topic buffer. We don't want any of the
 			// events in the topic buffer as they came before the snapshot.
 			// Append a link to any future items.
-			s.buffer.AppendItem(item.NextLink())
+			s.buffer.AppendItem(next)
 			return
 		}
 		// Proceed to the next item in the topic buffer

--- a/agent/consul/stream/event_snapshot.go
+++ b/agent/consul/stream/event_snapshot.go
@@ -49,34 +49,33 @@ func (s *eventSnapshot) appendAndSplice(req SubscribeRequest, fn SnapshotFunc, t
 func (s *eventSnapshot) spliceFromTopicBuffer(topicBufferHead *bufferItem, idx uint64) {
 	item := topicBufferHead
 	for {
-		next := item.NextNoBlock()
 		switch {
-		case next == nil:
-			// This is the head of the topic buffer (or was just now which is after
-			// the snapshot completed). We don't want any of the events (if any) in
-			// the snapshot buffer as they came before the snapshot but we do need to
-			// wait for the next update.
-			s.buffer.AppendItem(item.NextLink())
-			return
-
-		case next.Err != nil:
+		case item.Err != nil:
 			// This case is not currently possible because errors can only come
 			// from a snapshot func, and this is consuming events from a topic
 			// buffer which does not contain a snapshot.
 			// Handle this case anyway in case errors can come from other places
 			// in the future.
-			s.buffer.AppendItem(next)
+			s.buffer.AppendItem(item)
 			return
 
-		case len(next.Events) > 0 && next.Events[0].Index > idx:
+		case len(item.Events) > 0 && item.Events[0].Index > idx:
 			// We've found an update in the topic buffer that happened after our
 			// snapshot was taken, splice it into the snapshot buffer so subscribers
 			// can continue to read this and others after it.
-			s.buffer.AppendItem(next)
+			s.buffer.AppendItem(item)
 			return
 		}
 
-		// We don't need this item, continue to next
+		next := item.NextNoBlock()
+		if next == nil {
+			// We reached the head of the topic buffer. We don't want any of the
+			// events in the topic buffer as they came before the snapshot.
+			// Append a link to any future items.
+			s.buffer.AppendItem(item.NextLink())
+			return
+		}
+		// Proceed to the next item in the topic buffer
 		item = next
 	}
 }

--- a/agent/consul/stream/event_snapshot_test.go
+++ b/agent/consul/stream/event_snapshot_test.go
@@ -95,7 +95,7 @@ func TestEventSnapshot(t *testing.T) {
 			// be appended before the snapshot fn executes in another goroutine since
 			// it's operating an a possible stale "snapshot". This is the same as
 			// reality with the state store where updates that occur after the
-			// snapshot is taken but while the SnapFnis still running must be captured
+			// snapshot is taken but while the SnapFn is still running must be captured
 			// correctly.
 			for i := 0; i < tc.updatesAfterSnap; i++ {
 				index := snapIndex + 1 + uint64(i)


### PR DESCRIPTION
While working on an end-to-end test for streaming I encountered this bug. The e2e test isn't quite ready yet, but I thought I would surface this bug fix separately.

This PR is best viewed by individual commit.

The head of the topic buffer was being ignored when creating a snapshot. This commit fixes the bug by ensuring that the head of the topic buffer is included in the snapshot before handing it off to the subscription.