### PR TITLE
debug: use the new metrics stream in debug command

### DIFF
--- a/.changelog/10399.txt
+++ b/.changelog/10399.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+debug: Add a new /v1/agent/metrics/stream API endpoint for streaming of metrics
+```
+

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -172,10 +172,10 @@ func (s *HTTPHandlers) AgentMetricsStream(resp http.ResponseWriter, req *http.Re
 	var token string
 	s.parseToken(req, &token)
 	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
-	if err != nil {
+	switch {
+	case err != nil:
 		return nil, err
-	}
-	if rule != nil && rule.AgentRead(s.agent.config.NodeName, nil) != acl.Allow {
+	case rule != nil && rule.AgentRead(s.agent.config.NodeName, nil) != acl.Allow:
 		return nil, acl.ErrPermissionDenied
 	}
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -181,7 +181,7 @@ func (s *HTTPHandlers) AgentMetricsStream(resp http.ResponseWriter, req *http.Re
 
 	flusher, ok := resp.(http.Flusher)
 	if !ok {
-		return nil, fmt.Errorf("Streaming not supported")
+		return nil, fmt.Errorf("streaming not supported")
 	}
 
 	resp.WriteHeader(http.StatusOK)
@@ -196,6 +196,7 @@ func (s *HTTPHandlers) AgentMetricsStream(resp http.ResponseWriter, req *http.Re
 		encoder: json.NewEncoder(resp),
 		flusher: flusher,
 	}
+	enc.encoder.SetIndent("", "    ")
 	s.agent.baseDeps.MetricsHandler.Stream(req.Context(), enc)
 	return nil, nil
 }

--- a/agent/http.go
+++ b/agent/http.go
@@ -220,7 +220,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 
 		var gzipHandler http.Handler
 		minSize := gziphandler.DefaultMinSize
-		if pattern == "/v1/agent/monitor" {
+		if pattern == "/v1/agent/monitor" || pattern == "/v1/agent/metrics/stream" {
 			minSize = 0
 		}
 		gzipWrapper, err := gziphandler.GzipHandlerWithOpts(gziphandler.MinSize(minSize))

--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -38,6 +38,7 @@ func init() {
 	registerEndpoint("/v1/agent/reload", []string{"PUT"}, (*HTTPHandlers).AgentReload)
 	registerEndpoint("/v1/agent/monitor", []string{"GET"}, (*HTTPHandlers).AgentMonitor)
 	registerEndpoint("/v1/agent/metrics", []string{"GET"}, (*HTTPHandlers).AgentMetrics)
+	registerEndpoint("/v1/agent/metrics/stream", []string{"GET"}, (*HTTPHandlers).AgentMetricsStream)
 	registerEndpoint("/v1/agent/services", []string{"GET"}, (*HTTPHandlers).AgentServices)
 	registerEndpoint("/v1/agent/service/", []string{"GET"}, (*HTTPHandlers).AgentService)
 	registerEndpoint("/v1/agent/checks", []string{"GET"}, (*HTTPHandlers).AgentChecks)

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -8,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/grpclog"
@@ -48,6 +50,7 @@ type BaseDeps struct {
 // MetricsHandler provides an http.Handler for displaying metrics.
 type MetricsHandler interface {
 	DisplayMetrics(resp http.ResponseWriter, req *http.Request) (interface{}, error)
+	Stream(ctx context.Context, encoder metrics.Encoder)
 }
 
 type ConfigLoader func(source config.Source) (config.LoadResult, error)

--- a/api/agent.go
+++ b/api/agent.go
@@ -487,6 +487,19 @@ func (a *Agent) Metrics() (*MetricsInfo, error) {
 	return out, nil
 }
 
+// MetricsStream returns an io.ReadCloser which will emit a stream of metrics
+// until the context is cancelled. The metrics are json encoded.
+// The caller is responsible for closing the returned io.ReadCloser.
+func (a *Agent) MetricsStream(ctx context.Context) (io.ReadCloser, error) {
+	r := a.c.newRequest("GET", "/v1/agent/metrics/stream")
+	r.ctx = ctx
+	_, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
 // Reload triggers a configuration reload for the agent we are connected to.
 func (a *Agent) Reload() error {
 	r := a.c.newRequest("PUT", "/v1/agent/reload")

--- a/command/debug/debug.go
+++ b/command/debug/debug.go
@@ -3,17 +3,19 @@ package debug
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/cli"
@@ -386,14 +388,6 @@ func captureShortLived(c *cmd) error {
 			return c.captureGoRoutines(timestampDir)
 		})
 	}
-
-	// Capture metrics
-	if c.configuredTarget("metrics") {
-		g.Go(func() error {
-			return c.captureMetrics(timestampDir)
-		})
-	}
-
 	return g.Wait()
 }
 
@@ -412,7 +406,6 @@ func (c *cmd) captureLongRunning() error {
 	timestamp := time.Now().Local().Unix()
 
 	timestampDir, err := c.createTimestampDir(timestamp)
-
 	if err != nil {
 		return err
 	}
@@ -423,7 +416,6 @@ func (c *cmd) captureLongRunning() error {
 	if s < 1 {
 		s = 1
 	}
-	// Capture pprof
 	if c.configuredTarget("pprof") {
 		g.Go(func() error {
 			return c.captureProfile(s, timestampDir)
@@ -433,10 +425,18 @@ func (c *cmd) captureLongRunning() error {
 			return c.captureTrace(s, timestampDir)
 		})
 	}
-	// Capture logs
 	if c.configuredTarget("logs") {
 		g.Go(func() error {
 			return c.captureLogs(timestampDir)
+		})
+	}
+	if c.configuredTarget("metrics") {
+		// TODO: pass in context from caller
+		ctx, cancel := context.WithTimeout(context.Background(), c.duration)
+		defer cancel()
+
+		g.Go(func() error {
+			return c.captureMetrics(ctx, timestampDir)
 		})
 	}
 
@@ -515,20 +515,33 @@ func (c *cmd) captureLogs(timestampDir string) error {
 	}
 }
 
-func (c *cmd) captureMetrics(timestampDir string) error {
-
-	metrics, err := c.client.Agent().Metrics()
+func (c *cmd) captureMetrics(ctx context.Context, timestampDir string) error {
+	stream, err := c.client.Agent().MetricsStream(ctx)
 	if err != nil {
 		return err
 	}
+	defer stream.Close()
 
-	marshaled, err := json.MarshalIndent(metrics, "", "\t")
+	filename := fmt.Sprintf("%s/%s.json", timestampDir, "metrics")
+	fh, err := os.Create(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create metrics file: %w", err)
 	}
+	defer fh.Close()
 
-	err = ioutil.WriteFile(fmt.Sprintf("%s/%s.json", timestampDir, "metrics"), marshaled, 0644)
-	return err
+	decoder := json.NewDecoder(stream)
+	encoder := json.NewEncoder(fh)
+	// TODO: is More() correct here?
+	for decoder.More() {
+		var raw interface{}
+		if err := decoder.Decode(&raw); err != nil {
+			return fmt.Errorf("failed to decode metrics: %w", err)
+		}
+		if err := encoder.Encode(raw); err != nil {
+			return fmt.Errorf("failed to write metrics to file: %w", err)
+		}
+	}
+	return nil
 }
 
 // allowedTarget returns a boolean if the target is able to be captured

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.3 // indirect
 	github.com/NYTimes/gziphandler v1.0.1
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
-	github.com/armon/go-metrics v0.3.8
+	github.com/armon/go-metrics v0.3.9
 	github.com/armon/go-radix v1.0.0
 	github.com/aws/aws-sdk-go v1.25.41
 	github.com/coredns/coredns v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
-github.com/armon/go-metrics v0.3.8 h1:oOxq3KPj0WhCuy50EhzwiyMyG2ovRQZpZLXQuOh2a/M=
-github.com/armon/go-metrics v0.3.8/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
+github.com/armon/go-metrics v0.3.9 h1:O2sNqxBdvq8Eq5xmzljcYzAORli6RWCvEym4cJf9m18=
+github.com/armon/go-metrics v0.3.9/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
Related to #10320

Tested by running a dev agent and collecting a `consul debug` archive. All the metrics are indent formatted in the `metrics.json`.

TODO:
* [x] changelog
* [x] manual test to see what the metrics look like in the debug archive
* [ ] add a test for the API endpoint
* [ ] verify and improve the assertions in the debug CLI test for the metrics json file.