### PR TITLE
xds: fix representation of incremental xDS subscriptions

### DIFF
--- a/.changelog/10987.txt
+++ b/.changelog/10987.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: fixed a bug where Envoy sidecars could enter a state where they failed to receive xds updates from Consul
+```

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -189,6 +189,10 @@ func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discove
 			// index and hash the xDS structures
 			newResourceMap := indexResources(generator.Logger, newRes)
 
+			if s.ResourceMapMutateFn != nil {
+				s.ResourceMapMutateFn(newResourceMap)
+			}
+
 			if err := populateChildIndexMap(newResourceMap); err != nil {
 				return status.Errorf(codes.Unavailable, "failed to index xDS resource versions: %v", err)
 			}

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -568,16 +568,10 @@ func (t *xDSDeltaType) ack(nonce string) {
 
 	for name, obj := range pending {
 		if obj.Remove {
-			if obj.Version != "" {
-				panic("ACK: version is not empty for: " + name)
-			}
 			delete(t.resourceVersions, name)
 			continue
 		}
 
-		if obj.Version == "" {
-			panic("ACK: version is empty for: " + name)
-		}
 		t.resourceVersions[name] = obj.Version
 		if t.childType != nil {
 			// This branch only matters on UPDATE, since we already have
@@ -751,17 +745,11 @@ func (t *xDSDeltaType) createDeltaResponse(
 	realUpdates := make(map[string]PendingUpdate)
 	for name, obj := range updates {
 		if obj.Remove {
-			if obj.Version != "" {
-				panic("DIFF: version is not empty for: " + name)
-			}
 			if remove {
 				resp.RemovedResources = append(resp.RemovedResources, name)
 				realUpdates[name] = PendingUpdate{Remove: true}
 			}
 		} else if upsert {
-			if obj.Version == "" {
-				panic("DIFF: version is empty for: " + name)
-			}
 			resources, ok := resourceMap.Index[t.typeURL]
 			if !ok {
 				return nil, nil, fmt.Errorf("unknown type url: %s", t.typeURL)

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -710,18 +710,13 @@ func (t *xDSDeltaType) createDeltaResponse(
 		// Walk the list of things currently stored in envoy
 		for name, envoyVers := range t.resourceVersions {
 			if t.subscribed(name) {
-				currVers, ok := currentVersions[name]
-				if ok {
+				if currVers, ok := currentVersions[name]; ok {
 					if currVers != envoyVers {
 						if upsert {
 							hasRelevantUpdates = true
 						}
 						updates[name] = PendingUpdate{Version: currVers}
 					}
-				} else {
-					// Should we do anything here? This might be an eventual
-					// consistency issue, but it's unclear what we could do
-					// other than just wait until it resolves.
 				}
 			}
 		}
@@ -731,16 +726,11 @@ func (t *xDSDeltaType) createDeltaResponse(
 			if _, known := t.resourceVersions[name]; known {
 				continue
 			}
-			currVers, ok := currentVersions[name]
-			if ok {
+			if currVers, ok := currentVersions[name]; ok {
 				updates[name] = PendingUpdate{Version: currVers}
 				if upsert {
 					hasRelevantUpdates = true
 				}
-			} else {
-				// Should we do anything here? This might be an eventual
-				// consistency issue, but it's unclear what we could do
-				// other than just wait until it resolves.
 			}
 		}
 	}

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -384,7 +384,7 @@ type xDSDeltaType struct {
 	// sentToEnvoyOnce is true after we've sent one response to envoy.
 	sentToEnvoyOnce bool
 
-	// subscriptions is the set of currently subscribed envoy resources. 
+	// subscriptions is the set of currently subscribed envoy resources.
 	// If wildcard == true, this will be empty.
 	subscriptions map[string]struct{}
 

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -499,7 +499,7 @@ func (t *xDSDeltaType) Recv(req *envoy_discovery_v3.DeltaDiscoveryRequest) bool 
 			"resources", req.InitialResourceVersions)
 		t.resourceVersions = req.InitialResourceVersions
 		if !t.wildcard {
-			for k, _ := range req.InitialResourceVersions {
+			for k := range req.InitialResourceVersions {
 				t.subscriptions[k] = struct{}{}
 			}
 		}
@@ -727,7 +727,7 @@ func (t *xDSDeltaType) createDeltaResponse(
 		}
 
 		// Now find new things not in envoy yet
-		for name, _ := range t.subscriptions {
+		for name := range t.subscriptions {
 			if _, known := t.resourceVersions[name]; known {
 				continue
 			}

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -384,8 +384,8 @@ type xDSDeltaType struct {
 	// sentToEnvoyOnce is true after we've sent one response to envoy.
 	sentToEnvoyOnce bool
 
-	// subscriptions is the list of currently subscribed envoy resources. If
-	// the wildcard is in play this will be empty.
+	// subscriptions is the set of currently subscribed envoy resources. 
+	// If wildcard == true, this will be empty.
 	subscriptions map[string]struct{}
 
 	// resourceVersions is the current view of CONFIRMED/ACKed updates to

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -70,10 +69,6 @@ const (
 )
 
 func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discovery_v3.DeltaDiscoveryRequest) error {
-	slowHackValidUntil := time.Now().Add(1 * time.Minute)
-	slowHackDisabled := false
-	s.Logger.Info("HACK: forcing endpoints containing the string 'slow' to wait", "until", slowHackValidUntil)
-
 	// Loop state
 	var (
 		cfgSnap     *proxycfg.ConfigSnapshot
@@ -193,26 +188,6 @@ func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discove
 
 			// index and hash the xDS structures
 			newResourceMap := indexResources(generator.Logger, newRes)
-
-			// HACK to prove a theory
-			if !slowHackDisabled && time.Now().Before(slowHackValidUntil) {
-				if em, ok := newResourceMap.Index[EndpointType]; ok {
-					var deleteme []string
-					for k, _ := range em {
-						if strings.Contains(k, "slow") {
-							deleteme = append(deleteme, k)
-						}
-					}
-					for _, k := range deleteme {
-						delete(em, k)
-					}
-				}
-			} else {
-				if !slowHackDisabled {
-					slowHackDisabled = true
-					s.Logger.Info("HACK: forcing endpoints containing the string 'slow' to no longer wait")
-				}
-			}
 
 			if err := populateChildIndexMap(newResourceMap); err != nil {
 				return status.Errorf(codes.Unavailable, "failed to index xDS resource versions: %v", err)

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -719,14 +719,10 @@ func (t *xDSDeltaType) createDeltaResponse(
 						updates[name] = PendingUpdate{Version: currVers}
 					}
 				} else {
-					// TODO: should we do anything; this might be an eventual consistency hole
-					// i guess we'll let it ride?
+					// Should we do anything here? This might be an eventual
+					// consistency issue, but it's unclear what we could do
+					// other than just wait until it resolves.
 				}
-			} else {
-				if remove {
-					hasRelevantUpdates = true
-				}
-				updates[name] = PendingUpdate{Remove: true}
 			}
 		}
 
@@ -742,7 +738,9 @@ func (t *xDSDeltaType) createDeltaResponse(
 					hasRelevantUpdates = true
 				}
 			} else {
-				// TODO: should we do anything here? or should we just wait and see?
+				// Should we do anything here? This might be an eventual
+				// consistency issue, but it's unclear what we could do
+				// other than just wait until it resolves.
 			}
 		}
 	}

--- a/agent/xds/delta_test.go
+++ b/agent/xds/delta_test.go
@@ -430,7 +430,7 @@ func TestServer_DeltaAggregatedResources_v3_SlowEndpointPopulation(t *testing.T)
 		}
 		if em, ok := resourceMap.Index[EndpointType]; ok {
 			var deleteme []string
-			for k, _ := range em {
+			for k := range em {
 				if strings.Contains(k, "geo-cache") {
 					deleteme = append(deleteme, k)
 				}

--- a/agent/xds/delta_test.go
+++ b/agent/xds/delta_test.go
@@ -429,14 +429,10 @@ func TestServer_DeltaAggregatedResources_v3_SlowEndpointPopulation(t *testing.T)
 			return
 		}
 		if em, ok := resourceMap.Index[EndpointType]; ok {
-			var deleteme []string
 			for k := range em {
 				if strings.Contains(k, "geo-cache") {
-					deleteme = append(deleteme, k)
+					delete(em, k)
 				}
-			}
-			for _, k := range deleteme {
-				delete(em, k)
 			}
 		}
 	}

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -152,6 +152,9 @@ type Server struct {
 
 	DisableV2Protocol bool
 
+	// ResourceMapMutateFn exclusively exists for testing purposes.
+	ResourceMapMutateFn func(resourceMap *IndexedResources)
+
 	activeStreams *activeStreamCounters
 }
 

--- a/agent/xds/xds_protocol_helpers_test.go
+++ b/agent/xds/xds_protocol_helpers_test.go
@@ -177,7 +177,9 @@ func newTestServerScenarioInner(
 		nil, /*checkFetcher HTTPCheckFetcher*/
 		nil, /*cfgFetcher ConfigFetcher*/
 	)
-	s.AuthCheckFrequency = authCheckFrequency
+	if authCheckFrequency > 0 {
+		s.AuthCheckFrequency = authCheckFrequency
+	}
 
 	errCh := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
Fixes #10563

The `resourceVersion` map was doing two jobs prior to this PR. The first job was to track what version of every resource we know envoy currently has. The second was to track subscriptions to those resources (by way of the empty string for a version). This mostly works out fine, but occasionally leads to consul removing a resource and accidentally (effectively) unsubscribing at the same time.

The fix separates these two jobs. When all of the resources for a subscription are removed we continue to track the subscription until envoy explicitly unsubscribes.

### Mechanism of the bug

When building up the list of expected xDS resources all of LDS/RDS/CDS/EDS is generated from the same in-memory representation built by the `agent/proxycfg` package. For clusters there's a loop that will walk that representation and convert it to a desired set of envoy Cluster objects for CDS, and similarly there's a loop that does that for ClusterLoadAssignments for EDS. These are largely the same, except the EDS loop has a few more spots where it skips populating endpoints in a known cluster if we haven't gotten health information back yet within the inner plumbing of `agent/proxycfg`. This should ordinarily be fine, since we'll _eventually_ get health information back and then we'll emit correct ClusterLoadAssignments for that cluster to envoy.

Unfortunately due to the way the `resourceVersion` map was doing two jobs (tracking versions and tracking subscriptions), if it had not gotten any health data back yet about endpoints by the time the xDS stream starts exercising the incremental protocol it could lead to this scenario:

1. consul-CDS: reply `[here's your cluster-12345]`
2. envoy-CDS: ack! cool i now will care about `cluster-12345`
3. envoy-EDS: subscribe `[cluster-12345 endpoints please]`
4. consul-EDS: sure thing! (writes down `envoyVers=""` for the resource to start)
5. consul does the differential comparison using the pre-existing (technically incomplete because we're still waiting on some endpoints) snapshot data from `agent/proxycfg` and sees `<NO_DATA> vs <"">` and determines "whelp, i guess i should tell envoy to remove knowledge of endpoints for `cluster-12345` **and unsubscribe from future updates**

After separating the two jobs formerly assigned to the `resourceVersion` map the unsubscribe operation will not occur in (5) above and when the endpoint information shows up it'll properly inform envoy of that and everything will be great.

### Likelihood of occurrence

_(NOTE: There are most certainly other sequencing of events that would arrive at triggering the bug. This is just one such example that's illustrative.)_

For the bug to trigger, the _first_ time `agent/proxycfg` populates endpoint health information has to occur _after_ the EDS subscribe call.

The data in `agent/proxycfg` is populated in the background and is kicked off when a connect-enabled service is first registered to its agent. Background processes will begin kicking off the necessary local and cross-DC queries to fetch the necessary data and keep the aggregate snapshot of data assembled in one place in memory. If services are registered separately (in time) from when the envoy sidecars spin up, then barring extremely slow network calls the `agent/proxycfg` snapshot will already be complete before the xDS protocol is exercised and the bug will not occur.

One somewhat easy way to have a slow network call trigger the bug would be if you had a datacenter (`dc2`) that was network-far away from your calling datacenter (`dc1`) and it was a registered upstream for a service in the calling datacenter. Then there's a race to try and populate the initial snapshot in memory before the envoy starts up, and losing the race triggers the bug.