### PR TITLE
ui: Fix dropdown option duplications

### DIFF
--- a/.changelog/10706.txt
+++ b/.changelog/10706.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix dropdown option duplication in the new intentions form
+```

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -39,7 +39,7 @@
               @buildSuggestion={{action "createNewLabel" "Use a Consul Namespace called '{{term}}'"}}
               @showCreateWhen={{action "isUnique" nspaces}}
               @onCreate={{action onchange "SourceNS"}}
-              @onChange={{fn (mut SourceNS)}} as |nspace|>
+              @onChange={{fn (mut this.SourceNS)}} as |nspace|>
                 {{#if (eq nspace.Name '*') }}
                   * (All Namespaces)
                 {{else}}
@@ -88,7 +88,7 @@
               @buildSuggestion={{action "createNewLabel" "Use a future Consul Namespace called '{{term}}'"}}
               @showCreateWhen={{action "isUnique" nspaces}}
               @onCreate={{action onchange "DestinationNS"}}
-              @onChange={{fn (mut DestinationNS)}} as |nspace|>
+              @onChange={{fn (mut this.DestinationNS)}} as |nspace|>
                   {{#if (eq nspace.Name '*') }}
                     * (All Namespaces)
                   {{else}}

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -39,7 +39,7 @@
               @buildSuggestion={{action "createNewLabel" "Use a Consul Namespace called '{{term}}'"}}
               @showCreateWhen={{action "isUnique" nspaces}}
               @onCreate={{action onchange "SourceNS"}}
-              @onChange={{action (mut SourceNS)}} as |nspace|>
+              @onChange={{fn (mut SourceNS)}} as |nspace|>
                 {{#if (eq nspace.Name '*') }}
                   * (All Namespaces)
                 {{else}}
@@ -88,7 +88,7 @@
               @buildSuggestion={{action "createNewLabel" "Use a future Consul Namespace called '{{term}}'"}}
               @showCreateWhen={{action "isUnique" nspaces}}
               @onCreate={{action onchange "DestinationNS"}}
-              @onChange={{action (mut DestinationNS)}} as |nspace|>
+              @onChange={{fn (mut DestinationNS)}} as |nspace|>
                   {{#if (eq nspace.Name '*') }}
                     * (All Namespaces)
                   {{else}}

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -39,7 +39,7 @@
               @buildSuggestion={{action "createNewLabel" "Use a Consul Namespace called '{{term}}'"}}
               @showCreateWhen={{action "isUnique" nspaces}}
               @onCreate={{action onchange "SourceNS"}}
-              @onChange={{action onchange "SourceNS"}} as |nspace|>
+              @onChange={{action (mut SourceNS)}} as |nspace|>
                 {{#if (eq nspace.Name '*') }}
                   * (All Namespaces)
                 {{else}}
@@ -88,7 +88,7 @@
               @buildSuggestion={{action "createNewLabel" "Use a future Consul Namespace called '{{term}}'"}}
               @showCreateWhen={{action "isUnique" nspaces}}
               @onCreate={{action onchange "DestinationNS"}}
-              @onChange={{action onchange "DestinationNS"}} as |nspace|>
+              @onChange={{action (mut DestinationNS)}} as |nspace|>
                   {{#if (eq nspace.Name '*') }}
                     * (All Namespaces)
                   {{else}}


### PR DESCRIPTION
**🐛 Issue**: New intentions form - `Source Namespace` and `Destination Namespace` drop-downs have options duplicated with onChange action. Issue reported in #10686.

**🩹  Solution**: Update `onChange` action to mutate to the selected option. This is following the [usage documentation](https://github.com/cibernox/ember-power-select-with-create#usage) for `ember-power-select-with-create` package. 

**Screenshots:**
- Before
![intention_dropdown_before](https://user-images.githubusercontent.com/19161242/127223497-f222ae08-ba67-4ffe-be3d-e3190d76020f.gif)

- After
![intention_dropdown_after](https://user-images.githubusercontent.com/19161242/127222997-535c9b88-0a5a-4e58-8fdf-e2fff703cfec.gif)


Tests: ❌ 

- [x] Backlog

- [x] Changelog
