### PR TITLE
defer setting the state before returning to avoid  stuck in `INITIALIZING` state

### DIFF
--- a/.changelog/10630.txt
+++ b/.changelog/10630.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: fixed a bug when ca provider fail and provider state is stuck in `INITIALIZING` state.
+```

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -154,14 +154,22 @@ func (c *CAManager) setState(newState caState, validateState bool) (caState, err
 	state := c.state
 
 	if !validateState ||
-		state == caStateInitialized ||
+		(state == caStateInitialized && newState != caStateInitializing) ||
 		(state == caStateUninitialized && newState == caStateInitializing) ||
 		(state == caStateUninitialized && newState == caStateReconfig) {
 		c.state = newState
 	} else {
-		return state, fmt.Errorf("CA is already in state %q", state)
+		return state, &caStateError{Current: state}
 	}
 	return state, nil
+}
+
+type caStateError struct {
+	Current caState
+}
+
+func (e *caStateError) Error() string {
+	return fmt.Sprintf("CA is already in state %q", e.Current)
 }
 
 // setPrimaryRoots updates the most recently seen roots from the primary.
@@ -360,8 +368,12 @@ func (c *CAManager) InitializeCA() (reterr error) {
 	}
 
 	// Update the state before doing anything else.
-	oldState, err := c.setState(caStateInitializing, true)
-	if err != nil {
+	_, err := c.setState(caStateInitializing, true)
+	var errCaState *caStateError
+	switch {
+	case errors.As(err, &errCaState) && errCaState.Current == caStateInitialized:
+		return nil
+	case err != nil:
 		return err
 	}
 
@@ -376,11 +388,6 @@ func (c *CAManager) InitializeCA() (reterr error) {
 			c.setState(caStateUninitialized, false)
 		}
 	}()
-
-	// if we were already in the initialized state then there is nothing to be done.
-	if oldState == caStateInitialized {
-		return nil
-	}
 
 	// Initialize the provider based on the current config.
 	conf, err := c.initializeCAConfig()

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -361,7 +361,6 @@ func (c *CAManager) InitializeCA() (reterr error) {
 
 	// Update the state before doing anything else.
 	oldState, err := c.setState(caStateInitializing, true)
-	// if we were already in the initialized state then there is nothing to be done.
 	if err != nil {
 		return err
 	}
@@ -378,6 +377,7 @@ func (c *CAManager) InitializeCA() (reterr error) {
 		}
 	}()
 
+	// if we were already in the initialized state then there is nothing to be done.
 	if oldState == caStateInitialized {
 		return nil
 	}

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -362,9 +362,6 @@ func (c *CAManager) InitializeCA() (reterr error) {
 	// Update the state before doing anything else.
 	oldState, err := c.setState(caStateInitializing, true)
 	// if we were already in the initialized state then there is nothing to be done.
-	if oldState == caStateInitialized {
-		return nil
-	}
 	if err != nil {
 		return err
 	}
@@ -380,6 +377,10 @@ func (c *CAManager) InitializeCA() (reterr error) {
 			c.setState(caStateUninitialized, false)
 		}
 	}()
+
+	if oldState == caStateInitialized {
+		return nil
+	}
 
 	// Initialize the provider based on the current config.
 	conf, err := c.initializeCAConfig()

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -141,7 +141,7 @@ func NewCAManager(delegate caServerDelegate, leaderRoutineManager *routine.Manag
 // setState attempts to update the CA state to the given state.
 // Valid state transitions are:
 //
-// caStateInitialized -> <any state>
+// caStateInitialized -> <any state except caStateInitializing>
 // caStateUninitialized -> caStateInitializing
 // caStateUninitialized -> caStateReconfig
 //


### PR DESCRIPTION
fix #10625 