### PR TITLE
submatview: add test cases for store.Get with timeout and no index

### DIFF
--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -126,7 +126,7 @@ func (r serviceRequest) CacheInfo() cache.RequestInfo {
 }
 
 func (r serviceRequest) Type() string {
-	return "service-health"
+	return "agent.rpcclient.health.serviceRequest"
 }
 
 func (r serviceRequest) NewMaterializer() (*submatview.Materializer, error) {


### PR DESCRIPTION
Also set a more unique name for the serviceRequest.Type to prevent potential name conflicts in the future.