### PR TITLE
acl: acl replication routine to report the last error message

### DIFF
--- a/.changelog/10612.txt
+++ b/.changelog/10612.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: replication routine to report the last error message.
+```

--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -484,11 +484,12 @@ func (s *Server) IsACLReplicationEnabled() bool {
 		s.config.ACLTokenReplication
 }
 
-func (s *Server) updateACLReplicationStatusError() {
+func (s *Server) updateACLReplicationStatusError(errorMsg error) {
 	s.aclReplicationStatusLock.Lock()
 	defer s.aclReplicationStatusLock.Unlock()
 
 	s.aclReplicationStatus.LastError = time.Now().Round(time.Second).UTC()
+	s.aclReplicationStatus.LastErrorMessage = errorMsg
 }
 
 func (s *Server) updateACLReplicationStatusIndex(replicationType structs.ACLReplicationType, index uint64) {

--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -484,12 +484,12 @@ func (s *Server) IsACLReplicationEnabled() bool {
 		s.config.ACLTokenReplication
 }
 
-func (s *Server) updateACLReplicationStatusError(errorMsg error) {
+func (s *Server) updateACLReplicationStatusError(errorMsg string) {
 	s.aclReplicationStatusLock.Lock()
 	defer s.aclReplicationStatusLock.Unlock()
 
 	s.aclReplicationStatus.LastError = time.Now().Round(time.Second).UTC()
-	s.aclReplicationStatus.LastErrorMessage = errorMsg.Error()
+	s.aclReplicationStatus.LastErrorMessage = errorMsg
 }
 
 func (s *Server) updateACLReplicationStatusIndex(replicationType structs.ACLReplicationType, index uint64) {

--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -489,7 +489,7 @@ func (s *Server) updateACLReplicationStatusError(errorMsg error) {
 	defer s.aclReplicationStatusLock.Unlock()
 
 	s.aclReplicationStatus.LastError = time.Now().Round(time.Second).UTC()
-	s.aclReplicationStatus.LastErrorMessage = errorMsg
+	s.aclReplicationStatus.LastErrorMessage = errorMsg.Error()
 }
 
 func (s *Server) updateACLReplicationStatusIndex(replicationType structs.ACLReplicationType, index uint64) {

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -781,7 +780,7 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 		require.True(r, status.ReplicatedTokenIndex < token2.CreateIndex, "ReplicatedTokenIndex is not less than the token2s create index")
 		// ensures that token replication is erroring
 		require.True(r, status.LastError.After(minErrorTime), "Replication LastError not after the minErrorTime")
-		require.Equal(r, status.LastErrorMessage, errors.New("failed to retrieve unredacted tokens - replication token in use does not grant acl:write"))
+		require.Equal(r, status.LastErrorMessage, "failed to retrieve unredacted tokens - replication token in use does not grant acl:write")
 	})
 }
 

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -780,6 +781,7 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 		require.True(r, status.ReplicatedTokenIndex < token2.CreateIndex, "ReplicatedTokenIndex is not less than the token2s create index")
 		// ensures that token replication is erroring
 		require.True(r, status.LastError.After(minErrorTime), "Replication LastError not after the minErrorTime")
+		require.Equal(r, status.LastErrorMessage, errors.New("failed to retrieve unredacted tokens - replication token in use does not grant acl:write"))
 	})
 }
 

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -810,7 +810,7 @@ func (s *Server) runLegacyACLReplication(ctx context.Context) error {
 				0,
 			)
 			lastRemoteIndex = 0
-			s.updateACLReplicationStatusError(err)
+			s.updateACLReplicationStatusError(err.Error())
 			legacyACLLogger.Warn("Legacy ACL replication error (will retry if still leader)", "error", err)
 		} else {
 			metrics.SetGauge([]string{"leader", "replication", "acl-legacy", "status"},
@@ -927,7 +927,7 @@ func (s *Server) runACLReplicator(
 				0,
 			)
 			lastRemoteIndex = 0
-			s.updateACLReplicationStatusError(err)
+			s.updateACLReplicationStatusError(err.Error())
 			logger.Warn("ACL replication error (will retry if still leader)",
 				"error", err,
 			)

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -810,7 +810,7 @@ func (s *Server) runLegacyACLReplication(ctx context.Context) error {
 				0,
 			)
 			lastRemoteIndex = 0
-			s.updateACLReplicationStatusError()
+			s.updateACLReplicationStatusError(err)
 			legacyACLLogger.Warn("Legacy ACL replication error (will retry if still leader)", "error", err)
 		} else {
 			metrics.SetGauge([]string{"leader", "replication", "acl-legacy", "status"},
@@ -927,7 +927,7 @@ func (s *Server) runACLReplicator(
 				0,
 			)
 			lastRemoteIndex = 0
-			s.updateACLReplicationStatusError()
+			s.updateACLReplicationStatusError(err)
 			logger.Warn("ACL replication error (will retry if still leader)",
 				"error", err,
 			)

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1269,7 +1269,7 @@ type ACLReplicationStatus struct {
 	ReplicatedTokenIndex uint64
 	LastSuccess          time.Time
 	LastError            time.Time
-	LastErrorMessage     error
+	LastErrorMessage     string
 }
 
 // ACLTokenSetRequest is used for token creation and update operations

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1269,6 +1269,7 @@ type ACLReplicationStatus struct {
 	ReplicatedTokenIndex uint64
 	LastSuccess          time.Time
 	LastError            time.Time
+	LastErrorMessage     error
 }
 
 // ACLTokenSetRequest is used for token creation and update operations

--- a/api/acl.go
+++ b/api/acl.go
@@ -97,6 +97,7 @@ type ACLReplicationStatus struct {
 	ReplicatedTokenIndex uint64
 	LastSuccess          time.Time
 	LastError            time.Time
+	LastErrorMessage     string
 }
 
 // ACLServiceIdentity represents a high-level grant of all necessary privileges


### PR DESCRIPTION
This PR adds the new field `LastErrorMessage` to the `ACLReplicationStatus` endpoint. Whenever the Goroutine executing the `runACLReplicator` encounters an error, both `LastError` and `LastErrorMessage` field in the endpoint are updated. 

Test `TestACLReplication_TokensRedacted` is updated to check also the `LastErrorMessage` field.

Fixes #10521.