### PR TITLE
Relax validation for expose.paths config

### DIFF
--- a/.changelog/10394.txt
+++ b/.changelog/10394.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: allow exposing duplicate HTTP paths through a proxy instance.
+```

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1230,17 +1230,12 @@ func (s *NodeService) Validate() error {
 			}
 			bindAddrs[addr] = struct{}{}
 		}
-		var knownPaths = make(map[string]bool)
+
 		var knownListeners = make(map[int]bool)
 		for _, path := range s.Proxy.Expose.Paths {
 			if path.Path == "" {
 				result = multierror.Append(result, fmt.Errorf("expose.paths: empty path exposed"))
 			}
-
-			if seen := knownPaths[path.Path]; seen {
-				result = multierror.Append(result, fmt.Errorf("expose.paths: duplicate paths exposed"))
-			}
-			knownPaths[path.Path] = true
 
 			if seen := knownListeners[path.ListenerPort]; seen {
 				result = multierror.Append(result, fmt.Errorf("expose.paths: duplicate listener ports exposed"))

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -589,13 +589,6 @@ func TestStructs_NodeService_ValidateExposeConfig(t *testing.T) {
 			func(x *NodeService) { x.Proxy.Expose.Paths[0].ListenerPort = 65536 },
 			"invalid listener port",
 		},
-		"duplicate paths": {
-			func(x *NodeService) {
-				x.Proxy.Expose.Paths[0].Path = "/metrics"
-				x.Proxy.Expose.Paths[1].Path = "/metrics"
-			},
-			"duplicate paths exposed",
-		},
 		"duplicate ports": {
 			func(x *NodeService) {
 				x.Proxy.Expose.Paths[0].ListenerPort = 21600

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -574,31 +574,38 @@ func TestStructs_NodeService_ValidateExposeConfig(t *testing.T) {
 	}
 	cases := map[string]testCase{
 		"valid": {
-			func(x *NodeService) {},
-			"",
+			Modify: func(x *NodeService) {},
+			Err:    "",
 		},
 		"empty path": {
-			func(x *NodeService) { x.Proxy.Expose.Paths[0].Path = "" },
-			"empty path exposed",
+			Modify: func(x *NodeService) { x.Proxy.Expose.Paths[0].Path = "" },
+			Err:    "empty path exposed",
 		},
 		"invalid port negative": {
-			func(x *NodeService) { x.Proxy.Expose.Paths[0].ListenerPort = -1 },
-			"invalid listener port",
+			Modify: func(x *NodeService) { x.Proxy.Expose.Paths[0].ListenerPort = -1 },
+			Err:    "invalid listener port",
 		},
 		"invalid port too large": {
-			func(x *NodeService) { x.Proxy.Expose.Paths[0].ListenerPort = 65536 },
-			"invalid listener port",
+			Modify: func(x *NodeService) { x.Proxy.Expose.Paths[0].ListenerPort = 65536 },
+			Err:    "invalid listener port",
 		},
-		"duplicate ports": {
-			func(x *NodeService) {
+		"duplicate paths are allowed": {
+			Modify: func(x *NodeService) {
+				x.Proxy.Expose.Paths[0].Path = "/healthz"
+				x.Proxy.Expose.Paths[1].Path = "/healthz"
+			},
+			Err: "",
+		},
+		"duplicate listener ports are not allowed": {
+			Modify: func(x *NodeService) {
 				x.Proxy.Expose.Paths[0].ListenerPort = 21600
 				x.Proxy.Expose.Paths[1].ListenerPort = 21600
 			},
-			"duplicate listener ports exposed",
+			Err: "duplicate listener ports exposed",
 		},
 		"protocol not supported": {
-			func(x *NodeService) { x.Proxy.Expose.Paths[0].Protocol = "foo" },
-			"protocol 'foo' not supported for path",
+			Modify: func(x *NodeService) { x.Proxy.Expose.Paths[0].Protocol = "foo" },
+			Err:    "protocol 'foo' not supported for path",
 		},
 	}
 


### PR DESCRIPTION
Previously we would return an error if duplicate paths were specified.
This could lead to problems in cases where a user has the same path, 
say /healthz, on two different ports.

This validation was added to signal a potential misconfiguration.
Instead we will only check for duplicate listener ports, since that is
what would lead to ambiguity issues when generating xDS config.

In the future we could look into using a single listener and creating
distinct filter chains for each path/port.