### PR TITLE
http: add PrimaryDatacenter to the /v1/agent/self  response

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -74,19 +74,21 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 	}
 
 	config := struct {
-		Datacenter string
-		NodeName   string
-		NodeID     string
-		Revision   string
-		Server     bool
-		Version    string
+		Datacenter        string
+		PrimaryDatacenter string
+		NodeName          string
+		NodeID            string
+		Revision          string
+		Server            bool
+		Version           string
 	}{
-		Datacenter: s.agent.config.Datacenter,
-		NodeName:   s.agent.config.NodeName,
-		NodeID:     string(s.agent.config.NodeID),
-		Revision:   s.agent.config.Revision,
-		Server:     s.agent.config.ServerMode,
-		Version:    s.agent.config.Version,
+		Datacenter:        s.agent.config.Datacenter,
+		PrimaryDatacenter: s.agent.config.PrimaryDatacenter,
+		NodeName:          s.agent.config.NodeName,
+		NodeID:            string(s.agent.config.NodeID),
+		Revision:          s.agent.config.Revision,
+		Server:            s.agent.config.ServerMode,
+		Version:           s.agent.config.Version,
 	}
 	return Self{
 		Config:      config,


### PR DESCRIPTION
The `PrimaryDatacenter` value is available in the `DebugConfig` field, but that field is not stable and could change at any time.

The consul-k8s needs to be able to detect the primary DC for tests, so adding this value to the stable part of the API response.