### PR TITLE
tlsutil: additional godoc and small cleanup

### DIFF
--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -168,16 +168,20 @@ type manual struct {
 	cert   *tls.Certificate
 }
 
-// Configurator holds a Config and is responsible for generating all the
-// *tls.Config necessary for Consul. Except the one in the api package.
+// Configurator provides tls.Config and net.Dial wrappers to enable TLS for
+// clients and servers, for both HTTPS and RPC requests.
+// Configurator receives an initial TLS configuration from agent configuration,
+// and receives updates from config reloads, auto-encrypt, and auto-config.
 type Configurator struct {
 	// lock synchronizes access to all fields on this struct except for logger and version.
-	lock                 sync.RWMutex
-	base                 *Config
-	autoTLS              autoTLS
-	manual               *manual
+	lock    sync.RWMutex
+	base    *Config
+	autoTLS autoTLS
+	manual  *manual
+	caPool  *x509.CertPool
+	// peerDatacenterUseTLS is a map of DC name to a bool indicating if the DC
+	// uses TLS for RPC requests.
 	peerDatacenterUseTLS map[string]bool
-	caPool               *x509.CertPool
 
 	// logger is not protected by a lock. It must never be changed after
 	// Configurator is created.

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -163,6 +163,8 @@ func (a autoTLS) caPems() []string {
 	return append(a.manualCAPems, a.connectCAPems...)
 }
 
+// manual stores the TLS CA and cert received from Configurator.Update which
+// generally comes from the agent configuration.
 type manual struct {
 	caPems []string
 	cert   *tls.Certificate
@@ -177,7 +179,7 @@ type Configurator struct {
 	lock    sync.RWMutex
 	base    *Config
 	autoTLS autoTLS
-	manual  *manual
+	manual  manual
 	caPool  *x509.CertPool
 	// peerDatacenterUseTLS is a map of DC name to a bool indicating if the DC
 	// uses TLS for RPC requests.
@@ -202,7 +204,6 @@ func NewConfigurator(config Config, logger hclog.Logger) (*Configurator, error) 
 
 	c := &Configurator{
 		logger:               logger.Named(logging.TLSUtil),
-		manual:               &manual{},
 		peerDatacenterUseTLS: map[string]bool{},
 	}
 	err := c.Update(config)

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -139,11 +139,6 @@ func tlsVersions() []string {
 	return versions
 }
 
-// KeyPair is used to open and parse a certificate and key file
-func (c *Config) KeyPair() (*tls.Certificate, error) {
-	return loadKeyPair(c.CertFile, c.KeyFile)
-}
-
 // SpecificDC is used to invoke a static datacenter
 // and turns a DCWrapper into a Wrapper type.
 func SpecificDC(dc string, tlsWrap DCWrapper) Wrapper {

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -506,7 +506,7 @@ func TestConfigurator_ErrorPropagation(t *testing.T) {
 		variants = append(variants, variant{Config{TLSMinVersion: v}, false, false})
 	}
 
-	c := Configurator{autoTLS: &autoTLS{}, manual: &manual{}}
+	c := Configurator{manual: &manual{}}
 	for i, v := range variants {
 		info := fmt.Sprintf("case %d, config: %+v", i, v.config)
 		_, err1 := NewConfigurator(v.config, nil)
@@ -716,7 +716,7 @@ func TestConfigurator_CommonTLSConfigTLSMinVersion(t *testing.T) {
 }
 
 func TestConfigurator_CommonTLSConfigVerifyIncoming(t *testing.T) {
-	c := Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := Configurator{base: &Config{}}
 	type variant struct {
 		verify   bool
 		expected tls.ClientAuthType
@@ -731,7 +731,7 @@ func TestConfigurator_CommonTLSConfigVerifyIncoming(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingRPCTLSDisabled(t *testing.T) {
-	c := Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := Configurator{base: &Config{}}
 	type variant struct {
 		verify         bool
 		autoEncryptTLS bool
@@ -909,7 +909,7 @@ func TestConfigurator_IncomingALPNRPCConfig(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
-	c := Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := Configurator{base: &Config{}}
 	require.Equal(t, []string{"h2", "http/1.1"}, c.IncomingHTTPSConfig().NextProtos)
 }
 
@@ -917,7 +917,7 @@ func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {
 	c := Configurator{base: &Config{
 		TLSMinVersion:           "tls12",
 		EnableAgentTLSForChecks: false,
-	}, autoTLS: &autoTLS{}}
+	}}
 	tlsConf := c.OutgoingTLSConfigForCheck(true, "")
 	require.Equal(t, true, tlsConf.InsecureSkipVerify)
 	require.Equal(t, uint16(0), tlsConf.MinVersion)
@@ -936,7 +936,7 @@ func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingRPCConfig(t *testing.T) {
-	c := &Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := &Configurator{base: &Config{}}
 	require.Nil(t, c.OutgoingRPCConfig())
 
 	c, err := NewConfigurator(Config{
@@ -954,7 +954,7 @@ func TestConfigurator_OutgoingRPCConfig(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingALPNRPCConfig(t *testing.T) {
-	c := &Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := &Configurator{base: &Config{}}
 	require.Nil(t, c.OutgoingALPNRPCConfig())
 
 	c, err := NewConfigurator(Config{
@@ -974,7 +974,7 @@ func TestConfigurator_OutgoingALPNRPCConfig(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingRPCWrapper(t *testing.T) {
-	c := &Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := &Configurator{base: &Config{}}
 	wrapper := c.OutgoingRPCWrapper()
 	require.NotNil(t, wrapper)
 	conn := &net.TCPConn{}
@@ -996,7 +996,7 @@ func TestConfigurator_OutgoingRPCWrapper(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingALPNRPCWrapper(t *testing.T) {
-	c := &Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := &Configurator{base: &Config{}}
 	wrapper := c.OutgoingRPCWrapper()
 	require.NotNil(t, wrapper)
 	conn := &net.TCPConn{}
@@ -1071,7 +1071,7 @@ func TestConfigurator_ServerNameOrNodeName(t *testing.T) {
 }
 
 func TestConfigurator_VerifyOutgoing(t *testing.T) {
-	c := Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := Configurator{base: &Config{}}
 	type variant struct {
 		verify         bool
 		autoEncryptTLS bool
@@ -1104,7 +1104,7 @@ func TestConfigurator_Domain(t *testing.T) {
 }
 
 func TestConfigurator_VerifyServerHostname(t *testing.T) {
-	c := Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := Configurator{base: &Config{}}
 	require.False(t, c.VerifyServerHostname())
 
 	c.base.VerifyServerHostname = true
@@ -1121,7 +1121,7 @@ func TestConfigurator_VerifyServerHostname(t *testing.T) {
 }
 
 func TestConfigurator_AutoEncrytCertExpired(t *testing.T) {
-	c := Configurator{base: &Config{}, autoTLS: &autoTLS{}}
+	c := Configurator{base: &Config{}}
 	require.True(t, c.AutoEncryptCertExpired())
 
 	cert, err := loadKeyPair("../test/key/something_expired.cer", "../test/key/something_expired.key")

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -708,12 +708,12 @@ func TestConfigurator_CommonTLSConfigCAs(t *testing.T) {
 func TestConfigurator_CommonTLSConfigTLSMinVersion(t *testing.T) {
 	c, err := NewConfigurator(Config{TLSMinVersion: ""}, nil)
 	require.NoError(t, err)
-	require.Equal(t, c.commonTLSConfig(false).MinVersion, TLSLookup["tls10"])
+	require.Equal(t, c.commonTLSConfig(false).MinVersion, tlsLookup["tls10"])
 
 	for _, version := range tlsVersions() {
 		require.NoError(t, c.Update(Config{TLSMinVersion: version}))
 		require.Equal(t, c.commonTLSConfig(false).MinVersion,
-			TLSLookup[version])
+			tlsLookup[version])
 	}
 
 	require.Error(t, c.Update(Config{TLSMinVersion: "tlsBOGUS"}))
@@ -930,12 +930,12 @@ func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {
 	c.base.ServerName = "servername"
 	tlsConf = c.OutgoingTLSConfigForCheck(true, "")
 	require.Equal(t, true, tlsConf.InsecureSkipVerify)
-	require.Equal(t, TLSLookup[c.base.TLSMinVersion], tlsConf.MinVersion)
+	require.Equal(t, tlsLookup[c.base.TLSMinVersion], tlsConf.MinVersion)
 	require.Equal(t, c.base.ServerName, tlsConf.ServerName)
 
 	tlsConf = c.OutgoingTLSConfigForCheck(true, "servername2")
 	require.Equal(t, true, tlsConf.InsecureSkipVerify)
-	require.Equal(t, TLSLookup[c.base.TLSMinVersion], tlsConf.MinVersion)
+	require.Equal(t, tlsLookup[c.base.TLSMinVersion], tlsConf.MinVersion)
 	require.Equal(t, "servername2", tlsConf.ServerName)
 }
 
@@ -1141,5 +1141,6 @@ func TestConfigurator_AutoEncrytCertExpired(t *testing.T) {
 
 func TestConfig_tlsVersions(t *testing.T) {
 	require.Equal(t, []string{"tls10", "tls11", "tls12", "tls13"}, tlsVersions())
-	require.Equal(t, strings.Join(tlsVersions(), ", "), TLSVersions)
+	expected := "tls10, tls11, tls12, tls13"
+	require.Equal(t, expected, strings.Join(tlsVersions(), ", "))
 }

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -405,7 +405,7 @@ func TestConfig_ParseCiphers(t *testing.T) {
 	require.Equal(t, []uint16{}, v)
 }
 
-func TestConfigurator_loadKeyPair(t *testing.T) {
+func TestLoadKeyPair(t *testing.T) {
 	type variant struct {
 		cert, key string
 		shoulderr bool
@@ -422,24 +422,20 @@ func TestConfigurator_loadKeyPair(t *testing.T) {
 			false, false},
 	}
 	for i, v := range variants {
-		info := fmt.Sprintf("case %d", i)
-		cert1, err1 := loadKeyPair(v.cert, v.key)
-		config := &Config{CertFile: v.cert, KeyFile: v.key}
-		cert2, err2 := config.KeyPair()
-		if v.shoulderr {
-			require.Error(t, err1, info)
-			require.Error(t, err2, info)
-		} else {
-			require.NoError(t, err1, info)
-			require.NoError(t, err2, info)
-		}
-		if v.isnil {
-			require.Nil(t, cert1, info)
-			require.Nil(t, cert2, info)
-		} else {
-			require.NotNil(t, cert1, info)
-			require.NotNil(t, cert2, info)
-		}
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			cert, err := loadKeyPair(v.cert, v.key)
+			if v.shoulderr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if v.isnil {
+				require.Nil(t, cert)
+			} else {
+				require.NotNil(t, cert)
+			}
+		})
 	}
 }
 
@@ -518,7 +514,7 @@ func TestConfigurator_ErrorPropagation(t *testing.T) {
 
 		var err3 error
 		if !v.excludeCheck {
-			cert, err := v.config.KeyPair()
+			cert, err := loadKeyPair(v.config.CertFile, v.config.KeyFile)
 			require.NoError(t, err, info)
 			pems, err := LoadCAs(v.config.CAFile, v.config.CAPath)
 			require.NoError(t, err, info)

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -506,7 +506,7 @@ func TestConfigurator_ErrorPropagation(t *testing.T) {
 		variants = append(variants, variant{Config{TLSMinVersion: v}, false, false})
 	}
 
-	c := Configurator{manual: &manual{}}
+	c := Configurator{}
 	for i, v := range variants {
 		info := fmt.Sprintf("case %d, config: %+v", i, v.config)
 		_, err1 := NewConfigurator(v.config, nil)


### PR DESCRIPTION
Best viewed by individual commit.

Adds some godoc to explain what the types/fields are used for.
Removes some unused things, and un-exports internal things.
Change a couple pointer fields to non-pointers to remove the need to point at different places in memory.