### PR TITLE
ui: [BUGFIX] Fix KV Code Editor syntax loading

### DIFF
--- a/.changelog/10605.txt
+++ b/.changelog/10605.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix KV editor syntax highlighting
+```

--- a/ui/packages/consul-ui/app/instance-initializers/ivy-codemirror.js
+++ b/ui/packages/consul-ui/app/instance-initializers/ivy-codemirror.js
@@ -3,17 +3,19 @@ export function initialize(application) {
   const appName = application.application.name;
   const doc = application.lookup('service:-document');
   // pick codemirror syntax highlighting paths out of index.html
-  const fs = JSON.parse(doc.querySelector(`[data-${appName}-fs]`).textContent);
+  const fs = new Map(
+    Object.entries(JSON.parse(doc.querySelector(`[data-${appName}-fs]`).textContent))
+  );
   // configure syntax highlighting for CodeMirror
   CodeMirror.modeURL = {
     replace: function(n, mode) {
-      switch (mode) {
+      switch (mode.trim()) {
         case 'javascript':
-          return fs['codemirror/mode/javascript/javascript.js'];
+          return fs.get(['codemirror', 'mode', 'javascript', 'javascript.js'].join('/'));
         case 'ruby':
-          return fs['codemirror/mode/ruby/ruby.js'];
+          return fs.get(['codemirror', 'mode', 'ruby', 'ruby.js'].join('/'));
         case 'yaml':
-          return fs['codemirror/mode/yaml/yaml.js'];
+          return fs.get(['codemirror', 'mode', 'yaml', 'yaml.js'].join('/'));
       }
     },
   };

--- a/ui/packages/consul-ui/lib/startup/templates/body.html.js
+++ b/ui/packages/consul-ui/lib/startup/templates/body.html.js
@@ -34,7 +34,7 @@ ${environment === 'production' ? `{{jsonEncode .}}` : JSON.stringify(config.oper
   <script type="application/json" data-consul-ui-fs>
   {
     "text-encoding/encoding-indexes.js": "${rootURL}assets/encoding-indexes.js",
-    "text-encoding/encoding.js": "${rootURL}assets/encoding-indexes.js",
+    "text-encoding/encoding.js": "${rootURL}assets/encoding.js",
     "css.escape/css.escape.js": "${rootURL}assets/css.escape.js",
     "codemirror/mode/javascript/javascript.js": "${rootURL}assets/codemirror/mode/javascript/javascript.js",
     "codemirror/mode/ruby/ruby.js": "${rootURL}assets/codemirror/mode/ruby/ruby.js",

--- a/ui/packages/consul-ui/vendor/init.js
+++ b/ui/packages/consul-ui/vendor/init.js
@@ -1,5 +1,7 @@
 (function(doc, appName) {
-  const fs = JSON.parse(doc.querySelector(`[data-${appName}-fs]`).textContent);
+  const fs = new Map(
+    Object.entries(JSON.parse(doc.querySelector(`[data-${appName}-fs]`).textContent))
+  );
   const appendScript = function(src) {
     var $script = doc.createElement('script');
     $script.src = src;
@@ -8,11 +10,11 @@
 
   // polyfills
   if (!('TextDecoder' in window)) {
-    appendScript(fs['text-encoding/encoding-indexes.js']);
-    appendScript(fs['text-encoding/encoding.js']);
+    appendScript(fs.get(`${['text-encoding', 'encoding-indexes'].join('/')}.js`));
+    appendScript(fs.get(`${['text-encoding', 'encoding'].join('/')}.js`));
   }
   if (!(window.CSS && window.CSS.escape)) {
-    appendScript(fs['css.escape/css.escape.js']);
+    appendScript(fs.get(`${['css.escape', 'css.escape'].join('/')}.js`));
   }
 
   try {


### PR DESCRIPTION
Only whilst testing in/using the Consul binary itself, we unfortunately broke our runtime optional javascript loading. As a consequence of this, the KV editor would not load in the different user configurable syntax highlighting files on demand. 

Additionally, we use browser polyfills, but we only load these dynamically if the user is using a browser that requires them, saving on the downloaded payload (more on this to come)

Our JS framework includes URL fingerprinting features to enable 'cache busting' for downloaded assets for when the contents of a file changes. The idea here is, across different versions of Consul, if a file doesn't change, then the user won't have to re-download the file as it will have been cached. If we change the contents of a file then the fingerprint changes and the file is redownloaded when the user uses an upgraded UI.

In reality, we pretty much always change all of the downloaded assets for the UI, especially so between 1.?.0 versions, our vendor dependencies change quite a lot so we generally perform an LTS upgrade between each 1.?.0 version, and sometimes between 1.0.? versions. All other files (project JS and CSS) we always change. Polyfills (and our syntax highlighting files) are probably the only thing that pretty much never change.

The framework automatically fingerprints _most_ file paths within the code, I actually thought it only did this in the `.html` files needed for the app (which is where these things are loaded), but whether I'm misremembering or things have changed since Ember 2.18, it seems to also do this in all of your source code files. 

Additionally, it only seems to fingerprint _sometimes_ and I'm not entirely sure when it does and when it doesn't.

This fingerprinting is only done for the production code (i.e. not during testing/development), so currently we have no way to test anything around this continuously with our current testing approach.

---

Previous to this PR we had a small dictionary that we could use to look up files paths for example:

```js
{
  "actual/file/path.js": "assets/actual/file/path.js"
}
```

With the assumption that:

```js
console.log(dictionary['actual/file/path.js'])
```

would print `assets/actual/file/path.js`.

This would have meant that when the fingerprint was applied to the above dictionary it would convert it to:

```js
{
  "actual/file/path.js": "assets/actual/file/path-nhfw7f-fingerprinted-477fhe8n.js"
}
```

and mean

```js
console.log(dictionary['actual/file/path.js'])
```
would print `assets/actual/file/path-nhfw7f-fingerprinted-477fhe8n.js`.

Unfortunately, `console.log(dictionary['actual/file/path.js'])` is also being transformed into `console.log(dictionary['path-nhfw7f-fingerprinted-477fhe8n.js'])` in our javascript source file.

Confusingly, whilst references (the keys) in our javascript code to the keys **are** transformed, the keys in our dictionary are **not** transformed, only the values.

All in all this means that `undefined` is now printed out, and this is what we were seeing in this issue.

This PR adds a bit of string wrangling to avoid the keys in our javascript source file also being transformed. Additionally, whilst looking at this we decided that `Maps` are a better dictionary than javascript objects, so we moved to use those here also (but this doesn't affect the issue)

Regarding the polyfills, we realized we really don't need the polyfills we use anymore. They were primarily included for IE11 which we no longer support. So we are likely to remove these in a later PR.

Lastly, the original decision on how to load things at runtime here were based on what was achievable with Ember 2.18. Now Ember uses Webpack as a bundler (or alternatively, we target more modern browsers now), we could probably look to use ES6 dynamic import next time we are in the CodeEditor code.

Fixes https://github.com/hashicorp/consul/issues/10520