### PR TITLE
ui: Give CopyButtons an idle tooltip as well as success/error ones

### DIFF
--- a/ui/packages/consul-ui/app/components/copy-button/index.hbs
+++ b/ui/packages/consul-ui/app/components/copy-button/index.hbs
@@ -7,12 +7,25 @@
     ...attributes
   >
 {{#let (fn dispatch 'SUCCESS') (fn dispatch 'ERROR') (fn dispatch 'RESET') as |success error reset|}}
+<State @matches="idle">
     <button
       {{with-copyable @value success=success error=error}}
       aria-label={{t 'components.copy-button.title' name=@name}}
       type="button"
       class="copy-btn"
-      ...attributes
+      {{tooltip
+        (t 'components.copy-button.idle')
+      }}
+    >
+      {{~yield~}}
+    </button>
+</State>
+<State @matches="success">
+    <button
+      {{with-copyable @value success=success error=error}}
+      aria-label={{t 'components.copy-button.title' name=@name}}
+      type="button"
+      class="copy-btn"
       {{tooltip
         (if (state-matches state 'success') (t 'components.copy-button.success' name=@name) (t 'components.copy-button.error'))
         options=(hash
@@ -25,6 +38,7 @@
     >
       {{~yield~}}
     </button>
+</State>
 {{/let}}
   </div>
 </StateChart>

--- a/ui/packages/consul-ui/tests/unit/services/clipboard/native-test.js
+++ b/ui/packages/consul-ui/tests/unit/services/clipboard/native-test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Service | clipboard/os', function(hooks) {
+module('Unit | Service | clipboard/native', function(hooks) {
   setupTest(hooks);
 
   // Replace this with your real tests.
   test('it exists', function(assert) {
-    let service = this.owner.lookup('service:clipboard/os');
+    let service = this.owner.lookup('service:clipboard/native');
     assert.ok(service);
   });
 });

--- a/ui/packages/consul-ui/translations/components/copy-button/en-us.yaml
+++ b/ui/packages/consul-ui/translations/components/copy-button/en-us.yaml
@@ -1,3 +1,4 @@
+idle: Copy
 title: Copy {name} to the clipboard
-success: Copied {name}
-error: There was a problem.
+success: Copied
+error: There was a problem


### PR DESCRIPTION
This PR builds upon https://github.com/hashicorp/consul/pull/10655 and adds a tooltip saying "Copy" to all our CopyButtons. 

The success notification is now simply "Copied" as we figured that copying something isn't something to get that excited about! 🎉 

Notes:

It would have been nice to try use a conditional modifier here to avoid double buttons. We began by making a single button with a single modifier with conditional arguments, but that didn't work for whatever reason. I quickly tried doubling up the button and using our State component, and that worked fine. So considering this is in one place and we might have the ability to do conditional modifiers soon (there's an RFC somewhere for `(modifer 'modifer-name')`), I decided to stick with it for this case. We can circle back here when/if the conditional modifier thing happens.

- [ ] Needs a changelog