### PR TITLE
acl: adding a new mesh resource

### DIFF
--- a/acl/authorizer.go
+++ b/acl/authorizer.go
@@ -45,6 +45,7 @@ const (
 	ResourceKeyring   Resource = "keyring"
 	ResourceNode      Resource = "node"
 	ResourceOperator  Resource = "operator"
+	ResourceMesh      Resource = "mesh"
 	ResourceQuery     Resource = "query"
 	ResourceService   Resource = "service"
 	ResourceSession   Resource = "session"
@@ -103,6 +104,14 @@ type Authorizer interface {
 
 	// KeyringWrite determines if the keyring can be manipulated
 	KeyringWrite(*AuthorizerContext) EnforcementDecision
+
+	// MeshRead determines if the read-only Consul mesh functions
+	// can be used.
+	MeshRead(*AuthorizerContext) EnforcementDecision
+
+	// MeshWrite determines if the state-changing Consul mesh
+	// functions can be used.
+	MeshWrite(*AuthorizerContext) EnforcementDecision
 
 	// NodeRead checks for permission to read (discover) a given node.
 	NodeRead(string, *AuthorizerContext) EnforcementDecision
@@ -203,6 +212,13 @@ func Enforce(authz Authorizer, rsc Resource, segment string, access string, ctx 
 			return authz.KeyringRead(ctx), nil
 		case "write":
 			return authz.KeyringWrite(ctx), nil
+		}
+	case ResourceMesh:
+		switch lowerAccess {
+		case "read":
+			return authz.MeshRead(ctx), nil
+		case "write":
+			return authz.MeshWrite(ctx), nil
 		}
 	case ResourceNode:
 		switch lowerAccess {

--- a/acl/authorizer_test.go
+++ b/acl/authorizer_test.go
@@ -129,6 +129,16 @@ func (m *mockAuthorizer) NodeWrite(segment string, ctx *AuthorizerContext) Enfor
 	return ret.Get(0).(EnforcementDecision)
 }
 
+func (m *mockAuthorizer) MeshRead(ctx *AuthorizerContext) EnforcementDecision {
+	ret := m.Called(ctx)
+	return ret.Get(0).(EnforcementDecision)
+}
+
+func (m *mockAuthorizer) MeshWrite(ctx *AuthorizerContext) EnforcementDecision {
+	ret := m.Called(ctx)
+	return ret.Get(0).(EnforcementDecision)
+}
+
 // OperatorRead determines if the read-only Consul operator functions
 // can be used.	ret := m.Called(segment, ctx)
 func (m *mockAuthorizer) OperatorRead(ctx *AuthorizerContext) EnforcementDecision {

--- a/acl/chained_authorizer.go
+++ b/acl/chained_authorizer.go
@@ -145,6 +145,22 @@ func (c *ChainedAuthorizer) KeyringWrite(entCtx *AuthorizerContext) EnforcementD
 	})
 }
 
+// MeshRead determines if the read-only Consul mesh functions
+// can be used.
+func (c *ChainedAuthorizer) MeshRead(entCtx *AuthorizerContext) EnforcementDecision {
+	return c.executeChain(func(authz Authorizer) EnforcementDecision {
+		return authz.MeshRead(entCtx)
+	})
+}
+
+// MeshWrite determines if the state-changing Consul mesh
+// functions can be used.
+func (c *ChainedAuthorizer) MeshWrite(entCtx *AuthorizerContext) EnforcementDecision {
+	return c.executeChain(func(authz Authorizer) EnforcementDecision {
+		return authz.MeshWrite(entCtx)
+	})
+}
+
 // NodeRead checks for permission to read (discover) a given node.
 func (c *ChainedAuthorizer) NodeRead(node string, entCtx *AuthorizerContext) EnforcementDecision {
 	return c.executeChain(func(authz Authorizer) EnforcementDecision {

--- a/acl/chained_authorizer_test.go
+++ b/acl/chained_authorizer_test.go
@@ -62,6 +62,12 @@ func (authz testAuthorizer) NodeReadAll(*AuthorizerContext) EnforcementDecision 
 func (authz testAuthorizer) NodeWrite(string, *AuthorizerContext) EnforcementDecision {
 	return EnforcementDecision(authz)
 }
+func (authz testAuthorizer) MeshRead(*AuthorizerContext) EnforcementDecision {
+	return EnforcementDecision(authz)
+}
+func (authz testAuthorizer) MeshWrite(*AuthorizerContext) EnforcementDecision {
+	return EnforcementDecision(authz)
+}
 func (authz testAuthorizer) OperatorRead(*AuthorizerContext) EnforcementDecision {
 	return EnforcementDecision(authz)
 }
@@ -113,6 +119,8 @@ func TestChainedAuthorizer(t *testing.T) {
 		checkDenyKeyWritePrefix(t, authz, "foo", nil)
 		checkDenyNodeRead(t, authz, "foo", nil)
 		checkDenyNodeWrite(t, authz, "foo", nil)
+		checkDenyMeshRead(t, authz, "foo", nil)
+		checkDenyMeshWrite(t, authz, "foo", nil)
 		checkDenyOperatorRead(t, authz, "foo", nil)
 		checkDenyOperatorWrite(t, authz, "foo", nil)
 		checkDenyPreparedQueryRead(t, authz, "foo", nil)
@@ -143,6 +151,8 @@ func TestChainedAuthorizer(t *testing.T) {
 		checkDenyKeyWritePrefix(t, authz, "foo", nil)
 		checkDenyNodeRead(t, authz, "foo", nil)
 		checkDenyNodeWrite(t, authz, "foo", nil)
+		checkDenyMeshRead(t, authz, "foo", nil)
+		checkDenyMeshWrite(t, authz, "foo", nil)
 		checkDenyOperatorRead(t, authz, "foo", nil)
 		checkDenyOperatorWrite(t, authz, "foo", nil)
 		checkDenyPreparedQueryRead(t, authz, "foo", nil)
@@ -173,6 +183,8 @@ func TestChainedAuthorizer(t *testing.T) {
 		checkAllowKeyWritePrefix(t, authz, "foo", nil)
 		checkAllowNodeRead(t, authz, "foo", nil)
 		checkAllowNodeWrite(t, authz, "foo", nil)
+		checkAllowMeshRead(t, authz, "foo", nil)
+		checkAllowMeshWrite(t, authz, "foo", nil)
 		checkAllowOperatorRead(t, authz, "foo", nil)
 		checkAllowOperatorWrite(t, authz, "foo", nil)
 		checkAllowPreparedQueryRead(t, authz, "foo", nil)
@@ -203,6 +215,8 @@ func TestChainedAuthorizer(t *testing.T) {
 		checkDenyKeyWritePrefix(t, authz, "foo", nil)
 		checkDenyNodeRead(t, authz, "foo", nil)
 		checkDenyNodeWrite(t, authz, "foo", nil)
+		checkDenyMeshRead(t, authz, "foo", nil)
+		checkDenyMeshWrite(t, authz, "foo", nil)
 		checkDenyOperatorRead(t, authz, "foo", nil)
 		checkDenyOperatorWrite(t, authz, "foo", nil)
 		checkDenyPreparedQueryRead(t, authz, "foo", nil)
@@ -231,6 +245,8 @@ func TestChainedAuthorizer(t *testing.T) {
 		checkAllowKeyWritePrefix(t, authz, "foo", nil)
 		checkAllowNodeRead(t, authz, "foo", nil)
 		checkAllowNodeWrite(t, authz, "foo", nil)
+		checkAllowMeshRead(t, authz, "foo", nil)
+		checkAllowMeshWrite(t, authz, "foo", nil)
 		checkAllowOperatorRead(t, authz, "foo", nil)
 		checkAllowOperatorWrite(t, authz, "foo", nil)
 		checkAllowPreparedQueryRead(t, authz, "foo", nil)

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -84,6 +84,7 @@ type PolicyRules struct {
 	PreparedQueryPrefixes []*PreparedQueryRule `hcl:"query_prefix,expand"`
 	Keyring               string               `hcl:"keyring"`
 	Operator              string               `hcl:"operator"`
+	Mesh                  string               `hcl:"mesh"`
 }
 
 // Policy is used to represent the policy specified by an ACL configuration.
@@ -285,6 +286,11 @@ func (pr *PolicyRules) Validate(conf *Config) error {
 		return fmt.Errorf("Invalid operator policy: %#v", pr.Operator)
 	}
 
+	// Validate the mesh policy - this one is allowed to be empty
+	if pr.Mesh != "" && !isPolicyValid(pr.Mesh, false) {
+		return fmt.Errorf("Invalid mesh policy: %#v", pr.Mesh)
+	}
+
 	return nil
 }
 
@@ -318,6 +324,7 @@ func parseLegacy(rules string, conf *Config) (*Policy, error) {
 		PreparedQueries []*PreparedQueryRule `hcl:"query,expand"`
 		Keyring         string               `hcl:"keyring"`
 		Operator        string               `hcl:"operator"`
+		// NOTE: mesh resources not supported here
 	}
 
 	lp := &LegacyPolicy{}
@@ -446,6 +453,7 @@ func NewPolicyFromSource(id string, revision uint64, rules string, syntax Syntax
 	return policy, err
 }
 
+// TODO(ACL-Legacy): remove this
 func (policy *Policy) ConvertToLegacy() *Policy {
 	converted := &Policy{
 		ID:       policy.ID,
@@ -474,6 +482,7 @@ func (policy *Policy) ConvertToLegacy() *Policy {
 	return converted
 }
 
+// TODO(ACL-Legacy): remove this
 func (policy *Policy) ConvertFromLegacy() *Policy {
 	return &Policy{
 		ID:       policy.ID,

--- a/acl/policy_authorizer_test.go
+++ b/acl/policy_authorizer_test.go
@@ -48,6 +48,8 @@ func TestPolicyAuthorizer(t *testing.T) {
 				{name: "DefaultKeyWritePrefix", prefix: "foo", check: checkDefaultKeyWritePrefix},
 				{name: "DefaultNodeRead", prefix: "foo", check: checkDefaultNodeRead},
 				{name: "DefaultNodeWrite", prefix: "foo", check: checkDefaultNodeWrite},
+				{name: "DefaultMeshRead", prefix: "foo", check: checkDefaultMeshRead},
+				{name: "DefaultMeshWrite", prefix: "foo", check: checkDefaultMeshWrite},
 				{name: "DefaultOperatorRead", prefix: "foo", check: checkDefaultOperatorRead},
 				{name: "DefaultOperatorWrite", prefix: "foo", check: checkDefaultOperatorWrite},
 				{name: "DefaultPreparedQueryRead", prefix: "foo", check: checkDefaultPreparedQueryRead},

--- a/acl/policy_merger.go
+++ b/acl/policy_merger.go
@@ -17,6 +17,7 @@ type policyRulesMergeContext struct {
 	keyringRule              string
 	keyRules                 map[string]*KeyRule
 	keyPrefixRules           map[string]*KeyRule
+	meshRule                 string
 	nodeRules                map[string]*NodeRule
 	nodePrefixRules          map[string]*NodeRule
 	operatorRule             string
@@ -37,6 +38,7 @@ func (p *policyRulesMergeContext) init() {
 	p.keyringRule = ""
 	p.keyRules = make(map[string]*KeyRule)
 	p.keyPrefixRules = make(map[string]*KeyRule)
+	p.meshRule = ""
 	p.nodeRules = make(map[string]*NodeRule)
 	p.nodePrefixRules = make(map[string]*NodeRule)
 	p.operatorRule = ""
@@ -121,6 +123,10 @@ func (p *policyRulesMergeContext) merge(policy *PolicyRules) {
 		if update {
 			p.keyPrefixRules[kp.Prefix] = kp
 		}
+	}
+
+	if takesPrecedenceOver(policy.Mesh, p.meshRule) {
+		p.meshRule = policy.Mesh
 	}
 
 	for _, np := range policy.Nodes {
@@ -234,6 +240,7 @@ func (p *policyRulesMergeContext) update(merged *PolicyRules) {
 	merged.ACL = p.aclRule
 	merged.Keyring = p.keyringRule
 	merged.Operator = p.operatorRule
+	merged.Mesh = p.meshRule
 
 	// All the for loop appends are ugly but Go doesn't have a way to get
 	// a slice of all values within a map so this is necessary

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -14,80 +14,439 @@ func errStartsWith(t *testing.T, actual error, expected string) {
 }
 
 func TestPolicySourceParse(t *testing.T) {
-	ljoin := func(lines ...string) string {
-		return strings.Join(lines, "\n")
-	}
 	cases := []struct {
-		Name     string
-		Syntax   SyntaxVersion
-		Rules    string
-		Expected *Policy
-		Err      string
+		Name      string
+		Syntax    SyntaxVersion
+		Rules     string
+		RulesJSON string
+		Expected  *Policy
+		Err       string
 	}{
 		{
-			"Legacy Basic",
-			SyntaxLegacy,
-			ljoin(
-				`agent "foo" {      `,
-				`	policy = "read"  `,
-				`}                  `,
-				`agent "bar" {      `,
-				`	policy = "write" `,
-				`}                  `,
-				`event "" {         `,
-				`	policy = "read"  `,
-				`}                  `,
-				`event "foo" {      `,
-				`	policy = "write" `,
-				`}                  `,
-				`event "bar" {      `,
-				`	policy = "deny"  `,
-				`}                  `,
-				`key "" {           `,
-				`	policy = "read"  `,
-				`}                  `,
-				`key "foo/" {       `,
-				`	policy = "write" `,
-				`}                  `,
-				`key "foo/bar/" {   `,
-				`	policy = "read"  `,
-				`}                  `,
-				`key "foo/bar/baz" {`,
-				`	policy = "deny"  `,
-				`}                  `,
-				`keyring = "deny"   `,
-				`node "" {          `,
-				`	policy = "read"  `,
-				`}                  `,
-				`node "foo" {       `,
-				`	policy = "write" `,
-				`}                  `,
-				`node "bar" {       `,
-				`	policy = "deny"  `,
-				`}                  `,
-				`operator = "deny"  `,
-				`service "" {       `,
-				`	policy = "write" `,
-				`}                  `,
-				`service "foo" {    `,
-				`	policy = "read"  `,
-				`}                  `,
-				`session "foo" {    `,
-				`	policy = "write" `,
-				`}                  `,
-				`session "bar" {    `,
-				`	policy = "deny"  `,
-				`}                  `,
-				`query "" {         `,
-				`	policy = "read"  `,
-				`}                  `,
-				`query "foo" {      `,
-				`	policy = "write" `,
-				`}                  `,
-				`query "bar" {      `,
-				`	policy = "deny"  `,
-				`}                  `),
-			&Policy{PolicyRules: PolicyRules{
+			Name:   "Basic",
+			Syntax: SyntaxCurrent,
+			Rules: `
+				agent_prefix "bar" {
+					policy = "write"
+				}
+				agent "foo" {
+					policy = "read"
+				}
+				event_prefix "" {
+					policy = "read"
+				}
+				event "foo" {
+					policy = "write"
+				}
+				event "bar" {
+					policy = "deny"
+				}
+				key_prefix "" {
+					policy = "read"
+				}
+				key_prefix "foo/" {
+					policy = "write"
+				}
+				key_prefix "foo/bar/" {
+					policy = "read"
+				}
+				key "foo/bar/baz" {
+					policy = "deny"
+				}
+				keyring = "deny"
+				node_prefix "" {
+					policy = "read"
+				}
+				node "foo" {
+					policy = "write"
+				}
+				node "bar" {
+					policy = "deny"
+				}
+				operator = "deny"
+				mesh = "deny"
+				service_prefix "" {
+					policy = "write"
+				}
+				service "foo" {
+					policy = "read"
+				}
+				session "foo" {
+					policy = "write"
+				}
+				session "bar" {
+					policy = "deny"
+				}
+				session_prefix "baz" {
+					policy = "deny"
+				}
+				query_prefix "" {
+					policy = "read"
+				}
+				query "foo" {
+					policy = "write"
+				}
+				query "bar" {
+					policy = "deny"
+				}
+				`,
+			RulesJSON: `
+				{
+				  "agent_prefix": {
+					"bar": {
+					  "policy": "write"
+					}
+				  },
+				  "agent": {
+					"foo": {
+					  "policy": "read"
+					}
+				  },
+				  "event_prefix": {
+					"": {
+					  "policy": "read"
+					}
+				  },
+				  "event": {
+					"foo": {
+					  "policy": "write"
+					},
+					"bar": {
+					  "policy": "deny"
+					}
+				  },
+				  "key_prefix": {
+					"": {
+					  "policy": "read"
+					},
+					"foo/": {
+					  "policy": "write"
+					},
+					"foo/bar/": {
+					  "policy": "read"
+					}
+				  },
+				  "key": {
+					"foo/bar/baz": {
+					  "policy": "deny"
+					}
+				  },
+				  "keyring": "deny",
+				  "node_prefix": {
+					"": {
+					  "policy": "read"
+					}
+				  },
+				  "node": {
+					"foo": {
+					  "policy": "write"
+					},
+					"bar": {
+					  "policy": "deny"
+					}
+				  },
+				  "operator": "deny",
+				  "mesh": "deny",
+				  "service_prefix": {
+					"": {
+					  "policy": "write"
+					}
+				  },
+				  "service": {
+					"foo": {
+					  "policy": "read"
+					}
+				  },
+				  "session_prefix": {
+					"baz": {
+					  "policy": "deny"
+					}
+				  },
+				  "session": {
+					"foo": {
+					  "policy": "write"
+					},
+					"bar": {
+					  "policy": "deny"
+					}
+				  },
+				  "query_prefix": {
+					"": {
+					  "policy": "read"
+					}
+				  },
+				  "query": {
+					"foo": {
+					  "policy": "write"
+					},
+					"bar": {
+					  "policy": "deny"
+					}
+				  }
+				}
+				`,
+			Expected: &Policy{PolicyRules: PolicyRules{
+				AgentPrefixes: []*AgentRule{
+					{
+						Node:   "bar",
+						Policy: PolicyWrite,
+					},
+				},
+				Agents: []*AgentRule{
+					{
+						Node:   "foo",
+						Policy: PolicyRead,
+					},
+				},
+				EventPrefixes: []*EventRule{
+					{
+						Event:  "",
+						Policy: PolicyRead,
+					},
+				},
+				Events: []*EventRule{
+					{
+						Event:  "foo",
+						Policy: PolicyWrite,
+					},
+					{
+						Event:  "bar",
+						Policy: PolicyDeny,
+					},
+				},
+				Keyring: PolicyDeny,
+				KeyPrefixes: []*KeyRule{
+					{
+						Prefix: "",
+						Policy: PolicyRead,
+					},
+					{
+						Prefix: "foo/",
+						Policy: PolicyWrite,
+					},
+					{
+						Prefix: "foo/bar/",
+						Policy: PolicyRead,
+					},
+				},
+				Keys: []*KeyRule{
+					{
+						Prefix: "foo/bar/baz",
+						Policy: PolicyDeny,
+					},
+				},
+				NodePrefixes: []*NodeRule{
+					{
+						Name:   "",
+						Policy: PolicyRead,
+					},
+				},
+				Nodes: []*NodeRule{
+					{
+						Name:   "foo",
+						Policy: PolicyWrite,
+					},
+					{
+						Name:   "bar",
+						Policy: PolicyDeny,
+					},
+				},
+				Operator: PolicyDeny,
+				Mesh:     PolicyDeny,
+				PreparedQueryPrefixes: []*PreparedQueryRule{
+					{
+						Prefix: "",
+						Policy: PolicyRead,
+					},
+				},
+				PreparedQueries: []*PreparedQueryRule{
+					{
+						Prefix: "foo",
+						Policy: PolicyWrite,
+					},
+					{
+						Prefix: "bar",
+						Policy: PolicyDeny,
+					},
+				},
+				ServicePrefixes: []*ServiceRule{
+					{
+						Name:   "",
+						Policy: PolicyWrite,
+					},
+				},
+				Services: []*ServiceRule{
+					{
+						Name:   "foo",
+						Policy: PolicyRead,
+					},
+				},
+				SessionPrefixes: []*SessionRule{
+					{
+						Node:   "baz",
+						Policy: PolicyDeny,
+					},
+				},
+				Sessions: []*SessionRule{
+					{
+						Node:   "foo",
+						Policy: PolicyWrite,
+					},
+					{
+						Node:   "bar",
+						Policy: PolicyDeny,
+					},
+				},
+			}},
+		},
+		{
+			Name:   "Legacy Basic",
+			Syntax: SyntaxLegacy,
+			Rules: `
+				agent "foo" {
+					policy = "read"
+				}
+				agent "bar" {
+					policy = "write"
+				}
+				event "" {
+					policy = "read"
+				}
+				event "foo" {
+					policy = "write"
+				}
+				event "bar" {
+					policy = "deny"
+				}
+				key "" {
+					policy = "read"
+				}
+				key "foo/" {
+					policy = "write"
+				}
+				key "foo/bar/" {
+					policy = "read"
+				}
+				key "foo/bar/baz" {
+					policy = "deny"
+				}
+				keyring = "deny"
+				node "" {
+					policy = "read"
+				}
+				node "foo" {
+					policy = "write"
+				}
+				node "bar" {
+					policy = "deny"
+				}
+				operator = "deny"
+				service "" {
+					policy = "write"
+				}
+				service "foo" {
+					policy = "read"
+				}
+				session "foo" {
+					policy = "write"
+				}
+				session "bar" {
+					policy = "deny"
+				}
+				session "baz" {
+					policy = "deny"
+				}
+				query "" {
+					policy = "read"
+				}
+				query "foo" {
+					policy = "write"
+				}
+				query "bar" {
+					policy = "deny"
+				}
+				`,
+			RulesJSON: `
+				{
+				  "agent": {
+					"foo": {
+					  "policy": "read"
+					},
+					"bar": {
+					  "policy": "write"
+					}
+				  },
+				  "event": {
+					"": {
+					  "policy": "read"
+					},
+					"foo": {
+					  "policy": "write"
+					},
+					"bar": {
+					  "policy": "deny"
+					}
+				  },
+				  "key": {
+					"": {
+					  "policy": "read"
+					},
+					"foo/": {
+					  "policy": "write"
+					},
+					"foo/bar/": {
+					  "policy": "read"
+					},
+					"foo/bar/baz": {
+					  "policy": "deny"
+					}
+				  },
+				  "keyring": "deny",
+				  "node": {
+					"": {
+					  "policy": "read"
+					},
+					"foo": {
+					  "policy": "write"
+					},
+					"bar": {
+					  "policy": "deny"
+					}
+				  },
+				  "operator": "deny",
+				  "service": {
+					"": {
+					  "policy": "write"
+					},
+					"foo": {
+					  "policy": "read"
+					}
+				  },
+				  "session": {
+					"foo": {
+					  "policy": "write"
+					},
+					"bar": {
+					  "policy": "deny"
+					},
+					"baz": {
+					  "policy": "deny"
+					}
+				  },
+				  "query": {
+					"": {
+					  "policy": "read"
+					},
+					"foo": {
+					  "policy": "write"
+					},
+					"bar": {
+					  "policy": "deny"
+					}
+				  }
+				}
+				`,
+			Expected: &Policy{PolicyRules: PolicyRules{
 				AgentPrefixes: []*AgentRule{
 					{
 						Node:   "foo",
@@ -179,193 +538,19 @@ func TestPolicySourceParse(t *testing.T) {
 						Node:   "bar",
 						Policy: PolicyDeny,
 					},
-				},
-			}},
-			"",
-		},
-		{
-			"Legacy (JSON)",
-			SyntaxLegacy,
-			ljoin(
-				`{                         `,
-				`	"agent": {              `,
-				`		"foo": {             `,
-				`			"policy": "write" `,
-				`		},                   `,
-				`		"bar": {             `,
-				`			"policy": "deny"  `,
-				`		}                    `,
-				`	},                      `,
-				`	"event": {              `,
-				`		"": {                `,
-				`			"policy": "read"  `,
-				`		},                   `,
-				`		"foo": {             `,
-				`			"policy": "write" `,
-				`		},                   `,
-				`		"bar": {             `,
-				`			"policy": "deny"  `,
-				`		}                    `,
-				`	},                      `,
-				`	"key": {                `,
-				`		"": {                `,
-				`			"policy": "read"  `,
-				`		},                   `,
-				`		"foo/": {            `,
-				`			"policy": "write" `,
-				`		},                   `,
-				`		"foo/bar/": {        `,
-				`			"policy": "read"  `,
-				`		},                   `,
-				`		"foo/bar/baz": {     `,
-				`			"policy": "deny"  `,
-				`		}                    `,
-				`	},                      `,
-				`	"keyring": "deny",      `,
-				`	"node": {               `,
-				`		"": {                `,
-				`			"policy": "read"  `,
-				`		},                   `,
-				`		"foo": {             `,
-				`			"policy": "write" `,
-				`		},                   `,
-				`		"bar": {             `,
-				`			"policy": "deny"  `,
-				`		}                    `,
-				`	},                      `,
-				`	"operator": "deny",     `,
-				`	"query": {              `,
-				`		"": {                `,
-				`			"policy": "read"  `,
-				`		},                   `,
-				`		"foo": {             `,
-				`			"policy": "write" `,
-				`		},                   `,
-				`		"bar": {             `,
-				`			"policy": "deny"  `,
-				`		}                    `,
-				`	},                      `,
-				`	"service": {            `,
-				`		"": {                `,
-				`			"policy": "write" `,
-				`		},                   `,
-				`		"foo": {             `,
-				`			"policy": "read"  `,
-				`		}                    `,
-				`	},                      `,
-				`	"session": {            `,
-				`		"foo": {             `,
-				`			"policy": "write" `,
-				`		},                   `,
-				`		"bar": {             `,
-				`			"policy": "deny"  `,
-				`		}                    `,
-				`	}                       `,
-				`}                         `),
-			&Policy{PolicyRules: PolicyRules{
-				AgentPrefixes: []*AgentRule{
 					{
-						Node:   "foo",
-						Policy: PolicyWrite,
-					},
-					{
-						Node:   "bar",
-						Policy: PolicyDeny,
-					},
-				},
-				EventPrefixes: []*EventRule{
-					{
-						Event:  "",
-						Policy: PolicyRead,
-					},
-					{
-						Event:  "foo",
-						Policy: PolicyWrite,
-					},
-					{
-						Event:  "bar",
-						Policy: PolicyDeny,
-					},
-				},
-				Keyring: PolicyDeny,
-				KeyPrefixes: []*KeyRule{
-					{
-						Prefix: "",
-						Policy: PolicyRead,
-					},
-					{
-						Prefix: "foo/",
-						Policy: PolicyWrite,
-					},
-					{
-						Prefix: "foo/bar/",
-						Policy: PolicyRead,
-					},
-					{
-						Prefix: "foo/bar/baz",
-						Policy: PolicyDeny,
-					},
-				},
-				NodePrefixes: []*NodeRule{
-					{
-						Name:   "",
-						Policy: PolicyRead,
-					},
-					{
-						Name:   "foo",
-						Policy: PolicyWrite,
-					},
-					{
-						Name:   "bar",
-						Policy: PolicyDeny,
-					},
-				},
-				Operator: PolicyDeny,
-				PreparedQueryPrefixes: []*PreparedQueryRule{
-					{
-						Prefix: "",
-						Policy: PolicyRead,
-					},
-					{
-						Prefix: "foo",
-						Policy: PolicyWrite,
-					},
-					{
-						Prefix: "bar",
-						Policy: PolicyDeny,
-					},
-				},
-				ServicePrefixes: []*ServiceRule{
-					{
-						Name:   "",
-						Policy: PolicyWrite,
-					},
-					{
-						Name:   "foo",
-						Policy: PolicyRead,
-					},
-				},
-				SessionPrefixes: []*SessionRule{
-					{
-						Node:   "foo",
-						Policy: PolicyWrite,
-					},
-					{
-						Node:   "bar",
+						Node:   "baz",
 						Policy: PolicyDeny,
 					},
 				},
 			}},
-			"",
 		},
 		{
-			"Service No Intentions (Legacy)",
-			SyntaxLegacy,
-			ljoin(
-				`service "foo" {    `,
-				`   policy = "write"`,
-				`}                  `),
-			&Policy{PolicyRules: PolicyRules{
+			Name:      "Service No Intentions (Legacy)",
+			Syntax:    SyntaxLegacy,
+			Rules:     `service "foo" { policy = "write" }`,
+			RulesJSON: `{ "service": { "foo": { "policy": "write" }}}`,
+			Expected: &Policy{PolicyRules: PolicyRules{
 				ServicePrefixes: []*ServiceRule{
 					{
 						Name:   "foo",
@@ -373,17 +558,13 @@ func TestPolicySourceParse(t *testing.T) {
 					},
 				},
 			}},
-			"",
 		},
 		{
-			"Service Intentions (Legacy)",
-			SyntaxLegacy,
-			ljoin(
-				`service "foo" {       `,
-				`   policy = "write"   `,
-				`   intentions = "read"`,
-				`}                     `),
-			&Policy{PolicyRules: PolicyRules{
+			Name:      "Service Intentions (Legacy)",
+			Syntax:    SyntaxLegacy,
+			Rules:     `service "foo" { policy = "write" intentions = "read" }`,
+			RulesJSON: `{ "service": { "foo": { "policy": "write", "intentions": "read" }}}`,
+			Expected: &Policy{PolicyRules: PolicyRules{
 				ServicePrefixes: []*ServiceRule{
 					{
 						Name:       "foo",
@@ -392,163 +573,221 @@ func TestPolicySourceParse(t *testing.T) {
 					},
 				},
 			}},
-			"",
 		},
 		{
-			"Service Intention: invalid value (Legacy)",
-			SyntaxLegacy,
-			ljoin(
-				`service "foo" {      `,
-				`   policy = "write"  `,
-				`   intentions = "foo"`,
-				`}                    `),
-			nil,
-			"Invalid service intentions policy",
+			Name:      "Service Intention: invalid value (Legacy)",
+			Syntax:    SyntaxLegacy,
+			Rules:     `service "foo" { policy = "write" intentions = "foo" }`,
+			RulesJSON: `{ "service": { "foo": { "policy": "write", "intentions": "foo" }}}`,
+			Err:       "Invalid service intentions policy",
 		},
 		{
-			"Bad Policy - ACL",
-
-			SyntaxCurrent,
-			`acl = "list"`, // there is no list policy but this helps to exercise another check in isPolicyValid
-			nil,
-			"Invalid acl policy",
+			Name:      "Service No Intentions",
+			Syntax:    SyntaxCurrent,
+			Rules:     `service "foo" { policy = "write" }`,
+			RulesJSON: `{ "service": { "foo": { "policy": "write" }}}`,
+			Expected: &Policy{PolicyRules: PolicyRules{
+				Services: []*ServiceRule{
+					{
+						Name:   "foo",
+						Policy: "write",
+					},
+				},
+			}},
 		},
 		{
-			"Bad Policy - Agent",
-			SyntaxCurrent,
-			`agent "foo" { policy = "nope" }`,
-			nil,
-			"Invalid agent policy",
+			Name:      "Service Intentions",
+			Syntax:    SyntaxCurrent,
+			Rules:     `service "foo" { policy = "write" intentions = "read" }`,
+			RulesJSON: `{ "service": { "foo": { "policy": "write", "intentions": "read" }}}`,
+			Expected: &Policy{PolicyRules: PolicyRules{
+				Services: []*ServiceRule{
+					{
+						Name:       "foo",
+						Policy:     "write",
+						Intentions: "read",
+					},
+				},
+			}},
 		},
 		{
-			"Bad Policy - Agent Prefix",
-			SyntaxCurrent,
-			`agent_prefix "foo" { policy = "nope" }`,
-			nil,
-			"Invalid agent_prefix policy",
+			Name:      "Service Intention: invalid value",
+			Syntax:    SyntaxCurrent,
+			Rules:     `service "foo" { policy = "write" intentions = "foo" }`,
+			RulesJSON: `{ "service": { "foo": { "policy": "write", "intentions": "foo" }}}`,
+			Err:       "Invalid service intentions policy",
 		},
 		{
-			"Bad Policy - Key",
-			SyntaxCurrent,
-			`key "foo" { policy = "nope" }`,
-			nil,
-			"Invalid key policy",
+			Name:      "Bad Policy - ACL",
+			Syntax:    SyntaxCurrent,
+			Rules:     `acl = "list"`,      // there is no list policy but this helps to exercise another check in isPolicyValid
+			RulesJSON: `{ "acl": "list" }`, // there is no list policy but this helps to exercise another check in isPolicyValid
+			Err:       "Invalid acl policy",
 		},
 		{
-			"Bad Policy - Key Prefix",
-			SyntaxCurrent,
-			`key_prefix "foo" { policy = "nope" }`,
-			nil,
-			"Invalid key_prefix policy",
+			Name:      "Bad Policy - Agent",
+			Syntax:    SyntaxCurrent,
+			Rules:     `agent "foo" { policy = "nope" }`,
+			RulesJSON: `{ "agent": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid agent policy",
 		},
 		{
-			"Bad Policy - Node",
-			SyntaxCurrent,
-			`node "foo" { policy = "nope" }`,
-			nil,
-			"Invalid node policy",
+			Name:      "Bad Policy - Agent Prefix",
+			Syntax:    SyntaxCurrent,
+			Rules:     `agent_prefix "foo" { policy = "nope" }`,
+			RulesJSON: `{ "agent_prefix": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid agent_prefix policy",
 		},
 		{
-			"Bad Policy - Node Prefix",
-			SyntaxCurrent,
-			`node_prefix "foo" { policy = "nope" }`,
-			nil,
-			"Invalid node_prefix policy",
+			Name:      "Bad Policy - Key",
+			Syntax:    SyntaxCurrent,
+			Rules:     `key "foo" { policy = "nope" }`,
+			RulesJSON: `{ "key": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid key policy",
 		},
 		{
-			"Bad Policy - Service",
-			SyntaxCurrent,
-			`service "foo" { policy = "nope" }`,
-			nil,
-			"Invalid service policy",
+			Name:      "Bad Policy - Key Prefix",
+			Syntax:    SyntaxCurrent,
+			Rules:     `key_prefix "foo" { policy = "nope" }`,
+			RulesJSON: `{ "key_prefix": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid key_prefix policy",
 		},
 		{
-			"Bad Policy - Service Prefix",
-			SyntaxCurrent,
-			`service_prefix "foo" { policy = "nope" }`,
-			nil,
-			"Invalid service_prefix policy",
+			Name:      "Bad Policy - Node",
+			Syntax:    SyntaxCurrent,
+			Rules:     `node "foo" { policy = "nope" }`,
+			RulesJSON: `{ "node": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid node policy",
 		},
 		{
-			"Bad Policy - Session",
-			SyntaxCurrent,
-			`session "foo" { policy = "nope" }`,
-			nil,
-			"Invalid session policy",
+			Name:      "Bad Policy - Node Prefix",
+			Syntax:    SyntaxCurrent,
+			Rules:     `node_prefix "foo" { policy = "nope" }`,
+			RulesJSON: `{ "node_prefix": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid node_prefix policy",
 		},
 		{
-			"Bad Policy - Session Prefix",
-			SyntaxCurrent,
-			`session_prefix "foo" { policy = "nope" }`,
-			nil,
-			"Invalid session_prefix policy",
+			Name:      "Bad Policy - Service",
+			Syntax:    SyntaxCurrent,
+			Rules:     `service "foo" { policy = "nope" }`,
+			RulesJSON: `{ "service": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid service policy",
 		},
 		{
-			"Bad Policy - Event",
-			SyntaxCurrent,
-			`event "foo" { policy = "nope" }`,
-			nil,
-			"Invalid event policy",
+			Name:      "Bad Policy - Service Prefix",
+			Syntax:    SyntaxCurrent,
+			Rules:     `service_prefix "foo" { policy = "nope" }`,
+			RulesJSON: `{ "service_prefix": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid service_prefix policy",
 		},
 		{
-			"Bad Policy - Event Prefix",
-			SyntaxCurrent,
-			`event_prefix "foo" { policy = "nope" }`,
-			nil,
-			"Invalid event_prefix policy",
+			Name:      "Bad Policy - Session",
+			Syntax:    SyntaxCurrent,
+			Rules:     `session "foo" { policy = "nope" }`,
+			RulesJSON: `{ "session": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid session policy",
 		},
 		{
-			"Bad Policy - Prepared Query",
-			SyntaxCurrent,
-			`query "foo" { policy = "nope" }`,
-			nil,
-			"Invalid query policy",
+			Name:      "Bad Policy - Session Prefix",
+			Syntax:    SyntaxCurrent,
+			Rules:     `session_prefix "foo" { policy = "nope" }`,
+			RulesJSON: `{ "session_prefix": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid session_prefix policy",
 		},
 		{
-			"Bad Policy - Prepared Query Prefix",
-			SyntaxCurrent,
-			`query_prefix "foo" { policy = "nope" }`,
-			nil,
-			"Invalid query_prefix policy",
+			Name:      "Bad Policy - Event",
+			Syntax:    SyntaxCurrent,
+			Rules:     `event "foo" { policy = "nope" }`,
+			RulesJSON: `{ "event": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid event policy",
 		},
 		{
-			"Bad Policy - Keyring",
-			SyntaxCurrent,
-			`keyring = "nope"`,
-			nil,
-			"Invalid keyring policy",
+			Name:      "Bad Policy - Event Prefix",
+			Syntax:    SyntaxCurrent,
+			Rules:     `event_prefix "foo" { policy = "nope" }`,
+			RulesJSON: `{ "event_prefix": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid event_prefix policy",
 		},
 		{
-			"Bad Policy - Operator",
-			SyntaxCurrent,
-			`operator = "nope"`,
-			nil,
-			"Invalid operator policy",
+			Name:      "Bad Policy - Prepared Query",
+			Syntax:    SyntaxCurrent,
+			Rules:     `query "foo" { policy = "nope" }`,
+			RulesJSON: `{ "query": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid query policy",
 		},
 		{
-			"Keyring Empty",
-			SyntaxCurrent,
-			`keyring = ""`,
-			&Policy{PolicyRules: PolicyRules{Keyring: ""}},
-			"",
+			Name:      "Bad Policy - Prepared Query Prefix",
+			Syntax:    SyntaxCurrent,
+			Rules:     `query_prefix "foo" { policy = "nope" }`,
+			RulesJSON: `{ "query_prefix": { "foo": { "policy": "nope" }}}`,
+			Err:       "Invalid query_prefix policy",
 		},
 		{
-			"Operator Empty",
-			SyntaxCurrent,
-			`operator = ""`,
-			&Policy{PolicyRules: PolicyRules{Operator: ""}},
-			"",
+			Name:      "Bad Policy - Keyring",
+			Syntax:    SyntaxCurrent,
+			Rules:     `keyring = "nope"`,
+			RulesJSON: `{ "keyring": "nope" }`,
+			Err:       "Invalid keyring policy",
+		},
+		{
+			Name:      "Bad Policy - Operator",
+			Syntax:    SyntaxCurrent,
+			Rules:     `operator = "nope"`,
+			RulesJSON: `{ "operator": "nope" }`,
+			Err:       "Invalid operator policy",
+		},
+		{
+			Name:      "Bad Policy - Mesh",
+			Syntax:    SyntaxCurrent,
+			Rules:     `mesh = "nope"`,
+			RulesJSON: `{ "mesh": "nope" }`,
+			Err:       "Invalid mesh policy",
+		},
+		{
+			Name:      "Keyring Empty",
+			Syntax:    SyntaxCurrent,
+			Rules:     `keyring = ""`,
+			RulesJSON: `{ "keyring": "" }`,
+			Expected:  &Policy{PolicyRules: PolicyRules{Keyring: ""}},
+		},
+		{
+			Name:      "Operator Empty",
+			Syntax:    SyntaxCurrent,
+			Rules:     `operator = ""`,
+			RulesJSON: `{ "operator": "" }`,
+			Expected:  &Policy{PolicyRules: PolicyRules{Operator: ""}},
+		},
+		{
+			Name:      "Mesh Empty",
+			Syntax:    SyntaxCurrent,
+			Rules:     `mesh = ""`,
+			RulesJSON: `{ "mesh": "" }`,
+			Expected:  &Policy{PolicyRules: PolicyRules{Mesh: ""}},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			req := require.New(t)
-			actual, err := NewPolicyFromSource("", 0, tc.Rules, tc.Syntax, nil, nil)
-			if tc.Err != "" {
-				errStartsWith(t, err, tc.Err)
-			} else {
-				req.Equal(tc.Expected, actual)
+			require.True(t, tc.Rules != "" || tc.RulesJSON != "")
+			if tc.Rules != "" {
+				t.Run("hcl", func(t *testing.T) {
+					actual, err := NewPolicyFromSource("", 0, tc.Rules, tc.Syntax, nil, nil)
+					if tc.Err != "" {
+						errStartsWith(t, err, tc.Err)
+					} else {
+						require.Equal(t, tc.Expected, actual)
+					}
+				})
+			}
+			if tc.RulesJSON != "" {
+				t.Run("json", func(t *testing.T) {
+					actual, err := NewPolicyFromSource("", 0, tc.RulesJSON, tc.Syntax, nil, nil)
+					if tc.Err != "" {
+						errStartsWith(t, err, tc.Err)
+					} else {
+						require.Equal(t, tc.Expected, actual)
+					}
+				})
 			}
 		})
 	}
@@ -1218,17 +1457,20 @@ func TestMergePolicies(t *testing.T) {
 					ACL:      PolicyRead,
 					Keyring:  PolicyRead,
 					Operator: PolicyRead,
+					Mesh:     PolicyRead,
 				}},
 				{PolicyRules: PolicyRules{
 					ACL:      PolicyWrite,
 					Keyring:  PolicyWrite,
 					Operator: PolicyWrite,
+					Mesh:     PolicyWrite,
 				}},
 			},
 			expected: &Policy{PolicyRules: PolicyRules{
 				ACL:      PolicyWrite,
 				Keyring:  PolicyWrite,
 				Operator: PolicyWrite,
+				Mesh:     PolicyWrite,
 			}},
 		},
 		{
@@ -1238,17 +1480,20 @@ func TestMergePolicies(t *testing.T) {
 					ACL:      PolicyWrite,
 					Keyring:  PolicyWrite,
 					Operator: PolicyWrite,
+					Mesh:     PolicyWrite,
 				}},
 				{PolicyRules: PolicyRules{
 					ACL:      PolicyDeny,
 					Keyring:  PolicyDeny,
 					Operator: PolicyDeny,
+					Mesh:     PolicyDeny,
 				}},
 			},
 			expected: &Policy{PolicyRules: PolicyRules{
 				ACL:      PolicyDeny,
 				Keyring:  PolicyDeny,
 				Operator: PolicyDeny,
+				Mesh:     PolicyDeny,
 			}},
 		},
 		{
@@ -1258,6 +1503,7 @@ func TestMergePolicies(t *testing.T) {
 					ACL:      PolicyRead,
 					Keyring:  PolicyRead,
 					Operator: PolicyRead,
+					Mesh:     PolicyRead,
 				}},
 				{},
 			},
@@ -1265,6 +1511,7 @@ func TestMergePolicies(t *testing.T) {
 				ACL:      PolicyRead,
 				Keyring:  PolicyRead,
 				Operator: PolicyRead,
+				Mesh:     PolicyRead,
 			}},
 		},
 	}
@@ -1278,6 +1525,7 @@ func TestMergePolicies(t *testing.T) {
 			req.Equal(exp.ACL, act.ACL)
 			req.Equal(exp.Keyring, act.Keyring)
 			req.Equal(exp.Operator, act.Operator)
+			req.Equal(exp.Mesh, act.Mesh)
 			req.ElementsMatch(exp.Agents, act.Agents)
 			req.ElementsMatch(exp.AgentPrefixes, act.AgentPrefixes)
 			req.ElementsMatch(exp.Events, act.Events)
@@ -1348,6 +1596,9 @@ keyring = "write"
 
 # comment
 operator = "write"
+
+# comment
+mesh = "write"
 `
 
 	expected := `
@@ -1400,6 +1651,9 @@ keyring = "write"
 
 # comment
 operator = "write"
+
+# comment
+mesh = "write"
 `
 
 	output, err := TranslateLegacyRules([]byte(input))

--- a/acl/static_authorizer.go
+++ b/acl/static_authorizer.go
@@ -156,6 +156,20 @@ func (s *staticAuthorizer) NodeWrite(string, *AuthorizerContext) EnforcementDeci
 	return Deny
 }
 
+func (s *staticAuthorizer) MeshRead(*AuthorizerContext) EnforcementDecision {
+	if s.defaultAllow {
+		return Allow
+	}
+	return Deny
+}
+
+func (s *staticAuthorizer) MeshWrite(*AuthorizerContext) EnforcementDecision {
+	if s.defaultAllow {
+		return Allow
+	}
+	return Deny
+}
+
 func (s *staticAuthorizer) OperatorRead(*AuthorizerContext) EnforcementDecision {
 	if s.defaultAllow {
 		return Allow

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1964,6 +1964,14 @@ func TestACL_Authorize(t *testing.T) {
 				Access:   "write",
 			},
 			{
+				Resource: "mesh",
+				Access:   "read",
+			},
+			{
+				Resource: "mesh",
+				Access:   "write",
+			},
+			{
 				Resource: "query",
 				Segment:  "foo",
 				Access:   "read",
@@ -2098,6 +2106,14 @@ func TestACL_Authorize(t *testing.T) {
 			Access:   "write",
 		},
 		{
+			Resource: "mesh",
+			Access:   "read",
+		},
+		{
+			Resource: "mesh",
+			Access:   "write",
+		},
+		{
 			Resource: "query",
 			Segment:  "foo",
 			Access:   "read",
@@ -2147,6 +2163,8 @@ func TestACL_Authorize(t *testing.T) {
 		true,  // node:write
 		true,  // operator:read
 		true,  // operator:write
+		true,  // mesh:read
+		true,  // mesh:write
 		false, // query:read
 		false, // query:write
 		true,  // service:read

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -584,6 +584,7 @@ func (s *HTTPHandlers) AgentForceLeave(resp http.ResponseWriter, req *http.Reque
 	if err != nil {
 		return nil, err
 	}
+	// TODO(partitions): should this be possible in a partition?
 	if authz.OperatorWrite(nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
@@ -1536,6 +1537,7 @@ func (s *HTTPHandlers) AgentHost(resp http.ResponseWriter, req *http.Request) (i
 		return nil, err
 	}
 
+	// TODO(partitions): should this be possible in a partition?
 	if authz.OperatorRead(nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -1379,6 +1379,8 @@ func makeACLETag(parent string, policy *acl.Policy) string {
 
 // GetPolicy is used to retrieve a compiled policy object with a TTL. Does not
 // support a blocking query.
+//
+// TODO(ACL-Legacy): remove this
 func (a *ACL) GetPolicy(args *structs.ACLPolicyResolveLegacyRequest, reply *structs.ACLPolicyResolveLegacyResponse) error {
 	if done, err := a.srv.ForwardRPC("ACL.GetPolicy", args, reply); done {
 		return err

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -1906,6 +1906,7 @@ func testACLResolver_variousTokens(t *testing.T, delegate *ACLResolverTestDelega
 		authz, err := r.ResolveToken("legacy-client")
 		require.NoError(t, err)
 		require.NotNil(t, authz)
+		require.Equal(t, acl.Deny, authz.MeshRead(nil))
 		require.Equal(t, acl.Deny, authz.OperatorRead(nil))
 		require.Equal(t, acl.Allow, authz.ServiceRead("foo", nil))
 	})

--- a/agent/http.go
+++ b/agent/http.go
@@ -253,6 +253,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 
 			// If the token provided does not have the necessary permissions,
 			// write a forbidden response
+			// TODO(partitions): should this be possible in a partition?
 			if authz.OperatorRead(nil) != acl.Allow {
 				resp.WriteHeader(http.StatusForbidden)
 				return

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -73,6 +73,7 @@ node_prefix "" {
 	policy = "write"
 }
 operator = "write"
+mesh = "write"
 query_prefix "" {
 	policy = "write"
 }

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -315,7 +315,7 @@ func (e *ProxyConfigEntry) CanRead(authz acl.Authorizer) bool {
 func (e *ProxyConfigEntry) CanWrite(authz acl.Authorizer) bool {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.OperatorWrite(&authzContext) == acl.Allow
+	return authz.MeshWrite(&authzContext) == acl.Allow
 }
 
 func (e *ProxyConfigEntry) GetRaftIndex() *RaftIndex {

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -271,7 +271,7 @@ func (e *IngressGatewayConfigEntry) CanRead(authz acl.Authorizer) bool {
 func (e *IngressGatewayConfigEntry) CanWrite(authz acl.Authorizer) bool {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.OperatorWrite(&authzContext) == acl.Allow
+	return authz.MeshWrite(&authzContext) == acl.Allow
 }
 
 func (e *IngressGatewayConfigEntry) GetRaftIndex() *RaftIndex {
@@ -407,15 +407,13 @@ func (e *TerminatingGatewayConfigEntry) Validate() error {
 func (e *TerminatingGatewayConfigEntry) CanRead(authz acl.Authorizer) bool {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-
 	return authz.ServiceRead(e.Name, &authzContext) == acl.Allow
 }
 
 func (e *TerminatingGatewayConfigEntry) CanWrite(authz acl.Authorizer) bool {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-
-	return authz.OperatorWrite(&authzContext) == acl.Allow
+	return authz.MeshWrite(&authzContext) == acl.Allow
 }
 
 func (e *TerminatingGatewayConfigEntry) GetRaftIndex() *RaftIndex {

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -71,7 +71,7 @@ func (e *MeshConfigEntry) CanRead(authz acl.Authorizer) bool {
 func (e *MeshConfigEntry) CanWrite(authz acl.Authorizer) bool {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.OperatorWrite(&authzContext) == acl.Allow
+	return authz.MeshWrite(&authzContext) == acl.Allow
 }
 
 func (e *MeshConfigEntry) GetRaftIndex() *RaftIndex {


### PR DESCRIPTION
This PR adds a new mesh resource to Consul's ACLs for:
* Terminating and Ingress gateway writes
* Mesh config

The general approach here was basically to just "split" the operator resource completely, and then use the value of the operator resource during authz as the default value under the mesh resource.