### PR TITLE
ui: Adds Partitions to the HTTP layer

### DIFF
--- a/ui/packages/consul-ui/app/abilities/nspace.js
+++ b/ui/packages/consul-ui/app/abilities/nspace.js
@@ -16,7 +16,7 @@ export default class NspaceAbility extends BaseAbility {
   }
 
   get canChoose() {
-    return this.canUse && (this.nspaces.length || []) > 0;
+    return this.canUse && (this.nspaces || []).length > 0;
   }
 
   get canUse() {

--- a/ui/packages/consul-ui/app/abilities/partition.js
+++ b/ui/packages/consul-ui/app/abilities/partition.js
@@ -1,7 +1,7 @@
 import BaseAbility from './base';
 import { inject as service } from '@ember/service';
 
-export default class NspaceAbility extends BaseAbility {
+export default class PartitionAbility extends BaseAbility {
   @service('env') env;
 
   resource = 'operator';
@@ -16,10 +16,10 @@ export default class NspaceAbility extends BaseAbility {
   }
 
   get canChoose() {
-    return this.canUse && (this.nspaces.length || []) > 0;
+    return this.canUse && (this.partitions || []).length > 0;
   }
 
   get canUse() {
-    return this.env.var('CONSUL_NSPACES_ENABLED');
+    return this.env.var('CONSUL_PARTITIONS_ENABLED');
   }
 }

--- a/ui/packages/consul-ui/app/adapters/auth-method.js
+++ b/ui/packages/consul-ui/app/adapters/auth-method.js
@@ -1,18 +1,19 @@
 import Adapter from './application';
 
 export default class AuthMethodAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, id }) {
+  requestForQuery(request, { dc, ns, partition, index, id }) {
     return request`
       GET /v1/acl/auth-methods?${{ dc }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
   }
 
-  requestForQueryRecord(request, { dc, ns, index, id }) {
+  requestForQueryRecord(request, { dc, ns, partition, index, id }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -20,7 +21,8 @@ export default class AuthMethodAdapter extends Adapter {
       GET /v1/acl/auth-method/${id}?${{ dc }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/adapters/binding-rule.js
+++ b/ui/packages/consul-ui/app/adapters/binding-rule.js
@@ -1,12 +1,13 @@
 import Adapter from './application';
 
 export default class BindingRuleAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, authmethod, index, id }) {
+  requestForQuery(request, { dc, ns, partition, authmethod, index, id }) {
     return request`
       GET /v1/acl/binding-rules?${{ dc, authmethod }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/adapters/coordinate.js
+++ b/ui/packages/consul-ui/app/adapters/coordinate.js
@@ -1,12 +1,15 @@
 import Adapter from './application';
 // TODO: Update to use this.formatDatacenter()
 export default class CoordinateAdapter extends Adapter {
-  requestForQuery(request, { dc, index, uri }) {
+  requestForQuery(request, { dc, partition, index, uri }) {
     return request`
       GET /v1/coordinate/nodes?${{ dc }}
       X-Request-ID: ${uri}
 
-      ${{ index }}
+      ${{
+        partition,
+        index,
+      }}
     `;
   }
 }

--- a/ui/packages/consul-ui/app/adapters/discovery-chain.js
+++ b/ui/packages/consul-ui/app/adapters/discovery-chain.js
@@ -2,7 +2,7 @@ import Adapter from './application';
 
 // TODO: Update to use this.formatDatacenter()
 export default class DiscoveryChainAdapter extends Adapter {
-  requestForQueryRecord(request, { dc, ns, index, id, uri }) {
+  requestForQueryRecord(request, { dc, ns, partition, index, id, uri }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -11,7 +11,8 @@ export default class DiscoveryChainAdapter extends Adapter {
       X-Request-ID: ${uri}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/adapters/intention.js
+++ b/ui/packages/consul-ui/app/adapters/intention.js
@@ -22,7 +22,7 @@ export default class IntentionAdapter extends Adapter {
     }
 
       ${{
-        ...this.formatNspace('*'),
+        ns: '*',
         index,
         filter,
       }}

--- a/ui/packages/consul-ui/app/adapters/intention.js
+++ b/ui/packages/consul-ui/app/adapters/intention.js
@@ -1,6 +1,5 @@
-import Adapter, { DATACENTER_QUERY_PARAM as API_DATACENTER_KEY } from './application';
+import Adapter from './application';
 import { get } from '@ember/object';
-import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 
 // Intentions have different namespacing to the rest of the UI in that the don't
 // have a Namespace property, the DestinationNS is essentially its namespace.
@@ -76,7 +75,7 @@ export default class IntentionAdapter extends Adapter {
       PUT /v1/connect/intentions/exact?${{
         source: `${data.SourceNS}/${data.SourceName}`,
         destination: `${data.DestinationNS}/${data.DestinationName}`,
-        [API_DATACENTER_KEY]: data[DATACENTER_KEY],
+        dc: data.Datacenter,
       }}
 
       ${body}
@@ -95,7 +94,7 @@ export default class IntentionAdapter extends Adapter {
       DELETE /v1/connect/intentions/exact?${{
         source: `${data.SourceNS}/${data.SourceName}`,
         destination: `${data.DestinationNS}/${data.DestinationName}`,
-        [API_DATACENTER_KEY]: data[DATACENTER_KEY],
+        dc: data.Datacenter,
       }}
     `;
   }

--- a/ui/packages/consul-ui/app/adapters/kv.js
+++ b/ui/packages/consul-ui/app/adapters/kv.js
@@ -9,7 +9,7 @@ import { NSPACE_KEY } from 'consul-ui/models/nspace';
 const API_KEYS_KEY = 'keys';
 
 export default class KvAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, id, separator }) {
+  requestForQuery(request, { dc, ns, partition, index, id, separator }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -17,13 +17,14 @@ export default class KvAdapter extends Adapter {
       GET /v1/kv/${keyToArray(id)}?${{ [API_KEYS_KEY]: null, dc, separator }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
   }
 
-  requestForQueryRecord(request, { dc, ns, index, id }) {
+  requestForQueryRecord(request, { dc, ns, partition, index, id }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -31,7 +32,8 @@ export default class KvAdapter extends Adapter {
       GET /v1/kv/${keyToArray(id)}?${{ dc }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
@@ -41,8 +43,9 @@ export default class KvAdapter extends Adapter {
   // https://github.com/hashicorp/consul/issues/3804
   requestForCreateRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
+      dc: data.dc,
+      ns: data.ns,
+      partition: data.partition,
     };
     return request`
       PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${params}
@@ -54,9 +57,10 @@ export default class KvAdapter extends Adapter {
 
   requestForUpdateRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
+      dc: data.dc,
+      ns: data.ns,
+      partition: data.partition,
       flags: data.Flags,
-      ...this.formatNspace(data[NSPACE_KEY]),
     };
     return request`
       PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${params}
@@ -72,8 +76,9 @@ export default class KvAdapter extends Adapter {
       recurse = null;
     }
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
+      dc: data.dc,
+      ns: data.ns,
+      partition: data.partition,
       recurse,
     };
     return request`

--- a/ui/packages/consul-ui/app/adapters/kv.js
+++ b/ui/packages/consul-ui/app/adapters/kv.js
@@ -2,8 +2,6 @@ import Adapter from './application';
 import isFolder from 'consul-ui/utils/isFolder';
 import keyToArray from 'consul-ui/utils/keyToArray';
 import { SLUG_KEY } from 'consul-ui/models/kv';
-import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
-import { NSPACE_KEY } from 'consul-ui/models/nspace';
 
 // TODO: Update to use this.formatDatacenter()
 const API_KEYS_KEY = 'keys';
@@ -43,9 +41,9 @@ export default class KvAdapter extends Adapter {
   // https://github.com/hashicorp/consul/issues/3804
   requestForCreateRecord(request, serialized, data) {
     const params = {
-      dc: data.dc,
-      ns: data.ns,
-      partition: data.partition,
+      dc: data.Datacenter,
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${params}
@@ -57,9 +55,9 @@ export default class KvAdapter extends Adapter {
 
   requestForUpdateRecord(request, serialized, data) {
     const params = {
-      dc: data.dc,
-      ns: data.ns,
-      partition: data.partition,
+      dc: data.Datacenter,
+      ns: data.Namespace,
+      partition: data.Partition,
       flags: data.Flags,
     };
     return request`
@@ -76,9 +74,9 @@ export default class KvAdapter extends Adapter {
       recurse = null;
     }
     const params = {
-      dc: data.dc,
-      ns: data.ns,
-      partition: data.partition,
+      dc: data.Datacenter,
+      ns: data.Namespace,
+      partition: data.Partition,
       recurse,
     };
     return request`

--- a/ui/packages/consul-ui/app/adapters/node.js
+++ b/ui/packages/consul-ui/app/adapters/node.js
@@ -10,19 +10,20 @@ import Adapter from './application';
 // to the node.
 
 export default class NodeAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, id, uri }) {
+  requestForQuery(request, { dc, ns, partition, index, id, uri }) {
     return request`
       GET /v1/internal/ui/nodes?${{ dc }}
       X-Request-ID: ${uri}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
   }
 
-  requestForQueryRecord(request, { dc, ns, index, id, uri }) {
+  requestForQueryRecord(request, { dc, ns, partition, index, id, uri }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -31,7 +32,8 @@ export default class NodeAdapter extends Adapter {
       X-Request-ID: ${uri}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/adapters/nspace.js
+++ b/ui/packages/consul-ui/app/adapters/nspace.js
@@ -3,23 +3,29 @@ import { SLUG_KEY } from 'consul-ui/models/nspace';
 
 // namespaces aren't categorized by datacenter, therefore no dc
 export default class NspaceAdapter extends Adapter {
-  requestForQuery(request, { index, uri }) {
+  requestForQuery(request, { partition, index, uri }) {
     return request`
       GET /v1/namespaces
       X-Request-ID: ${uri}
 
-      ${{ index }}
+      ${{
+        partition,
+        index,
+      }}
     `;
   }
 
-  requestForQueryRecord(request, { index, id }) {
+  requestForQueryRecord(request, { partition, index, id }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an name');
     }
     return request`
       GET /v1/namespace/${id}
 
-      ${{ index }}
+      ${{
+        partition,
+        index,
+      }}
     `;
   }
 

--- a/ui/packages/consul-ui/app/adapters/nspace.js
+++ b/ui/packages/consul-ui/app/adapters/nspace.js
@@ -31,7 +31,9 @@ export default class NspaceAdapter extends Adapter {
 
   requestForCreateRecord(request, serialized, data) {
     return request`
-      PUT /v1/namespace/${data[SLUG_KEY]}
+      PUT /v1/namespace/${data[SLUG_KEY]}?${{
+      partition: data.partition,
+    }}
 
       ${{
         Name: serialized.Name,
@@ -46,7 +48,9 @@ export default class NspaceAdapter extends Adapter {
 
   requestForUpdateRecord(request, serialized, data) {
     return request`
-      PUT /v1/namespace/${data[SLUG_KEY]}
+      PUT /v1/namespace/${data[SLUG_KEY]}?${{
+      partition: data.partition,
+    }}
 
       ${{
         Description: serialized.Description,
@@ -60,7 +64,9 @@ export default class NspaceAdapter extends Adapter {
 
   requestForDeleteRecord(request, serialized, data) {
     return request`
-      DELETE /v1/namespace/${data[SLUG_KEY]}
+      DELETE /v1/namespace/${data[SLUG_KEY]}?${{
+      partition: data.partition,
+    }}
     `;
   }
 }

--- a/ui/packages/consul-ui/app/adapters/nspace.js
+++ b/ui/packages/consul-ui/app/adapters/nspace.js
@@ -32,7 +32,7 @@ export default class NspaceAdapter extends Adapter {
   requestForCreateRecord(request, serialized, data) {
     return request`
       PUT /v1/namespace/${data[SLUG_KEY]}?${{
-      partition: data.partition,
+      partition: data.Partition,
     }}
 
       ${{
@@ -49,7 +49,7 @@ export default class NspaceAdapter extends Adapter {
   requestForUpdateRecord(request, serialized, data) {
     return request`
       PUT /v1/namespace/${data[SLUG_KEY]}?${{
-      partition: data.partition,
+      partition: data.Partition,
     }}
 
       ${{
@@ -65,7 +65,7 @@ export default class NspaceAdapter extends Adapter {
   requestForDeleteRecord(request, serialized, data) {
     return request`
       DELETE /v1/namespace/${data[SLUG_KEY]}?${{
-      partition: data.partition,
+      partition: data.Partition,
     }}
     `;
   }

--- a/ui/packages/consul-ui/app/adapters/oidc-provider.js
+++ b/ui/packages/consul-ui/app/adapters/oidc-provider.js
@@ -31,11 +31,10 @@ export default class OidcProviderAdapter extends Adapter {
       throw new Error('You must specify an id');
     }
     return request`
-      POST /v1/acl/oidc/auth-url?${{ dc }}
+      POST /v1/acl/oidc/auth-url?${{ dc, ns, partition }}
       Cache-Control: no-store
 
       ${{
-        ...Namespace(ns),
         AuthMethod: id,
         RedirectURI: `${this.env.var('CONSUL_BASE_UI_URL')}/oidc/callback`,
       }}
@@ -53,11 +52,10 @@ export default class OidcProviderAdapter extends Adapter {
       throw new Error('You must specify an state');
     }
     return request`
-      POST /v1/acl/oidc/callback?${{ dc }}
+      POST /v1/acl/oidc/callback?${{ dc, ns, partition }}
       Cache-Control: no-store
 
       ${{
-        ...Namespace(ns),
         AuthMethod: id,
         Code: code,
         State: state,

--- a/ui/packages/consul-ui/app/adapters/oidc-provider.js
+++ b/ui/packages/consul-ui/app/adapters/oidc-provider.js
@@ -13,19 +13,20 @@ if (env('CONSUL_NSPACES_ENABLED')) {
 export default class OidcProviderAdapter extends Adapter {
   @service('env') env;
 
-  requestForQuery(request, { dc, ns, index, uri }) {
+  requestForQuery(request, { dc, ns, partition, index, uri }) {
     return request`
       GET /v1/internal/ui/oidc-auth-methods?${{ dc }}
       X-Request-ID: ${uri}
 
       ${{
+        ns,
+        partition,
         index,
-        ...this.formatNspace(ns),
       }}
     `;
   }
 
-  requestForQueryRecord(request, { dc, ns, id }) {
+  requestForQueryRecord(request, { dc, ns, partition, id }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -41,7 +42,7 @@ export default class OidcProviderAdapter extends Adapter {
     `;
   }
 
-  requestForAuthorize(request, { dc, ns, id, code, state }) {
+  requestForAuthorize(request, { dc, ns, partition, id, code, state }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }

--- a/ui/packages/consul-ui/app/adapters/oidc-provider.js
+++ b/ui/packages/consul-ui/app/adapters/oidc-provider.js
@@ -1,14 +1,5 @@
 import Adapter from './application';
 import { inject as service } from '@ember/service';
-import { env } from 'consul-ui/env';
-import nonEmptySet from 'consul-ui/utils/non-empty-set';
-
-let Namespace;
-if (env('CONSUL_NSPACES_ENABLED')) {
-  Namespace = nonEmptySet('Namespace');
-} else {
-  Namespace = () => ({});
-}
 
 export default class OidcProviderAdapter extends Adapter {
   @service('env') env;

--- a/ui/packages/consul-ui/app/adapters/permission.js
+++ b/ui/packages/consul-ui/app/adapters/permission.js
@@ -4,15 +4,21 @@ import { inject as service } from '@ember/service';
 export default class PermissionAdapter extends Adapter {
   @service('env') env;
 
-  requestForAuthorize(request, { dc, ns, resources = [], index }) {
+  requestForAuthorize(request, { dc, ns, partition, resources = [], index }) {
     // the authorize endpoint is slightly different to all others in that it
     // ignores an ns parameter, but accepts a Namespace property on each
     // resource. Here we hide this difference from the rest of the app as
     // currently we never need to ask for permissions/resources for multiple
     // different namespaces in one call so here we use the ns param and add
     // this to the resources instead of passing through on the queryParameter
+    //
+    // ^ same goes for Partitions
+
     if (this.env.var('CONSUL_NSPACES_ENABLED')) {
       resources = resources.map(item => ({ ...item, Namespace: ns }));
+    }
+    if (this.env.var('CONSUL_PARTITIONS_ENABLED')) {
+      resources = resources.map(item => ({ ...item, Partition: partition }));
     }
     return request`
       POST /v1/internal/acl/authorize?${{ dc, index }}

--- a/ui/packages/consul-ui/app/adapters/policy.js
+++ b/ui/packages/consul-ui/app/adapters/policy.js
@@ -51,8 +51,8 @@ export default class PolicyAdapter extends Adapter {
   requestForUpdateRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data.Datacenter),
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/acl/policy/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/policy.js
+++ b/ui/packages/consul-ui/app/adapters/policy.js
@@ -14,18 +14,19 @@ if (env('CONSUL_NSPACES_ENABLED')) {
 
 // TODO: Update to use this.formatDatacenter()
 export default class PolicyAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, id }) {
+  requestForQuery(request, { dc, ns, partition, index, id }) {
     return request`
       GET /v1/acl/policies?${{ dc }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
   }
 
-  requestForQueryRecord(request, { dc, ns, index, id }) {
+  requestForQueryRecord(request, { dc, ns, partition, index, id }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -33,7 +34,8 @@ export default class PolicyAdapter extends Adapter {
       GET /v1/acl/policy/${id}?${{ dc }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/adapters/policy.js
+++ b/ui/packages/consul-ui/app/adapters/policy.js
@@ -1,16 +1,6 @@
 import Adapter from './application';
 import { SLUG_KEY } from 'consul-ui/models/policy';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
-import { NSPACE_KEY } from 'consul-ui/models/nspace';
-import { env } from 'consul-ui/env';
-import nonEmptySet from 'consul-ui/utils/non-empty-set';
-
-let Namespace;
-if (env('CONSUL_NSPACES_ENABLED')) {
-  Namespace = nonEmptySet('Namespace');
-} else {
-  Namespace = () => ({});
-}
 
 // TODO: Update to use this.formatDatacenter()
 export default class PolicyAdapter extends Adapter {
@@ -44,6 +34,8 @@ export default class PolicyAdapter extends Adapter {
   requestForCreateRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       PUT /v1/acl/policy?${params}
@@ -53,7 +45,6 @@ export default class PolicyAdapter extends Adapter {
         Description: serialized.Description,
         Rules: serialized.Rules,
         Datacenters: serialized.Datacenters,
-        ...Namespace(serialized.Namespace),
       }}
     `;
   }
@@ -61,6 +52,8 @@ export default class PolicyAdapter extends Adapter {
   requestForUpdateRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       PUT /v1/acl/policy/${data[SLUG_KEY]}?${params}
@@ -70,7 +63,6 @@ export default class PolicyAdapter extends Adapter {
         Description: serialized.Description,
         Rules: serialized.Rules,
         Datacenters: serialized.Datacenters,
-        ...Namespace(serialized.Namespace),
       }}
     `;
   }
@@ -78,7 +70,8 @@ export default class PolicyAdapter extends Adapter {
   requestForDeleteRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       DELETE /v1/acl/policy/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/policy.js
+++ b/ui/packages/consul-ui/app/adapters/policy.js
@@ -1,6 +1,5 @@
 import Adapter from './application';
 import { SLUG_KEY } from 'consul-ui/models/policy';
-import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 
 // TODO: Update to use this.formatDatacenter()
 export default class PolicyAdapter extends Adapter {
@@ -33,9 +32,9 @@ export default class PolicyAdapter extends Adapter {
 
   requestForCreateRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      ...this.formatDatacenter(data.Datacenter),
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/acl/policy?${params}
@@ -51,7 +50,7 @@ export default class PolicyAdapter extends Adapter {
 
   requestForUpdateRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ...this.formatDatacenter(data.Datacenter),
       ns: serialized.Namespace,
       partition: serialized.Partition,
     };
@@ -69,9 +68,9 @@ export default class PolicyAdapter extends Adapter {
 
   requestForDeleteRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      ...this.formatDatacenter(data.Datacenter),
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       DELETE /v1/acl/policy/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/proxy.js
+++ b/ui/packages/consul-ui/app/adapters/proxy.js
@@ -1,7 +1,7 @@
 import Adapter from './application';
 // TODO: Update to use this.formatDatacenter()
 export default class ProxyAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, id, uri }) {
+  requestForQuery(request, { dc, ns, partition, index, id, uri }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -11,7 +11,8 @@ export default class ProxyAdapter extends Adapter {
       X-Range: ${id}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/adapters/role.js
+++ b/ui/packages/consul-ui/app/adapters/role.js
@@ -12,20 +12,20 @@ if (env('CONSUL_NSPACES_ENABLED')) {
   Namespace = () => ({});
 }
 
-// TODO: Update to use this.formatDatacenter()
 export default class RoleAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, id }) {
+  requestForQuery(request, { dc, ns, partition, index, id }) {
     return request`
       GET /v1/acl/roles?${{ dc }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
   }
 
-  requestForQueryRecord(request, { dc, ns, index, id }) {
+  requestForQueryRecord(request, { dc, ns, partition, index, id }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -33,7 +33,8 @@ export default class RoleAdapter extends Adapter {
       GET /v1/acl/role/${id}?${{ dc }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/adapters/role.js
+++ b/ui/packages/consul-ui/app/adapters/role.js
@@ -43,6 +43,8 @@ export default class RoleAdapter extends Adapter {
   requestForCreateRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       PUT /v1/acl/role?${params}
@@ -53,7 +55,6 @@ export default class RoleAdapter extends Adapter {
         Policies: serialized.Policies,
         ServiceIdentities: serialized.ServiceIdentities,
         NodeIdentities: serialized.NodeIdentities,
-        ...Namespace(serialized.Namespace),
       }}
     `;
   }
@@ -61,6 +62,8 @@ export default class RoleAdapter extends Adapter {
   requestForUpdateRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       PUT /v1/acl/role/${data[SLUG_KEY]}?${params}
@@ -71,7 +74,6 @@ export default class RoleAdapter extends Adapter {
         Policies: serialized.Policies,
         ServiceIdentities: serialized.ServiceIdentities,
         NodeIdentities: serialized.NodeIdentities,
-        ...Namespace(serialized.Namespace),
       }}
     `;
   }
@@ -79,7 +81,8 @@ export default class RoleAdapter extends Adapter {
   requestForDeleteRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       DELETE /v1/acl/role/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/role.js
+++ b/ui/packages/consul-ui/app/adapters/role.js
@@ -1,16 +1,5 @@
 import Adapter from './application';
 import { SLUG_KEY } from 'consul-ui/models/role';
-import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
-import { NSPACE_KEY } from 'consul-ui/models/nspace';
-import { env } from 'consul-ui/env';
-import nonEmptySet from 'consul-ui/utils/non-empty-set';
-
-let Namespace;
-if (env('CONSUL_NSPACES_ENABLED')) {
-  Namespace = nonEmptySet('Namespace');
-} else {
-  Namespace = () => ({});
-}
 
 export default class RoleAdapter extends Adapter {
   requestForQuery(request, { dc, ns, partition, index, id }) {
@@ -42,9 +31,9 @@ export default class RoleAdapter extends Adapter {
 
   requestForCreateRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      ...this.formatDatacenter(data.Datacenter),
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/acl/role?${params}
@@ -61,9 +50,9 @@ export default class RoleAdapter extends Adapter {
 
   requestForUpdateRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      ...this.formatDatacenter(data.Datacenter),
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/acl/role/${data[SLUG_KEY]}?${params}
@@ -80,9 +69,9 @@ export default class RoleAdapter extends Adapter {
 
   requestForDeleteRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      ...this.formatDatacenter(data.Datacenter),
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       DELETE /v1/acl/role/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/service-instance.js
+++ b/ui/packages/consul-ui/app/adapters/service-instance.js
@@ -2,7 +2,7 @@ import Adapter from './application';
 
 // TODO: Update to use this.formatDatacenter()
 export default class ServiceInstanceAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, id, uri }) {
+  requestForQuery(request, { dc, ns, partition, index, id, uri }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -12,13 +12,14 @@ export default class ServiceInstanceAdapter extends Adapter {
       X-Range: ${id}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
   }
 
-  requestForQueryRecord(request, { dc, ns, index, id, uri }) {
+  requestForQueryRecord() {
     // query and queryRecord both use the same endpoint
     // they are just serialized differently
     return this.requestForQuery(...arguments);

--- a/ui/packages/consul-ui/app/adapters/service.js
+++ b/ui/packages/consul-ui/app/adapters/service.js
@@ -1,8 +1,7 @@
 import Adapter from './application';
 
-// TODO: Update to use this.formatDatacenter()
 export default class ServiceAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, gateway, uri }) {
+  requestForQuery(request, { dc, ns, partition, index, gateway, uri }) {
     if (typeof gateway !== 'undefined') {
       return request`
         GET /v1/internal/ui/gateway-services-nodes/${gateway}?${{ dc }}
@@ -10,7 +9,8 @@ export default class ServiceAdapter extends Adapter {
         X-Request-ID: ${uri}
 
         ${{
-          ...this.formatNspace(ns),
+          ns,
+          partition,
           index,
         }}
       `;
@@ -20,14 +20,15 @@ export default class ServiceAdapter extends Adapter {
         X-Request-ID: ${uri}
 
         ${{
-          ...this.formatNspace(ns),
+          ns,
+          partition,
           index,
         }}
     `;
     }
   }
 
-  requestForQueryRecord(request, { dc, ns, index, id, uri }) {
+  requestForQueryRecord(request, { dc, ns, partition, index, id, uri }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -36,7 +37,8 @@ export default class ServiceAdapter extends Adapter {
       X-Request-ID: ${uri}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/adapters/session.js
+++ b/ui/packages/consul-ui/app/adapters/session.js
@@ -6,7 +6,7 @@ import { NSPACE_KEY } from 'consul-ui/models/nspace';
 
 // TODO: Update to use this.formatDatacenter()
 export default class SessionAdapter extends Adapter {
-  requestForQuery(request, { dc, ns, index, id, uri }) {
+  requestForQuery(request, { dc, ns, partition, index, id, uri }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -15,13 +15,14 @@ export default class SessionAdapter extends Adapter {
       X-Request-ID: ${uri}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
   }
 
-  requestForQueryRecord(request, { dc, ns, index, id }) {
+  requestForQueryRecord(request, { dc, ns, partition, index, id }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -29,7 +30,8 @@ export default class SessionAdapter extends Adapter {
       GET /v1/session/info/${id}?${{ dc }}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;
@@ -37,8 +39,9 @@ export default class SessionAdapter extends Adapter {
 
   requestForDeleteRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
+      dc: data.dc,
+      ns: data.ns,
+      partition: data.partition,
     };
     return request`
       PUT /v1/session/destroy/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/session.js
+++ b/ui/packages/consul-ui/app/adapters/session.js
@@ -1,8 +1,6 @@
 import Adapter from './application';
 
 import { SLUG_KEY } from 'consul-ui/models/session';
-import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
-import { NSPACE_KEY } from 'consul-ui/models/nspace';
 
 // TODO: Update to use this.formatDatacenter()
 export default class SessionAdapter extends Adapter {
@@ -39,9 +37,9 @@ export default class SessionAdapter extends Adapter {
 
   requestForDeleteRecord(request, serialized, data) {
     const params = {
-      dc: data.dc,
-      ns: data.ns,
-      partition: data.partition,
+      dc: data.Datacenter,
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/session/destroy/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/token.js
+++ b/ui/packages/consul-ui/app/adapters/token.js
@@ -46,6 +46,8 @@ export default class TokenAdapter extends Adapter {
   requestForCreateRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       PUT /v1/acl/token?${params}
@@ -57,7 +59,6 @@ export default class TokenAdapter extends Adapter {
         ServiceIdentities: serialized.ServiceIdentities,
         NodeIdentities: serialized.NodeIdentities,
         Local: serialized.Local,
-        ...Namespace(serialized.Namespace),
       }}
     `;
   }
@@ -79,6 +80,8 @@ export default class TokenAdapter extends Adapter {
     }
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       PUT /v1/acl/token/${data[SLUG_KEY]}?${params}
@@ -90,7 +93,6 @@ export default class TokenAdapter extends Adapter {
         ServiceIdentities: serialized.ServiceIdentities,
         NodeIdentities: serialized.NodeIdentities,
         Local: serialized.Local,
-        ...Namespace(serialized.Namespace),
       }}
     `;
   }
@@ -98,8 +100,8 @@ export default class TokenAdapter extends Adapter {
   requestForDeleteRecord(request, serialized, data) {
     const params = {
       dc: data.dc,
-      ns: data.ns,
-      partition: data.partition,
+      ns: serialized.Namespace,
+      partition: serialized.Partition,
     };
     return request`
       DELETE /v1/acl/token/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/token.js
+++ b/ui/packages/consul-ui/app/adapters/token.js
@@ -35,8 +35,8 @@ export default class TokenAdapter extends Adapter {
   requestForCreateRecord(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data.Datacenter),
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/acl/token?${params}
@@ -69,8 +69,8 @@ export default class TokenAdapter extends Adapter {
     }
     const params = {
       ...this.formatDatacenter(data.Datacenter),
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/acl/token/${data[SLUG_KEY]}?${params}

--- a/ui/packages/consul-ui/app/adapters/token.js
+++ b/ui/packages/consul-ui/app/adapters/token.js
@@ -1,17 +1,6 @@
 import Adapter from './application';
 import { inject as service } from '@ember/service';
 import { SLUG_KEY } from 'consul-ui/models/token';
-import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
-import { NSPACE_KEY } from 'consul-ui/models/nspace';
-import { env } from 'consul-ui/env';
-import nonEmptySet from 'consul-ui/utils/non-empty-set';
-
-let Namespace;
-if (env('CONSUL_NSPACES_ENABLED')) {
-  Namespace = nonEmptySet('Namespace');
-} else {
-  Namespace = () => ({});
-}
 
 export default class TokenAdapter extends Adapter {
   @service('store') store;
@@ -45,7 +34,7 @@ export default class TokenAdapter extends Adapter {
 
   requestForCreateRecord(request, serialized, data) {
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ...this.formatDatacenter(data.Datacenter),
       ns: serialized.Namespace,
       partition: serialized.Partition,
     };
@@ -73,13 +62,13 @@ export default class TokenAdapter extends Adapter {
       // https://www.consul.io/api/acl/legacy.html#update-acl-token
       // as we are using the old API we don't need to specify a nspace
       return request`
-        PUT /v1/acl/update?${this.formatDatacenter(data[DATACENTER_KEY])}
+        PUT /v1/acl/update?${this.formatDatacenter(data.Datacenter)}
 
         ${serialized}
       `;
     }
     const params = {
-      ...this.formatDatacenter(data[DATACENTER_KEY]),
+      ...this.formatDatacenter(data.Datacenter),
       ns: serialized.Namespace,
       partition: serialized.Partition,
     };
@@ -99,9 +88,9 @@ export default class TokenAdapter extends Adapter {
 
   requestForDeleteRecord(request, serialized, data) {
     const params = {
-      dc: data.dc,
-      ns: serialized.Namespace,
-      partition: serialized.Partition,
+      dc: data.Datacenter,
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       DELETE /v1/acl/token/${data[SLUG_KEY]}?${params}
@@ -127,9 +116,9 @@ export default class TokenAdapter extends Adapter {
       throw new Error('You must specify an id');
     }
     const params = {
-      dc: data.dc,
-      ns: data.ns,
-      partition: data.partition,
+      dc: data.Datacenter,
+      ns: data.Namespace,
+      partition: data.Partition,
     };
     return request`
       PUT /v1/acl/token/${id}/clone?${params}
@@ -163,9 +152,9 @@ export default class TokenAdapter extends Adapter {
         // eventually the id is created with this dc value and the id taken from the
         // json response of `acls/token/*/clone`
         const params = {
-          dc: data.dc,
-          ns: data.ns,
-          partition: data.partition,
+          dc: data.Datacenter,
+          ns: data.Namespace,
+          partition: data.Partition,
         };
         return serializer.respondForQueryRecord(respond, params);
       },

--- a/ui/packages/consul-ui/app/adapters/topology.js
+++ b/ui/packages/consul-ui/app/adapters/topology.js
@@ -2,7 +2,7 @@ import Adapter from './application';
 
 // TODO: Update to use this.formatDatacenter()
 export default class TopologyAdapter extends Adapter {
-  requestForQueryRecord(request, { dc, ns, index, id, uri, kind }) {
+  requestForQueryRecord(request, { dc, ns, partition, kind, index, id, uri }) {
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }
@@ -11,7 +11,8 @@ export default class TopologyAdapter extends Adapter {
       X-Request-ID: ${uri}
 
       ${{
-        ...this.formatNspace(ns),
+        ns,
+        partition,
         index,
       }}
     `;

--- a/ui/packages/consul-ui/app/locations/fsm-with-optional.js
+++ b/ui/packages/consul-ui/app/locations/fsm-with-optional.js
@@ -1,9 +1,9 @@
 import { env } from 'consul-ui/env';
 const OPTIONAL = {};
-// if (true) {
-//   OPTIONAL.partition = /^-([a-zA-Z0-9]([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?)$/;
-// }
-//
+if (env('CONSUL_PARTITIONS_ENABLED')) {
+  OPTIONAL.partition = /^-([a-zA-Z0-9]([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?)$/;
+}
+
 if (env('CONSUL_NSPACES_ENABLED')) {
   OPTIONAL.nspace = /^~([a-zA-Z0-9]([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?)$/;
 }
@@ -193,9 +193,9 @@ export default class FSMWithOptionalLocation {
     if (typeof hash.nspace !== 'undefined') {
       hash.nspace = `~${hash.nspace}`;
     }
-    // if (typeof hash.partition !== 'undefined') {
-    //   hash.partition = `-${hash.partition}`;
-    // }
+    if (typeof hash.partition !== 'undefined') {
+      hash.partition = `-${hash.partition}`;
+    }
     if (typeof this.router === 'undefined') {
       this.router = this.container.lookup('router:main');
     }

--- a/ui/packages/consul-ui/app/serializers/application.js
+++ b/ui/packages/consul-ui/app/serializers/application.js
@@ -1,5 +1,6 @@
 import Serializer from './http';
 import { set } from '@ember/object';
+
 import {
   HEADERS_SYMBOL as HTTP_HEADERS_SYMBOL,
   HEADERS_INDEX as HTTP_HEADERS_INDEX,
@@ -10,8 +11,6 @@ import { CACHE_CONTROL as HTTP_HEADERS_CACHE_CONTROL } from 'consul-ui/utils/htt
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 import { NSPACE_KEY } from 'consul-ui/models/nspace';
 import createFingerprinter from 'consul-ui/utils/create-fingerprinter';
-
-const DEFAULT_NSPACE = '';
 
 const map = function(obj, cb) {
   if (!Array.isArray(obj)) {
@@ -26,14 +25,6 @@ const attachHeaders = function(headers, body, query = {}) {
   Object.keys(headers).forEach(function(key) {
     lower[key.toLowerCase()] = headers[key];
   });
-  // Add a 'pretend' Datacenter/Nspace header, they are not headers the come
-  // from the request but we add them here so we can use them later for store
-  // reconciliation
-  if (typeof query.dc !== 'undefined') {
-    lower[HTTP_HEADERS_DATACENTER.toLowerCase()] = query.dc;
-  }
-  lower[HTTP_HEADERS_NAMESPACE.toLowerCase()] =
-    typeof query.ns !== 'undefined' ? query.ns : DEFAULT_NSPACE;
   //
   body[HTTP_HEADERS_SYMBOL] = lower;
   return body;
@@ -47,7 +38,10 @@ export default class ApplicationSerializer extends Serializer {
     return respond((headers, body) =>
       attachHeaders(
         headers,
-        map(body, this.fingerprint(this.primaryKey, this.slugKey, query.dc)),
+        map(
+          body,
+          this.fingerprint(this.primaryKey, this.slugKey, query.dc, headers[HTTP_HEADERS_NAMESPACE])
+        ),
         query
       )
     );
@@ -55,26 +49,42 @@ export default class ApplicationSerializer extends Serializer {
 
   respondForQueryRecord(respond, query) {
     return respond((headers, body) =>
-      attachHeaders(headers, this.fingerprint(this.primaryKey, this.slugKey, query.dc)(body), query)
+      attachHeaders(
+        headers,
+        this.fingerprint(
+          this.primaryKey,
+          this.slugKey,
+          query.dc,
+          headers[HTTP_HEADERS_NAMESPACE]
+        )(body),
+        query
+      )
     );
   }
 
   respondForCreateRecord(respond, serialized, data) {
     const slugKey = this.slugKey;
     const primaryKey = this.primaryKey;
+
     return respond((headers, body) => {
       // If creates are true use the info we already have
       if (body === true) {
         body = data;
       }
       // Creates need a primaryKey adding
-      return this.fingerprint(primaryKey, slugKey, data[DATACENTER_KEY])(body);
+      return this.fingerprint(
+        primaryKey,
+        slugKey,
+        data[DATACENTER_KEY],
+        headers[HTTP_HEADERS_NAMESPACE]
+      )(body);
     });
   }
 
   respondForUpdateRecord(respond, serialized, data) {
     const slugKey = this.slugKey;
     const primaryKey = this.primaryKey;
+
     return respond((headers, body) => {
       // If updates are true use the info we already have
       // TODO: We may aswell avoid re-fingerprinting here if we are just going
@@ -85,13 +95,19 @@ export default class ApplicationSerializer extends Serializer {
       if (body === true) {
         body = data;
       }
-      return this.fingerprint(primaryKey, slugKey, data[DATACENTER_KEY])(body);
+      return this.fingerprint(
+        primaryKey,
+        slugKey,
+        data[DATACENTER_KEY],
+        headers[HTTP_HEADERS_NAMESPACE]
+      )(body);
     });
   }
 
   respondForDeleteRecord(respond, serialized, data) {
     const slugKey = this.slugKey;
     const primaryKey = this.primaryKey;
+
     return respond((headers, body) => {
       // Deletes only need the primaryKey/uid returning and they need the slug
       // key AND potential namespace in order to create the correct
@@ -100,7 +116,8 @@ export default class ApplicationSerializer extends Serializer {
         [primaryKey]: this.fingerprint(
           primaryKey,
           slugKey,
-          data[DATACENTER_KEY]
+          data[DATACENTER_KEY],
+          headers[HTTP_HEADERS_NAMESPACE]
         )({
           [slugKey]: data[slugKey],
           [NSPACE_KEY]: data[NSPACE_KEY],

--- a/ui/packages/consul-ui/app/serializers/kv.js
+++ b/ui/packages/consul-ui/app/serializers/kv.js
@@ -1,8 +1,6 @@
 import Serializer from './application';
 import { inject as service } from '@ember/service';
 import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/kv';
-import { NSPACE_KEY } from 'consul-ui/models/nspace';
-import { NSPACE_QUERY_PARAM as API_NSPACE_KEY } from 'consul-ui/adapters/application';
 
 export default class KvSerializer extends Serializer {
   @service('atob') decoder;
@@ -32,7 +30,6 @@ export default class KvSerializer extends Serializer {
             body.map(item => {
               return {
                 [this.slugKey]: item,
-                [NSPACE_KEY]: query[API_NSPACE_KEY],
               };
             })
           );

--- a/ui/packages/consul-ui/app/services/client/http.js
+++ b/ui/packages/consul-ui/app/services/client/http.js
@@ -3,7 +3,11 @@ import { get } from '@ember/object';
 import { next } from '@ember/runloop';
 
 import { CACHE_CONTROL, CONTENT_TYPE } from 'consul-ui/utils/http/headers';
-import { HEADERS_TOKEN as CONSUL_TOKEN } from 'consul-ui/utils/http/consul';
+import {
+  HEADERS_TOKEN as CONSUL_TOKEN,
+  HEADERS_NAMESPACE as CONSUL_NAMESPACE,
+  HEADERS_DATACENTER as CONSUL_DATACENTER,
+} from 'consul-ui/utils/http/consul';
 
 import createURL from 'consul-ui/utils/http/create-url';
 import createHeaders from 'consul-ui/utils/http/create-headers';
@@ -220,6 +224,15 @@ export default class HttpService extends Service {
                   return prev;
                 }, {}),
                 ...params.clientHeaders,
+                // Add a 'pretend' Datacenter/Nspace header, they are not
+                // headers the come from the request but we add them here so
+                // we can use them later for store reconciliation.
+                // Namespace will look at the ns query parameter first,
+                // followed by the Namespace property of the users token,
+                // defaulting back to 'default' which will mainly be used in
+                // OSS
+                [CONSUL_DATACENTER]: params.data.dc,
+                [CONSUL_NAMESPACE]: params.data.ns || token.Namespace || 'default',
               };
               const respond = function(cb) {
                 return cb(headers, e.data.response);

--- a/ui/packages/consul-ui/app/services/client/http.js
+++ b/ui/packages/consul-ui/app/services/client/http.js
@@ -87,12 +87,16 @@ export default class HttpService extends Service {
 
   sanitize(obj) {
     if (!this.env.var('CONSUL_NSPACES_ENABLED')) {
-      if (typeof obj.ns !== 'undefined') {
+      delete obj.ns;
+    } else {
+      if (typeof obj.ns === 'undefined' || obj.ns === null || obj.ns === '') {
         delete obj.ns;
       }
     }
     if (!this.env.var('CONSUL_PARTITIONS_ENABLED')) {
-      if (typeof obj.partition !== 'undefined') {
+      delete obj.partition;
+    } else {
+      if (typeof obj.partition === 'undefined' || obj.partition === null || obj.partition === '') {
         delete obj.partition;
       }
     }

--- a/ui/packages/consul-ui/app/utils/create-fingerprinter.js
+++ b/ui/packages/consul-ui/app/utils/create-fingerprinter.js
@@ -12,11 +12,11 @@ export default function(foreignKey, nspaceKey, hash = JSON.stringify) {
         }
         return get(item, slugKey);
       });
-      const nspaceValue = get(item, nspaceKey) || 'default';
+      const nspaceValue = get(item, nspaceKey) || '';
 
       // This ensures that all data objects have a Namespace value set, even
       // in OSS. An empty Namespace will default to default
-      item[nspaceKey] = nspaceValue;
+      // item[nspaceKey] = nspaceValue;
 
       if (typeof item[foreignKey] === 'undefined') {
         item[foreignKey] = foreignKeyValue;

--- a/ui/packages/consul-ui/app/utils/create-fingerprinter.js
+++ b/ui/packages/consul-ui/app/utils/create-fingerprinter.js
@@ -1,4 +1,6 @@
 import { get } from '@ember/object';
+import { env } from 'consul-ui/env';
+
 export default function(foreignKey, nspaceKey, hash = JSON.stringify) {
   return function(primaryKey, slugKey, foreignKeyValue) {
     if (foreignKeyValue == null || foreignKeyValue.length < 1) {
@@ -12,11 +14,11 @@ export default function(foreignKey, nspaceKey, hash = JSON.stringify) {
         }
         return get(item, slugKey);
       });
-      const nspaceValue = get(item, nspaceKey) || '';
+      const nspaceValue = get(item, nspaceKey) || env('CONSUL_NSPACES_ENABLED') ? '' : 'default';
 
       // This ensures that all data objects have a Namespace value set, even
       // in OSS. An empty Namespace will default to default
-      // item[nspaceKey] = nspaceValue;
+      item[nspaceKey] = nspaceValue;
 
       if (typeof item[foreignKey] === 'undefined') {
         item[foreignKey] = foreignKeyValue;

--- a/ui/packages/consul-ui/app/utils/create-fingerprinter.js
+++ b/ui/packages/consul-ui/app/utils/create-fingerprinter.js
@@ -1,8 +1,7 @@
 import { get } from '@ember/object';
-import { env } from 'consul-ui/env';
 
 export default function(foreignKey, nspaceKey, hash = JSON.stringify) {
-  return function(primaryKey, slugKey, foreignKeyValue) {
+  return function(primaryKey, slugKey, foreignKeyValue, nspaceValue) {
     if (foreignKeyValue == null || foreignKeyValue.length < 1) {
       throw new Error('Unable to create fingerprint, missing foreignKey value');
     }
@@ -14,17 +13,22 @@ export default function(foreignKey, nspaceKey, hash = JSON.stringify) {
         }
         return get(item, slugKey);
       });
-      const nspaceValue = get(item, nspaceKey) || env('CONSUL_NSPACES_ENABLED') ? '' : 'default';
-
       // This ensures that all data objects have a Namespace value set, even
-      // in OSS. An empty Namespace will default to default
-      item[nspaceKey] = nspaceValue;
+      // in OSS.
+      if (typeof item[nspaceKey] === 'undefined') {
+        if (nspaceValue === '*') {
+          nspaceValue = 'default';
+        }
+        item[nspaceKey] = nspaceValue;
+      }
 
+      // console.log(nspaceValue);
+      // item[nspaceKey] = '*';
       if (typeof item[foreignKey] === 'undefined') {
         item[foreignKey] = foreignKeyValue;
       }
       if (typeof item[primaryKey] === 'undefined') {
-        item[primaryKey] = hash([nspaceValue, foreignKeyValue].concat(slugValues));
+        item[primaryKey] = hash([item[nspaceKey], foreignKeyValue].concat(slugValues));
       }
       return item;
     };

--- a/ui/packages/consul-ui/app/utils/http/xhr.js
+++ b/ui/packages/consul-ui/app/utils/http/xhr.js
@@ -13,7 +13,11 @@ export default function(parseHeaders, XHR) {
         options.complete(this.status);
       }
     };
-    xhr.open(options.method, options.url, true);
+    let url = options.url;
+    if (url.endsWith('?')) {
+      url = url.substr(0, url.length - 1);
+    }
+    xhr.open(options.method, url, true);
     if (typeof options.headers === 'undefined') {
       options.headers = {};
     }

--- a/ui/packages/consul-ui/mock-api/v1/acl/policy/_
+++ b/ui/packages/consul-ui/mock-api/v1/acl/policy/_
@@ -1,9 +1,8 @@
 {
   "ID": "${location.pathname.get(3)}",
-  "Namespace": "${
-    typeof location.search.ns !== 'undefined' ? location.search.ns :
-      typeof http.body.Namespace !== 'undefined' ? http.body.Namespace : 'default'
-  }",
+${typeof location.search.ns !== 'undefined' ? `
+  "Namespace": "${location.search.ns}",
+` : ``}
   "Description": "${location.pathname.get(3) === '00000000-0000-0000-0000-000000000001' ? 'Built-in Management Policy' : fake.lorem.sentence()}",
 ${ location.pathname.get(3) !== '00000000-0000-0000-0000-000000000001' ? `
   "Datacenters": ${fake.helpers.randomize(['["aq west-5", "ch east-4"]'])},

--- a/ui/packages/consul-ui/mock-api/v1/acl/role/_
+++ b/ui/packages/consul-ui/mock-api/v1/acl/role/_
@@ -1,10 +1,9 @@
 {
   "ID": "${location.pathname.get(3)}",
   "Name": "${fake.hacker.noun() + '-role'}",
-  "Namespace": "${
-    typeof location.search.ns !== 'undefined' ? location.search.ns :
-      typeof http.body.Namespace !== 'undefined' ? http.body.Namespace : 'default'
-  }",
+${typeof location.search.ns !== 'undefined' ? `
+  "Namespace": "${location.search.ns}",
+` : ``}
   "Description": "${fake.lorem.sentence()}",
   "Policies": [
     ${
@@ -50,7 +49,7 @@
           return `
             {
               "NodeName": "${fake.hacker.noun()}",
-              "Datacenter":"${fake.address.countryCode().toLowerCase()} ${ i % 2 ? "west" : "east"}-${i}" 
+              "Datacenter":"${fake.address.countryCode().toLowerCase()} ${ i % 2 ? "west" : "east"}-${i}"
             }
           `;
         }

--- a/ui/packages/consul-ui/mock-api/v1/acl/token/_
+++ b/ui/packages/consul-ui/mock-api/v1/acl/token/_
@@ -2,10 +2,9 @@
   "AccessorID": "${location.pathname.get(3)}",
   "SecretID":"${fake.random.uuid()}",
   "IDPName": "${fake.hacker.noun()}",
-  "Namespace": "${
-    typeof location.search.ns !== 'undefined' ? location.search.ns :
-      typeof http.body.Namespace !== 'undefined' ? http.body.Namespace : 'default'
-  }",
+${typeof location.search.ns !== 'undefined' ? `
+  "Namespace": "${location.search.ns}",
+` : ``}
   ${ location.pathname.get(3) === '00000000-0000-0000-0000-000000000002' ?
     `
       "Name": "${fake.hacker.noun()}",

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
@@ -31,14 +31,14 @@ Feature: dc / acls / policies / as many / add existing: Add existing policy
     And I click ".ember-power-select-option:first-child"
     And I see 2 policy models on the policies component
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
     ---
-      Namespace: @namespace
-      Policies:
-      - ID: policy-1
-        Name: Policy 1
-      - ID: policy-2
-        Name: Policy 2
+      body:
+        Policies:
+        - ID: policy-1
+          Name: Policy 1
+        - ID: policy-2
+          Name: Policy 2
     ---
     Then the url should be /datacenter/acls/[Model]s
     And "[data-notification]" has the "notification-update" class

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
@@ -31,7 +31,7 @@ Feature: dc / acls / policies / as many / add existing: Add existing policy
     And I click ".ember-power-select-option:first-child"
     And I see 2 policy models on the policies component
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         Policies:

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-new.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-new.feature
@@ -23,19 +23,17 @@ Feature: dc / acls / policies / as many / add new: Add new policy
       Rules: key {}
     ---
     And I click submit on the policies.form
-    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Name: New-Policy
         Description: New Policy Description
-        Namespace: @namespace
         Rules: key {}
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         Policies:
           - ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
             Name: New-Policy
@@ -57,10 +55,9 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     And I click serviceIdentity on the policies.form
     And I click submit on the policies.form
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         ServiceIdentities:
           - ServiceName: New-Service-Identity
     ---
@@ -81,10 +78,9 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     And I click nodeIdentity on the policies.form
     And I click submit on the policies.form
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         NodeIdentities:
           - NodeName: New-Node-Identity
             Datacenter: datacenter
@@ -112,12 +108,12 @@ Feature: dc / acls / policies / as many / add new: Add new policy
       Rules: key {}
     ---
     And I click submit on the policies.form
-    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter&ns=@namespace" from yaml
     ---
-      Name: New-Policy
-      Description: New Policy Description
-      Namespace: @namespace
-      Rules: key {}
+      body:
+        Name: New-Policy
+        Description: New Policy Description
+        Rules: key {}
     ---
     And I see error on the policies.form.rules like 'Invalid service policy: acl.ServicePolicy{Name:"service", Policy:"", Sentinel:acl.Sentinel{Code:"", EnforcementLevel:""}, Intentions:""}'
   Where:

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-new.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/add-new.feature
@@ -31,7 +31,7 @@ Feature: dc / acls / policies / as many / add new: Add new policy
         Rules: key {}
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         Policies:
@@ -55,7 +55,7 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     And I click serviceIdentity on the policies.form
     And I click submit on the policies.form
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         ServiceIdentities:
@@ -78,7 +78,7 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     And I click nodeIdentity on the policies.form
     And I click submit on the policies.form
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         NodeIdentities:

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/remove.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/remove.feature
@@ -25,10 +25,9 @@ Feature: dc / acls / policies / as many / remove: Remove
     And I click confirmDelete on the policies.selectedOptions
     And I see 0 policy models on the policies component
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         Policies: [[]]
     ---
     Then the url should be /datacenter/acls/[Model]s

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/remove.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/as-many/remove.feature
@@ -25,7 +25,7 @@ Feature: dc / acls / policies / as many / remove: Remove
     And I click confirmDelete on the policies.selectedOptions
     And I see 0 policy models on the policies component
     And I submit
-    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         Policies: [[]]

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/create.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/create.feature
@@ -17,11 +17,10 @@ Feature: dc / acls / policies / create
       Description: [Description]
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Name: my-policy
-        Namespace: @namespace
         Description: [Description]
     ---
     Then the url should be /datacenter/acls/policies

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/update.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/update.feature
@@ -26,7 +26,7 @@ Feature: dc / acls / policies / update: ACL Policy Update
     And I click validDatacenters
     And I click datacenter
     And I submit
-    Then a PUT request was made to "/v1/acl/policy/policy-id?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/policy/policy-id?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         Name: [Name]

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/update.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/update.feature
@@ -26,13 +26,12 @@ Feature: dc / acls / policies / update: ACL Policy Update
     And I click validDatacenters
     And I click datacenter
     And I submit
-    Then a PUT request was made to "/v1/acl/policy/policy-id?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/policy/policy-id?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Name: [Name]
         Description: [Description]
         Rules: [Rules]
-        Namespace: @namespace
         Datacenters:
           - datacenter
 

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
@@ -35,10 +35,9 @@ Feature: dc / acls / roles / as many / add existing: Add existing
       Description: The Description
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         Description: The Description
         Roles:
         - ID: role-1

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
@@ -35,7 +35,7 @@ Feature: dc / acls / roles / as many / add existing: Add existing
       Description: The Description
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         Description: The Description

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-new.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/add-new.feature
@@ -30,19 +30,17 @@ Feature: dc / acls / roles / as-many / add-new: Add new
     ---
   Scenario: Add Policy-less Role
     And I click submit on the roles.form
-    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Name: New-Role
-        Namespace: @namespace
         Description: New Role Description
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Description: The Description
-        Namespace: @namespace
         Roles:
           - Name: New-Role
             ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
@@ -54,22 +52,20 @@ Feature: dc / acls / roles / as-many / add-new: Add new
     And I click "#new-role .ember-power-select-trigger"
     And I click ".ember-power-select-option:first-child"
     And I click submit on the roles.form
-    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Name: New-Role
         Description: New Role Description
-        Namespace: @namespace
         Policies:
           - ID: policy-1
             Name: policy
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Description: The Description
-        Namespace: @namespace
         Roles:
           - Name: New-Role
             ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
@@ -87,32 +83,29 @@ Feature: dc / acls / roles / as-many / add-new: Add new
     ---
     # This next line is actually the popped up policyForm due to the way things currently work
     And I click submit on the roles.form
-    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Name: New-Policy
         Description: New Policy Description
-        Namespace: @namespace
         Rules: key {}
     ---
     And I click submit on the roles.form
-    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Name: New-Role
         Description: New Role Description
-        Namespace: @namespace
         Policies:
         # TODO: Ouch, we need to do deep partial comparisons here
           - ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
             Name: New-Policy
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Description: The Description
-        Namespace: @namespace
         Roles:
           - Name: New-Role
             ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
@@ -130,21 +123,19 @@ Feature: dc / acls / roles / as-many / add-new: Add new
     # This next line is actually the popped up policyForm due to the way things currently work
     And I click submit on the roles.form
     And I click submit on the roles.form
-    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Name: New-Role
         Description: New Role Description
-        Namespace: @namespace
         ServiceIdentities:
           - ServiceName: New-Service-Identity
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
         Description: The Description
-        Namespace: @namespace
         Roles:
           - Name: New-Role
             ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/remove.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/remove.feature
@@ -21,7 +21,7 @@ Feature: dc / acls / roles / as-many / remove: Remove
     And I click confirmDelete on the roles.selectedOptions
     And I see 0 role models on the roles component
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         Roles: []

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/remove.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/as-many/remove.feature
@@ -21,10 +21,9 @@ Feature: dc / acls / roles / as-many / remove: Remove
     And I click confirmDelete on the roles.selectedOptions
     And I see 0 role models on the roles component
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         Roles: []
     ---
     Then the url should be /datacenter/acls/tokens

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/create.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/create.feature
@@ -17,10 +17,9 @@ Feature: dc / acls / roles / create
       Description: [Description]
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         Name: my-role
         Description: [Description]
     ---

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/update.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/update.feature
@@ -22,7 +22,7 @@ Feature: dc / acls / roles / update: ACL Role Update
       Description: [Description]
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/role/role-id?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/role/role-id?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         Name: [Name]

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/update.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/roles/update.feature
@@ -22,10 +22,9 @@ Feature: dc / acls / roles / update: ACL Role Update
       Description: [Description]
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/role/role-id?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/role/role-id?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         Name: [Name]
         Description: [Description]
     ---

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/create.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/create.feature
@@ -15,10 +15,9 @@ Feature: dc / acls / tokens / create
       Description: [Description]
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/token?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         Description: [Description]
     ---
     Then the url should be /datacenter/acls/tokens

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/own-no-delete.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/own-no-delete.feature
@@ -6,6 +6,7 @@ Feature: dc / acls / tokens / own-no-delete: The your current token has no delet
     ---
       AccessorID: token
       SecretID: ee52203d-989f-4f7a-ab5a-2bef004164ca
+      Namespace: @!namespace
     ---
   Scenario: On the listing page
     Given settings from yaml

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/update.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/update.feature
@@ -20,10 +20,9 @@ Feature: dc / acls / tokens / update: ACL Token Update
       Description: [Description]
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
     ---
       body:
-        Namespace: @namespace
         Description: [Description]
     ---
     Then the url should be /datacenter/acls/tokens

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/update.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/update.feature
@@ -20,7 +20,7 @@ Feature: dc / acls / tokens / update: ACL Token Update
       Description: [Description]
     ---
     And I submit
-    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@namespace" from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter&ns=@!namespace" from yaml
     ---
       body:
         Description: [Description]

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/use.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/use.feature
@@ -6,6 +6,7 @@ Feature: dc / acls / tokens / use: Using an ACL token
     ---
       AccessorID: token
       SecretID: ee52203d-989f-4f7a-ab5a-2bef004164ca
+      Namespace: @!namespace
     ---
     And settings from yaml
     ---

--- a/ui/packages/consul-ui/tests/acceptance/dc/kvs/sessions/invalidate.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/kvs/sessions/invalidate.feature
@@ -24,7 +24,7 @@ Feature: dc / kvs / sessions / invalidate: Invalidate Lock Sessions
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class
   Scenario: Invalidating a lock session and receiving an error
-    Given the url "/v1/session/destroy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter&ns=@!namespace" responds with a 500 status
+    Given the url "/v1/session/destroy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter&ns=@namespace" responds with a 500 status
     And I click delete on the session
     And I click confirmDelete on the session
     Then the url should be /datacenter/kv/key/edit

--- a/ui/packages/consul-ui/tests/acceptance/dc/kvs/update.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/kvs/update.feature
@@ -22,7 +22,7 @@ Feature: dc / kvs / update: KV Update
       value: [Value]
     ---
     And I submit
-    Then a PUT request was made to "/v1/kv/[EncodedName]?dc=datacenter&flags=12&ns=@!namespace" with the body "[Value]"
+    Then a PUT request was made to "/v1/kv/[EncodedName]?dc=datacenter&ns=@!namespace&flags=12" with the body "[Value]"
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class
   Where:
@@ -53,7 +53,7 @@ Feature: dc / kvs / update: KV Update
       value: '   '
     ---
     And I submit
-    Then a PUT request was made to "/v1/kv/key?dc=datacenter&flags=12&ns=@!namespace" with the body "   "
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace&flags=12" with the body "   "
     Then the url should be /datacenter/kv
     And the title should be "Key/Value - Consul"
     And "[data-notification]" has the "notification-update" class
@@ -77,7 +77,7 @@ Feature: dc / kvs / update: KV Update
       value: ''
     ---
     And I submit
-    Then a PUT request was made to "/v1/kv/key?dc=datacenter&flags=12&ns=@!namespace" with no body
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace&flags=12" with no body
     Then the url should be /datacenter/kv
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class
@@ -95,7 +95,7 @@ Feature: dc / kvs / update: KV Update
     ---
     Then the url should be /datacenter/kv/key/edit
     And I submit
-    Then a PUT request was made to "/v1/kv/key?dc=datacenter&flags=12&ns=@!namespace" with no body
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace&flags=12" with no body
     Then the url should be /datacenter/kv
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/sessions/invalidate.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/sessions/invalidate.feature
@@ -30,7 +30,7 @@ Feature: dc / nodes / sessions / invalidate: Invalidate Lock Sessions
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class
   Scenario: Invalidating a lock session and receiving an error
-    Given the url "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1&ns=@!namespace" responds with a 500 status
+    Given the url "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1&ns=@namespace" responds with a 500 status
     And I click delete on the sessions
     And I click confirmDelete on the sessions
     Then the url should be /dc1/nodes/node-0/lock-sessions

--- a/ui/packages/consul-ui/tests/dictionary.js
+++ b/ui/packages/consul-ui/tests/dictionary.js
@@ -50,6 +50,7 @@ export default utils => (annotations, nspace, dict = new Yadda.Dictionary()) => 
       // mainly for DELETEs
       if (env('CONSUL_NSPACES_ENABLED')) {
         val = val.replace(/ns=@!namespace/g, `ns=${nspace || 'default'}`);
+        val = val.replace(/Namespace: @!namespace/g, `Namespace: ${nspace || 'default'}`);
       } else {
         val = val.replace(/&ns=@!namespace/g, '');
         val = val.replace(/&ns=\*/g, '');

--- a/ui/packages/consul-ui/tests/dictionary.js
+++ b/ui/packages/consul-ui/tests/dictionary.js
@@ -55,6 +55,7 @@ export default utils => (annotations, nspace, dict = new Yadda.Dictionary()) => 
         val = val.replace(/&ns=@!namespace/g, '');
         val = val.replace(/&ns=\*/g, '');
         val = val.replace(/- \/v1\/namespaces/g, '');
+        val = val.replace(/Namespace: @!namespace/g, '');
       }
       if (typeof nspace === 'undefined' || nspace === '') {
         val = val.replace(/Namespace: @namespace/g, '').replace(/&ns=@namespace/g, '');

--- a/ui/packages/consul-ui/tests/helpers/repo.js
+++ b/ui/packages/consul-ui/tests/helpers/repo.js
@@ -20,13 +20,15 @@ const stubAdapterResponse = function(cb, payload, adapter) {
   set(adapter, 'client', {
     request: function(cb) {
       return cb(function() {
+        const params = client.requestParams(...arguments);
+        payload.headers['X-Consul-Namespace'] = params.data.ns || 'default';
         return Promise.resolve(function(cb) {
-          return cb({}, payloadClone);
+          return cb(payload.headers, payloadClone.payload);
         });
       });
     },
   });
-  return cb(payload).then(function(result) {
+  return cb(payload.payload).then(function(result) {
     set(adapter, 'client', client);
     return result;
   });
@@ -61,6 +63,11 @@ export default function(name, method, service, stub, test, assert) {
       headers: {
         cookie: cookies,
       },
+    }).then(function(payload) {
+      return {
+        headers: {},
+        payload: payload,
+      };
     });
   };
   const parseResponse = function(response) {

--- a/ui/packages/consul-ui/tests/integration/adapters/acl-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/acl-test.js
@@ -7,8 +7,9 @@ module('Integration | Adapter | acl', function(hooks) {
   test('requestForQuery returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:acl');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `GET /v1/acl/list?dc=${dc}`;
-    const actual = adapter.requestForQuery(client.url, {
+    const actual = adapter.requestForQuery(request, {
       dc: dc,
     });
     assert.equal(actual, expected);
@@ -16,8 +17,9 @@ module('Integration | Adapter | acl', function(hooks) {
   test('requestForQueryRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:acl');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `GET /v1/acl/info/${id}?dc=${dc}`;
-    const actual = adapter.requestForQueryRecord(client.url, {
+    const actual = adapter.requestForQueryRecord(request, {
       dc: dc,
       id: id,
     });
@@ -26,8 +28,9 @@ module('Integration | Adapter | acl', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:acl');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });
@@ -35,10 +38,11 @@ module('Integration | Adapter | acl', function(hooks) {
   test('requestForCreateRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:acl');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `PUT /v1/acl/create?dc=${dc}`;
     const actual = adapter
       .requestForCreateRecord(
-        client.url,
+        request,
         {},
         {
           Datacenter: dc,
@@ -51,10 +55,11 @@ module('Integration | Adapter | acl', function(hooks) {
   test('requestForUpdateRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:acl');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `PUT /v1/acl/update?dc=${dc}`;
     const actual = adapter
       .requestForUpdateRecord(
-        client.url,
+        request,
         {},
         {
           Datacenter: dc,
@@ -67,10 +72,11 @@ module('Integration | Adapter | acl', function(hooks) {
   test('requestForDeleteRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:acl');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `PUT /v1/acl/destroy/${id}?dc=${dc}`;
     const actual = adapter
       .requestForDeleteRecord(
-        client.url,
+        request,
         {},
         {
           Datacenter: dc,
@@ -83,10 +89,11 @@ module('Integration | Adapter | acl', function(hooks) {
   test('requestForCloneRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:acl');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `PUT /v1/acl/clone/${id}?dc=${dc}`;
     const actual = adapter
       .requestForCloneRecord(
-        client.url,
+        request,
         {},
         {
           Datacenter: dc,

--- a/ui/packages/consul-ui/tests/integration/adapters/auth-method-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/auth-method-test.js
@@ -10,8 +10,9 @@ module('Integration | Adapter | auth-method', function(hooks) {
   test('requestForQueryRecord returns the correct url/method', function(assert) {
     const adapter = this.owner.lookup('adapter:auth-method');
     const client = this.owner.lookup('service:client/http');
+    const request = client.requestParams.bind(client);
     const expected = `GET /v1/acl/auth-method/${id}?dc=${dc}`;
-    const actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+    const actual = adapter.requestForQueryRecord(request, {
       dc: dc,
       id: id,
     });
@@ -20,8 +21,9 @@ module('Integration | Adapter | auth-method', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:auth-method');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });
@@ -29,7 +31,8 @@ module('Integration | Adapter | auth-method', function(hooks) {
   test('requestForQueryRecord returns the correct body', function(assert) {
     return nspaceRunner(
       (adapter, serializer, client) => {
-        return adapter.requestForQueryRecord(client.body, {
+        const request = client.body.bind(client);
+        return adapter.requestForQueryRecord(request, {
           id: id,
           dc: dc,
           ns: 'team-1',

--- a/ui/packages/consul-ui/tests/integration/adapters/binding-rule-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/binding-rule-test.js
@@ -9,8 +9,9 @@ module('Integration | Adapter | binding-rule', function(hooks) {
   test('requestForQuery returns the correct url/method', function(assert) {
     const adapter = this.owner.lookup('adapter:binding-rule');
     const client = this.owner.lookup('service:client/http');
+    const request = client.requestParams.bind(client);
     const expected = `GET /v1/acl/binding-rules?dc=${dc}`;
-    const actual = adapter.requestForQuery(client.requestParams.bind(client), {
+    const actual = adapter.requestForQuery(request, {
       dc: dc,
     });
     assert.equal(`${actual.method} ${actual.url}`, expected);
@@ -18,7 +19,8 @@ module('Integration | Adapter | binding-rule', function(hooks) {
   test('requestForQuery returns the correct body', function(assert) {
     return nspaceRunner(
       (adapter, serializer, client) => {
-        return adapter.requestForQuery(client.body, {
+        const request = client.body.bind(client);
+        return adapter.requestForQuery(request, {
           dc: dc,
           ns: 'team-1',
           index: 1,

--- a/ui/packages/consul-ui/tests/integration/adapters/coordinate-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/coordinate-test.js
@@ -6,8 +6,9 @@ module('Integration | Adapter | coordinate', function(hooks) {
   test('requestForQuery returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:coordinate');
     const client = this.owner.lookup('service:client/http');
+    const request = client.requestParams.bind(client);
     const expected = `GET /v1/coordinate/nodes?dc=${dc}`;
-    const actual = adapter.requestForQuery(client.requestParams.bind(client), {
+    const actual = adapter.requestForQuery(request, {
       dc: dc,
     });
     assert.equal(`${actual.method} ${actual.url}`, expected);
@@ -15,10 +16,11 @@ module('Integration | Adapter | coordinate', function(hooks) {
   test('requestForQuery returns the correct body', function(assert) {
     const adapter = this.owner.lookup('adapter:coordinate');
     const client = this.owner.lookup('service:client/http');
+    const request = client.body.bind(client);
     const expected = {
       index: 1,
     };
-    const [actual] = adapter.requestForQuery(client.body, {
+    const [actual] = adapter.requestForQuery(request, {
       dc: dc,
       index: 1,
     });

--- a/ui/packages/consul-ui/tests/integration/adapters/dc-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/dc-test.js
@@ -5,8 +5,9 @@ module('Integration | Adapter | dc', function(hooks) {
   test('requestForQuery returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:dc');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `GET /v1/catalog/datacenters`;
-    const actual = adapter.requestForQuery(client.url);
+    const actual = adapter.requestForQuery(request);
     assert.equal(actual, expected);
   });
 });

--- a/ui/packages/consul-ui/tests/integration/adapters/discovery-chain-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/discovery-chain-test.js
@@ -10,8 +10,9 @@ module('Integration | Adapter | discovery-chain', function(hooks) {
   test('requestForQueryRecord returns the correct url/method', function(assert) {
     const adapter = this.owner.lookup('adapter:discovery-chain');
     const client = this.owner.lookup('service:client/http');
+    const request = client.requestParams.bind(client);
     const expected = `GET /v1/discovery-chain/${id}?dc=${dc}`;
-    const actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+    const actual = adapter.requestForQueryRecord(request, {
       dc: dc,
       id: id,
     });
@@ -20,8 +21,9 @@ module('Integration | Adapter | discovery-chain', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:discovery-chain');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });
@@ -29,7 +31,8 @@ module('Integration | Adapter | discovery-chain', function(hooks) {
   test('requestForQueryRecord returns the correct body', function(assert) {
     return nspaceRunner(
       (adapter, serializer, client) => {
-        return adapter.requestForQueryRecord(client.body, {
+        const request = client.body.bind(client);
+        return adapter.requestForQueryRecord(request, {
           id: id,
           dc: dc,
           ns: 'team-1',

--- a/ui/packages/consul-ui/tests/integration/adapters/intention-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/intention-test.js
@@ -11,7 +11,8 @@ module('Integration | Adapter | intention', function(hooks) {
   test('requestForQuery returns the correct url', function(assert) {
     return nspaceRunner(
       (adapter, serializer, client) => {
-        return adapter.requestForQuery(client.body, {
+        const request = client.body.bind(client);
+        return adapter.requestForQuery(request, {
           dc: dc,
           ns: 'team-1',
           filter: '*',
@@ -34,9 +35,10 @@ module('Integration | Adapter | intention', function(hooks) {
   test('requestForQueryRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:intention');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `GET /v1/connect/intentions/exact?source=SourceNS%2FSourceName&destination=DestinationNS%2FDestinationName&dc=${dc}`;
     const actual = adapter
-      .requestForQueryRecord(client.url, {
+      .requestForQueryRecord(request, {
         dc: dc,
         id: id,
       })
@@ -46,8 +48,9 @@ module('Integration | Adapter | intention', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:intention');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });
@@ -55,10 +58,11 @@ module('Integration | Adapter | intention', function(hooks) {
   test('requestForCreateRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:intention');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `PUT /v1/connect/intentions/exact?source=SourceNS%2FSourceName&destination=DestinationNS%2FDestinationName&dc=${dc}`;
     const actual = adapter
       .requestForCreateRecord(
-        client.url,
+        request,
         {},
         {
           Datacenter: dc,
@@ -74,10 +78,11 @@ module('Integration | Adapter | intention', function(hooks) {
   test('requestForUpdateRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:intention');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `PUT /v1/connect/intentions/exact?source=SourceNS%2FSourceName&destination=DestinationNS%2FDestinationName&dc=${dc}`;
     const actual = adapter
       .requestForUpdateRecord(
-        client.url,
+        request,
         {},
         {
           Datacenter: dc,
@@ -93,10 +98,11 @@ module('Integration | Adapter | intention', function(hooks) {
   test('requestForDeleteRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:intention');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `DELETE /v1/connect/intentions/exact?source=SourceNS%2FSourceName&destination=DestinationNS%2FDestinationName&dc=${dc}`;
     const actual = adapter
       .requestForDeleteRecord(
-        client.url,
+        request,
         {},
         {
           Datacenter: dc,

--- a/ui/packages/consul-ui/tests/integration/adapters/kv-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/kv-test.js
@@ -13,10 +13,11 @@ module('Integration | Adapter | kv', function(hooks) {
     test(`requestForQuery returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:kv');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/kv/${id}?keys&dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -26,10 +27,11 @@ module('Integration | Adapter | kv', function(hooks) {
     test(`requestForQueryRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:kv');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/kv/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+      let actual = adapter.requestForQueryRecord(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -39,12 +41,13 @@ module('Integration | Adapter | kv', function(hooks) {
     test(`requestForCreateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:kv');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/kv/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       let actual = adapter
         .requestForCreateRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -60,13 +63,14 @@ module('Integration | Adapter | kv', function(hooks) {
     test(`requestForUpdateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:kv');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const flags = 12;
       const expected = `PUT /v1/kv/${id}?dc=${dc}&flags=${flags}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       let actual = adapter
         .requestForUpdateRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -83,12 +87,13 @@ module('Integration | Adapter | kv', function(hooks) {
     test(`requestForDeleteRecord returns the correct url/method when the nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:kv');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `DELETE /v1/kv/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       let actual = adapter
         .requestForDeleteRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -103,13 +108,14 @@ module('Integration | Adapter | kv', function(hooks) {
     test(`requestForDeleteRecord returns the correct url/method for folders when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:kv');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const folder = `${id}/`;
       const expected = `DELETE /v1/kv/${folder}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }&recurse`;
       let actual = adapter
         .requestForDeleteRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -125,8 +131,9 @@ module('Integration | Adapter | kv', function(hooks) {
   test("requestForQuery throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:kv');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQuery(client.url, {
+      adapter.requestForQuery(request, {
         dc: dc,
       });
     });
@@ -134,8 +141,9 @@ module('Integration | Adapter | kv', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:kv');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });

--- a/ui/packages/consul-ui/tests/integration/adapters/kv-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/kv-test.js
@@ -65,9 +65,9 @@ module('Integration | Adapter | kv', function(hooks) {
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
       const flags = 12;
-      const expected = `PUT /v1/kv/${id}?dc=${dc}&flags=${flags}${
+      const expected = `PUT /v1/kv/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
-      }`;
+      }&flags=${flags}`;
       let actual = adapter
         .requestForUpdateRecord(
           request,

--- a/ui/packages/consul-ui/tests/integration/adapters/node-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/node-test.js
@@ -13,10 +13,11 @@ module('Integration | Adapter | node', function(hooks) {
     test(`requestForQuery returns the correct url when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:node');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/internal/ui/nodes?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      const actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      const actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,
       });
@@ -25,10 +26,11 @@ module('Integration | Adapter | node', function(hooks) {
     test(`requestForQueryRecord returns the correct url when the nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:node');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/internal/ui/node/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      const actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+      const actual = adapter.requestForQueryRecord(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -40,8 +42,9 @@ module('Integration | Adapter | node', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:node');
     const client = this.owner.lookup('service:client/http');
+    const request = client.requestParams.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });
@@ -49,8 +52,9 @@ module('Integration | Adapter | node', function(hooks) {
   test('requestForQueryLeader returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:node');
     const client = this.owner.lookup('service:client/http');
+    const request = client.requestParams.bind(client);
     const expected = `GET /v1/status/leader?dc=${dc}`;
-    const actual = adapter.requestForQueryLeader(client.requestParams.bind(client), {
+    const actual = adapter.requestForQueryLeader(request, {
       dc: dc,
     });
     assert.equal(`${actual.method} ${actual.url}`, expected);

--- a/ui/packages/consul-ui/tests/integration/adapters/nspace-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/nspace-test.js
@@ -8,15 +8,17 @@ module('Integration | Adapter | nspace', function(hooks) {
   test('requestForQuery returns the correct url/method', function(assert) {
     const adapter = this.owner.lookup('adapter:nspace');
     const client = this.owner.lookup('service:client/http');
+    const request = client.requestParams.bind(client);
     const expected = `GET /v1/namespaces`;
-    const actual = adapter.requestForQuery(client.requestParams.bind(client), {});
+    const actual = adapter.requestForQuery(request, {});
     assert.equal(`${actual.method} ${actual.url}`, expected);
   });
   test('requestForQueryRecord returns the correct url/method', function(assert) {
     const adapter = this.owner.lookup('adapter:nspace');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `GET /v1/namespace/${id}`;
-    const actual = adapter.requestForQueryRecord(client.url, {
+    const actual = adapter.requestForQueryRecord(request, {
       id: id,
     });
     assert.equal(actual, expected);
@@ -24,8 +26,9 @@ module('Integration | Adapter | nspace', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:nspace');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {});
+      adapter.requestForQueryRecord(request, {});
     });
   });
 });

--- a/ui/packages/consul-ui/tests/integration/adapters/oidc-provider-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/oidc-provider-test.js
@@ -28,7 +28,9 @@ module('Integration | Adapter | oidc-provider', function(hooks) {
       const adapter = this.owner.lookup('adapter:oidc-provider');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
-      const expected = `POST /v1/acl/oidc/auth-url?dc=${dc}`;
+      const expected = `POST /v1/acl/oidc/auth-url?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
       const actual = adapter
         .requestForQueryRecord(request, {
           dc: dc,
@@ -53,7 +55,9 @@ module('Integration | Adapter | oidc-provider', function(hooks) {
       const adapter = this.owner.lookup('adapter:oidc-provider');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
-      const expected = `POST /v1/acl/oidc/callback?dc=${dc}`;
+      const expected = `POST /v1/acl/oidc/callback?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
       const actual = adapter
         .requestForAuthorize(request, {
           dc: dc,

--- a/ui/packages/consul-ui/tests/integration/adapters/oidc-provider-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/oidc-provider-test.js
@@ -14,10 +14,11 @@ module('Integration | Adapter | oidc-provider', function(hooks) {
     test('requestForQuery returns the correct url/method', function(assert) {
       const adapter = this.owner.lookup('adapter:oidc-provider');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/internal/ui/oidc-auth-methods?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,
       });
@@ -26,9 +27,10 @@ module('Integration | Adapter | oidc-provider', function(hooks) {
     test('requestForQueryRecord returns the correct url/method', function(assert) {
       const adapter = this.owner.lookup('adapter:oidc-provider');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `POST /v1/acl/oidc/auth-url?dc=${dc}`;
       const actual = adapter
-        .requestForQueryRecord(client.url, {
+        .requestForQueryRecord(request, {
           dc: dc,
           id: id,
           ns: nspace,
@@ -40,8 +42,9 @@ module('Integration | Adapter | oidc-provider', function(hooks) {
     test("requestForQueryRecord throws if you don't specify an id", function(assert) {
       const adapter = this.owner.lookup('adapter:oidc-provider');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       assert.throws(function() {
-        adapter.requestForQueryRecord(client.url, {
+        adapter.requestForQueryRecord(request, {
           dc: dc,
         });
       });
@@ -49,9 +52,10 @@ module('Integration | Adapter | oidc-provider', function(hooks) {
     test('requestForAuthorize returns the correct url/method', function(assert) {
       const adapter = this.owner.lookup('adapter:oidc-provider');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `POST /v1/acl/oidc/callback?dc=${dc}`;
       const actual = adapter
-        .requestForAuthorize(client.url, {
+        .requestForAuthorize(request, {
           dc: dc,
           id: id,
           code: 'code',
@@ -65,9 +69,10 @@ module('Integration | Adapter | oidc-provider', function(hooks) {
     test('requestForLogout returns the correct url/method', function(assert) {
       const adapter = this.owner.lookup('adapter:oidc-provider');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `POST /v1/acl/logout`;
       const actual = adapter
-        .requestForLogout(client.url, {
+        .requestForLogout(request, {
           id: id,
         })
         .split('\n')

--- a/ui/packages/consul-ui/tests/integration/adapters/permission-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/permission-test.js
@@ -13,11 +13,12 @@ module('Integration | Adapter | permission', function(hooks) {
     test('requestForAuthorize returns the correct url/method', function(assert) {
       const adapter = this.owner.lookup('adapter:permission');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       // authorize endpoint doesn't need an ns sending on the query param
       const expected = `POST /v1/internal/acl/authorize?dc=${dc}${
         shouldHaveNspace(nspace) ? `` : ``
       }`;
-      const actual = adapter.requestForAuthorize(client.requestParams.bind(client), {
+      const actual = adapter.requestForAuthorize(request, {
         dc: dc,
         ns: nspace,
       });

--- a/ui/packages/consul-ui/tests/integration/adapters/policy-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/policy-test.js
@@ -9,8 +9,9 @@ module('Integration | Adapter | policy', function(hooks) {
   skip('urlForTranslateRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:policy');
     const client = this.owner.lookup('service:client/http');
+    const request = client.id.bind(client);
     const expected = `GET /v1/acl/policy/translate`;
-    const actual = adapter.requestForTranslateRecord(client.id, {});
+    const actual = adapter.requestForTranslateRecord(request, {});
     assert.equal(actual, expected);
   });
   const dc = 'dc-1';
@@ -20,10 +21,11 @@ module('Integration | Adapter | policy', function(hooks) {
     test(`requestForQuery returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/acl/policies?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,
       });
@@ -32,10 +34,11 @@ module('Integration | Adapter | policy', function(hooks) {
     test(`requestForQueryRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/acl/policy/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+      let actual = adapter.requestForQueryRecord(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -45,10 +48,11 @@ module('Integration | Adapter | policy', function(hooks) {
     test(`requestForCreateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/acl/policy?dc=${dc}`;
       const actual = adapter
         .requestForCreateRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -62,10 +66,11 @@ module('Integration | Adapter | policy', function(hooks) {
     test(`requestForUpdateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/acl/policy/${id}?dc=${dc}`;
       const actual = adapter
         .requestForUpdateRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -80,12 +85,13 @@ module('Integration | Adapter | policy', function(hooks) {
     test(`requestForDeleteRecord returns the correct url/method when the nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `DELETE /v1/acl/policy/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       const actual = adapter
         .requestForDeleteRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -101,8 +107,9 @@ module('Integration | Adapter | policy', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:policy');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });

--- a/ui/packages/consul-ui/tests/integration/adapters/policy-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/policy-test.js
@@ -49,7 +49,9 @@ module('Integration | Adapter | policy', function(hooks) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
-      const expected = `PUT /v1/acl/policy?dc=${dc}`;
+      const expected = `PUT /v1/acl/policy?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
       const actual = adapter
         .requestForCreateRecord(
           request,
@@ -67,7 +69,9 @@ module('Integration | Adapter | policy', function(hooks) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
-      const expected = `PUT /v1/acl/policy/${id}?dc=${dc}`;
+      const expected = `PUT /v1/acl/policy/${id}?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
       const actual = adapter
         .requestForUpdateRecord(
           request,

--- a/ui/packages/consul-ui/tests/integration/adapters/role-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/role-test.js
@@ -13,10 +13,11 @@ module('Integration | Adapter | role', function(hooks) {
     test(`requestForQuery returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/acl/roles?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,
       });
@@ -25,10 +26,11 @@ module('Integration | Adapter | role', function(hooks) {
     test(`requestForQueryRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/acl/role/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+      let actual = adapter.requestForQueryRecord(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -38,10 +40,11 @@ module('Integration | Adapter | role', function(hooks) {
     test(`requestForCreateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/acl/role?dc=${dc}`;
       const actual = adapter
         .requestForCreateRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -55,10 +58,11 @@ module('Integration | Adapter | role', function(hooks) {
     test(`requestForUpdateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/acl/role/${id}?dc=${dc}`;
       const actual = adapter
         .requestForUpdateRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -73,12 +77,13 @@ module('Integration | Adapter | role', function(hooks) {
     test(`requestForDeleteRecord returns the correct url/method when the nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `DELETE /v1/acl/role/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       const actual = adapter
         .requestForDeleteRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -94,8 +99,9 @@ module('Integration | Adapter | role', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:role');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });

--- a/ui/packages/consul-ui/tests/integration/adapters/role-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/role-test.js
@@ -41,7 +41,9 @@ module('Integration | Adapter | role', function(hooks) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
-      const expected = `PUT /v1/acl/role?dc=${dc}`;
+      const expected = `PUT /v1/acl/role?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
       const actual = adapter
         .requestForCreateRecord(
           request,
@@ -59,7 +61,9 @@ module('Integration | Adapter | role', function(hooks) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
-      const expected = `PUT /v1/acl/role/${id}?dc=${dc}`;
+      const expected = `PUT /v1/acl/role/${id}?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
       const actual = adapter
         .requestForUpdateRecord(
           request,

--- a/ui/packages/consul-ui/tests/integration/adapters/service-instance-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/service-instance-test.js
@@ -13,10 +13,11 @@ module('Integration | Adapter | service-instance', function(hooks) {
     test(`requestForQueryRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:service-instance');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/health/service/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+      let actual = adapter.requestForQueryRecord(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -27,8 +28,9 @@ module('Integration | Adapter | service-instance', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:service-instance');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });

--- a/ui/packages/consul-ui/tests/integration/adapters/service-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/service-test.js
@@ -13,10 +13,11 @@ module('Integration | Adapter | service', function(hooks) {
     test(`requestForQuery returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:service');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/internal/ui/services?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,
       });
@@ -25,11 +26,12 @@ module('Integration | Adapter | service', function(hooks) {
     test(`requestForQuery returns the correct url/method when called with gateway when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:service');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const gateway = 'gateway';
       const expected = `GET /v1/internal/ui/gateway-services-nodes/${gateway}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,
         gateway: gateway,
@@ -39,10 +41,11 @@ module('Integration | Adapter | service', function(hooks) {
     test(`requestForQueryRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:service');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/health/service/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+      let actual = adapter.requestForQueryRecord(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -53,8 +56,9 @@ module('Integration | Adapter | service', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:service');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });

--- a/ui/packages/consul-ui/tests/integration/adapters/session-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/session-test.js
@@ -13,11 +13,12 @@ module('Integration | Adapter | session', function(hooks) {
     test(`requestForQuery returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:session');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const node = 'node-id';
       const expected = `GET /v1/session/node/${node}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         id: node,
         ns: nspace,
@@ -27,10 +28,11 @@ module('Integration | Adapter | session', function(hooks) {
     test(`requestForQueryRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:session');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/session/info/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+      let actual = adapter.requestForQueryRecord(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -40,12 +42,13 @@ module('Integration | Adapter | session', function(hooks) {
     test(`requestForDeleteRecord returns the correct url/method when the nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:session');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/session/destroy/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       const actual = adapter
         .requestForDeleteRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -61,8 +64,9 @@ module('Integration | Adapter | session', function(hooks) {
   test("requestForQuery throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:session');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQuery(client.url, {
+      adapter.requestForQuery(request, {
         dc: dc,
       });
     });
@@ -70,8 +74,9 @@ module('Integration | Adapter | session', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:session');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });

--- a/ui/packages/consul-ui/tests/integration/adapters/token-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/token-test.js
@@ -69,7 +69,9 @@ module('Integration | Adapter | token', function(hooks) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
-      const expected = `PUT /v1/acl/token?dc=${dc}`;
+      const expected = `PUT /v1/acl/token?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
       const actual = adapter
         .requestForCreateRecord(
           request,
@@ -87,7 +89,9 @@ module('Integration | Adapter | token', function(hooks) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
-      const expected = `PUT /v1/acl/token/${id}?dc=${dc}`;
+      const expected = `PUT /v1/acl/token/${id}?dc=${dc}${
+        shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
+      }`;
       const actual = adapter
         .requestForUpdateRecord(
           request,
@@ -106,6 +110,8 @@ module('Integration | Adapter | token', function(hooks) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
       const request = client.url.bind(client);
+      // As the title of the test says, this one uses the ACL legacy APIs and
+      // therefore does not expect a nspace
       const expected = `PUT /v1/acl/update?dc=${dc}`;
       const actual = adapter
         .requestForUpdateRecord(

--- a/ui/packages/consul-ui/tests/integration/adapters/token-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/token-test.js
@@ -13,10 +13,11 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForQuery returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/acl/tokens?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,
       });
@@ -25,10 +26,11 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForQuery returns the correct url/method when a policy is specified when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/acl/tokens?policy=${id}&dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         policy: id,
         ns: nspace,
@@ -38,10 +40,11 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForQuery returns the correct url/method when a role is specified when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/acl/tokens?role=${id}&dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQuery(client.requestParams.bind(client), {
+      let actual = adapter.requestForQuery(request, {
         dc: dc,
         role: id,
         ns: nspace,
@@ -51,10 +54,11 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForQueryRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.requestParams.bind(client);
       const expected = `GET /v1/acl/token/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
-      let actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+      let actual = adapter.requestForQueryRecord(request, {
         dc: dc,
         id: id,
         ns: nspace,
@@ -64,10 +68,11 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForCreateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/acl/token?dc=${dc}`;
       const actual = adapter
         .requestForCreateRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -81,10 +86,11 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForUpdateRecord returns the correct url (without Rules it uses the v2 API) when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/acl/token/${id}?dc=${dc}`;
       const actual = adapter
         .requestForUpdateRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -99,10 +105,11 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForUpdateRecord returns the correct url (with Rules it uses the v1 API) when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/acl/update?dc=${dc}`;
       const actual = adapter
         .requestForUpdateRecord(
-          client.url,
+          request,
           {},
           {
             Rules: 'key {}',
@@ -118,12 +125,13 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForDeleteRecord returns the correct url/method when the nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `DELETE /v1/acl/token/${id}?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       const actual = adapter
         .requestForDeleteRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -138,12 +146,13 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForCloneRecord returns the correct url when the nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
+      const request = client.url.bind(client);
       const expected = `PUT /v1/acl/token/${id}/clone?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       const actual = adapter
         .requestForCloneRecord(
-          client.url,
+          request,
           {},
           {
             Datacenter: dc,
@@ -159,8 +168,9 @@ module('Integration | Adapter | token', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:token');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });
@@ -168,10 +178,11 @@ module('Integration | Adapter | token', function(hooks) {
   test('requestForSelf returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:token');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const expected = `GET /v1/acl/token/self?dc=${dc}`;
     const actual = adapter
       .requestForSelf(
-        client.url,
+        request,
         {},
         {
           dc: dc,
@@ -183,11 +194,12 @@ module('Integration | Adapter | token', function(hooks) {
   test('requestForSelf sets a token header using a secret', function(assert) {
     const adapter = this.owner.lookup('adapter:token');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     const secret = 'sssh';
     const expected = `X-Consul-Token: ${secret}`;
     const actual = adapter
       .requestForSelf(
-        client.url,
+        request,
         {},
         {
           dc: dc,

--- a/ui/packages/consul-ui/tests/integration/adapters/topology-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/topology-test.js
@@ -11,8 +11,9 @@ module('Integration | Adapter | topology', function(hooks) {
   test('requestForQueryRecord returns the correct url/method', function(assert) {
     const adapter = this.owner.lookup('adapter:topology');
     const client = this.owner.lookup('service:client/http');
+    const request = client.requestParams.bind(client);
     const expected = `GET /v1/internal/ui/service-topology/${id}?dc=${dc}&kind=${kind}`;
-    const actual = adapter.requestForQueryRecord(client.requestParams.bind(client), {
+    const actual = adapter.requestForQueryRecord(request, {
       dc: dc,
       id: id,
       kind: kind,
@@ -22,8 +23,9 @@ module('Integration | Adapter | topology', function(hooks) {
   test("requestForQueryRecord throws if you don't specify an id", function(assert) {
     const adapter = this.owner.lookup('adapter:topology');
     const client = this.owner.lookup('service:client/http');
+    const request = client.url.bind(client);
     assert.throws(function() {
-      adapter.requestForQueryRecord(client.url, {
+      adapter.requestForQueryRecord(request, {
         dc: dc,
       });
     });
@@ -31,7 +33,8 @@ module('Integration | Adapter | topology', function(hooks) {
   test('requestForQueryRecord returns the correct body', function(assert) {
     return nspaceRunner(
       (adapter, serializer, client) => {
-        return adapter.requestForQueryRecord(client.body, {
+        const request = client.body.bind(client);
+        return adapter.requestForQueryRecord(request, {
           id: id,
           dc: dc,
           ns: 'team-1',

--- a/ui/packages/consul-ui/tests/integration/serializers/acl-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/acl-test.js
@@ -28,7 +28,9 @@ module('Integration | Serializer | acl', function(hooks) {
       );
       const actual = serializer.respondForQuery(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },
@@ -49,7 +51,7 @@ module('Integration | Serializer | acl', function(hooks) {
         Datacenter: dc,
         [META]: {
           [DC.toLowerCase()]: dc,
-          [NSPACE.toLowerCase()]: '',
+          [NSPACE.toLowerCase()]: nspace,
         },
         // TODO: default isn't required here, once we've
         // refactored out our Serializer this can go
@@ -58,7 +60,10 @@ module('Integration | Serializer | acl', function(hooks) {
       });
       const actual = serializer.respondForQueryRecord(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },

--- a/ui/packages/consul-ui/tests/integration/serializers/auth-method-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/auth-method-test.js
@@ -27,13 +27,16 @@ module('Integration | Serializer | auth-method', function(hooks) {
         );
         const actual = serializer.respondForQuery(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },
           {
             dc: dc,
-            ns: nspace,
+            ns: nspace || undefinedNspace,
           }
         );
         assert.deepEqual(actual, expected);
@@ -51,14 +54,17 @@ module('Integration | Serializer | auth-method', function(hooks) {
           Datacenter: dc,
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: nspace || '',
+            [NSPACE.toLowerCase()]: nspace || undefinedNspace,
           },
           Namespace: payload.Namespace || undefinedNspace,
           uid: `["${payload.Namespace || undefinedNspace}","${dc}","${id}"]`,
         });
         const actual = serializer.respondForQueryRecord(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },

--- a/ui/packages/consul-ui/tests/integration/serializers/coordinate-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/coordinate-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_DATACENTER as DC, HEADERS_NAMESPACE as NSPACE } from 'consul-ui/utils/http/consul';
 module('Integration | Serializer | coordinate', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -22,7 +23,10 @@ module('Integration | Serializer | coordinate', function(hooks) {
       );
       const actual = serializer.respondForQuery(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },

--- a/ui/packages/consul-ui/tests/integration/serializers/discovery-chain-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/discovery-chain-test.js
@@ -2,7 +2,11 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import {
+  HEADERS_SYMBOL as META,
+  HEADERS_DATACENTER as DC,
+  HEADERS_NAMESPACE as NSPACE,
+} from 'consul-ui/utils/http/consul';
 
 module('Integration | Serializer | discovery-chain', function(hooks) {
   setupTest(hooks);
@@ -10,6 +14,7 @@ module('Integration | Serializer | discovery-chain', function(hooks) {
     const serializer = this.owner.lookup('serializer:discovery-chain');
     const dc = 'dc-1';
     const id = 'slug';
+    const nspace = 'default';
     const request = {
       url: `/v1/discovery-chain/${id}?dc=${dc}`,
     };
@@ -17,11 +22,14 @@ module('Integration | Serializer | discovery-chain', function(hooks) {
       const expected = {
         Datacenter: dc,
         [META]: {},
-        uid: `["default","${dc}","${id}"]`,
+        uid: `["${nspace}","${dc}","${id}"]`,
       };
       const actual = serializer.respondForQueryRecord(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },

--- a/ui/packages/consul-ui/tests/integration/serializers/intention-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/intention-test.js
@@ -28,7 +28,10 @@ module('Integration | Serializer | intention', function(hooks) {
       );
       const actual = serializer.respondForQuery(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },
@@ -70,7 +73,10 @@ module('Integration | Serializer | intention', function(hooks) {
       });
       const actual = serializer.respondForQueryRecord(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },

--- a/ui/packages/consul-ui/tests/integration/serializers/kv-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/kv-test.js
@@ -35,7 +35,10 @@ module('Integration | Serializer | kv', function(hooks) {
         );
         const actual = serializer.respondForQuery(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },
@@ -57,20 +60,23 @@ module('Integration | Serializer | kv', function(hooks) {
           Datacenter: dc,
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: nspace || '',
+            [NSPACE.toLowerCase()]: nspace || undefinedNspace,
           },
           Namespace: payload[0].Namespace || undefinedNspace,
           uid: `["${payload[0].Namespace || undefinedNspace}","${dc}","${id}"]`,
         });
         const actual = serializer.respondForQueryRecord(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },
           {
             dc: dc,
-            ns: nspace,
+            ns: nspace || undefinedNspace,
             id: id,
           }
         );

--- a/ui/packages/consul-ui/tests/integration/serializers/node-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/node-test.js
@@ -21,7 +21,10 @@ module('Integration | Serializer | node', function(hooks) {
     return get(request.url).then(function(payload) {
       const actual = serializer.respondForQuery(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },
@@ -51,7 +54,10 @@ module('Integration | Serializer | node', function(hooks) {
     return get(request.url).then(function(payload) {
       const actual = serializer.respondForQueryRecord(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },
@@ -80,12 +86,15 @@ module('Integration | Serializer | node', function(hooks) {
         Port: '8500',
         [META]: {
           [DC.toLowerCase()]: dc,
-          [NSPACE.toLowerCase()]: '',
+          [NSPACE.toLowerCase()]: nspace,
         },
       };
       const actual = serializer.respondForQueryLeader(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },

--- a/ui/packages/consul-ui/tests/integration/serializers/oidc-provider-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/oidc-provider-test.js
@@ -28,7 +28,10 @@ module('Integration | Serializer | oidc-provider', function(hooks) {
         );
         const actual = serializer.respondForQuery(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },
@@ -58,14 +61,17 @@ module('Integration | Serializer | oidc-provider', function(hooks) {
           Datacenter: dc,
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: nspace || '',
+            [NSPACE.toLowerCase()]: nspace || undefinedNspace,
           },
           Namespace: nspace || undefinedNspace,
           uid: `["${nspace || undefinedNspace}","${dc}","${id}"]`,
         });
         const actual = serializer.respondForQueryRecord(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },

--- a/ui/packages/consul-ui/tests/integration/serializers/policy-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/policy-test.js
@@ -27,7 +27,10 @@ module('Integration | Serializer | policy', function(hooks) {
         );
         const actual = serializer.respondForQuery(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },
@@ -49,14 +52,17 @@ module('Integration | Serializer | policy', function(hooks) {
           Datacenter: dc,
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: nspace || '',
+            [NSPACE.toLowerCase()]: nspace || undefinedNspace,
           },
           Namespace: payload.Namespace || undefinedNspace,
           uid: `["${payload.Namespace || undefinedNspace}","${dc}","${id}"]`,
         });
         const actual = serializer.respondForQueryRecord(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },

--- a/ui/packages/consul-ui/tests/integration/serializers/role-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/role-test.js
@@ -30,7 +30,10 @@ module('Integration | Serializer | role', function(hooks) {
         );
         const actual = serializer.respondForQuery(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },
@@ -53,14 +56,17 @@ module('Integration | Serializer | role', function(hooks) {
           Policies: createPolicies(payload),
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: nspace || '',
+            [NSPACE.toLowerCase()]: nspace || undefinedNspace,
           },
           Namespace: payload.Namespace || undefinedNspace,
           uid: `["${payload.Namespace || undefinedNspace}","${dc}","${id}"]`,
         });
         const actual = serializer.respondForQueryRecord(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },

--- a/ui/packages/consul-ui/tests/integration/serializers/service-instance-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/service-instance-test.js
@@ -28,14 +28,17 @@ module('Integration | Serializer | service-instance', function(hooks) {
           Datacenter: dc,
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: nspace || '',
+            [NSPACE.toLowerCase()]: nspace || undefinedNspace,
           },
           Namespace: payload[0].Service.Namespace || undefinedNspace,
           uid: `["${payload[0].Service.Namespace || undefinedNspace}","${dc}","${node}","${id}"]`,
         };
         const actual = serializer.respondForQueryRecord(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },

--- a/ui/packages/consul-ui/tests/integration/serializers/service-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/service-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_DATACENTER as DC, HEADERS_NAMESPACE as NSPACE } from 'consul-ui/utils/http/consul';
 module('Integration | Serializer | service', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -23,7 +24,10 @@ module('Integration | Serializer | service', function(hooks) {
         );
         const actual = serializer.respondForQuery(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },

--- a/ui/packages/consul-ui/tests/integration/serializers/session-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/session-test.js
@@ -30,7 +30,10 @@ module('Integration | Serializer | session | response', function(hooks) {
         );
         const actual = serializer.respondForQuery(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },
@@ -54,14 +57,17 @@ module('Integration | Serializer | session | response', function(hooks) {
           Datacenter: dc,
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: nspace || '',
+            [NSPACE.toLowerCase()]: nspace || undefinedNspace,
           },
           Namespace: payload[0].Namespace || undefinedNspace,
           uid: `["${payload[0].Namespace || undefinedNspace}","${dc}","${id}"]`,
         });
         const actual = serializer.respondForQueryRecord(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },

--- a/ui/packages/consul-ui/tests/integration/serializers/token-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/token-test.js
@@ -31,7 +31,10 @@ module('Integration | Serializer | token', function(hooks) {
         );
         const actual = serializer.respondForQuery(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },
@@ -53,7 +56,7 @@ module('Integration | Serializer | token', function(hooks) {
           Datacenter: dc,
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: nspace || '',
+            [NSPACE.toLowerCase()]: nspace || undefinedNspace,
           },
           Namespace: payload.Namespace || undefinedNspace,
           uid: `["${payload.Namespace || undefinedNspace}","${dc}","${id}"]`,
@@ -61,7 +64,10 @@ module('Integration | Serializer | token', function(hooks) {
         });
         const actual = serializer.respondForQueryRecord(
           function(cb) {
-            const headers = {};
+            const headers = {
+              [DC]: dc,
+              [NSPACE]: nspace || undefinedNspace,
+            };
             const body = payload;
             return cb(headers, body);
           },

--- a/ui/packages/consul-ui/tests/integration/serializers/topology-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/topology-test.js
@@ -2,7 +2,11 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import {
+  HEADERS_SYMBOL as META,
+  HEADERS_DATACENTER as DC,
+  HEADERS_NAMESPACE as NSPACE,
+} from 'consul-ui/utils/http/consul';
 
 module('Integration | Serializer | topology', function(hooks) {
   setupTest(hooks);
@@ -11,6 +15,7 @@ module('Integration | Serializer | topology', function(hooks) {
     const dc = 'dc-1';
     const id = 'slug';
     const kind = '';
+    const nspace = 'default';
     const request = {
       url: `/v1/internal/ui/service-topology/${id}?dc=${dc}&kind=${kind}`,
     };
@@ -18,11 +23,14 @@ module('Integration | Serializer | topology', function(hooks) {
       const expected = {
         Datacenter: dc,
         [META]: {},
-        uid: `["default","${dc}","${id}"]`,
+        uid: `["${nspace}","${dc}","${id}"]`,
       };
       const actual = serializer.respondForQueryRecord(
         function(cb) {
-          const headers = {};
+          const headers = {
+            [DC]: dc,
+            [NSPACE]: nspace,
+          };
           const body = payload;
           return cb(headers, body);
         },

--- a/ui/packages/consul-ui/tests/integration/services/repository/acl-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/acl-test.js
@@ -19,7 +19,7 @@ test('findByDatacenter returns the correct data for list endpoint', function(ass
       });
     },
     function performTest(service) {
-      return service.findAllByDatacenter({ dc, ns: nspace });
+      return service.findAllByDatacenter({ dc });
     },
     function performAssertion(actual, expected) {
       assert.deepEqual(

--- a/ui/packages/consul-ui/tests/integration/services/repository/acl-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/acl-test.js
@@ -19,7 +19,7 @@ test('findByDatacenter returns the correct data for list endpoint', function(ass
       });
     },
     function performTest(service) {
-      return service.findAllByDatacenter({ dc });
+      return service.findAllByDatacenter({ dc, ns: nspace });
     },
     function performAssertion(actual, expected) {
       assert.deepEqual(

--- a/ui/packages/consul-ui/tests/integration/services/repository/kv-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/kv-test.js
@@ -1,5 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import repo from 'consul-ui/tests/helpers/repo';
+import { env } from '../../../../env';
+
 const NAME = 'kv';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
   // Specify the other units that are required for this test.
@@ -26,14 +28,17 @@ const undefinedNspace = 'default';
         return service.findAllBySlug({ id, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
+        const expectedNspace = env('CONSUL_NSPACES_ENABLED')
+          ? nspace || undefinedNspace
+          : 'default';
         assert.deepEqual(
           actual,
           expected(function(payload) {
             return payload.map(item => {
               return {
                 Datacenter: dc,
-                Namespace: nspace || undefinedNspace,
-                uid: `["${nspace || undefinedNspace}","${dc}","${item}"]`,
+                Namespace: expectedNspace,
+                uid: `["${expectedNspace}","${dc}","${item}"]`,
                 Key: item,
               };
             });

--- a/ui/packages/consul-ui/tests/integration/services/repository/policy-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/policy-test.js
@@ -62,23 +62,8 @@ const undefinedNspace = 'default';
         return service.findBySlug({ id, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
-        assert.deepEqual(
-          actual,
-          expected(function(payload) {
-            const item = payload;
-            return Object.assign({}, item, {
-              Datacenter: dc,
-              Namespace: item.Namespace || undefinedNspace,
-              uid: `["${item.Namespace || undefinedNspace}","${dc}","${item.ID}"]`,
-              meta: {
-                cacheControl: undefined,
-                cursor: undefined,
-                dc: dc,
-                nspace: item.Namespace || undefinedNspace,
-              },
-            });
-          })
-        );
+        assert.equal(actual.uid, `["${nspace || undefinedNspace}","${dc}","${actual.ID}"]`);
+        assert.equal(actual.Datacenter, dc);
       }
     );
   });

--- a/ui/packages/consul-ui/tests/integration/services/repository/token-test.js
+++ b/ui/packages/consul-ui/tests/integration/services/repository/token-test.js
@@ -60,25 +60,11 @@ const undefinedNspace = 'default';
         return service.findBySlug({ id, dc, ns: nspace || undefinedNspace });
       },
       function performAssertion(actual, expected) {
-        assert.deepEqual(
-          actual,
-          expected(function(payload) {
-            const item = payload;
-            return Object.assign({}, item, {
-              Datacenter: dc,
-              CreateTime: new Date(item.CreateTime),
-              Namespace: item.Namespace || undefinedNspace,
-              uid: `["${item.Namespace || undefinedNspace}","${dc}","${item.AccessorID}"]`,
-              meta: {
-                cacheControl: undefined,
-                cursor: undefined,
-                dc: dc,
-                nspace: item.Namespace || undefinedNspace,
-              },
-              Policies: createPolicies(item),
-            });
-          })
-        );
+        expected(function(item) {
+          assert.equal(actual.uid, `["${nspace || undefinedNspace}","${dc}","${item.AccessorID}"]`);
+          assert.equal(actual.Datacenter, dc);
+          assert.deepEqual(actual.Policies, createPolicies(item));
+        });
       }
     );
   });

--- a/ui/packages/consul-ui/tests/steps/assertions/http.js
+++ b/ui/packages/consul-ui/tests/steps/assertions/http.js
@@ -66,6 +66,7 @@ export default function(scenario, assert, lastNthRequest) {
         return method === item.method && url === item.url;
       });
       let data = yaml.body || {};
+      console.log(request.requestBody);
       const body = JSON.parse(request.requestBody);
       Object.keys(data).forEach(function(key, i, arr) {
         assert.deepEqual(

--- a/ui/packages/consul-ui/tests/steps/assertions/http.js
+++ b/ui/packages/consul-ui/tests/steps/assertions/http.js
@@ -66,7 +66,6 @@ export default function(scenario, assert, lastNthRequest) {
         return method === item.method && url === item.url;
       });
       let data = yaml.body || {};
-      console.log(request.requestBody);
       const body = JSON.parse(request.requestBody);
       Object.keys(data).forEach(function(key, i, arr) {
         assert.deepEqual(

--- a/ui/packages/consul-ui/tests/unit/serializers/application-test.js
+++ b/ui/packages/consul-ui/tests/unit/serializers/application-test.js
@@ -1,11 +1,7 @@
 import { module } from 'qunit';
 import test from 'ember-sinon-qunit/test-support/test';
 import { setupTest } from 'ember-qunit';
-import {
-  HEADERS_SYMBOL as META,
-  HEADERS_DATACENTER as DC,
-  HEADERS_NAMESPACE as NSPACE,
-} from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 
 module('Unit | Serializer | application', function(hooks) {
   setupTest(hooks);

--- a/ui/packages/consul-ui/tests/unit/serializers/application-test.js
+++ b/ui/packages/consul-ui/tests/unit/serializers/application-test.js
@@ -65,10 +65,7 @@ module('Unit | Serializer | application', function(hooks) {
     const expected = {
       Datacenter: 'dc-1',
       Name: 'name',
-      [META]: {
-        [DC.toLowerCase()]: 'dc-1',
-        [NSPACE.toLowerCase()]: '',
-      },
+      [META]: {},
       'primary-key-name': 'name',
     };
     const respond = function(cb) {

--- a/ui/packages/consul-ui/tests/unit/serializers/kv-test.js
+++ b/ui/packages/consul-ui/tests/unit/serializers/kv-test.js
@@ -42,7 +42,9 @@ module('Unit | Serializer | kv', function(hooks) {
     ['respondForCreateRecord', 'respondForUpdateRecord'].forEach(function(item) {
       const actual = serializer[item](
         function(cb) {
-          const headers = {};
+          const headers = {
+            'X-Consul-Namespace': 'default',
+          };
           const body = true;
           return cb(headers, body);
         },
@@ -71,7 +73,9 @@ module('Unit | Serializer | kv', function(hooks) {
     ['respondForCreateRecord', 'respondForUpdateRecord'].forEach(function(item) {
       const actual = serializer[item](
         function(cb) {
-          const headers = {};
+          const headers = {
+            'X-Consul-Namespace': 'default',
+          };
           const body = {
             Key: uid,
             Datacenter: dc,

--- a/ui/packages/consul-ui/tests/unit/utils/create-fingerprinter-test.js
+++ b/ui/packages/consul-ui/tests/unit/utils/create-fingerprinter-test.js
@@ -14,7 +14,7 @@ module('Unit | Utility | create fingerprinter', function() {
       uid: '["namespace","dc","slug"]',
     };
     const fingerprint = createFingerprinter('Datacenter', 'Namespace');
-    const actual = fingerprint('uid', 'ID', 'dc')(obj);
+    const actual = fingerprint('uid', 'ID', 'dc', 'namespace')(obj);
     assert.deepEqual(actual, expected);
   });
   test("fingerprint returns a 'unique' fingerprinted object based on primary, slug and foreign keys, and uses default namespace if none set", function(assert) {
@@ -28,7 +28,7 @@ module('Unit | Utility | create fingerprinter', function() {
       uid: '["default","dc","slug"]',
     };
     const fingerprint = createFingerprinter('Datacenter', 'Namespace');
-    const actual = fingerprint('uid', 'ID', 'dc')(obj);
+    const actual = fingerprint('uid', 'ID', 'dc', 'default')(obj);
     assert.deepEqual(actual, expected);
   });
   test("fingerprint throws an error if it can't find a foreignKey", function(assert) {


### PR DESCRIPTION
This PR mainly adds `partition` to our HTTP adapter. Additionally and perhaps most importantly, we've also taken the opportunity to move our 'conditional namespaces' deeper into the app.

The reason for doing this was, we like that namespaces should be thought of as required instead of conditional, 'special' things and would like the same thinking to be applied to `partitions`.

Now, instead of using code ~throughout the app~ throughout the adapters to add/remove namespaces or partitions depending on whether they are enabled or not. As a UI engineer you just pretend that namespaces and partitions are always enabled, and we remove them for you deeper in the app, out of the way of you forgetting to treat these properties as a special case.

Notes:

1. Added a PartitionAbility while we were there (not used as yet)
2. Started to remove the CONSTANT variables we had just for property names. I prefer that our adapters are as readable and straightforwards as possible, it just looks like HTTP.
3. We'll probably remove our `formatDatacenter` method we use also at some point, it was mainly too make it look the same as our previous `formatNspace`, but now we don't have that, it instead now looks different!
4. We enable parsing of `partition` in the UIs URL, but this is feature flagged so still does nothing just yet.
5. All of the test changes were related to the fact that we were treating `client.url` as a function rather than a method, and now that we reference `this` in `client.url` (etc) it needs binding to `client`.

There are no additional tests added for `partition` as yet.

---

I've been a AFK for a while since this originally went up in draft, and there is some additional information worthwhile adding here before I take it out of draft.

I also found out that whilst partitions are almost the same feature as namespaces, they are 'slightly' different even in the way the HTTP API works.

Namespace related HTTP API lets us use a `?ns=` queryParam, a `X-Consul-Namespace` HTTP header, or for PUTing/POSTing a `Namespace` property in the HTTP body.

When building our namespace support we decided to stick as close to recognised REST-like standards as possible. So for all GET requests we used the `?ns=` queryParam, and for all PUT/POST requests we used the `Namespace` HTTP body property (that was part of the data we were PUTing/POSTing.

One of the little 'slightly different' facts out our Partition support is that its HTTP API interaction doesn't allow you to specify the partition in the HTTP body at all. All partition HTTP interaction MUST use either the `?paritition=` or the `X-Consul-Partition` HTTP header. This means even though (from our UIs perspective) namespaces and partitions are pretty much the same thing, just different levels of the hierarchy, the HTTP interaction would have been (previous to the work in this PR) slightly different. Namespaces PUTing/POSTing using HTTP body and Partitions PUTing/POSTing using the `?partition=` query param.

Considering everything, now seemed like a good time to change the previous Namespace HTTP interaction to only use `?ns=` even for PUTing/POSTing rather than have this weird little confusing difference between Namespaces and Partitions in our codebase forever.

Therefore this PR included moving all the the Namespace HTTP interaction to only ever use `?ns=`.

And then came the tests...

As we had moved things around a little during this PR, we already had to make some integration test amends to reflect the fact that code that was affecting the result of the integration tests had been moved to a different level/layer, and therefore the expected result changed. But with this change to '`?ns=` everywhere' meant we also had to update all our tests to expect this - everywhere.

All in all this was a similar level of tedium that we mentioned in the earlier piece of this PR, and as well as just sitting down to get the same tiny little thing done everywhere throughout our tests - you need to sit a really think about whether you were actually changing the test to ensure its testing what it should be. As 'a namespace' can depend on whether you are in OSS or not, and then what happens with an undefined namespace with no token, and undefined namespace with a token that is different from the current namespace etc etc to take into account, you have to be careful going through this. Added to this is the fact that our test suite is currently ~4000-5000 tests strong, which means it take around 20-25 minutes or so to run the entire test suite, and whilst I'd generally be just filtering the tests I was interested in at anyone time, it still took quite a while of backwards and forwards-ing and re-running tests to make sure I'd thought everything through properly (🤞 ). Luckily I've had plenty to work on apart from this so it hasn't meant much "just watching and waiting for a green".

Finally this was just about adding partition support to the HTTP layer (and making namespaces consistent with it), once this is merged application layer will be next up.
