### PR TITLE
Update documentation for enable_key_list_policy

### DIFF
--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -609,10 +609,9 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     In "deny" mode, ACLs are an allowlist: any operation not specifically
     allowed is blocked. **Note**: this will not take effect until you've enabled ACLs.
 
-  - `enable_key_list_policy` ((#acl_enable_key_list_policy)) - Either "enabled"
-    or "disabled", defaults to "disabled". When enabled, the `list` permission will
-    be required on the prefix being recursively read from the KV store. Regardless
-    of being enabled, the full set of KV entries under the prefix will be filtered
+  - `enable_key_list_policy` ((#acl_enable_key_list_policy)) - Boolean value, defaults to false. 
+    When true, the `list` permission will be required on the prefix being recursively read from the KV store. 
+    Regardless of being enabled, the full set of KV entries under the prefix will be filtered
     to remove any entries that the request's ACL token does not grant at least read
     permissions. This option is only available in Consul 1.0 and newer.
 


### PR DESCRIPTION
The current suggests the option expects a string of either "enabled" or "disabled" but this results in an error `'acl.enable_key_list_policy' expected type 'bool', got unconvertible type 'string', value: 'enabled'`. Setting to a boolean value resolves this, also had a quick look at the code (https://github.com/hashicorp/consul/blob/d2b58cd0d6e84f04eed08d233b8e8b396f6d7663/agent/config/runtime.go#L109) and it suggests this too