### PR TITLE
Update error texts

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -787,7 +787,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 				return RuntimeConfig{}, fmt.Errorf("config_entries.bootstrap[%d]: %s", i, err)
 			}
 			if err := entry.Validate(); err != nil {
-				return RuntimeConfig{}, fmt.Errorf("config_entries.bootstrap[%d]: %s", i, err)
+				return RuntimeConfig{}, fmt.Errorf("config_entries.bootstrap[%d]: %w", i, err)
 			}
 			configEntries = append(configEntries, entry)
 		}

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -171,7 +171,7 @@ func (e *IngressGatewayConfigEntry) Validate() error {
 		serviceNames := make(map[ServiceID]struct{})
 		for i, s := range listener.Services {
 			if err := validateInnerEnterpriseMeta(&s.EnterpriseMeta, &e.EnterpriseMeta); err != nil {
-				return fmt.Errorf("Services[%d].%v", i, err)
+				return fmt.Errorf("services[%d]: %w", i, err)
 			}
 			sn := NewServiceName(s.Name, &s.EnterpriseMeta)
 			if err := s.RequestHeaders.Validate(listener.Protocol); err != nil {
@@ -401,7 +401,7 @@ func (e *TerminatingGatewayConfigEntry) Validate() error {
 		cid := NewServiceID(svc.Name, &svc.EnterpriseMeta)
 
 		if err := validateInnerEnterpriseMeta(&svc.EnterpriseMeta, &e.EnterpriseMeta); err != nil {
-			return fmt.Errorf("Service %q: %v", cid.String(), err)
+			return fmt.Errorf("service %q: %w", cid, err)
 		}
 
 		// Check for duplicates within the entry

--- a/sdk/testutil/assertions.go
+++ b/sdk/testutil/assertions.go
@@ -14,6 +14,6 @@ func RequireErrorContains(t testing.TB, err error, expectedErrorMessage string) 
 		t.Fatal("An error is expected but got nil.")
 	}
 	if !strings.Contains(err.Error(), expectedErrorMessage) {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expected err %v to contain %q", err, expectedErrorMessage)
 	}
 }


### PR DESCRIPTION
Synced from enterprise:
> Also made a few improvements to the error messages that used "current" to make the error easier to understand.
> 
> Also improved the failure message for `RequireErrorContains`, because the previous error message did not provide enough information for me to debug some of these test failures.