### PR TITLE
docs: Add JSON examples to all config entries

### DIFF
--- a/website/content/api-docs/config.mdx
+++ b/website/content/api-docs/config.mdx
@@ -67,7 +67,7 @@ The table below shows this endpoint's support for
 
 ### Sample Payload
 
-```javascript
+```json
 {
     "Kind": "service-defaults",
     "Name": "web",

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -48,11 +48,11 @@ A wildcard specifier cannot be set on a listener of protocol `tcp`.
 ### TCP listener
 
 <Tabs>
-<Tab heading="HCL">
-<Tabs>
 <Tab heading="Consul OSS">
 
 Set up a TCP listener on an ingress gateway named "us-east-ingress" to proxy traffic to the "db" service:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "ingress-gateway"
@@ -71,11 +71,46 @@ Listeners = [
 ]
 ```
 
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: IngressGateway
+metadata:
+  name: us-east-ingress
+spec:
+  listeners:
+    - port: 3456
+      protocol: tcp
+      services:
+        - name: db
+```
+
+```json
+{
+  "Kind": "ingress-gateway",
+  "Name": "us-east-ingress",
+  "Listeners": [
+    {
+      "Port": 3456,
+      "Protocol": "tcp",
+      "Services": [
+        {
+          "Name": "db"
+        }
+      ]
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
 
 Set up a TCP listener on an ingress gateway named "us-east-ingress" in the default namespace
 to proxy traffic to the "db" service in the ops namespace:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "ingress-gateway"
@@ -96,34 +131,6 @@ Listeners = [
 ]
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="Kubernetes YAML">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Set up a TCP listener on an ingress gateway named "us-east-ingress" to proxy traffic to the "db" service:
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: IngressGateway
-metadata:
-  name: us-east-ingress
-spec:
-  listeners:
-    - port: 3456
-      protocol: tcp
-      services:
-        - name: db
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Set up a TCP listener on an ingress gateway named "us-east-ingress" in the default namespace
-to proxy traffic to the "db" service in the ops namespace:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: IngressGateway
@@ -138,39 +145,6 @@ spec:
         - name: db
           namespace: ops
 ```
-
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="JSON">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Set up a TCP listener on an ingress gateway named "us-east-ingress" to proxy traffic to the "db" service:
-
-```json
-{
-  "Kind": "ingress-gateway",
-  "Name": "us-east-ingress",
-  "Listeners": [
-    {
-      "Port": 3456,
-      "Protocol": "tcp",
-      "Services": [
-        {
-          "Name": "db"
-        }
-      ]
-    }
-  ]
-}
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Set up a TCP listener on an ingress gateway named "us-east-ingress" in the default namespace
-to proxy traffic to the "db" service in the ops namespace:
 
 ```json
 {
@@ -192,20 +166,20 @@ to proxy traffic to the "db" service in the ops namespace:
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeTabs>
+
 </Tab>
 </Tabs>
 
 ### Wildcard HTTP listener
 
 <Tabs>
-<Tab heading="HCL">
-<Tabs>
 <Tab heading="Consul OSS">
 
 Set up a wildcard HTTP listener on an ingress gateway named "us-east-ingress" to proxy traffic to all services in the datacenter.
 Also make two services available over a custom port with user-provided hosts, and enable TLS on every listener:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "ingress-gateway"
@@ -242,11 +216,72 @@ Listeners = [
 ]
 ```
 
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: IngressGateway
+metadata:
+  name: us-east-ingress
+spec:
+  tls:
+    enabled: true
+  listeners:
+    - port: 8080
+      protocol: http
+      services:
+        - name: '*'
+    - port: 4567
+      protocol: http
+      services:
+        - name: api
+          hosts: ['foo.example.com', 'foo.example.com:4567']
+        - name: web
+          hosts: ['website.example.com', 'website.example.com:4567']
+```
+
+```json
+{
+  "Kind": "ingress-gateway",
+  "Name": "us-east-ingress",
+  "TLS": {
+    "Enabled": true
+  },
+  "Listeners": [
+    {
+      "Port": 8080,
+      "Protocol": "http",
+      "Services": [
+        {
+          "Name": "*"
+        }
+      ]
+    },
+    {
+      "Port": 4567,
+      "Protocol": "http",
+      "Services": [
+        {
+          "Name": "api",
+          "Hosts": ["foo.example.com", "foo.example.com:4567"]
+        },
+        {
+          "Name": "web",
+          "Hosts": ["website.example.com", "website.example.com:4567"]
+        }
+      ]
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
 
 Set up a wildcard HTTP listener on an ingress gateway named "us-east-ingress" to proxy traffic to all services in the frontend namespace.
 Also make two services in the frontend namespace available over a custom port with user-provided hosts, and enable TLS on every listener:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "ingress-gateway"
@@ -287,44 +322,6 @@ Listeners = [
 ]
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="Kubernetes YAML">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Set up a wildcard HTTP listener on an ingress gateway named "us-east-ingress" to proxy traffic to all services in the datacenter.
-Also make two services available over a custom port with user-provided hosts, and enable TLS on every listener:
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: IngressGateway
-metadata:
-  name: us-east-ingress
-spec:
-  tls:
-    enabled: true
-  listeners:
-    - port: 8080
-      protocol: http
-      services:
-        - name: '*'
-    - port: 4567
-      protocol: http
-      services:
-        - name: api
-          hosts: ['foo.example.com', 'foo.example.com:4567']
-        - name: web
-          hosts: ['website.example.com', 'website.example.com:4567']
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Set up a wildcard HTTP listener on an ingress gateway named "us-east-ingress" to proxy traffic to all services in the frontend namespace.
-Also make two services in the frontend namespace available over a custom port with user-provided hosts, and enable TLS on every listener:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: IngressGateway
@@ -350,57 +347,6 @@ spec:
           namespace: frontend
           hosts: ['website.example.com', 'website.example.com:4567']
 ```
-
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="JSON">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Set up a wildcard HTTP listener on an ingress gateway named "us-east-ingress" to proxy traffic to all services in the datacenter.
-Also make two services available over a custom port with user-provided hosts, and enable TLS on every listener:
-
-```json
-{
-  "Kind": "ingress-gateway",
-  "Name": "us-east-ingress",
-  "TLS": {
-    "Enabled": true
-  },
-  "Listeners": [
-    {
-      "Port": 8080,
-      "Protocol": "http",
-      "Services": [
-        {
-          "Name": "*"
-        }
-      ]
-    },
-    {
-      "Port": 4567,
-      "Protocol": "http",
-      "Services": [
-        {
-          "Name": "api",
-          "Hosts": ["foo.example.com", "foo.example.com:4567"]
-        },
-        {
-          "Name": "web",
-          "Hosts": ["website.example.com", "website.example.com:4567"]
-        }
-      ]
-    }
-  ]
-}
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Set up a wildcard HTTP listener on an ingress gateway named "us-east-ingress" to proxy traffic to all services in the frontend namespace.
-Also make two services in the frontend namespace available over a custom port with user-provided hosts, and enable TLS on every listener:
 
 ```json
 {
@@ -441,20 +387,20 @@ Also make two services in the frontend namespace available over a custom port wi
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeTabs>
+
 </Tab>
 </Tabs>
 
 ### HTTP listener with path-based routing
 
 <Tabs>
-<Tab heading="HCL">
-<Tabs>
 <Tab heading="Consul OSS">
 
 Set up a HTTP listener on an ingress gateway named "us-east-ingress" to proxy
 traffic to a virtual service named "api".
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "ingress-gateway"
@@ -473,11 +419,46 @@ Listeners = [
 ]
 ```
 
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: IngressGateway
+metadata:
+  name: us-east-ingress
+spec:
+  listeners:
+    - port: 80
+      protocol: http
+      services:
+        - name: api
+```
+
+```json
+{
+  "Kind": "ingress-gateway",
+  "Name": "us-east-ingress",
+  "Listeners": [
+    {
+      "Port": 80,
+      "Protocol": "http",
+      "Services": [
+        {
+          "Name": "api"
+        }
+      ]
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
 
 Set up a HTTP listener on an ingress gateway named "us-east-ingress" in the
 default namespace to proxy traffic to a virtual service named "api".
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "ingress-gateway"
@@ -498,35 +479,6 @@ Listeners = [
 ]
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="Kubernetes YAML">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Set up a HTTP listener on an ingress gateway named "us-east-ingress" to proxy
-traffic to a virtual service named "api".
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: IngressGateway
-metadata:
-  name: us-east-ingress
-spec:
-  listeners:
-    - port: 80
-      protocol: http
-      services:
-        - name: api
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Set up a HTTP listener on an ingress gateway named "us-east-ingress" in the
-default namespace to proxy traffic to a virtual service named "api".
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: IngressGateway
@@ -541,40 +493,6 @@ spec:
         - name: api
           namespace: frontend
 ```
-
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="JSON">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Set up a HTTP listener on an ingress gateway named "us-east-ingress" to proxy
-traffic to a virtual service named "api".
-
-```json
-{
-  "Kind": "ingress-gateway",
-  "Name": "us-east-ingress",
-  "Listeners": [
-    {
-      "Port": 80,
-      "Protocol": "http",
-      "Services": [
-        {
-          "Name": "api"
-        }
-      ]
-    }
-  ]
-}
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Set up a HTTP listener on an ingress gateway named "us-east-ingress" in the
-default namespace to proxy traffic to a virtual service named "api".
 
 ```json
 {
@@ -596,8 +514,8 @@ default namespace to proxy traffic to a virtual service named "api".
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeTabs>
+
 </Tab>
 </Tabs>
 
@@ -607,9 +525,9 @@ virtual service which uses path-based routing to route requests to different
 backend services:
 
 <Tabs>
-<Tab heading="HCL">
-<Tabs>
 <Tab heading="Consul OSS">
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-router"
@@ -640,48 +558,6 @@ Routes = [
 ]
 ```
 
-</Tab>
-<Tab heading="Consul Enterprise">
-
-```hcl
-Kind = "service-router"
-Name = "api"
-Namespace = "default"
-Routes = [
-  {
-    Match {
-      HTTP {
-        PathPrefix = "/billing"
-      }
-    }
-
-    Destination {
-      Service = "billing-api"
-      Namespace = "frontend"
-    }
-  },
-  {
-    Match {
-      HTTP {
-        PathPrefix = "/payments"
-      }
-    }
-
-    Destination {
-      Service = "payments-api"
-      Namespace = "frontend"
-    }
-  }
-]
-```
-
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="Kubernetes YAML">
-<Tabs>
-<Tab heading="Consul OSS">
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceRouter
@@ -700,38 +576,6 @@ spec:
       destination:
         service: payments-api
 ```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: ServiceRouter
-metadata:
-  name: api
-  namespace: default
-spec:
-  routes:
-    - match:
-        http:
-          pathPrefix: '/billing'
-      destination:
-        service: billing-api
-        namespace: frontend
-    - match:
-        http:
-          pathPrefix: '/payments'
-      destination:
-        service: payments-api
-        namespace: frontend
-```
-
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="JSON">
-<Tabs>
-<Tab heading="Consul OSS">
 
 ```json
 {
@@ -762,8 +606,66 @@ spec:
 }
 ```
 
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind = "service-router"
+Name = "api"
+Namespace = "default"
+Routes = [
+  {
+    Match {
+      HTTP {
+        PathPrefix = "/billing"
+      }
+    }
+
+    Destination {
+      Service = "billing-api"
+      Namespace = "frontend"
+    }
+  },
+  {
+    Match {
+      HTTP {
+        PathPrefix = "/payments"
+      }
+    }
+
+    Destination {
+      Service = "payments-api"
+      Namespace = "frontend"
+    }
+  }
+]
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceRouter
+metadata:
+  name: api
+  namespace: default
+spec:
+  routes:
+    - match:
+        http:
+          pathPrefix: '/billing'
+      destination:
+        service: billing-api
+        namespace: frontend
+    - match:
+        http:
+          pathPrefix: '/payments'
+      destination:
+        service: payments-api
+        namespace: frontend
+```
 
 ```json
 {
@@ -797,8 +699,8 @@ spec:
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeTabs>
+
 </Tab>
 </Tabs>
 

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -23,7 +23,9 @@ Settings in this config entry apply across all namespaces and federated datacent
 Only allow transparent proxies to dial addresses in the mesh.
 
 <Tabs>
-<Tab heading="HCL">
+<Tab heading="Consul OSS">
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "mesh"
@@ -32,11 +34,34 @@ TransparentProxy {
 }
 ```
 
-</Tab>
-<Tab heading="HCL (Consul Enterprise)">
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: Mesh
+metadata:
+  name: mesh
+spec:
+  transparentProxy:
+    meshDestinationsOnly: true
+```
 
-**NOTE:** The `mesh` config entry can only be created in the `default`
+```json
+{
+  "Kind": "mesh",
+  "TransparentProxy": {
+    "MeshDestinationsOnly": true
+  }
+}
+```
+
+</CodeTabs>
+
+</Tab>
+<Tab heading="Consul Enterprise">
+
+-> **Note**: The `mesh` config entry can only be created in the `default`
 namespace and it will apply to proxies across **all** namespaces.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind      = "mesh"
@@ -47,9 +72,6 @@ TransparentProxy {
 }
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: Mesh
@@ -60,22 +82,17 @@ spec:
     meshDestinationsOnly: true
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML (Consul Enterprise)">
-
-**NOTE:** A `Mesh` resource can be created in any Kubernetes
-namespace but it will apply to proxies across **all** namespaces. Only one
-`Mesh` resource can exist in the cluster.
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: Mesh
-metadata:
-  name: mesh
-spec:
-  transparentProxy:
-    meshDestinationsOnly: true
+```json
+{
+  "Kind": "mesh",
+  "Namespace": "default",
+  "TransparentProxy": {
+    "MeshDestinationsOnly": true
+  }
+}
 ```
+
+</CodeTabs>
 
 </Tab>
 </Tabs>

--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -20,10 +20,14 @@ one global entry is supported.
 
 ### Default protocol
 
+Set the default protocol for all sidecar proxies:
+
 <Tabs>
-<Tab heading="HCL">
+<Tab heading="Consul OSS">
 
 Set the default protocol for all sidecar proxies:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind      = "proxy-defaults"
@@ -33,13 +37,35 @@ Config {
 }
 ```
 
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ProxyDefaults
+metadata:
+  name: global
+spec:
+  config:
+    protocol: http
+```
+
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "Config": {
+    "protocol": "http"
+  }
+}
+```
+
+</CodeTabs>
+
 </Tab>
-<Tab heading="HCL (Consul Enterprise)">
+<Tab heading="Consul Enterprise">
 
-Set the default protocol for all sidecar proxies.
-
-**NOTE:** The `proxy-defaults` config entry can only be created in the `default`
+-> **NOTE:** The `proxy-defaults` config entry can only be created in the `default`
 namespace and it will configure proxies in **all** namespaces.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind      = "proxy-defaults"
@@ -50,45 +76,38 @@ Config {
 }
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Set the default protocol for all sidecar proxies:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ProxyDefaults
 metadata:
   name: global
+  namespace: default
 spec:
   config:
     protocol: http
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML (Consul Enterprise)">
-
-Set the default protocol for all sidecar proxies:
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: ProxyDefaults
-metadata:
-  name: global
-spec:
-  config:
-    protocol: http
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "Namespace": "default",
+  "Config": {
+    "protocol": "http"
+  }
+}
 ```
+
+</CodeTabs>
 
 </Tab>
 </Tabs>
 
 ### Prometheus
 
-<Tabs>
-<Tab heading="HCL">
-
 Expose prometheus metrics:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind      = "proxy-defaults"
@@ -97,11 +116,6 @@ Config {
   envoy_prometheus_bind_addr = "0.0.0.0:9102"
 }
 ```
-
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Expose prometheus metrics:
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
@@ -113,15 +127,23 @@ spec:
     envoy_prometheus_bind_addr: '0.0.0.0:9102'
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "Config": {
+    "envoy_prometheus_bind_addr": "0.0.0.0:9102"
+  }
+}
+```
+
+</CodeTabs>
 
 ### Proxy-specific defaults
 
-<Tabs>
-<Tab heading="HCL">
-
 Set proxy-specific defaults:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind      = "proxy-defaults"
@@ -131,11 +153,6 @@ Config {
   handshake_timeout_ms     = 10000
 }
 ```
-
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Set proxy-specific defaults:
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
@@ -148,8 +165,18 @@ spec:
     handshake_timeout_ms: 10000
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "proxy-defaults",
+  "Name": "global",
+  "Config": {
+    "local_connect_timeout_ms": 1000,
+    "handshake_timeout_ms": 10000
+  }
+}
+```
+
+</CodeTabs>
 
 ## Available Fields
 
@@ -207,8 +234,8 @@ spec:
       description: `An arbitrary map of configuration values used by Connect proxies.
     The available configurations depend on the Connect proxy you use.
      Any values that your proxy allows can be configured globally here. To explore these options please see the documentation for your chosen proxy.
-     <ul><li>[Envoy](/docs/connect/proxies/envoy#bootstrap-configuration)</li>
-     <li>[Consul's built-in proxy](/docs/connect/proxies/built-in)</li></ul>`,
+     <ul><li>[Envoy](/docs/connect/proxies/envoy#proxy-config-options)</li>
+     <li>[Consul's built-in proxy](/docs/connect/proxies/built-in#proxy-config-key-reference)</li></ul>`,
     },
     {
       name: 'Mode',

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -24,10 +24,9 @@ config entry. However, if the protocol value is specified in a service defaults
 config entry for a given service, that value will take precedence over the
 globally configured value from proxy defaults.
 
-<Tabs>
-<Tab heading="HCL">
-
 Set the default protocol for a service in the default namespace to HTTP:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind      = "service-defaults"
@@ -35,11 +34,6 @@ Name      = "web"
 Namespace = "default"
 Protocol  = "http"
 ```
-
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Set the default protocol for a service in the default namespace to HTTP:
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
@@ -50,19 +44,27 @@ spec:
   protocol: http
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-defaults",
+  "Name": "web",
+  "Namespace": "default",
+  "Protocol": "http"
+}
+```
+
+</CodeTabs>
 
 ### Upstream configuration
 
 <Tabs>
-<Tab heading="HCL">
-<Tabs>
 <Tab heading="Consul OSS">
 
 Set default connection limits and mesh gateway mode across all upstreams
-of "counting" and also override the mesh gateway mode used when dialing
+of "counting", and also override the mesh gateway mode used when dialing
 the "dashboard" service.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-defaults"
@@ -91,12 +93,63 @@ UpstreamConfig = {
 }
 ```
 
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceDefaults
+metadata:
+  name: counting
+spec:
+  upstreamConfig:
+    defaults:
+      meshGateway:
+        mode: local
+      limits:
+        maxConnections: 512
+        maxPendingRequests: 512
+        maxConcurrentRequests: 512
+    overrides:
+      - name: dashboard
+        meshGateway:
+          mode: remote
+```
+
+```json
+{
+  "Kind": "service-defaults",
+  "Name": "counting",
+  "UpstreamConfig": {
+    "Defaults": {
+      "MeshGateway": {
+        "Mode": "local"
+      },
+      "Limits": {
+        "MaxConnections": 512,
+        "MaxPendingRequests": 512,
+        "MaxConcurrentRequests": 512
+      }
+    },
+    "Overrides": [
+      {
+        "Name": "dashboard",
+        "MeshGateway": {
+          "Mode": "remote"
+        }
+      }
+    ]
+  }
+}
+```
+
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
 
 Set default connection limits and mesh gateway mode across all upstreams
 of "counting" and also override the mesh gateway mode used when dialing
 the "dashboard" service in the "frontend" namespace.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-defaults"
@@ -127,46 +180,6 @@ UpstreamConfig = {
 }
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-
-<Tab heading="Kubernetes YAML">
-
-<Tabs>
-<Tab heading="Consul OSS">
-
-Set default connection limits and mesh gateway mode across all upstreams
-of "counting" and also override the mesh gateway mode used when dialing
-the "dashboard" service.
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: ServiceDefaults
-metadata:
-  name: counting
-spec:
-  upstreamConfig:
-    defaults:
-      meshGateway:
-        mode: local
-      limits:
-        maxConnections: 512
-        maxPendingRequests: 512
-        maxConcurrentRequests: 512
-    overrides:
-      - name: dashboard
-        meshGateway:
-          mode: remote
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Set default connection limits and mesh gateway mode across all upstreams
-of "counting" and also override the mesh gateway mode used when dialing
-the "dashboard" service in the "frontend" namespace.
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceDefaults
@@ -189,8 +202,36 @@ spec:
           mode: remote
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-defaults",
+  "Name": "counting",
+  "Namespace": "product",
+  "UpstreamConfig": {
+    "Defaults": {
+      "MeshGateway": {
+        "Mode": "local"
+      },
+      "Limits": {
+        "MaxConnections": 512,
+        "MaxPendingRequests": 512,
+        "MaxConcurrentRequests": 512
+      }
+    },
+    "Overrides": [
+      {
+        "Name": "dashboard",
+        "Namespace": "frontend",
+        "MeshGateway": {
+          "Mode": "remote"
+        }
+      }
+    ]
+  }
+}
+```
+</CodeTabs>
+
 </Tab>
 </Tabs>
 

--- a/website/content/docs/connect/config-entries/service-intentions.mdx
+++ b/website/content/docs/connect/config-entries/service-intentions.mdx
@@ -36,10 +36,9 @@ or globally via [`proxy-defaults`](/docs/connect/config-entries/proxy-defaults) 
 
 ### REST Access
 
-<Tabs>
-<Tab heading="HCL">
-
 Grant some clients more REST access than others:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-intentions"
@@ -74,11 +73,6 @@ Sources = [
 ]
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Grant some clients more REST access than others:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
@@ -104,17 +98,47 @@ spec:
     # unmatched connections and requests. Typically this will be DENY.
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-intentions",
+  "Name": "api",
+  "Sources": [
+    {
+      "Name": "admin-dashboard",
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/v2",
+            "Methods": ["GET", "PUT", "POST", "DELETE", "HEAD"]
+          }
+        }
+      ]
+    },
+    {
+      "Name": "report-generator",
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/v2/widgets",
+            "Methods": ["GET"]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeTabs>
 
 ### gRPC
-
-<Tabs>
-<Tab heading="HCL">
 
 Selectively deny some gRPC service methods. Since gRPC method calls [are
 HTTP/2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), we can
 use an HTTP path match rule to control traffic:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-intentions"
@@ -156,13 +180,6 @@ Sources = [
 ]
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Selectively deny some gRPC service methods. Since gRPC method calls [are
-HTTP/2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), we can
-use an HTTP path match rule to control traffic:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
@@ -192,15 +209,50 @@ spec:
     # unmatched connections and requests. Typically this will be DENY.
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-intentions",
+  "Name": "billing",
+  "Sources": [
+    {
+      "Name": "frontend-web",
+      "Permissions": [
+        {
+          "Action": "deny",
+          "HTTP": {
+            "PathExact": "/mycompany.BillingService/IssueRefund"
+          }
+        },
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/mycompany.BillingService/"
+          }
+        }
+      ]
+    },
+    {
+      "Name": "support-portal",
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathPrefix": "/mycompany.BillingService/"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+</CodeTabs>
 
 ### L4 and L7
 
-<Tabs>
-<Tab heading="HCL">
-
 You can mix and match L4 and L7 intentions per source:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-intentions"
@@ -231,11 +283,6 @@ Sources = [
 ]
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-You can mix and match L4 and L7 intentions per source:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
@@ -259,8 +306,35 @@ spec:
     # unmatched connections and requests. Typically this will be DENY.
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-intentions",
+  "Name": "api",
+  "Sources": [
+    {
+      "Name": "hackathon-project",
+      "Action": "deny"
+    },
+    {
+      "Name": "web",
+      "Action": "allow"
+    },
+    {
+      "Name": "nightly-reconciler",
+      "Permissions": [
+        {
+          "Action": "allow",
+          "HTTP": {
+            "PathExact": "/v1/reconcile-data",
+            "Methods": ["POST"]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+</CodeTabs>
 
 ## Available Fields
 

--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -27,29 +27,23 @@ and discovery terminates.
 
 ### Filter on service version
 
-<Tabs>
-<Tab heading="HCL">
-
 Create service subsets based on a version metadata and override the defaults:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind          = "service-resolver"
 Name          = "web"
 DefaultSubset = "v1"
 Subsets = {
-  "v1" = {
+  v1 = {
     Filter = "Service.Meta.version == v1"
   }
-  "v2" = {
+  v2 = {
     Filter = "Service.Meta.version == v2"
   }
 }
 ```
-
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Create service subsets based on a version metadata and override the defaults:
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
@@ -57,23 +51,37 @@ kind: ServiceResolver
 metadata:
   name: web
 spec:
-  defaultSubset: 'v1'
+  defaultSubset: v1
   subsets:
-    'v1':
+    v1:
       filter: 'Service.Meta.version == v1'
-    'v2':
+    v2:
       filter: 'Service.Meta.version == v2'
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-resolver",
+  "Name": "web",
+  "DefaultSubset": "v1",
+  "Subsets": {
+    "v1": {
+      "Filter": "Service.Meta.version == v1"
+    },
+    "v2": {
+      "Filter": "Service.Meta.version == v2"
+    }
+  }
+}
+```
+
+</CodeTabs>
 
 ### Other datacenters
 
-<Tabs>
-<Tab heading="HCL">
-
 Expose a set of services in another datacenter as a virtual service:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-resolver"
@@ -83,11 +91,6 @@ Redirect {
   Datacenter = "dc2"
 }
 ```
-
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Expose a set of services in another datacenter as a virtual service:
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
@@ -100,31 +103,38 @@ spec:
     datacenter: dc2
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-resolver",
+  "Name": "web-dc2",
+  "Redirect": {
+    "Service": "web",
+    "Datacenter": "dc2"
+  }
+}
+```
+
+</CodeTabs>
 
 ### Datacenter failover
 
-<Tabs>
-<Tab heading="HCL">
+Enable failover for subset 'v2' to 'dc2', and all other subsets to dc3 or dc4:
 
-Enable failover for all subsets:
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind           = "service-resolver"
 Name           = "web"
 ConnectTimeout = "15s"
 Failover = {
+  v2 = {
+    Datacenters = ["dc2"]
+  }
   "*" = {
     Datacenters = ["dc3", "dc4"]
   }
 }
 ```
-
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Enable failover for all subsets:
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
@@ -134,19 +144,35 @@ metadata:
 spec:
   connectTimeout: 15s
   failover:
+    v2:
+      datacenters: ['dc2']
     '*':
       datacenters: ['dc3', 'dc4']
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-resolver",
+  "Name": "web",
+  "ConnectTimeout": "15s",
+  "Failover": {
+    "v2": {
+      "Datacenters": ["dc2"]
+    },
+    "*": {
+      "Datacenters": ["dc3", "dc4"]
+    }
+  }
+}
+```
+
+</CodeTabs>
 
 ### Consistent load balancing
 
-<Tabs>
-<Tab heading="HCL">
-
 Apply consistent load balancing for requests based on `x-user-id` header:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-resolver"
@@ -163,11 +189,6 @@ LoadBalancer = {
 }
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Apply consistent load balancing for requests based on `x-user-id` header:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceResolver
@@ -181,8 +202,23 @@ spec:
         fieldValue: x-user-id
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-resolver",
+  "Name": "web",
+  "LoadBalancer": {
+    "Policy": "maglev",
+    "HashPolicies": [
+      {
+        "Field": "header",
+        "FieldValue": "x-user-id"
+      }
+    ]
+  }
+}
+```
+
+</CodeTabs>
 
 ## Available Fields
 

--- a/website/content/docs/connect/config-entries/service-router.mdx
+++ b/website/content/docs/connect/config-entries/service-router.mdx
@@ -40,10 +40,9 @@ service of the same name.
 
 ### Path prefix matching
 
-<Tabs>
-<Tab heading="HCL">
-
 Route HTTP requests with a path starting with `/admin` to a different service:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-router"
@@ -64,11 +63,6 @@ Routes = [
 ]
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Route HTTP requests with a path starting with `/admin` to a different service:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceRouter
@@ -84,15 +78,32 @@ spec:
   # NOTE: a default catch-all will send unmatched traffic to "web"
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-router",
+  "Name": "web",
+  "Routes": [
+    {
+      "Match": {
+        "HTTP": {
+          "PathPrefix": "/admin"
+        }
+      },
+      "Destination": {
+        "Service": "admin"
+      }
+    }
+  ]
+}
+```
+
+</CodeTabs>
 
 ### Header/query parameter matching
 
-<Tabs>
-<Tab heading="HCL">
+Route HTTP requests with a special URL parameter or header to a canary subset:
 
-Route HTTP requests with a special url parameter or header to a canary subset:
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-router"
@@ -134,11 +145,6 @@ Routes = [
 ]
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Route HTTP requests with a special url parameter or header to a canary subset:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceRouter
@@ -165,16 +171,55 @@ spec:
   # NOTE: a default catch-all will send unmatched traffic to "web"
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-router",
+  "Name": "web",
+  "Routes": [
+    {
+      "Match": {
+        "HTTP": {
+          "Header": [
+            {
+              "Name": "x-debug",
+              "Exact": "1"
+            }
+          ]
+        }
+      },
+      "Destination": {
+        "Service": "web",
+        "ServiceSubset": "canary"
+      }
+    },
+    {
+      "Match": {
+        "HTTP": {
+          "QueryParam": [
+            {
+              "Name": "x-debug",
+              "Exact": "1"
+            }
+          ]
+        }
+      },
+      "Destination": {
+        "Service": "web",
+        "ServiceSubset": "canary"
+      }
+    }
+  ]
+}
+```
+
+</CodeTabs>
 
 ### gRPC routing
 
-<Tabs>
-<Tab heading="HCL">
-
 Re-route a gRPC method to another service. Since gRPC method calls [are
 HTTP/2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), we can use an HTTP path match rule to re-route traffic:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-router"
@@ -195,12 +240,6 @@ Routes = [
 ]
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Re-route a gRPC method to another service. Since gRPC method calls [are
-HTTP/2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), we can use an HTTP path match rule to re-route traffic:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceRouter
@@ -216,8 +255,26 @@ spec:
   # NOTE: a default catch-all will send unmatched traffic to "billing"
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-router",
+  "Name": "billing",
+  "Routes": [
+    {
+      "Match": {
+        "HTTP": {
+          "PathExact": "/mycompany.BillingService/GenerateInvoice"
+        }
+      },
+      "Destination": {
+        "Service": "invoice-generator"
+      }
+    }
+  ]
+}
+```
+
+</CodeTabs>
 
 ## Available Fields
 

--- a/website/content/docs/connect/config-entries/service-splitter.mdx
+++ b/website/content/docs/connect/config-entries/service-splitter.mdx
@@ -43,10 +43,9 @@ resolution stage.
 
 ### Two subsets of same service
 
-<Tabs>
-<Tab heading="HCL">
-
 Split traffic between two subsets of the same service:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-splitter"
@@ -63,11 +62,6 @@ Splits = [
 ]
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Split traffic between two subsets of the same service:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceSplitter
@@ -81,15 +75,30 @@ spec:
       serviceSubset: v2
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-splitter",
+  "Name": "web",
+  "Splits": [
+    {
+      "Weight": 90,
+      "ServiceSubset": "v1"
+    },
+    {
+      "Weight": 10,
+      "ServiceSubset": "v2"
+    }
+  ]
+}
+```
+
+</CodeTabs>
 
 ### Two different services
 
-<Tabs>
-<Tab heading="HCL">
-
 Split traffic between two services:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "service-splitter"
@@ -106,11 +115,6 @@ Splits = [
 ]
 ```
 
-</Tab>
-<Tab heading="Kubernetes YAML">
-
-Split traffic between two services:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceSplitter
@@ -124,8 +128,23 @@ spec:
       service: web-rewrite
 ```
 
-</Tab>
-</Tabs>
+```json
+{
+  "Kind": "service-splitter",
+  "Name": "web",
+  "Splits": [
+    {
+      "Weight": 50
+    },
+    {
+      "Weight": 50,
+      "Service": "web-rewrite"
+    }
+  ]
+}
+```
+
+</CodeTabs>
 
 ## Available Fields
 

--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -44,12 +44,16 @@ traffic from the mesh to those services will be evenly load-balanced between the
 
 ## Sample Config Entries
 
-<Tabs>
-<Tab heading="HCL">
+### Access an external service
+
 <Tabs>
 <Tab heading="Consul OSS">
 
-Link gateway named "us-west-gateway" with the billing service:
+Link gateway named "us-west-gateway" with the billing service.
+
+Connections to the external service will be unencrypted.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "terminating-gateway"
@@ -62,10 +66,38 @@ Services = [
 ]
 ```
 
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: TerminatingGateway
+metadata:
+  name: us-west-gateway
+spec:
+  services:
+    - name: billing
+```
+
+```json
+{
+  "Kind": "terminating-gateway",
+  "Name": "us-west-gateway",
+  "Services": [
+    {
+      "Name": "billing"
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
 
-Link gateway named "us-west-gateway" in the default namespace with the billing service in the finance namespace:
+Link gateway named "us-west-gateway" in the default namespace with the billing service in the finance namespace.
+
+Connections to the external service will be unencrypted.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "terminating-gateway"
@@ -80,30 +112,6 @@ Services = [
 ]
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="Kubernetes YAML">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Link gateway named "us-west-gateway" with the billing service:
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: TerminatingGateway
-metadata:
-  name: us-west-gateway
-spec:
-  services:
-    - name: billing
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Link gateway named "us-west-gateway" in the default namespace with the billing service in the finance namespace:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: TerminatingGateway
@@ -114,32 +122,6 @@ spec:
     - name: billing
       namespace: finance
 ```
-
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="JSON">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Link gateway named "us-west-gateway" with the billing service:
-
-```json
-{
-  "Kind": "terminating-gateway",
-  "Name": "us-west-gateway",
-  "Services": [
-    {
-      "Name": "billing"
-    }
-  ]
-}
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Link gateway named "us-west-gateway" in the default namespace with the billing service in the finance namespace:
 
 ```json
 {
@@ -155,17 +137,23 @@ Link gateway named "us-west-gateway" in the default namespace with the billing s
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeTabs>
+
 </Tab>
 </Tabs>
 
-<Tabs>
-<Tab heading="HCL">
+### Access an external service over TLS
+
 <Tabs>
 <Tab heading="Consul OSS">
 
-Link gateway named "us-west-gateway" with the billing service and specify a CA file for one-way TLS authentication:
+Link gateway named "us-west-gateway" with the billing service, and specify a CA
+file to be used for one-way TLS authentication.
+
+-> **Note**: The `CAFile` parameter must be specified _and_ point to a valid CA
+bundle in order to properly initiate a TLS connection to the destination service.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "terminating-gateway"
@@ -179,11 +167,42 @@ Services = [
 ]
 ```
 
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: TerminatingGateway
+metadata:
+  name: us-west-gateway
+spec:
+  services:
+    - name: billing
+      caFile: /etc/certs/ca-chain.cert.pem
+```
+
+```json
+{
+  "Kind": "terminating-gateway",
+  "Name": "us-west-gateway",
+  "Services": [
+    {
+      "Name": "billing",
+      "CAFile": "/etc/certs/ca-chain.cert.pem"
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
 
 Link gateway named "us-west-gateway" in the default namespace with the billing service in the finance namespace,
-and specify a CA file for one-way TLS authentication:
+and specify a CA file to be used for one-way TLS authentication.
+
+-> **Note**: The `CAFile` parameter must be specified _and_ point to a valid CA
+bundle in order to properly initiate a TLS connection to the destination service.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "terminating-gateway"
@@ -199,32 +218,6 @@ Services = [
 ]
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="Kubernetes YAML">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Link gateway named "us-west-gateway" with the billing service and specify a CA file for one-way TLS authentication:
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: TerminatingGateway
-metadata:
-  name: us-west-gateway
-spec:
-  services:
-    - name: billing
-      caFile: /etc/certs/ca-chain.cert.pem
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Link gateway named "us-west-gateway" in the default namespace with the billing service in the finance namespace,
-and specify a CA file for one-way TLS authentication:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: TerminatingGateway
@@ -236,34 +229,6 @@ spec:
       namespace: finance
       caFile: /etc/certs/ca-chain.cert.pem
 ```
-
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="JSON">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Link gateway named "us-west-gateway" with the billing service and specify a CA file for one-way TLS authentication:
-
-```json
-{
-  "Kind": "terminating-gateway",
-  "Name": "us-west-gateway",
-  "Services": [
-    {
-      "Name": "billing",
-      "CAFile": "/etc/certs/ca-chain.cert.pem"
-    }
-  ]
-}
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Link gateway named "us-west-gateway" in the default namespace with the billing service in the finance namespace,
-and specify a CA file for one-way TLS authentication:
 
 ```json
 {
@@ -280,17 +245,23 @@ and specify a CA file for one-way TLS authentication:
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeTabs>
+
 </Tab>
 </Tabs>
 
-<Tabs>
-<Tab heading="HCL">
+### Access an external service over mutual TLS
+
 <Tabs>
 <Tab heading="Consul OSS">
 
-Link gateway named "us-west-gateway" with the payments service and specify a CA file, key file, and cert file for mutual TLS authentication:
+Link gateway named "us-west-gateway" with the billing service, and specify a CA
+file, key file, and cert file to be used for mutual TLS authentication.
+
+-> **Note**: The `CAFile` parameter must be specified _and_ point to a valid CA
+bundle in order to properly initiate a TLS connection to the destination service.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "terminating-gateway"
@@ -306,11 +277,46 @@ Services = [
 ]
 ```
 
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: TerminatingGateway
+metadata:
+  name: us-west-gateway
+spec:
+  services:
+    - name: billing
+      caFile: /etc/certs/ca-chain.cert.pem
+      keyFile: /etc/certs/gateway.key.pem
+      certFile: /etc/certs/gateway.cert.pem
+```
+
+```json
+{
+  "Kind": "terminating-gateway",
+  "Name": "us-west-gateway",
+  "Services": [
+    {
+      "Name": "billing",
+      "CAFile": "/etc/certs/ca-chain.cert.pem",
+      "KeyFile": "/etc/certs/gateway.key.pem",
+      "CertFile": "/etc/certs/gateway.cert.pem"
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
 
-Link gateway named "us-west-gateway" in the default namespace with the payments service in the finance namespace.
-Also specify a CA file, key file, and cert file for mutual TLS authentication:
+Link gateway named "us-west-gateway" in the default namespace with the billing service in the finance namespace.
+Also specify a CA file, key file, and cert file to be used for mutual TLS authentication.
+
+-> **Note**: The `CAFile` parameter must be specified _and_ point to a valid CA
+bundle in order to properly initiate a TLS connection to the destination service.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
 Kind = "terminating-gateway"
@@ -328,34 +334,6 @@ Services = [
 ]
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="Kubernetes YAML">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Link gateway named "us-west-gateway" with the payments service and specify a CA file, key file, and cert file for mutual TLS authentication:
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: TerminatingGateway
-metadata:
-  name: us-west-gateway
-spec:
-  services:
-    - name: billing
-      caFile: /etc/certs/ca-chain.cert.pem
-      keyFile: /etc/certs/gateway.key.pem
-      certFile: /etc/certs/gateway.cert.pem
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Link gateway named "us-west-gateway" in the default namespace with the payments service in the finance namespace.
-Also specify a CA file, key file, and cert file for mutual TLS authentication:
-
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: TerminatingGateway
@@ -369,36 +347,6 @@ spec:
       keyFile: /etc/certs/gateway.key.pem
       certFile: /etc/certs/gateway.cert.pem
 ```
-
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="JSON">
-<Tabs>
-<Tab heading="Consul OSS">
-
-Link gateway named "us-west-gateway" with the payments service and specify a CA file, key file, and cert file for mutual TLS authentication:
-
-```json
-{
-  "Kind": "terminating-gateway",
-  "Name": "us-west-gateway",
-  "Services": [
-    {
-      "Name": "billing",
-      "CAFile": "/etc/certs/ca-chain.cert.pem",
-      "KeyFile": "/etc/certs/gateway.key.pem",
-      "CertFile": "/etc/certs/gateway.cert.pem"
-    }
-  ]
-}
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Link gateway named "us-west-gateway" in the default namespace with the payments service in the finance namespace.
-Also specify a CA file, key file, and cert file for mutual TLS authentication:
 
 ```json
 {
@@ -417,18 +365,23 @@ Also specify a CA file, key file, and cert file for mutual TLS authentication:
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeTabs>
+
 </Tab>
 </Tabs>
 
-<Tabs>
-<Tab heading="HCL">
+### Override connection parameters for a specific service
+
 <Tabs>
 <Tab heading="Consul OSS">
 
 Link gateway named "us-west-gateway" with all services in the datacenter, and configure default certificates for mutual TLS.
-Also override the SNI and CA file used for connections to the billing service:
+
+Override the SNI and CA file used for connections to the billing service.
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+<CodeBlockConfig highlight="11-15">
 
 ```hcl
 Kind = "terminating-gateway"
@@ -449,11 +402,65 @@ Services = [
 ]
 ```
 
+</CodeBlockConfig>
+
+<CodeBlockConfig highlight="11-13">
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: TerminatingGateway
+metadata:
+  name: us-west-gateway
+spec:
+  services:
+    - name: '*'
+      caFile: /etc/common-certs/ca-chain.cert.pem
+      keyFile: /etc/common-certs/gateway.key.pem
+      certFile: /etc/common-certs/gateway.cert.pem
+    - name: billing
+      caFile: /etc/billing-ca/ca-chain.cert.pem
+      sni: billing.service.com
+```
+
+</CodeBlockConfig>
+
+<CodeBlockConfig highlight="11-15">
+
+```json
+{
+  "Kind": "terminating-gateway",
+  "Name": "us-west-gateway",
+  "Services": [
+    {
+      "Name": "*",
+      "CAFile": "/etc/common-certs/ca-chain.cert.pem",
+      "KeyFile": "/etc/common-certs/gateway.key.pem",
+      "CertFile": "/etc/common-certs/gateway.cert.pem"
+    },
+    {
+      "Name": "billing",
+      "CAFile": "/etc/billing-ca/ca-chain.cert.pem",
+      "SNI": "billing.service.com"
+    }
+  ]
+}
+```
+
+</CodeBlockConfig>
+
+</CodeTabs>
+
 </Tab>
 <Tab heading="Consul Enterprise">
 
 Link gateway named "us-west-gateway" in the default namespace with all services in the finance namespace,
-and configure default certificates for mutual TLS. Also override the SNI and CA file used for connections to the billing service:
+and configure default certificates for mutual TLS.
+
+Override the SNI and CA file used for connections to the billing service:
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+<CodeBlockConfig highlight="13-18">
 
 ```hcl
 Kind = "terminating-gateway"
@@ -471,43 +478,15 @@ Services = [
   {
     Namespace = "finance"
     Name      = "billing"
-    CAFile    = "/etc/billing-ca/ca-chain.cert.pem",
+    CAFile    = "/etc/billing-ca/ca-chain.cert.pem"
     SNI       =  "billing.service.com"
   }
 ]
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="Kubernetes YAML">
-<Tabs>
-<Tab heading="Consul OSS">
+</CodeBlockConfig>
 
-Link gateway named "us-west-gateway" with all services in the datacenter, and configure default certificates for mutual TLS.
-Also override the SNI and CA file used for connections to the billing service:
-
-```yaml
-apiVersion: consul.hashicorp.com/v1alpha1
-kind: TerminatingGateway
-metadata:
-  name: us-west-gateway
-spec:
-  services:
-    - name: '*'
-      caFile: /etc/common-certs/ca-chain.cert.pem
-      keyFile: /etc/common-certs/gateway.key.pem
-      certFile: /etc/common-certs/gateway.cert.pem
-    - name: billing
-      caFile: /etc/billing-ca/ca-chain.cert.pem
-      sni: billing.service.com
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Link gateway named "us-west-gateway" in the default namespace with all services in the finance namespace,
-and configure default certificates for mutual TLS. Also override the SNI and CA file used for connections to the billing service:
+<CodeBlockConfig highlight="12-15">
 
 ```yaml
 apiVersion: consul.hashicorp.com/v1alpha1
@@ -527,42 +506,9 @@ spec:
       sni: billing.service.com
 ```
 
-</Tab>
-</Tabs>
-</Tab>
-<Tab heading="JSON">
-<Tabs>
-<Tab heading="Consul OSS">
+</CodeBlockConfig>
 
-Link gateway named "us-west-gateway" with all services in the datacenter, and configure default certificates for mutual TLS.
-Also override the SNI and CA file used for connections to the billing service:
-
-```json
-{
-  "Kind": "terminating-gateway",
-  "Name": "us-west-gateway",
-  "Services": [
-    {
-      "Name": "*",
-      "CAFile": "/etc/billing-ca/ca-chain.cert.pem",
-      "KeyFile": "/etc/certs/gateway.key.pem",
-      "CertFile": "/etc/certs/gateway.cert.pem",
-      "SNI": "billing.service.com"
-    },
-    {
-      "Name": "billing",
-      "CAFile": "/etc/billing-ca/ca-chain.cert.pem",
-      "SNI": "billing.service.com"
-    }
-  ]
-}
-```
-
-</Tab>
-<Tab heading="Consul Enterprise">
-
-Link gateway named "us-west-gateway" in the default namespace with all services in the finance namespace,
-and configure default certificates for mutual TLS. Also override the SNI and CA file used for connections to the billing service:
+<CodeBlockConfig highlight="13-18">
 
 ```json
 {
@@ -573,10 +519,9 @@ and configure default certificates for mutual TLS. Also override the SNI and CA 
     {
       "Namespace": "finance",
       "Name": "*",
-      "CAFile": "/etc/billing-ca/ca-chain.cert.pem",
-      "KeyFile": "/etc/certs/gateway.key.pem",
-      "CertFile": "/etc/certs/gateway.cert.pem",
-      "SNI": "billing.service.com"
+      "CAFile": "/etc/common-certs/ca-chain.cert.pem",
+      "KeyFile": "/etc/common-certs/gateway.key.pem",
+      "CertFile": "/etc/common-certs/gateway.cert.pem"
     },
     {
       "Namespace": "finance",
@@ -588,8 +533,10 @@ and configure default certificates for mutual TLS. Also override the SNI and CA 
 }
 ```
 
-</Tab>
-</Tabs>
+</CodeBlockConfig>
+
+</CodeTabs>
+
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
This commit adds example JSON configs for several config entry resources were missing examples in this language.

The examples have also been updated to use the new CodeTabs resource instead of the Tab component.

The changes can be previewed here https://consul-fb7xuafv0-hashicorp.vercel.app/docs/connect/config-entries.