### PR TITLE
docs: Update docs to reflect limitation in TProxy when using single Consul DC deployment with multiple k8s clusters

### DIFF
--- a/website/content/docs/connect/transparent-proxy.mdx
+++ b/website/content/docs/connect/transparent-proxy.mdx
@@ -134,11 +134,12 @@ configure exceptions on a per-Pod basis. The following Pod annotations allow you
 * Traffic can only be transparently proxied when the address dialed corresponds to the address of a service in the
 transparent proxy's datacenter. Cross-datacenter transparent proxying is only possible using
 [service-resolver configuration entries that resolve to remote datacenters](/docs/connect/config-entries/service-resolver#other-datacenters).
-This also applies to a [single Consul datacenter that spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), where services in one Kubernetes cluster must explicitly dial the service in another Kubernetes cluster when Transparent Proxy is enabled. 
 Services can also dial explicit upstreams in other datacenters without transparent proxy, for example, by adding an
 [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
 `"consul.hashicorp.com/connect-service-upstreams": "my-service:1234:dc2"` to reach an upstream service called `my-service`
 in the datacenter `dc2`.
+* In the deployment configuration where a [single Consul datacenter that spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), services in one Kubernetes cluster must explicitly dial a service in another Kubernetes cluster using an [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
+`"consul.hashicorp.com/connect-service-upstreams": "my-service:1234"`. Transparent proxy is supported but KubeDNS is not utilized when communicating across multiple Kubernetes clusters. 
 * When dialing headless services the request will be proxied using a plain TCP proxy with a 5s connection timeout.
 Currently the upstream's protocol and connection timeout are not considered.
 

--- a/website/content/docs/connect/transparent-proxy.mdx
+++ b/website/content/docs/connect/transparent-proxy.mdx
@@ -138,8 +138,8 @@ Services can also dial explicit upstreams in other datacenters without transpare
 [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
 `"consul.hashicorp.com/connect-service-upstreams": "my-service:1234:dc2"` to reach an upstream service called `my-service`
 in the datacenter `dc2`.
-* In the deployment configuration where a [single Consul datacenter spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), services in one Kubernetes cluster must explicitly dial a service in another Kubernetes cluster using an [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
-`"consul.hashicorp.com/connect-service-upstreams": "my-service:1234"`. Transparent proxy is supported but KubeDNS is not utilized when communicating across multiple Kubernetes clusters. 
+* In the deployment configuration where a [single Consul datacenter spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), services in one Kubernetes cluster must explicitly dial a service in another Kubernetes cluster using the [consul.hashicorp.com/connect-service-upstreams](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) annation. An example would be
+`"consul.hashicorp.com/connect-service-upstreams": "my-service:1234"`, where `my-service` is the service that exists in another Kubernetes cluster and is exposed on port `1234.` Althuogh Transparent Proxy is enabled, KubeDNS is not utilized when communicating between services existing on separate Kubernetes clusters. 
 * When dialing headless services the request will be proxied using a plain TCP proxy with a 5s connection timeout.
 Currently the upstream's protocol and connection timeout are not considered.
 

--- a/website/content/docs/connect/transparent-proxy.mdx
+++ b/website/content/docs/connect/transparent-proxy.mdx
@@ -138,7 +138,7 @@ Services can also dial explicit upstreams in other datacenters without transpare
 [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
 `"consul.hashicorp.com/connect-service-upstreams": "my-service:1234:dc2"` to reach an upstream service called `my-service`
 in the datacenter `dc2`.
-* In the deployment configuration where a [single Consul datacenter that spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), services in one Kubernetes cluster must explicitly dial a service in another Kubernetes cluster using an [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
+* In the deployment configuration where a [single Consul datacenter spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), services in one Kubernetes cluster must explicitly dial a service in another Kubernetes cluster using an [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
 `"consul.hashicorp.com/connect-service-upstreams": "my-service:1234"`. Transparent proxy is supported but KubeDNS is not utilized when communicating across multiple Kubernetes clusters. 
 * When dialing headless services the request will be proxied using a plain TCP proxy with a 5s connection timeout.
 Currently the upstream's protocol and connection timeout are not considered.

--- a/website/content/docs/connect/transparent-proxy.mdx
+++ b/website/content/docs/connect/transparent-proxy.mdx
@@ -134,6 +134,7 @@ configure exceptions on a per-Pod basis. The following Pod annotations allow you
 * Traffic can only be transparently proxied when the address dialed corresponds to the address of a service in the
 transparent proxy's datacenter. Cross-datacenter transparent proxying is only possible using
 [service-resolver configuration entries that resolve to remote datacenters](/docs/connect/config-entries/service-resolver#other-datacenters).
+This also applies to a [single Consul datacenter that spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), where services in one Kubernetes cluster must explicitly dial the service in another Kubernetes cluster when Transparent Proxy is enabled. 
 Services can also dial explicit upstreams in other datacenters without transparent proxy, for example, by adding an
 [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
 `"consul.hashicorp.com/connect-service-upstreams": "my-service:1234:dc2"` to reach an upstream service called `my-service`

--- a/website/content/docs/connect/transparent-proxy.mdx
+++ b/website/content/docs/connect/transparent-proxy.mdx
@@ -138,8 +138,8 @@ Services can also dial explicit upstreams in other datacenters without transpare
 [annotation](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) such as
 `"consul.hashicorp.com/connect-service-upstreams": "my-service:1234:dc2"` to reach an upstream service called `my-service`
 in the datacenter `dc2`.
-* In the deployment configuration where a [single Consul datacenter spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), services in one Kubernetes cluster must explicitly dial a service in another Kubernetes cluster using the [consul.hashicorp.com/connect-service-upstreams](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) annation. An example would be
-`"consul.hashicorp.com/connect-service-upstreams": "my-service:1234"`, where `my-service` is the service that exists in another Kubernetes cluster and is exposed on port `1234.` Althuogh Transparent Proxy is enabled, KubeDNS is not utilized when communicating between services existing on separate Kubernetes clusters. 
+* In the deployment configuration where a [single Consul datacenter spans multiple Kubernetes clusters](https://www.consul.io/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s), services in one Kubernetes cluster must explicitly dial a service in another Kubernetes cluster using the [consul.hashicorp.com/connect-service-upstreams](/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) annotation. An example would be
+`"consul.hashicorp.com/connect-service-upstreams": "my-service:1234"`, where `my-service` is the service that exists in another Kubernetes cluster and is exposed on port `1234`. Although Transparent Proxy is enabled, KubeDNS is not utilized when communicating between services existing on separate Kubernetes clusters. 
 * When dialing headless services the request will be proxied using a plain TCP proxy with a 5s connection timeout.
 Currently the upstream's protocol and connection timeout are not considered.
 

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -182,7 +182,7 @@ helm install cluster2 -f cluster2-config.yaml hashicorp/consul
 
 ## Verifying the Consul Service Mesh works
 
-~> When Transparent proxy is enabled, services in one Kubernetes cluster that need to communicate with with a service in another Kubernetes cluster, must dial explicit upstreams via an annotation such as ["consul.hashicorp.com/connect-service-upstreams"](https://www.consul.io/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams): "my-service:1234" to reach an upstream service called `my-service` with an separate Kubernetes cluster.  
+~> When Transparent proxy is enabled, services in one Kubernetes cluster that need to communicate with with a service in another Kubernetes cluster, must dial explicit upstreams via the ["consul.hashicorp.com/connect-service-upstreams"](https://www.consul.io/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) annotation.  
 
 Now that we have our Consul cluster in multiple k8s clusters up and running, we will
 deploy two services and verify that they can connect to each other.

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -182,6 +182,8 @@ helm install cluster2 -f cluster2-config.yaml hashicorp/consul
 
 ## Verifying the Consul Service Mesh works
 
+-> When Transparent proxy is enabled, services in one Kubernetes cluster that need to communicate with with a service in another Kubernetes cluster, must dial explicit upstreams via an annotation such as ["consul.hashicorp.com/connect-service-upstreams"](https://www.consul.io/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams): "my-service:1234" to reach an upstream service called my-service with an separate Kubernetes cluster.  
+
 Now that we have our Consul cluster in multiple k8s clusters up and running, we will
 deploy two services and verify that they can connect to each other.
 

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -182,7 +182,7 @@ helm install cluster2 -f cluster2-config.yaml hashicorp/consul
 
 ## Verifying the Consul Service Mesh works
 
--> When Transparent proxy is enabled, services in one Kubernetes cluster that need to communicate with with a service in another Kubernetes cluster, must dial explicit upstreams via an annotation such as ["consul.hashicorp.com/connect-service-upstreams"](https://www.consul.io/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams): "my-service:1234" to reach an upstream service called my-service with an separate Kubernetes cluster.  
+~> When Transparent proxy is enabled, services in one Kubernetes cluster that need to communicate with with a service in another Kubernetes cluster, must dial explicit upstreams via an annotation such as ["consul.hashicorp.com/connect-service-upstreams"](https://www.consul.io/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams): "my-service:1234" to reach an upstream service called `my-service` with an separate Kubernetes cluster.  
 
 Now that we have our Consul cluster in multiple k8s clusters up and running, we will
 deploy two services and verify that they can connect to each other.

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -182,7 +182,7 @@ helm install cluster2 -f cluster2-config.yaml hashicorp/consul
 
 ## Verifying the Consul Service Mesh works
 
-~> When Transparent proxy is enabled, services in one Kubernetes cluster that need to communicate with with a service in another Kubernetes cluster, must dial explicit upstreams via the ["consul.hashicorp.com/connect-service-upstreams"](https://www.consul.io/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) annotation.  
+~> When Transparent proxy is enabled, services in one Kubernetes cluster that need to communicate with a service in another Kubernetes cluster must have a explicit upstream configured through the ["consul.hashicorp.com/connect-service-upstreams"](https://www.consul.io/docs/k8s/connect#consul-hashicorp-com-connect-service-upstreams) annotation.  
 
 Now that we have our Consul cluster in multiple k8s clusters up and running, we will
 deploy two services and verify that they can connect to each other.


### PR DESCRIPTION
When Transparent Proxy is turned on, a service in one Kubernetes cluster must dial a service in a different Kubernetes cluster using explicit upstreams. KubeDNS is not supported, so the explicit upstream annotation must be utilized. 