### PR TITLE
config: add secure-defaults setting

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -758,8 +758,6 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		enableTokenReplication = true
 	}
 
-	boolValWithDefault(c.ACL.TokenReplication, boolValWithDefault(c.EnableACLReplication, enableTokenReplication))
-
 	enableRemoteScriptChecks := boolVal(c.EnableScriptChecks)
 	enableLocalScriptChecks := boolValWithDefault(c.EnableLocalScriptChecks, enableRemoteScriptChecks)
 
@@ -1130,6 +1128,12 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		rt.Bootstrap = true
 		rt.BootstrapExpect = 0
 		b.warn(`BootstrapExpect is set to 1; this is the same as Bootstrap mode.`)
+	}
+
+	if boolVal(c.SecureDefaults) {
+		if err := applyAndValidateSecureDefaults(&rt); err != nil {
+			return rt, fmt.Errorf("missing required value for secure defaults: %w", err)
+		}
 	}
 
 	return rt, nil

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -219,6 +219,7 @@ type Config struct {
 	RetryJoinMaxAttemptsLAN          *int                `mapstructure:"retry_max"`
 	RetryJoinMaxAttemptsWAN          *int                `mapstructure:"retry_max_wan"`
 	RetryJoinWAN                     []string            `mapstructure:"retry_join_wan"`
+	SecureDefaults                   *bool               `mapstructure:"secure_defaults"`
 	SerfAllowedCIDRsLAN              []string            `mapstructure:"serf_lan_allowed_cidrs"`
 	SerfAllowedCIDRsWAN              []string            `mapstructure:"serf_wan_allowed_cidrs"`
 	SerfBindAddrLAN                  *string             `mapstructure:"serf_lan"`

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -75,6 +75,7 @@ func AddFlags(fs *flag.FlagSet, f *LoadOpts) {
 	add(&f.FlagValues.RPCProtocol, "protocol", "Sets the protocol version. Defaults to latest.")
 	add(&f.FlagValues.RaftProtocol, "raft-protocol", "Sets the Raft protocol version. Defaults to latest.")
 	add(&f.FlagValues.DNSRecursors, "recursor", "Address of an upstream DNS server. Can be specified multiple times.")
+	add(&f.FlagValues.SecureDefaults, "secure-defaults", "Enable all security setting.")
 	add(&f.FlagValues.PrimaryGateways, "primary-gateway", "Address of a mesh gateway in the primary datacenter to use to bootstrap WAN federation at start time with retries enabled. Can be specified multiple times.")
 	add(&f.FlagValues.RejoinAfterLeave, "rejoin", "Ignores a previous leave and attempts to rejoin the cluster.")
 	add(&f.FlagValues.RetryJoinIntervalLAN, "retry-interval", "Time to wait between join attempts.")

--- a/agent/config/secure_defaults.go
+++ b/agent/config/secure_defaults.go
@@ -1,0 +1,57 @@
+package config
+
+import "fmt"
+
+// TODO: auto-encrypt may set some of these, so make an exception for things set
+// by auto-encrypt when it is enabled.
+func applyAndValidateSecureDefaults(rt *RuntimeConfig) error {
+	// Agent TLS
+	rt.VerifyOutgoing = true
+	rt.VerifyIncoming = true
+	rt.VerifyServerHostname = true
+	if rt.CAPath == "" && rt.CAFile == "" {
+		return fmt.Errorf("one of ca_file or ca_path must be specified")
+	}
+	if rt.CertFile == "" || rt.KeyFile == "" {
+		return fmt.Errorf("both cert_file and key_file must be specified")
+	}
+	// TODO: test cases for this
+	if rt.TLSMinVersion < "tls12" {
+		return fmt.Errorf("TLS minimum version must be at least tls1.2")
+	}
+
+	// Gossip
+	rt.EncryptVerifyIncoming = true
+	rt.EncryptVerifyOutgoing = true
+	// TODO: technically should not required, because it gets saved by the keyring
+	// TODO: when not specified, set some other field that can be checked later
+	// to ensure a key is set in the keyring.
+	if rt.EncryptKey == "" {
+		return fmt.Errorf("encrypt is required to secure gossip communication")
+	}
+
+	// ACLs
+	rt.ACLsEnabled = true
+	rt.ACLDefaultPolicy = "deny"
+	if rt.ACLDownPolicy == "allow" {
+		return fmt.Errorf(`acl.down_policy must not be set to "allow"`)
+	}
+	// TODO: rt.ACLEnableKeyListPolicy ?
+	// TODO: acl.tokens
+
+	// Ports
+	// TODO: allow HTTPPort if address is localhost
+	rt.HTTPPort = -1
+	if rt.HTTPSPort <= 0 {
+		return fmt.Errorf("ports.https is required")
+	}
+
+	// Misc
+	rt.EnableRemoteScriptChecks = false
+	rt.DisableRemoteExec = true
+
+	// TODO: require telemetry
+
+	// TODO: any additional validation when PrimaryDatacenter != Datacenter?
+	return nil
+}

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -232,8 +232,8 @@ The options below are all specified on the command-line.
   they are defined in the local configuration files. Script checks defined in HTTP
   API registrations will still not be allowed.
 
-- `-encrypt` ((#\_encrypt)) - Specifies the secret key to use for encryption
-  of Consul network traffic. This key must be 32-bytes that are Base64-encoded. The
+- `-encrypt` ((#\_encrypt)) - the secret key used to encrypt and decrypt 
+  gossip network traffic. This key must be 32-bytes that are Base64-encoded. The
   easiest way to create an encryption key is to use [`consul keygen`](/commands/keygen).
   All nodes within a cluster must share the same encryption key to communicate. The
   provided key is automatically persisted to the data directory and loaded automatically


### PR DESCRIPTION
This is a quick spike to demonstrate the idea of a `-secure-defaults` setting.

The setting would force enable a bunch of settings required for a secure setup (ex: ACLs enabled), and would make others required (ex: an agent TLS cert and key).