### PR TITLE
cli/sdk: Allow applying redirect-traffic rules in a provided Linux namespace

### DIFF
--- a/.changelog/10564.txt
+++ b/.changelog/10564.txt
@@ -1,0 +1,6 @@
+```release-note:feature
+cli: allow running `redirect-traffic` command in a provided Linux namespace.
+```
+```release-note:feature
+sdk: allow applying `iptables` rules in a provided Linux namespace.
+```

--- a/command/connect/redirecttraffic/redirect_traffic.go
+++ b/command/connect/redirecttraffic/redirect_traffic.go
@@ -44,6 +44,7 @@ type cmd struct {
 	excludeOutboundPorts []string
 	excludeOutboundCIDRs []string
 	excludeUIDs          []string
+	netNS                string
 }
 
 func (c *cmd) init() {
@@ -62,6 +63,8 @@ func (c *cmd) init() {
 		"Outbound CIDR to exclude from traffic redirection. May be provided multiple times.")
 	c.flags.Var((*flags.AppendSliceValue)(&c.excludeUIDs), "exclude-uid",
 		"Additional user ID to exclude from traffic redirection. May be provided multiple times.")
+	c.flags.StringVar(&c.netNS, "netns", "", "The network namespace where traffic redirection rules should apply."+
+		"This must be a path to the network namespace, e.g. /var/run/netns/foo.")
 
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flags, c.http.ClientFlags())
@@ -130,6 +133,7 @@ func (c *cmd) generateConfigFromFlags() (iptables.Config, error) {
 		ProxyUserID:       c.proxyUID,
 		ProxyInboundPort:  c.proxyInboundPort,
 		ProxyOutboundPort: c.proxyOutboundPort,
+		NetNS:             c.netNS,
 	}
 
 	// When proxyID is provided, we set up cfg with values

--- a/sdk/iptables/iptables.go
+++ b/sdk/iptables/iptables.go
@@ -6,16 +6,16 @@ import (
 )
 
 const (
-	// Chain to intercept inbound traffic
+	// ProxyInboundChain is the chain to intercept inbound traffic.
 	ProxyInboundChain = "CONSUL_PROXY_INBOUND"
 
-	// Chain to redirect inbound traffic to the proxy
+	// ProxyInboundRedirectChain is the chain to redirect inbound traffic to the proxy.
 	ProxyInboundRedirectChain = "CONSUL_PROXY_IN_REDIRECT"
 
-	// Chain to intercept outbound traffic
+	// ProxyOutputChain is the chain to intercept outbound traffic.
 	ProxyOutputChain = "CONSUL_PROXY_OUTPUT"
 
-	// Chain to redirect outbound traffic to the proxy
+	// ProxyOutputRedirectChain is the chain to redirect outbound traffic to the proxy
 	ProxyOutputRedirectChain = "CONSUL_PROXY_REDIRECT"
 
 	DefaultTProxyOutboundPort = 15001
@@ -49,6 +49,11 @@ type Config struct {
 	// from traffic redirection.
 	ExcludeUIDs []string
 
+	// NetNS is the network namespace where the traffic redirection rules
+	// should be applied. This must be a path to the network namespace,
+	// e.g. /var/run/netns/foo.
+	NetNS string
+
 	// IptablesProvider is the Provider that will apply iptables rules.
 	IptablesProvider Provider
 }
@@ -71,7 +76,7 @@ type Provider interface {
 // https://github.com/openservicemesh/osm/blob/650a1a1dcf081ae90825f3b5dba6f30a0e532725/pkg/injector/iptables.go
 func Setup(cfg Config) error {
 	if cfg.IptablesProvider == nil {
-		cfg.IptablesProvider = &iptablesExecutor{}
+		cfg.IptablesProvider = &iptablesExecutor{cfg: cfg}
 	}
 
 	err := validateConfig(cfg)

--- a/sdk/iptables/iptables_executor_unsupported.go
+++ b/sdk/iptables/iptables_executor_unsupported.go
@@ -5,7 +5,9 @@ package iptables
 import "errors"
 
 // iptablesExecutor implements IptablesProvider and errors out on any non-linux OS.
-type iptablesExecutor struct{}
+type iptablesExecutor struct {
+	cfg Config
+}
 
 func (i *iptablesExecutor) AddRule(_ string, _ ...string) {}
 

--- a/website/content/commands/connect/redirect-traffic.mdx
+++ b/website/content/commands/connect/redirect-traffic.mdx
@@ -53,6 +53,9 @@ Usage: `consul connect redirect-traffic [options]`
 
 - `exclude-uid` - Additional user ID to exclude from traffic redirection. May be provided multiple times.
 
+- `netns` - The Linux network namespace where traffic redirection rules should apply.
+  This must be a path to the network namespace, e.g. /var/run/netns/foo.
+
 #### Enterprise Options
 
 @include 'http_api_namespace_options.mdx'


### PR DESCRIPTION
This PR proposes to apply traffic redirection rules in a given Linux network namespace:
- The `iptables` SDK package now accepts `NetNS` configuration which should point to the path of the network namespace.
- The `redirect-traffic` command accepts `netns` flag with the same.

**Note:** I did not find a meaningful enough way to unit test this change since it's just wrapping every `iptables` command with a call to `nsenter`, and that's why there aren't tests added. I did test it manually on a VM:

```
root@test2:/home/irynashustava# ip netns add foo
root@test2:/home/irynashustava# ip netns
foo
root@test2:/home/irynashustava# ./consul connect redirect-traffic -netns=/var/run/netns/foo -proxy-uid=1234 -proxy-inbound-port=15001
    Successfully applied traffic redirection rules
root@test2:/home/irynashustava# nsenter --net=/var/run/netns/foo -- iptables -t nat --list
Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination
CONSUL_PROXY_INBOUND  tcp  --  anywhere             anywhere

Chain INPUT (policy ACCEPT)
target     prot opt source               destination

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination
CONSUL_PROXY_OUTPUT  tcp  --  anywhere             anywhere

Chain POSTROUTING (policy ACCEPT)
target     prot opt source               destination

Chain CONSUL_PROXY_INBOUND (1 references)
target     prot opt source               destination
CONSUL_PROXY_IN_REDIRECT  tcp  --  anywhere             anywhere

Chain CONSUL_PROXY_IN_REDIRECT (1 references)
target     prot opt source               destination
REDIRECT   tcp  --  anywhere             anywhere             redir ports 15001

Chain CONSUL_PROXY_OUTPUT (1 references)
target     prot opt source               destination
RETURN     all  --  anywhere             anywhere             owner UID match 1234
RETURN     all  --  anywhere             localhost
CONSUL_PROXY_REDIRECT  all  --  anywhere             anywhere

Chain CONSUL_PROXY_REDIRECT (1 references)
target     prot opt source               destination
REDIRECT   tcp  --  anywhere             anywhere             redir ports 15001
```
