### PR TITLE
ci: added CODEOWNER to automatically request tech writer review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Techical Writer Review
+
+/website/content/docs/* @trujillo-adam
+/website/content/commands/* @trujillo-adam
+/website/content/api-docs/* @trujillo-adam
+
+


### PR DESCRIPTION
This PR adds a `CODEOWNERS` file to the Consul repository. The purpose of this PR is to automatically add the Consul tech writer to documentation changes.

