### PR TITLE
Add ability to load a license from the configuration/environment

### DIFF
--- a/.changelog/10441.txt
+++ b/.changelog/10441.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+licensing: **(Enterprise Only)** In order to have forward compatibility with Consul Enterprise v1.10, the ability to parse licenses from the configuration or environment has been added. This can be specified with the `license_path` configuration, the `CONSUL_LICENSE` environment variable or the `CONSUL_LICENSE_PATH` environment variable. On server agents this configuration will be ignored. Client agents and the snapshot agent will use the configured license instead of automatically retrieving one.
+```
+

--- a/agent/config/builder_oss.go
+++ b/agent/config/builder_oss.go
@@ -50,6 +50,10 @@ func validateEnterpriseConfigKeys(config *Config) []error {
 		add("audit")
 		config.Audit = nil
 	}
+	if config.LicensePath != nil {
+		add("license_path")
+		config.LicensePath = nil
+	}
 
 	return result
 }

--- a/agent/config/builder_oss_test.go
+++ b/agent/config/builder_oss_test.go
@@ -97,6 +97,15 @@ func TestValidateEnterpriseConfigKeys(t *testing.T) {
 				require.Nil(t, c.ACL.Tokens.ManagedServiceProvider)
 			},
 		},
+		"license_path": {
+			config: Config{
+				LicensePath: &stringVal,
+			},
+			badKeys: []string{"license_path"},
+			check: func(t *testing.T, c *Config) {
+				require.Empty(t, c.LicensePath)
+			},
+		},
 		"multi": {
 			config: Config{
 				ReadReplica: &boolVal,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -187,6 +187,7 @@ type Config struct {
 	HTTPConfig                       HTTPConfig          `mapstructure:"http_config"`
 	KeyFile                          *string             `mapstructure:"key_file"`
 	LeaveOnTerm                      *bool               `mapstructure:"leave_on_terminate"`
+	LicensePath                      *string             `mapstructure:"license_path"`
 	Limits                           Limits              `mapstructure:"limits"`
 	LogLevel                         *string             `mapstructure:"log_level"`
 	LogJSON                          *bool               `mapstructure:"log_json"`

--- a/agent/config/runtime_oss_test.go
+++ b/agent/config/runtime_oss_test.go
@@ -9,6 +9,7 @@ func entFullRuntimeConfig(rt *RuntimeConfig) {}
 var enterpriseReadReplicaWarnings = []string{enterpriseConfigKeyError{key: "read_replica (or the deprecated non_voting_server)"}.Error()}
 
 var enterpriseConfigKeyWarnings = []string{
+	enterpriseConfigKeyError{key: "license_path"}.Error(),
 	enterpriseConfigKeyError{key: "read_replica (or the deprecated non_voting_server)"}.Error(),
 	enterpriseConfigKeyError{key: "segment"}.Error(),
 	enterpriseConfigKeyError{key: "segments"}.Error(),

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5301,6 +5301,7 @@ func TestFullConfig(t *testing.T) {
 			},
 			"key_file": "IEkkwgIA",
 			"leave_on_terminate": true,
+			"license_path": "/path/to/license.lic",
 			"limits": {
 				"http_max_conns_per_client": 100,
 				"https_handshake_timeout": "2391ms",
@@ -5990,6 +5991,7 @@ func TestFullConfig(t *testing.T) {
 			}
 			key_file = "IEkkwgIA"
 			leave_on_terminate = true
+			license_path = "/path/to/license.lic"
 			limits {
 				http_max_conns_per_client = 100
 				https_handshake_timeout = "2391ms"


### PR DESCRIPTION
This is mainly for forward compatibility with 1.10 where licensing requirements are changing.

For older releases we are adding the ability to load the license from a configuration/environment to facilitate a smoother upgrade process. For servers, we will allow the configuration to be set but it will not be used (a warning log is emitted saying as much). For client agents it will actually cause the license to be used in place of the auto-retrieval process.

Unlike with 1.10, client agents will not be able to update the license loaded via config with a reload. It is expected that this configuration is only used while on the path to upgrading to 1.10 and therefore the ability to reload the license should not be necessary.