### PR TITLE
ca: replace ca.PrimaryIntermediateProviders

### DIFF
--- a/agent/connect/ca/provider.go
+++ b/agent/connect/ca/provider.go
@@ -16,11 +16,12 @@ import (
 // on servers and CA provider.
 var ErrRateLimited = errors.New("operation rate limited by CA provider")
 
-// PrimaryIntermediateProviders is a list of CA providers that make use use of an
-// intermediate cert in the primary datacenter as well as the secondary. This is used
-// when determining whether to run the intermediate renewal routine in the primary.
-var PrimaryIntermediateProviders = map[string]struct{}{
-	"vault": {},
+// PrimaryUsesIntermediate is an optional interface  that CA providers may implement
+// to indicate that they use an intermediate cert in the primary datacenter as
+// well as the secondary. This is used when determining whether to run the
+// intermediate renewal routine in the primary.
+type PrimaryUsesIntermediate interface {
+	PrimaryUsesIntermediate()
 }
 
 // ProviderConfig encapsulates all the data Consul passes to `Configure` on a

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -11,12 +11,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/consul/agent/connect"
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/go-hclog"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/logging"
 )
 
 const VaultCALeafCertRole = "leaf-cert"
@@ -518,7 +519,7 @@ func (v *VaultProvider) CrossSignCA(cert *x509.Certificate) (string, error) {
 }
 
 // SupportsCrossSigning implements Provider
-func (c *VaultProvider) SupportsCrossSigning() (bool, error) {
+func (v *VaultProvider) SupportsCrossSigning() (bool, error) {
 	return true, nil
 }
 
@@ -556,6 +557,8 @@ func (v *VaultProvider) Cleanup(providerTypeChange bool, otherConfig map[string]
 func (v *VaultProvider) Stop() {
 	v.shutdown()
 }
+
+func (v *VaultProvider) PrimaryUsesIntermediate() {}
 
 func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderConfig, error) {
 	config := structs.VaultCAProviderConfig{

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -9,13 +9,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+	uuid "github.com/hashicorp/go-uuid"
+
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/connect/ca"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib/routine"
-	"github.com/hashicorp/go-hclog"
-	uuid "github.com/hashicorp/go-uuid"
 )
 
 type caState string
@@ -1070,12 +1071,7 @@ func (c *CAManager) RenewIntermediate(ctx context.Context, isPrimary bool) error
 	// If this is the primary, check if this is a provider that uses an intermediate cert. If
 	// it isn't, we don't need to check for a renewal.
 	if isPrimary {
-		_, config, err := state.CAConfig(nil)
-		if err != nil {
-			return err
-		}
-
-		if _, ok := ca.PrimaryIntermediateProviders[config.Provider]; !ok {
+		if _, ok := provider.(ca.PrimaryUsesIntermediate); !ok {
 			return nil
 		}
 	}


### PR DESCRIPTION
With an optional interface that providers can use to indicate if they
use an intermediate cert in the primary DC.

This removes the need to look up the provider config when renewing the
intermediate.