### PR TITLE
streaming: fix not being able to enable streaming

### DIFF
--- a/.changelog/10514.txt
+++ b/.changelog/10514.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+streaming: fix a bug that was preventing streaming from being enabled.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -394,6 +394,7 @@ func New(bd BaseDeps) (*Agent, error) {
 			Conn:   conn,
 			Logger: bd.Logger.Named("rpcclient.health"),
 		},
+		UseStreamingBackend: a.config.UseStreamingBackend,
 	}
 
 	a.serviceManager = NewServiceManager(&a)

--- a/agent/http.go
+++ b/agent/http.go
@@ -723,6 +723,13 @@ func setMeta(resp http.ResponseWriter, m structs.QueryMetaCompat) {
 	setLastContact(resp, m.GetLastContact())
 	setKnownLeader(resp, m.GetKnownLeader())
 	setConsistency(resp, m.GetConsistencyLevel())
+	setQueryBackend(resp, m.GetBackend())
+}
+
+func setQueryBackend(resp http.ResponseWriter, backend structs.QueryBackend) {
+	if b := backend.String(); b != "" {
+		resp.Header().Set("X-Consul-Query-Backend", b)
+	}
 }
 
 // setCacheMeta sets http response headers to indicate cache status.

--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -42,7 +42,8 @@ func (c *Client) ServiceNodes(
 		if err != nil {
 			return structs.IndexedCheckServiceNodes{}, cache.ResultMeta{}, err
 		}
-		return *result.Value.(*structs.IndexedCheckServiceNodes), cache.ResultMeta{Index: result.Index}, err
+		meta := cache.ResultMeta{Index: result.Index, Hit: result.Cached}
+		return *result.Value.(*structs.IndexedCheckServiceNodes), meta, err
 	}
 
 	out, md, err := c.getServiceNodes(ctx, req)

--- a/agent/rpcclient/health/view.go
+++ b/agent/rpcclient/health/view.go
@@ -171,7 +171,8 @@ func (s *healthView) Result(index uint64) interface{} {
 	result := structs.IndexedCheckServiceNodes{
 		Nodes: make(structs.CheckServiceNodes, 0, len(s.state)),
 		QueryMeta: structs.QueryMeta{
-			Index: index,
+			Index:   index,
+			Backend: structs.QueryBackendStreaming,
 		},
 	}
 	for _, node := range s.state {

--- a/agent/rpcclient/health/view_test.go
+++ b/agent/rpcclient/health/view_test.go
@@ -101,7 +101,8 @@ func TestHealthView_IntegrationWithStore_WithEmptySnapshot(t *testing.T) {
 	empty := &structs.IndexedCheckServiceNodes{
 		Nodes: structs.CheckServiceNodes{},
 		QueryMeta: structs.QueryMeta{
-			Index: 1,
+			Index:   1,
+			Backend: structs.QueryBackendStreaming,
 		},
 	}
 
@@ -381,6 +382,7 @@ func TestHealthView_IntegrationWithStore_WithFullSnapshot(t *testing.T) {
 
 func newExpectedNodes(nodes ...string) *structs.IndexedCheckServiceNodes {
 	result := &structs.IndexedCheckServiceNodes{}
+	result.QueryMeta.Backend = structs.QueryBackendStreaming
 	for _, node := range nodes {
 		result.Nodes = append(result.Nodes, structs.CheckServiceNode{
 			Node: &structs.Node{Node: node},

--- a/agent/streaming_test.go
+++ b/agent/streaming_test.go
@@ -30,6 +30,7 @@ func testGRPCStreamingWorking(t *testing.T, config string) {
 
 	assertIndex(t, resp)
 	require.NotEmpty(t, resp.Header().Get("X-Consul-Index"))
+	require.Equal(t, "streaming", resp.Header().Get("X-Consul-Query-Backend"))
 }
 
 func TestGRPCWithTLSConfigs(t *testing.T) {

--- a/agent/structs/protobuf_compat.go
+++ b/agent/structs/protobuf_compat.go
@@ -44,6 +44,7 @@ type QueryMetaCompat interface {
 	SetIndex(uint64)
 	GetConsistencyLevel() string
 	SetConsistencyLevel(string)
+	GetBackend() QueryBackend
 }
 
 // GetToken helps implement the QueryOptionsCompat interface
@@ -268,4 +269,8 @@ func (q *QueryMeta) SetIndex(index uint64) {
 // Copied from proto/pbcommon/common.go
 func (q *QueryMeta) SetConsistencyLevel(consistencyLevel string) {
 	q.ConsistencyLevel = consistencyLevel
+}
+
+func (q *QueryMeta) GetBackend() QueryBackend {
+	return q.Backend
 }

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -339,6 +339,24 @@ func (w WriteRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime,
 	return time.Since(start) > rpcHoldTimeout
 }
 
+type QueryBackend int
+
+const (
+	QueryBackendBlocking QueryBackend = iota
+	QueryBackendStreaming
+)
+
+func (q QueryBackend) String() string {
+	switch q {
+	case QueryBackendBlocking:
+		return "blocking-query"
+	case QueryBackendStreaming:
+		return "streaming"
+	default:
+		return ""
+	}
+}
+
 // QueryMeta allows a query response to include potentially
 // useful metadata about a query
 type QueryMeta struct {
@@ -363,6 +381,9 @@ type QueryMeta struct {
 	// When NotModified is true, the response will not contain the result of
 	// the query.
 	NotModified bool
+
+	// Backend used to handle this query, either blocking-query or streaming.
+	Backend QueryBackend
 }
 
 // RegisterRequest is used for the Catalog.Register endpoint

--- a/agent/submatview/materializer.go
+++ b/agent/submatview/materializer.go
@@ -215,9 +215,13 @@ func (m *Materializer) notifyUpdateLocked(err error) {
 	m.updateCh = make(chan struct{})
 }
 
+// Result returned from the View.
 type Result struct {
 	Index uint64
 	Value interface{}
+	// Cached is true if the requested value was already available locally. If
+	// the value is false, it indicates that getFromView had to wait for an update,
+	Cached bool
 }
 
 // getFromView blocks until the index of the View is greater than opts.MinIndex,
@@ -237,6 +241,7 @@ func (m *Materializer) getFromView(ctx context.Context, minIndex uint64) (Result
 	// haven't loaded a snapshot at all yet which means we should wait for one on
 	// the update chan.
 	if result.Index > 0 && result.Index > minIndex {
+		result.Cached = true
 		return result, nil
 	}
 

--- a/agent/submatview/store.go
+++ b/agent/submatview/store.go
@@ -171,7 +171,7 @@ func (s *Store) Notify(
 			u := cache.UpdateEvent{
 				CorrelationID: correlationID,
 				Result:        result.Value,
-				Meta:          cache.ResultMeta{Index: result.Index},
+				Meta:          cache.ResultMeta{Index: result.Index, Hit: result.Cached},
 			}
 			select {
 			case updateCh <- u:

--- a/proto/pbcommon/common.go
+++ b/proto/pbcommon/common.go
@@ -2,6 +2,8 @@ package pbcommon
 
 import (
 	"time"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 // IsRead is always true for QueryOption
@@ -95,6 +97,10 @@ func (q *QueryMeta) SetIndex(index uint64) {
 // SetConsistencyLevel is needed to implement the structs.QueryMetaCompat interface
 func (q *QueryMeta) SetConsistencyLevel(consistencyLevel string) {
 	q.ConsistencyLevel = consistencyLevel
+}
+
+func (q *QueryMeta) GetBackend() structs.QueryBackend {
+	return structs.QueryBackend(0)
 }
 
 // WriteRequest only applies to writes, always false

--- a/website/content/api-docs/features/blocking.mdx
+++ b/website/content/api-docs/features/blocking.mdx
@@ -99,6 +99,9 @@ While streaming is a significant optimization over long polling, it will not pop
 `X-Consul-LastContact` or `X-Consul-KnownLeader` response headers, because the required
 data is not available to the client.
 
+When the streaming backend is used, API responses will include the `X-Consul-Query-Backend`
+header with a value of `streaming`.
+
 
 ## Hash-based Blocking Queries
 


### PR DESCRIPTION
This PR adds a new `X-Consul-Query-Backend` response header to make it easier to determine when streaming was used for a query. Adds a check for this header to a few tests that are meant to check that streaming is being used.

And finally fix the bug that was preventing streaming from being enabled on the client.

One commit is cherry-picked from #10396. It removes a test that is both very racy and also no longer valid because the requests are made via streaming, not the cache. Since the cache rate limit functionality is already tested in the appropriate package (agent/cache) it seems like we can remove this failing/flaky test.