### PR TITLE
Fixed a typo that broke the example static-server deployment

### DIFF
--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -246,7 +246,7 @@ spec:
           ports:
             - containerPort: 8080
               name: http
-      serviceAccountName: static-serve
+      serviceAccountName: static-server
 ```
 
 Note that we're defining a Service intention so that our services are allowed to talk to each other.


### PR DESCRIPTION
The service account was typo'd and needs to be fixed

The documentation will not work to actually demo the mesh working unless this is changed.