### PR TITLE
fix godoc comment for Namespaces client method

### DIFF
--- a/api/namespace.go
+++ b/api/namespace.go
@@ -50,7 +50,7 @@ type Namespaces struct {
 	c *Client
 }
 
-// Operator returns a handle to the operator endpoints.
+// Namespaces returns a handle to the namespaces endpoints.
 func (c *Client) Namespaces() *Namespaces {
 	return &Namespaces{c}
 }


### PR DESCRIPTION
Namespaces method godoc has same sentence as Operator method.
Presumably a cut-n-paste error. Fix that.