### PR TITLE
ui: Update intention permissions notice wording

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/intention/notice/permissions/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/notice/permissions/index.hbs
@@ -3,12 +3,14 @@
 as |notice|>
   <notice.Body>
     <p>
-      Permissions are L7 attributes. If any of the following permissions match the request, the Intention will apply. Requests that fail to match any of the provided routes will do the opposite of the allow/deny action above.
+      {{t "components.consul.intention.notice.permissions.body"}}
     </p>
   </notice.Body>
   <notice.Footer>
     <p>
-      <a href="{{env 'CONSUL_DOCS_URL'}}/connect/intentions" target="_blank" rel="noopener noreferrer">Learn more about permissions</a>
+      <a href="{{env 'CONSUL_DOCS_URL'}}/connect/intentions" target="_blank" rel="noopener noreferrer">
+        {{t "components.consul.intention.notice.permissions.footer"}}
+      </a>
     </p>
   </notice.Footer>
 </Notice>

--- a/ui/packages/consul-ui/translations/components/consul/en-us.yaml
+++ b/ui/packages/consul-ui/translations/components/consul/en-us.yaml
@@ -110,6 +110,10 @@ intention:
         name: Precedence
         asc: Ascending
         desc: Descending
+  notice:
+    permissions:
+      body: Permissions are L7 attributes. If any of the following permissions match the request, the Intention will apply. Requests that fail to match any of the provided routes will follow the default ACL policy.
+      footer: Learn more about permissions
 transparent-proxy: Transparent Proxy
 topology-metrics:
   source-type:


### PR DESCRIPTION
### ✨ Description:

This PR updates the wording in the L7 Permissions notice in the Intentions edit/create form. 

[Demo Link](https://consul-ui-staging-pru8uijja-hashicorp.vercel.app/ui/dc1/intentions/default:array-1:default:driver#CONSUL_ACLS_ENABLE=1)

### 📸Screenshots:
Before:
<img width="1262" alt="Screen Shot 2021-08-12 at 11 21 22 AM" src="https://user-images.githubusercontent.com/19161242/129223321-0956de3e-d12f-4407-95c0-5a8b7258d432.png">


After:
<img width="1266" alt="Screen Shot 2021-08-12 at 11 20 24 AM" src="https://user-images.githubusercontent.com/19161242/129223214-f40aa167-27b2-4aae-b097-e6ce57862233.png">

### ⚡ Backend Changes:

No backend changes required.

### 🤡 Updates to mock-api:

No updates to mock data.

### 🧪 Testing:

No tests were updated.

- [x]  Backport
- [x]  Demo Link