### PR TITLE
use intermediates when verifying

### DIFF
--- a/.changelog/10964.txt
+++ b/.changelog/10964.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+tls: use intermediate certificates when verifying TLS certificates.
+```

--- a/.changelog/10964.txt
+++ b/.changelog/10964.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-tls: use intermediate certificates when verifying TLS certificates.
+tls: consider presented intermediates during server connection tls handshake.
 ```

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -935,7 +935,7 @@ func (c *Configurator) AuthorizeServerConn(dc string, conn *tls.Conn) error {
 		}
 		c.logger.Debug("AuthorizeServerConn failed certificate validation", "error", err)
 	}
-	return fmt.Errorf("a TLS certificate with a CommonName of %v is required for this operation", expected)
+	return fmt.Errorf("AuthorizeServerConn failed certificate validation with a CommonName of %v", expected)
 }
 
 // ParseCiphers parse ciphersuites from the comma-separated string into

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -923,8 +923,8 @@ func (c *Configurator) AuthorizeServerConn(dc string, conn *tls.Conn) error {
 		opts := x509.VerifyOptions{
 			DNSName:       expected,
 			Intermediates: x509.NewCertPool(),
-			Roots: caPool,
-			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			Roots:         caPool,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		}
 		for _, cert := range cs.PeerCertificates[1:] {
 			opts.Intermediates.AddCert(cert)

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -937,7 +937,7 @@ func (c *Configurator) AuthorizeServerConn(dc string, conn *tls.Conn) error {
 		}
 		multierror.Append(errs, err)
 	}
-	return fmt.Errorf("AuthorizeServerConn failed certificate validation for certificate with a CommonName of %v: %w", expected, errs)
+	return fmt.Errorf("AuthorizeServerConn failed certificate validation for certificate with a SAN.DNSName of %v: %w", expected, errs)
 
 }
 

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -919,12 +919,16 @@ func (c *Configurator) AuthorizeServerConn(dc string, conn *tls.Conn) error {
 		if len(chain) == 0 {
 			continue
 		}
-		clientCert := chain[0]
-		_, err := clientCert.Verify(x509.VerifyOptions{
-			DNSName:   expected,
-			Roots:     caPool,
+		opts := x509.VerifyOptions{
+			DNSName:       expected,
+			Intermediates: x509.NewCertPool(),
+			Roots: caPool,
 			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		})
+		}
+		for _, cert := range chain.PeerCertificates[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+		_, err := cs.PeerCertificates[0].Verify(opts)
 		if err == nil {
 			return nil
 		}

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/hashicorp/consul/vendor/github.com/hashicorp/go-hclog"
 	"io/ioutil"
 	"net"
 	"os"

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/hashicorp/consul/vendor/github.com/hashicorp/go-hclog"
 	"io/ioutil"
 	"net"
 	"os"
@@ -915,7 +916,8 @@ func (c *Configurator) AuthorizeServerConn(dc string, conn *tls.Conn) error {
 	c.lock.RUnlock()
 
 	expected := c.ServerSNI(dc, "")
-	for _, chain := range conn.ConnectionState().VerifiedChains {
+	cs := conn.ConnectionState()
+	for _, chain := range cs.VerifiedChains {
 		if len(chain) == 0 {
 			continue
 		}
@@ -925,7 +927,7 @@ func (c *Configurator) AuthorizeServerConn(dc string, conn *tls.Conn) error {
 			Roots: caPool,
 			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		}
-		for _, cert := range chain.PeerCertificates[1:] {
+		for _, cert := range cs.PeerCertificates[1:] {
 			opts.Intermediates.AddCert(cert)
 		}
 		_, err := cs.PeerCertificates[0].Verify(opts)

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -935,7 +935,7 @@ func (c *Configurator) AuthorizeServerConn(dc string, conn *tls.Conn) error {
 		}
 		c.logger.Debug("AuthorizeServerConn failed certificate validation", "error", err)
 	}
-	return fmt.Errorf("AuthorizeServerConn failed certificate validation with a CommonName of %v", expected)
+	return fmt.Errorf("AuthorizeServerConn failed certificate validation for certificate with a CommonName of %v", expected)
 }
 
 // ParseCiphers parse ciphersuites from the comma-separated string into

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -843,15 +843,11 @@ func (c *Configurator) wrapTLSClient(dc string, conn net.Conn) (net.Conn, error)
 		Intermediates: x509.NewCertPool(),
 	}
 
-	certs := tlsConn.ConnectionState().PeerCertificates
-	for i, cert := range certs {
-		if i == 0 {
-			continue
-		}
+	cs := tlsConn.ConnectionState()
+	for _, cert := range cs.PeerCertificates[1:] {
 		opts.Intermediates.AddCert(cert)
 	}
-
-	_, err = certs[0].Verify(opts)
+	_, err = cs.PeerCertificates[0].Verify(opts)
 	if err != nil {
 		tlsConn.Close()
 		return nil, err

--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -54,6 +54,7 @@ type CertOpts struct {
 	DNSNames    []string
 	IPAddresses []net.IP
 	ExtKeyUsage []x509.ExtKeyUsage
+	IsCA        bool
 }
 
 // GenerateCA generates a new CA for agent TLS (not to be confused with Connect TLS)
@@ -176,6 +177,10 @@ func GenerateCert(opts CertOpts) (string, string, error) {
 		SubjectKeyId:          id,
 		DNSNames:              opts.DNSNames,
 		IPAddresses:           opts.IPAddresses,
+	}
+	if opts.IsCA {
+		template.IsCA = true
+		template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature
 	}
 
 	bs, err := x509.CreateCertificate(rand.Reader, &template, parent, signee.Public(), opts.Signer)


### PR DESCRIPTION
Until now Consul never used the intermediate certificates to verify TLS certs, but it should! Like the [stdlib](https://pkg.go.dev/crypto/tls#example-Config-VerifyConnection).