### PR TITLE
Reset root prune interval after TestLeader_CARootPruning completes

### DIFF
--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -1173,7 +1173,12 @@ func TestLeader_CARootPruning(t *testing.T) {
 	}
 
 	// Can not use t.Parallel(), because this modifies a global.
+	origPruneInterval := caRootPruneInterval
 	caRootPruneInterval = 200 * time.Millisecond
+	t.Cleanup(func() {
+		// Reset the value of the global prune interval so that it doesn't affect other tests
+		caRootPruneInterval = origPruneInterval
+	})
 
 	require := require.New(t)
 	dir1, s1 := testServer(t)
@@ -1229,9 +1234,6 @@ func TestLeader_CARootPruning(t *testing.T) {
 	require.Len(roots, 1)
 	require.True(roots[0].Active)
 	require.NotEqual(roots[0].ID, oldRoot.ID)
-
-	// Reset the value of the global prune interval so that it doesn't affect other tests
-	caRootPruneInterval = 1 * time.Hour
 }
 
 func TestLeader_PersistIntermediateCAs(t *testing.T) {

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -592,6 +592,8 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 
 	t.Parallel()
 
+	require := require.New(t)
+
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Build = "1.6.0"
 	})
@@ -616,15 +618,15 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 	// Get the original intermediate
 	secondaryProvider, _ := getCAProviderWithLock(s2)
 	oldIntermediatePEM, err := secondaryProvider.ActiveIntermediate()
-	require.NoError(t, err)
-	require.NotEmpty(t, oldIntermediatePEM)
+	require.NoError(err)
+	require.NotEmpty(oldIntermediatePEM)
 
 	// Capture the current root
 	var originalRoot *structs.CARoot
 	{
 		rootList, activeRoot, err := getTestRoots(s1, "dc1")
-		require.NoError(t, err)
-		require.Len(t, rootList.Roots, 1)
+		require.NoError(err)
+		require.Len(rootList.Roots, 1)
 		originalRoot = activeRoot
 	}
 
@@ -635,7 +637,7 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 	// Update the provider config to use a new private key, which should
 	// cause a rotation.
 	_, newKey, err := connect.GeneratePrivateKey()
-	require.NoError(t, err)
+	require.NoError(err)
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
@@ -651,16 +653,16 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 		}
 		var reply interface{}
 
-		require.NoError(t, s1.RPC("ConnectCA.ConfigurationSet", args, &reply))
+		require.NoError(s1.RPC("ConnectCA.ConfigurationSet", args, &reply))
 	}
 
 	var updatedRoot *structs.CARoot
-	retry.Run(t, func(r *retry.R) {
+	{
 		rootList, activeRoot, err := getTestRoots(s1, "dc1")
-		require.NoError(r, err)
-		require.Len(r, rootList.Roots, 2)
+		require.NoError(err)
+		require.Len(rootList.Roots, 2)
 		updatedRoot = activeRoot
-	})
+	}
 
 	testrpc.WaitForActiveCARoot(t, s1.RPC, "dc1", updatedRoot)
 	testrpc.WaitForActiveCARoot(t, s2.RPC, "dc2", updatedRoot)
@@ -674,17 +676,17 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 			r.Fatal("not a new intermediate")
 		}
 	})
-	require.NoError(t, err)
+	require.NoError(err)
 
 	// Verify the root lists have been rotated in each DC's state store.
 	state1 := s1.fsm.State()
 	_, primaryRoot, err := state1.CARootActive(nil)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	state2 := s2.fsm.State()
 	_, roots2, err := state2.CARoots(nil)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(roots2))
+	require.NoError(err)
+	require.Equal(2, len(roots2))
 
 	newRoot := roots2[0]
 	oldRoot := roots2[1]
@@ -692,10 +694,10 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 		newRoot = roots2[1]
 		oldRoot = roots2[0]
 	}
-	require.False(t, oldRoot.Active)
-	require.True(t, newRoot.Active)
-	require.Equal(t, primaryRoot.ID, newRoot.ID)
-	require.Equal(t, primaryRoot.RootCert, newRoot.RootCert)
+	require.False(oldRoot.Active)
+	require.True(newRoot.Active)
+	require.Equal(primaryRoot.ID, newRoot.ID)
+	require.Equal(primaryRoot.RootCert, newRoot.RootCert)
 
 	// Get the new root from dc1 and validate a chain of:
 	// dc2 leaf -> dc2 intermediate -> dc1 root
@@ -711,13 +713,13 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 	raw, _ := connect.TestCSR(t, spiffeService)
 
 	leafCsr, err := connect.ParseCSR(raw)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	leafPEM, err := secondaryProvider.Sign(leafCsr)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	cert, err := connect.ParseCert(leafPEM)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	// Check that the leaf signed by the new intermediate can be verified using the
 	// returned cert chain (signed intermediate + remote root).
@@ -730,7 +732,7 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 		Intermediates: intermediatePool,
 		Roots:         rootPool,
 	})
-	require.NoError(t, err)
+	require.NoError(err)
 }
 
 func TestLeader_Vault_PrimaryCA_FixSigningKeyID_OnRestart(t *testing.T) {

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -1227,6 +1227,9 @@ func TestLeader_CARootPruning(t *testing.T) {
 	require.Len(roots, 1)
 	require.True(roots[0].Active)
 	require.NotEqual(roots[0].ID, oldRoot.ID)
+
+	// Reset the value of the global prune interval so that it doesn't affect other tests
+	caRootPruneInterval = 1 * time.Hour
 }
 
 func TestLeader_PersistIntermediateCAs(t *testing.T) {


### PR DESCRIPTION
Aims to address this failure:
https://app.circleci.com/pipelines/github/hashicorp/consul/20339/workflows/dcdee545-794f-4a80-8d42-f359b79fdd4f/jobs/412315/tests#failed-test-0

Failing assertion:
https://github.com/hashicorp/consul/blob/766d62e4918050d7576f530daa2eb50c32cab251/agent/consul/leader_connect_test.go#L494

Relevant log:

> TestLeader_SecondaryCA_IntermediateRefresh-node-377.server.connect: pruning old unused root CA: <id>

This test ran after TestLeader_CARootPruning, which sets the pruning interval to 200ms. Since it is set to run in parallel, there could have been a long enough delay between setting and reading the CA config to trigger a prune.