### PR TITLE
website: Add redirect for /connect/ingress-gateways

### DIFF
--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -103,6 +103,11 @@ module.exports = [
     permanent: true,
   },
   {
+    source: '/docs/connect/ingress-gateways',
+    destination: '/docs/connect/gateways/ingress-gateway',
+    permanent: true,
+  },
+  {
     source: '/docs/connect/terminating(_|-)gateway',
     destination: '/docs/connect/gateways/terminating-gateway',
     permanent: true,


### PR DESCRIPTION
Add redirect [/docs/connect/ingress-gateways](https://www.consul.io/docs/connect/ingress-gateways), which currently returns
404, to [/docs/connect/gateways/ingress-gateway](https://www.consul.io/docs/connect/gateways/ingress-gateway).

Fixes #10748