### PR TITLE
ui: Allow disabling of sourcemaps via env var

### DIFF
--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -13,29 +13,8 @@ const repositorySHA = utils.repositorySHA;
 const binaryVersion = utils.binaryVersion(repositoryRoot);
 
 module.exports = function(environment, $ = process.env) {
+  const env = utils.env($);
   // basic 'get env var with fallback' accessor
-  const env = function(flag, fallback) {
-    // a fallback value MUST be set
-    if (typeof fallback === 'undefined') {
-      throw new Error(`Please provide a fallback value for $${flag}`);
-    }
-    // return the env var if set
-    if (typeof $[flag] !== 'undefined') {
-      if (typeof fallback === 'boolean') {
-        // if we are expecting a boolean JSON parse strings to numbers/booleans
-        return !!JSON.parse($[flag]);
-      }
-      return $[flag];
-    }
-    // If the fallback is a function call it and return the result.
-    // Lazily calling the function means binaries used for fallback don't need
-    // to be available if we are sure the environment variables will be set
-    if (typeof fallback === 'function') {
-      return fallback();
-    }
-    // just return the fallback value
-    return fallback;
-  };
 
   let ENV = {
     modulePrefix: 'consul-ui',

--- a/ui/packages/consul-ui/config/utils.js
+++ b/ui/packages/consul-ui/config/utils.js
@@ -25,8 +25,34 @@ const binaryVersion = function(repositoryRoot) {
       .split('"')[1];
   };
 };
+const env = function($) {
+  return function(flag, fallback) {
+    // a fallback value MUST be set
+    if (typeof fallback === 'undefined') {
+      throw new Error(`Please provide a fallback value for $${flag}`);
+    }
+    // return the env var if set
+    if (typeof $[flag] !== 'undefined') {
+      if (typeof fallback === 'boolean') {
+        // if we are expecting a boolean JSON parse strings to numbers/booleans
+        return !!JSON.parse($[flag]);
+      }
+      return $[flag];
+    }
+    // If the fallback is a function call it and return the result.
+    // Lazily calling the function means binaries used for fallback don't need
+    // to be available if we are sure the environment variables will be set
+    if (typeof fallback === 'function') {
+      return fallback();
+    }
+    // just return the fallback value
+    return fallback;
+  };
+};
+
 module.exports = {
   repositoryYear: repositoryYear,
   repositorySHA: repositorySHA,
   binaryVersion: binaryVersion,
+  env: env,
 };

--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -1,14 +1,16 @@
 'use strict';
 const Funnel = require('broccoli-funnel');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const utils = require('./config/utils');
 
-module.exports = function(defaults) {
+module.exports = function(defaults, $ = process.env) {
   // available environments
   // ['production', 'development', 'staging', 'test'];
 
+  $ = utils.env($);
   const env = EmberApp.env();
   const prodlike = ['production', 'staging'];
-  const sourcemaps = !['production'].includes(env);
+  const sourcemaps = !['production'].includes(env) && !$('BABEL_DISABLE_SOURCEMAPS', false);
 
   const trees = {};
   const addons = {};


### PR DESCRIPTION
The rebuild of the Consul UI used very minimal ES6 features for 2 reasons:

1. Ember at the time felt very ES5-like (we started on Ember 2.18), to a certain extent there are still things in Ember that feel ES5-like (no real support for non-syntax related ES6 features like `Sets` and `Maps` in handlebars templates for example)
2. Using less layers makes things simpler in lots of subtle ways, for example we didn't even realize that we had sourcemaps disabled for such a long time before https://github.com/hashicorp/consul/pull/7651

We had a period of time that we were we started moving to use more ES6 style syntax, but pretty soon after that we reduced our browser support (https://github.com/hashicorp/consul/pull/9729) by not supporting anything older than ~2016. This brought us back to being able transpile as little as possible (decorators are so necessary for ember work we can't really avoid having to transpile those until they are native), and thus removing extra layers again. This means that sourcemaps aren't that much of a necessity again (depending on what your preference is)

Additionally, for a good while now I've noticed that since we enabled sourcemaps, they don't really work correctly in Ember. I often find myself debugging something and the stack trace line numbers are completely wrong, often reporting line numbers of over 1000 when the file where the error is is only a few lines long, it even sometimes gives me minus numbers. This can sometimes make chasing down errors a little frustrating as it is essentially saying 'the error is....umm I dunno, somewhere in this file but I'm not sure where'.

Here's one I noticed today which points me to line 1336 in a file of only 85 lines.

<img width="914" alt="Screenshot 2021-06-24 at 12 39 29" src="https://user-images.githubusercontent.com/554604/123312799-b65ab600-d520-11eb-9595-8229bd0788c9.png">

And another from a few days ago telling me the error was in a comment

<img width="632" alt="Screenshot 2021-06-21 at 16 45 28" src="https://user-images.githubusercontent.com/554604/123312967-e2763700-d520-11eb-90ee-3ee0cdb06bfe.png">

I've also heard both online and offline that there are problems with sourcemaps and ember, potentially related to ember-auto-import, and this might be the root of the problem. Its a strange one, as you don't notice at first, and the line numbers seem fine to begin with, but as time goes on the line numbers seem to get wildly out of kilter.

I've experimented a little with turning sourcemaps off again and I no longer seem to have problems with line numbers and my browser points me to exactly where the error is within the file. As we aren't really doing much transpilation, this is much easier for me to read and figure out what is happening.

Therefore (for the moment at least) I personally prefer not to have sourcemaps enabled, but I understand other folks might not. This PR makes enabling/disabling sourcemaps possible via a local environment variable, so I can choose what is best for me whilst not affecting anyone else and not have to remember to not commit change in our config files that I use just for myself.

We can revisit this when the new ember build tooling is ready for prime time, but if you don't set the environment variable then there is no real change here.
