### PR TITLE
tests: skip cases that depend on test server when -short flag set

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -61,6 +61,11 @@ func makeClientWithConfig(
 	var server *testutil.TestServer
 	var err error
 	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
+		// Skip test when -short flag provided; any tests that create a test
+		// server will take at least 100ms which is undesirable for -short
+		if testing.Short() {
+			t.Skip("too slow for testing.Short")
+		}
 		server, err = testutil.NewTestServerConfigT(t, cb2)
 		if err != nil {
 			r.Fatalf("Failed to start server: %v", err.Error())

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -50,6 +50,11 @@ func makeClientWithConfig(
 	t *testing.T,
 	cb1 configCallback,
 	cb2 testutil.ServerConfigCallback) (*Client, *testutil.TestServer) {
+	// Skip test when -short flag provided; any tests that create a test
+	// server will take at least 100ms which is undesirable for -short
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
 
 	// Make client config
 	conf := DefaultConfig()
@@ -61,11 +66,6 @@ func makeClientWithConfig(
 	var server *testutil.TestServer
 	var err error
 	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
-		// Skip test when -short flag provided; any tests that create a test
-		// server will take at least 100ms which is undesirable for -short
-		if testing.Short() {
-			t.Skip("too slow for testing.Short")
-		}
 		server, err = testutil.NewTestServerConfigT(t, cb2)
 		if err != nil {
 			r.Fatalf("Failed to start server: %v", err.Error())

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -24,6 +24,12 @@ import (
 )
 
 func makeClient(t *testing.T) (*api.Client, *testutil.TestServer) {
+	// Skip test when -short flag provided; any tests that create a test server
+	// will take at least 100ms which is undesirable for -short
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
 	// Make client config
 	conf := api.DefaultConfig()
 

--- a/command/connect/redirecttraffic/redirect_traffic_test.go
+++ b/command/connect/redirecttraffic/redirect_traffic_test.go
@@ -549,6 +549,12 @@ func TestGenerateConfigFromFlags(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			cmd := c.command()
 			if c.consulServices != nil {
+				// Skip test when -short flag provided; any tests that create a test server
+				// will take at least 100ms which is undesirable for -short
+				if testing.Short() {
+					t.Skip("too slow for testing.Short")
+				}
+
 				testServer, err := testutil.NewTestServerConfigT(t, nil)
 				require.NoError(t, err)
 				testServer.WaitForLeader(t)

--- a/command/connect/redirecttraffic/redirect_traffic_test.go
+++ b/command/connect/redirecttraffic/redirect_traffic_test.go
@@ -549,12 +549,6 @@ func TestGenerateConfigFromFlags(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			cmd := c.command()
 			if c.consulServices != nil {
-				// Skip test when -short flag provided; any tests that create a test server
-				// will take at least 100ms which is undesirable for -short
-				if testing.Short() {
-					t.Skip("too slow for testing.Short")
-				}
-
 				testServer, err := testutil.NewTestServerConfigT(t, nil)
 				require.NoError(t, err)
 				testServer.WaitForLeader(t)


### PR DESCRIPTION
For cases where `go test -short` is used to invoke tests, we want to skip those that involve invoking the `consul` binary. 

Fixes #10575.