### PR TITLE
docs: Remove step for deleting webhook-cert-manager secret on Consul K8s uninstall

### DIFF
--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -64,8 +64,7 @@ secret "consul-mesh-gateway-acl-token" deleted
 secret "consul-gossip-encryption-key" deleted
 ```
 
-1. If installing with `tls.enabled` then there will be a `ServiceAccount`
-   that is left behind:
+If installing with `tls.enabled` then there will be a `ServiceAccount` that is left behind:
 
    ```shell-session
    $ kubectl get serviceaccount consul-tls-init

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -64,20 +64,6 @@ secret "consul-mesh-gateway-acl-token" deleted
 secret "consul-gossip-encryption-key" deleted
 ```
 
-1. If installing with `controller.enabled` then you will need to delete the
-   webhook certificate:
-
-   ```shell-session
-   $ kubectl get secret consul-controller-webhook-cert
-   NAME                             TYPE                DATA   AGE
-   consul-controller-webhook-cert   kubernetes.io/tls   2      47m
-   ```
-
-   ```shell-session
-   $ kubectl delete secret consul-controller-webhook-cert
-   secret "consul-consul-controller-webhook-cert" deleted
-   ```
-
 1. If installing with `tls.enabled` then there will be a `ServiceAccount`
    that is left behind:
 


### PR DESCRIPTION
As of Consul Helm 0.26.0, for Consul 1.8.x, we no longer need to manually remove the `consul-controller-webhook-cert` secret. This is a result of https://github.com/hashicorp/consul-k8s/pull/530.  