### PR TITLE
regenerate expired root certs for aws consul and vault

### DIFF
--- a/.changelog/10461.txt
+++ b/.changelog/10461.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+added a check to the intermediate certificate expiration time before it's used to sign a leaf certificate.
+```

--- a/agent/connect/ca/common.go
+++ b/agent/connect/ca/common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/consul/agent/connect"
 )
@@ -88,4 +89,10 @@ func validateSignIntermediate(csr *x509.CertificateRequest, spiffeID *connect.Sp
 		}
 	}
 	return nil
+}
+
+const rootExpiryGracePeriod = -1
+
+func isExpired(rootCert *x509.Certificate) bool {
+	return rootCert.NotAfter.Before(time.Now().AddDate(0, 0, rootExpiryGracePeriod))
 }

--- a/agent/connect/ca/provider_aws.go
+++ b/agent/connect/ca/provider_aws.go
@@ -189,7 +189,7 @@ func (a *AWSProvider) ensureCA() error {
 			rootCert, err2 := connect.ParseCert(a.rootPEM)
 			if err2 == nil {
 				// cert is still valid
-				if rootCert.NotAfter.After(time.Now()) {
+				if !isExpired(rootCert) {
 					// Load the certs
 					if err := a.loadCACerts(); err != nil {
 						return err

--- a/agent/connect/ca/provider_aws.go
+++ b/agent/connect/ca/provider_aws.go
@@ -185,12 +185,20 @@ func (a *AWSProvider) ensureCA() error {
 				*output.CertificateAuthority.Status)
 		}
 
-		// Load the certs
-		if err := a.loadCACerts(); err != nil {
-			return err
+		if a.rootPEM != "" {
+			rootCert, err2 := connect.ParseCert(a.rootPEM)
+			if err2 == nil {
+				// cert is still valid
+				if rootCert.NotAfter.After(time.Now()) {
+					// Load the certs
+					if err := a.loadCACerts(); err != nil {
+						return err
+					}
+					a.arnChecked = true
+					return nil
+				}
+			}
 		}
-		a.arnChecked = true
-		return nil
 	}
 
 	// Need to create a Private CA resource.

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -171,7 +171,7 @@ func (c *ConsulProvider) GenerateRoot() error {
 		rootCert, err2 := connect.ParseCert(providerState.RootCert)
 		if err2 == nil {
 			// cert is still valid
-			if rootCert.NotAfter.After(time.Now()) {
+			if !isExpired(rootCert) {
 				return nil
 			}
 		}

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -164,8 +164,17 @@ func (c *ConsulProvider) GenerateRoot() error {
 	if !c.isPrimary {
 		return fmt.Errorf("provider is not the root certificate authority")
 	}
+
+	// try to parse and check the validity of the root cert
+	// if any error or expired regenerate it
 	if providerState.RootCert != "" {
-		return nil
+		rootCert, err2 := connect.ParseCert(providerState.RootCert)
+		if err2 == nil {
+			// cert is still valid
+			if rootCert.NotAfter.After(time.Now()) {
+				return nil
+			}
+		}
 	}
 
 	// Generate a private key if needed

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -178,7 +178,7 @@ func (v *VaultProvider) GenerateRoot() error {
 		// if parsing fail we assume it's not initialized and regenerate
 		if err2 != nil {
 			err = ErrBackendNotInitialized
-		} else if rootCert.NotAfter.Before(time.Now()) {
+		} else if isExpired(rootCert) {
 			err = ErrCertExpired
 		}
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -110,6 +110,7 @@ const (
 	intentionMigrationRoutineName         = "intention config entry migration"
 	secondaryCARootWatchRoutineName       = "secondary CA roots watch"
 	intermediateCertRenewWatchRoutineName = "intermediate cert renew watch"
+	rootCertRenewWatchRoutineName         = "root cert renew watch"
 	backgroundCAInitializationRoutineName = "CA initialization"
 )
 

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -375,6 +375,10 @@ var MaxLeafCertTTL = 365 * 24 * time.Hour
 // of the intermediate cert is checked and renewed if necessary.
 var IntermediateCertRenewInterval = time.Hour
 
+// RootCertRenewInterval is the interval at which the expiration
+// of the root cert is checked and renewed if necessary.
+var RootCertRenewInterval = time.Hour
+
 func (c CommonCAProviderConfig) Validate() error {
 	if c.SkipValidate {
 		return nil


### PR DESCRIPTION
Fix #9574 
Check if cert is expired in `GenerateRoot` of each ca provider and regenerate it if so