### PR TITLE
ui: Unskip auth-method serializer test

### DIFF
--- a/ui/packages/consul-ui/tests/integration/serializers/auth-method-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/auth-method-test.js
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
 import {
@@ -39,7 +39,7 @@ module('Integration | Serializer | auth-method', function(hooks) {
         assert.deepEqual(actual, expected);
       });
     });
-    skip(`respondForQueryRecord returns the correct data for item endpoint when nspace is ${nspace}`, function(assert) {
+    test(`respondForQueryRecord returns the correct data for item endpoint when nspace is ${nspace}`, function(assert) {
       const serializer = this.owner.lookup('serializer:auth-method');
       const request = {
         url: `/v1/acl/auth-method/${id}?dc=${dc}${
@@ -51,7 +51,7 @@ module('Integration | Serializer | auth-method', function(hooks) {
           Datacenter: dc,
           [META]: {
             [DC.toLowerCase()]: dc,
-            [NSPACE.toLowerCase()]: payload.Namespace || undefinedNspace,
+            [NSPACE.toLowerCase()]: nspace || '',
           },
           Namespace: payload.Namespace || undefinedNspace,
           uid: `["${payload.Namespace || undefinedNspace}","${dc}","${id}"]`,


### PR DESCRIPTION
During https://github.com/hashicorp/consul/pull/9617 we added a list view only for AuthMethods, but not a detail view. We did add the Adapter/Serializer that collected/reshaped data for a detail view.

The test for this serializer was skipped here, but I'm not sure why.

We then added https://github.com/hashicorp/consul/pull/9845 which began to use this AuthMethod Serializer, but we didn't go back to finish up the skipped test here either.

This PR unskips this test and finishes off the test correctly.