### PR TITLE
cli: Fix broken KV import on Windows

### DIFF
--- a/.changelog/10820.txt
+++ b/.changelog/10820.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix broken KV import command on Windows.
+```

--- a/command/kv/imp/kv_import.go
+++ b/command/kv/imp/kv_import.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"
@@ -79,7 +79,7 @@ func (c *cmd) Run(args []string) int {
 		}
 
 		pair := &api.KVPair{
-			Key:   filepath.Join(c.prefix, entry.Key),
+			Key:   path.Join(c.prefix, entry.Key),
 			Flags: entry.Flags,
 			Value: value,
 		}


### PR DESCRIPTION
Consul 1.10 (PR #9792) introduced the ability to specify a prefix when importing KV's. This however introduced a regression on Windows systems which breaks `kv import`. The key name is joined with specified`-prefix` using `filepath.Join()` which uses a forward slash (/) to delimit values on Unix-based systems, and a backslash (\) to delimit values on Windows – the latter of which is incompatible with Consul KV paths.

This commit replaces filepath.Join() with path.Join() which uses a forward slash as the delimiter, providing consistent key join behavior across supported operating systems.

Fixes #10583

**Note**: No additional tests were added in this commit because the existing tests would have caught this error if they had been run on Windows.