### PR TITLE
docs: add deprecation version for ports.grpc settings

### DIFF
--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -245,8 +245,8 @@ The options below are all specified on the command-line.
 - `-xds-port` - the xDS gRPC port to listen on. Default
   -1 (disabled). See [ports](#ports) documentation for more detail.
 
-- `-grpc-port` ((#\_grpc_port)) - Deprecated, use `-xds-port` instead.
-  The xDS gRPC port to listen on. Default
+- `-grpc-port` ((#\_grpc_port)) - **Deprecated in Consul 1.11**.
+  Use `-xds-port` instead. The xDS gRPC port to listen on. Default
   -1 (disabled). See [ports](#ports) documentation for more detail.
 
 - `-hcl` ((#\_hcl)) - A HCL configuration fragment. This HCL configuration
@@ -802,7 +802,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
   - `http` - The HTTP API. Defaults to `client_addr`
   - `https` - The HTTPS API. Defaults to `client_addr`
   - `xds` - The xDS gRPC API. Defaults to `client_addr`
-  - `grpc` - Deprecated: use `xds` instead. The xDS gRPC API. Defaults to `client_addr`
+  - `grpc` - **Deprecated in Consul 1.11**. Use `xds` instead. The xDS gRPC API. Defaults to `client_addr`
 
 - `advertise_addr` Equivalent to the [`-advertise` command-line flag](#_advertise).
 
@@ -1681,7 +1681,7 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
     automatically with this. This is set to `8502` by default when the agent runs
     in `-dev` mode. Currently xDS is only used to expose Envoy xDS API to Envoy
     proxies.
-  - `grpc` ((#grpc_port)) - Deprecated: use `xds` instead.
+  - `grpc` ((#grpc_port)) - **Deprecated in Consul 1.11**. Use `xds` instead.
     The xDS gRPC API, -1 to disable. Default -1 (disabled).
     **We recommend using `8502`** for `xds` by convention as some tooling will work
     automatically with this. This is set to `8502` by default when the agent runs


### PR DESCRIPTION
Follow up to #10588

Adds the version when these settings will be deprecated.