### PR TITLE
Document how to make namespace wildcard intentions.

### DIFF
--- a/website/content/docs/connect/intentions.mdx
+++ b/website/content/docs/connect/intentions.mdx
@@ -97,6 +97,9 @@ accepted.
 An intention source or destination may also be the special wildcard
 value `*`. This matches _any_ value and is used as a catch-all.
 
+Wildcards can be used for service name matching. In Consul <EnterpriseAlert inline />
+they can also be used for Namespace matching.
+
 This example says that the "web" service cannot connect to _any_ service:
 
 ```hcl
@@ -119,6 +122,22 @@ Sources = [
   {
     Name   = "*"
     Action = "deny"
+  }
+]
+```
+
+This <EnterpriseAlert inline /> example grants access to Prometheus 
+access to any service in any namespace.
+
+```hcl
+Kind = "service-intentions"
+Name = "*"
+Namespace = "*"
+Sources = [
+  {
+    Name      = "prometheus"
+    Namespace = "monitoring"
+    Action = "allow"
   }
 ]
 ```

--- a/website/content/docs/connect/intentions.mdx
+++ b/website/content/docs/connect/intentions.mdx
@@ -94,11 +94,9 @@ accepted.
 
 ### Wildcard Intentions
 
-An intention source or destination may also be the special wildcard
-value `*`. This matches _any_ value and is used as a catch-all.
+You can use the `*` wildcard when defining an intention source or destination. The wildcard matches _any_ value and can serve as a "catch-all" entry for intentions that should have a wide scope.     
 
-Wildcards can be used for service name matching. In Consul <EnterpriseAlert inline />
-they can also be used for Namespace matching.
+You can use a wildcard to match service names. If you are using Consul Enterprise, you can also use a wildcard to match a namespace.
 
 This example says that the "web" service cannot connect to _any_ service:
 
@@ -126,7 +124,7 @@ Sources = [
 ]
 ```
 
-This <EnterpriseAlert inline /> example grants access to Prometheus 
+<EnterpriseAlert inline /> This example grants Prometheus
 access to any service in any namespace.
 
 ```hcl


### PR DESCRIPTION
Trying to work something out for a user I realise that while we do document the ability to wildcard namespaces in the [Config Entry reference](https://www.consul.io/docs/connect/config-entries/service-intentions#namespace), we just didn't mention it at all in this overview which made it hard to discover this is possible even when I already suspected it was!

There is an additional issue I found that wasn't super clearly documented: that L7 Permissions and wildcard destinations are mutually exclusive. I'll address that in a separate PR as we don't seem to call that out anywhere clearly.