### PR TITLE
docs: Add link to learn guide on migrating ACL tokens

### DIFF
--- a/website/content/docs/security/acl/acl-legacy.mdx
+++ b/website/content/docs/security/acl/acl-legacy.mdx
@@ -14,7 +14,7 @@ description: >-
 
 ~> **Alert: Deprecation Notice**
 The ACL system described here was Consul's original ACL implementation. In Consul 1.4.0
-the ACL system was rewritten and the legacy system was deprecated. The new ACL system information can be found [here](/docs/acl/acl-system). For information on how to migrate to the new ACL System please read our learn guide on [Migrate Legacy ACL Tokens](https://learn.hashicorp.com/tutorials/consul/access-control-token-migration).
+the ACL system was rewritten and the legacy system was deprecated. The new ACL system information can be found [here](/docs/acl/acl-system). For a guide on how to migrate to the new ACL System, please read our learn guide on [Migrate Legacy ACL Tokens](https://learn.hashicorp.com/tutorials/consul/access-control-token-migration).
 
 The legacy documentation has two sections.
 

--- a/website/content/docs/security/acl/acl-legacy.mdx
+++ b/website/content/docs/security/acl/acl-legacy.mdx
@@ -14,7 +14,7 @@ description: >-
 
 ~> **Alert: Deprecation Notice**
 The ACL system described here was Consul's original ACL implementation. In Consul 1.4.0
-the ACL system was rewritten and the legacy system was deprecated. The new ACL system information can be found [here](/docs/acl/acl-system).
+the ACL system was rewritten and the legacy system was deprecated. The new ACL system information can be found [here](/docs/acl/acl-system). For information on how to migrate to the new ACL System please read our learn guide on [Migrate Legacy ACL Tokens](https://learn.hashicorp.com/tutorials/consul/access-control-token-migration).
 
 The legacy documentation has two sections.
 

--- a/website/content/docs/security/acl/acl-legacy.mdx
+++ b/website/content/docs/security/acl/acl-legacy.mdx
@@ -14,7 +14,7 @@ description: >-
 
 ~> **Alert: Deprecation Notice**
 The ACL system described here was Consul's original ACL implementation. In Consul 1.4.0
-the ACL system was rewritten and the legacy system was deprecated. The new ACL system information can be found [here](/docs/acl/acl-system). For a guide on how to migrate to the new ACL System, please read our learn guide on [Migrate Legacy ACL Tokens](https://learn.hashicorp.com/tutorials/consul/access-control-token-migration).
+the ACL system was rewritten and the legacy system was deprecated. The new ACL system information can be found [here](/docs/acl/acl-system). For information on how to migrate to the new ACL System, please read the [Migrate Legacy ACL Tokens](https://learn.hashicorp.com/tutorials/consul/access-control-token-migration) tutorial.
 
 The legacy documentation has two sections.
 


### PR DESCRIPTION
Add link in deprecation notice to Learn guide on migrating ACL tokens.