### PR TITLE
ui: [BUGFIX] Properly encode non-URL safe characters in OIDC responses

### DIFF
--- a/.changelog/10901.txt
+++ b/.changelog/10901.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Properly encode non-URL safe characters in OIDC responses
+```

--- a/ui/packages/consul-ui/app/components/token-source/index.hbs
+++ b/ui/packages/consul-ui/app/components/token-source/index.hbs
@@ -25,7 +25,14 @@
     </State>
     <State @matches="token">
       <DataSource
-        @src={{concat path '/oidc/authorize/' provider.Name '/' jwt.authorizationCode '/' jwt.authorizationState}}
+        @src={{uri
+          (concat path '/oidc/authorize/${provider}/${code}/${state}')
+            (hash
+              provider=provider.Name
+              code=jwt.authorizationCode
+              state=(or jwt.authorizationState '')
+            )
+        }}
         @onchange={{action 'change'}}
         @onerror={{action onerror}}
       />

--- a/ui/packages/consul-ui/app/services/repository/oidc-provider.js
+++ b/ui/packages/consul-ui/app/services/repository/oidc-provider.js
@@ -8,7 +8,7 @@ const modelName = 'oidc-provider';
 const OAUTH_PROVIDER_NAME = 'oidc-with-url';
 export default class OidcProviderService extends RepositoryService {
   @service('torii') manager;
-  @service('repository/settings') settings;
+  @service('settings') settings;
 
   init() {
     super.init(...arguments);

--- a/ui/packages/consul-ui/tests/unit/services/repository/oidc-provider-test.js
+++ b/ui/packages/consul-ui/tests/unit/services/repository/oidc-provider-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Repository | oidc-provider', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:repository/oidc-provider');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
This PR fixes 2 problems with our OIDC flow in the UI, the first is straightforwards, the second is relatively more in depth:

1: A typo (1.10.1 only)

During https://github.com/hashicorp/consul/pull/10503 we injected our settings service into the our oidc-provider service, there are some comments in the PR as to the whys and wherefores for this change (https://github.com/hashicorp/consul/pull/10503/files#diff-aa2ffda6d0a966ba631c079fa3a5f60a2a1bdc7eed5b3a98ee7b5b682f1cb4c3R28)

During development, this manifests itself as a javascript error:

<img width="887" alt="Screenshot 2021-08-24 at 13 53 12" src="https://user-images.githubusercontent.com/554604/130619844-301248b1-277c-4818-a184-d0a1795a044d.png">

Whereas during production, it simply breaks with no clear reason as to what the problem is.

Fixing the typo so it was no longer looking for an unknown service (`repository/settings` > `settings`)
fixed this part of the issue which was added as part of the above PR [here](https://github.com/hashicorp/consul/pull/10503/files#diff-aa2ffda6d0a966ba631c079fa3a5f60a2a1bdc7eed5b3a98ee7b5b682f1cb4c3R11.)  

2: URL encoding (1.9.x, 1.10.x)

TL;DR: `/oidc/authorize/provider/with/slashes/code/with/slashes/status/with/slashes` should be `/oidc/authorize/provider%2Fwith%2Fslashes/code%2Fwith%2Fslashes/status%2Fwith%2Fslashes`

When we receive our authorization response back from the OIDC 3rd party, [we POST the `code` and `status` data from that response back to consul via a`callback` as part of the OIDC flow](https://github.com/hashicorp/consul/blob/329ec62582403fc39e18d8f25406afdf456f63da/ui/packages/consul-ui/app/adapters/oidc-provider.js#L55). From what I remember back when this feature was originally added, the method is a POST request to avoid folks putting secret-like things into API requests/URLs/query params that are more likely to be visible to the human eye, and POSTing is expected behaviour.

Additionally, in the UI we identify all external resources using unique resource identifiers. Our OIDC flow uses these resources and their identifiers to perform the OIDC flow using a declarative state machine. If any information in these identifiers uses non-URL-safe characters then these characters require URL encoding and we added a helper a while back to specifically help us to do this once we started using this for things that required URL encoding.

In the majority of the examples you see for OIDC auth flow use examples like:

```
https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA&state=xyz

// and

grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA&redirect_uri=https%3A%2F%2Fclient%2Eexample%2Ecom%2Fcb

...etc
```
In all the examples in the OIDC spec it 'seems' like `code` should be alpha-numeric, but if you dig a little deeper `code` is specified as:

```
 code       = 1*VSCHAR
```
which therefore means it can contain non-URL-safe characters 💥 

The final fix here make sure that we URL encode `code` and `status` before using them with one of our unique resource identifiers, just like we do with the majority of other places where we use these identifiers.

Both fixes here are required for the 1.10.x branch (the typo was added in 1.10.1), our 1.9.x branch doesn't require the first fix for the typo and requires a slightly different way of writing the second fix. Therefore I'll be backporting it here only for changelog reasons, but then manually fixing the backport when it fails.




