### PR TITLE
docs/nia: Update CTS compatible versions

### DIFF
--- a/website/content/docs/nia/compatibility.mdx
+++ b/website/content/docs/nia/compatibility.mdx
@@ -12,6 +12,15 @@ Below are the supported Consul versions with compatible Consul-Terraform-Sync ve
 
 | Consul Version                       | Compatible Consul-Terraform-Sync Version |
 | ------------------------------------ | ---------------------------------------- |
-| Latest patch version of 1.9          | 0.1.0                                    |
-| Latest patch version of 1.8 (1.8.9)  | 0.1.0                                    |
-| Latest patch version of 1.7 (1.7.13) | 0.1.0                                    |
+| Latest patch version of 1.10         | 0.1 - 0.2                                |
+| Latest patch version of 1.9          | 0.1 - 0.2                                |
+| Latest patch version of 1.8          | 0.1 - 0.2                                |
+
+## Terraform
+
+Consul-Terraform-Sync is compatible with the following Terraform OSS versions:
+
+| Consul-Terraform-Sync | Compatible Terraform Version |
+|-----------------------|------------------------------|
+| 0.2                   | 0.13 - 0.15                  |
+| 0.1                   | 0.13 - 0.14                  |


### PR DESCRIPTION
Did a quick verification running CTS v0.2.0 with Consul 1.9.7 and 1.10.0 (the CI tests run with 1.8.0 so I didn't manually test that). Also tested CTS v0.1.2 with Consul 1.10.0

Added Terraform versions too because it's probably helpful 🙂 

[Preview link](https://consul-prf0b3obb-hashicorp.vercel.app/docs/nia/compatibility)