### PR TITLE
[1.10.x] tlsutil: fix ServerName used for health checks that use TLS

### DIFF
--- a/.changelog/10490.txt
+++ b/.changelog/10490.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+checks: fixes the default ServerName used with TLS health checks.
+```

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -718,10 +718,6 @@ func (c *Configurator) IncomingHTTPSConfig() *tls.Config {
 func (c *Configurator) OutgoingTLSConfigForCheck(skipVerify bool, serverName string) *tls.Config {
 	c.log("OutgoingTLSConfigForCheck")
 
-	if serverName == "" {
-		serverName = c.serverNameOrNodeName()
-	}
-
 	if !c.enableAgentTLSForChecks() {
 		return &tls.Config{
 			InsecureSkipVerify: skipVerify,
@@ -729,6 +725,9 @@ func (c *Configurator) OutgoingTLSConfigForCheck(skipVerify bool, serverName str
 		}
 	}
 
+	if serverName == "" {
+		serverName = c.serverNameOrNodeName()
+	}
 	config := c.commonTLSConfig(false)
 	config.InsecureSkipVerify = skipVerify
 	config.ServerName = serverName


### PR DESCRIPTION
Backport of #10490