### PR TITLE
[1.8.x] Backport #10441 - Add ability to load a license from the configuration/environment

### DIFF
--- a/.changelog/10442.txt
+++ b/.changelog/10442.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ licensing: **(Enterprise Only)** In order to have forward compatibility with Consul Enterprise v1.10, the ability to parse licenses from the configuration or environment has been added. This can be specified with the `license_path` configuration, the `CONSUL_LICENSE` environment variable or the `CONSUL_LICENSE_PATH` environment variable. On server agents this configuration will be ignored. Client agents and the snapshot agent will use the configured license instead of automatically retrieving one.
+ ```

--- a/agent/config/builder_oss.go
+++ b/agent/config/builder_oss.go
@@ -40,6 +40,9 @@ var (
 		"audit": func(c *Config) {
 			c.Audit = nil
 		},
+		"license_path": func(c *Config) {
+			c.LicensePath = nil
+		},
 	}
 )
 

--- a/agent/config/builder_oss_test.go
+++ b/agent/config/builder_oss_test.go
@@ -116,6 +116,16 @@ func TestBuilder_validateEnterpriseConfigKeys(t *testing.T) {
 				require.Nil(t, c.ACL.Tokens.ManagedServiceProvider)
 			},
 		},
+		"license_path": {
+			config: Config{
+				LicensePath: &stringVal,
+			},
+			keys:    []string{"license_path"},
+			badKeys: []string{"license_path"},
+			check: func(t *testing.T, c *Config) {
+				require.Empty(t, c.LicensePath)
+			},
+		},
 		"multi": {
 			config: Config{
 				NonVotingServer: &boolVal,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -191,6 +191,7 @@ type Config struct {
 	HTTPConfig                       HTTPConfig               `json:"http_config,omitempty" hcl:"http_config" mapstructure:"http_config"`
 	KeyFile                          *string                  `json:"key_file,omitempty" hcl:"key_file" mapstructure:"key_file"`
 	LeaveOnTerm                      *bool                    `json:"leave_on_terminate,omitempty" hcl:"leave_on_terminate" mapstructure:"leave_on_terminate"`
+	LicensePath                      *string                  `json:"license_path,omitempty" hcl:"license_path" mapstructure:"license_path"`
 	Limits                           Limits                   `json:"limits,omitempty" hcl:"limits" mapstructure:"limits"`
 	LogLevel                         *string                  `json:"log_level,omitempty" hcl:"log_level" mapstructure:"log_level"`
 	LogJSON                          *bool                    `json:"log_json,omitempty" hcl:"log_json" mapstructure:"log_json"`

--- a/agent/config/runtime_oss_test.go
+++ b/agent/config/runtime_oss_test.go
@@ -4,6 +4,8 @@ package config
 
 var entMetaJSON = `{}`
 
+var entAuthMethodFieldsJSON = `{}`
+
 var entRuntimeConfigSanitize = `{}`
 
 var entFullDNSJSONConfig = ``

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4707,6 +4707,7 @@ func TestFullConfig(t *testing.T) {
 			},
 			"key_file": "IEkkwgIA",
 			"leave_on_terminate": true,
+			"license_path": "/path/to/license.lic",
 			"limits": {
 				"http_max_conns_per_client": 100,
 				"https_handshake_timeout": "2391ms",
@@ -5372,6 +5373,7 @@ func TestFullConfig(t *testing.T) {
 			}
 			key_file = "IEkkwgIA"
 			leave_on_terminate = true
+			license_path = "/path/to/license.lic"
 			limits {
 				http_max_conns_per_client = 100
 				https_handshake_timeout = "2391ms"
@@ -7194,11 +7196,11 @@ func TestSanitize(t *testing.T) {
 				"Enabled": false,
 				"AllowReuse": false,
 				"AuthMethod": {
-					"ACLAuthMethodEnterpriseFields": {},
+					"ACLAuthMethodEnterpriseFields": ` + entAuthMethodFieldsJSON + `,
 					"Config": {},
 					"Description": "",
 					"DisplayName": "",
-					"EnterpriseMeta": {},
+					"EnterpriseMeta": ` + entMetaJSON + `,
 					"MaxTokenTTL": "0s",
 					"Name": "",
 					"RaftIndex": {

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -78,7 +79,9 @@ func testClientWithConfigWithErr(t *testing.T, cb func(c *Config)) (string, *Cli
 		t.Fatalf("err: %v", err)
 	}
 
-	client, err := NewClient(config, WithLogger(logger), WithTLSConfigurator(tlsConf))
+	store := &token.Store{}
+
+	client, err := NewClient(config, WithLogger(logger), WithTLSConfigurator(tlsConf), WithTokenStore(store))
 	return dir, client, err
 }
 


### PR DESCRIPTION
This is mainly for forwards compatibility with 1.10 and should not be relied on for a cluster staying on a 1.8.x/1.9.x version. This was also just a backport of #10441 to the release/1.8.x branch.

For older releases we are adding the ability to load the license from a configuration/environment to facilitate a smoother upgrade process. For servers, we will allow the configuration to be set but it will not be used (a warning log is emitted saying as much). For client agents it will actually cause the license to be used in place of the auto-retrieval process.

Unlike with 1.10, client agents will not be able to update the license loaded via config with a reload. It is expected that this configuration is only used while on the path to upgrading to 1.10 and therefore the ability to reload the license should not be necessary.