### PR TITLE
Configurable max DNS requests over reused TCP conn

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -922,6 +922,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		DNSNodeMetaTXT:        boolValWithDefault(c.DNS.NodeMetaTXT, true),
 		DNSUseCache:           boolVal(c.DNS.UseCache),
 		DNSCacheMaxAge:        b.durationVal("dns_config.cache_max_age", c.DNS.CacheMaxAge),
+		DNSMaxTCPQueries:      intValWithDefault(c.DNS.MaxTCPQueries, 128),
 
 		// HTTP
 		HTTPPort:            httpPort,
@@ -1330,6 +1331,9 @@ func (b *builder) validate(rt RuntimeConfig) error {
 	}
 	if rt.DNSARecordLimit < 0 {
 		return fmt.Errorf("dns_config.a_record_limit cannot be %d. Must be greater than or equal to zero", rt.DNSARecordLimit)
+	}
+	if rt.DNSMaxTCPQueries < -1 {
+		return fmt.Errorf("dns_config.max_tcp_queries cannot be %d. Must be greater than or equal to -1", rt.DNSMaxTCPQueries)
 	}
 	if err := structs.ValidateNodeMetadata(rt.NodeMeta, false); err != nil {
 		return fmt.Errorf("node_meta invalid: %v", err)

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -641,6 +641,7 @@ type DNS struct {
 	SOA                *SOA              `mapstructure:"soa"`
 	UseCache           *bool             `mapstructure:"use_cache"`
 	CacheMaxAge        *string           `mapstructure:"cache_max_age"`
+	MaxTCPQueries      *int              `mapstructure:"max_tcp_queries"`
 
 	// Enterprise Only
 	PreferNamespace *bool `mapstructure:"prefer_namespace"`

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -88,6 +88,7 @@ func DefaultSource() Source {
 			udp_answer_limit = 3
 			max_stale = "87600h"
 			recursor_timeout = "2s"
+			max_tcp_queries = 128
 		}
 		limits = {
 			http_max_conns_per_client = 200

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -273,6 +273,15 @@ type RuntimeConfig struct {
 	// hcl: dns_config { cache_max_age = "duration" }
 	DNSCacheMaxAge time.Duration
 
+	// DNSMaxTCPQueries controls how many queries will be serviced by a
+	// single TCP connection before closing it. Default is the value of
+	// `maxTCPQueries` (currently 128) as defined here
+	// https://pkg.go.dev/github.com/miekg/dns#Server.MaxTCPQueries or can
+	// be set to -1 for unlimited.
+	//
+	// hcl: dns_config { max_tcp_queries = int }
+	DNSMaxTCPQueries int
+
 	// HTTPUseCache whether or not to use cache for http queries. Defaults
 	// to true.
 	//

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2002,6 +2002,15 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		expectedErr: "dns_config.a_record_limit cannot be -1. Must be greater than or equal to zero",
 	})
 	run(t, testCase{
+		desc: "dns_config.max_tcp_queries invalid",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json:        []string{`{ "dns_config": { "max_tcp_queries": -2 } }`},
+		hcl:         []string{`dns_config = { max_tcp_queries = -2 }`},
+		expectedErr: "dns_config.max_tcp_queries cannot be -2. Must be greater than or equal to -1",
+	})
+	run(t, testCase{
 		desc: "performance.raft_multiplier < 0",
 		args: []string{
 			`-data-dir=` + dataDir,
@@ -5442,6 +5451,7 @@ func TestLoad_FullConfig(t *testing.T) {
 		DNSNodeMetaTXT:                         true,
 		DNSUseCache:                            true,
 		DNSCacheMaxAge:                         5 * time.Minute,
+		DNSMaxTCPQueries:                       128,
 		DataDir:                                dataDir,
 		Datacenter:                             "rzo029wg",
 		DefaultQueryTime:                       16743 * time.Second,
@@ -6195,6 +6205,7 @@ func TestRuntimeConfig_Sanitize(t *testing.T) {
 				},
 			},
 		},
+		DNSMaxTCPQueries: 128,
 	}
 
 	b, err := json.MarshalIndent(rt.Sanitized(), "", "    ")

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -146,6 +146,7 @@
     "DNSDomain": "",
     "DNSEnableTruncate": false,
     "DNSMaxStale": "0s",
+    "DNSMaxTCPQueries": 128,
     "DNSNodeMetaTXT": false,
     "DNSNodeTTL": "0s",
     "DNSOnlyPassing": false,

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -252,6 +252,7 @@ dns_config {
     udp_answer_limit = 29909
     use_cache = true
     cache_max_age = "5m"
+    max_tcp_queries = 128
     prefer_namespace = true
 }
 enable_acl_replication = true

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -252,6 +252,7 @@
     "udp_answer_limit": 29909,
     "use_cache": true,
     "cache_max_age": "5m",
+    "max_tcp_queries": 128,
     "prefer_namespace": true
   },
   "enable_acl_replication": true,

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -86,6 +86,7 @@ type dnsConfig struct {
 	UDPAnswerLimit   int
 	ARecordLimit     int
 	NodeMetaTXT      bool
+	MaxTCPQueries    int
 	SOAConfig        dnsSOAConfig
 	// TTLRadix sets service TTLs by prefix, eg: "database-*"
 	TTLRadix *radix.Tree
@@ -166,6 +167,7 @@ func GetDNSConfig(conf *config.RuntimeConfig) (*dnsConfig, error) {
 		DisableCompression: conf.DNSDisableCompression,
 		UseCache:           conf.DNSUseCache,
 		CacheMaxAge:        conf.DNSCacheMaxAge,
+		MaxTCPQueries:      conf.DNSMaxTCPQueries,
 		SOAConfig: dnsSOAConfig{
 			Expire:  conf.DNSSOA.Expire,
 			Minttl:  conf.DNSSOA.Minttl,
@@ -243,6 +245,8 @@ func (d *DNSServer) ListenAndServe(network, addr string, notif func()) error {
 	if network == "udp" {
 		d.UDPSize = 65535
 	}
+
+	d.MaxTCPQueries = cfg.MaxTCPQueries
 	return d.Server.ListenAndServe()
 }
 

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1431,6 +1431,10 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
     versions and will assume the label is the datacenter. See: [this section](/docs/discovery/dns#namespaced-services)
     for more details.
 
+  - `max_tcp_queries` ((#dns_max_tcp_queries)) - The maximum number of queries
+    answered over a reused TCP socket before the connection is closed. Defaults
+    to 128. Set to -1 for unlimited.
+
 - `domain` Equivalent to the [`-domain` command-line flag](#_domain).
 
 - `enable_acl_replication` When set on a Consul server, enables ACL replication without having to set


### PR DESCRIPTION
Currently the DNS server implementation closes resused TCP connections after `maxTCPQueries` https://pkg.go.dev/github.com/miekg/dns#Server.MaxTCPQueries  have been processed. This change exposes this setting in the Consul agent config so that we can customize this value to our liking.

## Adding a Simple Config Field for Client Agents

 - [x] Add the field to the Config struct (or an appropriate sub-struct) in
   `agent/config/config.go`.
 - [x] Add the field to the actual RuntimeConfig struct in
   `agent/config/runtime.go`.
 - [x] Add an appropriate parser/setter in `agent/config/builder.go` to
   translate.
 - [x] Add the new field with a random value to both the JSON and HCL files in
   `agent/config/testdata/full-config.*`, which should cause the test to fail.
   Then update the expected value in `TestLoad_FullConfig` in
   `agent/config/runtime_test.go` to make the test pass again.
 - [x] Run `go test -run TestRuntimeConfig_Sanitize ./agent/config -update` to update
   the expected value for `TestRuntimeConfig_Sanitize`. Look at `git diff` to
   make sure the value changed as you expect.
 - [x] **If** your new config field needed some validation as it's only valid in
   some cases or with some values (often true).
      - [x] Add validation to Validate in `agent/config/builder.go`.
      - [x] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
        `agent/config/runtime_test.go`.
 - [x] **If** your new config field needs a non-zero-value default.
      - [x] Add that to `DefaultSource` in `agent/config/defaults.go`.
      - [x] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
        `agent/config/runtime_test.go`.
 - [ ] **If** your config should take effect on a reload/HUP.
      - [ ] Add necessary code to to trigger a safe (locked or atomic) update to
        any state the feature needs changing. This needs to be added to one or
        more of the following places:
         - `ReloadConfig` in `agent/agent.go` if it needs to affect the local
           client state or another client agent component.
         - `ReloadConfig` in `agent/consul/client.go` if it needs to affect
           state for client agent's RPC client.
      - [ ] Add a test to `agent/agent_test.go` similar to others with prefix
        `TestAgent_reloadConfig*`.
 - [x] Add documentation to `website/content/docs/agent/options.mdx`.

Done! You can now use your new field in a client agent by accessing
`s.agent.Config.<FieldName>`.

If you need a CLI flag, access to the variable in a Server context, or touched
the Service Definition, make sure you continue on to follow the appropriate
checklists below.
