### PR TITLE
streaming: set default query timeout

### DIFF
--- a/.changelog/10707.txt
+++ b/.changelog/10707.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+streaming: set the default wait timeout for health queries
+```
+```release-note:bug
+http: log cancelled requests as such at the INFO level, instead of logging them as errored requests.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -395,6 +395,7 @@ func New(bd BaseDeps) (*Agent, error) {
 			Logger: bd.Logger.Named("rpcclient.health"),
 		},
 		UseStreamingBackend: a.config.UseStreamingBackend,
+		QueryOptionDefaults: config.ApplyDefaultQueryOptions(a.config),
 	}
 
 	a.serviceManager = NewServiceManager(&a)

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1930,3 +1930,16 @@ func isFloat(t reflect.Type) bool { return t.Kind() == reflect.Float32 || t.Kind
 func isComplex(t reflect.Type) bool {
 	return t.Kind() == reflect.Complex64 || t.Kind() == reflect.Complex128
 }
+
+// ApplyDefaultQueryOptions returns a function which will set default values on
+// the options based on the configuration. The RuntimeConfig must not be nil.
+func ApplyDefaultQueryOptions(config *RuntimeConfig) func(options *structs.QueryOptions) {
+	return func(options *structs.QueryOptions) {
+		switch {
+		case options.MaxQueryTime > config.MaxQueryTime:
+			options.MaxQueryTime = config.MaxQueryTime
+		case options.MaxQueryTime == 0:
+			options.MaxQueryTime = config.DefaultQueryTime
+		}
+	}
+}

--- a/agent/http.go
+++ b/agent/http.go
@@ -432,12 +432,20 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 		}
 
 		handleErr := func(err error) {
-			httpLogger.Error("Request error",
-				"method", req.Method,
-				"url", logURL,
-				"from", req.RemoteAddr,
-				"error", err,
-			)
+			if req.Context().Err() != nil {
+				httpLogger.Info("Request cancelled",
+					"method", req.Method,
+					"url", logURL,
+					"from", req.RemoteAddr,
+					"error", err)
+			} else {
+				httpLogger.Error("Request error",
+					"method", req.Method,
+					"url", logURL,
+					"from", req.RemoteAddr,
+					"error", err)
+			}
+
 			switch {
 			case isForbidden(err):
 				resp.WriteHeader(http.StatusForbidden)

--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -17,6 +17,7 @@ type Client struct {
 	MaterializerDeps    MaterializerDeps
 	CacheName           string
 	UseStreamingBackend bool
+	QueryOptionDefaults func(options *structs.QueryOptions)
 }
 
 type NetRPC interface {
@@ -38,6 +39,8 @@ func (c *Client) ServiceNodes(
 	req structs.ServiceSpecificRequest,
 ) (structs.IndexedCheckServiceNodes, cache.ResultMeta, error) {
 	if c.useStreaming(req) && (req.QueryOptions.UseCache || req.QueryOptions.MinQueryIndex > 0) {
+		c.QueryOptionDefaults(&req.QueryOptions)
+
 		result, err := c.ViewStore.Get(ctx, c.newServiceRequest(req))
 		if err != nil {
 			return structs.IndexedCheckServiceNodes{}, cache.ResultMeta{}, err


### PR DESCRIPTION
This PR fixes two problems:

1. the HTTP API would log cancelled requests as an error
2. the health endpoint, with the streaming backend, did not set the default timeout that was used with the blocking query backend