### PR TITLE
tutum/curl doesn't exist anymore let's use curlimages/curl instead

### DIFF
--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -178,7 +178,7 @@ spec:
     spec:
       containers:
         - name: static-client
-          image: tutum/curl:latest
+          image: curlimages/curl:latest
           # Just spin & wait forever, we'll use `kubectl exec` to demo
           command: ['/bin/sh', '-c', '--']
           args: ['while true; do sleep 30; done;']

--- a/website/content/docs/k8s/connect/terminating-gateways.mdx
+++ b/website/content/docs/k8s/connect/terminating-gateways.mdx
@@ -268,7 +268,7 @@ spec:
     spec:
       containers:
         - name: static-client
-          image: tutum/curl:latest
+          image: curlimages/curl:latest
           command: ['/bin/sh', '-c', '--']
           args: ['while true; do sleep 30; done;']
       serviceAccountName: static-client


### PR DESCRIPTION
[Deploy example services](https://learn.hashicorp.com/tutorials/consul/kubernetes-secure-agents?in=consul%2Fkubernetes-production#deploy-example-services) and another documentation refers to an image that doesn't exist anymore. Let's correct these docs and use https://hub.docker.com/r/curlimages/curl instead of tutum/curl