### PR TITLE
debug: rename cluster.json -> members.json  and fix handling of Interrupt Signal

### DIFF
--- a/.changelog/10804.txt
+++ b/.changelog/10804.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+debug: rename cluster capture target to members, to be more consistent with the terms used by the API.
+```

--- a/command/commands_oss.go
+++ b/command/commands_oss.go
@@ -166,7 +166,7 @@ func init() {
 	Register("connect envoy pipe-bootstrap", func(ui cli.Ui) (cli.Command, error) { return pipebootstrap.New(ui), nil })
 	Register("connect expose", func(ui cli.Ui) (cli.Command, error) { return expose.New(ui), nil })
 	Register("connect redirect-traffic", func(ui cli.Ui) (cli.Command, error) { return redirecttraffic.New(ui), nil })
-	Register("debug", func(ui cli.Ui) (cli.Command, error) { return debug.New(ui, MakeShutdownCh()), nil })
+	Register("debug", func(ui cli.Ui) (cli.Command, error) { return debug.New(ui), nil })
 	Register("event", func(ui cli.Ui) (cli.Command, error) { return event.New(ui), nil })
 	Register("exec", func(ui cli.Ui) (cli.Command, error) { return exec.New(ui, MakeShutdownCh()), nil })
 	Register("force-leave", func(ui cli.Ui) (cli.Command, error) { return forceleave.New(ui), nil })

--- a/command/debug/debug.go
+++ b/command/debug/debug.go
@@ -679,30 +679,17 @@ func (c *cmd) createArchiveTemp(path string) (tempName string, err error) {
 // defaultTargets specifies the list of all targets that
 // will be captured by default
 func (c *cmd) defaultTargets() []string {
-	return append(c.dynamicTargets(), c.staticTargets()...)
-}
-
-// dynamicTargets returns all the supported targets
-// that are retrieved at the interval specified
-func (c *cmd) dynamicTargets() []string {
-	return []string{"metrics", "logs", "pprof"}
-}
-
-// staticTargets returns all the supported targets
-// that are retrieved at the start of the command execution
-func (c *cmd) staticTargets() []string {
-	return []string{"host", "agent", "cluster"}
+	return []string{"metrics", "logs", "pprof", "host", "agent", "cluster"}
 }
 
 func (c *cmd) Synopsis() string {
-	return synopsis
+	return "Records a debugging archive for operators"
 }
 
 func (c *cmd) Help() string {
 	return c.help
 }
 
-const synopsis = "Records a debugging archive for operators"
 const help = `
 Usage: consul debug [options]
 

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestDebugCommand_Help_TextContainsNoTabs(t *testing.T) {
-	if strings.ContainsRune(New(cli.NewMockUi(), nil).Help(), '\t') {
+	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
 		t.Fatal("help has tabs")
 	}
 }
@@ -46,7 +46,7 @@ func TestDebugCommand(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, nil)
+	cmd := New(ui)
 	cmd.validateTiming = false
 
 	outputPath := fmt.Sprintf("%s/debug", testDir)
@@ -92,7 +92,7 @@ func TestDebugCommand_Archive(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, nil)
+	cmd := New(ui)
 	cmd.validateTiming = false
 
 	outputPath := fmt.Sprintf("%s/debug", testDir)
@@ -137,7 +137,7 @@ func TestDebugCommand_Archive(t *testing.T) {
 
 func TestDebugCommand_ArgsBad(t *testing.T) {
 	ui := cli.NewMockUi()
-	cmd := New(ui, nil)
+	cmd := New(ui)
 
 	args := []string{"foo", "bad"}
 
@@ -153,7 +153,7 @@ func TestDebugCommand_ArgsBad(t *testing.T) {
 
 func TestDebugCommand_InvalidFlags(t *testing.T) {
 	ui := cli.NewMockUi()
-	cmd := New(ui, nil)
+	cmd := New(ui)
 	cmd.validateTiming = false
 
 	outputPath := ""
@@ -186,7 +186,7 @@ func TestDebugCommand_OutputPathBad(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, nil)
+	cmd := New(ui)
 	cmd.validateTiming = false
 
 	outputPath := ""
@@ -219,7 +219,7 @@ func TestDebugCommand_OutputPathExists(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, nil)
+	cmd := New(ui)
 	cmd.validateTiming = false
 
 	outputPath := fmt.Sprintf("%s/debug", testDir)
@@ -304,7 +304,7 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 		ui := cli.NewMockUi()
-		cmd := New(ui, nil)
+		cmd := New(ui)
 		cmd.validateTiming = false
 
 		outputPath := fmt.Sprintf("%s/debug-%s", testDir, name)
@@ -387,7 +387,7 @@ func TestDebugCommand_CaptureLogs(t *testing.T) {
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 		ui := cli.NewMockUi()
-		cmd := New(ui, nil)
+		cmd := New(ui)
 		cmd.validateTiming = false
 
 		outputPath := fmt.Sprintf("%s/debug-%s", testDir, name)
@@ -480,7 +480,7 @@ func TestDebugCommand_ProfilesExist(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, nil)
+	cmd := New(ui)
 	cmd.validateTiming = false
 
 	outputPath := fmt.Sprintf("%s/debug", testDir)
@@ -548,7 +548,7 @@ func TestDebugCommand_Prepare_ValidateTiming(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			cmd := New(ui, nil)
+			cmd := New(ui)
 
 			args := []string{
 				"-duration=" + tc.duration,
@@ -579,7 +579,7 @@ func TestDebugCommand_DebugDisabled(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui, nil)
+	cmd := New(ui)
 	cmd.validateTiming = false
 
 	outputPath := fmt.Sprintf("%s/debug", testDir)

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -258,17 +258,17 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 		"single": {
 			[]string{"agent"},
 			[]string{"agent.json"},
-			[]string{"host.json", "cluster.json"},
+			[]string{"host.json", "members.json"},
 		},
 		"static": {
 			[]string{"agent", "host", "cluster"},
-			[]string{"agent.json", "host.json", "cluster.json"},
+			[]string{"agent.json", "host.json", "members.json"},
 			[]string{"*/metrics.json"},
 		},
 		"metrics-only": {
 			[]string{"metrics"},
 			[]string{"*/metrics.json"},
-			[]string{"agent.json", "host.json", "cluster.json"},
+			[]string{"agent.json", "host.json", "members.json"},
 		},
 		"all-but-pprof": {
 			[]string{
@@ -281,7 +281,7 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 			[]string{
 				"host.json",
 				"agent.json",
-				"cluster.json",
+				"members.json",
 				"*/metrics.json",
 				"*/consul.log",
 			},

--- a/command/registry.go
+++ b/command/registry.go
@@ -47,6 +47,7 @@ var registry map[string]Factory
 // MakeShutdownCh returns a channel that can be used for shutdown notifications
 // for commands. This channel will send a message for every interrupt or SIGTERM
 // received.
+// Deprecated: use signal.NotifyContext
 func MakeShutdownCh() <-chan struct{} {
 	resultCh := make(chan struct{})
 	signalCh := make(chan os.Signal, 4)

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,7 @@ require (
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 	google.golang.org/grpc v1.25.1
 	gopkg.in/square/go-jose.v2 v2.5.1
+	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.16.9
 	k8s.io/apimachinery v0.16.9
 	k8s.io/client-go v0.16.9

--- a/go.sum
+++ b/go.sum
@@ -652,6 +652,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -710,6 +711,8 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/website/content/commands/debug.mdx
+++ b/website/content/commands/debug.mdx
@@ -8,13 +8,13 @@ page_title: 'Commands: Debug'
 Command: `consul debug`
 
 The `consul debug` command monitors a Consul agent for the specified period of
-time, recording information about the agent, cluster, and environment to an archive
+time, recording information about the agent, cluster membership, and environment to an archive
 written to the current directory.
 
 Providing support for complex issues encountered by Consul operators often
 requires a large amount of debugging information to be retrieved. This command
 aims to shortcut that coordination and provide a simple workflow for accessing
-data about Consul agent, cluster, and environment to enable faster
+data about Consul agent, cluster membership, and environment to enable faster
 isolation and debugging of issues.
 
 This command requires an `operator:read` ACL token in order to retrieve the
@@ -75,7 +75,7 @@ information when `debug` is running. By default, it captures all information.
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `agent`   | Version and configuration information about the agent.                                                                                                                                                                                                                                                                                                                                                                    |
 | `host`    | Information about resources on the host running the target agent such as CPU, memory, and disk.                                                                                                                                                                                                                                                                                                                           |
-| `cluster` | A list of all the WAN and LAN members in the cluster.                                                                                                                                                                                                                                                                                                                                                                     |
+| `members` | A list of all the WAN and LAN members in the cluster.                                                                                                                                                                                                                                                                                                                                                                     |
 | `metrics` | Metrics from the in-memory metrics endpoint in the target, captured at the interval.                                                                                                                                                                                                                                                                                                                                      |
 | `logs`    | `DEBUG` level logs for the target agent, captured for the duration.                                                                                                                                                                                                                                                                                                                                                       |
 | `pprof`   | Golang heap, CPU, goroutine, and trace profiling. CPU and traces are captured for `duration` in a single file while heap and goroutine are separate snapshots for each `interval`. This information is not retrieved unless [`enable_debug`](/docs/agent/options#enable_debug) is set to `true` on the target agent or ACLs are enable and an ACL token with `operator:read` is provided. |


### PR DESCRIPTION
Related to #10320
Best viewed by individual commit.

Renames `cluster.json` to `members.json` to be more consistent with the API and internal method names we use for this data.


While working on this I noticed that handling of SIGINT was broken due to other changes we made for #10320. I fixed that problem by using a context, and changing the signal handler to cancel the context instead of only closing a channel.
