### PR TITLE
tlsutil: fix a possible panic, and make the package safer

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -669,7 +669,6 @@ func (b *builder) Build() (rt RuntimeConfig, err error) {
 
 	// autoEncrypt and autoConfig implicitly turns on connect which is why
 	// they need to be above other settings that rely on connect.
-	autoEncryptTLS := boolVal(c.AutoEncrypt.TLS)
 	autoEncryptDNSSAN := []string{}
 	for _, d := range c.AutoEncrypt.DNSSAN {
 		autoEncryptDNSSAN = append(autoEncryptDNSSAN, d)
@@ -685,13 +684,8 @@ func (b *builder) Build() (rt RuntimeConfig, err error) {
 
 	}
 	autoEncryptAllowTLS := boolVal(c.AutoEncrypt.AllowTLS)
-
-	if autoEncryptAllowTLS {
-		connectEnabled = true
-	}
-
 	autoConfig := b.autoConfigVal(c.AutoConfig)
-	if autoConfig.Enabled {
+	if autoEncryptAllowTLS || autoConfig.Enabled {
 		connectEnabled = true
 	}
 
@@ -984,7 +978,7 @@ func (b *builder) Build() (rt RuntimeConfig, err error) {
 		Checks:                                 checks,
 		ClientAddrs:                            clientAddrs,
 		ConfigEntryBootstrap:                   configEntries,
-		AutoEncryptTLS:                         autoEncryptTLS,
+		AutoEncryptTLS:                         boolVal(c.AutoEncrypt.TLS),
 		AutoEncryptDNSSAN:                      autoEncryptDNSSAN,
 		AutoEncryptIPSAN:                       autoEncryptIPSAN,
 		AutoEncryptAllowTLS:                    autoEncryptAllowTLS,

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -245,7 +245,7 @@ func (c *Configurator) Update(config Config) error {
 	if err != nil {
 		return err
 	}
-	if err = c.check(config, pool, cert); err != nil {
+	if err = validateConfig(config, pool, cert); err != nil {
 		return err
 	}
 	c.base = &config
@@ -270,7 +270,7 @@ func (c *Configurator) UpdateAutoTLSCA(connectCAPems []string) error {
 	if err != nil {
 		return err
 	}
-	if err = c.check(*c.base, pool, c.manual.cert); err != nil {
+	if err = validateConfig(*c.base, pool, c.manual.cert); err != nil {
 		return err
 	}
 	c.autoTLS.connectCAPems = connectCAPems
@@ -357,7 +357,9 @@ func pool(pems []string) (*x509.CertPool, error) {
 	return pool, nil
 }
 
-func (c *Configurator) check(config Config, pool *x509.CertPool, cert *tls.Certificate) error {
+// validateConfig checks that config is valid and does not conflict with the pool
+// or cert.
+func validateConfig(config Config, pool *x509.CertPool, cert *tls.Certificate) error {
 	// Check if a minimum TLS version was set
 	if config.TLSMinVersion != "" {
 		if _, ok := TLSLookup[config.TLSMinVersion]; !ok {

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -268,11 +268,9 @@ func (c *Configurator) UpdateAutoTLSCA(connectCAPems []string) error {
 
 	pool, err := pool(append(c.manual.caPems, append(c.autoTLS.manualCAPems, connectCAPems...)...))
 	if err != nil {
-		c.lock.RUnlock()
 		return err
 	}
 	if err = c.check(*c.base, pool, c.manual.cert); err != nil {
-		c.lock.RUnlock()
 		return err
 	}
 	c.autoTLS.connectCAPems = connectCAPems

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -524,7 +524,7 @@ func TestConfigurator_ErrorPropagation(t *testing.T) {
 			require.NoError(t, err, info)
 			pool, err := pool(pems)
 			require.NoError(t, err, info)
-			err3 = c.check(v.config, pool, cert)
+			err3 = validateConfig(v.config, pool, cert)
 		}
 		if v.shouldErr {
 			require.Error(t, err1, info)

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func startRPCTLSServer(config *Config) (net.Conn, chan error) {
@@ -829,6 +831,17 @@ func TestConfigurator_MutualTLSCapable(t *testing.T) {
 
 		require.True(t, c.mutualTLSCapable())
 	})
+}
+
+func TestConfigurator_UpdateAutoTLSCA_DoesNotPanic(t *testing.T) {
+	config := Config{
+		Domain: "consul",
+	}
+	c, err := NewConfigurator(config, hclog.New(nil))
+	require.NoError(t, err)
+
+	err = c.UpdateAutoTLSCA([]string{"invalid pem"})
+	require.Error(t, err)
 }
 
 func TestConfigurator_VerifyIncomingRPC(t *testing.T) {

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -1026,11 +1026,10 @@ func TestConfigurator_UpdateChecks(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.Update(Config{}))
 	require.Error(t, c.Update(Config{VerifyOutgoing: true}))
-	require.Error(t, c.Update(Config{VerifyIncoming: true,
-		CAFile: "../test/ca/root.cer"}))
+	require.Error(t, c.Update(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer"}))
 	require.False(t, c.base.VerifyIncoming)
 	require.False(t, c.base.VerifyOutgoing)
-	require.Equal(t, c.version, 2)
+	require.Equal(t, uint64(2), c.version)
 }
 
 func TestConfigurator_UpdateSetsStuff(t *testing.T) {
@@ -1039,10 +1038,10 @@ func TestConfigurator_UpdateSetsStuff(t *testing.T) {
 	require.Nil(t, c.caPool)
 	require.Nil(t, c.manual.cert)
 	require.Equal(t, c.base, &Config{})
-	require.Equal(t, 1, c.version)
+	require.Equal(t, uint64(1), c.version)
 
 	require.Error(t, c.Update(Config{VerifyOutgoing: true}))
-	require.Equal(t, c.version, 1)
+	require.Equal(t, uint64(1), c.version)
 
 	config := Config{
 		CAFile:   "../test/ca/root.cer",
@@ -1054,7 +1053,7 @@ func TestConfigurator_UpdateSetsStuff(t *testing.T) {
 	require.Len(t, c.caPool.Subjects(), 1)
 	require.NotNil(t, c.manual.cert)
 	require.Equal(t, c.base, &config)
-	require.Equal(t, 2, c.version)
+	require.Equal(t, uint64(2), c.version)
 }
 
 func TestConfigurator_ServerNameOrNodeName(t *testing.T) {


### PR DESCRIPTION
Best viewed by individual commit.

As I have been reading through the `tlsutil` package I noticed a panic and a few other things that were potentially unsafe or made it more difficult to read. This PR fixes the issues.