### PR TITLE
fix state index for `CAOpSetRootsAndConfig` op

### DIFF
--- a/.changelog/10675.txt
+++ b/.changelog/10675.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-fix index passed to raft when applying `CAOpSetRootsAndConfig` operatio.
+ca: use the correct raft index when saving the CA config
 ```

--- a/.changelog/10675.txt
+++ b/.changelog/10675.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix index passed to raft when applying `CAOpSetRootsAndConfig` operatio.
+```

--- a/.changelog/10675.txt
+++ b/.changelog/10675.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-ca: use the correct raft index when saving the CA config
-```

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -462,7 +462,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 			return act
 		}
 
-		act, err = c.state.CACheckAndSetConfig(index+1, req.Config.ModifyIndex, req.Config)
+		act, err = c.state.CACheckAndSetConfig(index, req.Config.ModifyIndex, req.Config)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This fix the index passed to the state when performing op `CAOpSetRootsAndConfig`