### PR TITLE
ui: Split up the socket mode from the socket path

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.hbs
@@ -40,19 +40,19 @@
       {{#if item.LocalBindSocketPath}}
 {{#let (if item.LocalBindSocketMode
           (hash
-            label=(concat '(Local bind mode)')
-            value=(concat '(Mode:' item.LocalBindSocketMode ')')
+            label='Local bind mode'
+            value='item.LocalBindSocketMode'
           )
           (hash
-            label=""
-            value=""
+            label='Local bind mode'
+            value="-"
           )
         )
 as |mode|}}
           <dl class="local-bind-socket">
             <dt>
               <span>
-                Local bind socket {{mode.label}}
+                Local bind socket
               </span>
             </dt>
             <dd>
@@ -61,6 +61,16 @@ as |mode|}}
                 @name="Socket path"
               />
               {{item.LocalBindSocketPath}}
+            </dd>
+          </dl>
+          <dl class="local-bind-mode">
+            <dt>
+              <span>
+                Local bind mode
+              </span>
+            </dt>
+            <dd>
+              <span>mode:</span> {{mode.value}}
             </dd>
           </dl>
 {{/let}}

--- a/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.scss
@@ -11,4 +11,7 @@
   dl.nspace dt::before {
     @extend %with-folder-outline-mask, %as-pseudo;
   }
+  dl.local-bind-mode dd span {
+    font-weight: $typo-weight-semibold;
+  }
 }


### PR DESCRIPTION
When there is no `LocalBindSocketMode`:
<img width="528" alt="Screen Shot 2021-07-09 at 10 54 47 AM" src="https://user-images.githubusercontent.com/19161242/125097436-20886480-e0a4-11eb-8f73-98ea91234c3e.png">

With  a `LocalBindSocketMode`:
<img width="524" alt="Screen Shot 2021-07-09 at 10 54 59 AM" src="https://user-images.githubusercontent.com/19161242/125097438-2120fb00-e0a4-11eb-9332-2403adba5055.png">
