### PR TITLE
changelog: add note on EULA/ToE packaging with Enterprise binaries

### DIFF
--- a/.changelog/_releases-111.txt
+++ b/.changelog/_releases-111.txt
@@ -1,0 +1,3 @@
+```release-note:note
+legal: **(Enterprise only)** Enterprise binary downloads will now include a copy of the EULA and Terms of Evaluation in the zip archive
+```

--- a/.changelog/changelog.tmpl
+++ b/.changelog/changelog.tmpl
@@ -46,3 +46,11 @@ BUG FIXES:
 {{ end -}}
 {{- end -}}
 
+{{- if .NotesByType.note }}
+NOTES:
+
+{{range .NotesByType.note -}}
+* {{ template "note" . }}
+{{ end -}}
+{{- end -}}
+


### PR DESCRIPTION
Adding as a changelog entry to clarify this is Enterprise-only instead of adding to the OSS README in https://github.com/hashicorp/consul/pull/10412

Will show up as a changelog entry for 1.10 as:
```
NOTES:

* legal: **(Enterprise only)** Enterprise binary downloads will now include a copy of the EULA and Terms of Evaluation in the zip archive
```