### PR TITLE
[1.8.x] Backport proxycfg: Use acl.tokens.default token as a default

### DIFF
--- a/.changelog/10824.txt
+++ b/.changelog/10824.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: fixes a bug that prevented the default user token from being used to authorize service registration for connect proxies.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -507,7 +507,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		Cache:  a.cache,
 		Logger: a.logger.Named(logging.ProxyConfig),
 		State:  a.State,
-		Tokens: a.baseDeps.Tokens,
+		Tokens: a.tokens,
 		Source: &structs.QuerySource{
 			Node:       a.config.NodeName,
 			Datacenter: a.config.Datacenter,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -507,6 +507,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		Cache:  a.cache,
 		Logger: a.logger.Named(logging.ProxyConfig),
 		State:  a.State,
+		Tokens: a.baseDeps.Tokens,
 		Source: &structs.QuerySource{
 			Node:       a.config.NodeName,
 			Datacenter: a.config.Datacenter,

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -525,3 +525,48 @@ func testGenCacheKey(req cache.Request) string {
 	info := req.CacheInfo()
 	return path.Join(info.Key, info.Datacenter)
 }
+
+func TestManager_SyncState_DefaultToken(t *testing.T) {
+	types := NewTestCacheTypes(t)
+	c := TestCacheWithTypes(t, types)
+	logger := testutil.Logger(t)
+	tokens := new(token.Store)
+	tokens.UpdateUserToken("default-token", token.TokenSourceConfig)
+
+	state := local.NewState(local.Config{}, logger, tokens)
+	state.TriggerSyncChanges = func() {}
+
+	m, err := NewManager(ManagerConfig{
+		Cache:  c,
+		Health: &health.Client{Cache: c, CacheName: cachetype.HealthServicesName},
+		State:  state,
+		Tokens: tokens,
+		Source: &structs.QuerySource{Datacenter: "dc1"},
+		Logger: logger,
+	})
+	require.NoError(t, err)
+	defer m.Close()
+
+	srv := &structs.NodeService{
+		Kind:    structs.ServiceKindConnectProxy,
+		ID:      "web-sidecar-proxy",
+		Service: "web-sidecar-proxy",
+		Port:    9999,
+		Meta:    map[string]string{},
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceID:   "web",
+			DestinationServiceName: "web",
+			LocalServiceAddress:    "127.0.0.1",
+			LocalServicePort:       8080,
+			Config: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+	}
+
+	err = state.AddServiceWithChecks(srv, nil, "")
+	require.NoError(t, err)
+	m.syncState()
+
+	require.Equal(t, "default-token", m.proxies[srv.CompoundServiceID()].serviceInstance.token)
+}

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -336,7 +336,7 @@ func testManager_BasicLifecycle(
 	state.TriggerSyncChanges = func() {}
 
 	// Create manager
-	m, err := NewManager(ManagerConfig{c, state, source, DNSConfig{}, logger, nil})
+	m, err := NewManager(ManagerConfig{Cache: c, State: state, Source: source, Logger: logger})
 	require.NoError(err)
 
 	// And run it
@@ -538,7 +538,6 @@ func TestManager_SyncState_DefaultToken(t *testing.T) {
 
 	m, err := NewManager(ManagerConfig{
 		Cache:  c,
-		Health: &health.Client{Cache: c, CacheName: cachetype.HealthServicesName},
 		State:  state,
 		Tokens: tokens,
 		Source: &structs.QuerySource{Datacenter: "dc1"},
@@ -568,5 +567,5 @@ func TestManager_SyncState_DefaultToken(t *testing.T) {
 	require.NoError(t, err)
 	m.syncState()
 
-	require.Equal(t, "default-token", m.proxies[srv.CompoundServiceID()].serviceInstance.token)
+	require.Equal(t, "default-token", m.proxies[srv.CompoundServiceID()].token)
 }


### PR DESCRIPTION
Backport of #10824