### PR TITLE
Generalize base64 command usage in docs

### DIFF
--- a/website/content/docs/k8s/connect/terminating-gateways.mdx
+++ b/website/content/docs/k8s/connect/terminating-gateways.mdx
@@ -69,7 +69,7 @@ $ export CONSUL_HTTP_SSL_VERIFY=false
 If ACLs are enabled also set:
 
 ```shell-session
-$ export CONSUL_HTTP_TOKEN=$(kubectl get secret consul-bootstrap-acl-token -o jsonpath={.data.token} | base64 -D)
+$ export CONSUL_HTTP_TOKEN=$(kubectl get secret consul-bootstrap-acl-token -o jsonpath={.data.token} | base64 --decode)
 ```
 
 ## Register external services with Consul

--- a/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
@@ -104,7 +104,7 @@ Then you have likely enabled ACLs. You need to specify your ACL token when
 running the `license get` command. First, assign the ACL token to the `CONSUL_HTTP_TOKEN` environment variable:
 
 ```shell-session
-$ export CONSUL_HTTP_TOKEN=$(kubectl get secrets/hashicorp-consul-bootstrap-acl-token --template={{.data.token}} | base64 -D)
+$ export CONSUL_HTTP_TOKEN=$(kubectl get secrets/hashicorp-consul-bootstrap-acl-token --template={{.data.token}} | base64 --decode)
 ```
 
 Now the token will be used when running Consul commands:

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -158,7 +158,7 @@ to see all resources and make modifications.
 To retrieve the bootstrap token that has full permissions, run:
 
 ```shell-session
-$ kubectl get secrets/consul-bootstrap-acl-token --template={{.data.token}} | base64 -D
+$ kubectl get secrets/consul-bootstrap-acl-token --template={{.data.token}} | base64 --decode
 e7924dd1-dc3f-f644-da54-81a73ba0a178%
 ```
 

--- a/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
+++ b/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
@@ -36,14 +36,14 @@ The following sections detail how to export this data.
 
    ```sh
    kubectl get secrets/consul-ca-cert --template='{{index .data "tls.crt" }}' |
-     base64 -D > consul-agent-ca.pem
+     base64 --decode > consul-agent-ca.pem
    ```
 
 1. And the certificate authority signing key:
 
    ```sh
    kubectl get secrets/consul-ca-key --template='{{index .data "tls.key" }}' |
-      base64 -D > consul-agent-ca-key.pem
+      base64 --decode > consul-agent-ca-key.pem
    ```
 
 1. With the `consul-agent-ca.pem` and `consul-agent-ca-key.pem` files you can

--- a/website/content/docs/security/acl/auth-methods/oidc.mdx
+++ b/website/content/docs/security/acl/auth-methods/oidc.mdx
@@ -201,7 +201,7 @@ be tricky to debug why things aren't working. Some tips for setting up OIDC:
   request to obtain a JWT that you can inspect. An example of how to decode the
   JWT (in this case located in the `access_token` field of a JSON response):
 
-      cat jwt.json | jq -r .access_token | cut -d. -f2 | base64 -D
+      cat jwt.json | jq -r .access_token | cut -d. -f2 | base64 --decode
 
 - The [`VerboseOIDCLogging`](#verboseoidclogging) option is available which
   will log the received OIDC token if debug level logging is enabled. This can


### PR DESCRIPTION
The base64 CLI utility has two different short flag arguments for decode depending on the platform: [-D](https://www.unix.com/man-page/osx/1/base64/) and [-d](https://linux.die.net/man/1/base64).

Previously, the docs used the -D flag exclusively with the base64 utility. Luckily, the long form of the flag is the same across platforms: --decode.

All uses of the base64 -D flag have been replaced with --decode. Said uses were identified with grep:
![image](https://user-images.githubusercontent.com/85913323/127353510-75bbb32d-9b83-4512-a4b3-79b9f87e7f0c.png)

