### PR TITLE
Account for partition when matching src intentions

### DIFF
--- a/agent/xds/rbac.go
+++ b/agent/xds/rbac.go
@@ -296,15 +296,16 @@ func (p *rbacPermission) Flatten() *envoy_rbac_v3.Permission {
 	return andPermissions(parts)
 }
 
+// simplifyNotSourceSlice will collapse NotSources elements together if any element is
+// a subset of another.
+// For example "default/web" is a subset of "default/*" because it is covered by the wildcard.
 func simplifyNotSourceSlice(notSources []structs.ServiceName) []structs.ServiceName {
 	if len(notSources) <= 1 {
 		return notSources
 	}
 
-	// Collapse NotSources elements together if any element is a subset of
-	// another.
-
 	// Sort, keeping the least wildcarded elements first.
+	// More specific elements have a higher precedence over more wildcarded elements.
 	sort.SliceStable(notSources, func(i, j int) bool {
 		return countWild(notSources[i]) < countWild(notSources[j])
 	})

--- a/agent/xds/rbac.go
+++ b/agent/xds/rbac.go
@@ -457,6 +457,16 @@ func makeRBACRules(intentions structs.Intentions, intentionDefaultAllow bool, is
 	return rbac, nil
 }
 
+// removeSameSourceIntentions will iterate over intentions and remove any lower precedence
+// intentions that share the same source. Intentions are sorted by descending precedence
+// so once a source has been seen, additional intentions with the same source can be dropped.
+//
+// Example for the default/web service:
+// input: [(backend/* -> default/web), (backend/* -> default/*)]
+// output: [(backend/* -> default/web)]
+//
+// (backend/* -> default/*) was dropped because it is already known that any service
+// in the backend namespace can target default/web.
 func removeSameSourceIntentions(intentions structs.Intentions) structs.Intentions {
 	if len(intentions) < 2 {
 		return intentions

--- a/agent/xds/rbac_test.go
+++ b/agent/xds/rbac_test.go
@@ -887,14 +887,3 @@ func makeServiceNameSlice(slice []string) []structs.ServiceName {
 	}
 	return out
 }
-
-func unmakeServiceNameSlice(slice []structs.ServiceName) []string {
-	if len(slice) == 0 {
-		return nil
-	}
-	var out []string
-	for _, src := range slice {
-		out = append(out, src.String())
-	}
-	return out
-}


### PR DESCRIPTION
The code changes are fairly narrow:
- ixnSourceMatches was updated to account for partitions
- SpiffeID pattern generation was updated to account for partitions
- Validation panics if a wildcard partition source is being used
