### PR TITLE
cli: Document pass-through option for `consul connect envoy`

### DIFF
--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -662,7 +662,7 @@ func (c *cmd) Help() string {
 
 const synopsis = "Runs or Configures Envoy as a Connect proxy"
 const help = `
-Usage: consul connect envoy [options]
+Usage: consul connect envoy [options] [-- pass-through options]
 
   Generates the bootstrap configuration needed to start an Envoy proxy instance
   for use as a Connect sidecar for a particular service instance. By default it

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -684,4 +684,8 @@ Usage: consul connect envoy [options]
 
     $ consul connect envoy -sidecar-for web
 
+  Additional arguments may be passed directly to Envoy by specifying a double
+  dash followed by a list of options.
+
+    $ consul connect envoy -sidecar-for web -- --log-level debug
 `


### PR DESCRIPTION
Update help text of `consul connect envoy` command to mention the ability to provide pass-through options.