### PR TITLE
acl: small resolver changes to account for partitions

### DIFF
--- a/agent/consul/acl_oss_test.go
+++ b/agent/consul/acl_oss_test.go
@@ -3,6 +3,8 @@
 package consul
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 )
@@ -27,5 +29,9 @@ func (d *EnterpriseACLResolverTestDelegate) RPC(string, interface{}, interface{}
 	return false, nil
 }
 
-func (d *EnterpriseACLResolverTestDelegate) UseTestLocalData(_ []interface{}) {}
-func (d *EnterpriseACLResolverTestDelegate) UseDefaultData()                  {}
+func (d *EnterpriseACLResolverTestDelegate) UseTestLocalData(data []interface{}) {
+	if len(data) > 0 {
+		panic(fmt.Sprintf("unexpected data type: %T", data[0]))
+	}
+}
+func (d *EnterpriseACLResolverTestDelegate) UseDefaultData() {}

--- a/agent/consul/acl_oss_test.go
+++ b/agent/consul/acl_oss_test.go
@@ -26,3 +26,6 @@ type EnterpriseACLResolverTestDelegate struct{}
 func (d *EnterpriseACLResolverTestDelegate) RPC(string, interface{}, interface{}) (bool, error) {
 	return false, nil
 }
+
+func (d *EnterpriseACLResolverTestDelegate) UseTestLocalData(_ []interface{}) {}
+func (d *EnterpriseACLResolverTestDelegate) UseDefaultData()                  {}

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -2103,15 +2103,15 @@ func testACLResolver_variousTokens(t *testing.T, delegate *ACLResolverTestDelega
 			require.NotNil(t, authz)
 
 			// spot check some random perms
-			assert.Equal(t, acl.Deny, authz.ACLRead(nil))
-			assert.Equal(t, acl.Deny, authz.NodeWrite("foo", nil))
+			require.Equal(t, acl.Deny, authz.ACLRead(nil))
+			require.Equal(t, acl.Deny, authz.NodeWrite("foo", nil))
 			// ensure we didn't bleed over to the other synthetic policy
-			assert.Equal(t, acl.Deny, authz.NodeWrite("test-node2", nil))
+			require.Equal(t, acl.Deny, authz.NodeWrite("test-node2", nil))
 			// check our own synthetic policy
-			assert.Equal(t, acl.Allow, authz.ServiceRead("literally-anything", nil))
-			assert.Equal(t, acl.Allow, authz.NodeWrite("test-node1", nil))
+			require.Equal(t, acl.Allow, authz.ServiceRead("literally-anything", nil))
+			require.Equal(t, acl.Allow, authz.NodeWrite("test-node1", nil))
 			// ensure node identity for other DC is ignored
-			assert.Equal(t, acl.Deny, authz.NodeWrite("test-node-dc2", nil))
+			require.Equal(t, acl.Deny, authz.NodeWrite("test-node-dc2", nil))
 		})
 		t.Run("synthetic-policy-4", func(t *testing.T) { // node identity
 			authz, err := r.ResolveToken("found-synthetic-policy-4")

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -567,14 +567,13 @@ func (d *ACLResolverTestDelegate) defaultTokenReadFn(errAfterCached error) func(
 func (d *ACLResolverTestDelegate) plainTokenReadFn(args *structs.ACLTokenGetRequest, reply *structs.ACLTokenResponse) error {
 	if d.testTokens != nil {
 		token, ok := d.testTokens[args.TokenID]
-		if !ok {
-			return nil
-		}
-		if token != nil {
+		if ok {
+			if token == nil {
+				return acl.ErrNotFound
+			}
 			reply.Token = token
-			return nil
 		}
-		return acl.ErrNotFound
+		return nil
 	}
 
 	_, token, err := testIdentityForToken(args.TokenID)
@@ -602,15 +601,9 @@ func (d *ACLResolverTestDelegate) plainPolicyResolveFn(args *structs.ACLPolicyBa
 
 	for _, policyID := range args.PolicyIDs {
 		if d.testPolicies != nil {
-			policy, ok := d.testPolicies[policyID]
-			if !ok {
-				return nil
-			}
-			if policy != nil {
+			if policy := d.testPolicies[policyID]; policy != nil {
 				reply.Policies = append(reply.Policies, policy)
-				return nil
 			}
-			return acl.ErrNotFound
 		} else {
 			_, policy, _ := testPolicyForID(policyID)
 			if policy != nil {
@@ -642,15 +635,9 @@ func (d *ACLResolverTestDelegate) plainRoleResolveFn(args *structs.ACLRoleBatchG
 
 	for _, roleID := range args.RoleIDs {
 		if d.testRoles != nil {
-			role, ok := d.testRoles[roleID]
-			if !ok {
-				return nil
-			}
-			if role != nil {
+			if role := d.testRoles[roleID]; role != nil {
 				reply.Roles = append(reply.Roles, role)
-				return nil
 			}
-			return acl.ErrNotFound
 		} else {
 			_, role, _ := testRoleForID(roleID)
 			if role != nil {

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -216,10 +216,10 @@ func (s *ACLNodeIdentity) EstimateSize() int {
 	return len(s.NodeName) + len(s.Datacenter)
 }
 
-func (s *ACLNodeIdentity) SyntheticPolicy() *ACLPolicy {
+func (s *ACLNodeIdentity) SyntheticPolicy(entMeta *EnterpriseMeta) *ACLPolicy {
 	// Given that we validate this string name before persisting, we do not
 	// have to escape it before doing the following interpolation.
-	rules := fmt.Sprintf(aclPolicyTemplateNodeIdentity, s.NodeName)
+	rules := aclNodeIdentityRules(s.NodeName, entMeta)
 
 	hasher := fnv.New128a()
 	hashID := fmt.Sprintf("%x", hasher.Sum([]byte(rules)))
@@ -231,8 +231,7 @@ func (s *ACLNodeIdentity) SyntheticPolicy() *ACLPolicy {
 	policy.Rules = rules
 	policy.Syntax = acl.SyntaxCurrent
 	policy.Datacenters = []string{s.Datacenter}
-	// TODO(partitions,acls): this needs to be fed the correct partition
-	policy.EnterpriseMeta = *DefaultEnterpriseMetaInDefaultPartition()
+	policy.EnterpriseMeta.Merge(entMeta)
 	policy.SetHash(true)
 	return policy
 }

--- a/agent/structs/acl_oss.go
+++ b/agent/structs/acl_oss.go
@@ -62,6 +62,10 @@ func aclServiceIdentityRules(svc string, _ *EnterpriseMeta) string {
 	return fmt.Sprintf(aclPolicyTemplateServiceIdentity, svc)
 }
 
+func aclNodeIdentityRules(node string, _ *EnterpriseMeta) string {
+	return fmt.Sprintf(aclPolicyTemplateNodeIdentity, node)
+}
+
 func (p *ACLPolicy) EnterprisePolicyMeta() *acl.EnterprisePolicyMeta {
 	return nil
 }


### PR DESCRIPTION
Also refactoring the enterprise side of a test to make it easier to reason about.

The main change here is to change the Service Identity and Node Identity templates.