### PR TITLE
return an empty record when asked for an addr dns with type other then A, AAAA and ANY

### DIFF
--- a/.changelog/10401.txt
+++ b/.changelog/10401.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+return an invalid record when asked for an addr dns with type other then A and AAAA.
+```

--- a/.changelog/10401.txt
+++ b/.changelog/10401.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-dns: return an invalid record when asked for an addr dns with type other then A and AAAA.
+dns: return an empty answer when asked for an addr dns with type other then A and AAAA.
 ```

--- a/.changelog/10401.txt
+++ b/.changelog/10401.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-return an invalid record when asked for an addr dns with type other then A and AAAA.
+dns: return an invalid record when asked for an addr dns with type other then A and AAAA.
 ```

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -783,8 +783,8 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 	case "addr":
 		// <address>.addr.<suffixes>.<domain> - addr must be the second label, datacenter is optional
 
-		//check if the query type is A for IPv4 or AAAA for IPv6
-		if req.Question[0].Qtype != dns.TypeA && len(queryParts[0])/2 == 4 || req.Question[0].Qtype != dns.TypeAAAA && len(queryParts[0])/2 == 16 {
+		//check if the query type is A for IPv4 or AAAA for IPv6 or ANY
+		if (req.Question[0].Qtype != dns.TypeANY) && (req.Question[0].Qtype != dns.TypeA || len(queryParts[0])/2 != 4) && (req.Question[0].Qtype != dns.TypeAAAA || len(queryParts[0])/2 != 16) {
 			return invalid()
 		}
 		if len(queryParts) != 1 {

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -826,7 +826,6 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 				AAAA: ip,
 			}
 			if req.Question[0].Qtype != dns.TypeAAAA && req.Question[0].Qtype != dns.TypeANY {
-				//resp.SetRcode(req, dns.RcodeSuccess)
 				resp.Extra = append(resp.Extra, AAAARecord)
 			} else {
 				resp.Answer = append(resp.Answer, AAAARecord)

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -783,7 +783,6 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 	case "addr":
 		// <address>.addr.<suffixes>.<domain> - addr must be the second label, datacenter is optional
 
-		//check if the query type is A for IPv4 or AAAA for IPv6 or ANY
 		if len(queryParts) != 1 {
 			return invalid()
 		}
@@ -795,6 +794,7 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 			if err != nil {
 				return invalid()
 			}
+			//check if the query type is  A for IPv4 or ANY
 			if req.Question[0].Qtype != dns.TypeA && req.Question[0].Qtype != dns.TypeANY {
 				resp.SetRcode(req, dns.RcodeSuccess)
 			} else {
@@ -814,6 +814,7 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 			if err != nil {
 				return invalid()
 			}
+			//check if the query type is  AAAA for IPv6 or ANY
 			if req.Question[0].Qtype != dns.TypeAAAA && req.Question[0].Qtype != dns.TypeANY {
 				resp.SetRcode(req, dns.RcodeSuccess)
 			} else {

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -805,7 +805,6 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 				A: ip,
 			}
 			if req.Question[0].Qtype != dns.TypeA && req.Question[0].Qtype != dns.TypeANY {
-				//resp.SetRcode(req, dns.RcodeSuccess)
 				resp.Extra = append(resp.Answer, ARecord)
 			} else {
 				resp.Answer = append(resp.Answer, ARecord)

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -796,7 +796,16 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 			}
 			//check if the query type is  A for IPv4 or ANY
 			if req.Question[0].Qtype != dns.TypeA && req.Question[0].Qtype != dns.TypeANY {
-				resp.SetRcode(req, dns.RcodeSuccess)
+				//resp.SetRcode(req, dns.RcodeSuccess)
+				resp.Extra = append(resp.Answer, &dns.A{
+					Hdr: dns.RR_Header{
+						Name:   qName + d.domain,
+						Rrtype: dns.TypeA,
+						Class:  dns.ClassINET,
+						Ttl:    uint32(cfg.NodeTTL / time.Second),
+					},
+					A: ip,
+				})
 			} else {
 				resp.Answer = append(resp.Answer, &dns.A{
 					Hdr: dns.RR_Header{
@@ -816,7 +825,16 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 			}
 			//check if the query type is  AAAA for IPv6 or ANY
 			if req.Question[0].Qtype != dns.TypeAAAA && req.Question[0].Qtype != dns.TypeANY {
-				resp.SetRcode(req, dns.RcodeSuccess)
+				//resp.SetRcode(req, dns.RcodeSuccess)
+				resp.Extra = append(resp.Extra, &dns.AAAA{
+					Hdr: dns.RR_Header{
+						Name:   qName + d.domain,
+						Rrtype: dns.TypeAAAA,
+						Class:  dns.ClassINET,
+						Ttl:    uint32(cfg.NodeTTL / time.Second),
+					},
+					AAAA: ip,
+				})
 			} else {
 				resp.Answer = append(resp.Answer, &dns.AAAA{
 					Hdr: dns.RR_Header{

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -795,7 +795,7 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 				return invalid()
 			}
 			//check if the query type is  A for IPv4 or ANY
-			ARecord := &dns.A{
+			aRecord := &dns.A{
 				Hdr: dns.RR_Header{
 					Name:   qName + d.domain,
 					Rrtype: dns.TypeA,

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -816,7 +816,7 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 				return invalid()
 			}
 			//check if the query type is  AAAA for IPv6 or ANY
-			AAAARecord := &dns.AAAA{
+			aaaaRecord := &dns.AAAA{
 				Hdr: dns.RR_Header{
 					Name:   qName + d.domain,
 					Rrtype: dns.TypeAAAA,

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -782,6 +782,11 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 
 	case "addr":
 		// <address>.addr.<suffixes>.<domain> - addr must be the second label, datacenter is optional
+
+		//check if the query type is A for IPv4 or AAAA for IPv6
+		if req.Question[0].Qtype != dns.TypeA && len(queryParts[0])/2 == 4 || req.Question[0].Qtype != dns.TypeAAAA && len(queryParts[0])/2 == 16 {
+			return invalid()
+		}
 		if len(queryParts) != 1 {
 			return invalid()
 		}

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -795,26 +795,20 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 				return invalid()
 			}
 			//check if the query type is  A for IPv4 or ANY
+			ARecord := &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   qName + d.domain,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    uint32(cfg.NodeTTL / time.Second),
+				},
+				A: ip,
+			}
 			if req.Question[0].Qtype != dns.TypeA && req.Question[0].Qtype != dns.TypeANY {
-				resp.Extra = append(resp.Answer, &dns.A{
-					Hdr: dns.RR_Header{
-						Name:   qName + d.domain,
-						Rrtype: dns.TypeA,
-						Class:  dns.ClassINET,
-						Ttl:    uint32(cfg.NodeTTL / time.Second),
-					},
-					A: ip,
-				})
+				//resp.SetRcode(req, dns.RcodeSuccess)
+				resp.Extra = append(resp.Answer, ARecord)
 			} else {
-				resp.Answer = append(resp.Answer, &dns.A{
-					Hdr: dns.RR_Header{
-						Name:   qName + d.domain,
-						Rrtype: dns.TypeA,
-						Class:  dns.ClassINET,
-						Ttl:    uint32(cfg.NodeTTL / time.Second),
-					},
-					A: ip,
-				})
+				resp.Answer = append(resp.Answer, ARecord)
 			}
 		// IPv6
 		case 16:
@@ -823,27 +817,20 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 				return invalid()
 			}
 			//check if the query type is  AAAA for IPv6 or ANY
+			AAAARecord := &dns.AAAA{
+				Hdr: dns.RR_Header{
+					Name:   qName + d.domain,
+					Rrtype: dns.TypeAAAA,
+					Class:  dns.ClassINET,
+					Ttl:    uint32(cfg.NodeTTL / time.Second),
+				},
+				AAAA: ip,
+			}
 			if req.Question[0].Qtype != dns.TypeAAAA && req.Question[0].Qtype != dns.TypeANY {
 				//resp.SetRcode(req, dns.RcodeSuccess)
-				resp.Extra = append(resp.Extra, &dns.AAAA{
-					Hdr: dns.RR_Header{
-						Name:   qName + d.domain,
-						Rrtype: dns.TypeAAAA,
-						Class:  dns.ClassINET,
-						Ttl:    uint32(cfg.NodeTTL / time.Second),
-					},
-					AAAA: ip,
-				})
+				resp.Extra = append(resp.Extra, AAAARecord)
 			} else {
-				resp.Answer = append(resp.Answer, &dns.AAAA{
-					Hdr: dns.RR_Header{
-						Name:   qName + d.domain,
-						Rrtype: dns.TypeAAAA,
-						Class:  dns.ClassINET,
-						Ttl:    uint32(cfg.NodeTTL / time.Second),
-					},
-					AAAA: ip,
-				})
+				resp.Answer = append(resp.Answer, AAAARecord)
 			}
 		}
 	}

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -805,9 +805,9 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 				A: ip,
 			}
 			if req.Question[0].Qtype != dns.TypeA && req.Question[0].Qtype != dns.TypeANY {
-				resp.Extra = append(resp.Answer, ARecord)
+				resp.Extra = append(resp.Answer, aRecord)
 			} else {
-				resp.Answer = append(resp.Answer, ARecord)
+				resp.Answer = append(resp.Answer, aRecord)
 			}
 		// IPv6
 		case 16:
@@ -826,9 +826,9 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 				AAAA: ip,
 			}
 			if req.Question[0].Qtype != dns.TypeAAAA && req.Question[0].Qtype != dns.TypeANY {
-				resp.Extra = append(resp.Extra, AAAARecord)
+				resp.Extra = append(resp.Extra, aaaaRecord)
 			} else {
-				resp.Answer = append(resp.Answer, AAAARecord)
+				resp.Answer = append(resp.Answer, aaaaRecord)
 			}
 		}
 	}

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -796,7 +796,6 @@ func (d *DNSServer) doDispatch(network string, remoteAddr net.Addr, req, resp *d
 			}
 			//check if the query type is  A for IPv4 or ANY
 			if req.Question[0].Qtype != dns.TypeA && req.Question[0].Qtype != dns.TypeANY {
-				//resp.SetRcode(req, dns.RcodeSuccess)
 				resp.Extra = append(resp.Answer, &dns.A{
 					Hdr: dns.RR_Header{
 						Name:   qName + d.domain,

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6052,23 +6052,13 @@ func TestDNS_AddressLookup(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
+		require.Len(t, in.Answer, 1)
 
-		if in.Answer[0].Header().Rrtype != dns.TypeA {
-			t.Fatalf("Invalid type: %#v", in.Answer[0])
-		}
+		require.Equal(t, dns.TypeA, in.Answer[0].Header().Rrtype)
 		aRec, ok := in.Answer[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if aRec.A.To4().String() != answer {
-			t.Fatalf("Bad: %#v", aRec)
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+		require.True(t, ok)
+		require.Equal(t, aRec.A.To4().String(), answer)
+		require.Zero(t, aRec.Hdr.Ttl)
 	}
 }
 
@@ -6092,27 +6082,15 @@ func TestDNS_AddressLookupANY(t *testing.T) {
 
 		c := new(dns.Client)
 		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
 
-		if len(in.Answer) != 1 {
-			t.Fatalf("Bad: %#v", in)
-		}
-
-		if in.Answer[0].Header().Rrtype != dns.TypeA {
-			t.Fatalf("Invalid type: %#v", in.Answer[0])
-		}
+		require.NoError(t, err)
+		require.Len(t, in.Answer, 1)
+		require.Equal(t, in.Answer[0].Header().Rrtype, dns.TypeA)
 		aRec, ok := in.Answer[0].(*dns.A)
-		if !ok {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
-		if aRec.A.To4().String() != answer {
-			t.Fatalf("Bad: %#v", aRec)
-		}
-		if aRec.Hdr.Ttl != 0 {
-			t.Fatalf("Bad: %#v", in.Answer[0])
-		}
+		require.True(t, ok)
+		require.Equal(t, aRec.A.To4().String(), answer)
+		require.Zero(t, aRec.Hdr.Ttl)
+
 	}
 }
 
@@ -6136,20 +6114,10 @@ func TestDNS_AddressLookupInvalidType(t *testing.T) {
 
 		c := new(dns.Client)
 		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		if in.Rcode != 0 {
-			t.Fatalf("Bad Rcode: %#v", in)
-		}
-
-		if in.Answer != nil {
-			t.Fatalf("Bad: %#v", in)
-		}
-		if in.Extra == nil {
-			t.Fatalf("Bad: %#v", in)
-		}
+		require.NoError(t, err)
+		require.Zero(t, in.Rcode)
+		require.Nil(t, in.Answer)
+		require.Nil(t, in.Extra)
 		require.Len(t, in.Extra, 1)
 	}
 }

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6132,7 +6132,7 @@ func TestDNS_AddressLookupInvalidType(t *testing.T) {
 	}
 	for question := range cases {
 		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSOA)
+		m.SetQuestion(question, dns.TypeSRV)
 
 		c := new(dns.Client)
 		in, _, err := c.Exchange(m, a.DNSAddr())
@@ -6146,6 +6146,7 @@ func TestDNS_AddressLookupInvalidType(t *testing.T) {
 		if in.Answer == nil {
 			t.Fatalf("Bad: %#v", in)
 		}
+		require.Len(t, in.Extra, 1)
 	}
 }
 

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6117,7 +6117,7 @@ func TestDNS_AddressLookupInvalidType(t *testing.T) {
 		require.NoError(t, err)
 		require.Zero(t, in.Rcode)
 		require.Nil(t, in.Answer)
-		require.Nil(t, in.Extra)
+		require.NotNil(t, in.Extra)
 		require.Len(t, in.Extra, 1)
 	}
 }

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6044,7 +6044,7 @@ func TestDNS_AddressLookup(t *testing.T) {
 	}
 	for question, answer := range cases {
 		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+		m.SetQuestion(question, dns.TypeA)
 
 		c := new(dns.Client)
 		in, _, err := c.Exchange(m, a.DNSAddr())
@@ -6056,6 +6056,9 @@ func TestDNS_AddressLookup(t *testing.T) {
 			t.Fatalf("Bad: %#v", in)
 		}
 
+		if in.Answer[0].Header().Rrtype != dns.TypeA {
+			t.Fatalf("Invalid type: %#v", in.Answer[0])
+		}
 		aRec, ok := in.Answer[0].(*dns.A)
 		if !ok {
 			t.Fatalf("Bad: %#v", in.Answer[0])
@@ -6065,6 +6068,36 @@ func TestDNS_AddressLookup(t *testing.T) {
 		}
 		if aRec.Hdr.Ttl != 0 {
 			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+	}
+}
+
+func TestDNS_AddressLookupInvalidType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	// Look up the addresses
+	cases := map[string]string{
+		"7f000001.addr.dc1.consul.": "",
+	}
+	for question := range cases {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeSOA)
+
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if in.Answer == nil {
+			t.Fatalf("Bad: %#v", in)
 		}
 	}
 }
@@ -6086,7 +6119,7 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 	}
 	for question, answer := range cases {
 		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+		m.SetQuestion(question, dns.TypeAAAA)
 
 		c := new(dns.Client)
 		in, _, err := c.Exchange(m, a.DNSAddr())
@@ -6098,6 +6131,9 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 			t.Fatalf("Bad: %#v", in)
 		}
 
+		if in.Answer[0].Header().Rrtype != dns.TypeAAAA {
+			t.Fatalf("Invalid type: %#v", in.Answer[0])
+		}
 		aaaaRec, ok := in.Answer[0].(*dns.AAAA)
 		if !ok {
 			t.Fatalf("Bad: %#v", in.Answer[0])
@@ -6107,6 +6143,37 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 		}
 		if aaaaRec.Hdr.Ttl != 0 {
 			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+	}
+}
+
+func TestDNS_AddressLookupIPV6InvalidType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	// Look up the addresses
+	cases := map[string]string{
+		"2607002040050808000000000000200e.addr.consul.": "2607:20:4005:808::200e",
+		"2607112040051808ffffffffffff200e.addr.consul.": "2607:1120:4005:1808:ffff:ffff:ffff:200e",
+	}
+	for question := range cases {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeSRV)
+
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if in.Answer != nil {
+			t.Fatalf("Bad: %#v", in)
 		}
 	}
 }

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6140,6 +6140,9 @@ func TestDNS_AddressLookupInvalidType(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
+		if in.Rcode != 0 {
+			t.Fatalf("Bad Rcode: %#v", in)
+		}
 		if in.Answer == nil {
 			t.Fatalf("Bad: %#v", in)
 		}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6143,7 +6143,11 @@ func TestDNS_AddressLookupInvalidType(t *testing.T) {
 		if in.Rcode != 0 {
 			t.Fatalf("Bad Rcode: %#v", in)
 		}
-		if in.Answer == nil {
+
+		if in.Answer != nil {
+			t.Fatalf("Bad: %#v", in)
+		}
+		if in.Extra == nil {
 			t.Fatalf("Bad: %#v", in)
 		}
 		require.Len(t, in.Extra, 1)


### PR DESCRIPTION
This fix #10393
 
this is a bug for sure because we return a different record type then the one requested. That said we need to verify what is the intended behaviour:

- [x] is returning `A` or `AAAA` in case the origin query part is `IPv4` or `IPv6` respectively enough? ---> yes
- [x] What we do about `ANY` queries? ---> we should return an A or AAAA record
- [x] do this break any existing behaviour or users call flow? ---> no