### PR TITLE
ui: [BUGFIX] Ensure we use the ns query param name when requesting permissions

### DIFF
--- a/.changelog/10608.txt
+++ b/.changelog/10608.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: **(Enterprise only)** Ensure permissions are checked based on the actively selected namespace
+```

--- a/ui/packages/consul-ui/app/adapters/permission.js
+++ b/ui/packages/consul-ui/app/adapters/permission.js
@@ -7,7 +7,7 @@ export default class PermissionAdapter extends Adapter {
   requestForAuthorize(request, { dc, ns, resources = [], index }) {
     // the authorize endpoint is slightly different to all others in that it
     // ignores an ns parameter, but accepts a Namespace property on each
-    // resource. Here we hide this different from the rest of the app as
+    // resource. Here we hide this difference from the rest of the app as
     // currently we never need to ask for permissions/resources for multiple
     // different namespaces in one call so here we use the ns param and add
     // this to the resources instead of passing through on the queryParameter

--- a/ui/packages/consul-ui/app/routes/dc.js
+++ b/ui/packages/consul-ui/app/routes/dc.js
@@ -21,7 +21,7 @@ export default class DcRoute extends Route {
     // When disabled nspaces is [], so nspace is undefined
     const permissions = await this.permissionsRepo.findAll({
       dc: params.dc,
-      nspace: get(nspace || {}, 'Name'),
+      ns: get(nspace || {}, 'Name'),
     });
     // the model here is actually required for the entire application
     // but we need to wait until we are in this route so we know what the dc

--- a/ui/packages/consul-ui/app/routes/settings.js
+++ b/ui/packages/consul-ui/app/routes/settings.js
@@ -28,7 +28,7 @@ export default class SettingsRoute extends Route {
       typeof app.permissions === 'undefined'
         ? await this.permissionsRepo.findAll({
             dc: dc.Name,
-            nspace: nspace.Name,
+            ns: nspace.Name,
           })
         : app.permissions;
 

--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -112,11 +112,6 @@ export default class PermissionService extends RepositoryService {
     } else {
       let resources = [];
       try {
-        const { nspace, ...rest } = params;
-        params = {
-          ...rest,
-          ns: nspace,
-        };
         resources = await this.store.authorize('permission', params);
       } catch (e) {
         runInDebug(() => console.error(e));

--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -112,6 +112,11 @@ export default class PermissionService extends RepositoryService {
     } else {
       let resources = [];
       try {
+        const { nspace, ...rest } = params;
+        params = {
+          ...rest,
+          ns: nspace,
+        };
         resources = await this.store.authorize('permission', params);
       } catch (e) {
         runInDebug(() => console.error(e));


### PR DESCRIPTION
Previously when namespaces were enabled, we weren't requesting permission for the actively selected namespace, and instead always checking the permissions for the default namespace.

This PR ensures we request permissions for the actively selected namespace.

Notes:

All of the UI/API reading interaction uses a GET request with`?ns=` to specify the namespace, we have one API request which requires a POST with the request body containing the `Namespace`. This is so we can request various pieces of information required for the UI using a method we can customise for exactly what we need (there are more details in the comments in the changeset here). Unfortunately we were passing through a `nspace` parameter instead of a `ns` parameter which is the param name we are expecting deeper down, pretty much a typo.

An initial fix (https://github.com/hashicorp/consul/pull/10608/commits/6f00c81ca897febda1e528af166c770fc6edb249) meant  converting this from nspace to ns inside the repository itself. But then I realized that the entire 'repository' interface as of not too long ago now uses/expects `ns` not `nspace`, so in a follow up commit (https://github.com/hashicorp/consul/pull/10608/commits/5c868272faff4724c1fe7b6866341b02076c2cb7) I undid the first approach and made the fix consistent with the rest of the interface.
