### PR TITLE
Ensure Envoy can subscribe to services in non-default partition

### DIFF
--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -585,7 +585,7 @@ func (s *Intention) Match(args *structs.IntentionQueryRequest, reply *structs.In
 		return err
 	}
 
-	// Finish defaulting the namespace fields.
+	// Finish defaulting the namespace and partition fields.
 	for i := range args.Match.Entries {
 		if args.Match.Entries[i].Namespace == "" {
 			args.Match.Entries[i].Namespace = entMeta.NamespaceOrDefault()
@@ -593,6 +593,14 @@ func (s *Intention) Match(args *structs.IntentionQueryRequest, reply *structs.In
 		if err := s.srv.validateEnterpriseIntentionNamespace(args.Match.Entries[i].Namespace, true); err != nil {
 			return fmt.Errorf("Invalid match entry namespace %q: %v",
 				args.Match.Entries[i].Namespace, err)
+		}
+
+		if args.Match.Entries[i].Partition == "" {
+			args.Match.Entries[i].Partition = entMeta.PartitionOrDefault()
+		}
+		if err := s.srv.validateEnterpriseIntentionPartition(args.Match.Entries[i].Partition); err != nil {
+			return fmt.Errorf("Invalid match entry partition %q: %v",
+				args.Match.Entries[i].Partition, err)
 		}
 	}
 

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -911,6 +911,7 @@ func intentionMatchOneTxn(tx ReadTxn, ws memdb.WatchSet,
 	return result, nil
 }
 
+// TODO(partitions): Update for partitions
 // intentionMatchGetParams returns the tx.Get parameters to find all the
 // intentions for a certain entry.
 func intentionMatchGetParams(entry structs.IntentionMatchEntry) ([][]interface{}, error) {

--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -59,6 +59,7 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 			Entries: []structs.IntentionMatchEntry{
 				{
 					Namespace: s.proxyID.NamespaceOrDefault(),
+					Partition: s.proxyID.PartitionOrDefault(),
 					Name:      s.proxyCfg.DestinationServiceName,
 				},
 			},

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -139,6 +139,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 			Entries: []structs.IntentionMatchEntry{
 				{
 					Namespace: structs.IntentionDefaultNamespace,
+					Partition: structs.IntentionDefaultNamespace,
 					Name:      "web",
 				},
 			},

--- a/agent/proxycfg/terminating_gateway.go
+++ b/agent/proxycfg/terminating_gateway.go
@@ -121,6 +121,7 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u cache.Up
 						Entries: []structs.IntentionMatchEntry{
 							{
 								Namespace: svc.Service.NamespaceOrDefault(),
+								Partition: svc.Service.PartitionOrDefault(),
 								Name:      svc.Service.Name,
 							},
 						},

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -639,10 +639,9 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 		targetSpiffeID := connect.SpiffeIDService{
 			Host:       cfgSnap.Roots.TrustDomain,
 			Namespace:  target.Namespace,
+			Partition:  target.Partition,
 			Datacenter: target.Datacenter,
 			Service:    target.Service,
-
-			// TODO(partitions) Store partition
 		}
 
 		if failoverThroughMeshGateway {
@@ -676,10 +675,9 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 				id := connect.SpiffeIDService{
 					Host:       cfgSnap.Roots.TrustDomain,
 					Namespace:  target.Namespace,
+					Partition:  target.Partition,
 					Datacenter: target.Datacenter,
 					Service:    target.Service,
-
-					// TODO(partitions) Store partition
 				}
 
 				// Failover targets might be subsets of the same service, so these are deduplicated.

--- a/api/api.go
+++ b/api/api.go
@@ -1117,7 +1117,9 @@ func generateUnexpectedResponseCodeError(resp *http.Response) error {
 	var buf bytes.Buffer
 	io.Copy(&buf, resp.Body)
 	closeResponseBody(resp)
-	return fmt.Errorf("Unexpected response code: %d (%s)", resp.StatusCode, buf.Bytes())
+
+	trimmed := strings.TrimSpace(string(buf.Bytes()))
+	return fmt.Errorf("Unexpected response code: %d (%s)", resp.StatusCode, trimmed)
 }
 
 func requireNotFoundOrOK(d time.Duration, resp *http.Response, e error) (bool, time.Duration, *http.Response, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -660,6 +660,14 @@ func NewClient(config *Config) (*Client, error) {
 		}
 	}
 
+	if config.Namespace == "" {
+		config.Namespace = defConfig.Namespace
+	}
+
+	if config.Partition == "" {
+		config.Partition = defConfig.Partition
+	}
+
 	parts := strings.SplitN(config.Address, "://", 2)
 	if len(parts) == 2 {
 		switch parts[0] {

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -513,10 +513,15 @@ func generateStatsTags(args *BootstrapTplArgs, initialTags []string, omitDepreca
 	}
 	tagJSONs = append(tagJSONs, tags...)
 
-	// Default the namespace here since it is also done for cluster SNI
+	// Default the namespace and partition here since it is also done for cluster SNI
 	ns := args.Namespace
 	if ns == "" {
 		ns = api.IntentionDefaultNamespace
+	}
+
+	ap := args.Partition
+	if ap == "" {
+		ap = api.IntentionDefaultNamespace
 	}
 
 	// Add some default tags if not already overridden. Note this is a slice not a
@@ -539,6 +544,10 @@ func generateStatsTags(args *BootstrapTplArgs, initialTags []string, omitDepreca
 		{
 			name: "consul.source.namespace",
 			val:  ns,
+		},
+		{
+			name: "consul.source.partition",
+			val:  ap,
 		},
 		{
 			name: "consul.source.datacenter",

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -89,6 +89,10 @@ type BootstrapTplArgs struct {
 	// as registered with the Consul agent.
 	Namespace string
 
+	// Partition is the Consul Enterprise Partition of the proxy service instance
+	// as registered with the Consul agent.
+	Partition string
+
 	// Datacenter is the datacenter where the proxy service instance is registered.
 	Datacenter string
 
@@ -141,6 +145,7 @@ const bootstrapTemplate = `{
     "id": "{{ .ProxyID }}",
     "metadata": {
       "namespace": "{{if ne .Namespace ""}}{{ .Namespace }}{{else}}default{{end}}",
+      "partition": "{{if ne .Partition ""}}{{ .Partition }}{{else}}default{{end}}",
       "envoy_version": "{{ .EnvoyVersion }}"
     }
   },

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -482,6 +482,7 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 		Token:                 httpCfg.Token,
 		LocalAgentClusterName: xds.LocalAgentClusterName,
 		Namespace:             httpCfg.Namespace,
+		Partition:             httpCfg.Partition,
 		EnvoyVersion:          c.envoyVersion,
 		Datacenter:            httpCfg.Datacenter,
 		PrometheusBackendPort: c.prometheusBackendPort,
@@ -524,18 +525,6 @@ func (c *cmd) generateConfig() ([]byte, error) {
 	} else {
 		// Set the source service name from the proxy's own registration
 		args.ProxySourceService = svc.Service
-	}
-	if svc.Namespace != "" {
-		// In most cases where namespaces are enabled this will already be set
-		// correctly because the http client that fetched this will need to have
-		// had the namespace set on it which is also how we initially populate
-		// this. However in the case of "default" namespace being accessed because
-		// there was no namespace argument, args.Namespace will be empty even
-		// though Namespaces are actually being used and the namespace of the request was
-		// inferred from the ACL token or defaulted to the "default" namespace.
-		// Overriding it here ensures that we always set the Namespace arg if the
-		// cluster is using namespaces regardless.
-		args.Namespace = svc.Namespace
 	}
 
 	if svc.Datacenter != "" {

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -527,6 +527,20 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		args.ProxySourceService = svc.Service
 	}
 
+	// In most cases where namespaces and partitions are enabled they will already be set
+	// correctly because the http client that fetched this will provide them explicitly.
+	// However, if these arguments were not provided, they will be empty even
+	// though Namespaces and Partitions are actually being used.
+	// Overriding them ensures that we always set the Namespace and Partition args
+	// if the cluster is using them. This prevents us from defaulting to the "default"
+	// when a non-default partition or namespace was inferred from the ACL token.
+	if svc.Namespace != "" {
+		args.Namespace = svc.Namespace
+	}
+	if svc.Partition != "" {
+		args.Partition = svc.Partition
+	}
+
 	if svc.Datacenter != "" {
 		// The agent will definitely have the definitive answer here.
 		args.Datacenter = svc.Datacenter

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -155,6 +156,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -155,6 +156,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -155,6 +156,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -164,6 +165,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -155,6 +156,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -141,6 +142,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -13,6 +13,7 @@
     "id": "ingress-gateway",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -228,6 +229,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -13,6 +13,7 @@
     "id": "ingress-gateway",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -228,6 +229,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -13,6 +13,7 @@
     "id": "my-gateway-123",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -228,6 +229,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -13,6 +13,7 @@
     "id": "my-gateway",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -228,6 +229,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -13,6 +13,7 @@
     "id": "ingress-gateway-1",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -228,6 +229,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/prometheus-metrics.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -228,6 +229,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/xds-addr-config.golden
+++ b/command/connect/envoy/testdata/xds-addr-config.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -142,6 +143,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -13,6 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
+      "partition": "default",
       "envoy_version": "1.18.4"
     }
   },
@@ -166,6 +167,10 @@
       },
       {
         "tag_name": "consul.source.namespace",
+        "fixed_value": "default"
+      },
+      {
+        "tag_name": "consul.source.partition",
         "fixed_value": "default"
       },
       {


### PR DESCRIPTION
Partitions need to be propagated to the bootstrap template so that they can be passed on xDS requests via `envoy_core_v3.Node`.

Also have some other fixes in each commit.