### PR TITLE
Revert "Avoid adding original_dst filter when not needed"

### DIFF
--- a/.changelog/10302.txt
+++ b/.changelog/10302.txt
@@ -1,4 +1,0 @@
-```release-note:improvement
-connect: Avoid adding original_dst listener filter when it won't be used.
-```
-

--- a/.changelog/10365.txt
+++ b/.changelog/10365.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fix bug that prevented transparent proxies from working when mesh config restricted routing to catalog destinations.
+```

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -78,6 +78,12 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 
 		outboundListener = makePortListener(OutboundListenerName, "127.0.0.1", port, envoy_core_v3.TrafficDirection_OUTBOUND)
 		outboundListener.FilterChains = make([]*envoy_listener_v3.FilterChain, 0)
+		outboundListener.ListenerFilters = []*envoy_listener_v3.ListenerFilter{
+			{
+				// TODO (freddy): Hard-coded until we upgrade the go-control-plane library
+				Name: "envoy.filters.listener.original_dst",
+			},
+		}
 	}
 
 	var hasFilterChains bool
@@ -200,13 +206,6 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		// Add a catch-all filter chain that acts as a TCP proxy to non-catalog destinations
 		if cfgSnap.ConnectProxy.MeshConfig == nil ||
 			!cfgSnap.ConnectProxy.MeshConfig.TransparentProxy.CatalogDestinationsOnly {
-
-			outboundListener.ListenerFilters = []*envoy_listener_v3.ListenerFilter{
-				{
-					// TODO (freddy): Hard-coded until we upgrade the go-control-plane library
-					Name: "envoy.filters.listener.original_dst",
-				},
-			}
 
 			filterChain, err := s.makeUpstreamFilterChainForDiscoveryChain(
 				"passthrough",

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -80,7 +80,12 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		outboundListener.FilterChains = make([]*envoy_listener_v3.FilterChain, 0)
 		outboundListener.ListenerFilters = []*envoy_listener_v3.ListenerFilter{
 			{
-				// TODO (freddy): Hard-coded until we upgrade the go-control-plane library
+				// The original_dst filter is a listener filter that recovers the original destination
+				// address before the iptables redirection. This filter is needed for transparent
+				// proxies because they route to upstreams using filter chains that match on the
+				// destination IP address. If the filter is not present, no chain will match.
+				//
+				// TODO(tproxy): Hard-coded until we upgrade the go-control-plane library
 				Name: "envoy.filters.listener.original_dst",
 			},
 		}

--- a/agent/xds/testdata/listeners/transparent-proxy-catalog-destinations-only.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-catalog-destinations-only.envoy-1-18-x.golden
@@ -57,6 +57,11 @@
           ]
         }
       ],
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.original_dst"
+        }
+      ],
       "trafficDirection": "OUTBOUND"
     },
     {

--- a/agent/xds/testdata/listeners/transparent-proxy-catalog-destinations-only.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-catalog-destinations-only.v2compat.envoy-1-16-x.golden
@@ -57,6 +57,11 @@
           ]
         }
       ],
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.original_dst"
+        }
+      ],
       "trafficDirection": "OUTBOUND"
     },
     {


### PR DESCRIPTION
This reverts commit 19334e8abf7f3c9507bb400b9cc9045bb86845c0.

The addition of the "original_dst" filter does not depend on the mesh config, only on whether the proxy is in transparent mode. 

The PR to revert made it so that transparent proxying didn't work when `Mesh.TransparentProxy.CatalogDestinationsOnly` was set to `true` because Envoy couldn't recover the original IP address before iptables redirection.
