### PR TITLE
tlsutil: unexport and remove methods

### DIFF
--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -394,19 +394,11 @@ func validateConfig(config Config, pool *x509.CertPool, cert *tls.Certificate) e
 }
 
 func (c Config) anyVerifyIncoming() bool {
-	return c.baseVerifyIncoming() || c.VerifyIncomingRPC || c.VerifyIncomingHTTPS
+	return c.VerifyIncoming || c.VerifyIncomingRPC || c.VerifyIncomingHTTPS
 }
 
 func (c Config) verifyIncomingRPC() bool {
-	return c.baseVerifyIncoming() || c.VerifyIncomingRPC
-}
-
-func (c Config) verifyIncomingHTTPS() bool {
-	return c.baseVerifyIncoming() || c.VerifyIncomingHTTPS
-}
-
-func (c *Config) baseVerifyIncoming() bool {
-	return c.VerifyIncoming
+	return c.VerifyIncoming || c.VerifyIncomingRPC
 }
 
 func loadKeyPair(certFile, keyFile string) (*tls.Certificate, error) {
@@ -616,7 +608,7 @@ func (c *Configurator) verifyIncomingRPC() bool {
 func (c *Configurator) verifyIncomingHTTPS() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.base.verifyIncomingHTTPS()
+	return c.base.VerifyIncoming || c.base.VerifyIncomingHTTPS
 }
 
 // This function acquires a read lock because it reads from the config.

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -846,7 +846,7 @@ func TestConfigurator_VerifyIncomingRPC(t *testing.T) {
 	c := Configurator{base: &Config{
 		VerifyIncomingRPC: true,
 	}}
-	verify := c.verifyIncomingRPC()
+	verify := c.VerifyIncomingRPC()
 	require.Equal(t, c.base.VerifyIncomingRPC, verify)
 }
 

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -741,22 +741,21 @@ func TestConfigurator_OutgoingRPCTLSDisabled(t *testing.T) {
 		expected       bool
 	}
 	variants := []variant{
-		{false, false, nil, true},
-		{true, false, nil, false},
-		{false, true, nil, false},
-		{true, true, nil, false},
+		{false, false, nil, false},
+		{true, false, nil, true},
+		{false, true, nil, true},
+		{true, true, nil, true},
 
-		// {false, false, &x509.CertPool{}, false},
-		{true, false, &x509.CertPool{}, false},
-		{false, true, &x509.CertPool{}, false},
-		{true, true, &x509.CertPool{}, false},
+		{true, false, &x509.CertPool{}, true},
+		{false, true, &x509.CertPool{}, true},
+		{true, true, &x509.CertPool{}, true},
 	}
 	for i, v := range variants {
 		info := fmt.Sprintf("case %d", i)
 		c.caPool = v.pool
 		c.base.VerifyOutgoing = v.verify
 		c.base.AutoTLS = v.autoEncryptTLS
-		require.Equal(t, v.expected, c.outgoingRPCTLSDisabled(), info)
+		require.Equal(t, v.expected, c.outgoingRPCTLSEnabled(), info)
 	}
 }
 

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -768,7 +768,7 @@ func TestConfigurator_MutualTLSCapable(t *testing.T) {
 		c, err := NewConfigurator(config, nil)
 		require.NoError(t, err)
 
-		require.False(t, c.mutualTLSCapable())
+		require.False(t, c.MutualTLSCapable())
 	})
 
 	t.Run("ca and no keys", func(t *testing.T) {
@@ -779,7 +779,7 @@ func TestConfigurator_MutualTLSCapable(t *testing.T) {
 		c, err := NewConfigurator(config, nil)
 		require.NoError(t, err)
 
-		require.False(t, c.mutualTLSCapable())
+		require.False(t, c.MutualTLSCapable())
 	})
 
 	t.Run("ca and manual key", func(t *testing.T) {
@@ -792,7 +792,7 @@ func TestConfigurator_MutualTLSCapable(t *testing.T) {
 		c, err := NewConfigurator(config, nil)
 		require.NoError(t, err)
 
-		require.True(t, c.mutualTLSCapable())
+		require.True(t, c.MutualTLSCapable())
 	})
 
 	loadFile := func(t *testing.T, path string) string {
@@ -811,7 +811,7 @@ func TestConfigurator_MutualTLSCapable(t *testing.T) {
 		caPEM := loadFile(t, "../test/hostname/CertAuth.crt")
 		require.NoError(t, c.UpdateAutoTLSCA([]string{caPEM}))
 
-		require.False(t, c.mutualTLSCapable())
+		require.False(t, c.MutualTLSCapable())
 	})
 
 	t.Run("autoencrypt ca and autoencrypt key", func(t *testing.T) {
@@ -827,7 +827,7 @@ func TestConfigurator_MutualTLSCapable(t *testing.T) {
 		require.NoError(t, c.UpdateAutoTLSCA([]string{caPEM}))
 		require.NoError(t, c.UpdateAutoTLSCert(certPEM, keyPEM))
 
-		require.True(t, c.mutualTLSCapable())
+		require.True(t, c.MutualTLSCapable())
 	})
 }
 
@@ -856,14 +856,6 @@ func TestConfigurator_VerifyIncomingHTTPS(t *testing.T) {
 	}}
 	verify := c.verifyIncomingHTTPS()
 	require.Equal(t, c.base.VerifyIncomingHTTPS, verify)
-}
-
-func TestConfigurator_EnableAgentTLSForChecks(t *testing.T) {
-	c := Configurator{base: &Config{
-		EnableAgentTLSForChecks: true,
-	}}
-	enabled := c.enableAgentTLSForChecks()
-	require.Equal(t, c.base.EnableAgentTLSForChecks, enabled)
 }
 
 func TestConfigurator_IncomingRPCConfig(t *testing.T) {
@@ -1068,7 +1060,7 @@ func TestConfigurator_OutgoingRPCConfig(t *testing.T) {
 
 func TestConfigurator_OutgoingALPNRPCConfig(t *testing.T) {
 	c := &Configurator{base: &Config{}}
-	require.Nil(t, c.OutgoingALPNRPCConfig())
+	require.Nil(t, c.outgoingALPNRPCConfig())
 
 	c, err := NewConfigurator(Config{
 		VerifyOutgoing: false, // ignored, assumed true
@@ -1078,7 +1070,7 @@ func TestConfigurator_OutgoingALPNRPCConfig(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	tlsConf := c.OutgoingALPNRPCConfig()
+	tlsConf := c.outgoingALPNRPCConfig()
 	require.NotNil(t, tlsConf)
 	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
 	require.False(t, tlsConf.InsecureSkipVerify)


### PR DESCRIPTION
This PR makes a number of changes to try and reduce the size of tlsutil, and also make the logic a bit easier to trace by removing some functions.
Best viewed by individual commit.

* unexports a method that was only used internally
* removes methods whose sole purpose is to read a single field ("getter methods") and read the field directly
* removes some duplicate methods
* adds some slightly more descriptive docstrings
* inverts the logic in `outgoingRPCTLSDisabled` to remove double negatives.