### PR TITLE
docs: Note proxy-defaults can globally set service protocol

### DIFF
--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -18,6 +18,12 @@ service, such as its protocol.
 
 ### Default protocol
 
+-> **NOTE**: The default protocol can also be configured globally for all proxies
+using the [`proxy defaults`](/docs/connect/config-entries/proxy-defaults#default-protocol)
+config entry. However, if a protocol value is specified in service defaults
+config entry for a given service, that value will take precedence over the
+globally configured value from proxy defaults.
+
 <Tabs>
 <Tab heading="HCL">
 

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -19,8 +19,8 @@ service, such as its protocol.
 ### Default protocol
 
 -> **NOTE**: The default protocol can also be configured globally for all proxies
-using the [`proxy defaults`](/docs/connect/config-entries/proxy-defaults#default-protocol)
-config entry. However, if a protocol value is specified in service defaults
+using the [proxy defaults](/docs/connect/config-entries/proxy-defaults#default-protocol)
+config entry. However, if the protocol value is specified in a service defaults
 config entry for a given service, that value will take precedence over the
 globally configured value from proxy defaults.
 


### PR DESCRIPTION
Add a note to the docs for the service defaults config entry which informs users that the service protocol can be configured for all services using the proxy defaults config entry.

Resolves #8279