### PR TITLE
docs: changing license faq title to align with Nomad and Vault faq pages

### DIFF
--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -4,7 +4,7 @@ page_title: Consul Enterprise License FAQ
 description: Frequently Asked Questions pertaining to Consul Enterprise Licensing.
 ---
 
-# Licensing Frequently Asked Questions (FAQ)
+# Frequently Asked Questions (FAQ)
 
 This FAQ is for the license changes introduced in Consul Enterprise version 1.10.0.
 Consul Enterprise automatically loads Consul licenses when the server agent starts.


### PR DESCRIPTION
This PR changes the faq license page title to align with the same title used for Nomad and Vault