### PR TITLE
[1.8.x] Backport #10432

### DIFF
--- a/.changelog/10432.txt
+++ b/.changelog/10432.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+license: **(Enterprise only)** Fixed an issue that would cause client agents on versions before 1.10 to not be able to retrieve the license from a 1.10+ server.
+```

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/tlsutil"
@@ -87,6 +88,9 @@ type Client struct {
 	EnterpriseClient
 
 	tlsConfigurator *tlsutil.Configurator
+
+	// tokens is the agent wide token store
+	tokens *token.Store
 }
 
 // NewClient creates and returns a Client
@@ -131,6 +135,7 @@ func NewClient(config *Config, options ...ConsulOption) (*Client, error) {
 		logger:          logger,
 		shutdownCh:      make(chan struct{}),
 		tlsConfigurator: tlsConfigurator,
+		tokens:          flat.tokens,
 	}
 
 	c.rpcLimiter.Store(rate.NewLimiter(config.RPCRate, config.RPCMaxBurst))


### PR DESCRIPTION
This backports #10432. There was a conflict with because the `Client` in 1.8.x doesn't have the agent `BaseDeps` passed into it but rather has the token store provided in its options.