### PR TITLE
[1.8.x] cli: Use admin bind address in self_admin cluster (#10757)

### DIFF
--- a/.changelog/10757.txt
+++ b/.changelog/10757.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+cli: Ensure the metrics endpoint is accessible when Envoy is configured to use
+a non-default admin bind address.
+```

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -416,7 +416,7 @@ func (c *BootstrapConfig) generateListenerConfig(args *BootstrapTplArgs, bindAdd
 		"hosts": [
 			{
 				"socket_address": {
-					"address": "127.0.0.1",
+					"address": "` + args.AdminBindAddress + `",
 					"port_value": ` + args.AdminBindPort + `
 				}
 			}

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -23,6 +23,20 @@ const (
 			}
 		]
 	}`
+	expectedSelfAdminClusterNonLoopbackIP = `{
+		"name": "self_admin",
+		"connect_timeout": "5s",
+		"type": "STATIC",
+		"http_protocol_options": {},
+		"hosts": [
+			{
+				"socket_address": {
+					"address": "192.0.2.10",
+					"port_value": 19002
+				}
+			}
+		]
+	}`
 	expectedPromListener = `{
 		"name": "envoy_prometheus_metrics_listener",
 		"address": {
@@ -436,6 +450,26 @@ func TestBootstrapConfig_ConfigureArgs(t *testing.T) {
 				AdminBindPort:    "19000",
 				// Should add a static cluster for the self-proxy to admin
 				StaticClustersJSON: expectedSelfAdminCluster,
+				// Should add a static http listener too
+				StaticListenersJSON: expectedPromListener,
+				StatsConfigJSON:     defaultStatsConfigJSON,
+			},
+			wantErr: false,
+		},
+		{
+			name: "prometheus-bind-addr-non-loopback-ip",
+			input: BootstrapConfig{
+				PrometheusBindAddr: "0.0.0.0:9000",
+			},
+			baseArgs: BootstrapTplArgs{
+				AdminBindAddress: "192.0.2.10",
+				AdminBindPort:    "19002",
+			},
+			wantArgs: BootstrapTplArgs{
+				AdminBindAddress: "192.0.2.10",
+				AdminBindPort:    "19002",
+				// Should add a static cluster for the self-proxy to admin
+				StaticClustersJSON: expectedSelfAdminClusterNonLoopbackIP,
 				// Should add a static http listener too
 				StaticListenersJSON: expectedPromListener,
 				StatsConfigJSON:     defaultStatsConfigJSON,


### PR DESCRIPTION
Backport of #10757 to 1.8.x.

Configure the self_admin cluster to use the admin bind address provided when starting Envoy.

Fixes #10747