### PR TITLE
Update ingress/terminating gateway stats labeling

### DIFF
--- a/.changelog/10404.txt
+++ b/.changelog/10404.txt
@@ -1,0 +1,8 @@
+```release-note:feature
+connect: generate upstream service labels for terminating gateway listener stats.
+```
+
+```release-note:breaking-change
+connect: avoid encoding listener info in ingress and terminating gateway listener stats names.
+```
+

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -536,7 +536,7 @@ func (s *ResourceGenerator) makeIngressGatewayListeners(address string, cfgSnap 
 				filterName:      listenerKey.RouteName(),
 				routeName:       listenerKey.RouteName(),
 				cluster:         "",
-				statPrefix:      "ingress_upstream.",
+				statPrefix:      "ingress_upstream_",
 				routePath:       "",
 				httpAuthzFilter: nil,
 			}

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1133,13 +1133,12 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(
 	// Lastly we setup the actual proxying component. For L4 this is a straight
 	// tcp proxy. For L7 this is a very hands-off HTTP proxy just to inject an
 	// HTTP filter to do intention checks here instead.
-	statPrefix := fmt.Sprintf("terminating_gateway.%s.%s.", service.NamespaceOrDefault(), service.Name)
 	opts := listenerFilterOpts{
 		protocol:   protocol,
-		filterName: listener,
+		filterName: fmt.Sprintf("%s.%s.%s.", service.Name, service.NamespaceOrDefault(), cfgSnap.Datacenter),
 		routeName:  cluster, // Set cluster name for route config since each will have its own
 		cluster:    cluster,
-		statPrefix: statPrefix,
+		statPrefix: "upstream.",
 		routePath:  "",
 	}
 

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1033,7 +1033,6 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 
 		clusterChain, err := s.makeFilterChainTerminatingGateway(
 			cfgSnap,
-			name,
 			clusterName,
 			svc,
 			intentions,
@@ -1052,7 +1051,6 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 
 				subsetClusterChain, err := s.makeFilterChainTerminatingGateway(
 					cfgSnap,
-					name,
 					subsetClusterName,
 					svc,
 					intentions,
@@ -1095,7 +1093,7 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 
 func (s *ResourceGenerator) makeFilterChainTerminatingGateway(
 	cfgSnap *proxycfg.ConfigSnapshot,
-	listener, cluster string,
+	cluster string,
 	service structs.ServiceName,
 	intentions structs.Intentions,
 	protocol string,

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1133,7 +1133,7 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(
 	// HTTP filter to do intention checks here instead.
 	opts := listenerFilterOpts{
 		protocol:   protocol,
-		filterName: fmt.Sprintf("%s.%s.%s.", service.Name, service.NamespaceOrDefault(), cfgSnap.Datacenter),
+		filterName: fmt.Sprintf("%s.%s.%s", service.Name, service.NamespaceOrDefault(), cfgSnap.Datacenter),
 		routeName:  cluster, // Set cluster name for route config since each will have its own
 		cluster:    cluster,
 		statPrefix: "upstream.",

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.envoy-1-18-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "ingress_upstream.443",
+                "statPrefix": "ingress_upstream_443",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -60,7 +60,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "ingress_upstream.8080",
+                "statPrefix": "ingress_upstream_8080",
                 "rds": {
                   "configSource": {
                     "ads": {

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.v2compat.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "ingress_upstream.443",
+                "statPrefix": "ingress_upstream_443",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -60,7 +60,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "ingress_upstream.8080",
+                "statPrefix": "ingress_upstream_8080",
                 "rds": {
                   "configSource": {
                     "ads": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.envoy-1-18-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "ingress_upstream.9191",
+                "statPrefix": "ingress_upstream_9191",
                 "rds": {
                   "configSource": {
                     "ads": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.v2compat.envoy-1-16-x.golden
@@ -17,7 +17,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "ingress_upstream.9191",
+                "statPrefix": "ingress_upstream_9191",
                 "rds": {
                   "configSource": {
                     "ads": {

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-18-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.api.default.dc1.",
+                "statPrefix": "upstream.api.default.dc1",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -194,7 +194,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -281,7 +281,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.api.default.dc1.",
+                "statPrefix": "upstream.api.default.dc1",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -335,7 +335,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -389,7 +389,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -443,7 +443,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.envoy-1-18-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.api.foo",
+                "statPrefix": "upstream.api.default.dc1.",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.foo",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.foo",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -194,7 +194,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.web.foo",
+                "statPrefix": "upstream.web.default.dc1.",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -281,7 +281,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.api.wan",
+                "statPrefix": "upstream.api.default.dc1.",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -335,7 +335,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.wan",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -389,7 +389,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.wan",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -443,7 +443,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.web.wan",
+                "statPrefix": "upstream.web.default.dc1.",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.v2compat.envoy-1-16-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.api.default.dc1.",
+                "statPrefix": "upstream.api.default.dc1",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -194,7 +194,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -281,7 +281,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.api.default.dc1.",
+                "statPrefix": "upstream.api.default.dc1",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -335,7 +335,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -389,7 +389,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -443,7 +443,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-custom-and-tagged-addresses.v2compat.envoy-1-16-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.api.foo",
+                "statPrefix": "upstream.api.default.dc1.",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.foo",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.foo",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -194,7 +194,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.web.foo",
+                "statPrefix": "upstream.web.default.dc1.",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -281,7 +281,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.api.wan",
+                "statPrefix": "upstream.api.default.dc1.",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -335,7 +335,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.wan",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -389,7 +389,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.wan",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -443,7 +443,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.web.wan",
+                "statPrefix": "upstream.web.default.dc1.",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-18-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.default",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.default",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.envoy-1-18-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.v2compat.envoy-1-16-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-no-api-cert.v2compat.envoy-1-16-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.default",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.default",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-18-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.api.default.dc1.",
+                "statPrefix": "upstream.api.default.dc1",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -184,7 +184,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -255,7 +255,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -326,7 +326,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "rds": {
                   "configSource": {
                     "ads": {

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.envoy-1-18-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.api.default",
+                "statPrefix": "upstream.api.default.dc1.",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.default",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.default",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -184,7 +184,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -255,7 +255,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -326,7 +326,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "rds": {
                   "configSource": {
                     "ads": {

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.v2compat.envoy-1-16-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.api.default.dc1.",
+                "statPrefix": "upstream.api.default.dc1",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -184,7 +184,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -255,7 +255,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -326,7 +326,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "rds": {
                   "configSource": {
                     "ads": {

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.v2compat.envoy-1-16-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.api.default",
+                "statPrefix": "upstream.api.default.dc1.",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.default",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.default",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -184,7 +184,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -255,7 +255,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "rds": {
                   "configSource": {
                     "ads": {
@@ -326,7 +326,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "rds": {
                   "configSource": {
                     "ads": {

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-18-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.api.default",
+                "statPrefix": "upstream.api.default.dc1.",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.default",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.default",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -194,7 +194,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.envoy-1-18-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.api.default.dc1.",
+                "statPrefix": "upstream.api.default.dc1",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -194,7 +194,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.v2compat.envoy-1-16-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.api.default.dc1.",
+                "statPrefix": "upstream.api.default.dc1",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.cache.default.dc1.",
+                "statPrefix": "upstream.cache.default.dc1",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.db.default.dc1.",
+                "statPrefix": "upstream.db.default.dc1",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -194,7 +194,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.web.default.dc1.",
+                "statPrefix": "upstream.web.default.dc1",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }

--- a/agent/xds/testdata/listeners/terminating-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway.v2compat.envoy-1-16-x.golden
@@ -32,7 +32,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.api.default",
+                "statPrefix": "upstream.api.default.dc1.",
                 "cluster": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -86,7 +86,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.cache.default",
+                "statPrefix": "upstream.cache.default.dc1.",
                 "cluster": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -140,7 +140,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.db.default",
+                "statPrefix": "upstream.db.default.dc1.",
                 "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
@@ -194,7 +194,7 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "terminating_gateway.default.web.default",
+                "statPrefix": "upstream.web.default.dc1.",
                 "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }


### PR DESCRIPTION
Fixes: #9887

This PR updates the stats_prefix for ingress and terminating gateways.

1. For ingress gateways the change makes it so that the listener _port_ (`listenerKey.RouteName()`) does not get encoded in the metric name. (Brought up in the issue)
2. For terminating gateways we also make it so that the listener _name_ does not get encoded in the metric name. There was also a change to the filter name so that the rules defined [here](https://github.com/hashicorp/consul/blob/64d122b0a2447a6e0597bdaa3912e83cd15ef3ed/command/connect/envoy/bootstrap_config.go#L392:L410) apply. This will enable per-destination listener metrics.

These changes are **NOT** backwards compatible.


### Example from issue:

In 1.9.x:

```
# envoy stat: http.ingress_upstream.14146.no_route: 0
envoy_http_14146_no_route{
  local_cluster="ingress-service",
  consul_source_service="ingress-service",
  consul_source_namespace="default",
  consul_source_datacenter="dc1",
  envoy_http_conn_manager_prefix="ingress_upstream"
} 0
```
```
envoy_tcp_default_web_default_downstream_cx_no_route{
  local_cluster="terminating-gateway
  consul_source_service="terminating-gateway
  consul_source_namespace="default
  consul_source_datacenter="dc1
  envoy_tcp_prefix="terminating_gateway"
} 0
```

Proposed in PR:

```
envoy_http_no_route{
  local_cluster="ingress-service",
  consul_source_service="ingress-service",
  consul_source_namespace="default",
  consul_source_datacenter="dc1",
  envoy_http_conn_manager_prefix="ingress_upstream_14146"
} 0
```

```
envoy_tcp_downstream_cx_no_route{
  local_cluster="terminating-gateway",
  consul_source_service="terminating-gateway",
  consul_source_namespace="default",
  consul_source_datacenter="dc1",
  consul_upstream_service="web",
  consul_upstream_datacenter="dc1",
  consul_upstream_namespace="default",
  envoy_tcp_prefix="upstream"
} 0
```