### PR TITLE
api: enable query opts on agent health and maintenance endpoints

### DIFF
--- a/.changelog/10691.txt
+++ b/.changelog/10691.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Enable setting query options on agent health and maintenance endpoints.
+```

--- a/api/agent.go
+++ b/api/agent.go
@@ -578,8 +578,13 @@ func (a *Agent) ServicesWithFilterOpts(filter string, q *QueryOptions) (map[stri
 // - If the service is found, will return (critical|passing|warning), AgentServiceChecksInfo, nil)
 // - In all other cases, will return an error
 func (a *Agent) AgentHealthServiceByID(serviceID string) (string, *AgentServiceChecksInfo, error) {
+	return a.AgentHealthServiceByIDOpts(serviceID, nil)
+}
+
+func (a *Agent) AgentHealthServiceByIDOpts(serviceID string, q *QueryOptions) (string, *AgentServiceChecksInfo, error) {
 	path := fmt.Sprintf("/v1/agent/health/service/id/%v", url.PathEscape(serviceID))
 	r := a.c.newRequest("GET", path)
+	r.setQueryOptions(q)
 	r.params.Add("format", "json")
 	r.header.Set("Accept", "application/json")
 	_, resp, err := a.c.doRequest(r)
@@ -612,8 +617,13 @@ func (a *Agent) AgentHealthServiceByID(serviceID string) (string, *AgentServiceC
 // - If the service is found, will return (critical|passing|warning), []api.AgentServiceChecksInfo, nil)
 // - In all other cases, will return an error
 func (a *Agent) AgentHealthServiceByName(service string) (string, []AgentServiceChecksInfo, error) {
+	return a.AgentHealthServiceByNameOpts(service, nil)
+}
+
+func (a *Agent) AgentHealthServiceByNameOpts(service string, q *QueryOptions) (string, []AgentServiceChecksInfo, error) {
 	path := fmt.Sprintf("/v1/agent/health/service/name/%v", url.PathEscape(service))
 	r := a.c.newRequest("GET", path)
+	r.setQueryOptions(q)
 	r.params.Add("format", "json")
 	r.header.Set("Accept", "application/json")
 	_, resp, err := a.c.doRequest(r)
@@ -1015,7 +1025,12 @@ func (a *Agent) ConnectCALeaf(serviceID string, q *QueryOptions) (*LeafCert, *Qu
 // EnableServiceMaintenance toggles service maintenance mode on
 // for the given service ID.
 func (a *Agent) EnableServiceMaintenance(serviceID, reason string) error {
+	return a.EnableServiceMaintenanceOpts(serviceID, reason, nil)
+}
+
+func (a *Agent) EnableServiceMaintenanceOpts(serviceID, reason string, q *QueryOptions) error {
 	r := a.c.newRequest("PUT", "/v1/agent/service/maintenance/"+serviceID)
+	r.setQueryOptions(q)
 	r.params.Set("enable", "true")
 	r.params.Set("reason", reason)
 	_, resp, err := requireOK(a.c.doRequest(r))
@@ -1029,7 +1044,12 @@ func (a *Agent) EnableServiceMaintenance(serviceID, reason string) error {
 // DisableServiceMaintenance toggles service maintenance mode off
 // for the given service ID.
 func (a *Agent) DisableServiceMaintenance(serviceID string) error {
+	return a.DisableServiceMaintenanceOpts(serviceID, nil)
+}
+
+func (a *Agent) DisableServiceMaintenanceOpts(serviceID string, q *QueryOptions) error {
 	r := a.c.newRequest("PUT", "/v1/agent/service/maintenance/"+serviceID)
+	r.setQueryOptions(q)
 	r.params.Set("enable", "false")
 	_, resp, err := requireOK(a.c.doRequest(r))
 	if err != nil {

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1322,7 +1322,7 @@ func TestAPI_AgentMonitorJSON(t *testing.T) {
 	})
 }
 
-func TestAPI_ServiceMaintenance(t *testing.T) {
+func TestAPI_ServiceMaintenanceOpts(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -1337,8 +1337,11 @@ func TestAPI_ServiceMaintenance(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Specify namespace in query option
+	opts := &QueryOptions{Namespace: defaultNamespace}
+
 	// Enable maintenance mode
-	if err := agent.EnableServiceMaintenance("redis", "broken"); err != nil {
+	if err := agent.EnableServiceMaintenanceOpts("redis", "broken", opts); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1361,7 +1364,7 @@ func TestAPI_ServiceMaintenance(t *testing.T) {
 	}
 
 	// Disable maintenance mode
-	if err := agent.DisableServiceMaintenance("redis"); err != nil {
+	if err := agent.DisableServiceMaintenanceOpts("redis", opts); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1641,7 +1644,7 @@ func TestAPI_AgentConnectAuthorize(t *testing.T) {
 	require.Equal(auth.Reason, "ACLs disabled, access is allowed by default")
 }
 
-func TestAPI_AgentHealthService(t *testing.T) {
+func TestAPI_AgentHealthServiceOpts(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -1651,7 +1654,8 @@ func TestAPI_AgentHealthService(t *testing.T) {
 	requireServiceHealthID := func(t *testing.T, serviceID, expected string, shouldExist bool) {
 		msg := fmt.Sprintf("service id:%s, shouldExist:%v, expectedStatus:%s : bad %%s", serviceID, shouldExist, expected)
 
-		state, out, err := agent.AgentHealthServiceByID(serviceID)
+		opts := &QueryOptions{Namespace: defaultNamespace}
+		state, out, err := agent.AgentHealthServiceByIDOpts(serviceID, opts)
 		require.Nil(t, err, msg, "err")
 		require.Equal(t, expected, state, msg, "state")
 		if !shouldExist {
@@ -1664,7 +1668,8 @@ func TestAPI_AgentHealthService(t *testing.T) {
 	requireServiceHealthName := func(t *testing.T, serviceName, expected string, shouldExist bool) {
 		msg := fmt.Sprintf("service name:%s, shouldExist:%v, expectedStatus:%s : bad %%s", serviceName, shouldExist, expected)
 
-		state, outs, err := agent.AgentHealthServiceByName(serviceName)
+		opts := &QueryOptions{Namespace: defaultNamespace}
+		state, outs, err := agent.AgentHealthServiceByNameOpts(serviceName, opts)
 		require.Nil(t, err, msg, "err")
 		require.Equal(t, expected, state, msg, "state")
 		if !shouldExist {


### PR DESCRIPTION
This PR adds support for setting QueryOptions on the following agent API endpoints:

- /agent/service/maintenance
- /agent/health/service/name/:name
- /agent/health/service/id/:id

This follows the same pattern used in #9903 to support query options for other agent API endpoints.

Resolves #9710