### PR TITLE
Add OSS bits for specifying audit log permission mode

### DIFF
--- a/.changelog/10732.txt
+++ b/.changelog/10732.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+config: **(Enterprise Only)** Allow specifying permission mode for audit logs.
+```

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -786,6 +786,7 @@ type AuditSink struct {
 	Format            *string `mapstructure:"format"`
 	Path              *string `mapstructure:"path"`
 	DeliveryGuarantee *string `mapstructure:"delivery_guarantee"`
+	Mode              *string `mapstructure:"mode"`
 	RotateBytes       *int    `mapstructure:"rotate_bytes"`
 	RotateDuration    *string `mapstructure:"rotate_duration"`
 	RotateMaxFiles    *int    `mapstructure:"rotate_max_files"`

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -867,6 +867,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
       the rules governing how audit events are written.
       The following keys are valid:
       - `best-effort` - Consul only supports `best-effort` event delivery.
+    - `mode` - The permissions to set on the audit log files.
     - `rotate_duration` - Specifies the
       interval by which the system rotates to a new log file. At least one of `rotate_duration` or `rotate_bytes`
       must be configured to enable audit logging.


### PR DESCRIPTION
Consul Enterprise is adding the ability to configure the permission mode for audit logs. This PR contains the necessary OSS modifications to allow that to work, and associated documentation updates.