### PR TITLE
ci: mirror oss:main to ent:oss-mirror

### DIFF
--- a/.github/workflows/ent-mirror.yml
+++ b/.github/workflows/ent-mirror.yml
@@ -1,0 +1,20 @@
+# mirrors main to consul-enterprise:oss-mirror
+name: "ent-mirror"
+
+# Runs on pushes to main
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  ent-mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: git-sync
+        uses: wei/git-sync@v3
+        with:
+          source_repo: "https://github.com/hashicorp/consul"
+          source_branch: "main"
+          destination_repo: "https://hc-github-team-consul-core:${{ secrets.PUSH_ENT_TOKEN }}@github.com/hashicorp/consul-enterprise.git"
+          destination_branch: "oss-mirror"


### PR DESCRIPTION
This is a part of the effort to improve our oss<->ent branch/merge automation. It adds a GitHub action to sync changes to `consul-enterprise:oss-mirror` on pushes to `main`. I tested it locally with `act`:
```
act -j ent-mirror -s PUSH_ENT_TOKEN=$TOKEN
```
This `PUSH_ENT_TOKEN` secret is populated with a PAT associated to our CI automation user. 