### PR TITLE
Fixup to support unix domain socket via command line

### DIFF
--- a/.changelog/10758.txt
+++ b/.changelog/10758.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+connect: add support for unix domain socket config via API/CLI
+```

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -256,6 +256,7 @@ func buildAgentService(s *structs.NodeService, dc string) api.AgentService {
 		Meta:              s.Meta,
 		Port:              s.Port,
 		Address:           s.Address,
+		SocketPath:        s.SocketPath,
 		TaggedAddresses:   taggedAddrs,
 		EnableTagOverride: s.EnableTagOverride,
 		CreateIndex:       s.CreateIndex,

--- a/api/agent.go
+++ b/api/agent.go
@@ -263,6 +263,7 @@ type AgentServiceRegistration struct {
 	Tags              []string                  `json:",omitempty"`
 	Port              int                       `json:",omitempty"`
 	Address           string                    `json:",omitempty"`
+	SocketPath        string                    `json:",omitempty"`
 	TaggedAddresses   map[string]ServiceAddress `json:",omitempty"`
 	EnableTagOverride bool                      `json:",omitempty"`
 	Meta              map[string]string         `json:",omitempty"`

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -626,6 +626,46 @@ func TestAPI_AgentServiceAddress(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 }
+func TestAPI_AgentServiceSocket(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	agent := c.Agent()
+
+	reg1 := &AgentServiceRegistration{
+		Name:    "foo1",
+		Port:    8000,
+		Address: "192.168.0.42",
+	}
+	reg2 := &AgentServiceRegistration{
+		Name:       "foo2",
+		SocketPath: "/tmp/foo2.sock",
+	}
+
+	if err := agent.ServiceRegister(reg1); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := agent.ServiceRegister(reg2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	services, err := agent.Services()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	require.Contains(t, services, "foo1", "missing service foo1")
+	require.Contains(t, services, "foo2", "missing service foo2")
+
+	require.Equal(t, "192.168.0.42", services["foo1"].Address,
+		"missing Address field in service foo1: %v", services["foo1"])
+
+	require.Equal(t, "", services["foo2"].Address,
+		"unexpected Address field in service foo1: %v", services["foo2"])
+	require.Equal(t, "/tmp/foo2.sock", services["foo2"].SocketPath,
+		"missing SocketPath field in service foo1: %v", services["foo2"])
+}
 
 func TestAPI_AgentEnableTagOverride(t *testing.T) {
 	t.Parallel()

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -782,6 +782,7 @@ func TestAPI_CatalogNodeServiceList(t *testing.T) {
 
 		if proxySvc == nil {
 			r.Fatalf("Missing proxy service: %v", info.Services)
+			return
 		}
 
 		if !reflect.DeepEqual(proxyReg.Service.Proxy, proxySvc.Proxy) {

--- a/command/services/register/register.go
+++ b/command/services/register/register.go
@@ -28,6 +28,7 @@ type cmd struct {
 	flagName            string
 	flagAddress         string
 	flagPort            int
+	flagSocketPath      string
 	flagTags            []string
 	flagMeta            map[string]string
 	flagTaggedAddresses map[string]string
@@ -44,6 +45,8 @@ func (c *cmd) init() {
 		"Address of the service to register for arg-based registration.")
 	c.flags.IntVar(&c.flagPort, "port", 0,
 		"Port of the service to register for arg-based registration.")
+	c.flags.StringVar(&c.flagSocketPath, "socket", "",
+		"Path to the Unix domain socket to register for arg-based registration (conflicts with address and port).")
 	c.flags.Var((*flags.FlagMapValue)(&c.flagMeta), "meta",
 		"Metadata to set on the service, formatted as key=value. This flag "+
 			"may be specified multiple times to set multiple meta fields.")
@@ -86,6 +89,7 @@ func (c *cmd) Run(args []string) int {
 		Name:            c.flagName,
 		Address:         c.flagAddress,
 		Port:            c.flagPort,
+		SocketPath:      c.flagSocketPath,
 		Tags:            c.flagTags,
 		Meta:            c.flagMeta,
 		TaggedAddresses: taggedAddrs,

--- a/website/content/commands/services/register.mdx
+++ b/website/content/commands/services/register.mdx
@@ -74,6 +74,8 @@ Please refer to that documentation for full details.
 
 - `-port` - The port of the service.
 
+- `-socket` - The Unix Domain socket of the service. Conflicts with address and port flags.
+
 - `-meta key=value` - Specify arbitrary KV metadata to associate with the
   service instance. This can be specified multiple times.
 


### PR DESCRIPTION
Fix missed code to support unix domain sockets over command line. Also fixed error in rendering in services API.

Signed-off-by: Mark Anderson <manderson@hashicorp.com>