### PR TITLE
ca: remove unused RotationPeriod field

### DIFF
--- a/.changelog/10552.txt
+++ b/.changelog/10552.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+connect/ca: remove the `RotationPeriod` field from the Consul CA provider, it was not used for anything.
+```

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -4909,7 +4909,6 @@ func TestAutoConfig_Integration(t *testing.T) {
 				"LeafCertTTL":         "1h",
 				"PrivateKey":          ca.SigningKey,
 				"RootCert":            ca.RootCert,
-				"RotationPeriod":      "6h",
 				"IntermediateCertTTL": "3h",
 			},
 		},

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -700,7 +700,6 @@ func (b *builder) Build() (rt RuntimeConfig, err error) {
 			// Consul CA config
 			"private_key":           "PrivateKey",
 			"root_cert":             "RootCert",
-			"rotation_period":       "RotationPeriod",
 			"intermediate_cert_ttl": "IntermediateCertTTL",
 
 			// Vault CA config

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1661,7 +1661,6 @@ func (c *RuntimeConfig) ConnectCAConfiguration() (*structs.CAConfiguration, erro
 	ca := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"RotationPeriod":      structs.DefaultCARotationPeriod,
 			"LeafCertTTL":         structs.DefaultLeafCertTTL,
 			"IntermediateCertTTL": structs.DefaultIntermediateCertTTL,
 		},

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5413,7 +5413,6 @@ func TestLoad_FullConfig(t *testing.T) {
 		ExposeMaxPort:         2222,
 		ConnectCAProvider:     "consul",
 		ConnectCAConfig: map[string]interface{}{
-			"RotationPeriod":      "90h",
 			"IntermediateCertTTL": "8760h",
 			"LeafCertTTL":         "1h",
 			"CSRMaxPerSecond":     float64(100),
@@ -6594,7 +6593,6 @@ func TestConnectCAConfiguration(t *testing.T) {
 			expected: &structs.CAConfiguration{
 				Provider: "consul",
 				Config: map[string]interface{}{
-					"RotationPeriod":      "2160h",
 					"LeafCertTTL":         "72h",
 					"IntermediateCertTTL": "8760h", // 365 * 24h
 				},
@@ -6611,7 +6609,6 @@ func TestConnectCAConfiguration(t *testing.T) {
 				Provider:  "consul",
 				ClusterID: "adfe7697-09b4-413a-ac0a-fa81ed3a3001",
 				Config: map[string]interface{}{
-					"RotationPeriod":      "2160h",
 					"LeafCertTTL":         "72h",
 					"IntermediateCertTTL": "8760h", // 365 * 24h
 					"cluster_id":          "adfe7697-09b4-413a-ac0a-fa81ed3a3001",
@@ -6635,7 +6632,6 @@ func TestConnectCAConfiguration(t *testing.T) {
 			expected: &structs.CAConfiguration{
 				Provider: "vault",
 				Config: map[string]interface{}{
-					"RotationPeriod":      "2160h",
 					"LeafCertTTL":         "72h",
 					"IntermediateCertTTL": "8760h", // 365 * 24h
 				},
@@ -6651,7 +6647,6 @@ func TestConnectCAConfiguration(t *testing.T) {
 			expected: &structs.CAConfiguration{
 				Provider: "consul",
 				Config: map[string]interface{}{
-					"RotationPeriod":      "2160h",
 					"LeafCertTTL":         "72h",
 					"IntermediateCertTTL": "8760h", // 365 * 24h
 					"foo":                 "bar",

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -198,7 +198,6 @@ auto_encrypt = {
 connect {
     ca_provider = "consul"
     ca_config {
-        rotation_period = "90h"
         intermediate_cert_ttl = "8760h"
         leaf_cert_ttl = "1h"
         # hack float since json parses numbers as float and we have to

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -200,7 +200,6 @@
   "connect": {
     "ca_provider": "consul",
     "ca_config": {
-      "rotation_period": "90h",
       "intermediate_cert_ttl": "8760h",
       "leaf_cert_ttl": "1h",
       "csr_max_per_second": 100,

--- a/agent/connect/ca/provider_test.go
+++ b/agent/connect/ca/provider_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func TestStructs_CAConfiguration_MsgpackEncodeDecode(t *testing.T) {
@@ -51,7 +52,7 @@ func TestStructs_CAConfiguration_MsgpackEncodeDecode(t *testing.T) {
 				Config: map[string]interface{}{
 					"PrivateKey":          "key",
 					"RootCert":            "cert",
-					"RotationPeriod":      "5m",
+					"RotationPeriod":      "5m", // old unused field
 					"IntermediateCertTTL": "90h",
 					"DisableCrossSigning": true,
 				},
@@ -60,7 +61,6 @@ func TestStructs_CAConfiguration_MsgpackEncodeDecode(t *testing.T) {
 				CommonCAProviderConfig: *expectCommonBase,
 				PrivateKey:             "key",
 				RootCert:               "cert",
-				RotationPeriod:         5 * time.Minute,
 				DisableCrossSigning:    true,
 			},
 			parseFunc: func(t *testing.T, raw map[string]interface{}) interface{} {

--- a/agent/connect/testing_ca.go
+++ b/agent/connect/testing_ca.go
@@ -398,7 +398,6 @@ func testCAConfigSet(t testing.T, a TestAgentRPC,
 		Config: map[string]interface{}{
 			"PrivateKey":          ca.SigningKey,
 			"RootCert":            ca.RootCert,
-			"RotationPeriod":      180 * 24 * time.Hour,
 			"IntermediateCertTTL": 288 * time.Hour,
 		},
 	}

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -12,9 +12,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestConnectCARoots_empty(t *testing.T) {
@@ -89,7 +90,6 @@ func TestConnectCAConfig(t *testing.T) {
 				"Provider": "consul",
 				"Config": {
 					"LeafCertTTL": "72h",
-					"RotationPeriod": "1h",
 					"IntermediateCertTTL": "288h"
 				}
 			}`,
@@ -99,7 +99,6 @@ func TestConnectCAConfig(t *testing.T) {
 				ClusterID: connect.TestClusterID,
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
-					"RotationPeriod":      "1h",
 					"IntermediateCertTTL": "288h",
 				},
 			},
@@ -111,7 +110,6 @@ func TestConnectCAConfig(t *testing.T) {
 				"Provider": "consul",
 				"Config": {
 					"LeafCertTTL": "72h",
-					"RotationPeriod": "1h",
 					"IntermediateCertTTL": "288h"
 				}
 			}`,
@@ -121,7 +119,6 @@ func TestConnectCAConfig(t *testing.T) {
 				ClusterID: connect.TestClusterID,
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
-					"RotationPeriod":      "1h",
 					"IntermediateCertTTL": "288h",
 				},
 			},
@@ -133,7 +130,6 @@ func TestConnectCAConfig(t *testing.T) {
 				"Provider": "consul",
 				"Config": {
 					"LeafCertTTL": "72h",
-					"RotationPeriod": "1h",
 					"IntermediateCertTTL": "288h"
 				},
 				"ForceWithoutCrossSigning": true
@@ -144,7 +140,6 @@ func TestConnectCAConfig(t *testing.T) {
 				ClusterID: connect.TestClusterID,
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
-					"RotationPeriod":      "1h",
 					"IntermediateCertTTL": "288h",
 				},
 				ForceWithoutCrossSigning: true,
@@ -162,7 +157,6 @@ func TestConnectCAConfig(t *testing.T) {
 				"provider": "consul",
 				"config": {
 					"LeafCertTTL": "72h",
-					"RotationPeriod": "1h",
 					"IntermediateCertTTL": "288h"
 				},
 				"force_without_cross_signing": true
@@ -173,7 +167,6 @@ func TestConnectCAConfig(t *testing.T) {
 				ClusterID: connect.TestClusterID,
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
-					"RotationPeriod":      "1h",
 					"IntermediateCertTTL": "288h",
 				},
 				ForceWithoutCrossSigning: true,
@@ -198,8 +191,7 @@ func TestConnectCAConfig(t *testing.T) {
 				"Provider": "consul",
 				"config": {
 					"LeafCertTTL": "72h",
-					"RotationPeriod": "1h",
-				        "IntermediateCertTTL": "288h"
+					"IntermediateCertTTL": "288h"
 				},
 				"State": {
 					"foo": "bar"
@@ -211,7 +203,6 @@ func TestConnectCAConfig(t *testing.T) {
 				ClusterID: connect.TestClusterID,
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
-					"RotationPeriod":      "1h",
 					"IntermediateCertTTL": "288h",
 				},
 				State: map[string]string{

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -596,7 +596,6 @@ func DefaultConfig() *Config {
 		CAConfig: &structs.CAConfiguration{
 			Provider: "consul",
 			Config: map[string]interface{}{
-				"RotationPeriod":      structs.DefaultCARotationPeriod,
 				"LeafCertTTL":         structs.DefaultLeafCertTTL,
 				"IntermediateCertTTL": structs.DefaultIntermediateCertTTL,
 			},

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -9,15 +9,16 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
 	ca "github.com/hashicorp/consul/agent/connect/ca"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func testParseCert(t *testing.T, pemValue string) *x509.Certificate {
@@ -115,9 +116,8 @@ func TestConnectCAConfig_GetSet(t *testing.T) {
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"PrivateKey":     "",
-			"RootCert":       "",
-			"RotationPeriod": 180 * 24 * time.Hour,
+			"PrivateKey": "",
+			"RootCert":   "",
 			// This verifies the state persistence for providers although Consul
 			// provider doesn't actually use that mechanism outside of tests.
 			"test_state": testState,
@@ -386,9 +386,8 @@ func TestConnectCAConfig_TriggerRotation(t *testing.T) {
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"PrivateKey":     newKey,
-			"RootCert":       "",
-			"RotationPeriod": 90 * 24 * time.Hour,
+			"PrivateKey": newKey,
+			"RootCert":   "",
 		},
 	}
 	{
@@ -568,9 +567,8 @@ func TestConnectCAConfig_UpdateSecondary(t *testing.T) {
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"PrivateKey":     newKey,
-			"RootCert":       "",
-			"RotationPeriod": 90 * 24 * time.Hour,
+			"PrivateKey": newKey,
+			"RootCert":   "",
 		},
 	}
 	{
@@ -654,9 +652,8 @@ func TestConnectCAConfig_UpdateSecondary(t *testing.T) {
 		newConfig := &structs.CAConfiguration{
 			Provider: "consul",
 			Config: map[string]interface{}{
-				"PrivateKey":     newKey,
-				"RootCert":       "",
-				"RotationPeriod": 180 * 24 * time.Hour,
+				"PrivateKey": newKey,
+				"RootCert":   "",
 			},
 		}
 		{

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -9,11 +9,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/hashicorp/consul/agent/connect"
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-raftchunking"
 	raftchunkingtypes "github.com/hashicorp/go-raftchunking/types"
 	"github.com/hashicorp/go-uuid"
@@ -22,6 +17,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/types"
 )
 
 func generateUUID() (ret string) {
@@ -1301,7 +1302,6 @@ func TestFSM_CAConfig(t *testing.T) {
 			Config: map[string]interface{}{
 				"PrivateKey":          "asdf",
 				"RootCert":            "qwer",
-				"RotationPeriod":      90 * 24 * time.Hour,
 				"IntermediateCertTTL": 365 * 24 * time.Hour,
 			},
 		},
@@ -1329,9 +1329,6 @@ func TestFSM_CAConfig(t *testing.T) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
 	if got, want := conf.RootCert, "qwer"; got != want {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-	if got, want := conf.RotationPeriod, 90*24*time.Hour; got != want {
 		t.Fatalf("got %v, want %v", got, want)
 	}
 	if got, want := conf.IntermediateCertTTL, 365*24*time.Hour; got != want {

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -318,10 +318,9 @@ func TestLeader_SecondaryCA_IntermediateRenew(t *testing.T) {
 		c.CAConfig = &structs.CAConfiguration{
 			Provider: "consul",
 			Config: map[string]interface{}{
-				"PrivateKey":     "",
-				"RootCert":       "",
-				"RotationPeriod": "2160h",
-				"LeafCertTTL":    "5s",
+				"PrivateKey":  "",
+				"RootCert":    "",
+				"LeafCertTTL": "5s",
 				// The retry loop only retries for 7sec max and
 				// the ttl needs to be below so that it
 				// triggers definitely.
@@ -486,7 +485,6 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 		Config: map[string]interface{}{
 			"PrivateKey":          newKey,
 			"RootCert":            "",
-			"RotationPeriod":      90 * 24 * time.Hour,
 			"IntermediateCertTTL": 72 * 24 * time.Hour,
 		},
 	}
@@ -1051,11 +1049,10 @@ func TestLeader_CARootPruning(t *testing.T) {
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"LeafCertTTL":    "500ms",
-			"PrivateKey":     newKey,
-			"RootCert":       "",
-			"RotationPeriod": "2160h",
-			"SkipValidate":   true,
+			"LeafCertTTL":  "500ms",
+			"PrivateKey":   newKey,
+			"RootCert":     "",
+			"SkipValidate": true,
 		},
 	}
 	{
@@ -1125,9 +1122,8 @@ func TestLeader_PersistIntermediateCAs(t *testing.T) {
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"PrivateKey":     newKey,
-			"RootCert":       "",
-			"RotationPeriod": 90 * 24 * time.Hour,
+			"PrivateKey": newKey,
+			"RootCert":   "",
 		},
 	}
 	{
@@ -1431,11 +1427,10 @@ func TestLeader_Consul_ForceWithoutCrossSigning(t *testing.T) {
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"LeafCertTTL":    "500ms",
-			"PrivateKey":     newKey,
-			"RootCert":       "",
-			"RotationPeriod": "2160h",
-			"SkipValidate":   true,
+			"LeafCertTTL":  "500ms",
+			"PrivateKey":   newKey,
+			"RootCert":     "",
+			"SkipValidate": true,
 		},
 		ForceWithoutCrossSigning: true,
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -186,7 +186,6 @@ func testServerConfig(t *testing.T) (string, *Config) {
 		Config: map[string]interface{}{
 			"PrivateKey":          "",
 			"RootCert":            "",
-			"RotationPeriod":      "2160h",
 			"LeafCertTTL":         "72h",
 			"IntermediateCertTTL": "288h",
 		},

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -3,7 +3,6 @@ package state
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/assert"
@@ -19,9 +18,8 @@ func TestStore_CAConfig(t *testing.T) {
 	expected := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"PrivateKey":     "asdf",
-			"RootCert":       "qwer",
-			"RotationPeriod": 90 * 24 * time.Hour,
+			"PrivateKey": "asdf",
+			"RootCert":   "qwer",
 		},
 	}
 
@@ -104,9 +102,8 @@ func TestStore_CAConfig_Snapshot_Restore(t *testing.T) {
 	before := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"PrivateKey":     "asdf",
-			"RootCert":       "qwer",
-			"RotationPeriod": 90 * 24 * time.Hour,
+			"PrivateKey": "asdf",
+			"RootCert":   "qwer",
 		},
 	}
 	if err := s.CASetConfig(99, before); err != nil {

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -5,12 +5,12 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/hashicorp/consul/lib"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/hashicorp/consul/lib"
 )
 
 const (
-	DefaultCARotationPeriod    = "2160h"
 	DefaultLeafCertTTL         = "72h"
 	DefaultIntermediateCertTTL = "8760h" // 365 * 24h
 )
@@ -434,9 +434,8 @@ func (c CommonCAProviderConfig) Validate() error {
 type ConsulCAProviderConfig struct {
 	CommonCAProviderConfig `mapstructure:",squash"`
 
-	PrivateKey     string
-	RootCert       string
-	RotationPeriod time.Duration
+	PrivateKey string
+	RootCert   string
 
 	// DisableCrossSigning is really only useful in test code to use the built in
 	// provider while exercising logic that depends on the CA provider ability to

--- a/agent/structs/connect_ca_test.go
+++ b/agent/structs/connect_ca_test.go
@@ -18,7 +18,6 @@ func TestCAConfiguration_GetCommonConfig(t *testing.T) {
 			name: "basic defaults",
 			cfg: &CAConfiguration{
 				Config: map[string]interface{}{
-					"RotationPeriod":      "2160h",
 					"LeafCertTTL":         "72h",
 					"IntermediateCertTTL": "4320h",
 					"CSRMaxPerSecond":     "50",
@@ -40,7 +39,6 @@ func TestCAConfiguration_GetCommonConfig(t *testing.T) {
 			name: "basic defaults after encoding fun",
 			cfg: &CAConfiguration{
 				Config: map[string]interface{}{
-					"RotationPeriod":      []uint8("2160h"),
 					"LeafCertTTL":         []uint8("72h"),
 					"IntermediateCertTTL": []uint8("4320h"),
 				},

--- a/api/connect_ca.go
+++ b/api/connect_ca.go
@@ -49,7 +49,6 @@ type ConsulCAProviderConfig struct {
 
 	PrivateKey          string
 	RootCert            string
-	RotationPeriod      time.Duration
 	IntermediateCertTTL time.Duration
 }
 

--- a/api/connect_ca_test.go
+++ b/api/connect_ca_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAPI_ConnectCARoots_empty(t *testing.T) {
@@ -62,7 +63,6 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 
 	s.WaitForSerfCheck(t)
 	expected := &ConsulCAProviderConfig{
-		RotationPeriod:      90 * 24 * time.Hour,
 		IntermediateCertTTL: 365 * 24 * time.Hour,
 	}
 	expected.LeafCertTTL = 72 * time.Hour
@@ -83,7 +83,6 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 
 		// Change a config value and update
 		conf.Config["PrivateKey"] = ""
-		conf.Config["RotationPeriod"] = 120 * 24 * time.Hour
 		conf.Config["IntermediateCertTTL"] = 300 * 24 * time.Hour
 
 		// Pass through some state as if the provider stored it so we can make sure
@@ -95,7 +94,6 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 
 		updated, _, err := connect.CAGetConfig(nil)
 		r.Check(err)
-		expected.RotationPeriod = 120 * 24 * time.Hour
 		expected.IntermediateCertTTL = 300 * 24 * time.Hour
 		parsed, err = ParseConsulCAConfig(updated.Config)
 		r.Check(err)

--- a/command/connect/ca/set/connect_ca_set_test.go
+++ b/command/connect/ca/set/connect_ca_set_test.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/mitchellh/cli"
+
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/connect/ca"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/mitchellh/cli"
 )
 
 func TestConnectCASetConfigCommand_noTabs(t *testing.T) {
@@ -53,6 +54,5 @@ func TestConnectCASetConfigCommand(t *testing.T) {
 
 	parsed, err := ca.ParseConsulCAConfig(reply.Config)
 	require.NoError(err)
-	require.Equal(24*time.Hour, parsed.RotationPeriod)
 	require.Equal(288*time.Hour, parsed.IntermediateCertTTL)
 }

--- a/command/connect/ca/set/test-fixtures/ca_config.json
+++ b/command/connect/ca/set/test-fixtures/ca_config.json
@@ -3,7 +3,6 @@
 	"Config": {
 		"PrivateKey": "",
 		"RootCert": "",
-		"RotationPeriod": "24h",
 		"IntermediateCertTTL": "288h"
 	}
 }

--- a/ui/packages/consul-ui/mock-api/v1/connect/ca/configuration
+++ b/ui/packages/consul-ui/mock-api/v1/connect/ca/configuration
@@ -3,7 +3,6 @@
   "Config": {
     "PrivateKey": null,
     "RootCert": null,
-    "RotationPeriod": 7776000000000000
   },
   "CreateIndex": 5,
   "ModifyIndex": 5

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -139,7 +139,6 @@ $ curl \
   "Provider": "consul",
   "Config": {
     "LeafCertTTL": "72h",
-    "RotationPeriod": "2160h",
     "IntermediateCertTTL": "8760h"
   },
   "CreateIndex": 5,
@@ -190,7 +189,6 @@ The table below shows this endpoint's support for
     "LeafCertTTL": "72h",
     "PrivateKey": "-----BEGIN RSA PRIVATE KEY-----...",
     "RootCert": "-----BEGIN CERTIFICATE-----...",
-    "RotationPeriod": "2160h",
     "IntermediateCertTTL": "8760h"
   },
   "ForceWithoutCrossSigning": false

--- a/website/content/docs/connect/ca/consul.mdx
+++ b/website/content/docs/connect/ca/consul.mdx
@@ -74,7 +74,6 @@ $ curl localhost:8500/v1/connect/ca/configuration
     "Provider": "consul",
     "Config": {
         "LeafCertTTL": "72h",
-        "RotationPeriod": "2160h",
         "IntermediateCertTTL": "8760h"
     },
     "CreateIndex": 5,
@@ -105,7 +104,6 @@ $ jq -n --arg key "$(cat root.key)"  --arg cert "$(cat root.crt)" '
         "LeafCertTTL": "72h",
         "PrivateKey": $key,
         "RootCert": $cert,
-        "RotationPeriod": "2160h",
         "IntermediateCertTTL": "8760h"
     }
 }' > ca_config.json
@@ -121,7 +119,6 @@ $ cat ca_config.json
     "LeafCertTTL": "72h",
     "PrivateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEArqiy1c3pbT3cSkjdEM1APALUareU...",
     "RootCert": "-----BEGIN CERTIFICATE-----\nMIIDijCCAnKgAwIBAgIJAOFZ66em1qC7MA0GCSqGSIb3...",
-    "RotationPeriod": "2160h",
     "IntermediateCertTTL": "8760h"
   }
 }

--- a/website/content/docs/connect/ca/index.mdx
+++ b/website/content/docs/connect/ca/index.mdx
@@ -89,7 +89,6 @@ $ curl http://localhost:8500/v1/connect/ca/configuration
     "Provider": "consul",
     "Config": {
         "LeafCertTTL": "72h",
-        "RotationPeriod": "2160h",
         "IntermediateCertTTL": "8760h"
     },
     "CreateIndex": 5,

--- a/website/content/docs/k8s/connect/connect-ca-provider.mdx
+++ b/website/content/docs/k8s/connect/connect-ca-provider.mdx
@@ -127,7 +127,6 @@ $ kubectl exec consul-server-0 -- curl -s http://localhost:8500/v1/connect/ca/co
     "IntermediatePKIPath": "connect-intermediate",
     "LeafCertTTL": "72h",
     "RootPKIPath": "connect-root",
-    "RotationPeriod": "2160h",
     "Token": "s.VgQvaXl8xGFO1RUxAPbPbsfN"
   },
   "State": null,


### PR DESCRIPTION
This field was never used. Since it is persisted as part of a `map[string]interface{}` it is pretty easy to remove it. We use mapstructure to decode this map into a struct, and we don't set `ErrorUnused=true`, so any unexpected keys in the map will be ignored.