### PR TITLE
Update Docs nav for deprecated proxies

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -200,9 +200,8 @@
             "path": "connect/proxies/integrate"
           },
           {
-            "title": "Managed (Deprecated)",
-            "path": "connect/proxies/managed-deprecated",
-            "hidden": true
+            "title": "Managed Proxies (Deprecated)",
+            "path": "connect/proxies/managed-deprecated"
           }
         ]
       },


### PR DESCRIPTION
Replaces #10012 

For some reason, the existing PR isn't picking up the latest changes in the branch. (EDIT: it's because I forgot to reopen 10012 - oh well.)

I verified that the nav item exists and works.

![image](https://user-images.githubusercontent.com/85913323/127350424-abc0f0fd-c746-4a3d-b02d-71a2f3177b76.png)
