### PR TITLE
config: remove ACLDatacenter

### DIFF
--- a/agent/acl_endpoint_legacy.go
+++ b/agent/acl_endpoint_legacy.go
@@ -19,7 +19,7 @@ func (s *HTTPHandlers) ACLDestroy(resp http.ResponseWriter, req *http.Request) (
 	}
 
 	args := structs.ACLRequest{
-		Datacenter: s.agent.config.ACLDatacenter,
+		Datacenter: s.agent.config.PrimaryDatacenter,
 		Op:         structs.ACLDelete,
 	}
 	s.parseToken(req, &args.Token)
@@ -55,7 +55,7 @@ func (s *HTTPHandlers) ACLUpdate(resp http.ResponseWriter, req *http.Request) (i
 
 func (s *HTTPHandlers) aclSet(resp http.ResponseWriter, req *http.Request, update bool) (interface{}, error) {
 	args := structs.ACLRequest{
-		Datacenter: s.agent.config.ACLDatacenter,
+		Datacenter: s.agent.config.PrimaryDatacenter,
 		Op:         structs.ACLSet,
 		ACL: structs.ACL{
 			Type: structs.ACLTokenTypeClient,
@@ -96,7 +96,7 @@ func (s *HTTPHandlers) ACLClone(resp http.ResponseWriter, req *http.Request) (in
 	}
 
 	args := structs.ACLSpecificRequest{
-		Datacenter: s.agent.config.ACLDatacenter,
+		Datacenter: s.agent.config.PrimaryDatacenter,
 	}
 	var dc string
 	if done := s.parse(resp, req, &dc, &args.QueryOptions); done {
@@ -148,7 +148,7 @@ func (s *HTTPHandlers) ACLGet(resp http.ResponseWriter, req *http.Request) (inte
 	}
 
 	args := structs.ACLSpecificRequest{
-		Datacenter: s.agent.config.ACLDatacenter,
+		Datacenter: s.agent.config.PrimaryDatacenter,
 	}
 	var dc string
 	if done := s.parse(resp, req, &dc, &args.QueryOptions); done {
@@ -182,7 +182,7 @@ func (s *HTTPHandlers) ACLList(resp http.ResponseWriter, req *http.Request) (int
 	}
 
 	args := structs.DCSpecificRequest{
-		Datacenter: s.agent.config.ACLDatacenter,
+		Datacenter: s.agent.config.PrimaryDatacenter,
 	}
 	var dc string
 	if done := s.parse(resp, req, &dc, &args.QueryOptions); done {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1114,9 +1114,6 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	if runtimeCfg.ACLMasterToken != "" {
 		cfg.ACLMasterToken = runtimeCfg.ACLMasterToken
 	}
-	if runtimeCfg.ACLDatacenter != "" {
-		cfg.ACLDatacenter = runtimeCfg.ACLDatacenter
-	}
 	if runtimeCfg.ACLTokenTTL != 0 {
 		cfg.ACLTokenTTL = runtimeCfg.ACLTokenTTL
 	}

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -867,7 +867,6 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 
 		// ACL
 		ACLsEnabled:            aclsEnabled,
-		ACLDatacenter:          primaryDatacenter,
 		ACLDefaultPolicy:       stringValWithDefault(c.ACL.DefaultPolicy, stringVal(c.ACLDefaultPolicy)),
 		ACLDownPolicy:          stringValWithDefault(c.ACL.DownPolicy, stringVal(c.ACLDownPolicy)),
 		ACLEnableKeyListPolicy: boolValWithDefault(c.ACL.EnableKeyListPolicy, boolVal(c.ACLEnableKeyListPolicy)),
@@ -1311,7 +1310,7 @@ func (b *builder) validate(rt RuntimeConfig) error {
 	if rt.AutopilotMaxTrailingLogs < 0 {
 		return fmt.Errorf("autopilot.max_trailing_logs cannot be %d. Must be greater than or equal to zero", rt.AutopilotMaxTrailingLogs)
 	}
-	if err := validateBasicName("acl_datacenter", rt.ACLDatacenter, true); err != nil {
+	if err := validateBasicName("primary_datacenter", rt.PrimaryDatacenter, true); err != nil {
 		return err
 	}
 	// In DevMode, UI is enabled by default, so to enable rt.UIDir, don't perform this check

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -69,13 +69,6 @@ type RuntimeConfig struct {
 
 	ACLTokens token.Config
 
-	// ACLDatacenter is the central datacenter that holds authoritative
-	// ACL records. This must be the same for the entire cluster.
-	// If this is not set, ACLs are not enabled. Off by default.
-	//
-	// hcl: acl_datacenter = string
-	ACLDatacenter string
-
 	// ACLDefaultPolicy is used to control the ACL interaction when
 	// there is no defined policy. This can be "allow" which means
 	// ACLs are used to deny-list, or "deny" which means ACLs are
@@ -85,7 +78,7 @@ type RuntimeConfig struct {
 	ACLDefaultPolicy string
 
 	// ACLDownPolicy is used to control the ACL interaction when we cannot
-	// reach the ACLDatacenter and the token is not in the cache.
+	// reach the PrimaryDatacenter and the token is not in the cache.
 	// There are the following modes:
 	//   * allow - Allow all requests
 	//   * deny - Deny all requests
@@ -109,7 +102,7 @@ type RuntimeConfig struct {
 	ACLEnableKeyListPolicy bool
 
 	// ACLMasterToken is used to bootstrap the ACL system. It should be specified
-	// on the servers in the ACLDatacenter. When the leader comes online, it ensures
+	// on the servers in the PrimaryDatacenter. When the leader comes online, it ensures
 	// that the Master token is available. This provides the initial token.
 	//
 	// hcl: acl.tokens.master = string

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -221,7 +221,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "a"
-			rt.ACLDatacenter = "a"
 			rt.PrimaryDatacenter = "a"
 			rt.DataDir = dataDir
 		},
@@ -237,7 +236,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "a"
-			rt.ACLDatacenter = "a"
 			rt.PrimaryDatacenter = "a"
 			rt.DataDir = dataDir
 		},
@@ -254,7 +252,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "b"
-			rt.ACLDatacenter = "b"
 			rt.PrimaryDatacenter = "b"
 			rt.DataDir = dataDir
 		},
@@ -285,7 +282,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "a"
-			rt.ACLDatacenter = "a"
 			rt.PrimaryDatacenter = "a"
 			rt.DataDir = dataDir
 		},
@@ -471,7 +467,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "a"
-			rt.ACLDatacenter = "a"
 			rt.PrimaryDatacenter = "a"
 			rt.DataDir = dataDir
 		},
@@ -492,7 +487,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "a"
-			rt.ACLDatacenter = "a"
 			rt.PrimaryDatacenter = "a"
 			rt.DataDir = dataDir
 		},
@@ -509,7 +503,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "a"
-			rt.ACLDatacenter = "a"
 			rt.PrimaryDatacenter = "a"
 			rt.DataDir = dataDir
 		},
@@ -659,7 +652,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "dc2"
 			rt.PrimaryDatacenter = "dc1"
-			rt.ACLDatacenter = "dc1"
 			rt.PrimaryGateways = []string{"a", "b"}
 			rt.DataDir = dataDir
 			// server things
@@ -1484,7 +1476,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.Bootstrap = false
 			rt.BootstrapExpect = 0
 			rt.Datacenter = "b"
-			rt.ACLDatacenter = "b"
 			rt.PrimaryDatacenter = "b"
 			rt.StartJoinAddrsLAN = []string{"a", "b", "c", "d"}
 			rt.NodeMeta = map[string]string{"a": "c"}
@@ -1540,7 +1531,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.SerfAdvertiseAddrLAN = tcpAddr("1.1.1.1:8301")
 			rt.SerfAdvertiseAddrWAN = tcpAddr("2.2.2.2:8302")
 			rt.Datacenter = "b"
-			rt.ACLDatacenter = "b"
 			rt.PrimaryDatacenter = "b"
 			rt.DNSRecursors = []string{"1.2.3.6", "5.6.7.10", "1.2.3.5", "5.6.7.9"}
 			rt.NodeMeta = map[string]string{"a": "c"}
@@ -1626,7 +1616,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		hcl:  []string{`datacenter = "A"`},
 		expected: func(rt *RuntimeConfig) {
 			rt.Datacenter = "a"
-			rt.ACLDatacenter = "a"
 			rt.PrimaryDatacenter = "a"
 			rt.DataDir = dataDir
 		},
@@ -1638,7 +1627,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		hcl:  []string{`acl_datacenter = "A"`},
 		expected: func(rt *RuntimeConfig) {
 			rt.ACLsEnabled = true
-			rt.ACLDatacenter = "a"
 			rt.DataDir = dataDir
 			rt.PrimaryDatacenter = "a"
 		},
@@ -1749,15 +1737,28 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 	})
 	run(t, testCase{
-		desc: "acl_datacenter invalid",
+		desc: "primary_datacenter invalid",
 		args: []string{
 			`-datacenter=a`,
 			`-data-dir=` + dataDir,
 		},
-		json:             []string{`{ "acl_datacenter": "%" }`},
-		hcl:              []string{`acl_datacenter = "%"`},
-		expectedErr:      `acl_datacenter can only contain lowercase alphanumeric, - or _ characters.`,
+		json:        []string{`{ "primary_datacenter": "%" }`},
+		hcl:         []string{`primary_datacenter = "%"`},
+		expectedErr: `primary_datacenter can only contain lowercase alphanumeric, - or _ characters.`,
+	})
+	run(t, testCase{
+		desc: "acl_datacenter deprecated",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json:             []string{`{ "acl_datacenter": "ab" }`},
+		hcl:              []string{`acl_datacenter = "ab"`},
 		expectedWarnings: []string{`The 'acl_datacenter' field is deprecated. Use the 'primary_datacenter' field instead.`},
+		expected: func(rt *RuntimeConfig) {
+			rt.ACLsEnabled = true
+			rt.PrimaryDatacenter = "ab"
+			rt.DataDir = dataDir
+		},
 	})
 	run(t, testCase{
 		desc: "autopilot.max_trailing_logs invalid",
@@ -3373,7 +3374,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			rt.DataDir = dataDir
 			rt.Datacenter = "two"
 			rt.PrimaryDatacenter = "one"
-			rt.ACLDatacenter = "one"
 			rt.PrimaryGateways = []string{"foo.local", "bar.local"}
 			rt.ConnectEnabled = true
 			rt.ConnectMeshGatewayWANFederationEnabled = true
@@ -5233,7 +5233,7 @@ func TestLoad_FullConfig(t *testing.T) {
 		},
 
 		ACLsEnabled:                      true,
-		ACLDatacenter:                    "ejtmd43d",
+		PrimaryDatacenter:                "ejtmd43d",
 		ACLDefaultPolicy:                 "72c2e7a0",
 		ACLDownPolicy:                    "03eb2aee",
 		ACLEnableKeyListPolicy:           true,
@@ -5483,7 +5483,6 @@ func TestLoad_FullConfig(t *testing.T) {
 		NodeName:                "otlLxGaI",
 		ReadReplica:             true,
 		PidFile:                 "43xN80Km",
-		PrimaryDatacenter:       "ejtmd43d",
 		PrimaryGateways:         []string{"aej8eeZo", "roh2KahS"},
 		PrimaryGatewaysInterval: 18866 * time.Second,
 		RPCAdvertiseAddr:        tcpAddr("17.99.29.16:3757"),

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -1,5 +1,4 @@
 {
-    "ACLDatacenter": "",
     "ACLDefaultPolicy": "",
     "ACLDisabledTTL": "0s",
     "ACLDownPolicy": "",

--- a/agent/consul/acl_client.go
+++ b/agent/consul/acl_client.go
@@ -64,8 +64,8 @@ func (c *Client) ACLDatacenter(legacy bool) string {
 	// in legacy mode the clients should directly query the
 	// ACL Datacenter. When no ACL datacenter has been set
 	// then we assume that the local DC is the ACL DC
-	if legacy && c.config.ACLDatacenter != "" {
-		return c.config.ACLDatacenter
+	if legacy && c.config.PrimaryDatacenter != "" {
+		return c.config.PrimaryDatacenter
 	}
 
 	return c.config.Datacenter

--- a/agent/consul/acl_endpoint_legacy.go
+++ b/agent/consul/acl_endpoint_legacy.go
@@ -56,7 +56,7 @@ func (a *ACL) Bootstrap(args *structs.DCSpecificRequest, reply *structs.ACL) err
 
 	// Attempt a bootstrap.
 	req := structs.ACLRequest{
-		Datacenter: a.srv.config.ACLDatacenter,
+		Datacenter: a.srv.config.PrimaryDatacenter,
 		Op:         structs.ACLBootstrapNow,
 		ACL: structs.ACL{
 			ID:   token,

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -33,7 +33,7 @@ func TestACLEndpoint_Bootstrap(t *testing.T) {
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
 		c.Build = "0.8.0" // Too low for auto init of bootstrap.
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		// remove the default as we want to bootstrap
 		c.ACLMasterToken = ""
@@ -490,7 +490,7 @@ func TestACLEndpoint_ReplicationStatus(t *testing.T) {
 
 	t.Parallel()
 	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc2"
+		c.PrimaryDatacenter = "dc2"
 		c.ACLTokenReplication = true
 		c.ACLReplicationRate = 100
 		c.ACLReplicationBurst = 100

--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -8,8 +8,9 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 const (
@@ -86,7 +87,7 @@ var errContainsRedactedData = errors.New("replication results contain redacted d
 
 func (s *Server) fetchACLRolesBatch(roleIDs []string) (*structs.ACLRoleBatchResponse, error) {
 	req := structs.ACLRoleBatchGetRequest{
-		Datacenter: s.config.ACLDatacenter,
+		Datacenter: s.config.PrimaryDatacenter,
 		RoleIDs:    roleIDs,
 		QueryOptions: structs.QueryOptions{
 			AllowStale: true,
@@ -106,7 +107,7 @@ func (s *Server) fetchACLRoles(lastRemoteIndex uint64) (*structs.ACLRoleListResp
 	defer metrics.MeasureSince([]string{"leader", "replication", "acl", "role", "fetch"}, time.Now())
 
 	req := structs.ACLRoleListRequest{
-		Datacenter: s.config.ACLDatacenter,
+		Datacenter: s.config.PrimaryDatacenter,
 		QueryOptions: structs.QueryOptions{
 			AllowStale:    true,
 			MinQueryIndex: lastRemoteIndex,
@@ -124,7 +125,7 @@ func (s *Server) fetchACLRoles(lastRemoteIndex uint64) (*structs.ACLRoleListResp
 
 func (s *Server) fetchACLPoliciesBatch(policyIDs []string) (*structs.ACLPolicyBatchResponse, error) {
 	req := structs.ACLPolicyBatchGetRequest{
-		Datacenter: s.config.ACLDatacenter,
+		Datacenter: s.config.PrimaryDatacenter,
 		PolicyIDs:  policyIDs,
 		QueryOptions: structs.QueryOptions{
 			AllowStale: true,
@@ -144,7 +145,7 @@ func (s *Server) fetchACLPolicies(lastRemoteIndex uint64) (*structs.ACLPolicyLis
 	defer metrics.MeasureSince([]string{"leader", "replication", "acl", "policy", "fetch"}, time.Now())
 
 	req := structs.ACLPolicyListRequest{
-		Datacenter: s.config.ACLDatacenter,
+		Datacenter: s.config.PrimaryDatacenter,
 		QueryOptions: structs.QueryOptions{
 			AllowStale:    true,
 			MinQueryIndex: lastRemoteIndex,
@@ -314,7 +315,7 @@ func (s *Server) updateLocalACLType(ctx context.Context, logger hclog.Logger, tr
 
 func (s *Server) fetchACLTokensBatch(tokenIDs []string) (*structs.ACLTokenBatchResponse, error) {
 	req := structs.ACLTokenBatchGetRequest{
-		Datacenter:  s.config.ACLDatacenter,
+		Datacenter:  s.config.PrimaryDatacenter,
 		AccessorIDs: tokenIDs,
 		QueryOptions: structs.QueryOptions{
 			AllowStale: true,
@@ -334,7 +335,7 @@ func (s *Server) fetchACLTokens(lastRemoteIndex uint64) (*structs.ACLTokenListRe
 	defer metrics.MeasureSince([]string{"leader", "replication", "acl", "token", "fetch"}, time.Now())
 
 	req := structs.ACLTokenListRequest{
-		Datacenter: s.config.ACLDatacenter,
+		Datacenter: s.config.PrimaryDatacenter,
 		QueryOptions: structs.QueryOptions{
 			AllowStale:    true,
 			MinQueryIndex: lastRemoteIndex,
@@ -479,7 +480,7 @@ func (s *Server) replicateACLType(ctx context.Context, logger hclog.Logger, tr a
 // IsACLReplicationEnabled returns true if ACL replication is enabled.
 // DEPRECATED (ACL-Legacy-Compat) - with new ACLs at least policy replication is required
 func (s *Server) IsACLReplicationEnabled() bool {
-	authDC := s.config.ACLDatacenter
+	authDC := s.config.PrimaryDatacenter
 	return len(authDC) > 0 && (authDC != s.config.Datacenter) &&
 		s.config.ACLTokenReplication
 }
@@ -516,7 +517,7 @@ func (s *Server) initReplicationStatus() {
 
 	s.aclReplicationStatus.Enabled = true
 	s.aclReplicationStatus.Running = true
-	s.aclReplicationStatus.SourceDatacenter = s.config.ACLDatacenter
+	s.aclReplicationStatus.SourceDatacenter = s.config.PrimaryDatacenter
 }
 
 func (s *Server) updateACLReplicationStatusStopped() {

--- a/agent/consul/acl_replication_legacy.go
+++ b/agent/consul/acl_replication_legacy.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 // aclIterator simplifies the algorithm below by providing a basic iterator that
@@ -166,7 +167,7 @@ func (s *Server) fetchRemoteLegacyACLs(lastRemoteIndex uint64) (*structs.Indexed
 	defer metrics.MeasureSince([]string{"leader", "fetchRemoteACLs"}, time.Now())
 
 	args := structs.DCSpecificRequest{
-		Datacenter: s.config.ACLDatacenter,
+		Datacenter: s.config.PrimaryDatacenter,
 		QueryOptions: structs.QueryOptions{
 			Token:         s.tokens.ReplicationToken(),
 			MinQueryIndex: lastRemoteIndex,

--- a/agent/consul/acl_replication_legacy_test.go
+++ b/agent/consul/acl_replication_legacy_test.go
@@ -234,7 +234,7 @@ func TestACLReplication_updateLocalACLs_RateLimit(t *testing.T) {
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLReplicationApplyLimit = 1
 	})
@@ -289,7 +289,7 @@ func TestACLReplication_IsACLReplicationEnabled(t *testing.T) {
 	t.Parallel()
 	// ACLs not enabled.
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = ""
+		c.PrimaryDatacenter = ""
 		c.ACLsEnabled = false
 	})
 	defer os.RemoveAll(dir1)
@@ -301,7 +301,7 @@ func TestACLReplication_IsACLReplicationEnabled(t *testing.T) {
 	// ACLs enabled but not replication.
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 	})
 	defer os.RemoveAll(dir2)
@@ -316,7 +316,7 @@ func TestACLReplication_IsACLReplicationEnabled(t *testing.T) {
 	// ACLs enabled with replication.
 	dir3, s3 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = true
 	})
@@ -331,7 +331,7 @@ func TestACLReplication_IsACLReplicationEnabled(t *testing.T) {
 	// so replication should be disabled.
 	dir4, s4 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = true
 	})
@@ -354,7 +354,7 @@ func TestACLReplication_LegacyTokens(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 	})
@@ -366,7 +366,7 @@ func TestACLReplication_LegacyTokens(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = true
 		c.ACLReplicationRate = 100

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/authmethod/testauth"
 	"github.com/hashicorp/consul/agent/structs"
 	tokenStore "github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestACLReplication_diffACLPolicies(t *testing.T) {
@@ -298,7 +299,7 @@ func TestACLReplication_Tokens(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 	})
@@ -310,7 +311,7 @@ func TestACLReplication_Tokens(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = true
 		c.ACLReplicationRate = 100
@@ -515,7 +516,7 @@ func TestACLReplication_Policies(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 	})
@@ -527,7 +528,7 @@ func TestACLReplication_Policies(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = false
 		c.ACLReplicationRate = 100
@@ -640,7 +641,7 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 	})
@@ -683,7 +684,7 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = true
 		c.ACLReplicationRate = 100
@@ -790,7 +791,7 @@ func TestACLReplication_AllTypes(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 	})
@@ -802,7 +803,7 @@ func TestACLReplication_AllTypes(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = true
 		c.ACLReplicationRate = 100

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -119,9 +119,9 @@ func (s *Server) canUpgradeToNewACLs(isLeader bool) bool {
 	}
 
 	if !s.InACLDatacenter() {
-		foundServers, mode, _ := ServersGetACLMode(s, "", s.config.ACLDatacenter)
+		foundServers, mode, _ := ServersGetACLMode(s, "", s.config.PrimaryDatacenter)
 		if mode != structs.ACLModeEnabled || !foundServers {
-			s.logger.Debug("Cannot upgrade to new ACLs, servers in acl datacenter are not yet upgraded", "ACLDatacenter", s.config.ACLDatacenter, "mode", mode, "found", foundServers)
+			s.logger.Debug("Cannot upgrade to new ACLs, servers in acl datacenter are not yet upgraded", "PrimaryDatacenter", s.config.PrimaryDatacenter, "mode", mode, "found", foundServers)
 			return false
 		}
 	}
@@ -143,7 +143,7 @@ func (s *Server) canUpgradeToNewACLs(isLeader bool) bool {
 }
 
 func (s *Server) InACLDatacenter() bool {
-	return s.config.ACLDatacenter == "" || s.config.Datacenter == s.config.ACLDatacenter
+	return s.config.PrimaryDatacenter == "" || s.config.Datacenter == s.config.PrimaryDatacenter
 }
 
 func (s *Server) UseLegacyACLs() bool {
@@ -167,8 +167,8 @@ func (s *Server) LocalTokensEnabled() bool {
 func (s *Server) ACLDatacenter(legacy bool) string {
 	// For resolution running on servers the only option
 	// is to contact the configured ACL Datacenter
-	if s.config.ACLDatacenter != "" {
-		return s.config.ACLDatacenter
+	if s.config.PrimaryDatacenter != "" {
+		return s.config.PrimaryDatacenter
 	}
 
 	// This function only gets called if ACLs are enabled.

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -2194,7 +2194,7 @@ func TestACL_Replication(t *testing.T) {
 
 	for _, aclDownPolicy := range aclExtendPolicies {
 		dir1, s1 := testServerWithConfig(t, func(c *Config) {
-			c.ACLDatacenter = "dc1"
+			c.PrimaryDatacenter = "dc1"
 			c.ACLMasterToken = "root"
 		})
 		defer os.RemoveAll(dir1)
@@ -2204,7 +2204,7 @@ func TestACL_Replication(t *testing.T) {
 
 		dir2, s2 := testServerWithConfig(t, func(c *Config) {
 			c.Datacenter = "dc2"
-			c.ACLDatacenter = "dc1"
+			c.PrimaryDatacenter = "dc1"
 			c.ACLDefaultPolicy = "deny"
 			c.ACLDownPolicy = aclDownPolicy
 			c.ACLTokenReplication = true
@@ -2218,7 +2218,7 @@ func TestACL_Replication(t *testing.T) {
 
 		dir3, s3 := testServerWithConfig(t, func(c *Config) {
 			c.Datacenter = "dc3"
-			c.ACLDatacenter = "dc1"
+			c.PrimaryDatacenter = "dc1"
 			c.ACLDownPolicy = "deny"
 			c.ACLTokenReplication = true
 			c.ACLReplicationRate = 100
@@ -2312,7 +2312,7 @@ func TestACL_Replication(t *testing.T) {
 func TestACL_MultiDC_Found(t *testing.T) {
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLMasterToken = "root"
 	})
 	defer os.RemoveAll(dir1)
@@ -2322,7 +2322,7 @@ func TestACL_MultiDC_Found(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1" // Enable ACLs!
+		c.PrimaryDatacenter = "dc1" // Enable ACLs!
 	})
 	defer os.RemoveAll(dir2)
 	defer s2.Shutdown()

--- a/agent/consul/acl_token_exp_test.go
+++ b/agent/consul/acl_token_exp_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestACLTokenReap_Primary(t *testing.T) {
@@ -41,7 +42,7 @@ func testACLTokenReap_Primary(t *testing.T, local, global bool) {
 	require.NotEqual(t, local, global)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLTokenMinExpirationTTL = 10 * time.Millisecond

--- a/agent/consul/auto_encrypt_endpoint_test.go
+++ b/agent/consul/auto_encrypt_endpoint_test.go
@@ -57,6 +57,7 @@ func TestAutoEncryptSign(t *testing.T) {
 			}
 			dir, s := testServerWithConfig(t, func(c *Config) {
 				c.AutoEncryptAllowTLS = true
+				c.PrimaryDatacenter = "dc1"
 				c.Bootstrap = true
 				c.TLSConfig.CAFile = root
 				c.TLSConfig.VerifyOutgoing = true

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -180,7 +180,7 @@ func TestCatalog_Register_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -426,7 +426,7 @@ func TestCatalog_Register_ConnectProxy_ACLDestinationServiceName(t *testing.T) {
 
 	assert := assert.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -555,7 +555,7 @@ func TestCatalog_Deregister_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1295,7 +1295,7 @@ func TestCatalog_ListNodes_ACLFilter(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1636,7 +1636,7 @@ func TestCatalog_ListServices_Stale(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 	})
 	defer os.RemoveAll(dir1)
@@ -1644,7 +1644,7 @@ func TestCatalog_ListServices_Stale(t *testing.T) {
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1" // Enable ACLs!
+		c.PrimaryDatacenter = "dc1" // Enable ACLs!
 		c.ACLsEnabled = true
 		c.Bootstrap = false // Disable bootstrap
 	})
@@ -2413,7 +2413,7 @@ func TestCatalog_ListServiceNodes_ConnectProxy_ACL(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -2708,7 +2708,7 @@ func TestCatalog_Register_FailedCase1(t *testing.T) {
 
 func testACLFilterServer(t *testing.T) (dir, token string, srv *Server, codec rpc.ClientCodec) {
 	dir, srv = testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -2871,7 +2871,7 @@ func TestCatalog_NodeServices_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -3284,7 +3284,7 @@ func TestCatalog_GatewayServices_ACLFiltering(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -179,13 +179,9 @@ type Config struct {
 	ACLsEnabled bool
 
 	// ACLMasterToken is used to bootstrap the ACL system. It should be specified
-	// on the servers in the ACLDatacenter. When the leader comes online, it ensures
+	// on the servers in the PrimaryDatacenter. When the leader comes online, it ensures
 	// that the Master token is available. This provides the initial token.
 	ACLMasterToken string
-
-	// ACLDatacenter provides the authoritative datacenter for ACL
-	// tokens. If not provided, ACL verification is disabled.
-	ACLDatacenter string
 
 	// ACLTokenTTL controls the time-to-live of cached ACL tokens.
 	// It can be set to zero to disable caching, but this adds
@@ -219,7 +215,7 @@ type Config struct {
 	// allow-lists.
 	ACLDefaultPolicy string
 
-	// ACLDownPolicy controls the behavior of ACLs if the ACLDatacenter
+	// ACLDownPolicy controls the behavior of ACLs if the PrimaryDatacenter
 	// cannot be contacted. It can be either "deny" to deny all requests,
 	// "extend-cache" or "async-cache" which ignores the ACLCacheInterval and
 	// uses cached policies.

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -152,7 +152,7 @@ func TestConfigEntry_Apply_ACLDeny(t *testing.T) {
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -281,7 +281,7 @@ func TestConfigEntry_Get_ACLDeny(t *testing.T) {
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -494,7 +494,7 @@ func TestConfigEntry_List_ACLDeny(t *testing.T) {
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -579,7 +579,7 @@ func TestConfigEntry_ListAll_ACLDeny(t *testing.T) {
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -738,7 +738,7 @@ func TestConfigEntry_Delete_ACLDeny(t *testing.T) {
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1960,7 +1960,7 @@ func TestConfigEntry_ResolveServiceConfig_ACLDeny(t *testing.T) {
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -670,6 +670,7 @@ func TestConnectCAConfig_UpdateSecondary(t *testing.T) {
 	// Initialize primary as the primary DC
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "primary"
+		c.PrimaryDatacenter = "primary"
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -842,6 +843,7 @@ func TestConnectCASign(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 			dir1, s1 := testServerWithConfig(t, func(cfg *Config) {
+				cfg.PrimaryDatacenter = "dc1"
 				cfg.CAConfig.Config["PrivateKeyType"] = tt.caKeyType
 				cfg.CAConfig.Config["PrivateKeyBits"] = tt.caKeyBits
 			})
@@ -931,6 +933,7 @@ func TestConnectCASign_rateLimit(t *testing.T) {
 	require := require.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.Bootstrap = true
 		c.CAConfig.Config = map[string]interface{}{
 			// It actually doesn't work as expected with some higher values because
@@ -996,6 +999,7 @@ func TestConnectCASign_concurrencyLimit(t *testing.T) {
 	require := require.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.Bootstrap = true
 		c.CAConfig.Config = map[string]interface{}{
 			// Must disable the rate limit since it takes precedence

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -161,7 +161,7 @@ func TestConnectCAConfig_GetSet_ACLDeny(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = TestDefaultMasterToken
 		c.ACLDefaultPolicy = "deny"
@@ -1102,7 +1102,7 @@ func TestConnectCASignValidation(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/coordinate_endpoint_test.go
+++ b/agent/consul/coordinate_endpoint_test.go
@@ -194,7 +194,7 @@ func TestCoordinate_Update_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -370,7 +370,7 @@ func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -562,7 +562,7 @@ func TestCoordinate_Node_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/discovery_chain_endpoint_test.go
+++ b/agent/consul/discovery_chain_endpoint_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testrpc"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDiscoveryChainEndpoint_Get(t *testing.T) {
@@ -23,7 +24,7 @@ func TestDiscoveryChainEndpoint_Get(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/federation_state_endpoint_test.go
+++ b/agent/consul/federation_state_endpoint_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 	"time"
 
+	uuid "github.com/hashicorp/go-uuid"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/types"
-	uuid "github.com/hashicorp/go-uuid"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestFederationState_Apply_Upsert(t *testing.T) {
@@ -112,7 +113,7 @@ func TestFederationState_Apply_Upsert_ACLDeny(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.DisableFederationStateAntiEntropy = true
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -232,7 +233,7 @@ func TestFederationState_Get_ACLDeny(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.DisableFederationStateAntiEntropy = true
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -403,7 +404,7 @@ func TestFederationState_List_ACLDeny(t *testing.T) {
 		c.DisableFederationStateAntiEntropy = true
 		c.Datacenter = "dc1"
 		c.PrimaryDatacenter = "dc1"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -419,7 +420,7 @@ func TestFederationState_List_ACLDeny(t *testing.T) {
 		c.DisableFederationStateAntiEntropy = true
 		c.Datacenter = "dc2"
 		c.PrimaryDatacenter = "dc1"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -678,7 +679,7 @@ func TestFederationState_Apply_Delete_ACLDeny(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.DisableFederationStateAntiEntropy = true
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/federation_state_endpoint_test.go
+++ b/agent/consul/federation_state_endpoint_test.go
@@ -27,6 +27,7 @@ func TestFederationState_Apply_Upsert(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.DisableFederationStateAntiEntropy = true
+		c.PrimaryDatacenter = "dc1"
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -190,6 +191,7 @@ func TestFederationState_Get(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.DisableFederationStateAntiEntropy = true
+		c.PrimaryDatacenter = "dc1"
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -306,6 +308,7 @@ func TestFederationState_List(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.DisableFederationStateAntiEntropy = true
+		c.PrimaryDatacenter = "dc1"
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -596,6 +599,7 @@ func TestFederationState_Apply_Delete(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.DisableFederationStateAntiEntropy = true
+		c.PrimaryDatacenter = "dc1"
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -12,9 +16,6 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/types"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestHealth_ChecksInState(t *testing.T) {
@@ -980,7 +981,7 @@ func TestHealth_ServiceNodes_ConnectProxy_ACL(t *testing.T) {
 
 	assert := assert.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1294,7 +1295,7 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/require"
 )
 
 // Test basic creation
@@ -859,7 +860,7 @@ func TestIntentionApply_aclDeny(t *testing.T) {
 
 	require := require.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1264,7 +1265,7 @@ func TestIntentionApply_aclDelete(t *testing.T) {
 
 	require := require.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1345,7 +1346,7 @@ func TestIntentionApply_aclUpdate(t *testing.T) {
 
 	require := require.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1414,7 +1415,7 @@ func TestIntentionApply_aclManagement(t *testing.T) {
 
 	require := require.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1459,7 +1460,7 @@ func TestIntentionApply_aclUpdateChange(t *testing.T) {
 
 	require := require.New(t)
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1524,7 +1525,7 @@ func TestIntentionGet_acl(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1928,7 +1929,7 @@ func TestIntentionCheck_defaultACLDeny(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1964,7 +1965,7 @@ func TestIntentionCheck_defaultACLAllow(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "allow"
@@ -2000,7 +2001,7 @@ func TestIntentionCheck_aclDeny(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
@@ -13,9 +17,6 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/types"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestInternal_NodeInfo(t *testing.T) {
@@ -559,7 +560,7 @@ func TestInternal_EventFire_Token(t *testing.T) {
 
 	t.Parallel()
 	dir, srv := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDownPolicy = "deny"
@@ -958,7 +959,7 @@ func TestInternal_GatewayServiceDump_Terminating_ACL(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1301,7 +1302,7 @@ func TestInternal_GatewayServiceDump_Ingress_ACL(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1904,7 +1905,7 @@ func TestInternal_ServiceTopology_ACL(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = TestDefaultMasterToken
 		c.ACLDefaultPolicy = "deny"
@@ -2041,7 +2042,7 @@ func TestInternal_IntentionUpstreams_ACL(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = TestDefaultMasterToken
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/kvs_endpoint_test.go
+++ b/agent/consul/kvs_endpoint_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestKVS_Apply(t *testing.T) {
@@ -81,7 +82,7 @@ func TestKVS_Apply_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -201,7 +202,7 @@ func TestKVS_Get_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -422,7 +423,7 @@ func TestKVSEndpoint_List_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -512,7 +513,7 @@ func TestKVSEndpoint_List_ACLEnableKeyListPolicy(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -715,7 +716,7 @@ func TestKVSEndpoint_ListKeys_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -404,7 +404,7 @@ func (s *Server) initializeLegacyACL() error {
 		return nil
 	}
 
-	authDC := s.config.ACLDatacenter
+	authDC := s.config.PrimaryDatacenter
 
 	// Create anonymous token if missing.
 	state := s.fsm.State()

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -200,7 +200,7 @@ func TestLeader_SecondaryCA_Initialize(t *testing.T) {
 			// Initialize primary as the primary DC
 			dir1, s1 := testServerWithConfig(t, func(c *Config) {
 				c.Datacenter = "primary"
-				c.ACLDatacenter = "primary"
+				c.PrimaryDatacenter = "primary"
 				c.Build = "1.6.0"
 				c.ACLsEnabled = true
 				c.ACLMasterToken = masterToken
@@ -219,7 +219,7 @@ func TestLeader_SecondaryCA_Initialize(t *testing.T) {
 			// secondary as a secondary DC
 			dir2, s2 := testServerWithConfig(t, func(c *Config) {
 				c.Datacenter = "secondary"
-				c.ACLDatacenter = "primary"
+				c.PrimaryDatacenter = "primary"
 				c.Build = "1.6.0"
 				c.ACLsEnabled = true
 				c.ACLDefaultPolicy = "deny"

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -55,6 +55,7 @@ func TestLeader_Builtin_PrimaryCA_ChangeKeyConfig(t *testing.T) {
 				// Initialize primary as the primary DC
 				dir1, srv := testServerWithConfig(t, func(c *Config) {
 					c.Datacenter = "dc1"
+					c.PrimaryDatacenter = "dc1"
 					c.Build = "1.6.0"
 					c.CAConfig.Config["PrivateKeyType"] = src.keyType
 					c.CAConfig.Config["PrivateKeyBits"] = src.keyBits
@@ -600,6 +601,7 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Build = "1.6.0"
+		c.PrimaryDatacenter = "dc1"
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -850,6 +852,7 @@ func TestLeader_SecondaryCA_FixSigningKeyID_via_IntermediateRefresh(t *testing.T
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Build = "1.6.0"
+		c.PrimaryDatacenter = "dc1"
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/leader_federation_state_ae_test.go
+++ b/agent/consul/leader_federation_state_ae_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLeader_FederationStateAntiEntropy_FeatureIsStickyEvenIfSerfTagsRegress(t *testing.T) {
@@ -356,7 +357,7 @@ func TestLeader_FederationStateAntiEntropyPruning_ACLDeny(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -370,7 +371,7 @@ func TestLeader_FederationStateAntiEntropyPruning_ACLDeny(t *testing.T) {
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
 		c.PrimaryDatacenter = "dc1"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/leader_intentions_test.go
+++ b/agent/consul/leader_intentions_test.go
@@ -27,7 +27,7 @@ func TestLeader_ReplicateIntentions(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -62,7 +62,7 @@ func TestLeader_ReplicateIntentions(t *testing.T) {
 	// dc2 as a secondary DC
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLDefaultPolicy = "deny"
 		c.ACLTokenReplication = false

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -29,7 +29,7 @@ func TestLeader_RegisterMember(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -106,7 +106,7 @@ func TestLeader_FailedMember(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -172,7 +172,7 @@ func TestLeader_LeftMember(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -224,7 +224,7 @@ func TestLeader_ReapMember(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -291,7 +291,7 @@ func TestLeader_CheckServersMeta(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "allow"
@@ -301,7 +301,7 @@ func TestLeader_CheckServersMeta(t *testing.T) {
 	defer s1.Shutdown()
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "allow"
@@ -311,7 +311,7 @@ func TestLeader_CheckServersMeta(t *testing.T) {
 	defer s2.Shutdown()
 
 	dir3, s3 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "allow"
@@ -399,7 +399,7 @@ func TestLeader_ReapServer(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "allow"
@@ -409,7 +409,7 @@ func TestLeader_ReapServer(t *testing.T) {
 	defer s1.Shutdown()
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "allow"
@@ -419,7 +419,7 @@ func TestLeader_ReapServer(t *testing.T) {
 	defer s2.Shutdown()
 
 	dir3, s3 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "allow"
@@ -480,7 +480,7 @@ func TestLeader_Reconcile_ReapMember(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -534,7 +534,7 @@ func TestLeader_Reconcile(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -889,7 +889,7 @@ func TestLeader_ReapTombstones(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1194,7 +1194,7 @@ func TestLeader_ACL_Initialization(t *testing.T) {
 				c.Build = tt.build
 				c.Bootstrap = true
 				c.Datacenter = "dc1"
-				c.ACLDatacenter = "dc1"
+				c.PrimaryDatacenter = "dc1"
 				c.ACLsEnabled = true
 				c.ACLMasterToken = tt.master
 			}
@@ -1305,7 +1305,7 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 	})
@@ -1318,7 +1318,7 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = false
 		c.ACLReplicationRate = 100
@@ -1363,7 +1363,7 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 
 	dir2new, s2new := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLTokenReplication = false
 		c.ACLReplicationRate = 100

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1232,6 +1232,7 @@ func TestLeader_ACLUpgrade(t *testing.T) {
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLsEnabled = true
+		c.PrimaryDatacenter = "dc1"
 		c.ACLMasterToken = "root"
 	})
 	defer os.RemoveAll(dir1)

--- a/agent/consul/operator_autopilot_endpoint_test.go
+++ b/agent/consul/operator_autopilot_endpoint_test.go
@@ -5,14 +5,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/hashicorp/consul/testrpc"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/raft"
 	autopilot "github.com/hashicorp/raft-autopilot"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/testrpc"
 )
 
 func TestOperator_Autopilot_GetConfiguration(t *testing.T) {
@@ -51,7 +52,7 @@ func TestOperator_Autopilot_GetConfiguration_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -155,7 +156,7 @@ func TestOperator_Autopilot_SetConfiguration_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/operator_raft_endpoint_test.go
+++ b/agent/consul/operator_raft_endpoint_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/testrpc"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/hashicorp/raft"
-	"github.com/stretchr/testify/require"
 )
 
 func TestOperator_RaftGetConfiguration(t *testing.T) {
@@ -69,7 +70,7 @@ func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -217,7 +218,7 @@ func TestOperator_RaftRemovePeerByAddress_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -346,7 +347,7 @@ func TestOperator_RaftRemovePeerByID_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -11,6 +11,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/serf/coordinate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	tokenStore "github.com/hashicorp/consul/agent/token"
@@ -18,11 +24,6 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-hclog"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	"github.com/hashicorp/serf/coordinate"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestPreparedQuery_Apply(t *testing.T) {
@@ -197,7 +198,7 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -643,7 +644,7 @@ func TestPreparedQuery_ACLDeny_Catchall_Template(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -862,7 +863,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1120,7 +1121,7 @@ func TestPreparedQuery_List(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1333,7 +1334,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1474,7 +1475,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -1487,7 +1488,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLDefaultPolicy = "deny"
 	})
@@ -2780,7 +2781,7 @@ func TestPreparedQuery_Wrapper(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -2790,7 +2791,7 @@ func TestPreparedQuery_Wrapper(t *testing.T) {
 
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -331,20 +331,6 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 		return nil, err
 	}
 
-	// Set the primary DC if it wasn't set.
-	// TODO: remove
-	if config.PrimaryDatacenter == "" {
-		if config.PrimaryDatacenter != "" {
-			config.PrimaryDatacenter = config.PrimaryDatacenter
-		} else {
-			config.PrimaryDatacenter = config.Datacenter
-		}
-	}
-
-	if config.PrimaryDatacenter != "" {
-		config.PrimaryDatacenter = config.PrimaryDatacenter
-	}
-
 	// Create the tombstone GC.
 	gc, err := state.NewTombstoneGC(config.TombstoneTTL, config.TombstoneTTLGranularity)
 	if err != nil {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -332,16 +332,17 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 	}
 
 	// Set the primary DC if it wasn't set.
+	// TODO: remove
 	if config.PrimaryDatacenter == "" {
-		if config.ACLDatacenter != "" {
-			config.PrimaryDatacenter = config.ACLDatacenter
+		if config.PrimaryDatacenter != "" {
+			config.PrimaryDatacenter = config.PrimaryDatacenter
 		} else {
 			config.PrimaryDatacenter = config.Datacenter
 		}
 	}
 
 	if config.PrimaryDatacenter != "" {
-		config.ACLDatacenter = config.PrimaryDatacenter
+		config.PrimaryDatacenter = config.PrimaryDatacenter
 	}
 
 	// Create the tombstone GC.

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -74,7 +74,7 @@ func testTLSCertificates(serverName string) (cert string, key string, cacert str
 // up all of the ACL configurations (so they can still be overridden)
 func testServerACLConfig(cb func(*Config)) func(*Config) {
 	return func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = TestDefaultMasterToken
 		c.ACLDefaultPolicy = "deny"
@@ -349,11 +349,11 @@ func TestServer_fixupACLDatacenter(t *testing.T) {
 	testrpc.WaitForLeader(t, s2.RPC, "bee")
 
 	require.Equal(t, "aye", s1.config.Datacenter)
-	require.Equal(t, "aye", s1.config.ACLDatacenter)
+	require.Equal(t, "aye", s1.config.PrimaryDatacenter)
 	require.Equal(t, "aye", s1.config.PrimaryDatacenter)
 
 	require.Equal(t, "bee", s2.config.Datacenter)
-	require.Equal(t, "aye", s2.config.ACLDatacenter)
+	require.Equal(t, "aye", s2.config.PrimaryDatacenter)
 	require.Equal(t, "aye", s2.config.PrimaryDatacenter)
 }
 

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -125,6 +125,7 @@ func testServerConfig(t *testing.T) (string, *Config) {
 	config.NodeName = uniqueNodeName(t.Name())
 	config.Bootstrap = true
 	config.Datacenter = "dc1"
+	config.PrimaryDatacenter = "dc1"
 	config.DataDir = dir
 
 	// bind the rpc server to a random port. config.RPCAdvertise will be
@@ -195,6 +196,7 @@ func testServerConfig(t *testing.T) (string, *Config) {
 func testServer(t *testing.T) (string, *Server) {
 	return testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.Bootstrap = true
 	})
 }
@@ -209,6 +211,7 @@ func testServerDC(t *testing.T, dc string) (string, *Server) {
 func testServerDCBootstrap(t *testing.T, dc string, bootstrap bool) (string, *Server) {
 	return testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = dc
+		c.PrimaryDatacenter = dc
 		c.Bootstrap = bootstrap
 	})
 }

--- a/agent/consul/session_endpoint_test.go
+++ b/agent/consul/session_endpoint_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib/stringslice"
 	"github.com/hashicorp/consul/testrpc"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 )
 
 func TestSession_Apply(t *testing.T) {
@@ -153,7 +154,7 @@ func TestSession_Apply_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -391,7 +392,7 @@ func TestSession_Get_List_NodeSessions_ACLFilter(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -750,7 +751,7 @@ func TestSession_Renew_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/snapshot_endpoint_test.go
+++ b/agent/consul/snapshot_endpoint_test.go
@@ -7,14 +7,15 @@ import (
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
+	autopilot "github.com/hashicorp/raft-autopilot"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
-	autopilot "github.com/hashicorp/raft-autopilot"
-	"github.com/stretchr/testify/require"
 )
 
 // verifySnapshot is a helper that does a snapshot and restore.
@@ -268,7 +269,7 @@ func TestSnapshot_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -319,7 +319,7 @@ func TestTxn_Apply_ACLDeny(t *testing.T) {
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
@@ -854,7 +854,7 @@ func TestTxn_Read_ACLDeny(t *testing.T) {
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -226,7 +226,7 @@ func basicUIEnabledConfig(opts ...cfgFunc) *config.RuntimeConfig {
 
 func withACLs() cfgFunc {
 	return func(cfg *config.RuntimeConfig) {
-		cfg.ACLDatacenter = "dc1"
+		cfg.PrimaryDatacenter = "dc1"
 		cfg.ACLDefaultPolicy = "deny"
 		cfg.ACLsEnabled = true
 	}


### PR DESCRIPTION
The `ACLDatacenter` field in `agent/config.RuntimeConfig` and `agent/consul.Config` has been unnecessary for a while now. It was always set to the same value as `PrimaryDatacenter`. So we can remove the duplicate field and use `PrimaryDatacenter`
directly. The field remains in `agent/config.Config` which is necessary for backwards compatibility for now.

This change was made by GoLand refactor, which did most of the work for me.

Also , the constructor for Server is not at all the appropriate place to be setting default values for a config struct that was passed in. In production this value is always set from agent/config. In tests we should set the default in a test helper. The second commit removes this defaulting.