### PR TITLE
ui: [BUGFIX] Ensure in-folder KVs are created in the correct folder

### DIFF
--- a/.changelog/10569.txt
+++ b/.changelog/10569.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Ensure in-folder KVs are created in the correct folder
+```

--- a/ui/packages/consul-ui/app/components/app-view/index.hbs
+++ b/ui/packages/consul-ui/app/components/app-view/index.hbs
@@ -54,7 +54,7 @@
       <div>
           <div>
     {{#if authorized}}
-              <nav aria-label="Breadcrumb">
+              <nav aria-label="Breadcrumb" data-test-breadcrumbs>
                   <YieldSlot @name="breadcrumbs">
                     {{document-attrs class="with-breadcrumbs"}}
                     {{yield}}

--- a/ui/packages/consul-ui/app/locations/fsm-with-optional.js
+++ b/ui/packages/consul-ui/app/locations/fsm-with-optional.js
@@ -9,7 +9,9 @@ if (env('CONSUL_NSPACES_ENABLED')) {
 }
 
 const trailingSlashRe = /\/$/;
-const moreThan1SlashRe = /\/{2,}/g;
+
+// see below re: ember double slashes
+// const moreThan1SlashRe = /\/{2,}/g;
 
 const _uuid = function() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
@@ -123,15 +125,16 @@ export default class FSMWithOptionalLocation {
   }
 
   getURLFrom(url) {
-    // remove trailing slashes if they exists
+    // remove trailing slashes if they exist
     url = url || this.location.pathname;
     this.rootURL = this.rootURL.replace(trailingSlashRe, '');
     this.baseURL = this.baseURL.replace(trailingSlashRe, '');
     // remove baseURL and rootURL from start of path
     return url
       .replace(new RegExp(`^${this.baseURL}(?=/|$)`), '')
-      .replace(new RegExp(`^${this.rootURL}(?=/|$)`), '')
-      .replace(moreThan1SlashRe, '/'); // remove extra slashes
+      .replace(new RegExp(`^${this.rootURL}(?=/|$)`), '');
+    // ember default locations remove double slashes here e.g. '//'
+    // .replace(moreThan1SlashRe, '/'); // remove extra slashes
   }
 
   getURLForTransition(url) {

--- a/ui/packages/consul-ui/tests/acceptance/dc/kvs/create.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/kvs/create.feature
@@ -48,3 +48,4 @@ Feature: dc / kvs / create
     And I click kv on the kvs
     And I click create
     And I see the text "New Key / Value" in "h1"
+    And I see the text "key-value" in "[data-test-breadcrumbs] li:nth-child(2) a"


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/10212 we made a fairly significant change to how our routing for namespaces works, with an eye to supporting a future feature of the UI (more details on that PR)

We based the majority of that work on code already existing in the ember framework but noticed that our app would slightly inconsistently use the some of the code in here, which meant it was possible to set empty URL segments in URLs for example `/kv/folder-name//create` (the URL for creating a new KV within the `folder-name` folder).

Ember seems to generally strips these, and whilst I've not looked too far into it as yet, this wasn't happening previous to the above PR.

https://github.com/emberjs/ember.js/blob/297ab0e771409d61dcb014a9a40144cd7fdd5ee8/packages/%40ember/-internals/routing/lib/location/history_location.ts#L145

With the addition of the above PR, the double slash stripping began to work, without us noticing! So when clicking to create a KV within folder name, would would be viewing a form that was a form for creating a KV in the root, which when the user clicked to save, saved the KV in the root.

For the moment at least I've removed the code that strips double slashes, and whilst this isn't ideal, it looks like we've picked up one of those bugs that turns into a 'feature', and completely reworking KV to not rely on the double slashes is not really an option right now.

This fixes the problem. Typically it doesn't look like we had a test here to cover this exact pattern, so I've added an additional line to our tests that fails before this bug was fixed.

Fixes #10502