### PR TITLE
ci: set CGO_ENABLED: 0 for arm/arm64 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ jobs:
       - image: *GOLANG_IMAGE
     environment:
       <<: *ENVIRONMENT
-      CGO_ENABLED: 1
+      CGO_ENABLED: 0
       GOOS: linux
     steps:
       - checkout


### PR DESCRIPTION
Refs https://github.com/hashicorp/consul/pull/7970 for context on the ARM crash in versions of Go prior to 1.14 that required enabling CGO.

As an open question, is the suggested approach in https://github.com/hashicorp/consul/issues/6519#issuecomment-547951176 sufficient for running on ARMv7 hardware @jwalzer @mrmstn? It seems that approach (aside from the reported bug) has been working for some users according to https://github.com/hashicorp/consul/issues/10545.

**TODO:** This change only affects our test suite, and will require a followup to our build pipelines if it looks good to merge.a