### PR TITLE
docs: Document supported `consul connect` env vars

### DIFF
--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -55,7 +55,7 @@ proxy configuration needed.
 - `-proxy-id` - The [proxy service](/docs/connect/registration/service-registration) ID.
   This service ID must already be registered with the local agent unless a gateway is being
   registered with the `-register` flag. As of Consul 1.8.0, this can also be
-  specified via the CONNECT_PROXY_ID environment variable.
+  specified via the `CONNECT_PROXY_ID` environment variable.
 
 - `-envoy-binary` - The full path to a specific Envoy binary to exec. By
   default the current `$PATH` is searched for `envoy`.
@@ -105,13 +105,14 @@ proxy configuration needed.
 #### Envoy Sidecar Proxy Options
 
 - `-sidecar-for` - The _ID_ (not name if they differ) of the service instance
-  this proxy will represent. As of Consul 1.8.0, this can also be specified via
-  the CONNECT_SIDECAR_FOR environment variable. The target service doesn't need to exist on the
+  this proxy will represent. The target service doesn't need to exist on the
   local agent yet but a [sidecar proxy
   registration](/docs/connect/registration/service-registration) with
   `proxy.destination_service_id` equal to the passed value must be present. If
   multiple proxy registrations targeting the same local service instance are
   present the command will error and `-proxy-id` should be used instead.
+  As of Consul 1.8.0, this can also be specified via the `CONNECT_SIDECAR_FOR`
+  environment variable.
 
   -> **Note:** If ACLs are enabled, a token granting `service:write` for the
   _target_ service (configured in `proxy.destination_service_name`) must be

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -54,7 +54,8 @@ proxy configuration needed.
 
 - `-proxy-id` - The [proxy service](/docs/connect/registration/service-registration) ID.
   This service ID must already be registered with the local agent unless a gateway is being
-  registered with the `-register` flag.
+  registered with the `-register` flag. As of Consul 1.8.0, this can also be
+  specified via the CONNECT_PROXY_ID environment variable.
 
 - `-envoy-binary` - The full path to a specific Envoy binary to exec. By
   default the current `$PATH` is searched for `envoy`.
@@ -104,7 +105,8 @@ proxy configuration needed.
 #### Envoy Sidecar Proxy Options
 
 - `-sidecar-for` - The _ID_ (not name if they differ) of the service instance
-  this proxy will represent. The target service doesn't need to exist on the
+  this proxy will represent. As of Consul 1.8.0, this can also be specified via
+  the CONNECT_SIDECAR_FOR environment variable. The target service doesn't need to exist on the
   local agent yet but a [sidecar proxy
   registration](/docs/connect/registration/service-registration) with
   `proxy.destination_service_id` equal to the passed value must be present. If

--- a/website/content/commands/connect/proxy.mdx
+++ b/website/content/commands/connect/proxy.mdx
@@ -28,7 +28,8 @@ Usage: `consul connect proxy [options]`
 #### Proxy Options
 
 - `-sidecar-for` - The _ID_ (not name if they differ) of the service instance
-  this proxy will represent. The target service doesn't need to exist on the
+  this proxy will represent. This can also be specified via the CONNECT_SIDECAR_FOR
+  environment variable. The target service doesn't need to exist on the
   local agent yet but a [sidecar proxy
   registration](/docs/connect/registration/service-registration) with
   `proxy.destination_service_id` equal to the passed value must be present. If
@@ -37,7 +38,8 @@ Usage: `consul connect proxy [options]`
 
 - `-proxy-id` - The [proxy
   service](/docs/connect/registration/service-registration) ID on the
-  local agent. This must already be present on the local agent.
+  local agent. This must already be present on the local agent. This can also be
+  specified via the CONNECT_PROXY_ID environment variable.
 
 - `-log-level` - Specifies the log level.
 

--- a/website/content/commands/connect/proxy.mdx
+++ b/website/content/commands/connect/proxy.mdx
@@ -28,18 +28,18 @@ Usage: `consul connect proxy [options]`
 #### Proxy Options
 
 - `-sidecar-for` - The _ID_ (not name if they differ) of the service instance
-  this proxy will represent. This can also be specified via the CONNECT_SIDECAR_FOR
-  environment variable. The target service doesn't need to exist on the
+  this proxy will represent. The target service doesn't need to exist on the
   local agent yet but a [sidecar proxy
   registration](/docs/connect/registration/service-registration) with
   `proxy.destination_service_id` equal to the passed value must be present. If
   multiple proxy registrations targeting the same local service instance are
   present the command will error and `-proxy-id` should be used instead.
+  This can also be specified via the `CONNECT_SIDECAR_FOR` environment variable.
 
 - `-proxy-id` - The [proxy
   service](/docs/connect/registration/service-registration) ID on the
-  local agent. This must already be present on the local agent. This can also be
-  specified via the CONNECT_PROXY_ID environment variable.
+  local agent. This must already be present on the local agent. This option
+  can also be specified via the `CONNECT_PROXY_ID` environment variable.
 
 - `-log-level` - Specifies the log level.
 


### PR DESCRIPTION
Document the ability to specify `-sidecar-for` and `-proxy-id` flags via environment variables.

These environment variables have been supported for `consul connect proxy` since Connect was introduced in 1.2.0.

Support was added for using these variables with `consul connect envoy` in Consul 1.8.0 with PR #7498.