### PR TITLE
Allow configuring graceful stop in testutil

### DIFF
--- a/.changelog/10566.txt
+++ b/.changelog/10566.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Allow configuring graceful stop in testutil.
+```


### PR DESCRIPTION
Before this PR it wasn't possible to configure graceful consul shutdown in testutil. [this](https://github.com/hashicorp/consul/blob/21e855d860865f1472b3fdcb64a916e92bc83a9f/command/agent/agent.go#L313-L316) code was always triggered.

Now the default behavior is exactly the same as it used to be, but the users are able to set SkipLeaveOnInt flag, which causes consul to actually do the graceful shutdown on receiving SIGINT, and StopTimeout flag, which allows configuring for how long we are going to wait before sending `syscall.SIGABRT` to consul