### PR TITLE
docs: Reformat Uninstall steps

### DIFF
--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -33,8 +33,8 @@ up some resources that Helm does not delete.
   persistentvolumeclaim "data-default-hashicorp-consul-server-2" deleted
   ```
 
-~> **NOTE:** This will delete **all** data stored in Consul and it can't be
-   recovered unless you've taken other backups.
+  ~> **NOTE:** This will delete **all** data stored in Consul and it can't be
+     recovered unless you've taken other backups.
 
   3. If installing with ACLs enabled, you will need to then delete the ACL secrets:
 

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -33,7 +33,7 @@ up some resources that Helm does not delete.
   persistentvolumeclaim "data-default-hashicorp-consul-server-2" deleted
   ```
 
-   ~> **NOTE:** This will delete **all** data stored in Consul and it can't be
+~> **NOTE:** This will delete **all** data stored in Consul and it can't be
    recovered unless you've taken other backups.
 
   3. If installing with ACLs enabled, you will need to then delete the ACL secrets:

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -50,7 +50,7 @@ up some resources that Helm does not delete.
   ```
 
   4. Ensure that the secrets you're about to delete are all created by Consul and not 
-  created by someone else that happen to have the word `consul`.
+  created by someone else that happen to have the word `consul`:
 
   ```shell-session
   $ kubectl get secret | grep consul | grep Opaque | awk '{print $1}' | xargs kubectl delete secret

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -9,70 +9,70 @@ description: Uninstall Consul on Kubernetes
 Uninstalling Consul requires running `helm delete` **and** then manually cleaning
 up some resources that Helm does not delete.
 
-1. First, run `helm delete`:
+  1. First, run `helm delete`:
 
-   ```shell-session
-   $ helm delete hashicorp
-   release "hashicorp" uninstalled
-   ```
+  ```shell-session
+  $ helm delete hashicorp
+  release "hashicorp" uninstalled
+  ```
 
-1. After deleting the Helm release, you need to delete the `PersistentVolumeClaim`'s
-   for the persistent volumes that store Consul's data. These are not deleted by Helm due to a [bug](https://github.com/helm/helm/issues/5156).
-   To delete, run:
+  2. After deleting the Helm release, you need to delete the `PersistentVolumeClaim`'s
+  for the persistent volumes that store Consul's data. These are not deleted by Helm due to a [bug](https://github.com/helm/helm/issues/5156).
+  To delete, run:
 
-   ```shell-session
-   $ kubectl get pvc -l chart=consul-helm
-   NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-   data-default-hashicorp-consul-server-0   Bound    pvc-32cb296b-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
-   data-default-hashicorp-consul-server-1   Bound    pvc-32d79919-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
-   data-default-hashicorp-consul-server-2   Bound    pvc-331581ea-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
+  ```shell-session
+  $ kubectl get pvc -l chart=consul-helm
+  NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+  data-default-hashicorp-consul-server-0   Bound    pvc-32cb296b-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
+  data-default-hashicorp-consul-server-1   Bound    pvc-32d79919-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
+  data-default-hashicorp-consul-server-2   Bound    pvc-331581ea-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
 
-   $ kubectl delete pvc -l chart=consul-helm
-   persistentvolumeclaim "data-default-hashicorp-consul-server-0" deleted
-   persistentvolumeclaim "data-default-hashicorp-consul-server-1" deleted
-   persistentvolumeclaim "data-default-hashicorp-consul-server-2" deleted
-   ```
+  $ kubectl delete pvc -l chart=consul-helm
+  persistentvolumeclaim "data-default-hashicorp-consul-server-0" deleted
+  persistentvolumeclaim "data-default-hashicorp-consul-server-1" deleted
+  persistentvolumeclaim "data-default-hashicorp-consul-server-2" deleted
+  ```
 
    ~> **NOTE:** This will delete **all** data stored in Consul and it can't be
    recovered unless you've taken other backups.
 
-1. If installing with ACLs enabled, you will need to then delete the ACL secrets:
+  3. If installing with ACLs enabled, you will need to then delete the ACL secrets:
 
-```shell-session
-$ kubectl get secret | grep consul | grep Opaque
-consul-acl-replication-acl-token    Opaque                                1      41m
-consul-bootstrap-acl-token          Opaque                                1      41m
-consul-client-acl-token             Opaque                                1      41m
-consul-connect-inject-acl-token     Opaque                                1      37m
-consul-controller-acl-token         Opaque                                1      37m
-consul-federation                   Opaque                                4      41m
-consul-mesh-gateway-acl-token       Opaque                                1      41m
-```
+  ```shell-session
+  $ kubectl get secret | grep consul | grep Opaque
+  consul-acl-replication-acl-token    Opaque                                1      41m
+  consul-bootstrap-acl-token          Opaque                                1      41m
+  consul-client-acl-token             Opaque                                1      41m
+  consul-connect-inject-acl-token     Opaque                                1      37m
+  consul-controller-acl-token         Opaque                                1      37m
+  consul-federation                   Opaque                                4      41m
+  consul-mesh-gateway-acl-token       Opaque                                1      41m
+  ```
 
-Ensure that the secrets you're about to delete are all created by Consul and not
-created by someone else that happen to have the word `consul`.
+  4. Ensure that the secrets you're about to delete are all created by Consul and not 
+  created by someone else that happen to have the word `consul`.
 
-```shell-session
-$ kubectl get secret | grep consul | grep Opaque | awk '{print $1}' | xargs kubectl delete secret
-secret "consul-acl-replication-acl-token" deleted
-secret "consul-bootstrap-acl-token" deleted
-secret "consul-client-acl-token" deleted
-secret "consul-connect-inject-acl-token" deleted
-secret "consul-controller-acl-token" deleted
-secret "consul-federation" deleted
-secret "consul-mesh-gateway-acl-token" deleted
-secret "consul-gossip-encryption-key" deleted
-```
+  ```shell-session
+  $ kubectl get secret | grep consul | grep Opaque | awk '{print $1}' | xargs kubectl delete secret
+  secret "consul-acl-replication-acl-token" deleted
+  secret "consul-bootstrap-acl-token" deleted
+  secret "consul-client-acl-token" deleted
+  secret "consul-connect-inject-acl-token" deleted
+  secret "consul-controller-acl-token" deleted
+  secret "consul-federation" deleted
+  secret "consul-mesh-gateway-acl-token" deleted
+  secret "consul-gossip-encryption-key" deleted
+  ```
 
-If installing with `tls.enabled` then there will be a `ServiceAccount` that is left behind:
+  5. If installing with `tls.enabled` then there will be a `ServiceAccount` that is left behind:
 
-   ```shell-session
-   $ kubectl get serviceaccount consul-tls-init
-   NAME              SECRETS   AGE
-   consul-tls-init   1         47m
-   ```
+  ```shell-session
+  $ kubectl get serviceaccount consul-tls-init
+  NAME              SECRETS   AGE
+  consul-tls-init   1         47m
+  ```
 
-   ```shell-session
-   $ kubectl delete serviceaccount consul-tls-init
-   serviceaccount "consul-tls-init" deleted
-   ```
+  ```shell-session
+  $ kubectl delete serviceaccount consul-tls-init
+  serviceaccount "consul-tls-init" deleted
+  ```


### PR DESCRIPTION
Reformatting uninstall as steps to make uninstall instructions more clear.