### PR TITLE
website: bump use-cases to latest

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1808,9 +1808,9 @@
       "integrity": "sha512-wB/SE9ZA8dYr47ezA8rfGFp/HovcGElYVsN/O7qaL2BJkQMs36s7ok2qTDnimmTIX87q2OwnbLNfpyZZsXYnwg=="
     },
     "@hashicorp/react-use-cases": {
-      "version": "3.0.3-alpha.6",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-use-cases/-/react-use-cases-3.0.3-alpha.6.tgz",
-      "integrity": "sha512-+L/MVT9x/ipQFSwSrmOXctLnpMbwQH2vzUvGfLKyXRvM823iYjWgzWp4gVPkh8cfEy2Dx3BcghVeM0WTIFelZg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-use-cases/-/react-use-cases-4.0.0.tgz",
+      "integrity": "sha512-CEu0UcPtewOWXa3IY34hdpnpWocHGarDRKy7hOPGREc+/ofVGaN7DxGwpWU6+t4UeBSa0M1KnrlM2LQ9bm3img==",
       "requires": {
         "@hashicorp/react-image": "^4.0.1",
         "@hashicorp/react-inline-svg": "^6.0.1"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1808,13 +1808,12 @@
       "integrity": "sha512-wB/SE9ZA8dYr47ezA8rfGFp/HovcGElYVsN/O7qaL2BJkQMs36s7ok2qTDnimmTIX87q2OwnbLNfpyZZsXYnwg=="
     },
     "@hashicorp/react-use-cases": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-use-cases/-/react-use-cases-3.0.2.tgz",
-      "integrity": "sha512-ICha+uTe62qq1BpnKlIrZhMFKBf+YD8efJITsV+HiKVZnhNdeoTmq8xzv4mK2tz/hCkxT3fNC1HYwTxUczFErQ==",
+      "version": "3.0.3-alpha.6",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-use-cases/-/react-use-cases-3.0.3-alpha.6.tgz",
+      "integrity": "sha512-+L/MVT9x/ipQFSwSrmOXctLnpMbwQH2vzUvGfLKyXRvM823iYjWgzWp4gVPkh8cfEy2Dx3BcghVeM0WTIFelZg==",
       "requires": {
         "@hashicorp/react-image": "^4.0.1",
-        "@hashicorp/react-inline-svg": "^6.0.1",
-        "marked": "^0.7.0"
+        "@hashicorp/react-inline-svg": "^6.0.1"
       }
     },
     "@hashicorp/react-vertical-text-block-list": {
@@ -8346,11 +8345,6 @@
       "requires": {
         "repeat-string": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",

--- a/website/package.json
+++ b/website/package.json
@@ -32,7 +32,7 @@
     "@hashicorp/react-text-split": "3.1.1",
     "@hashicorp/react-text-split-with-code": "3.3.2",
     "@hashicorp/react-text-split-with-image": "4.1.1",
-    "@hashicorp/react-use-cases": "3.0.3-alpha.6",
+    "@hashicorp/react-use-cases": "4.0.0",
     "@hashicorp/react-vertical-text-block-list": "6.0.2",
     "next": "10.1.3",
     "next-mdx-remote": "3.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -32,7 +32,7 @@
     "@hashicorp/react-text-split": "3.1.1",
     "@hashicorp/react-text-split-with-code": "3.3.2",
     "@hashicorp/react-text-split-with-image": "4.1.1",
-    "@hashicorp/react-use-cases": "3.0.2",
+    "@hashicorp/react-use-cases": "3.0.3-alpha.6",
     "@hashicorp/react-vertical-text-block-list": "6.0.2",
     "next": "10.1.3",
     "next-mdx-remote": "3.0.1",


### PR DESCRIPTION
This PR bumps `@hashicorp/react-use-cases` to the latest version, which no longer includes `marked` for client-side text processing.

As used on the Consul website, there was no markdown in use with this component, so no other changes were necessary.