### PR TITLE
proxycfg: Use acl.tokens.default token as a default when there is no token in the registration

### DIFF
--- a/.changelog/10824.txt
+++ b/.changelog/10824.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: fixes a bug that prevented the default user token from being used to authorize service registration for connect proxies.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -559,6 +559,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		Health: a.rpcClientHealth,
 		Logger: a.logger.Named(logging.ProxyConfig),
 		State:  a.State,
+		Tokens: a.baseDeps.Tokens,
 		Source: &structs.QuerySource{
 			Datacenter: a.config.Datacenter,
 			Segment:    a.config.SegmentName,

--- a/agent/proxycfg/manager.go
+++ b/agent/proxycfg/manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/tlsutil"
 )
 
@@ -73,6 +74,9 @@ type ManagerConfig struct {
 	// logger is the agent's logger to be used for logging logs.
 	Logger          hclog.Logger
 	TLSConfigurator *tlsutil.Configurator
+	// Tokens configured on the local agent. Used to look up the agent token if
+	// a service is registered without a token.
+	Tokens *token.Store
 
 	// IntentionDefaultAllow is set by the agent so that we can pass this
 	// information to proxies that need to make intention decisions on their
@@ -156,7 +160,7 @@ func (m *Manager) syncState() {
 		// know that so we'd need to set it here if not during registration of the
 		// proxy service. Sidecar Service in the interim can do that, but we should
 		// validate more generally that that is always true.
-		err := m.ensureProxyServiceLocked(svc, m.State.ServiceToken(sid))
+		err := m.ensureProxyServiceLocked(svc)
 		if err != nil {
 			m.Logger.Error("failed to watch proxy service",
 				"service", sid.String(),
@@ -175,10 +179,18 @@ func (m *Manager) syncState() {
 }
 
 // ensureProxyServiceLocked adds or changes the proxy to our state.
-func (m *Manager) ensureProxyServiceLocked(ns *structs.NodeService, token string) error {
+func (m *Manager) ensureProxyServiceLocked(ns *structs.NodeService) error {
 	sid := ns.CompoundServiceID()
-	state, ok := m.proxies[sid]
 
+	// Retrieve the token used to register the service, or fallback to the
+	// default user token. This token is expected to match the token used in
+	// the xDS request for this data.
+	token := m.State.ServiceToken(sid)
+	if token == "" {
+		token = m.Tokens.UserToken()
+	}
+
+	state, ok := m.proxies[sid]
 	if ok {
 		if !state.Changed(ns, token) {
 			// No change

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -572,7 +572,7 @@ func TestManager_SyncState_DefaultToken(t *testing.T) {
 		Cache:  c,
 		Health: &health.Client{Cache: c, CacheName: cachetype.HealthServicesName},
 		State:  state,
-		// TODO: Tokens: tokens,
+		Tokens: tokens,
 		Source: &structs.QuerySource{Datacenter: "dc1"},
 		Logger: logger,
 	})


### PR DESCRIPTION
Fixes #10714
May also fix #10821, but maybe there are other improvements to make there, waiting on confirmation.

Use the agent token in `proxycfg.Manager` as a default when no token is provided by the registration.  This was broken in #10188.

TODO:
* [x] changelog
* [x] default token or agent token?