### PR TITLE
ui: Always show main navigation Key/Value link

### DIFF
--- a/.changelog/10916.txt
+++ b/.changelog/10916.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Ignore reported permissions for KV area meaning the KV is always enabled
+for both read/write access if the HTTP API allows.
+```

--- a/ui/packages/consul-ui/app/abilities/kv.js
+++ b/ui/packages/consul-ui/app/abilities/kv.js
@@ -10,4 +10,15 @@ export default class KVAbility extends BaseAbility {
     }
     return resources;
   }
+  get canRead() {
+    return true;
+  }
+
+  get canList() {
+    return true;
+  }
+
+  get canWrite() {
+    return true;
+  }
 }

--- a/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/acls/tokens/index.feature
@@ -11,6 +11,21 @@ Feature: dc / acls / tokens / index: ACL Token List
     Then the url should be /dc-1/acls/tokens
     And the title should be "Tokens - Consul"
     Then I see 3 token models
+  Scenario: Viewing tokens with no write access
+    Given 1 datacenter model with the value "dc-1"
+    And 3 token models
+    And permissions from yaml
+    ---
+    acl:
+      write: false
+    ---
+    When I visit the tokens page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/acls/tokens
+    And I don't see create
+
   Scenario: Searching the tokens
     Given 1 datacenter model with the value "dc-1"
     And 4 token models from yaml

--- a/ui/packages/consul-ui/tests/acceptance/dc/kvs/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/kvs/index.feature
@@ -10,6 +10,7 @@ Feature: dc / kvs / index
     Then the url should be /dc-1/kv
     And the title should be "Key/Value - Consul"
     Then I see 3 kv models
+  @ignore
   Scenario: Viewing kvs with no write access
     Given 1 datacenter model with the value "dc-1"
     And 3 kv models

--- a/ui/packages/consul-ui/tests/acceptance/navigation-links.feature
+++ b/ui/packages/consul-ui/tests/acceptance/navigation-links.feature
@@ -16,18 +16,18 @@ Feature: navigation-links: Main Navigation link visibility
         Allow: true
       - Resource: key
         Access: read
-        Allow: false
+        Allow: true
       - Resource: intention
         Access: read
         Allow: true
       - Resource: acl
         Access: read
-        Allow: true
+        Allow: false
     ---
     When I visit the services page for yaml
     ---
       dc: dc-1
     ---
     Then I see services on the navigation
-    Then I don't see kvs on the navigation
+    Then I don't see roles on the navigation
 


### PR DESCRIPTION
Currently there is no way for us to use our HTTP authorization API
endpoint to tell us whether a user has access to any KVs (including the
case where a user may not have access to the root KV store, but do have
access to a sub item)

This is a little weird still as in the above case the user would click
on this link and still get a 403 for the root, and then have to manually
type in the URL for the KV they do have access to.

Despite this we think this change makes sense as at least something about KV is
visible in the main navigation.

Once we have the ability to know if any KVs are accessible, we can add
this guard back in.

We'd initially just removed the logic around the button, but then
noticed there may be further related KV issues due to the nested nature
of KVs so we finally decided on simply ignoring the responses from the
HTTP API, essentially reverting the KV area back to being a thin client.
This means when things are revisted in the backend we can undo this
change easily in one place.

- edit: fixes https://github.com/hashicorp/consul/issues/10944
- edit: fixes https://github.com/hashicorp/consul/issues/10997
- edit: fixes https://github.com/hashicorp/consul/issues/11023