### PR TITLE
ui: Disabling policy form fields from users with 'read' permissions

### DIFF
--- a/.changelog/10902.txt
+++ b/.changelog/10902.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Disabling policy form fields from users with 'read' permissions
+```

--- a/ui/packages/consul-ui/app/abilities/policy.js
+++ b/ui/packages/consul-ui/app/abilities/policy.js
@@ -16,7 +16,7 @@ export default class PolicyAbility extends BaseAbility {
     return (
       this.env.var('CONSUL_ACLS_ENABLED') &&
       (typeof this.item === 'undefined' || typeOf([this.item]) !== 'policy-management') &&
-      super.canRead
+      super.canWrite
     );
   }
 


### PR DESCRIPTION
### 🐛 Description:
User with `read` permission can `edit` policies. An error message denying their request appears. The change temporarily appears in policy list page. The changes do not persist. Refreshing the page resets the changes.

### 💻 Replication Steps:

Using a new Consul cluster with ACLs enabled with default deny.

- Create the a new policy with the following rules:
acl = "read" 
operator = "read" 
service_prefix "" { policy = "write" }
node_prefix "" { policy = "write" }
agent_prefix "" { policy = "write" }
- Create a new Role
- Update the Anonymous Token to use the new Role and Policy
- Log off and log back in with Anonymous Token
- Try to update a Policy name

### 🎉 Solution:

Fix up a typo in the `canWrite()` permission for policy.

Now, the user can't edit any policies because form fields are disabled. 

### 🧪 Testing:

Test coverage can be found [here](https://github.com/hashicorp/consul/blob/main/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/update.feature#L19. ).

### 📝 PR Tasks:

- [x]  Backport
- [x]  Changelog