### PR TITLE
docs: Remove beta version references from Helm reference

### DIFF
--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -1090,7 +1090,7 @@ and consider if they're appropriate for your deployment.
     to explicitly opt-out of injection.
 
   - `transparentProxy` ((#v-connectinject-transparentproxy)) - Configures Transparent Proxy for Consul Service mesh services.
-    Using this feature requires Consul 1.10.0-beta1+ and consul-k8s 0.26.0-beta1+.
+    Using this feature requires Consul 1.10.0+ and consul-k8s 0.26.0+.
 
     - `defaultEnabled` ((#v-connectinject-transparentproxy-defaultenabled)) (`boolean: true`) - If true, then all Consul Service mesh will run with transparent proxy enabled by default,
       i.e. we enforce that all traffic within the pod will go through the proxy.


### PR DESCRIPTION
Removing references from the 1.10 beta that were included in Helm Configuration Reference