### PR TITLE
Replace use of 'sane' where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1673,7 +1673,7 @@ BUG FIXES:
 * dns: Ensure that only 1 CNAME is returned when querying for services that have non-IP service addresses. [[PR-4328](https://github.com/hashicorp/consul/pull/4328)]
 * api: Fixed issue where `Lock` and `Semaphore` would return earlier than their requested timeout when unable to acquire the lock. [[GH-4003](https://github.com/hashicorp/consul/issues/4003)], [[GH-3262](https://github.com/hashicorp/consul/issues/3262)], [[GH-2399](https://github.com/hashicorp/consul/issues/2399)]
 * watch: Fix issue with HTTPs only agents not executing watches properly [[GH-4358](https://github.com/hashicorp/consul/issues/4358)]
-* agent: Managed proxies that bind to 0.0.0.0 now get a health check on a sane IP [[GH-4301](https://github.com/hashicorp/consul/issues/4301)]
+* agent: Managed proxies that bind to 0.0.0.0 now get a health check on a reasonable IP [[GH-4301](https://github.com/hashicorp/consul/issues/4301)]
 * server: (Consul Enterprise) Fixed an issue causing Consul to panic when network areas were used
 * license: (Consul Enterprise) Fixed an issue causing the snapshot agent to log erroneous licensing errors
 

--- a/agent/connect/uri.go
+++ b/agent/connect/uri.go
@@ -53,7 +53,7 @@ func ParseCertURI(input *url.URL) (CertURI, error) {
 
 	// Test for service IDs
 	if v := spiffeIDServiceRegexp.FindStringSubmatch(path); v != nil {
-		// Determine the values. We assume they're sane to save cycles,
+		// Determine the values. We assume they're reasonable to save cycles,
 		// but if the raw path is not empty that means that something is
 		// URL encoded so we go to the slow path.
 		ns := v[1]
@@ -79,7 +79,7 @@ func ParseCertURI(input *url.URL) (CertURI, error) {
 			Service:    service,
 		}, nil
 	} else if v := spiffeIDAgentRegexp.FindStringSubmatch(path); v != nil {
-		// Determine the values. We assume they're sane to save cycles,
+		// Determine the values. We assume they're reasonable to save cycles,
 		// but if the raw path is not empty that means that something is
 		// URL encoded so we go to the slow path.
 		dc := v[1]

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -4371,7 +4371,7 @@ func TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData(t *testing.T) {
 	})
 
 	// We delay until now to setup an auth method and binding rule in the
-	// primary so our earlier listing tests were sane. We need to be able to
+	// primary so our earlier listing tests were reasonable. We need to be able to
 	// use auth methods in both datacenters in order to verify Logout is
 	// properly scoped.
 	t.Run("initialize primary so we can test logout", func(t *testing.T) {

--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -47,7 +47,7 @@ type aclTypeReplicator interface {
 	FetchLocal(srv *Server) (int, uint64, error)
 
 	// SortState sorts the internal working state output of FetchRemote and
-	// FetchLocal so that a sane diff can be performed.
+	// FetchLocal so that a reasonable diff can be performed.
 	SortState() (lenLocal, lenRemote int)
 
 	// LocalMeta allows for type-agnostic metadata from the sorted local state

--- a/agent/consul/authmethod/authmethods.go
+++ b/agent/consul/authmethod/authmethods.go
@@ -36,7 +36,7 @@ type Validator interface {
 	NewIdentity() *Identity
 
 	// ValidateLogin takes raw user-provided auth method metadata and ensures
-	// it is sane, provably correct, and currently valid. Relevant identifying
+	// it is reasonable, provably correct, and currently valid. Relevant identifying
 	// data is extracted and returned for immediate use by the role binding
 	// process.
 	//

--- a/agent/consul/authmethod/testauth/testing.go
+++ b/agent/consul/authmethod/testauth/testing.go
@@ -120,7 +120,7 @@ func (v *Validator) Name() string { return v.name }
 func (v *Validator) Stop() {}
 
 // ValidateLogin takes raw user-provided auth method metadata and ensures it is
-// sane, provably correct, and currently valid. Relevant identifying data is
+// reasonable, provably correct, and currently valid. Relevant identifying data is
 // extracted and returned for immediate use by the role binding process.
 //
 // Depending upon the method, it may make sense to use these calls to continue

--- a/agent/consul/discoverychain/compile.go
+++ b/agent/consul/discoverychain/compile.go
@@ -705,7 +705,7 @@ func (c *compiler) getSplitterNode(sid structs.ServiceID) (*structs.DiscoveryGra
 	}
 
 	// If we record this exists before recursing down it will short-circuit
-	// sanely if there is some sort of graph loop below.
+	// reasonably if there is some sort of graph loop below.
 	c.recordNode(splitNode)
 
 	var hasLB bool
@@ -941,7 +941,7 @@ RESOLVE_AGAIN:
 	}
 
 	// If we record this exists before recursing down it will short-circuit
-	// sanely if there is some sort of graph loop below.
+	// reasonably if there is some sort of graph loop below.
 	c.recordNode(node)
 
 	if len(resolver.Failover) > 0 {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1002,7 +1002,7 @@ func (s *Server) Leave() error {
 	// If we are the current leader, and we have any other peers (cluster has multiple
 	// servers), we should do a RemoveServer/RemovePeer to safely reduce the quorum size.
 	// If we are not the leader, then we should issue our leave intention and wait to be
-	// removed for some sane period of time.
+	// removed for some reasonable period of time.
 	isLeader := s.IsLeader()
 	if isLeader && numPeers > 1 {
 		if err := s.autopilot.RemoveServer(raft.ServerID(s.config.NodeID)); err != nil {
@@ -1265,7 +1265,7 @@ func (s *Server) RPC(method string, args interface{}, reply interface{}) error {
 	// internal server API. It's odd that the same request directed to a server is
 	// recorded differently. On the other hand this possibly masks the different
 	// between regular client requests that traverse the network and these which
-	// don't (unless forwarded). This still seems most sane.
+	// don't (unless forwarded). This still seems most reasonable.
 	metrics.IncrCounter([]string{"client", "rpc"}, 1)
 	if !s.rpcLimiter.Load().(*rate.Limiter).Allow() {
 		metrics.IncrCounter([]string{"client", "rpc", "exceeded"}, 1)
@@ -1288,7 +1288,7 @@ func (s *Server) SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io
 	// internal server API. It's odd that the same request directed to a server is
 	// recorded differently. On the other hand this possibly masks the different
 	// between regular client requests that traverse the network and these which
-	// don't (unless forwarded). This still seems most sane.
+	// don't (unless forwarded). This still seems most reasonable.
 	metrics.IncrCounter([]string{"client", "rpc"}, 1)
 	if !s.rpcLimiter.Load().(*rate.Limiter).Allow() {
 		metrics.IncrCounter([]string{"client", "rpc", "exceeded"}, 1)

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -407,14 +407,14 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 	requireFileIsPresent(t, svcFile)
 	requireFileIsPresent(t, configFile)
 
-	// Service definition file is sane.
+	// Service definition file is reasonable.
 	expectJSONFile(t, svcFile, persistedService{
 		Token:   "mytoken",
 		Service: svc,
 		Source:  "remote",
 	}, nil)
 
-	// Service config file is sane.
+	// Service config file is reasonable.
 	pcfg := persistedServiceConfig{
 		ServiceID: "web-sidecar-proxy",
 		Defaults: &structs.ServiceConfigResponse{
@@ -632,7 +632,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 	requireFileIsAbsent(t, svcFile)
 	requireFileIsPresent(t, configFile)
 
-	// Service config file is sane.
+	// Service config file is reasonable.
 	expectJSONFile(t, configFile, persistedServiceConfig{
 		ServiceID: "web-sidecar-proxy",
 		Defaults: &structs.ServiceConfigResponse{

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -80,7 +80,7 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 		token = ns.Connect.SidecarService.Token
 	}
 
-	// Setup some sane connect proxy defaults.
+	// Setup some reasonable connect proxy defaults.
 	if sidecar.Kind == "" {
 		sidecar.Kind = structs.ServiceKindConnectProxy
 	}

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -398,7 +398,7 @@ type ServiceRouteDestination struct {
 	RetryOnConnectFailure bool `json:",omitempty" alias:"retry_on_connect_failure"`
 
 	// RetryOnStatusCodes is a flat list of http response status codes that are
-	// eligible for retry. This again should be feasible in any sane proxy.
+	// eligible for retry. This again should be feasible in any reasonable proxy.
 	RetryOnStatusCodes []uint32 `json:",omitempty" alias:"retry_on_status_codes"`
 }
 

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -57,7 +57,7 @@ func (s *ResourceGenerator) routesForConnectProxy(chains map[string]*structs.Com
 			Name:         id,
 			VirtualHosts: []*envoy_route_v3.VirtualHost{virtualHost},
 			// ValidateClusters defaults to true when defined statically and false
-			// when done via RDS. Re-set the sane value of true to prevent
+			// when done via RDS. Re-set the reasonable value of true to prevent
 			// null-routing traffic.
 			ValidateClusters: makeBoolValue(true),
 		}
@@ -151,7 +151,7 @@ func makeNamedDefaultRouteWithLB(clusterName string, lb *structs.LoadBalancer, a
 			},
 		},
 		// ValidateClusters defaults to true when defined statically and false
-		// when done via RDS. Re-set the sane value of true to prevent
+		// when done via RDS. Re-set the reasonable value of true to prevent
 		// null-routing traffic.
 		ValidateClusters: makeBoolValue(true),
 	}, nil
@@ -174,7 +174,7 @@ func (s *ResourceGenerator) routesForIngressGateway(
 		upstreamRoute := &envoy_route_v3.RouteConfiguration{
 			Name: listenerKey.RouteName(),
 			// ValidateClusters defaults to true when defined statically and false
-			// when done via RDS. Re-set the sane value of true to prevent
+			// when done via RDS. Re-set the reasonable value of true to prevent
 			// null-routing traffic.
 			ValidateClusters: makeBoolValue(true),
 		}

--- a/build-support/scripts/test-flake.sh
+++ b/build-support/scripts/test-flake.sh
@@ -26,7 +26,7 @@ Description:
   Single or package-wide tests are run for multiple iterations with a configurable
   amount of CPU resources. 
 
-  0.15 CPUs and 30 iterations are configured as sane defaults.
+  0.15 CPUs and 30 iterations are configured as reasonable defaults.
 
   See Docker docs for more info on tuning 'cpus' param: 
   https://docs.docker.com/config/containers/resource_constraints/#cpu

--- a/command/exec/exec.go
+++ b/command/exec/exec.go
@@ -370,7 +370,7 @@ ERR_EXIT:
 	}
 }
 
-// validate checks that the configuration is sane
+// validate checks that the configuration is reasonable
 func (conf *rExecConf) validate() error {
 	// Validate the filters
 	if conf.node != "" {

--- a/connect/proxy/config.go
+++ b/connect/proxy/config.go
@@ -72,7 +72,7 @@ type PublicListenerConfig struct {
 	HandshakeTimeoutMs int `json:"handshake_timeout_ms" hcl:"handshake_timeout_ms" mapstructure:"handshake_timeout_ms"`
 }
 
-// applyDefaults sets zero-valued params to a sane default.
+// applyDefaults sets zero-valued params to a reasonable default.
 func (plc *PublicListenerConfig) applyDefaults() {
 	if plc.LocalConnectTimeoutMs == 0 {
 		plc.LocalConnectTimeoutMs = 1000
@@ -98,7 +98,7 @@ func (uc *UpstreamConfig) ConnectTimeout() time.Duration {
 	return 10000 * time.Millisecond
 }
 
-// applyDefaults sets zero-valued params to a sane default.
+// applyDefaults sets zero-valued params to a reasonable default.
 func (uc *UpstreamConfig) applyDefaults() {
 	if uc.DestinationType == "" {
 		uc.DestinationType = "service"

--- a/ui/packages/consul-ui/app/mixins/with-blocking-actions.js
+++ b/ui/packages/consul-ui/app/mixins/with-blocking-actions.js
@@ -7,7 +7,7 @@ import { set } from '@ember/object';
  *
  * Each 'blocking action' (blocking in terms of showing some sort of blocking loader) is
  * wrapped in the functionality to signal that the page should be blocked
- * (currently via the 'feedback' service) as well as some sane default hooks for where the page
+ * (currently via the 'feedback' service) as well as some reasonable default hooks for where the page
  * should go when the action has finished.
  *
  * Hooks can and are being overwritten for custom redirects/error handling on a route by route basis.

--- a/website/content/docs/agent/index.mdx
+++ b/website/content/docs/agent/index.mdx
@@ -32,7 +32,7 @@ local agent by following the
 
 The agent command takes a variety of
 [`configuration options`](/docs/agent/options#command-line-options), but most
-have sane defaults.
+have reasonable defaults.
 
 When running [`consul agent`](/commands/agent), you should see output
 similar to this:

--- a/website/content/docs/connect/proxies/built-in.mdx
+++ b/website/content/docs/connect/proxies/built-in.mdx
@@ -53,7 +53,7 @@ for the built-in proxy.
 }
 ```
 
-All fields are optional with a sane default.
+All fields are optional with a reasonable default.
 
 - `bind_address` - The address the proxy will bind its
   _public_ mTLS listener to. It defaults to the same address the agent binds to.
@@ -101,7 +101,7 @@ All fields are optional with a sane default.
 
 ## Proxy Upstream Config Key Reference
 
-All fields are optional with a sane default.
+All fields are optional with a reasonable default.
 
 - `connect_timeout_ms` - The number of milliseconds
   the proxy will wait to establish a TLS connection to the discovered upstream instance

--- a/website/content/docs/connect/proxies/managed-deprecated.mdx
+++ b/website/content/docs/connect/proxies/managed-deprecated.mdx
@@ -64,7 +64,7 @@ token is more restrictive than can be currently expressed manually in
 an ACL policy.
 
 The default managed proxy is a basic proxy built-in to Consul and written
-in Go. Having a basic built-in proxy allows Consul to have a sane default
+in Go. Having a basic built-in proxy allows Consul to have a reasonable default
 with performance that is good enough for most workloads. In some basic
 benchmarks, the service-to-service communication over the built-in proxy
 could sustain 5 Gbps with sub-millisecond latency. Therefore,

--- a/website/content/docs/connect/registration/service-registration.mdx
+++ b/website/content/docs/connect/registration/service-registration.mdx
@@ -3,7 +3,7 @@ layout: docs
 page_title: Connect - Service Registration
 description: >-
   A per-service proxy sidecar transparently handles inbound and outbound service
-  connections. You can register these sidecars with sane defaults by nesting
+  connections. You can register these sidecars with reasonable defaults by nesting
   their definitions in the service definition.
 ---
 

--- a/website/content/docs/dynamic-app-config/kv.mdx
+++ b/website/content/docs/dynamic-app-config/kv.mdx
@@ -7,7 +7,7 @@ description: Consul KV is a core feature of Consul and is installed with the Con
 # Consul KV
 
 Consul KV is a core feature of Consul and is installed with the Consul agent.
-Once installed with the agent, it will have sane defaults. Consul KV allows
+Once installed with the agent, it will have reasonable defaults. Consul KV allows
 users to store indexed objects, though its main uses are storing configuration
 parameters and metadata. Please note that it is a simple KV store and is not
 intended to be a full featured datastore (such as DynamoDB) but has some

--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -10,7 +10,7 @@ description: Configuration for the Consul Helm chart.
 
 The chart is highly customizable using
 [Helm configuration values](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
-Each value has a sane default tuned for an optimal getting started experience
+Each value has a reasonable default tuned for an optimal getting started experience
 with Consul. Before going into production, please review the parameters below
 and consider if they're appropriate for your deployment.
 

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -40,7 +40,7 @@ You are still responsible for learning how to monitor, backup,
 upgrade, etc. the Consul cluster.
 
 The Helm chart has no required configuration and will install a Consul
-cluster with sane defaults out of the box. Prior to going to production,
+cluster with reasonable defaults out of the box. Prior to going to production,
 it is highly recommended that you
 [learn about the configuration options](/docs/k8s/helm#configuration-values).
 


### PR DESCRIPTION
HashiCorp voice, style, and language guidelines recommend avoiding ableist
language unless its reference to ability is accurate in a particular use.

Changes were not made to:
- Any file in `/vendor`
- Any package manager dependency file (e.g., funnily enough, there's a `sane` package used in the repo)

Changes were only needed to comments, not code (e.g., variable names).