### PR TITLE
Hold onto the token store from the base deps in the Client

### DIFF
--- a/.changelog/10432.txt
+++ b/.changelog/10432.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+license: **(Enterprise only)** Fixed an issue that would cause client agents on versions before 1.10 to not be able to retrieve the license from a 1.10+ server.
+```

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/tlsutil"
@@ -90,6 +91,9 @@ type Client struct {
 	EnterpriseClient
 
 	tlsConfigurator *tlsutil.Configurator
+
+	// tokens is the agent wide token store
+	tokens *token.Store
 }
 
 // NewClient creates and returns a Client
@@ -111,6 +115,7 @@ func NewClient(config *Config, deps Deps) (*Client, error) {
 		logger:          deps.Logger.NamedIntercept(logging.ConsulClient),
 		shutdownCh:      make(chan struct{}),
 		tlsConfigurator: deps.TLSConfigurator,
+		tokens:          deps.Tokens,
 	}
 
 	c.rpcLimiter.Store(rate.NewLimiter(config.RPCRate, config.RPCMaxBurst))


### PR DESCRIPTION
This is needed in order to access the agent token in some enterprise code.