### PR TITLE
Revert early out errors in license API

### DIFF
--- a/.changelog/10952.txt
+++ b/.changelog/10952.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+api: Revert early out errors from license APIs to allow v1.10+ clients to
+manage licenses on older servers
+```

--- a/api/operator_license.go
+++ b/api/operator_license.go
@@ -1,8 +1,8 @@
 package api
 
 import (
-	"fmt"
 	"io/ioutil"
+	"strings"
 	"time"
 )
 
@@ -81,14 +81,39 @@ func (op *Operator) LicenseGetSigned(q *QueryOptions) (string, error) {
 //
 // DEPRECATED: Consul 1.10 removes the corresponding HTTP endpoint as licenses
 // are now set via agent configuration instead of through the API
-func (*Operator) LicenseReset(_ *WriteOptions) (*LicenseReply, error) {
-	return nil, fmt.Errorf("Consul 1.10 no longer supports API driven license management.")
+func (op *Operator) LicenseReset(opts *WriteOptions) (*LicenseReply, error) {
+	var reply LicenseReply
+	r := op.c.newRequest("DELETE", "/v1/operator/license")
+	r.setWriteOptions(opts)
+	_, resp, err := requireOK(op.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if err := decodeBody(resp, &reply); err != nil {
+		return nil, err
+	}
+	return &reply, nil
 }
 
 // LicensePut will configure the Consul Enterprise license for the target datacenter
 //
 // DEPRECATED: Consul 1.10 removes the corresponding HTTP endpoint as licenses
 // are now set via agent configuration instead of through the API
-func (*Operator) LicensePut(_ string, _ *WriteOptions) (*LicenseReply, error) {
-	return nil, fmt.Errorf("Consul 1.10 no longer supports API driven license management.")
+func (op *Operator) LicensePut(license string, opts *WriteOptions) (*LicenseReply, error) {
+	var reply LicenseReply
+	r := op.c.newRequest("PUT", "/v1/operator/license")
+	r.setWriteOptions(opts)
+	r.body = strings.NewReader(license)
+	_, resp, err := requireOK(op.c.doRequest(r))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := decodeBody(resp, &reply); err != nil {
+		return nil, err
+	}
+
+	return &reply, nil
 }


### PR DESCRIPTION
Licensing recently changed in Consul v1.10 and along with those changes
the client API was updated such that PutLicense and ResetLicense both
immediately return an error to avoid an unecessary round trip that will
inevitably fail.

For reference, see: https://github.com/hashicorp/consul/commit/08eb600ee5e4eacfeef8223fc217973eeecdc692

Unfortunately, this change broke forward compatibility such that a v1.10
client can no longer make these requests to a v1.9 server which is a
valid use case.

This commit reintroduces these requests to fix this compatibility
breakage but leaves the deprecation notices in tact.