### PR TITLE
[1.8.x] use intermediates when verifying

### DIFF
--- a/.changelog/10964.txt
+++ b/.changelog/10964.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+tls: consider presented intermediates during server connection tls handshake.
+```

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -929,11 +929,20 @@ func TestRPC_LocalTokenStrippedOnForward(t *testing.T) {
 }
 
 func TestRPC_AuthorizeRaftRPC(t *testing.T) {
-	caPEM, pk, err := tlsutil.GenerateCA(tlsutil.CAOpts{Days: 5, Domain: "consul"})
+	caPEM, caPK, err := tlsutil.GenerateCA(tlsutil.CAOpts{Days: 5, Domain: "consul"})
+	require.NoError(t, err)
+
+	caSigner, err := tlsutil.ParseSigner(caPK)
 	require.NoError(t, err)
 
 	dir := testutil.TempDir(t, "certs")
 	err = ioutil.WriteFile(filepath.Join(dir, "ca.pem"), []byte(caPEM), 0600)
+	require.NoError(t, err)
+
+	intermediatePEM, intermediatePK, err := tlsutil.GenerateCert(tlsutil.CertOpts{IsCA: true, CA: caPEM, Signer: caSigner, Days: 5})
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(dir, "intermediate.pem"), []byte(intermediatePEM), 0600)
 	require.NoError(t, err)
 
 	newCert := func(t *testing.T, caPEM, pk, node, name string) {
@@ -958,7 +967,7 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	newCert(t, caPEM, pk, "srv1", "server.dc1.consul")
+	newCert(t, caPEM, caPK, "srv1", "server.dc1.consul")
 
 	_, connectCApk, err := connect.GeneratePrivateKey()
 	require.NoError(t, err)
@@ -1015,8 +1024,26 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 
 	setupAgentTLSCert := func(name string) func(t *testing.T) string {
 		return func(t *testing.T) string {
-			newCert(t, caPEM, pk, "node1", name)
+			newCert(t, caPEM, caPK, "node1", name)
 			return filepath.Join(dir, "node1-"+name)
+		}
+	}
+
+	setupAgentTLSCertWithIntermediate := func(name string) func(t *testing.T) string {
+		return func(t *testing.T) string {
+			newCert(t, intermediatePEM, intermediatePK, "node1", name)
+			certPrefix := filepath.Join(dir, "node1-"+name)
+			f, err := os.OpenFile(certPrefix+".pem", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := f.Write([]byte(intermediatePEM)); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+			return certPrefix
 		}
 	}
 
@@ -1075,6 +1102,11 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 		{
 			name:      "TLS byte with server cert in same DC",
 			setupCert: setupAgentTLSCert("server.dc1.consul"),
+			conn:      useTLSByte,
+		},
+		{
+			name:      "TLS byte with server cert in same DC and with unknown intermediate",
+			setupCert: setupAgentTLSCertWithIntermediate("server.dc1.consul"),
 			conn:      useTLSByte,
 		},
 		{

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-multierror"
 )
 
 // ALPNWrapper is a function that is used to wrap a non-TLS connection and
@@ -881,15 +882,11 @@ func (c *Configurator) wrapTLSClient(dc string, conn net.Conn) (net.Conn, error)
 		Intermediates: x509.NewCertPool(),
 	}
 
-	certs := tlsConn.ConnectionState().PeerCertificates
-	for i, cert := range certs {
-		if i == 0 {
-			continue
-		}
+	cs := tlsConn.ConnectionState()
+	for _, cert := range cs.PeerCertificates[1:] {
 		opts.Intermediates.AddCert(cert)
 	}
-
-	_, err = certs[0].Verify(opts)
+	_, err = cs.PeerCertificates[0].Verify(opts)
 	if err != nil {
 		tlsConn.Close()
 		return nil, err
@@ -959,22 +956,29 @@ func (c *Configurator) AuthorizeServerConn(dc string, conn *tls.Conn) error {
 	c.RUnlock()
 
 	expected := c.ServerSNI(dc, "")
-	for _, chain := range conn.ConnectionState().VerifiedChains {
+	cs := conn.ConnectionState()
+	var errs error
+	for _, chain := range cs.VerifiedChains {
 		if len(chain) == 0 {
 			continue
 		}
-		clientCert := chain[0]
-		_, err := clientCert.Verify(x509.VerifyOptions{
-			DNSName:   expected,
-			Roots:     caPool,
-			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		})
+		opts := x509.VerifyOptions{
+			DNSName:       expected,
+			Intermediates: x509.NewCertPool(),
+			Roots:         caPool,
+			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+		for _, cert := range cs.PeerCertificates[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+		_, err := cs.PeerCertificates[0].Verify(opts)
 		if err == nil {
 			return nil
 		}
-		c.logger.Debug("AuthorizeServerConn failed certificate validation", "error", err)
+		multierror.Append(errs, err)
 	}
-	return fmt.Errorf("a TLS certificate with a CommonName of %v is required for this operation", expected)
+	return fmt.Errorf("AuthorizeServerConn failed certificate validation for certificate with a SAN.DNSName of %v: %w", expected, errs)
+
 }
 
 // ParseCiphers parse ciphersuites from the comma-separated string into

--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -52,6 +52,7 @@ type CertOpts struct {
 	DNSNames    []string
 	IPAddresses []net.IP
 	ExtKeyUsage []x509.ExtKeyUsage
+	IsCA        bool
 }
 
 // GenerateCA generates a new CA for agent TLS (not to be confused with Connect TLS)
@@ -174,6 +175,10 @@ func GenerateCert(opts CertOpts) (string, string, error) {
 		SubjectKeyId:          id,
 		DNSNames:              opts.DNSNames,
 		IPAddresses:           opts.IPAddresses,
+	}
+	if opts.IsCA {
+		template.IsCA = true
+		template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature
 	}
 
 	bs, err := x509.CreateCertificate(rand.Reader, &template, parent, signee.Public(), opts.Signer)


### PR DESCRIPTION
This is a backport of #10964. 