### PR TITLE
ui: Hide create buttons for policies/roles/namespaces with readonly access

### DIFF
--- a/.changelog/10914.txt
+++ b/.changelog/10914.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: hide create button for policies/roles/namespace if users token has no write permissions to those areas
+```

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/index.hbs
@@ -69,7 +69,9 @@ as |route|>
         </h1>
       </BlockSlot>
       <BlockSlot @name="actions">
+  {{#if (can "create policies")}}
           <a data-test-create href="{{href-to 'dc.acls.policies.create'}}" class="type-create">Create</a>
+  {{/if}}
       </BlockSlot>
       <BlockSlot @name="toolbar">
       {{#if (gt items.length 0) }}

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/index.hbs
@@ -63,7 +63,9 @@ as |route|>
         </h1>
       </BlockSlot>
       <BlockSlot @name="actions">
+  {{#if (can "create roles")}}
         <a data-test-create href="{{href-to 'dc.acls.roles.create'}}" class="type-create">Create</a>
+  {{/if}}
       </BlockSlot>
       <BlockSlot @name="toolbar">
       {{#if (gt items.length 0) }}

--- a/ui/packages/consul-ui/app/templates/dc/nspaces/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nspaces/index.hbs
@@ -55,7 +55,9 @@ as |route|>
         </h1>
       </BlockSlot>
       <BlockSlot @name="actions">
+  {{#if (can "create nspaces")}}
           <a data-test-create href="{{href-to 'dc.nspaces.create'}}" class="type-create">Create</a>
+  {{/if}}
       </BlockSlot>
       <BlockSlot @name="toolbar">
       {{#if (gt items.length 0)}}


### PR DESCRIPTION
This PR adds a check to policy, role and namespace list pages to make sure the user has can write those things before offering to create them via a button. (The create page/form would then be a read-only form)

Before (when read only):

<img width="1361" alt="Screenshot 2021-08-26 at 11 11 06" src="https://user-images.githubusercontent.com/554604/130944951-f6b9e94b-c875-4b51-943e-586e1e4c70ce.png">

After (when read only):

<img width="1365" alt="Screenshot 2021-08-26 at 11 10 36" src="https://user-images.githubusercontent.com/554604/130944904-1e0d7e5c-2928-41f9-92d6-46cf4dd053d8.png">


