### PR TITLE
Add rs-consul client to community-provided SDKs list

### DIFF
--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -131,4 +131,8 @@ the community.
     <a href="https://github.com/alphaHeavy/consul-haskell">consul-haskell</a> -
     Haskell client for the Consul HTTP API
   </li>
+  <li>
+    <a href="https://github.com/Roblox/rs-consul">rs-consul</a> -
+    Rust client Consul HTTP API
+  </li>
 </ul>

--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -133,6 +133,6 @@ the community.
   </li>
   <li>
     <a href="https://github.com/Roblox/rs-consul">rs-consul</a> -
-    Rust client Consul HTTP API
+    Rust client for the Consul HTTP API
   </li>
 </ul>


### PR DESCRIPTION
We (Roblox) just published https://github.com/Roblox/rs-consul -- adding it to the list here for discovery by others.