### PR TITLE
website: Fix circular redirect with TLS on existing cluster

### DIFF
--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -179,11 +179,6 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/docs/k8s/operations/tls-on-existing-cluster',
-    destination: '/docs/k8s/tls-on-existing-cluster',
-    permanent: true,
-  },
-  {
     source: '/docs/agent/services',
     destination: '/docs/discovery/services',
     permanent: true,


### PR DESCRIPTION
Fix an issue where [/docs/k8s/operations/tls-on-existing-cluster](https://www.consul.io/docs/k8s/operations/tls-on-existing-cluster) would never load when navigating directly to the URL because of a circular redirect.