### PR TITLE
docs/nia: add CTS enterprise license information

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -38,7 +38,7 @@ buffer_period {
   - `facility` - (string: "local0") Name of the syslog facility to log to.
   - `name` - (string: "consul-terraform-sync") Name to use for the daemon process when logging to syslog.
 - `working_dir` - (string: "sync-tasks") The base working directory to manage generated artifacts by Consul-Terraform-Sync, including Terraform configuration files for each task. Each task will have a subdirectory used as the working directory, e.g. `./sync-tasks/task-name`. The working directory for tasks can be overridden using the [`task.working_dir`](#working_dir-1) option.
- - `license_path` <EnterpriseAlert inline /> - (string: "") Configures the path to the file containing the license. License must be set in order to use enterprise but can be alternatively set through environment variables `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` instead. See section on [setting a license](/docs/nia/license#setting-the-license) for more details.
+ - `license_path` <EnterpriseAlert inline /> - (string: "") Configures the path to the file containing the license. License must be set in order to use enterprise but can be alternatively set through environment variables `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` instead. See section on [setting a license](/docs/nia/enterprise/license#setting-the-license) for more details.
 
 ## Consul
 

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -38,6 +38,7 @@ buffer_period {
   - `facility` - (string: "local0") Name of the syslog facility to log to.
   - `name` - (string: "consul-terraform-sync") Name to use for the daemon process when logging to syslog.
 - `working_dir` - (string: "sync-tasks") The base working directory to manage generated artifacts by Consul-Terraform-Sync, including Terraform configuration files for each task. Each task will have a subdirectory used as the working directory, e.g. `./sync-tasks/task-name`. The working directory for tasks can be overridden using the [`task.working_dir`](#working_dir-1) option.
+ - `license_path` <EnterpriseAlert inline /> - (string: "") Configures the path to the file containing the license. License must be set in order to use enterprise but can be alternatively set through environment variables `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` instead. See section on [setting a license](/docs/nia/license#setting-the-license) for more details.
 
 ## Consul
 

--- a/website/content/docs/nia/enterprise/index.mdx
+++ b/website/content/docs/nia/enterprise/index.mdx
@@ -1,0 +1,14 @@
+---
+layout: docs
+page_title: Consul-Terraform-Sync Enterprise
+description: >-
+  Consul-Terraform-Sync Enterprise
+---
+
+# Consul-Terraform-Sync Enterprise
+
+Consul-Terraform-Sync Enterprise features address organization complexities of collaboration, operations, scale, and governance. Please see the sidebar navigation on the left to view all enterprise features.
+
+Enterprise features require a Consul [license](/docs/nia/enterprise/license) to be applied.
+
+These features are part of Consul-Terraform-Sync Enterprise which is part of [Consul Enterprise](https://www.hashicorp.com/products/consul).

--- a/website/content/docs/nia/enterprise/license.mdx
+++ b/website/content/docs/nia/enterprise/license.mdx
@@ -10,7 +10,9 @@ description: >-
   Licenses are only required for Consul-Terraform-Sync Enterprise
 </EnterpriseAlert>
 
-Consul-Terraform-Sync Enterprise binaries require a license in order to start. The required license must be a [Consul Enterprise license](/docs/enterprise/license/overview) as there is no specific Consul-Terraform-Sync Enterprise license. As a result, Consul-Terraform-Sync Enterprise's licensing is very similar to Consul Enterprise. Consul-Terraform-Sync Enterprise is available with all its features with any valid, unexpired Consul Enterprise license regardless of its packaging/pricing model or level.
+Consul-Terraform-Sync Enterprise binaries require a [Consul Enterprise license](/docs/enterprise/license/overview) to run. There is no Consul-Terraform-Sync Enterprise specific license. As a result, Consul-Terraform-Sync Enterprise's licensing is very similar to Consul Enterprise.
+
+All features offered in Consul-Terraform-Sync Enterprise is available with any valid, unexpired Consul Enterprise license. It is not dependent on your Consul Enterprise packaging or pricing model.
 
 To get a trial license for Consul-Terraform-Sync Enterprise, you can sign-up for the [trial license for Consul Enterprise](/docs/enterprise/license/faq#q-where-can-users-get-a-trial-license-for-consul-enterprise).
 

--- a/website/content/docs/nia/license.mdx
+++ b/website/content/docs/nia/license.mdx
@@ -1,0 +1,48 @@
+---
+layout: docs
+page_title: Consul-Terraform-Sync Enterprise License
+description: >-
+  Consul-Terraform-Sync Enterprise License
+---
+
+# Consul-Terraform-Sync Enterprise License
+<EnterpriseAlert>
+  Licenses are only required for Consul-Terraform-Sync Enterprise
+</EnterpriseAlert>
+
+Consul-Terraform-Sync Enterprise binaries require a license in order to start. The required license must be a [Consul Enterprise license](/docs/enterprise/license/overview) as there is no specific Consul-Terraform-Sync Enterprise license. As a result, Consul-Terraform-Sync Enterprise's licensing is very similar to Consul Enterprise. Consul-Terraform-Sync Enterprise is available with all its features with any valid, unexpired Consul Enterprise license regardless of its packaging/pricing model or level.
+
+To get a trial license for Consul-Terraform-Sync Enterprise, you can sign-up for the [trial license for Consul Enterprise](/docs/enterprise/license/faq#q-where-can-users-get-a-trial-license-for-consul-enterprise).
+
+## Setting the License
+
+Consul-Terraform-Sync Enterprise binary is only offered without a built-in license. Depending on how you would like to set the license, have the license value at hand or saved in a file to disk.
+
+The options to set the license:
+ - `CONSUL_LICENSE`: environment variable to set the license value
+ - `CONSUL_LICENSE_PATH`: environment variable to set the path to the file containing the license
+ - [`license_path`](/docs/nia/configuration#license_path): configuration file variable to set the path to the file containing the license
+
+If multiple license options are set, the order of precedence is as follows:
+1. `CONSUL_LICENSE`
+1. `CONSUL_LICENSE_PATH`
+1. `license_path`
+
+Note: the [options to set the license and order of precedence](](/docs/enterprise/license/overview#binaries-without-built-in-licenses)) is the same as Consul Enterprise server agents.
+
+## Notification and Termination Behavior
+
+Licenses have an expiration date and termination date where termination is a time at or after expiration. Consul-Terraform-Sync Enterprise will cease to function once the termination date has passed. The time between the expiration and termination date is a grace period. Grace periods are generally 24-hours; however, please refer to your license for accurate understanding of your grace period.
+
+When approaching expiration and termination, Consul-Terraform-Sync Enterprise will provide notifications in the system logs:
+
+| Time period                                 | Behavior                          |
+|---------------------------------------------|-----------------------------------|
+| 30 days before expiration                   | Warning-level log every 24-hours  |
+| 7 days before expiration                    | Warning-level log every 1 hour    |
+| 1 hour before expiration                    | Warning-level log every 1 minute  |
+| 1 day before expiration                     | Warning-level log every 5 minutes |
+| At or after expiration (before termination) | Error-level log every 1 minute    |
+| At or after termination                     | Error-level log and exit          |
+
+Note: notification frequency and [grace period](/docs/enterprise/license/faq#q-is-there-a-grace-period-when-licenses-expire) behavior is the same as Consul Enterprise.

--- a/website/content/docs/nia/license.mdx
+++ b/website/content/docs/nia/license.mdx
@@ -16,19 +16,14 @@ To get a trial license for Consul-Terraform-Sync Enterprise, you can sign-up for
 
 ## Setting the License
 
-Consul-Terraform-Sync Enterprise binary is only offered without a built-in license. Depending on how you would like to set the license, have the license value at hand or saved in a file to disk.
+Depending on how you would like to set the license, have the license value at hand or saved in a file to disk.
 
-The options to set the license:
+The options to set the license in order of precedence:
  - `CONSUL_LICENSE`: environment variable to set the license value
  - `CONSUL_LICENSE_PATH`: environment variable to set the path to the file containing the license
  - [`license_path`](/docs/nia/configuration#license_path): configuration file variable to set the path to the file containing the license
 
-If multiple license options are set, the order of precedence is as follows:
-1. `CONSUL_LICENSE`
-1. `CONSUL_LICENSE_PATH`
-1. `license_path`
-
-Note: the [options to set the license and order of precedence](](/docs/enterprise/license/overview#binaries-without-built-in-licenses)) is the same as Consul Enterprise server agents.
+Note: the [options to set the license and order of precedence](/docs/enterprise/license/overview#binaries-without-built-in-licenses) is the same as Consul Enterprise server agents.
 
 ## Notification and Termination Behavior
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -652,16 +652,30 @@
         "path": "nia/configuration"
       },
       {
-        "title": "License",
-        "path": "nia/license"
-      },
-      {
         "title": "Tasks",
         "path": "nia/tasks"
       },
       {
         "title": "Terraform Modules",
         "path": "nia/terraform-modules"
+      },
+      {
+        "title": "Enterprise",
+        "routes": [
+          {
+            "title": "Overview",
+            "path": "nia/enterprise"
+          },
+
+          {
+            "title": "License",
+            "path": "nia/enterprise/license"
+          },
+          {
+            "title": "Terraform Cloud Driver",
+            "href": "/docs/nia/network-drivers/terraform-cloud"
+          }
+        ]
       },
       {
         "title": "Network Drivers",

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -652,6 +652,10 @@
         "path": "nia/configuration"
       },
       {
+        "title": "License",
+        "path": "nia/license"
+      },
+      {
         "title": "Tasks",
         "path": "nia/tasks"
       },


### PR DESCRIPTION
Update links:
 - [preview license_path config](https://consul-o9m20q4gc-hashicorp.vercel.app/docs/nia/configuration#license_path)
 - [preview licensing page](https://consul-o9m20q4gc-hashicorp.vercel.app/docs/nia/enterprise/license)
 - [preview enterprise overview page](https://consul-o9m20q4gc-hashicorp.vercel.app/docs/nia/enterprise)