### PR TITLE
cli: Test API access using /status/leader in consul watch

### DIFF
--- a/.changelog/10795.txt
+++ b/.changelog/10795.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Fix a bug which prevented initializing a watch when using a namespaced
+token.
+```

--- a/command/watch/watch.go
+++ b/command/watch/watch.go
@@ -158,13 +158,19 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	// Create and test the HTTP client
+	// Create and test that the API is accessible before starting a blocking
+	// loop for the watch.
+	//
+	// Consul does not have a /ping endpoint, so the /status/leader endpoint
+	// will be used as a substitute since it does not require an ACL token to
+	// query, and will always return a response to the client, unless there is a
+	// network communication error.
 	client, err := c.http.APIClient()
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
 		return 1
 	}
-	_, err = client.Agent().NodeName()
+	_, err = client.Status().Leader()
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error querying Consul agent: %s", err))
 		return 1


### PR DESCRIPTION
Replace call to /agent/self with /status/leader to verify agent reachability before initializing a watch. This endpoint is not guarded by ACLs, and as such can be queried by any unauthenticated API client.

Fixes #9353