### PR TITLE
ui: Enable specifying additional docfy config as json

### DIFF
--- a/ui/packages/consul-ui/.docfy-config.js
+++ b/ui/packages/consul-ui/.docfy-config.js
@@ -1,10 +1,32 @@
 const path = require('path');
+
 const autolinkHeadings = require('remark-autolink-headings');
 const refractor = require('refractor');
 const prism = require('@mapbox/rehype-prism');
 
+const fs = require('fs');
+const read = fs.readFileSync;
+const exists = fs.existsSync;
+const chalk = require('chalk'); // comes with ember
+
+// allow extra docfy config
+let user = {sources: [], labels: {}};
+const $CONSUL_DOCFY_CONFIG = process.env.CONSUL_DOCFY_CONFIG || '';
+if($CONSUL_DOCFY_CONFIG.length > 0) {
+  try {
+      if(exists($CONSUL_DOCFY_CONFIG)) {
+        user = JSON.parse(read($CONSUL_DOCFY_CONFIG));
+      } else {
+        throw new Error(`Unable to locate ${$CONSUL_DOCFY_CONFIG}`);
+      }
+  } catch(e) {
+    console.error(chalk.yellow(`Docfy: ${e.message}`));
+  }
+}
+
 refractor.alias('handlebars', 'hbs');
 refractor.alias('shell', 'sh');
+
 
 module.exports = {
   remarkHbsOptions: {
@@ -56,8 +78,9 @@ module.exports = {
       urlSchema: 'auto',
       urlPrefix: 'docs/consul',
     }
-  ],
+  ].concat(user.sources),
   labels: {
-    "consul": "Consul Components"
+    "consul": "Consul Components",
+    ...user.labels
   }
 };

--- a/ui/packages/consul-ui/README.md
+++ b/ui/packages/consul-ui/README.md
@@ -90,12 +90,7 @@ CONSUL_HTTP_ADDR=http://10.0.0.1:8500 make start-consul
 
 ### Environment Variables
 
-There are various environment variable you can use whilst running `make start` or `make test` to configure various features:
-
-| Variable | Default Value | Description |
-| -------- | ------------- | ----------- |
-| `TESTEM_AUTOLAUNCH` | Chrome | Controls which browser to open tests in. A setting of "" means 'let me manually open the browser' |
-| `EMBER_TEST_REPORT` |  | Output a test report |
+See [./docs/index.mdx](./docs/index.mdx#environment-variables)
 
 ### Contributing/Engineering Documentation
 

--- a/ui/packages/consul-ui/app/styles/debug.scss
+++ b/ui/packages/consul-ui/app/styles/debug.scss
@@ -57,7 +57,8 @@ html.is-debug body > .brand-loader {
     }
     > h1,
     > h2,
-    > h3 {
+    > h3,
+    > h4 {
       margin-bottom: 1em;
     }
     > h1 {
@@ -69,6 +70,9 @@ html.is-debug body > .brand-loader {
     }
     > h3 {
       @extend %h300;
+    }
+    > h4 {
+      @extend %h400;
     }
     > p {
       @extend %p1;

--- a/ui/packages/consul-ui/docs/index.mdx
+++ b/ui/packages/consul-ui/docs/index.mdx
@@ -5,6 +5,16 @@ title: Introduction
 
 Welcome to Consul UIs engineering documentation.
 
+## Environment Variables
+
+There are various environment variable you can use whilst running `make start` or `make test` to configure various features:
+
+| Variable | Default Value | Description |
+| -------- | ------------- | ----------- |
+| `TESTEM_AUTOLAUNCH` | Chrome | Controls which browser to open tests in. A setting of `""` means 'let me manually open the browser' |
+| `EMBER_TEST_REPORT` |  | Output a test report |
+| `CONSUL_DOCFY_CONFIG` |  | Define an additional `docfy-config.json` file to use |
+
 ## Adding documentation
 
 Our documentation use [docfy](https://docfy.dev/docs) for rendering our markdown+glimmer-component documentation. In order to live render any code examples use the `preview-template` meta, for example:


### PR DESCRIPTION
This PR allows an engineer to colocate additional documentation within the Consul UIs Engineering Documentation, if need be, by specifying a local environment variable. This additional documentation will then be available only to the engineer on their machine, it does not get bundled in with any of our automated builds or UI preview sites.

It began as a single line change but I added a little more error checking for if someone tries this and for whatever reason they haven't quite done it correctly. Errors will warn in terminal but not block compilation/application serving.

We also specifically take extra care to avoid using `require` (a cousin of `eval`) to pull in the extra config, and only use a JSON file for anything specified in the environment file, so nothing specified in this file can be executed.