### PR TITLE
website: upgrade react-head

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1516,9 +1516,9 @@
       }
     },
     "@hashicorp/react-head": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.0.2.tgz",
-      "integrity": "sha512-kKY/5XwWkBsDSvF8jHgNnxG4hx8ryPjoEtPFxPMVCly/ouwbslilIrWzqSYbeP7vUO686JzBLf5xkwq+HV0aig=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.1.0.tgz",
+      "integrity": "sha512-tXfxi9Aqhx83p6wt753WfiYUhOEMzrsWKON200zsNFdwN2WkHPwArWbR6+ludVXleEmsBufL8GRYq7iqnnKKlQ=="
     },
     "@hashicorp/react-hero": {
       "version": "7.2.1",

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "@hashicorp/react-docs-page": "13.2.0",
     "@hashicorp/react-featured-slider": "4.0.0",
     "@hashicorp/react-hashi-stack-menu": "2.0.3",
-    "@hashicorp/react-head": "3.0.2",
+    "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-hero": "7.2.1",
     "@hashicorp/react-image": "4.0.1",
     "@hashicorp/react-inline-svg": "6.0.1",


### PR DESCRIPTION
[Preview](https://consul-3yg0hhocp-hashicorp.vercel.app/)

Upgrading `react-head` and dependencies to set the new Safari theme-color feature.

[_Created by Sourcegraph campaign `kstraut/upgrade-react-head`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/upgrade-react-head)

**Before**
<img width="1266" alt="Screen Shot 2021-06-25 at 8 36 27 AM" src="https://user-images.githubusercontent.com/36613477/123449454-8cd97300-d590-11eb-9d1a-9066cf2b9ef3.png">


**After**
<img width="1260" alt="Screen Shot 2021-06-25 at 8 36 20 AM" src="https://user-images.githubusercontent.com/36613477/123449446-8b0faf80-d590-11eb-8086-3d0bd1630269.png">
