### PR TITLE
acl: update GetPolicyByName method implementation

### DIFF
--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
 )
 
 func GetTokenIDFromPartial(client *api.Client, partialID string) (string, error) {
@@ -71,23 +72,26 @@ func GetPolicyIDFromPartial(client *api.Client, partialID string) (string, error
 	return policyID, nil
 }
 
-func GetPolicyIDByName(client *api.Client, name string) (string, error) {
+func GetPolicyByName(client *api.Client, name string) (*api.ACLPolicy, error) {
 	if name == "" {
-		return "", fmt.Errorf("No name specified")
+		return nil, fmt.Errorf("No name specified")
 	}
 
-	policies, _, err := client.ACL().PolicyList(nil)
+	policy, _, err := client.ACL().PolicyReadByName(name, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to find policy with name %s", name)
+	}
+
+	return policy, nil
+}
+
+func GetPolicyIDByName(client *api.Client, name string) (string, error) {
+	policy, err := GetPolicyByName(client, name)
 	if err != nil {
 		return "", err
 	}
 
-	for _, policy := range policies {
-		if policy.Name == name {
-			return policy.ID, nil
-		}
-	}
-
-	return "", fmt.Errorf("No such policy with name %s", name)
+	return policy.ID, nil
 }
 
 func GetRulesFromLegacyToken(client *api.Client, tokenID string, isSecret bool) (string, error) {

--- a/command/acl/policy/read/policy_read.go
+++ b/command/acl/policy/read/policy_read.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/acl"
 	"github.com/hashicorp/consul/command/acl/policy"
 	"github.com/hashicorp/consul/command/flags"
@@ -66,20 +67,26 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	var policyID string
+	var pol *api.ACLPolicy
 	if c.policyID != "" {
-		policyID, err = acl.GetPolicyIDFromPartial(client, c.policyID)
+		c.policyID, err = acl.GetPolicyIDFromPartial(client, c.policyID)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error determining policy ID: %v", err))
+			return 1
+		}
+		pol, _, err = client.ACL().PolicyRead(c.policyID, nil)
 	} else {
-		policyID, err = acl.GetPolicyIDByName(client, c.policyName)
-	}
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error determining policy ID: %v", err))
-		return 1
+		pol, err = acl.GetPolicyByName(client, c.policyName)
 	}
 
-	p, _, err := client.ACL().PolicyRead(policyID, nil)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error reading policy %q: %v", policyID, err))
+		var errArg string
+		if c.policyID != "" {
+			errArg = fmt.Sprintf("id:%s", c.policyID)
+		} else {
+			errArg = fmt.Sprintf("name:%s", c.policyName)
+		}
+		c.UI.Error(fmt.Sprintf("Error reading policy %q: %v", errArg, err))
 		return 1
 	}
 
@@ -88,7 +95,7 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error(err.Error())
 		return 1
 	}
-	out, err := formatter.FormatPolicy(p)
+	out, err := formatter.FormatPolicy(pol)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/command/acl/policy/read/policy_read_test.go
+++ b/command/acl/policy/read/policy_read_test.go
@@ -53,6 +53,7 @@ func TestPolicyReadCommand(t *testing.T) {
 	)
 	assert.NoError(err)
 
+	// Test id field
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
 		"-token=root",
@@ -64,6 +65,22 @@ func TestPolicyReadCommand(t *testing.T) {
 	assert.Empty(ui.ErrorWriter.String())
 
 	output := ui.OutputWriter.String()
+	assert.Contains(output, fmt.Sprintf("test-policy"))
+	assert.Contains(output, policy.ID)
+
+	// Test name field
+	argsName := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-token=root",
+		"-name=test-policy",
+	}
+
+	cmd = New(ui)
+	code = cmd.Run(argsName)
+	assert.Equal(code, 0)
+	assert.Empty(ui.ErrorWriter.String())
+
+	output = ui.OutputWriter.String()
 	assert.Contains(output, fmt.Sprintf("test-policy"))
 	assert.Contains(output, policy.ID)
 }


### PR DESCRIPTION
This PR updates the existing `GetPolicyIDByName` method implementation. As discussed in https://github.com/hashicorp/consul/issues/5649#issuecomment-482115991, new `GetPolicyByName` uses `/acl/policy/name/:name` endpoint.

Closes #5649 

Thanks.

