### PR TITLE
cli: Use admin bind address in self_admin cluster

### DIFF
--- a/.changelog/10757.txt
+++ b/.changelog/10757.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Ensure the metrics endpoint is accessible when Envoy is configured to use
+a non-default admin bind address.
+```

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -579,6 +579,7 @@ func (c *BootstrapConfig) generateListenerConfig(args *BootstrapTplArgs, bindAdd
 	// metrics. This cluster will only be created once since it's only created
 	// when prometheusBackendPort is set, and prometheusBackendPort is only set
 	// when calling this function if c.PrometheusBindAddr is set.
+	clusterAddress := args.AdminBindAddress
 	clusterPort := args.AdminBindPort
 	clusterName := selfAdminName
 	if prometheusBackendPort != "" {
@@ -601,7 +602,7 @@ func (c *BootstrapConfig) generateListenerConfig(args *BootstrapTplArgs, bindAdd
 							"endpoint": {
 								"address": {
 									"socket_address": {
-										"address": "127.0.0.1",
+										"address": "` + clusterAddress + `",
 										"port_value": ` + clusterPort + `
 									}
 								}

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -38,6 +38,32 @@ const (
     ]
   }
 }`
+	expectedSelfAdminClusterNonLoopbackIP = `{
+  "name": "self_admin",
+  "ignore_health_on_host_removal": false,
+  "connect_timeout": "5s",
+  "type": "STATIC",
+  "http_protocol_options": {},
+  "loadAssignment": {
+    "clusterName": "self_admin",
+    "endpoints": [
+      {
+        "lbEndpoints": [
+          {
+            "endpoint": {
+              "address": {
+                "socket_address": {
+                  "address": "192.0.2.10",
+                  "port_value": 19002
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}`
 	expectedPrometheusBackendCluster = `{
   "name": "prometheus_backend",
   "ignore_health_on_host_removal": false,
@@ -642,6 +668,28 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 				AdminBindPort:    "19000",
 				// Should add a static cluster for the self-proxy to admin
 				StaticClustersJSON: expectedSelfAdminCluster,
+				// Should add a static http listener too
+				StaticListenersJSON:  expectedPromListener,
+				StatsConfigJSON:      defaultStatsConfigJSON,
+				PrometheusScrapePath: "/metrics",
+			},
+			wantErr: false,
+		},
+		{
+			name: "prometheus-bind-addr-non-loopback-ip",
+			input: BootstrapConfig{
+				PrometheusBindAddr: "0.0.0.0:9000",
+			},
+			baseArgs: BootstrapTplArgs{
+				AdminBindAddress:     "192.0.2.10",
+				AdminBindPort:        "19002",
+				PrometheusScrapePath: "/metrics",
+			},
+			wantArgs: BootstrapTplArgs{
+				AdminBindAddress: "192.0.2.10",
+				AdminBindPort:    "19002",
+				// Should add a static cluster for the self-proxy to admin
+				StaticClustersJSON: expectedSelfAdminClusterNonLoopbackIP,
 				// Should add a static http listener too
 				StaticListenersJSON:  expectedPromListener,
 				StatsConfigJSON:      defaultStatsConfigJSON,


### PR DESCRIPTION
Configure the self_admin cluster to use the admin bind address provided when starting Envoy.

Fixes #10747