### PR TITLE
ui: Increase z-index of main menus to avoid layering issues

### DIFF
--- a/ui/packages/consul-ui/app/components/main-header-horizontal/layout.scss
+++ b/ui/packages/consul-ui/app/components/main-header-horizontal/layout.scss
@@ -1,7 +1,7 @@
 %main-header-horizontal {
   display: flex;
   position: fixed;
-  z-index: 5;
+  z-index: 50;
   left: 0;
   padding: 0 25px;
   width: calc(100% - 50px);


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/10295 we made a minor CSS layout bugfix that involved some z-index dancing. As is often the case with z-index dancing, once you change step everyone else has to change step also otherwise things like this happen:

<img width="439" alt="Screenshot 2021-06-18 at 09 41 05" src="https://user-images.githubusercontent.com/554604/122533323-55f7e000-d019-11eb-95e7-bd37c2f67a5e.png">

This PR increases the z-index of the main menus in order to fix this layering bug.

Ideally we really need to get around to using our `tippy.js` based `{{with-overlay}}` modifier for all our menus, but for the moment this kicks the can a little further down the road, ten times 😄 .