### PR TITLE
fixing the policy for configuring k8 clusters as secondary in federated arch

### DIFF
--- a/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
+++ b/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
@@ -243,7 +243,7 @@ You'll need:
      policy = "write"
    }
    namespace_prefix "" {
-     acl="write"
+     acl = "write"
      service_prefix "" {
        policy = "read"
        intentions = "read"

--- a/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
+++ b/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
@@ -243,6 +243,7 @@ You'll need:
      policy = "write"
    }
    namespace_prefix "" {
+     acl="write"
      service_prefix "" {
        policy = "read"
        intentions = "read"


### PR DESCRIPTION
Per @lanceplarsen:

This policy is wrong because it misses ACL write in the namespace.  When using enterprise the policy is this:

namespace_prefix "" {
  acl = "write"
  service_prefix "" {
    policy = "read"
    intentions = "read"
  }
}

This PR fixes this.