### PR TITLE
ui: Add copy button for Secret ID in Tokens list page

### DIFF
--- a/.changelog/10735.txt
+++ b/.changelog/10735.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Adds a copy button to each composite row in tokens list page, if Secret ID returns an actual ID
+```

--- a/ui/packages/consul-ui/app/components/composite-row/layout.scss
+++ b/ui/packages/consul-ui/app/components/composite-row/layout.scss
@@ -1,6 +1,6 @@
 %composite-row {
   display: grid;
-  grid-template-columns: auto 50px;
+  grid-template-columns: 1fr auto;
   grid-template-rows: 50% 50%;
 
   grid-template-areas:
@@ -25,8 +25,7 @@
 }
 %composite-row-actions {
   grid-area: actions;
-  justify-self: center;
-  align-self: center;
+  display: inline-flex;
 }
 
 %composite-row-header:nth-last-child(2) {

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
@@ -30,7 +30,7 @@ as |item|>
         </dl>
     </BlockSlot>
     <BlockSlot @name="actions" as |Actions|>
-    {{#if (and (not-eq item.SecretID '') (not-eq item.SecretID '<hidden>'))}}
+    {{#if item.hasSecretID}}
       <CopyButton
         @value={{item.SecretID}}
         @name={{t "common.consul.secretID"}}

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
@@ -33,9 +33,9 @@ as |item|>
     {{#if item.hasSecretID}}
       <CopyButton
         @value={{item.SecretID}}
-        @name={{t "common.consul.secretID"}}
+        @name={{t "components.consul.token.secretID"}}
       >
-        {{t "common.consul.secretID"}}
+        {{t "components.consul.token.secretID"}}
       </CopyButton>
     {{/if}}
       <Actions as |Action|>

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
@@ -30,7 +30,14 @@ as |item|>
         </dl>
     </BlockSlot>
     <BlockSlot @name="actions" as |Actions|>
-
+    {{#if (and (not-eq item.SecretID '') (not-eq item.SecretID '<hidden>'))}}
+      <CopyButton
+        @value={{item.SecretID}}
+        @name={{t "common.consul.secretID"}}
+      >
+        {{t "common.consul.secretID"}}
+      </CopyButton>
+    {{/if}}
       <Actions as |Action|>
         <Action data-test-edit-action @href={{href-to 'dc.acls.tokens.edit' item.AccessorID}}>
           <BlockSlot @name="label">

--- a/ui/packages/consul-ui/app/models/token.js
+++ b/ui/packages/consul-ui/app/models/token.js
@@ -38,4 +38,9 @@ export default class Token extends Model {
   get isGlobalManagement() {
     return (this.Policies || []).find(item => item.ID === MANAGEMENT_ID);
   }
+
+  @computed('SecretID')
+  get hasSecretID() {
+    return this.SecretID !== '' && this.SecretID !== '<hidden>';
+  }
 }

--- a/ui/packages/consul-ui/mock-api/v1/acl/tokens
+++ b/ui/packages/consul-ui/mock-api/v1/acl/tokens
@@ -15,6 +15,7 @@ ${ env('CONSUL_ACLS_LEGACY', false) ? `rpc error making call: rpc: can't find me
         return `
           {
             "AccessorID": "${i === 1 ? '00000000-0000-0000-0000-000000000002' : fake.random.uuid()}",
+            "SecretID": "${fake.helpers.randomize([fake.random.uuid(), '<hidden>', ''])}",
             "Name": "token-${i}",
 ${typeof location.search.ns !== 'undefined' ? `
             "Namespace": "${location.search.ns}",
@@ -22,7 +23,7 @@ ${typeof location.search.ns !== 'undefined' ? `
             "IDPName": "${fake.hacker.noun()}",
             "Policies": [
               ${
-                range(env('CONSUL_POLICY_COUNT', 10)).map(
+                range(env('CONSUL_POLICY_COUNT', 3)).map(
                   function(item, j) {
                     if(i == 1 && j == 0) {
                       return `
@@ -44,7 +45,7 @@ ${typeof location.search.ns !== 'undefined' ? `
             ],
             "Roles": [
               ${
-                range(env('CONSUL_ROLE_COUNT', 10)).map(
+                range(env('CONSUL_ROLE_COUNT', 3)).map(
                   function(item, j) {
                     return `
                       {

--- a/ui/packages/consul-ui/translations/common/en-us.yaml
+++ b/ui/packages/consul-ui/translations/common/en-us.yaml
@@ -38,6 +38,7 @@ consul:
   destinationname: Destination Name
   sourcename: Source Name
   displayname: Display Name
+  secretID: Secret ID
 search:
   search: Search
   searchproperty: Search Across

--- a/ui/packages/consul-ui/translations/common/en-us.yaml
+++ b/ui/packages/consul-ui/translations/common/en-us.yaml
@@ -38,7 +38,6 @@ consul:
   destinationname: Destination Name
   sourcename: Source Name
   displayname: Display Name
-  secretID: Secret ID
 search:
   search: Search
   searchproperty: Search Across

--- a/ui/packages/consul-ui/translations/components/consul/en-us.yaml
+++ b/ui/packages/consul-ui/translations/components/consul/en-us.yaml
@@ -52,6 +52,7 @@ token:
         global-management: Global Management
         global: Global Scope
         local: Local Scope
+  secretID: Secret ID
 policy:
   search-bar:
     kind:


### PR DESCRIPTION
### ✨  Description:
Adds a copy button to each composite row in tokens list page, if Secret ID returns an actual ID. 
Reuses the [CopyButton](https://github.com/hashicorp/consul/blob/main/ui/packages/consul-ui/app/components/copy-button/README.mdx) component and some conditional logic to flag Secret ID returning an empty string or `'<hidden>'`.
Adds secretID as a common consul translation.

Note: The styling changes did not impact the other composite rows with actions.

[Demo Link](https://consul-ui-staging-jbjn83adm-hashicorp.vercel.app/ui/dc1/acls/tokens#CONSUL_ACLS_ENABLE=1
)

### 📸  Screenshots:
<img width="1576" alt="Screen Shot 2021-07-30 at 10 35 35 AM" src="https://user-images.githubusercontent.com/19161242/127671050-9367983c-836e-4620-9280-9f52c0bfb91d.png">

### ⚡  Backend Changes:
Implemented in #10546.
In the backend, user permission are checked. 
If the user has the correct permission then the SecretID attribute returns an actual ID. 
If the user does not have the correct permissions `'<hiddlen>'` is returned.
It is rare but possible for SecretID to be an empty string. The endpoint would still return the attribute.

### 🤡 Updates to mock-api:
Updates made to /acl/tokens mock data.
Added SecretID attribute with 3 possible responses.
Updated the count of tokens and policies returned because it was making the composite row look very busy. 

Busy composite row:
<img width="1576" alt="Screen Shot 2021-07-30 at 10 34 56 AM" src="https://user-images.githubusercontent.com/19161242/127671892-3440aa84-abea-4922-aba7-1bd5d63f4b37.png">

### 🧪 Testing: 
No added tests. Simple conditional logic used and the CopyButton component has testing.

### 📌  Before merging: 
- [x] Changelog
- [x] Demo Link