### PR TITLE
docs: Add version callout for `kv import -prefix`

### DIFF
--- a/website/content/commands/kv/import.mdx
+++ b/website/content/commands/kv/import.mdx
@@ -23,7 +23,7 @@ Usage: `consul kv import [options] [DATA]`
 #### KV Import Options
 
 - `-prefix` - Key prefix for imported data. The default value is empty meaning
-  root.
+  root. Added in Consul 1.10.
 
 #### Enterprise Options
 


### PR DESCRIPTION
Add a sentence stating the version of Consul that introduced the `-prefix` option for `consul kv import`.

Resolves #10172