### PR TITLE
config raft apply silent error (#10657)

### DIFF
--- a/.changelog/10657.txt
+++ b/.changelog/10657.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: report an error when setting the ca config fail because of an index check.
+```

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -3,8 +3,10 @@ package state
 import (
 	"fmt"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-memdb"
+	"github.com/pkg/errors"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 const (
@@ -147,7 +149,7 @@ func (s *Store) CASetConfig(idx uint64, config *structs.CAConfiguration) error {
 
 // CACheckAndSetConfig is used to try updating the CA configuration with a
 // given Raft index. If the CAS index specified is not equal to the last observed index
-// for the config, then the call is a noop,
+// for the config, then the call will return an error,
 func (s *Store) CACheckAndSetConfig(idx, cidx uint64, config *structs.CAConfiguration) (bool, error) {
 	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
@@ -163,7 +165,7 @@ func (s *Store) CACheckAndSetConfig(idx, cidx uint64, config *structs.CAConfigur
 	// return early here.
 	e, ok := existing.(*structs.CAConfiguration)
 	if (ok && e.ModifyIndex != cidx) || (!ok && cidx != 0) {
-		return false, nil
+		return false, errors.Errorf("ModifyIndex did not match existing")
 	}
 
 	if err := s.caSetConfigTxn(idx, tx, config); err != nil {

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
+
 	"github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,9 +62,9 @@ func TestStore_CAConfigCAS(t *testing.T) {
 	ok, err := s.CACheckAndSetConfig(2, 0, &structs.CAConfiguration{
 		Provider: "static",
 	})
-	if ok || err != nil {
-		t.Fatalf("expected (false, nil), got: (%v, %#v)", ok, err)
-	}
+
+	require.False(t, ok)
+	testutil.RequireErrorContains(t, err, "ModifyIndex did not match existing")
 
 	// Check that the index is untouched and the entry
 	// has not been updated.


### PR DESCRIPTION
This is a manual cherry-pick of #10657  to 1.9.x

- CONFLICT (content): Merge conflict in agent/consul/state/connect_ca_test.go
- CONFLICT (content): Merge conflict in agent/consul/state/connect_ca.go





* return an error when the index is not valid

* check response as bool when applying `CAOpSetConfig`

* remove check for bool response

* fix error message and add check to test

* fix comment

* add changelog