### PR TITLE
docs - Adding Mesh as CRD in Consul K8s

### DIFF
--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -257,7 +257,7 @@ spec:
                     \`transparent\` represents that inbound and outbound application traffic is being
                     captured and redirected through the proxy. This mode does not enable the traffic redirection
                      itself. Instead it signals Consul to configure Envoy as if traffic is already being redirected.
-                    \`direct\` represents that the proxy's listeners must be dialed directly by the local
+                    \`direct\` represents that the proxy&apos;s listeners must be dialed directly by the local
                     application and other proxies.
                     Added in v1.10.0.`,
       yaml: false,

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -257,7 +257,7 @@ spec:
                     \`transparent\` represents that inbound and outbound application traffic is being
                     captured and redirected through the proxy. This mode does not enable the traffic redirection
                      itself. Instead it signals Consul to configure Envoy as if traffic is already being redirected.
-                    \`direct\` represents that the proxy&apos;s listeners must be dialed directly by the local
+                    \`direct\` represents that the proxy's listeners must be dialed directly by the local
                     application and other proxies.
                     Added in v1.10.0.`,
       yaml: false,
@@ -303,12 +303,11 @@ spec:
                     It is supported here for backwards compatibility with Consul versions prior to 1.6.0.
                   `,
               },
-            },
-            {
-              name: 'ConnectTimeoutMs',
-              type: 'int: 5000',
-              description: {
-                hcl: `The number of milliseconds to allow when making upstream connections before timing out.<br><br>
+              {
+                name: 'ConnectTimeoutMs',
+                type: 'int: 5000',
+                description: {
+                  hcl: `The number of milliseconds to allow when making upstream connections before timing out.<br><br>
                     NOTE: The connect timeout of a service should ideally be configured via the
                       [\`connect_timeout\`](/docs/connect/config-entries/service-resolver#connecttimeout)
                       field of a
@@ -318,7 +317,7 @@ spec:
                       [L7 features](/docs/connect/l7-traffic-management).
                       It is supported here for backwards compatibility with Consul versions prior to 1.6.0.
                     `,
-                yaml: `The number of milliseconds to allow when making upstream connections before timing out.<br><br>
+                  yaml: `The number of milliseconds to allow when making upstream connections before timing out.<br><br>
                     NOTE: The connect timeout of a service should ideally be configured via the
                       [\`connectTimeout\`](/docs/connect/config-entries/service-resolver#connecttimeout)
                       field of a
@@ -327,83 +326,83 @@ spec:
                       Configuring it in a proxy upstream config will not fully enable some
                       [L7 features](/docs/connect/l7-traffic-management).
                       It is supported here for backwards compatibility with Consul versions prior to 1.6.0.
-                    `,
-              },
-            },
-            {
-              name: 'MeshGateway',
-              type: 'MeshGatewayConfig: <optional>',
-              description: `Controls the default
+                `,
+                },
+              }, 
+              {
+                name: 'MeshGateway',
+                type: 'MeshGatewayConfig: <optional>',
+                description: `Controls the default
                   [mesh gateway configuration](/docs/connect/mesh-gateway#connect-proxy-configuration)
                   for this upstream.`,
-              children: [
-                {
-                  name: 'Mode',
-                  type: 'string: ""',
-                  description: 'One of `none`, `local`, or `remote`.',
-                },
-              ],
-            },
-            {
-              name: 'Limits',
-              type: 'Limits: <optional>',
-              description: `A set of limits to apply when connecting to the upstream service.
-                  These limits are applied on a per-service-instance basis.
-                  The following limits are respected.`,
-              children: [
-                {
-                  name: 'MaxConnections',
-                  type: 'int: 0',
-                  description: `The maximum number of connections a service instance
-                      will be allowed to establish against the given upstream. Use this to limit
-                      HTTP/1.1 traffic, since HTTP/1.1 has a request per connection.`,
-                },
-                {
-                  name: 'MaxPendingRequests',
-                  type: 'int: 0',
-                  description: `The maximum number of requests that will be queued
-                      while waiting for a connection to be established. For this configuration to
-                      be respected, a L7 protocol must be defined in the \`protocol\` field.`,
-                },
-                {
-                  name: 'MaxConcurrentRequests',
-                  type: 'int: 0',
-                  description: `The maximum number of concurrent requests that
-                      will be allowed at a single point in time. Use this to limit HTTP/2 traffic,
-                      since HTTP/2 has many requests per connection. For this configuration to be
-                      respected, a L7 protocol must be defined in the \`protocol\` field.`,
-                },
-              ],
-            },
-            {
-              name: 'PassiveHealthCheck',
-              type: 'PassiveHealthCheck: <optional>',
-              description: `Passive health checks are used to remove hosts from
-                    the upstream cluster which are unreachable or are returning errors..`,
-              children: [
-                {
-                  name: 'Interval',
-                  type: 'duration: 0s',
-                  description: {
-                    hcl: `The time between checks. Each check will cause hosts which
-                        have exceeded \`max_failures\` to be removed from the load balancer, and
-                        any hosts which have passed their ejection time to be returned to the
-                        load balancer.`,
-                    yaml: `The time between checks. Each check will cause hosts which
-                        have exceeded \`maxFailures\` to be removed from the load balancer, and
-                        any hosts which have passed their ejection time to be returned to the
-                        load balancer.`,
+                children: [
+                  {
+                    name: 'Mode',
+                    type: 'string: ""',
+                    description: 'One of `none`, `local`, or `remote`.',
                   },
-                },
-                {
-                  name: 'MaxFailures',
-                  type: 'int: 0',
-                  description: `The number of consecutive failures which cause a host to be
-                    removed from the load balancer.`,
-                },
-              ],
-            },
-          ],
+                ],
+              },
+              {
+                name: 'Limits',
+                type: 'Limits: <optional>',
+                description: `A set of limits to apply when connecting to the upstream service.
+                    These limits are applied on a per-service-instance basis.
+                    The following limits are respected.`,
+                children: [
+                  {
+                    name: 'MaxConnections',
+                    type: 'int: 0',
+                    description: `The maximum number of connections a service instance
+                        will be allowed to establish against the given upstream. Use this to limit
+                        HTTP/1.1 traffic, since HTTP/1.1 has a request per connection.`,
+                  },
+                  {
+                    name: 'MaxPendingRequests',
+                    type: 'int: 0',
+                    description: `The maximum number of requests that will be queued
+                        while waiting for a connection to be established. For this configuration to
+                        be respected, a L7 protocol must be defined in the \`protocol\` field.`,
+                  },
+                  {
+                    name: 'MaxConcurrentRequests',
+                    type: 'int: 0',
+                    description: `The maximum number of concurrent requests that
+                        will be allowed at a single point in time. Use this to limit HTTP/2 traffic,
+                        since HTTP/2 has many requests per connection. For this configuration to be
+                        respected, a L7 protocol must be defined in the \`protocol\` field.`,
+                  },
+                ],
+              },
+              {
+                name: 'PassiveHealthCheck',
+                type: 'PassiveHealthCheck: <optional>',
+                description: `Passive health checks are used to remove hosts from
+                    the upstream cluster which are unreachable or are returning errors..`,
+                children: [
+                  {
+                    name: 'Interval',
+                    type: 'duration: 0s',
+                    description: {
+                      hcl: `The time between checks. Each check will cause hosts which
+                          have exceeded \`max_failures\` to be removed from the load balancer, and
+                          any hosts which have passed their ejection time to be returned to the
+                          load balancer.`,
+                      yaml: `The time between checks. Each check will cause hosts which
+                          have exceeded \`maxFailures\` to be removed from the load balancer, and
+                          any hosts which have passed their ejection time to be returned to the
+                          load balancer.`,
+                    },
+                  },
+                  {
+                    name: 'MaxFailures',
+                    type: 'int: 0',
+                    description: `The number of consecutive failures which cause a host to be
+                      removed from the load balancer.`,
+                  },
+                ],
+              },
+            ],
         },
         {
           name: 'Defaults',

--- a/website/content/docs/k8s/crds/index.mdx
+++ b/website/content/docs/k8s/crds/index.mdx
@@ -17,6 +17,7 @@ cluster-wide defaults for the service mesh.
 
 We currently support the follow configuration entry kinds:
 
+- [`Mesh`](/docs/connect/config-entries/mesh)
 - [`ProxyDefaults`](/docs/connect/config-entries/proxy-defaults)
 - [`ServiceDefaults`](/docs/connect/config-entries/service-defaults)
 - [`ServiceSplitter`](/docs/connect/config-entries/service-splitter)


### PR DESCRIPTION
Mesh is now a Config Entry as well as CRD as of Consul 1.10 GA. Also removing extra brace on ServiceDefaults that was causing Vercel deployments to fail.