### PR TITLE
docs: Clarify ingress gateway's -address flag

### DIFF
--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -136,15 +136,16 @@ proxy configuration needed.
   `-register`. This takes the form of `<ip address>:<port>` but also supports go-sockaddr
   templates.
 
-  For terminating and mesh gateways, this is the IP and port on which
-  to receive traffic from services in the mesh. For ingress gateways, this is
-  the IP and port at which to instantiate a `/ready` HTTP endpoint which is used
-  by Consul for health checking the gateway. The specified IP will also be used
-  by the ingress gateway when instantiating user-defined listeners
-  configured in the
+  If Envoy is configured as a terminating or mesh gateway, traffic from services
+  within the mesh will be received at the specified IP and port.
+
+  If Envoy is configured as an ingress gateway, a `/ready` HTTP endpoint will be
+  instantiated at the specified IP and port. Consul uses `/ready` HTTP endpoints
+  to check gateway health. The specified IP will also be used by the ingress
+  gateway when instantiating user-defined listeners configured in the
   [ingress gateway](/docs/connect/gateways/ingress-gateway) configuration entry.
 
-  ~> **Note**: Ensure that user-defined ingress gateway listeners utilize a
+  ~> **Note**: Ensure that user-defined ingress gateway listeners use a
      different port than the port specified in `-address` so that they do not
      conflict with the health check endpoint.
 
@@ -153,7 +154,7 @@ proxy configuration needed.
   use `/dev/null`.
 
 - `-bind-address` - The bind address to use instead of the default binding rules.
-  Speciifed as `<name>=<ip>:<port>` pairs. This flag may be specified multiple times
+  Specified as `<name>=<ip>:<port>` pairs. This flag may be used multiple times
   to add multiple bind addresses.
 
 - `-expose-servers` - Expose the servers for WAN federation via this mesh

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -136,12 +136,24 @@ proxy configuration needed.
   `-register`. This takes the form of `<ip address>:<port>` but also supports go-sockaddr
   templates.
 
+  For terminating and mesh gateways, this is the IP and port on which
+  to receive traffic from services in the mesh. For ingress gateways, this is
+  the IP and port at which to instantiate a `/ready` HTTP endpoint which is used
+  by Consul for health checking the gateway. The specified IP will also be used
+  by the ingress gateway when instantiating user-defined listeners
+  configured in the
+  [ingress gateway](/docs/connect/gateways/ingress-gateway) configuration entry.
+
+  ~> **Note**: Ensure that user-defined ingress gateway listeners utilize a
+     different port than the port specified in `-address` so that they do not
+     conflict with the health check endpoint.
+
 - `-admin-access-log-path` The path to write the access log for the administration
   server. If no access log is desired specify `/dev/null`. By default it will
   use `/dev/null`.
 
-- `-bind-address` - The bind address to use instead of the default binding rules
-  given as `<name>=<ip>:<port>` pairs. This flag may be specified multiple times
+- `-bind-address` - The bind address to use instead of the default binding rules.
+  Speciifed as `<name>=<ip>:<port>` pairs. This flag may be specified multiple times
   to add multiple bind addresses.
 
 - `-expose-servers` - Expose the servers for WAN federation via this mesh

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -786,12 +786,11 @@ spec:
           type: 'int: 0',
           description: `The port on which the ingress listener should receive
                         traffic. The port will be bound to the IP address that
-                        was specified in the [`-address`](/commands/connect/envoy#address)
+                        was specified in the [\`-address\`](/commands/connect/envoy#address)
                         flag when starting the gateway.
-
                         <b>Note:</b> The ingress listener port must not conflict
-                        with the health check port specified in the `-address\`
-                        flag.`
+                        with the health check port specified in the \`-address\`
+                        flag.`,
         },
         {
           name: 'Protocol',
@@ -803,7 +802,7 @@ spec:
           name: 'Services',
           type: 'array<IngressService>: <optional>',
           description:
-            'A list of services to be exposed via this listener. For "tcp" listeners, only a single service is allowed.',
+            'A list of services to be exposed via this listener. For `tcp` listeners, only a single service is allowed.',
           children: [
             {
               name: 'Name',
@@ -812,7 +811,7 @@ spec:
                                   through this listener. This can be either a service registered in the
                                   catalog, or a service defined only by [other config entries](/docs/connect/l7-traffic-management). If the wildcard specifier,
                                   \`*\`, is provided, then ALL services will be exposed through the listener.
-                                  This is not supported for listener's with protocol "tcp".`,
+                                  This is not supported for listener's with protocol \`tcp\`.`,
             },
             {
               name: 'Namespace',

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -784,11 +784,14 @@ spec:
         {
           name: 'Port',
           type: 'int: 0',
-          description: `The port on which the listener should receive traffic.
-                        <b>Note:</b> This port must not conflict with the port
-                        that was specified in the
-                        [\`-address\`](/commands/connect/envoy#address) flag
-                        when starting the gateway.`,
+          description: `The port on which the ingress listener should receive
+                        traffic. The port will be bound to the IP address that
+                        was specified in the [`-address`](/commands/connect/envoy#address)
+                        flag when starting the gateway.
+
+                        <b>Note:</b> The ingress listener port must not conflict
+                        with the health check port specified in the `-address\`
+                        flag.`
         },
         {
           name: 'Protocol',

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -784,7 +784,11 @@ spec:
         {
           name: 'Port',
           type: 'int: 0',
-          description: 'The port that the listener should receive traffic on.',
+          description: `The port on which the listener should receive traffic.
+                        <b>Note:</b> This port must not conflict with the port
+                        that was specified in the
+                        [\`-address\`](/commands/connect/envoy#address) flag
+                        when starting the gateway.`,
         },
         {
           name: 'Protocol',


### PR DESCRIPTION
Clarify the function of `-address` flag when instantiating an ingress gateway.

Resolves #9849