### PR TITLE
Sync ent test fixes

### DIFF
--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5605,6 +5605,7 @@ func TestFullConfig(t *testing.T) {
 						"upstreams": [
 							{
 								"destination_name": "KPtAj2cb",
+								"destination_namespace": "` + defaultEntMeta.NamespaceOrEmpty() + `",
 								"local_bind_port": 4051,
 								"config": {
 									"kzRnZOyd": "nUNKoL8H"
@@ -6287,6 +6288,7 @@ func TestFullConfig(t *testing.T) {
 						upstreams = [
 							{
 								destination_name = "KPtAj2cb"
+								destination_namespace = "` + defaultEntMeta.NamespaceOrEmpty() + `"
 								local_bind_port = 4051
 								config {
 									kzRnZOyd = "nUNKoL8H"
@@ -6296,6 +6298,7 @@ func TestFullConfig(t *testing.T) {
 								destination_type = "prepared_query"
 								destination_namespace = "9nakw0td"
 								destination_name = "KSd8HsRl"
+								destination_namespace = "9nakw0td"
 								local_bind_port = 11884
 								local_bind_address = "127.24.88.0"
 							},

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -542,6 +542,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 
 	// Now register a sidecar proxy via the API.
 	svcID := "web-sidecar-proxy"
+	defaultMeta := structs.DefaultEnterpriseMeta()
 
 	expectState := &structs.NodeService{
 		Kind:            structs.ServiceKindConnectProxy,
@@ -560,9 +561,10 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 			},
 			Upstreams: structs.Upstreams{
 				{
-					DestinationType: "service",
-					DestinationName: "redis",
-					LocalBindPort:   5000,
+					DestinationType:      "service",
+					DestinationName:      "redis",
+					DestinationNamespace: defaultMeta.NamespaceOrEmpty(),
+					LocalBindPort:        5000,
 					Config: map[string]interface{}{
 						"protocol": "tcp",
 					},
@@ -573,7 +575,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 			Passing: 1,
 			Warning: 1,
 		},
-		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+		EnterpriseMeta: *defaultMeta,
 	}
 
 	// Now wait until we've re-registered using central config updated data.


### PR DESCRIPTION
The OSS->Ent merge was broken due to some namespace handling in shared files, this PR syncs the changes that fixed the merge.