### PR TITLE
telemetry: improve cert expiry metrics

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -667,7 +667,7 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	if a.tlsConfigurator.Cert() != nil {
-		m := consul.AgentTLSCertExpirationMonitor(a.tlsConfigurator, a.logger, a.config.Datacenter)
+		m := consul.AgentTLSCertExpirationMonitor(a.tlsConfigurator, a.logger)
 		go m.Monitor(&lib.StopChannelContext{StopCh: a.shutdownCh})
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -667,7 +667,7 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 
 	if a.tlsConfigurator.Cert() != nil {
-		m := consul.AgentTLSCertExpirationMonitor(a.tlsConfigurator, a.logger)
+		m := tlsCertExpirationMonitor(a.tlsConfigurator, a.logger)
 		go m.Monitor(&lib.StopChannelContext{StopCh: a.shutdownCh})
 	}
 

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -156,6 +157,9 @@ func (m CertExpirationMonitor) Monitor(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			// "Zero-out" the metric on exit so that when prometheus scrapes this
+			// metric from a non-leader, it does not get a stale value.
+			metrics.SetGauge(m.Key, float32(math.NaN()))
 			return nil
 		case <-ticker.C:
 			fn()

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -169,7 +169,7 @@ var metricsKeyAgentTLSCertExpiry = []string{"agent", "tls", "cert", "expiry"}
 
 // AgentTLSCertExpirationMonitor returns a CertExpirationMonitor which will
 // monitor the expiration of the certificate used for agent TLS.
-func AgentTLSCertExpirationMonitor(c *tlsutil.Configurator, logger hclog.Logger, dc string) CertExpirationMonitor {
+func AgentTLSCertExpirationMonitor(c *tlsutil.Configurator, logger hclog.Logger) CertExpirationMonitor {
 	return CertExpirationMonitor{
 		Key:    metricsKeyAgentTLSCertExpiry,
 		Logger: logger,
@@ -185,5 +185,14 @@ func AgentTLSCertExpirationMonitor(c *tlsutil.Configurator, logger hclog.Logger,
 			}
 			return time.Until(cert.NotAfter), nil
 		},
+	}
+}
+
+// initLeaderMetrics sets all metrics that are emitted only on leaders to a NaN
+// value so that they don't incorrectly report 0 when a server starts as a
+// follower.
+func initLeaderMetrics() {
+	for _, g := range LeaderCertExpirationGauges {
+		metrics.SetGaugeWithLabels(g.Name, float32(math.NaN()), g.ConstLabels)
 	}
 }

--- a/agent/consul/leader_metrics.go
+++ b/agent/consul/leader_metrics.go
@@ -22,7 +22,7 @@ import (
 var metricsKeyMeshRootCAExpiry = []string{"mesh", "active-root-ca", "expiry"}
 var metricsKeyMeshActiveSigningCAExpiry = []string{"mesh", "active-signing-ca", "expiry"}
 
-var CertExpirationGauges = []prometheus.GaugeDefinition{
+var LeaderCertExpirationGauges = []prometheus.GaugeDefinition{
 	{
 		Name: metricsKeyMeshRootCAExpiry,
 		Help: "Seconds until the service mesh root certificate expires. Updated every hour",
@@ -31,6 +31,9 @@ var CertExpirationGauges = []prometheus.GaugeDefinition{
 		Name: metricsKeyMeshActiveSigningCAExpiry,
 		Help: "Seconds until the service mesh signing certificate expires. Updated every hour",
 	},
+}
+
+var AgentCertExpirationGauges = []prometheus.GaugeDefinition{
 	{
 		Name: metricsKeyAgentTLSCertExpiry,
 		Help: "Seconds until the agent tls certificate expires. Updated every hour",

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -389,6 +389,8 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 		return nil, err
 	}
 
+	initLeaderMetrics()
+
 	s.rpcLimiter.Store(rate.NewLimiter(config.RPCRateLimit, config.RPCMaxBurst))
 
 	configReplicatorConfig := ReplicatorConfig{

--- a/agent/metrics.go
+++ b/agent/metrics.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/armon/go-metrics/prometheus"
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/agent/consul"
+	"github.com/hashicorp/consul/tlsutil"
+)
+
+var CertExpirationGauges = []prometheus.GaugeDefinition{
+	{
+		Name: metricsKeyAgentTLSCertExpiry,
+		Help: "Seconds until the agent tls certificate expires. Updated every hour",
+	},
+}
+
+var metricsKeyAgentTLSCertExpiry = []string{"agent", "tls", "cert", "expiry"}
+
+// tlsCertExpirationMonitor returns a CertExpirationMonitor which will
+// monitor the expiration of the certificate used for agent TLS.
+func tlsCertExpirationMonitor(c *tlsutil.Configurator, logger hclog.Logger) consul.CertExpirationMonitor {
+	return consul.CertExpirationMonitor{
+		Key:    metricsKeyAgentTLSCertExpiry,
+		Logger: logger,
+		Query: func() (time.Duration, error) {
+			raw := c.Cert()
+			if raw == nil {
+				return 0, fmt.Errorf("tls not enabled")
+			}
+
+			cert, err := x509.ParseCertificate(raw.Certificate[0])
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse agent tls cert: %w", err)
+			}
+			return time.Until(cert.NotAfter), nil
+		},
+	}
+}

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -1,20 +1,29 @@
 package agent
 
 import (
-	"github.com/stretchr/testify/require"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/tlsutil"
+
+	"github.com/stretchr/testify/require"
 )
 
-func checkForShortTesting(t *testing.T) {
+func skipIfShortTesting(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 }
 
 func recordPromMetrics(t *testing.T, a *TestAgent, respRec *httptest.ResponseRecorder) {
+	t.Helper()
 	req, err := http.NewRequest("GET", "/v1/agent/metrics?format=prometheus", nil)
 	require.NoError(t, err, "Failed to generate new http request.")
 
@@ -49,7 +58,7 @@ func assertMetricNotExists(t *testing.T, respRec *httptest.ResponseRecorder, met
 // TestHTTPHandlers_AgentMetrics_ConsulAutopilot_Prometheus adds testing around
 // the published autopilot metrics on https://www.consul.io/docs/agent/telemetry#autopilot
 func TestHTTPHandlers_AgentMetrics_ConsulAutopilot_Prometheus(t *testing.T) {
-	checkForShortTesting(t)
+	skipIfShortTesting(t)
 	// This test cannot use t.Parallel() since we modify global state, ie the global metrics instance
 
 	t.Run("Check consul_autopilot_* are not emitted metrics on clients", func(t *testing.T) {
@@ -94,4 +103,56 @@ func TestHTTPHandlers_AgentMetrics_ConsulAutopilot_Prometheus(t *testing.T) {
 		assertMetricExistsWithValue(t, respRec, "agent_2_autopilot_healthy", "NaN")
 		assertMetricExistsWithValue(t, respRec, "agent_2_autopilot_failure_tolerance", "NaN")
 	})
+}
+
+func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
+	skipIfShortTesting(t)
+	// This test cannot use t.Parallel() since we modify global state, ie the global metrics instance
+
+	dir := testutil.TempDir(t, "ca")
+	caPEM, caPK, err := tlsutil.GenerateCA(tlsutil.CAOpts{Days: 20, Domain: "consul"})
+	require.NoError(t, err)
+
+	caPath := filepath.Join(dir, "ca.pem")
+	err = ioutil.WriteFile(caPath, []byte(caPEM), 0600)
+	require.NoError(t, err)
+
+	signer, err := tlsutil.ParseSigner(caPK)
+	require.NoError(t, err)
+
+	pem, key, err := tlsutil.GenerateCert(tlsutil.CertOpts{
+		Signer:      signer,
+		CA:          caPEM,
+		Name:        "server.dc1.consul",
+		Days:        20,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	require.NoError(t, err)
+
+	certPath := filepath.Join(dir, "cert.pem")
+	err = ioutil.WriteFile(certPath, []byte(pem), 0600)
+	require.NoError(t, err)
+
+	keyPath := filepath.Join(dir, "cert.key")
+	err = ioutil.WriteFile(keyPath, []byte(key), 0600)
+	require.NoError(t, err)
+
+	hcl := fmt.Sprintf(`
+		telemetry = {
+			prometheus_retention_time = "5s",
+			disable_hostname = true
+			metrics_prefix = "agent_3"
+		}
+		ca_file = "%s"
+		cert_file = "%s"
+		key_file = "%s"
+	`, caPath, certPath, keyPath)
+
+	a := StartTestAgent(t, TestAgent{HCL: hcl})
+	defer a.Shutdown()
+
+	respRec := httptest.NewRecorder()
+	recordPromMetrics(t, a, respRec)
+
+	require.Contains(t, respRec.Body.String(), "agent_3_agent_tls_cert_expiry 1.7")
 }

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -211,14 +211,16 @@ func getPrometheusDefs(cfg lib.TelemetryConfig, isServer bool) ([]prometheus.Gau
 		xds.StatsGauges,
 		usagemetrics.Gauges,
 		consul.ReplicationGauges,
-		consul.CertExpirationGauges,
+		consul.AgentCertExpirationGauges,
 		Gauges,
 		raftGauges,
 	}
 
 	// TODO(ffmmm): conditionally add only leader specific metrics to gauges, counters, summaries, etc
 	if isServer {
-		gauges = append(gauges, consul.AutopilotGauges)
+		gauges = append(gauges,
+			consul.AutopilotGauges,
+			consul.LeaderCertExpirationGauges)
 	}
 
 	// Flatten definitions

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -211,7 +211,7 @@ func getPrometheusDefs(cfg lib.TelemetryConfig, isServer bool) ([]prometheus.Gau
 		xds.StatsGauges,
 		usagemetrics.Gauges,
 		consul.ReplicationGauges,
-		consul.AgentCertExpirationGauges,
+		CertExpirationGauges,
 		Gauges,
 		raftGauges,
 	}


### PR DESCRIPTION
Related to some improvements suggested here: https://github.com/hashicorp/consul/pull/10768#discussion_r682871038

Emit the metric immediately so that after restarting an agent, the new expiry time will be
emitted. This is particularly important when this metric is being monitored, because we want
the alert to resovle itself immediately.

Fixed a bug that was exposed in one of these metrics. The CARoot can be nil, so we have
to handle that case.

Removed the labels. With the labels these metrics would not match the predefined metric, and the prometheus sink would expire them long before they were emitted again. It should be the responsibility of agent or tool that pulls these metrics to add node and dc tags.

Only declare these metrics on servers, and emit a NaN when a server starts so that it only has a value on leaders. Otherwise attempting to use this metric in a monitor would be challenging because followers would always report 0.

TODO:
* [x] handle "erasing" the metrics from non-leaders so that when a server transitions from leader to follower prometheus sees the correct data.
* [x] test the "emit NaN value" as a fix for above