### PR TITLE
docs: Refer to macOS vs Mac OS X in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Consul provides several key features:
   dynamic configuration, feature flagging, coordination, leader election and
   more. The simple HTTP API makes it easy to use anywhere.
 
-Consul runs on Linux, Mac OS X, FreeBSD, Solaris, and Windows. A commercial
+Consul runs on Linux, macOS, FreeBSD, Solaris, and Windows. A commercial
 version called [Consul Enterprise](https://www.hashicorp.com/products/consul)
 is also available.
 


### PR DESCRIPTION
I checked a couple more of our repos before doing this.

- Vault: Don't seem to refer to either in the README
- Boundary: Don't seem to refer to either in the README
- Nomad: Uses `macOS`
- Vagrant: Uses `Mac OS X`

All in all, feels like its time to make this change for us?