### PR TITLE
Omit empty tproxy config in JSON responses

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -399,7 +399,7 @@ func TestAgent_Service(t *testing.T) {
 		Service:     "web-sidecar-proxy",
 		Port:        8000,
 		Proxy:       expectProxy.ToAPI(),
-		ContentHash: "518ece989813bc13",
+		ContentHash: "854327a458fe02a6",
 		Weights: api.AgentWeights{
 			Passing: 1,
 			Warning: 1,
@@ -413,7 +413,7 @@ func TestAgent_Service(t *testing.T) {
 	// Copy and modify
 	updatedResponse := *expectedResponse
 	updatedResponse.Port = 9999
-	updatedResponse.ContentHash = "6cc7a4afb000afb1"
+	updatedResponse.ContentHash = "b80a4d9370ed1104"
 
 	// Simple response for non-proxy service registered in TestAgent config
 	expectWebResponse := &api.AgentService{

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -257,6 +257,13 @@ func (c *ConnectProxyConfig) MarshalJSON() ([]byte, error) {
 	}{
 		Alias: (Alias)(*c),
 	}
+
+	proxyConfig, err := lib.MapWalk(c.Config)
+	if err != nil {
+		return nil, err
+	}
+	out.Alias.Config = proxyConfig
+
 	if !c.TransparentProxy.IsZero() {
 		out.TransparentProxy = &out.Alias.TransparentProxy
 	}

--- a/agent/structs/connect_proxy_config_test.go
+++ b/agent/structs/connect_proxy_config_test.go
@@ -94,6 +94,121 @@ func TestConnectProxyConfig_ToAPI(t *testing.T) {
 	}
 }
 
+func TestConnectProxyConfig_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      ConnectProxyConfig
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "direct proxy",
+			in: ConnectProxyConfig{
+				DestinationServiceName: "api",
+				DestinationServiceID:   "api-1",
+				LocalServiceAddress:    "127.0.0.1",
+				LocalServicePort:       8080,
+				Mode:                   ProxyModeDirect,
+				Config: map[string]interface{}{
+					"connect_timeout_ms": 5000,
+				},
+				Upstreams: Upstreams{
+					Upstream{
+						DestinationType: UpstreamDestTypeService,
+						DestinationName: "db",
+						Datacenter:      "dc1",
+						LocalBindPort:   1234,
+					},
+				},
+				MeshGateway: MeshGatewayConfig{Mode: MeshGatewayModeLocal},
+				Expose:      ExposeConfig{Checks: true},
+
+				// No transparent proxy config, since proxy is direct.
+				// Field should be omitted from json output.
+				// TransparentProxy: TransparentProxyConfig{},
+			},
+			want: `{
+				"DestinationServiceName": "api",
+				"DestinationServiceID": "api-1",
+				"LocalServiceAddress": "127.0.0.1",
+				"LocalServicePort": 8080,
+				"Mode": "direct",
+				"Config": {
+					"connect_timeout_ms": 5000
+				},
+				"Upstreams": [
+					{
+						"DestinationType": "service",
+						"DestinationName": "db",
+						"Datacenter": "dc1",
+						"LocalBindPort": 1234,
+						"MeshGateway": {}
+					}
+				],
+				"MeshGateway": {
+					"Mode": "local"
+				},
+				"Expose": {
+					"Checks": true
+				}
+			}`,
+			wantErr: false,
+		},
+		{
+			name: "transparent proxy",
+			in: ConnectProxyConfig{
+				DestinationServiceName: "billing",
+				DestinationServiceID:   "billing-1",
+				LocalServiceAddress:    "127.0.0.1",
+				LocalServicePort:       8080,
+				Mode:                   ProxyModeTransparent,
+				Config: map[string]interface{}{
+					"connect_timeout_ms": 5000,
+				},
+				MeshGateway: MeshGatewayConfig{Mode: MeshGatewayModeLocal},
+				Expose:      ExposeConfig{Checks: true},
+				TransparentProxy: TransparentProxyConfig{
+					DialedDirectly:       true,
+					OutboundListenerPort: 16001,
+				},
+			},
+			want: `{
+				"DestinationServiceName": "billing",
+				"DestinationServiceID": "billing-1",
+				"LocalServiceAddress": "127.0.0.1",
+				"LocalServicePort": 8080,
+				"Mode": "transparent",
+				"Config": {
+					"connect_timeout_ms": 5000
+				},
+				"TransparentProxy": {
+					"DialedDirectly": true,
+					"OutboundListenerPort": 16001
+				},
+				"MeshGateway": {
+					"Mode": "local"
+				},
+				"Expose": {
+					"Checks": true
+				}
+			}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			got, err := tt.in.MarshalJSON()
+			if tt.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+			require.JSONEq(tt.want, string(got))
+		})
+	}
+}
+
 func TestUpstream_MarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/agent/structs/connect_proxy_config_test.go
+++ b/agent/structs/connect_proxy_config_test.go
@@ -123,7 +123,7 @@ func TestConnectProxyConfig_MarshalJSON(t *testing.T) {
 				MeshGateway: MeshGatewayConfig{Mode: MeshGatewayModeLocal},
 				Expose:      ExposeConfig{Checks: true},
 
-				// No transparent proxy config, since proxy is direct.
+				// No transparent proxy config, since proxy is set to "direct" mode.
 				// Field should be omitted from json output.
 				// TransparentProxy: TransparentProxyConfig{},
 			},


### PR DESCRIPTION
Updated JSON marshaling to avoid returning the proxy.transparent_proxy field when empty.

Opted to avoid turning it into a pointer so that it doesn't have to be nil-checked on every access.

Is there anything I'm missing about this approach?