### PR TITLE
docs: remove alpha from 1.10.0 reference for observability on k8s metrics merging

### DIFF
--- a/website/content/docs/k8s/connect/observability/metrics.mdx
+++ b/website/content/docs/k8s/connect/observability/metrics.mdx
@@ -17,8 +17,8 @@ available are:
 Specific sidecar proxy metrics can also be seen in the Consul UI Topology Visualization view. This section documents how to enable each of these.
 
 -> **Note:** Metrics will be supported in Consul-helm >= `0.31.0` and consul-k8s >= `0.25.0`. However, enabling the [metrics merging feature](#connect-service-and-sidecar-metrics-with-metrics-merging) with Helm value (`defaultEnableMerging`) or
-annotation (`consul.hashicorp.com/enable-metrics-merging`) can only be used with Consul `1.10.0-alpha1` and above. The
-other metrics configuration can still be used before Consul `1.10.0-alpha1`.
+annotation (`consul.hashicorp.com/enable-metrics-merging`) can only be used with Consul `1.10.0` and above. The
+other metrics configuration can still be used before Consul `1.10.0`.
 
 ## Connect Service and Sidecar Metrics with Metrics Merging
 


### PR DESCRIPTION
The docs note an alpha pre-release version on K8s observability. Updating to only reference the GA 1.10.0 version of Consul for observability on k8s and metrics merging.