### PR TITLE
acl: Remove legacy bootstrap and legacy translate rules API endpoints

### DIFF
--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -46,7 +46,6 @@ func TestACL_Disabled_Response(t *testing.T) {
 		{"ACLReplicationStatus", a.srv.ACLReplicationStatus},
 		{"AgentToken", a.srv.AgentToken}, // See TestAgent_Token
 		{"ACLRulesTranslate", a.srv.ACLRulesTranslate},
-		{"ACLRulesTranslateLegacyToken", a.srv.ACLRulesTranslateLegacyToken},
 		{"ACLPolicyList", a.srv.ACLPolicyList},
 		{"ACLPolicyCRUD", a.srv.ACLPolicyCRUD},
 		{"ACLPolicyCreate", a.srv.ACLPolicyCreate},

--- a/agent/consul/acl_endpoint_legacy.go
+++ b/agent/consul/acl_endpoint_legacy.go
@@ -21,65 +21,8 @@ var ACLEndpointLegacySummaries = []prometheus.SummaryDefinition{
 	},
 }
 
-// Bootstrap is used to perform a one-time ACL bootstrap operation on
-// a cluster to get the first management token.
-func (a *ACL) Bootstrap(args *structs.DCSpecificRequest, reply *structs.ACL) error {
-	if done, err := a.srv.ForwardRPC("ACL.Bootstrap", args, reply); done {
-		return err
-	}
-
-	// Verify we are allowed to serve this request
-	if !a.srv.InACLDatacenter() {
-		return acl.ErrDisabled
-	}
-
-	if err := a.srv.aclBootstrapAllowed(); err != nil {
-		return err
-	}
-
-	// By doing some pre-checks we can head off later bootstrap attempts
-	// without having to run them through Raft, which should curb abuse.
-	state := a.srv.fsm.State()
-	allowed, _, err := state.CanBootstrapACLToken()
-	if err != nil {
-		return err
-	}
-	if !allowed {
-		return structs.ACLBootstrapNotAllowedErr
-	}
-
-	// Propose a new token.
-	token, err := lib.GenerateUUID(a.srv.checkTokenUUID)
-	if err != nil {
-		return fmt.Errorf("failed to make random token: %v", err)
-	}
-
-	// Attempt a bootstrap.
-	req := structs.ACLRequest{
-		Datacenter: a.srv.config.ACLDatacenter,
-		Op:         structs.ACLBootstrapNow,
-		ACL: structs.ACL{
-			ID:   token,
-			Name: "Bootstrap Token",
-			Type: structs.ACLTokenTypeManagement,
-		},
-	}
-	resp, err := a.srv.raftApply(structs.ACLRequestType, &req)
-	if err != nil {
-		return err
-	}
-	switch v := resp.(type) {
-	case *structs.ACL:
-		*reply = *v
-
-	default:
-		// Just log this, since it looks like the bootstrap may have
-		// completed.
-		a.logger.Error("Unexpected response during bootstrap", "type", fmt.Sprintf("%T", v))
-	}
-
-	a.logger.Info("ACL bootstrap completed")
-	return nil
+func (a *ACL) Bootstrap(*structs.DCSpecificRequest, *structs.ACL) error {
+	return fmt.Errorf("ACL.Bootstrap: the legacy ACL system has been removed")
 }
 
 // aclApplyInternal is used to apply an ACL request after it has been vetted that

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -25,42 +25,6 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 
-func TestACLEndpoint_Bootstrap(t *testing.T) {
-	if testing.Short() {
-		t.Skip("too slow for testing.Short")
-	}
-
-	t.Parallel()
-	_, srv, codec := testACLServerWithConfig(t, func(c *Config) {
-		c.Build = "0.8.0" // Too low for auto init of bootstrap.
-		c.ACLDatacenter = "dc1"
-		c.ACLsEnabled = true
-		// remove the default as we want to bootstrap
-		c.ACLMasterToken = ""
-	}, false)
-	waitForLeaderEstablishment(t, srv)
-
-	// Expect an error initially since ACL bootstrap is not initialized.
-	arg := structs.DCSpecificRequest{
-		Datacenter: "dc1",
-	}
-	var out structs.ACL
-	// We can only do some high
-	// level checks on the ACL since we don't have control over the UUID or
-	// Raft indexes at this level.
-	err := msgpackrpc.CallWithCodec(codec, "ACL.Bootstrap", &arg, &out)
-	require.NoError(t, err)
-	require.Len(t, out.ID, len("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"))
-	require.True(t, strings.HasPrefix(out.Name, "Bootstrap Token"))
-	require.Equal(t, structs.ACLTokenTypeManagement, out.Type)
-	require.NotEqual(t, uint64(0), out.CreateIndex)
-	require.NotEqual(t, uint64(0), out.ModifyIndex)
-
-	// Finally, make sure that another attempt is rejected.
-	err = msgpackrpc.CallWithCodec(codec, "ACL.Bootstrap", &arg, &out)
-	testutil.RequireErrorContains(t, err, structs.ACLBootstrapNotAllowedErr.Error())
-}
-
 func TestACLEndpoint_BootstrapTokens(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -20,7 +20,7 @@ func init() {
 	registerEndpoint("/v1/acl/auth-method", []string{"PUT"}, (*HTTPHandlers).ACLAuthMethodCreate)
 	registerEndpoint("/v1/acl/auth-method/", []string{"GET", "PUT", "DELETE"}, (*HTTPHandlers).ACLAuthMethodCRUD)
 	registerEndpoint("/v1/acl/rules/translate", []string{"POST"}, (*HTTPHandlers).ACLRulesTranslate)
-	registerEndpoint("/v1/acl/rules/translate/", []string{"GET"}, (*HTTPHandlers).ACLRulesTranslateLegacyToken)
+	registerEndpoint("/v1/acl/rules/translate/", []string{"GET"}, (*HTTPHandlers).ACLLegacy)
 	registerEndpoint("/v1/acl/tokens", []string{"GET"}, (*HTTPHandlers).ACLTokenList)
 	registerEndpoint("/v1/acl/token", []string{"PUT"}, (*HTTPHandlers).ACLTokenCreate)
 	registerEndpoint("/v1/acl/token/self", []string{"GET"}, (*HTTPHandlers).ACLTokenSelf)


### PR DESCRIPTION
Branched from #10661