### PR TITLE
docs: Fix service checks docs on session endpoint

### DIFF
--- a/website/content/api-docs/session.mdx
+++ b/website/content/api-docs/session.mdx
@@ -57,8 +57,14 @@ The table below shows this endpoint's support for
   if you override this list, you include the default `serfHealth`. Added in
   Consul 1.7.0.
 
-- `ServiceChecks` `(array<string>: nil)` - Specifies a list of service health
-  check IDs (commonly `CheckID` in API responses). Added in Consul 1.7.0.
+- `ServiceChecks` `(array<ServiceCheck>: nil)` - Specifies a list of service
+  checks. Added in Consul 1.7.0.
+
+  - `ID` `(string: <required>)` - The ID of the service check to monitor
+    (commonly `CheckID` in API responses).
+
+  - `Namespace` `(string: "")` <EnterpriseAlert inline /> - Specifies the
+    namespace in which to resolve the service check ID.
 
 - `Behavior` `(string: "release")` - Controls the behavior to take when a
   session is invalidated. Valid values are:

--- a/website/content/api-docs/session.mdx
+++ b/website/content/api-docs/session.mdx
@@ -58,7 +58,7 @@ The table below shows this endpoint's support for
   Consul 1.7.0.
 
 - `ServiceChecks` `(array<ServiceCheck>: nil)` - Specifies a list of service
-  checks. Added in Consul 1.7.0.
+  checks. Added in Consul 1.7.0. A service check has the following fields:
 
   - `ID` `(string: <required>)` - The ID of the service check to monitor
     (commonly `CheckID` in API responses).


### PR DESCRIPTION
The ServiceChecks parameter was incorrectly documented in e515c9d44 to state that it accepted a list of string values, when actually the API requires an array of ServiceCheck objects.

This commit updates the docs for the parameter to correctly reflect the fields required by the API.

Resolves #10752