### PR TITLE
xds: ensure single L7 deny intention with default deny policy does not result in allow action (CVE-2021-36213)

### DIFF
--- a/.changelog/10619.txt
+++ b/.changelog/10619.txt
@@ -1,0 +1,3 @@
+```release-note:security
+xds: ensure single L7 deny intention with default deny policy does not result in allow action [CVE-2021-36213](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36213)
+```

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow--httpfilter.golden
@@ -1,0 +1,52 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "andIds": {
+                "ids": [
+                  {
+                    "authenticated": {
+                      "principalName": {
+                        "safeRegex": {
+                          "googleRe2": {
+
+                          },
+                          "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/[^/]+$"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "notId": {
+                      "authenticated": {
+                        "principalName": {
+                          "safeRegex": {
+                            "googleRe2": {
+
+                            },
+                            "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow--httpfilter.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow--httpfilter.v2compat.golden
@@ -1,0 +1,52 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "andIds": {
+                "ids": [
+                  {
+                    "authenticated": {
+                      "principalName": {
+                        "safeRegex": {
+                          "googleRe2": {
+
+                          },
+                          "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/[^/]+$"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "notId": {
+                      "authenticated": {
+                        "principalName": {
+                          "safeRegex": {
+                            "googleRe2": {
+
+                            },
+                            "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow.golden
@@ -1,0 +1,65 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            },
+            {
+              "andIds": {
+                "ids": [
+                  {
+                    "authenticated": {
+                      "principalName": {
+                        "safeRegex": {
+                          "googleRe2": {
+
+                          },
+                          "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/[^/]+$"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "notId": {
+                      "authenticated": {
+                        "principalName": {
+                          "safeRegex": {
+                            "googleRe2": {
+
+                            },
+                            "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-allow.v2compat.golden
@@ -1,0 +1,65 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            },
+            {
+              "andIds": {
+                "ids": [
+                  {
+                    "authenticated": {
+                      "principalName": {
+                        "safeRegex": {
+                          "googleRe2": {
+
+                          },
+                          "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/[^/]+$"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "notId": {
+                      "authenticated": {
+                        "principalName": {
+                          "safeRegex": {
+                            "googleRe2": {
+
+                            },
+                            "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny--httpfilter.golden
@@ -1,0 +1,77 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "andIds": {
+                "ids": [
+                  {
+                    "authenticated": {
+                      "principalName": {
+                        "safeRegex": {
+                          "googleRe2": {
+
+                          },
+                          "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/[^/]+$"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "notId": {
+                      "authenticated": {
+                        "principalName": {
+                          "safeRegex": {
+                            "googleRe2": {
+
+                            },
+                            "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "consul-intentions-layer7-0": {
+          "permissions": [
+            {
+              "urlPath": {
+                "path": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny--httpfilter.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny--httpfilter.v2compat.golden
@@ -1,0 +1,77 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "andIds": {
+                "ids": [
+                  {
+                    "authenticated": {
+                      "principalName": {
+                        "safeRegex": {
+                          "googleRe2": {
+
+                          },
+                          "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/[^/]+$"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "notId": {
+                      "authenticated": {
+                        "principalName": {
+                          "safeRegex": {
+                            "googleRe2": {
+
+                            },
+                            "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "consul-intentions-layer7-0": {
+          "permissions": [
+            {
+              "urlPath": {
+                "path": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny.golden
@@ -1,0 +1,65 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            },
+            {
+              "andIds": {
+                "ids": [
+                  {
+                    "authenticated": {
+                      "principalName": {
+                        "safeRegex": {
+                          "googleRe2": {
+
+                          },
+                          "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/[^/]+$"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "notId": {
+                      "authenticated": {
+                        "principalName": {
+                          "safeRegex": {
+                            "googleRe2": {
+
+                            },
+                            "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-allow-deny-all-and-path-deny.v2compat.golden
@@ -1,0 +1,65 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            },
+            {
+              "andIds": {
+                "ids": [
+                  {
+                    "authenticated": {
+                      "principalName": {
+                        "safeRegex": {
+                          "googleRe2": {
+
+                          },
+                          "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/[^/]+$"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "notId": {
+                      "authenticated": {
+                        "principalName": {
+                          "safeRegex": {
+                            "googleRe2": {
+
+                            },
+                            "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-allow--httpfilter.golden
@@ -1,0 +1,9 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+    "rules": {
+      "action": "DENY"
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-path-allow--httpfilter.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-allow--httpfilter.v2compat.golden
@@ -1,0 +1,9 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
+    "rules": {
+      "action": "DENY"
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-allow.golden
@@ -1,0 +1,33 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-path-allow.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-allow.v2compat.golden
@@ -1,0 +1,33 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-path-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-deny--httpfilter.golden
@@ -1,0 +1,36 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer7-0": {
+          "permissions": [
+            {
+              "urlPath": {
+                "path": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-path-deny--httpfilter.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-deny--httpfilter.v2compat.golden
@@ -1,0 +1,36 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer7-0": {
+          "permissions": [
+            {
+              "urlPath": {
+                "path": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-path-deny.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-deny.golden
@@ -1,0 +1,33 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-allow-path-deny.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-allow-path-deny.v2compat.golden
@@ -1,0 +1,33 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
+    "rules": {
+      "action": "DENY",
+      "policies": {
+        "consul-intentions-layer4": {
+          "permissions": [
+            {
+              "any": true
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow--httpfilter.golden
@@ -1,0 +1,35 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+    "rules": {
+      "policies": {
+        "consul-intentions-layer7-0": {
+          "permissions": [
+            {
+              "urlPath": {
+                "path": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow--httpfilter.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow--httpfilter.v2compat.golden
@@ -1,0 +1,35 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
+    "rules": {
+      "policies": {
+        "consul-intentions-layer7-0": {
+          "permissions": [
+            {
+              "urlPath": {
+                "path": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow.golden
@@ -1,0 +1,10 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {
+
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-allow.v2compat.golden
@@ -1,0 +1,10 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
+    "rules": {
+
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-deny--httpfilter.golden
@@ -1,0 +1,9 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+    "rules": {
+
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-deny--httpfilter.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-deny--httpfilter.v2compat.golden
@@ -1,0 +1,9 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
+    "rules": {
+
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-deny.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-deny.golden
@@ -1,0 +1,10 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {
+
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-deny-all-and-path-deny.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-deny-deny-all-and-path-deny.v2compat.golden
@@ -1,0 +1,10 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
+    "rules": {
+
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-path-allow--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-allow--httpfilter.golden
@@ -1,0 +1,35 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+    "rules": {
+      "policies": {
+        "consul-intentions-layer7-0": {
+          "permissions": [
+            {
+              "urlPath": {
+                "path": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-path-allow--httpfilter.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-allow--httpfilter.v2compat.golden
@@ -1,0 +1,35 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
+    "rules": {
+      "policies": {
+        "consul-intentions-layer7-0": {
+          "permissions": [
+            {
+              "urlPath": {
+                "path": {
+                  "prefix": "/"
+                }
+              }
+            }
+          ],
+          "principals": [
+            {
+              "authenticated": {
+                "principalName": {
+                  "safeRegex": {
+                    "googleRe2": {
+
+                    },
+                    "regex": "^spiffe://[^/]+/ns/default/dc/[^/]+/svc/web$"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-path-allow.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-allow.golden
@@ -1,0 +1,10 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {
+
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-path-allow.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-allow.v2compat.golden
@@ -1,0 +1,10 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
+    "rules": {
+
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-path-deny--httpfilter.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-deny--httpfilter.golden
@@ -1,0 +1,9 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+    "rules": {
+
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-path-deny--httpfilter.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-deny--httpfilter.v2compat.golden
@@ -1,0 +1,9 @@
+{
+  "name": "envoy.filters.http.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.http.rbac.v2.RBAC",
+    "rules": {
+
+    }
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-path-deny.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-deny.golden
@@ -1,0 +1,10 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+    "rules": {
+
+    },
+    "statPrefix": "connect_authz"
+  }
+}

--- a/agent/xds/testdata/rbac/default-deny-path-deny.v2compat.golden
+++ b/agent/xds/testdata/rbac/default-deny-path-deny.v2compat.golden
@@ -1,0 +1,10 @@
+{
+  "name": "envoy.filters.network.rbac",
+  "typedConfig": {
+    "@type": "type.googleapis.com/envoy.config.filter.network.rbac.v2.RBAC",
+    "rules": {
+
+    },
+    "statPrefix": "connect_authz"
+  }
+}


### PR DESCRIPTION
Note to self:

- 1.10.x will cleanly backport
- 1.9.x requires a manual backport (which is not bad) : https://github.com/hashicorp/consul/pull/10620