### PR TITLE
Update audit logging example

### DIFF
--- a/website/content/docs/enterprise/audit-logging.mdx
+++ b/website/content/docs/enterprise/audit-logging.mdx
@@ -41,9 +41,10 @@ communication channel used for agent communication.
 <Tabs>
 <Tab heading="Log to file">
 
-The following example configures a destination called "My Sink" which stores audit
-events at the file `/tmp/audit.json`. The log file will be rotated either every
-24 hours, or when the log file size is greater than 25165824 bytes (24 megabytes).
+The following example configures a destination called "My Sink". Since rotation is enabled,
+adit events will be stored at files named: `/tmp/audit-<TIMESTAMP>.json`. The log file will 
+be rotated either every 24 hours, or when the log file size is greater than 25165824 bytes 
+(24 megabytes).
 
 <CodeTabs>
 

--- a/website/content/docs/enterprise/audit-logging.mdx
+++ b/website/content/docs/enterprise/audit-logging.mdx
@@ -42,7 +42,7 @@ communication channel used for agent communication.
 <Tab heading="Log to file">
 
 The following example configures a destination called "My Sink". Since rotation is enabled,
-adit events will be stored at files named: `/tmp/audit-<TIMESTAMP>.json`. The log file will 
+audit events will be stored at files named: `/tmp/audit-<TIMESTAMP>.json`. The log file will 
 be rotated either every 24 hours, or when the log file size is greater than 25165824 bytes 
 (24 megabytes).
 


### PR DESCRIPTION
When file rotation is enabled a timestamp will always be added as a suffix to the filename, even if the logs have not been rotated yet.

See the filename in this tutorial:
https://learn.hashicorp.com/tutorials/consul/audit-logging#explore-audit-logs