### PR TITLE
ui: Fix Health Checks in K/V form Lock Sessions Info section

### DIFF
--- a/.changelog/10767.txt
+++ b/.changelog/10767.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix Health Checks in K/V form Lock Sessions Info section
+```

--- a/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
@@ -32,7 +32,7 @@
           <dd>{{or api.data.TTL '-'}}</dd>
           <dt>Behavior</dt>
           <dd>{{api.data.Behavior}}</dd>
-{{#let (union api.data.NodeChecks api.data.ServiceChecks) as |checks|}}
+{{#let api.data.checks as |checks|}}
           <dt>Health Checks</dt>
           <dd>
   {{#if (gt checks.length 0)}}

--- a/ui/packages/consul-ui/app/models/session.js
+++ b/ui/packages/consul-ui/app/models/session.js
@@ -1,4 +1,5 @@
 import Model, { attr } from '@ember-data/model';
+import { computed } from '@ember/object';
 import { nullValue } from 'consul-ui/decorators/replace';
 
 export const PRIMARY_KEY = 'uid';
@@ -23,4 +24,9 @@ export default class Session extends Model {
   @nullValue([]) @attr({ defaultValue: () => [] }) ServiceChecks;
 
   @attr({ defaultValue: () => [] }) Resources; // []
+
+  @computed('NodeChecks', 'ServiceChecks')
+  get checks() {
+    return [...this.NodeChecks, ...this.ServiceChecks.map(item => item.ID)];
+  }
 }

--- a/ui/packages/consul-ui/app/models/session.js
+++ b/ui/packages/consul-ui/app/models/session.js
@@ -27,6 +27,6 @@ export default class Session extends Model {
 
   @computed('NodeChecks', 'ServiceChecks')
   get checks() {
-    return [...this.NodeChecks, ...this.ServiceChecks.map(item => item.ID)];
+    return [...this.NodeChecks, ...this.ServiceChecks.map(({ ID }) => ID)];
   }
 }

--- a/ui/packages/consul-ui/mock-api/v1/session/info/_
+++ b/ui/packages/consul-ui/mock-api/v1/session/info/_
@@ -8,7 +8,15 @@
         }",
         "Node":"node-1",
         "NodeChecks":["serfHealth"],
-        "ServiceChecks": ["${fake.hacker.noun()}Health"],
+        "ServiceChecks": [
+            {
+                "ID": "${fake.hacker.noun()}Health",
+                "Namespace": "${
+                typeof location.search.ns !== 'undefined' ? location.search.ns :
+                    typeof http.body.Namespace !== 'undefined' ? http.body.Namespace : 'default'
+                }"
+            }
+        ],
         "LockDelay":15000000000,
         "Behavior":"${fake.helpers.randomize(['release', 'delete'])}",
         "TTL":"",


### PR DESCRIPTION
### Description:
Resolves #10754. The `ServiceChecks` attribute formatting was outdated in the Lock Session endpoint API docs and in the UI mock data.

[Demo Link](https://consul-ui-staging-ioqavlpji-hashicorp.vercel.app/ui/dc1/kv/0-key-value/edit)

### Solution:
- API Docs were updated in #10759 . 
- UI mock data is update in this PR to match the [update docs](https://www.consul.io/api-docs/session#servicechecks).
- We grab all "ID" values from ServiceChecks objects and merged them with the [NodeChecks array](https://www.consul.io/api-docs/session#nodechecks). NodeChecks and ServiceChecks will unlikely have the same name, but if they do we will display them all.

### Screenshots:
Before:
<img width="518" alt="Screen Shot 2021-08-04 at 9 18 34 AM" src="https://user-images.githubusercontent.com/19161242/128197466-a07eb53e-88ac-45aa-a5fa-0e5b2bc70535.png">

After:
<img width="520" alt="Screen Shot 2021-08-04 at 9 11 25 AM" src="https://user-images.githubusercontent.com/19161242/128197469-15e34589-24ec-4c2f-ae08-65c6eface43f.png">

### Testing:
No additional testing. This change was not about integration, but on reading the response properly.

- [x]  Backport
- [x]  Changelog
- [x] Demo Link