### PR TITLE
docs: Fix build error on k8s/connect/ingress-gateways

### DIFF
--- a/website/content/docs/k8s/connect/ingress-gateways.mdx
+++ b/website/content/docs/k8s/connect/ingress-gateways.mdx
@@ -84,12 +84,13 @@ spec:
       services:
         - name: static-server
 ```
+
+</CodeBlockConfig>
+
 ~> **Note:** The 'name' field for the IngressGateway resource must match the name
 specified when creating the gateway in the Helm chart. In the above example, the
 name "ingress-gateway" is the [default name](/docs/k8s/helm#v-ingressgateways-gateways-name)
 used by the Helm chart when enabling ingress gateways.
-
-</CodeBlockConfig>
 
 Apply the `IngressGateway` resource with `kubectl apply`:
 


### PR DESCRIPTION
Move callout outside of CodeBlockConfig to fix an issue with the page not building.