### PR TITLE
fix monitor to only start the monitor in json format when requested

### DIFF
--- a/.changelog/10358.txt
+++ b/.changelog/10358.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+monitor: fix monitor to produce json format logs when requested
+```

--- a/command/monitor/monitor.go
+++ b/command/monitor/monitor.go
@@ -68,11 +68,12 @@ func (c *cmd) Run(args []string) int {
 			c.UI.Error(fmt.Sprintf("Error starting JSON monitor: %s", err))
 			return 1
 		}
-	}
-	logCh, err = client.Agent().Monitor(c.logLevel, eventDoneCh, nil)
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error starting monitor: %s", err))
-		return 1
+	} else {
+		logCh, err = client.Agent().Monitor(c.logLevel, eventDoneCh, nil)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error starting monitor: %s", err))
+			return 1
+		}
 	}
 
 	go func() {


### PR DESCRIPTION
when starting a new monitor we were starting (in case of json monitor) a json monitor and then overwrite it with a line monitor.
This will start one or the other.
Fix #10357 