### PR TITLE
WIP: Cross-Reference API Endpoints & CLI Commands; Include Command ACL Info

### DIFF
--- a/website/content/api-docs/acl/index.mdx
+++ b/website/content/api-docs/acl/index.mdx
@@ -24,9 +24,19 @@ and requires all Consul servers to be upgraded in order to operate.
 This provides a mechanism to bootstrap ACLs without having any secrets present in Consul's
 configuration files.
 
+**vv Cross ref option 1: text**
+
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
 | `PUT`  | `/acl/bootstrap` | `application/json` |
+
+The corresponding CLI command is [`consul acl bootstrap`](/commands/acl/bootstrap).
+
+**vv Cross ref option 2: table**
+
+| Method | Path             | Produces           | Corresponding CLI Command                         |
+| ------ | ---------------- | ------------------ | ------------------------------------------------- |
+| `PUT`  | `/acl/bootstrap` | `application/json` | [`consul acl bootstrap`](/commands/acl/bootstrap) |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/features/blocking),
@@ -387,10 +397,7 @@ $ curl \
 
 ## OIDC Authorization URL Request
 
-<EnterpriseAlert>
-  {' '}
-  This is an enterprise only endpoint.
-</EnterpriseAlert>
+<EnterpriseAlert> This is an enterprise only endpoint.</EnterpriseAlert>
 
 This endpoint was added in Consul 1.8.0 and is used to obtain an authorization
 URL from Consul to start an [OIDC login flow](/docs/acl/auth-methods/oidc).
@@ -466,10 +473,7 @@ $ curl \
 
 ## OIDC Callback
 
-<EnterpriseAlert>
-  {' '}
-  This is an enterprise only endpoint.
-</EnterpriseAlert>
+<EnterpriseAlert> This is an enterprise only endpoint.</EnterpriseAlert>
 
 This endpoint was added in Consul 1.8.0 and is used to exchange an OIDC
 authorization code for an OIDC ID Token. The ID token will in turn be exchanged

--- a/website/content/commands/acl/bootstrap.mdx
+++ b/website/content/commands/acl/bootstrap.mdx
@@ -7,12 +7,83 @@ page_title: 'Commands: ACL Bootstrap'
 
 Command: `consul acl bootstrap`
 
+Corresponding HTTP API Endpoint:
+[`[GET] /v1/acl/bootstrap`](/api-docs/acl#bootstrap-acls)
+
+**^^ Cross ref option 1: inline with command**
+
 The `acl bootstrap` command will request Consul to generate a new token with unlimited privileges to use
 for management purposes and output its details. This can only be done once and afterwards bootstrapping
 will be disabled. If all tokens are lost and you need to bootstrap again you can follow the bootstrap
 [reset procedure](https://learn.hashicorp.com/consul/security-networking/acl-troubleshooting?utm_source=consul.io&utm_medium=docs#reset-the-acl-system).
 
-The ACL system can also be bootstrapped via the [HTTP API](/api/acl/acl#bootstrap-acls).
+**vv Cross ref option 2: aside at bottom of command overview**
+
+The corresponding HTTP endpoint is [`[GET] /v1/acl/bootstrap`](/api-docs/acl#bootstrap-acls).
+
+**vv ACLs option 1: bare minimum**
+
+The table below shows this command's support for
+[required ACLs](/commands#consul_http_token).
+
+| ACL Required |
+| ------------ |
+| `none`       |
+
+**vv ACLs option 2: mention API config possibilities**
+
+The table below shows this command's support for [required ACLs](/commands#consul_http_token).
+Configuration of
+[blocking queries](/api/features/blocking),
+[consistency modes](/api/features/consistency), and
+[agent caching](/api/features/caching)
+are not supported from commands, but may be from the
+corresponding HTTP endpoint.
+
+| ACL Required |
+| ------------ |
+| `none`       |
+
+**vv ACLs option 3: full command details**
+
+The table below shows this command's support for
+[consistency modes](/api/features/consistency) and
+[required ACLs](/commands#consul_http_token).
+Configuration of
+[blocking queries](/api/features/blocking),
+the `consistent` [consistency mode](/api/features/consistency), and
+[agent caching](/api/features/caching)
+are not supported from commands, but may be from the
+corresponding HTTP endpoint.
+
+| Consistency Modes | ACL Required |
+| ----------------- | ------------ |
+| `none`            | `none`       |
+
+(**internal note**: this HTTP API endpoint doesn't really support consistency modes. It
+technically accepts the `-stale` argument according to the docs, but it has
+no effect on non-read operations.)
+
+**vv ACLs option 4: full command details and extra API config options**
+
+The table below shows this command's support for
+[consistency modes](/api/features/consistency), and
+[required ACLs](/commands#consul_http_token).
+
+\*Configuration of
+[blocking queries](/api/features/blocking) and
+[agent caching](/api/features/caching)
+are not supported from commands, so the table below instead shows support from
+the corresponding HTTP API endpoint. If such configuration is needed, use that
+HTTP API endpoint instead of this command.
+
+| \*Blocking Queries | Consistency Modes  | \*Agent Caching | ACL Required |
+| ------------------ | ------------------ | --------------- | ------------ |
+| `NO`               | `default`, `stale` | `none`          | `none`       |
+
+(**internal note**: this HTTP API endpoint doesn't really support consistency modes. It
+technically accepts the `-stale` argument according to the docs, but it has
+no effect on non-read operations.)
 
 ## Usage
 


### PR DESCRIPTION
Intended to close #3134. Meant to accomplish:
- Just like we give additional info (e.g., required ACLs) for using HTTP API endpoints, we should provide the same info for CLI commands
- CLI commands and HTTP API endpoints should cross-reference each other in the docs, in case the user (1) is looking for one but ends up on the other, such as through a Google search, or (2) wants to convert from one usage to another.

We should align on a consistent approach for one command/endpoint before applying the approach to all commands/endpoints.

Steps:
- [ ] Align on consistent approach for one endpoint
- [ ] Align on how to make this information easy to manage (e.g., include some of the info in partials?)
- [ ] Deploy approach across all commands/endpoints (based on a spreadsheet I've created mapping CLI commands, HTTP API endpoints, and required ACLs)