### PR TITLE
Add initial Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
+  directory: "/api"
+  schedule:
+    interval: daily
+- package-ecosystem: npm 
+  directory: "/ui"
+  schedule:
+    interval: daily
+- package-ecosystem: npm 
+  directory: "/website"
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
   directory: "/api"
   schedule:
     interval: daily
+- package-ecosystem: gomod
+  directory: "/sdk"
+  schedule:
+    interval: daily
 - package-ecosystem: npm 
   directory: "/ui"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,8 @@ updates:
   directory: "/website"
   schedule:
     interval: daily
+- package-ecosystem: github-actions
+  open-pull-requests-limit: 5
+  directory: /
+  schedule:
+    interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,27 @@
 version: 2
 updates:
 - package-ecosystem: gomod
+  open-pull-requests-limit: 5
   directory: "/"
   schedule:
     interval: daily
 - package-ecosystem: gomod
+  open-pull-requests-limit: 5
   directory: "/api"
   schedule:
     interval: daily
 - package-ecosystem: gomod
+  open-pull-requests-limit: 5
   directory: "/sdk"
   schedule:
     interval: daily
 - package-ecosystem: npm 
+  open-pull-requests-limit: 5
   directory: "/ui"
   schedule:
     interval: daily
 - package-ecosystem: npm 
+  open-pull-requests-limit: 5
   directory: "/website"
   schedule:
     interval: daily


### PR DESCRIPTION
This PR adds a Dependabot configuration file to enable daily Go module and NPM scanning. More information on this feature can be found [here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates).