### PR TITLE
ui: Show the correct 'ACLs Disabled' page when ACLs are disabled

### DIFF
--- a/.changelog/10604.txt
+++ b/.changelog/10604.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Show ACLs disabled page at Tokens page instead of 403 error when ACLs are disabled
+```

--- a/ui/packages/consul-ui/app/abilities/acl.js
+++ b/ui/packages/consul-ui/app/abilities/acl.js
@@ -6,6 +6,12 @@ export default class ACLAbility extends BaseAbility {
 
   resource = 'acl';
   segmented = false;
+  // Access is very similar to read, but when ACLs are disabled you still need
+  // access to ACLs in order to see the ACLs disabled page, which is accessing
+  // the ACLs area, but without read
+  get canAccess() {
+    return this.env.var('CONSUL_ACLS_ENABLED') ? this.canRead : true;
+  }
 
   get canRead() {
     return this.env.var('CONSUL_ACLS_ENABLED') && super.canRead;

--- a/ui/packages/consul-ui/app/components/app-view/index.hbs
+++ b/ui/packages/consul-ui/app/components/app-view/index.hbs
@@ -88,7 +88,7 @@
   </header>
   <div>
       {{#if (not enabled) }}
-        <EmptyState>
+        <EmptyState data-test-acls-disabled>
           <BlockSlot @name="header">
             <h2>Welcome to ACLs</h2>
           </BlockSlot>

--- a/ui/packages/consul-ui/app/router.js
+++ b/ui/packages/consul-ui/app/router.js
@@ -130,7 +130,7 @@ export const routes = {
     acls: {
       _options: {
         path: '/acls',
-        abilities: ['read acls'],
+        abilities: ['access acls'],
       },
       edit: {
         _options: { path: '/:id' },

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/access.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/access.feature
@@ -1,0 +1,11 @@
+@setupApplicationTest
+Feature: dc / acls / access: ACLs Access
+  Scenario: ACLs are disabled
+    Given ACLs are disabled
+    And 1 datacenter model with the value "dc-1"
+    When I visit the tokens page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/acls/tokens
+    And I see the "[data-test-acls-disabled]" element

--- a/ui/packages/consul-ui/tests/acceptance/steps/dc/acls/access-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/dc/acls/access-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui/packages/consul-ui/tests/helpers/set-cookies.js
+++ b/ui/packages/consul-ui/tests/helpers/set-cookies.js
@@ -1,8 +1,10 @@
-export default function(type, value) {
+export default function(type, value, doc = document) {
   const obj = {};
   if (type !== '*') {
     let key = '';
-    obj['CONSUL_ACLS_ENABLE'] = 1;
+    if (!doc.cookie.includes('CONSUL_ACLS_ENABLE=0')) {
+      obj['CONSUL_ACLS_ENABLE'] = 1;
+    }
     switch (type) {
       case 'dc':
         key = 'CONSUL_DATACENTER_COUNT';
@@ -22,7 +24,6 @@ export default function(type, value) {
         break;
       case 'acl':
         key = 'CONSUL_ACL_COUNT';
-        obj['CONSUL_ACLS_ENABLE'] = 1;
         break;
       case 'session':
         key = 'CONSUL_SESSION_COUNT';
@@ -32,19 +33,15 @@ export default function(type, value) {
         break;
       case 'policy':
         key = 'CONSUL_POLICY_COUNT';
-        obj['CONSUL_ACLS_ENABLE'] = 1;
         break;
       case 'role':
         key = 'CONSUL_ROLE_COUNT';
-        obj['CONSUL_ACLS_ENABLE'] = 1;
         break;
       case 'token':
         key = 'CONSUL_TOKEN_COUNT';
-        obj['CONSUL_ACLS_ENABLE'] = 1;
         break;
       case 'authMethod':
         key = 'CONSUL_AUTH_METHOD_COUNT';
-        obj['CONSUL_ACLS_ENABLE'] = 1;
         break;
       case 'nspace':
         key = 'CONSUL_NSPACE_COUNT';

--- a/ui/packages/consul-ui/tests/steps/doubles/model.js
+++ b/ui/packages/consul-ui/tests/steps/doubles/model.js
@@ -29,6 +29,9 @@ export default function(scenario, create, set, win = window, doc = document) {
     .given(['the local datacenter is "$value"'], function(value) {
       doc.cookie = `CONSUL_DATACENTER_LOCAL=${value}`;
     })
+    .given(['ACLs are disabled'], function() {
+      doc.cookie = `CONSUL_ACLS_ENABLE=0`;
+    })
     .given(['permissions from yaml\n$yaml'], function(data) {
       Object.entries(data).forEach(([key, value]) => {
         const resource = `CONSUL_RESOURCE_${key.toUpperCase()}`;


### PR DESCRIPTION
With ACLs disabled:

Before:

![image](https://user-images.githubusercontent.com/1034429/125206080-1b5d1e00-e23a-11eb-88a6-4d347106a237.png)

After:

<img width="1363" alt="Screenshot 2021-07-13 at 13 33 54" src="https://user-images.githubusercontent.com/554604/125452337-bf42dabd-87c5-44ac-a661-ded1535d99ae.png">

Fixes #10591 

Extra note here. Out testing mostly runs everything with ACLs enabled, so we had to do a little bit of gymnastics to disable ACLs just for this test, which is also related to work going on elsewhere, got me thinking we might want to shuffle this around a little at some point. Not an urgent thing in the slightest, it's been fine for a number of years and has held up pretty well, but seeing as its a good few years old now and we have a better picture it could be an area we might want to tweak at some point.

- [x] Needs a changelog