### PR TITLE
refactor CACheckAndSetConfig to not return unnecessary bool value

### DIFF
--- a/agent/connect_ca_endpoint.go
+++ b/agent/connect_ca_endpoint.go
@@ -98,10 +98,10 @@ func (s *HTTPHandlers) ConnectCAConfigurationSet(req *http.Request) (interface{}
 			}
 		}
 		args.Op = structs.CAOpSetConfigCAS
-		args.Cas = casVal
+		args.ConfigCASIndex = casVal
 	} else {
 		args.Op = structs.CAOpSetConfig
-		args.Cas = 0
+		args.ConfigCASIndex = 0
 	}
 	if err := decodeBody(req.Body, &args.Config); err != nil {
 		return nil, BadRequestError{

--- a/agent/connect_ca_endpoint.go
+++ b/agent/connect_ca_endpoint.go
@@ -98,10 +98,10 @@ func (s *HTTPHandlers) ConnectCAConfigurationSet(req *http.Request) (interface{}
 			}
 		}
 		args.Op = structs.CAOpSetConfigCAS
-		args.Index = casVal
+		args.Cas = casVal
 	} else {
 		args.Op = structs.CAOpSetConfig
-		args.Index = 0
+		args.Cas = 0
 	}
 	if err := decodeBody(req.Body, &args.Config); err != nil {
 		return nil, BadRequestError{

--- a/agent/connect_ca_endpoint.go
+++ b/agent/connect_ca_endpoint.go
@@ -89,6 +89,15 @@ func (s *HTTPHandlers) ConnectCAConfigurationSet(req *http.Request) (interface{}
 	var args structs.CARequest
 	s.parseDC(req, &args.Datacenter)
 	s.parseToken(req, &args.Token)
+	if casStr := req.URL.Query().Get("cas"); casStr != "" {
+		casVal, err := strconv.ParseUint(casStr, 10, 64)
+		if err != nil {
+			return nil, BadRequestError{
+				Reason: fmt.Sprintf("Request decode failed: %v", err),
+			}
+		}
+		args.Cas = casVal
+	}
 	if err := decodeBody(req.Body, &args.Config); err != nil {
 		return nil, BadRequestError{
 			Reason: fmt.Sprintf("Request decode failed: %v", err),

--- a/agent/connect_ca_endpoint.go
+++ b/agent/connect_ca_endpoint.go
@@ -89,6 +89,7 @@ func (s *HTTPHandlers) ConnectCAConfigurationSet(req *http.Request) (interface{}
 	var args structs.CARequest
 	s.parseDC(req, &args.Datacenter)
 	s.parseToken(req, &args.Token)
+	// Check for cas value
 	if casStr := req.URL.Query().Get("cas"); casStr != "" {
 		casVal, err := strconv.ParseUint(casStr, 10, 64)
 		if err != nil {
@@ -96,7 +97,11 @@ func (s *HTTPHandlers) ConnectCAConfigurationSet(req *http.Request) (interface{}
 				Reason: fmt.Sprintf("Request decode failed: %v", err),
 			}
 		}
-		args.Cas = casVal
+		args.Op = structs.CAOpSetConfigCAS
+		args.Index = casVal
+	} else {
+		args.Op = structs.CAOpSetConfig
+		args.Index = 0
 	}
 	if err := decodeBody(req.Body, &args.Config); err != nil {
 		return nil, BadRequestError{

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -423,7 +423,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	switch req.Op {
 	case structs.CAOpSetConfigCAS:
-		return c.state.CACheckAndSetConfig(index, req.Index, req.Config)
+		return c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
 
 	case structs.CAOpSetConfig:
 		return c.state.CASetConfig(index, req.Config)
@@ -457,7 +457,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 			return act
 		}
 
-		return c.state.CACheckAndSetConfig(index, req.Index, req.Config)
+		return c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
 	case structs.CAOpIncrementProviderSerialNumber:
 		sn, err := c.state.CAIncrementProviderSerialNumber(index)
 		if err != nil {

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -424,12 +424,13 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 	switch req.Op {
 	case structs.CAOpSetConfig:
 		if req.Config.ModifyIndex != 0 {
-			act, err := c.state.CACheckAndSetConfig(index, req.Config.ModifyIndex, req.Config)
+			var emptyResp interface{}
+			err := c.state.CACheckAndSetConfig(index, req.Config.ModifyIndex, req.Config)
 			if err != nil {
 				return err
 			}
 
-			return act
+			return emptyResp
 		}
 
 		return c.state.CASetConfig(index, req.Config)
@@ -461,12 +462,12 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 		if !act {
 			return act
 		}
-
-		act, err = c.state.CACheckAndSetConfig(index, req.Config.ModifyIndex, req.Config)
+		var emptyResp interface{}
+		err = c.state.CACheckAndSetConfig(index, req.Config.ModifyIndex, req.Config)
 		if err != nil {
 			return err
 		}
-		return act
+		return emptyResp
 	case structs.CAOpIncrementProviderSerialNumber:
 		sn, err := c.state.CAIncrementProviderSerialNumber(index)
 		if err != nil {

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -423,9 +423,9 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	switch req.Op {
 	case structs.CAOpSetConfig:
-		if req.Config.ModifyIndex != 0 {
+		if req.Cas != 0 {
 			var emptyResp interface{}
-			err := c.state.CACheckAndSetConfig(index, req.Config.ModifyIndex, req.Config)
+			err := c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
 			if err != nil {
 				return err
 			}
@@ -463,7 +463,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 			return act
 		}
 		var emptyResp interface{}
-		err = c.state.CACheckAndSetConfig(index, req.Config.ModifyIndex, req.Config)
+		err = c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
 		if err != nil {
 			return err
 		}

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -423,7 +423,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	switch req.Op {
 	case structs.CAOpSetConfigCAS:
-		return c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
+		return c.state.CACheckAndSetConfig(index, req.ConfigCASIndex, req.Config)
 
 	case structs.CAOpSetConfig:
 		return c.state.CASetConfig(index, req.Config)
@@ -457,7 +457,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 			return act
 		}
 
-		return c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
+		return c.state.CACheckAndSetConfig(index, req.ConfigCASIndex, req.Config)
 	case structs.CAOpIncrementProviderSerialNumber:
 		sn, err := c.state.CAIncrementProviderSerialNumber(index)
 		if err != nil {

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -424,13 +424,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 	switch req.Op {
 	case structs.CAOpSetConfig:
 		if req.Cas != 0 {
-			var emptyResp interface{}
-			err := c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
-			if err != nil {
-				return err
-			}
-
-			return emptyResp
+			return c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
 		}
 
 		return c.state.CASetConfig(index, req.Config)
@@ -462,12 +456,8 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 		if !act {
 			return act
 		}
-		var emptyResp interface{}
-		err = c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
-		if err != nil {
-			return err
-		}
-		return emptyResp
+
+		return c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
 	case structs.CAOpIncrementProviderSerialNumber:
 		sn, err := c.state.CAIncrementProviderSerialNumber(index)
 		if err != nil {

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -422,12 +422,12 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSinceWithLabels([]string{"fsm", "ca"}, time.Now(),
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	switch req.Op {
-	case structs.CAOpSetConfig:
-		if req.Cas != 0 {
-			return c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
-		}
+	case structs.CAOpSetConfigCAS:
+		return c.state.CACheckAndSetConfig(index, req.Index, req.Config)
 
+	case structs.CAOpSetConfig:
 		return c.state.CASetConfig(index, req.Config)
+
 	case structs.CAOpSetRoots:
 		act, err := c.state.CARootSetCAS(index, req.Index, req.Roots)
 		if err != nil {
@@ -457,7 +457,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 			return act
 		}
 
-		return c.state.CACheckAndSetConfig(index, req.Cas, req.Config)
+		return c.state.CACheckAndSetConfig(index, req.Index, req.Config)
 	case structs.CAOpIncrementProviderSerialNumber:
 		sn, err := c.state.CAIncrementProviderSerialNumber(index)
 		if err != nil {

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -217,6 +217,7 @@ func (c *CAManager) initializeCAConfig() (*structs.CAConfiguration, error) {
 	req := structs.CARequest{
 		Op:     structs.CAOpSetConfig,
 		Config: config,
+		Cas:    config.ModifyIndex,
 	}
 	if resp, err := c.delegate.ApplyCARequest(&req); err != nil {
 		return nil, err
@@ -503,6 +504,7 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 		req := structs.CARequest{
 			Op:     structs.CAOpSetConfig,
 			Config: conf,
+			Cas:    conf.ModifyIndex,
 		}
 		if _, err = c.delegate.ApplyCARequest(&req); err != nil {
 			return fmt.Errorf("error persisting provider state: %v", err)
@@ -760,6 +762,7 @@ func (c *CAManager) persistNewRootAndConfig(provider ca.Provider, newActiveRoot 
 		Index:  idx,
 		Roots:  newRoots,
 		Config: &newConf,
+		Cas:    newConf.ModifyIndex,
 	}
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {
@@ -1004,6 +1007,7 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 	args.Op = structs.CAOpSetRootsAndConfig
 	args.Index = idx
 	args.Config.ModifyIndex = confIdx
+	args.Cas = confIdx
 	args.Roots = newRoots
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -756,11 +756,11 @@ func (c *CAManager) persistNewRootAndConfig(provider ca.Provider, newActiveRoot 
 	}
 
 	args := &structs.CARequest{
-		Op:     structs.CAOpSetRootsAndConfig,
-		Index:  idx,
-		Roots:  newRoots,
-		Config: &newConf,
-		Cas:    confIdx,
+		Op:             structs.CAOpSetRootsAndConfig,
+		Index:          idx,
+		Roots:          newRoots,
+		Config:         &newConf,
+		ConfigCASIndex: confIdx,
 	}
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {
@@ -1004,7 +1004,7 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 	args.Op = structs.CAOpSetRootsAndConfig
 	args.Index = idx
 	args.Roots = newRoots
-	args.Cas = confIdx
+	args.ConfigCASIndex = confIdx
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {
 		return err

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -909,6 +909,9 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 		if respErr, ok := resp.(error); ok {
 			return respErr
 		}
+		if respOk, ok := resp.(bool); ok && !respOk {
+			return errors.New("configuration not applied")
+		}
 
 		// If the config has been committed, update the local provider instance
 		cleanupNewProvider = false

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -700,7 +700,7 @@ func (c *CAManager) persistNewRootAndConfig(provider ca.Provider, newActiveRoot 
 
 	// Look up the existing CA config if a new one wasn't provided.
 	var newConf structs.CAConfiguration
-	_, storedConfig, err := state.CAConfig(nil)
+	confIdx, storedConfig, err := state.CAConfig(nil)
 	if err != nil {
 		return err
 	}
@@ -760,6 +760,7 @@ func (c *CAManager) persistNewRootAndConfig(provider ca.Provider, newActiveRoot 
 		Index:  idx,
 		Roots:  newRoots,
 		Config: &newConf,
+		Cas:    confIdx,
 	}
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {
@@ -802,7 +803,7 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 
 	// Exit early if it's a no-op change
 	state := c.delegate.State()
-	_, config, err := state.CAConfig(nil)
+	confIdx, config, err := state.CAConfig(nil)
 	if err != nil {
 		return err
 	}
@@ -1003,6 +1004,7 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 	args.Op = structs.CAOpSetRootsAndConfig
 	args.Index = idx
 	args.Roots = newRoots
+	args.Cas = confIdx
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {
 		return err

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -217,7 +217,6 @@ func (c *CAManager) initializeCAConfig() (*structs.CAConfiguration, error) {
 	req := structs.CARequest{
 		Op:     structs.CAOpSetConfig,
 		Config: config,
-		Cas:    config.ModifyIndex,
 	}
 	if resp, err := c.delegate.ApplyCARequest(&req); err != nil {
 		return nil, err
@@ -504,7 +503,6 @@ func (c *CAManager) initializeRootCA(provider ca.Provider, conf *structs.CAConfi
 		req := structs.CARequest{
 			Op:     structs.CAOpSetConfig,
 			Config: conf,
-			Cas:    conf.ModifyIndex,
 		}
 		if _, err = c.delegate.ApplyCARequest(&req); err != nil {
 			return fmt.Errorf("error persisting provider state: %v", err)
@@ -762,7 +760,6 @@ func (c *CAManager) persistNewRootAndConfig(provider ca.Provider, newActiveRoot 
 		Index:  idx,
 		Roots:  newRoots,
 		Config: &newConf,
-		Cas:    newConf.ModifyIndex,
 	}
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {
@@ -904,7 +901,6 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 
 	// If the root didn't change, just update the config and return.
 	if root != nil && root.ID == newActiveRoot.ID {
-		args.Op = structs.CAOpSetConfig
 		resp, err := c.delegate.ApplyCARequest(args)
 		if err != nil {
 			return err
@@ -1007,7 +1003,6 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 	args.Op = structs.CAOpSetRootsAndConfig
 	args.Index = idx
 	args.Config.ModifyIndex = confIdx
-	args.Cas = confIdx
 	args.Roots = newRoots
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -909,9 +909,6 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 		if respErr, ok := resp.(error); ok {
 			return respErr
 		}
-		if respOk, ok := resp.(bool); ok && !respOk {
-			return errors.New("configuration not applied")
-		}
 
 		// If the config has been committed, update the local provider instance
 		cleanupNewProvider = false

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -802,7 +802,7 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 
 	// Exit early if it's a no-op change
 	state := c.delegate.State()
-	confIdx, config, err := state.CAConfig(nil)
+	_, config, err := state.CAConfig(nil)
 	if err != nil {
 		return err
 	}
@@ -1002,7 +1002,6 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 
 	args.Op = structs.CAOpSetRootsAndConfig
 	args.Index = idx
-	args.Config.ModifyIndex = confIdx
 	args.Roots = newRoots
 	resp, err := c.delegate.ApplyCARequest(args)
 	if err != nil {

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -85,14 +85,14 @@ func (m *mockCAServerDelegate) ApplyCARequest(req *structs.CARequest) (interface
 	switch req.Op {
 	case structs.CAOpSetConfig:
 		if req.Config.ModifyIndex != 0 {
-			act, err := m.store.CACheckAndSetConfig(idx+1, req.Config.ModifyIndex, req.Config)
+			var emptyResp interface{}
+			err := m.store.CACheckAndSetConfig(idx+1, req.Config.ModifyIndex, req.Config)
 			if err != nil {
 				return nil, err
 			}
 
-			return act, nil
+			return emptyResp, nil
 		}
-
 		return nil, m.store.CASetConfig(idx+1, req.Config)
 	case structs.CAOpSetRootsAndConfig:
 		act, err := m.store.CARootSetCAS(idx, req.Index, req.Roots)
@@ -100,11 +100,12 @@ func (m *mockCAServerDelegate) ApplyCARequest(req *structs.CARequest) (interface
 			return act, err
 		}
 
-		act, err = m.store.CACheckAndSetConfig(idx+1, req.Config.ModifyIndex, req.Config)
+		var emptyResp interface{}
+		err = m.store.CACheckAndSetConfig(idx+1, req.Config.ModifyIndex, req.Config)
 		if err != nil {
 			return nil, err
 		}
-		return act, nil
+		return emptyResp, nil
 	case structs.CAOpSetProviderState:
 		_, err := m.store.CASetProviderState(idx+1, req.ProviderState)
 		if err != nil {

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -48,17 +48,15 @@ func TestStore_CAConfigCAS(t *testing.T) {
 		Provider: "consul",
 	}
 
-	if err := s.CASetConfig(0, expected); err != nil {
-		t.Fatal(err)
-	}
+	err := s.CASetConfig(0, expected)
+	require.NoError(t, err)
 	// Do an extra operation to move the index up by 1 for the
 	// check-and-set operation after this
-	if err := s.CASetConfig(1, expected); err != nil {
-		t.Fatal(err)
-	}
+	err = s.CASetConfig(1, expected)
+	require.NoError(t, err)
 
 	// Do a CAS with an index lower than the entry
-	err := s.CACheckAndSetConfig(2, 0, &structs.CAConfiguration{
+	err = s.CACheckAndSetConfig(2, 0, &structs.CAConfiguration{
 		Provider: "static",
 	})
 
@@ -67,35 +65,21 @@ func TestStore_CAConfigCAS(t *testing.T) {
 	// Check that the index is untouched and the entry
 	// has not been updated.
 	idx, config, err := s.CAConfig(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if idx != 1 {
-		t.Fatalf("bad: %d", idx)
-	}
-	if config.Provider != "consul" {
-		t.Fatalf("bad: %#v", config)
-	}
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), idx)
+	require.Equal(t, "consul", config.Provider)
 
 	// Do another CAS, this time with the correct index
 	err = s.CACheckAndSetConfig(2, 1, &structs.CAConfiguration{
 		Provider: "static",
 	})
-	if err != nil {
-		t.Fatalf("expected (true, nil), got: (%#v)", err)
-	}
+	require.NoError(t, err)
 
 	// Make sure the config was updated
 	idx, config, err = s.CAConfig(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if idx != 2 {
-		t.Fatalf("bad: %d", idx)
-	}
-	if config.Provider != "static" {
-		t.Fatalf("bad: %#v", config)
-	}
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), idx)
+	require.Equal(t, "static", config.Provider)
 }
 
 func TestStore_CAConfig_Snapshot_Restore(t *testing.T) {

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -58,11 +58,10 @@ func TestStore_CAConfigCAS(t *testing.T) {
 	}
 
 	// Do a CAS with an index lower than the entry
-	ok, err := s.CACheckAndSetConfig(2, 0, &structs.CAConfiguration{
+	err := s.CACheckAndSetConfig(2, 0, &structs.CAConfiguration{
 		Provider: "static",
 	})
 
-	require.False(t, ok)
 	testutil.RequireErrorContains(t, err, "ModifyIndex did not match existing")
 
 	// Check that the index is untouched and the entry
@@ -79,11 +78,11 @@ func TestStore_CAConfigCAS(t *testing.T) {
 	}
 
 	// Do another CAS, this time with the correct index
-	ok, err = s.CACheckAndSetConfig(2, 1, &structs.CAConfiguration{
+	err = s.CACheckAndSetConfig(2, 1, &structs.CAConfiguration{
 		Provider: "static",
 	})
-	if !ok || err != nil {
-		t.Fatalf("expected (true, nil), got: (%v, %#v)", ok, err)
+	if err != nil {
+		t.Fatalf("expected (true, nil), got: (%#v)", err)
 	}
 
 	// Make sure the config was updated

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -192,6 +192,7 @@ type CAOp string
 const (
 	CAOpSetRoots                      CAOp = "set-roots"
 	CAOpSetConfig                     CAOp = "set-config"
+	CAOpSetConfigCAS                  CAOp = "set-config-cas"
 	CAOpSetProviderState              CAOp = "set-provider-state"
 	CAOpDeleteProviderState           CAOp = "delete-provider-state"
 	CAOpSetRootsAndConfig             CAOp = "set-roots-config"
@@ -220,11 +221,6 @@ type CARequest struct {
 
 	// ProviderState is the state for the builtin CA provider.
 	ProviderState *CAConsulProviderState
-
-	// Cas is an int,  Specifies to use a Check-And-Set operation.
-	// If the index is 0, Consul will only store the entry if it does not already exist.
-	// If the index is non-zero, the entry is only set if the current index matches the ModifyIndex of that entry
-	Cas uint64
 
 	// WriteRequest is a common struct containing ACL tokens and other
 	// write-related common elements for requests.

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -209,8 +209,11 @@ type CARequest struct {
 	// Datacenter is the target for this request.
 	Datacenter string
 
-	// Index is used by CAOpSetRoots and CAOpSetConfig for a CAS operation.
+	// Index is used by CAOpSetRoots for a CAS operation.
 	Index uint64
+
+	// Index is used by CAOpSetRootsAndConfig and CAOpSetConfigCAS for a CAS operation.
+	Cas uint64
 
 	// Roots is a list of roots. This is used for CAOpSet. One root must
 	// always be active.

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -212,8 +212,9 @@ type CARequest struct {
 	// Index is used by CAOpSetRoots for a CAS operation.
 	Index uint64
 
-	// Index is used by CAOpSetRootsAndConfig and CAOpSetConfigCAS for a CAS operation.
-	Cas uint64
+	// ConfigCASIndex is used as the check-and-set index for the CAOpSetConfigCAS operation, and for the
+	// Config portion of the CAOpSetRootsAndConfig operation.
+	ConfigCASIndex uint64
 
 	// Roots is a list of roots. This is used for CAOpSet. One root must
 	// always be active.

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -221,6 +221,11 @@ type CARequest struct {
 	// ProviderState is the state for the builtin CA provider.
 	ProviderState *CAConsulProviderState
 
+	// Cas is an int,  Specifies to use a Check-And-Set operation.
+	// If the index is 0, Consul will only store the entry if it does not already exist.
+	// If the index is non-zero, the entry is only set if the current index matches the ModifyIndex of that entry
+	Cas uint64
+
 	// WriteRequest is a common struct containing ACL tokens and other
 	// write-related common elements for requests.
 	WriteRequest

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -167,6 +167,11 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
+- `cas` `(int: 0)` - Specifies to use a Check-And-Set operation. If the index is
+  0, Consul will only store the entry if it does not already exist. If the index is
+  non-zero, the entry is only set if the current index matches the `ModifyIndex`
+  of that entry.
+
 - `Provider` `(string: <required>)` - Specifies the CA provider type to use.
 
 - `Config` `(map[string]string: <required>)` - The raw configuration to use


### PR DESCRIPTION
This PR is to refactor `CACheckAndSetConfig` to not return unnecessary bool value. 
The reason behind this change is the bug filed in #10656 and prevent other bugs like this to be introduced in `CACheckAndSetConfig`