### PR TITLE
docs: add config options that were missing

### DIFF
--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1477,6 +1477,10 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
 - `disable_keyring_file` - Equivalent to the
   [`-disable-keyring-file` command-line flag](#_disable_keyring_file).
 
+- `disable_coordinates` - Disables sending of [network coordinates](/docs/architecture/coordinates).
+  When network coordinates are disabled the `near` query param will not work to sort the nodes,
+  and the [`consul rtt`](/commands/rtt) command will not be able to provide round trip time between nodes.
+
 - `gossip_lan` - **(Advanced)** This object contains a
   number of sub-keys which can be set to tune the LAN gossip communications. These
   are only provided for users running especially large clusters that need fine tuning
@@ -1666,6 +1670,8 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
     circumstances, this can prevent clients from experiencing "no leader" errors.
     This was added in Consul 1.0. Must be a duration value such as 10s. Defaults
     to 7s.
+
+- `pid_file` Equivalent to the [`-pid-file` command line flag](#_pid_file).
 
 - `ports` This is a nested object that allows setting the bind ports for the following keys:
 


### PR DESCRIPTION
While looking at the code with @Kedevlin we noticed these two config fields were missing from our configuration reference doc. Both of these seem like they would be useful, so this PR adds them to the docs.

https://github.com/hashicorp/consul/pull/128 added pid_file
https://github.com/hashicorp/consul/pull/1331 added disable_coordinates