### PR TITLE
Document possible risk w.r.t exposing the admin API in Envoy

### DIFF
--- a/website/content/docs/connect/security.mdx
+++ b/website/content/docs/connect/security.mdx
@@ -100,19 +100,16 @@ will not be encrypted or authorized via Connect.
 
 ### Restrict Access to Envoy's Administration Interface
 
-Envoy exposes a local, unauthenticated
+Envoy exposes an **unauthenticated**
 [administration interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
-that can be used to query and modify different aspects of the proxy. The admin
-interface allows potentially sensitive information to be retrieved, such as:
+that can be used to query and modify the proxy. This interface 
+allows potentially sensitive information to be retrieved, such as:
 
-* Envoy configuration.
+* Envoy configuration
 * TLS certificates
 * List of upstream services and endpoints
 
-In addition, the admin interface allows you to perform operations that affect how
-connections are routed to or from the proxy within the service mesh.
-
-We **highly recommend** only exposing the endpoint on a loopback
+We **strongly advise** only exposing the administration interface on a loopback
 address (default configuration) and restricting access to a subset of users.
 
 **If the administration interface is exposed externally**, for

--- a/website/content/docs/connect/security.mdx
+++ b/website/content/docs/connect/security.mdx
@@ -103,17 +103,17 @@ will not be encrypted or authorized via Connect.
 Envoy exposes a local, unauthenticated
 [administration interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
 that can be used to query and modify different aspects of the proxy. The admin
-interface allows retrieving potentially sensitive information such as:
+interface allows potentially sensitive information to be retrieved, such as:
 
 * Envoy configuration.
 * TLS certificates
 * List of upstream services and endpoints
 
-In addition, the admin interface allows performing operations which affect how
+In addition, the admin interface allows you to perform operations that affect how
 connections are routed to or from the proxy within the service mesh.
 
-It is **highly recommended** that this endpoint only be exposed on a loopback
-address (default configuration), and access restricted to a subset of users.
+We **highly recommend** only exposing the endpoint on a loopback
+address (default configuration) and restricting access to a subset of users.
 
 **If the administration interface is exposed externally**, for
 example by specifying a routable [`-admin-bind`](/commands/connect/envoy#admin-bind)

--- a/website/content/docs/connect/security.mdx
+++ b/website/content/docs/connect/security.mdx
@@ -97,3 +97,25 @@ using a local Connect proxy. This is documented in the
 
 **If non-proxy traffic can communicate with the service**, this traffic
 will not be encrypted or authorized via Connect.
+
+### Restrict Access to Envoy's Administration Interface
+
+Envoy exposes a local, unauthenticated
+[administration interface](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
+that can be used to query and modify different aspects of the proxy. The admin
+interface allows retrieving potentially sensitive information such as:
+
+* Envoy configuration.
+* TLS certificates
+* List of upstream services and endpoints
+
+In addition, the admin interface allows performing operations which affect how
+connections are routed to or from the proxy within the service mesh.
+
+It is **highly recommended** that this endpoint only be exposed on a loopback
+address (default configuration), and access restricted to a subset of users.
+
+**If the administration interface is exposed externally**, for
+example by specifying a routable [`-admin-bind`](/commands/connect/envoy#admin-bind)
+address, it may be possible for a malicious actor to gain access to Envoy's
+configuration, or impact the service's availability within the cluster.


### PR DESCRIPTION
Add a section to the Connect Security page which highlights the risks of exposing Envoy's administration interface outside of localhost.

Resolves #5692