### PR TITLE
Fix defaults for autopilot config update

### DIFF
--- a/.changelog/10559.txt
+++ b/.changelog/10559.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fix default values used for optional fields in autopilot configuration update (POST to `/v1/operator/autopilot/configuration`) [[GH-10558](https://github.com/hashicorp/consul/issues/10558)]
+```

--- a/agent/operator_endpoint.go
+++ b/agent/operator_endpoint.go
@@ -217,7 +217,7 @@ func (s *HTTPHandlers) OperatorAutopilotConfiguration(resp http.ResponseWriter, 
 		s.parseDC(req, &args.Datacenter)
 		s.parseToken(req, &args.Token)
 
-		var conf api.AutopilotConfiguration
+		conf := api.NewAutopilotConfiguration()
 		if err := decodeBody(req.Body, &conf); err != nil {
 			return nil, BadRequestError{Reason: fmt.Sprintf("Error parsing autopilot config: %v", err)}
 		}

--- a/api/operator_autopilot.go
+++ b/api/operator_autopilot.go
@@ -58,6 +58,23 @@ type AutopilotConfiguration struct {
 	ModifyIndex uint64
 }
 
+// Defines default values for the AutopilotConfiguration type, consistent with
+// https://www.consul.io/api-docs/operator/autopilot#parameters-1
+func NewAutopilotConfiguration() AutopilotConfiguration {
+	cfg := AutopilotConfiguration{
+		CleanupDeadServers:      true,
+		LastContactThreshold:    NewReadableDuration(200 * time.Millisecond),
+		MaxTrailingLogs:         250,
+		MinQuorum:               0,
+		ServerStabilizationTime: NewReadableDuration(10 * time.Second),
+		RedundancyZoneTag:       "",
+		DisableUpgradeMigration: false,
+		UpgradeVersionTag:       "",
+	}
+
+	return cfg
+}
+
 // ServerHealth is the health (from the leader's point of view) of a server.
 type ServerHealth struct {
 	// ID is the raft ID of the server.


### PR DESCRIPTION
Closes #10558

Previously, for a POST request to the /v1/operator/autopilot/configuration
endpoint, any fields not included in the payload were set to a zero-initialized
value rather than the documented default value.

Now, if an optional field is not included in the payload, it will be set to its
documented default value:
```
- CleanupDeadServers:      true
- LastContactThreshold:    "200ms"
- MaxTrailingLogs:         250
- MinQuorum:               0
- ServerStabilizationTime: "10s"
- RedundancyZoneTag:       ""
- DisableUpgradeMigration: false
- UpgradeVersionTag:       ""
```