### PR TITLE
grpc: move gRPC INFO logs to be emitted as TRACE logs from Consul

### DIFF
--- a/.changelog/10395.txt
+++ b/.changelog/10395.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+grpc: move gRPC INFO logs to be emitted as TRACE logs from Consul
+```

--- a/logging/grpc.go
+++ b/logging/grpc.go
@@ -28,7 +28,8 @@ func NewGRPCLogger(logLevel string, logger hclog.Logger) *GRPCLogger {
 
 // Info implements grpclog.LoggerV2
 func (g *GRPCLogger) Info(args ...interface{}) {
-	g.logger.Info(fmt.Sprint(args...))
+	// gRPC's INFO level is more akin to Consul's TRACE level
+	g.logger.Trace(fmt.Sprint(args...))
 }
 
 // Infoln implements grpclog.LoggerV2

--- a/logging/grpc_test.go
+++ b/logging/grpc_test.go
@@ -36,9 +36,9 @@ func TestGRPCLogger(t *testing.T) {
 	grpclog.Errorf("Errorf: %d", 1)
 
 	// Fatal tests are hard... assume they are good!
-	expect := `timeformat [INFO]  Info,
-timeformat [INFO]  Infoln
-timeformat [INFO]  Infof: 1
+	expect := `timeformat [TRACE] Info,
+timeformat [TRACE] Infoln
+timeformat [TRACE] Infof: 1
 timeformat [WARN]  Warning,
 timeformat [WARN]  Warningln
 timeformat [WARN]  Warningf: 1


### PR DESCRIPTION
Fixes #10183