### PR TITLE
acl: use authz consistently as the variable name for an acl.Authorizer

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -141,7 +141,7 @@ func (a *Agent) vetCheckUpdateWithAuthorizer(authz acl.Authorizer, checkID struc
 // filterMembers redacts members that the token doesn't have access to.
 func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 	// Resolve the token and bail if ACLs aren't enabled.
-	rule, err := a.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := a.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 	m := *members
 	for i := 0; i < len(m); i++ {
 		node := m[i].Name
-		if rule.NodeRead(node, &authzContext) == acl.Allow {
+		if authz.NodeRead(node, &authzContext) == acl.Allow {
 			continue
 		}
 		accessorID := a.aclAccessorID(token)

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -104,13 +104,13 @@ func (s *HTTPHandlers) ACLRulesTranslate(resp http.ResponseWriter, req *http.Req
 
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 	// Should this require lesser permissions? Really the only reason to require authorization at all is
 	// to prevent external entities from DoS Consul with repeated rule translation requests
-	if rule.ACLRead(nil) != acl.Allow {
+	if authz.ACLRead(nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -51,11 +51,11 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.AgentRead(s.agent.config.NodeName, nil) != acl.Allow {
+	if authz.AgentRead(s.agent.config.NodeName, nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -140,11 +140,11 @@ func (s *HTTPHandlers) AgentMetrics(resp http.ResponseWriter, req *http.Request)
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.AgentRead(s.agent.config.NodeName, nil) != acl.Allow {
+	if authz.AgentRead(s.agent.config.NodeName, nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 	if enablePrometheusOutput(req) {
@@ -171,11 +171,11 @@ func (s *HTTPHandlers) AgentMetricsStream(resp http.ResponseWriter, req *http.Re
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	switch {
 	case err != nil:
 		return nil, err
-	case rule.AgentRead(s.agent.config.NodeName, nil) != acl.Allow:
+	case authz.AgentRead(s.agent.config.NodeName, nil) != acl.Allow:
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -220,11 +220,11 @@ func (s *HTTPHandlers) AgentReload(resp http.ResponseWriter, req *http.Request) 
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
+	if authz.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -509,11 +509,11 @@ func (s *HTTPHandlers) AgentJoin(resp http.ResponseWriter, req *http.Request) (i
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
+	if authz.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -541,11 +541,11 @@ func (s *HTTPHandlers) AgentLeave(resp http.ResponseWriter, req *http.Request) (
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
+	if authz.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -559,11 +559,11 @@ func (s *HTTPHandlers) AgentForceLeave(resp http.ResponseWriter, req *http.Reque
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.OperatorWrite(nil) != acl.Allow {
+	if authz.OperatorWrite(nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -1195,11 +1195,11 @@ func (s *HTTPHandlers) AgentNodeMaintenance(resp http.ResponseWriter, req *http.
 	// Get the provided token, if any, and vet against any ACL policies.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.NodeWrite(s.agent.config.NodeName, nil) != acl.Allow {
+	if authz.NodeWrite(s.agent.config.NodeName, nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -1216,11 +1216,11 @@ func (s *HTTPHandlers) AgentMonitor(resp http.ResponseWriter, req *http.Request)
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.AgentRead(s.agent.config.NodeName, nil) != acl.Allow {
+	if authz.AgentRead(s.agent.config.NodeName, nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -1295,11 +1295,11 @@ func (s *HTTPHandlers) AgentToken(resp http.ResponseWriter, req *http.Request) (
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	if rule.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
+	if authz.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 
@@ -1472,12 +1472,12 @@ func (s *HTTPHandlers) AgentHost(resp http.ResponseWriter, req *http.Request) (i
 	// Fetch the ACL token, if any, and enforce agent policy.
 	var token string
 	s.parseToken(req, &token)
-	rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+	authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if rule.OperatorRead(nil) != acl.Allow {
+	if authz.OperatorRead(nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 

--- a/agent/consul/acl_endpoint_legacy.go
+++ b/agent/consul/acl_endpoint_legacy.go
@@ -167,9 +167,9 @@ func (a *ACL) Apply(args *structs.ACLRequest, reply *string) error {
 
 	// Verify token is permitted to modify ACLs
 	// NOTE: We will not support enterprise authorizer contexts with legacy ACLs
-	if rule, err := a.srv.ResolveToken(args.Token); err != nil {
+	if authz, err := a.srv.ResolveToken(args.Token); err != nil {
 		return err
-	} else if rule.ACLWrite(nil) != acl.Allow {
+	} else if authz.ACLWrite(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 
@@ -259,9 +259,9 @@ func (a *ACL) List(args *structs.DCSpecificRequest,
 	// Verify token is permitted to list ACLs
 	// NOTES: Previously with legacy ACL there was no read-only ACL permissions
 	// and this check for ACLWrite is basically what it did before.
-	if rule, err := a.srv.ResolveToken(args.Token); err != nil {
+	if authz, err := a.srv.ResolveToken(args.Token); err != nil {
 		return err
-	} else if rule.ACLWrite(nil) != acl.Allow {
+	} else if authz.ACLWrite(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -61,11 +61,11 @@ func (s *ConnectCA) ConfigurationGet(
 	}
 
 	// This action requires operator read access.
-	rule, err := s.srv.ResolveToken(args.Token)
+	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if rule.OperatorWrite(nil) != acl.Allow {
+	if authz.OperatorWrite(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 
@@ -93,11 +93,11 @@ func (s *ConnectCA) ConfigurationSet(
 	}
 
 	// This action requires operator write access.
-	rule, err := s.srv.ResolveToken(args.Token)
+	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if rule.OperatorWrite(nil) != acl.Allow {
+	if authz.OperatorWrite(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 
@@ -158,7 +158,7 @@ func (s *ConnectCA) Sign(
 	}
 
 	// Verify that the ACL token provided has permission to act as this service
-	rule, err := s.srv.ResolveToken(args.Token)
+	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func (s *ConnectCA) Sign(
 	if isService {
 		entMeta.Merge(serviceID.GetEnterpriseMeta())
 		entMeta.FillAuthzContext(&authzContext)
-		if rule.ServiceWrite(serviceID.Service, &authzContext) != acl.Allow {
+		if authz.ServiceWrite(serviceID.Service, &authzContext) != acl.Allow {
 			return acl.ErrPermissionDenied
 		}
 
@@ -188,7 +188,7 @@ func (s *ConnectCA) Sign(
 	} else if isAgent {
 
 		structs.DefaultEnterpriseMetaInDefaultPartition().FillAuthzContext(&authzContext)
-		if rule.NodeWrite(agentID.Agent, &authzContext) != acl.Allow {
+		if authz.NodeWrite(agentID.Agent, &authzContext) != acl.Allow {
 			return acl.ErrPermissionDenied
 		}
 	}
@@ -220,11 +220,11 @@ func (s *ConnectCA) SignIntermediate(
 	}
 
 	// This action requires operator write access.
-	rule, err := s.srv.ResolveToken(args.Token)
+	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if rule.OperatorWrite(nil) != acl.Allow {
+	if authz.OperatorWrite(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 

--- a/agent/consul/discovery_chain_endpoint.go
+++ b/agent/consul/discovery_chain_endpoint.go
@@ -31,11 +31,11 @@ func (c *DiscoveryChain) Get(args *structs.DiscoveryChainRequest, reply *structs
 	// Fetch the ACL token, if any.
 	entMeta := args.GetEnterpriseMeta()
 	var authzContext acl.AuthorizerContext
-	rule, err := c.srv.ResolveTokenAndDefaultMeta(args.Token, entMeta, &authzContext)
+	authz, err := c.srv.ResolveTokenAndDefaultMeta(args.Token, entMeta, &authzContext)
 	if err != nil {
 		return err
 	}
-	if rule.ServiceRead(args.Name, &authzContext) != acl.Allow {
+	if authz.ServiceRead(args.Name, &authzContext) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 

--- a/agent/consul/federation_state_endpoint.go
+++ b/agent/consul/federation_state_endpoint.go
@@ -59,11 +59,11 @@ func (c *FederationState) Apply(args *structs.FederationStateRequest, reply *boo
 	defer metrics.MeasureSince([]string{"federation_state", "apply"}, time.Now())
 
 	// Fetch the ACL token, if any.
-	rule, err := c.srv.ResolveToken(args.Token)
+	authz, err := c.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if rule.OperatorWrite(nil) != acl.Allow {
+	if authz.OperatorWrite(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 
@@ -105,11 +105,11 @@ func (c *FederationState) Get(args *structs.FederationStateQuery, reply *structs
 	defer metrics.MeasureSince([]string{"federation_state", "get"}, time.Now())
 
 	// Fetch the ACL token, if any.
-	rule, err := c.srv.ResolveToken(args.Token)
+	authz, err := c.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if rule.OperatorRead(nil) != acl.Allow {
+	if authz.OperatorRead(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 
@@ -146,11 +146,11 @@ func (c *FederationState) List(args *structs.DCSpecificRequest, reply *structs.I
 	defer metrics.MeasureSince([]string{"federation_state", "list"}, time.Now())
 
 	// Fetch the ACL token, if any.
-	rule, err := c.srv.ResolveToken(args.Token)
+	authz, err := c.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if rule.OperatorRead(nil) != acl.Allow {
+	if authz.OperatorRead(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 

--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -399,12 +399,12 @@ func (m *Internal) EventFire(args *structs.EventFireRequest,
 	}
 
 	// Check ACLs
-	rule, err := m.srv.ResolveToken(args.Token)
+	authz, err := m.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
 
-	if rule.EventWrite(args.Name, nil) != acl.Allow {
+	if authz.EventWrite(args.Name, nil) != acl.Allow {
 		accessorID := m.aclAccessorID(args.Token)
 		m.logger.Warn("user event blocked by ACLs", "event", args.Name, "accessorID", accessorID)
 		return acl.ErrPermissionDenied
@@ -440,7 +440,7 @@ func (m *Internal) KeyringOperation(
 	}
 
 	// Check ACLs
-	identity, rule, err := m.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
+	identity, authz, err := m.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
 	if err != nil {
 		return err
 	}
@@ -449,7 +449,7 @@ func (m *Internal) KeyringOperation(
 	}
 	switch args.Operation {
 	case structs.KeyringList:
-		if rule.KeyringRead(nil) != acl.Allow {
+		if authz.KeyringRead(nil) != acl.Allow {
 			return fmt.Errorf("Reading keyring denied by ACLs")
 		}
 	case structs.KeyringInstall:
@@ -457,7 +457,7 @@ func (m *Internal) KeyringOperation(
 	case structs.KeyringUse:
 		fallthrough
 	case structs.KeyringRemove:
-		if rule.KeyringWrite(nil) != acl.Allow {
+		if authz.KeyringWrite(nil) != acl.Allow {
 			return fmt.Errorf("Modifying keyring denied due to ACLs")
 		}
 	default:

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -17,14 +17,14 @@ func (op *Operator) AutopilotGetConfiguration(args *structs.DCSpecificRequest, r
 	}
 
 	// This action requires operator read access.
-	identity, rule, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
+	identity, authz, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
 	if err != nil {
 		return err
 	}
 	if err := op.srv.validateEnterpriseToken(identity); err != nil {
 		return err
 	}
-	if rule.OperatorRead(nil) != acl.Allow {
+	if authz.OperatorRead(nil) != acl.Allow {
 		return acl.PermissionDenied("Missing operator:read permissions")
 	}
 
@@ -49,14 +49,14 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 	}
 
 	// This action requires operator write access.
-	identity, rule, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
+	identity, authz, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
 	if err != nil {
 		return err
 	}
 	if err := op.srv.validateEnterpriseToken(identity); err != nil {
 		return err
 	}
-	if rule.OperatorWrite(nil) != acl.Allow {
+	if authz.OperatorWrite(nil) != acl.Allow {
 		return acl.PermissionDenied("Missing operator:write permissions")
 	}
 
@@ -84,14 +84,14 @@ func (op *Operator) ServerHealth(args *structs.DCSpecificRequest, reply *structs
 	}
 
 	// This action requires operator read access.
-	identity, rule, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
+	identity, authz, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
 	if err != nil {
 		return err
 	}
 	if err := op.srv.validateEnterpriseToken(identity); err != nil {
 		return err
 	}
-	if rule.OperatorRead(nil) != acl.Allow {
+	if authz.OperatorRead(nil) != acl.Allow {
 		return acl.PermissionDenied("Missing operator:read permissions")
 	}
 
@@ -151,14 +151,14 @@ func (op *Operator) AutopilotState(args *structs.DCSpecificRequest, reply *autop
 	}
 
 	// This action requires operator read access.
-	identity, rule, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
+	identity, authz, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
 	if err != nil {
 		return err
 	}
 	if err := op.srv.validateEnterpriseToken(identity); err != nil {
 		return err
 	}
-	if rule.OperatorRead(nil) != acl.Allow {
+	if authz.OperatorRead(nil) != acl.Allow {
 		return acl.PermissionDenied("Missing operator:read permissions")
 	}
 

--- a/agent/consul/operator_raft_endpoint.go
+++ b/agent/consul/operator_raft_endpoint.go
@@ -19,11 +19,11 @@ func (op *Operator) RaftGetConfiguration(args *structs.DCSpecificRequest, reply 
 	}
 
 	// This action requires operator read access.
-	rule, err := op.srv.ResolveToken(args.Token)
+	authz, err := op.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if rule.OperatorRead(nil) != acl.Allow {
+	if authz.OperatorRead(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 
@@ -81,14 +81,14 @@ func (op *Operator) RaftRemovePeerByAddress(args *structs.RaftRemovePeerRequest,
 
 	// This is a super dangerous operation that requires operator write
 	// access.
-	identity, rule, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
+	identity, authz, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
 	if err != nil {
 		return err
 	}
 	if err := op.srv.validateEnterpriseToken(identity); err != nil {
 		return err
 	}
-	if rule.OperatorWrite(nil) != acl.Allow {
+	if authz.OperatorWrite(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 
@@ -134,14 +134,14 @@ func (op *Operator) RaftRemovePeerByID(args *structs.RaftRemovePeerRequest, repl
 
 	// This is a super dangerous operation that requires operator write
 	// access.
-	identity, rule, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
+	identity, authz, err := op.srv.acls.ResolveTokenToIdentityAndAuthorizer(args.Token)
 	if err != nil {
 		return err
 	}
 	if err := op.srv.validateEnterpriseToken(identity); err != nil {
 		return err
 	}
-	if rule.OperatorWrite(nil) != acl.Allow {
+	if authz.OperatorWrite(nil) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -77,7 +77,7 @@ func (p *PreparedQuery) Apply(args *structs.PreparedQueryRequest, reply *string)
 	*reply = args.Query.ID
 
 	// Get the ACL token for the request for the checks below.
-	rule, err := p.srv.ResolveToken(args.Token)
+	authz, err := p.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (p *PreparedQuery) Apply(args *structs.PreparedQueryRequest, reply *string)
 	// need to make sure they have write access for whatever they are
 	// proposing.
 	if prefix, ok := args.Query.GetACLPrefix(); ok {
-		if rule.PreparedQueryWrite(prefix, nil) != acl.Allow {
+		if authz.PreparedQueryWrite(prefix, nil) != acl.Allow {
 			p.logger.Warn("Operation on prepared query denied due to ACLs", "query", args.Query.ID)
 			return acl.ErrPermissionDenied
 		}
@@ -106,7 +106,7 @@ func (p *PreparedQuery) Apply(args *structs.PreparedQueryRequest, reply *string)
 		}
 
 		if prefix, ok := query.GetACLPrefix(); ok {
-			if rule.PreparedQueryWrite(prefix, nil) != acl.Allow {
+			if authz.PreparedQueryWrite(prefix, nil) != acl.Allow {
 				p.logger.Warn("Operation on prepared query denied due to ACLs", "query", args.Query.ID)
 				return acl.ErrPermissionDenied
 			}

--- a/agent/consul/snapshot_endpoint.go
+++ b/agent/consul/snapshot_endpoint.go
@@ -60,9 +60,9 @@ func (s *Server) dispatchSnapshotRequest(args *structs.SnapshotRequest, in io.Re
 	// Verify token is allowed to operate on snapshots. There's only a
 	// single ACL sense here (not read and write) since reading gets you
 	// all the ACLs and you could escalate from there.
-	if rule, err := s.ResolveToken(args.Token); err != nil {
+	if authz, err := s.ResolveToken(args.Token); err != nil {
 		return nil, err
-	} else if rule.Snapshot(nil) != acl.Allow {
+	} else if authz.Snapshot(nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 

--- a/agent/http.go
+++ b/agent/http.go
@@ -245,7 +245,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 				return
 			}
 
-			rule, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
+			authz, err := s.agent.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 			if err != nil {
 				resp.WriteHeader(http.StatusForbidden)
 				return
@@ -253,7 +253,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 
 			// If the token provided does not have the necessary permissions,
 			// write a forbidden response
-			if rule.OperatorRead(nil) != acl.Allow {
+			if authz.OperatorRead(nil) != acl.Allow {
 				resp.WriteHeader(http.StatusForbidden)
 				return
 			}

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -246,12 +246,12 @@ func isValidHTTPMethod(method string) bool {
 	}
 }
 
-func (e *ServiceRouterConfigEntry) CanRead(rule acl.Authorizer) bool {
-	return canReadDiscoveryChain(e, rule)
+func (e *ServiceRouterConfigEntry) CanRead(authz acl.Authorizer) bool {
+	return canReadDiscoveryChain(e, authz)
 }
 
-func (e *ServiceRouterConfigEntry) CanWrite(rule acl.Authorizer) bool {
-	return canWriteDiscoveryChain(e, rule)
+func (e *ServiceRouterConfigEntry) CanWrite(authz acl.Authorizer) bool {
+	return canWriteDiscoveryChain(e, authz)
 }
 
 func (e *ServiceRouterConfigEntry) GetRaftIndex() *RaftIndex {
@@ -580,12 +580,12 @@ func scaleWeight(v float32) int {
 	return int(math.Round(float64(v * 100.0)))
 }
 
-func (e *ServiceSplitterConfigEntry) CanRead(rule acl.Authorizer) bool {
-	return canReadDiscoveryChain(e, rule)
+func (e *ServiceSplitterConfigEntry) CanRead(authz acl.Authorizer) bool {
+	return canReadDiscoveryChain(e, authz)
 }
 
-func (e *ServiceSplitterConfigEntry) CanWrite(rule acl.Authorizer) bool {
-	return canWriteDiscoveryChain(e, rule)
+func (e *ServiceSplitterConfigEntry) CanWrite(authz acl.Authorizer) bool {
+	return canWriteDiscoveryChain(e, authz)
 }
 
 func (e *ServiceSplitterConfigEntry) GetRaftIndex() *RaftIndex {
@@ -955,12 +955,12 @@ func (e *ServiceResolverConfigEntry) Validate() error {
 	return nil
 }
 
-func (e *ServiceResolverConfigEntry) CanRead(rule acl.Authorizer) bool {
-	return canReadDiscoveryChain(e, rule)
+func (e *ServiceResolverConfigEntry) CanRead(authz acl.Authorizer) bool {
+	return canReadDiscoveryChain(e, authz)
 }
 
-func (e *ServiceResolverConfigEntry) CanWrite(rule acl.Authorizer) bool {
-	return canWriteDiscoveryChain(e, rule)
+func (e *ServiceResolverConfigEntry) CanWrite(authz acl.Authorizer) bool {
+	return canWriteDiscoveryChain(e, authz)
 }
 
 func (e *ServiceResolverConfigEntry) GetRaftIndex() *RaftIndex {
@@ -1191,7 +1191,7 @@ func canReadDiscoveryChain(entry discoveryChainConfigEntry, authz acl.Authorizer
 	return authz.ServiceRead(entry.GetName(), &authzContext) == acl.Allow
 }
 
-func canWriteDiscoveryChain(entry discoveryChainConfigEntry, rule acl.Authorizer) bool {
+func canWriteDiscoveryChain(entry discoveryChainConfigEntry, authz acl.Authorizer) bool {
 	entryID := NewServiceID(entry.GetName(), entry.GetEnterpriseMeta())
 
 	var authzContext acl.AuthorizerContext
@@ -1199,7 +1199,7 @@ func canWriteDiscoveryChain(entry discoveryChainConfigEntry, rule acl.Authorizer
 
 	name := entry.GetName()
 
-	if rule.ServiceWrite(name, &authzContext) != acl.Allow {
+	if authz.ServiceWrite(name, &authzContext) != acl.Allow {
 		return false
 	}
 
@@ -1211,7 +1211,7 @@ func canWriteDiscoveryChain(entry discoveryChainConfigEntry, rule acl.Authorizer
 		svc.FillAuthzContext(&authzContext)
 		// You only need read on related services to redirect traffic flow for
 		// your own service.
-		if rule.ServiceRead(svc.ID, &authzContext) != acl.Allow {
+		if authz.ServiceRead(svc.ID, &authzContext) != acl.Allow {
 			return false
 		}
 	}

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -569,7 +569,7 @@ func (s *Server) checkStreamACLs(streamCtx context.Context, cfgSnap *proxycfg.Co
 		return status.Errorf(codes.Unauthenticated, "unauthenticated: no config snapshot")
 	}
 
-	rule, err := s.ResolveToken(tokenFromContext(streamCtx))
+	authz, err := s.ResolveToken(tokenFromContext(streamCtx))
 
 	if acl.IsErrNotFound(err) {
 		return status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
@@ -583,12 +583,12 @@ func (s *Server) checkStreamACLs(streamCtx context.Context, cfgSnap *proxycfg.Co
 	switch cfgSnap.Kind {
 	case structs.ServiceKindConnectProxy:
 		cfgSnap.ProxyID.EnterpriseMeta.FillAuthzContext(&authzContext)
-		if rule.ServiceWrite(cfgSnap.Proxy.DestinationServiceName, &authzContext) != acl.Allow {
+		if authz.ServiceWrite(cfgSnap.Proxy.DestinationServiceName, &authzContext) != acl.Allow {
 			return status.Errorf(codes.PermissionDenied, "permission denied")
 		}
 	case structs.ServiceKindMeshGateway, structs.ServiceKindTerminatingGateway, structs.ServiceKindIngressGateway:
 		cfgSnap.ProxyID.EnterpriseMeta.FillAuthzContext(&authzContext)
-		if rule.ServiceWrite(cfgSnap.Service, &authzContext) != acl.Allow {
+		if authz.ServiceWrite(cfgSnap.Service, &authzContext) != acl.Allow {
 			return status.Errorf(codes.PermissionDenied, "permission denied")
 		}
 	default:


### PR DESCRIPTION
Follow up to https://github.com/hashicorp/consul/pull/10737#discussion_r682147950

Renames all variables for `acl.Authorizer` to use `authz`. Previously some places used `rule` which I believe was an old name carried over from the legacy ACL system.

A couple places also used `authorizer`.

This commit also removes another couple of authorizer nil checks that are no longer necessary.