### PR TITLE
docs: updated FAQ to accommodate new requirements prior to upgrading

### DIFF
--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -20,6 +20,11 @@ This check is part of the server boot-up process.
 In previous versions of HashiCorp enterprise products, one server could distribute a license to other servers via the Raft protocol.
 This will no longer work since each server must be able to find a valid license during the startup process.
 
+## Q: What are the upgrade requirements?
+
+If ACLs are enabled, customers on Consul Enterprise 1.8+ or 1.9+ must upgrade Consul agents to the latest patch available (1.8.13 or 1.9.7) prior to upgrading the Consul server instances to 1.10.0.
+Otherwise, the Consul agents will fail to retrieve the license with a valid agent token.
+
 ## Q: Is there a tutorial available for the license configuration steps?
 
 Please visit the [Enterprise License Tutorial](https://learn.hashicorp.com/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise).
@@ -49,7 +54,7 @@ The in-storage license feature will not be supported starting with Consul Entepr
 
 ## Q: What is the impact on evaluation licenses due to this change?
 
-The 6-hour trial period for evaluation licenses will be deprecated as of Consul Enterprise 1.10.0.  
+The 6-hour trial period for evaluation licenses will be deprecated as of Consul Enterprise 1.10.0.
 This means that any clusters deployed with Consul 1.10.0+ent binaries will need to have a valid license on the disk (auto-loaded) or as an environment variable.
 Failure to provide a valid license key will result in the Consul server agent not starting.
 
@@ -61,13 +66,14 @@ As Consul Enterprise approaches the expiration date, warnings will be issued in 
 
 ## Q: Does this affect client agents?
 
-For existing clusters, if the clients agents are using ACLs and have a valid token, then they will be able to retrieve the license from the server.
+For existing clusters, if the clients agents are using ACLs and have a valid token, then they will be able to retrieve the license from the server if the upgrade requirements have been met. Please see the [upgrade requirements](faq#q-what-are-the-upgrade-requirements).
+
 If the client agents are not using ACLs, then the client agents will be need to have the license on-disk (auto-loading) or as an environment variable.
 For new Consul clusters using Consul 1.10.0+ent, customers must ensure that there is a valid license on-disk (auto-loaded) or as an environment variable.
 
 ## Q: Does this affect snapshot agents?
 
-Same behavior as Consul clients. See answer for [Does this affect snapshot agents? ](faq#q-does-this-affect-client-agents)
+Same behavior as Consul clients. See answer for [Does this affect client agents? ](faq#q-does-this-affect-client-agents)
 
 ## Q: What is the behavior if the license is missing?
 
@@ -108,6 +114,7 @@ When a customer deploys new clusters to a 1.10.0+ent release, they need to have 
 
 New Consul cluster deployments using 1.10.0+ent will need to have a valid license to successfully deploy.
 This valid license must be on-disk (auto-loaded) or as an environment variable.
+Please see the [upgrade requirements](faq#q-what-are-the-upgrade-requirements).
 
 ## Q: What is the migration path for customers who want to migrate from their existing license-as-applied-via-the-CLI flow to the license on disk flow?
 
@@ -127,6 +134,7 @@ This valid license must be on-disk (auto-loaded) or as an environment variable.
 1. Follow the [Kubernetes Upgrade Docs](/docs/k8s/upgrade) to upgrade. No changes to your `values.yaml` file are needed to enable enterprise autoloading since this support is built in to consul-helm 0.32.0 and greater.
 
 ~> **WARNING:** If you are upgrading the Helm chart but **not** upgrading the Consul version, you must set `server.enterpriseLicense.enableLicenseAutoload: false`. See [Kubernetes - Consul Enterprise](/docs/k8s/installation/deployment-configurations/consul-enterprise) for more details.
+
 ## Q: What is the migration path for customers who want to migrate from their existing perpetually-licensed binaries to the license on disk flow?
 
 ### VM
@@ -148,7 +156,9 @@ This valid license must be on-disk (auto-loaded) or as an environment variable.
 
 When downgrading to a version of Consul before 1.10.0+ent, customers will need to follow the previous process for applying an enterprise licenses to Consul Enterprise.
 
-## Q: Are there potential pitfalls when downgrading or upgrading?
+## Q: Are there potential pitfalls when downgrading or upgrading Consul server instances?
+
+~> Verify that you meet the [upgrade requirements](faq#q-what-are-the-upgrade-requirements).
 
 Assume a scenario where there are three Consul server nodes:
 

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -25,6 +25,54 @@ This will no longer work since each server must be able to find a valid license 
 If ACLs are enabled, customers on Consul Enterprise 1.8+ or 1.9+ must upgrade Consul agents to the latest patch available (1.8.13 or 1.9.7) prior to upgrading the Consul server instances to 1.10.0.
 Otherwise, the Consul agents will fail to retrieve the license with a valid agent token.
 
+The following table provides an overview of 1.10.0 upgrade scenarios.
+
+| Client Version | Server Version | ACLs     | Snapshot Agent Version                             | Guidance                                                                                                                                      |
+| -------------- | -------------- | -------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.9.x          | 1.9.x          | Enabled  | Do not upgrade Snapshot Agent to the latest 1.9.x. | See [Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Enabled](faq#upgrade-path-for-consul-clients-and-servers-1-9-x-acls-enabled).   |
+| 1.9.x          | 1.9.x          | Disabled | Snapshot Agent affected by upgrade.                | See [Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-9-x-acls-disabled). |
+| 1.8.x          | 1.8.x          | Enabled  | Do not upgrade Snapshot Agent to the latest 1.8.x  | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-enabled).  |
+| 1.8.x          | 1.8.x          | Disabled | Snapshot Agent affected by upgrade.                | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-disabled). |
+
+For Consul clients and servers older than 1.8, follow the instructions for [upgrading to specific versions](https://www.consul.io/docs/upgrading/upgrade-specific) to install Consul 1.8.X on clients and servers before performing one of the following upgrade scenarios.
+
+### Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Enabled
+
+1. Upgrade Consul clients to the latest version of 1.9.x.
+1. Upgrade Consul servers to the latest version of 1.9.x.
+1. Upgrade Consul servers to 1.10.0 and configure the license file or set the license environment variable.
+1. Upgrade Consul clients to 1.10.0.
+1. Upgrade Snapshot Agent to 1.10.0.
+
+### Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Disabled
+
+1. Upgrade Snapshot Agent to the latest version of 1.9.x and the license file/environment variable must be configured.
+1. Configure the license file or set the license environment variable for Consul clients and servers.
+1. Upgrade Consul clients to the latest version of 1.9.x.
+1. Upgrade Consul servers to the latest version of 1.9.x.
+1. Upgrade Consul servers to 1.10.0.
+1. Upgrade Consul clients to 1.10.0.
+1. Upgrade Snapshot Agents to 1.10.0.
+
+### Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Enabled
+
+1. Configure the license file or set the license environment variable for Consul clients and servers.
+1. Upgrade Consul clients to the latest version of 1.8.x.
+1. Upgrade Consul servers to the latest version of 1.8.x.
+1. Upgrade Consul servers to 1.10.0.
+1. Upgrade Consul clients to 1.10.0.
+1. Upgrade Snapshot Agents to 1.10.0.
+
+### Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled
+
+1. Upgrade Snapshot Agent to the latest version of 1.8.x and the license file/environment variable must be configured.
+1. Configure the license file or set the license environment variable for Consul clients and servers.
+1. Upgrade Consul clients to the latest version of 1.8.x.
+1. Upgrade Consul servers to the latest version of 1.8.x.
+1. Upgrade Consul servers to 1.10.0.
+1. Upgrade Consul clients to 1.10.0.
+1. Upgrade Snapshot Agents to 1.10.0.
+
 ## Q: Is there a tutorial available for the license configuration steps?
 
 Please visit the [Enterprise License Tutorial](https://learn.hashicorp.com/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise).

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -22,8 +22,8 @@ This will no longer work since each server must be able to find a valid license 
 
 ## Q: What are the upgrade requirements?
 
-All customers on Consul Enterprise 1.8/1.9 must first upgrade their agents to the latest patch release.
-The license file must also be set in an environment variable or file path, otherwise the Consul agents will fail to retrieve the license with a valid agent token.
+All customers on Consul Enterprise 1.8/1.9 must first upgrade their client and server agents to the latest patch release.
+During the upgrade the license file must also be configured on client agents in an environment variable or file path, otherwise the Consul agents will fail to retrieve the license with a valid agent token.
 The upgrade process varies if ACLs are enabled or disabled in the cluster.
 Refer to the instructions on [upgrading to 1.10.x](/docs/upgrading/instructions/upgrade-to-1-10-x) for details.
 
@@ -114,7 +114,7 @@ When a customer deploys new clusters to a 1.10.0+ent release, they need to have 
 
 ## Q: What are the scenarios that a customer must plan for because of these changes?
 
-New Consul cluster deployments using 1.10.0+ent will need to have a valid license to successfully deploy.
+New Consul cluster deployments using 1.10.0+ent will need to have a valid license on servers to successfully deploy.
 This valid license must be on-disk (auto-loaded) or as an environment variable.
 Please see the [upgrade requirements](faq#q-what-are-the-upgrade-requirements).
 

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -37,9 +37,9 @@ The list below is a great starting point for learning more about the license cha
 
 - [Consul Enterprise Upgrade Documentation](https://www.consul.io/docs/enterprise/upgrades)
 
-- [Consul License Documentation](http://localhost:3000/docs/enterprise/license)
+- [Consul License Documentation](/docs/enterprise/license)
 
-- [License configuration values documentation](http://localhost:3000/docs/enterprise/license/overview#binaries-without-built-in-licenses)
+- [License configuration values documentation](/docs/enterprise/license/overview#binaries-without-built-in-licenses)
 
 - [Install a HashiCorp Enterprise License Tutorial](https://learn.hashicorp.com/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise)
 
@@ -68,7 +68,8 @@ As Consul Enterprise approaches the expiration date, warnings will be issued in 
 
 ## Q: Does this affect client agents?
 
-For existing clusters, if the clients agents are using ACLs and have a valid token, then they will be able to retrieve the license from the server if the upgrade requirements have been met. Please see the [upgrade requirements](faq#q-what-are-the-upgrade-requirements).
+There are upgrade requirements that affect Consul Enterprise clients.
+Please review the [upgrade requirements](faq#q-what-are-the-upgrade-requirements) documentation.
 
 If the client agents are not using ACLs, then the client agents will be need to have the license on-disk (auto-loading) or as an environment variable.
 For new Consul clusters using Consul 1.10.0+ent, customers must ensure that there is a valid license on-disk (auto-loaded) or as an environment variable.

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -34,7 +34,7 @@ The upgrade process varies if ACLs are enabled or disabled in the cluster. The f
 | 1.8.x          | 1.8.x          | Enabled  | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-enabled).  |
 | 1.8.x          | 1.8.x          | Disabled | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-disabled). |
 
-For Consul clients and servers older than 1.8, follow the instructions for [upgrading to specific versions](https://www.consul.io/docs/upgrading/upgrade-specific) to install Consul 1.8.X on clients and servers before performing one of the following upgrade scenarios.
+For Consul clients and servers older than 1.8, follow the instructions for [upgrading to specific versions](/docs/upgrading/upgrade-specific) to install Consul 1.8.X on clients and servers before performing one of the following upgrade scenarios.
 
 ### Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Enabled
 

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -71,9 +71,6 @@ As Consul Enterprise approaches the expiration date, warnings will be issued in 
 There are upgrade requirements that affect Consul Enterprise clients.
 Please review the [upgrade requirements](faq#q-what-are-the-upgrade-requirements) documentation.
 
-If the client agents are not using ACLs, then the client agents will be need to have the license on-disk (auto-loading) or as an environment variable.
-For new Consul clusters using Consul 1.10.0+ent, customers must ensure that there is a valid license on-disk (auto-loaded) or as an environment variable.
-
 ## Q: Does this affect snapshot agents?
 
 Same behavior as Consul clients. See answer for [Does this affect client agents? ](faq#q-does-this-affect-client-agents)

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -22,56 +22,55 @@ This will no longer work since each server must be able to find a valid license 
 
 ## Q: What are the upgrade requirements?
 
-If ACLs are enabled, customers on Consul Enterprise 1.8+ or 1.9+ must upgrade Consul agents to the latest patch available (1.8.13 or 1.9.7) prior to upgrading the Consul server instances to 1.10.0.
-Otherwise, the Consul agents will fail to retrieve the license with a valid agent token.
+All customers on Consul Enterprise 1.8/1.9 must first upgrade their agents to the latest patch release.
+The license file must also be set in an environment variable or file path. Otherwise,
+the Consul agents will fail to retrieve the license with a valid agent token.
+The upgrade process varies if ACLs are enabled or disabled in the cluster. The following table and corresponding sections describe common 1.10.0 upgrade scenarios.
 
-The following table provides an overview of 1.10.0 upgrade scenarios.
-
-| Client Version | Server Version | ACLs     | Snapshot Agent Version                             | Guidance                                                                                                                                      |
-| -------------- | -------------- | -------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1.9.x          | 1.9.x          | Enabled  | Do not upgrade Snapshot Agent to the latest 1.9.x. | See [Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Enabled](faq#upgrade-path-for-consul-clients-and-servers-1-9-x-acls-enabled).   |
-| 1.9.x          | 1.9.x          | Disabled | Snapshot Agent affected by upgrade.                | See [Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-9-x-acls-disabled). |
-| 1.8.x          | 1.8.x          | Enabled  | Do not upgrade Snapshot Agent to the latest 1.8.x  | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-enabled).  |
-| 1.8.x          | 1.8.x          | Disabled | Snapshot Agent affected by upgrade.                | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-disabled). |
+| Client Version | Server Version | ACLs     | Guidance                                                                                                                                      |
+| -------------- | -------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.9.x          | 1.9.x          | Enabled  | See [Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Enabled](faq#upgrade-path-for-consul-clients-and-servers-1-9-x-acls-enabled).   |
+| 1.9.x          | 1.9.x          | Disabled | See [Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-9-x-acls-disabled). |
+| 1.8.x          | 1.8.x          | Enabled  | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-enabled).  |
+| 1.8.x          | 1.8.x          | Disabled | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-disabled). |
 
 For Consul clients and servers older than 1.8, follow the instructions for [upgrading to specific versions](https://www.consul.io/docs/upgrading/upgrade-specific) to install Consul 1.8.X on clients and servers before performing one of the following upgrade scenarios.
 
 ### Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Enabled
 
-1. Upgrade Consul clients to the latest version of 1.9.x.
-1. Upgrade Consul servers to the latest version of 1.9.x.
-1. Upgrade Consul servers to 1.10.0 and configure the license file or set the license environment variable.
+1. Upgrade Consul servers to the latest version of 1.9.x and confiure the license file or set the license environment variable.
+1. Upgrade Consul clients to the latest version of 1.9.x and configure the license file or set the license environment variable.
+1. Upgrade Consul servers to 1.10.0.
 1. Upgrade Consul clients to 1.10.0.
-1. Upgrade Snapshot Agent to 1.10.0.
+1. Upgrade the Snapshot agent to 1.10.0.
 
 ### Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Disabled
 
-1. Upgrade Snapshot Agent to the latest version of 1.9.x and the license file/environment variable must be configured.
-1. Configure the license file or set the license environment variable for Consul clients and servers.
-1. Upgrade Consul clients to the latest version of 1.9.x.
-1. Upgrade Consul servers to the latest version of 1.9.x.
+1. Upgrade Consul servers to the latest version of 1.9.x and confiure the license file or set the license environment variable.
+1. Upgrade Consul clients to the latest version of 1.9.x and confiure the license file or set the license environment variable.
+1. Upgrade Snapshot agents to the latest version of 1.9.x and confiure the license file or set the license environment variable.
 1. Upgrade Consul servers to 1.10.0.
 1. Upgrade Consul clients to 1.10.0.
-1. Upgrade Snapshot Agents to 1.10.0.
+1. Upgrade the Snapshot agent to 1.10.0.
 
 ### Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Enabled
 
 1. Configure the license file or set the license environment variable for Consul clients and servers.
-1. Upgrade Consul clients to the latest version of 1.8.x.
 1. Upgrade Consul servers to the latest version of 1.8.x.
-1. Upgrade Consul servers to 1.10.0.
-1. Upgrade Consul clients to 1.10.0.
-1. Upgrade Snapshot Agents to 1.10.0.
+1. Upgrade Consul clients to the latest version of 1.8.x.
+1. Upgrade Consul servers to 1.10.0 and confiure the license file or set the license environment variable.
+1. Upgrade Consul clients to 1.10.0 and confiure the license file or set the license environment variable.
+1. Upgrade the Snapshot agent to 1.10.0 and confiure the license file or set the license environment variable.
 
 ### Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled
 
-1. Upgrade Snapshot Agent to the latest version of 1.8.x and the license file/environment variable must be configured.
 1. Configure the license file or set the license environment variable for Consul clients and servers.
-1. Upgrade Consul clients to the latest version of 1.8.x.
-1. Upgrade Consul servers to the latest version of 1.8.x.
+1. Upgrade Consul servers to the latest version of 1.8.x and confiure the license file or set the license environment variable.
+1. Upgrade Consul clients to the latest version of 1.8.x and confiure the license file or set the license environment variable.
+1. Upgrade Snapshot Agents to the latest version of 1.8.x and confiure the license file or set the license environment variable.
 1. Upgrade Consul servers to 1.10.0.
 1. Upgrade Consul clients to 1.10.0.
-1. Upgrade Snapshot Agents to 1.10.0.
+1. Upgrade the Snapshot agent to 1.10.0.
 
 ## Q: Is there a tutorial available for the license configuration steps?
 

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -23,54 +23,9 @@ This will no longer work since each server must be able to find a valid license 
 ## Q: What are the upgrade requirements?
 
 All customers on Consul Enterprise 1.8/1.9 must first upgrade their agents to the latest patch release.
-The license file must also be set in an environment variable or file path. Otherwise,
-the Consul agents will fail to retrieve the license with a valid agent token.
-The upgrade process varies if ACLs are enabled or disabled in the cluster. The following table and corresponding sections describe common 1.10.0 upgrade scenarios.
-
-| Client Version | Server Version | ACLs     | Guidance                                                                                                                                      |
-| -------------- | -------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1.9.x          | 1.9.x          | Enabled  | See [Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Enabled](faq#upgrade-path-for-consul-clients-and-servers-1-9-x-acls-enabled).   |
-| 1.9.x          | 1.9.x          | Disabled | See [Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-9-x-acls-disabled). |
-| 1.8.x          | 1.8.x          | Enabled  | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-enabled).  |
-| 1.8.x          | 1.8.x          | Disabled | See [Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled](faq#upgrade-path-for-consul-clients-and-servers-1-8-x-acls-disabled). |
-
-For Consul clients and servers older than 1.8, follow the instructions for [upgrading to specific versions](/docs/upgrading/upgrade-specific) to install Consul 1.8.X on clients and servers before performing one of the following upgrade scenarios.
-
-### Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Enabled
-
-1. Upgrade Consul servers to the latest version of 1.9.x and confiure the license file or set the license environment variable.
-1. Upgrade Consul clients to the latest version of 1.9.x and configure the license file or set the license environment variable.
-1. Upgrade Consul servers to 1.10.0.
-1. Upgrade Consul clients to 1.10.0.
-1. Upgrade the Snapshot agent to 1.10.0.
-
-### Upgrade Path for Consul Clients and Servers 1.9.x - ACLs Disabled
-
-1. Upgrade Consul servers to the latest version of 1.9.x and confiure the license file or set the license environment variable.
-1. Upgrade Consul clients to the latest version of 1.9.x and confiure the license file or set the license environment variable.
-1. Upgrade Snapshot agents to the latest version of 1.9.x and confiure the license file or set the license environment variable.
-1. Upgrade Consul servers to 1.10.0.
-1. Upgrade Consul clients to 1.10.0.
-1. Upgrade the Snapshot agent to 1.10.0.
-
-### Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Enabled
-
-1. Configure the license file or set the license environment variable for Consul clients and servers.
-1. Upgrade Consul servers to the latest version of 1.8.x.
-1. Upgrade Consul clients to the latest version of 1.8.x.
-1. Upgrade Consul servers to 1.10.0 and confiure the license file or set the license environment variable.
-1. Upgrade Consul clients to 1.10.0 and confiure the license file or set the license environment variable.
-1. Upgrade the Snapshot agent to 1.10.0 and confiure the license file or set the license environment variable.
-
-### Upgrade Path for Consul Clients and Servers 1.8.x - ACLs Disabled
-
-1. Configure the license file or set the license environment variable for Consul clients and servers.
-1. Upgrade Consul servers to the latest version of 1.8.x and confiure the license file or set the license environment variable.
-1. Upgrade Consul clients to the latest version of 1.8.x and confiure the license file or set the license environment variable.
-1. Upgrade Snapshot Agents to the latest version of 1.8.x and confiure the license file or set the license environment variable.
-1. Upgrade Consul servers to 1.10.0.
-1. Upgrade Consul clients to 1.10.0.
-1. Upgrade the Snapshot agent to 1.10.0.
+The license file must also be set in an environment variable or file path, otherwise the Consul agents will fail to retrieve the license with a valid agent token.
+The upgrade process varies if ACLs are enabled or disabled in the cluster.
+Refer to the instructions on [upgrading to 1.10.x](/docs/upgrading/instructions/upgrade-to-1-10-x) for details.
 
 ## Q: Is there a tutorial available for the license configuration steps?
 


### PR DESCRIPTION
This PR was to update the FAQ to include information about the upgrade requirements for 1.10.0: customers on Consul Enterprise 1.8+ or 1.9+ must upgrade Consul agents to the latest patch available (1.8.13 or 1.9.7) prior to upgrading the Consul server instances to 1.10.0.