### PR TITLE
docs: fixed numbering of license bullets and corrected indent

### DIFF
--- a/website/content/docs/nia/enterprise/license.mdx
+++ b/website/content/docs/nia/enterprise/license.mdx
@@ -29,9 +29,9 @@ export CONSUL_LICENSE=<LICENSE_VALUE>
 
 1. Set the `CONSUL_LICENSE_PATH` environment variable to the path of the file containing the license.
 
-```shell-session
-export CONSUL_LICENSE_PATH=<PATH>/<TO>/<FILE>
-```
+    ```shell-session
+    export CONSUL_LICENSE_PATH=<PATH>/<TO>/<FILE>
+    ```
 
 1. Configure the [`license_path`](/docs/nia/configuration#license_path) option in the configuration file to point to the file containing the license.
 

--- a/website/content/docs/nia/enterprise/license.mdx
+++ b/website/content/docs/nia/enterprise/license.mdx
@@ -23,21 +23,21 @@ Choose one of the following methods (in order of precedence) to set the license:
 
 1. Set the `CONSUL_LICENSE` environment variable to the license string.
 
-```shell-session
-export CONSUL_LICENSE=<LICENSE_VALUE>
-```
+   ```shell-session
+   export CONSUL_LICENSE=<LICENSE_VALUE>
+   ```
 
 1. Set the `CONSUL_LICENSE_PATH` environment variable to the path of the file containing the license.
 
-    ```shell-session
-    export CONSUL_LICENSE_PATH=<PATH>/<TO>/<FILE>
-    ```
+   ```shell-session
+   export CONSUL_LICENSE_PATH=<PATH>/<TO>/<FILE>
+   ```
 
 1. Configure the [`license_path`](/docs/nia/configuration#license_path) option in the configuration file to point to the file containing the license.
 
-```hcl
-license_path = "<PATH>/<TO>/<FILE>"
-```
+   ```hcl
+   license_path = "<PATH>/<TO>/<FILE>"
+   ```
 
 ~> **Note**: the [options to set the license and the order of precedence](/docs/enterprise/license/overview#binaries-without-built-in-licenses) are the same as Consul Enterprise server agents.
 Visit the [Enterprise License Tutorial](https://learn.hashicorp.com/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise) for detailed steps on how to install the license key.

--- a/website/content/docs/nia/enterprise/license.mdx
+++ b/website/content/docs/nia/enterprise/license.mdx
@@ -27,13 +27,13 @@ Choose one of the following methods (in order of precedence) to set the license:
 export CONSUL_LICENSE=<LICENSE_VALUE>
 ```
 
-2. Set the `CONSUL_LICENSE_PATH` environment variable to the path of the file containing the license.
+1. Set the `CONSUL_LICENSE_PATH` environment variable to the path of the file containing the license.
 
 ```shell-session
 export CONSUL_LICENSE_PATH=<PATH>/<TO>/<FILE>
 ```
 
-3. Configure the [`license_path`](/docs/nia/configuration#license_path) option in the configuration file to point to the file containing the license.
+1. Configure the [`license_path`](/docs/nia/configuration#license_path) option in the configuration file to point to the file containing the license.
 
 ```hcl
 license_path = "<PATH>/<TO>/<FILE>"


### PR DESCRIPTION
This PR fixes the license list numbering behaving incorrectly 

![image](https://user-images.githubusercontent.com/29551334/131882775-30c7e700-439c-4c02-a293-cd91fe68126d.png)
