### PR TITLE
docs: Vault as a Connected CA with Consul missing Managed PKI Paths

### DIFF
--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -149,6 +149,14 @@ path "/connect_root/root/sign-intermediate" {
 path "/connect_inter/*" {
   capabilities = [ "create", "read", "update", "delete", "list" ]
 }
+
+path "auth/token/renew-self" {
+	capabilities = [ "update" ]
+}
+	
+path "auth/token/lookup-self" {
+	capabilities = [ "read" ]
+}
 ```
 
 ### Consul Managed PKI Paths


### PR DESCRIPTION
Folks using Vault as a Connected CA with Consul, and using these instructions https://www.consul.io/docs/connect/ca/vault#vault-acl-policies found that besides the Vault Managed PKI Paths mentioned in there they had to add the following

```
path "auth/token/renew-self" {
	capabilities = ["update"]
}
	
path "auth/token/lookup-self" {
	capabilities = ["read"]
}
```

Suggestion is to add those in the page or mention this somewhere in the docs