### PR TITLE
ui: Remove routeName from tokens route, we do this app wide

### DIFF
--- a/ui/packages/consul-ui/app/routes/dc/acls/tokens/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/acls/tokens/edit.js
@@ -5,18 +5,14 @@ import { hash } from 'rsvp';
 import WithTokenActions from 'consul-ui/mixins/token/with-actions';
 
 export default class EditRoute extends SingleRoute.extend(WithTokenActions) {
-  @service('repository/token')
-  repo;
-
-  @service('settings')
-  settings;
+  @service('repository/token') repo;
+  @service('settings') settings;
 
   model(params, transition) {
     return super.model(...arguments).then(model => {
       return hash({
         ...model,
         ...{
-          routeName: this.routeName,
           token: this.settings.findBySlug('token'),
         },
       });


### PR DESCRIPTION
I noticed this on my travels whilst working on something else.

At one point we defined a `routeName` on all out controllers so we had access to that property from within all of route templates. A while back we changed this so it was global instead (see our app wide consul specific abstract Route), so this is just dead code removal now. We must have missed this one when we did that PR from while back.