### PR TITLE
telemetry: add log message when certs are about to expire

### DIFF
--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -140,6 +140,12 @@ func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
 				logger.Warn("failed to emit certificate expiry metric", "error", err)
 				continue
 			}
+
+			if d < 24*time.Hour {
+				logger.Warn("certificate will expire soon",
+					"time_to_expiry", d, "expiration", time.Now().Add(d))
+			}
+
 			expiry := d / time.Second
 			metrics.SetGaugeWithLabels(m.Key, float32(expiry), m.Labels)
 		}


### PR DESCRIPTION
Branched from #10768
Closes #9891

Adds a warning log when any of the monitored certificates are within 1 day of expiration. Ideally the metrics should be used to monitor the expiration, but these logs will help in case the metrics are not being monitored correctly.