### PR TITLE
Update Helm SDK link

### DIFF
--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -53,7 +53,7 @@ the community.
     - Clojure discovery client for the Consul HTTP API
   </li>
   <li>
-    <a href="https://github.com/Verizon/helm">helm</a> - A native Scala client
+    <a href="https://github.com/getnelson/helm">helm</a> - A native Scala client
     for interacting with Consul
   </li>
   <li>


### PR DESCRIPTION
The Verizon repository for the Helm Scala client for Consul is no longer actively maintained, but the people from the team that created the library at Verizon have forked it to their `getnelson` repo. This PR updates the link.

The library has not been super well maintained so hopefully with a corrected link it'll gain more adoption.