### PR TITLE
Rename CatalogDestinationsOnly

### DIFF
--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4196,7 +4196,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 								"gir": "zim"
 							},
 							"transparent_proxy": {
-								"catalog_destinations_only": true
+								"mesh_destinations_only": true
 							}
 						}
 					]
@@ -4212,7 +4212,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 						"gir" = "zim"
 					}
 					transparent_proxy {
-						catalog_destinations_only = true
+						mesh_destinations_only = true
 					}
 				  }
 				}
@@ -4228,7 +4228,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 					},
 					EnterpriseMeta: *defaultEntMeta,
 					TransparentProxy: structs.TransparentProxyMeshConfig{
-						CatalogDestinationsOnly: true,
+						MeshDestinationsOnly: true,
 					},
 				},
 			}
@@ -4247,7 +4247,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 								"gir": "zim"
 							},
 							"TransparentProxy": {
-								"CatalogDestinationsOnly": true
+								"MeshDestinationsOnly": true
 							}
 						}
 					]
@@ -4263,7 +4263,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 						"gir" = "zim"
 					}
 					TransparentProxy {
-						CatalogDestinationsOnly = true
+						MeshDestinationsOnly = true
 					}
 				  }
 				}
@@ -4279,7 +4279,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 					},
 					EnterpriseMeta: *defaultEntMeta,
 					TransparentProxy: structs.TransparentProxyMeshConfig{
-						CatalogDestinationsOnly: true,
+						MeshDestinationsOnly: true,
 					},
 				},
 			}

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -53,7 +53,7 @@ func TestConfig_Get(t *testing.T) {
 			Datacenter: "dc1",
 			Entry: &structs.MeshConfigEntry{
 				TransparentProxy: structs.TransparentProxyMeshConfig{
-					CatalogDestinationsOnly: true,
+					MeshDestinationsOnly: true,
 				},
 				Meta: map[string]string{
 					"key1": "value1",
@@ -128,7 +128,7 @@ func TestConfig_Get(t *testing.T) {
 {
 	"Kind": "mesh",
 	"TransparentProxy": {
-		"CatalogDestinationsOnly": true
+		"MeshDestinationsOnly": true
 	},
 	"Meta":{
 		"key1": "value1",

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -429,7 +429,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	// mesh config entry
 	meshConfig := &structs.MeshConfigEntry{
 		TransparentProxy: structs.TransparentProxyMeshConfig{
-			CatalogDestinationsOnly: true,
+			MeshDestinationsOnly: true,
 		},
 	}
 	require.NoError(t, fsm.state.EnsureConfigEntry(27, meshConfig))

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -20,9 +20,9 @@ type MeshConfigEntry struct {
 // TransparentProxyMeshConfig contains cluster-wide options pertaining to
 // TPROXY mode when enabled.
 type TransparentProxyMeshConfig struct {
-	// CatalogDestinationsOnly can be used to disable the pass-through that
+	// MeshDestinationsOnly can be used to disable the pass-through that
 	// allows traffic to destinations outside of the mesh.
-	CatalogDestinationsOnly bool `alias:"catalog_destinations_only"`
+	MeshDestinationsOnly bool `alias:"mesh_destinations_only"`
 }
 
 func (e *MeshConfigEntry) GetKind() string {

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1316,7 +1316,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"gir" = "zim"
 				}
 				transparent_proxy {
-					catalog_destinations_only = true
+					mesh_destinations_only = true
 				}
 			`,
 			camel: `
@@ -1326,7 +1326,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"gir" = "zim"
 				}
 				TransparentProxy {
-					CatalogDestinationsOnly = true
+					MeshDestinationsOnly = true
 				}
 			`,
 			expect: &MeshConfigEntry{
@@ -1335,7 +1335,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"gir": "zim",
 				},
 				TransparentProxy: TransparentProxyMeshConfig{
-					CatalogDestinationsOnly: true,
+					MeshDestinationsOnly: true,
 				},
 			},
 		},

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -178,7 +178,7 @@ func makePassthroughClusters(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message,
 	clusters := make([]proto.Message, 0, len(cfgSnap.ConnectProxy.PassthroughUpstreams)+1)
 
 	if cfgSnap.ConnectProxy.MeshConfig == nil ||
-		!cfgSnap.ConnectProxy.MeshConfig.TransparentProxy.CatalogDestinationsOnly {
+		!cfgSnap.ConnectProxy.MeshConfig.TransparentProxy.MeshDestinationsOnly {
 
 		clusters = append(clusters, &envoy_cluster_v3.Cluster{
 			Name: OriginalDestinationClusterName,

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -656,7 +656,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 				snap.ConnectProxy.MeshConfigSet = true
 				snap.ConnectProxy.MeshConfig = &structs.MeshConfigEntry{
 					TransparentProxy: structs.TransparentProxyMeshConfig{
-						CatalogDestinationsOnly: true,
+						MeshDestinationsOnly: true,
 					},
 				}
 			},

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -212,9 +212,9 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 				outboundListener.FilterChains[j].FilterChainMatch.PrefixRanges[0].AddressPrefix
 		})
 
-		// Add a catch-all filter chain that acts as a TCP proxy to non-catalog destinations
+		// Add a catch-all filter chain that acts as a TCP proxy to destinations outside the mesh
 		if cfgSnap.ConnectProxy.MeshConfig == nil ||
-			!cfgSnap.ConnectProxy.MeshConfig.TransparentProxy.CatalogDestinationsOnly {
+			!cfgSnap.ConnectProxy.MeshConfig.TransparentProxy.MeshDestinationsOnly {
 
 			filterChain, err := s.makeUpstreamFilterChainForDiscoveryChain(
 				"",

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -551,7 +551,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				snap.ConnectProxy.MeshConfigSet = true
 				snap.ConnectProxy.MeshConfig = &structs.MeshConfigEntry{
 					TransparentProxy: structs.TransparentProxyMeshConfig{
-						CatalogDestinationsOnly: true,
+						MeshDestinationsOnly: true,
 					},
 				}
 

--- a/api/config_entry_cluster.go
+++ b/api/config_entry_cluster.go
@@ -11,7 +11,7 @@ type MeshConfigEntry struct {
 }
 
 type TransparentProxyMeshConfig struct {
-	CatalogDestinationsOnly bool `alias:"catalog_destinations_only"`
+	MeshDestinationsOnly bool `alias:"mesh_destinations_only"`
 }
 
 func (e *MeshConfigEntry) GetKind() string {

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -199,7 +199,7 @@ func TestAPI_ConfigEntries(t *testing.T) {
 
 	t.Run("Mesh", func(t *testing.T) {
 		mesh := &MeshConfigEntry{
-			TransparentProxy: TransparentProxyMeshConfig{CatalogDestinationsOnly: true},
+			TransparentProxy: TransparentProxyMeshConfig{MeshDestinationsOnly: true},
 			Meta: map[string]string{
 				"foo": "bar",
 				"gir": "zim",
@@ -1213,7 +1213,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"gir": "zim"
 				},
 				"TransparentProxy": {
-					"CatalogDestinationsOnly": true
+					"MeshDestinationsOnly": true
 				}
 			}
 			`,
@@ -1223,7 +1223,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"gir": "zim",
 				},
 				TransparentProxy: TransparentProxyMeshConfig{
-					CatalogDestinationsOnly: true,
+					MeshDestinationsOnly: true,
 				},
 			},
 		},

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -124,7 +124,7 @@ meta {
 	"gir" = "zim"
 }
 transparent_proxy {
-	catalog_destinations_only = true
+	mesh_destinations_only = true
 }
 `)
 
@@ -2674,7 +2674,7 @@ func TestParseConfigEntry(t *testing.T) {
 					"gir" = "zim"
 				}
 				transparent_proxy {
-					catalog_destinations_only = true
+					mesh_destinations_only = true
 				}
 			`,
 			camel: `
@@ -2684,7 +2684,7 @@ func TestParseConfigEntry(t *testing.T) {
 					"gir" = "zim"
 				}
 				TransparentProxy {
-					CatalogDestinationsOnly = true
+					MeshDestinationsOnly = true
 				}
 			`,
 			snakeJSON: `
@@ -2695,7 +2695,7 @@ func TestParseConfigEntry(t *testing.T) {
 					"gir": "zim"
 				},
 				"transparent_proxy": {
-					"catalog_destinations_only": true
+					"mesh_destinations_only": true
 				}
 			}
 			`,
@@ -2707,7 +2707,7 @@ func TestParseConfigEntry(t *testing.T) {
 					"gir": "zim"
 				},
 				"TransparentProxy": {
-					"CatalogDestinationsOnly": true
+					"MeshDestinationsOnly": true
 				}
 			}
 			`,
@@ -2717,7 +2717,7 @@ func TestParseConfigEntry(t *testing.T) {
 					"gir": "zim",
 				},
 				TransparentProxy: api.TransparentProxyMeshConfig{
-					CatalogDestinationsOnly: true,
+					MeshDestinationsOnly: true,
 				},
 			},
 		},

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -18,7 +18,7 @@ Settings in this config entry apply across all namespaces and federated datacent
 
 ## Sample Config Entries
 
-### Proxy traffic to catalog destinations only
+### Only allow transparent proxies to dial addresses in the mesh.
 
 <Tabs>
 <Tab heading="HCL">
@@ -27,7 +27,7 @@ Settings in this config entry apply across all namespaces and federated datacent
 Kind      = "mesh"
 
 TransparentProxy {
-  CatalogDestinationsOnly = true
+  MeshDestinationsOnly = true
 }
 ```
 
@@ -42,7 +42,7 @@ Kind      = "mesh"
 Namespace = "default" # Can only be set to "default".
 
 TransparentProxy {
-  CatalogDestinationsOnly = true
+  MeshDestinationsOnly = true
 }
 ```
 
@@ -61,7 +61,7 @@ TransparentProxy {
 - `TransparentProxy` `(TransparentProxyConfig: <optional>)` - Controls configuration specific to proxies in
   `transparent` [mode](/docs/connect/config-entries/service-defaults#mode). Added in v1.10.0.
 
-  - `CatalogDestinationsOnly` `(bool: false)` - Determines whether sidecar proxies operating in transparent mode can
+  - `MeshDestinationsOnly` `(bool: false)` - Determines whether sidecar proxies operating in transparent mode can
     proxy traffic to IP addresses not registered in Consul's catalog. If enabled, traffic will only be proxied
     to upstreams with service registrations in the catalog. If disabled, requests will be proxied as-is to the
     original destination IP address. Consul will not encrypt the connection.

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -62,8 +62,8 @@ TransparentProxy {
   `transparent` [mode](/docs/connect/config-entries/service-defaults#mode). Added in v1.10.0.
 
   - `MeshDestinationsOnly` `(bool: false)` - Determines whether sidecar proxies operating in transparent mode can
-    proxy traffic to IP addresses not registered in Consul's catalog. If enabled, traffic will only be proxied
-    to upstreams with service registrations in the catalog. If disabled, requests will be proxied as-is to the
+    proxy traffic to IP addresses not registered in Consul's mesh. If enabled, traffic will only be proxied
+    to upstream proxies or Connect-native services. If disabled, requests will be proxied as-is to the
     original destination IP address. Consul will not encrypt the connection.
 
 ## ACLs


### PR DESCRIPTION
CatalogDestinationsOnly is a passthrough that would enable dialing
addresses outside of Consul's catalog. However, when this flag is set to
true only _connect_ endpoints for services can be dialed.

This flag is being renamed to signal that non-Connect endpoints can't be
dialed by transparent proxies when the value is set to true.