### PR TITLE
add StatusError to api package

### DIFF
--- a/api/operator_autopilot.go
+++ b/api/operator_autopilot.go
@@ -354,7 +354,7 @@ func (op *Operator) AutopilotServerHealth(q *QueryOptions) (*OperatorHealthReply
 
 	// we use 429 status to indicate unhealthiness
 	d, resp, err := op.c.doRequest(r)
-	_, resp, err = requireHttpCodes(d, resp, err, []int{200, 429})
+	_, resp, err = requireHttpCodes(d, resp, err, 200, 429)
 
 	if err != nil {
 		if resp != nil {

--- a/api/operator_autopilot.go
+++ b/api/operator_autopilot.go
@@ -352,20 +352,15 @@ func (op *Operator) AutopilotServerHealth(q *QueryOptions) (*OperatorHealthReply
 	r := op.c.newRequest("GET", "/v1/operator/autopilot/health")
 	r.setQueryOptions(q)
 
-	// we cannot just use requireOK because this endpoint might use a 429 status to indicate
-	// that unhealthiness
-	_, resp, err := op.c.doRequest(r)
+	// we use 429 status to indicate unhealthiness
+	d, resp, err := op.c.doRequest(r)
+	_, resp, err = requireHttpCodes(d, resp, err, []int{200, 429})
+
 	if err != nil {
 		if resp != nil {
 			closeResponseBody(resp)
 		}
 		return nil, err
-	}
-
-	// these are the only 2 status codes that would indicate that we should
-	// expect the body to contain the right format.
-	if resp.StatusCode != 200 && resp.StatusCode != 429 {
-		return nil, generateUnexpectedResponseCodeError(resp)
 	}
 
 	defer closeResponseBody(resp)

--- a/api/operator_autopilot_test.go
+++ b/api/operator_autopilot_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -181,4 +182,15 @@ func TestAPI_OperatorAutopilotServerHealth_429(t *testing.T) {
 	out, err := client.Operator().AutopilotServerHealth(nil)
 	require.NoError(t, err)
 	require.Equal(t, &reply, out)
+
+	mapi.withReply("GET", "/v1/operator/autopilot/health", nil, 500, nil).Once()
+	_, err = client.Operator().AutopilotServerHealth(nil)
+
+	var statusE StatusError
+	if errors.As(err, &statusE) {
+		require.Equal(t, 500, statusE.Code)
+	} else {
+		t.Error("Failed to unwrap error as StatusError")
+	}
+
 }


### PR DESCRIPTION
### Overview

This PR adds a `StatusError` struct to the `api` package. Now devs can unwrap the errors returned thru `query()` or `write()` funcs and inspect the error code programatically. 

### Issue Related
https://github.com/hashicorp/consul/issues/10865

### Notes:
* added a `requireHttpCodes` method to mark acceptable codes (200, 429, etc)
  * adoption of that func to all/ most `doRequest()` calls can be added in a subsequent PR
* this PR mostly builds on feedback from https://github.com/hashicorp/consul/pull/8816

### PR Checklist
[x] `go fmt`
[x] `go mod`
[x] n/a pr/changelog -- no "public" api changes
