### PR TITLE
structs: prohibit config entries from referencing more than one partition at a time

### DIFF
--- a/.changelog/10478.txt
+++ b/.changelog/10478.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+structs: prohibit config entries from referencing more than one partition at a time
+```

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -169,6 +169,10 @@ func (e *ServiceConfigEntry) Validate() error {
 			if err != nil {
 				validationErr = multierror.Append(validationErr, fmt.Errorf("error in upstream override for %s: %v", override.ServiceName(), err))
 			}
+
+			if err := validateInnerEnterpriseMeta(&override.EnterpriseMeta, &e.EnterpriseMeta); err != nil {
+				validationErr = multierror.Append(validationErr, fmt.Errorf("error in upstream override for %s: %v", override.ServiceName(), err))
+			}
 		}
 
 		if e.UpstreamConfig.Defaults != nil {
@@ -801,6 +805,9 @@ func (cfg UpstreamConfig) validate(named bool) error {
 		}
 		if cfg.EnterpriseMeta.NamespaceOrEmpty() != "" {
 			return fmt.Errorf("Namespace must be empty")
+		}
+		if cfg.EnterpriseMeta.PartitionOrEmpty() != "" {
+			return fmt.Errorf("Partition must be empty")
 		}
 	}
 

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -379,6 +379,8 @@ type ServiceRouteDestination struct {
 	// splitting.
 	Namespace string `json:",omitempty"`
 
+	// NOTE: Partition is not represented here by design. Do not add it.
+
 	// PrefixRewrite allows for the proxied request to have its matching path
 	// prefix modified before being sent to the destination. Described more
 	// below in the envoy implementation section.
@@ -658,6 +660,8 @@ type ServiceSplit struct {
 	// If this field is specified then this route is ineligible for further
 	// splitting.
 	Namespace string `json:",omitempty"`
+
+	// NOTE: Partition is not represented here by design. Do not add it.
 }
 
 // ServiceResolverConfigEntry defines which instances of a service should
@@ -1048,6 +1052,8 @@ type ServiceResolverRedirect struct {
 	// Datacenter is the datacenter to resolve the service from instead of the
 	// current one (optional).
 	Datacenter string `json:",omitempty"`
+
+	// NOTE: Partition is not represented here by design. Do not add it.
 }
 
 // There are some restrictions on what is allowed in here:
@@ -1082,6 +1088,8 @@ type ServiceResolverFailover struct {
 	//
 	// This is a DESTINATION during failover.
 	Datacenters []string `json:",omitempty"`
+
+	// NOTE: Partition is not represented here by design. Do not add it.
 }
 
 // LoadBalancer determines the load balancing policy and configuration for services
@@ -1335,6 +1343,8 @@ type DiscoveryChainRequest struct {
 	Name                 string
 	EvaluateInDatacenter string
 	EvaluateInNamespace  string
+
+	// NOTE: Partition is not represented here by design. Do not add it.
 
 	// OverrideMeshGateway allows for the mesh gateway setting to be overridden
 	// for any resolver in the compiled chain.

--- a/agent/structs/config_entry_intentions.go
+++ b/agent/structs/config_entry_intentions.go
@@ -567,7 +567,7 @@ func (e *ServiceIntentionsConfigEntry) validate(legacyWrite bool) error {
 			return fmt.Errorf("Sources[%d].%v", i, err)
 		}
 
-		if err := validateSourceIntentionEnterpriseMeta(&src.EnterpriseMeta); err != nil {
+		if err := validateSourceIntentionEnterpriseMeta(&src.EnterpriseMeta, &e.EnterpriseMeta); err != nil {
 			return fmt.Errorf("Sources[%d].%v", i, err)
 		}
 

--- a/agent/structs/config_entry_intentions_oss.go
+++ b/agent/structs/config_entry_intentions_oss.go
@@ -2,6 +2,6 @@
 
 package structs
 
-func validateSourceIntentionEnterpriseMeta(_ *EnterpriseMeta) error {
+func validateSourceIntentionEnterpriseMeta(_, _ *EnterpriseMeta) error {
 	return nil
 }

--- a/agent/structs/config_entry_intentions_test.go
+++ b/agent/structs/config_entry_intentions_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func generateUUID() (ret string) {

--- a/agent/structs/config_entry_oss.go
+++ b/agent/structs/config_entry_oss.go
@@ -30,3 +30,7 @@ func validateUnusedKeys(unused []string) error {
 	}
 	return err
 }
+
+func validateInnerEnterpriseMeta(_, _ *EnterpriseMeta) error {
+	return nil
+}


### PR DESCRIPTION
affected kinds: service-defaults, ingress-gateway, terminating-gateway, service-intentions