### PR TITLE
docs: Remove beta tag for 1.10 features

### DIFF
--- a/website/content/docs/connect/config-entries/index.mdx
+++ b/website/content/docs/connect/config-entries/index.mdx
@@ -15,7 +15,7 @@ The following configuration entries are supported:
 - [Ingress Gateway](/docs/connect/config-entries/ingress-gateway) - defines the
   configuration for an ingress gateway
 
-- [Mesh](/docs/connect/config-entries/mesh) <sup>Beta</sup> - controls
+- [Mesh](/docs/connect/config-entries/mesh) - controls
   mesh-wide configuration that applies across namespaces and federated datacenters.
 
 - [Proxy Defaults](/docs/connect/config-entries/proxy-defaults) - controls

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -8,7 +8,7 @@ description: >-
   Currently, only one mesh entry is supported.
 ---
 
-# Mesh <sup>Beta</sup>
+# Mesh
 
 -> **v1.10.0+:** This config entry is supported in Consul versions 1.10.0+.
 

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -47,7 +47,7 @@ spec:
 </Tab>
 </Tabs>
 
-### Upstream configuration <sup>Beta</sup>
+### Upstream configuration
 
 <Tabs>
 <Tab heading="HCL">

--- a/website/content/docs/connect/registration/service-registration.mdx
+++ b/website/content/docs/connect/registration/service-registration.mdx
@@ -122,7 +122,7 @@ registering a proxy instance.
   instance. This is created by the application. This conflicts with `local_service_address`
   and `local_service_port`.  This is only supported when using Envoy for the proxy.
 
-- `mode` `(string: "")` <sup>Beta</sup> - One of \`direct\` or \`transparent\`. Added in v1.10.0.
+- `mode` `(string: "")` - One of \`direct\` or \`transparent\`. Added in v1.10.0.
   - `"transparent"` - represents that inbound and outbound application traffic is being
     captured and redirected through the proxy. This mode does not enable the traffic redirection
     itself. Instead it signals Consul to configure Envoy as if traffic is already being redirected.
@@ -134,7 +134,7 @@ registering a proxy instance.
     2.  The `service-defaults` configuration for the service.
     3.  The `global` `proxy-defaults`.
 
-- `transparent_proxy` `(object: {})` <sup>Beta</sup> - Specifies the configuration specific to proxies in `transparent` mode.
+- `transparent_proxy` `(object: {})` - Specifies the configuration specific to proxies in `transparent` mode.
   The format is defined in the [Transparent Proxy Configuration Reference](#transparent-proxy-configuration-reference).
   Added in v1.10.0.
 
@@ -225,7 +225,7 @@ followed by documentation for each attribute.
 - `mesh_gateway` `(object: {})` - Specifies the mesh gateway configuration
   for this proxy. The format is defined in the [Mesh Gateway Configuration Reference](#mesh-gateway-configuration-reference).
 
-### Transparent Proxy Configuration Reference <sup>Beta</sup>
+### Transparent Proxy Configuration Reference
 
 The following examples show additional configuration for transparent proxies.
 
@@ -375,7 +375,7 @@ registrations](/docs/agent/services#service-definition-parameter-case).
     but the proxy registration will not fail.
   - `protocol` `(string: "http")` - Sets the protocol of the listener. One of `http` or `http2`. For gRPC use `http2`.
 
-### Unix Domain Sockets <sup>Beta</sup>
+### Unix Domain Sockets
 
 The following examples show additional configuration for Unix domain sockets.
 

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -123,7 +123,7 @@ This is useful to transition to Connect by allowing both Connect and
 non-Connect connections. To restrict access to only Connect-authorized clients,
 any listeners should bind to localhost only (such as `127.0.0.1`).
 
--> **Note:** As of consul `v1.10.0-beta1`, consul-k8s `v0.26.0-beta1` and Consul Helm `v0.32.0-beta1`,
+-> **Note:** As of consul `v1.10.0`, consul-k8s `v0.26.0` and Consul Helm `v0.32.0`,
 all Consul Service Mesh services will run with transparent proxy enabled by default. Running with transparent
 proxy will enforce all inbound and outbound traffic to go through the Envoy proxy.
 

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -48,7 +48,7 @@ would work on a Pod, a StatefulSet, or a DaemonSet.
 This Deployment specification starts a server that responds to any
 HTTP request with the static text "hello world".
 
--> **Note:** As of consul-k8s `v0.26.0-beta1` and Consul Helm `v0.32.0-beta1`, having a Kubernetes
+-> **Note:** As of consul-k8s `v0.26.0` and Consul Helm `v0.32.0`, having a Kubernetes
 service is **required** to run services on the Consul Service Mesh.
 
 ```yaml

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -70,14 +70,6 @@ export default function DownloadsPage(staticProps) {
               &quot;armhf&quot; || echo &quot;armel&quot;
             </code>
           </div>
-          <div className={s.releaseCandidate}>
-            <p>
-              A beta for Consul v1.10.0 is available! The release can be{' '}
-              <a href="https://releases.hashicorp.com/consul/1.10.0-beta3/">
-                downloaded here
-              </a>
-            </p>
-          </div>
         </>
       }
       {...staticProps}


### PR DESCRIPTION
Remove beta tag for 1.10 features which are now GA.

Also remove beta callout on downloads page.