### PR TITLE
[1.10.x] Fix the build

### DIFF
--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -600,5 +600,5 @@ func TestManager_SyncState_DefaultToken(t *testing.T) {
 	require.NoError(t, err)
 	m.syncState()
 
-	require.Equal(t, "default-token", m.proxies[srv.CompoundServiceID()].serviceInstance.token)
+	require.Equal(t, "default-token", m.proxies[srv.CompoundServiceID()].token)
 }


### PR DESCRIPTION
#10824 was cherry-picked automatically into 1.10.x, but the code was incompatible, so the build failed.