### PR TITLE
Fix SAN validation for prepared queries

### DIFF
--- a/.changelog/10873.txt
+++ b/.changelog/10873.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: ensure SAN validation for prepared queries validates against all possible prepared query targets
+```

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -199,7 +199,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 			setup: func(t *testing.T, types *TestCacheTypes) {
 				// Note that we deliberately leave the 'geo-cache' prepared query to time out
 				types.health.Set(dbHealthCacheKey, &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t),
+					Nodes: TestUpstreamNodes(t, db.Name),
 				})
 				types.compiledChain.Set(dbChainCacheKey, &structs.DiscoveryChainResponse{
 					Chain: dbDefaultChain(),
@@ -225,7 +225,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 						WatchedUpstreams:       nil, // Clone() clears this out
 						WatchedUpstreamEndpoints: map[string]map[string]structs.CheckServiceNodes{
 							db.String(): {
-								"db.default.dc1": TestUpstreamNodes(t),
+								"db.default.dc1": TestUpstreamNodes(t, db.Name),
 							},
 						},
 						WatchedGateways: nil, // Clone() clears this out
@@ -252,7 +252,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 			setup: func(t *testing.T, types *TestCacheTypes) {
 				// Note that we deliberately leave the 'geo-cache' prepared query to time out
 				types.health.Set(db_v1_HealthCacheKey, &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t),
+					Nodes: TestUpstreamNodes(t, db.Name),
 				})
 				types.health.Set(db_v2_HealthCacheKey, &structs.IndexedCheckServiceNodes{
 					Nodes: TestUpstreamNodesAlternate(t),
@@ -281,7 +281,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 						WatchedUpstreams:       nil, // Clone() clears this out
 						WatchedUpstreamEndpoints: map[string]map[string]structs.CheckServiceNodes{
 							db.String(): {
-								"v1.db.default.dc1": TestUpstreamNodes(t),
+								"v1.db.default.dc1": TestUpstreamNodes(t, db.Name),
 								"v2.db.default.dc1": TestUpstreamNodesAlternate(t),
 							},
 						},

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -144,11 +144,11 @@ func TestUpstreamNodes(t testing.T, service string) structs.CheckServiceNodes {
 	}
 }
 
-func TestPreparedQueryNodes(t testing.T, service string) structs.CheckServiceNodes {
-
-	// The service instances targeted by the prepared query are given the slightly different name
-	// "geo-cache-target" to ensure we don't use the prepared query's name for SAN validation.
-	// The name of prepared queries won't always match the name of the service they target.
+// TestPreparedQueryNodes returns instances of a service spread across two datacenters.
+// The service instance names use a "-target" suffix to ensure we don't use the
+// prepared query's name for SAN validation.
+// The name of prepared queries won't always match the name of the service they target.
+func TestPreparedQueryNodes(t testing.T, query string) structs.CheckServiceNodes {
 	nodes := structs.CheckServiceNodes{
 		structs.CheckServiceNode{
 			Node: &structs.Node{
@@ -159,10 +159,10 @@ func TestPreparedQueryNodes(t testing.T, service string) structs.CheckServiceNod
 			},
 			Service: &structs.NodeService{
 				Kind:    structs.ServiceKindConnectProxy,
-				Service: service + "-sidecar-proxy",
+				Service: query + "-sidecar-proxy",
 				Port:    8080,
 				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: service + "-target",
+					DestinationServiceName: query + "-target",
 				},
 			},
 		},
@@ -175,7 +175,7 @@ func TestPreparedQueryNodes(t testing.T, service string) structs.CheckServiceNod
 			},
 			Service: &structs.NodeService{
 				Kind:    structs.ServiceKindTypical,
-				Service: service + "-target",
+				Service: query + "-target",
 				Port:    8080,
 				Connect: structs.ServiceConnect{Native: true},
 			},

--- a/agent/structs/testing_catalog.go
+++ b/agent/structs/testing_catalog.go
@@ -40,11 +40,15 @@ func TestRegisterIngressGateway(t testing.T) *RegisterRequest {
 	}
 }
 
-// TestNodeService returns a *NodeService representing a valid regular service.
+// TestNodeService returns a *NodeService representing a valid regular service: "web".
 func TestNodeService(t testing.T) *NodeService {
+	return TestNodeServiceWithName(t, "web")
+}
+
+func TestNodeServiceWithName(t testing.T, name string) *NodeService {
 	return &NodeService{
 		Kind:    ServiceKindTypical,
-		Service: "web",
+		Service: name,
 		Port:    8080,
 	}
 }

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -535,17 +535,34 @@ func (s *ResourceGenerator) makeUpstreamClusterForPreparedQuery(upstream structs
 		}
 	}
 
-	spiffeID := connect.SpiffeIDService{
-		Host:       cfgSnap.Roots.TrustDomain,
-		Partition:  upstream.DestinationPartition,
-		Namespace:  upstream.DestinationNamespace,
-		Datacenter: dc,
-		Service:    upstream.DestinationName,
+	endpoints := cfgSnap.ConnectProxy.PreparedQueryEndpoints[upstream.Identifier()]
+	var (
+		spiffeIDs = make([]connect.SpiffeIDService, 0)
+		seen      = make(map[string]struct{})
+	)
+	for _, e := range endpoints {
+		id := fmt.Sprintf("%s/%s", e.Node.Datacenter, e.Service.CompoundServiceName())
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		name := e.Service.Proxy.DestinationServiceName
+		if e.Service.Connect.Native {
+			name = e.Service.Service
+		}
+		spiffeIDs = append(spiffeIDs, connect.SpiffeIDService{
+			Host:       cfgSnap.Roots.TrustDomain,
+			Namespace:  e.Service.NamespaceOrDefault(),
+			Partition:  e.Service.PartitionOrDefault(),
+			Datacenter: e.Node.Datacenter,
+			Service:    name,
+		})
 	}
 
 	// Enable TLS upstream with the configured client certificate.
 	commonTLSContext := makeCommonTLSContextFromLeaf(cfgSnap, cfgSnap.Leaf())
-	err = injectSANMatcher(commonTLSContext, spiffeID)
+	err = injectSANMatcher(commonTLSContext, spiffeIDs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to inject SAN matcher rules for cluster %q: %v", sni, err)
 	}

--- a/agent/xds/testdata/clusters/connect-proxy-lb-in-resolver.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-lb-in-resolver.envoy-1-18-x.golden
@@ -107,7 +107,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-lb-in-resolver.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-lb-in-resolver.v2compat.envoy-1-16-x.golden
@@ -107,7 +107,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover.envoy-1-18-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover.v2compat.envoy-1-16-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.envoy-1-18-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.v2compat.envoy-1-16-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-external-sni.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-external-sni.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-external-sni.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-external-sni.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.envoy-1-18-x.golden
@@ -108,7 +108,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -108,7 +108,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.envoy-1-18-x.golden
@@ -108,7 +108,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
@@ -108,7 +108,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
@@ -108,7 +108,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -108,7 +108,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.envoy-1-18-x.golden
@@ -108,7 +108,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
@@ -108,7 +108,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.envoy-1-18-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-18-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-18-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
@@ -105,7 +105,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-limits-max-connections-only.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/custom-limits-max-connections-only.envoy-1-18-x.golden
@@ -110,7 +110,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-limits-max-connections-only.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/custom-limits-max-connections-only.v2compat.envoy-1-16-x.golden
@@ -110,7 +110,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-limits-set-to-zero.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/custom-limits-set-to-zero.envoy-1-18-x.golden
@@ -114,7 +114,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-limits-set-to-zero.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/custom-limits-set-to-zero.v2compat.envoy-1-16-x.golden
@@ -114,7 +114,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-limits.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/custom-limits.envoy-1-18-x.golden
@@ -114,7 +114,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-limits.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/custom-limits.v2compat.envoy-1-16-x.golden
@@ -114,7 +114,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-local-app.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/custom-local-app.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-local-app.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/custom-local-app.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-timeouts.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/custom-timeouts.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-timeouts.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/custom-timeouts.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-upstream-default-chain.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/custom-upstream-default-chain.envoy-1-18-x.golden
@@ -44,7 +44,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-upstream-default-chain.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/custom-upstream-default-chain.v2compat.envoy-1-16-x.golden
@@ -44,7 +44,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-upstream.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/custom-upstream.envoy-1-18-x.golden
@@ -44,7 +44,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/custom-upstream.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/custom-upstream.v2compat.envoy-1-16-x.golden
@@ -44,7 +44,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/defaults.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/defaults.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/defaults.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/defaults.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/downstream-service-with-unix-sockets.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/downstream-service-with-unix-sockets.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/downstream-service-with-unix-sockets.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/downstream-service-with-unix-sockets.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/splitter-with-resolver-redirect.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/splitter-with-resolver-redirect.envoy-1-18-x.golden
@@ -44,7 +44,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/splitter-with-resolver-redirect.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/splitter-with-resolver-redirect.v2compat.envoy-1-16-x.golden
@@ -44,7 +44,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/transparent-proxy-catalog-destinations-only.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-catalog-destinations-only.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/transparent-proxy-catalog-destinations-only.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-catalog-destinations-only.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/transparent-proxy-dial-instances-directly.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-dial-instances-directly.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/transparent-proxy-dial-instances-directly.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-dial-instances-directly.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/transparent-proxy.envoy-1-18-x.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy.envoy-1-18-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/clusters/transparent-proxy.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy.v2compat.envoy-1-16-x.golden
@@ -102,7 +102,10 @@
               },
               "matchSubjectAltNames": [
                 {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache"
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/geo-cache-target"
+                },
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/geo-cache-target"
                 }
               ]
             }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-failover.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-failover.envoy-1-18-x.golden
@@ -89,7 +89,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-failover.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-failover.envoy-1-18-x.golden
@@ -66,6 +66,40 @@
       "policy": {
         "overprovisioningFactor": 100000
       }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-failover.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-failover.v2compat.envoy-1-16-x.golden
@@ -89,7 +89,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-failover.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-failover.v2compat.envoy-1-16-x.golden
@@ -66,6 +66,40 @@
       "policy": {
         "overprovisioningFactor": 100000
       }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-external-sni.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-external-sni.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-external-sni.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-external-sni.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-external-sni.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-external-sni.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-external-sni.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-external-sni.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.envoy-1-18-x.golden
@@ -23,7 +23,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.envoy-1-18-x.golden
@@ -3,6 +3,40 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
       "clusterName": "myservice",
       "endpoints": [
         {

--- a/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.v2compat.envoy-1-16-x.golden
@@ -23,7 +23,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.v2compat.envoy-1-16-x.golden
@@ -3,6 +3,40 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
       "clusterName": "myservice",
       "endpoints": [
         {

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-local-gateway.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-18-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-tcp-chain-failover-through-remote-gateway.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/defaults.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/defaults.envoy-1-18-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/defaults.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/defaults.v2compat.envoy-1-16-x.golden
@@ -57,7 +57,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/splitter-with-resolver-redirect.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/splitter-with-resolver-redirect.envoy-1-18-x.golden
@@ -23,7 +23,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/splitter-with-resolver-redirect.envoy-1-18-x.golden
+++ b/agent/xds/testdata/endpoints/splitter-with-resolver-redirect.envoy-1-18-x.golden
@@ -3,6 +3,40 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
       "clusterName": "v1.db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {

--- a/agent/xds/testdata/endpoints/splitter-with-resolver-redirect.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/splitter-with-resolver-redirect.v2compat.envoy-1-16-x.golden
@@ -23,7 +23,7 @@
               "endpoint": {
                 "address": {
                   "socketAddress": {
-                    "address": "10.10.1.2",
+                    "address": "10.20.1.2",
                     "portValue": 8080
                   }
                 }

--- a/agent/xds/testdata/endpoints/splitter-with-resolver-redirect.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/endpoints/splitter-with-resolver-redirect.v2compat.envoy-1-16-x.golden
@@ -3,6 +3,40 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
       "clusterName": "v1.db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {

--- a/agent/xds/xds_protocol_helpers_test.go
+++ b/agent/xds/xds_protocol_helpers_test.go
@@ -43,7 +43,7 @@ func newTestSnapshot(
 ) *proxycfg.ConfigSnapshot {
 	snap := proxycfg.TestConfigSnapshotDiscoveryChainDefaultWithEntries(t, additionalEntries...)
 	snap.ConnectProxy.PreparedQueryEndpoints = map[string]structs.CheckServiceNodes{
-		"prepared_query:geo-cache": proxycfg.TestUpstreamNodes(t),
+		"prepared_query:geo-cache": proxycfg.TestUpstreamNodes(t, "geo-cache"),
 	}
 	if prevSnap != nil {
 		snap.Roots = prevSnap.Roots

--- a/agent/xds/xds_protocol_helpers_test.go
+++ b/agent/xds/xds_protocol_helpers_test.go
@@ -243,7 +243,7 @@ func xdsNewPublicTransportSocket(
 	t *testing.T,
 	snap *proxycfg.ConfigSnapshot,
 ) *envoy_core_v3.TransportSocket {
-	return xdsNewTransportSocket(t, snap, true, true, "", connect.SpiffeIDService{})
+	return xdsNewTransportSocket(t, snap, true, true, "")
 }
 
 func xdsNewUpstreamTransportSocket(
@@ -278,7 +278,7 @@ func xdsNewTransportSocket(
 			},
 		},
 	}
-	if uri[0].Service != "" {
+	if len(uri) > 0 {
 		require.NoError(t, injectSANMatcher(commonTLSContext, uri...))
 	}
 


### PR DESCRIPTION
Fixes #10825

Previously SAN validation for prepared queries was broken because we
validated against the name, namespace, and datacenter for prepared
queries. 

This PR updates validation to be against prepared query endpoints
rather than the prepared query itself.

--

Additional context in commits.