### PR TITLE
ui: Fixup definition-table + copy-button margin

### DIFF
--- a/ui/packages/consul-ui/app/components/definition-table/README.mdx
+++ b/ui/packages/consul-ui/app/components/definition-table/README.mdx
@@ -1,0 +1,25 @@
+---
+class: css
+---
+# definition-table
+
+Simple CSS component to render a `dl` similar to a table with column headers.
+Contents of the `dd` are currently inline-block'ed for CopyButton reasons.
+
+```hbs preview-template
+<div class="definition-table">
+  <dl>
+    <dt>Title 1</dt>
+    <dd>Value</dd>
+    <dt>Title 2</dt>
+    <dd><CopyButton @name="Title 2" @value="Value"/>Value</dd>
+  </dl>
+</div>
+```
+
+
+```css
+.definition-table {
+  @extend %definition-table;
+}
+```

--- a/ui/packages/consul-ui/app/components/definition-table/debug.scss
+++ b/ui/packages/consul-ui/app/components/definition-table/debug.scss
@@ -1,0 +1,5 @@
+[id^='docfy-demo-preview-definition-table'] {
+  .definition-table {
+    @extend %definition-table;
+  }
+}

--- a/ui/packages/consul-ui/app/components/definition-table/layout.scss
+++ b/ui/packages/consul-ui/app/components/definition-table/layout.scss
@@ -3,6 +3,6 @@
   grid-template-columns: 140px auto;
   grid-gap: 0.4em 20px;
 }
-%definition-table .copy-button {
-  float: left;
+%definition-table dd > * {
+  display: inline-block;
 }

--- a/ui/packages/consul-ui/app/styles/debug.scss
+++ b/ui/packages/consul-ui/app/styles/debug.scss
@@ -8,6 +8,7 @@
 @import 'consul-ui/components/horizontal-kv-list/debug';
 @import 'consul-ui/components/icon-definition/debug';
 @import 'consul-ui/components/inline-alert/debug';
+@import 'consul-ui/components/definition-table/debug';
 
 html.is-debug body > .brand-loader {
   display: none !important;


### PR DESCRIPTION
Whilst working on https://github.com/hashicorp/consul/pull/10511 I noticed this:

<img width="352" alt="Screenshot 2021-06-28 at 13 40 32" src="https://user-images.githubusercontent.com/554604/123637946-80664c00-d816-11eb-92e3-bfdf4a862ae3.png">

(note the margin between the copy button and the texts)

This was introduced during https://github.com/hashicorp/consul/pull/10285, which we delayed from merging to 1.10.0 for this kind of reason.

This PR fixes this up in the same way as our `horizontal-kv-list`s work (there's potentially some sort of reusability here but its getting to that 'is it even worth DRYing this out' stage)

<img width="501" alt="Screenshot 2021-06-28 at 13 42 48" src="https://user-images.githubusercontent.com/554604/123638263-e357e300-d816-11eb-9c45-ab035a4d0f9c.png">

I took the opportunity here to add some documentation around this CSS component also.

