### PR TITLE
config raft apply silent error (#10657)

### DIFF
--- a/.changelog/10657.txt
+++ b/.changelog/10657.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: report an error when setting the ca config fail because of an index check.
+```

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -3,7 +3,6 @@ package state
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-memdb"
 	"github.com/pkg/errors"
 
 	"github.com/hashicorp/consul/agent/structs"

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -3,6 +3,9 @@ package state
 import (
 	"fmt"
 
+	"github.com/hashicorp/go-memdb"
+	"github.com/pkg/errors"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-memdb"
 )
@@ -148,7 +151,7 @@ func (s *Store) CASetConfig(idx uint64, config *structs.CAConfiguration) error {
 
 // CACheckAndSetConfig is used to try updating the CA configuration with a
 // given Raft index. If the CAS index specified is not equal to the last observed index
-// for the config, then the call is a noop,
+// for the config, then the call will return an error,
 func (s *Store) CACheckAndSetConfig(idx, cidx uint64, config *structs.CAConfiguration) (bool, error) {
 	tx := s.db.Txn(true)
 	defer tx.Abort()
@@ -164,7 +167,7 @@ func (s *Store) CACheckAndSetConfig(idx, cidx uint64, config *structs.CAConfigur
 	// return early here.
 	e, ok := existing.(*structs.CAConfiguration)
 	if (ok && e.ModifyIndex != cidx) || (!ok && cidx != 0) {
-		return false, nil
+		return false, errors.Errorf("ModifyIndex did not match existing")
 	}
 
 	if err := s.caSetConfigTxn(idx, tx, config); err != nil {

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -3,7 +3,14 @@ package state
 import (
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/consul/sdk/testutil"
+
 	"time"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
@@ -60,9 +67,9 @@ func TestStore_CAConfigCAS(t *testing.T) {
 	ok, err := s.CACheckAndSetConfig(2, 0, &structs.CAConfiguration{
 		Provider: "static",
 	})
-	if ok || err != nil {
-		t.Fatalf("expected (false, nil), got: (%v, %#v)", ok, err)
-	}
+
+	require.False(t, ok)
+	testutil.RequireErrorContains(t, err, "ModifyIndex did not match existing")
 
 	// Check that the index is untouched and the entry
 	// has not been updated.

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -14,9 +14,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/go-memdb"
 	"github.com/pascaldekloe/goe/verify"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestStore_CAConfig(t *testing.T) {


### PR DESCRIPTION
This is a manual cherry-pick of #10657  to 1.8.x

CONFLICT (content): Merge conflict in agent/consul/state/connect_ca_test.go
CONFLICT (content): Merge conflict in agent/consul/state/connect_ca.go


* return an error when the index is not valid

* check response as bool when applying `CAOpSetConfig`

* remove check for bool response

* fix error message and add check to test

* fix comment

* add changelog
Conflicts:
  agent/consul/state/connect_ca.go
  agent/consul/state/connect_ca_test.go