### PR TITLE
Sync partition fields from enterprise

### DIFF
--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -30,6 +30,7 @@ const (
 type ConfigEntry interface {
 	GetKind() string
 	GetName() string
+	GetPartition() string
 	GetNamespace() string
 	GetMeta() map[string]string
 	GetCreateIndex() uint64
@@ -133,6 +134,10 @@ type UpstreamConfiguration struct {
 type UpstreamConfig struct {
 	// Name is only accepted within a service-defaults config entry.
 	Name string `json:",omitempty"`
+
+	// Partition is only accepted within a service-defaults config entry.
+	Partition string `json:",omitempty"`
+
 	// Namespace is only accepted within a service-defaults config entry.
 	Namespace string `json:",omitempty"`
 
@@ -205,6 +210,7 @@ type UpstreamLimits struct {
 type ServiceConfigEntry struct {
 	Kind             string
 	Name             string
+	Partition        string                  `json:",omitempty"`
 	Namespace        string                  `json:",omitempty"`
 	Protocol         string                  `json:",omitempty"`
 	Mode             ProxyMode               `json:",omitempty"`
@@ -219,33 +225,18 @@ type ServiceConfigEntry struct {
 	ModifyIndex uint64
 }
 
-func (s *ServiceConfigEntry) GetKind() string {
-	return s.Kind
-}
-
-func (s *ServiceConfigEntry) GetName() string {
-	return s.Name
-}
-
-func (s *ServiceConfigEntry) GetNamespace() string {
-	return s.Namespace
-}
-
-func (s *ServiceConfigEntry) GetMeta() map[string]string {
-	return s.Meta
-}
-
-func (s *ServiceConfigEntry) GetCreateIndex() uint64 {
-	return s.CreateIndex
-}
-
-func (s *ServiceConfigEntry) GetModifyIndex() uint64 {
-	return s.ModifyIndex
-}
+func (s *ServiceConfigEntry) GetKind() string            { return s.Kind }
+func (s *ServiceConfigEntry) GetName() string            { return s.Name }
+func (s *ServiceConfigEntry) GetPartition() string       { return s.Partition }
+func (s *ServiceConfigEntry) GetNamespace() string       { return s.Namespace }
+func (s *ServiceConfigEntry) GetMeta() map[string]string { return s.Meta }
+func (s *ServiceConfigEntry) GetCreateIndex() uint64     { return s.CreateIndex }
+func (s *ServiceConfigEntry) GetModifyIndex() uint64     { return s.ModifyIndex }
 
 type ProxyConfigEntry struct {
 	Kind             string
 	Name             string
+	Partition        string                  `json:",omitempty"`
 	Namespace        string                  `json:",omitempty"`
 	Mode             ProxyMode               `json:",omitempty"`
 	TransparentProxy *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
@@ -257,29 +248,13 @@ type ProxyConfigEntry struct {
 	ModifyIndex      uint64
 }
 
-func (p *ProxyConfigEntry) GetKind() string {
-	return p.Kind
-}
-
-func (p *ProxyConfigEntry) GetName() string {
-	return p.Name
-}
-
-func (p *ProxyConfigEntry) GetNamespace() string {
-	return p.Namespace
-}
-
-func (p *ProxyConfigEntry) GetMeta() map[string]string {
-	return p.Meta
-}
-
-func (p *ProxyConfigEntry) GetCreateIndex() uint64 {
-	return p.CreateIndex
-}
-
-func (p *ProxyConfigEntry) GetModifyIndex() uint64 {
-	return p.ModifyIndex
-}
+func (p *ProxyConfigEntry) GetKind() string            { return p.Kind }
+func (p *ProxyConfigEntry) GetName() string            { return p.Name }
+func (p *ProxyConfigEntry) GetPartition() string       { return p.Partition }
+func (p *ProxyConfigEntry) GetNamespace() string       { return p.Namespace }
+func (p *ProxyConfigEntry) GetMeta() map[string]string { return p.Meta }
+func (p *ProxyConfigEntry) GetCreateIndex() uint64     { return p.CreateIndex }
+func (p *ProxyConfigEntry) GetModifyIndex() uint64     { return p.ModifyIndex }
 
 func makeConfigEntry(kind, name string) (ConfigEntry, error) {
 	switch kind {

--- a/api/config_entry_cluster.go
+++ b/api/config_entry_cluster.go
@@ -2,41 +2,44 @@ package api
 
 import "encoding/json"
 
+// MeshConfigEntry manages the global configuration for all service mesh
+// proxies.
 type MeshConfigEntry struct {
-	Namespace        string                     `json:",omitempty"`
+	// Partition is the partition the MeshConfigEntry applies to.
+	// Partitioning is a Consul Enterprise feature.
+	Partition string `json:",omitempty"`
+
+	// Namespace is the namespace the MeshConfigEntry applies to.
+	// Namespacing is a Consul Enterprise feature.
+	Namespace string `json:",omitempty"`
+
+	// TransparentProxy applies configuration specific to proxies
+	// in transparent mode.
 	TransparentProxy TransparentProxyMeshConfig `alias:"transparent_proxy"`
-	Meta             map[string]string          `json:",omitempty"`
-	CreateIndex      uint64
-	ModifyIndex      uint64
+
+	Meta map[string]string `json:",omitempty"`
+
+	// CreateIndex is the Raft index this entry was created at. This is a
+	// read-only field.
+	CreateIndex uint64
+
+	// ModifyIndex is used for the Check-And-Set operations and can also be fed
+	// back into the WaitIndex of the QueryOptions in order to perform blocking
+	// queries.
+	ModifyIndex uint64
 }
 
 type TransparentProxyMeshConfig struct {
 	MeshDestinationsOnly bool `alias:"mesh_destinations_only"`
 }
 
-func (e *MeshConfigEntry) GetKind() string {
-	return MeshConfig
-}
-
-func (e *MeshConfigEntry) GetName() string {
-	return MeshConfigMesh
-}
-
-func (e *MeshConfigEntry) GetNamespace() string {
-	return e.Namespace
-}
-
-func (e *MeshConfigEntry) GetMeta() map[string]string {
-	return e.Meta
-}
-
-func (e *MeshConfigEntry) GetCreateIndex() uint64 {
-	return e.CreateIndex
-}
-
-func (e *MeshConfigEntry) GetModifyIndex() uint64 {
-	return e.ModifyIndex
-}
+func (e *MeshConfigEntry) GetKind() string            { return MeshConfig }
+func (e *MeshConfigEntry) GetName() string            { return MeshConfigMesh }
+func (e *MeshConfigEntry) GetPartition() string       { return e.Partition }
+func (e *MeshConfigEntry) GetNamespace() string       { return e.Namespace }
+func (e *MeshConfigEntry) GetMeta() map[string]string { return e.Meta }
+func (e *MeshConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
+func (e *MeshConfigEntry) GetModifyIndex() uint64     { return e.ModifyIndex }
 
 // MarshalJSON adds the Kind field so that the JSON can be decoded back into the
 // correct type.

--- a/api/config_entry_discoverychain.go
+++ b/api/config_entry_discoverychain.go
@@ -8,6 +8,7 @@ import (
 type ServiceRouterConfigEntry struct {
 	Kind      string
 	Name      string
+	Partition string `json:",omitempty"`
 	Namespace string `json:",omitempty"`
 
 	Routes []ServiceRoute `json:",omitempty"`
@@ -19,6 +20,7 @@ type ServiceRouterConfigEntry struct {
 
 func (e *ServiceRouterConfigEntry) GetKind() string            { return e.Kind }
 func (e *ServiceRouterConfigEntry) GetName() string            { return e.Name }
+func (e *ServiceRouterConfigEntry) GetPartition() string       { return e.Partition }
 func (e *ServiceRouterConfigEntry) GetNamespace() string       { return e.Namespace }
 func (e *ServiceRouterConfigEntry) GetMeta() map[string]string { return e.Meta }
 func (e *ServiceRouterConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
@@ -61,8 +63,9 @@ type ServiceRouteHTTPMatchQueryParam struct {
 }
 
 type ServiceRouteDestination struct {
-	Service               string               `json:",omitempty"`
-	ServiceSubset         string               `json:",omitempty" alias:"service_subset"`
+	Service       string `json:",omitempty"`
+	ServiceSubset string `json:",omitempty" alias:"service_subset"`
+	// Referencing other partitions is not supported.
 	Namespace             string               `json:",omitempty"`
 	PrefixRewrite         string               `json:",omitempty" alias:"prefix_rewrite"`
 	RequestTimeout        time.Duration        `json:",omitempty" alias:"request_timeout"`
@@ -112,6 +115,7 @@ func (e *ServiceRouteDestination) UnmarshalJSON(data []byte) error {
 type ServiceSplitterConfigEntry struct {
 	Kind      string
 	Name      string
+	Partition string `json:",omitempty"`
 	Namespace string `json:",omitempty"`
 
 	Splits []ServiceSplit `json:",omitempty"`
@@ -123,15 +127,17 @@ type ServiceSplitterConfigEntry struct {
 
 func (e *ServiceSplitterConfigEntry) GetKind() string            { return e.Kind }
 func (e *ServiceSplitterConfigEntry) GetName() string            { return e.Name }
+func (e *ServiceSplitterConfigEntry) GetPartition() string       { return e.Partition }
 func (e *ServiceSplitterConfigEntry) GetNamespace() string       { return e.Namespace }
 func (e *ServiceSplitterConfigEntry) GetMeta() map[string]string { return e.Meta }
 func (e *ServiceSplitterConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
 func (e *ServiceSplitterConfigEntry) GetModifyIndex() uint64     { return e.ModifyIndex }
 
 type ServiceSplit struct {
-	Weight          float32
-	Service         string               `json:",omitempty"`
-	ServiceSubset   string               `json:",omitempty" alias:"service_subset"`
+	Weight        float32
+	Service       string `json:",omitempty"`
+	ServiceSubset string `json:",omitempty" alias:"service_subset"`
+	// Referencing other partitions is not supported.
 	Namespace       string               `json:",omitempty"`
 	RequestHeaders  *HTTPHeaderModifiers `json:",omitempty" alias:"request_headers"`
 	ResponseHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"response_headers"`
@@ -140,6 +146,7 @@ type ServiceSplit struct {
 type ServiceResolverConfigEntry struct {
 	Kind      string
 	Name      string
+	Partition string `json:",omitempty"`
 	Namespace string `json:",omitempty"`
 
 	DefaultSubset  string                             `json:",omitempty" alias:"default_subset"`
@@ -195,6 +202,7 @@ func (e *ServiceResolverConfigEntry) UnmarshalJSON(data []byte) error {
 
 func (e *ServiceResolverConfigEntry) GetKind() string            { return e.Kind }
 func (e *ServiceResolverConfigEntry) GetName() string            { return e.Name }
+func (e *ServiceResolverConfigEntry) GetPartition() string       { return e.Partition }
 func (e *ServiceResolverConfigEntry) GetNamespace() string       { return e.Namespace }
 func (e *ServiceResolverConfigEntry) GetMeta() map[string]string { return e.Meta }
 func (e *ServiceResolverConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
@@ -208,15 +216,17 @@ type ServiceResolverSubset struct {
 type ServiceResolverRedirect struct {
 	Service       string `json:",omitempty"`
 	ServiceSubset string `json:",omitempty" alias:"service_subset"`
-	Namespace     string `json:",omitempty"`
-	Datacenter    string `json:",omitempty"`
+	// Referencing other partitions is not supported.
+	Namespace  string `json:",omitempty"`
+	Datacenter string `json:",omitempty"`
 }
 
 type ServiceResolverFailover struct {
-	Service       string   `json:",omitempty"`
-	ServiceSubset string   `json:",omitempty" alias:"service_subset"`
-	Namespace     string   `json:",omitempty"`
-	Datacenters   []string `json:",omitempty"`
+	Service       string `json:",omitempty"`
+	ServiceSubset string `json:",omitempty" alias:"service_subset"`
+	// Referencing other partitions is not supported.
+	Namespace   string   `json:",omitempty"`
+	Datacenters []string `json:",omitempty"`
 }
 
 // LoadBalancer determines the load balancing policy and configuration for services

--- a/api/config_entry_discoverychain_test.go
+++ b/api/config_entry_discoverychain_test.go
@@ -139,6 +139,7 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 			entry: &ServiceResolverConfigEntry{
 				Kind:          ServiceResolver,
 				Name:          "test-failover",
+				Partition:     defaultPartition,
 				Namespace:     defaultNamespace,
 				DefaultSubset: "v1",
 				Subsets: map[string]ServiceResolverSubset{
@@ -171,6 +172,7 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 			entry: &ServiceResolverConfigEntry{
 				Kind:      ServiceResolver,
 				Name:      "test-redirect",
+				Partition: defaultPartition,
 				Namespace: defaultNamespace,
 				Redirect: &ServiceResolverRedirect{
 					Service:       "test-failover",
@@ -186,6 +188,7 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 			entry: &ServiceSplitterConfigEntry{
 				Kind:      ServiceSplitter,
 				Name:      "test-split",
+				Partition: defaultPartition,
 				Namespace: defaultNamespace,
 				Splits: []ServiceSplit{
 					{
@@ -220,6 +223,7 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 			entry: &ServiceRouterConfigEntry{
 				Kind:      ServiceRouter,
 				Name:      "test-route",
+				Partition: defaultPartition,
 				Namespace: defaultNamespace,
 				Routes: []ServiceRoute{
 					{
@@ -329,6 +333,7 @@ func TestAPI_ConfigEntry_ServiceResolver_LoadBalancer(t *testing.T) {
 			entry: &ServiceResolverConfigEntry{
 				Kind:      ServiceResolver,
 				Name:      "test-least-req",
+				Partition: defaultPartition,
 				Namespace: defaultNamespace,
 				LoadBalancer: &LoadBalancer{
 					Policy:             "least_request",
@@ -343,6 +348,7 @@ func TestAPI_ConfigEntry_ServiceResolver_LoadBalancer(t *testing.T) {
 				Kind:      ServiceResolver,
 				Name:      "test-ring-hash",
 				Namespace: defaultNamespace,
+				Partition: defaultPartition,
 				LoadBalancer: &LoadBalancer{
 					Policy: "ring_hash",
 					RingHashConfig: &RingHashConfig{

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -10,7 +10,11 @@ type IngressGatewayConfigEntry struct {
 	// service. This should match the name provided in the service definition.
 	Name string
 
-	// Namespace is the namespace the IngressGateway is associated with
+	// Partition is the partition the IngressGateway is associated with.
+	// Partitioning is a Consul Enterprise feature.
+	Partition string `json:",omitempty"`
+
+	// Namespace is the namespace the IngressGateway is associated with.
 	// Namespacing is a Consul Enterprise feature.
 	Namespace string `json:",omitempty"`
 
@@ -34,7 +38,7 @@ type IngressGatewayConfigEntry struct {
 }
 
 type GatewayTLSConfig struct {
-	// Indicates that TLS should be enabled for this gateway service
+	// Indicates that TLS should be enabled for this gateway service.
 	Enabled bool
 }
 
@@ -67,7 +71,7 @@ type IngressService struct {
 	// protocol and means that the listener will forward traffic to all services.
 	//
 	// A name can be specified on multiple listeners, and will be exposed on both
-	// of the listeners
+	// of the listeners.
 	Name string
 
 	// Hosts is a list of hostnames which should be associated to this service on
@@ -83,38 +87,24 @@ type IngressService struct {
 	// using a "tcp" listener.
 	Hosts []string
 
-	// Allow HTTP header manipulation to be configured.
-	RequestHeaders  *HTTPHeaderModifiers `json:",omitempty" alias:"request_headers"`
-	ResponseHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"response_headers"`
+	// Referencing other partitions is not supported.
 
 	// Namespace is the namespace where the service is located.
 	// Namespacing is a Consul Enterprise feature.
 	Namespace string `json:",omitempty"`
+
+	// Allow HTTP header manipulation to be configured.
+	RequestHeaders  *HTTPHeaderModifiers `json:",omitempty" alias:"request_headers"`
+	ResponseHeaders *HTTPHeaderModifiers `json:",omitempty" alias:"response_headers"`
 }
 
-func (i *IngressGatewayConfigEntry) GetKind() string {
-	return i.Kind
-}
-
-func (i *IngressGatewayConfigEntry) GetName() string {
-	return i.Name
-}
-
-func (i *IngressGatewayConfigEntry) GetNamespace() string {
-	return i.Namespace
-}
-
-func (i *IngressGatewayConfigEntry) GetMeta() map[string]string {
-	return i.Meta
-}
-
-func (i *IngressGatewayConfigEntry) GetCreateIndex() uint64 {
-	return i.CreateIndex
-}
-
-func (i *IngressGatewayConfigEntry) GetModifyIndex() uint64 {
-	return i.ModifyIndex
-}
+func (i *IngressGatewayConfigEntry) GetKind() string            { return i.Kind }
+func (i *IngressGatewayConfigEntry) GetName() string            { return i.Name }
+func (i *IngressGatewayConfigEntry) GetPartition() string       { return i.Partition }
+func (i *IngressGatewayConfigEntry) GetNamespace() string       { return i.Namespace }
+func (i *IngressGatewayConfigEntry) GetMeta() map[string]string { return i.Meta }
+func (i *IngressGatewayConfigEntry) GetCreateIndex() uint64     { return i.CreateIndex }
+func (i *IngressGatewayConfigEntry) GetModifyIndex() uint64     { return i.ModifyIndex }
 
 // TerminatingGatewayConfigEntry manages the configuration for a terminating gateway
 // with the given name.
@@ -140,55 +130,45 @@ type TerminatingGatewayConfigEntry struct {
 	// queries.
 	ModifyIndex uint64
 
-	// Namespace is the namespace the config entry is associated with
+	// Partition is the partition the config entry is associated with.
+	// Partitioning is a Consul Enterprise feature.
+	Partition string `json:",omitempty"`
+
+	// Namespace is the namespace the config entry is associated with.
 	// Namespacing is a Consul Enterprise feature.
 	Namespace string `json:",omitempty"`
 }
 
 // A LinkedService is a service represented by a terminating gateway
 type LinkedService struct {
-	// The namespace the service is registered in
+	// Referencing other partitions is not supported.
+
+	// Namespace is where the service is registered.
 	Namespace string `json:",omitempty"`
 
-	// Name is the name of the service, as defined in Consul's catalog
+	// Name is the name of the service, as defined in Consul's catalog.
 	Name string `json:",omitempty"`
 
 	// CAFile is the optional path to a CA certificate to use for TLS connections
-	// from the gateway to the linked service
+	// from the gateway to the linked service.
 	CAFile string `json:",omitempty" alias:"ca_file"`
 
 	// CertFile is the optional path to a client certificate to use for TLS connections
-	// from the gateway to the linked service
+	// from the gateway to the linked service.
 	CertFile string `json:",omitempty" alias:"cert_file"`
 
 	// KeyFile is the optional path to a private key to use for TLS connections
-	// from the gateway to the linked service
+	// from the gateway to the linked service.
 	KeyFile string `json:",omitempty" alias:"key_file"`
 
-	// SNI is the optional name to specify during the TLS handshake with a linked service
+	// SNI is the optional name to specify during the TLS handshake with a linked service.
 	SNI string `json:",omitempty"`
 }
 
-func (g *TerminatingGatewayConfigEntry) GetKind() string {
-	return g.Kind
-}
-
-func (g *TerminatingGatewayConfigEntry) GetName() string {
-	return g.Name
-}
-
-func (g *TerminatingGatewayConfigEntry) GetNamespace() string {
-	return g.Namespace
-}
-
-func (g *TerminatingGatewayConfigEntry) GetMeta() map[string]string {
-	return g.Meta
-}
-
-func (g *TerminatingGatewayConfigEntry) GetCreateIndex() uint64 {
-	return g.CreateIndex
-}
-
-func (g *TerminatingGatewayConfigEntry) GetModifyIndex() uint64 {
-	return g.ModifyIndex
-}
+func (g *TerminatingGatewayConfigEntry) GetKind() string            { return g.Kind }
+func (g *TerminatingGatewayConfigEntry) GetName() string            { return g.Name }
+func (g *TerminatingGatewayConfigEntry) GetPartition() string       { return g.Partition }
+func (g *TerminatingGatewayConfigEntry) GetNamespace() string       { return g.Namespace }
+func (g *TerminatingGatewayConfigEntry) GetMeta() map[string]string { return g.Meta }
+func (g *TerminatingGatewayConfigEntry) GetCreateIndex() uint64     { return g.CreateIndex }
+func (g *TerminatingGatewayConfigEntry) GetModifyIndex() uint64     { return g.ModifyIndex }

--- a/api/config_entry_intentions.go
+++ b/api/config_entry_intentions.go
@@ -5,6 +5,7 @@ import "time"
 type ServiceIntentionsConfigEntry struct {
 	Kind      string
 	Name      string
+	Partition string `json:",omitempty"`
 	Namespace string `json:",omitempty"`
 
 	Sources []*SourceIntention
@@ -17,6 +18,7 @@ type ServiceIntentionsConfigEntry struct {
 
 type SourceIntention struct {
 	Name        string
+	Partition   string                 `json:",omitempty"`
 	Namespace   string                 `json:",omitempty"`
 	Action      IntentionAction        `json:",omitempty"`
 	Permissions []*IntentionPermission `json:",omitempty"`
@@ -30,29 +32,13 @@ type SourceIntention struct {
 	LegacyUpdateTime *time.Time        `json:",omitempty" alias:"legacy_update_time"`
 }
 
-func (e *ServiceIntentionsConfigEntry) GetKind() string {
-	return e.Kind
-}
-
-func (e *ServiceIntentionsConfigEntry) GetName() string {
-	return e.Name
-}
-
-func (e *ServiceIntentionsConfigEntry) GetNamespace() string {
-	return e.Namespace
-}
-
-func (e *ServiceIntentionsConfigEntry) GetMeta() map[string]string {
-	return e.Meta
-}
-
-func (e *ServiceIntentionsConfigEntry) GetCreateIndex() uint64 {
-	return e.CreateIndex
-}
-
-func (e *ServiceIntentionsConfigEntry) GetModifyIndex() uint64 {
-	return e.ModifyIndex
-}
+func (e *ServiceIntentionsConfigEntry) GetKind() string            { return e.Kind }
+func (e *ServiceIntentionsConfigEntry) GetName() string            { return e.Name }
+func (e *ServiceIntentionsConfigEntry) GetPartition() string       { return e.Partition }
+func (e *ServiceIntentionsConfigEntry) GetNamespace() string       { return e.Namespace }
+func (e *ServiceIntentionsConfigEntry) GetMeta() map[string]string { return e.Meta }
+func (e *ServiceIntentionsConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
+func (e *ServiceIntentionsConfigEntry) GetModifyIndex() uint64     { return e.ModifyIndex }
 
 type IntentionPermission struct {
 	Action IntentionAction

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -204,6 +204,7 @@ func TestAPI_ConfigEntries(t *testing.T) {
 				"foo": "bar",
 				"gir": "zim",
 			},
+			Partition: defaultPartition,
 			Namespace: defaultNamespace,
 		}
 		ce := c.ConfigEntries()


### PR DESCRIPTION
ent->oss merge

Add the partition field to api.ConfigEntry structs and related tests.

Admin partitions are a Consul Enterprise feature.