### PR TITLE
improve monitor performance

### DIFF
--- a/.changelog/10368.txt
+++ b/.changelog/10368.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+monitoring: optimize the monitoring endpoint to avoid losing logs when under high load
+```

--- a/.changelog/10368.txt
+++ b/.changelog/10368.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-monitoring: optimize the monitoring endpoint to avoid losing logs when under high load. [GH-10368](https://github.com/hashicorp/consul/pull/10368)
+monitoring: optimize the monitoring endpoint to avoid losing logs when under high load.
 ```

--- a/.changelog/10368.txt
+++ b/.changelog/10368.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-monitoring: optimize the monitoring endpoint to avoid losing logs when under high load
+monitoring: optimize the monitoring endpoint to avoid losing logs when under high load. [GH-10368](https://api.github.com/repos/hashicorp/consul/issues/10368)
 ```

--- a/.changelog/10368.txt
+++ b/.changelog/10368.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-monitoring: optimize the monitoring endpoint to avoid losing logs when under high load. [GH-10368](https://api.github.com/repos/hashicorp/consul/issues/10368)
+monitoring: optimize the monitoring endpoint to avoid losing logs when under high load. [GH-10368](https://github.com/hashicorp/consul/pull/10368)
 ```

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1211,10 +1211,10 @@ func (s *HTTPHandlers) AgentMonitor(resp http.ResponseWriter, req *http.Request)
 			if droppedCount > 0 {
 				s.agent.logger.Warn("Dropped logs during monitor request", "dropped_count", droppedCount)
 			}
+			flusher.Flush()
 			return nil, nil
 		case log := <-logsCh:
 			fmt.Fprint(resp, string(log))
-			flusher.Flush()
 		}
 	}
 }

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1205,6 +1205,7 @@ func (s *HTTPHandlers) AgentMonitor(resp http.ResponseWriter, req *http.Request)
 	flusher.Flush()
 	const flushDelay = 200 * time.Millisecond
 	flushTicker := time.NewTicker(flushDelay)
+	defer flushTicker.Stop()
 
 	// Stream logs until the connection is closed.
 	for {

--- a/logging/monitor/monitor.go
+++ b/logging/monitor/monitor.go
@@ -35,7 +35,7 @@ type monitor struct {
 	droppedCount int
 
 	// doneCh coordinates the shutdown of logCh
-	doneCh chan bool
+	doneCh chan struct{}
 
 	// Defaults to 512.
 	bufSize int
@@ -58,7 +58,7 @@ func New(cfg Config) Monitor {
 	sw := &monitor{
 		logger:  cfg.Logger,
 		logCh:   make(chan []byte, bufSize),
-		doneCh:  make(chan bool, 1),
+		doneCh:  make(chan struct{}, 1),
 		bufSize: bufSize,
 	}
 
@@ -72,11 +72,7 @@ func New(cfg Config) Monitor {
 // Stop deregisters the sink and stops the monitoring process
 func (d *monitor) Stop() int {
 	d.logger.DeregisterSink(d.sink)
-	select {
-	case d.doneCh <- true:
-	default:
-	}
-
+	close(d.doneCh)
 	return d.droppedCount
 }
 

--- a/logging/monitor/monitor.go
+++ b/logging/monitor/monitor.go
@@ -84,9 +84,7 @@ func (d *monitor) Stop() int {
 // received log messages over the returned channel.
 func (d *monitor) Start() <-chan []byte {
 	// register our sink with the logger
-	d.logger.RegisterSink(d.sink)
 	streamCh := make(chan []byte, d.bufSize)
-
 	// run a go routine that listens for streamed
 	// log messages and sends them to streamCh
 	go func() {
@@ -105,7 +103,7 @@ func (d *monitor) Start() <-chan []byte {
 			}
 		}
 	}()
-
+	d.logger.RegisterSink(d.sink)
 	return streamCh
 }
 

--- a/logging/monitor/monitor_test.go
+++ b/logging/monitor/monitor_test.go
@@ -178,7 +178,7 @@ func TestMonitor_WriteStopped(t *testing.T) {
 
 	mwriter := &monitor{
 		logger: logger,
-		doneCh: make(chan bool, 1),
+		doneCh: make(chan struct{}, 1),
 	}
 
 	mwriter.Stop()

--- a/logging/monitor/monitor_test.go
+++ b/logging/monitor/monitor_test.go
@@ -178,7 +178,7 @@ func TestMonitor_WriteStopped(t *testing.T) {
 
 	mwriter := &monitor{
 		logger: logger,
-		doneCh: make(chan struct{}, 1),
+		doneCh: make(chan bool, 1),
 	}
 
 	mwriter.Stop()


### PR DESCRIPTION
Fixes #10347

improve monitor performance to avoid filling the log channel and loose logs when running monitor or debug.

An issue was reported that we loose some logs when are running `consul monitor` or `consul debug` commands. 

the current underlying monitor implementation avoid blocking when writing logs to not impact performance and allow losing some logs when we overflow the log channel (size 512 lines of code). This PR is to enhance the performance of the log channel read so we can avoid loosing logs.