### PR TITLE
Document HTTP Header manipulation options added in #10613

### DIFF
--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -400,6 +400,10 @@ spec:
 Set up a HTTP listener on an ingress gateway named "us-east-ingress" to proxy
 traffic to a virtual service named "api".
 
+Additionally, ensure internal-only debug headers are stripped before responding
+to external clients, and that requests to internal services are labelled to
+indicate which gateway they came through.
+
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
 ```hcl
@@ -413,6 +417,14 @@ Listeners = [
     Services = [
       {
         Name = "api"
+        RequestHeaders {
+          Add {
+            "x-gateway" = "us-east-ingress"
+          }
+        }
+        ResponseHeaders {
+          Remove = ["x-debug"]
+        }
       }
     ]
   }
@@ -430,6 +442,7 @@ spec:
       protocol: http
       services:
         - name: api
+          # HTTP Header manipulation is not yet supported in Kubernetes CRD
 ```
 
 ```json
@@ -442,7 +455,15 @@ spec:
       "Protocol": "http",
       "Services": [
         {
-          "Name": "api"
+          "Name": "api",
+          "RequestHeaders": {
+            "Add": {
+              "x-gateway": "us-east-ingress"
+            }
+          },
+          "ResponseHeaders": {
+            "Remove": ["x-debug"]
+          }
         }
       ]
     }
@@ -457,6 +478,10 @@ spec:
 
 Set up a HTTP listener on an ingress gateway named "us-east-ingress" in the
 default namespace to proxy traffic to a virtual service named "api".
+
+Additionally, ensure internal-only debug headers are stripped before responding
+to external clients, and that requests to internal services are labelled to
+indicate which gateway they came through.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
@@ -473,6 +498,14 @@ Listeners = [
       {
         Name = "api"
         Namespace = "frontend"
+        RequestHeaders {
+          Add {
+            "x-gateway" = "us-east-ingress"
+          }
+        }
+        ResponseHeaders {
+          Remove = ["x-debug"]
+        }
       }
     ]
   }
@@ -492,6 +525,7 @@ spec:
       services:
         - name: api
           namespace: frontend
+          # HTTP Header manipulation is not yet supported in Kubernetes CRD
 ```
 
 ```json
@@ -506,7 +540,15 @@ spec:
       "Services": [
         {
           "Name": "api",
-          "Namespace": "frontend"
+          "Namespace": "frontend",
+           "RequestHeaders": {
+            "Add": {
+              "x-gateway": "us-east-ingress"
+            }
+          },
+          "ResponseHeaders": {
+            "Remove": ["x-debug"]
+          }
         }
       ]
     }
@@ -837,6 +879,22 @@ spec:
               leftmost DNS label. This ensures that all defined hosts are valid DNS
               records. For example, \`*.example.com\` is valid, while \`example.*\` and
               \`*-suffix.example.com\` are not.`,
+            },
+            {
+              yaml: false,
+              name: 'RequestHeaders',
+              type: 'HTTPHeaderModifiers: <optional>',
+              description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+              that will be applied to requests routed to this service.
+              This cannot be used with a \`tcp\` listener.`,
+            },
+            {
+              yaml: false,
+              name: 'ResponseHeaders',
+              type: 'HTTPHeaderModifiers: <optional>',
+              description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+              that will be applied to responses from this service.
+              This cannot be used with a \`tcp\` listener.`,
             },
           ],
         },

--- a/website/content/docs/connect/config-entries/service-router.mdx
+++ b/website/content/docs/connect/config-entries/service-router.mdx
@@ -574,6 +574,69 @@ spec:
       description:
         'A list of HTTP response status codes that are eligible for retry.',
     },
+    {
+      yaml: false,
+      name: 'RequestHeaders',
+      type: 'HTTPHeaderModifiers: <optional>',
+      description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+      that will be applied to requests routed to this service.
+      This cannot be used with a \`tcp\` listener.`,
+    },
+    {
+      yaml: false,
+      name: 'ResponseHeaders',
+      type: 'HTTPHeaderModifiers: <optional>',
+      description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+      that will be applied to responses from this service.
+      This cannot be used with a \`tcp\` listener.`,
+    },
+  ]}
+/>
+
+
+### `HTTPHeaderModifiers`
+
+<ConfigEntryReference
+  topLevel={false}
+  yaml={false}
+  keys={[
+    {
+      hcl: false,
+      name: 'Unsupported',
+      type: '',
+      description: `HTTP Header modification is not yet supported in our Kubernetes CRDs.`,
+    },
+    {
+      yaml: false,
+      name: 'Add',
+      type: 'map<string|string>: optional',
+      description: `The set of header value keyed by header name to
+      add. If a header with the same (case-insensitive) name already
+      exists, the value set here will be appended and both will be present.
+      If Envoy is used as the proxy, the value may contain
+      [variable placeholders](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#custom-request-response-headers) for example
+      \`%DOWNSTREAM_REMOTE_ADDRESS%\` to interpolate dynamic request
+      metadata into the value added.`,
+    },
+    {
+      yaml: false,
+      name: 'Set',
+      type: 'map<string|string>: optional',
+      description: `The set of header value keyed by header name to
+      add. If one or more header values with the same (case-insensitive) name already exist,
+      the value set here will replace them all.
+      If Envoy is used as the proxy, the value may contain
+      [variable placeholders](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#custom-request-response-headers) for example
+      \`%DOWNSTREAM_REMOTE_ADDRESS%\` to interpolate dynamic request
+      metadata into the value added.`,
+    },
+    {
+      yaml: false,
+      name: 'Remove',
+      type: 'array<string>: optional',
+      description: `The set of header names to remove. Only headers
+      whose names are an <i>case-insensitive</i> exact match will be removed`,
+    },
   ]}
 />
 

--- a/website/content/docs/connect/config-entries/service-splitter.mdx
+++ b/website/content/docs/connect/config-entries/service-splitter.mdx
@@ -146,6 +146,68 @@ spec:
 
 </CodeTabs>
 
+
+### Set HTTP Headers
+
+Split traffic between two subsets with extra headers added so clients can tell
+which version (not yet supported in Kubernetes CRD):
+
+<CodeTabs tabs={[ "HCL", "JSON" ]}>
+
+```hcl
+Kind = "service-splitter"
+Name = "web"
+Splits = [
+  {
+    Weight        = 90
+    ServiceSubset = "v1"
+    ResponseHeaders {
+      Set {
+        "X-Web-Version": "v1"
+      }
+    }
+  },
+  {
+    Weight        = 10
+    ServiceSubset = "v2"
+    ResponseHeaders {
+      Set {
+        "X-Web-Version": "v2"
+      }
+    }
+  },
+]
+```
+
+```json
+{
+  "Kind": "service-splitter",
+  "Name": "web",
+  "Splits": [
+    {
+      "Weight": 90,
+      "ServiceSubset": "v1",
+      "ResponseHeaders": {
+        "Set": {
+          "X-Web-Version": "v1"
+        }
+      }
+    },
+    {
+      "Weight": 10,
+      "ServiceSubset": "v2",
+      "ResponseHeaders": {
+        "Set": {
+          "X-Web-Version": "v2"
+        }
+      }
+    }
+  ]
+}
+```
+
+</CodeTabs>
+
 ## Available Fields
 
 <ConfigEntryReference
@@ -230,6 +292,22 @@ spec:
           type: 'string: ""',
           description:
             'The namespace to resolve the service from instead of the current namespace. If empty the current namespace is assumed.',
+        },
+        {
+          yaml: false,
+          name: 'RequestHeaders',
+          type: 'HTTPHeaderModifiers: <optional>',
+          description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+          that will be applied to requests routed to this split.
+          This cannot be used with a \`tcp\` listener.`,
+        },
+        {
+          yaml: false,
+          name: 'ResponseHeaders',
+          type: 'HTTPHeaderModifiers: <optional>',
+          description: `A set of [HTTP-specific header modification rules](/docs/connect/config-entries/service-router#httpheadermodifiers)
+          that will be applied to responses from this split.
+          This cannot be used with a \`tcp\` listener.`,
         },
       ],
     },


### PR DESCRIPTION
Questions for reviewers:

 1. I choose to only document `HTTPHeaderModifiers` struct in one place and cross link to avoid duplication and getting out of sync. I'm happy with that, although picking one of the three places was pretty arbitrary. I went with `service-router` since that is perhaps the most natural fit for discovering HTTP manipulation config but I don't think it matters much since it's cross linked from other places anyway. Does this seem reasonable or would either duplicating or creating a more specific place for shared structures make more sense?
 2. I wanted to add at least a couple of examples of use. For ingress I was in two minds about whether I should make a whole new example. On the plus side a separate example would keep each example more specifically focussed on each feature and use-case, on the other hand I can see it getting harder to find as we grow features if every one has a separate example. I tried it combined for now in the more complex example block but open to changing that if we think it's better to split the examples.

Notes:
* We've not yet scheduled the work to update the Kube CRD. It may well get done before 1.11 so we can remove the `yaml: false` and "Not supported in Kube" messages here, but I thought I'd put it up like this reflecting reality now in case that work doesn't get done before 1.11 and we forget. I'm open to changing that if we decide it's simple to add them to the CRDs.