### PR TITLE
Remove udp_answer_limit (deprecated in 1.0.7)

### DIFF
--- a/.changelog/11027.txt
+++ b/.changelog/11027.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+dns: Remove dns_config.udp_answer_limit agent config option, which was had side effects (see GH-10694) when unspecified despite being deprecated and replaced by dns_config.a_record_limit in v1.0.7.
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -918,7 +918,6 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		DNSRecursors:          dnsRecursors,
 		DNSServiceTTL:         dnsServiceTTL,
 		DNSSOA:                soa,
-		DNSUDPAnswerLimit:     intVal(c.DNS.UDPAnswerLimit),
 		DNSNodeMetaTXT:        boolValWithDefault(c.DNS.NodeMetaTXT, true),
 		DNSUseCache:           boolVal(c.DNS.UseCache),
 		DNSCacheMaxAge:        b.durationVal("dns_config.cache_max_age", c.DNS.CacheMaxAge),
@@ -1324,9 +1323,6 @@ func (b *builder) validate(rt RuntimeConfig) error {
 			"Both the ui_config.enabled and ui_config.dir (or -ui and -ui-dir) were specified, please provide only one.\n" +
 				"If trying to use your own web UI resources, use ui_config.dir or the -ui-dir flag.\n" +
 				"The web UI is included in the binary so use ui_config.enabled or the -ui flag to enable it")
-	}
-	if rt.DNSUDPAnswerLimit < 0 {
-		return fmt.Errorf("dns_config.udp_answer_limit cannot be %d. Must be greater than or equal to zero", rt.DNSUDPAnswerLimit)
 	}
 	if rt.DNSARecordLimit < 0 {
 		return fmt.Errorf("dns_config.a_record_limit cannot be %d. Must be greater than or equal to zero", rt.DNSARecordLimit)

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -636,7 +636,6 @@ type DNS struct {
 	RecursorStrategy   *string           `mapstructure:"recursor_strategy"`
 	RecursorTimeout    *string           `mapstructure:"recursor_timeout"`
 	ServiceTTL         map[string]string `mapstructure:"service_ttl"`
-	UDPAnswerLimit     *int              `mapstructure:"udp_answer_limit"`
 	NodeMetaTXT        *bool             `mapstructure:"enable_additional_node_meta_txt"`
 	SOA                *SOA              `mapstructure:"soa"`
 	UseCache           *bool             `mapstructure:"use_cache"`

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -85,7 +85,6 @@ func DefaultSource() Source {
 		dns_config = {
 			allow_stale = true
 			a_record_limit = 0
-			udp_answer_limit = 3
 			max_stale = "87600h"
 			recursor_timeout = "2s"
 		}

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -241,16 +241,6 @@ type RuntimeConfig struct {
 	// hcl: dns_config { service_ttl = map[string]"duration" }
 	DNSServiceTTL map[string]time.Duration
 
-	// DNSUDPAnswerLimit is used to limit the maximum number of DNS Resource
-	// Records returned in the ANSWER section of a DNS response for UDP
-	// responses without EDNS support (limited to 512 bytes).
-	// This parameter is deprecated, if you want to limit the number of
-	// records returned by A or AAAA questions, please use DNSARecordLimit
-	// instead.
-	//
-	// hcl: dns_config { udp_answer_limit = int }
-	DNSUDPAnswerLimit int
-
 	// DNSNodeMetaTXT controls whether DNS queries will synthesize
 	// TXT records for the node metadata and add them when not specifically
 	// request (query type = TXT). If unset this will default to true

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -1984,15 +1984,6 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		expectedErr: "DNS recursor address cannot be 0.0.0.0, :: or [::]",
 	})
 	run(t, testCase{
-		desc: "dns_config.udp_answer_limit invalid",
-		args: []string{
-			`-data-dir=` + dataDir,
-		},
-		json:        []string{`{ "dns_config": { "udp_answer_limit": -1 } }`},
-		hcl:         []string{`dns_config = { udp_answer_limit = -1 }`},
-		expectedErr: "dns_config.udp_answer_limit cannot be -1. Must be greater than or equal to zero",
-	})
-	run(t, testCase{
 		desc: "dns_config.a_record_limit invalid",
 		args: []string{
 			`-data-dir=` + dataDir,
@@ -2045,11 +2036,9 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			`-data-dir=` + dataDir,
 		},
 		json: []string{
-			`{ "dns_config": { "udp_answer_limit": 1 } }`,
 			`{ "node_meta": { "` + randomString(130) + `": "a" } }`,
 		},
 		hcl: []string{
-			`dns_config = { udp_answer_limit = 1 }`,
 			`node_meta = { "` + randomString(130) + `" = "a" }`,
 		},
 		expectedErr: "Key is too long (limit: 128 characters)",
@@ -2060,11 +2049,9 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			`-data-dir=` + dataDir,
 		},
 		json: []string{
-			`{ "dns_config": { "udp_answer_limit": 1 } }`,
 			`{ "node_meta": { "a": "` + randomString(520) + `" } }`,
 		},
 		hcl: []string{
-			`dns_config = { udp_answer_limit = 1 }`,
 			`node_meta = { "a" = "` + randomString(520) + `" }`,
 		},
 		expectedErr: "Value is too long (limit: 512 characters)",
@@ -2075,11 +2062,9 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			`-data-dir=` + dataDir,
 		},
 		json: []string{
-			`{ "dns_config": { "udp_answer_limit": 1 } }`,
 			`{ "node_meta": {` + metaPairs(70, "json") + `} }`,
 		},
 		hcl: []string{
-			`dns_config = { udp_answer_limit = 1 }`,
 			`node_meta = {` + metaPairs(70, "hcl") + ` }`,
 		},
 		expectedErr: "Node metadata cannot contain more than 64 key/value pairs",
@@ -5441,7 +5426,6 @@ func TestLoad_FullConfig(t *testing.T) {
 		DNSRecursors:                           []string{"63.38.39.58", "92.49.18.18"},
 		DNSSOA:                                 RuntimeSOAConfig{Refresh: 3600, Retry: 600, Expire: 86400, Minttl: 0},
 		DNSServiceTTL:                          map[string]time.Duration{"*": 32030 * time.Second},
-		DNSUDPAnswerLimit:                      29909,
 		DNSNodeMetaTXT:                         true,
 		DNSUseCache:                            true,
 		DNSCacheMaxAge:                         5 * time.Minute,

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -161,7 +161,6 @@
         "Retry": 600
     },
     "DNSServiceTTL": {},
-    "DNSUDPAnswerLimit": 0,
     "DNSUseCache": false,
     "DataDir": "",
     "Datacenter": "",

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -249,7 +249,6 @@ dns_config {
     service_ttl = {
         "*" = "32030s"
     }
-    udp_answer_limit = 29909
     use_cache = true
     cache_max_age = "5m"
     prefer_namespace = true

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -249,7 +249,6 @@
     "service_ttl": {
       "*": "32030s"
     },
-    "udp_answer_limit": 29909,
     "use_cache": true,
     "cache_max_age": "5m",
     "prefer_namespace": true

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1375,10 +1375,13 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
     responses will not be compressed. Compression was added and enabled by default
     in Consul 0.7.
 
-  - `udp_answer_limit` - Limit the number of resource
-    records contained in the answer section of a UDP-based DNS response. This parameter
-    applies only to UDP DNS queries that are less than 512 bytes. This setting is
-    deprecated and replaced in Consul 1.0.7 by [`a_record_limit`](#a_record_limit).
+  - `udp_answer_limit` - **Deprecated in Consul 1.0.7 and removed in 1.11.0.**
+    For UDP-based DNS queries without EDNS supported (limited to 512 bytes),
+    limit the maximum number of DNS resource records contained in the ANSWER section
+    of the response. Even without this option, Consul ensures that all DNS responses
+    are within the response size limit (512 bytes without EDNS support). Since Consul
+    1.0.7, the [`a_record_limit`](#a_record_limit) option is the recommended method to
+    limit the number of records returned by A, AAAA, and ANY queries (over UDP and TCP).
 
   - `a_record_limit` - Limit the number of resource
     records contained in the answer section of a A, AAAA or ANY DNS response (both


### PR DESCRIPTION
Fix #10694 by removing [`udp_answer_limit`](https://www.consul.io/docs/agent/options#udp_answer_limit).

Consul's documentation states that the `udp_answer_limit` was deprecated and replaced by [`a_record_limit`](https://www.consul.io/docs/agent/options#a_record_limit) in Consul 1.0.7. However, these two settings were treated as independent options in the source which could both cause a message to be truncated.

`a_record_limit` affects the number of records contained in the answer section of an A, AAAA, or ANY DNS response (independent of network protocol). It won't affect DNS behavior unless the user opts in.

`udp_answer_limit` also limited the number of records contained in the answer section, but only applied to DNS requests without EDNS over UDP (not TCP). Because it defaulted to 3 (which isn't stated in our docs), it would affect DNS behavior even if the user had not opted in, despite being listed as a deprecated option. This can understandably confuse users, such as in #10694 in which a user found this deprecated setting was still necessary.

Therefore, to avoid future user confusion and unexpected DNS behavior, remove the `udp_answer_limit` option.

Additionally, the DNS code has been made slightly more DRY and commented.

Easiest to review by commit.

**Question to Reviewer**
- How do we properly remove a previously deprecated option? (e.g., how do we communicate this?)