### PR TITLE
ci: test api/sdk against last 2 Go versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ parameters:
 
 references:
   images:
+    # When updating the Go version, remember to also update the versions in the
+    # workflows section for go-test-lib jobs.
     go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.16.3
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:14-browsers
 
@@ -273,10 +275,15 @@ jobs:
           path: /tmp/jsonfile
       - run: *notify-slack-failure
 
-  # split off a job for the API package since it is separate
-  go-test-api:
+  go-test-lib:
+    description: "test a library against a specific Go version"
+    parameters:
+      go-version:
+        type: string
+      path:
+        type: string
     docker:
-      - image: *GOLANG_IMAGE
+      - image: "docker.mirror.hashicorp.services/circleci/golang:<<parameters.go-version>>"
     environment:
       <<: *ENVIRONMENT
       GOTAGS: "" # No tags for OSS but there are for enterprise
@@ -286,16 +293,16 @@ jobs:
           at: /go/bin
       - run: *install-gotestsum
       - run:
-          working_directory: api
+          working_directory: <<parameters.path>>
           command: go mod download
       - run:
-          working_directory: api
+          working_directory: <<parameters.path>>
           name: go test
           command: |
             mkdir -p $TEST_RESULTS_DIR /tmp/jsonfile
             gotestsum \
               --format=short-verbose \
-              --jsonfile /tmp/jsonfile/go-test-api.log \
+              --jsonfile /tmp/jsonfile/go-test-<<parameters.path>>.log \
               --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
               -tags="$GOTAGS" -cover -coverprofile=coverage.txt \
               ./...
@@ -306,38 +313,6 @@ jobs:
           path: *TEST_RESULTS_DIR
       - store_artifacts:
           path: /tmp/jsonfile
-      - run: *notify-slack-failure
-
-  # split off a job for the SDK package since it is separate
-  go-test-sdk:
-    docker:
-      - image: *GOLANG_IMAGE
-    environment:
-      <<: *ENVIRONMENT
-      GOTAGS: "" # No tags for OSS but there are for enterprise
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /go/bin
-      - run: *install-gotestsum
-      - run:
-          working_directory: sdk
-          command: go mod download
-      - run:
-          working_directory: sdk
-          name: go test
-          command: |
-            mkdir -p $TEST_RESULTS_DIR
-            gotestsum \
-              --format=short-verbose \
-              --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
-              -tags=$GOTAGS -cover -coverprofile=coverage.txt \
-              ./...
-
-      - store_test_results:
-          path: *TEST_RESULTS_DIR
-      - store_artifacts:
-          path: *TEST_RESULTS_DIR
       - run: *notify-slack-failure
 
   # build all distros
@@ -988,10 +963,27 @@ workflows:
       - dev-build: *filter-ignore-non-go-branches
       - go-test:
           requires: [dev-build]
-      - go-test-api:
+      - go-test-lib:
+          name: "go-test-api go1.16"
+          path: api
+          go-version: "1.16"
           requires: [dev-build]
+      - go-test-lib:
+          name: "go-test-api go1.15"
+          path: api
+          go-version: "1.15"
+          requires: [dev-build]
+      - go-test-lib:
+          name: "go-test-sdk go1.16"
+          path: sdk
+          go-version: "1.16"
+          <<: *filter-ignore-non-go-branches
+      - go-test-lib:
+          name: "go-test-sdk go1.15"
+          path: sdk
+          go-version: "1.15"
+          <<: *filter-ignore-non-go-branches
       - go-test-race: *filter-ignore-non-go-branches
-      - go-test-sdk: *filter-ignore-non-go-branches
   build-distros:
     unless: << pipeline.parameters.trigger-load-test >>
     jobs:


### PR DESCRIPTION
So that we catch any incompatibilities with the preivous Go version.

Related to #10470