### PR TITLE
Update namespaced replication token example

### DIFF
--- a/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
+++ b/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
@@ -232,7 +232,6 @@ You'll need:
    If you're running Consul Enterprise you'll need the rules:
 
    ```hcl
-   acl = "write"
    operator = "write"
    agent_prefix "" {
      policy = "read"


### PR DESCRIPTION
This documentation patch updates the sample replication token policy provided for multi-cluster federation using namespaces.

As ACLs are namespace-scoped resources, the `acl = "write"` permission must be applicable to all namespaces. Otherwise secondary datacenters will fail to replicate ACL tokens and policies outside the `default` namespace.