### PR TITLE
tlsutil: fix ServerName used for health checks that use TLS

### DIFF
--- a/.changelog/10490.txt
+++ b/.changelog/10490.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+checks: fixes the default ServerName used with TLS health checks.
+```

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -720,10 +720,6 @@ func (c *Configurator) IncomingHTTPSConfig() *tls.Config {
 func (c *Configurator) OutgoingTLSConfigForCheck(skipVerify bool, serverName string) *tls.Config {
 	c.log("OutgoingTLSConfigForCheck")
 
-	if serverName == "" {
-		serverName = c.serverNameOrNodeName()
-	}
-
 	if !c.enableAgentTLSForChecks() {
 		return &tls.Config{
 			InsecureSkipVerify: skipVerify,
@@ -731,6 +727,9 @@ func (c *Configurator) OutgoingTLSConfigForCheck(skipVerify bool, serverName str
 		}
 	}
 
+	if serverName == "" {
+		serverName = c.serverNameOrNodeName()
+	}
 	config := c.commonTLSConfig(false)
 	config.InsecureSkipVerify = skipVerify
 	config.ServerName = serverName

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -949,6 +949,34 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 			expected:   &tls.Config{InsecureSkipVerify: true},
 		},
 		{
+			name: "default tls, skip verify, default server name",
+			conf: func() (*Configurator, error) {
+				return NewConfigurator(Config{
+					TLSMinVersion:           "tls12",
+					EnableAgentTLSForChecks: false,
+					ServerName:              "servername",
+				}, nil)
+			},
+			skipVerify: true,
+			expected:   &tls.Config{InsecureSkipVerify: true},
+		},
+		{
+			name: "default tls, skip verify, check server name",
+			conf: func() (*Configurator, error) {
+				return NewConfigurator(Config{
+					TLSMinVersion:           "tls12",
+					EnableAgentTLSForChecks: false,
+					ServerName:              "servername",
+				}, nil)
+			},
+			skipVerify: true,
+			serverName: "check-server-name",
+			expected: &tls.Config{
+				InsecureSkipVerify: true,
+				ServerName:         "check-server-name",
+			},
+		},
+		{
 			name: "agent tls, skip verify, default server name",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -938,6 +938,13 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 
 	testCases := []testCase{
 		{
+			name: "default tls",
+			conf: func() (*Configurator, error) {
+				return NewConfigurator(Config{}, nil)
+			},
+			expected: &tls.Config{},
+		},
+		{
 			name: "default tls, skip verify, no server name",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{
@@ -955,6 +962,7 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 					TLSMinVersion:           "tls12",
 					EnableAgentTLSForChecks: false,
 					ServerName:              "servername",
+					NodeName:                "nodename",
 				}, nil)
 			},
 			skipVerify: true,
@@ -977,19 +985,34 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 			},
 		},
 		{
-			name: "agent tls, skip verify, default server name",
+			name: "agent tls, default server name",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{
 					TLSMinVersion:           "tls12",
 					EnableAgentTLSForChecks: true,
+					NodeName:                "nodename",
 					ServerName:              "servername",
+				}, nil)
+			},
+			expected: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				ServerName: "servername",
+			},
+		},
+		{
+			name: "agent tls, skip verify, node name for server name",
+			conf: func() (*Configurator, error) {
+				return NewConfigurator(Config{
+					TLSMinVersion:           "tls12",
+					EnableAgentTLSForChecks: true,
+					NodeName:                "nodename",
 				}, nil)
 			},
 			skipVerify: true,
 			expected: &tls.Config{
 				InsecureSkipVerify: true,
 				MinVersion:         tls.VersionTLS12,
-				ServerName:         "servername",
+				ServerName:         "nodename",
 			},
 		},
 		{

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
@@ -913,26 +915,86 @@ func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
 	require.Equal(t, []string{"h2", "http/1.1"}, c.IncomingHTTPSConfig().NextProtos)
 }
 
-func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {
-	c := Configurator{base: &Config{
-		TLSMinVersion:           "tls12",
-		EnableAgentTLSForChecks: false,
-	}}
-	tlsConf := c.OutgoingTLSConfigForCheck(true, "")
-	require.Equal(t, true, tlsConf.InsecureSkipVerify)
-	require.Equal(t, uint16(0), tlsConf.MinVersion)
+func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
+	type testCase struct {
+		name       string
+		conf       func() (*Configurator, error)
+		skipVerify bool
+		serverName string
+		expected   *tls.Config
+	}
 
-	c.base.EnableAgentTLSForChecks = true
-	c.base.ServerName = "servername"
-	tlsConf = c.OutgoingTLSConfigForCheck(true, "")
-	require.Equal(t, true, tlsConf.InsecureSkipVerify)
-	require.Equal(t, tlsLookup[c.base.TLSMinVersion], tlsConf.MinVersion)
-	require.Equal(t, c.base.ServerName, tlsConf.ServerName)
+	cmpTLSConfig := cmp.Options{
+		cmpopts.IgnoreFields(tls.Config{}, "GetCertificate", "GetClientCertificate"),
+		cmpopts.IgnoreUnexported(tls.Config{}),
+	}
 
-	tlsConf = c.OutgoingTLSConfigForCheck(true, "servername2")
-	require.Equal(t, true, tlsConf.InsecureSkipVerify)
-	require.Equal(t, tlsLookup[c.base.TLSMinVersion], tlsConf.MinVersion)
-	require.Equal(t, "servername2", tlsConf.ServerName)
+	run := func(t *testing.T, tc testCase) {
+		configurator, err := tc.conf()
+		require.NoError(t, err)
+		c := configurator.OutgoingTLSConfigForCheck(tc.skipVerify, tc.serverName)
+		assertDeepEqual(t, tc.expected, c, cmpTLSConfig)
+	}
+
+	testCases := []testCase{
+		{
+			name: "default tls, skip verify, no server name",
+			conf: func() (*Configurator, error) {
+				return NewConfigurator(Config{
+					TLSMinVersion:           "tls12",
+					EnableAgentTLSForChecks: false,
+				}, nil)
+			},
+			skipVerify: true,
+			expected:   &tls.Config{InsecureSkipVerify: true},
+		},
+		{
+			name: "agent tls, skip verify, default server name",
+			conf: func() (*Configurator, error) {
+				return NewConfigurator(Config{
+					TLSMinVersion:           "tls12",
+					EnableAgentTLSForChecks: true,
+					ServerName:              "servername",
+				}, nil)
+			},
+			skipVerify: true,
+			expected: &tls.Config{
+				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS12,
+				ServerName:         "servername",
+			},
+		},
+		{
+			name: "agent tls, skip verify, with server name override",
+			conf: func() (*Configurator, error) {
+				return NewConfigurator(Config{
+					TLSMinVersion:           "tls12",
+					EnableAgentTLSForChecks: true,
+					ServerName:              "servername",
+				}, nil)
+			},
+			skipVerify: true,
+			serverName: "override",
+			expected: &tls.Config{
+				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS12,
+				ServerName:         "override",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func assertDeepEqual(t *testing.T, x, y interface{}, opts ...cmp.Option) {
+	t.Helper()
+	if diff := cmp.Diff(x, y, opts...); diff != "" {
+		t.Fatalf("assertion failed: values are not equal\n--- expected\n+++ actual\n%v", diff)
+	}
 }
 
 func TestConfigurator_OutgoingRPCConfig(t *testing.T) {


### PR DESCRIPTION
Fixes #10481 
Related to https://github.com/hashicorp/consul/pull/9475#discussion_r566328324

When `EnableAgentTLSForChecks` is disabled we should not default to the agent server or node name.

The specific fix and test case can be seen in the second commit.