### PR TITLE
ci: query for max number of possible labels

### DIFF
--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -22,7 +22,7 @@ function get_latest_backport_label {
     local ret
     local latest_backport_label
 
-    resp=$(curl -f -s -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/labels")
+    resp=$(curl -f -s -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/labels?per_page=100")
     ret="$?"
     if [[ "$ret" -ne 0 ]]; then
         status "The GitHub API returned $ret which means it was probably rate limited."


### PR DESCRIPTION
To fix a failure in our docs-cherrypick automation. This started to fail today, I suspect because
github silently changed the order the labels were being returned, and by default it only
returns 30 labels.

We currently have 68 labels, so using per_page=100 (the maximum allowed) we should be able to fix
this failure.

Relevant API docs: https://docs.github.com/en/rest/reference/issues#list-labels-for-a-repository

I tested the commands from this script locally, and this change appears to fix the problem