### PR TITLE
Log the correlation ID when blocking queries fire

### DIFF
--- a/.changelog/10689.txt
+++ b/.changelog/10689.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+proxycfg: log correlation IDs for proxy configuration snapshot blocking queries.
+```

--- a/.changelog/10689.txt
+++ b/.changelog/10689.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-proxycfg: log correlation IDs for proxy configuration snapshot blocking queries.
+proxycfg: log correlation IDs for the proxy configuration snapshot's blocking queries.
 ```

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -277,7 +277,7 @@ func (s *state) run(ctx context.Context, snap *ConfigSnapshot) {
 		case <-ctx.Done():
 			return
 		case u := <-s.ch:
-			s.logger.Trace("A blocking query returned; handling snapshot update")
+			s.logger.Trace("A blocking query returned; handling snapshot update", "correlationID", u.CorrelationID)
 
 			if err := s.handler.handleUpdate(ctx, u, snap); err != nil {
 				s.logger.Error("Failed to handle update from watch",


### PR DESCRIPTION
Knowing that blocking queries are firing does not provide much
information on its own. If we know the correlation IDs we can
piece together which parts of the snapshot have been populated.

Some of these responses might be empty from the blocking
query timing out. But if they're returning quickly I think we
can reasonably assume they contain data.