### PR TITLE
UI: Rollback attributes when saving/updating fails

### DIFF
--- a/ui/packages/consul-ui/app/mixins/with-blocking-actions.js
+++ b/ui/packages/consul-ui/app/mixins/with-blocking-actions.js
@@ -1,6 +1,7 @@
 import Mixin from '@ember/object/mixin';
 import { inject as service } from '@ember/service';
 import { set } from '@ember/object';
+import { TYPE_ERROR } from 'consul-ui/services/feedback';
 /** With Blocking Actions
  * This mixin contains common write actions (Create Update Delete) for routes.
  * It could also be an Route to extend but decoration seems to be more sense right now.
@@ -90,6 +91,9 @@ export default Mixin.create({
         },
         'update',
         (type, e) => {
+          if (type === TYPE_ERROR) {
+            this.repo.rollback(item);
+          }
           return this.errorUpdate(type, e);
         }
       );

--- a/ui/packages/consul-ui/app/services/feedback.js
+++ b/ui/packages/consul-ui/app/services/feedback.js
@@ -1,8 +1,8 @@
 import Service, { inject as service } from '@ember/service';
 import callableType from 'consul-ui/utils/callable-type';
 
-const TYPE_SUCCESS = 'success';
-const TYPE_ERROR = 'error';
+export const TYPE_SUCCESS = 'success';
+export const TYPE_ERROR = 'error';
 const defaultStatus = function(type, obj) {
   return type;
 };

--- a/ui/packages/consul-ui/app/services/repository.js
+++ b/ui/packages/consul-ui/app/services/repository.js
@@ -134,6 +134,16 @@ export default class RepositoryService extends Service {
     return item.save();
   }
 
+  rollback(item) {
+    // assuming the item is an Ember Data model, attributes can be rolled
+    // back in the event that the server disagrees with the client (e.g.,
+    // unauthorized to submit a form)
+    if (isChangeset(item)) {
+      item = item.data;
+    }
+    return item.rollbackAttributes();
+  }
+
   remove(obj) {
     let item = obj;
     if (typeof obj.destroyRecord === 'undefined') {


### PR DESCRIPTION
This way the client-side state continues to match the server-side state.

This was observed when editing ACL roles when the active token only allowed read access. Attempting to save changes would result in a server error, but the client-side state would still show the change. This is ultimately harmless but still spooky.

Note that 1.10 introduced a permissions-based UI (#9835) that make this particular reported issue no longer possible. Since this change impacts the underlying repo service and blocking actions mixin, it makes sense to still commit this change.