### PR TITLE
ui: Adds Flight icons to our icon set

### DIFF
--- a/ui/packages/consul-ui/app/styles/base/icons/base-variables.scss
+++ b/ui/packages/consul-ui/app/styles/base/icons/base-variables.scss
@@ -1,3 +1,27 @@
+%activity-16-svg-prop {
+  --activity-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M6.016 1a.75.75 0 01.698.521l3.306 10.33 1.47-4.341A.75.75 0 0112.2 7H15a.75.75 0 010 1.5h-2.262l-2.028 5.99a.75.75 0 01-1.424-.011L5.952 4.06 4.504 8.008A.75.75 0 013.8 8.5H1A.75.75 0 111 7h2.276l2.02-5.508c.11-.301.4-.499.72-.492z" clip-rule="evenodd"/></svg>');
+}
+
+%activity-24-svg-prop {
+  --activity-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M9.003 2a.75.75 0 01.71.519l5.278 16.27 2.294-7.265A.75.75 0 0118 11h4a.75.75 0 010 1.5h-3.45l-2.835 8.976a.75.75 0 01-1.428.005L8.99 5.151l-2.278 6.836A.75.75 0 016 12.5H2A.75.75 0 012 11h3.46l2.828-8.487A.75.75 0 019.003 2z" clip-rule="evenodd"/></svg>');
+}
+
+%alert-circle-16-svg-prop {
+  --alert-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 4a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 018 4zM8 10a1 1 0 100 2h.007a1 1 0 100-2H8z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%alert-circle-24-svg-prop {
+  --alert-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 7a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0112 7zM12 15a1 1 0 100 2h.01a1 1 0 100-2H12z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
+}
+
+%alert-circle-fill-16-svg-prop {
+  --alert-circle-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-4a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 018 4zm0 6a1 1 0 100 2h.007a1 1 0 100-2H8z" clip-rule="evenodd"/></svg>');
+}
+
+%alert-circle-fill-24-svg-prop {
+  --alert-circle-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zm-.75 6.75a.75.75 0 011.5 0v4.5a.75.75 0 01-1.5 0v-4.5zM11 16a1 1 0 011-1h.01a1 1 0 110 2H12a1 1 0 01-1-1z" clip-rule="evenodd"/></svg>');
+}
+
 %alert-circle-fill-svg-prop {
   --alert-circle-fill-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" fill="%23000"/></svg>');
 }
@@ -6,28 +30,468 @@
   --alert-circle-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11 15h2v2h-2v-2zm0-8h2v6h-2V7zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" fill="%23000"/></svg>');
 }
 
+%alert-octagon-16-svg-prop {
+  --alert-octagon-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7 11a1 1 0 011-1h.007a1 1 0 110 2H8a1 1 0 01-1-1zM8.75 4.75a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"/><path fill-rule="evenodd" d="M3.882.805A2.75 2.75 0 015.827 0h4.346c.73 0 1.429.29 1.945.805l3.076 3.077A2.75 2.75 0 0116 5.827v4.346c0 .73-.29 1.429-.806 1.945l-3.076 3.076a2.75 2.75 0 01-1.945.806H5.827a2.75 2.75 0 01-1.945-.806L.805 12.118A2.75 2.75 0 010 10.173V5.827c0-.73.29-1.429.805-1.945L3.882.805zm1.945.695c-.332 0-.65.132-.884.366L1.866 4.943a1.25 1.25 0 00-.366.884v4.346c0 .332.132.65.366.884l3.077 3.077c.234.234.552.366.884.366h4.346c.332 0 .65-.132.884-.366l3.077-3.077a1.25 1.25 0 00.366-.884V5.827c0-.332-.132-.65-.366-.884l-3.077-3.077a1.25 1.25 0 00-.884-.366H5.827z" clip-rule="evenodd"/></g></svg>');
+}
+
+%alert-octagon-24-svg-prop {
+  --alert-octagon-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11 16a1 1 0 011-1h.01a1 1 0 110 2H12a1 1 0 01-1-1zM12.75 7.75a.75.75 0 00-1.5 0v4.5a.75.75 0 001.5 0v-4.5z"/><path fill-rule="evenodd" d="M6.64 1.805A2.75 2.75 0 018.585 1h6.83c.73 0 1.429.29 1.945.805l4.835 4.835A2.75 2.75 0 0123 8.585v6.83c0 .73-.29 1.429-.805 1.945l-4.835 4.835a2.75 2.75 0 01-1.945.805h-6.83a2.75 2.75 0 01-1.945-.805L1.805 17.36A2.75 2.75 0 011 15.415v-6.83c0-.73.29-1.429.805-1.945L6.64 1.805zm1.945.695c-.332 0-.65.132-.884.366L2.866 7.701a1.25 1.25 0 00-.366.884v6.83c0 .332.132.65.366.884l4.835 4.835c.234.234.552.366.884.366h6.83c.332 0 .65-.132.884-.366l4.835-4.835a1.25 1.25 0 00.366-.884v-6.83c0-.332-.132-.65-.366-.884l-4.835-4.835a1.25 1.25 0 00-.884-.366h-6.83z" clip-rule="evenodd"/></g></svg>');
+}
+
+%alert-octagon-fill-16-svg-prop {
+  --alert-octagon-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.882.805A2.75 2.75 0 015.827 0h4.346c.73 0 1.429.29 1.945.805l3.076 3.077A2.75 2.75 0 0116 5.827v4.346c0 .73-.29 1.429-.806 1.945l-3.076 3.076a2.75 2.75 0 01-1.945.806H5.827a2.75 2.75 0 01-1.945-.806L.805 12.118A2.75 2.75 0 010 10.173V5.827c0-.73.29-1.429.805-1.945L3.882.805zM7 11a1 1 0 011-1h.007a1 1 0 110 2H8a1 1 0 01-1-1zm1.75-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z" clip-rule="evenodd"/></svg>');
+}
+
+%alert-octagon-fill-24-svg-prop {
+  --alert-octagon-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M8.585 1c-.73 0-1.429.29-1.945.805L1.805 6.64A2.75 2.75 0 001 8.585v6.83c0 .73.29 1.429.805 1.945l4.835 4.835A2.75 2.75 0 008.585 23h6.83c.73 0 1.429-.29 1.945-.805l4.835-4.835A2.75 2.75 0 0023 15.415v-6.83c0-.73-.29-1.429-.805-1.945L17.36 1.805A2.75 2.75 0 0015.415 1h-6.83zm2.665 6.75a.75.75 0 011.5 0v4.5a.75.75 0 01-1.5 0v-4.5zM11 16a1 1 0 011-1h.01a1 1 0 110 2H12a1 1 0 01-1-1z" clip-rule="evenodd"/></svg>');
+}
+
+%alert-triangle-16-svg-prop {
+  --alert-triangle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7 11a1 1 0 011-1h.007a1 1 0 110 2H8a1 1 0 01-1-1zM8.75 5.75a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"/><path fill-rule="evenodd" d="M6.953 1.273a2.143 2.143 0 012.874.751l.002.004 5.884 9.774a2.126 2.126 0 01-.768 2.905c-.322.188-.687.289-1.06.293H2.115a2.143 2.143 0 01-1.833-1.074 2.125 2.125 0 01.006-2.124l.006-.01 5.878-9.764.002-.004c.191-.313.46-.571.78-.75zm.502 1.53l-.001.002-5.872 9.754a.626.626 0 00.231.853.644.644 0 00.314.088h11.746a.643.643 0 00.544-.32.626.626 0 000-.62l-5.87-9.755-.002-.001A.635.635 0 008 2.5a.643.643 0 00-.545.304z" clip-rule="evenodd"/></g></svg>');
+}
+
+%alert-triangle-24-svg-prop {
+  --alert-triangle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11 17a1 1 0 011-1h.01a1 1 0 110 2H12a1 1 0 01-1-1zM12.75 8.75a.75.75 0 00-1.5 0v4.5a.75.75 0 001.5 0v-4.5z"/><path fill-rule="evenodd" d="M10.658 2.366a2.651 2.651 0 012.684 0c.407.239.745.581.984.99l.002.004 8.315 14.46a2.86 2.86 0 01.008 2.758 2.757 2.757 0 01-.976 1.03c-.41.25-.877.386-1.357.392H3.682a2.653 2.653 0 01-1.357-.393 2.757 2.757 0 01-.975-1.029 2.86 2.86 0 01.007-2.758l.006-.01 8.31-14.45.001-.004a2.75 2.75 0 01.984-.99zm.313 1.744v.001L2.665 18.552a1.36 1.36 0 000 1.306c.108.198.262.36.443.47.18.11.382.169.586.172h16.61c.204-.003.406-.061.586-.172.181-.11.335-.272.444-.47a1.361 1.361 0 00-.001-1.306L13.03 4.112l-.001-.002a1.25 1.25 0 00-.446-.45 1.151 1.151 0 00-1.166 0 1.25 1.25 0 00-.446.45z" clip-rule="evenodd"/></g></svg>');
+}
+
+%alert-triangle-fill-16-svg-prop {
+  --alert-triangle-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 1a2.143 2.143 0 00-1.827 1.024l-5.88 9.768a2.125 2.125 0 00.762 2.915c.322.188.687.289 1.06.293h11.77a2.143 2.143 0 001.834-1.074 2.126 2.126 0 00-.006-2.124L9.829 2.028A2.149 2.149 0 008 1zM7 11a1 1 0 011-1h.007a1 1 0 110 2H8a1 1 0 01-1-1zm1.75-5.25a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z" clip-rule="evenodd"/></svg>');
+}
+
+%alert-triangle-fill-24-svg-prop {
+  --alert-triangle-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 2c-.472 0-.934.127-1.342.366a2.75 2.75 0 00-.984.99L1.363 17.81l-.006.01a2.86 2.86 0 00-.007 2.758c.23.423.566.778.975 1.03.41.25.877.386 1.357.392h16.637c.479-.006.947-.142 1.356-.393.41-.25.744-.606.976-1.029a2.86 2.86 0 00-.008-2.758L14.328 3.36l-.002-.004a2.75 2.75 0 00-.984-.99A2.651 2.651 0 0012 2zm-.75 6.75a.75.75 0 011.5 0v4.5a.75.75 0 01-1.5 0v-4.5zM11 17a1 1 0 011-1h.01a1 1 0 110 2H12a1 1 0 01-1-1z" clip-rule="evenodd"/></svg>');
+}
+
 %alert-triangle-svg-prop {
   --alert-triangle-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.531 21c1.54 0 2.503-1.669 1.731-3.002L13.731 4.99c-.77-1.33-2.691-1.33-3.462 0L2.738 17.998C1.966 19.33 2.928 21 4.468 21h15.063zM13 18h-2v-2h2v2zm0-4h-2v-4h2v4z" fill="%23000"/></svg>');
+}
+
+%alibaba-16-svg-prop {
+  --alibaba-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M10.676 7.373H5.338v1.2h5.338v-1.2z"/><path d="M13.338 3H9.81l.852 1.213L13.244 5c.48.147.786.6.773 1.067v3.866c0 .48-.307.92-.772 1.067l-2.57.787L9.81 13h3.528C14.815 13 16 11.8 16 10.333V5.667C16.013 4.2 14.815 3 13.338 3zM2.662 3H6.19l-.852 1.213L2.768 5c-.478.147-.785.6-.771 1.067v3.866c0 .48.306.92.772 1.067l2.569.787L6.19 13H2.662A2.672 2.672 0 010 10.333V5.667A2.672 2.672 0 012.662 3z"/></g></svg>');
+}
+
+%alibaba-24-svg-prop {
+  --alibaba-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M15.21 11.248H8.806v1.44h6.406v-1.44z"/><path d="M18.405 6h-4.233l1.023 1.456 3.098.944c.576.176.943.72.927 1.28v4.64a1.34 1.34 0 01-.927 1.28l-3.082.944L14.172 18h4.233a3.196 3.196 0 003.195-3.2V9.2c.016-1.76-1.422-3.2-3.195-3.2zM5.595 6h4.233L8.805 7.456 5.722 8.4c-.575.176-.942.72-.926 1.28v4.64c0 .576.367 1.104.926 1.28l3.083.944L9.828 18H5.595A3.207 3.207 0 012.4 14.8V9.2C2.4 7.44 3.838 6 5.595 6z"/></g></svg>');
+}
+
+%alibaba-color-16-svg-prop {
+  --alibaba-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23ED6B1E"><path d="M10.676 7.373H5.338v1.2h5.338v-1.2z"/><path d="M13.338 3H9.81l.852 1.213L13.244 5c.48.147.786.6.773 1.067v3.866c0 .48-.307.92-.772 1.067l-2.57.787L9.81 13h3.528C14.815 13 16 11.8 16 10.333V5.667C16.013 4.2 14.815 3 13.338 3zM2.662 3H6.19l-.852 1.213L2.768 5c-.478.147-.785.6-.771 1.067v3.866c0 .48.306.92.772 1.067l2.569.787L6.19 13H2.662A2.672 2.672 0 010 10.333V5.667A2.672 2.672 0 012.662 3z"/></g></svg>');
+}
+
+%alibaba-color-24-svg-prop {
+  --alibaba-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23ED6B1E"><path d="M15.21 11.248H8.806v1.44h6.406v-1.44z"/><path d="M18.405 6h-4.233l1.023 1.456 3.098.944c.576.176.943.72.927 1.28v4.64a1.34 1.34 0 01-.927 1.28l-3.082.944L14.172 18h4.233a3.196 3.196 0 003.195-3.2V9.2c.016-1.76-1.422-3.2-3.195-3.2zM5.595 6h4.233L8.805 7.456 5.722 8.4c-.575.176-.942.72-.926 1.28v4.64c0 .576.367 1.104.926 1.28l3.083.944L9.828 18H5.595A3.207 3.207 0 012.4 14.8V9.2C2.4 7.44 3.838 6 5.595 6z"/></g></svg>');
+}
+
+%align-center-16-svg-prop {
+  --align-center-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.75 3a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75zM3.75 6a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5zM1 9.75A.75.75 0 011.75 9h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 9.75zM3.75 12a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5z"/></g></svg>');
+}
+
+%align-center-24-svg-prop {
+  --align-center-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M2.75 5a.75.75 0 000 1.5h18.5a.75.75 0 000-1.5H2.75zM5.75 9a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H5.75zM2 13.75a.75.75 0 01.75-.75h18.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75zM5.75 17a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H5.75z"/></g></svg>');
+}
+
+%align-justify-16-svg-prop {
+  --align-justify-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.75 3a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75zM1.75 6a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75zM1 9.75A.75.75 0 011.75 9h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 9.75zM1.75 12a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75z"/></g></svg>');
+}
+
+%align-justify-24-svg-prop {
+  --align-justify-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M2.75 5a.75.75 0 000 1.5h18.5a.75.75 0 000-1.5H2.75zM2.75 9a.75.75 0 000 1.5h18.5a.75.75 0 000-1.5H2.75zM2 13.75a.75.75 0 01.75-.75h18.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75zM2.75 17a.75.75 0 000 1.5h18.5a.75.75 0 000-1.5H2.75z"/></g></svg>');
+}
+
+%align-left-16-svg-prop {
+  --align-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.75 3a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75zM1.75 6a.75.75 0 000 1.5h9.5a.75.75 0 000-1.5h-9.5zM1 9.75A.75.75 0 011.75 9h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 9.75zM1.75 12a.75.75 0 000 1.5h9.5a.75.75 0 000-1.5h-9.5z"/></g></svg>');
+}
+
+%align-left-24-svg-prop {
+  --align-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M2.75 5a.75.75 0 000 1.5h18.5a.75.75 0 000-1.5H2.75zM2.75 9a.75.75 0 000 1.5h14.5a.75.75 0 000-1.5H2.75zM2 13.75a.75.75 0 01.75-.75h18.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75zM2.75 17a.75.75 0 000 1.5h14.5a.75.75 0 000-1.5H2.75z"/></g></svg>');
+}
+
+%align-right-16-svg-prop {
+  --align-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.75 3a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75zM4.75 6a.75.75 0 000 1.5h9.5a.75.75 0 000-1.5h-9.5zM1 9.75A.75.75 0 011.75 9h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 9.75zM4.75 12a.75.75 0 000 1.5h9.5a.75.75 0 000-1.5h-9.5z"/></g></svg>');
+}
+
+%align-right-24-svg-prop {
+  --align-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M2.75 5a.75.75 0 000 1.5h18.5a.75.75 0 000-1.5H2.75zM6.75 9a.75.75 0 000 1.5h14.5a.75.75 0 000-1.5H6.75zM2 13.75a.75.75 0 01.75-.75h18.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75zM6.75 17a.75.75 0 000 1.5h14.5a.75.75 0 000-1.5H6.75z"/></g></svg>');
+}
+
+%apple-16-svg-prop {
+  --apple-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M10.167 3.242c.435-.523.742-1.24.742-1.958 0-.105-.008-.202-.03-.284-.704.03-1.55.47-2.06 1.069-.397.448-.771 1.173-.771 1.891 0 .112.022.217.03.254.044.008.12.015.187.015.636 0 1.43-.419 1.902-.987zm.495 1.144c-1.056 0-1.918.643-2.465.643-.591 0-1.355-.606-2.284-.606C4.168 4.423 2.4 5.866 2.4 8.58c0 1.697.652 3.491 1.46 4.642C4.558 14.193 5.165 15 6.04 15c.87 0 1.251-.575 2.33-.575 1.093 0 1.333.56 2.292.56.95 0 1.588-.867 2.18-1.727.673-.986.95-1.943.958-1.988-.052-.015-1.873-.755-1.873-2.833 0-1.794 1.431-2.6 1.514-2.66-.944-1.354-2.382-1.391-2.78-1.391z"/></svg>');
+}
+
+%apple-24-svg-prop {
+  --apple-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M15.073 5.203c.62-.747 1.057-1.772 1.057-2.797 0-.15-.01-.289-.042-.406-1.004.043-2.21.673-2.937 1.527-.566.64-1.1 1.676-1.1 2.702 0 .16.032.31.043.363.064.01.17.02.267.02.908 0 2.04-.597 2.712-1.409zm.705 1.634c-1.506 0-2.734.918-3.513.918-.844 0-1.933-.864-3.257-.864C6.52 6.89 4 8.95 4 12.828c0 2.424.929 4.986 2.082 6.63C7.075 20.848 7.94 22 9.19 22c1.238 0 1.783-.822 3.32-.822 1.56 0 1.901.8 3.268.8 1.356 0 2.264-1.238 3.107-2.466.961-1.41 1.356-2.776 1.367-2.84-.075-.022-2.67-1.079-2.67-4.047 0-2.563 2.04-3.716 2.157-3.802-1.345-1.932-3.395-1.986-3.961-1.986z"/></svg>');
+}
+
+%apple-color-16-svg-prop {
+  --apple-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M10.167 3.242c.435-.523.742-1.24.742-1.958 0-.105-.008-.202-.03-.284-.704.03-1.55.47-2.06 1.069-.397.448-.771 1.173-.771 1.891 0 .112.022.217.03.254.044.008.12.015.187.015.636 0 1.43-.419 1.902-.987zm.495 1.144c-1.056 0-1.918.643-2.465.643-.591 0-1.355-.606-2.284-.606C4.168 4.423 2.4 5.866 2.4 8.58c0 1.697.652 3.49 1.46 4.642C4.558 14.193 5.165 15 6.04 15c.87 0 1.251-.575 2.33-.575 1.093 0 1.333.56 2.292.56.95 0 1.588-.867 2.18-1.727.673-.986.95-1.943.958-1.988-.052-.015-1.873-.755-1.873-2.833 0-1.794 1.431-2.6 1.514-2.66-.944-1.354-2.382-1.391-2.78-1.391z"/></svg>');
+}
+
+%apple-color-24-svg-prop {
+  --apple-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M15.073 5.203c.62-.747 1.057-1.772 1.057-2.797 0-.15-.01-.289-.042-.406-1.004.043-2.21.673-2.937 1.527-.566.64-1.1 1.676-1.1 2.702 0 .16.032.31.043.363.064.01.17.02.267.02.908 0 2.04-.597 2.712-1.409zm.705 1.634c-1.506 0-2.734.918-3.513.918-.844 0-1.933-.864-3.257-.864C6.52 6.89 4 8.95 4 12.828c0 2.424.929 4.986 2.082 6.63C7.075 20.848 7.94 22 9.19 22c1.238 0 1.783-.822 3.32-.822 1.56 0 1.901.8 3.268.8 1.356 0 2.264-1.238 3.107-2.466.961-1.41 1.356-2.776 1.367-2.84-.075-.022-2.67-1.079-2.67-4.047 0-2.563 2.04-3.716 2.157-3.802-1.345-1.932-3.395-1.986-3.961-1.986z"/></svg>');
+}
+
+%archive-16-svg-prop {
+  --archive-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.75 8a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z"/><path fill-rule="evenodd" d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v1.5c0 .698-.409 1.3-1 1.582v6.918A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75V5.832A1.75 1.75 0 010 4.25v-1.5zm13.5 10V6h-11v6.75c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75zm1-8.5a.25.25 0 01-.25.25H1.75a.25.25 0 01-.25-.25v-1.5a.25.25 0 01.25-.25h12.5a.25.25 0 01.25.25v1.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%archive-24-svg-prop {
+  --archive-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9.75 11a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5z"/><path fill-rule="evenodd" d="M1 4.25A2.25 2.25 0 013.25 2h17.5A2.25 2.25 0 0123 4.25v1.5c0 .78-.397 1.467-1 1.871V19.25A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25V7.621A2.248 2.248 0 011 5.75v-1.5zM3.5 8h17v11.25c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25V8zm-.25-4.5a.75.75 0 00-.75.75v1.5c0 .414.336.75.75.75h17.5a.75.75 0 00.75-.75v-1.5a.75.75 0 00-.75-.75H3.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%arrow-down-16-svg-prop {
+  --arrow-down-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M8.5 2.75a.75.75 0 00-1.5 0v8.614L4.045 8.235a.75.75 0 00-1.09 1.03l4.248 4.498a.862.862 0 00.025.026.747.747 0 00.51.21L7.75 14h.012a.747.747 0 00.533-.235l4.25-4.5a.75.75 0 00-1.09-1.03L8.5 11.364V2.75z"/></svg>');
+}
+
+%arrow-down-24-svg-prop {
+  --arrow-down-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M12.5 3.75a.75.75 0 00-1.5 0v14.645l-5.96-6.166a.75.75 0 00-1.08 1.042l7.25 7.5a.75.75 0 001.08 0l7.25-7.5a.75.75 0 10-1.08-1.042l-5.96 6.166V3.75z"/></svg>');
+}
+
+%arrow-down-circle-16-svg-prop {
+  --arrow-down-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/><path d="M5.755 8.195a.75.75 0 00-1.01 1.11l2.75 2.5a.748.748 0 001.01 0l2.75-2.5a.75.75 0 10-1.01-1.11L8.75 9.555V4.75a.75.75 0 00-1.5 0v4.805l-1.495-1.36z"/></g></svg>');
+}
+
+%arrow-down-circle-24-svg-prop {
+  --arrow-down-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 6a.75.75 0 01.75.75v8.614l2.955-3.129a.75.75 0 011.09 1.03l-4.25 4.5a.541.541 0 01-.068.064.747.747 0 01-.465.17L12 18h-.012a.748.748 0 01-.535-.237l-4.248-4.498a.75.75 0 011.09-1.03l2.955 3.129V6.75A.75.75 0 0112 6z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
+}
+
+%arrow-down-left-16-svg-prop {
+  --arrow-down-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M12.78 4.28a.75.75 0 00-1.06-1.06L4.5 10.44V6.75a.75.75 0 00-1.5 0v5.5a.748.748 0 00.75.75h5.5a.75.75 0 000-1.5H5.56l7.22-7.22z"/></svg>');
+}
+
+%arrow-down-left-24-svg-prop {
+  --arrow-down-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M18.78 6.28a.75.75 0 00-1.06-1.06L6.5 16.44V8.75a.75.75 0 00-1.5 0v9.5a.748.748 0 00.218.529l.002.001.001.002A.748.748 0 005.75 19h9.5a.75.75 0 000-1.5H7.56L18.78 6.28z"/></svg>');
+}
+
+%arrow-down-right-16-svg-prop {
+  --arrow-down-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M3.22 4.28a.75.75 0 011.06-1.06l7.22 7.22V6.75a.75.75 0 011.5 0v5.5a.747.747 0 01-.75.75h-5.5a.75.75 0 010-1.5h3.69L3.22 4.28z"/></svg>');
+}
+
+%arrow-down-right-24-svg-prop {
+  --arrow-down-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M5.22 7.28a.75.75 0 011.06-1.06L17.5 17.44V9.75a.75.75 0 011.5 0v9.5a.747.747 0 01-.75.75h-9.5a.75.75 0 010-1.5h7.69L5.22 7.28z"/></svg>');
 }
 
 %arrow-down-svg-prop {
   --arrow-down-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11 3v14.17l-3.59-3.58L6 15l6 6 6-6-1.41-1.41L13 17.17V3h-2z" fill="%23000"/></svg>');
 }
 
+%arrow-left-16-svg-prop {
+  --arrow-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M7.765 4.045a.75.75 0 10-1.03-1.09L2.237 7.203a.748.748 0 00-.001 1.093l4.499 4.25a.75.75 0 001.03-1.091L4.636 8.5h8.614a.75.75 0 000-1.5H4.636l3.129-2.955z"/></svg>');
+}
+
+%arrow-left-24-svg-prop {
+  --arrow-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M11.771 5.04a.75.75 0 00-1.042-1.08l-7.5 7.25a.75.75 0 000 1.08l7.5 7.25a.75.75 0 101.042-1.08L5.605 12.5H20.25a.75.75 0 000-1.5H5.605l6.166-5.96z"/></svg>');
+}
+
+%arrow-left-circle-16-svg-prop {
+  --arrow-left-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.755 4.695a.75.75 0 01.05 1.06L6.445 7.25h4.805a.75.75 0 010 1.5H6.445l1.36 1.495a.75.75 0 01-1.11 1.01l-2.499-2.75A.747.747 0 014 8.003v-.004c0-.195.075-.372.197-.505l2.498-2.748a.75.75 0 011.06-.05z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%arrow-left-circle-24-svg-prop {
+  --arrow-left-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.636 11.25l3.129-2.955a.75.75 0 00-1.03-1.09l-4.498 4.248a.748.748 0 00-.007 1.088M6.236 12.546l4.499 4.25a.75.75 0 001.03-1.091L8.636 12.75h8.614a.75.75 0 000-1.5H8.636"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
+}
+
 %arrow-left-svg-prop {
   --arrow-left-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M21 11H6.83l3.58-3.59L9 6l-6 6 6 6 1.41-1.41L6.83 13H21v-2z" fill="%23000"/></svg>');
+}
+
+%arrow-right-16-svg-prop {
+  --arrow-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M8.235 4.045a.75.75 0 111.03-1.09l4.5 4.25a.75.75 0 010 1.09l-4.5 4.25a.75.75 0 01-1.03-1.09L11.364 8.5H2.75a.75.75 0 010-1.5h8.614L8.235 4.045z"/></svg>');
+}
+
+%arrow-right-24-svg-prop {
+  --arrow-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M12.229 5.04a.75.75 0 011.042-1.08l7.5 7.25a.75.75 0 010 1.08l-7.5 7.25a.75.75 0 11-1.042-1.08l6.166-5.96H3.75a.75.75 0 010-1.5h14.645l-6.166-5.96z"/></svg>');
+}
+
+%arrow-right-circle-16-svg-prop {
+  --arrow-right-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.245 4.695a.75.75 0 00-.05 1.06l1.36 1.495H4.75a.75.75 0 000 1.5h4.805l-1.36 1.495a.75.75 0 001.11 1.01l2.5-2.75a.75.75 0 000-1.01l-2.5-2.75a.75.75 0 00-1.06-.05z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%arrow-right-circle-24-svg-prop {
+  --arrow-right-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M6 12a.75.75 0 01.75-.75h8.614l-3.129-2.955a.75.75 0 011.03-1.09l4.5 4.25a.75.75 0 010 1.09l-4.5 4.25a.75.75 0 01-1.03-1.09l3.129-2.955H6.75A.75.75 0 016 12z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
 }
 
 %arrow-right-svg-prop {
   --arrow-right-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 13h14.17l-3.58 3.59L15 18l6-6-6-6-1.41 1.41L17.17 11H3v2z" fill="%23000"/></svg>');
 }
 
+%arrow-up-16-svg-prop {
+  --arrow-up-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M4.045 7.765a.75.75 0 11-1.09-1.03l4.25-4.5a.75.75 0 011.09 0l4.25 4.5a.75.75 0 01-1.09 1.03L8.5 4.636v8.614a.75.75 0 01-1.5 0V4.636L4.045 7.765z"/></svg>');
+}
+
+%arrow-up-24-svg-prop {
+  --arrow-up-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M5.04 10.771A.75.75 0 013.96 9.73l7.25-7.5a.75.75 0 011.08 0l7.25 7.5a.75.75 0 11-1.08 1.042L12.5 4.605V20.25a.75.75 0 01-1.5 0V4.605l-5.96 6.166z"/></svg>');
+}
+
+%arrow-up-circle-16-svg-prop {
+  --arrow-up-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M4.695 7.755a.75.75 0 001.06.05l1.495-1.36v4.805a.75.75 0 001.5 0V6.445l1.495 1.36a.75.75 0 001.01-1.11l-2.75-2.5a.75.75 0 00-1.01 0l-2.75 2.5a.75.75 0 00-.05 1.06z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%arrow-up-circle-24-svg-prop {
+  --arrow-up-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.75 8.636l2.955 3.129a.75.75 0 001.09-1.03l-4.25-4.5a.75.75 0 00-1.09 0l-4.25 4.5a.75.75 0 001.09 1.03l2.955-3.129v8.614a.75.75 0 001.5 0V8.636z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
+}
+
+%arrow-up-left-16-svg-prop {
+  --arrow-up-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M3.057 3.463A.748.748 0 013.75 3h5.5a.75.75 0 010 1.5H5.56l7.22 7.22a.75.75 0 11-1.06 1.06L4.5 5.56v3.69a.75.75 0 01-1.5 0v-5.5c0-.102.02-.199.057-.287z"/></svg>');
+}
+
+%arrow-up-left-24-svg-prop {
+  --arrow-up-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M6.5 15.25a.75.75 0 01-1.5 0v-9.5c0-.206.083-.393.218-.529l.002-.001.001-.002A.748.748 0 015.75 5h9.5a.75.75 0 010 1.5H7.56l11.22 11.22a.75.75 0 11-1.06 1.06L6.5 7.56v7.69z"/></svg>');
+}
+
+%arrow-up-right-16-svg-prop {
+  --arrow-up-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M12.943 3.463A.748.748 0 0012.25 3h-5.5a.75.75 0 000 1.5h3.69l-7.22 7.22a.75.75 0 101.06 1.06l7.22-7.22v3.69a.75.75 0 001.5 0v-5.5a.747.747 0 00-.057-.287z"/></svg>');
+}
+
+%arrow-up-right-24-svg-prop {
+  --arrow-up-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M18.943 5.463a.748.748 0 00-.161-.242l-.002-.001-.001-.002A.748.748 0 0018.25 5h-9.5a.75.75 0 000 1.5h7.69L5.22 17.72a.75.75 0 101.06 1.06L17.5 7.56v7.69a.75.75 0 001.5 0v-9.5a.747.747 0 00-.057-.287z"/></svg>');
+}
+
 %arrow-up-svg-prop {
   --arrow-up-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13 21V6.83l3.59 3.58L18 9l-6-6-6 6 1.41 1.41L11 6.83V21h2z" fill="%23000"/></svg>');
 }
 
+%at-sign-16-svg-prop {
+  --at-sign-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.818.21a8 8 0 103.046 14.141.75.75 0 10-.912-1.19A6.5 6.5 0 1114.5 8v1c0 .908-.54 1.5-1.25 1.5-.4 0-.691-.157-.894-.399C12.142 9.847 12 9.463 12 9V4.75a.75.75 0 00-1.5 0v.127a4 4 0 10.449 5.825c.076.128.162.25.258.364.484.577 1.194.934 2.043.934C15.04 12 16 10.461 16 9V8A8 8 0 009.818.21zM10.5 8a2.5 2.5 0 10-5 0 2.5 2.5 0 005 0z" clip-rule="evenodd"/></svg>');
+}
+
+%at-sign-24-svg-prop {
+  --at-sign-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M14.5 1.288a11 11 0 104.188 19.445.75.75 0 10-.912-1.19 9.5 9.5 0 113.724-7.544v1.025c0 1.258-.995 2.476-2.325 2.476-1.288 0-2.175-1.142-2.175-2.476V7.75a.75.75 0 00-1.5 0v.68a5 5 0 10.488 6.587c.58 1.12 1.666 1.983 3.187 1.983C21.495 17 23 14.94 23 13.024V12a11 11 0 00-8.5-10.711zM15.5 12a3.5 3.5 0 10-7 0 3.5 3.5 0 007 0z" clip-rule="evenodd"/></svg>');
+}
+
+%auth0-16-svg-prop {
+  --auth0-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M12.549 1h-4.55l1.407 4.38h4.548l-3.68 2.61 1.406 4.405c2.37-1.725 3.143-4.336 2.274-7.016L12.55 1zM2.045 5.38h4.55L8 1H3.45L2.045 5.38c-.868 2.68-.094 5.29 2.275 7.015L5.725 7.99l-3.68-2.612zm2.275 7.015L8 15l3.68-2.605L8 9.745l-3.68 2.65z"/></svg>');
+}
+
+%auth0-24-svg-prop {
+  --auth0-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M17.848 3H12l1.807 5.63h5.849l-4.732 3.358 1.808 5.663c3.046-2.218 4.041-5.575 2.924-9.02L17.848 3zM4.344 8.63h5.849L12 3H6.152L4.344 8.63c-1.117 3.446-.122 6.802 2.924 9.02l1.808-5.662-4.732-3.357zm2.924 9.02L12 21l4.732-3.35L12 14.244 7.268 17.65z"/></svg>');
+}
+
+%auth0-color-16-svg-prop {
+  --auth0-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M12.549 1h-4.55l1.407 4.38h4.548l-3.68 2.61 1.406 4.405c2.37-1.725 3.143-4.336 2.274-7.016L12.55 1zM2.045 5.38h4.55L8 1H3.45L2.045 5.38c-.868 2.68-.094 5.29 2.275 7.015L5.725 7.99l-3.68-2.612zm2.275 7.015L8 15l3.68-2.605L8 9.745l-3.68 2.65z"/></svg>');
+}
+
+%auth0-color-24-svg-prop {
+  --auth0-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M17.848 3H12l1.807 5.63h5.849l-4.732 3.358 1.808 5.663c3.046-2.218 4.041-5.575 2.924-9.02L17.848 3zM4.344 8.63h5.849L12 3H6.152L4.344 8.63c-1.117 3.446-.122 6.802 2.924 9.02l1.808-5.662-4.732-3.357zm2.924 9.02L12 21l4.732-3.35L12 14.244 7.268 17.65z"/></svg>');
+}
+
+%auto-apply-16-svg-prop {
+  --auto-apply-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M7.734 4.192C6.572 3.402 5 4.234 5 5.64v4.722c0 1.405 1.572 2.237 2.734 1.447l3.472-2.36a1.75 1.75 0 000-2.895l-3.472-2.36zM6.5 5.64c0-.2.225-.32.39-.206l3.472 2.36a.25.25 0 010 .414l-3.471 2.36a.25.25 0 01-.391-.206V5.639z"/><path d="M7.25 0A1.75 1.75 0 005.5 1.728a6.715 6.715 0 00-.167.07 1.75 1.75 0 00-2.46.015l-1.06 1.06a1.75 1.75 0 00-.015 2.46 6.712 6.712 0 00-.07.167A1.75 1.75 0 000 7.25v1.5c0 .96.772 1.738 1.728 1.75l.07.167a1.75 1.75 0 00.015 2.46l1.06 1.06a1.75 1.75 0 002.46.015l.167.07A1.75 1.75 0 007.25 16h1.5a1.75 1.75 0 001.75-1.728l.167-.07a1.75 1.75 0 002.46-.015l1.06-1.06a1.75 1.75 0 00.015-2.46l.07-.167A1.75 1.75 0 0016 8.75v-1.5a1.75 1.75 0 00-1.728-1.75 6.185 6.185 0 00-.07-.167 1.75 1.75 0 00-.015-2.46l-1.06-1.06a1.75 1.75 0 00-2.46-.015 6.794 6.794 0 00-.167-.07A1.75 1.75 0 008.75 0h-1.5zM7 1.75a.25.25 0 01.25-.25h1.5a.25.25 0 01.25.25v.51c0 .33.216.62.532.717.326.1.64.23.936.388a.75.75 0 00.884-.131l.36-.36a.25.25 0 01.354 0l1.06 1.06a.25.25 0 010 .354l-.36.36a.75.75 0 00-.131.884c.158.296.289.61.388.936a.75.75 0 00.718.532h.509a.25.25 0 01.25.25v1.5a.25.25 0 01-.25.25h-.51a.75.75 0 00-.717.532c-.1.326-.23.64-.388.936a.75.75 0 00.131.884l.36.36a.25.25 0 010 .354l-1.06 1.06a.25.25 0 01-.354 0l-.36-.36a.75.75 0 00-.884-.131c-.296.158-.61.289-.936.388a.75.75 0 00-.532.718v.509a.25.25 0 01-.25.25h-1.5a.25.25 0 01-.25-.25v-.51a.75.75 0 00-.532-.717c-.326-.1-.64-.23-.936-.388a.75.75 0 00-.884.131l-.36.36a.25.25 0 01-.354 0l-1.06-1.06a.25.25 0 010-.354l.36-.36a.75.75 0 00.131-.884 5.213 5.213 0 01-.388-.936A.75.75 0 002.259 9H1.75a.25.25 0 01-.25-.25v-1.5A.25.25 0 011.75 7h.51a.75.75 0 00.717-.532c.1-.326.23-.64.388-.936a.75.75 0 00-.131-.884l-.36-.36a.25.25 0 010-.354l1.06-1.06a.25.25 0 01.354 0l.36.36a.75.75 0 00.884.131c.296-.158.61-.289.936-.388A.75.75 0 007 2.259V1.75z"/></g></svg>');
+}
+
+%auto-apply-24-svg-prop {
+  --auto-apply-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M11.23 6.684c-1.162-.786-2.73.047-2.73 1.45v7.732c0 1.403 1.568 2.236 2.73 1.45l5.716-3.866a1.75 1.75 0 000-2.9L11.23 6.684zM10 8.134c0-.2.224-.32.39-.207l5.715 3.866a.25.25 0 010 .414l-5.715 3.866a.25.25 0 01-.39-.207V8.134z"/><path d="M11.305 0a2.25 2.25 0 00-2.25 2.25v.395a9.747 9.747 0 00-1.587.658l-.28-.28a2.25 2.25 0 00-3.182 0l-.983.983a2.25 2.25 0 000 3.182l.28.28a9.748 9.748 0 00-.658 1.587H2.25A2.25 2.25 0 000 11.305v1.39a2.25 2.25 0 002.25 2.25h.395c.174.552.395 1.082.658 1.587l-.28.28a2.25 2.25 0 000 3.182l.983.983a2.25 2.25 0 003.182 0l.28-.28a9.744 9.744 0 001.587.658v.395a2.25 2.25 0 002.25 2.25h1.39a2.25 2.25 0 002.25-2.25v-.395a9.743 9.743 0 001.587-.658l.28.28a2.25 2.25 0 003.182 0l.983-.983a2.25 2.25 0 000-3.182l-.28-.28a9.742 9.742 0 00.658-1.587h.395a2.25 2.25 0 002.25-2.25v-1.39a2.25 2.25 0 00-2.25-2.25h-.395a9.744 9.744 0 00-.658-1.587l.28-.28a2.25 2.25 0 000-3.182l-.983-.983a2.25 2.25 0 00-3.182 0l-.28.28a9.748 9.748 0 00-1.587-.658V2.25A2.25 2.25 0 0012.695 0h-1.39zm-.75 2.25a.75.75 0 01.75-.75h1.39a.75.75 0 01.75.75v.963a.75.75 0 00.569.728c.806.2 1.566.52 2.26.937a.75.75 0 00.917-.113l.681-.681a.75.75 0 011.061 0l.983.983a.75.75 0 010 1.06l-.681.682a.75.75 0 00-.113.917c.418.694.736 1.454.937 2.26a.75.75 0 00.728.569h.963a.75.75 0 01.75.75v1.39a.75.75 0 01-.75.75h-.963a.75.75 0 00-.728.569 8.25 8.25 0 01-.937 2.26.75.75 0 00.113.917l.681.681a.75.75 0 010 1.061l-.983.983a.75.75 0 01-1.06 0l-.682-.681a.75.75 0 00-.917-.113 8.253 8.253 0 01-2.26.937.75.75 0 00-.569.728v.963a.75.75 0 01-.75.75h-1.39a.75.75 0 01-.75-.75v-.963a.75.75 0 00-.569-.728 8.253 8.253 0 01-2.26-.937.75.75 0 00-.917.113l-.681.681a.75.75 0 01-1.061 0l-.983-.983a.75.75 0 010-1.06l.681-.682a.75.75 0 00.113-.917 8.251 8.251 0 01-.937-2.26.75.75 0 00-.728-.569H2.25a.75.75 0 01-.75-.75v-1.39a.75.75 0 01.75-.75h.963a.75.75 0 00.728-.569c.2-.806.52-1.566.937-2.26a.75.75 0 00-.113-.917l-.681-.681a.75.75 0 010-1.061l.983-.983a.75.75 0 011.06 0l.682.681a.75.75 0 00.917.113 8.251 8.251 0 012.26-.937.75.75 0 00.569-.728V2.25z"/></g></svg>');
+}
+
+%award-16-svg-prop {
+  --award-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a6 6 0 00-4.214 10.27.756.756 0 00-.027.113l-.75 4.75a.75.75 0 00.99.824L8 14.545l4 1.412a.75.75 0 00.99-.824l-.75-4.75a.764.764 0 00-.026-.112A6 6 0 008 0zM3.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zm7.363 5.274A5.974 5.974 0 018 12a5.973 5.973 0 01-2.863-.726l-.45 2.85 3.063-1.081a.75.75 0 01.5 0l3.063 1.08-.45-2.849z" clip-rule="evenodd"/></svg>');
+}
+
+%award-24-svg-prop {
+  --award-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1a8 8 0 00-4.751 14.437l-1.236 6.676a.75.75 0 001.004.838L12 21.053l4.983 1.898a.75.75 0 001.005-.838l-1.237-6.676A8 8 0 0012 1zM5.5 9a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zm9.877 7.254A7.97 7.97 0 0112 17a7.97 7.97 0 01-3.377-.746l-.892 4.82 4.002-1.525a.75.75 0 01.534 0l4.003 1.525-.893-4.82z" clip-rule="evenodd"/></svg>');
+}
+
+%aws-16-svg-prop {
+  --aws-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M4.51 7.687c0 .197.02.357.058.475.042.117.096.245.17.384a.233.233 0 01.037.123c0 .053-.032.107-.1.16l-.336.224a.255.255 0 01-.138.048c-.054 0-.107-.026-.16-.074a1.65 1.65 0 01-.192-.251 4.133 4.133 0 01-.165-.315c-.415.49-.936.737-1.564.737-.447 0-.804-.129-1.064-.385-.261-.256-.394-.598-.394-1.025 0-.454.16-.822.484-1.1.325-.278.756-.416 1.304-.416.18 0 .367.016.564.042.197.027.4.07.612.118v-.39c0-.406-.085-.689-.25-.854-.17-.166-.458-.246-.868-.246-.186 0-.377.022-.574.07a4.23 4.23 0 00-.575.181 1.525 1.525 0 01-.186.07.325.325 0 01-.085.016c-.075 0-.112-.054-.112-.166v-.262c0-.085.01-.15.037-.186a.399.399 0 01.15-.113c.185-.096.409-.176.67-.24.26-.07.537-.101.83-.101.633 0 1.096.144 1.394.432.293.288.442.726.442 1.314v1.73h.01zm-2.161.811c.175 0 .356-.032.548-.096.192-.064.362-.182.505-.342a.848.848 0 00.181-.341c.032-.129.054-.283.054-.465V7.03a4.432 4.432 0 00-.49-.091 3.998 3.998 0 00-.5-.032c-.357 0-.617.07-.793.214-.176.144-.26.347-.26.614 0 .25.063.437.196.566.128.133.314.197.559.197zm4.273.577c-.096 0-.16-.016-.202-.054-.043-.032-.08-.106-.112-.208l-1.25-4.127a.938.938 0 01-.048-.214c0-.085.042-.133.127-.133h.522c.1 0 .17.016.207.053.043.032.075.107.107.208l.894 3.535.83-3.535c.026-.106.058-.176.101-.208a.365.365 0 01.213-.053h.426c.1 0 .17.016.212.053.043.032.08.107.101.208l.841 3.578.92-3.578a.458.458 0 01.107-.208.346.346 0 01.208-.053h.495c.085 0 .133.043.133.133 0 .027-.006.054-.01.086a.757.757 0 01-.038.133l-1.283 4.127c-.031.107-.069.177-.111.209a.34.34 0 01-.203.053h-.457c-.101 0-.17-.016-.213-.053-.043-.038-.08-.107-.101-.214L8.213 5.37l-.82 3.439c-.026.107-.058.176-.1.213-.043.038-.118.054-.213.054h-.458zm6.838.144a3.51 3.51 0 01-.82-.096c-.266-.064-.473-.134-.612-.214-.085-.048-.143-.101-.165-.15a.378.378 0 01-.031-.149v-.272c0-.112.042-.166.122-.166a.3.3 0 01.096.016c.032.011.08.032.133.054.18.08.378.144.585.187.213.042.42.064.633.064.336 0 .596-.059.777-.176a.575.575 0 00.277-.508.521.521 0 00-.144-.373c-.095-.102-.276-.193-.537-.278l-.772-.24c-.388-.123-.676-.305-.851-.545a1.275 1.275 0 01-.266-.774c0-.224.048-.422.143-.593.096-.17.224-.32.384-.438.16-.122.34-.213.553-.277.213-.064.436-.091.67-.091.118 0 .24.005.357.021.122.016.234.038.346.06.106.026.208.052.303.085.096.032.17.064.224.096a.46.46 0 01.16.133.288.288 0 01.047.176v.251c0 .112-.042.171-.122.171a.553.553 0 01-.202-.064 2.427 2.427 0 00-1.022-.208c-.303 0-.543.048-.708.15-.165.1-.25.256-.25.474 0 .15.053.278.16.38.106.101.303.202.585.293l.756.24c.383.123.66.294.825.513.165.219.244.47.244.748 0 .23-.047.437-.138.619a1.436 1.436 0 01-.388.47c-.165.133-.362.23-.591.299-.24.075-.49.112-.761.112z"/><path fill-rule="evenodd" d="M14.465 11.813c-1.75 1.297-4.294 1.986-6.481 1.986-3.065 0-5.827-1.137-7.913-3.027-.165-.15-.016-.353.18-.235 2.257 1.313 5.04 2.109 7.92 2.109 1.941 0 4.075-.406 6.039-1.239.293-.133.543.192.255.406z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M15.194 10.98c-.223-.287-1.479-.138-2.048-.069-.17.022-.197-.128-.043-.24 1-.705 2.645-.502 2.836-.267.192.24-.053 1.89-.99 2.68-.143.123-.281.06-.218-.1.213-.53.687-1.72.463-2.003z" clip-rule="evenodd"/></g></svg>');
+}
+
+%aws-24-svg-prop {
+  --aws-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M6.895 10.085c0 .288.031.521.086.692.062.172.14.359.249.561a.338.338 0 01.054.18c0 .077-.047.155-.148.233l-.49.327a.373.373 0 01-.202.07c-.078 0-.156-.039-.234-.11a2.407 2.407 0 01-.28-.365 6.028 6.028 0 01-.241-.46c-.607.717-1.37 1.075-2.288 1.075-.654 0-1.176-.187-1.557-.56-.381-.374-.576-.873-.576-1.495 0-.662.234-1.2.708-1.605.475-.404 1.105-.607 1.907-.607.265 0 .537.023.825.062.288.04.584.102.895.172v-.569c0-.591-.125-1.004-.366-1.246-.249-.24-.67-.358-1.268-.358a3.54 3.54 0 00-.84.102 6.2 6.2 0 00-.841.264 2.232 2.232 0 01-.273.101.477.477 0 01-.124.024c-.11 0-.164-.078-.164-.242V5.95c0-.125.016-.218.055-.273A.583.583 0 012 5.514c.272-.14.599-.257.98-.35a4.716 4.716 0 011.214-.148c.926 0 1.604.21 2.04.63.427.42.645 1.06.645 1.916v2.522h.016zm-3.16 1.183c.257 0 .522-.047.802-.14.28-.094.529-.265.74-.498.124-.148.217-.312.264-.499.046-.187.078-.412.078-.677v-.327a6.493 6.493 0 00-.716-.133 5.86 5.86 0 00-.732-.046c-.521 0-.903.1-1.16.311-.256.21-.381.506-.381.896 0 .366.093.638.288.825.187.195.46.288.817.288zm6.25.841c-.14 0-.234-.023-.296-.078-.062-.047-.117-.156-.164-.304L7.696 5.71a1.365 1.365 0 01-.07-.312c0-.124.063-.195.187-.195h.763c.148 0 .249.024.303.078.063.047.11.156.156.304l1.308 5.155 1.214-5.155c.039-.156.085-.257.147-.304a.535.535 0 01.312-.078h.622c.148 0 .25.024.312.078.062.047.117.156.148.304l1.23 5.217 1.346-5.217c.046-.156.1-.257.155-.304a.508.508 0 01.304-.078h.724c.124 0 .194.063.194.195 0 .039-.008.078-.015.125a1.104 1.104 0 01-.055.194l-1.876 6.02c-.046.155-.1.256-.163.303a.497.497 0 01-.296.078h-.669c-.148 0-.249-.024-.311-.078-.063-.055-.117-.156-.148-.312l-1.206-5.022-1.199 5.015c-.039.155-.085.257-.148.311-.062.055-.171.078-.311.078h-.67zm10 .21a5.15 5.15 0 01-1.198-.14c-.39-.093-.693-.195-.895-.311-.125-.07-.21-.148-.242-.218a.55.55 0 01-.046-.218v-.398c0-.163.062-.24.179-.24a.44.44 0 01.14.022c.047.016.117.047.194.078.265.117.553.21.857.273.31.062.614.093.926.093.49 0 .871-.085 1.136-.257a.839.839 0 00.405-.74.758.758 0 00-.21-.544c-.14-.148-.405-.28-.787-.405l-1.128-.35c-.568-.18-.988-.445-1.245-.795a1.856 1.856 0 01-.39-1.129c0-.327.07-.615.21-.864.14-.25.328-.467.561-.639a2.47 2.47 0 01.81-.405 3.39 3.39 0 01.98-.132c.171 0 .35.008.521.031.18.024.343.055.506.086.156.039.304.078.444.124.14.047.249.094.327.14a.673.673 0 01.233.195.42.42 0 01.07.257V6.2c0 .164-.062.25-.179.25a.81.81 0 01-.295-.094 3.559 3.559 0 00-1.495-.304c-.443 0-.793.07-1.035.218-.241.148-.365.374-.365.693 0 .218.077.405.233.553.156.148.444.296.856.428l1.105.35c.56.18.965.429 1.207.748.24.32.358.685.358 1.09 0 .335-.07.639-.203.903-.14.265-.327.499-.568.686-.241.194-.53.335-.864.436a3.7 3.7 0 01-1.113.163z"/><path fill-rule="evenodd" d="M21.456 16.103c-2.56 1.892-6.28 2.897-9.48 2.897-4.482 0-8.522-1.659-11.572-4.415-.242-.218-.024-.514.264-.343 3.3 1.916 7.37 3.076 11.58 3.076 2.841 0 5.962-.592 8.834-1.806.428-.195.794.28.374.591z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M22.522 14.889c-.327-.42-2.164-.203-2.996-.101-.25.03-.288-.187-.063-.35 1.463-1.029 3.868-.733 4.148-.39.28.35-.077 2.756-1.447 3.909-.21.179-.413.085-.32-.148.312-.771 1.005-2.508.678-2.92z" clip-rule="evenodd"/></g></svg>');
+}
+
+%aws-color-16-svg-prop {
+  --aws-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23252F3E" d="M4.51 7.687c0 .197.02.357.058.475.042.117.096.245.17.384a.233.233 0 01.037.123c0 .053-.032.107-.1.16l-.336.224a.255.255 0 01-.138.048c-.053 0-.107-.026-.16-.074a1.652 1.652 0 01-.192-.251 4.138 4.138 0 01-.164-.315c-.416.49-.937.737-1.565.737-.447 0-.803-.129-1.064-.385S.662 8.215.662 7.788c0-.454.16-.822.484-1.1.325-.278.756-.416 1.304-.416.18 0 .367.016.564.042.197.027.4.07.612.118v-.39c0-.406-.085-.689-.25-.854-.17-.166-.458-.246-.867-.246-.187 0-.378.021-.575.07a4.23 4.23 0 00-.575.181 1.525 1.525 0 01-.186.07.326.326 0 01-.085.016c-.075 0-.112-.054-.112-.166v-.262c0-.085.01-.15.037-.186a.399.399 0 01.15-.113c.185-.096.409-.176.67-.24.26-.07.537-.101.83-.101.633 0 1.096.144 1.394.432.293.288.442.726.442 1.314v1.73h.01zm-2.161.811c.175 0 .356-.032.548-.096.192-.064.362-.182.506-.342a.848.848 0 00.18-.341c.032-.129.054-.283.054-.465V7.03a4.433 4.433 0 00-.49-.091 3.998 3.998 0 00-.5-.032c-.357 0-.617.07-.793.214-.176.144-.26.347-.26.614 0 .25.063.437.196.566.128.133.314.197.559.197zm4.273.577c-.096 0-.16-.016-.202-.054-.043-.032-.08-.106-.112-.208l-1.25-4.127a.938.938 0 01-.048-.214c0-.085.042-.133.127-.133h.522c.1 0 .17.016.207.053.043.032.075.107.107.208l.894 3.535.83-3.535c.026-.106.058-.176.101-.208a.365.365 0 01.213-.053h.426c.1 0 .17.016.212.053.043.032.08.107.102.208l.84 3.578.92-3.578a.459.459 0 01.107-.208.347.347 0 01.208-.053h.495c.085 0 .133.043.133.133 0 .027-.006.054-.01.086a.757.757 0 01-.038.133l-1.283 4.127c-.031.107-.069.177-.111.209a.34.34 0 01-.203.053h-.457c-.101 0-.17-.016-.213-.053-.043-.038-.08-.107-.101-.214L8.213 5.37l-.82 3.439c-.026.107-.058.176-.1.213-.043.038-.118.054-.213.054h-.458zm6.838.144a3.51 3.51 0 01-.82-.096c-.266-.064-.473-.134-.612-.214-.085-.048-.143-.101-.165-.15a.378.378 0 01-.031-.149v-.272c0-.112.042-.166.122-.166a.3.3 0 01.096.016c.032.011.08.032.133.054.18.08.378.144.585.187.213.042.42.064.633.064.336 0 .596-.059.777-.176a.575.575 0 00.277-.508.52.52 0 00-.144-.373c-.095-.102-.276-.193-.537-.278l-.772-.24c-.388-.123-.676-.305-.851-.545a1.275 1.275 0 01-.266-.774c0-.224.048-.422.143-.593.096-.17.224-.32.384-.438.16-.122.34-.213.553-.277.213-.064.436-.091.67-.091.118 0 .24.005.357.021.122.016.234.038.346.06.106.026.208.052.303.085.096.032.17.064.224.096a.46.46 0 01.16.133.288.288 0 01.047.176v.251c0 .112-.042.171-.122.171a.553.553 0 01-.202-.064 2.427 2.427 0 00-1.022-.208c-.303 0-.543.048-.708.15-.165.1-.25.256-.25.474 0 .15.053.278.16.38.106.101.303.202.585.293l.756.24c.383.123.66.294.825.513.165.219.244.47.244.748 0 .23-.047.437-.138.619a1.434 1.434 0 01-.388.47c-.165.133-.362.23-.591.299-.24.074-.49.112-.761.112z"/><g fill="%23F90" fill-rule="evenodd" clip-rule="evenodd"><path d="M14.465 11.813c-1.75 1.297-4.294 1.986-6.481 1.986-3.065 0-5.827-1.137-7.913-3.027-.165-.15-.016-.353.18-.235 2.257 1.313 5.04 2.109 7.92 2.109 1.941 0 4.075-.406 6.039-1.239.292-.133.543.192.255.406z"/><path d="M15.194 10.98c-.223-.287-1.479-.138-2.048-.069-.17.022-.197-.128-.043-.24 1-.705 2.645-.502 2.836-.267.192.24-.053 1.89-.99 2.68-.143.123-.281.06-.218-.101.213-.529.687-1.72.463-2.002z"/></g></svg>');
+}
+
+%aws-color-24-svg-prop {
+  --aws-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23252F3E" d="M6.895 10.085c0 .288.031.521.085.692.063.172.14.359.25.561a.338.338 0 01.054.18c0 .077-.047.155-.148.233l-.49.327a.373.373 0 01-.203.07c-.077 0-.155-.039-.233-.11a2.408 2.408 0 01-.28-.365 6.031 6.031 0 01-.241-.46c-.607.717-1.37 1.075-2.288 1.075-.654 0-1.176-.187-1.557-.56-.381-.374-.576-.873-.576-1.495 0-.662.234-1.2.708-1.605.475-.404 1.105-.607 1.907-.607.265 0 .537.023.825.062.288.04.584.102.895.172v-.569c0-.591-.125-1.004-.366-1.246-.249-.24-.67-.358-1.268-.358a3.54 3.54 0 00-.84.102 6.2 6.2 0 00-.841.264 2.234 2.234 0 01-.273.101.477.477 0 01-.124.024c-.11 0-.164-.078-.164-.242V5.95c0-.125.016-.218.055-.273A.583.583 0 012 5.514c.272-.14.599-.257.98-.35a4.716 4.716 0 011.214-.148c.926 0 1.604.21 2.04.63.427.42.645 1.06.645 1.916v2.522h.016zm-3.16 1.183c.257 0 .522-.047.802-.14.28-.094.529-.265.74-.498.124-.148.217-.312.264-.499.046-.187.078-.412.078-.677v-.327a6.494 6.494 0 00-.716-.133 5.86 5.86 0 00-.732-.046c-.521 0-.903.1-1.16.311-.256.21-.381.506-.381.896 0 .366.093.638.288.825.187.195.46.288.817.288zm6.25.841c-.14 0-.234-.023-.296-.078-.062-.047-.117-.156-.164-.304L7.696 5.71a1.364 1.364 0 01-.07-.312c0-.124.063-.195.187-.195h.763c.148 0 .249.024.303.078.063.047.11.156.156.304l1.308 5.155 1.214-5.155c.039-.156.085-.257.147-.304a.535.535 0 01.312-.078h.622c.148 0 .25.024.312.078.062.047.117.156.148.304l1.23 5.217 1.346-5.217c.046-.156.1-.257.155-.304a.508.508 0 01.304-.078h.724c.124 0 .194.063.194.195 0 .039-.008.078-.015.125a1.104 1.104 0 01-.055.194l-1.876 6.02c-.046.155-.1.256-.163.303a.497.497 0 01-.296.078h-.669c-.148 0-.249-.024-.311-.078-.063-.055-.117-.156-.148-.312l-1.206-5.022-1.199 5.015c-.039.155-.086.257-.148.311-.062.055-.171.078-.311.078h-.67zm10 .21a5.15 5.15 0 01-1.198-.14c-.39-.093-.693-.195-.895-.311-.125-.07-.21-.148-.242-.218a.55.55 0 01-.046-.218v-.398c0-.163.062-.24.179-.24a.44.44 0 01.14.022c.047.016.117.047.194.078.265.117.553.21.857.273.31.062.614.093.926.093.49 0 .871-.085 1.136-.257a.838.838 0 00.404-.74.758.758 0 00-.21-.544c-.14-.148-.404-.28-.786-.405l-1.128-.35c-.568-.18-.988-.445-1.245-.795a1.856 1.856 0 01-.39-1.129c0-.327.07-.615.21-.864.14-.25.328-.467.561-.639a2.47 2.47 0 01.81-.405 3.39 3.39 0 01.98-.132c.171 0 .35.008.521.031.18.024.343.055.506.086.156.039.304.078.444.124.14.047.249.094.327.14a.673.673 0 01.233.195.42.42 0 01.07.257V6.2c0 .164-.062.25-.179.25a.81.81 0 01-.295-.094 3.559 3.559 0 00-1.495-.304c-.443 0-.793.07-1.035.218-.241.148-.365.374-.365.693 0 .218.077.405.233.553.156.148.444.296.856.428l1.105.35c.56.18.965.429 1.207.748.24.32.358.685.358 1.09 0 .335-.07.639-.203.903-.14.265-.327.499-.568.686-.241.194-.53.335-.864.436a3.7 3.7 0 01-1.113.163z"/><g fill="%23F90" fill-rule="evenodd" clip-rule="evenodd"><path d="M21.456 16.103c-2.56 1.892-6.28 2.897-9.48 2.897-4.482 0-8.522-1.659-11.572-4.415-.242-.218-.024-.514.264-.343 3.3 1.916 7.37 3.076 11.58 3.076 2.841 0 5.962-.592 8.834-1.806.428-.195.794.28.374.591z"/><path d="M22.522 14.889c-.327-.42-2.164-.203-2.996-.101-.25.03-.288-.187-.063-.35 1.463-1.029 3.868-.733 4.148-.39.28.35-.078 2.756-1.447 3.909-.21.179-.413.085-.32-.148.312-.771 1.005-2.508.678-2.92z"/></g></svg>');
+}
+
+%azure-16-svg-prop {
+  --azure-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.47 12.412l3.348-.592.031-.007-1.722-2.049a291.474 291.474 0 01-1.722-2.058c0-.01 1.778-4.909 1.788-4.926.003-.006 1.214 2.084 2.934 5.066l2.95 5.115.023.039-10.948-.001 3.317-.587zM.9 11.788c0-.003.812-1.412 1.804-3.131L4.507 5.53l2.102-1.764C7.765 2.797 8.714 2 8.718 2a.37.37 0 01-.034.085L6.4 6.981 4.16 11.789l-1.63.002c-.896.001-1.63 0-1.63-.003z"/></g></svg>');
+}
+
+%azure-24-svg-prop {
+  --azure-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.275 18.199l4.575-.808.043-.01-2.353-2.793a400.617 400.617 0 01-2.353-2.808c0-.013 2.43-6.693 2.443-6.717.004-.008 1.658 2.842 4.008 6.908 2.2 3.807 4.015 6.946 4.031 6.976L21.7 19l-14.957-.002 4.532-.8zM2.3 17.347c0-.004 1.109-1.925 2.464-4.27l2.464-4.262 2.871-2.406A1076.68 1076.68 0 0112.98 4a.504.504 0 01-.046.116l-3.118 6.676-3.062 6.557-2.227.002c-1.225.002-2.227 0-2.227-.004z"/></g></svg>');
+}
+
+%azure-color-16-svg-prop {
+  --azure-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%230089D6"><path d="M7.47 12.412l3.348-.592.031-.007-1.722-2.049a291.474 291.474 0 01-1.722-2.058c0-.01 1.778-4.909 1.788-4.926.003-.006 1.214 2.084 2.934 5.066l2.95 5.115.023.039-10.948-.001 3.317-.587zM.9 11.788c0-.003.812-1.412 1.804-3.131L4.507 5.53l2.102-1.764C7.765 2.797 8.714 2 8.718 2a.37.37 0 01-.034.085L6.4 6.981 4.16 11.789l-1.63.002c-.896.001-1.63 0-1.63-.003z"/></g></svg>');
+}
+
+%azure-color-24-svg-prop {
+  --azure-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%230089D6"><path d="M11.275 18.199l4.575-.808.043-.01-2.353-2.793a400.617 400.617 0 01-2.353-2.808c0-.013 2.43-6.693 2.443-6.717.004-.008 1.658 2.842 4.008 6.908 2.2 3.807 4.015 6.946 4.031 6.976L21.7 19l-14.957-.002 4.532-.8zM2.3 17.347c0-.004 1.109-1.925 2.464-4.27l2.464-4.262 2.871-2.406A1076.68 1076.68 0 0112.98 4a.504.504 0 01-.046.116l-3.118 6.676-3.062 6.557-2.227.002c-1.225.002-2.227 0-2.227-.004z"/></g></svg>');
+}
+
+%azure-devops-16-svg-prop {
+  --azure-devops-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M15 3.622v8.512L11.5 15l-5.425-1.975v1.958L3.004 10.97l8.951.7V4.005L15 3.622zm-2.984.428L6.994 1v2.001L2.382 4.356 1 6.13v4.029l1.978.873V5.869l9.038-1.818z"/></svg>');
+}
+
+%azure-devops-24-svg-prop {
+  --azure-devops-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M21 6.37v10.945L16.5 21l-6.975-2.54v2.518L5.576 15.82l11.509.9V6.864L21 6.371zm-3.836.551L10.706 3v2.573L4.778 7.315 3 9.595v5.18L5.543 15.9v-6.64l11.62-2.338z"/></svg>');
+}
+
+%azure-devops-color-16-svg-prop {
+  --azure-devops-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="url(%23azure-devops-color-16__paint0_linear)" d="M15 3.622v8.512L11.5 15l-5.425-1.975v1.958L3.004 10.97l8.951.7V4.005L15 3.622zm-2.984.428L6.994 1v2.001L2.382 4.356 1 6.13v4.029l1.978.873V5.869l9.038-1.818z"/><defs><linearGradient id="azure-devops-color-16__paint0_linear" x1="8" x2="8" y1="14.956" y2="1.026" gradientUnits="userSpaceOnUse"><stop stop-color="%230078D4"/><stop offset=".16" stop-color="%231380DA"/><stop offset=".53" stop-color="%233C91E5"/><stop offset=".82" stop-color="%23559CEC"/><stop offset="1" stop-color="%235EA0EF"/></linearGradient></defs></svg>');
+}
+
+%azure-devops-color-24-svg-prop {
+  --azure-devops-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="url(%23azure-devops-color-24__paint0_linear)" d="M21 6.37v10.945L16.5 21l-6.975-2.54v2.518L5.576 15.82l11.509.9V6.864L21 6.371zm-3.836.551L10.706 3v2.573L4.778 7.315 3 9.595v5.18L5.543 15.9v-6.64l11.62-2.338z"/><defs><linearGradient id="azure-devops-color-24__paint0_linear" x1="12" x2="12" y1="20.944" y2="3.034" gradientUnits="userSpaceOnUse"><stop stop-color="%230078D4"/><stop offset=".16" stop-color="%231380DA"/><stop offset=".53" stop-color="%233C91E5"/><stop offset=".82" stop-color="%23559CEC"/><stop offset="1" stop-color="%235EA0EF"/></linearGradient></defs></svg>');
+}
+
+%bar-chart-16-svg-prop {
+  --bar-chart-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M12 2a1 1 0 011 1v10a1 1 0 11-2 0V3a1 1 0 011-1zM8 6a1 1 0 011 1v6a1 1 0 11-2 0V7a1 1 0 011-1zM5 10a1 1 0 00-2 0v3a1 1 0 102 0v-3z"/></g></svg>');
+}
+
+%bar-chart-24-svg-prop {
+  --bar-chart-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M18 3a1 1 0 011 1v16a1 1 0 11-2 0V4a1 1 0 011-1zM12 9a1 1 0 011 1v10a1 1 0 11-2 0V10a1 1 0 011-1zM7 16a1 1 0 10-2 0v4a1 1 0 102 0v-4z"/></g></svg>');
+}
+
+%bar-chart-alt-16-svg-prop {
+  --bar-chart-alt-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 2a1 1 0 011 1v10a1 1 0 11-2 0V3a1 1 0 011-1zM12 6a1 1 0 011 1v6a1 1 0 11-2 0V7a1 1 0 011-1zM5 9a1 1 0 00-2 0v4a1 1 0 102 0V9z"/></g></svg>');
+}
+
+%bar-chart-alt-24-svg-prop {
+  --bar-chart-alt-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 3a1 1 0 011 1v16a1 1 0 11-2 0V4a1 1 0 011-1zM18 9a1 1 0 011 1v10a1 1 0 11-2 0V10a1 1 0 011-1zM7 14a1 1 0 10-2 0v6a1 1 0 102 0v-6z"/></g></svg>');
+}
+
+%battery-16-svg-prop {
+  --battery-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M2.25 3A2.25 2.25 0 000 5.25v5.5A2.25 2.25 0 002.25 13h8.5A2.25 2.25 0 0013 10.75v-5.5A2.25 2.25 0 0010.75 3h-8.5zM1.5 5.25a.75.75 0 01.75-.75h8.5a.75.75 0 01.75.75v5.5a.75.75 0 01-.75.75h-8.5a.75.75 0 01-.75-.75v-5.5z" clip-rule="evenodd"/><path d="M15.5 6.75a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"/></g></svg>');
+}
+
+%battery-24-svg-prop {
+  --battery-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M3.75 5A2.75 2.75 0 001 7.75v8.5A2.75 2.75 0 003.75 19h14.5A2.75 2.75 0 0021 16.25v-8.5A2.75 2.75 0 0018.25 5H3.75zM2.5 7.75c0-.69.56-1.25 1.25-1.25h14.5c.69 0 1.25.56 1.25 1.25v8.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25v-8.5z" clip-rule="evenodd"/><path d="M23.5 10.75a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"/></g></svg>');
+}
+
+%battery-charging-16-svg-prop {
+  --battery-charging-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.605 3.944a.75.75 0 10-1.21-.888l-2.75 3.75a.75.75 0 00.368 1.155l3.524 1.175-2.142 2.92a.75.75 0 101.21.888l2.75-3.75a.75.75 0 00-.368-1.156L5.463 6.864l2.142-2.92z"/><path d="M2.25 4.5a.75.75 0 00-.75.75v5.5c0 .414.336.75.75.75h.5a.75.75 0 010 1.5h-.5A2.25 2.25 0 010 10.75v-5.5A2.25 2.25 0 012.25 3h.5a.75.75 0 010 1.5h-.5zM9.5 3.75a.75.75 0 01.75-.75h.5A2.25 2.25 0 0113 5.25v5.5A2.25 2.25 0 0110.75 13h-.5a.75.75 0 010-1.5h.5a.75.75 0 00.75-.75v-5.5a.75.75 0 00-.75-.75h-.5a.75.75 0 01-.75-.75zM14.75 6a.75.75 0 01.75.75v2.5a.75.75 0 01-1.5 0v-2.5a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
+%battery-charging-24-svg-prop {
+  --battery-charging-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M13.056 6.003a.75.75 0 10-1.112-1.006l-4.75 5.25a.75.75 0 00.335 1.22l5.428 1.67-4.035 4.885a.75.75 0 001.156.956l4.75-5.75a.75.75 0 00-.357-1.195L9.097 10.38l3.96-4.377z"/><path d="M3.75 6.5c-.69 0-1.25.56-1.25 1.25v8.5c0 .69.56 1.25 1.25 1.25h2.5a.75.75 0 010 1.5h-2.5A2.75 2.75 0 011 16.25v-8.5A2.75 2.75 0 013.75 5h4.5a.75.75 0 010 1.5h-4.5zM15 5.75a.75.75 0 01.75-.75h2.5A2.75 2.75 0 0121 7.75v8.5A2.75 2.75 0 0118.25 19h-4.5a.75.75 0 010-1.5h4.5c.69 0 1.25-.56 1.25-1.25v-8.5c0-.69-.56-1.25-1.25-1.25h-2.5a.75.75 0 01-.75-.75zM22.75 10a.75.75 0 01.75.75v2.5a.75.75 0 01-1.5 0v-2.5a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
+%beaker-16-svg-prop {
+  --beaker-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4.608 2H3.75a.75.75 0 000 1.5h.394l.987 2.154c.03.065.03.14.001.205l-2.949 6.685A1.75 1.75 0 003.784 15h8.432a1.75 1.75 0 001.6-2.456l-2.948-6.685a.25.25 0 01.001-.205l.987-2.154h.394a.75.75 0 000-1.5h-.858a.76.76 0 00-.033 0H4.64a.76.76 0 00-.033 0zm5.598 1.5H5.794l.7 1.529c.209.455.213.977.01 1.435L5.828 8h4.346l-.678-1.536a1.75 1.75 0 01.01-1.435l.701-1.529zm-6.65 9.65l1.61-3.65h5.669l1.61 3.65a.25.25 0 01-.23.35h-8.43a.25.25 0 01-.23-.35z" clip-rule="evenodd"/></svg>');
+}
+
+%beaker-24-svg-prop {
+  --beaker-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M6.75 4a.75.75 0 000 1.5h.662l1.441 2.883a.25.25 0 010 .226l-4.657 9.118C3.432 19.224 4.52 21 6.2 21h11.6c1.68 0 2.768-1.776 2.004-3.273l-4.656-9.118a.25.25 0 01-.001-.226L16.588 5.5h.662a.75.75 0 000-1.5H6.75zm8.162 1.5H9.088l1.106 2.213a1.75 1.75 0 01-.007 1.578L8.805 12h6.39l-1.383-2.709a1.75 1.75 0 01-.007-1.578L14.912 5.5zm-9.38 12.909L8.04 13.5h7.922l2.507 4.909A.75.75 0 0117.8 19.5H6.2a.75.75 0 01-.668-1.091z" clip-rule="evenodd"/></svg>');
+}
+
+%bell-16-svg-prop {
+  --bell-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M13 8.78c0 1.334.788 1.72 1.25 1.72a.75.75 0 010 1.5H1.75a.75.75 0 010-1.5c.462 0 1.25-.386 1.25-1.72V6.405C3 3.665 4.907 1 8 1s5 2.665 5 5.405V8.78zM4.5 6.405C4.5 4.275 5.938 2.5 8 2.5c2.062 0 3.5 1.776 3.5 3.905V8.78c0 .677.145 1.252.387 1.72H4.113c.242-.468.387-1.043.387-1.72V6.405z" clip-rule="evenodd"/><path d="M6.898 12.872a.75.75 0 00-1.296.756A2.773 2.773 0 008 15c1.023 0 1.918-.55 2.398-1.372a.75.75 0 00-1.296-.756c-.219.374-.63.628-1.102.628-.473 0-.883-.254-1.102-.628z"/></g></svg>');
+}
+
+%bell-24-svg-prop {
+  --bell-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M20 14.15c0 1.304 1.019 2.35 2.25 2.35a.75.75 0 010 1.5H1.75a.75.75 0 010-1.5C2.981 16.5 4 15.454 4 14.15V8.983C4 4.665 7.702 1 12 1s8 3.665 8 7.983v5.167zM5.5 8.983C5.5 5.5 8.524 2.5 12 2.5s6.5 3 6.5 6.483v5.167c0 .873.29 1.693.782 2.35H4.718a3.917 3.917 0 00.782-2.35V8.983z" clip-rule="evenodd"/><path d="M10.42 20.414a.75.75 0 00-1.34.672C9.63 22.188 10.703 23 12 23c1.296 0 2.369-.812 2.92-1.914a.75.75 0 10-1.34-.672c-.347.691-.953 1.086-1.58 1.086-.627 0-1.233-.395-1.58-1.086z"/></g></svg>');
+}
+
+%bell-active-16-svg-prop {
+  --bell-active-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 2.5c-2.062 0-3.5 1.776-3.5 3.905V8.78c0 .677-.145 1.252-.387 1.72h7.774c-.242-.468-.387-1.043-.387-1.72V6.781a.75.75 0 011.5 0V8.78c0 1.334.788 1.72 1.25 1.72a.75.75 0 010 1.5H1.75a.75.75 0 010-1.5c.462 0 1.25-.386 1.25-1.72V6.405C3 3.665 4.907 1 8 1c.2 0 .395.011.587.034a.75.75 0 01-.174 1.49A3.578 3.578 0 008 2.5z"/><path d="M14 3a2 2 0 11-4 0 2 2 0 014 0zM6.898 12.872a.75.75 0 00-1.296.756A2.773 2.773 0 008 15c1.023 0 1.918-.55 2.398-1.372a.75.75 0 00-1.296-.756c-.219.374-.63.628-1.102.628-.473 0-.883-.254-1.102-.628z"/></g></svg>');
+}
+
+%bell-active-24-svg-prop {
+  --bell-active-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 2.5c-3.476 0-6.5 3-6.5 6.483v5.167c0 .873-.29 1.693-.782 2.35h14.564a3.917 3.917 0 01-.782-2.35V8.983c0-.295-.022-.587-.064-.875a.75.75 0 011.485-.216c.052.357.079.722.079 1.091v5.167c0 1.304 1.019 2.35 2.25 2.35a.75.75 0 010 1.5H1.75a.75.75 0 010-1.5C2.981 16.5 4 15.454 4 14.15V8.983C4 4.665 7.702 1 12 1a7.631 7.631 0 012.389.385.75.75 0 11-.468 1.425A6.131 6.131 0 0012 2.5z"/><path d="M21 3.5a2.5 2.5 0 11-5 0 2.5 2.5 0 015 0zM10.42 20.414a.75.75 0 00-1.34.672C9.63 22.188 10.703 23 12 23c1.296 0 2.369-.812 2.92-1.914a.75.75 0 10-1.34-.672c-.347.691-.953 1.086-1.58 1.086-.627 0-1.233-.395-1.58-1.086z"/></g></svg>');
+}
+
+%bell-active-fill-16-svg-prop {
+  --bell-active-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M14.25 10.5c-.462 0-1.25-.386-1.25-1.72V6.742a.75.75 0 00-.8-.749 3 3 0 01-3.037-3.975.75.75 0 00-.63-.99A5.092 5.092 0 008 1C4.907 1 3 3.665 3 6.405V8.78c0 1.334-.788 1.72-1.25 1.72a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5z"/><path d="M12 5a2 2 0 100-4 2 2 0 000 4zM6.898 12.872a.75.75 0 00-1.296.756A2.773 2.773 0 008 15c1.023 0 1.918-.55 2.398-1.372a.75.75 0 00-1.296-.756c-.219.374-.63.628-1.102.628-.473 0-.883-.254-1.102-.628z"/></g></svg>');
+}
+
+%bell-active-fill-24-svg-prop {
+  --bell-active-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M22.25 16.5c-1.231 0-2.25-1.046-2.25-2.35V8.983a7.54 7.54 0 00-.05-.872.75.75 0 00-.856-.655 4 4 0 01-4.402-5.185.75.75 0 00-.499-.948A7.643 7.643 0 0012 1C7.702 1 4 4.665 4 8.983v5.167c0 1.304-1.019 2.35-2.25 2.35a.75.75 0 000 1.5h20.5a.75.75 0 000-1.5z"/><path d="M18.5 6a2.5 2.5 0 100-5 2.5 2.5 0 000 5zM10.42 20.414a.75.75 0 00-1.34.672C9.63 22.188 10.703 23 12 23c1.296 0 2.369-.812 2.92-1.914a.75.75 0 10-1.34-.672c-.347.691-.953 1.086-1.58 1.086-.627 0-1.233-.395-1.58-1.086z"/></g></svg>');
+}
+
+%bell-off-16-svg-prop {
+  --bell-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 2.5c-.546 0-1.033.12-1.457.326a.75.75 0 01-.655-1.35A4.802 4.802 0 018 1c3.093 0 5 2.665 5 5.405v1.78a.75.75 0 01-1.5 0v-1.78C11.5 4.275 10.062 2.5 8 2.5z"/><path fill-rule="evenodd" d="M3.343 4.404L1.22 2.28a.75.75 0 011.06-1.06l12.5 12.5a.75.75 0 11-1.06 1.06L10.94 12H1.75a.75.75 0 010-1.5c.462 0 1.25-.386 1.25-1.72V6.405c0-.691.118-1.37.343-2.001zM9.44 10.5H4.113c.242-.468.387-1.043.387-1.72V6.405c0-.264.023-.524.067-.777L9.439 10.5z" clip-rule="evenodd"/><path d="M5.872 12.602a.75.75 0 011.026.27c.219.374.63.628 1.102.628.473 0 .883-.254 1.102-.628a.75.75 0 011.296.756A2.773 2.773 0 018 15a2.773 2.773 0 01-2.398-1.372.75.75 0 01.27-1.026z"/></g></svg>');
+}
+
+%bell-off-24-svg-prop {
+  --bell-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 2.5c-1.4 0-2.734.487-3.83 1.31a.75.75 0 01-.9-1.2C8.602 1.609 10.247 1 12 1c4.298 0 8 3.665 8 7.983v5.167c0 .173.018.341.052.504a.75.75 0 11-1.467.31 3.939 3.939 0 01-.085-.814V8.983C18.5 5.5 15.476 2.5 12 2.5z"/><path fill-rule="evenodd" d="M4.71 5.77L1.22 2.28a.75.75 0 011.06-1.06l20.5 20.5a.75.75 0 11-1.06 1.06L16.94 18H1.75a.75.75 0 010-1.5C2.981 16.5 4 15.454 4 14.15V8.983c0-1.136.257-2.225.71-3.212zM15.44 16.5H4.717a3.917 3.917 0 00.782-2.35V8.983c0-.714.127-1.408.36-2.062l9.58 9.579z" clip-rule="evenodd"/><path d="M9.414 20.08a.75.75 0 011.007.334c.346.691.952 1.086 1.579 1.086s1.233-.395 1.58-1.086a.75.75 0 111.34.672C14.37 22.188 13.297 23 12 23c-1.296 0-2.369-.812-2.92-1.914a.75.75 0 01.334-1.007z"/></g></svg>');
+}
+
+%bitbucket-16-svg-prop {
+  --bitbucket-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1.403 2.15A.43.43 0 011.73 2l12.54.002a.43.43 0 01.424.496l-1.81 11.135a.43.43 0 01-.425.36H3.693a.585.585 0 01-.568-.478l-1.82-11.02a.425.425 0 01.098-.345zm5.203 7.814H9.41l.677-3.93H5.859l.747 3.93z" clip-rule="evenodd"/></svg>');
+}
+
+%bitbucket-24-svg-prop {
+  --bitbucket-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M2.153 3.225A.64.64 0 012.643 3l18.715.003a.64.64 0 01.634.744L19.289 20.45a.644.644 0 01-.634.54H5.572a.874.874 0 01-.847-.717L2.008 3.743a.64.64 0 01.145-.518zm7.765 11.722h4.187l1.011-5.897H8.804l1.114 5.897z" clip-rule="evenodd"/></svg>');
+}
+
+%bitbucket-color-16-svg-prop {
+  --bitbucket-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%232684FF" fill-rule="evenodd" d="M1.403 2.15A.43.43 0 011.73 2l12.54.002a.43.43 0 01.424.496l-1.81 11.135a.43.43 0 01-.425.36H3.693a.585.585 0 01-.568-.478l-1.82-11.02a.425.425 0 01.098-.345zm5.203 7.814H9.41l.677-3.93H5.859l.747 3.93z" clip-rule="evenodd"/><path fill="url(%23bitbucket-color-16__paint0_linear)" d="M14.122 6.033H10.1l-.67 3.931H6.604L3.317 13.86c.105.09.238.139.376.14h8.766a.43.43 0 00.425-.36l1.238-7.607z"/><defs><linearGradient id="bitbucket-color-16__paint0_linear" x1="11.544" x2="6.918" y1="4.676" y2="11.282" gradientUnits="userSpaceOnUse"><stop offset=".18" stop-color="%230052CC"/><stop offset="1" stop-color="%232684FF"/></linearGradient></defs></svg>');
+}
+
+%bitbucket-color-24-svg-prop {
+  --bitbucket-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%232684FF" fill-rule="evenodd" d="M2.153 3.225A.64.64 0 012.643 3l18.715.003a.64.64 0 01.634.744L19.289 20.45a.644.644 0 01-.634.54H5.572a.874.874 0 01-.847-.717L2.008 3.743a.64.64 0 01.145-.518zm7.765 11.722h4.187l1.011-5.897H8.804l1.114 5.897z" clip-rule="evenodd"/><path fill="url(%23bitbucket-color-24__paint0_linear)" d="M21.138 9.05h-6.005l-1.001 5.897H9.918L5.011 20.79a.871.871 0 00.56.21h13.085c.315 0 .583-.23.634-.54l1.848-11.41z"/><defs><linearGradient id="bitbucket-color-24__paint0_linear" x1="17.29" x2="10.339" y1="7.014" y2="16.89" gradientUnits="userSpaceOnUse"><stop offset=".18" stop-color="%230052CC"/><stop offset="1" stop-color="%232684FF"/></linearGradient></defs></svg>');
+}
+
 %bolt-svg-prop {
   --bolt-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M13 2L6 14h5v8l7-12h-5V2z" fill="%23000"/></svg>');
+}
+
+%bookmark-16-svg-prop {
+  --bookmark-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2 3.25A2.25 2.25 0 014.25 1h7.5A2.25 2.25 0 0114 3.25v10.83a1 1 0 01-1.478.878L8.12 12.564a.25.25 0 00-.238 0l-4.403 2.394A1 1 0 012 14.08V3.25zm2.25-.75a.75.75 0 00-.75.75v9.989l3.664-1.992a1.75 1.75 0 011.672 0l3.664 1.992V3.25a.75.75 0 00-.75-.75h-7.5z" clip-rule="evenodd"/></svg>');
+}
+
+%bookmark-24-svg-prop {
+  --bookmark-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4 4.75A2.75 2.75 0 016.75 2h10.5A2.75 2.75 0 0120 4.75v16.376a1 1 0 01-1.382.924l-6.522-2.699a.25.25 0 00-.192 0L5.382 22.05A1 1 0 014 21.126V4.75zM6.75 3.5c-.69 0-1.25.56-1.25 1.25v15.628l5.83-2.413a1.75 1.75 0 011.34 0l5.83 2.413V4.75c0-.69-.56-1.25-1.25-1.25H6.75z" clip-rule="evenodd"/></svg>');
+}
+
+%bookmark-add-16-svg-prop {
+  --bookmark-add-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.75 4a.75.75 0 01.75.75V6h1.25a.75.75 0 010 1.5H8.5v1.25a.75.75 0 01-1.5 0V7.5H5.75a.75.75 0 010-1.5H7V4.75A.75.75 0 017.75 4z"/><path fill-rule="evenodd" d="M2 3.25A2.25 2.25 0 014.25 1h7.5A2.25 2.25 0 0114 3.25v10.83a1 1 0 01-1.478.878L8.12 12.564a.25.25 0 00-.238 0l-4.403 2.394A1 1 0 012 14.08V3.25zm2.25-.75a.75.75 0 00-.75.75v9.989l3.664-1.992a1.75 1.75 0 011.672 0l3.664 1.992V3.25a.75.75 0 00-.75-.75h-7.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%bookmark-add-24-svg-prop {
+  --bookmark-add-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.75 7a.75.75 0 01.75.75V10h2.25a.75.75 0 010 1.5H12.5v2.25a.75.75 0 01-1.5 0V11.5H8.75a.75.75 0 010-1.5H11V7.75a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M4 4.75A2.75 2.75 0 016.75 2h10.5A2.75 2.75 0 0120 4.75v16.376a1 1 0 01-1.382.924l-6.522-2.699a.25.25 0 00-.192 0L5.382 22.05A1 1 0 014 21.126V4.75zM6.75 3.5c-.69 0-1.25.56-1.25 1.25v15.628l5.83-2.413a1.75 1.75 0 011.34 0l5.83 2.413V4.75c0-.69-.56-1.25-1.25-1.25H6.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%bookmark-add-fill-16-svg-prop {
+  --bookmark-add-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4.25 1A2.25 2.25 0 002 3.25v10.83a1 1 0 001.478.878l4.403-2.394a.25.25 0 01.238 0l4.403 2.394A1 1 0 0014 14.08V3.25A2.25 2.25 0 0011.75 1h-7.5zM7 4.75a.75.75 0 011.5 0V6h1.25a.75.75 0 010 1.5H8.5v1.25a.75.75 0 01-1.5 0V7.5H5.75a.75.75 0 010-1.5H7V4.75z" clip-rule="evenodd"/></svg>');
+}
+
+%bookmark-add-fill-24-svg-prop {
+  --bookmark-add-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4 4.75A2.75 2.75 0 016.75 2h10.5A2.75 2.75 0 0120 4.75v16.376a1 1 0 01-1.382.924l-6.522-2.699a.25.25 0 00-.192 0L5.382 22.05A1 1 0 014 21.126V4.75zM11.75 7a.75.75 0 00-.75.75V10H8.75a.75.75 0 000 1.5H11v2.25a.75.75 0 001.5 0V11.5h2.25a.75.75 0 000-1.5H12.5V7.75a.75.75 0 00-.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%bookmark-fill-16-svg-prop {
+  --bookmark-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M4.25 1A2.25 2.25 0 002 3.25v10.83a1 1 0 001.478.878l4.403-2.394a.25.25 0 01.238 0l4.403 2.394A1 1 0 0014 14.08V3.25A2.25 2.25 0 0011.75 1h-7.5z"/></svg>');
+}
+
+%bookmark-fill-24-svg-prop {
+  --bookmark-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M6.75 2A2.75 2.75 0 004 4.75v16.376a1 1 0 001.382.924l6.522-2.699a.25.25 0 01.192 0l6.522 2.699A1 1 0 0020 21.126V4.75A2.75 2.75 0 0017.25 2H6.75z"/></svg>');
+}
+
+%bookmark-remove-16-svg-prop {
+  --bookmark-remove-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.75 6a.75.75 0 000 1.5h4a.75.75 0 000-1.5h-4z"/><path fill-rule="evenodd" d="M4.25 1A2.25 2.25 0 002 3.25v10.83a1 1 0 001.478.878l4.403-2.394a.25.25 0 01.238 0l4.403 2.394A1 1 0 0014 14.08V3.25A2.25 2.25 0 0011.75 1h-7.5zM3.5 3.25a.75.75 0 01.75-.75h7.5a.75.75 0 01.75.75v9.989l-3.664-1.992a1.75 1.75 0 00-1.672 0L3.5 13.239V3.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%bookmark-remove-24-svg-prop {
+  --bookmark-remove-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.75 10a.75.75 0 000 1.5h6a.75.75 0 000-1.5h-6z"/><path fill-rule="evenodd" d="M6.75 2A2.75 2.75 0 004 4.75v16.376a1 1 0 001.382.924l6.522-2.699a.25.25 0 01.192 0l6.522 2.699A1 1 0 0020 21.126V4.75A2.75 2.75 0 0017.25 2H6.75zM5.5 4.75c0-.69.56-1.25 1.25-1.25h10.5c.69 0 1.25.56 1.25 1.25v15.628l-5.83-2.413a1.75 1.75 0 00-1.34 0L5.5 20.378V4.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%bookmark-remove-fill-16-svg-prop {
+  --bookmark-remove-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2 3.25A2.25 2.25 0 014.25 1h7.5A2.25 2.25 0 0114 3.25v10.83a1 1 0 01-1.478.878L8.12 12.564a.25.25 0 00-.238 0l-4.403 2.394A1 1 0 012 14.08V3.25zM5.75 6a.75.75 0 000 1.5h4a.75.75 0 000-1.5h-4z" clip-rule="evenodd"/></svg>');
+}
+
+%bookmark-remove-fill-24-svg-prop {
+  --bookmark-remove-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4 4.75A2.75 2.75 0 016.75 2h10.5A2.75 2.75 0 0120 4.75v16.376a1 1 0 01-1.382.924l-6.522-2.699a.25.25 0 00-.192 0L5.382 22.05A1 1 0 014 21.126V4.75zM8.75 10a.75.75 0 000 1.5h6a.75.75 0 000-1.5h-6z" clip-rule="evenodd"/></svg>');
+}
+
+%bottom-16-svg-prop {
+  --bottom-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.75 1a.75.75 0 01.75.75v7.614l2.955-3.129a.75.75 0 011.09 1.03l-4.25 4.5a.747.747 0 01-.533.235h-.024a.747.747 0 01-.51-.211l-.004-.005a.862.862 0 01-.02-.02l-4.25-4.499a.75.75 0 011.091-1.03L7 9.364V1.75A.75.75 0 017.75 1zM2.5 13.5a.75.75 0 000 1.5H13a.75.75 0 000-1.5H2.5z"/></g></svg>');
+}
+
+%bottom-24-svg-prop {
+  --bottom-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.75 2a.75.75 0 01.75.75v12.638l4.96-5.158a.75.75 0 111.08 1.04l-6.25 6.5a.75.75 0 01-1.08 0l-6.25-6.5a.75.75 0 111.08-1.04L11 15.388V2.75a.75.75 0 01.75-.75zM3.5 20.5a.75.75 0 000 1.5H20a.75.75 0 000-1.5H3.5z"/></g></svg>');
+}
+
+%box-16-svg-prop {
+  --box-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M6.98.678a2.25 2.25 0 012.04 0l5.297 2.696c.42.214.683.644.683 1.114v6.717c0 .658-.37 1.261-.956 1.56L9.02 15.322a2.25 2.25 0 01-2.042 0l-5.023-2.557A1.75 1.75 0 011 11.205V4.488c0-.47.264-.9.683-1.114L6.979.678zm1.36 1.337a.75.75 0 00-.68 0L3.224 4.273 8 6.661l4.776-2.388L8.34 2.015zm-5.84 9.19V5.588l4.75 2.375v5.814l-4.613-2.35a.25.25 0 01-.137-.222zm6.25 2.572l4.613-2.35a.25.25 0 00.137-.222V5.588L8.75 7.963v5.814z" clip-rule="evenodd"/></svg>');
+}
+
+%box-24-svg-prop {
+  --box-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13.206.754a2.75 2.75 0 00-2.412 0L1.983 5.052A1.75 1.75 0 001 6.625v9.902a2.75 2.75 0 001.496 2.448l8.25 4.226a2.75 2.75 0 002.508 0l8.25-4.226A2.75 2.75 0 0023 16.527V6.625a1.75 1.75 0 00-.983-1.573L13.206.754zm-1.754 1.348a1.25 1.25 0 011.096 0l8.11 3.956L12 10.17 3.343 6.058l8.109-3.956zM2.5 7.318v9.21c0 .468.263.898.68 1.112l8.07 4.133V11.474L2.5 7.318zm10.25 14.455l8.07-4.133a1.25 1.25 0 00.68-1.113v-9.21l-8.75 4.157v10.3z" clip-rule="evenodd"/></svg>');
 }
 
 %box-check-fill-svg-prop {
@@ -38,16 +502,64 @@
   --box-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 5v14H5V5h14zm0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" fill="%23000"/></svg>');
 }
 
+%briefcase-16-svg-prop {
+  --briefcase-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M5.75 1A1.75 1.75 0 004 2.75V4H2.25A2.25 2.25 0 000 6.25v6.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-6.5A2.25 2.25 0 0013.75 4H12V2.75A1.75 1.75 0 0010.25 1h-4.5zm6.75 12.5h1.25a.75.75 0 00.75-.75v-6.5a.75.75 0 00-.75-.75H12.5v8zm-1.5-8v8H5v-8h6zm-7.5 8v-8H2.25a.75.75 0 00-.75.75v6.5c0 .414.336.75.75.75H3.5zm7-9.5V2.75a.25.25 0 00-.25-.25h-4.5a.25.25 0 00-.25.25V4h5z" clip-rule="evenodd"/></svg>');
+}
+
+%briefcase-24-svg-prop {
+  --briefcase-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M9.75 2A2.75 2.75 0 007 4.75V6H3.75A2.75 2.75 0 001 8.75v10.5A2.75 2.75 0 003.75 22h16.5A2.75 2.75 0 0023 19.25V8.75A2.75 2.75 0 0020.25 6H17V4.75A2.75 2.75 0 0014.25 2h-4.5zm6.75 5.5h-9v13h9v-13zm1.5 13v-13h2.25c.69 0 1.25.56 1.25 1.25v10.5c0 .69-.56 1.25-1.25 1.25H18zM3.75 7.5H6v13H3.75c-.69 0-1.25-.56-1.25-1.25V8.75c0-.69.56-1.25 1.25-1.25zM15.5 6V4.75c0-.69-.56-1.25-1.25-1.25h-4.5c-.69 0-1.25.56-1.25 1.25V6h7z" clip-rule="evenodd"/></svg>');
+}
+
 %broadcast-svg-prop {
   --broadcast-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 12a9.975 9.975 0 0 1 3.274-7.398l1.348 1.482a7.987 7.987 0 0 0 .26 12.059L5.598 19.68A9.98 9.98 0 0 1 2 12zm16.726-7.398l-1.348 1.482a7.987 7.987 0 0 1-.26 12.059l1.283 1.538A9.98 9.98 0 0 0 22 12a9.975 9.975 0 0 0-3.274-7.398zM6 12c0-1.759.758-3.341 1.965-4.439l1.346 1.48a3.99 3.99 0 0 0 .13 6.03L8.159 16.61A5.988 5.988 0 0 1 6 12zm10.035-4.439l-1.346 1.48a3.99 3.99 0 0 1-.13 6.03l1.282 1.538A5.988 5.988 0 0 0 18 12a5.985 5.985 0 0 0-1.965-4.439zM10 12c0 1.102.898 2 2 2 1.102 0 2-.898 2-2 0-1.102-.898-2-2-2-1.102 0-2 .898-2 2z" fill="%23000"/></svg>');
+}
+
+%bug-16-svg-prop {
+  --bug-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M10.136.803a.75.75 0 011.061 1.06l-.415.416C11.525 2.932 12 3.853 12 4.909c0 .103-.005.205-.014.306.094.016.173.03.238.045a.973.973 0 01.776.951V6.6l1.571-.629a.75.75 0 01.557 1.393L13 8.214v1.13l1.849.246a.75.75 0 11-.198 1.487l-1.659-.221a3.935 3.935 0 01-.426 1.555l2.364.887a.75.75 0 01-.527 1.404l-2.667-1a.752.752 0 01-.12-.058C10.687 14.491 9.384 15 8 15s-2.687-.509-3.616-1.356a.752.752 0 01-.12.058l-2.667 1a.75.75 0 11-.527-1.404l2.364-.887a3.935 3.935 0 01-.426-1.555l-1.659.22a.75.75 0 01-.198-1.486L3 9.343V8.174L.971 7.363a.75.75 0 01.557-1.393L3 6.56V6.21c0-.474.334-.854.776-.95.065-.015.144-.03.238-.046C4.004 5.114 4 5.012 4 4.909c0-1.056.475-1.977 1.218-2.63l-.415-.415A.75.75 0 015.863.803l.695.694a4.318 4.318 0 012.884 0l.694-.694zm-4.63 4.26C6.133 5.026 6.946 5 8 5c1.054 0 1.867.026 2.494.063.004-.051.006-.102.006-.154C10.5 3.793 9.461 2.75 8 2.75S5.5 3.793 5.5 4.91c0 .05.002.102.006.153zM4.5 7.652v-.994C5.043 6.586 6.093 6.5 8 6.5s2.957.086 3.5.158v3.949c0 1.494-1.454 2.893-3.5 2.893-2.046 0-3.5-1.4-3.5-2.893v-.59-2.335-.03z" clip-rule="evenodd"/></svg>');
+}
+
+%bug-24-svg-prop {
+  --bug-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M15.72 1.22a.75.75 0 111.06 1.06l-1.176 1.177a4.597 4.597 0 011.293 4.256c.612.071 1.008.147 1.258.208.54.133.845.61.845 1.089v1.408l2.987-1.12a.75.75 0 01.526 1.404L19 12.02v2.318l3.343.418a.75.75 0 11-.186 1.488L19 15.85v.4c0 .931-.195 1.816-.545 2.62l3.808 1.428a.75.75 0 01-.526 1.404l-4-1.5a.754.754 0 01-.046-.019C16.415 21.894 14.332 23 12 23s-4.415-1.106-5.69-2.817a.775.775 0 01-.047.02l-4 1.5a.75.75 0 11-.526-1.405l3.808-1.429A6.523 6.523 0 015 16.25v-.4l-3.157.394a.75.75 0 01-.186-1.488L5 14.338V12.02l-3.513-1.318a.75.75 0 01.526-1.404L5 10.418V9.01c0-.479.305-.956.845-1.089.25-.06.646-.137 1.258-.208a4.597 4.597 0 011.293-4.256L7.22 2.28a.75.75 0 011.06-1.06L9.63 2.568A5.196 5.196 0 0112 2c.852 0 1.661.205 2.371.568L15.72 1.22zM8.617 7.586A58.06 58.06 0 0112 7.5c1.4 0 2.508.035 3.383.086.076-.266.117-.547.117-.836 0-1.753-1.524-3.25-3.5-3.25S8.5 4.997 8.5 6.75c0 .29.04.57.117.836zM6.5 11.485v-2.17C7.198 9.188 8.772 9 12 9s4.802.187 5.5.316v6.934c0 2.87-2.433 5.25-5.5 5.25s-5.5-2.38-5.5-5.25v-1.234-3.5-.031z" clip-rule="evenodd"/></svg>');
 }
 
 %bug-svg-prop {
   --bug-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 8h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17C12.96 5.06 12.49 5 12 5c-.49 0-.96.06-1.41.17L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8zm-6 8h-4v-2h4v2zm0-4h-4v-2h4v2z" fill="%23000"/></svg>');
 }
 
+%build-16-svg-prop {
+  --build-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8.603 2.549A4.251 4.251 0 005.47 8.696a1.076 1.076 0 01-.255 1.312l-3 2.374a.75.75 0 01-.93-1.176l2.701-2.139A5.75 5.75 0 019.47 1.004c.53.02.924.363 1.066.797.137.42.035.902-.306 1.243L8.75 4.523v1.596l1.13 1.13h1.597l1.48-1.479a1.22 1.22 0 011.241-.306c.435.142.778.537.798 1.066a5.75 5.75 0 01-7.978 5.52l-2.102 2.664a.75.75 0 01-1.177-.928l2.333-2.959a1.076 1.076 0 011.297-.265 4.251 4.251 0 006.082-3.165L12.41 8.438c-.199.2-.47.312-.75.312h-1.96c-.282 0-.552-.112-.751-.312L7.56 7.052c-.2-.2-.311-.47-.311-.751V4.34c0-.281.112-.551.311-.75l1.042-1.042z" clip-rule="evenodd"/></svg>');
+}
+
+%build-24-svg-prop {
+  --build-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M14.05 2.5a7.45 7.45 0 00-6.625 10.86 1.284 1.284 0 01-.29 1.556l-4.92 3.894a.75.75 0 01-.93-1.176l4.727-3.743a8.95 8.95 0 019.013-12.839c1.1.12 1.369 1.403.703 2.068L12.75 6.1v3.016l2.135 2.134H17.9l2.979-2.978c.665-.666 1.948-.396 2.067.703a8.95 8.95 0 01-12.704 9.078l-3.677 4.663a.75.75 0 01-1.178-.93l3.827-4.851a.763.763 0 01.059-.066 1.284 1.284 0 011.478-.236 7.45 7.45 0 0010.746-6.859l-2.606 2.607c-.237.236-.558.37-.893.37h-3.212c-.335 0-.657-.133-.893-.37l-2.274-2.274a1.262 1.262 0 01-.37-.893V6c0-.335.133-.656.37-.892l2.605-2.606a7.62 7.62 0 00-.175-.002z" clip-rule="evenodd"/></svg>');
+}
+
+%calendar-16-svg-prop {
+  --calendar-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M11.5.75a.75.75 0 00-1.5 0V1H6V.75a.75.75 0 00-1.5 0V1H3.25A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1H11.5V.75zm-7 2.5V2.5H3.25a.75.75 0 00-.75.75V5h11V3.25a.75.75 0 00-.75-.75H11.5v.75a.75.75 0 01-1.5 0V2.5H6v.75a.75.75 0 01-1.5 0zm9 3.25h-11v6.25c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6.5z" clip-rule="evenodd"/></svg>');
+}
+
+%calendar-24-svg-prop {
+  --calendar-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M17 1a.75.75 0 00-1.5 0v1h-7V1A.75.75 0 007 1v1H4.75A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V4.75A2.75 2.75 0 0019.25 2H17V1zm3.5 7V4.75c0-.69-.56-1.25-1.25-1.25H17V5a.75.75 0 01-1.5 0V3.5h-7V5A.75.75 0 017 5V3.5H4.75c-.69 0-1.25.56-1.25 1.25V8h17zm-17 1.5h17v9.75c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25V9.5z" clip-rule="evenodd"/></svg>');
+}
+
 %calendar-svg-prop {
   --calendar-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16 5h1V2h-1v3zM7 5h1V2H7v3zM4 19c0 .5.5 1 1 1h14c.58-.02 1-.5 1-1V7H4v12zM18 3v3h-3V3H9v3H6V3H5C4 3 3 4 3 5v14c0 1 1 2 2 2h14c1 0 2-1 2-2V5c0-1-1-2-2-2h-1z" fill="%23000"/><path fill-rule="evenodd" clip-rule="evenodd" d="M14 19h2v-2h-2v2zM11 19h2v-2h-2v2zM8 19h2v-2H8v2zM5 19h2v-2H5v2zM17 16h2v-2h-2v2zM14 16h2v-2h-2v2zM11 16h2v-2h-2v2zM8 16h2v-2H8v2zM5 16h2v-2H5v2zM17 13h2v-2h-2v2zM14 13h2v-2h-2v2zM11 13h2v-2h-2v2zM8 13h2v-2H8v2zM5 13h2v-2H5v2zM17 10h2V8h-2v2zM14 10h2V8h-2v2zM11 10h2V8h-2v2zM8 10h2V8H8v2z" fill="currentColor"/></svg>');
+}
+
+%camera-16-svg-prop {
+  --camera-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3 6a1 1 0 011-1h.01a1 1 0 010 2H4a1 1 0 01-1-1z"/><path fill-rule="evenodd" d="M8 5a3 3 0 100 6 3 3 0 000-6zM6.5 8a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M5.056 1.696A1.25 1.25 0 016.176 1h3.648c.475 0 .91.27 1.12.696l.54 1.093 1.457.124A2.25 2.25 0 0115 5.155v6.595A2.25 2.25 0 0112.75 14h-9.5A2.25 2.25 0 011 11.75V5.155a2.25 2.25 0 012.059-2.242l1.456-.124.541-1.093zm1.276.804l-.66 1.333a.75.75 0 01-.608.414l-1.878.16a.75.75 0 00-.686.748v6.595c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V5.155a.75.75 0 00-.686-.748l-1.878-.16a.75.75 0 01-.608-.414L9.668 2.5H6.332z" clip-rule="evenodd"/></g></svg>');
+}
+
+%camera-24-svg-prop {
+  --camera-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M7 13a5 5 0 1110 0 5 5 0 01-10 0zm5-3.5a3.5 3.5 0 100 7 3.5 3.5 0 000-7z" clip-rule="evenodd"/><path d="M5 8a1 1 0 000 2h.01a1 1 0 000-2H5z"/><path fill-rule="evenodd" d="M7.557 2.912A1.75 1.75 0 019.094 2h5.812c.64 0 1.23.35 1.537.912l1.014 1.859 2.924.14A2.75 2.75 0 0123 7.656V19.25A2.75 2.75 0 0120.25 22H3.75A2.75 2.75 0 011 19.25V7.657A2.75 2.75 0 013.62 4.91l2.923-.14 1.014-1.858zm1.537.588a.25.25 0 00-.22.13L7.658 5.86a.75.75 0 01-.622.39l-3.345.158A1.25 1.25 0 002.5 7.657V19.25c0 .69.56 1.25 1.25 1.25h16.5c.69 0 1.25-.56 1.25-1.25V7.657a1.25 1.25 0 00-1.19-1.249l-3.346-.159a.75.75 0 01-.622-.39L15.126 3.63a.25.25 0 00-.22-.13H9.094z" clip-rule="evenodd"/></g></svg>');
+}
+
+%camera-off-16-svg-prop {
+  --camera-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M1.22 1.22a.75.75 0 011.06 0l12.5 12.5a.75.75 0 11-1.06 1.06l-.78-.78H3.25A2.25 2.25 0 011 11.75V5.155a2.25 2.25 0 011.138-1.957L1.22 2.28a.75.75 0 010-1.06zm8.304 9.364l1.915 1.916H3.25a.75.75 0 01-.75-.75V5.155a.75.75 0 01.686-.748l.148-.012 2.081 2.081a3 3 0 004.108 4.108zM8.389 9.45L6.55 7.611A1.5 1.5 0 008.389 9.45z" clip-rule="evenodd"/><path d="M5.866 1h3.958c.475 0 .91.27 1.12.696l.54 1.093 1.457.124A2.25 2.25 0 0115 5.155v5.595a.75.75 0 01-1.5 0V5.155a.75.75 0 00-.686-.748l-1.878-.16a.75.75 0 01-.608-.414L9.668 2.5H5.866a.75.75 0 010-1.5z"/></g></svg>');
+}
+
+%camera-off-24-svg-prop {
+  --camera-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5 8a1 1 0 000 2h.01a1 1 0 100-2H5z"/><path fill-rule="evenodd" d="M2.28 1.22a.75.75 0 00-1.06 1.06l2.615 2.616-.221.01A2.75 2.75 0 001 7.654V19.25A2.75 2.75 0 003.75 22h17.19l.78.78a.75.75 0 101.06-1.06L2.28 1.22zM19.44 20.5l-3.935-3.934a5 5 0 01-7.07-7.07l-3.17-3.17-1.577.079A1.25 1.25 0 002.5 7.653V19.25c0 .69.56 1.25 1.25 1.25h15.69zm-9.945-9.944l4.95 4.949a3.5 3.5 0 01-4.95-4.95z" clip-rule="evenodd"/><path d="M9.094 2c-.64 0-1.23.35-1.537.912l-.421.773a.75.75 0 101.317.718l.421-.773a.25.25 0 01.22-.13h5.812a.25.25 0 01.22.13l1.216 2.23a.75.75 0 00.622.39l3.346.158a1.25 1.25 0 011.19 1.249V18.5a.75.75 0 001.5 0V7.657a2.75 2.75 0 00-2.62-2.747l-2.923-.14-1.014-1.858A1.75 1.75 0 0014.906 2H9.094z"/><path d="M12.345 8.698a.75.75 0 01.915-.538 5.007 5.007 0 013.58 3.58.75.75 0 01-1.452.377 3.507 3.507 0 00-2.505-2.505.75.75 0 01-.538-.914z"/></g></svg>');
 }
 
 %cancel-circle-fill-svg-prop {
@@ -70,12 +582,84 @@
   --cancel-square-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 5v14H5V5h14zM5 3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5zm9.266 5.5L12 10.766 9.734 8.5 8.5 9.734 10.766 12 8.5 14.266 9.734 15.5 12 13.234l2.266 2.266 1.234-1.234L13.234 12 15.5 9.734 14.266 8.5z" fill="%23000"/></svg>');
 }
 
+%caret-16-svg-prop {
+  --caret-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.55 2.24a.75.75 0 00-1.1 0L4.2 5.74a.75.75 0 101.1 1.02L8 3.852l2.7 2.908a.75.75 0 101.1-1.02l-3.25-3.5zM7.45 13.76a.75.75 0 001.1 0l3.25-3.5a.75.75 0 10-1.1-1.02L8 12.148 5.3 9.24a.75.75 0 00-1.1 1.02l3.25 3.5z"/></g></svg>');
+}
+
+%caret-24-svg-prop {
+  --caret-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.543 3.232a.75.75 0 00-1.085 0l-5.25 5.5a.75.75 0 101.085 1.036L12 4.836l4.707 4.932a.75.75 0 001.085-1.036l-5.25-5.5zM11.457 20.768a.75.75 0 001.085 0l5.25-5.5a.75.75 0 00-1.085-1.036L12 19.164l-4.707-4.932a.75.75 0 00-1.086 1.036l5.25 5.5z"/></g></svg>');
+}
+
 %caret-down-svg-prop {
   --caret-down-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 10l5 5 5-5H7z" fill="%23000"/></svg>');
 }
 
 %caret-up-svg-prop {
   --caret-up-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 14l5-5 5 5H7z" fill="%23000"/></svg>');
+}
+
+%cast-16-svg-prop {
+  --cast-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.25 2A2.25 2.25 0 001 4.25v1.23a.75.75 0 001.5 0V4.25a.75.75 0 01.75-.75h9.5a.75.75 0 01.75.75v7.5a.75.75 0 01-.75.75H9.724a.75.75 0 000 1.5h3.026A2.25 2.25 0 0015 11.75v-7.5A2.25 2.25 0 0012.75 2h-9.5z"/><path d="M1.833 7.505a.75.75 0 10-.166 1.49 4.91 4.91 0 014.338 4.338.75.75 0 101.49-.166 6.41 6.41 0 00-5.662-5.662z"/><path d="M1.9 10.062a.75.75 0 00-.3 1.47A2.394 2.394 0 013.468 13.4a.75.75 0 101.47-.3A3.894 3.894 0 001.9 10.062z"/></g></svg>');
+}
+
+%cast-24-svg-prop {
+  --cast-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.75 3A2.75 2.75 0 001 5.75V8a.75.75 0 001.5 0V5.75c0-.69.56-1.25 1.25-1.25h16.5c.69 0 1.25.56 1.25 1.25v12.5c0 .69-.56 1.25-1.25 1.25H14a.75.75 0 000 1.5h6.25A2.75 2.75 0 0023 18.25V5.75A2.75 2.75 0 0020.25 3H3.75z"/><path d="M1.833 11.005a.75.75 0 10-.166 1.49 8.873 8.873 0 017.838 7.838.75.75 0 101.49-.166 10.373 10.373 0 00-9.162-9.162zM1.9 15.345a.75.75 0 00-.3 1.47A4.596 4.596 0 015.185 20.4a.75.75 0 001.47-.3A6.096 6.096 0 001.9 15.345z"/></g></svg>');
+}
+
+%certificate-16-svg-prop {
+  --certificate-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.25 3.25A.75.75 0 017 2.5h2A.75.75 0 019 4H7a.75.75 0 01-.75-.75z"/><path fill-rule="evenodd" d="M3.25 0A2.25 2.25 0 001 2.25v9.5A2.25 2.25 0 003.25 14h1.67l-.115.913a.7.7 0 00.955.737L8 14.754l2.24.896a.7.7 0 00.955-.737L11.08 14h1.669A2.25 2.25 0 0015 11.75v-9.5A2.25 2.25 0 0012.75 0h-9.5zm7.643 12.5h1.857a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75h-9.5a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h1.857l.172-1.378a3.45 3.45 0 115.441 0l.173 1.378zm-1.456-.362c-.438.2-.924.312-1.437.312s-1-.112-1.437-.312l-.221 1.771 1.398-.559a.7.7 0 01.52 0l1.398.56-.221-1.772zM5.95 9a2.05 2.05 0 114.1 0 2.05 2.05 0 01-4.1 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%certificate-24-svg-prop {
+  --certificate-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M10 5a.75.75 0 000 1.5h4A.75.75 0 0014 5h-4z"/><path fill-rule="evenodd" d="M5.75 1A2.75 2.75 0 003 3.75v14.5A2.75 2.75 0 005.75 21h1.485l-.22 1.103a.75.75 0 001.054.826L12 21.079l3.93 1.85a.75.75 0 001.055-.826L16.765 21h1.485A2.75 2.75 0 0021 18.25V3.75A2.75 2.75 0 0018.25 1H5.75zm2.438 15.236L7.535 19.5H5.75c-.69 0-1.25-.56-1.25-1.25V3.75c0-.69.56-1.25 1.25-1.25h12.5c.69 0 1.25.56 1.25 1.25v14.5c0 .69-.56 1.25-1.25 1.25h-1.785l-.653-3.264a5 5 0 10-7.624 0zm6.219-.695a.75.75 0 01.135-.135 3.5 3.5 0 10-5.084 0c.051.04.096.085.135.135A3.488 3.488 0 0012 16.5c.932 0 1.78-.364 2.407-.959zM12 18a4.977 4.977 0 01-2.501-.67l-.722 3.608 2.904-1.367a.75.75 0 01.638 0l2.904 1.367-.722-3.608c-.736.426-1.59.67-2.501.67z" clip-rule="evenodd"/></g></svg>');
+}
+
+%change-16-svg-prop {
+  --change-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.721 8.453c-.27-.087-.658-.324-1.135-.921-.595-.745-1.211-1.21-1.852-1.414a2.434 2.434 0 00-1.743.094c-.472.206-.842.522-1.095.778a5.881 5.881 0 00-.382.427l-.025.029-.024.029a.75.75 0 001.064 1.057c.05-.05.121-.135.17-.193.01-.014.021-.026.03-.036.065-.078.143-.166.233-.257.185-.188.399-.359.627-.458a.936.936 0 01.69-.04c.27.086.658.323 1.135.92.595.745 1.211 1.21 1.852 1.414.656.209 1.254.118 1.743-.094.472-.206.841-.522 1.095-.778.129-.13.235-.252.313-.344l.069-.082a4.562 4.562 0 01.05-.059.75.75 0 00-1.065-1.057 3.29 3.29 0 00-.2.229 4.39 4.39 0 01-.233.257 2.102 2.102 0 01-.627.458.936.936 0 01-.69.04z" clip-rule="evenodd"/></svg>');
+}
+
+%change-24-svg-prop {
+  --change-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M5.534 12.224a7.725 7.725 0 01-.219.269.75.75 0 11-1.13-.986 3.1 3.1 0 00.097-.123c.308-.404 1.183-1.548 2.442-2.08a3.783 3.783 0 012.699-.106c1.003.324 2.05 1.056 3.142 2.31.98 1.122 1.81 1.652 2.473 1.866a2.284 2.284 0 001.654-.06c.837-.354 1.402-1.068 1.774-1.538.082-.104.155-.195.219-.269a.75.75 0 011.13.986c-.02.023-.053.066-.097.123-.308.404-1.183 1.548-2.442 2.08a3.783 3.783 0 01-2.699.106c-1.003-.324-2.05-1.056-3.142-2.31-.98-1.122-1.81-1.652-2.473-1.866a2.284 2.284 0 00-1.654.06c-.837.354-1.402 1.068-1.774 1.538z" clip-rule="evenodd"/></svg>');
+}
+
+%change-circle-16-svg-prop {
+  --change-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.586 7.532c.477.597.864.834 1.135.92a.936.936 0 00.69-.04c.228-.1.442-.27.627-.458.09-.09.168-.18.234-.257l.03-.036c.048-.058.12-.143.17-.193a.75.75 0 011.062 1.06l-.023.026-.025.03-.07.082a5.846 5.846 0 01-.312.344c-.253.256-.623.572-1.095.778a2.434 2.434 0 01-1.743.094c-.64-.204-1.257-.67-1.852-1.414-.477-.597-.864-.834-1.135-.92a.936.936 0 00-.69.04c-.228.1-.442.27-.627.458-.09.09-.168.18-.234.257l-.03.036a3.3 3.3 0 01-.17.193.75.75 0 01-1.063-1.057l.024-.03.025-.028.07-.083c.077-.092.183-.214.312-.344.253-.256.623-.572 1.095-.777a2.434 2.434 0 011.743-.095c.64.204 1.257.67 1.852 1.414z"/><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%change-circle-24-svg-prop {
+  --change-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M7.071 12.486c.056-.065.116-.143.182-.229.284-.366.677-.874 1.264-1.128a1.5 1.5 0 011.117-.041c.46.152 1.064.539 1.795 1.398.84.988 1.66 1.583 2.465 1.85a2.998 2.998 0 002.185-.089c1.012-.438 1.715-1.388 1.933-1.682.028-.038.048-.066.06-.08a.75.75 0 00-1.143-.97 6.64 6.64 0 00-.182.227c-.284.367-.677.875-1.264 1.129a1.5 1.5 0 01-1.117.041c-.46-.152-1.064-.539-1.795-1.398-.84-.988-1.66-1.584-2.465-1.85a2.998 2.998 0 00-2.185.089c-1.012.438-1.715 1.388-1.933 1.682-.028.038-.048.066-.06.08a.75.75 0 101.143.97z"/><path fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%change-square-16-svg-prop {
+  --change-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.586 7.532c.477.597.864.834 1.135.92a.936.936 0 00.69-.04c.228-.1.442-.27.627-.458.09-.09.168-.18.234-.257l.03-.036c.048-.058.12-.143.17-.193a.75.75 0 011.062 1.06l-.023.026-.025.03-.07.082a5.846 5.846 0 01-.312.344c-.253.256-.623.572-1.095.778a2.434 2.434 0 01-1.743.094c-.64-.204-1.257-.67-1.852-1.414-.477-.597-.864-.834-1.135-.92a.936.936 0 00-.69.04c-.228.1-.442.27-.627.458-.09.09-.168.18-.234.257l-.03.036a3.3 3.3 0 01-.17.193.75.75 0 01-1.063-1.057l.001-.002.023-.027.025-.03.07-.082c.077-.092.183-.214.312-.344.253-.256.623-.572 1.095-.777a2.434 2.434 0 011.743-.095c.64.204 1.257.67 1.852 1.414z"/><path fill-rule="evenodd" d="M3.25 1A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1h-9.5zM2.5 3.25a.75.75 0 01.75-.75h9.5a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75v-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%change-square-24-svg-prop {
+  --change-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M7.071 12.486c.056-.065.116-.143.182-.229.284-.366.677-.874 1.264-1.128a1.5 1.5 0 011.117-.041c.46.152 1.064.539 1.795 1.398.84.988 1.66 1.583 2.465 1.85a2.998 2.998 0 002.185-.089c1.012-.438 1.715-1.388 1.933-1.682.028-.038.048-.066.06-.08a.75.75 0 00-1.143-.97 6.64 6.64 0 00-.182.227c-.284.367-.677.875-1.264 1.129a1.5 1.5 0 01-1.117.041c-.46-.152-1.064-.539-1.795-1.398-.84-.988-1.66-1.584-2.465-1.85a2.998 2.998 0 00-2.185.089c-1.012.438-1.715 1.388-1.933 1.682a2.056 2.056 0 01-.06.08.75.75 0 101.143.97z"/><path fill-rule="evenodd" d="M4.75 2A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V4.75A2.75 2.75 0 0019.25 2H4.75zM3.5 4.75c0-.69.56-1.25 1.25-1.25h14.5c.69 0 1.25.56 1.25 1.25v14.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25V4.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-16-svg-prop {
+  --check-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M14.78 4.28a.75.75 0 00-1.06-1.06l-7.97 7.97-3.47-3.47a.75.75 0 00-1.06 1.06l4 4a.75.75 0 001.06 0l8.5-8.5z"/></svg>');
+}
+
+%check-24-svg-prop {
+  --check-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M21.78 6.28a.75.75 0 00-1.06-1.06L8.75 17.19l-5.47-5.47a.75.75 0 00-1.06 1.06l6 6a.75.75 0 001.06 0l12.5-12.5z"/></svg>');
+}
+
+%check-circle-16-svg-prop {
+  --check-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.78 5.22a.75.75 0 010 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.97-3.97a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-circle-24-svg-prop {
+  --check-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M17.78 8.22a.75.75 0 010 1.06l-7.5 7.5a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l2.47 2.47 6.97-6.97a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-circle-fill-16-svg-prop {
+  --check-circle-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zm2.72 5.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.97-3.97z" clip-rule="evenodd"/></svg>');
+}
+
+%check-circle-fill-24-svg-prop {
+  --check-circle-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zm4.72 7.22a.75.75 0 111.06 1.06l-7.5 7.5a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l2.47 2.47 6.97-6.97z" clip-rule="evenodd"/></svg>');
 }
 
 %check-circle-fill-svg-prop {
@@ -86,24 +670,200 @@
   --check-circle-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.41 3.59-8 8-8s8 3.59 8 8-3.59 8-8 8-8-3.59-8-8zm4.41-1.41L7 12l4 4 7-7-1.41-1.42L11 13.17l-2.59-2.58z" fill="%23000"/></svg>');
 }
 
+%check-diamond-16-svg-prop {
+  --check-diamond-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.28 5.72a.75.75 0 010 1.06l-4 4a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.47-3.47a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M.75 6.41L6.407.752a2.25 2.25 0 013.182 0l5.657 5.656a2.25 2.25 0 010 3.182l-5.657 5.657a2.25 2.25 0 01-3.182 0L.75 9.591a2.25 2.25 0 010-3.182zm6.718-4.597L1.81 7.47a.75.75 0 000 1.06l5.657 5.657a.75.75 0 001.06 0l5.657-5.656a.75.75 0 000-1.061L8.528 1.813a.75.75 0 00-1.06 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-diamond-24-svg-prop {
+  --check-diamond-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M16.28 8.72a.75.75 0 010 1.06l-5.5 5.5a.75.75 0 01-1.06 0l-2.5-2.5a.75.75 0 011.06-1.06l1.97 1.97 4.97-4.97a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M1.884 10.056l8.171-8.172a2.75 2.75 0 013.89 0l8.171 8.172a2.75 2.75 0 010 3.889l-8.171 8.171a2.75 2.75 0 01-3.89 0l-8.171-8.171a2.75 2.75 0 010-3.89zm9.232-7.111l-8.172 8.171a1.25 1.25 0 000 1.768l8.172 8.172a1.25 1.25 0 001.768 0l8.171-8.172a1.25 1.25 0 000-1.768l-8.171-8.171a1.25 1.25 0 00-1.768 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-diamond-fill-16-svg-prop {
+  --check-diamond-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.57.752a2.25 2.25 0 00-3.183 0L.73 6.41a2.25 2.25 0 000 3.182l5.657 5.657a2.25 2.25 0 003.182 0l5.657-5.657a2.25 2.25 0 000-3.182L9.569.752zm1.71 6.028l-4 4a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.47-3.47a.75.75 0 011.06 1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%check-diamond-fill-24-svg-prop {
+  --check-diamond-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13.945 1.884a2.75 2.75 0 00-3.89 0l-8.171 8.172a2.75 2.75 0 000 3.889l8.171 8.171a2.75 2.75 0 003.89 0l8.171-8.171a2.75 2.75 0 000-3.89l-8.171-8.17zM16.28 9.78l-5.5 5.5a.75.75 0 01-1.06 0l-2.5-2.5a.75.75 0 111.06-1.06l1.97 1.97 4.97-4.97a.75.75 0 011.06 1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%check-hexagon-16-svg-prop {
+  --check-hexagon-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.28 5.72a.75.75 0 010 1.06l-4 4a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.47-3.47a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M6.834.33a2.25 2.25 0 012.332 0l5.25 3.182A2.25 2.25 0 0115.5 5.436v5.128a2.25 2.25 0 01-1.084 1.924l-5.25 3.182a2.25 2.25 0 01-2.332 0l-5.25-3.182A2.25 2.25 0 01.5 10.564V5.436a2.25 2.25 0 011.084-1.924L6.834.33zm1.555 1.283a.75.75 0 00-.778 0l-5.25 3.181A.75.75 0 002 5.436v5.128a.75.75 0 00.361.642l5.25 3.181a.75.75 0 00.778 0l5.25-3.181a.75.75 0 00.361-.642V5.436a.75.75 0 00-.361-.642l-5.25-3.181z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-hexagon-24-svg-prop {
+  --check-hexagon-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M16.28 8.72a.75.75 0 010 1.06l-5.5 5.5a.75.75 0 01-1.06 0l-2.5-2.5a.75.75 0 111.06-1.06l1.97 1.97 4.97-4.97a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M10.559 1.006a2.75 2.75 0 012.882 0l7.75 4.77A2.75 2.75 0 0122.5 8.118v7.764a2.75 2.75 0 01-1.309 2.342l-7.75 4.77a2.75 2.75 0 01-2.882 0l-7.75-4.77A2.75 2.75 0 011.5 15.882V8.118a2.75 2.75 0 011.309-2.342l7.75-4.77zm2.096 1.278a1.25 1.25 0 00-1.31 0l-7.75 4.77A1.25 1.25 0 003 8.117v7.764c0 .435.225.838.595 1.065l7.75 4.77a1.25 1.25 0 001.31 0l7.75-4.77c.37-.227.595-.63.595-1.065V8.118a1.25 1.25 0 00-.595-1.065l-7.75-4.77z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-hexagon-fill-16-svg-prop {
+  --check-hexagon-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.166.33a2.25 2.25 0 00-2.332 0l-5.25 3.182A2.25 2.25 0 00.5 5.436v5.128a2.25 2.25 0 001.084 1.924l5.25 3.182a2.25 2.25 0 002.332 0l5.25-3.182a2.25 2.25 0 001.084-1.924V5.436a2.25 2.25 0 00-1.084-1.924L9.166.33zm1.054 5.39a.75.75 0 011.06 1.06l-4 4a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.47-3.47z" clip-rule="evenodd"/></svg>');
+}
+
+%check-hexagon-fill-24-svg-prop {
+  --check-hexagon-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13.441 1.006a2.75 2.75 0 00-2.882 0l-7.75 4.77A2.75 2.75 0 001.5 8.118v7.764a2.75 2.75 0 001.309 2.342l7.75 4.77a2.75 2.75 0 002.882 0l7.75-4.77a2.75 2.75 0 001.309-2.342V8.118a2.75 2.75 0 00-1.309-2.342l-7.75-4.77zm2.84 8.774l-5.5 5.5a.75.75 0 01-1.061 0l-2.5-2.5a.75.75 0 111.06-1.06l1.97 1.97 4.97-4.97a.75.75 0 011.06 1.06z" clip-rule="evenodd"/></svg>');
+}
+
 %check-plain-svg-prop {
   --check-plain-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" fill="%23000"/></svg>');
+}
+
+%check-square-16-svg-prop {
+  --check-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.78 5.22a.75.75 0 010 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.97-3.97a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h9.5A2.25 2.25 0 0115 3.25v9.5A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-9.5zm2.25-.75a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75h-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-square-24-svg-prop {
+  --check-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M17.78 8.22a.75.75 0 010 1.06l-7.5 7.5a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l2.47 2.47 6.97-6.97a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2h14.5A2.75 2.75 0 0122 4.75v14.5A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25V4.75zM4.75 3.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25h14.5c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%check-square-fill-16-svg-prop {
+  --check-square-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.25 1A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1h-9.5zm7.47 4.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.97-3.97z" clip-rule="evenodd"/></svg>');
+}
+
+%check-square-fill-24-svg-prop {
+  --check-square-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4.75 2A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V4.75A2.75 2.75 0 0019.25 2H4.75zm11.97 6.22a.75.75 0 111.06 1.06l-7.5 7.5a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l2.47 2.47 6.97-6.97z" clip-rule="evenodd"/></svg>');
+}
+
+%chevron-down-16-svg-prop {
+  --chevron-down-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.235 5.205a.75.75 0 011.06.03L8 9.158l3.705-3.923a.75.75 0 011.09 1.03l-4.25 4.5a.75.75 0 01-1.09 0l-4.25-4.5a.75.75 0 01.03-1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%chevron-down-24-svg-prop {
+  --chevron-down-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M5.23 8.21a.75.75 0 011.06.02L12 14.168l5.71-5.938a.75.75 0 111.08 1.04l-6.25 6.5a.75.75 0 01-1.08 0l-6.25-6.5a.75.75 0 01.02-1.06z" clip-rule="evenodd"/></svg>');
 }
 
 %chevron-down-svg-prop {
   --chevron-down-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6-1.41-1.41z" fill="%23000"/></svg>');
 }
 
+%chevron-left-16-svg-prop {
+  --chevron-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M10.795 3.235a.75.75 0 01-.03 1.06L6.842 8l3.923 3.705a.75.75 0 01-1.03 1.09l-4.5-4.25a.75.75 0 010-1.09l4.5-4.25a.75.75 0 011.06.03z" clip-rule="evenodd"/></svg>');
+}
+
+%chevron-left-24-svg-prop {
+  --chevron-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M15.79 18.77a.75.75 0 00-.02-1.06L9.832 12l5.938-5.71a.75.75 0 10-1.04-1.08l-6.5 6.25a.75.75 0 000 1.08l6.5 6.25a.75.75 0 001.06-.02z" clip-rule="evenodd"/></svg>');
+}
+
 %chevron-left-svg-prop {
   --chevron-left-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.705 16.885l-4.58-4.59 4.58-4.59-1.41-1.41-6 6 6 6 1.41-1.41z" fill="%23000"/></svg>');
+}
+
+%chevron-right-16-svg-prop {
+  --chevron-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M5.205 3.235a.75.75 0 00.03 1.06L9.158 8l-3.923 3.705a.75.75 0 001.03 1.09l4.5-4.25a.75.75 0 000-1.09l-4.5-4.25a.75.75 0 00-1.06.03z" clip-rule="evenodd"/></svg>');
+}
+
+%chevron-right-24-svg-prop {
+  --chevron-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M8.21 18.77a.75.75 0 01.02-1.06L14.168 12 8.23 6.29a.75.75 0 111.04-1.08l6.5 6.25a.75.75 0 010 1.08l-6.5 6.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"/></svg>');
 }
 
 %chevron-right-svg-prop {
   --chevron-right-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8.295 7.705l4.58 4.59-4.58 4.59 1.41 1.41 6-6-6-6-1.41 1.41z" fill="%23000"/></svg>');
 }
 
+%chevron-up-16-svg-prop {
+  --chevron-up-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.235 10.795a.75.75 0 001.06-.03L8 6.842l3.705 3.923a.75.75 0 001.09-1.03l-4.25-4.5a.75.75 0 00-1.09 0l-4.25 4.5a.75.75 0 00.03 1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%chevron-up-24-svg-prop {
+  --chevron-up-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M5.23 15.79a.75.75 0 001.06-.02L12 9.832l5.71 5.938a.75.75 0 101.08-1.04l-6.25-6.5a.75.75 0 00-1.08 0l-6.25 6.5a.75.75 0 00.02 1.06z" clip-rule="evenodd"/></svg>');
+}
+
 %chevron-up-svg-prop {
   --chevron-up-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.41 16L12 11.42 16.59 16 18 14.59l-6-6-6 6L7.41 16z" fill="%23000"/></svg>');
+}
+
+%chevrons-down-16-svg-prop {
+  --chevrons-down-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.3 3.24a.75.75 0 00-1.1 1.02l3.25 3.5a.75.75 0 001.1 0l3.25-3.5a.75.75 0 10-1.1-1.02L8 6.148 5.3 3.24z"/><path d="M5.3 8.24a.75.75 0 10-1.1 1.02l3.25 3.5a.75.75 0 001.1 0l3.25-3.5a.75.75 0 10-1.1-1.02L8 11.148 5.3 8.24z"/></g></svg>');
+}
+
+%chevrons-down-24-svg-prop {
+  --chevrons-down-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M7.293 5.232a.75.75 0 00-1.086 1.036l5.25 5.5a.75.75 0 001.085 0l5.25-5.5a.75.75 0 10-1.085-1.036L12 10.164 7.293 5.232z"/><path d="M7.293 12.232a.75.75 0 00-1.086 1.036l5.25 5.5a.75.75 0 001.085 0l5.25-5.5a.75.75 0 00-1.085-1.036L12 17.164l-4.707-4.932z"/></g></svg>');
+}
+
+%chevrons-left-16-svg-prop {
+  --chevrons-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.76 5.3a.75.75 0 00-1.02-1.1l-3.5 3.25a.75.75 0 000 1.1l3.5 3.25a.75.75 0 101.02-1.1L4.852 8 7.76 5.3z"/><path d="M12.76 5.3a.75.75 0 10-1.02-1.1l-3.5 3.25a.75.75 0 000 1.1l3.5 3.25a.75.75 0 101.02-1.1L9.852 8l2.908-2.7z"/></g></svg>');
+}
+
+%chevrons-left-24-svg-prop {
+  --chevrons-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.768 16.707a.75.75 0 01-1.036 1.085l-5.5-5.25a.75.75 0 010-1.085l5.5-5.25a.75.75 0 011.036 1.086L6.836 12l4.932 4.707z"/><path d="M18.768 16.707a.75.75 0 01-1.036 1.085l-5.5-5.25a.75.75 0 010-1.085l5.5-5.25a.75.75 0 011.036 1.086L13.836 12l4.932 4.707z"/></g></svg>');
+}
+
+%chevrons-right-16-svg-prop {
+  --chevrons-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.24 5.3a.75.75 0 011.02-1.1l3.5 3.25a.75.75 0 010 1.1l-3.5 3.25a.75.75 0 11-1.02-1.1L6.148 8 3.24 5.3z"/><path d="M8.24 5.3a.75.75 0 111.02-1.1l3.5 3.25a.75.75 0 010 1.1l-3.5 3.25a.75.75 0 11-1.02-1.1L11.148 8 8.24 5.3z"/></g></svg>');
+}
+
+%chevrons-right-24-svg-prop {
+  --chevrons-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5.232 16.707a.75.75 0 001.036 1.085l5.5-5.25a.75.75 0 000-1.085l-5.5-5.25a.75.75 0 00-1.036 1.086L10.164 12l-4.932 4.707z"/><path d="M12.232 16.707a.75.75 0 001.036 1.085l5.5-5.25a.75.75 0 000-1.085l-5.5-5.25a.75.75 0 00-1.036 1.086L17.164 12l-4.932 4.707z"/></g></svg>');
+}
+
+%chevrons-up-16-svg-prop {
+  --chevrons-up-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5a.75.75 0 011.1 0l3.25 3.5a.75.75 0 11-1.1 1.02L8 4.852 5.3 7.76z"/><path d="M5.3 12.76a.75.75 0 11-1.1-1.02l3.25-3.5a.75.75 0 011.1 0l3.25 3.5a.75.75 0 11-1.1 1.02L8 9.852 5.3 12.76z"/></g></svg>');
+}
+
+%chevrons-up-24-svg-prop {
+  --chevrons-up-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M7.293 11.768a.75.75 0 01-1.086-1.036l5.25-5.5a.75.75 0 011.085 0l5.25 5.5a.75.75 0 01-1.085 1.036L12 6.836l-4.707 4.932z"/><path d="M7.293 18.768a.75.75 0 01-1.086-1.036l5.25-5.5a.75.75 0 011.085 0l5.25 5.5a.75.75 0 01-1.085 1.036L12 13.836l-4.707 4.932z"/></g></svg>');
+}
+
+%circle-16-svg-prop {
+  --circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8z" clip-rule="evenodd"/></svg>');
+}
+
+%circle-24-svg-prop {
+  --circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 2.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19zM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12z" clip-rule="evenodd"/></svg>');
+}
+
+%circle-dot-16-svg-prop {
+  --circle-dot-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 3a5 5 0 100 10A5 5 0 008 3z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%circle-dot-24-svg-prop {
+  --circle-dot-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 5a7 7 0 100 14 7 7 0 000-14z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
+}
+
+%circle-fill-16-svg-prop {
+  --circle-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M8 0a8 8 0 100 16A8 8 0 008 0z"/></svg>');
+}
+
+%circle-fill-24-svg-prop {
+  --circle-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1z"/></svg>');
+}
+
+%circle-half-16-svg-prop {
+  --circle-half-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zm0 1.5v13a6.5 6.5 0 100-13z" clip-rule="evenodd"/></svg>');
+}
+
+%circle-half-24-svg-prop {
+  --circle-half-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zm0 1.5v19a9.5 9.5 0 000-19z" clip-rule="evenodd"/></svg>');
+}
+
+%clipboard-16-svg-prop {
+  --clipboard-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M11.975 1h.775A2.25 2.25 0 0115 3.25v10.5A2.25 2.25 0 0112.75 16h-9.5A2.25 2.25 0 011 13.75V3.25A2.25 2.25 0 013.25 1h.775c.116-.57.62-1 1.225-1h5.5c.605 0 1.11.43 1.225 1zM4 2.5h-.75a.75.75 0 00-.75.75v10.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V3.25a.75.75 0 00-.75-.75H12v.25C12 3.44 11.44 4 10.75 4h-5.5C4.56 4 4 3.44 4 2.75V2.5zm1.5 0v-1h5v1h-5z" clip-rule="evenodd"/></svg>');
+}
+
+%clipboard-24-svg-prop {
+  --clipboard-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M8.75 1A1.75 1.75 0 007 2.75V3H5.75A2.75 2.75 0 003 5.75v14.5A2.75 2.75 0 005.75 23h12.5A2.75 2.75 0 0021 20.25V5.75A2.75 2.75 0 0018.25 3H17v-.25A1.75 1.75 0 0015.25 1h-6.5zm8.232 3.5A1.75 1.75 0 0115.25 6h-6.5a1.75 1.75 0 01-1.732-1.5H5.75c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25h12.5c.69 0 1.25-.56 1.25-1.25V5.75c0-.69-.56-1.25-1.25-1.25h-1.268zM8.5 2.75a.25.25 0 01.25-.25h6.5a.25.25 0 01.25.25v1.5a.25.25 0 01-.25.25h-6.5a.25.25 0 01-.25-.25v-1.5z" clip-rule="evenodd"/></svg>');
+}
+
+%clipboard-checked-16-svg-prop {
+  --clipboard-checked-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M11.975 1h.775A2.25 2.25 0 0115 3.25v10.5A2.25 2.25 0 0112.75 16h-9.5A2.25 2.25 0 011 13.75V3.25A2.25 2.25 0 013.25 1h.775c.116-.57.62-1 1.225-1h5.5c.605 0 1.11.43 1.225 1zM5.5 2.5v-1h5v1h-5zm6.28 3.72a.75.75 0 010 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.97-3.97a.75.75 0 011.06 0z" clip-rule="evenodd"/></svg>');
+}
+
+%clipboard-checked-24-svg-prop {
+  --clipboard-checked-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M8.75 1A1.75 1.75 0 007 2.75V3H5.75A2.75 2.75 0 003 5.75v14.5A2.75 2.75 0 005.75 23h12.5A2.75 2.75 0 0021 20.25V5.75A2.75 2.75 0 0018.25 3H17v-.25A1.75 1.75 0 0015.25 1h-6.5zM8.5 2.75a.25.25 0 01.25-.25h6.5a.25.25 0 01.25.25v1.5a.25.25 0 01-.25.25h-6.5a.25.25 0 01-.25-.25v-1.5zm8.28 7.47a.75.75 0 00-1.06 0l-5.47 5.47-1.97-1.97a.75.75 0 00-1.06 1.06l2.5 2.5a.75.75 0 001.06 0l6-6a.75.75 0 000-1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%clipboard-copy-16-svg-prop {
+  --clipboard-copy-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M3.25 2.5H4v.25C4 3.44 4.56 4 5.25 4h5.5C11.44 4 12 3.44 12 2.75V2.5h.75a.75.75 0 01.75.75v3a.75.75 0 001.5 0v-3A2.25 2.25 0 0012.75 1h-.775c-.116-.57-.62-1-1.225-1h-5.5c-.605 0-1.11.43-1.225 1H3.25A2.25 2.25 0 001 3.25v10.5A2.25 2.25 0 003.25 16h9.5A2.25 2.25 0 0015 13.75v-1a.75.75 0 00-1.5 0v1a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75V3.25a.75.75 0 01.75-.75zm2.25-1v1h5v-1h-5z" clip-rule="evenodd"/><path d="M4.75 5.5a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zM4 12.25a.75.75 0 01.75-.75h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zM4.75 8.5a.75.75 0 000 1.5h2a.75.75 0 000-1.5h-2zM16 9.25a.75.75 0 01-.75.75h-4.19l1.22 1.22a.75.75 0 11-1.06 1.06l-2.5-2.5a.752.752 0 010-1.06l2.5-2.5a.75.75 0 111.06 1.06L11.06 8.5h4.19a.75.75 0 01.75.75z"/></g></svg>');
+}
+
+%clipboard-copy-24-svg-prop {
+  --clipboard-copy-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M8.75 1A1.75 1.75 0 007 2.75V3H5.75A2.75 2.75 0 003 5.75v14.5A2.75 2.75 0 005.75 23h12.5A2.75 2.75 0 0021 20.25v-2.5a.75.75 0 00-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H5.75c-.69 0-1.25-.56-1.25-1.25V5.75c0-.69.56-1.25 1.25-1.25h1.268c.121.848.85 1.5 1.732 1.5h6.5a1.75 1.75 0 001.732-1.5h1.268c.69 0 1.25.56 1.25 1.25v4.5a.75.75 0 001.5 0v-4.5A2.75 2.75 0 0018.25 3H17v-.25A1.75 1.75 0 0015.25 1h-6.5zM8.5 2.75a.25.25 0 01.25-.25h6.5a.25.25 0 01.25.25v1.5a.25.25 0 01-.25.25h-6.5a.25.25 0 01-.25-.25v-1.5z" clip-rule="evenodd"/><path d="M7 9.75A.75.75 0 017.75 9h4.5a.75.75 0 010 1.5h-4.5A.75.75 0 017 9.75zM7 17.75a.75.75 0 01.75-.75h4.5a.75.75 0 010 1.5h-4.5a.75.75 0 01-.75-.75zM7.75 13a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5zM22.75 14a.75.75 0 01-.75.75h-6.34l2.1 1.95a.75.75 0 11-1.02 1.1l-3.5-3.25a.747.747 0 01-.24-.533v-.034a.748.748 0 01.227-.521l.014-.013L16.74 10.2a.75.75 0 111.02 1.1l-2.1 1.95H22a.75.75 0 01.75.75z"/></g></svg>');
+}
+
+%clock-16-svg-prop {
+  --clock-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.5 3.75a.75.75 0 00-1.5 0V8c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L8.5 7.535V3.75z"/><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%clock-24-svg-prop {
+  --clock-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.5 5.75a.75.75 0 00-1.5 0V12c0 .284.16.544.415.67l4.5 2.25a.75.75 0 10.67-1.34L12.5 11.536V5.75z"/><path fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z" clip-rule="evenodd"/></g></svg>');
 }
 
 %clock-fill-svg-prop {
@@ -114,12 +874,124 @@
   --clock-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67V7z" fill="%23000"/></svg>');
 }
 
+%cloud-16-svg-prop {
+  --cloud-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.932 2.373a6.041 6.041 0 016.239 1.28 5.998 5.998 0 011.505 2.284h.28c1.071 0 2.1.424 2.858 1.18a4.025 4.025 0 010 5.703A4.051 4.051 0 0111.955 14H6.026a6.037 6.037 0 01-3.186-.906 6.008 6.008 0 01-2.223-2.448 5.982 5.982 0 01.644-6.32 6.02 6.02 0 012.67-1.953zm.526 1.405l-.007.002a4.52 4.52 0 00-2.006 1.467 4.488 4.488 0 001.186 6.572c.716.444 1.542.68 2.386.681h5.938c.676 0 1.324-.268 1.8-.742a2.524 2.524 0 000-3.578 2.551 2.551 0 00-1.8-.743h-.83a.75.75 0 01-.726-.561A4.496 4.496 0 009.14 4.74a4.541 4.541 0 00-4.681-.963z" clip-rule="evenodd"/></svg>');
+}
+
+%cloud-24-svg-prop {
+  --cloud-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M5.836 3.558a8.864 8.864 0 014.895-.373 8.906 8.906 0 014.356 2.297 9.009 9.009 0 012.325 3.705h.726a5.84 5.84 0 014.147 1.733A5.929 5.929 0 0124 15.094a5.929 5.929 0 01-1.715 4.174A5.84 5.84 0 0118.138 21H8.929a8.878 8.878 0 01-4.721-1.361 8.976 8.976 0 01-3.295-3.675 9.062 9.062 0 01.953-9.47 8.934 8.934 0 013.97-2.936zm.509 1.41a7.434 7.434 0 00-3.289 2.439 7.562 7.562 0 00-.795 7.9 7.475 7.475 0 002.745 3.062 7.378 7.378 0 003.93 1.131h9.202a4.34 4.34 0 003.082-1.288 4.429 4.429 0 001.28-3.118c0-1.17-.461-2.292-1.28-3.118a4.34 4.34 0 00-3.082-1.289h-1.289a.75.75 0 01-.726-.563 7.515 7.515 0 00-2.074-3.56 7.407 7.407 0 00-3.623-1.91 7.364 7.364 0 00-4.081.314z" clip-rule="evenodd"/></svg>');
+}
+
+%cloud-check-16-svg-prop {
+  --cloud-check-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.932 1.373a6.041 6.041 0 016.239 1.28 5.998 5.998 0 011.505 2.284h.28c1.071 0 2.1.424 2.858 1.18a4.025 4.025 0 01-.665 6.239.75.75 0 01-.812-1.262 2.524 2.524 0 00.418-3.914 2.551 2.551 0 00-1.8-.742h-.83a.75.75 0 01-.726-.562A4.496 4.496 0 009.14 3.74a4.541 4.541 0 00-4.688-.96 4.52 4.52 0 00-2.006 1.466 4.488 4.488 0 00.386 5.942.75.75 0 01-1.055 1.066 5.982 5.982 0 01-.515-7.928 6.02 6.02 0 012.67-1.954z"/><path d="M11.78 9.22a.75.75 0 010 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-2-2a.75.75 0 111.06-1.06l1.47 1.47 3.97-3.97a.75.75 0 011.06 0z"/></g></svg>');
+}
+
+%cloud-check-24-svg-prop {
+  --cloud-check-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.026 1.046a8.87 8.87 0 014.152.57 8.932 8.932 0 013.436 2.412 9.017 9.017 0 011.802 3.16h.726a5.84 5.84 0 013.698 1.326 5.914 5.914 0 012.037 3.374 5.945 5.945 0 01-.528 3.91 5.882 5.882 0 01-2.858 2.705.75.75 0 01-.606-1.372 4.381 4.381 0 002.129-2.016c.46-.9.599-1.932.394-2.923a4.413 4.413 0 00-1.52-2.518 4.338 4.338 0 00-2.746-.987h-1.288a.75.75 0 01-.727-.564 7.521 7.521 0 00-1.639-3.104 7.431 7.431 0 00-2.859-2.008 7.37 7.37 0 00-6.734.692 7.472 7.472 0 00-2.4 2.549 7.55 7.55 0 00-.338 6.832 7.49 7.49 0 002.138 2.777.75.75 0 01-.941 1.168 8.99 8.99 0 01-2.566-3.333 9.06 9.06 0 01.404-8.189 8.971 8.971 0 012.883-3.06 8.888 8.888 0 013.951-1.4z"/><path d="M17.78 14.22a.75.75 0 010 1.06l-7.5 7.5a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l2.47 2.47 6.97-6.97a.75.75 0 011.06 0z"/></g></svg>');
+}
+
 %cloud-cross-svg-prop {
   --cloud-cross-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 23 20" xmlns="http://www.w3.org/2000/svg"><path d="M12 13.586l3-3L16.414 12l-3 3 3 3L15 19.414l-3-3-3 3L7.586 18l3-3-2.75-2.75 1.414-1.414 2.75 2.75zM13.905.856c2.706.498 4.595 2.544 4.816 5.64l.234.066c2.46.754 3.884 2.79 3.5 5.036-.445 2.592-2.083 4.371-5.876 4.371v-2c5.054 0 4.868-5.46.23-6.152.242-2.277-1.278-4.628-3.267-4.995-1.789-.33-3.757.564-4.572 2.164-1.629-.727-2.605-.345-3.442.362-.836.706-.527 2.194-.225 2.823-1.089.915-1.901 2.013-2.152 2.987-.101.395-.091 1.014 0 1.212.428.928 1.016 1.6 4.403 1.6v2c-4.117 0-5.672-.96-6.448-2.874-.652-1.61.137-3.457 1.882-5.118-.544-1.734.01-3.297 1.391-4.267a4.89 4.89 0 013.689-.77C9.222 1.26 11.603.431 13.905.855z" fill="%236F7682" fill-rule="nonzero"/></svg>');
 }
 
+%cloud-download-16-svg-prop {
+  --cloud-download-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.235 1.123a6.041 6.041 0 00-3.303.25A6.02 6.02 0 001.26 3.326a5.988 5.988 0 00.515 7.929.75.75 0 001.055-1.066 4.482 4.482 0 01-.386-5.942A4.52 4.52 0 014.451 2.78a4.541 4.541 0 014.688.961 4.496 4.496 0 011.26 2.135.75.75 0 00.726.561h.83c.676 0 1.324.268 1.8.743a2.524 2.524 0 01-.418 3.914.75.75 0 00.812 1.262 4.024 4.024 0 00.665-6.239 4.051 4.051 0 00-2.859-1.18h-.28a5.998 5.998 0 00-1.504-2.285 6.028 6.028 0 00-2.936-1.529z"/><path d="M8 7.25a.75.75 0 01.75.75v4.44l1.47-1.47a.75.75 0 111.06 1.06l-2.75 2.75a.75.75 0 01-1.06 0l-2.75-2.75a.75.75 0 111.06-1.06l1.47 1.47V8A.75.75 0 018 7.25z"/></g></svg>');
+}
+
+%cloud-download-24-svg-prop {
+  --cloud-download-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.178 1.615a8.87 8.87 0 00-8.103.832 8.971 8.971 0 00-2.883 3.06 9.05 9.05 0 00-.404 8.189 8.99 8.99 0 002.566 3.333.75.75 0 10.94-1.168 7.49 7.49 0 01-2.137-2.777 7.56 7.56 0 01.338-6.832 7.472 7.472 0 012.4-2.549 7.37 7.37 0 016.734-.692 7.431 7.431 0 012.859 2.008 7.521 7.521 0 011.64 3.104.75.75 0 00.726.564h1.288c1 .001 1.97.35 2.746.987a4.413 4.413 0 011.52 2.518 4.444 4.444 0 01-.394 2.923c-.46.9-1.212 1.61-2.13 2.016a.75.75 0 00.607 1.372 5.882 5.882 0 002.858-2.705 5.945 5.945 0 00.527-3.91 5.914 5.914 0 00-2.036-3.374 5.84 5.84 0 00-3.698-1.327h-.726a9.017 9.017 0 00-1.802-3.159 8.932 8.932 0 00-3.436-2.413z"/><path d="M12 22h.012a.747.747 0 00.533-.235l4.25-4.5a.75.75 0 00-1.09-1.03l-2.955 3.129V12.75a.75.75 0 00-1.5 0v6.614l-2.955-3.129a.75.75 0 00-1.09 1.03l4.248 4.498a.748.748 0 00.535.237H12z"/></g></svg>');
+}
+
+%cloud-lightning-16-svg-prop {
+  --cloud-lightning-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.235 1.123a6.041 6.041 0 00-3.303.25A6.02 6.02 0 001.26 3.326a5.988 5.988 0 00.515 7.929.75.75 0 001.055-1.066 4.482 4.482 0 01-.386-5.942A4.52 4.52 0 014.451 2.78a4.541 4.541 0 014.688.961 4.496 4.496 0 011.26 2.135.75.75 0 00.726.561h.83c.676 0 1.324.268 1.8.743a2.524 2.524 0 01-.418 3.914.75.75 0 00.812 1.262 4.024 4.024 0 00.665-6.239 4.051 4.051 0 00-2.859-1.18h-.28a5.998 5.998 0 00-1.504-2.285 6.028 6.028 0 00-2.936-1.529z"/><path d="M9.053 7.257a.75.75 0 00-1.106-1.014l-2.75 3a.75.75 0 00.316 1.218l3.403 1.135-1.969 2.147a.75.75 0 001.106 1.014l2.75-3a.75.75 0 00-.316-1.218L7.084 9.404l1.969-2.147z"/></g></svg>');
+}
+
+%cloud-lightning-24-svg-prop {
+  --cloud-lightning-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.819 1.485a8.86 8.86 0 00-4.357-.363 8.892 8.892 0 00-4.004 1.765A8.99 8.99 0 00.766 6.353a9.065 9.065 0 00.649 8.509 8.958 8.958 0 003.187 3.01.75.75 0 00.731-1.309 7.457 7.457 0 01-2.653-2.507 7.565 7.565 0 01-.54-7.1A7.49 7.49 0 014.381 4.07 7.392 7.392 0 017.711 2.6a7.36 7.36 0 013.618.302 7.421 7.421 0 013.046 1.999 7.522 7.522 0 011.744 3.22.75.75 0 00.727.565c1.732 0 3.082.103 4.213 1.134a4.44 4.44 0 01.589 5.888 4.356 4.356 0 01-2.643 1.702.75.75 0 00.302 1.47 5.857 5.857 0 003.553-2.288 5.94 5.94 0 00-.79-7.88c-1.427-1.3-3.094-1.495-4.66-1.522a9.017 9.017 0 00-1.93-3.304 8.92 8.92 0 00-3.662-2.402z"/><path d="M14.031 11.03a.75.75 0 10-1.062-1.06l-4.75 4.77a.75.75 0 00.31 1.246l5.372 1.653-3.956 4.357a.75.75 0 001.11 1.008l4.75-5.23a.75.75 0 00-.334-1.222l-5.313-1.634 3.873-3.889z"/></g></svg>');
+}
+
+%cloud-lock-16-svg-prop {
+  --cloud-lock-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.235 1.123a6.041 6.041 0 00-3.303.25A6.02 6.02 0 001.26 3.326a5.988 5.988 0 00-.404 6.76.75.75 0 101.286-.774 4.49 4.49 0 01-.62-2.766 4.488 4.488 0 01.922-2.3A4.52 4.52 0 014.451 2.78a4.541 4.541 0 014.688.961 4.496 4.496 0 011.26 2.135.75.75 0 00.726.561h.83c.676 0 1.324.268 1.8.743a2.524 2.524 0 01.451 2.969.75.75 0 101.326.702 4.02 4.02 0 00-.718-4.734 4.051 4.051 0 00-2.859-1.18h-.28a5.998 5.998 0 00-1.504-2.285 6.028 6.028 0 00-2.936-1.529zM8.75 12.25a.75.75 0 00-1.5 0v.5a.75.75 0 001.5 0v-.5z"/><path fill-rule="evenodd" d="M5.518 9.012c.035-.627.13-1.235.366-1.738.174-.37.435-.704.816-.94C7.08 6.101 7.52 6 8 6c.48 0 .921.1 1.3.334.381.236.642.57.816.94.236.503.331 1.111.366 1.738A2.25 2.25 0 0112.5 11.25v2.5A2.25 2.25 0 0110.25 16h-4.5a2.25 2.25 0 01-2.25-2.25v-2.5a2.25 2.25 0 012.018-2.238zM7.022 9c.032-.481.102-.838.22-1.087a.662.662 0 01.245-.302c.09-.055.243-.111.513-.111s.423.056.513.111c.087.054.17.141.246.302.117.249.187.606.219 1.087H7.022zm3.228 1.5a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75h-4.5a.75.75 0 01-.75-.75v-2.5a.75.75 0 01.75-.75h4.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%cloud-lock-24-svg-prop {
+  --cloud-lock-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.178 1.615a8.87 8.87 0 00-8.103.832 8.971 8.971 0 00-2.883 3.06 9.05 9.05 0 00-.404 8.189c.386.863 1.302 2.042 1.848 2.665a.75.75 0 101.129-.987c-.533-.609-1.32-1.645-1.608-2.29a7.56 7.56 0 01.338-6.832 7.472 7.472 0 012.4-2.549 7.37 7.37 0 016.734-.692 7.431 7.431 0 012.859 2.008 7.521 7.521 0 011.64 3.104.75.75 0 00.726.564h1.288c1 .001 1.97.35 2.746.987a4.413 4.413 0 011.52 2.518 4.444 4.444 0 01-.394 2.923 4.394 4.394 0 01-1.37 1.585.75.75 0 00.867 1.224 5.895 5.895 0 001.838-2.126 5.945 5.945 0 00.527-3.91 5.914 5.914 0 00-2.036-3.374 5.84 5.84 0 00-3.698-1.327h-.726a9.017 9.017 0 00-1.802-3.159 8.932 8.932 0 00-3.436-2.413zM12.75 18.75a.75.75 0 00-1.5 0v.5a.75.75 0 001.5 0v-.5z"/><path fill-rule="evenodd" d="M8 14.014v-.93c0-1.078.417-2.114 1.165-2.881A3.96 3.96 0 0112 9a3.96 3.96 0 012.835 1.203A4.127 4.127 0 0116 13.083v.93a2.25 2.25 0 012 2.237v4.5A2.25 2.25 0 0115.75 23h-7.5A2.25 2.25 0 016 20.75v-4.5a2.25 2.25 0 012-2.236zM9.5 14v-.917c0-.69.268-1.35.739-1.833A2.46 2.46 0 0112 10.5c.657 0 1.29.267 1.761.75.471.483.739 1.142.739 1.833V14h-5zm6.25 1.5a.75.75 0 01.75.75v4.5a.75.75 0 01-.75.75h-7.5a.75.75 0 01-.75-.75v-4.5a.75.75 0 01.75-.75h7.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%cloud-off-16-svg-prop {
+  --cloud-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M1.22 1.22a.75.75 0 011.06 0l12.5 12.5a.75.75 0 11-1.06 1.06l-1.11-1.11c-.258.053-.523.08-.791.08H6.094a5.907 5.907 0 01-3.085-.865A5.783 5.783 0 01.85 10.539a5.674 5.674 0 01-.57-3.117v-.004a5.701 5.701 0 011.196-2.943c.284-.361.61-.686.97-.968L1.22 2.28a.75.75 0 010-1.06zm2.297 3.357a4.299 4.299 0 00-.863.827 4.201 4.201 0 00-.882 2.165v.003a4.174 4.174 0 00.42 2.296c.356.713.91 1.315 1.6 1.737a4.407 4.407 0 002.298.645h5.099L3.517 4.577z" clip-rule="evenodd"/><path d="M6.38 2.954a.75.75 0 01.884-.586A5.87 5.87 0 0110.11 3.83 5.743 5.743 0 0111.564 6h.255a3.96 3.96 0 012.775 1.13 3.848 3.848 0 011.156 2.745c0 .409-.066.81-.19 1.193a.75.75 0 11-1.426-.468c.076-.232.116-.477.116-.725 0-.626-.253-1.228-.707-1.675a2.46 2.46 0 00-1.724-.7h-.802a.75.75 0 01-.725-.56 4.233 4.233 0 00-1.206-2.014 4.37 4.37 0 00-2.119-1.088.75.75 0 01-.587-.884z"/></g></svg>');
+}
+
+%cloud-off-24-svg-prop {
+  --cloud-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M2.28 1.22a.75.75 0 00-1.06 1.06l2.447 2.448a8.96 8.96 0 00-1.801 1.766 9.041 9.041 0 00-1.82 4.598v.003a9.064 9.064 0 00.867 4.87 8.975 8.975 0 003.294 3.674A8.873 8.873 0 008.934 21h9.2c.54 0 1.073-.075 1.585-.22l2 2a.75.75 0 101.061-1.06L2.28 1.22zm16.15 18.27L4.742 5.804c-.639.44-1.209.98-1.687 1.603a7.541 7.541 0 00-1.518 3.832v.003a7.564 7.564 0 00.723 4.066 7.475 7.475 0 002.744 3.06A7.374 7.374 0 008.923 19.5H18.133c.1 0 .198-.003.296-.01z" clip-rule="evenodd"/><path d="M9.702 3.003a.75.75 0 10-.133 1.494 7.394 7.394 0 014.16 1.757 7.51 7.51 0 012.387 3.867.75.75 0 00.727.566h.061c1.304 0 2.327 0 3.292.522.635.343 1.176.84 1.575 1.447a4.436 4.436 0 01.383 4.158.75.75 0 101.383.581 5.946 5.946 0 00-.512-5.563 5.879 5.879 0 00-2.116-1.943c-1.17-.632-2.393-.696-3.5-.701a9.005 9.005 0 00-2.704-4.072 8.894 8.894 0 00-5.003-2.113z"/></g></svg>');
+}
+
+%cloud-upload-16-svg-prop {
+  --cloud-upload-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.235 1.123a6.041 6.041 0 00-3.303.25A6.02 6.02 0 001.26 3.326a5.988 5.988 0 00.515 7.929.75.75 0 001.055-1.066 4.482 4.482 0 01-.386-5.942A4.52 4.52 0 014.451 2.78a4.541 4.541 0 014.688.961 4.496 4.496 0 011.26 2.135.75.75 0 00.726.561h.83c.676 0 1.324.268 1.8.743a2.524 2.524 0 01-.418 3.914.75.75 0 00.812 1.262 4.024 4.024 0 00.665-6.239 4.051 4.051 0 00-2.859-1.18h-.28a5.998 5.998 0 00-1.504-2.285 6.028 6.028 0 00-2.936-1.529z"/><path d="M4.72 11.28a.75.75 0 001.06 0l1.47-1.47v4.44a.75.75 0 001.5 0V9.81l1.47 1.47a.75.75 0 101.06-1.06L8.53 7.47l-.01-.01a.747.747 0 00-1.05.01l-2.75 2.75a.75.75 0 000 1.06z"/></g></svg>');
+}
+
+%cloud-upload-24-svg-prop {
+  --cloud-upload-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.178 1.615a8.87 8.87 0 00-8.103.832 8.971 8.971 0 00-2.883 3.06 9.05 9.05 0 00-.404 8.189 8.99 8.99 0 002.566 3.333.75.75 0 10.94-1.168 7.49 7.49 0 01-2.137-2.777 7.56 7.56 0 01.338-6.832 7.472 7.472 0 012.4-2.549 7.37 7.37 0 016.734-.692 7.431 7.431 0 012.859 2.008 7.521 7.521 0 011.64 3.104.75.75 0 00.726.564h1.288c1 .001 1.97.35 2.746.987a4.413 4.413 0 011.52 2.518 4.444 4.444 0 01-.394 2.923c-.46.9-1.212 1.61-2.13 2.016a.75.75 0 00.607 1.372 5.882 5.882 0 002.858-2.705 5.945 5.945 0 00.527-3.91 5.914 5.914 0 00-2.036-3.374 5.84 5.84 0 00-3.698-1.327h-.726a9.017 9.017 0 00-1.802-3.159 8.932 8.932 0 00-3.436-2.413z"/><path d="M7.235 17.795a.75.75 0 001.06-.03l2.955-3.129v6.614a.75.75 0 001.5 0v-6.614l2.955 3.129a.75.75 0 001.09-1.03l-4.25-4.5a.75.75 0 00-.533-.235h-.024a.748.748 0 00-.535.237l-4.248 4.498a.75.75 0 00.03 1.06z"/></g></svg>');
+}
+
+%cloud-x-16-svg-prop {
+  --cloud-x-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.932 1.373a6.041 6.041 0 016.239 1.28 5.998 5.998 0 011.505 2.284h.28c1.071 0 2.1.424 2.858 1.18a4.025 4.025 0 01-.665 6.239.75.75 0 01-.812-1.262 2.524 2.524 0 00.418-3.914 2.551 2.551 0 00-1.8-.742h-.83a.75.75 0 01-.726-.562A4.496 4.496 0 009.14 3.74a4.541 4.541 0 00-4.688-.96 4.52 4.52 0 00-2.006 1.466 4.488 4.488 0 00.386 5.942.75.75 0 01-1.055 1.066 5.982 5.982 0 01-.515-7.928 6.02 6.02 0 012.67-1.954z"/><path d="M10.78 9.22a.75.75 0 010 1.06L9.06 12l1.72 1.72a.75.75 0 11-1.06 1.06L8 13.06l-1.72 1.72a.75.75 0 01-1.06-1.06L6.94 12l-1.72-1.72a.75.75 0 111.06-1.06L8 10.94l1.72-1.72a.75.75 0 011.06 0z"/></g></svg>');
+}
+
+%cloud-x-24-svg-prop {
+  --cloud-x-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.026 1.046a8.87 8.87 0 014.152.57 8.932 8.932 0 013.436 2.412 9.017 9.017 0 011.802 3.16h.726a5.84 5.84 0 013.698 1.326 5.914 5.914 0 012.037 3.374 5.945 5.945 0 01-.528 3.91 5.882 5.882 0 01-2.858 2.705.75.75 0 01-.606-1.372 4.381 4.381 0 002.129-2.016c.46-.9.599-1.932.394-2.923a4.413 4.413 0 00-1.52-2.518 4.338 4.338 0 00-2.746-.987h-1.288a.75.75 0 01-.727-.564 7.521 7.521 0 00-1.639-3.104 7.431 7.431 0 00-2.859-2.008 7.37 7.37 0 00-6.734.692 7.472 7.472 0 00-2.4 2.549 7.55 7.55 0 00-.338 6.832 7.49 7.49 0 002.138 2.777.75.75 0 01-.941 1.168 8.99 8.99 0 01-2.566-3.333 9.06 9.06 0 01.404-8.189 8.971 8.971 0 012.883-3.06 8.888 8.888 0 013.951-1.4z"/><path d="M8.22 14.22a.75.75 0 011.06 0L12 16.94l2.72-2.72a.75.75 0 111.06 1.06L13.06 18l2.72 2.72a.75.75 0 11-1.06 1.06L12 19.06l-2.72 2.72a.75.75 0 01-1.06-1.06L10.94 18l-2.72-2.72a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%code-16-svg-prop {
+  --code-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M9.424 2.02a.75.75 0 00-.904.556l-2.5 10.5a.75.75 0 001.46.348l2.5-10.5a.75.75 0 00-.556-.904zM11.2 4.24a.75.75 0 011.06-.04l3.5 3.25a.75.75 0 010 1.1l-3.5 3.25a.75.75 0 11-1.02-1.1L14.148 8 11.24 5.3a.75.75 0 01-.04-1.06zM4.76 5.3a.75.75 0 00-1.02-1.1L.24 7.45a.75.75 0 000 1.1l3.5 3.25a.75.75 0 001.02-1.1L1.852 8 4.76 5.3z"/></g></svg>');
+}
+
+%code-24-svg-prop {
+  --code-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M14.447 3.026a.75.75 0 00-.92.527l-4.5 16.5a.75.75 0 001.447.394l4.5-16.5a.75.75 0 00-.527-.92zM16.207 6.232a.75.75 0 011.06-.025l5.5 5.25a.75.75 0 010 1.085l-5.5 5.25a.75.75 0 01-1.035-1.085L21.164 12l-4.932-4.707a.75.75 0 01-.024-1.06zM7.768 7.293a.75.75 0 00-1.036-1.086l-5.5 5.25a.75.75 0 000 1.085l5.5 5.25a.75.75 0 101.036-1.085L2.836 12l4.932-4.707z"/></g></svg>');
+}
+
 %code-svg-prop {
   --code-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z" fill="%23000"/></svg>');
+}
+
+%collections-16-svg-prop {
+  --collections-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.05 4.75a.7.7 0 01.7-.7h3.5a.7.7 0 110 1.4h-3.5a.7.7 0 01-.7-.7zM3.75 7.05a.7.7 0 100 1.4h2.5a.7.7 0 100-1.4h-2.5z"/><path fill-rule="evenodd" d="M0 3.25A2.25 2.25 0 012.25 1h6.5c.883 0 1.648.51 2.016 1.25h.984c.698 0 1.3.409 1.582 1h.918c.966 0 1.75.784 1.75 1.75v6a1.75 1.75 0 01-1.75 1.75h-.918c-.281.591-.884 1-1.582 1h-.984A2.25 2.25 0 018.75 15h-6.5A2.25 2.25 0 010 12.75v-9.5zm13.5 8h.75a.25.25 0 00.25-.25V5a.25.25 0 00-.25-.25h-.75v6.5zm-2.5 1v-8.5h.75A.25.25 0 0112 4v8a.25.25 0 01-.25.25H11zM2.25 2.5a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h6.5a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75h-6.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%collections-24-svg-prop {
+  --collections-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5 6.75A.75.75 0 015.75 6h6.5a.75.75 0 010 1.5h-6.5A.75.75 0 015 6.75zM5.75 9a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5z"/><path fill-rule="evenodd" d="M1 4.75A2.75 2.75 0 013.75 2h10.5c.854 0 1.617.39 2.121 1h.879c.854 0 1.617.39 2.121 1h.879A2.75 2.75 0 0123 6.75v10.5A2.75 2.75 0 0120.25 20h-.879c-.504.61-1.267 1-2.121 1h-.879c-.504.61-1.267 1-2.121 1H3.75A2.75 2.75 0 011 19.25V4.75zM19.989 18.5h.261c.69 0 1.25-.56 1.25-1.25V6.75c0-.69-.56-1.25-1.25-1.25h-.261c.007.082.011.166.011.25v12.5c0 .084-.004.168-.011.25zM17 4.75c0-.084-.004-.168-.011-.25h.261c.69 0 1.25.56 1.25 1.25v12.5c0 .69-.56 1.25-1.25 1.25h-.261c.007-.082.011-.166.011-.25V4.75zM3.75 3.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H3.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%command-16-svg-prop {
+  --command-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M6.5 3.75V5h3V3.75a2.75 2.75 0 112.75 2.75H11v3h1.25a2.75 2.75 0 11-2.75 2.75V11h-3v1.25A2.75 2.75 0 113.75 9.5H5v-3H3.75A2.75 2.75 0 116.5 3.75zM3.75 2.5a1.25 1.25 0 100 2.5H5V3.75c0-.69-.56-1.25-1.25-1.25zM11 11v1.25A1.25 1.25 0 1012.25 11H11zM9.5 9.5v-3h-3v3h3zM3.75 11H5v1.25A1.25 1.25 0 113.75 11zM11 5h1.25A1.25 1.25 0 1011 3.75V5z" clip-rule="evenodd"/></svg>');
+}
+
+%command-24-svg-prop {
+  --command-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M9.5 5.75V8h5V5.75a3.75 3.75 0 113.75 3.75H16v5h2.25a3.75 3.75 0 11-3.75 3.75V16h-5v2.25a3.75 3.75 0 11-3.75-3.75H8v-5H5.75A3.75 3.75 0 119.5 5.75zM5.75 3.5a2.25 2.25 0 000 4.5H8V5.75A2.25 2.25 0 005.75 3.5zM16 16v2.25A2.25 2.25 0 1018.25 16H16zm-1.5-1.5v-5h-5v5h5zM5.75 16H8v2.25A2.25 2.25 0 115.75 16zM16 8h2.25A2.25 2.25 0 1016 5.75V8z" clip-rule="evenodd"/></svg>');
+}
+
+%compass-16-svg-prop {
+  --compass-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M11.914 4.971a.7.7 0 00-.885-.885L6.154 5.71a.7.7 0 00-.443.443l-1.625 4.875a.7.7 0 00.885.885l4.875-1.625a.7.7 0 00.443-.443l1.625-4.875zm-6.057 5.172l1.071-3.215 3.215-1.071-1.071 3.215-3.215 1.071z"/><path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></g></svg>');
+}
+
+%compass-24-svg-prop {
+  --compass-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M16.951 7.997a.75.75 0 00-.948-.948l-6.36 2.12a.75.75 0 00-.474.474l-2.12 6.36a.75.75 0 00.948.948l6.36-2.12a.75.75 0 00.475-.474l2.12-6.36zm-8.005 7.057l1.527-4.581 4.581-1.527-1.527 4.581-4.581 1.527z"/><path d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z"/></g></svg>');
+}
+
+%connection-16-svg-prop {
+  --connection-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 7.75A3 3 0 015.905 7h4.19a3.001 3.001 0 110 1.5h-4.19A3.001 3.001 0 010 7.75zm3-1.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm10 0a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" clip-rule="evenodd"/></svg>');
+}
+
+%connection-24-svg-prop {
+  --connection-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M1 11.75A3.5 3.5 0 017.92 11h8.16a3.501 3.501 0 016.92.75 3.5 3.5 0 01-6.92.75H7.92A3.501 3.501 0 011 11.75zm3.5-2a2 2 0 100 4 2 2 0 000-4zm15 0a2 2 0 100 4 2 2 0 000-4z" clip-rule="evenodd"/></svg>');
+}
+
+%connection-gateway-16-svg-prop {
+  --connection-gateway-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M13.75.5a2.25 2.25 0 00-1.847 3.536l-.933.934a.752.752 0 00-.11.14c-.19-.071-.396-.11-.61-.11h-2.5A1.75 1.75 0 006 6.75v.5H4.372a2.25 2.25 0 100 1.5H6v.5c0 .966.784 1.75 1.75 1.75h2.5c.214 0 .42-.039.61-.11.03.05.067.097.11.14l.933.934a2.25 2.25 0 101.24-.881L12.03 9.97a.75.75 0 00-.14-.11c.071-.19.11-.396.11-.61v-2.5c0-.214-.039-.42-.11-.61a.75.75 0 00.14-.11l1.113-1.113A2.252 2.252 0 0016 2.75 2.25 2.25 0 0013.75.5zM13 2.75a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM7.75 6.5a.25.25 0 00-.25.25v2.5c0 .138.112.25.25.25h2.5a.25.25 0 00.25-.25v-2.5a.25.25 0 00-.25-.25h-2.5zm6 6a.75.75 0 100 1.5.75.75 0 000-1.5zM1.5 8A.75.75 0 113 8a.75.75 0 01-1.5 0z" clip-rule="evenodd"/></svg>');
+}
+
+%connection-gateway-24-svg-prop {
+  --connection-gateway-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M20.5 1.75a3 3 0 00-2.665 4.378l-2.441 2.184A2.24 2.24 0 0014.25 8h-3A2.25 2.25 0 009 10.25V11H6.405a3.001 3.001 0 00-5.905.75 3 3 0 005.905.75H9v.75a2.25 2.25 0 002.25 2.25h3a2.24 2.24 0 001.144-.312l2.44 2.184a3 3 0 101-1.118l-2.476-2.216c.092-.245.142-.51.142-.788v-3c0-.277-.05-.543-.142-.788l2.477-2.216A3 3 0 1020.5 1.75zm-1.5 3a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zM11.25 9.5a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h3a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-3zm9.25 7.75a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM2 11.75a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/></svg>');
 }
 
 %console-svg-prop {
@@ -134,12 +1006,140 @@
   --copy-success-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14.82 3C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v16.025c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2h-4.18zM12 3c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm-2 15l-4-4 1.41-1.41L10 15.17l6.59-6.59L18 10l-8 8z" fill="%23000"/></svg>');
 }
 
+%corner-down-left-16-svg-prop {
+  --corner-down-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M13.5 2.75a.75.75 0 00-1.5 0v4.5A1.75 1.75 0 0110.25 9H4.56l2.22-2.22a.75.75 0 00-1.06-1.06l-3.5 3.5a.748.748 0 000 1.06l3.5 3.5a.75.75 0 001.06-1.06L4.56 10.5h5.69a3.25 3.25 0 003.25-3.25v-4.5z"/></svg>');
+}
+
+%corner-down-left-24-svg-prop {
+  --corner-down-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M21.5 3.75a.75.75 0 00-1.5 0v7c0 .847-.357 1.669-1.009 2.282A3.639 3.639 0 0116.5 14H5.622l4.146-3.957a.75.75 0 10-1.036-1.086l-5.498 5.25a.748.748 0 00-.002 1.085l5.5 5.25a.75.75 0 101.036-1.085L5.622 15.5H16.5c1.312 0 2.578-.49 3.52-1.375a4.634 4.634 0 001.48-3.375v-7z"/></svg>');
+}
+
+%corner-down-right-16-svg-prop {
+  --corner-down-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M2.5 2.75a.75.75 0 011.5 0v4.5A1.75 1.75 0 005.75 9h5.69L9.22 6.78a.75.75 0 011.06-1.06l3.5 3.5a.75.75 0 010 1.06l-3.5 3.5a.75.75 0 11-1.06-1.06l2.22-2.22H5.75A3.25 3.25 0 012.5 7.25v-4.5z"/></svg>');
+}
+
+%corner-down-right-24-svg-prop {
+  --corner-down-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M2.5 3.75a.75.75 0 011.5 0v7c0 .847.357 1.669 1.009 2.282A3.639 3.639 0 007.5 14h10.878l-4.146-3.957a.75.75 0 011.036-1.086l5.498 5.25a.748.748 0 01.002 1.085l-5.5 5.25a.75.75 0 01-1.036-1.085l4.146-3.957H7.5a5.139 5.139 0 01-3.52-1.375A4.634 4.634 0 012.5 10.75v-7z"/></svg>');
+}
+
+%corner-left-down-16-svg-prop {
+  --corner-left-down-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M13.25 2.5a.75.75 0 010 1.5h-4.5A1.75 1.75 0 007 5.75v5.69l2.22-2.22a.75.75 0 111.06 1.06l-3.5 3.5a.75.75 0 01-1.06 0l-3.5-3.5a.75.75 0 111.06-1.06l2.22 2.22V5.75A3.25 3.25 0 018.75 2.5h4.5z"/></svg>');
+}
+
+%corner-left-down-24-svg-prop {
+  --corner-left-down-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M20.25 2.5a.75.75 0 010 1.5h-7c-.847 0-1.669.357-2.282 1.009A3.639 3.639 0 0010 7.5v10.878l3.957-4.146a.75.75 0 011.085 1.036l-5.25 5.5a.75.75 0 01-1.085 0l-5.25-5.5a.75.75 0 011.086-1.036L8.5 18.378V7.5c0-1.312.49-2.579 1.375-3.52A4.634 4.634 0 0113.25 2.5h7z"/></svg>');
+}
+
+%corner-left-up-16-svg-prop {
+  --corner-left-up-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M9.22 6.78a.75.75 0 101.06-1.06l-3.5-3.5a.75.75 0 00-1.06 0l-3.5 3.5a.75.75 0 001.06 1.06L5.5 4.56v5.69a3.25 3.25 0 003.25 3.25h4.5a.75.75 0 000-1.5h-4.5A1.75 1.75 0 017 10.25V4.56l2.22 2.22z"/></svg>');
+}
+
+%corner-left-up-24-svg-prop {
+  --corner-left-up-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M13.957 9.768a.75.75 0 001.085-1.036l-5.25-5.5a.75.75 0 00-1.085 0l-5.25 5.5a.75.75 0 001.086 1.036L8.5 5.622V16.5c0 1.312.49 2.578 1.375 3.52.887.942 2.1 1.48 3.375 1.48h7a.75.75 0 000-1.5h-7a3.135 3.135 0 01-2.282-1.009A3.639 3.639 0 0110 16.5V5.622l3.957 4.146z"/></svg>');
+}
+
+%corner-right-down-16-svg-prop {
+  --corner-right-down-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M2.75 2.5a.75.75 0 000 1.5h4.5A1.75 1.75 0 019 5.75v5.69L6.78 9.22a.75.75 0 00-1.06 1.06l3.5 3.5a.75.75 0 001.06 0l3.5-3.5a.75.75 0 10-1.06-1.06l-2.22 2.22V5.75A3.25 3.25 0 007.25 2.5h-4.5z"/></svg>');
+}
+
+%corner-right-down-24-svg-prop {
+  --corner-right-down-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M3.75 2.5a.75.75 0 000 1.5h7c.847 0 1.669.357 2.282 1.009.615.653.968 1.549.968 2.491v10.878l-3.957-4.146a.75.75 0 00-1.086 1.036l5.25 5.5a.75.75 0 001.085 0l5.25-5.5a.75.75 0 00-1.085-1.036L15.5 18.378V7.5c0-1.312-.49-2.579-1.375-3.52A4.634 4.634 0 0010.75 2.5h-7z"/></svg>');
+}
+
+%corner-right-up-16-svg-prop {
+  --corner-right-up-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M6.78 6.78a.75.75 0 01-1.06-1.06l3.5-3.5a.75.75 0 011.06 0l3.5 3.5a.75.75 0 01-1.06 1.06L10.5 4.56v5.69a3.25 3.25 0 01-3.25 3.25h-4.5a.75.75 0 010-1.5h4.5A1.75 1.75 0 009 10.25V4.56L6.78 6.78z"/></svg>');
+}
+
+%corner-right-up-24-svg-prop {
+  --corner-right-up-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M10.043 9.768a.75.75 0 11-1.086-1.036l5.25-5.5a.75.75 0 011.085 0l5.25 5.5a.75.75 0 11-1.085 1.036L15.5 5.622V16.5c0 1.312-.49 2.578-1.375 3.52a4.634 4.634 0 01-3.375 1.48h-7a.75.75 0 010-1.5h7c.847 0 1.669-.357 2.282-1.009A3.639 3.639 0 0014 16.5V5.622l-3.957 4.146z"/></svg>');
+}
+
+%corner-up-left-16-svg-prop {
+  --corner-up-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M6.78 9.22a.75.75 0 11-1.06 1.06l-3.5-3.5a.75.75 0 010-1.06l3.5-3.5a.75.75 0 011.06 1.06L4.56 5.5h5.69a3.25 3.25 0 013.25 3.25v4.5a.75.75 0 01-1.5 0v-4.5A1.75 1.75 0 0010.25 7H4.56l2.22 2.22z"/></svg>');
+}
+
+%corner-up-left-24-svg-prop {
+  --corner-up-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M9.768 13.957a.75.75 0 01-1.036 1.085l-5.5-5.25a.75.75 0 010-1.085l5.5-5.25a.75.75 0 011.036 1.086L5.622 8.5H16.5c1.312 0 2.578.49 3.52 1.375.942.887 1.48 2.1 1.48 3.375v7a.75.75 0 01-1.5 0v-7c0-.847-.357-1.669-1.009-2.282A3.639 3.639 0 0016.5 10H5.622l4.146 3.957z"/></svg>');
+}
+
+%corner-up-right-16-svg-prop {
+  --corner-up-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M9.22 9.22a.75.75 0 101.06 1.06l3.5-3.5a.75.75 0 000-1.06l-3.5-3.5a.75.75 0 10-1.06 1.06l2.22 2.22H5.75A3.25 3.25 0 002.5 8.75v4.5a.75.75 0 001.5 0v-4.5A1.75 1.75 0 015.75 7h5.69L9.22 9.22z"/></svg>');
+}
+
+%corner-up-right-24-svg-prop {
+  --corner-up-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M14.232 13.957a.75.75 0 001.036 1.085l5.5-5.25a.75.75 0 000-1.085l-5.5-5.25a.75.75 0 00-1.036 1.086L18.378 8.5H7.5c-1.312 0-2.579.49-3.52 1.375A4.634 4.634 0 002.5 13.25v7a.75.75 0 001.5 0v-7c0-.847.357-1.669 1.009-2.282A3.639 3.639 0 017.5 10h10.878l-4.146 3.957z"/></svg>');
+}
+
+%cpu-16-svg-prop {
+  --cpu-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M6.25 5C5.56 5 5 5.56 5 6.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5C11 5.56 10.44 5 9.75 5h-3.5zm.25 4.5v-3h3v3h-3z"/><path d="M6.25.05a.7.7 0 01.7.7V2h2.1V.75a.7.7 0 111.4 0V2h1.3A2.25 2.25 0 0114 4.25v1.3h1.25a.7.7 0 110 1.4H14v2.1h1.25a.7.7 0 110 1.4H14v1.3A2.25 2.25 0 0111.75 14h-1.3v1.25a.7.7 0 11-1.4 0V14h-2.1v1.25a.7.7 0 11-1.4 0V14h-1.3A2.25 2.25 0 012 11.75v-1.3H.75a.7.7 0 110-1.4H2v-2.1H.75a.7.7 0 110-1.4H2v-1.3A2.25 2.25 0 014.25 2h1.3V.75a.7.7 0 01.7-.7zM3.5 4.25a.75.75 0 01.75-.75h7.5a.75.75 0 01.75.75v7.5a.75.75 0 01-.75.75h-7.5a.75.75 0 01-.75-.75v-7.5z"/></g></svg>');
+}
+
+%cpu-24-svg-prop {
+  --cpu-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M9.75 8A1.75 1.75 0 008 9.75v4.5c0 .966.784 1.75 1.75 1.75h4.5A1.75 1.75 0 0016 14.25v-4.5A1.75 1.75 0 0014.25 8h-4.5zM9.5 9.75a.25.25 0 01.25-.25h4.5a.25.25 0 01.25.25v4.5a.25.25 0 01-.25.25h-4.5a.25.25 0 01-.25-.25v-4.5z"/><path d="M9.25 0a.75.75 0 01.75.75V3h4V.75a.75.75 0 011.5 0V3h2.75A2.75 2.75 0 0121 5.75V8.5h2.25a.75.75 0 010 1.5H21v3h2.25a.75.75 0 010 1.5H21v3.75A2.75 2.75 0 0118.25 21H15.5v2.25a.75.75 0 01-1.5 0V21h-4v2.25a.75.75 0 01-1.5 0V21H5.75A2.75 2.75 0 013 18.25V14.5H.75a.75.75 0 010-1.5H3v-3H.75a.75.75 0 010-1.5H3V5.75A2.75 2.75 0 015.75 3H8.5V.75A.75.75 0 019.25 0zM4.5 18.25c0 .69.56 1.25 1.25 1.25h12.5c.69 0 1.25-.56 1.25-1.25V5.75c0-.69-.56-1.25-1.25-1.25H5.75c-.69 0-1.25.56-1.25 1.25v12.5z"/></g></svg>');
+}
+
+%credit-card-16-svg-prop {
+  --credit-card-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.75 9a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5z"/><path fill-rule="evenodd" d="M0 4.25A2.25 2.25 0 012.25 2h11.5A2.25 2.25 0 0116 4.25v7.5A2.25 2.25 0 0113.75 14H2.25A2.25 2.25 0 010 11.75v-7.5zm14.5 0V5h-13v-.75a.75.75 0 01.75-.75h11.5a.75.75 0 01.75.75zm0 2.75h-13v4.75c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75V7z" clip-rule="evenodd"/></g></svg>');
+}
+
+%credit-card-24-svg-prop {
+  --credit-card-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M4.75 15a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z"/><path fill-rule="evenodd" d="M0 5.75A2.75 2.75 0 012.75 3h18.5A2.75 2.75 0 0124 5.75v12.5A2.75 2.75 0 0121.25 21H2.75A2.75 2.75 0 010 18.25V5.75zm22.5 0V8h-21V5.75c0-.69.56-1.25 1.25-1.25h18.5c.69 0 1.25.56 1.25 1.25zm0 5.25h-21v7.25c0 .69.56 1.25 1.25 1.25h18.5c.69 0 1.25-.56 1.25-1.25V11z" clip-rule="evenodd"/></g></svg>');
+}
+
+%crop-16-svg-prop {
+  --crop-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4.5 1.25a.75.75 0 00-1.5 0V3H1.25a.75.75 0 000 1.5H3v6.456A2.044 2.044 0 005.044 13H11.5v1.75a.75.75 0 001.5 0V13h1.75a.75.75 0 000-1.5H13V5.044A2.044 2.044 0 0010.956 3H4.5V1.25zm0 3.25v6.456a.544.544 0 00.544.544H11.5V5.044a.544.544 0 00-.544-.544H4.5z" clip-rule="evenodd"/></svg>');
+}
+
+%crop-24-svg-prop {
+  --crop-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M6.5 1.25a.75.75 0 00-1.5 0V5H1.25a.75.75 0 000 1.5H5v9.75A2.75 2.75 0 007.75 19h9.75v3.75a.75.75 0 001.5 0V19h3.75a.75.75 0 000-1.5H19V7.75A2.75 2.75 0 0016.25 5H6.5V1.25zm0 5.25v9.75a1.25 1.25 0 001.25 1.25h9.75V7.75a1.25 1.25 0 00-1.25-1.25H6.5z" clip-rule="evenodd"/></svg>');
+}
+
+%crosshair-16-svg-prop {
+  --crosshair-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8.75 6.457V12.75a.75.75 0 00-1.5 0v1.707A6.503 6.503 0 011.543 8.75H3.25a.75.75 0 000-1.5H1.543A6.503 6.503 0 017.25 1.543V3.25a.75.75 0 001.5 0V1.543a6.503 6.503 0 015.707 5.707H12.75a.75.75 0 000 1.5h1.707a6.503 6.503 0 01-5.707 5.707z" clip-rule="evenodd"/></svg>');
+}
+
+%crosshair-24-svg-prop {
+  --crosshair-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11.75 9.47v-2.72a.75.75 0 00-1.5 0v2.72a9.502 9.502 0 01-8.72-8.72h2.72a.75.75 0 000-1.5H2.53a9.502 9.502 0 018.72-8.72v2.72a.75.75 0 001.5 0V2.53a9.502 9.502 0 018.72 8.72h-2.72a.75.75 0 000 1.5h2.72a9.502 9.502 0 01-8.72 8.72z" clip-rule="evenodd"/></svg>');
+}
+
+%dashboard-16-svg-prop {
+  --dashboard-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M1 2.25C1 1.56 1.56 1 2.25 1h3.5C6.44 1 7 1.56 7 2.25v11.5C7 14.44 6.44 15 5.75 15h-3.5C1.56 15 1 14.44 1 13.75V2.25zm1.5.25v11h3v-11h-3zM9 2.25C9 1.56 9.56 1 10.25 1h3.5c.69 0 1.25.56 1.25 1.25v3.5C15 6.44 14.44 7 13.75 7h-3.5C9.56 7 9 6.44 9 5.75v-3.5zm1.5.25v3h3v-3h-3zM10.25 9C9.56 9 9 9.56 9 10.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5C15 9.56 14.44 9 13.75 9h-3.5zm.25 4.5v-3h3v3h-3z"/></g></svg>');
+}
+
+%dashboard-24-svg-prop {
+  --dashboard-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M2 3.75C2 2.784 2.784 2 3.75 2h5.5c.966 0 1.75.784 1.75 1.75v16.5A1.75 1.75 0 019.25 22h-5.5A1.75 1.75 0 012 20.25V3.75zm1.75-.25a.25.25 0 00-.25.25v16.5c0 .138.112.25.25.25h5.5a.25.25 0 00.25-.25V3.75a.25.25 0 00-.25-.25h-5.5zM13 3.75c0-.966.784-1.75 1.75-1.75h5.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0120.25 11h-5.5A1.75 1.75 0 0113 9.25v-5.5zm1.75-.25a.25.25 0 00-.25.25v5.5c0 .138.112.25.25.25h5.5a.25.25 0 00.25-.25v-5.5a.25.25 0 00-.25-.25h-5.5zM14.75 13A1.75 1.75 0 0013 14.75v5.5c0 .966.784 1.75 1.75 1.75h5.5A1.75 1.75 0 0022 20.25v-5.5A1.75 1.75 0 0020.25 13h-5.5zm-.25 1.75a.25.25 0 01.25-.25h5.5a.25.25 0 01.25.25v5.5a.25.25 0 01-.25.25h-5.5a.25.25 0 01-.25-.25v-5.5z"/></g></svg>');
+}
+
+%database-16-svg-prop {
+  --database-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.352 1.621C4.575 1.23 6.218 1 8 1c1.782 0 3.425.23 4.648.621.607.195 1.153.442 1.563.752.398.301.789.76.789 1.377v8.5c0 .616-.386 1.074-.784 1.376-.41.311-.954.559-1.56.753C11.435 14.771 9.791 15 8 15c-1.791 0-3.435-.23-4.656-.62-.606-.195-1.15-.443-1.56-.754-.398-.302-.784-.76-.784-1.376v-8.5c0-.618.39-1.076.789-1.377.41-.31.956-.557 1.563-.752zM2.509 3.75a.738.738 0 01.185-.18c.222-.169.591-.352 1.115-.52C4.848 2.718 6.33 2.5 8 2.5c1.67 0 3.152.218 4.19.55.524.168.894.351 1.116.52a.74.74 0 01.185.18.74.74 0 01-.185.18c-.222.169-.591.352-1.115.52C11.152 4.782 9.67 5 8 5c-1.67 0-3.152-.218-4.19-.55-.525-.168-.894-.351-1.116-.52a.738.738 0 01-.185-.18zM2.5 9.723v2.511c.01.021.049.09.192.198.22.168.588.351 1.11.519 1.035.332 2.517.549 4.198.549 1.681 0 3.162-.217 4.198-.55.522-.166.89-.35 1.11-.518.143-.109.183-.177.192-.198V9.723c-.272.113-.57.21-.88.292-1.215.322-2.848.485-4.62.485-1.772 0-3.405-.163-4.62-.485a6.903 6.903 0 01-.88-.292zm11-1.746a.591.591 0 01-.163.145c-.213.146-.575.303-1.102.443C11.192 8.841 9.7 9 8 9c-1.7 0-3.192-.159-4.235-.435-.527-.14-.889-.297-1.102-.443a.59.59 0 01-.163-.145v-2.43c.263.125.55.235.852.332C4.575 6.27 6.218 6.5 8 6.5c1.782 0 3.425-.23 4.648-.621.302-.097.59-.207.852-.331v2.429z" clip-rule="evenodd"/></svg>');
+}
+
+%database-24-svg-prop {
+  --database-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M22 5.75c0-.751-.47-1.34-1.02-1.763-.563-.43-1.329-.787-2.208-1.072C17.005 2.342 14.611 2 12 2c-2.61 0-5.005.342-6.772.915-.88.285-1.646.641-2.207 1.072C2.469 4.41 2 5 2 5.75v12.412c0 .752.454 1.352 1.006 1.79.56.445 1.325.812 2.204 1.106 1.766.59 4.163.942 6.79.942s5.024-.352 6.79-.942c.88-.294 1.644-.66 2.204-1.105.552-.439 1.006-1.039 1.006-1.791V5.75zM3.933 5.177c-.385.296-.433.496-.433.573 0 .077.048.277.433.573.374.286.963.577 1.758.835C7.27 7.67 9.502 8 12 8s4.729-.33 6.31-.842c.794-.258 1.383-.549 1.757-.835.385-.296.433-.496.433-.573 0-.077-.048-.277-.433-.573-.375-.286-.963-.577-1.758-.835C16.73 3.83 14.498 3.5 12 3.5s-4.729.33-6.31.842c-.794.258-1.383.549-1.757.835zM20.5 7.835c-.49.29-1.078.539-1.728.75-1.767.573-4.161.915-6.772.915-2.61 0-5.005-.342-6.772-.915-.65-.211-1.238-.46-1.728-.75v3.915c0 .08.05.281.43.575.372.287.957.577 1.75.834C7.256 13.671 9.486 14 12 14c2.514 0 4.744-.329 6.32-.84.793-.258 1.378-.549 1.75-.835.38-.294.43-.495.43-.575V7.835zm0 6.005c-.486.288-1.07.536-1.716.746-1.764.573-4.159.914-6.784.914s-5.02-.341-6.784-.914c-.646-.21-1.23-.458-1.716-.746v4.322c0 .102.06.315.439.616.371.295.956.593 1.747.857 1.574.527 3.802.865 6.314.865s4.74-.338 6.314-.865c.791-.264 1.376-.563 1.747-.857.379-.3.439-.514.439-.616V13.84z" clip-rule="evenodd"/></svg>');
+}
+
 %database-svg-prop {
   --database-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11.571 3.429c-3.157 0-5.714.642-5.714 1.428 0 .786 2.557 1.429 5.714 1.429 3.158 0 5.715-.643 5.715-1.429S14.729 3.43 11.57 3.43zm0 7.142C6.843 10.571 3 9.286 3 7.714V4.857C3 3.286 6.843 2 11.571 2c4.729 0 8.572 1.286 8.572 2.857v2.857c0 1.572-3.843 2.857-8.572 2.857zm0 5.715C6.843 16.286 3 15 3 13.429V10.57c0-.157.057-.3.129-.442.042-.086.1-.186.171-.272C4.257 11.086 7.586 12 11.571 12c3.986 0 7.315-.914 8.272-2.143.071.086.128.186.171.272.072.142.129.3.129.442v2.858c0 1.571-3.843 2.857-8.572 2.857zm0 5.714C6.843 22 3 20.714 3 19.143v-2.857c0-.243.129-.486.3-.715.957 1.229 4.286 2.143 8.271 2.143 3.986 0 7.315-.914 8.272-2.143.186.229.3.472.3.715v2.857C20.143 20.714 16.3 22 11.57 22z" fill="%23000"/></svg>');
 }
 
+%delay-16-svg-prop {
+  --delay-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.5 8a6.5 6.5 0 016.744-6.496.75.75 0 10.055-1.499 8 8 0 107.036 11.193.75.75 0 00-1.375-.6 6.722 6.722 0 01-.22.453A6.5 6.5 0 011.5 8zM10.726 1.238a.75.75 0 011.013-.312c.177.094.35.194.518.3a.75.75 0 01-.799 1.27 6.512 6.512 0 00-.42-.244.75.75 0 01-.312-1.014zM13.74 3.508a.75.75 0 011.034.235c.106.168.206.34.3.518a.75.75 0 11-1.326.702 6.452 6.452 0 00-.243-.421.75.75 0 01.235-1.034zM15.217 6.979a.75.75 0 01.777.722 8.034 8.034 0 01.002.552.75.75 0 01-1.5-.047 6.713 6.713 0 000-.45.75.75 0 01.721-.777z"/><path d="M7.75 3a.75.75 0 01.75.75v3.786l2.085 1.043a.75.75 0 11-.67 1.342l-2.5-1.25A.75.75 0 017 8V3.75A.75.75 0 017.75 3z"/></g></svg>');
+}
+
+%delay-24-svg-prop {
+  --delay-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 2.5a9.5 9.5 0 100 19 9.5 9.5 0 008.747-5.788.75.75 0 111.382.583c-.072.17-.148.338-.23.506v.002A11 11 0 0112 23C5.925 23 1 18.075 1 12S5.925 1 12 1c.186 0 .371.005.555.014a.75.75 0 01-.079 1.498A9.14 9.14 0 0012 2.5zM14.822 2.136a.75.75 0 01.971-.427c.346.135.683.287 1.01.455a.75.75 0 01-.687 1.334 9.08 9.08 0 00-.866-.39.75.75 0 01-.428-.972zM18.414 4.112a.75.75 0 011.06-.011c.263.257.513.527.749.807a.75.75 0 11-1.147.966 10.025 10.025 0 00-.651-.702.75.75 0 01-.01-1.06zM20.977 7.315a.75.75 0 01.99.381c.149.335.282.677.398 1.026a.75.75 0 11-1.422.476c-.102-.303-.218-.601-.347-.893a.75.75 0 01.38-.99zM22.174 11.239a.75.75 0 01.768.73c.01.368 0 .737-.029 1.107a.75.75 0 01-1.495-.118c.025-.317.033-.634.025-.95a.75.75 0 01.73-.77z"/><path d="M12.5 5.75a.75.75 0 00-1.5 0V12c0 .284.16.544.415.67l4.5 2.25a.75.75 0 10.67-1.34L12.5 11.536V5.75z"/></g></svg>');
+}
+
 %delay-svg-prop {
   --delay-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 18.75C15.7279 18.75 18.75 15.7279 18.75 12H21C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3V5.25C8.27208 5.25 5.25 8.27208 5.25 12C5.25 15.7279 8.27208 18.75 12 18.75ZM20.7532 9.89814L18.565 10.4217C18.4822 10.0756 18.3727 9.73993 18.2387 9.41684L20.3171 8.55497C20.4961 8.98676 20.6425 9.43551 20.7532 9.89814ZM19.6749 7.29702L17.7576 8.47443C17.5721 8.17235 17.3633 7.88568 17.1336 7.61701L18.8438 6.15496C19.1495 6.5125 19.4276 6.89428 19.6749 7.29702ZM17.8451 5.15624L16.383 6.86647C16.1144 6.63679 15.8277 6.42798 15.5256 6.24247L16.703 4.32513C17.1058 4.57245 17.4876 4.85058 17.8451 5.15624ZM15.4451 3.68298L14.5832 5.76136C14.2601 5.62738 13.9245 5.51787 13.5784 5.43507L14.1019 3.24683C14.5645 3.35751 15.0133 3.50392 15.4451 3.68298ZM15.0609 14.0147L12.75 12.364V8.25H11.25V12.75V13.136L11.5641 13.3603L14.1891 15.2353L15.0609 14.0147Z" fill="%236F7682"/></svg>');
+}
+
+%delete-16-svg-prop {
+  --delete-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.78 5.22a.75.75 0 010 1.06L10.06 8l1.72 1.72a.75.75 0 11-1.06 1.06L9 9.06l-1.72 1.72a.75.75 0 11-1.06-1.06L7.94 8 6.22 6.28a.75.75 0 011.06-1.06L9 6.94l1.72-1.72a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M4.393 2.61A1.75 1.75 0 015.72 2h8.03A2.25 2.25 0 0116 4.25v7.5A2.25 2.25 0 0113.75 14H5.72a1.75 1.75 0 01-1.327-.61L.181 8.49a.75.75 0 010-.978L4.393 2.61zm1.327.89a.25.25 0 00-.19.087L1.74 8l3.792 4.413a.25.25 0 00.19.087h8.029a.75.75 0 00.75-.75v-7.5a.75.75 0 00-.75-.75H5.72z" clip-rule="evenodd"/></g></svg>');
+}
+
+%delete-24-svg-prop {
+  --delete-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.22 8.22a.75.75 0 011.06 0L15 10.94l2.72-2.72a.75.75 0 111.06 1.06L16.06 12l2.72 2.72a.75.75 0 11-1.06 1.06L15 13.06l-2.72 2.72a.75.75 0 11-1.06-1.06L13.94 12l-2.72-2.72a.75.75 0 010-1.06z"/><path fill-rule="evenodd" d="M6.579 3.97A2.75 2.75 0 018.676 3H21.25A2.75 2.75 0 0124 5.75v12.5A2.75 2.75 0 0121.25 21H8.676a2.75 2.75 0 01-2.097-.97l-6.4-7.545a.75.75 0 010-.97l6.4-7.544zm2.097.53a1.25 1.25 0 00-.953.441L1.733 12l5.99 7.059c.237.28.586.441.953.441H21.25c.69 0 1.25-.56 1.25-1.25V5.75c0-.69-.56-1.25-1.25-1.25H8.676z" clip-rule="evenodd"/></g></svg>');
 }
 
 %deny-alt-svg-prop {
@@ -154,20 +1154,164 @@
   --deny-default-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12s4.477 10 10 10 10-4.477 10-10zM6.956 5.63A8.125 8.125 0 0 1 18.37 17.044l-2.72-2.72L18 12l-5.053-5-.884.875 3.537 3.5h-2.9L6.957 5.63zM5.63 6.956A8.125 8.125 0 0 0 17.044 18.37l-2.726-2.726L12.948 17l-.885-.875 1.375-1.36-2.139-2.14H6v-1.25h4.05l-4.42-4.42zm8.32 5.669l.821.82.829-.82h-1.65z" fill="%23000"/></svg>');
 }
 
+%diamond-16-svg-prop {
+  --diamond-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M7.468 1.813L1.81 7.47a.75.75 0 000 1.06l5.657 5.657a.75.75 0 001.06 0l5.657-5.656a.75.75 0 000-1.061L8.528 1.813a.75.75 0 00-1.06 0zM.75 6.41L6.407.753a2.25 2.25 0 013.182 0l5.657 5.656a2.25 2.25 0 010 3.182l-5.657 5.657a2.25 2.25 0 01-3.182 0L.75 9.591a2.25 2.25 0 010-3.182z" clip-rule="evenodd"/></svg>');
+}
+
+%diamond-24-svg-prop {
+  --diamond-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M11.116 2.985l-8.131 8.132a1.25 1.25 0 000 1.767l8.131 8.132a1.25 1.25 0 001.768 0l8.131-8.132a1.25 1.25 0 000-1.768l-8.131-8.131a1.25 1.25 0 00-1.768 0zm-9.192 7.07l8.132-8.13a2.75 2.75 0 013.889 0l8.131 8.13a2.75 2.75 0 010 3.89l-8.131 8.131a2.75 2.75 0 01-3.89 0l-8.131-8.131a2.75 2.75 0 010-3.89z" clip-rule="evenodd"/></svg>');
+}
+
+%diamond-fill-16-svg-prop {
+  --diamond-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M6.407.753L.75 6.409a2.25 2.25 0 000 3.182l5.657 5.657a2.25 2.25 0 003.182 0l5.657-5.657a2.25 2.25 0 000-3.182L9.589.753a2.25 2.25 0 00-3.182 0z"/></svg>');
+}
+
+%diamond-fill-24-svg-prop {
+  --diamond-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M10.056 1.924l-8.132 8.132a2.75 2.75 0 000 3.889l8.132 8.131a2.75 2.75 0 003.889 0l8.131-8.131a2.75 2.75 0 000-3.89l-8.131-8.13a2.75 2.75 0 00-3.89 0z"/></svg>');
+}
+
 %disabled-svg-prop {
   --disabled-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8 0-1.85.63-3.55 1.69-4.9L16.9 18.31A7.902 7.902 0 0 1 12 20zm6.31-3.1L7.1 5.69A7.902 7.902 0 0 1 12 4c4.42 0 8 3.58 8 8 0 1.85-.63 3.55-1.69 4.9z" fill="%23000"/></svg>');
+}
+
+%disc-16-svg-prop {
+  --disc-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 5.05a2.95 2.95 0 100 5.9 2.95 2.95 0 000-5.9zM6.45 8a1.55 1.55 0 113.1 0 1.55 1.55 0 01-3.1 0z"/><path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></g></svg>');
+}
+
+%disc-24-svg-prop {
+  --disc-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 8a4 4 0 100 8 4 4 0 000-8zm-2.5 4a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0z"/><path d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z"/></g></svg>');
+}
+
+%discussion-circle-16-svg-prop {
+  --discussion-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8.302 3.288A3.633 3.633 0 002.756 7.76c.124.237.112.49.102.61a2.984 2.984 0 01-.084.468 7.853 7.853 0 01-.2.655c.26-.09.52-.17.75-.223a.7.7 0 11.312 1.365c-.34.078-.837.258-1.278.434a23.211 23.211 0 00-.701.295l-.042.018-.01.005-.003.001a.7.7 0 01-.925-.927v-.001l.002-.004.008-.018.03-.07a21.252 21.252 0 00.43-1.047c.113-.3.211-.592.27-.822.021-.09.034-.157.041-.205a5.033 5.033 0 017.74-6.082.7.7 0 01-.896 1.076zM1.463 8.226v0z"/><path d="M4.75 9.333a5.083 5.083 0 119.657 2.221c.006.033.015.077.029.133.05.197.14.453.248.734.087.223.178.443.262.646l.06.146c.049.118.094.23.131.326.03.082.074.2.097.306a.75.75 0 01-.734.905c-.169 0-.332-.04-.447-.072a4.867 4.867 0 01-.394-.134c-.188-.072-.402-.162-.606-.248l-.216-.09a7.634 7.634 0 00-.705-.265 1.739 1.739 0 00-.095-.026A5.083 5.083 0 014.75 9.333zm1.5 0a3.583 3.583 0 116.763 1.654c-.124.239-.12.485-.11.614.01.155.043.313.08.456.054.214.132.448.216.676a7.37 7.37 0 00-.643-.231 2.456 2.456 0 00-.443-.093 1.113 1.113 0 00-.626.104 3.583 3.583 0 01-5.237-3.18zm8.15 2.16l-.001-.012v.013z"/></g></svg>');
+}
+
+%discussion-circle-24-svg-prop {
+  --discussion-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M13.02 4.827a5.75 5.75 0 00-8.777 7.077c.144.275.134.58.12.751a4.183 4.183 0 01-.118.655 13.903 13.903 0 01-.512 1.557c.563-.214 1.188-.429 1.694-.545a.75.75 0 11.335 1.463c-.535.122-1.3.401-1.961.666a34.515 34.515 0 00-1.062.445l-.064.029-.016.007-.004.002h-.001a.75.75 0 01-.99-.994v-.002l.003-.006.012-.027a21.137 21.137 0 00.214-.49c.137-.322.316-.755.484-1.204.17-.453.323-.903.413-1.265.046-.183.07-.32.078-.413l.001-.022a7.25 7.25 0 0111.11-8.837.75.75 0 11-.959 1.153z"/><path d="M21.781 20.78a.75.75 0 00.152-.84l-.004-.008-.012-.027a18.62 18.62 0 01-.214-.49 30.259 30.259 0 01-.484-1.204 12.45 12.45 0 01-.413-1.265 2.734 2.734 0 01-.077-.414l-.002-.021a7.25 7.25 0 10-3.22 3.219h.018c.092.009.23.033.413.08.363.09.814.243 1.268.413a31.27 31.27 0 011.701.695l.027.012.008.004a.75.75 0 00.84-.155zM8.5 13.25a5.75 5.75 0 1110.853 2.653c-.144.276-.134.58-.12.752.018.208.063.434.118.655a13.92 13.92 0 00.512 1.557 14.298 14.298 0 00-1.56-.512c-.218-.056-.443-.101-.649-.119-.167-.014-.474-.028-.75.117A5.75 5.75 0 018.5 13.25z"/></g></svg>');
+}
+
+%discussion-square-16-svg-prop {
+  --discussion-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.25 1a.75.75 0 010 1.5h-9a.75.75 0 00-.75.75v6.531l.706-.51a.75.75 0 01.88 1.214L1.19 11.858A.75.75 0 010 11.25v-8A2.25 2.25 0 012.25 1h9z"/><path fill-rule="evenodd" d="M6.25 4A2.25 2.25 0 004 6.25v4.534a2.25 2.25 0 002.25 2.25h6.041l2.52 1.824A.75.75 0 0016 14.25v-8A2.25 2.25 0 0013.75 4h-7.5zM5.5 6.25a.75.75 0 01.75-.75h7.5a.75.75 0 01.75.75v6.531l-1.526-1.104a.75.75 0 00-.44-.143H6.25a.75.75 0 01-.75-.75V6.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%discussion-square-24-svg-prop {
+  --discussion-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M14.25 2A2.75 2.75 0 0117 4.75v.5a.75.75 0 01-1.5 0v-.5c0-.69-.56-1.25-1.25-1.25H3.75c-.69 0-1.25.56-1.25 1.25v10.94l2.531-2.026a.75.75 0 01.938 1.172l-3.75 3A.75.75 0 011 17.25V4.75A2.75 2.75 0 013.75 2h10.5z"/><path fill-rule="evenodd" d="M9.75 7A2.75 2.75 0 007 9.75v7.5A2.75 2.75 0 009.75 20h8.048c.284 0 .56.097.781.274l3.203 2.562A.75.75 0 0023 22.25V9.75A2.75 2.75 0 0020.25 7H9.75zM8.5 9.75c0-.69.56-1.25 1.25-1.25h10.5c.69 0 1.25.56 1.25 1.25v10.94l-1.984-1.587a2.75 2.75 0 00-1.718-.603H9.75c-.69 0-1.25-.56-1.25-1.25v-7.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%docker-16-svg-prop {
+  --docker-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M12.342 4.536l.15-.227.262.159.116.083c.28.216.869.768.996 1.684.223-.04.448-.06.673-.06.534 0 .893.124 1.097.227l.105.057.068.045.191.156-.066.2a2.044 2.044 0 01-.47.73c-.29.299-.8.652-1.609.698l-.178.005h-.148c-.37.977-.867 2.078-1.702 3.066a7.081 7.081 0 01-1.74 1.488 7.941 7.941 0 01-2.549.968c-.644.125-1.298.187-1.953.185-1.45 0-2.73-.288-3.517-.792-.703-.449-1.243-1.182-1.606-2.177a8.25 8.25 0 01-.461-2.83.516.516 0 01.432-.516l.068-.005h10.54l.092-.007.149-.016c.256-.034.646-.11.92-.27-.328-.543-.421-1.178-.268-1.854a3.3 3.3 0 01.3-.81l.108-.187zM2.89 5.784l.04.007a.127.127 0 01.077.082l.006.04v1.315l-.006.041a.127.127 0 01-.078.082l-.039.006H1.478a.124.124 0 01-.117-.088l-.007-.04V5.912l.007-.04a.127.127 0 01.078-.083l.039-.006H2.89zm1.947 0l.039.007a.127.127 0 01.078.082l.006.04v1.315l-.007.041a.127.127 0 01-.078.082l-.039.006H3.424a.125.125 0 01-.117-.088L3.3 7.23V5.913a.13.13 0 01.085-.123l.039-.007h1.413zm1.976 0l.039.007a.127.127 0 01.077.082l.007.04v1.315l-.007.041a.127.127 0 01-.078.082l-.039.006H5.4a.124.124 0 01-.117-.088l-.006-.04V5.912l.006-.04a.127.127 0 01.078-.083l.039-.006h1.413zm1.952 0l.039.007a.127.127 0 01.078.082l.007.04v1.315a.13.13 0 01-.085.123l-.04.006H7.353a.124.124 0 01-.117-.088l-.006-.04V5.912l.006-.04a.127.127 0 01.078-.083l.04-.006h1.412zm1.97 0l.039.007a.127.127 0 01.078.082l.006.04v1.315a.13.13 0 01-.085.123l-.039.006H9.322a.124.124 0 01-.117-.088l-.006-.04V5.912l.006-.04a.127.127 0 01.078-.083l.04-.006h1.411zM4.835 3.892l.04.007a.127.127 0 01.077.081l.007.041v1.315a.13.13 0 01-.085.123l-.039.007H3.424a.125.125 0 01-.117-.09l-.007-.04V4.021a.13.13 0 01.085-.122l.039-.007h1.412zm1.976 0l.04.007a.127.127 0 01.077.081l.007.041v1.315a.13.13 0 01-.085.123l-.039.007H5.4a.125.125 0 01-.117-.09l-.006-.04V4.021l.006-.04a.127.127 0 01.078-.082l.039-.007h1.412zm1.953 0c.054 0 .1.037.117.088l.007.041v1.315a.13.13 0 01-.085.123l-.04.007H7.353a.125.125 0 01-.117-.09l-.006-.04V4.021l.006-.04a.127.127 0 01.078-.082l.04-.007h1.412zm0-1.892c.054 0 .1.037.117.088l.007.04v1.316a.13.13 0 01-.085.123l-.04.006H7.353a.124.124 0 01-.117-.088l-.006-.04V2.128l.006-.04a.127.127 0 01.078-.082L7.353 2h1.412z"/></svg>');
+}
+
+%docker-24-svg-prop {
+  --docker-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M17.97 7.445l.207-.31.36.217.159.113c.385.293 1.194 1.044 1.37 2.287.306-.053.616-.08.926-.082.734 0 1.227.17 1.508.309l.143.078.094.061.263.212-.09.272a2.774 2.774 0 01-.648.99c-.398.407-1.098.887-2.211.949l-.245.006h-.203c-.509 1.329-1.193 2.823-2.34 4.165a9.706 9.706 0 01-2.393 2.022 11.003 11.003 0 01-3.505 1.314c-.885.17-1.784.255-2.685.252-1.994 0-3.753-.391-4.836-1.076-.966-.61-1.71-1.605-2.208-2.957A11.083 11.083 0 011 12.422a.704.704 0 01.595-.7l.093-.007H16.18l.128-.009.204-.022c.353-.046.889-.15 1.267-.367-.452-.737-.58-1.6-.37-2.518.09-.385.228-.755.413-1.1l.148-.254zM4.974 9.14l.054.01c.05.017.09.058.107.11l.008.056v1.786l-.008.055a.173.173 0 01-.108.111l-.053.009H3.032a.17.17 0 01-.161-.12l-.009-.055V9.315l.009-.055a.173.173 0 01.107-.111l.054-.01h1.942zm2.676 0l.054.01c.05.017.09.058.107.11l.009.056v1.786l-.01.055a.173.173 0 01-.106.111l-.054.009H5.708a.171.171 0 01-.162-.12l-.009-.055V9.316c0-.078.05-.144.117-.167l.054-.01H7.65zm2.717 0l.054.01c.05.017.09.058.107.11l.008.056v1.786l-.008.055a.173.173 0 01-.108.111l-.053.009H8.425a.17.17 0 01-.161-.12l-.009-.055V9.315l.009-.055a.173.173 0 01.107-.111l.054-.01h1.942zm2.684 0l.054.009c.051.017.091.059.108.111l.009.056v1.786c0 .077-.05.143-.117.166l-.053.009H11.11a.17.17 0 01-.161-.12l-.01-.055V9.315l.01-.055a.173.173 0 01.107-.111l.054-.01h1.942zm2.709 0l.054.009c.05.017.09.059.108.111l.008.056v1.786c0 .077-.049.143-.117.166l-.053.009h-1.942a.17.17 0 01-.161-.12l-.009-.055V9.315l.009-.055a.173.173 0 01.107-.111l.054-.01h1.942zM7.65 6.57l.054.01c.05.017.09.058.107.11l.009.056V8.53a.176.176 0 01-.116.167l-.054.01H5.708a.172.172 0 01-.162-.121l-.008-.056V6.746c0-.078.049-.144.116-.167l.054-.009H7.65zm2.717 0l.053.01c.05.017.09.058.108.11l.008.056V8.53a.176.176 0 01-.115.167l-.054.01H8.425a.171.171 0 01-.161-.121l-.009-.056V6.746l.009-.056a.173.173 0 01.107-.11l.054-.01h1.942zm2.684 0c.075 0 .14.05.162.12l.009.056V8.53c0 .078-.05.144-.117.167l-.053.01H11.11a.171.171 0 01-.161-.121l-.01-.056V6.746l.01-.056a.173.173 0 01.107-.11l.054-.01h1.942zm0-2.57c.075 0 .14.05.162.12l.009.055v1.787c0 .078-.05.143-.117.166l-.053.01H11.11a.17.17 0 01-.161-.12l-.01-.056V4.175l.01-.055a.173.173 0 01.107-.111L11.11 4h1.942z"/></svg>');
+}
+
+%docker-color-16-svg-prop {
+  --docker-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%232396ED" d="M12.342 4.536l.15-.227.262.159.116.083c.28.216.869.768.996 1.684.223-.04.448-.06.673-.06.534 0 .893.124 1.097.227l.105.057.068.045.191.156-.066.2a2.044 2.044 0 01-.47.73c-.29.299-.8.652-1.609.698l-.178.005h-.148c-.37.977-.867 2.078-1.702 3.066a7.081 7.081 0 01-1.74 1.488 7.941 7.941 0 01-2.549.968c-.644.125-1.298.187-1.953.185-1.45 0-2.73-.288-3.517-.792-.703-.449-1.243-1.182-1.606-2.177a8.25 8.25 0 01-.461-2.83.516.516 0 01.432-.516l.068-.005h10.54l.092-.007.149-.016c.256-.034.646-.11.92-.27-.328-.543-.421-1.178-.268-1.854a3.3 3.3 0 01.3-.81l.108-.187zM2.89 5.784l.04.007a.127.127 0 01.077.082l.006.04v1.315l-.006.041a.127.127 0 01-.078.082l-.039.006H1.478a.124.124 0 01-.117-.088l-.007-.04V5.912l.007-.04a.127.127 0 01.078-.083l.039-.006H2.89zm1.947 0l.039.007a.127.127 0 01.078.082l.006.04v1.315l-.007.041a.127.127 0 01-.078.082l-.039.006H3.424a.125.125 0 01-.117-.088L3.3 7.23V5.913a.13.13 0 01.085-.123l.039-.007h1.413zm1.976 0l.039.007a.127.127 0 01.077.082l.007.04v1.315l-.007.041a.127.127 0 01-.078.082l-.039.006H5.4a.124.124 0 01-.117-.088l-.006-.04V5.912l.006-.04a.127.127 0 01.078-.083l.039-.006h1.413zm1.952 0l.039.007a.127.127 0 01.078.082l.007.04v1.315a.13.13 0 01-.085.123l-.04.006H7.353a.124.124 0 01-.117-.088l-.006-.04V5.912l.006-.04a.127.127 0 01.078-.083l.04-.006h1.412zm1.97 0l.039.007a.127.127 0 01.078.082l.006.04v1.315a.13.13 0 01-.085.123l-.039.006H9.322a.124.124 0 01-.117-.088l-.006-.04V5.912l.006-.04a.127.127 0 01.078-.083l.04-.006h1.411zM4.835 3.892l.04.007a.127.127 0 01.077.081l.007.041v1.315a.13.13 0 01-.085.123l-.039.007H3.424a.125.125 0 01-.117-.09l-.007-.04V4.021a.13.13 0 01.085-.122l.039-.007h1.412zm1.976 0l.04.007a.127.127 0 01.077.081l.007.041v1.315a.13.13 0 01-.085.123l-.039.007H5.4a.125.125 0 01-.117-.09l-.006-.04V4.021l.006-.04a.127.127 0 01.078-.082l.039-.007h1.412zm1.953 0c.054 0 .1.037.117.088l.007.041v1.315a.13.13 0 01-.085.123l-.04.007H7.353a.125.125 0 01-.117-.09l-.006-.04V4.021l.006-.04a.127.127 0 01.078-.082l.04-.007h1.412zm0-1.892c.054 0 .1.037.117.088l.007.04v1.316a.13.13 0 01-.085.123l-.04.006H7.353a.124.124 0 01-.117-.088l-.006-.04V2.128l.006-.04a.127.127 0 01.078-.082L7.353 2h1.412z"/></svg>');
+}
+
+%docker-color-24-svg-prop {
+  --docker-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%232396ED" d="M17.97 7.445l.207-.31.36.217.159.113c.385.293 1.194 1.044 1.37 2.287.306-.053.616-.08.926-.082.734 0 1.227.17 1.508.309l.143.078.094.061.263.212-.09.272a2.774 2.774 0 01-.648.99c-.398.407-1.098.887-2.211.949l-.245.006h-.203c-.509 1.329-1.193 2.823-2.34 4.165a9.706 9.706 0 01-2.393 2.022 11.003 11.003 0 01-3.505 1.314c-.885.17-1.784.255-2.685.252-1.994 0-3.753-.391-4.836-1.076-.966-.61-1.71-1.605-2.208-2.957A11.083 11.083 0 011 12.422a.704.704 0 01.595-.7l.093-.007H16.18l.128-.009.204-.022c.353-.046.889-.15 1.267-.367-.452-.737-.58-1.6-.37-2.518.09-.385.228-.755.413-1.1l.148-.254zM4.974 9.14l.054.01c.05.017.09.058.107.11l.008.056v1.786l-.008.055a.173.173 0 01-.108.111l-.053.009H3.032a.17.17 0 01-.161-.12l-.009-.055V9.315l.009-.055a.173.173 0 01.107-.111l.054-.01h1.942zm2.676 0l.054.01c.05.017.09.058.107.11l.009.056v1.786l-.01.055a.173.173 0 01-.106.111l-.054.009H5.708a.171.171 0 01-.162-.12l-.009-.055V9.316c0-.078.05-.144.117-.167l.054-.01H7.65zm2.717 0l.054.01c.05.017.09.058.107.11l.008.056v1.786l-.008.055a.173.173 0 01-.108.111l-.053.009H8.425a.17.17 0 01-.161-.12l-.009-.055V9.315l.009-.055a.173.173 0 01.107-.111l.054-.01h1.942zm2.684 0l.054.009c.051.017.091.059.108.111l.009.056v1.786c0 .077-.05.143-.117.166l-.053.009H11.11a.17.17 0 01-.161-.12l-.01-.055V9.315l.01-.055a.173.173 0 01.107-.111l.054-.01h1.942zm2.709 0l.054.009c.05.017.09.059.108.111l.008.056v1.786c0 .077-.049.143-.117.166l-.053.009h-1.942a.17.17 0 01-.161-.12l-.009-.055V9.315l.009-.055a.173.173 0 01.107-.111l.054-.01h1.942zM7.65 6.57l.054.01c.05.017.09.058.107.11l.009.056V8.53a.176.176 0 01-.116.167l-.054.01H5.708a.172.172 0 01-.162-.121l-.008-.056V6.746c0-.078.049-.144.116-.167l.054-.009H7.65zm2.717 0l.053.01c.05.017.09.058.108.11l.008.056V8.53a.176.176 0 01-.115.167l-.054.01H8.425a.171.171 0 01-.161-.121l-.009-.056V6.746l.009-.056a.173.173 0 01.107-.11l.054-.01h1.942zm2.684 0c.075 0 .14.05.162.12l.009.056V8.53c0 .078-.05.144-.117.167l-.053.01H11.11a.171.171 0 01-.161-.121l-.01-.056V6.746l.01-.056a.173.173 0 01.107-.11l.054-.01h1.942zm0-2.57c.075 0 .14.05.162.12l.009.055v1.787c0 .078-.05.143-.117.166l-.053.01H11.11a.17.17 0 01-.161-.12l-.01-.056V4.175l.01-.055a.173.173 0 01.107-.111L11.11 4h1.942z"/></svg>');
+}
+
+%docs-16-svg-prop {
+  --docs-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4.25 1A2.25 2.25 0 002 3.25v9.5A2.25 2.25 0 004.25 15h8.5c.69 0 1.25-.56 1.25-1.25V2.25C14 1.56 13.44 1 12.75 1h-8.5zM3.5 12.75c0 .414.336.75.75.75h8.25v-2H4.25a.75.75 0 00-.75.75v.5zm0-2.622c.235-.083.487-.128.75-.128h8.25V2.5H4.25a.75.75 0 00-.75.75v6.878z" clip-rule="evenodd"/></svg>');
+}
+
+%docs-24-svg-prop {
+  --docs-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M5.75 1A2.75 2.75 0 003 3.75v16.5A2.75 2.75 0 005.75 23h13.5A1.75 1.75 0 0021 21.25V2.75A1.75 1.75 0 0019.25 1H5.75zM19.5 17.5V2.75a.25.25 0 00-.25-.25H5.75c-.69 0-1.25.56-1.25 1.25V17.8c.375-.192.8-.3 1.25-.3H19.5zm-15 2.75c0 .69.56 1.25 1.25 1.25h13.5a.25.25 0 00.25-.25V19H5.75c-.69 0-1.25.56-1.25 1.25z" clip-rule="evenodd"/></svg>');
+}
+
+%docs-download-16-svg-prop {
+  --docs-download-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M2 3.25A2.25 2.25 0 014.25 1h8.5c.69 0 1.25.56 1.25 1.25V4.5a.75.75 0 01-1.5 0v-2H4.25a.75.75 0 00-.75.75v6.878c.235-.083.487-.128.75-.128h.25a.75.75 0 010 1.5h-.25a.75.75 0 00-.75.75v.5c0 .414.336.75.75.75h1a.75.75 0 010 1.5h-1A2.25 2.25 0 012 12.75v-9.5z"/><path d="M8.826 10.826a.6.6 0 01.848 0l.726.725V9a.6.6 0 011.2 0v2.551l.726-.725a.6.6 0 11.848.848l-1.75 1.75a.6.6 0 01-.848 0l-1.75-1.75a.6.6 0 010-.848z"/><path fill-rule="evenodd" d="M11 6.05a4.95 4.95 0 100 9.9 4.95 4.95 0 000-9.9zM7.45 11a3.55 3.55 0 117.1 0 3.55 3.55 0 01-7.1 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%docs-download-24-svg-prop {
+  --docs-download-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3 3.75A2.75 2.75 0 015.75 1h13.5c.966 0 1.75.784 1.75 1.75v6.5a.75.75 0 01-1.5 0v-6.5a.25.25 0 00-.25-.25H5.75c-.69 0-1.25.56-1.25 1.25V17.8c.375-.192.8-.3 1.25-.3h1.5a.75.75 0 010 1.5h-1.5a1.25 1.25 0 100 2.5h3a.75.75 0 010 1.5h-3A2.75 2.75 0 013 20.25V3.75z"/><path d="M12.97 17.22a.75.75 0 011.06 0l1.22 1.22v-4.69a.75.75 0 011.5 0v4.69l1.22-1.22a.75.75 0 111.06 1.06l-2.5 2.5a.747.747 0 01-1.06 0l-2.5-2.5a.75.75 0 010-1.06z"/><path fill-rule="evenodd" d="M16 10a7 7 0 100 14 7 7 0 000-14zm-5.5 7a5.5 5.5 0 1111 0 5.5 5.5 0 01-11 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%docs-link-16-svg-prop {
+  --docs-link-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M3.5 3.25a.75.75 0 01.75-.75H8A.75.75 0 008 1H4.25A2.25 2.25 0 002 3.25v9.5A2.25 2.25 0 004.25 15h8.5c.69 0 1.25-.56 1.25-1.25V7a.75.75 0 00-1.5 0v3H4.25c-.263 0-.515.045-.75.128V3.25zm0 9v.5c0 .414.336.75.75.75h8.25v-2H4.25a.75.75 0 00-.75.75z" clip-rule="evenodd"/><path d="M12.5 3.56v.69a.75.75 0 001.5 0v-2.5a.75.75 0 00-.75-.75h-2.5a.75.75 0 000 1.5h.69L9.47 4.47a.75.75 0 001.06 1.06l1.97-1.97z"/></g></svg>');
+}
+
+%docs-link-24-svg-prop {
+  --docs-link-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M4.5 3.75c0-.69.56-1.25 1.25-1.25h7.5a.75.75 0 000-1.5h-7.5A2.75 2.75 0 003 3.75v16.5A2.75 2.75 0 005.75 23h13.5A1.75 1.75 0 0021 21.25V8.75a.75.75 0 00-1.5 0v8.75H5.75c-.45 0-.875.108-1.25.3V3.75zm0 16.5c0 .69.56 1.25 1.25 1.25h13.5a.25.25 0 00.25-.25V19H5.75c-.69 0-1.25.56-1.25 1.25z" clip-rule="evenodd"/><path d="M19.5 3.56v1.69a.75.75 0 001.5 0v-3.5a.75.75 0 00-.75-.75h-3.5a.75.75 0 000 1.5h1.69l-2.97 2.97a.75.75 0 001.06 1.06l2.97-2.97z"/></g></svg>');
 }
 
 %docs-svg-prop {
   --docs-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M18 11h2v9.5c0 .786-.714 1.5-1.5 1.5h-14c-.786 0-1.5-.714-1.5-1.5v-17C3 2.714 3.714 2 4.5 2H13v2H5v16h13v-9zM7 18h9v-2H7v2zm0-3h9v-2H7v2zm0-3h9v-2H7v2zm0-4V6h5v2H7zm10-5.5V1h6v6h-1.5V3.429L18 7l-1-1 3.5-3.5H17z" fill="%23000"/></svg>');
 }
 
+%dollar-sign-16-svg-prop {
+  --dollar-sign-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8.5.75a.75.75 0 00-1.5 0V2h-.594c-.9 0-1.766.353-2.405.985A3.36 3.36 0 003 5.375a3.36 3.36 0 001 2.39c.64.632 1.506.985 2.406.985H7v3.75H4.25a.75.75 0 000 1.5H7v1.25a.75.75 0 001.5 0V14h1.094c.9 0 1.766-.353 2.405-.985A3.36 3.36 0 0013 10.625a3.36 3.36 0 00-1-2.39 3.422 3.422 0 00-2.406-.985H8.5V3.5h3.25a.75.75 0 000-1.5H8.5V.75zM7 3.5h-.594c-.508 0-.994.2-1.35.552A1.86 1.86 0 004.5 5.375c0 .494.199.97.555 1.323.357.352.843.552 1.351.552H7V3.5zm1.5 5.25v3.75h1.094c.508 0 .994-.2 1.35-.552a1.86 1.86 0 00.556-1.323c0-.494-.199-.97-.555-1.323a1.922 1.922 0 00-1.351-.552H8.5z" clip-rule="evenodd"/></svg>');
+}
+
+%dollar-sign-24-svg-prop {
+  --dollar-sign-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12.5 1.75a.75.75 0 00-1.5 0V4H9.396c-1.165 0-2.282.46-3.107 1.28a4.365 4.365 0 000 6.19 4.406 4.406 0 003.107 1.28H11v5.75H5.75a.75.75 0 000 1.5H11v2.25a.75.75 0 001.5 0V20h2.104c1.165 0 2.282-.46 3.107-1.28a4.365 4.365 0 000-6.19 4.407 4.407 0 00-3.107-1.28H12.5V5.5h4.708a.75.75 0 000-1.5H12.5V1.75zM11 5.5H9.396c-.77 0-1.507.304-2.05.844a2.865 2.865 0 000 4.062c.543.54 1.28.844 2.05.844H11V5.5zm1.5 7.25v5.75h2.104c.77 0 1.507-.304 2.05-.844a2.864 2.864 0 000-4.062 2.906 2.906 0 00-2.05-.844H12.5z" clip-rule="evenodd"/></svg>');
+}
+
+%dot-16-svg-prop {
+  --dot-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M8 3a5 5 0 100 10A5 5 0 008 3z"/></svg>');
+}
+
+%dot-24-svg-prop {
+  --dot-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M12 5a7 7 0 100 14 7 7 0 000-14z"/></svg>');
+}
+
+%dot-half-16-svg-prop {
+  --dot-half-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 3a5 5 0 100 10A5 5 0 008 3zm0 1.5v7a3.5 3.5 0 100-7z" clip-rule="evenodd"/></svg>');
+}
+
+%dot-half-24-svg-prop {
+  --dot-half-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 5a7 7 0 100 14 7 7 0 000-14zm0 1.5v11a5.5 5.5 0 100-11z" clip-rule="evenodd"/></svg>');
+}
+
+%download-16-svg-prop {
+  --download-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.75 1.75a.75.75 0 00-1.5 0v6.59L5.3 6.24a.75.75 0 10-1.1 1.02L7.45 10.76a.78.78 0 00.038.038.748.748 0 001.063-.037l3.25-3.5a.75.75 0 10-1.1-1.02l-1.95 2.1V1.75z"/><path d="M1.75 9a.75.75 0 01.75.75v3c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75v-3a.75.75 0 011.5 0v3A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-3A.75.75 0 011.75 9z"/></g></svg>');
+}
+
+%download-24-svg-prop {
+  --download-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.75 2.75a.75.75 0 00-1.5 0v10.628L7.293 9.232a.75.75 0 10-1.086 1.036l5.25 5.499A.748.748 0 0012 16h.012a.747.747 0 00.53-.232l5.25-5.5a.75.75 0 00-1.085-1.036l-3.957 4.146V2.75z"/><path d="M2.75 14a.75.75 0 01.75.75v4.5c0 .69.56 1.25 1.25 1.25h14.5c.69 0 1.25-.56 1.25-1.25v-4.5a.75.75 0 011.5 0v4.5A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25v-4.5a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
 %download-svg-prop {
   --download-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5zm-2 2h2v-4H3v4zm16 0h2v-4h-2v4z" fill="%23000"/></svg>');
 }
 
+%droplet-16-svg-prop {
+  --droplet-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M7.477 1.212a.75.75 0 011.046 0l3.813 3.71A5.92 5.92 0 0114 9.04C13.999 12.337 11.307 15 7.999 15c-3.308 0-6-2.663-6-5.96a5.92 5.92 0 011.665-4.118l3.812-3.71zM4.721 5.987A4.42 4.42 0 003.5 9.04C3.5 11.498 5.51 13.5 8 13.5s4.5-2.002 4.5-4.46a4.42 4.42 0 00-1.22-3.053L8 2.797l-3.28 3.19z" clip-rule="evenodd"/></svg>');
+}
+
+%droplet-24-svg-prop {
+  --droplet-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1a.75.75 0 01.544.233l5.997 6.314A9.22 9.22 0 0121 13.84c0 5.045-4.016 9.16-9 9.16s-9-4.115-9-9.16c0-2.435.934-4.651 2.46-6.293l.005-.006 5.991-6.308A.75.75 0 0112 1zM6.556 8.571A7.719 7.719 0 004.5 13.84c0 4.244 3.371 7.66 7.5 7.66s7.5-3.416 7.5-7.66a7.719 7.719 0 00-2.056-5.269L12 2.84 6.556 8.571z" clip-rule="evenodd"/></svg>');
+}
+
+%duplicate-16-svg-prop {
+  --duplicate-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M2.25 0A2.25 2.25 0 000 2.25v7.5A2.25 2.25 0 002.25 12h.25a.75.75 0 000-1.5h-.25a.75.75 0 01-.75-.75v-7.5a.75.75 0 01.75-.75h7.5a.75.75 0 01.75.75v.25a.75.75 0 001.5 0v-.25A2.25 2.25 0 009.75 0h-7.5z"/><path fill-rule="evenodd" d="M6.25 4A2.25 2.25 0 004 6.25v7.5A2.25 2.25 0 006.25 16h7.5A2.25 2.25 0 0016 13.75v-7.5A2.25 2.25 0 0013.75 4h-7.5zM5.5 6.25a.75.75 0 01.75-.75h7.5a.75.75 0 01.75.75v7.5a.75.75 0 01-.75.75h-7.5a.75.75 0 01-.75-.75v-7.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%duplicate-24-svg-prop {
+  --duplicate-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.75 1A2.75 2.75 0 001 3.75v10.5A2.75 2.75 0 003.75 17h1a.75.75 0 000-1.5h-1c-.69 0-1.25-.56-1.25-1.25V3.75c0-.69.56-1.25 1.25-1.25h10.5c.69 0 1.25.56 1.25 1.25v1a.75.75 0 001.5 0v-1A2.75 2.75 0 0014.25 1H3.75z"/><path fill-rule="evenodd" d="M9.75 7A2.75 2.75 0 007 9.75v10.5A2.75 2.75 0 009.75 23h10.5A2.75 2.75 0 0023 20.25V9.75A2.75 2.75 0 0020.25 7H9.75zM8.5 9.75c0-.69.56-1.25 1.25-1.25h10.5c.69 0 1.25.56 1.25 1.25v10.5c0 .69-.56 1.25-1.25 1.25H9.75c-.69 0-1.25-.56-1.25-1.25V9.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%edit-16-svg-prop {
+  --edit-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M11.436 1.005A1.75 1.75 0 0113.902.79l.702.589a1.75 1.75 0 01.216 2.465l-5.704 6.798a4.75 4.75 0 01-1.497 1.187l-2.572 1.299a.75.75 0 01-1.056-.886l.833-2.759a4.75 4.75 0 01.908-1.68l5.704-6.798zm1.502.934a.25.25 0 00-.353.03l-.53.633 1.082.914.534-.636a.25.25 0 00-.031-.352l-.703-.59zm-.765 2.726l-1.082-.914-4.21 5.016a3.25 3.25 0 00-.621 1.15L5.933 11l1.01-.51a3.249 3.249 0 001.024-.812l4.206-5.013z" clip-rule="evenodd"/><path d="M3.25 3.5a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V9A.75.75 0 0115 9v4.75A2.25 2.25 0 0112.75 16h-9.5A2.25 2.25 0 011 13.75v-9.5A2.25 2.25 0 013.25 2H6a.75.75 0 010 1.5H3.25z"/></g></svg>');
+}
+
+%edit-24-svg-prop {
+  --edit-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M17.055 2.884a2.75 2.75 0 013.89 0l.171.171a2.75 2.75 0 010 3.89l-9.005 9.005A4.75 4.75 0 0110.516 17L6.28 18.696a.75.75 0 01-.975-.975l1.695-4.237a4.749 4.749 0 011.051-1.595l9.005-9.005zm2.829 1.06a1.25 1.25 0 00-1.768 0l-.555.556L19.5 6.44l.555-.556a1.25 1.25 0 000-1.768l-.171-.172zM18.439 7.5L16.5 5.56l-7.39 7.39a3.25 3.25 0 00-.719 1.09l-1.045 2.614 2.613-1.046a3.25 3.25 0 001.091-.719L18.44 7.5z" clip-rule="evenodd"/><path d="M3.75 4.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25h14.5c.69 0 1.25-.56 1.25-1.25V13a.75.75 0 011.5 0v7.25A2.75 2.75 0 0118.25 23H3.75A2.75 2.75 0 011 20.25V5.75A2.75 2.75 0 013.75 3H11a.75.75 0 010 1.5H3.75z"/></g></svg>');
+}
+
 %edit-svg-prop {
   --edit-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M17.23 9.68l1.326-1.324a1.016 1.016 0 0 0 0-1.437l-1.62-1.621-.002-.001a1.015 1.015 0 0 0-1.436 0l-1.325 1.327L17.23 9.68z" fill="%23000"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 18.854v-3.058l8.154-8.153 3.057 3.057-8.153 8.154H5zm2.038-3.058H6.02v2.038h2.038v-1.018h-1.02v-1.02z" fill="currentColor"/></svg>');
+}
+
+%entry-point-16-svg-prop {
+  --entry-point-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 2.5a5.494 5.494 0 00-4.558 2.42.75.75 0 01-1.242-.84 7 7 0 110 7.841.75.75 0 111.242-.841A5.5 5.5 0 108 2.5z"/><path d="M7.245 4.695a.75.75 0 00-.05 1.06l1.36 1.495H1.75a.75.75 0 000 1.5h6.805l-1.36 1.495a.75.75 0 001.11 1.01l2.5-2.75a.75.75 0 000-1.01l-2.5-2.75a.75.75 0 00-1.06-.05z"/></g></svg>');
+}
+
+%entry-point-24-svg-prop {
+  --entry-point-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 4.5a7.498 7.498 0 00-6.561 3.864.75.75 0 01-1.312-.728 9 9 0 110 8.728.75.75 0 011.312-.728A7.5 7.5 0 1012 4.5z"/><path d="M3 12a.75.75 0 01.75-.75h9.614l-3.129-2.955a.75.75 0 011.03-1.09l4.5 4.25a.75.75 0 010 1.09l-4.5 4.25a.75.75 0 01-1.03-1.09l3.129-2.955H3.75A.75.75 0 013 12z"/></g></svg>');
 }
 
 %envelope-sealed-fill-svg-prop {
@@ -186,6 +1330,22 @@
   --envelope-unsealed-fill-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.106 6.447a2 2 0 0 0-1.093 1.56l9.473 5.684a1 1 0 0 0 1.028 0l9.473-5.683a2 2 0 0 0-1.093-1.56l-8.447-4.224a1 1 0 0 0-.894 0L3.106 6.447zM22 10l-4.383 2.63L22 17.5V10z" fill="%23000"/><path d="M22 20l-5.94-6.436-3.545 2.127a1 1 0 0 1-1.03 0l-3.544-2.127L2 20a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2zM2 17.5l4.383-4.87L2 10v7.5z" fill="currentColor"/></svg>');
 }
 
+%event-16-svg-prop {
+  --event-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8.675 4.173a.75.75 0 00-1.35 0l-1.14 2.359-2.546.38a.75.75 0 00-.418 1.273l1.85 1.84-.437 2.6a.75.75 0 001.094.786L8 12.19l2.272 1.22a.75.75 0 001.094-.785l-.437-2.602 1.85-1.839a.75.75 0 00-.418-1.273l-2.545-.38-1.14-2.359zM7.362 7.542L8 6.222l.638 1.32a.75.75 0 00.565.415l1.459.218-1.066 1.059a.75.75 0 00-.21.656l.247 1.476-1.278-.686a.75.75 0 00-.71 0l-1.278.686.248-1.476a.75.75 0 00-.211-.656l-1.066-1.06 1.46-.217a.75.75 0 00.564-.415z"/><path d="M12 .75a.75.75 0 00-1.5 0V1h-5V.75a.75.75 0 00-1.5 0V1H2.25A2.25 2.25 0 000 3.25v10.5A2.25 2.25 0 002.25 16h11.5A2.25 2.25 0 0016 13.75V3.25A2.25 2.25 0 0013.75 1H12V.75zm-8 2.5V2.5H2.25a.75.75 0 00-.75.75v10.5c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75V3.25a.75.75 0 00-.75-.75H12v.75a.75.75 0 01-1.5 0V2.5h-5v.75a.75.75 0 01-1.5 0z"/></g></svg>');
+}
+
+%event-24-svg-prop {
+  --event-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12.673 7.668a.75.75 0 00-1.345 0l-1.526 3.09-3.41.498a.75.75 0 00-.415 1.28l2.467 2.403-.582 3.395a.75.75 0 001.088.79L12 17.522l3.05 1.604a.75.75 0 001.088-.79l-.582-3.396 2.467-2.403a.75.75 0 00-.415-1.28l-3.41-.498-1.525-3.09zm-1.7 4.107L12 9.695l1.027 2.08a.75.75 0 00.564.41l2.298.336-1.662 1.619a.75.75 0 00-.216.664l.392 2.286-2.054-1.08a.75.75 0 00-.698 0l-2.054 1.08.392-2.286a.75.75 0 00-.216-.664L8.111 12.52l2.298-.336a.75.75 0 00.564-.41z"/><path d="M17 2a.75.75 0 00-1.5 0v1h-7V2A.75.75 0 007 2v1H4.75A2.75 2.75 0 002 5.75v14.5A2.75 2.75 0 004.75 23h14.5A2.75 2.75 0 0022 20.25V5.75A2.75 2.75 0 0019.25 3H17V2zM7 6V4.5H4.75c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25h14.5c.69 0 1.25-.56 1.25-1.25V5.75c0-.69-.56-1.25-1.25-1.25H17V6a.75.75 0 01-1.5 0V4.5h-7V6A.75.75 0 017 6z"/></g></svg>');
+}
+
+%exit-point-16-svg-prop {
+  --exit-point-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1 8a6 6 0 018.514-5.45.75.75 0 01-.629 1.363 4.5 4.5 0 100 8.175.75.75 0 11.63 1.361A6 6 0 011 8z"/><path d="M11.245 4.695a.75.75 0 00-.05 1.06l1.36 1.495H6.75a.75.75 0 000 1.5h5.805l-1.36 1.495a.75.75 0 001.11 1.01l2.5-2.75a.748.748 0 00-.002-1.012l-2.498-2.748a.75.75 0 00-1.06-.05z"/></g></svg>');
+}
+
+%exit-point-24-svg-prop {
+  --exit-point-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3 12a7 7 0 0110.707-5.939.75.75 0 01-.795 1.272 5.5 5.5 0 100 9.334.75.75 0 01.795 1.272A7 7 0 013 12z"/><path d="M9 12a.75.75 0 01.75-.75h9.614l-3.129-2.955a.75.75 0 011.03-1.09l4.498 4.248a.748.748 0 010 1.093l-4.498 4.25a.75.75 0 01-1.03-1.091l3.129-2.955H9.75A.75.75 0 019 12z"/></g></svg>');
+}
+
 %exit-svg-prop {
   --exit-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5 19V5h5.944V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-5.98h-2V19H5zm9-16v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z" fill="%23000"/></svg>');
 }
@@ -198,32 +1358,312 @@
   --expand-more-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14 4l2.3 2.3-2.89 2.87 1.42 1.42L17.7 7.7 20 10V4h-6zm-4 16l-2.3-2.3 2.89-2.87-1.42-1.42L6.3 16.3 4 14v6h6z" fill="%23000"/></svg>');
 }
 
+%external-link-16-svg-prop {
+  --external-link-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M9 .75A.75.75 0 019.75 0h4.5c.206 0 .393.083.529.218l.001.002.002.001A.748.748 0 0115 .75v4.5a.75.75 0 01-1.5 0V2.56L7.28 8.78a.75.75 0 01-1.06-1.06l6.22-6.22H9.75A.75.75 0 019 .75z"/><path d="M3.25 3.5a.75.75 0 00-.75.75v7.5c0 .414.336.75.75.75h7.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0110.75 14h-7.5A2.25 2.25 0 011 11.75v-7.5A2.25 2.25 0 013.25 2h4a.75.75 0 010 1.5h-4z"/></g></svg>');
+}
+
+%external-link-24-svg-prop {
+  --external-link-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M15 1.75a.75.75 0 01.75-.75h5.5a.748.748 0 01.75.75v5.5a.75.75 0 01-1.5 0V3.56L10.28 13.78a.75.75 0 11-1.06-1.06L19.44 2.5h-3.69a.75.75 0 01-.75-.75z"/><path d="M4.75 5.5c-.69 0-1.25.56-1.25 1.25v11.5c0 .69.56 1.25 1.25 1.25h11.5c.69 0 1.25-.56 1.25-1.25v-6.5a.75.75 0 011.5 0v6.5A2.75 2.75 0 0116.25 21H4.75A2.75 2.75 0 012 18.25V6.75A2.75 2.75 0 014.75 4h6.5a.75.75 0 010 1.5h-6.5z"/></g></svg>');
+}
+
+%eye-16-svg-prop {
+  --eye-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 5a3 3 0 100 6 3 3 0 000-6zM6.5 8a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z"/><path d="M8 2C5.422 2 3.43 3.32 2.112 4.65A10.948 10.948 0 00.596 6.564c-.173.28-.31.536-.407.75a3 3 0 00-.122.31C.04 7.705 0 7.846 0 8s.041.296.067.375a3 3 0 00.122.31c.097.215.234.471.407.751.346.56.854 1.246 1.516 1.914C3.43 12.68 5.422 14 8 14s4.57-1.32 5.888-2.65a10.952 10.952 0 001.516-1.914c.173-.28.31-.536.407-.75.048-.107.09-.212.122-.31.026-.08.067-.221.067-.376s-.041-.296-.067-.375a2.978 2.978 0 00-.122-.31 6.777 6.777 0 00-.407-.751 10.952 10.952 0 00-1.516-1.914C12.57 3.32 10.578 2 8 2zM1.556 7.933a2.314 2.314 0 00-.03.067l.03.067c.065.145.17.344.316.58a9.45 9.45 0 001.306 1.647C4.332 11.458 5.964 12.5 8 12.5s3.668-1.042 4.822-2.206a9.45 9.45 0 001.306-1.646A5.336 5.336 0 0014.473 8a5.335 5.335 0 00-.346-.648 9.452 9.452 0 00-1.305-1.646C11.668 4.542 10.036 3.5 8 3.5S4.332 4.542 3.178 5.706a9.45 9.45 0 00-1.306 1.646 5.316 5.316 0 00-.316.58z"/></g></svg>');
+}
+
+%eye-24-svg-prop {
+  --eye-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 8a4 4 0 100 8 4 4 0 000-8zm-2.5 4a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0z"/><path d="M12 3C8.135 3 5.14 5.088 3.15 7.162c-1.001 1.043-1.767 2.1-2.286 2.936-.26.417-.46.785-.6 1.074-.069.143-.127.275-.169.388a1.952 1.952 0 00-.058.177A1.024 1.024 0 000 12c0 .116.025.216.037.263.017.06.037.12.058.177.042.113.1.245.17.388.138.289.34.657.599 1.074a18.14 18.14 0 002.285 2.936C5.14 18.912 8.135 21 12 21c3.864 0 6.86-2.088 8.85-4.162 1.001-1.043 1.767-2.1 2.286-2.936.26-.417.46-.785.6-1.074.069-.143.127-.275.169-.388a1.98 1.98 0 00.058-.177c.012-.047.037-.147.037-.263 0-.116-.025-.216-.037-.263a1.98 1.98 0 00-.058-.177 4.709 4.709 0 00-.17-.388c-.139-.289-.34-.657-.599-1.074a18.146 18.146 0 00-2.285-2.936C18.86 5.088 15.865 3 12 3zM1.615 12.177a4.225 4.225 0 01-.08-.177c.02-.048.047-.107.08-.177.113-.233.287-.554.523-.934a16.641 16.641 0 012.093-2.688C6.076 6.28 8.705 4.5 12 4.5c3.294 0 5.924 1.78 7.768 3.701a16.639 16.639 0 012.094 2.688c.236.38.41.701.523.934.033.07.06.129.08.177a4.03 4.03 0 01-.08.177c-.113.233-.287.554-.523.934a16.639 16.639 0 01-2.093 2.688C17.924 17.72 15.294 19.5 12 19.5s-5.925-1.78-7.769-3.701a16.641 16.641 0 01-2.093-2.688c-.236-.38-.41-.701-.523-.934z"/></g></svg>');
+}
+
+%eye-off-16-svg-prop {
+  --eye-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M2.28 1.22a.75.75 0 00-1.06 1.06l1.664 1.665A10.99 10.99 0 00.977 5.994c-.295.41-.524.791-.683 1.103a4.16 4.16 0 00-.194.431A1.4 1.4 0 000 8c0 .155.041.296.067.375a3 3 0 00.122.31c.097.215.234.471.407.751.346.56.854 1.246 1.516 1.914C3.43 12.68 5.422 14 8 14c1.49 0 2.786-.442 3.868-1.071l1.852 1.851a.75.75 0 101.06-1.06l-4.645-4.646a.383.383 0 00-.008-.007v-.001l-3.19-3.19a.555.555 0 00-.014-.014L2.28 1.22zm3.127 5.248L3.95 5.01a9.444 9.444 0 00-1.754 1.857 7.362 7.362 0 00-.566.911c-.046.09-.08.164-.104.221l.03.067c.065.145.17.344.316.58a9.45 9.45 0 001.306 1.647C4.332 11.458 5.964 12.5 8 12.5c1.028 0 1.95-.264 2.763-.677l-1.23-1.23C9.078 10.858 8.552 11 8 11a3 3 0 01-3-3c0-.553.142-1.079.407-1.532zm2.985 2.985L6.547 7.608A1.62 1.62 0 006.5 8 1.5 1.5 0 008 9.5c.137 0 .269-.016.392-.047zM8 3.5c-.306 0-.602.023-.887.067a.75.75 0 11-.226-1.483C7.247 2.029 7.617 2 8 2c2.578 0 4.57 1.32 5.888 2.65.662.668 1.17 1.354 1.516 1.914.173.28.31.536.407.75.048.107.09.212.122.31.026.08.067.221.067.376 0 .21-.079.42-.126.537a4.99 4.99 0 01-.251.524c-.21.384-.515.857-.909 1.355a.75.75 0 11-1.176-.93c.343-.434.6-.836.768-1.144.078-.143.133-.258.168-.342a5.336 5.336 0 00-.346-.648 9.452 9.452 0 00-1.306-1.646C11.668 4.542 10.036 3.5 8 3.5zm6.511 4.604l-.002-.008.001.005.001.003z"/></g></svg>');
+}
+
+%eye-off-24-svg-prop {
+  --eye-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M2.28 1.22a.75.75 0 00-1.06 1.06l3.468 3.468C3.294 6.87 2.204 8.154 1.437 9.236a15.323 15.323 0 00-1.02 1.635c-.117.22-.21.415-.277.574-.033.08-.063.16-.086.234A1.102 1.102 0 000 12c0 .116.025.216.037.263.017.06.037.12.058.177.042.113.1.245.17.388.138.289.34.657.599 1.074a18.14 18.14 0 002.285 2.936C5.14 18.912 8.135 21 12 21c2.361 0 4.4-.78 6.08-1.86l3.64 3.64a.75.75 0 101.06-1.06L2.28 1.22zm10.88 13l-3.38-3.38c-.18.345-.28.738-.28 1.16a2.5 2.5 0 002.5 2.5c.422 0 .815-.1 1.16-.28zM8.688 9.75A3.976 3.976 0 008 12a4 4 0 004 4c.835 0 1.609-.25 2.251-.688l2.74 2.74c-1.43.863-3.1 1.448-4.991 1.448-3.295 0-5.925-1.78-7.769-3.701a16.641 16.641 0 01-2.093-2.688c-.236-.38-.41-.701-.523-.934a4.225 4.225 0 01-.08-.177 5.8 5.8 0 01.207-.426c.202-.38.51-.893.919-1.47.733-1.036 1.776-2.253 3.094-3.288l2.933 2.933zM12 4.5c-.813 0-1.583.108-2.31.299a.75.75 0 11-.38-1.451A10.568 10.568 0 0112 3c3.864 0 6.86 2.088 8.85 4.162 1.001 1.043 1.767 2.1 2.286 2.936.26.417.46.785.6 1.074.069.143.127.275.169.388.021.056.041.117.058.177.012.047.037.147.037.263 0 .171-.057.332-.08.396-.034.098-.08.208-.134.326-.109.236-.265.535-.465.874-.4.68-.99 1.551-1.759 2.455a.75.75 0 01-1.142-.973 16.232 16.232 0 001.608-2.242 8.709 8.709 0 00.438-.836 4.03 4.03 0 00-.081-.177 10.392 10.392 0 00-.523-.934 16.639 16.639 0 00-2.093-2.688C17.924 6.28 15.294 4.5 12 4.5zm10.516 7.365z"/></g></svg>');
+}
+
+%f5-16-svg-prop {
+  --f5-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M13.777 4.048c-.086.354-.13.722-.213 1.098a39.715 39.715 0 00-3.668-.285c-.112.351-.217.696-.337 1.071 2.318.143 3.444.754 4.112 1.473.65.728.788 1.533.75 2.28-.084 1.213-.619 1.98-1.353 2.549a4.712 4.712 0 01-2.361.898c-1.061.08-2.48-.173-2.782-.358-.182-.414-.36-.83-.553-1.285-.047-.096-.077-.196.056-.31.206-.199.405-.39.613-.593.093-.09.195-.174.273-.045.285.44.552.844.82 1.246.304.449.768.858 1.78.79.851-.076 1.498-.72 1.567-1.428.075-1.31-1.251-2.24-4.699-2.538.662-1.997 1.306-3.93 1.822-5.466a27.93 27.93 0 012.302.198c.535.068 1.033.193 1.532.25a7 7 0 00-11.076 8.555c.297.002.502-.064.525-.192.027-.133.004-.34-.02-.549a32.121 32.121 0 01-.136-4.343c-.355.015-.674.031-.98.05.013-.276.028-.536.05-.807.302-.029.621-.054.972-.084.015-.237.032-.466.053-.697.157-1.418 1.65-2.285 2.893-2.62.552-.134.89-.176 1.154-.19.096-.003.2-.007.302-.007.258 0 .52.024.685.137.268.2.533.4.815.623.028.038.059.098-.011.201l-.386.452c-.076.092-.201.067-.307.039a32.529 32.529 0 00-.652-.323c-.392-.174-.798-.354-1.25-.336-.281.023-.554.311-.582.706-.04.6-.066 1.215-.088 1.882a100.06 100.06 0 012.389-.04l-.001.552c-.27.12-.523.241-.792.364-.556.006-1.085.01-1.617.02a72.993 72.993 0 00.07 4.627c.014.22.024.444.088.593.076.189.513.334 1.464.387l.014.483c-1.549-.046-3.036-.194-4.228-.408a7 7 0 0010.991-8.62z"/></svg>');
+}
+
+%f5-24-svg-prop {
+  --f5-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M20.253 6.354c-.123.506-.187 1.031-.305 1.568a56.737 56.737 0 00-5.24-.406c-.16.502-.31.993-.482 1.53 3.311.204 4.92 1.076 5.875 2.104.928 1.04 1.125 2.19 1.071 3.256-.12 1.734-.884 2.83-1.933 3.642-1.061.8-2.345 1.197-3.373 1.283-1.515.114-3.542-.247-3.973-.511-.26-.59-.516-1.186-.791-1.835-.067-.138-.11-.28.08-.445.295-.282.578-.556.877-.845.132-.13.278-.25.389-.065.407.629.79 1.206 1.172 1.78.434.641 1.096 1.226 2.543 1.128 1.215-.108 2.14-1.028 2.238-2.04.107-1.872-1.788-3.2-6.713-3.625.945-2.853 1.867-5.614 2.603-7.809 1.17.054 2.253.15 3.288.283.765.097 1.476.276 2.19.358A9.978 9.978 0 0011.998 2C6.477 2 2 6.477 2 12a9.953 9.953 0 001.947 5.926c.423.003.717-.091.749-.274.039-.191.006-.487-.027-.785-.2-1.962-.271-4.081-.196-6.204-.507.022-.962.045-1.399.07.018-.392.04-.764.07-1.152.432-.041.888-.077 1.39-.12.021-.338.046-.665.075-.996.225-2.025 2.357-3.263 4.134-3.741.788-.192 1.27-.253 1.648-.273.137-.004.284-.01.431-.01.368 0 .742.035.979.196.383.287.761.573 1.164.89.04.055.084.14-.016.287-.185.217-.363.423-.551.646-.108.131-.288.096-.44.055a46.47 46.47 0 00-.93-.46c-.56-.25-1.14-.506-1.785-.48-.403.032-.793.444-.833 1.007a84.509 84.509 0 00-.125 2.69 142.94 142.94 0 013.412-.057l-.001.788c-.384.171-.746.345-1.131.52-.794.009-1.55.015-2.31.028-.036 2.266-.002 4.523.1 6.61.02.315.035.634.125.848.109.269.733.476 2.092.553.005.236.012.46.02.689-2.212-.065-4.337-.276-6.04-.583A9.968 9.968 0 0012 22c5.524 0 10-4.477 10-10a9.952 9.952 0 00-1.746-5.646z"/></svg>');
+}
+
+%f5-color-16-svg-prop {
+  --f5-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23E4002B" d="M13.777 4.048c-.086.354-.13.722-.213 1.098a39.715 39.715 0 00-3.668-.285c-.112.351-.217.696-.337 1.071 2.318.143 3.444.754 4.112 1.473.65.728.788 1.533.75 2.28-.084 1.213-.619 1.98-1.353 2.549a4.712 4.712 0 01-2.361.898c-1.061.08-2.48-.173-2.782-.358-.182-.414-.36-.83-.553-1.285-.047-.096-.077-.196.056-.31.206-.199.405-.39.613-.593.093-.09.195-.174.273-.045.285.44.552.844.82 1.246.304.449.768.858 1.78.79.851-.076 1.498-.72 1.567-1.428.075-1.31-1.251-2.24-4.699-2.538.662-1.997 1.306-3.93 1.822-5.466a27.93 27.93 0 012.302.198c.535.068 1.033.193 1.532.25a7 7 0 00-11.076 8.555c.297.002.502-.064.525-.192.027-.133.004-.34-.02-.549a32.121 32.121 0 01-.136-4.343c-.355.015-.674.031-.98.05.013-.276.028-.536.05-.807.302-.029.621-.054.972-.084.015-.237.032-.466.053-.697.157-1.418 1.65-2.285 2.893-2.62.552-.134.89-.176 1.154-.19.096-.003.2-.007.302-.007.258 0 .52.024.685.137.268.2.533.4.815.623.028.038.059.098-.011.201l-.386.452c-.076.092-.201.067-.307.039a32.529 32.529 0 00-.652-.323c-.392-.174-.798-.354-1.25-.336-.281.023-.554.311-.582.706-.04.6-.066 1.215-.088 1.882a100.06 100.06 0 012.389-.04l-.001.552c-.27.12-.523.241-.792.364-.556.006-1.085.01-1.617.02a72.993 72.993 0 00.07 4.627c.014.22.024.444.088.593.076.189.513.334 1.464.387l.014.483c-1.549-.046-3.036-.194-4.228-.408a7 7 0 0010.991-8.62z"/><path fill="%23fff" d="M14.42 9.684c.038-.746-.1-1.55-.75-2.279-.667-.72-1.794-1.33-4.112-1.473.12-.375.226-.72.337-1.071 1.386.049 2.619.149 3.668.285.083-.376.128-.744.214-1.098a6.934 6.934 0 00-.339-.454c-.499-.058-.997-.182-1.532-.251a27.931 27.931 0 00-2.301-.198c-.516 1.536-1.16 3.469-1.822 5.467 3.447.298 4.773 1.227 4.699 2.538-.07.708-.716 1.352-1.567 1.428-1.013.068-1.476-.34-1.78-.79-.268-.402-.536-.806-.82-1.246-.078-.129-.18-.045-.273.045-.209.203-.407.395-.614.592-.132.116-.103.215-.056.312.193.454.372.87.554 1.284.302.185 1.72.438 2.781.358a4.713 4.713 0 002.361-.898c.735-.57 1.27-1.337 1.353-2.55z"/><path fill="%23fff" d="M2.363 12.148c.132.18.273.354.422.52 1.193.215 2.68.363 4.23.408-.006-.16-.01-.317-.015-.483-.951-.053-1.388-.198-1.464-.386-.064-.15-.075-.373-.088-.594a72.784 72.784 0 01-.07-4.627c.532-.01 1.061-.014 1.617-.02.27-.123.523-.244.792-.364v-.551c-.823.003-1.604.017-2.387.039.022-.667.048-1.282.087-1.883.028-.394.301-.683.583-.705.451-.018.857.162 1.25.336.216.105.43.209.651.323.106.028.232.052.307-.04l.386-.451c.07-.104.04-.163.011-.201a39.675 39.675 0 00-.815-.624c-.165-.112-.427-.136-.685-.136-.102 0-.206.004-.301.007-.265.014-.602.056-1.154.19-1.244.335-2.736 1.202-2.894 2.62-.02.231-.037.46-.052.697-.351.03-.671.055-.973.084-.022.271-.037.532-.05.806.306-.018.625-.033.98-.049a32.19 32.19 0 00.137 4.343c.023.209.046.416.019.55-.022.127-.228.193-.524.191z"/></svg>');
+}
+
+%f5-color-24-svg-prop {
+  --f5-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23E4002B" d="M20.253 6.354c-.123.506-.187 1.031-.305 1.568a56.737 56.737 0 00-5.24-.406c-.16.502-.31.993-.482 1.53 3.311.204 4.92 1.076 5.875 2.104.928 1.04 1.125 2.19 1.071 3.256-.12 1.734-.884 2.83-1.933 3.642-1.061.8-2.345 1.197-3.373 1.283-1.515.114-3.542-.247-3.973-.511-.26-.59-.516-1.186-.791-1.835-.067-.138-.11-.28.08-.445.295-.282.578-.556.877-.845.132-.13.278-.25.389-.065.407.629.79 1.206 1.172 1.78.434.641 1.096 1.226 2.543 1.128 1.215-.108 2.14-1.028 2.238-2.04.107-1.872-1.788-3.2-6.713-3.625.945-2.853 1.867-5.614 2.603-7.809 1.17.054 2.253.15 3.288.283.765.097 1.476.276 2.19.358A9.978 9.978 0 0011.998 2C6.477 2 2 6.477 2 12a9.953 9.953 0 001.947 5.926c.423.003.717-.091.749-.274.039-.191.006-.487-.027-.785-.2-1.962-.271-4.081-.196-6.204-.507.022-.962.045-1.399.07.018-.392.04-.764.07-1.152.432-.041.888-.077 1.39-.12.021-.338.046-.665.075-.996.225-2.025 2.357-3.263 4.134-3.741.788-.192 1.27-.253 1.648-.273.137-.004.284-.01.431-.01.368 0 .742.035.979.196.383.287.761.573 1.164.89.04.055.084.14-.016.287-.185.217-.363.423-.551.646-.108.131-.288.096-.44.055a46.47 46.47 0 00-.93-.46c-.56-.25-1.14-.506-1.785-.48-.403.032-.793.444-.833 1.007a84.509 84.509 0 00-.125 2.69 142.94 142.94 0 013.412-.057l-.001.788c-.384.171-.746.345-1.131.52-.794.009-1.55.015-2.31.028-.036 2.266-.002 4.523.1 6.61.02.315.035.634.125.848.109.269.733.476 2.092.553.005.236.012.46.02.689-2.212-.065-4.337-.276-6.04-.583A9.968 9.968 0 0012 22c5.524 0 10-4.477 10-10a9.952 9.952 0 00-1.746-5.646z"/><path fill="%23fff" d="M21.172 14.406c.053-1.067-.144-2.216-1.072-3.256-.954-1.028-2.563-1.9-5.874-2.104.172-.537.322-1.028.481-1.53 1.98.07 3.741.212 5.24.406.118-.537.183-1.062.305-1.568a9.887 9.887 0 00-.483-.649c-.713-.082-1.424-.26-2.19-.358a39.903 39.903 0 00-3.287-.283c-.737 2.195-1.658 4.956-2.603 7.81 4.925.426 6.82 1.753 6.713 3.626-.098 1.011-1.023 1.931-2.239 2.04-1.446.097-2.108-.487-2.542-1.128-.383-.576-.765-1.152-1.173-1.78-.11-.185-.257-.065-.388.064-.299.29-.582.563-.877.846-.19.165-.148.306-.08.444.275.65.532 1.245.79 1.836.432.264 2.459.625 3.974.511 1.028-.086 2.312-.483 3.373-1.283 1.049-.814 1.813-1.91 1.932-3.644z"/><path fill="%23fff" d="M3.946 17.926c.19.257.391.505.604.743 1.704.306 3.829.518 6.041.582l-.02-.689c-1.359-.077-1.983-.284-2.092-.553-.09-.213-.106-.532-.126-.847a103.977 103.977 0 01-.1-6.61c.76-.014 1.517-.02 2.31-.029.386-.175.748-.349 1.132-.52l.002-.788a143.01 143.01 0 00-3.412.056c.031-.952.069-1.832.124-2.69.04-.563.43-.975.833-1.007.645-.025 1.225.231 1.785.48.31.15.615.299.931.461.152.04.331.076.44-.056.187-.222.366-.429.55-.645.1-.148.057-.233.016-.287a56.679 56.679 0 00-1.164-.89c-.237-.16-.61-.196-.979-.196-.146 0-.294.005-.43.01-.379.02-.86.08-1.65.272-1.775.479-3.908 1.717-4.133 3.742-.03.331-.053.658-.075.997-.501.042-.958.078-1.389.12-.031.387-.053.76-.07 1.151.436-.025.891-.048 1.399-.07a45.987 45.987 0 00.195 6.204c.033.299.066.594.027.785-.032.183-.325.277-.749.274z"/></svg>');
+}
+
+%fast-forward-16-svg-prop {
+  --fast-forward-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8.926 3.364A1.25 1.25 0 007 4.416v1.806L2.962 3.427A1.25 1.25 0 001 4.454v7.092a1.25 1.25 0 001.962 1.027L7 9.778v1.806a1.25 1.25 0 001.926 1.052L14.5 9.052a1.25 1.25 0 000-2.103L8.926 3.364zM13.363 8L8.5 11.126V4.874L13.363 8zM2.5 11.069V4.93L6.932 8 2.5 11.069z" clip-rule="evenodd"/></svg>');
+}
+
+%fast-forward-24-svg-prop {
+  --fast-forward-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13.812 5.38C12.66 4.5 11 5.322 11 6.77v3.331L4.812 5.38C3.66 4.5 2 5.322 2 6.77v10.458c0 1.449 1.66 2.27 2.812 1.391L11 13.897v3.332c0 1.449 1.66 2.27 2.812 1.391l6.851-5.229a1.75 1.75 0 000-2.782l-6.851-5.23zM12.5 6.77a.25.25 0 01.402-.199l6.851 5.23a.25.25 0 010 .397l-6.851 5.229a.25.25 0 01-.402-.2V6.772zm-9 0a.25.25 0 01.402-.199l7.061 5.39v.077l-7.061 5.389a.25.25 0 01-.402-.2V6.772z" clip-rule="evenodd"/></svg>');
+}
+
+%file-16-svg-prop {
+  --file-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.25 0A2.25 2.25 0 001 2.25v11.5A2.25 2.25 0 003.25 16h9.5A2.25 2.25 0 0015 13.75V5.457c0-.331-.132-.65-.366-.884L10.427.366A1.25 1.25 0 009.543 0H3.25zM2.5 2.25a.75.75 0 01.75-.75H9v3.75c0 .414.336.75.75.75h3.75v7.75a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75V2.25zm9.94 2.25L10.5 2.56V4.5h1.94z" clip-rule="evenodd"/></svg>');
+}
+
+%file-24-svg-prop {
+  --file-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M5.75 1A2.75 2.75 0 003 3.75v16.5A2.75 2.75 0 005.75 23h12.5A2.75 2.75 0 0021 20.25V8.664c0-.464-.184-.909-.513-1.237l-5.914-5.914A1.75 1.75 0 0013.336 1H5.75zM4.5 3.75c0-.69.56-1.25 1.25-1.25H13v5.75c0 .414.336.75.75.75h5.75v11.25c0 .69-.56 1.25-1.25 1.25H5.75c-.69 0-1.25-.56-1.25-1.25V3.75zM18.44 7.5L14.5 3.56V7.5h3.94z" clip-rule="evenodd"/></svg>');
+}
+
+%file-change-16-svg-prop {
+  --file-change-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M3.25 0A2.25 2.25 0 001 2.25v11.5A2.25 2.25 0 003.25 16h9.5A2.25 2.25 0 0015 13.75V5.457c0-.331-.132-.65-.366-.884L10.427.366A1.25 1.25 0 009.543 0H3.25zM2.5 2.25a.75.75 0 01.75-.75H9v3.75c0 .414.336.75.75.75h3.75v7.75a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75V2.25zm9.94 2.25L10.5 2.56V4.5h1.94zM9.583 9.156z" clip-rule="evenodd"/><path d="M5.5 8.595C5.77 8.325 6.23 8 6.876 8c.904 0 1.44.71 1.7 1.017.37.443.464.483.55.483.194 0 .375-.18.458-.344a.75.75 0 011.338.68 2.222 2.222 0 01-.422.57c-.27.269-.73.594-1.374.594-.904 0-1.44-.71-1.7-1.017-.37-.443-.465-.483-.55-.483-.2 0-.367.181-.458.344a.75.75 0 01-1.338-.68c.107-.212.254-.402.422-.57z"/></g></svg>');
+}
+
+%file-change-24-svg-prop {
+  --file-change-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.458 15.328c.218-.26.487-.58.899-.745a1.12 1.12 0 01.778-.026c.324.1.766.356 1.313.95.667.726 1.325 1.17 1.979 1.37.667.204 1.27.135 1.774-.067a3.433 3.433 0 001.127-.768 5.357 5.357 0 00.41-.459l.02-.022.032-.04.012-.013a.75.75 0 10-1.104-1.016c-.05.054-.101.115-.156.18-.218.26-.487.58-.899.745a1.12 1.12 0 01-.778.026c-.324-.1-.766-.356-1.313-.95-.667-.726-1.325-1.17-1.979-1.37a2.619 2.619 0 00-1.774.067 3.433 3.433 0 00-1.127.768 5.4 5.4 0 00-.326.356l-.085.103-.018.022a4.557 4.557 0 01-.045.053.75.75 0 101.104 1.016c.05-.054.101-.115.156-.18z"/><path fill-rule="evenodd" d="M3 3.75A2.75 2.75 0 015.75 1h7.586c.464 0 .909.184 1.237.513l5.914 5.914c.329.328.513.773.513 1.237V20.25A2.75 2.75 0 0118.25 23H5.75A2.75 2.75 0 013 20.25V3.75zM5.75 2.5c-.69 0-1.25.56-1.25 1.25v16.5c0 .69.56 1.25 1.25 1.25h12.5c.69 0 1.25-.56 1.25-1.25V9h-5.75a.75.75 0 01-.75-.75V2.5H5.75zm8.75 1.06l3.94 3.94H14.5V3.56z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-check-16-svg-prop {
+  --file-check-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M3.25 1.5a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h4a.75.75 0 010 1.5h-4A2.25 2.25 0 011 13.75V2.25A2.25 2.25 0 013.25 0h6.293c.331 0 .65.132.884.366l4.207 4.207c.234.235.366.553.366.884V6.75a.75.75 0 01-1.5 0V6H9.75A.75.75 0 019 5.25V1.5H3.25zm7.25 1.06l1.94 1.94H10.5V2.56z"/><path d="M16 12a4 4 0 11-8 0 4 4 0 018 0zm-1.712-1.272a.75.75 0 01-.016 1.06l-2.406 2.334a.75.75 0 01-1.044 0l-1.094-1.06a.75.75 0 011.044-1.078l.572.555 1.884-1.827a.75.75 0 011.06.016z"/></g></svg>');
+}
+
+%file-check-24-svg-prop {
+  --file-check-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M5.75 2.5c-.69 0-1.25.56-1.25 1.25v16.5c0 .69.56 1.25 1.25 1.25H11a.75.75 0 010 1.5H5.75A2.75 2.75 0 013 20.25V3.75A2.75 2.75 0 015.75 1h7.586c.464 0 .909.184 1.237.513l5.914 5.914c.329.328.513.773.513 1.237V13a.75.75 0 01-1.5 0V9h-5.75a.75.75 0 01-.75-.75V2.5H5.75zm8.75 1.06l3.94 3.94H14.5V3.56z"/><path d="M22 19a5 5 0 11-10 0 5 5 0 0110 0zm-1.879-2.03a.75.75 0 010 1.06l-3.5 3.5a.75.75 0 01-1.06 0l-1.591-1.59a.75.75 0 111.06-1.061l1.06 1.06 2.97-2.97a.75.75 0 011.061 0z"/></g></svg>');
+}
+
+%file-diff-16-svg-prop {
+  --file-diff-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.5 6.25a.75.75 0 00-1.5 0V7.5H5.75a.75.75 0 000 1.5H7v1.25a.75.75 0 001.5 0V9h1.25a.75.75 0 000-1.5H8.5V6.25zM5.75 11.5a.75.75 0 000 1.5h4a.75.75 0 000-1.5h-4z"/><path fill-rule="evenodd" d="M1 2.25A2.25 2.25 0 013.25 0h6.293c.331 0 .65.132.884.366l4.207 4.207c.234.235.366.553.366.884v8.293A2.25 2.25 0 0112.75 16h-9.5A2.25 2.25 0 011 13.75V2.25zm2.25-.75a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6H9.75A.75.75 0 019 5.25V1.5H3.25zm7.25 1.06l1.94 1.94H10.5V2.56z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-diff-24-svg-prop {
+  --file-diff-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.5 10.25a.75.75 0 00-1.5 0v2.25H8.75a.75.75 0 000 1.5H11v2.25a.75.75 0 001.5 0V14h2.25a.75.75 0 000-1.5H12.5v-2.25zM8.75 18a.75.75 0 000 1.5h6a.75.75 0 000-1.5h-6z"/><path fill-rule="evenodd" d="M3 3.75A2.75 2.75 0 015.75 1h7.586c.464 0 .909.184 1.237.513l5.914 5.914c.329.328.513.773.513 1.237V20.25A2.75 2.75 0 0118.25 23H5.75A2.75 2.75 0 013 20.25V3.75zM5.75 2.5c-.69 0-1.25.56-1.25 1.25v16.5c0 .69.56 1.25 1.25 1.25h12.5c.69 0 1.25-.56 1.25-1.25V9h-5.75a.75.75 0 01-.75-.75V2.5H5.75zm8.75 1.06l3.94 3.94H14.5V3.56z" clip-rule="evenodd"/></g></svg>');
+}
+
 %file-fill-svg-prop {
   --file-fill-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14 4l4 4v12H6V4h8zm6 16V7l-5-5H6c-1.25 0-2 .75-2 2v16c0 1.25.75 2 2 2h12c1.25 0 2-.75 2-2zm-4-2H8v-2h8v2zm0-3H8v-2h8v2zm0-3H8v-2h8v2zM8 8h4V6H8v2z" fill="%23000"/></svg>');
+}
+
+%file-minus-16-svg-prop {
+  --file-minus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.75 9a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5z"/><path fill-rule="evenodd" d="M1 2.25A2.25 2.25 0 013.25 0h6.293c.331 0 .65.132.884.366l4.207 4.207c.234.235.366.553.366.884v8.293A2.25 2.25 0 0112.75 16h-9.5A2.25 2.25 0 011 13.75V2.25zm2.25-.75a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6H9.75A.75.75 0 019 5.25V1.5H3.25zm7.25 1.06l1.94 1.94H10.5V2.56z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-minus-24-svg-prop {
+  --file-minus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.75 14a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5z"/><path fill-rule="evenodd" d="M3 3.75A2.75 2.75 0 015.75 1h7.586c.464 0 .909.184 1.237.513l5.914 5.914c.329.328.513.773.513 1.237V20.25A2.75 2.75 0 0118.25 23H5.75A2.75 2.75 0 013 20.25V3.75zM5.75 2.5c-.69 0-1.25.56-1.25 1.25v16.5c0 .69.56 1.25 1.25 1.25h12.5c.69 0 1.25-.56 1.25-1.25V9h-5.75a.75.75 0 01-.75-.75V2.5H5.75zm8.75 1.06l3.94 3.94H14.5V3.56z" clip-rule="evenodd"/></g></svg>');
 }
 
 %file-outline-svg-prop {
   --file-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 7v13.5c0 .786-.714 1.5-1.5 1.5h-13c-.786 0-1.5-.714-1.5-1.5v-17C4 2.714 4.714 2 5.5 2H15l5 5zm-2 .714h-3.571V4H6v16h12V7.714z" fill="%23000"/></svg>');
 }
 
+%file-plus-16-svg-prop {
+  --file-plus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.75 7a.75.75 0 01.75.75V9h1.25a.75.75 0 010 1.5H8.5v1.25a.75.75 0 01-1.5 0V10.5H5.75a.75.75 0 010-1.5H7V7.75A.75.75 0 017.75 7z"/><path fill-rule="evenodd" d="M3.25 0A2.25 2.25 0 001 2.25v11.5A2.25 2.25 0 003.25 16h9.5A2.25 2.25 0 0015 13.75V5.457c0-.331-.132-.65-.366-.884L10.427.366A1.25 1.25 0 009.543 0H3.25zM2.5 2.25a.75.75 0 01.75-.75H9v3.75c0 .414.336.75.75.75h3.75v7.75a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75V2.25zm9.94 2.25L10.5 2.56V4.5h1.94z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-plus-24-svg-prop {
+  --file-plus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.75 10.75a.75.75 0 01.75.75V14H15a.75.75 0 010 1.5h-2.5V18a.75.75 0 01-1.5 0v-2.5H8.5a.75.75 0 010-1.5H11v-2.5a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M5.75 1A2.75 2.75 0 003 3.75v16.5A2.75 2.75 0 005.75 23h12.5A2.75 2.75 0 0021 20.25V8.664c0-.464-.184-.909-.513-1.237l-5.914-5.914A1.75 1.75 0 0013.336 1H5.75zM4.5 3.75c0-.69.56-1.25 1.25-1.25H13v5.75c0 .414.336.75.75.75h5.75v11.25c0 .69-.56 1.25-1.25 1.25H5.75c-.69 0-1.25-.56-1.25-1.25V3.75zM18.44 7.5L14.5 3.56V7.5h3.94z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-source-16-svg-prop {
+  --file-source-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.22 7.838a.625.625 0 01-.058.882L5.699 10l1.463 1.28a.625.625 0 01-.824.94l-2-1.75a.625.625 0 010-.94l2-1.75a.625.625 0 01.882.058zM8.838 8.72a.625.625 0 01.824-.94l2 1.75a.625.625 0 010 .94l-2 1.75a.625.625 0 01-.824-.94L10.301 10 8.838 8.72z"/><path fill-rule="evenodd" d="M3.25 0A2.25 2.25 0 001 2.25v11.5A2.25 2.25 0 003.25 16h9.5A2.25 2.25 0 0015 13.75V5.457c0-.331-.132-.65-.366-.884L10.427.366A1.25 1.25 0 009.543 0H3.25zM2.5 2.25a.75.75 0 01.75-.75H9v3.75c0 .414.336.75.75.75h3.75v7.75a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75V2.25zm9.94 2.25L10.5 2.56V4.5h1.94z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-source-24-svg-prop {
+  --file-source-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M13.15 12.3a.75.75 0 011.05-.15l3 2.25a.75.75 0 010 1.2l-3 2.25a.75.75 0 11-.9-1.2L15.5 15l-2.2-1.65a.75.75 0 01-.15-1.05zM10.7 13.35a.75.75 0 10-.9-1.2l-3 2.25a.75.75 0 000 1.2l3 2.25a.75.75 0 10.9-1.2L8.5 15l2.2-1.65z"/><path fill-rule="evenodd" d="M5.75 1A2.75 2.75 0 003 3.75v16.5A2.75 2.75 0 005.75 23h12.5A2.75 2.75 0 0021 20.25V8.664c0-.464-.184-.909-.513-1.237l-5.914-5.914A1.75 1.75 0 0013.336 1H5.75zM4.5 3.75c0-.69.56-1.25 1.25-1.25H13v5.75c0 .414.336.75.75.75h5.75v11.25c0 .69-.56 1.25-1.25 1.25H5.75c-.69 0-1.25-.56-1.25-1.25V3.75zM18.44 7.5L14.5 3.56V7.5h3.94z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-text-16-svg-prop {
+  --file-text-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M4.75 8a.75.75 0 000 1.5h5.5a.75.75 0 000-1.5h-5.5zM4 11.75a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5h-3.5a.75.75 0 01-.75-.75zM4.75 5a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5z"/><path fill-rule="evenodd" d="M1 2.25A2.25 2.25 0 013.25 0h6.293c.331 0 .65.132.884.366l4.207 4.207c.234.235.366.553.366.884v8.293A2.25 2.25 0 0112.75 16h-9.5A2.25 2.25 0 011 13.75V2.25zm2.25-.75a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V6H9.75A.75.75 0 019 5.25V1.5H3.25zm7.25 1.06l1.94 1.94H10.5V2.56z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-text-24-svg-prop {
+  --file-text-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M7.75 12a.75.75 0 000 1.5h8a.75.75 0 000-1.5h-8zM7 16.75a.75.75 0 01.75-.75h6a.75.75 0 010 1.5h-6a.75.75 0 01-.75-.75zM7.75 8a.75.75 0 000 1.5h2a.75.75 0 000-1.5h-2z"/><path fill-rule="evenodd" d="M3 3.75A2.75 2.75 0 015.75 1h7.586c.464 0 .909.184 1.237.513l5.914 5.914c.329.328.513.773.513 1.237V20.25A2.75 2.75 0 0118.25 23H5.75A2.75 2.75 0 013 20.25V3.75zM5.75 2.5c-.69 0-1.25.56-1.25 1.25v16.5c0 .69.56 1.25 1.25 1.25h12.5c.69 0 1.25-.56 1.25-1.25V9h-5.75a.75.75 0 01-.75-.75V2.5H5.75zm8.75 1.06l3.94 3.94H14.5V3.56z" clip-rule="evenodd"/></g></svg>');
+}
+
+%file-x-16-svg-prop {
+  --file-x-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M3.25 1.5a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h4.5a.75.75 0 010 1.5h-4.5A2.25 2.25 0 011 13.75V2.25A2.25 2.25 0 013.25 0h6.293c.331 0 .65.132.884.366l4.207 4.207c.234.235.366.553.366.884V7.5a.75.75 0 01-1.5 0V6H9.75A.75.75 0 019 5.25V1.5H3.25zm7.25 1.06l1.94 1.94H10.5V2.56z"/><path d="M11 9a2 2 0 00-2 2v3a2 2 0 002 2h3a2 2 0 002-2v-3a2 2 0 00-2-2h-3zm.53 5.53l.97-.97.97.97a.75.75 0 101.06-1.06l-.97-.97.97-.97a.75.75 0 10-1.06-1.06l-.97.97-.97-.97a.75.75 0 10-1.06 1.06l.97.97-.97.97a.75.75 0 101.06 1.06z"/></g></svg>');
+}
+
+%file-x-24-svg-prop {
+  --file-x-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M5.75 2.5c-.69 0-1.25.56-1.25 1.25v16.5c0 .69.56 1.25 1.25 1.25h4.5a.75.75 0 010 1.5h-4.5A2.75 2.75 0 013 20.25V3.75A2.75 2.75 0 015.75 1h7.586c.464 0 .909.184 1.237.513l5.914 5.914c.329.328.513.773.513 1.237v3.586a.75.75 0 01-1.5 0V9h-5.75a.75.75 0 01-.75-.75V2.5H5.75zm8.75 1.06l3.94 3.94H14.5V3.56z"/><path d="M14 14a2 2 0 00-2 2v6a2 2 0 002 2h6a2 2 0 002-2v-6a2 2 0 00-2-2h-6zm5.78 3.28a.75.75 0 10-1.06-1.06L17 17.94l-1.72-1.72a.75.75 0 10-1.06 1.06L15.94 19l-1.72 1.72a.75.75 0 101.06 1.06L17 20.06l1.72 1.72a.75.75 0 101.06-1.06L18.06 19l1.72-1.72z"/></g></svg>');
+}
+
+%files-16-svg-prop {
+  --files-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1 2.25A2.25 2.25 0 013.25 0h4.793c.331 0 .65.132.884.366l3.207 3.207c.076.076.141.161.195.253a.75.75 0 01.201.144l2.104 2.103c.234.235.366.553.366.884v6.793A2.25 2.25 0 0112.75 16h-7a2.25 2.25 0 01-2.25-2.25v-.25h-.25A2.25 2.25 0 011 11.25v-9zm2.25-.75a.75.75 0 00-.75.75v9c0 .414.336.75.75.75h7a.75.75 0 00.75-.75V6H7.75A.75.75 0 017 5.25V1.5H3.25zm5.25.56V4.5h2.44L8.5 2.06zm4 9.19V6.06l1 1v6.69a.75.75 0 01-.75.75h-7a.75.75 0 01-.75-.75v-.25h5.25a2.25 2.25 0 002.25-2.25z" clip-rule="evenodd"/></svg>');
+}
+
+%files-24-svg-prop {
+  --files-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M5.25 1A2.25 2.25 0 003 3.25v11.5A2.25 2.25 0 005.25 17H6v.75A2.25 2.25 0 008.25 20H9v.75A2.25 2.25 0 0011.25 23h8.5A2.25 2.25 0 0022 20.75v-7.879a2.25 2.25 0 00-.659-1.59l-2.31-2.311a.746.746 0 00-.312-.187 2.25 2.25 0 00-.378-.503l-2.31-2.31a.746.746 0 00-.312-.187 2.25 2.25 0 00-.378-.503L11.72 1.66A2.25 2.25 0 0010.129 1H5.25zM4.5 3.25a.75.75 0 01.75-.75H10v3.75c0 .414.336.75.75.75h3.75v7.75a.75.75 0 01-.75.75h-8.5a.75.75 0 01-.75-.75V3.25zm8.94 2.25L11.5 3.56V5.5h1.94zM19 11.06v6.69A2.25 2.25 0 0116.75 20H10.5v.75c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-7.879a.75.75 0 00-.22-.53L19 11.061zM7.5 17.75V17h6.25A2.25 2.25 0 0016 14.75V8.06l1.28 1.281c.141.14.22.331.22.53v7.879a.75.75 0 01-.75.75h-8.5a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%film-16-svg-prop {
+  --film-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2.25 0A2.25 2.25 0 000 2.25v11.5A2.25 2.25 0 002.25 16h11.5A2.25 2.25 0 0016 13.75V2.25A2.25 2.25 0 0013.75 0H2.25zM14.5 3.5V2.25a.75.75 0 00-.75-.75H12.5v2h2zm-2 1.5h2v2h-2V5zM11 1.5H5V7h6V1.5zm3.5 7v2h-2v-2h2zm0 3.5h-2v2.5h1.25a.75.75 0 00.75-.75V12zM11 8.5v6H5v-6h6zM1.5 12v1.75c0 .414.336.75.75.75H3.5V12h-2zm2-1.5h-2v-2h2v2zM1.5 7V5h2v2h-2zm0-3.5h2v-2H2.25a.75.75 0 00-.75.75V3.5z" clip-rule="evenodd"/></svg>');
+}
+
+%film-24-svg-prop {
+  --film-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M3.75 1A2.75 2.75 0 001 3.75v16.5A2.75 2.75 0 003.75 23h16.5A2.75 2.75 0 0023 20.25V3.75A2.75 2.75 0 0020.25 1H3.75zM21.5 6V3.75c0-.69-.56-1.25-1.25-1.25H18V6h3.5zM18 7.5h3.5V11H18V7.5zm-1.5-5h-9V11h9V2.5zm5 10V16H18v-3.5h3.5zm0 5H18v4h2.25c.69 0 1.25-.56 1.25-1.25V17.5zm-5-5v9h-9v-9h9zm-14 5v2.75c0 .69.56 1.25 1.25 1.25H6v-4H2.5zM6 16H2.5v-3.5H6V16zm-3.5-5V7.5H6V11H2.5zm0-5H6V2.5H3.75c-.69 0-1.25.56-1.25 1.25V6z" clip-rule="evenodd"/></svg>');
+}
+
+%filter-16-svg-prop {
+  --filter-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1 3.75A.75.75 0 011.75 3h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 3.75zM3.5 7.75A.75.75 0 014.25 7h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM6.75 11a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z"/></g></svg>');
+}
+
+%filter-24-svg-prop {
+  --filter-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3 6.75A.75.75 0 013.75 6h16.5a.75.75 0 010 1.5H3.75A.75.75 0 013 6.75zM6 11.75a.75.75 0 01.75-.75h10.5a.75.75 0 010 1.5H6.75a.75.75 0 01-.75-.75zM9.75 16a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5z"/></g></svg>');
+}
+
+%filter-circle-16-svg-prop {
+  --filter-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.75 7.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5zM3.5 5.75A.75.75 0 014.25 5h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM7 10a.75.75 0 000 1.5h2A.75.75 0 009 10H7z"/><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%filter-circle-24-svg-prop {
+  --filter-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.25 12a.75.75 0 000 1.5h7.5a.75.75 0 000-1.5h-7.5zM5 8.75A.75.75 0 015.75 8h12.5a.75.75 0 010 1.5H5.75A.75.75 0 015 8.75zM10.75 16a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z"/><path fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%filter-fill-16-svg-prop {
+  --filter-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM4.25 5a.75.75 0 000 1.5h7.5a.75.75 0 000-1.5h-7.5zm1.5 2.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5zm.5 3.25A.75.75 0 017 10h2a.75.75 0 010 1.5H7a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%filter-fill-24-svg-prop {
+  --filter-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM5 8.75A.75.75 0 015.75 8h12.5a.75.75 0 010 1.5H5.75A.75.75 0 015 8.75zm2.5 4a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zm2.5 4a.75.75 0 01.75-.75h2.5a.75.75 0 010 1.5h-2.5a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
 %filter-svg-prop {
   --filter-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z" fill="%23000"/></svg>');
+}
+
+%fingerprint-16-svg-prop {
+  --fingerprint-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4.925.827A7.583 7.583 0 0115.66 9.316a.75.75 0 11-1.463-.333 6.083 6.083 0 00-8.61-6.81.75.75 0 01-.662-1.346zM3.278 2.903a.75.75 0 01.143 1.05 6.058 6.058 0 00-1.087 2.332 26.684 26.684 0 01-.811 2.9.75.75 0 11-1.416-.495c.262-.747.514-1.634.765-2.737a7.558 7.558 0 011.355-2.907.75.75 0 011.05-.143zm.259 3.656a4.85 4.85 0 019.176-.859.75.75 0 01-1.375.6A3.35 3.35 0 005 6.891c-.174.766-.354 1.46-.543 2.098a.75.75 0 01-1.438-.426c.179-.603.35-1.265.519-2.005zm3.548-.682a2.117 2.117 0 013.244 2.226 38.526 38.526 0 01-.684 2.614.75.75 0 11-1.436-.434c.235-.777.452-1.608.658-2.512a.617.617 0 00-.945-.649.75.75 0 01-.837-1.245zm5.345 1.935a.75.75 0 01.565.897c-.57 2.505-1.25 4.627-2.178 6.609a.75.75 0 01-1.358-.636c.871-1.86 1.52-3.874 2.073-6.305a.75.75 0 01.898-.565zm-5.768.673a.75.75 0 01.518.926c-.531 1.874-1.146 3.384-1.93 4.794-.057.103-.115.205-.174.307a.75.75 0 01-1.298-.75c.054-.095.108-.19.16-.285.72-1.296 1.295-2.696 1.798-4.475a.75.75 0 01.926-.517zm-3.487 1.998a.75.75 0 01.384.988c-.218.497-.45.96-.698 1.407a.75.75 0 01-1.311-.728c.226-.407.437-.83.637-1.283a.75.75 0 01.988-.385zm11.361.295a.75.75 0 01.516.927 34.364 34.364 0 01-.833 2.556.75.75 0 11-1.406-.522c.291-.785.554-1.596.796-2.445a.75.75 0 01.927-.516zm-6.21 1.53c.381.16.561.6.401.982a22.529 22.529 0 01-1.088 2.243.75.75 0 11-1.31-.729 21.03 21.03 0 001.015-2.094.75.75 0 01.981-.402z" clip-rule="evenodd"/></svg>');
+}
+
+%fingerprint-24-svg-prop {
+  --fingerprint-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M14.802 1.26c-3.792-.863-7.57.48-9.995 3.177A.75.75 0 105.923 5.44a8.841 8.841 0 018.546-2.718A8.8 8.8 0 0119.09 5.44a.75.75 0 001.118-1 10.3 10.3 0 00-5.407-3.18zM4.737 7.118a.75.75 0 00-1.318-.716 10.352 10.352 0 00-.998 2.65c-.466 2.05-.897 3.074-1.327 3.848a.75.75 0 101.312.728c.516-.929.99-2.095 1.478-4.244.185-.812.475-1.57.853-2.266zm16.857-.717a.75.75 0 00-1.317.718 8.807 8.807 0 01.855 6.187c-.385 1.694-.828 3.262-1.374 4.76a.75.75 0 001.409.514c.572-1.57 1.032-3.2 1.428-4.941.58-2.555.16-5.105-1-7.238zm-7.99.185a4.85 4.85 0 00-5.805 3.654 27.905 27.905 0 01-.82 2.94.75.75 0 101.418.49 29.39 29.39 0 00.865-3.097 3.35 3.35 0 016.426-.373.75.75 0 001.414-.502 4.847 4.847 0 00-3.498-3.112zm3.654 5.805a.75.75 0 10-1.463-.333c-.698 3.071-1.55 5.48-2.815 7.756-.383.69-.798 1.356-1.245 2.012a.75.75 0 001.239.845c.47-.69.91-1.394 1.318-2.13 1.35-2.43 2.245-4.98 2.966-8.15zm-10.135 4.17a.75.75 0 00-1.311-.73c-.488.88-1.082 1.754-1.874 2.767a.75.75 0 001.182.924c.826-1.057 1.468-1.997 2.003-2.962zm5.238-12.12a.75.75 0 01-.644.844 6.086 6.086 0 00-5.12 4.682c-.558 2.451-1.143 3.968-1.863 5.266a17.572 17.572 0 01-1.165 1.808.75.75 0 01-1.214-.882c.437-.601.778-1.134 1.067-1.655.635-1.142 1.177-2.517 1.712-4.87A7.586 7.586 0 0111.517 3.8a.75.75 0 01.844.643zm.951.045a.75.75 0 01.898-.565 7.583 7.583 0 015.713 9.076 44.944 44.944 0 01-.677 2.629.75.75 0 11-1.44-.42c.236-.81.453-1.654.654-2.542a6.083 6.083 0 00-4.583-7.28.75.75 0 01-.565-.898zm4.562 12.964a.75.75 0 01.426.972 28.137 28.137 0 01-1.619 3.447.75.75 0 01-1.311-.728 26.645 26.645 0 001.533-3.265.75.75 0 01.971-.426zm-4.876-8.198a2.115 2.115 0 00-1.88.485.75.75 0 10.999 1.12.615.615 0 011.013.595c-.446 1.962-.946 3.58-1.564 5.037a.75.75 0 001.38.586c.663-1.56 1.187-3.267 1.647-5.29a2.117 2.117 0 00-1.595-2.533zm-1.496 3.63a.75.75 0 00-1.447-.4c-.517 1.876-1.107 3.333-1.853 4.677-.563 1.013-1.231 1.993-2.066 3.066a.75.75 0 001.184.921c.868-1.117 1.584-2.162 2.193-3.259.813-1.463 1.444-3.033 1.989-5.005zm.4 6.333a.75.75 0 00-1.311-.729 25.143 25.143 0 01-1.871 2.858.75.75 0 001.201.898 26.641 26.641 0 001.981-3.027z" clip-rule="evenodd"/></svg>');
+}
+
+%flag-16-svg-prop {
+  --flag-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M5.375 1c-1.072 0-1.827.185-2.337.396a3.125 3.125 0 00-.58.309 2.006 2.006 0 00-.233.188l-.007.007-.004.004-.002.002s.898.871-.001.001A.75.75 0 002 2.43V14.25a.75.75 0 001.5 0v-3.275c.033-.016.07-.033.11-.05.31-.128.868-.282 1.765-.282.815 0 1.503.276 2.338.621l.043.018c.796.33 1.735.718 2.869.718 1.072 0 1.827-.185 2.337-.396a3.13 3.13 0 00.58-.309 2.03 2.03 0 00.214-.17l.01-.009.009-.009.008-.007.003-.004.002-.002s-.899-.872.001-.001A.75.75 0 0014 10.57V2.43a.75.75 0 00-1.27-.54 1.642 1.642 0 01-.34.186c-.31.128-.868.282-1.765.282-.815 0-1.503-.276-2.338-.621l-.043-.018C7.448 1.388 6.51 1 5.375 1zM3.5 9.379V2.832c.033-.016.07-.033.11-.05.31-.128.868-.282 1.765-.282.815 0 1.503.276 2.338.622l.043.017c.796.33 1.735.718 2.869.718.786 0 1.401-.1 1.875-.236v6.547a2.27 2.27 0 01-.11.05c-.31.128-.868.282-1.765.282-.815 0-1.503-.276-2.338-.622l-.043-.017c-.796-.33-1.735-.718-2.869-.718-.786 0-1.401.1-1.875.236z" clip-rule="evenodd"/></svg>');
+}
+
+%flag-24-svg-prop {
+  --flag-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M7.875 1c-1.632 0-2.76.273-3.502.572-.371.149-.643.303-.83.429a2.719 2.719 0 00-.22.162l-.104.094A.75.75 0 003 2.786V22.25a.75.75 0 001.5 0V15.6c.104-.06.246-.133.432-.208.546-.219 1.481-.463 2.943-.463 1.382 0 2.543.458 3.845.981l.044.018c1.264.508 2.669 1.072 4.361 1.072 1.632 0 2.76-.273 3.502-.572.371-.149.643-.303.83-.429 0 0 .184-.115.325-.256a.75.75 0 00.218-.529V2.786a.75.75 0 00-1.27-.541l-.008.007a1.23 1.23 0 01-.099.072 3.038 3.038 0 01-.555.284c-.546.219-1.481.463-2.943.463-1.382 0-2.543-.458-3.845-.981l-.044-.018C10.972 1.564 9.567 1 7.875 1zM4.5 13.951V3.171c.104-.06.246-.133.432-.207.546-.22 1.481-.464 2.943-.464 1.382 0 2.543.458 3.845.982l.044.017c1.264.508 2.669 1.072 4.361 1.072 1.541 0 2.633-.244 3.375-.522v10.78c-.104.06-.246.133-.432.207-.546.22-1.481.464-2.943.464-1.382 0-2.543-.458-3.845-.982l-.044-.017c-1.264-.508-2.669-1.072-4.361-1.072-1.541 0-2.633.243-3.375.522z" clip-rule="evenodd"/></svg>');
 }
 
 %flag-svg-prop {
   --flag-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6h-5.6z" fill="%23000"/></svg>');
 }
 
+%folder-16-svg-prop {
+  --folder-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2.25 1A2.25 2.25 0 000 3.25v9.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-7.5A2.25 2.25 0 0013.75 3H9.871a.75.75 0 01-.53-.22L8.22 1.66A2.25 2.25 0 006.629 1H2.25zM1.5 3.25a.75.75 0 01.75-.75h4.379a.75.75 0 01.53.22L8.28 3.84a2.25 2.25 0 001.591.659h3.879a.75.75 0 01.75.75v7.5a.75.75 0 01-.75.75H2.25a.75.75 0 01-.75-.75V7h10.75a.75.75 0 000-1.5H1.5V3.25z" clip-rule="evenodd"/></svg>');
+}
+
+%folder-24-svg-prop {
+  --folder-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M3.75 2A2.75 2.75 0 001 4.75v14.5A2.75 2.75 0 003.75 22h16.5A2.75 2.75 0 0023 19.25V6.75A2.75 2.75 0 0020.25 4h-7.172a1.25 1.25 0 01-.883-.366l-.829-.829A2.75 2.75 0 009.422 2H3.75zM2.5 4.75c0-.69.56-1.25 1.25-1.25h5.672c.331 0 .649.132.883.366l.829.829a2.75 2.75 0 001.944.805h7.172c.69 0 1.25.56 1.25 1.25v12.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25V8.5h16.75a.75.75 0 000-1.5H2.5V4.75z" clip-rule="evenodd"/></svg>');
+}
+
+%folder-fill-16-svg-prop {
+  --folder-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M2.25 1A2.25 2.25 0 000 3.25v1c0 .414.336.75.75.75h12.5a.75.75 0 010 1.5H.75a.75.75 0 00-.75.75v5.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-7.5A2.25 2.25 0 0013.75 3H9.871a.75.75 0 01-.53-.22L8.22 1.66A2.25 2.25 0 006.629 1H2.25z"/></svg>');
+}
+
+%folder-fill-24-svg-prop {
+  --folder-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M3.75 2A2.75 2.75 0 001 4.75v1c0 .414.336.75.75.75h18.5a.75.75 0 010 1.5H1.75a.75.75 0 00-.75.75v10.5A2.75 2.75 0 003.75 22h16.5A2.75 2.75 0 0023 19.25V6.75A2.75 2.75 0 0020.25 4h-7.172a1.25 1.25 0 01-.883-.366l-.829-.829A2.75 2.75 0 009.422 2H3.75z"/></svg>');
+}
+
 %folder-fill-svg-prop {
   --folder-fill-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" fill="%23000"/></svg>');
+}
+
+%folder-minus-16-svg-prop {
+  --folder-minus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.75 7.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5z"/><path fill-rule="evenodd" d="M2.25 1A2.25 2.25 0 000 3.25v9.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-7.5A2.25 2.25 0 0013.75 3H9.871a.75.75 0 01-.53-.22L8.22 1.66A2.25 2.25 0 006.629 1H2.25zM1.5 3.25a.75.75 0 01.75-.75h4.379a.75.75 0 01.53.22L8.28 3.84a2.25 2.25 0 001.591.659h3.879a.75.75 0 01.75.75v7.5a.75.75 0 01-.75.75H2.25a.75.75 0 01-.75-.75v-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%folder-minus-24-svg-prop {
+  --folder-minus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.75 13a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5z"/><path fill-rule="evenodd" d="M1 4.75A2.75 2.75 0 013.75 2h5.672c.729 0 1.428.29 1.944.805l.829.829c.234.234.552.366.883.366h7.172A2.75 2.75 0 0123 6.75v12.5A2.75 2.75 0 0120.25 22H3.75A2.75 2.75 0 011 19.25V4.75zM3.75 3.5c-.69 0-1.25.56-1.25 1.25V7h16.75a.75.75 0 010 1.5H2.5v10.75c0 .69.56 1.25 1.25 1.25h16.5c.69 0 1.25-.56 1.25-1.25V6.75c0-.69-.56-1.25-1.25-1.25h-7.172a2.75 2.75 0 01-1.944-.805l-.829-.829a1.25 1.25 0 00-.883-.366H3.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%folder-minus-fill-16-svg-prop {
+  --folder-minus-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2.25 1A2.25 2.25 0 000 3.25v9.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-7.5A2.25 2.25 0 0013.75 3H9.871a.75.75 0 01-.53-.22L8.22 1.66A2.25 2.25 0 006.629 1H2.25zM5 8.253a.75.75 0 01.75-.75h4.5a.75.75 0 010 1.5h-4.5a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%folder-minus-fill-24-svg-prop {
+  --folder-minus-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M3.75 2A2.75 2.75 0 001 4.75v1c0 .414.336.75.75.75h18.5a.75.75 0 010 1.5H1.75a.75.75 0 00-.75.75v10.5A2.75 2.75 0 003.75 22h16.5A2.75 2.75 0 0023 19.25V6.75A2.75 2.75 0 0020.25 4h-7.172a1.25 1.25 0 01-.883-.366l-.829-.829A2.75 2.75 0 009.422 2H3.75zM8 13.75a.75.75 0 01.75-.75h6.5a.75.75 0 010 1.5h-6.5a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></svg>');
 }
 
 %folder-outline-svg-prop {
   --folder-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 12H4V8h16v10z" fill="%23000"/></svg>');
 }
 
+%folder-plus-16-svg-prop {
+  --folder-plus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.75 6a.75.75 0 01.75.75V8h1.25a.75.75 0 010 1.5H8.5v1.25a.75.75 0 01-1.5 0V9.5H5.75a.75.75 0 010-1.5H7V6.75A.75.75 0 017.75 6z"/><path fill-rule="evenodd" d="M0 3.25A2.25 2.25 0 012.25 1h4.379a2.25 2.25 0 011.59.659L9.342 2.78c.14.141.331.22.53.22h3.879A2.25 2.25 0 0116 5.25v7.5A2.25 2.25 0 0113.75 15H2.25A2.25 2.25 0 010 12.75v-9.5zm2.25-.75a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75v-7.5a.75.75 0 00-.75-.75H9.871a2.25 2.25 0 01-1.59-.659L7.158 2.72a.75.75 0 00-.53-.22H2.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%folder-plus-24-svg-prop {
+  --folder-plus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.75 10.5a.75.75 0 01.75.75v2.25h2.25a.75.75 0 010 1.5H12.5v2.25a.75.75 0 01-1.5 0V15H8.75a.75.75 0 010-1.5H11v-2.25a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M3.75 2A2.75 2.75 0 001 4.75v14.5A2.75 2.75 0 003.75 22h16.5A2.75 2.75 0 0023 19.25V6.75A2.75 2.75 0 0020.25 4h-7.172a1.25 1.25 0 01-.883-.366l-.829-.829A2.75 2.75 0 009.422 2H3.75zM2.5 4.75c0-.69.56-1.25 1.25-1.25h5.672c.331 0 .649.132.883.366l.829.829a2.75 2.75 0 001.944.805h7.172c.69 0 1.25.56 1.25 1.25v12.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25V8.5h16.75a.75.75 0 000-1.5H2.5V4.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%folder-plus-fill-16-svg-prop {
+  --folder-plus-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 3.25A2.25 2.25 0 012.25 1h4.379a2.25 2.25 0 011.59.659L9.342 2.78c.14.141.331.22.53.22h3.879A2.25 2.25 0 0116 5.25v7.5A2.25 2.25 0 0113.75 15H2.25A2.25 2.25 0 010 12.75v-9.5zM7.75 6a.75.75 0 01.75.75V8h1.25a.75.75 0 010 1.5H8.5v1.25a.75.75 0 01-1.5 0V9.5H5.75a.75.75 0 010-1.5H7V6.75A.75.75 0 017.75 6z" clip-rule="evenodd"/></svg>');
+}
+
+%folder-plus-fill-24-svg-prop {
+  --folder-plus-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M1 4.75A2.75 2.75 0 013.75 2h5.672c.729 0 1.428.29 1.944.805l.829.829c.234.234.552.366.883.366h7.172A2.75 2.75 0 0123 6.75v12.5A2.75 2.75 0 0120.25 22H3.75A2.75 2.75 0 011 19.25V8.75A.75.75 0 011.75 8h18.5a.75.75 0 000-1.5H1.75A.75.75 0 011 5.75v-1zm10.75 5.75a.75.75 0 01.75.75v2.25h2.25a.75.75 0 010 1.5H12.5v2.25a.75.75 0 01-1.5 0V15H8.75a.75.75 0 010-1.5H11v-2.25a.75.75 0 01.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%folder-star-16-svg-prop {
+  --folder-star-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.5 3.25a.75.75 0 01.75-.75h4.379a.75.75 0 01.53.22L8.28 3.84a2.25 2.25 0 001.591.659h3.879a.75.75 0 01.75.75V6.5a.75.75 0 101.5 0V5.25A2.25 2.25 0 0013.75 3H9.871a.75.75 0 01-.53-.22L8.22 1.66A2.25 2.25 0 006.629 1H2.25A2.25 2.25 0 000 3.25v9.5A2.25 2.25 0 002.25 15h2.5a.75.75 0 000-1.5h-2.5a.75.75 0 01-.75-.75v-9.5z"/><path fill-rule="evenodd" d="M11.179 5.431a.75.75 0 00-1.358 0L8.523 8.196l-2.887.444a.75.75 0 00-.409 1.279l2.201 2.142-.66 3.029a.75.75 0 001.089.82l2.643-1.43 2.643 1.43a.75.75 0 001.09-.82l-.661-3.03 2.201-2.141a.75.75 0 00-.41-1.28l-2.886-.443-1.298-2.765zM9.71 9.195l.789-1.68.789 1.68a.75.75 0 00.565.423l1.794.276-1.421 1.382a.75.75 0 00-.21.697l.402 1.839-1.562-.845a.75.75 0 00-.714 0l-1.562.845.402-1.838a.75.75 0 00-.21-.698l-1.42-1.382 1.793-.276a.75.75 0 00.565-.423z" clip-rule="evenodd"/></g></svg>');
+}
+
+%folder-star-24-svg-prop {
+  --folder-star-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.75 3.5c-.69 0-1.25.56-1.25 1.25V7h16.75a.75.75 0 010 1.5H2.5v10.75c0 .69.56 1.25 1.25 1.25h6.75a.75.75 0 010 1.5H3.75A2.75 2.75 0 011 19.25V4.75A2.75 2.75 0 013.75 2h5.672c.729 0 1.428.29 1.944.805l.829.829c.234.234.552.366.883.366h7.172A2.75 2.75 0 0123 6.75v5.5a.75.75 0 01-1.5 0v-5.5c0-.69-.56-1.25-1.25-1.25h-7.172a2.75 2.75 0 01-1.944-.805l-.829-.829a1.25 1.25 0 00-.883-.366H3.75z"/><path fill-rule="evenodd" d="M17.674 10.42a.75.75 0 00-1.348 0l-1.68 3.43-3.755.554a.75.75 0 00-.416 1.277l2.72 2.67-.642 3.773a.75.75 0 001.09.789L17 21.133l3.357 1.78a.75.75 0 001.09-.789l-.642-3.773 2.72-2.67a.75.75 0 00-.416-1.277l-3.755-.553-1.68-3.43zm-1.854 4.445l1.18-2.41 1.18 2.41a.75.75 0 00.565.412l2.652.39-1.922 1.888a.75.75 0 00-.214.661l.452 2.658-2.362-1.252a.75.75 0 00-.702 0l-2.362 1.252.452-2.658a.75.75 0 00-.214-.661l-1.922-1.887 2.652-.391a.75.75 0 00.565-.412z" clip-rule="evenodd"/></g></svg>');
+}
+
+%folder-users-16-svg-prop {
+  --folder-users-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M2.25 2.5a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h.25a.75.75 0 010 1.5h-.25A2.25 2.25 0 010 12.75v-9.5A2.25 2.25 0 012.25 1h4.379a2.25 2.25 0 011.59.659L9.342 2.78c.14.141.331.22.53.22h3.879A2.25 2.25 0 0116 5.25v5.25a.75.75 0 01-1.5 0V5.25a.75.75 0 00-.75-.75H9.871a2.25 2.25 0 01-1.59-.659L7.158 2.72a.75.75 0 00-.53-.22H2.25z"/><path d="M4.574 11.76c.383-.463.936-.76 1.551-.76h2.75c.615 0 1.168.297 1.55.76A2.61 2.61 0 0111 13.418v.833a.75.75 0 01-1.5 0v-.833c0-.285-.095-.536-.231-.702-.134-.161-.28-.215-.394-.215h-2.75c-.114 0-.26.054-.394.215a1.113 1.113 0 00-.231.702v.833a.75.75 0 01-1.5 0v-.833c0-.6.195-1.197.574-1.656z"/><path fill-rule="evenodd" d="M7.5 5.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM6.5 8a1 1 0 112 0 1 1 0 01-2 0z" clip-rule="evenodd"/><path d="M11.518 11.589a.75.75 0 01.893-.572c.567.125 1.089.41 1.474.834.388.426.614.969.615 1.546v.853a.75.75 0 01-1.5 0v-.851a.8.8 0 00-.224-.538 1.306 1.306 0 00-.687-.379.75.75 0 01-.572-.893zM11.42 5.52a.75.75 0 10-.34 1.46c.283.066.52.212.682.4A.95.95 0 0112 8a.95.95 0 01-.238.62 1.272 1.272 0 01-.681.4.75.75 0 10.338 1.46 2.77 2.77 0 001.481-.884A2.45 2.45 0 0013.5 8a2.45 2.45 0 00-.6-1.596 2.77 2.77 0 00-1.48-.885z"/></g></svg>');
+}
+
+%folder-users-24-svg-prop {
+  --folder-users-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M2.5 4.75c0-.69.56-1.25 1.25-1.25h5.672c.331 0 .649.132.883.366l.829.829a2.75 2.75 0 001.944.805h7.172c.69 0 1.25.56 1.25 1.25v9a.75.75 0 001.5 0v-9A2.75 2.75 0 0020.25 4h-7.172a1.25 1.25 0 01-.883-.366l-.829-.829A2.75 2.75 0 009.422 2H3.75A2.75 2.75 0 001 4.75v14.5A2.75 2.75 0 003.75 22h1.5a.75.75 0 000-1.5h-1.5c-.69 0-1.25-.56-1.25-1.25V8.5h16.75a.75.75 0 000-1.5H2.5V4.75z"/><path d="M8.318 17.928A2.783 2.783 0 0110.375 17h4.25c.786 0 1.524.344 2.057.928.53.583.818 1.359.818 2.155v1.167a.75.75 0 11-1.5 0v-1.167c0-.441-.16-.852-.427-1.145a1.284 1.284 0 00-.948-.438h-4.25c-.34 0-.684.148-.948.438A1.705 1.705 0 009 20.083v1.167a.75.75 0 11-1.5 0v-1.167c0-.796.287-1.572.818-2.155z"/><path fill-rule="evenodd" d="M12.5 10a3 3 0 100 6 3 3 0 000-6zM11 13a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/><path d="M18.275 17.559a.75.75 0 01.916-.534 3.08 3.08 0 011.667 1.12c.417.549.642 1.221.642 1.912v1.193a.75.75 0 11-1.5 0v-1.192c0-.367-.12-.72-.337-1.007a1.58 1.58 0 00-.854-.576.75.75 0 01-.534-.916zM17.186 10.023a.75.75 0 00-.372 1.454A1.578 1.578 0 0118 13a1.57 1.57 0 01-1.186 1.523.75.75 0 10.372 1.454A3.078 3.078 0 0019.5 13a3.07 3.07 0 00-2.314-2.977z"/></g></svg>');
+}
+
+%frown-16-svg-prop {
+  --frown-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5 6a1 1 0 011-1h.007a1 1 0 010 2H6a1 1 0 01-1-1zM10 5a1 1 0 100 2h.007a1 1 0 100-2H10z"/><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/><path d="M5.785 9.777C6.279 9.403 7.035 9 8 9c.965 0 1.721.403 2.215.777.25.189.441.377.573.52.078.085.153.171.22.265a.75.75 0 01-.17 1.047.759.759 0 01-1.046-.17 2.736 2.736 0 00-.482-.466c-.331-.25-.776-.473-1.31-.473-.535 0-.979.222-1.31.473-.177.134-.35.29-.484.469a.75.75 0 01-1.215-.88l.001-.001c.217-.3.5-.562.793-.784z"/></g></svg>');
+}
+
+%frown-24-svg-prop {
+  --frown-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.457 14.424C9.27 13.746 10.5 13 12 13s2.73.746 3.543 1.424c.413.344.738.687.961.944.126.145.25.294.36.451a.75.75 0 01-1.227.862h-.001v-.002a4.882 4.882 0 00-.265-.328 6.91 6.91 0 00-.789-.775C13.895 15.004 13 14.5 12 14.5c-1 0-1.895.504-2.582 1.076a6.21 6.21 0 00-1.054 1.104.75.75 0 01-1.228-.86 5.67 5.67 0 01.36-.452c.223-.257.548-.6.961-.944zM8 9a1 1 0 011-1h.01a1 1 0 110 2H9a1 1 0 01-1-1zM15 8a1 1 0 100 2h.01a1 1 0 100-2H15z"/><path fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%gateway-16-svg-prop {
+  --gateway-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.537 5.354c.415-1.153.971-2.12 1.695-2.794C5.938 1.903 6.83 1.5 8 1.5c1.251 0 2.188.46 2.921 1.21.752.768 1.31 1.865 1.71 3.146.802 2.566.901 5.638.862 7.563-.013.594-.508 1.081-1.16 1.081H3.668c-.653 0-1.148-.487-1.16-1.083-.012-.545-.012-1.189.012-1.89a.75.75 0 10-1.499-.053 35.678 35.678 0 00-.013 1.974C1.038 14.916 2.256 16 3.668 16h8.665c1.41 0 2.63-1.082 2.66-2.55.04-1.968-.054-5.238-.93-8.041-.438-1.404-1.09-2.747-2.07-3.749C10.994.64 9.677 0 8 0 6.439 0 5.185.554 4.21 1.462c-.96.893-1.622 2.1-2.084 3.384a.75.75 0 101.411.508z"/><path d="M6.22 4.47a.75.75 0 011.06 0l3.25 3.25.008.008a.75.75 0 01-.008 1.052l-3.25 3.25a.75.75 0 01-1.06-1.06L8.19 9H1a.75.75 0 010-1.5h7.19L6.22 5.53a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%gateway-24-svg-prop {
+  --gateway-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5.052 8.165c.624-1.654 1.469-3.072 2.593-4.071C8.753 3.108 10.164 2.5 12 2.5c2.06 0 3.592.765 4.763 1.987 1.19 1.242 2.03 2.984 2.608 4.946 1.155 3.929 1.19 8.503 1.096 10.985-.023.6-.523 1.082-1.173 1.082H4.706c-.648 0-1.15-.484-1.173-1.086a46.334 46.334 0 01.016-3.879.75.75 0 10-1.498-.07 47.832 47.832 0 00-.017 4.006C2.09 21.924 3.297 23 4.706 23h14.588c1.406 0 2.616-1.07 2.672-2.525.096-2.523.07-7.297-1.156-11.465-.614-2.086-1.545-4.08-2.964-5.561C16.405 1.946 14.488 1 12 1c-2.207 0-3.971.745-5.352 1.973-1.365 1.214-2.324 2.871-3 4.662a.75.75 0 001.404.53z"/><path d="M9.207 6.482a.75.75 0 011.06-.025l5.5 5.25c.14.133.23.322.233.531v.024a.75.75 0 01-.232.53l-5.5 5.25a.75.75 0 01-1.036-1.085L13.378 13H1.75a.75.75 0 010-1.5h11.628L9.232 7.543a.75.75 0 01-.025-1.06z"/></g></svg>');
+}
+
 %gateway-svg-prop {
   --gateway-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M21.009 19.08C20.7 14.366 19.214 3 12.045 3c-4.068 0-6.306 3.658-7.538 7.684h2.111c.477-1.412 1.073-2.675 1.806-3.652.997-1.33 2.149-2.022 3.62-2.022 1.472 0 2.624.692 3.621 2.022 1.04 1.387 1.807 3.352 2.344 5.5.53 2.12.8 4.265.936 5.898.03.35-.25.65-.602.65H5.746a.602.602 0 01-.602-.65c.097-1.164.262-2.588.541-4.077H3.642a44.169 44.169 0 00-.561 4.726c-.073 1.109.82 2.01 1.93 2.01h14.066c1.111 0 2.004-.901 1.932-2.01zm-8.152-5.695H3V11.71h9.857L9.859 8.703l1.18-1.18 5.025 5.024-5.024 5.025-1.181-1.181 2.998-3.006z" fill="%231F2124"/></svg>');
+}
+
+%gcp-16-svg-prop {
+  --gcp-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M11.87 3.465l-.002-.003a5.935 5.935 0 00-5.586-1.217 5.89 5.89 0 00-3.98 4.092 4.206 4.206 0 00-.149 6.792 4.255 4.255 0 002.558.87h6.52a4.234 4.234 0 004.078-2.961A4.2 4.2 0 0013.637 6.3a5.835 5.835 0 00-1.767-2.835zm-7.828 7.78c.21.095.438.16.67.16l6.518.002c.9 0 1.63-.725 1.63-1.619s-.73-1.619-1.63-1.619v-.323a3.226 3.226 0 00-1.187-2.56h-.002c-1.339-1.078-3.305-.912-4.465.354l-.014.015c.996.2 1.897.751 2.525 1.568L6.198 9.101a1.63 1.63 0 00-3.097.439 1.617 1.617 0 00.942 1.704l-.001.001z" clip-rule="evenodd"/></svg>');
+}
+
+%gcp-24-svg-prop {
+  --gcp-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M17.157 5.95l.004.004a7.78 7.78 0 012.355 3.78 5.599 5.599 0 012.23 6.317A5.645 5.645 0 0116.306 20l-8.692-.002c-1.227.005-2.427-.429-3.408-1.163l-.002.003a5.608 5.608 0 01-1.91-6.252 5.612 5.612 0 012.108-2.804A7.853 7.853 0 019.71 4.326a7.913 7.913 0 017.448 1.624zm1.322 8.434a2.165 2.165 0 01-2.172 2.16l-8.692-.004s-.428 0-.915-.226a2.156 2.156 0 01-1.231-2.26 2.165 2.165 0 011.843-1.834 2.174 2.174 0 012.285 1.249l2.52-2.505a5.647 5.647 0 00-3.367-2.09l.018-.02c1.546-1.689 4.168-1.91 5.954-.473l.002.001a4.302 4.302 0 011.583 3.413v.43c1.2 0 2.172.967 2.172 2.16z" clip-rule="evenodd"/></svg>');
+}
+
+%gcp-color-16-svg-prop {
+  --gcp-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23EA4335" d="M10.313 5.376l1.887-1.5-.332-.414a5.935 5.935 0 00-5.586-1.217 5.89 5.89 0 00-3.978 4.084c-.03.113.312-.098.463-.056l2.608-.428s.127-.124.2-.205c1.16-1.266 3.127-1.432 4.466-.354l.272.09z"/><path fill="%234285F4" d="M13.637 6.3a5.835 5.835 0 00-1.77-2.838l-1.83 1.819a3.226 3.226 0 011.193 2.565v.323c.9 0 1.63.725 1.63 1.62 0 .893-.73 1.618-1.63 1.618l-3.257-.002-.325.035v2.507l.325.053h3.257a4.234 4.234 0 004.08-2.962A4.2 4.2 0 0013.636 6.3z"/><path fill="%2334A853" d="M4.711 13.999H7.97v-2.594H4.71c-.232 0-.461-.066-.672-.161l-.458.14-1.313 1.297-.114.447a4.254 4.254 0 002.557.87z"/><path fill="%23FBBC05" d="M4.711 5.572A4.234 4.234 0 00.721 8.44a4.206 4.206 0 001.433 4.688l1.89-1.884a1.617 1.617 0 01.44-3.079 1.63 1.63 0 011.714.937l1.89-1.879a4.24 4.24 0 00-3.377-1.65z"/></svg>');
+}
+
+%gcp-color-24-svg-prop {
+  --gcp-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23EA4335" d="M15.084 8.501l2.516-2-.443-.551A7.913 7.913 0 009.71 4.326a7.853 7.853 0 00-5.303 5.446c-.042.15.415-.13.617-.075l3.477-.57s.17-.166.268-.273c1.546-1.689 4.168-1.91 5.954-.473l.362.12z"/><path fill="%234285F4" d="M19.516 9.733a7.78 7.78 0 00-2.36-3.784l-2.44 2.426a4.302 4.302 0 011.591 3.42v.43c1.2 0 2.172.967 2.172 2.16a2.165 2.165 0 01-2.172 2.158l-4.343-.003-.433.046v3.344l.433.07h4.343c2.49.02 4.7-1.585 5.438-3.95a5.599 5.599 0 00-2.23-6.317z"/><path fill="%2334A853" d="M7.615 19.998h4.343V16.54H7.615c-.31 0-.615-.087-.897-.215l-.61.188-1.75 1.728-.153.596c.982.738 2.18 1.167 3.41 1.161z"/><path fill="%23FBBC05" d="M7.615 8.763a5.646 5.646 0 00-5.32 3.823 5.608 5.608 0 001.91 6.252l2.52-2.513a2.156 2.156 0 01-1.256-2.272 2.165 2.165 0 011.843-1.833 2.174 2.174 0 012.285 1.249l2.52-2.505a5.654 5.654 0 00-4.502-2.201z"/></svg>');
+}
+
+%gift-16-svg-prop {
+  --gift-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1.5 2.75c0 .438.103.866.297 1.25H.75a.75.75 0 00-.75.75v3.5c0 .414.336.75.75.75H2v6.25c0 .414.336.75.75.75h10.5a.75.75 0 00.75-.75V9h1.25a.75.75 0 00.75-.75v-3.5a.75.75 0 00-.75-.75h-.547A2.78 2.78 0 0014.21.81 2.697 2.697 0 0012.286 0c-1.8 0-2.878 1.318-3.46 2.394-.262.486-.449.967-.576 1.351a8.466 8.466 0 00-.577-1.351C7.093 1.318 6.013 0 4.214 0 3.49 0 2.798.293 2.29.81a2.769 2.769 0 00-.79 1.94zM4.214 1.5c-.317 0-.625.128-.854.361-.229.234-.36.553-.36.889 0 .336.131.655.36.889.23.233.537.361.854.361h2.537a6.754 6.754 0 00-.397-.894c-.5-.924-1.189-1.606-2.14-1.606zM9.75 4h2.537c.317 0 .625-.128.854-.361.229-.234.36-.553.36-.889 0-.336-.131-.655-.36-.889a1.197 1.197 0 00-.854-.361c-.951 0-1.64.682-2.14 1.606A6.753 6.753 0 009.75 4zM9 5.5v2h5.5v-2H9zm-1.5 0v2h-6v-2h6zm1.5 9h3.5V9H9v5.5zM7.5 9v5.5h-4V9h4z" clip-rule="evenodd"/></svg>');
+}
+
+%gift-24-svg-prop {
+  --gift-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M3.5 4.25c0 .63.192 1.235.54 1.75H2.75A1.75 1.75 0 001 7.75v3.5c0 .966.784 1.75 1.75 1.75H3v7.25A2.75 2.75 0 005.75 23h12.5A2.75 2.75 0 0021 20.25V13h.25A1.75 1.75 0 0023 11.25v-3.5A1.75 1.75 0 0021.25 6h-.79c.348-.515.54-1.12.54-1.75 0-.88-.375-1.711-1.023-2.316A3.529 3.529 0 0017.571 1c-2.266 0-3.67 1.524-4.463 2.87a10.098 10.098 0 00-.842 1.858l-.016.047-.016-.047c-.17-.501-.44-1.177-.842-1.859C10.599 2.524 9.195 1 6.929 1c-.894 0-1.76.33-2.406.934A3.168 3.168 0 003.5 4.25zM6.929 2.5c-.528 0-1.024.196-1.383.53A1.669 1.669 0 005 4.25c0 .447.19.887.546 1.22.359.334.855.53 1.383.53h3.81a8.46 8.46 0 00-.64-1.37C9.42 3.477 8.413 2.5 6.93 2.5zM13.76 6h3.811c.528 0 1.024-.196 1.383-.53.356-.333.546-.773.546-1.22 0-.447-.19-.887-.546-1.22a2.029 2.029 0 00-1.383-.53c-1.484 0-2.49.976-3.17 2.13A8.46 8.46 0 0013.76 6zM13 7.5v4h8.25a.25.25 0 00.25-.25v-3.5a.25.25 0 00-.25-.25H13zm-1.5 0v4H2.75a.25.25 0 01-.25-.25v-3.5a.25.25 0 01.25-.25h8.75zm8 12.75V13H13v8.5h5.25c.69 0 1.25-.56 1.25-1.25zm-8 1.25H5.75c-.69 0-1.25-.56-1.25-1.25V13h7v8.5z" clip-rule="evenodd"/></svg>');
 }
 
 %gift-fill-svg-prop {
@@ -234,28 +1674,228 @@
   --gift-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5.856 6.447c.29.58.643 1.1 1.062 1.553H4a2 2 0 0 0-2 2v4h1v6a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6h1v-4a2 2 0 0 0-2-2h-2.918c.419-.453.773-.973 1.062-1.553C18.79 5.158 19 3.891 19 3V2h-1c-2.89 0-4.87 1.239-6 3.278C10.87 3.238 8.89 2 6 2H5v1c0 .891.211 2.158.856 3.447zM13 20h6v-6h-6v6zm0-8h7v-2h-7v2zm-2-2H4v2h7v-2zm0 4v6H5v-6h6zm5.356-8.447c.23-.463.396-.96.504-1.464-1.567.263-2.584 1.094-3.216 2.358-.185.37-.327.763-.432 1.163l-.072.3c1.567-.262 2.584-1.093 3.216-2.357zM7.14 4.089c.108.504.273 1.001.504 1.464.632 1.264 1.648 2.095 3.216 2.358l-.072-.301a6.008 6.008 0 0 0-.432-1.163C9.724 5.183 8.708 4.352 7.14 4.09z" fill="%23000"/></svg>');
 }
 
+%git-branch-16-svg-prop {
+  --git-branch-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M12.719 6.913A3.001 3.001 0 0012 1a3 3 0 00-.787 5.896c-.282 2.395-2.124 4.164-4.561 4.34A3.005 3.005 0 004.5 9.095V2A.75.75 0 003 2v7.095a3.001 3.001 0 103.658 3.643c3.26-.187 5.758-2.606 6.061-5.825zM10.5 4a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zm-8.25 8a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/></svg>');
+}
+
+%git-branch-24-svg-prop {
+  --git-branch-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M7 3.25a.75.75 0 00-1.5 0v10.83a3.501 3.501 0 104.171 4.162c2.447-.091 4.553-.979 6.073-2.498 1.467-1.468 2.345-3.481 2.486-5.82A3.501 3.501 0 0017.5 3a3.5 3.5 0 00-.773 6.914c-.136 1.976-.88 3.604-2.044 4.769-1.213 1.213-2.929 1.97-5.015 2.058A3.505 3.505 0 007 14.081V3.25zM17.5 8.5a2 2 0 100-4 2 2 0 000 4zm-13.25 9a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/></svg>');
+}
+
 %git-branch-svg-prop {
   --git-branch-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.286 9.699a1.556 1.556 0 0 1-1.543-1.543c0-.836.707-1.543 1.543-1.543.835 0 1.543.707 1.543 1.543 0 .835-.708 1.543-1.543 1.543zM8.57 19.984a1.556 1.556 0 0 1-1.542-1.543c0-.835.707-1.542 1.542-1.542.836 0 1.543.707 1.543 1.542 0 .836-.707 1.543-1.543 1.543zm0-15.955c.849 0 1.543.707 1.543 1.542 0 .836-.707 1.543-1.543 1.543A1.564 1.564 0 0 1 7.03 5.571c0-.835.707-1.542 1.542-1.542zm10.286 4.114a2.562 2.562 0 0 0-2.571-2.572A2.562 2.562 0 0 0 15 10.354v.386c-.026.669-.296 1.26-.81 1.774-.514.515-1.106.785-1.774.81-1.067.026-1.903.206-2.572.58V7.783A2.563 2.563 0 0 0 8.56 3 2.552 2.552 0 0 0 6 5.571a2.571 2.571 0 0 0 1.286 2.212v8.434C6.527 16.667 6 17.49 6 18.43A2.563 2.563 0 0 0 8.571 21a2.563 2.563 0 0 0 2.572-2.571c0-.682-.257-1.286-.682-1.749.116-.077.618-.526.759-.604.321-.142.72-.219 1.209-.219 1.35-.064 2.507-.578 3.535-1.607 1.029-1.029 1.543-2.546 1.607-3.883h-.025c.784-.463 1.311-1.286 1.311-2.224z" fill="%23000"/></svg>');
+}
+
+%git-commit-16-svg-prop {
+  --git-commit-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M10.905 7a3.001 3.001 0 00-5.81 0H2.75a.75.75 0 000 1.5h2.345a3.001 3.001 0 005.81 0h2.345a.75.75 0 000-1.5h-2.345zM8 6.25a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" clip-rule="evenodd"/></svg>');
+}
+
+%git-commit-24-svg-prop {
+  --git-commit-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M15.93 11a4.001 4.001 0 00-7.86 0H3.75a.75.75 0 000 1.5h4.32a4.001 4.001 0 007.86 0h4.32a.75.75 0 000-1.5h-4.32zM12 9.25a2.5 2.5 0 100 5 2.5 2.5 0 000-5z" clip-rule="evenodd"/></svg>');
 }
 
 %git-commit-svg-prop {
   --git-commit-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 14.971a2.82 2.82 0 0 1-2.829-2.828A2.82 2.82 0 0 1 12 9.314a2.82 2.82 0 0 1 2.829 2.829A2.82 2.82 0 0 1 12 14.97zm4.963-4.114C16.384 8.646 14.39 7 12 7s-4.384 1.646-4.963 3.857H3v2.572h4.037C7.616 15.64 9.61 17.286 12 17.286s4.384-1.646 4.963-3.857H21v-2.572h-4.037z" fill="%23000"/></svg>');
 }
 
+%git-merge-16-svg-prop {
+  --git-merge-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4.644 6.865A3.001 3.001 0 003.75 1 3 3 0 003 6.905V14a.75.75 0 001.5 0V9.518c.21.266.436.527.675.78C6.21 11.39 7.619 12.432 9.08 12.69a3.001 3.001 0 10.038-1.526c-.92-.237-1.951-.946-2.855-1.899A9.018 9.018 0 014.955 7.52a4.969 4.969 0 01-.311-.655zM3.75 2.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM10.5 12a1.5 1.5 0 103 0 1.5 1.5 0 00-3 0z" clip-rule="evenodd"/></svg>');
+}
+
+%git-merge-24-svg-prop {
+  --git-merge-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M3.5 6.5a3.5 3.5 0 114.096 3.45c.102.41.284.886.551 1.406a11.743 11.743 0 001.81 2.54c1.35 1.456 3.014 2.56 4.635 2.804a3.502 3.502 0 016.908.8 3.5 3.5 0 01-6.928.71c-2.178-.252-4.217-1.677-5.716-3.294A13.885 13.885 0 017.5 13.202v7.548a.75.75 0 01-1.5 0V9.855A3.502 3.502 0 013.5 6.5zm3.5-2a2 2 0 100 4 2 2 0 000-4zm9 13a2 2 0 104 0 2 2 0 00-4 0z" clip-rule="evenodd"/></svg>');
+}
+
+%git-pull-request-16-svg-prop {
+  --git-pull-request-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M5 6.905A3.001 3.001 0 004.25 1a3 3 0 00-.75 5.905V14A.75.75 0 005 14V6.905zM2.75 4a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zM12.5 5.25v3.595a3.001 3.001 0 01-.75 5.905A3 3 0 0111 8.845V5.25a.75.75 0 00-.75-.75H9A.75.75 0 019 3h1.25a2.25 2.25 0 012.25 2.25zm-2.25 6.5a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z"/></g></svg>');
+}
+
+%git-pull-request-24-svg-prop {
+  --git-pull-request-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M7.5 9.92A3.501 3.501 0 006.75 3 3.5 3.5 0 006 9.92v10.83a.75.75 0 001.5 0V9.92zM4.75 6.5a2 2 0 114 0 2 2 0 01-4 0zM18 8.75v5.58a3.501 3.501 0 01-.75 6.92 3.5 3.5 0 01-.75-6.92V8.75c0-.69-.56-1.25-1.25-1.25H13A.75.75 0 0113 6h2.25A2.75 2.75 0 0118 8.75zm-2.75 9a2 2 0 114 0 2 2 0 01-4 0z"/></g></svg>');
+}
+
 %git-pull-request-svg-prop {
   --git-pull-request-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.398 8.04c-.792 0-1.44-.66-1.44-1.44 0-.78.66-1.44 1.44-1.44.78 0 1.44.66 1.44 1.44 0 .78-.66 1.44-1.44 1.44zm1.44 10.56c0 .792-.66 1.44-1.44 1.44-.78 0-1.44-.66-1.44-1.44 0-.781.66-1.44 1.44-1.44.78 0 1.44.659 1.44 1.44zm.96-12c0-1.332-1.068-2.4-2.4-2.4a2.391 2.391 0 0 0-1.2 4.464v7.872A2.39 2.39 0 0 0 7.398 21a2.39 2.39 0 0 0 1.2-4.464V8.664a2.386 2.386 0 0 0 1.2-2.064zm7.2 13.44c-.792 0-1.44-.66-1.44-1.44 0-.781.66-1.44 1.44-1.44.78 0 1.44.659 1.44 1.44 0 .78-.66 1.44-1.44 1.44zm1.2-3.504V9c-.035-.936-.407-1.764-1.128-2.472-.72-.708-1.536-1.092-2.472-1.128h-1.2V3l-3.6 3.6 3.6 3.6V7.8h1.2c.324.024.576.132.829.372.252.24.36.504.372.828v7.536a2.392 2.392 0 0 0 1.2 4.464 2.39 2.39 0 0 0 1.2-4.464z" fill="%23000"/></svg>');
+}
+
+%git-repo-16-svg-prop {
+  --git-repo-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M3.25 0A2.25 2.25 0 001 2.25v10.5A2.25 2.25 0 003.25 15h.25a.75.75 0 000-1.5h-.25a.75.75 0 01-.75-.75v-1.5a.75.75 0 01.75-.75H13.5v3h-3a.75.75 0 000 1.5h3.25c.69 0 1.25-.56 1.25-1.25V1.25C15 .56 14.44 0 13.75 0H3.25zM13.5 9V1.5H3.25a.75.75 0 00-.75.75v6.878c.235-.083.487-.128.75-.128H13.5z" clip-rule="evenodd"/><path d="M5.5 12a.5.5 0 00-.5.5v3a.5.5 0 00.777.416L7 15.101l1.223.815A.5.5 0 009 15.5v-3a.5.5 0 00-.5-.5h-3z"/></g></svg>');
+}
+
+%git-repo-24-svg-prop {
+  --git-repo-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M5.75 1A2.75 2.75 0 003 3.75v14.5A2.75 2.75 0 005.75 21H6a.75.75 0 000-1.5h-.25c-.69 0-1.25-.56-1.25-1.25v-1c0-.69.56-1.25 1.25-1.25H19.5v3.25a.25.25 0 01-.25.25H16a.75.75 0 000 1.5h3.25A1.75 1.75 0 0021 19.25V2.75A1.75 1.75 0 0019.25 1H5.75zM19.5 14.5V2.75a.25.25 0 00-.25-.25H5.75c-.69 0-1.25.56-1.25 1.25V14.8c.375-.192.8-.3 1.25-.3H19.5z" clip-rule="evenodd"/><path d="M8.75 18a.75.75 0 00-.75.75v3.5a.75.75 0 001.128.648L11 21.806l1.872 1.092A.75.75 0 0014 22.25v-3.5a.75.75 0 00-.75-.75h-4.5z"/></g></svg>');
 }
 
 %git-repository-svg-prop {
   --git-repository-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20 19V4c0-1-1-2-2-2H6C5 2 4 3 4 4v15c0 1 1 2 2 2h1v3l2-2 2 2v-3h7c1 0 2-1 2-2zM9 5H7v2h2V5zM7 8h2v2H7V8zm0 3h2v2H7v-2zm11 5H6v3h1v-2h4v2h7v-3zM6 4h12v11H6V4z" fill="%23000"/></svg>');
 }
 
+%github-16-svg-prop {
+  --github-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 1C4.133 1 1 4.13 1 7.993c0 3.09 2.006 5.71 4.787 6.635.35.064.478-.152.478-.337 0-.166-.006-.606-.01-1.19-1.947.423-2.357-.937-2.357-.937-.319-.808-.778-1.023-.778-1.023-.635-.434.048-.425.048-.425.703.05 1.073.72 1.073.72.624 1.07 1.638.76 2.037.582.063-.452.244-.76.444-.935-1.554-.176-3.188-.776-3.188-3.456 0-.763.273-1.388.72-1.876-.072-.177-.312-.888.07-1.85 0 0 .586-.189 1.924.716A6.711 6.711 0 018 4.381c.595.003 1.194.08 1.753.236 1.336-.905 1.923-.717 1.923-.717.382.963.142 1.674.07 1.85.448.49.72 1.114.72 1.877 0 2.686-1.638 3.278-3.197 3.45.251.216.475.643.475 1.296 0 .934-.009 1.688-.009 1.918 0 .187.127.404.482.336A6.996 6.996 0 0015 7.993 6.997 6.997 0 008 1z" clip-rule="evenodd"/></svg>');
+}
+
+%github-24-svg-prop {
+  --github-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 2C6.477 2 2 6.476 2 11.997c0 4.417 2.865 8.163 6.839 9.485.5.092.682-.216.682-.482 0-.236-.008-.865-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.528 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.252-4.555-1.11-4.555-4.94 0-1.092.39-1.985 1.029-2.683-.103-.253-.446-1.27.098-2.646 0 0 .84-.269 2.75 1.025A9.581 9.581 0 0112 6.834c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.376.202 2.393.1 2.646.64.698 1.028 1.591 1.028 2.682 0 3.84-2.339 4.686-4.566 4.933.359.309.678.919.678 1.852 0 1.336-.012 2.414-.012 2.741 0 .268.18.58.688.482 3.97-1.325 6.833-5.07 6.833-9.485C22 6.476 17.522 2 12 2z" clip-rule="evenodd"/></svg>');
+}
+
+%github-color-16-svg-prop {
+  --github-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23161514" fill-rule="evenodd" d="M8 1C4.133 1 1 4.13 1 7.993c0 3.09 2.006 5.71 4.787 6.635.35.064.478-.152.478-.337 0-.166-.006-.606-.01-1.19-1.947.423-2.357-.937-2.357-.937-.319-.808-.778-1.023-.778-1.023-.635-.434.048-.425.048-.425.703.05 1.073.72 1.073.72.624 1.07 1.638.76 2.037.582.063-.452.244-.76.444-.935-1.554-.176-3.188-.776-3.188-3.456 0-.763.273-1.388.72-1.876-.072-.177-.312-.888.07-1.85 0 0 .586-.189 1.924.716A6.711 6.711 0 018 4.381c.595.003 1.194.08 1.753.236 1.336-.905 1.923-.717 1.923-.717.382.963.142 1.674.07 1.85.448.49.72 1.114.72 1.877 0 2.686-1.638 3.278-3.197 3.45.251.216.475.643.475 1.296 0 .934-.009 1.688-.009 1.918 0 .187.127.404.482.336A6.996 6.996 0 0015 7.993 6.997 6.997 0 008 1z" clip-rule="evenodd"/></svg>');
+}
+
+%github-color-24-svg-prop {
+  --github-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23161514" fill-rule="evenodd" d="M12 2C6.477 2 2 6.476 2 11.997c0 4.417 2.865 8.163 6.839 9.485.5.092.682-.216.682-.482 0-.236-.008-.865-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.528 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.252-4.555-1.11-4.555-4.94 0-1.092.39-1.985 1.029-2.683-.103-.253-.446-1.27.098-2.646 0 0 .84-.269 2.75 1.025A9.581 9.581 0 0112 6.834c.85.004 1.705.115 2.504.337 1.909-1.294 2.747-1.025 2.747-1.025.546 1.376.202 2.393.1 2.646.64.698 1.028 1.591 1.028 2.682 0 3.84-2.339 4.686-4.566 4.933.359.309.678.919.678 1.852 0 1.336-.012 2.414-.012 2.741 0 .268.18.58.688.482 3.97-1.325 6.833-5.07 6.833-9.485C22 6.476 17.522 2 12 2z" clip-rule="evenodd"/></svg>');
+}
+
+%gitlab-16-svg-prop {
+  --gitlab-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M14.975 8.904L14.19 6.55l-1.552-4.67a.268.268 0 00-.255-.18.268.268 0 00-.254.18l-1.552 4.667H5.422L3.87 1.879a.267.267 0 00-.254-.179.267.267 0 00-.254.18l-1.55 4.667-.784 2.357a.515.515 0 00.193.583l6.78 4.812 6.778-4.812a.516.516 0 00.196-.583z"/></svg>');
+}
+
+%gitlab-24-svg-prop {
+  --gitlab-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M21.963 13.292l-1.12-3.363-2.217-6.673a.383.383 0 00-.363-.255.383.383 0 00-.364.255l-2.217 6.669H8.316L6.1 3.256A.382.382 0 005.736 3a.382.382 0 00-.363.256L3.16 9.925l-1.12 3.367a.736.736 0 00.275.833L12 21l9.683-6.875a.737.737 0 00.28-.833z"/></svg>');
+}
+
+%gitlab-color-16-svg-prop {
+  --gitlab-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23FC6D26" d="M14.975 8.904L14.19 6.55l-1.552-4.67a.268.268 0 00-.255-.18.268.268 0 00-.254.18l-1.552 4.667H5.422L3.87 1.879a.267.267 0 00-.254-.179.267.267 0 00-.254.18l-1.55 4.667-.784 2.357a.515.515 0 00.193.583l6.78 4.812 6.778-4.812a.516.516 0 00.196-.583z"/><path fill="%23E24329" d="M8 14.296l2.578-7.75H5.423L8 14.296z"/><path fill="%23FC6D26" d="M8 14.296l-2.579-7.75H1.813L8 14.296z"/><path fill="%23FCA326" d="M1.81 6.549l-.784 2.354a.515.515 0 00.193.583L8 14.3 1.81 6.55z"/><path fill="%23E24329" d="M1.812 6.549h3.612L3.87 1.882a.268.268 0 00-.254-.18.268.268 0 00-.255.18L1.812 6.549z"/><path fill="%23FC6D26" d="M8 14.296l2.578-7.75h3.614L8 14.296z"/><path fill="%23FCA326" d="M14.19 6.549l.783 2.354a.514.514 0 01-.193.583L8 14.296l6.188-7.747h.001z"/><path fill="%23E24329" d="M14.19 6.549H10.58l1.552-4.667a.267.267 0 01.254-.18c.115 0 .218.073.254.18l1.552 4.667z"/></svg>');
+}
+
+%gitlab-color-24-svg-prop {
+  --gitlab-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23FC6D26" d="M21.963 13.292l-1.12-3.363-2.217-6.673a.383.383 0 00-.363-.255.383.383 0 00-.364.255l-2.217 6.669H8.316L6.1 3.256A.382.382 0 005.736 3a.382.382 0 00-.363.256L3.16 9.925l-1.12 3.367a.736.736 0 00.275.833L12 21l9.683-6.875a.737.737 0 00.28-.833z"/><path fill="%23E24329" d="M12 20.995l3.683-11.071H8.319L12 20.994z"/><path fill="%23FC6D26" d="M12 20.995L8.316 9.924H3.162L12 20.994z"/><path fill="%23FCA326" d="M3.158 9.927l-1.12 3.364a.736.736 0 00.276.833L12 21 3.158 9.927z"/><path fill="%23E24329" d="M3.16 9.927h5.16L6.1 3.26a.383.383 0 00-.364-.256.383.383 0 00-.364.256L3.16 9.927z"/><path fill="%23FC6D26" d="M12 20.995l3.683-11.071h5.162L12 20.994z"/><path fill="%23FCA326" d="M20.842 9.927l1.12 3.364a.734.734 0 01-.276.833L12 20.994l8.84-11.067h.002z"/><path fill="%23E24329" d="M20.844 9.927h-5.16l2.217-6.667a.382.382 0 01.363-.256c.165 0 .311.103.363.256l2.217 6.667z"/></svg>');
+}
+
+%globe-16-svg-prop {
+  --globe-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM6.128 1.774A6.508 6.508 0 001.576 7H4.07a11.095 11.095 0 012.06-5.226zm3.744 0A11.096 11.096 0 0111.932 7h2.492a6.508 6.508 0 00-4.552-5.226zM10.42 7C10.165 5.124 9.333 3.335 8 1.836 6.667 3.335 5.835 5.124 5.58 7h4.84zM5.527 8.5h4.946C10.31 10.557 9.451 12.533 8 14.164 6.55 12.533 5.691 10.557 5.527 8.5zm-1.505 0H1.52a6.505 6.505 0 004.61 5.726C4.896 12.525 4.163 10.555 4.021 8.5zm5.85 5.726c1.231-1.701 1.964-3.671 2.106-5.726h2.503a6.505 6.505 0 01-4.61 5.726z" clip-rule="evenodd"/></svg>');
+}
+
+%globe-24-svg-prop {
+  --globe-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zm-1.673 1.647A9.506 9.506 0 002.552 11h4.747a16.673 16.673 0 013.028-8.353zm3.346 0A16.673 16.673 0 0116.701 11h4.747a9.506 9.506 0 00-7.775-8.353zM15.196 11A15.149 15.149 0 0012 2.916 15.149 15.149 0 008.804 11h6.392zm-6.427 1.5h6.462A15.16 15.16 0 0112 21.084 15.16 15.16 0 018.769 12.5zm-1.502 0H2.513c.23 4.45 3.525 8.091 7.814 8.853a16.683 16.683 0 01-3.06-8.853zm6.406 8.853a16.683 16.683 0 003.06-8.853h4.754c-.23 4.45-3.525 8.091-7.814 8.853z" clip-rule="evenodd"/></svg>');
+}
+
+%globe-private-16-svg-prop {
+  --globe-private-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M5.58 7C5.835 5.124 6.667 3.335 8 1.836a10.074 10.074 0 011.806 2.878.75.75 0 101.388-.568 11.412 11.412 0 00-1.322-2.372A6.503 6.503 0 0114.5 8 .75.75 0 0016 8a8 8 0 10-11.31 7.285.75.75 0 10.622-1.365A6.504 6.504 0 011.519 8.5h2.503c.04.563.122 1.12.248 1.668a.75.75 0 101.462-.336c-.1-.438-.17-.883-.205-1.332H7A.75.75 0 007 7H5.58zM4.07 7H1.576a6.508 6.508 0 014.552-5.226A11.095 11.095 0 004.068 7z" clip-rule="evenodd"/><path d="M11.75 12.25a.75.75 0 00-1.5 0v.5a.75.75 0 001.5 0v-.5z"/><path fill-rule="evenodd" d="M8.518 9.012c.035-.627.13-1.235.366-1.738.174-.37.435-.704.816-.94C10.08 6.101 10.52 6 11 6c.48 0 .921.1 1.3.334.381.236.642.57.816.94.236.503.331 1.111.366 1.738A2.25 2.25 0 0115.5 11.25v2.5A2.25 2.25 0 0113.25 16h-4.5a2.25 2.25 0 01-2.25-2.25v-2.5a2.25 2.25 0 012.018-2.238zM10.022 9c.032-.481.102-.838.22-1.087a.662.662 0 01.245-.302c.09-.055.243-.111.513-.111s.423.056.513.111c.087.054.17.141.246.302.117.249.187.606.219 1.087h-1.956zm3.228 1.5a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75h-4.5a.75.75 0 01-.75-.75v-2.5a.75.75 0 01.75-.75h4.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%globe-private-24-svg-prop {
+  --globe-private-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M8.804 11A15.149 15.149 0 0112 2.916a15.087 15.087 0 012.813 5.763.75.75 0 001.456-.358 16.614 16.614 0 00-2.596-5.674 9.512 9.512 0 017.542 7.035.75.75 0 101.456-.364C21.473 4.539 17.15 1 12 1 5.925 1 1 5.925 1 12c0 5.243 3.667 9.627 8.575 10.732a.75.75 0 00.33-1.464c-4.082-.918-7.169-4.465-7.392-8.768h4.754c.128 2.606.86 5.13 2.117 7.367a.75.75 0 101.308-.734A15.221 15.221 0 018.77 12.5H12.5a.75.75 0 000-1.5H8.804zM7.3 11H2.552a9.506 9.506 0 017.775-8.353A16.673 16.673 0 007.299 11z" clip-rule="evenodd"/><path d="M18 19a.75.75 0 01.75.75v.5a.75.75 0 01-1.5 0v-.5A.75.75 0 0118 19z"/><path fill-rule="evenodd" d="M14 15.014a2.25 2.25 0 00-2 2.236v4.5A2.25 2.25 0 0014.25 24h7.5A2.25 2.25 0 0024 21.75v-4.5a2.25 2.25 0 00-2-2.236v-.93a4.127 4.127 0 00-1.165-2.881A3.96 3.96 0 0018 10a3.96 3.96 0 00-2.835 1.203A4.127 4.127 0 0014 14.083v.93zM15.5 15v-.917c0-.69.268-1.35.739-1.833A2.46 2.46 0 0118 11.5c.657 0 1.29.267 1.761.75.471.483.739 1.142.739 1.833V15h-5zm-1.25 1.5a.75.75 0 00-.75.75v4.5c0 .414.336.75.75.75h7.5a.75.75 0 00.75-.75v-4.5a.75.75 0 00-.75-.75h-7.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%google-16-svg-prop {
+  --google-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M10.84 4.82a3.837 3.837 0 00-2.7-1.05c-1.837 0-3.397 1.233-3.953 2.891a4.17 4.17 0 000 2.68h.003c.558 1.657 2.115 2.889 3.952 2.889.948 0 1.761-.241 2.392-.667v-.002a3.239 3.239 0 001.407-2.127H8.14V6.74h6.64c.082.468.121.946.121 1.422 0 2.129-.765 3.929-2.096 5.148l.001.001C11.64 14.38 10.038 15 8.14 15a7.044 7.044 0 01-6.29-3.855 6.97 6.97 0 010-6.287A7.042 7.042 0 018.139 1a6.786 6.786 0 014.71 1.821L10.84 4.82z"/></svg>');
+}
+
+%google-24-svg-prop {
+  --google-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M16.036 7.457a5.434 5.434 0 00-3.836-1.5c-2.609 0-4.825 1.76-5.615 4.13a5.99 5.99 0 000 3.83h.004c.794 2.366 3.006 4.126 5.614 4.126 1.347 0 2.503-.345 3.4-.953v-.003A4.63 4.63 0 0017.6 14.05H12.2v-3.85h9.432c.117.668.172 1.351.172 2.031 0 3.041-1.087 5.613-2.978 7.354l.002.002C17.171 21.115 14.897 22 12.2 22c-3.781 0-7.239-2.131-8.936-5.508a10.008 10.008 0 010-8.98A9.998 9.998 0 0112.2 2.001a9.61 9.61 0 016.69 2.601l-2.854 2.855z"/></svg>');
+}
+
+%google-color-16-svg-prop {
+  --google-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%234285F4" d="M14.9 8.161c0-.476-.039-.954-.122-1.422H8.14v2.695h3.802a3.24 3.24 0 01-1.407 2.127v1.75h2.268c1.332-1.22 2.098-3.02 2.098-5.15z"/><path fill="%2334A853" d="M8.14 15c1.897 0 3.499-.62 4.665-1.69l-2.268-1.749c-.631.427-1.446.669-2.395.669-1.837 0-3.394-1.232-3.952-2.888H1.849v1.803A7.044 7.044 0 008.139 15z"/><path fill="%23FBBC04" d="M4.187 9.341a4.17 4.17 0 010-2.68V4.858H1.849a6.97 6.97 0 000 6.287l2.338-1.803z"/><path fill="%23EA4335" d="M8.14 3.77a3.837 3.837 0 012.7 1.05l2.01-1.999a6.786 6.786 0 00-4.71-1.82 7.042 7.042 0 00-6.291 3.858L4.187 6.66c.556-1.658 2.116-2.89 3.952-2.89z"/></svg>');
+}
+
+%google-color-24-svg-prop {
+  --google-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%234285F4" d="M21.804 12.23c0-.68-.055-1.363-.172-2.032H12.2v3.85h5.4a4.629 4.629 0 01-1.998 3.04v2.498h3.222c1.893-1.742 2.98-4.314 2.98-7.356z"/><path fill="%2334A853" d="M12.2 22c2.697 0 4.971-.886 6.628-2.414l-3.222-2.499c-.897.61-2.054.956-3.403.956-2.608 0-4.82-1.76-5.614-4.127H3.264v2.576A10.001 10.001 0 0012.2 22z"/><path fill="%23FBBC04" d="M6.585 13.916a5.99 5.99 0 010-3.828V7.512H3.264a10.008 10.008 0 000 8.98l3.321-2.576z"/><path fill="%23EA4335" d="M12.2 5.958a5.434 5.434 0 013.836 1.499l2.855-2.855A9.61 9.61 0 0012.2 2.001a9.998 9.998 0 00-8.936 5.511l3.321 2.576c.79-2.37 3.006-4.13 5.615-4.13z"/></svg>');
+}
+
+%grid-16-svg-prop {
+  --grid-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M2.25 1C1.56 1 1 1.56 1 2.25v3.5C1 6.44 1.56 7 2.25 7h3.5C6.44 7 7 6.44 7 5.75v-3.5C7 1.56 6.44 1 5.75 1h-3.5zm.25 4.5v-3h3v3h-3zM10.25 1C9.56 1 9 1.56 9 2.25v3.5C9 6.44 9.56 7 10.25 7h3.5C14.44 7 15 6.44 15 5.75v-3.5C15 1.56 14.44 1 13.75 1h-3.5zm.25 4.5v-3h3v3h-3zM9 10.25C9 9.56 9.56 9 10.25 9h3.5c.69 0 1.25.56 1.25 1.25v3.5c0 .69-.56 1.25-1.25 1.25h-3.5C9.56 15 9 14.44 9 13.75v-3.5zm1.5.25v3h3v-3h-3zM2.25 9C1.56 9 1 9.56 1 10.25v3.5c0 .69.56 1.25 1.25 1.25h3.5C6.44 15 7 14.44 7 13.75v-3.5C7 9.56 6.44 9 5.75 9h-3.5zm.25 4.5v-3h3v3h-3z"/></g></svg>');
+}
+
+%grid-24-svg-prop {
+  --grid-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M3.75 2A1.75 1.75 0 002 3.75v5.5c0 .966.784 1.75 1.75 1.75h5.5A1.75 1.75 0 0011 9.25v-5.5A1.75 1.75 0 009.25 2h-5.5zM3.5 3.75a.25.25 0 01.25-.25h5.5a.25.25 0 01.25.25v5.5a.25.25 0 01-.25.25h-5.5a.25.25 0 01-.25-.25v-5.5zM14.75 2A1.75 1.75 0 0013 3.75v5.5c0 .966.784 1.75 1.75 1.75h5.5A1.75 1.75 0 0022 9.25v-5.5A1.75 1.75 0 0020.25 2h-5.5zm-.25 1.75a.25.25 0 01.25-.25h5.5a.25.25 0 01.25.25v5.5a.25.25 0 01-.25.25h-5.5a.25.25 0 01-.25-.25v-5.5zM13 14.75c0-.966.784-1.75 1.75-1.75h5.5c.966 0 1.75.784 1.75 1.75v5.5A1.75 1.75 0 0120.25 22h-5.5A1.75 1.75 0 0113 20.25v-5.5zm1.75-.25a.25.25 0 00-.25.25v5.5c0 .138.112.25.25.25h5.5a.25.25 0 00.25-.25v-5.5a.25.25 0 00-.25-.25h-5.5zM3.75 13A1.75 1.75 0 002 14.75v5.5c0 .966.784 1.75 1.75 1.75h5.5A1.75 1.75 0 0011 20.25v-5.5A1.75 1.75 0 009.25 13h-5.5zm-.25 1.75a.25.25 0 01.25-.25h5.5a.25.25 0 01.25.25v5.5a.25.25 0 01-.25.25h-5.5a.25.25 0 01-.25-.25v-5.5z"/></g></svg>');
+}
+
+%grid-alt-16-svg-prop {
+  --grid-alt-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M0 .75A.75.75 0 01.75 0h2.5A.75.75 0 014 .75v2.5a.75.75 0 01-.75.75H.75A.75.75 0 010 3.25V.75zm1.5.75v1h1v-1h-1zM6 .75A.75.75 0 016.75 0h2.5a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75h-2.5A.75.75 0 016 3.25V.75zm1.5.75v1h1v-1h-1zM12.75 0a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75V.75a.75.75 0 00-.75-.75h-2.5zm.75 2.5v-1h1v1h-1zM0 6.75A.75.75 0 01.75 6h2.5a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75H.75A.75.75 0 010 9.25v-2.5zm1.5.75v1h1v-1h-1zM6.75 6a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-2.5A.75.75 0 009.25 6h-2.5zm.75 2.5v-1h1v1h-1zM12 6.75a.75.75 0 01.75-.75h2.5a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75h-2.5a.75.75 0 01-.75-.75v-2.5zm1.5.75v1h1v-1h-1zM.75 12a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-2.5a.75.75 0 00-.75-.75H.75zm.75 2.5v-1h1v1h-1zM6 12.75a.75.75 0 01.75-.75h2.5a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75h-2.5a.75.75 0 01-.75-.75v-2.5zm1.5.75v1h1v-1h-1zM12.75 12a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-2.5a.75.75 0 00-.75-.75h-2.5zm.75 2.5v-1h1v1h-1z"/></g></svg>');
+}
+
+%grid-alt-24-svg-prop {
+  --grid-alt-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M1 2.25C1 1.56 1.56 1 2.25 1h3.5C6.44 1 7 1.56 7 2.25v3.5C7 6.44 6.44 7 5.75 7h-3.5C1.56 7 1 6.44 1 5.75v-3.5zm1.5.25v3h3v-3h-3zM9 2.25C9 1.56 9.56 1 10.25 1h3.5c.69 0 1.25.56 1.25 1.25v3.5C15 6.44 14.44 7 13.75 7h-3.5C9.56 7 9 6.44 9 5.75v-3.5zm1.5.25v3h3v-3h-3zM18.25 1C17.56 1 17 1.56 17 2.25v3.5c0 .69.56 1.25 1.25 1.25h3.5C22.44 7 23 6.44 23 5.75v-3.5C23 1.56 22.44 1 21.75 1h-3.5zm.25 4.5v-3h3v3h-3zM1 10.25C1 9.56 1.56 9 2.25 9h3.5C6.44 9 7 9.56 7 10.25v3.5C7 14.44 6.44 15 5.75 15h-3.5C1.56 15 1 14.44 1 13.75v-3.5zm1.5.25v3h3v-3h-3zM10.25 9C9.56 9 9 9.56 9 10.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5C15 9.56 14.44 9 13.75 9h-3.5zm.25 4.5v-3h3v3h-3zM17 10.25c0-.69.56-1.25 1.25-1.25h3.5c.69 0 1.25.56 1.25 1.25v3.5c0 .69-.56 1.25-1.25 1.25h-3.5c-.69 0-1.25-.56-1.25-1.25v-3.5zm1.5.25v3h3v-3h-3zM2.25 17C1.56 17 1 17.56 1 18.25v3.5c0 .69.56 1.25 1.25 1.25h3.5C6.44 23 7 22.44 7 21.75v-3.5C7 17.56 6.44 17 5.75 17h-3.5zm.25 4.5v-3h3v3h-3zM9 18.25c0-.69.56-1.25 1.25-1.25h3.5c.69 0 1.25.56 1.25 1.25v3.5c0 .69-.56 1.25-1.25 1.25h-3.5C9.56 23 9 22.44 9 21.75v-3.5zm1.5.25v3h3v-3h-3zM18.25 17c-.69 0-1.25.56-1.25 1.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5c0-.69-.56-1.25-1.25-1.25h-3.5zm.25 4.5v-3h3v3h-3z"/></g></svg>');
+}
+
+%guide-16-svg-prop {
+  --guide-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1.25 2C.56 2 0 2.56 0 3.25v8.5C0 12.44.56 13 1.25 13H5c.896 0 1.475.205 1.809.448.317.23.441.51.441.802a.75.75 0 001.5 0c0-.292.124-.572.441-.802.334-.243.913-.448 1.809-.448h3.75c.69 0 1.25-.56 1.25-1.25v-8.5C16 2.56 15.44 2 14.75 2H11c-1.154 0-2.106.354-2.772 1-.081.08-.157.161-.228.246A3.131 3.131 0 007.772 3C7.106 2.354 6.154 2 5 2H1.25zm7.5 9.967c.61-.309 1.372-.467 2.25-.467h3.5v-8H11c-.846 0-1.394.253-1.728.577-.335.325-.522.787-.522 1.34v6.55zm-1.5 0v-6.55c0-.553-.187-1.015-.522-1.34C6.394 3.753 5.846 3.5 5 3.5H1.5v8H5c.878 0 1.64.158 2.25.467z" clip-rule="evenodd"/></svg>');
+}
+
+%guide-24-svg-prop {
+  --guide-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M2.75 3A1.75 1.75 0 001 4.75v12.5c0 .966.784 1.75 1.75 1.75h5.175c2.342 0 3.325 1.19 3.325 2.25a.75.75 0 001.5 0c0-1.06.983-2.25 3.325-2.25h5.175A1.75 1.75 0 0023 17.25V4.75A1.75 1.75 0 0021.25 3H16.1c-1.7 0-2.958.505-3.777 1.439-.119.136-.226.278-.323.426a3.789 3.789 0 00-.323-.426C10.858 3.505 9.6 3 7.9 3H2.75zm10 15.443c.845-.598 1.996-.943 3.325-.943h5.175a.25.25 0 00.25-.25V4.75a.25.25 0 00-.25-.25H16.1c-1.4 0-2.192.406-2.648.927-.473.54-.702 1.334-.702 2.323v10.693zm-1.5 0V7.75c0-.99-.229-1.783-.702-2.323C10.092 4.906 9.3 4.5 7.9 4.5H2.75a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h5.175c1.329 0 2.48.345 3.325.943z" clip-rule="evenodd"/></svg>');
+}
+
+%guide-link-16-svg-prop {
+  --guide-link-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M12.75 1a.75.75 0 000 1.5h.69l-1.97 1.97a.75.75 0 001.06 1.06l1.97-1.97v.69a.75.75 0 001.5 0v-2.5a.75.75 0 00-.75-.75h-2.5z"/><path fill-rule="evenodd" d="M1.25 2C.56 2 0 2.56 0 3.25v8.5C0 12.44.56 13 1.25 13H5c.896 0 1.475.205 1.809.448.317.23.441.51.441.802a.751.751 0 101.5 0c0-.292.124-.572.441-.802.334-.243.913-.448 1.809-.448h3.75c.69 0 1.25-.56 1.25-1.25v-4.5a.75.75 0 00-1.5 0v4.25H11c-.878 0-1.64.158-2.25.467v-6.55c0-.788.376-1.42 1.12-1.722a.75.75 0 00-.561-1.39 3.27 3.27 0 00-1.31.941A3.13 3.13 0 007.773 3C7.106 2.354 6.154 2 5 2H1.25zm6 3.417c0-.553-.187-1.015-.522-1.34C6.394 3.753 5.846 3.5 5 3.5H1.5v8H5c.878 0 1.64.158 2.25.467v-6.55z" clip-rule="evenodd"/></g></svg>');
+}
+
+%guide-link-24-svg-prop {
+  --guide-link-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M19.75 2a.75.75 0 000 1.5h1.69l-2.97 2.97a.75.75 0 001.06 1.06l2.97-2.97v1.69a.75.75 0 001.5 0v-3.5a.75.75 0 00-.75-.75h-3.5z"/><path fill-rule="evenodd" d="M2.75 3A1.75 1.75 0 001 4.75v12.5c0 .966.784 1.75 1.75 1.75h5.175c2.342 0 3.325 1.19 3.325 2.25A.749.749 0 0012 22a.75.75 0 00.75-.75c0-1.06.983-2.25 3.325-2.25h5.175A1.75 1.75 0 0023 17.25v-7a.75.75 0 10-1.5 0v7a.25.25 0 01-.25.25h-5.175c-1.329 0-2.48.345-3.325.943V7.75c0-.921.199-1.675.609-2.21.393-.512 1.055-.92 2.204-1.018a.75.75 0 10-.126-1.495c-1.481.126-2.57.689-3.269 1.6-.059.078-.115.158-.168.238a3.789 3.789 0 00-.323-.426C10.858 3.505 9.6 3 7.9 3H2.75zm8.5 4.75c0-.99-.229-1.783-.702-2.323C10.092 4.906 9.3 4.5 7.9 4.5H2.75a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h5.175c1.329 0 2.48.345 3.325.943V7.75z" clip-rule="evenodd"/></g></svg>');
+}
+
 %guide-svg-prop {
   --guide-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M18 11h2v9.5c0 .786-.714 1.5-1.5 1.5h-13c-.786 0-1.5-.714-1.5-1.5V4c0-1.5.5-2 2-2h7l-.975.975L11 4H6v16h12v-9zM8 18h8v-2H8v2zm0-3h8v-2H8v2zm0-3h6v-2H8v2zm13-5c.17.502.42.92.75 1.25.33.33.747.58 1.25.75a3.124 3.124 0 0 0-1.25.75A3.123 3.123 0 0 0 21 11c-.17-.504-.42-.92-.75-1.25-.33-.33-.746-.58-1.25-.75.5-.167.917-.417 1.25-.75.333-.333.583-.75.75-1.25zm-4-7c.406 1.24 1.03 2.28 1.875 3.125.844.844 1.886 1.47 3.125 1.875-1.259.425-2.3 1.05-3.125 1.875C18.05 7.7 17.425 8.741 17 10c-.417-1.25-1.042-2.292-1.875-3.125C14.292 6.042 13.25 5.417 12 5c1.264-.43 2.305-1.055 3.125-1.875C15.945 2.305 16.57 1.264 17 0zm-6 6v2H8V6h3zm6-3c-.167.5-.417.917-.75 1.25-.333.333-.75.583-1.25.75.504.17.92.42 1.25.75.33.33.58.746.75 1.25.165-.498.415-.915.75-1.25A3.124 3.124 0 0 1 19 5a3.16 3.16 0 0 1-1.25-.75c-.33-.33-.58-.748-.75-1.25z" fill="%23000"/></svg>');
 }
 
+%hammer-16-svg-prop {
+  --hammer-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M5.484 2.917c.817.22 1.612.62 2.509 1.403a.75.75 0 01.085 1.044l-.422.51 1.13.855.62-.802a.75.75 0 011.08-.113c.678.576.906 1.133.959 1.642.011.111.013.21.014.283v.044c.204.187.417.369.635.552l1.784-2.098-.712-.584-.1.018-.021.003a3.018 3.018 0 01-.395.051c-.132.006-.456.009-.736-.217a1.173 1.173 0 01-.388-.646c-.039-.16-.054-.33-.063-.436l-.002-.012a8.261 8.261 0 00-.012-.128c-1.814-1.199-3.99-1.864-5.965-1.37zm7.789 2.723h-.002.002zM7.868 7.915l-1.17-.884-3.972 4.804a.25.25 0 00.036.354l.913.73a.25.25 0 00.354-.042l3.84-4.962zM6.433 5a4.169 4.169 0 00-1.352-.638c-.463-.123-.908-.167-1.47-.224a42.642 42.642 0 01-.68-.073.75.75 0 01-.378-1.333c3.21-2.54 7.208-1.427 9.914.432a1.142 1.142 0 01.428.681c.026.112.04.23.05.325a2.32 2.32 0 01.285-.028c.143-.004.46.003.734.227l.148.12c.45.368.773.633 1.31 1.082a.75.75 0 01.09 1.062l-2.757 3.24a.75.75 0 01-1.052.089l-.253-.21a23.8 23.8 0 01-1.146-.994 1.128 1.128 0 01-.34-.779c-.004-.066-.004-.141-.005-.192v-.03a2.37 2.37 0 00-.002-.089l-4.742 6.128a1.75 1.75 0 01-2.477.296l-.913-.73a1.75 1.75 0 01-.255-2.482l4.863-5.88zm6.153-.772a.127.127 0 01.002 0h-.002z" clip-rule="evenodd"/></svg>');
+}
+
+%hammer-24-svg-prop {
+  --hammer-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M19.502 5.858C15.71 2.773 10.384.225 5.334 3.59a.75.75 0 00.269 1.36c1.292.258 2.317.466 3.309.888.814.346 1.625.846 2.52 1.67L1.03 17.909a2.25 2.25 0 000 3.182l.879.879a2.25 2.25 0 003.182 0l10.864-10.864c.212.322.24.532.247.66.004.065.002.13-.001.21l-.002.041c-.004.068-.009.16-.008.245.002.243.047.586.328.898.513.571 1.078 1.123 1.607 1.64.124.121.247.24.366.358a.75.75 0 001.06-.008l4.148-4.208a.75.75 0 00-.008-1.061c-.763-.752-1.224-1.196-1.866-1.814l-.21-.203c-.283-.273-.643-.316-.838-.327a4.072 4.072 0 00-.589.026l-.013.001-.209.019a6.363 6.363 0 01-.005-.263v-.031c-.002-.161-.003-.383-.034-.588-.03-.206-.108-.548-.388-.81a.74.74 0 00-.038-.033zM9.499 4.456a11.55 11.55 0 00-1.546-.523c3.597-1.278 7.34.464 10.493 3 .012.092.014.21.016.398v.013c.001.167.003.4.038.62.035.217.12.55.393.81.288.273.654.307.837.314.195.007.407-.013.56-.028l.029-.003c.162-.015.27-.024.35-.023l.117.113c.475.458.848.818 1.318 1.277l-3.095 3.14a32.343 32.343 0 01-1.318-1.343c0-.027.002-.056.004-.099l.004-.077a3.49 3.49 0 000-.363c-.034-.633-.299-1.343-1.169-2.212a.75.75 0 00-1.06 0L14 10.94 12.06 9l.97-.97a.75.75 0 00.007-1.053c-1.233-1.266-2.362-2.02-3.538-2.52zM11 10.061L2.091 18.97a.75.75 0 000 1.06l.879.879a.75.75 0 001.06 0L12.94 12 11 10.06zm9.74-1.021l-.01-.002a.04.04 0 01.01.002zm-.996-1.455l.013.002a.05.05 0 01-.013-.002z" clip-rule="evenodd"/></svg>');
+}
+
+%hard-drive-16-svg-prop {
+  --hard-drive-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3 11.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5a.75.75 0 01-.75-.75z"/><path fill-rule="evenodd" d="M4.748 1a2.25 2.25 0 00-2.07 1.369L.18 8.235a2.25 2.25 0 00-.18.882v3.633A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75V9.117c0-.303-.061-.603-.18-.882L13.322 2.37A2.25 2.25 0 0011.252 1H4.748zm-.69 1.956a.75.75 0 01.69-.456h6.504c.3 0 .572.18.69.456L14.09 8H1.91l2.148-5.044zM1.5 9.5v3.25c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75V9.5h-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%hard-drive-24-svg-prop {
+  --hard-drive-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M4 15.75a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5a.75.75 0 01-.75-.75z"/><path fill-rule="evenodd" d="M7.202 3a2.75 2.75 0 00-2.428 1.46L1.32 10.958A2.75 2.75 0 001 12.248v6.002A2.75 2.75 0 003.75 21h16.5A2.75 2.75 0 0023 18.25v-6.002c0-.45-.11-.893-.321-1.29L19.226 4.46A2.75 2.75 0 0016.798 3H7.202zM6.098 5.164A1.25 1.25 0 017.202 4.5h9.596c.462 0 .887.255 1.104.664l3.366 6.336H2.732l3.366-6.336zM2.5 13v5.25c0 .69.56 1.25 1.25 1.25h16.5c.69 0 1.25-.56 1.25-1.25V13h-19z" clip-rule="evenodd"/></g></svg>');
+}
+
+%hash-16-svg-prop {
+  --hash-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M6.884 1.762a.75.75 0 01.604.872L7.058 5h2.975l.479-2.634a.75.75 0 111.476.268L11.558 5h1.192a.75.75 0 010 1.5h-1.465l-.546 3h2.011a.75.75 0 010 1.5h-2.283l-.48 2.634a.75.75 0 11-1.475-.268L8.942 11H5.967l-.48 2.634a.75.75 0 11-1.475-.268L4.442 11H3.25a.75.75 0 010-1.5h1.465l.545-3H3.25a.75.75 0 010-1.5h2.283l.479-2.634a.75.75 0 01.872-.604zM9.214 9.5l.546-3H6.785l-.546 3h2.976z" clip-rule="evenodd"/></svg>');
+}
+
+%hash-24-svg-prop {
+  --hash-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M10.363 3.009a.75.75 0 01.629.853L10.365 8h4.483l.66-4.362a.75.75 0 111.484.224L16.365 8h2.885a.75.75 0 010 1.5h-3.113l-.681 4.5h3.794a.75.75 0 010 1.5h-4.022l-.736 4.863a.75.75 0 11-1.483-.225l.702-4.638H9.228l-.736 4.863a.75.75 0 11-1.483-.225L7.71 15.5H4.75a.75.75 0 010-1.5h3.189l.681-4.5H4.75a.75.75 0 010-1.5h4.098l.66-4.362a.75.75 0 01.855-.63zM13.938 14l.682-4.5h-4.482L9.455 14h4.482z" clip-rule="evenodd"/></svg>');
+}
+
+%headphones-16-svg-prop {
+  --headphones-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 2.5c-1.468 0-2.87.56-3.9 1.548A5.13 5.13 0 002.5 7.75V8h1.25A2.25 2.25 0 016 10.25v2.5A2.25 2.25 0 013.75 15h-.5A2.25 2.25 0 011 12.75v-5c0-1.8.745-3.52 2.061-4.784A7.135 7.135 0 018 1c1.847 0 3.624.704 4.939 1.966A6.63 6.63 0 0115 7.75v5A2.25 2.25 0 0112.75 15h-.5A2.25 2.25 0 0110 12.75v-2.5A2.25 2.25 0 0112.25 8h1.25v-.25a5.13 5.13 0 00-1.6-3.702A5.635 5.635 0 008 2.5zm5.5 7h-1.25a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h.5a.75.75 0 00.75-.75V9.5zm-11 0h1.25a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75h-.5a.75.75 0 01-.75-.75V9.5z" clip-rule="evenodd"/></svg>');
+}
+
+%headphones-24-svg-prop {
+  --headphones-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 3.5c-2.26 0-4.425.874-6.018 2.424A8.128 8.128 0 003.5 11.75V13h2.75A2.75 2.75 0 019 15.75v3.5A2.75 2.75 0 016.25 22h-1.5A2.75 2.75 0 012 19.25v-7.5a9.628 9.628 0 012.936-6.902A10.132 10.132 0 0112 2c2.646 0 5.187 1.022 7.064 2.848A9.629 9.629 0 0122 11.75v7.5A2.75 2.75 0 0119.25 22h-1.5A2.75 2.75 0 0115 19.25v-3.5A2.75 2.75 0 0117.75 13h2.75v-1.25c0-2.181-.89-4.278-2.482-5.826A8.632 8.632 0 0012 3.5zm8.5 11h-2.75c-.69 0-1.25.56-1.25 1.25v3.5c0 .69.56 1.25 1.25 1.25h1.5c.69 0 1.25-.56 1.25-1.25V14.5zm-17 0h2.75c.69 0 1.25.56 1.25 1.25v3.5c0 .69-.56 1.25-1.25 1.25h-1.5c-.69 0-1.25-.56-1.25-1.25V14.5z" clip-rule="evenodd"/></svg>');
+}
+
 %health-svg-prop {
   --health-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.5 8.5l5 10.5 3.5-6h4v-2h-5l-2.5 4.5L9.5 5 6 11H2v2h5l2.5-4.5z" fill="%23000"/></svg>');
+}
+
+%heart-16-svg-prop {
+  --heart-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.689 1.343a4.604 4.604 0 014.97.979 4.482 4.482 0 010 6.4l-6.132 6.061a.75.75 0 01-1.054 0L1.34 8.723A4.5 4.5 0 010 5.523a4.5 4.5 0 011.34-3.201A4.589 4.589 0 014.566 1c1.208 0 2.369.475 3.226 1.322L8 2.527l.208-.205a4.57 4.57 0 011.48-.979zm3.916 2.045a3.104 3.104 0 00-4.342 0l-.736.727a.75.75 0 01-1.054 0l-.736-.726a3.089 3.089 0 00-2.17-.889c-.817 0-1.598.32-2.172.889A3 3 0 001.5 5.522a3 3 0 00.895 2.134L8 13.196l5.605-5.54c.284-.281.51-.614.663-.98a2.981 2.981 0 00-.663-3.288z" clip-rule="evenodd"/></svg>');
+}
+
+%heart-24-svg-prop {
+  --heart-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M14.508 3.457a6.246 6.246 0 014.693 0 6.154 6.154 0 011.993 1.304 6.024 6.024 0 011.336 1.957 5.931 5.931 0 010 4.626 6.022 6.022 0 01-1.336 1.957l-8.67 8.485a.75.75 0 01-1.049 0l-8.67-8.485A5.974 5.974 0 011 9.03c0-1.605.651-3.14 1.806-4.27a6.205 6.205 0 014.34-1.76c1.624 0 3.185.631 4.339 1.76l.515.504.515-.504a6.154 6.154 0 011.993-1.304zm5.637 2.376a4.653 4.653 0 00-1.508-.986 4.746 4.746 0 00-3.566 0 4.653 4.653 0 00-1.507.986l-1.04 1.018a.75.75 0 01-1.049 0l-1.04-1.018a4.705 4.705 0 00-3.29-1.332c-1.237 0-2.42.48-3.29 1.332A4.474 4.474 0 002.5 9.031c0 1.196.485 2.347 1.355 3.198L12 20.2l8.145-7.972c.43-.421.771-.921 1.003-1.47a4.431 4.431 0 000-3.456 4.524 4.524 0 00-1.003-1.47z" clip-rule="evenodd"/></svg>');
+}
+
+%heart-fill-16-svg-prop {
+  --heart-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M11.434 1a4.604 4.604 0 00-3.226 1.322L8 2.527l-.208-.205A4.589 4.589 0 004.566 1 4.589 4.589 0 001.34 2.322 4.5 4.5 0 000 5.522a4.5 4.5 0 001.34 3.2l6.133 6.061a.75.75 0 001.054 0l6.132-6.06a4.52 4.52 0 00.992-1.467 4.482 4.482 0 00-.992-4.934A4.604 4.604 0 0011.433 1z"/></svg>');
+}
+
+%heart-fill-24-svg-prop {
+  --heart-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M16.854 3c-.805 0-1.602.155-2.346.457a6.154 6.154 0 00-1.993 1.304L12 5.265l-.515-.504a6.205 6.205 0 00-4.34-1.76 6.205 6.205 0 00-4.34 1.76A5.974 5.974 0 001 9.031c0 1.605.651 3.14 1.806 4.27l8.67 8.485a.75.75 0 001.048 0l8.67-8.485a6.022 6.022 0 001.336-1.957 5.93 5.93 0 000-4.626 6.024 6.024 0 00-1.336-1.957 6.154 6.154 0 00-1.993-1.304A6.246 6.246 0 0016.854 3z"/></svg>');
+}
+
+%heart-off-16-svg-prop {
+  --heart-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M1.78.72A.75.75 0 00.72 1.78l.58.581A4.5 4.5 0 000 5.522a4.5 4.5 0 001.34 3.2l6.133 6.061a.75.75 0 001.054 0l2.613-2.582 3.08 3.08a.75.75 0 101.06-1.061L1.78.72zm8.3 10.42L2.36 3.422a2.999 2.999 0 00-.861 2.1 3 3 0 00.895 2.134L8 13.196l2.08-2.056z" clip-rule="evenodd"/><path d="M11.434 1a4.604 4.604 0 00-3.226 1.322l-.735.726a.75.75 0 001.054 1.067l.735-.727a3.104 3.104 0 014.342 0 2.981 2.981 0 010 4.267l-.735.727a.75.75 0 101.055 1.067l.735-.726a4.52 4.52 0 00.992-1.467 4.482 4.482 0 00-.992-4.934A4.604 4.604 0 0011.433 1z"/></g></svg>');
+}
+
+%heart-off-24-svg-prop {
+  --heart-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M2.28 1.22a.75.75 0 00-1.06 1.06L3.28 4.342c-.165.13-.324.27-.475.42A5.974 5.974 0 001 9.03c0 1.605.651 3.14 1.806 4.27l8.67 8.485a.75.75 0 001.048 0l4.145-4.056 5.05 5.05a.75.75 0 101.061-1.06L2.28 1.22zm13.328 15.449L4.351 5.412c-.174.128-.34.269-.496.421A4.474 4.474 0 002.5 9.031c0 1.196.485 2.347 1.355 3.198L12 20.2l3.608-3.532z" clip-rule="evenodd"/><path d="M14.508 3.457a6.246 6.246 0 014.693 0 6.153 6.153 0 011.993 1.304 6.024 6.024 0 011.336 1.957 5.931 5.931 0 010 4.626 6.022 6.022 0 01-1.336 1.957l-1.04 1.017a.75.75 0 01-1.049-1.072l1.04-1.017c.43-.421.771-.921 1.003-1.47a4.431 4.431 0 000-3.456 4.524 4.524 0 00-1.003-1.47 4.653 4.653 0 00-1.508-.986 4.746 4.746 0 00-3.566 0 4.653 4.653 0 00-1.507.986l-1.04 1.018a.75.75 0 01-1.049 0l-1.04-1.018a4.644 4.644 0 00-1.257-.875.75.75 0 11.644-1.356c.61.29 1.173.68 1.663 1.16l.515.503.515-.504a6.154 6.154 0 011.993-1.304z"/></g></svg>');
+}
+
+%help-16-svg-prop {
+  --help-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M8.197 4.523a1.532 1.532 0 00-1.051.196c-.318.19-.563.49-.687.85a.75.75 0 01-1.418-.49c.239-.69.71-1.274 1.335-1.648a3.032 3.032 0 012.079-.386 3.057 3.057 0 011.829 1.065 3.13 3.13 0 01.716 2c0 .487-.092.905-.275 1.266-.182.36-.431.62-.679.817-.194.156-.41.291-.581.398l-.096.06a2.507 2.507 0 00-.452.34.643.643 0 00-.172.292.75.75 0 01-1.499-.033c0-.163.035-.324.086-.479.08-.243.232-.543.515-.832.239-.243.505-.419.72-.554.044-.029.086-.056.126-.08.169-.106.296-.186.415-.282a.976.976 0 00.279-.323c.059-.117.113-.296.113-.59v-.002a1.63 1.63 0 00-.372-1.041c-.24-.29-.57-.481-.931-.544z" clip-rule="evenodd"/><path d="M8 11a1 1 0 100 2h.007a1 1 0 100-2H8z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%help-24-svg-prop {
+  --help-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M12.349 7.536c-.612-.1-1.24.01-1.77.31s-.926.765-1.125 1.308a.75.75 0 11-1.408-.516A3.995 3.995 0 019.842 6.54a4.212 4.212 0 012.75-.484c.946.156 1.81.63 2.436 1.343.627.715.973 1.624.972 2.569 0 .636-.127 1.168-.369 1.62-.24.449-.569.77-.9 1.021a8.43 8.43 0 01-.804.519l-.144.085c-.294.177-.526.329-.712.507-.185.178-.264.341-.298.441a.62.62 0 00-.028.107l-.001.007a.75.75 0 01-1.5-.025c0-.198.047-.394.111-.58a2.63 2.63 0 01.677-1.032c.318-.304.675-.529.98-.712l.177-.104a6.68 6.68 0 00.636-.409 1.64 1.64 0 00.484-.533c.107-.2.191-.482.191-.913v-.001c0-.573-.21-1.132-.6-1.578a2.628 2.628 0 00-1.551-.852z" clip-rule="evenodd"/><path d="M12 16a1 1 0 100 2h.01a1 1 0 100-2H12z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
 }
 
 %help-circle-fill-svg-prop {
@@ -266,8 +1906,88 @@
   --help-circle-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11 18h2v-2h-2v2zm1-16C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm0-14c-2.21 0-4 1.79-4 4h2c0-1.1.9-2 2-2s2 .9 2 2c0 2-3 1.75-3 5h2c0-2.25 3-2.5 3-5 0-2.21-1.79-4-4-4z" fill="%23000"/></svg>');
 }
 
+%hexagon-16-svg-prop {
+  --hexagon-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M6.834.33a2.25 2.25 0 012.332 0l5.25 3.182A2.25 2.25 0 0115.5 5.436v5.128a2.25 2.25 0 01-1.084 1.924l-5.25 3.182a2.25 2.25 0 01-2.332 0l-5.25-3.182A2.25 2.25 0 01.5 10.564V5.436a2.25 2.25 0 011.084-1.924L6.834.33zm1.555 1.283a.75.75 0 00-.778 0l-5.25 3.181A.75.75 0 002 5.436v5.128a.75.75 0 00.361.642l5.25 3.181a.75.75 0 00.778 0l5.25-3.181a.75.75 0 00.361-.642V5.436a.75.75 0 00-.361-.642l-5.25-3.181z" clip-rule="evenodd"/></svg>');
+}
+
+%hexagon-24-svg-prop {
+  --hexagon-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M10.559 1.006a2.75 2.75 0 012.882 0l7.75 4.77A2.75 2.75 0 0122.5 8.118v7.764a2.75 2.75 0 01-1.309 2.342l-7.75 4.77a2.75 2.75 0 01-2.882 0l-7.75-4.77A2.75 2.75 0 011.5 15.882V8.118a2.75 2.75 0 011.309-2.342l7.75-4.77zm2.096 1.278a1.25 1.25 0 00-1.31 0l-7.75 4.77A1.25 1.25 0 003 8.117v7.764c0 .435.225.838.595 1.065l7.75 4.77a1.25 1.25 0 001.31 0l7.75-4.77c.37-.227.595-.63.595-1.065V8.118a1.25 1.25 0 00-.595-1.065l-7.75-4.77z" clip-rule="evenodd"/></svg>');
+}
+
+%hexagon-fill-16-svg-prop {
+  --hexagon-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M9.166.33a2.25 2.25 0 00-2.332 0l-5.25 3.182A2.25 2.25 0 00.5 5.436v5.128a2.25 2.25 0 001.084 1.924l5.25 3.182a2.25 2.25 0 002.332 0l5.25-3.182a2.25 2.25 0 001.084-1.924V5.436a2.25 2.25 0 00-1.084-1.924L9.166.33z"/></svg>');
+}
+
+%hexagon-fill-24-svg-prop {
+  --hexagon-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M13.441 1.006a2.75 2.75 0 00-2.882 0l-7.75 4.77A2.75 2.75 0 001.5 8.118v7.764a2.75 2.75 0 001.309 2.342l7.75 4.77a2.75 2.75 0 002.882 0l7.75-4.77a2.75 2.75 0 001.309-2.342V8.118a2.75 2.75 0 00-1.309-2.342l-7.75-4.77z"/></svg>');
+}
+
+%history-16-svg-prop {
+  --history-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.5 1.25a.75.75 0 011.5 0v1.851A7 7 0 111 8a.75.75 0 011.5 0 5.5 5.5 0 101.725-4H5.75a.75.75 0 010 1.5h-3.5a.75.75 0 01-.75-.75v-3.5z"/><path d="M8.25 4a.75.75 0 01.75.75v3.763l1.805.802a.75.75 0 01-.61 1.37l-2.25-1A.75.75 0 017.5 9V4.75A.75.75 0 018.25 4z"/></g></svg>');
+}
+
+%history-24-svg-prop {
+  --history-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 3.5c-2.347 0-4.471.95-6.01 2.49A8.55 8.55 0 005.125 7H8.25a.75.75 0 010 1.5h-4.5A.75.75 0 013 7.75v-4.5a.75.75 0 011.5 0v2.135A9.971 9.971 0 0112 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12a.75.75 0 011.5 0A8.5 8.5 0 1012 3.5z"/><path d="M11.75 6a.75.75 0 01.75.75v5.787l4.085 2.042a.75.75 0 11-.67 1.342l-4.5-2.25A.75.75 0 0111 13V6.75a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
 %history-svg-prop {
   --history-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13 3a9 9 0 0 0-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42A8.954 8.954 0 0 0 13 21a9 9 0 0 0 0-18zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z" fill="%23000"/></svg>');
+}
+
+%home-16-svg-prop {
+  --home-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.846 2.574a.25.25 0 01.308 0l5.25 4.12a.25.25 0 01.096.196v7.36a.75.75 0 001.5 0V6.89a1.75 1.75 0 00-.67-1.377L9.08 1.394a1.75 1.75 0 00-2.16 0l-5.25 4.12A1.75 1.75 0 001 6.89v7.36a.75.75 0 001.5 0V6.89a.25.25 0 01.096-.196l5.25-4.12z"/><path d="M6.5 14.25V10.5h3v3.75a.75.75 0 001.5 0v-4C11 9.56 10.44 9 9.75 9h-3.5C5.56 9 5 9.56 5 10.25v4a.75.75 0 001.5 0z"/></g></svg>');
+}
+
+%home-24-svg-prop {
+  --home-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.847 2.819a.25.25 0 01.306 0l8.25 6.407a.25.25 0 01.097.198V21.25a.75.75 0 001.5 0V9.424c0-.54-.25-1.05-.677-1.382l-8.25-6.408a1.75 1.75 0 00-2.146 0l-8.25 6.408A1.75 1.75 0 002 9.424V21.25a.75.75 0 001.5 0V9.424a.25.25 0 01.097-.198l8.25-6.407z"/><path d="M9.5 15.75a.25.25 0 01.25-.25h4.5a.25.25 0 01.25.25v5.5a.75.75 0 001.5 0v-5.5A1.75 1.75 0 0014.25 14h-4.5A1.75 1.75 0 008 15.75v5.5a.75.75 0 001.5 0v-5.5z"/></g></svg>');
+}
+
+%hourglass-16-svg-prop {
+  --hourglass-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.75 12.75A.75.75 0 016.5 12h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zM7.75 4.5a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5z"/><path fill-rule="evenodd" d="M2.695 2.717A1.5 1.5 0 014.012.5h7.976a1.5 1.5 0 011.317 2.217L10.494 7.88a.25.25 0 000 .24l2.811 5.163a1.5 1.5 0 01-1.317 2.217H4.012a1.5 1.5 0 01-1.317-2.217l2.81-5.163a.25.25 0 000-.24l-2.81-5.163zM11.988 2H4.012l2.811 5.163a1.75 1.75 0 010 1.674L4.013 14h7.975L9.177 8.837a1.75 1.75 0 010-1.674L11.987 2z" clip-rule="evenodd"/></g></svg>');
+}
+
+%hourglass-24-svg-prop {
+  --hourglass-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8 19.75a.75.75 0 01.75-.75h6.5a.75.75 0 010 1.5h-6.5a.75.75 0 01-.75-.75zM11.75 8a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5z"/><path fill-rule="evenodd" d="M4.694 4.503C3.69 3.01 4.762 1 6.562 1h10.876c1.8 0 2.871 2.009 1.868 3.503l-4.748 7.08a.75.75 0 000 .835l4.748 7.079C20.31 20.99 19.238 23 17.438 23H6.562c-1.8 0-2.871-2.009-1.868-3.503l4.748-7.08a.75.75 0 000-.835L4.694 4.503zM6.562 2.5a.75.75 0 00-.623 1.168l4.748 7.079a2.25 2.25 0 010 2.506l-4.748 7.08a.75.75 0 00.623 1.167h10.876c.6 0 .957-.67.623-1.168l-4.748-7.079a2.25 2.25 0 010-2.506l4.748-7.08a.75.75 0 00-.623-1.167H6.562z" clip-rule="evenodd"/></g></svg>');
+}
+
+%identity-service-16-svg-prop {
+  --identity-service-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 5a4 4 0 100 8 4 4 0 000-8zm-.904 3H5.708a2.504 2.504 0 011.847-1.46A5.94 5.94 0 007.096 8zm-.068 1.5H5.55c.203.998 1 1.78 2.005 1.96a6.01 6.01 0 01-.527-1.96zm2.103 1.73a4.376 4.376 0 01-.594-1.73h1.913a2.504 2.504 0 01-1.319 1.73zM8.628 8c.107-.445.278-.862.503-1.23A2.51 2.51 0 0110.292 8H8.628z"/><path d="M4 1.25C4 .56 4.56 0 5.25 0h5.5C11.44 0 12 .56 12 1.25V2h1.75A2.25 2.25 0 0116 4.25v8.5A2.25 2.25 0 0113.75 15H2.25A2.25 2.25 0 010 12.75v-8.5A2.25 2.25 0 012.25 2H4v-.75zM10.75 4c.409 0 .772-.196 1-.5h2a.75.75 0 01.75.75v8.5a.75.75 0 01-.75.75H2.25a.75.75 0 01-.75-.75v-8.5a.75.75 0 01.75-.75h2c.228.304.591.5 1 .5h5.5zM5.5 2.5h5v-1h-5v1z"/></g></svg>');
+}
+
+%identity-service-24-svg-prop {
+  --identity-service-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 7.25a5.75 5.75 0 100 11.5 5.75 5.75 0 000-11.5zM9.329 12h-1.46a4.26 4.26 0 012.42-2.892A8.401 8.401 0 009.33 12zm-.055 1.5H7.78a4.254 4.254 0 002.51 3.392A8.4 8.4 0 019.275 13.5zm4.436 3.392a4.254 4.254 0 002.51-3.392h-1.494a8.4 8.4 0 01-1.016 3.392zm-.49-3.392A6.9 6.9 0 0112 16.804a6.9 6.9 0 01-1.22-3.304h2.44zm-.066-1.5h-2.308A6.9 6.9 0 0112 9.196 6.9 6.9 0 0113.154 12zm1.517 0h1.46a4.26 4.26 0 00-2.42-2.892c.492.895.819 1.875.96 2.892z"/><path d="M7 2.75C7 1.784 7.784 1 8.75 1h6.5c.966 0 1.75.784 1.75 1.75V3h3.25A2.75 2.75 0 0123 5.75v12.5A2.75 2.75 0 0120.25 21H3.75A2.75 2.75 0 011 18.25V5.75A2.75 2.75 0 013.75 3H7v-.25zM20.25 4.5H17v.25a1.75 1.75 0 01-1.75 1.75h-6.5A1.75 1.75 0 017 4.75V4.5H3.75c-.69 0-1.25.56-1.25 1.25v12.5c0 .69.56 1.25 1.25 1.25h16.5c.69 0 1.25-.56 1.25-1.25V5.75c0-.69-.56-1.25-1.25-1.25zM8.5 4.75v-2a.25.25 0 01.25-.25h6.5a.25.25 0 01.25.25v2a.25.25 0 01-.25.25h-6.5a.25.25 0 01-.25-.25z"/></g></svg>');
+}
+
+%identity-user-16-svg-prop {
+  --identity-user-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.187 10.482A2.324 2.324 0 016.625 10h2.75c.515 0 1.034.16 1.438.482.41.325.687.807.687 1.359v.409a.75.75 0 01-1.5 0v-.41c0-.026-.012-.098-.119-.183a.828.828 0 00-.506-.157h-2.75a.828.828 0 00-.506.157c-.107.085-.119.157-.119.184v.409a.75.75 0 01-1.5 0v-.41c0-.55.277-1.033.687-1.358z"/><path fill-rule="evenodd" d="M8 4.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM7 7a1 1 0 112 0 1 1 0 01-2 0z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M5.25 0C4.56 0 4 .56 4 1.25V2H2.25A2.25 2.25 0 000 4.25v8.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-8.5A2.25 2.25 0 0013.75 2H12v-.75C12 .56 11.44 0 10.75 0h-5.5zm6.5 3.5c-.228.304-.591.5-1 .5h-5.5c-.409 0-.772-.196-1-.5h-2a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75v-8.5a.75.75 0 00-.75-.75h-2zm-1.25-1h-5v-1h5v1z" clip-rule="evenodd"/></g></svg>');
+}
+
+%identity-user-24-svg-prop {
+  --identity-user-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M7.858 14.79A2.944 2.944 0 019.875 14h4.25c.748 0 1.475.28 2.017.79.543.511.858 1.216.858 1.96v.5a.75.75 0 01-1.5 0v-.5c0-.316-.133-.63-.386-.868a1.445 1.445 0 00-.989-.382h-4.25c-.379 0-.734.142-.989.382a1.193 1.193 0 00-.386.868v.5a.75.75 0 01-1.5 0v-.5c0-.744.315-1.449.858-1.96z"/><path fill-rule="evenodd" d="M12 7.5a3 3 0 100 6 3 3 0 000-6zm-1.5 3a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M8.75 1A1.75 1.75 0 007 2.75V3H3.75A2.75 2.75 0 001 5.75v12.5A2.75 2.75 0 003.75 21h16.5A2.75 2.75 0 0023 18.25V5.75A2.75 2.75 0 0020.25 3H17v-.25A1.75 1.75 0 0015.25 1h-6.5zM17 4.5h3.25c.69 0 1.25.56 1.25 1.25v12.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25V5.75c0-.69.56-1.25 1.25-1.25H7v.25c0 .966.784 1.75 1.75 1.75h6.5A1.75 1.75 0 0017 4.75V4.5zm-8.5.25c0 .138.112.25.25.25h6.5a.25.25 0 00.25-.25v-2a.25.25 0 00-.25-.25h-6.5a.25.25 0 00-.25.25v2z" clip-rule="evenodd"/></g></svg>');
+}
+
+%image-16-svg-prop {
+  --image-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M5.5 3a2.5 2.5 0 100 5 2.5 2.5 0 000-5zm-1 2.5a1 1 0 112 0 1 1 0 01-2 0z"/><path d="M0 2.25A2.25 2.25 0 012.25 0h11.5A2.25 2.25 0 0116 2.25v11.5A2.25 2.25 0 0113.75 16H2.25A2.25 2.25 0 010 13.75V2.25zm14.5 0v5.94l-1.835-1.836a1.75 1.75 0 00-2.335-.125L1.5 13.336V2.25a.75.75 0 01.75-.75h11.5a.75.75 0 01.75.75zm-.75 12.25H2.446l8.825-7.103a.25.25 0 01.333.018l2.896 2.896v3.439a.75.75 0 01-.75.75z"/></g></svg>');
+}
+
+%image-24-svg-prop {
+  --image-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M6 8.5a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0zm2.5-1a1 1 0 100 2 1 1 0 000-2z"/><path d="M2 4.75A2.75 2.75 0 014.75 2h14.5A2.75 2.75 0 0122 4.75v14.5A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25V4.75zm18.5 8.5v-8.5c0-.69-.56-1.25-1.25-1.25H4.75c-.69 0-1.25.56-1.25 1.25v14.5c0 .024 0 .047.002.07l10.654-8.773a2.75 2.75 0 013.644.132l2.7 2.571zM4.468 20.468l10.641-8.763a1.25 1.25 0 011.657.06l3.734 3.556v3.929c0 .69-.56 1.25-1.25 1.25H4.75c-.097 0-.191-.011-.282-.032z"/></g></svg>');
+}
+
+%inbox-16-svg-prop {
+  --inbox-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4.748 1a2.25 2.25 0 00-2.07 1.369L.18 8.235a2.25 2.25 0 00-.18.882v3.633A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75V9.117c0-.303-.061-.603-.18-.882L13.322 2.37A2.25 2.25 0 0011.252 1H4.748zm-.69 1.956a.75.75 0 01.69-.456h6.504c.3 0 .572.18.69.456L14.09 8H10.5a.75.75 0 00-.53.22L8.69 9.5H7.31L6.03 8.22A.75.75 0 005.5 8H1.91l2.148-5.044zM1.5 9.5v3.25c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75V9.5h-3.69l-1.28 1.28A.75.75 0 019 11H7a.75.75 0 01-.53-.22L5.19 9.5H1.5z" clip-rule="evenodd"/></svg>');
+}
+
+%inbox-24-svg-prop {
+  --inbox-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M7.202 3a2.75 2.75 0 00-2.428 1.46L1.32 10.958A2.75 2.75 0 001 12.248v6.002A2.75 2.75 0 003.75 21h16.5A2.75 2.75 0 0023 18.25v-6.002c0-.45-.11-.893-.321-1.29L19.226 4.46A2.75 2.75 0 0016.798 3H7.202zM6.098 5.164A1.25 1.25 0 017.202 4.5h9.596c.462 0 .887.255 1.104.664l3.366 6.336H16a.75.75 0 00-.624.334L13.599 14.5H10.4l-1.777-2.666A.75.75 0 008 11.5H2.732l3.366-6.336zM2.5 13v5.25c0 .69.56 1.25 1.25 1.25h16.5c.69 0 1.25-.56 1.25-1.25V13h-5.099l-1.777 2.666A.75.75 0 0114 16h-4a.75.75 0 01-.624-.334L7.599 13H2.5z" clip-rule="evenodd"/></svg>');
+}
+
+%info-16-svg-prop {
+  --info-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 7a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 018 7zM8 4a1 1 0 000 2h.007a1 1 0 000-2H8z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%info-24-svg-prop {
+  --info-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 10.5a.75.75 0 01.75.75v5.5a.75.75 0 01-1.5 0v-5.5a.75.75 0 01.75-.75zM12 7a1 1 0 100 2h.01a1 1 0 100-2H12z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
 }
 
 %info-circle-fill-svg-prop {
@@ -278,24 +1998,144 @@
   --info-circle-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2c5.514 0 10 4.486 10 10s-4.486 10-10 10S2 17.543 2 12 6.486 2 12 2zm0 1.886c-4.486 0-8.143 3.628-8.143 8.114 0 4.486 3.657 8.143 8.143 8.143 4.486 0 8.143-3.643 8.143-8.143 0-4.5-3.657-8.129-8.143-8.129v.015zm1.429 8.128a1.555 1.555 0 0 0-.443-.985c-.286-.272-.6-.429-.986-.443h-1.429c-.385.028-.685.185-.985.443a1.456 1.456 0 0 0-.443.985h1.428V16.3c.029.386.158.714.443.986.286.285.6.443.986.443h1.429c.385 0 .685-.158.985-.443.286-.272.429-.6.443-.986H13.43V12v.014zM11 8.73a1.345 1.345 0 0 1-.4-1c0-.4.129-.743.4-1 .271-.258.6-.4 1-.4s.743.128 1 .4c.257.271.4.6.4 1s-.129.742-.4 1a1.433 1.433 0 0 1-1 .428c-.4 0-.743-.157-1-.428z" fill="%23000"/></svg>');
 }
 
+%jump-link-16-svg-prop {
+  --jump-link-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.75 2a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM1 6.25a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5h-3.5A.75.75 0 011 6.25zM1.75 9a.75.75 0 000 1.5h3.5a.75.75 0 000-1.5h-3.5zM1.75 12.5a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75zM7.49 6.2a.75.75 0 011.06.04l1.95 2.1V5.55c0-.545-.215-1.067-.597-1.451A2.024 2.024 0 008.467 3.5H7.25a.75.75 0 010-1.5h1.217c.939 0 1.838.375 2.5 1.041A3.56 3.56 0 0112 5.55v2.79l1.95-2.1a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z"/></g></svg>');
+}
+
+%jump-link-24-svg-prop {
+  --jump-link-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.75 4a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5zM3 9.75A.75.75 0 013.75 9h6.5a.75.75 0 010 1.5h-6.5A.75.75 0 013 9.75zM3.75 14a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5zM3.75 19a.75.75 0 000 1.5H20a.75.75 0 000-1.5H3.75zM12.952 12.238a.75.75 0 011.06-.036l2.488 2.322V8.75a3.25 3.25 0 00-3.25-3.25h-2a.75.75 0 010-1.5h2A4.75 4.75 0 0118 8.75v5.774l2.488-2.322a.75.75 0 011.024 1.096l-3.75 3.5a.75.75 0 01-1.024 0l-3.75-3.5a.75.75 0 01-.036-1.06z"/></g></svg>');
+}
+
+%key-16-svg-prop {
+  --key-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M9.16 3.657A2.236 2.236 0 0110.752 3a2.248 2.248 0 11-2.078 3.11l-.001-.002a2.243 2.243 0 01.489-2.451zm1.06 1.061a.737.737 0 01.815-.16.748.748 0 01-.284 1.44.748.748 0 01-.532-1.278l.001-.002z"/><path d="M10.354 0a5.68 5.68 0 00-4.906 2.846 5.68 5.68 0 00-.466 4.555L.22 12.162a.75.75 0 00-.22.53v2.558c0 .414.336.75.75.75h2.547a.75.75 0 00.53-.22l.655-.655a1.072 1.072 0 00.311-.784v-.64h.548c.31 0 .618-.123.843-.355l.008-.008c.204-.216.324-.498.33-.801v-.556h.676c.288 0 .566-.117.767-.327l.638-.637a5.664 5.664 0 004.55-.468 5.683 5.683 0 002.798-4.152v-.001a5.68 5.68 0 00-1.602-4.742A5.619 5.619 0 0010.354 0zm-.548 1.536a4.12 4.12 0 013.482 1.178 4.18 4.18 0 011.176 3.483 4.183 4.183 0 01-2.054 3.05 4.163 4.163 0 01-3.671.221.75.75 0 00-.143-.043l-.023-.005a.806.806 0 00-.714.219l-.842.842H5.973a.951.951 0 00-.95.951v.768h-.779a.951.951 0 00-.95.952v1.04l-.308.308H1.5v-1.497L6.355 8.15c.22-.22.311-.567.174-.888a4.178 4.178 0 01.221-3.67 4.18 4.18 0 013.053-2.054h.003z"/></g></svg>');
+}
+
+%key-24-svg-prop {
+  --key-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M13.88 5.877A2.978 2.978 0 0116.001 5a2.999 2.999 0 11-2.772 4.148v-.002a2.992 2.992 0 01.651-3.27zm1.06 1.06a1.479 1.479 0 011.062-.437 1.499 1.499 0 11-1.387 2.072 1.492 1.492 0 01.324-1.633l.002-.001z"/><path d="M14.307 1.068c.34-.047.684-.068 1.021-.068 2.049 0 3.98.799 5.429 2.247a7.72 7.72 0 012.176 6.444v.001a7.725 7.725 0 01-3.8 5.642 7.697 7.697 0 01-3.811 1.012 7.653 7.653 0 01-2.553-.437l-1.04 1.04c-.225.236-.54.37-.863.37H9.6v1.089c-.008.35-.146.675-.383.926l-.007.007a1.356 1.356 0 01-.97.408H7.155v1.22c.011.323-.11.63-.331.867l-.011.012-.007.006-.926.926a.75.75 0 01-.53.22H1.75a.75.75 0 01-.75-.75v-3.616a.75.75 0 01.22-.53l6.869-6.868a7.719 7.719 0 01.572-6.369 7.72 7.72 0 015.646-3.799zm.203 1.486c.267-.037.543-.054.818-.054 1.651 0 3.2.641 4.368 1.807a6.22 6.22 0 011.75 5.185 6.225 6.225 0 01-3.057 4.54 6.173 6.173 0 01-5.464.33.833.833 0 00-.904.175l-1.282 1.281H9.135c-.578 0-1.034.47-1.034 1.034v1.397H6.69c-.578 0-1.035.47-1.035 1.034v1.6l-.616.617H2.5v-2.555l6.955-6.954a.831.831 0 00.18-.915 6.217 6.217 0 01.328-5.464 6.22 6.22 0 014.544-3.057h.003z"/></g></svg>');
+}
+
+%key-values-16-svg-prop {
+  --key-values-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.75 2a.75.75 0 000 1.5h1a.75.75 0 000-1.5h-1zM6.75 5.5a.75.75 0 000 1.5h3.5a.75.75 0 000-1.5h-3.5zM1 6.25a.75.75 0 01.75-.75h1.5a.75.75 0 010 1.5h-1.5A.75.75 0 011 6.25zM1.75 9a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM1 13.25a.75.75 0 01.75-.75h1.5a.75.75 0 010 1.5h-1.5a.75.75 0 01-.75-.75zM6.75 2a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5zM6 9.75A.75.75 0 016.75 9h5.5a.75.75 0 010 1.5h-5.5A.75.75 0 016 9.75zM6.75 12.5a.75.75 0 000 1.5h7.5a.75.75 0 000-1.5h-7.5z"/></g></svg>');
+}
+
+%key-values-24-svg-prop {
+  --key-values-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.75 5a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5zM10.75 9a.75.75 0 000 1.5h5.5a.75.75 0 000-1.5h-5.5zM3 9.75A.75.75 0 013.75 9h3.5a.75.75 0 010 1.5h-3.5A.75.75 0 013 9.75zM3.75 13a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM3 17.75a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5h-3.5a.75.75 0 01-.75-.75zM10.75 5a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5zM10 13.75a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM10.75 17a.75.75 0 000 1.5h9.5a.75.75 0 000-1.5h-9.5z"/></g></svg>');
+}
+
 %key-svg-prop {
   --key-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M21 18v3h-2.969L17 20v-2h-2v-2h-2l-4-4 3.052-3L21 18zM10 6L8 4 5.003 5 4 8l2 2 4-4zm-4.217 7.839L1.132 9.188l1.702-6.354 6.354-1.702 4.65 4.65-1.702 6.354-6.353 1.703z" fill="%23000"/></svg>');
+}
+
+%kubernetes-16-svg-prop {
+  --kubernetes-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M5.374 15c-.335 0-.66-.153-.874-.431l-3.254-4.172a1.15 1.15 0 01-.214-.978l1.165-5.207c.074-.345.298-.623.605-.776l4.715-2.32c.15-.078.317-.116.485-.116.168 0 .335.038.485.115L13.2 3.426c.308.153.532.432.606.777l1.165 5.207c.074.345 0 .7-.214.978L11.5 14.566c-.214.268-.54.434-.875.434h-5.25zm7.718-5.835l.031.008a.308.308 0 01.26.371.306.306 0 01-.396.223h-.004l-.003-.001-.003-.001-.03-.007-.05-.01a2.548 2.548 0 01-.274-.106 2.87 2.87 0 00-.533-.156.242.242 0 00-.171.063 4.76 4.76 0 00-.131-.023 3.972 3.972 0 01-1.764 2.212c.015.042.032.083.051.123a.239.239 0 00-.023.18c.074.17.165.332.271.484.06.078.114.16.164.244l.028.057.012.025a.306.306 0 01-.381.44.307.307 0 01-.172-.18 2.608 2.608 0 00-.01-.02l-.028-.058a2.545 2.545 0 01-.089-.28 2.835 2.835 0 00-.21-.512.242.242 0 00-.156-.095 5.926 5.926 0 01-.03-.053l-.035-.064a3.97 3.97 0 01-2.824-.007l-.069.125a.249.249 0 00-.132.064c-.104.17-.184.355-.237.548a2.525 2.525 0 01-.088.28l-.025.05-.013.027v.001a.307.307 0 11-.553-.261l.014-.03.026-.052c.05-.085.104-.166.164-.244.108-.156.2-.322.277-.496a.302.302 0 00-.028-.173l.056-.133A3.972 3.972 0 014.22 9.532l-.134.023a.34.34 0 00-.176-.062 2.872 2.872 0 00-.533.156c-.09.04-.181.075-.274.105l-.05.011-.03.007H3.02l-.002.002h-.005a.308.308 0 01-.397-.349.306.306 0 01.261-.245l.004-.001h.003l.006-.002c.024-.006.054-.014.076-.018.097-.013.195-.021.293-.023.186-.013.37-.043.549-.09a.422.422 0 00.131-.133l.128-.037a3.938 3.938 0 01.624-2.752l-.097-.087a.338.338 0 00-.062-.176 2.854 2.854 0 00-.455-.319 2.557 2.557 0 01-.254-.148 1.129 1.129 0 01-.063-.05l-.004-.004a.323.323 0 01-.076-.45.295.295 0 01.244-.107.365.365 0 01.213.08l.022.017c.016.013.034.026.046.037.071.067.139.139.202.213.125.137.263.262.412.372.056.03.121.036.182.018l.11.078a3.938 3.938 0 012.552-1.224l.007-.129a.332.332 0 00.1-.157 2.844 2.844 0 00-.034-.554 2.555 2.555 0 01-.042-.29v-.053-.025-.004-.004A.306.306 0 018 2.82a.308.308 0 01.306.337v.087a2.53 2.53 0 01-.041.29 2.85 2.85 0 00-.035.553.242.242 0 00.1.153v.007l.007.13c.967.087 1.87.522 2.54 1.223l.116-.083a.34.34 0 00.186-.02c.149-.11.287-.235.412-.373a2.53 2.53 0 01.202-.213l.051-.04.017-.014a.308.308 0 01.472.388.307.307 0 01-.09.09c-.008.005-.017.012-.025.02l-.043.033a2.549 2.549 0 01-.254.148 2.865 2.865 0 00-.455.32.24.24 0 00-.058.172 4.458 4.458 0 01-.05.044l-.058.053c.542.806.769 1.783.637 2.745l.123.036c.031.056.077.101.132.132.18.048.364.078.55.09.097.003.195.01.292.024l.058.013zm-2.875-3.1l-1.308.925-.004-.002a.27.27 0 01-.43-.205v-.001l-.091-1.598a3.183 3.183 0 011.833.882zM7.754 7.818h.492l.306.381-.11.476L8 8.886l-.443-.213-.11-.475.307-.381zM7.29 5.24c.107-.024.216-.043.326-.056l-.09 1.6-.008.004a.268.268 0 01-.293.256.27.27 0 01-.135-.05l-.002.001-1.316-.93c.419-.41.945-.696 1.518-.825zM5.296 6.663l1.201 1.071-.001.007a.269.269 0 01-.106.462l-.001.005-1.54.443a3.134 3.134 0 01.447-1.988zm1.608 2.846l-.612 1.474a3.16 3.16 0 01-1.27-1.586L6.6 9.13l.003.003a.265.265 0 01.18.029.27.27 0 01.117.341l.004.006zm1.806 1.896c-.572.13-1.17.1-1.726-.088l.777-1.4h.001a.27.27 0 01.475-.001h.006l.779 1.402a3.286 3.286 0 01-.312.087zm1.004-.416L9.096 9.5l.001-.003a.269.269 0 01.296-.37l.003-.004 1.593.269a3.147 3.147 0 01-1.275 1.597zm1.442-2.343L9.61 8.201l-.002-.006a.27.27 0 01-.185-.343.27.27 0 01.08-.12L9.5 7.73l1.195-1.067c.366.594.527 1.29.46 1.983z" clip-rule="evenodd"/></svg>');
+}
+
+%kubernetes-24-svg-prop {
+  --kubernetes-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M8.249 22c-.48 0-.943-.22-1.249-.616l-4.648-5.96a1.644 1.644 0 01-.306-1.397L3.71 6.59c.106-.493.426-.89.865-1.11l6.736-3.315c.213-.11.452-.164.692-.164.24 0 .479.055.692.164l6.736 3.302c.439.219.758.616.865 1.11l1.664 7.438c.106.493 0 1-.306 1.397L17 21.38c-.306.384-.77.62-1.25.62H8.249zm11.025-8.335l.045.01a.439.439 0 01.294.695.437.437 0 01-.488.155l-.007-.001-.004-.002a6.82 6.82 0 00-1.703-.342 5.673 5.673 0 01-2.52 3.16c.021.06.046.12.074.176a.342.342 0 00-.034.257c.106.243.236.474.388.692.084.111.162.227.234.347l.04.082.017.036a.438.438 0 01-.695.526.439.439 0 01-.095-.154l-.015-.03-.04-.082a3.632 3.632 0 01-.126-.399 4.058 4.058 0 00-.3-.733.345.345 0 00-.223-.135l-.043-.076-.05-.092a5.67 5.67 0 01-4.034-.01l-.099.179a.356.356 0 00-.188.091 3.044 3.044 0 00-.339.783 3.594 3.594 0 01-.126.4 1.764 1.764 0 01-.054.11v.002a.436.436 0 01-.425.29.442.442 0 01-.409-.311.436.436 0 01.044-.352l.02-.043a1.69 1.69 0 01.036-.074c.072-.121.15-.237.235-.349.154-.223.286-.46.395-.709a.431.431 0 00-.039-.246l.08-.19a5.674 5.674 0 01-2.52-3.138l-.191.033a.486.486 0 00-.251-.088 4.1 4.1 0 00-.762.223 3.704 3.704 0 01-.392.15l-.071.016a3.181 3.181 0 00-.042.01h-.005l-.004.002h-.006a.44.44 0 01-.568-.498.437.437 0 01.374-.35l.006-.002.004-.001.008-.002c.035-.009.077-.02.108-.025.14-.02.28-.03.42-.034a4.09 4.09 0 00.783-.128.603.603 0 00.188-.19l.183-.052a5.626 5.626 0 01.892-3.931l-.14-.125a.483.483 0 00-.088-.251 4.077 4.077 0 00-.65-.456 3.653 3.653 0 01-.363-.211 1.616 1.616 0 01-.09-.073L5.936 8.2a.462.462 0 01-.107-.642.42.42 0 01.348-.154.522.522 0 01.336.139l.066.053c.102.096.198.198.288.305.178.195.376.373.589.53.08.042.173.051.26.026.051.037.104.075.157.111A5.626 5.626 0 0111.52 6.82l.01-.184a.475.475 0 00.142-.225c.01-.265-.007-.53-.049-.79a3.644 3.644 0 01-.06-.415l.001-.076v-.036-.005-.007a.437.437 0 01.615-.444.44.44 0 01.259.444v.046c.001.027.002.056 0 .078-.011.139-.031.277-.059.414a4.063 4.063 0 00-.05.79.345.345 0 00.143.218v.011l.01.184a5.734 5.734 0 013.629 1.748l.166-.119c.09.016.181.006.265-.028.213-.158.41-.336.59-.532.09-.107.186-.209.288-.305l.073-.058.024-.019a.44.44 0 11.544.682l-.035.028-.061.05a3.638 3.638 0 01-.363.21c-.231.13-.449.283-.65.456a.344.344 0 00-.082.247 7.827 7.827 0 01-.155.138 5.65 5.65 0 01.91 3.922l.177.051a.49.49 0 00.188.19c.257.068.52.11.784.128.14.003.28.014.419.034.023.004.054.011.082.018zm-4.108-4.428l-1.867 1.32-.007-.003a.386.386 0 01-.612-.293l-.002-.001-.13-2.282a4.546 4.546 0 012.618 1.259zm-3.518 2.501h.703l.437.545-.157.68-.631.303-.633-.304-.157-.68.438-.544zm-.661-3.68a4.64 4.64 0 01.466-.08l-.13 2.285-.01.005a.383.383 0 01-.419.366.387.387 0 01-.192-.072l-.004.003-1.88-1.33a4.505 4.505 0 012.169-1.177zm-2.85 2.032l1.716 1.53-.002.01a.384.384 0 01-.151.66l-.002.007-2.2.633c-.11-.991.115-1.99.639-2.84zm2.298 4.066l-.874 2.106a4.514 4.514 0 01-1.816-2.266L10 13.614l.003.005a.376.376 0 01.257.04.385.385 0 01.167.488l.007.009zm2.58 2.708a4.531 4.531 0 01-2.466-.126l1.11-2h.001a.385.385 0 01.679 0h.008l1.113 2.003c-.145.048-.293.089-.445.123zm1.433-.594l-.883-2.127.003-.004a.384.384 0 01.423-.53l.004-.004 2.275.383a4.497 4.497 0 01-1.822 2.282zm2.061-3.347l-2.21-.635-.003-.01a.386.386 0 01-.264-.489.386.386 0 01.113-.17v-.005l1.706-1.523a4.56 4.56 0 01.658 2.832z" clip-rule="evenodd"/></svg>');
+}
+
+%kubernetes-color-16-svg-prop {
+  --kubernetes-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23326DE6" d="M4.5 14.569c.214.278.539.431.874.431h5.251c.335 0 .66-.165.875-.434l3.258-4.178c.214-.278.288-.633.214-.978l-1.165-5.207a1.128 1.128 0 00-.606-.777l-4.714-2.31A1.062 1.062 0 008.002 1c-.168 0-.335.038-.485.115l-4.715 2.32a1.129 1.129 0 00-.605.777L1.032 9.42c-.084.345 0 .7.214.978L4.5 14.568z"/><path fill="%23fff" fill-rule="evenodd" d="M12.741 9.128c.098.003.196.01.293.024a1.043 1.043 0 01.09.02.307.307 0 11-.137.595h-.004l-.003-.001-.003-.001-.03-.007a.915.915 0 01-.05-.01 2.55 2.55 0 01-.274-.106 2.867 2.867 0 00-.533-.156.243.243 0 00-.171.063 4.656 4.656 0 00-.131-.023 3.971 3.971 0 01-1.764 2.212c.015.042.032.083.051.123a.239.239 0 00-.023.18c.074.17.165.332.27.484.06.078.115.16.165.244l.028.057.012.025a.305.305 0 01-.256.463.31.31 0 01-.297-.203l-.01-.02a1.57 1.57 0 01-.028-.058 2.553 2.553 0 01-.089-.28 2.835 2.835 0 00-.21-.512.242.242 0 00-.156-.095 5.926 5.926 0 01-.03-.053l-.035-.064a3.97 3.97 0 01-2.824-.007l-.069.125a.249.249 0 00-.132.064 2.13 2.13 0 00-.237.548 2.52 2.52 0 01-.088.28l-.025.05-.013.027v.001a.306.306 0 01-.421.173.307.307 0 01-.132-.434l.014-.03.026-.052c.05-.085.104-.166.164-.244.107-.156.2-.322.276-.496a.302.302 0 00-.027-.173l.056-.133A3.972 3.972 0 014.22 9.532l-.134.023a.34.34 0 00-.176-.062 2.872 2.872 0 00-.533.156c-.09.04-.181.075-.275.105l-.05.011-.029.007H3.02l-.002.002h-.005a.308.308 0 01-.397-.349.306.306 0 01.261-.245l.004-.001h.003l.006-.002c.024-.006.054-.014.076-.018.097-.013.195-.021.293-.023.186-.013.37-.043.549-.09a.422.422 0 00.131-.133l.128-.037a3.938 3.938 0 01.624-2.752l-.098-.087a.338.338 0 00-.061-.176 2.854 2.854 0 00-.455-.319 2.555 2.555 0 01-.254-.148l-.048-.038-.015-.012-.005-.004a.323.323 0 01-.075-.45.295.295 0 01.244-.107.365.365 0 01.213.08l.022.017c.016.013.034.026.046.037.071.067.139.139.202.213.125.137.263.262.412.372.056.03.121.036.182.018a5.2 5.2 0 00.11.078 3.938 3.938 0 012.552-1.224l.007-.129a.332.332 0 00.1-.157 2.844 2.844 0 00-.034-.554 2.555 2.555 0 01-.042-.29v-.082-.004A.306.306 0 018 2.82a.308.308 0 01.306.337v.087a2.533 2.533 0 01-.041.29 2.85 2.85 0 00-.035.553.242.242 0 00.1.153v.007l.007.13c.967.087 1.87.522 2.54 1.223l.116-.083c.063.01.127.003.186-.02.149-.11.287-.235.412-.373.063-.074.13-.146.202-.213l.051-.04.017-.014a.307.307 0 11.381.477 1.962 1.962 0 00-.067.054 2.547 2.547 0 01-.255.148 2.86 2.86 0 00-.454.32.241.241 0 00-.058.172 7.481 7.481 0 01-.05.044l-.058.053c.542.806.769 1.783.637 2.745l.123.036c.031.056.077.101.132.132.18.048.364.078.55.09zM7.291 5.24c.107-.024.216-.043.326-.056l-.091 1.6-.007.004a.268.268 0 01-.293.256.27.27 0 01-.135-.05l-.002.001-1.316-.93c.419-.41.945-.696 1.518-.825zm1.618 1.75l1.307-.924a3.182 3.182 0 00-1.832-.882l.09 1.598h.002a.268.268 0 00.294.256.27.27 0 00.134-.05l.005.002zm2.247 1.656L9.61 8.201l-.002-.006a.27.27 0 01-.185-.343.27.27 0 01.08-.12L9.5 7.73l1.195-1.067c.365.594.527 1.29.46 1.983zm-2.06.854l.618 1.49a3.148 3.148 0 001.275-1.598l-1.593-.269-.003.004a.26.26 0 00-.165.022.27.27 0 00-.13.348l-.002.003zm-.386 1.905c-.572.13-1.17.1-1.726-.088l.777-1.4h.001a.27.27 0 01.475-.001h.006l.779 1.402a3.286 3.286 0 01-.312.087zm-2.418-.422l.612-1.474-.004-.006a.268.268 0 00-.297-.37L6.6 9.13l-1.579.267a3.16 3.16 0 001.271 1.586zm-.996-4.32l1.201 1.071-.001.007a.269.269 0 01-.106.462l-.001.005-1.54.443a3.134 3.134 0 01.447-1.988zm2.95 1.154h-.493l-.306.38.11.476.443.213.442-.212.11-.476-.306-.381z" clip-rule="evenodd"/></svg>');
+}
+
+%kubernetes-color-24-svg-prop {
+  --kubernetes-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23326DE6" d="M7 21.384c.306.397.77.616 1.249.616h7.501c.48 0 .944-.236 1.25-.62l4.654-5.969a1.69 1.69 0 00.306-1.397l-1.664-7.439a1.612 1.612 0 00-.865-1.11l-6.736-3.3A1.517 1.517 0 0012.003 2c-.24 0-.48.055-.692.164L4.575 5.48c-.44.22-.759.617-.865 1.11l-1.664 7.438c-.12.494 0 1 .306 1.398L7 21.384z"/><path fill="%23fff" fill-rule="evenodd" d="M18.773 13.612c.14.003.28.014.419.033a1.424 1.424 0 01.127.03.439.439 0 01.294.695.437.437 0 01-.488.155l-.007-.001-.004-.002-.004-.001-.043-.01-.07-.014a3.664 3.664 0 01-.392-.151 4.094 4.094 0 00-.762-.224.346.346 0 00-.245.09 6.82 6.82 0 00-.187-.032 5.674 5.674 0 01-2.52 3.16c.021.06.046.119.074.176a.342.342 0 00-.034.257c.106.243.236.474.388.692.084.111.162.227.234.347l.04.082.017.036a.437.437 0 01-.545.629.44.44 0 01-.245-.257l-.015-.03-.04-.082a3.625 3.625 0 01-.126-.4 4.058 4.058 0 00-.3-.732.346.346 0 00-.223-.135l-.043-.076-.05-.092c-1.3.491-2.736.488-4.034-.01l-.099.179a.356.356 0 00-.188.091 3.044 3.044 0 00-.339.783 3.6 3.6 0 01-.126.4l-.035.073-.019.037v.002a.437.437 0 01-.602.248.439.439 0 01-.188-.621l.02-.043.036-.075c.072-.12.15-.236.235-.348.154-.223.286-.46.395-.709a.432.432 0 00-.039-.246l.08-.19a5.674 5.674 0 01-2.52-3.138l-.191.033a.485.485 0 00-.251-.088c-.261.05-.516.124-.762.223a3.683 3.683 0 01-.392.15l-.071.016c-.015.003-.03.006-.042.01h-.005l-.004.002h-.006a.44.44 0 01-.568-.498.437.437 0 01.374-.35l.006-.002.004-.001.008-.002c.035-.009.077-.02.108-.025.14-.02.28-.03.42-.034.264-.017.527-.06.783-.129a.603.603 0 00.188-.188l.183-.053a5.626 5.626 0 01.892-3.931l-.14-.125a.483.483 0 00-.088-.251 4.077 4.077 0 00-.65-.456 3.655 3.655 0 01-.363-.212 1.61 1.61 0 01-.069-.055l-.02-.017-.008-.005a.462.462 0 01-.107-.642.42.42 0 01.348-.154.522.522 0 01.305.115l.03.024.067.053c.102.096.198.198.288.305.178.195.376.373.589.53.08.042.173.051.26.026.051.037.104.075.157.111A5.626 5.626 0 0111.52 6.82l.01-.184a.474.474 0 00.142-.225c.01-.265-.007-.53-.049-.79a3.644 3.644 0 01-.06-.415l.001-.076V5.089v-.007a.437.437 0 01.615-.444.44.44 0 01.259.444v.046c.001.027.002.056 0 .078-.011.139-.031.277-.059.414a4.063 4.063 0 00-.05.79.345.345 0 00.143.218v.011l.01.184A5.734 5.734 0 0116.11 8.57l.166-.119c.09.016.181.006.265-.028.213-.158.41-.336.59-.532.09-.107.186-.209.288-.305l.073-.058.024-.019a.44.44 0 11.544.682l-.035.028-.061.05a3.634 3.634 0 01-.363.21c-.231.13-.449.283-.65.456a.344.344 0 00-.082.247 8.03 8.03 0 01-.155.138 5.65 5.65 0 01.91 3.922l.177.051a.49.49 0 00.188.19c.257.068.52.11.784.128zm-7.786-5.554a4.64 4.64 0 01.466-.08l-.13 2.285-.01.005a.383.383 0 01-.419.366.386.386 0 01-.192-.072l-.004.003-1.88-1.33a4.505 4.505 0 012.169-1.177zm2.312 2.5l1.867-1.321a4.546 4.546 0 00-2.618-1.26l.13 2.283h.002a.383.383 0 00.42.366.386.386 0 00.192-.072l.007.003zm3.21 2.365l-2.21-.635-.003-.01a.386.386 0 01-.264-.489.385.385 0 01.113-.17v-.005l1.706-1.523a4.56 4.56 0 01.658 2.832zm-2.944 1.22l.883 2.127a4.497 4.497 0 001.822-2.282l-2.275-.383-.004.004a.37.37 0 00-.236.032.385.385 0 00-.187.498l-.003.004zm-.55 2.721a4.531 4.531 0 01-2.466-.126l1.11-2h.001a.386.386 0 01.679-.001h.008l1.113 2.004c-.145.048-.293.089-.445.123zm-3.454-.602l.874-2.106-.007-.009a.383.383 0 00-.424-.528l-.003-.005-2.256.382c.338.934.977 1.73 1.816 2.266zM8.137 10.09l1.716 1.53-.002.01a.384.384 0 01-.151.66l-.002.007-2.2.633c-.11-.991.115-1.99.639-2.84zm4.214 1.648h-.703l-.438.544.157.68.633.303.631-.302.157-.68-.437-.545z" clip-rule="evenodd"/></svg>');
+}
+
+%labyrinth-16-svg-prop {
+  --labyrinth-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M8 1.5a6.502 6.502 0 00-6.392 5.317.75.75 0 01-1.476-.27 8 8 0 110 2.907.75.75 0 111.476-.272A6.502 6.502 0 0014.48 8.5h-1.555a4.95 4.95 0 11-6.34-5.231.7.7 0 11.4 1.342A3.558 3.558 0 004.595 7h1.167a2.45 2.45 0 113.87 2.826.7.7 0 11-.933-1.043 1.05 1.05 0 10-1.4 0 .7.7 0 11-.934 1.043A2.45 2.45 0 015.601 8.5H4.483a3.55 3.55 0 104.531-3.89.7.7 0 11.4-1.341 4.958 4.958 0 013.432 3.73h1.578A6.501 6.501 0 008 1.5z"/></svg>');
+}
+
+%labyrinth-24-svg-prop {
+  --labyrinth-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M1.694 10.094C2.59 5.216 6.864 1.52 12 1.52c5.45 0 9.929 4.16 10.432 9.479h-2.525a7.977 7.977 0 00-5.63-6.639.75.75 0 10-.428 1.438A6.469 6.469 0 115.55 12.5h2.543c.122.964.593 1.82 1.28 2.435a.75.75 0 101.001-1.118 2.437 2.437 0 113.25 0 .75.75 0 001 1.118A3.938 3.938 0 108.19 11H5.609a6.477 6.477 0 014.543-5.201.75.75 0 10-.427-1.438 7.969 7.969 0 1010.23 8.139h2.513c-.26 5.555-4.847 9.98-10.467 9.98-5.136 0-9.41-3.697-10.306-8.574a.75.75 0 00-1.476.271C1.243 19.754 6.127 23.98 12 23.98c6.616 0 11.98-5.363 11.98-11.98C23.98 5.385 18.615.022 12 .022 6.127.02 1.243 4.246.218 9.823a.75.75 0 101.476.27z"/></svg>');
+}
+
+%layers-16-svg-prop {
+  --layers-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M7.656.084a.75.75 0 01.689 0l7.25 3.75a.75.75 0 010 1.332l-7.25 3.75a.75.75 0 01-.69 0l-7.25-3.75a.75.75 0 010-1.332l7.25-3.75zM2.383 4.5L8 7.405 13.617 4.5 8 1.594 2.383 4.5z" clip-rule="evenodd"/><path d="M.093 10.887a.75.75 0 011.02-.294L8 14.393l6.888-3.8a.75.75 0 11.724 1.313l-7.25 4a.75.75 0 01-.724 0l-7.25-4a.75.75 0 01-.295-1.019z"/><path d="M1.112 7.093a.75.75 0 10-.724 1.313l7.25 4a.75.75 0 00.724 0l7.25-4a.75.75 0 00-.724-1.313L8 10.893l-6.888-3.8z"/></g></svg>');
+}
+
+%layers-24-svg-prop {
+  --layers-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M11.658 1.082a.75.75 0 01.684 0l10.25 5.25a.75.75 0 010 1.336l-10.25 5.25a.75.75 0 01-.684 0l-10.25-5.25a.75.75 0 010-1.336l10.25-5.25zM3.395 7L12 11.407 20.605 7 12 2.593 3.395 7z" clip-rule="evenodd"/><path d="M1.089 16.395a.75.75 0 011.016-.306L12 21.399l9.895-5.31a.75.75 0 01.71 1.322l-10.25 5.5a.75.75 0 01-.71 0l-10.25-5.5a.75.75 0 01-.306-1.016z"/><path d="M2.105 11.089a.75.75 0 00-.71 1.322l10.25 5.5a.75.75 0 00.71 0l10.25-5.5a.75.75 0 00-.71-1.322L12 16.399l-9.895-5.31z"/></g></svg>');
 }
 
 %layers-svg-prop {
   --layers-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.815 18.637l-.101.029c-.169.043-.34.064-.51.064H12.103l-.09-.007a1.74 1.74 0 01-.319-.054l-.061-.01-.163-.058c-.108-.043-3.833-1.667-6.675-2.907l-2.559 1.328a.422.422 0 00-.184.149.329.329 0 00-.044.256v.01c.011.042.03.08.055.117.006.008.006.018.013.026l.007.007c.018.021.042.038.066.056.025.021.049.041.078.057.002 0 .005.004.007.005.128.059 9.629 4.205 9.76 4.258.01.005.02.004.03.007a.506.506 0 00.315.012l.023-.008c.03-.01.062-.015.09-.03l9.319-4.833c.015-.006.023-.019.036-.026a.461.461 0 00.125-.115c.008-.011.02-.018.026-.03.007-.01.006-.023.012-.034a.368.368 0 00.029-.151.323.323 0 00-.013-.072.343.343 0 00-.03-.076c-.006-.011-.006-.023-.013-.034-.008-.01-.02-.018-.03-.028a.445.445 0 00-.134-.106c-.014-.007-.023-.018-.037-.024l-2.479-1.082-6.128 3.178a1.403 1.403 0 01-.321.126z" fill="%23000"/><path fill-rule="evenodd" clip-rule="evenodd" d="M12.819 13.873l-.095.028a2.104 2.104 0 01-.531.067h-.073l-.106-.008c-.1-.006-.22-.027-.342-.06l-.056-.01-.145-.05a2798 2798 0 01-6.674-2.909l-2.56 1.33a.423.423 0 00-.184.148.33.33 0 00-.044.257v.01c.011.041.03.079.055.116.006.008.006.017.013.026.002.004.005.005.007.007.018.021.042.039.066.057.025.02.049.041.078.056l.007.005c.128.06 9.629 4.206 9.76 4.26.01.003.02.002.03.006a.506.506 0 00.135.028l.033.001a.542.542 0 00.17-.026c.03-.01.062-.014.09-.03l9.319-4.832c.015-.008.023-.019.036-.027a.489.489 0 00.125-.114c.008-.012.02-.019.026-.03.007-.011.006-.023.012-.035a.362.362 0 00.029-.15.311.311 0 00-.013-.072.333.333 0 00-.03-.076c-.006-.012-.006-.023-.013-.034-.008-.011-.02-.018-.03-.028a.412.412 0 00-.134-.107c-.014-.007-.023-.017-.037-.024l-2.478-1.082-6.129 3.178a1.462 1.462 0 01-.317.124z" fill="%23000"/><path fill-rule="evenodd" clip-rule="evenodd" d="M12.029 2.045c-.018-.008-.036-.01-.053-.015A.45.45 0 0011.79 2a.44.44 0 00-.182.04c-.01.005-.023.005-.034.01-.123.064-8.853 4.87-9.338 5.141a.433.433 0 00-.184.157.37.37 0 00-.044.273v.01c.011.045.03.085.055.124.006.01.006.02.013.029l.007.006c.018.024.042.041.066.06.025.022.049.044.078.06a5453.121 5453.121 0 009.766 4.528c.011.004.021.004.031.007a.482.482 0 00.315.012l.023-.008c.03-.01.062-.016.09-.033l9.319-5.13c.015-.008.023-.02.036-.029a.464.464 0 00.125-.122c.008-.011.02-.019.026-.032.007-.011.006-.023.012-.035A.435.435 0 0022 6.907a.345.345 0 00-.013-.076.367.367 0 00-.03-.081c-.006-.012-.006-.024-.013-.035-.008-.013-.02-.02-.03-.03a.457.457 0 00-.134-.113c-.014-.008-.023-.02-.037-.026l-9.714-4.501z" fill="%23000"/></svg>');
 }
 
+%layout-16-svg-prop {
+  --layout-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h9.5A2.25 2.25 0 0115 3.25v9.5A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-9.5zM6.5 13.5h6.25a.75.75 0 00.75-.75V6.5h-7v7zM5 6.5v7H3.25a.75.75 0 01-.75-.75V6.5H5zM13.5 5V3.25a.75.75 0 00-.75-.75h-9.5a.75.75 0 00-.75.75V5h11z" clip-rule="evenodd"/></svg>');
+}
+
+%layout-24-svg-prop {
+  --layout-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2h14.5A2.75 2.75 0 0122 4.75v14.5A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25V4.75zM9 20.5h10.25c.69 0 1.25-.56 1.25-1.25V9.5H9v11zm-1.5-11v11H4.75c-.69 0-1.25-.56-1.25-1.25V9.5h4zm13-1.5V4.75c0-.69-.56-1.25-1.25-1.25H4.75c-.69 0-1.25.56-1.25 1.25V8h17z" clip-rule="evenodd"/></svg>');
+}
+
+%learn-16-svg-prop {
+  --learn-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8.316 2.07a.75.75 0 00-.632 0l-7 3.25a.75.75 0 000 1.36l1.434.666A.746.746 0 002 7.75V11a.75.75 0 00.158.46L2.75 11l-.592.46.001.002.001.001.003.004.008.01a1.882 1.882 0 00.103.12c.068.076.165.178.292.299.254.24.63.555 1.132.866C4.706 13.388 6.217 14 8.25 14c2.037 0 3.44-.615 4.345-1.266a5.32 5.32 0 00.977-.902 3.916 3.916 0 00.322-.448l.007-.012.003-.004v-.002h.001c0-.001 0-.002-.655-.366l.655.365A.754.754 0 0014 11V7.75a.747.747 0 00-.118-.404l1.434-.666a.75.75 0 000-1.36l-7-3.25zM12.5 7.988L8.316 9.93a.75.75 0 01-.632 0L3.5 7.988v2.723a5.585 5.585 0 00.99.776c.804.5 2.043 1.013 3.76 1.013 1.713 0 2.81-.51 3.468-.984a3.812 3.812 0 00.782-.745V7.988zM8 8.423L2.781 6 8 3.577 13.219 6 8 8.423z" clip-rule="evenodd"/></svg>');
+}
+
+%learn-24-svg-prop {
+  --learn-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12.367 3.096a.75.75 0 00-.734 0l-10.25 5.75a.75.75 0 000 1.308l2.82 1.582A.747.747 0 004 12.25v5a.75.75 0 00.12.407l.63-.407-.63.408.001.001.002.002.003.005.009.013a2.202 2.202 0 00.118.162c.08.1.194.237.348.397.308.321.774.736 1.427 1.147C7.34 20.21 9.378 21 12.345 21c2.968 0 4.854-.79 6.018-1.646a5.597 5.597 0 001.209-1.193 3.945 3.945 0 00.339-.553 1.8 1.8 0 00.02-.043l.007-.016.002-.006.001-.002v-.001s.001-.002-.691-.29l.692.288A.75.75 0 0020 17.25v-5a.747.747 0 00-.203-.514l2.82-1.582a.75.75 0 000-1.308l-10.25-5.75zm6.133 9.368l-6.133 3.44a.75.75 0 01-.734 0L5.5 12.464v4.533c.047.055.107.124.182.202.233.242.605.577 1.144.916 1.072.675 2.833 1.385 5.52 1.385 2.686 0 4.252-.71 5.128-1.354.442-.325.722-.644.887-.87.061-.084.107-.155.139-.21v-4.602zM12 14.39L3.283 9.5 12 4.61l8.717 4.89L12 14.39z" clip-rule="evenodd"/></svg>');
+}
+
+%learn-link-16-svg-prop {
+  --learn-link-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M12.75 0a.75.75 0 000 1.5h.69l-1.97 1.97a.75.75 0 001.06 1.06l1.97-1.97v.69a.75.75 0 001.5 0V.75a.75.75 0 00-.75-.75h-2.5z"/><path fill-rule="evenodd" d="M8.075 4.074a.75.75 0 00-.65 0l-6.75 3.25a.75.75 0 000 1.352L2 9.314v3.511a.75.75 0 00.064.302l.686-.302c-.686.302-.686.304-.686.304l.002.004.003.006.006.013a1.268 1.268 0 00.075.139c.047.08.116.184.21.303.19.238.483.533.917.82.871.575 2.265 1.086 4.45 1.086 2.177 0 3.487-.508 4.271-1.122.39-.305.632-.623.78-.884a2.194 2.194 0 00.19-.447l.01-.041.004-.017.001-.007.001-.003v-.001s0-.002-.734-.153l.735.151c.01-.05.015-.1.015-.151v-3.27l1.825-.88a.75.75 0 000-1.35l-6.75-3.25zm3.425 6.203l-3.425 1.649a.75.75 0 01-.65 0L3.5 10.036v2.579l.033.043c.098.123.276.309.57.504.585.386 1.679.838 3.623.838 1.95 0 2.902-.454 3.348-.803.225-.176.34-.34.396-.44a.878.878 0 00.03-.057v-2.423zm-3.75.14L2.729 8 7.75 5.582 12.771 8 7.75 10.418z" clip-rule="evenodd"/></g></svg>');
+}
+
+%learn-link-24-svg-prop {
+  --learn-link-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M18.75 1a.75.75 0 000 1.5h1.69l-2.97 2.97a.75.75 0 001.06 1.06l2.97-2.97v1.69a.75.75 0 001.5 0v-3.5a.75.75 0 00-.75-.75h-3.5z"/><path fill-rule="evenodd" d="M11.856 5.09a.75.75 0 00-.712 0l-9.75 5.25a.75.75 0 000 1.32l2.627 1.415A.752.752 0 004 13.25v5.333a.75.75 0 00.067.31l.683-.31-.683.31v.002l.002.003.003.006.007.016a1.657 1.657 0 00.094.168c.061.101.151.234.277.387.251.308.643.694 1.23 1.072C6.857 21.306 8.772 22 11.82 22c3.043 0 4.827-.692 5.87-1.487.52-.397.838-.806 1.029-1.138a2.714 2.714 0 00.244-.557c.005-.018.01-.034.012-.048l.005-.018.001-.007.001-.004v-.001s0-.002-.733-.157l.734.155a.752.752 0 00.016-.155V13.25c0-.06-.007-.12-.02-.175l2.626-1.415a.75.75 0 000-1.32l-9.75-5.25zM17.5 13.87l-5.644 3.04a.75.75 0 01-.712 0L5.5 13.87v4.508c.028.04.064.09.11.146.158.192.434.472.882.761.892.575 2.513 1.214 5.33 1.214 2.823 0 4.253-.641 4.959-1.18a2.41 2.41 0 00.64-.695c.039-.067.064-.121.079-.159v-4.595zm-6 1.527L3.332 11 11.5 6.602 19.668 11 11.5 15.398z" clip-rule="evenodd"/></g></svg>');
+}
+
 %learn-svg-prop {
   --learn-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12.409 5.273l8.915 3.958c.46.204.676.681.676 1.108 0 .427-.216.904-.676 1.108l-3.111 1.381v3.767c0 .145-.05.279-.134.385-.157.35-.434.633-.743.858-.377.274-.855.502-1.39.684-1.073.365-2.462.578-3.963.578-1.5 0-2.89-.213-3.962-.578-.536-.182-1.014-.41-1.39-.684-.31-.225-.586-.509-.744-.858a.618.618 0 0 1-.133-.385v-2.824l.029-.945L5.5 12.5c-.38.525-.897 1.436-1.023 2.536a1.122 1.122 0 0 1 .007 1.912 3.343 3.343 0 0 1-.039.813h.028c0 .004.003.028.016.074.015.052.04.119.077.196.074.156.186.333.327.497.3.35.628.533.9.533L5.014 20c-.346 0-.726-.252-1.14-.756-.583.504-1.04.756-1.374.756l-.404-.987c.37 0 .703-.266.938-.812.112-.26.181-.546.207-.806.02-.165.014-.332-.017-.496a1.121 1.121 0 0 1 .329-1.976c.134-1.173.522-2.041.942-2.668l-1.819-.808C2.216 11.243 2 10.766 2 10.34c0-.427.216-.904.676-1.108l8.915-3.958c.262-.116.556-.116.818 0v-.001zm-.432 3.745l-5.52 2.749L12 14.227l8.758-3.888L12 6.45l-8.758 3.89 2.11.937L11 8.5l.977.518zm4.994 4.362l-4.562 2.025a1.003 1.003 0 0 1-.818 0L7.01 13.371l-.013.429v2.6a.531.531 0 0 1 .008.027c.022.079.107.224.358.407.244.178.6.356 1.059.512.917.313 2.167.512 3.562.512s2.645-.2 3.563-.512c.46-.156.814-.334 1.058-.512.251-.183.336-.328.358-.407a.61.61 0 0 1 .009-.027l-.001-3.02zM17 2.5V1h6v6h-1.5V3.429L18.25 6.75 17 6l3.5-3.5H17z" fill="%23000"/></svg>');
+}
+
+%line-chart-16-svg-prop {
+  --line-chart-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2.25 1A2.25 2.25 0 000 3.25v9.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-9.5A2.25 2.25 0 0013.75 1H2.25zM1.5 3.25a.75.75 0 01.75-.75h11.5a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75H11V13a.75.75 0 00-1.5 0v.5h-3V13A.75.75 0 005 13v.5H2.25a.75.75 0 01-.75-.75v-1.19l4.636-3.708 3.586 1.345a.752.752 0 00.76-.122l2.487-1.99a.75.75 0 10-.938-1.17L9.864 7.647 6.28 6.303a.754.754 0 00-.754.116L1.5 9.64V3.25z" clip-rule="evenodd"/></svg>');
+}
+
+%line-chart-24-svg-prop {
+  --line-chart-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M3.75 2A2.75 2.75 0 001 4.75v14.5A2.75 2.75 0 003.75 22h16.5A2.75 2.75 0 0023 19.25V4.75A2.75 2.75 0 0020.25 2H3.75zM2.5 16.353v2.897c0 .69.56 1.25 1.25 1.25H8v-.75a.75.75 0 011.5 0v.75h5v-.75a.75.75 0 011.5 0v.75h4.25c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H3.75c-.69 0-1.25.56-1.25 1.25v9.656l6.007-4.971a.748.748 0 01.842-.1l5.572 2.787L18.55 9.4a.75.75 0 11.9 1.2l-3.987 2.99a.754.754 0 01-.812.074l-5.55-2.775L2.5 16.353z" clip-rule="evenodd"/></svg>');
+}
+
+%line-chart-up-16-svg-prop {
+  --line-chart-up-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 3.25A2.25 2.25 0 012.25 1h11.5A2.25 2.25 0 0116 3.25v9.5A2.25 2.25 0 0113.75 15H2.25A2.25 2.25 0 010 12.75v-9.5zm2.25-.75a.75.75 0 00-.75.75v7.075L5.61 7.86a.73.73 0 01.278-.101.747.747 0 01.318.02L9.08 8.6l1.328-2.988-.9.405a.75.75 0 01-.615-1.368l2.58-1.16a.75.75 0 01.991.376l1.16 2.58a.75.75 0 01-1.367.615l-.428-.951-1.638 3.686a.75.75 0 01-.908.423L6.107 9.31 1.5 12.075v.675c0 .414.336.75.75.75H5V13a.75.75 0 011.5 0v.5h3V13a.75.75 0 011.5 0v.5h2.75a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75H2.25z" clip-rule="evenodd"/></svg>');
+}
+
+%line-chart-up-24-svg-prop {
+  --line-chart-up-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M1 4.75A2.75 2.75 0 013.75 2h16.5A2.75 2.75 0 0123 4.75v14.5A2.75 2.75 0 0120.25 22H3.75A2.75 2.75 0 011 19.25v-2.236V4.75zm1.5 12.644v1.856c0 .69.56 1.25 1.25 1.25H8v-.75a.75.75 0 011.5 0v.75h5v-.75a.75.75 0 011.5 0v.75h4.25c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H3.75c-.69 0-1.25.56-1.25 1.25v10.822l6.074-4.19a.746.746 0 01.721-.072l4.304 1.722 2.163-5.047-1.554.699a.75.75 0 01-.616-1.368l3.192-1.436a.75.75 0 01.992.376l1.436 3.192a.75.75 0 11-1.368.615l-.687-1.526-2.463 5.747a.75.75 0 01-.973.413l-4.626-1.851L2.5 17.394z" clip-rule="evenodd"/></svg>');
+}
+
+%link-16-svg-prop {
+  --link-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.141 1a3.893 3.893 0 00-2.738 1.093L7.314 3.175A.75.75 0 008.372 4.24l1.077-1.07a2.393 2.393 0 013.384 3.382l-1.881 1.88a2.393 2.393 0 01-3.608-.258.75.75 0 00-1.202.899 3.893 3.893 0 005.87.42l1.886-1.886.01-.009A3.893 3.893 0 0011.14 1z"/><path d="M7.019 5.365a3.893 3.893 0 00-3.032 1.13L2.102 8.382l-.01.01a3.893 3.893 0 005.505 5.504l1.084-1.084a.75.75 0 00-1.06-1.06l-1.07 1.07a2.393 2.393 0 01-3.384-3.384l1.881-1.88a2.393 2.393 0 013.609.258.75.75 0 101.2-.899A3.893 3.893 0 007.02 5.365z"/></g></svg>');
+}
+
+%link-24-svg-prop {
+  --link-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M16.575 2a5.48 5.48 0 00-3.848 1.531L11.094 5.15a.75.75 0 001.056 1.065l1.62-1.606a3.98 3.98 0 015.567.052 3.951 3.951 0 01.053 5.542l-2.829 2.82a3.974 3.974 0 01-3.094 1.15 3.984 3.984 0 01-2.898-1.577.75.75 0 10-1.2.9 5.47 5.47 0 003.991 2.174 5.486 5.486 0 004.26-1.585l2.834-2.824.009-.01a5.45 5.45 0 00-.067-7.652A5.48 5.48 0 0016.576 2z"/><path d="M10.64 8.33a5.486 5.486 0 00-4.26 1.585L3.545 12.74l-.009.01a5.45 5.45 0 00.067 7.652 5.48 5.48 0 007.67.067l1.624-1.62a.75.75 0 10-1.06-1.062l-1.61 1.605a3.98 3.98 0 01-5.565-.052 3.951 3.951 0 01-.053-5.543l2.829-2.82a3.973 3.973 0 013.094-1.15 3.984 3.984 0 012.898 1.578.75.75 0 001.2-.9A5.468 5.468 0 0010.64 8.33z"/></g></svg>');
 }
 
 %link-svg-prop {
   --link-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.073 10.015l-2.294 2.294a3.063 3.063 0 0 1-2.25.926c-.897 0-1.661-.323-2.294-.97l-.97.97c.647.633.97 1.401.97 2.305 0 .883-.305 1.63-.915 2.24l-2.272 2.282c-.61.625-1.36.938-2.25.938-.883 0-1.629-.305-2.24-.915l-1.62-1.61C3.312 17.863 3 17.117 3 16.234c0-.882.309-1.632.926-2.25l2.295-2.294a3.063 3.063 0 0 1 2.25-.926c.897 0 1.661.323 2.294.97l.97-.97a3.102 3.102 0 0 1-.97-2.305c0-.883.305-1.63.915-2.24l2.272-2.282c.61-.626 1.36-.938 2.25-.938.883 0 1.629.305 2.24.915l1.62 1.61c.625.611.938 1.357.938 2.24 0 .882-.309 1.632-.927 2.25zm-9.436 4.83l-.204.21a6.67 6.67 0 0 1-.237.238c-.044.04-.113.096-.209.166a.886.886 0 0 1-.583.182c-.294 0-.543-.103-.749-.31a1.025 1.025 0 0 1-.308-.75.89.89 0 0 1 .182-.586c.07-.096.124-.166.165-.21.04-.045.119-.124.236-.238l.21-.205A1.062 1.062 0 0 0 8.346 13c-.301 0-.55.1-.749.298l-2.29 2.299a1.025 1.025 0 0 0-.308.751c0 .287.103.534.308.74l1.619 1.614c.212.199.462.298.748.298.294 0 .543-.103.749-.31l2.268-2.287c.205-.206.308-.456.308-.751 0-.31-.121-.578-.363-.807zm8.055-7.944l-1.619-1.614A1.058 1.058 0 0 0 16.325 5c-.301 0-.55.1-.749.298l-2.268 2.288a1.025 1.025 0 0 0-.308.751c0 .31.121.578.363.807l.204-.21c.114-.118.193-.197.237-.238a2.61 2.61 0 0 1 .209-.166.885.885 0 0 1 .583-.182c.294 0 .543.103.749.31.205.206.308.456.308.75a.89.89 0 0 1-.182.586c-.07.096-.124.166-.165.21-.04.045-.119.124-.236.238l-.21.204c.22.236.485.354.793.354.294 0 .543-.103.749-.31l2.29-2.298c.205-.206.308-.456.308-.751 0-.287-.103-.534-.308-.74z" fill="%23000"/></svg>');
 }
 
+%list-16-svg-prop {
+  --list-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3 3.75A.75.75 0 013.75 3h8.5a.75.75 0 010 1.5h-8.5A.75.75 0 013 3.75zM3 7.75A.75.75 0 013.75 7h8.5a.75.75 0 010 1.5h-8.5A.75.75 0 013 7.75zM3.75 11a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5z"/></g></svg>');
+}
+
+%list-24-svg-prop {
+  --list-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M4.5 5.75A.75.75 0 015.25 5h13.5a.75.75 0 010 1.5H5.25a.75.75 0 01-.75-.75zM4.5 11.75a.75.75 0 01.75-.75h13.5a.75.75 0 010 1.5H5.25a.75.75 0 01-.75-.75zM5.25 17a.75.75 0 000 1.5h13.5a.75.75 0 000-1.5H5.25z"/></g></svg>');
+}
+
 %loading-svg-prop {
-  --loading-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" class="structure-icon-loading"><style>.structure-icon-loading-base{opacity:.1}.structure-icon-loading-progress{animation:structure-icon-loading-fancy-spin 3s infinite linear;opacity:.25;stroke-dasharray:0 44;stroke-dashoffset:0;stroke-linecap:round;transform-origin:50% 50%}@keyframes structure-icon-loading-fancy-spin{0%{stroke-dasharray:0 44;stroke-dashoffset:0}25%{stroke-dasharray:33 11;stroke-dashoffset:-40}50%{stroke-dasharray:0 44;stroke-dashoffset:-110}75%{stroke-dasharray:33 11;stroke-dashoffset:-150}to{stroke-dasharray:0 44;stroke-dashoffset:-220}}@keyframes structure-icon-loading-simple-spin{0%{transform:rotate(0deg)}to{transform:rotate(360deg)}}</style><defs><path stroke="%23000" stroke-width="3" fill="none" id="a" d="M12 5l6 3v8l-6 3-6-3V8z"/></defs><use xlink:href="%23a" class="structure-icon-loading-base"/><use xlink:href="%23a" class="structure-icon-loading-progress"/></svg>');
+  --loading-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" class="structure-icon-loading"><style>.structure-icon-loading-base{opacity:.1}.structure-icon-loading-progress{animation:structure-icon-loading-fancy-spin 3s infinite linear;opacity:.25;stroke-dasharray:0 44;stroke-dashoffset:0;stroke-linecap:round;transform-origin:50% 50%}@keyframes structure-icon-loading-fancy-spin{0%{stroke-dasharray:0 44;stroke-dashoffset:0}25%{stroke-dasharray:33 11;stroke-dashoffset:-40}50%{stroke-dasharray:0 44;stroke-dashoffset:-110}75%{stroke-dasharray:33 11;stroke-dashoffset:-150}to{stroke-dasharray:0 44;stroke-dashoffset:-220}}@keyframes structure-icon-loading-simple-spin{0%{transform:rotate(0deg)}to{transform:rotate(360deg)}}</style><defs><path stroke="%23000" stroke-width="3" fill="none" id="a" d="M12 5l6 3v8l-6 3-6-3V8z"/></defs><use xlink:href="%23a" class="structure-icon-loading-base"/><use xlink:href="%23a" class="structure-icon-loading-progress"/></svg>');
+}
+
+%lock-16-svg-prop {
+  --lock-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 9.25a.75.75 0 01.75.75v1a.75.75 0 01-1.5 0v-1A.75.75 0 018 9.25z"/><path fill-rule="evenodd" d="M4 5.014v-.93c0-1.078.417-2.114 1.165-2.881A3.96 3.96 0 018 0a3.96 3.96 0 012.835 1.203A4.127 4.127 0 0112 4.083v.93a2.25 2.25 0 012 2.237v5.5A2.25 2.25 0 0111.75 15h-7.5A2.25 2.25 0 012 12.75v-5.5a2.25 2.25 0 012-2.236zM6.239 2.25A2.46 2.46 0 018 1.5c.657 0 1.29.267 1.761.75.471.483.739 1.142.739 1.833V5h-5v-.917c0-.69.268-1.35.739-1.833zM11.75 6.5a.75.75 0 01.75.75v5.5a.75.75 0 01-.75.75h-7.5a.75.75 0 01-.75-.75v-5.5a.75.75 0 01.75-.75h7.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%lock-24-svg-prop {
+  --lock-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 16.25a.75.75 0 01.75.75v2a.75.75 0 01-1.5 0v-2a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M6 10.104V6.75c0-1.537.641-3.003 1.77-4.079A6.136 6.136 0 0112 1c1.58 0 3.102.597 4.23 1.671A5.632 5.632 0 0118 6.75v3.354c1.154.326 2 1.387 2 2.646v7.5A2.75 2.75 0 0117.25 23H6.75A2.75 2.75 0 014 20.25v-7.5c0-1.259.846-2.32 2-2.646zm2.805-6.346A4.636 4.636 0 0112 2.5c1.205 0 2.354.456 3.195 1.258.84.8 1.305 1.877 1.305 2.992V10h-9V6.75c0-1.115.465-2.192 1.305-2.992zM17.25 11.5H6.75c-.69 0-1.25.56-1.25 1.25v7.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-7.5c0-.69-.56-1.25-1.25-1.25z" clip-rule="evenodd"/></g></svg>');
 }
 
 %lock-closed-fill-svg-prop {
@@ -312,6 +2152,22 @@
 
 %lock-disabled-svg-prop {
   --lock-disabled-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M21 21.78L4.22 5 3 6.22l2.04 2.04C4.42 8.6 4 9.25 4 10v10c0 1.1.9 2 2 2h12c.23 0 .45-.05.66-.12L19.78 23 21 21.78zM8.9 6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2H9.66L20 18.34V10c0-1.1-.9-2-2-2h-1V6c0-2.76-2.24-5-5-5-2.56 0-4.64 1.93-4.94 4.4L8.9 7.24V6z" fill="%23000"/></svg>');
+}
+
+%lock-fill-16-svg-prop {
+  --lock-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4 5.014v-.93c0-1.078.417-2.114 1.165-2.881A3.96 3.96 0 018 0a3.96 3.96 0 012.835 1.203A4.127 4.127 0 0112 4.083v.93a2.25 2.25 0 012 2.237v5.5A2.25 2.25 0 0111.75 15h-7.5A2.25 2.25 0 012 12.75v-5.5a2.25 2.25 0 012-2.236zM6.239 2.25A2.46 2.46 0 018 1.5c.657 0 1.29.267 1.761.75.471.483.739 1.142.739 1.833V5h-5v-.917c0-.69.268-1.35.739-1.833zM8 9.25a.75.75 0 00-.75.75v1a.75.75 0 001.5 0v-1A.75.75 0 008 9.25z" clip-rule="evenodd"/></svg>');
+}
+
+%lock-fill-24-svg-prop {
+  --lock-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M6 10.104V6.75c0-1.537.641-3.003 1.77-4.079A6.136 6.136 0 0112 1c1.58 0 3.102.597 4.23 1.671A5.632 5.632 0 0118 6.75v3.354c1.154.326 2 1.387 2 2.646v7.5A2.75 2.75 0 0117.25 23H6.75A2.75 2.75 0 014 20.25v-7.5c0-1.259.846-2.32 2-2.646zm2.805-6.346A4.636 4.636 0 0112 2.5c1.205 0 2.354.456 3.195 1.258.84.8 1.305 1.877 1.305 2.992V10h-9V6.75c0-1.115.465-2.192 1.305-2.992zM12 16.25a.75.75 0 00-.75.75v2a.75.75 0 001.5 0v-2a.75.75 0 00-.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%lock-off-16-svg-prop {
+  --lock-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 1.5a2.46 2.46 0 00-1.761.75.75.75 0 01-1.074-1.047A3.96 3.96 0 018 0a3.96 3.96 0 012.835 1.203A4.127 4.127 0 0112 4.083v.93a2.25 2.25 0 012 2.237V9.5a.75.75 0 01-1.5 0V7.25a.75.75 0 00-.75-.75H9.5a.75.75 0 010-1.5h1v-.917c0-.69-.268-1.35-.739-1.833A2.46 2.46 0 008 1.5z"/><path fill-rule="evenodd" d="M3.958 5.019A2.25 2.25 0 002 7.25v5.5A2.25 2.25 0 004.25 15h7.5c.606 0 1.156-.24 1.56-.629l1.16 1.16a.75.75 0 101.06-1.061l-14-14A.75.75 0 00.47 1.53L3.958 5.02zM4.25 6.5a.75.75 0 00-.75.75v5.5c0 .414.336.75.75.75h7.5a.749.749 0 00.5-.19L5.44 6.5H4.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%lock-off-24-svg-prop {
+  --lock-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.75 17a.75.75 0 00-1.5 0v2a.75.75 0 001.5 0v-2z"/><path fill-rule="evenodd" d="M1.53.47A.75.75 0 00.47 1.53L6 7.06v3.044a2.751 2.751 0 00-2 2.646v7.5A2.75 2.75 0 006.75 23h10.5c1.271 0 2.34-.862 2.656-2.034l2.564 2.564a.75.75 0 101.06-1.06l-22-22zM18.5 19.56l-8.06-8.06H6.75c-.69 0-1.25.56-1.25 1.25v7.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-.69zM8.94 10L7.5 8.56V10h1.44z" clip-rule="evenodd"/><path d="M12 2.5a4.636 4.636 0 00-3.195 1.258c-.123.117-.238.24-.345.368a.75.75 0 01-1.153-.959c.144-.173.298-.338.463-.496A6.136 6.136 0 0112 1c1.58 0 3.102.597 4.23 1.671A5.632 5.632 0 0118 6.75v3.354c1.154.326 2 1.387 2 2.646v2.75a.75.75 0 01-1.5 0v-2.75c0-.69-.56-1.25-1.25-1.25H14.5a.75.75 0 010-1.5h2V6.75a4.133 4.133 0 00-1.305-2.992A4.636 4.636 0 0012 2.5z"/></g></svg>');
 }
 
 %lock-open-svg-prop {
@@ -459,7 +2315,7 @@
 }
 
 %logo-vault-color-svg-prop {
-  --logo-vault-color-svg: url('data:image/svg+xml;charset=UTF-8,<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M0 0L14.9453 30L30 0H0ZM16.724 6.02083H18.4635V7.76042H16.724V6.02083ZM11.5208 12.9766H13.2604V11.237H11.5208V12.9766ZM13.2604 10.3724H11.5208V8.6302H13.2604V10.3724ZM11.5208 7.76823H13.2604V6.02083H11.5208V7.76823ZM15.8646 15.5937H14.1302V13.8463H15.8698L15.8646 15.5937ZM14.1302 12.9896H15.8646L15.8698 11.237H14.1302V12.9896ZM15.8646 10.3854H14.1302V8.6302H15.8698L15.8646 10.3854ZM14.1302 7.78125H15.8646L15.8698 6.02083H14.1302V7.78125ZM16.7187 8.65105H18.4635V10.3906H16.7239L16.7187 8.65105ZM16.7344 11.237V13L18.4896 12.9766V11.237H16.7344Z" fill="black"/></svg>');
+  --logo-vault-color-svg: url('data:image/svg+xml;charset=UTF-8,<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M0 0L14.9453 30L30 0H0ZM16.724 6.02083H18.4635V7.76042H16.724V6.02083ZM11.5208 12.9766H13.2604V11.237H11.5208V12.9766ZM13.2604 10.3724H11.5208V8.6302H13.2604V10.3724ZM11.5208 7.76823H13.2604V6.02083H11.5208V7.76823ZM15.8646 15.5937H14.1302V13.8463H15.8698L15.8646 15.5937ZM14.1302 12.9896H15.8646L15.8698 11.237H14.1302V12.9896ZM15.8646 10.3854H14.1302V8.6302H15.8698L15.8646 10.3854ZM14.1302 7.78125H15.8646L15.8698 6.02083H14.1302V7.78125ZM16.7187 8.65105H18.4635V10.3906H16.7239L16.7187 8.65105ZM16.7344 11.237V13L18.4896 12.9766V11.237H16.7344Z" fill="%23000"/></svg>');
 }
 
 %logo-vmware-color-svg-prop {
@@ -470,16 +2326,192 @@
   --logo-vmware-monochrome-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4.096 8.663c-.251-.566-.873-.822-1.453-.558-.58.265-.795.927-.532 1.493l2.436 5.437c.383.852.787 1.298 1.545 1.298.81 0 1.163-.486 1.545-1.298l2.147-4.8a.308.308 0 0 1 .306-.202c.183 0 .336.15.336.352v4.645c0 .716.387 1.303 1.131 1.303s1.146-.587 1.146-1.303v-3.801c0-.733.512-1.21 1.21-1.21.697 0 1.16.494 1.16 1.21v3.801c0 .716.389 1.303 1.132 1.303.743 0 1.147-.587 1.147-1.303v-3.801c0-.733.51-1.21 1.208-1.21.696 0 1.162.494 1.162 1.21v3.801c0 .716.388 1.303 1.131 1.303.744 0 1.147-.587 1.147-1.303v-4.326C22 9.114 20.755 8 19.256 8c-1.497 0-2.434 1.063-2.434 1.063-.498-.663-1.185-1.062-2.347-1.062-1.227 0-2.3 1.062-2.3 1.062-.499-.663-1.348-1.062-2.05-1.062-1.087 0-1.95.491-2.477 1.727l-1.556 3.765-1.996-4.83z" fill="%23000"/></svg>');
 }
 
+%mail-16-svg-prop {
+  --mail-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 3.25A2.25 2.25 0 012.25 1h11.5A2.25 2.25 0 0116 3.25v9.5A2.25 2.25 0 0113.75 15H2.25A2.25 2.25 0 010 12.75v-9.5zm2.25-.75a.75.75 0 00-.748.69L8 8.297l6.498-5.105a.75.75 0 00-.748-.691H2.25zm-.75 9.885V5.097l3.865 3.037L1.5 12.385zM2.514 13.5h10.972L9.452 9.063l-.989.777a.75.75 0 01-.926 0l-.99-.777L2.515 13.5zm8.12-5.366l3.866 4.251V5.097l-3.865 3.037z" clip-rule="evenodd"/></svg>');
+}
+
+%mail-24-svg-prop {
+  --mail-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M1 5.75A2.75 2.75 0 013.75 3h16.5A2.75 2.75 0 0123 5.75v12.5A2.75 2.75 0 0120.25 21H3.75A2.75 2.75 0 011 18.25V5.75zM3.75 4.5a1.25 1.25 0 00-1.057.582L12 12.062l9.307-6.98A1.25 1.25 0 0020.25 4.5H3.75zM2.5 16.44V6.812l5.501 4.125L2.5 16.44zm.031 2.09c.127.555.625.97 1.219.97h16.5a1.25 1.25 0 001.219-.97l-6.682-6.683L12.45 13.6a.75.75 0 01-.9 0l-2.337-1.752-6.682 6.681zM16 10.937L21.5 16.44V6.813l-5.501 4.125z" clip-rule="evenodd"/></svg>');
+}
+
+%mail-open-16-svg-prop {
+  --mail-open-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8.803.254a2.25 2.25 0 00-1.606 0L1.447 2.45A2.25 2.25 0 000 4.552v8.198A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75V4.552a2.25 2.25 0 00-1.447-2.102L8.803.254zm-1.07 1.401a.75.75 0 01.535 0l5.75 2.196a.75.75 0 01.302.213L8 8.578 1.68 4.064a.749.749 0 01.302-.213l5.75-2.196zM1.5 5.78v6.6L5.116 8.36 1.5 5.78zM2.509 13.5h10.982L9.656 9.239l-1.22.871a.75.75 0 01-.872 0l-1.22-.871L2.509 13.5zM14.5 12.379v-6.6l-3.616 2.583 3.616 4.017z" clip-rule="evenodd"/></svg>');
+}
+
+%mail-open-24-svg-prop {
+  --mail-open-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13 .335a2.75 2.75 0 00-2 0l-8.25 3.22A2.75 2.75 0 001 6.116V18.25A2.75 2.75 0 003.75 21h16.5A2.75 2.75 0 0023 18.25V6.116a2.75 2.75 0 00-1.75-2.561L13 .335zm-1.454 1.397a1.25 1.25 0 01.908 0l8.25 3.22c.48.187.796.65.796 1.164v.134a.746.746 0 00-.4.116l-9.11 5.753L2.5 6.425v-.309c0-.514.316-.977.796-1.164l8.25-3.22zM2.5 8.175v8.264l5.165-5.165-5.165-3.1zm.031 10.354c.127.556.625.971 1.219.971h16.5a1.25 1.25 0 001.219-.97l-6.51-6.511-2.559 1.615a.75.75 0 01-.786.01l-2.623-1.575-6.46 6.46zM21.5 16.44V7.887l-5.242 3.31L21.5 16.44z" clip-rule="evenodd"/></svg>');
+}
+
+%map-16-svg-prop {
+  --map-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M5.2 1.187c.34-.17.738-.176 1.083-.016l3.983 1.843 4.003-1.668A1.25 1.25 0 0116 2.5v8.941c0 .473-.268.906-.691 1.118l-4.508 2.254c-.34.17-.74.176-1.085.017l-3.982-1.844-4.003 1.668A1.25 1.25 0 010 13.5V4.56c0-.474.268-.907.691-1.119l4.508-2.254zM1.5 4.714L5 2.964v8.703l-3.5 1.458V4.714zm8 8.362l-3-1.389V2.925l3 1.389v8.763zm1.5-.04l3.5-1.75v-8.41L11 4.332v8.704z" clip-rule="evenodd"/></svg>');
+}
+
+%map-24-svg-prop {
+  --map-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M6.926 1.607a1.75 1.75 0 011.614-.064L16.099 5.1a.25.25 0 00.23-.01l5.053-2.886C22.548 1.537 24 2.379 24 3.724V17.42a1.75 1.75 0 01-.882 1.52l-6.044 3.453a1.75 1.75 0 01-1.614.064L7.901 18.9a.25.25 0 00-.23.01l-5.053 2.886C1.452 22.463 0 21.621 0 20.276V6.58c0-.628.337-1.208.882-1.52l6.044-3.453zm-5.3 4.756L7 3.293v14.274l-.074.04-5.052 2.887a.25.25 0 01-.374-.217V6.58a.25.25 0 01.126-.217zm6.914 11.18a1.557 1.557 0 00-.04-.018V3.182l6.96 3.275.04.018v14.343l-6.96-3.275zM17 20.708l5.374-3.071a.25.25 0 00.126-.217V3.723a.25.25 0 00-.374-.217l-5.052 2.887a1.755 1.755 0 01-.074.04v14.275z" clip-rule="evenodd"/></svg>');
+}
+
+%map-pin-16-svg-prop {
+  --map-pin-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 4.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM7 7a1 1 0 112 0 1 1 0 01-2 0z"/><path d="M8 0C4.138 0 1 3.114 1 6.964a6.927 6.927 0 002.085 4.957l4.42 3.892a.75.75 0 00.99 0l4.42-3.892A6.927 6.927 0 0015 6.964C15 3.114 11.862 0 8 0zM2.5 6.964C2.5 3.95 4.958 1.5 8 1.5s5.5 2.45 5.5 5.464c0 1.5-.607 2.858-1.594 3.847L8 14.251l-3.906-3.44A5.427 5.427 0 012.5 6.964z"/></g></svg>');
+}
+
+%map-pin-24-svg-prop {
+  --map-pin-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.585 23.875L12 23.25l.415.625a.75.75 0 01-.83 0z"/><path fill-rule="evenodd" d="M12 6a4 4 0 100 8 4 4 0 000-8zm-2.5 4a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M11.585 23.875L12 23.25c.415.625.416.624.416.624l.002-.001.006-.004.023-.015.083-.057c.071-.05.175-.122.305-.216a31.98 31.98 0 004.333-3.777C19.51 17.344 22 13.837 22 9.954a9.932 9.932 0 00-2.93-7.04A10.023 10.023 0 0012 0a10.023 10.023 0 00-7.07 2.914A9.932 9.932 0 002 9.954c0 3.883 2.49 7.39 4.832 9.85a31.978 31.978 0 004.333 3.777c.13.094.234.166.306.216l.082.057.023.015.006.004.003.002zM5.988 3.978A8.523 8.523 0 0112 1.5c2.255 0 4.418.892 6.012 2.478A8.432 8.432 0 0120.5 9.955c0 3.276-2.135 6.417-4.418 8.815A30.46 30.46 0 0112 22.334a30.463 30.463 0 01-4.082-3.564C5.635 16.372 3.5 13.23 3.5 9.955c0-2.242.895-4.392 2.488-5.977z" clip-rule="evenodd"/></g></svg>');
+}
+
+%maximize-16-svg-prop {
+  --maximize-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M10.25 1a.75.75 0 000 1.5h2.19L9.47 5.47a.75.75 0 001.06 1.06l2.97-2.97v2.19a.75.75 0 001.5 0v-4a.75.75 0 00-.75-.75h-4zM2.5 10.25a.75.75 0 00-1.5 0v4c0 .414.336.75.75.75h4a.75.75 0 000-1.5H3.56l2.97-2.97a.75.75 0 10-1.06-1.06L2.5 12.44v-2.19z"/></g></svg>');
+}
+
+%maximize-24-svg-prop {
+  --maximize-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M15.75 2a.75.75 0 000 1.5h3.69l-5.22 5.22a.75.75 0 001.06 1.06l5.22-5.22v3.69a.75.75 0 001.5 0v-5.5l-.001-.039a.745.745 0 00-.462-.654A.748.748 0 0021.25 2h-5.5zM3.5 15.75a.75.75 0 00-1.5 0v5.5a.748.748 0 00.75.75h5.5a.75.75 0 000-1.5H4.56l5.22-5.22a.75.75 0 10-1.06-1.06L3.5 19.44v-3.69z"/></g></svg>');
+}
+
+%maximize-alt-16-svg-prop {
+  --maximize-alt-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h2.047a.75.75 0 010 1.5H3.25a.75.75 0 00-.75.75v2.047a.75.75 0 01-1.5 0V3.25zm8.953-1.5a.75.75 0 01.75-.75h2.047A2.25 2.25 0 0115 3.25v2.047a.75.75 0 01-1.5 0V3.25a.75.75 0 00-.75-.75h-2.047a.75.75 0 01-.75-.75zM1.75 9.953a.75.75 0 01.75.75v2.047c0 .414.336.75.75.75h2.047a.75.75 0 010 1.5H3.25A2.25 2.25 0 011 12.75v-2.047a.75.75 0 01.75-.75zm12.5 0a.75.75 0 01.75.75v2.047A2.25 2.25 0 0112.75 15h-2.047a.75.75 0 010-1.5h2.047a.75.75 0 00.75-.75v-2.047a.75.75 0 01.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%maximize-alt-24-svg-prop {
+  --maximize-alt-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2H8a.75.75 0 010 1.5H4.75c-.69 0-1.25.56-1.25 1.25V8A.75.75 0 012 8V4.75zm13.25-2A.75.75 0 0116 2h3.25A2.75 2.75 0 0122 4.75V8a.75.75 0 01-1.5 0V4.75c0-.69-.56-1.25-1.25-1.25H16a.75.75 0 01-.75-.75zm-12.5 12.5a.75.75 0 01.75.75v3.25c0 .69.56 1.25 1.25 1.25H8A.75.75 0 018 22H4.75A2.75 2.75 0 012 19.25V16a.75.75 0 01.75-.75zm18.5 0A.75.75 0 0122 16v3.25A2.75 2.75 0 0119.25 22H16a.75.75 0 010-1.5h3.25c.69 0 1.25-.56 1.25-1.25V16a.75.75 0 01.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%meh-16-svg-prop {
+  --meh-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.5 9.5a.75.75 0 000 1.5h5a.75.75 0 000-1.5h-5zM5 6a1 1 0 011-1h.007a1 1 0 010 2H6a1 1 0 01-1-1zM10 5a1 1 0 100 2h.007a1 1 0 100-2H10z"/><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%meh-24-svg-prop {
+  --meh-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8 14.5A.75.75 0 008 16h8a.75.75 0 000-1.5H8zM8 9a1 1 0 011-1h.01a1 1 0 110 2H9a1 1 0 01-1-1zM15 8a1 1 0 100 2h.01a1 1 0 100-2H15z"/><path fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%menu-16-svg-prop {
+  --menu-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1 3.75A.75.75 0 011.75 3h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 3.75zM1 7.75A.75.75 0 011.75 7h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 7.75zM1.75 11a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H1.75z"/></g></svg>');
+}
+
+%menu-24-svg-prop {
+  --menu-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M2 5.75A.75.75 0 012.75 5h18.5a.75.75 0 010 1.5H2.75A.75.75 0 012 5.75zM2 11.75a.75.75 0 01.75-.75h18.5a.75.75 0 010 1.5H2.75a.75.75 0 01-.75-.75zM2.75 17a.75.75 0 000 1.5h18.5a.75.75 0 000-1.5H2.75z"/></g></svg>');
+}
+
 %menu-svg-prop {
   --menu-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 18h16v-2H4v2zm0-5h16v-2H4v2zm0-7v2h16V6H4z" fill="%23000"/></svg>');
+}
+
+%mesh-16-svg-prop {
+  --mesh-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M15.681 10.243A8.001 8.001 0 0016 8a7.97 7.97 0 00-2.047-5.345A1.752 1.752 0 0012.25.5h-.007c-.321 0-.623.087-.882.238A7.97 7.97 0 008 0a7.963 7.963 0 00-4.321 1.266A1.742 1.742 0 002.75 1h-.007a1.75 1.75 0 00-1.48 2.684A7.963 7.963 0 000 8a7.985 7.985 0 002.994 6.24 1.75 1.75 0 001.75 1.71h.006c.353 0 .681-.104.956-.284A8.004 8.004 0 008 16a7.985 7.985 0 006.245-3h.005a1.75 1.75 0 001.431-2.757zM2.573 4.492a1.758 1.758 0 01-.043-.005A6.47 6.47 0 001.5 8c0 1.918.83 3.642 2.152 4.832.112-.09.234-.165.366-.225-.029-3.003-.435-5.146-1.445-8.115zM6.5 14.2c0 .042-.001.084-.004.125.482.114.986.175 1.504.175a6.484 6.484 0 004.858-2.181 1.742 1.742 0 01-.242-1.713 32.908 32.908 0 00-2.306-2.179c-.067.116-.136.232-.205.347-.942 1.56-2.101 3.078-3.71 4.829.068.186.105.387.105.597zm7.826-4.698a1.776 1.776 0 00-.076-.002h-.007a1.75 1.75 0 00-.53.082 33.906 33.906 0 00-2.675-2.503c.484-.967.918-1.976 1.352-3.085a1.74 1.74 0 00.601-.158 6.518 6.518 0 011.335 5.666zM8 1.5c.89 0 1.738.179 2.51.503a1.755 1.755 0 00.476 1.464c-.379.964-.75 1.836-1.152 2.662C8.338 5.013 6.66 3.984 4.499 2.823a1.784 1.784 0 00-.013-.292A6.47 6.47 0 018 1.5zM4.094 4.309c.957 2.878 1.371 5.082 1.42 8.034 1.44-1.591 2.471-2.96 3.306-4.344.105-.174.208-.348.307-.524-1.41-1.072-2.989-2.056-5.033-3.166z" clip-rule="evenodd"/></svg>');
+}
+
+%mesh-24-svg-prop {
+  --mesh-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M22.56 15.09c.286-.98.44-2.017.44-3.09 0-3.075-1.262-5.855-3.296-7.851A1.75 1.75 0 0018 2h-.01c-.328 0-.635.09-.897.247A10.953 10.953 0 0012 1c-2.448 0-4.709.8-6.536 2.152A1.744 1.744 0 004.75 3h-.01a1.75 1.75 0 00-1.595 2.472A10.95 10.95 0 001 12a10.99 10.99 0 004.99 9.215v.035c0 .966.784 1.75 1.75 1.75h.01c.445 0 .851-.166 1.16-.44.98.286 2.017.44 3.09.44a10.99 10.99 0 009.221-5H21.25a1.75 1.75 0 001.31-2.91zM4.603 6.495a1.745 1.745 0 01-.309-.052A9.457 9.457 0 002.5 12a9.49 9.49 0 004.17 7.865c.106-.082.222-.152.345-.208-.012-4.964-.626-8.255-2.412-13.162zm4.74 14.03c.09.198.144.414.155.642A9.513 9.513 0 0012 21.5a9.49 9.49 0 007.864-4.169 1.743 1.743 0 01-.262-1.697c-1.477-1.49-2.83-2.747-4.193-3.859-1.514 2.857-3.359 5.497-6.065 8.75zm11.824-6.023c-.17.006-.333.037-.487.09-1.61-1.626-3.083-2.986-4.578-4.186.729-1.509 1.393-3.11 2.064-4.914.212-.02.412-.077.595-.166A9.47 9.47 0 0121.5 12a9.51 9.51 0 01-.333 2.502zM12 2.5a9.46 9.46 0 014.257 1.005 1.745 1.745 0 00.496 1.483 55.99 55.99 0 01-1.866 4.483c-2.418-1.785-5-3.234-8.388-4.768a1.75 1.75 0 00-.059-.407A9.457 9.457 0 0112 2.5zM6.077 6.159c1.737 4.813 2.384 8.186 2.435 13.02 2.538-3.084 4.267-5.6 5.697-8.343-2.352-1.763-4.843-3.177-8.132-4.677z" clip-rule="evenodd"/></svg>');
 }
 
 %mesh-svg-prop {
   --mesh-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M6.5 20v-.25l-.2-.15A9.485 9.485 0 012.5 12c0-1.663.427-3.225 1.177-4.583l.117-.214L3.7 6.98a2.5 2.5 0 013.28-3.28l.224.095.214-.117A9.455 9.455 0 0112 2.5c1.09 0 2.135.183 3.108.52l.243.084.21-.148a2.5 2.5 0 013.84 2.746l-.073.247.158.202A9.457 9.457 0 0121.5 12a9.57 9.57 0 01-.129 1.568l-.048.29.23.183a2.5 2.5 0 01-2.19 4.377l-.285-.075-.203.214a9.471 9.471 0 01-7.579 2.917l-.248-.018-.165.188A2.5 2.5 0 016.5 20.001zm11.41-1.891l.31-.3-.251-.351A2.486 2.486 0 0117.5 16c0-.264.04-.518.116-.756l.114-.358-.313-.209-3.14-2.093-.459-.306-.26.487-2.703 5.07-.159.297.218.26c.366.434.586.995.586 1.608v.5h.5a8.474 8.474 0 005.91-2.391zm-8.434-.564l.363.07.173-.325 2.757-5.17.213-.4-.377-.25-4.883-3.256-.252-.168-.266.145-.009.005-.334.184.088.37 2.004 8.398.078.33.336.049c.037.005.073.011.11.018zm-1.747.301l.318-.187-.086-.359-2.02-8.465-.075-.317-.32-.06a2.478 2.478 0 01-.623-.201l-.461-.22-.21.465A8.471 8.471 0 003.5 12a8.481 8.481 0 002.91 6.404l.377.329.33-.377c.175-.2.382-.373.612-.51zM19.043 7.24l-.275-.405-.411.266a2.486 2.486 0 01-1.628.386l-.335-.037-.16.298-1.73 3.245-.213.4.377.25 3.403 2.27.276.183.277-.183a2.485 2.485 0 011.324-.412l.433-.008.053-.43c.044-.348.066-.702.066-1.062a8.463 8.463 0 00-1.457-4.76zm-6.047 3.289l.46.306.259-.487 1.598-2.997.174-.326-.26-.262a2.49 2.49 0 01-.654-2.366l.118-.476-.473-.127A8.51 8.51 0 0012 3.5c-1.246 0-2.43.268-3.498.751l-.466.21.22.462a2.492 2.492 0 01.064 2.01l-.151.377.338.225 4.49 2.993z" stroke="%23000"/></svg>');
 }
 
+%message-circle-16-svg-prop {
+  --message-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8.231 2.5a5.269 5.269 0 11-2.43 9.944 1.18 1.18 0 00-.535-.122 2.432 2.432 0 00-.424.038c-.27.046-.577.13-.879.225-.272.085-.557.186-.834.29.103-.275.203-.557.288-.828.096-.302.18-.612.225-.885.023-.136.04-.283.037-.428a1.193 1.193 0 00-.123-.534 5.269 5.269 0 014.675-7.7zM2.058 14.934l.002-.001.01-.004.037-.017a28.983 28.983 0 01.658-.281 21.485 21.485 0 011.649-.616c.274-.086.506-.147.678-.176.049-.008.086-.012.113-.015a6.768 6.768 0 10-3.028-3.026 1.384 1.384 0 01-.014.119 5.296 5.296 0 01-.176.679c-.172.545-.42 1.17-.618 1.646a31.45 31.45 0 01-.28.65l-.017.036-.004.01v.002a.75.75 0 00.99.994z" clip-rule="evenodd"/></svg>');
+}
+
+%message-circle-24-svg-prop {
+  --message-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12.343 3.5a8.157 8.157 0 11-3.765 15.396 1.439 1.439 0 00-.688-.139c-.2.003-.416.033-.628.074-.426.082-.922.227-1.417.391-.566.188-1.157.412-1.684.621.204-.51.421-1.081.606-1.63.169-.505.318-1.012.403-1.448.042-.217.072-.438.075-.643a1.466 1.466 0 00-.141-.7A8.157 8.157 0 0112.343 3.5zM3.7 21.655a37.13 37.13 0 012.618-1.01c.47-.156.896-.277 1.228-.341a2.28 2.28 0 01.398-.047A9.657 9.657 0 0022 11.657 9.657 9.657 0 0012.343 2a9.657 9.657 0 00-8.598 14.06v.038a2.32 2.32 0 01-.048.382c-.066.34-.191.776-.352 1.255a36.658 36.658 0 01-1.21 3.052l-.05.114-.014.03-.004.009a.75.75 0 00.982.998l.648-.282.003-.001zm.043-5.621v.002-.002z" clip-rule="evenodd"/></svg>');
+}
+
+%message-circle-fill-16-svg-prop {
+  --message-circle-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5 8.75A.75.75 0 015.75 8h2.5a.75.75 0 010 1.5h-2.5A.75.75 0 015 8.75zM5.75 5.5a.75.75 0 100 1.5h4.5a.75.75 0 000-1.5h-4.5z"/><path fill-rule="evenodd" d="M2.058 14.934l.002-.001.01-.004.037-.017a28.983 28.983 0 01.658-.281 21.485 21.485 0 011.649-.616c.274-.086.506-.147.678-.176.049-.008.086-.012.113-.015a6.768 6.768 0 10-3.028-3.026 1.384 1.384 0 01-.014.119 5.296 5.296 0 01-.176.679c-.172.545-.42 1.17-.618 1.646a31.45 31.45 0 01-.28.65l-.017.036-.004.01v.002a.75.75 0 00.99.994zM8.231 2.5a5.269 5.269 0 11-2.43 9.944 1.18 1.18 0 00-.535-.122 2.432 2.432 0 00-.424.038c-.27.046-.577.13-.879.225-.272.085-.557.186-.834.29.103-.275.203-.557.288-.828.096-.302.18-.612.225-.885.023-.136.04-.283.037-.428a1.193 1.193 0 00-.123-.534 5.269 5.269 0 014.675-7.7z" clip-rule="evenodd"/></g></svg>');
+}
+
+%message-circle-fill-24-svg-prop {
+  --message-circle-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8 8.75A.75.75 0 018.75 8h7a.75.75 0 010 1.5h-7A.75.75 0 018 8.75zM8 11.75a.75.75 0 01.75-.75h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zM8 14.75a.75.75 0 01.75-.75h5a.75.75 0 010 1.5h-5a.75.75 0 01-.75-.75z"/><path fill-rule="evenodd" d="M7.546 20.304c-.332.064-.757.185-1.228.342-1.113.37-2.194.825-3.27 1.292a.75.75 0 01-.98-.998c.086-.192.17-.384.253-.577.273-.635.704-1.675 1.024-2.628.16-.48.286-.915.352-1.255a2.32 2.32 0 00.048-.42 9.62 9.62 0 01-1.06-4.403C2.685 6.324 7.01 2 12.343 2 17.676 2 22 6.324 22 11.657c0 5.334-4.324 9.658-9.657 9.658a9.619 9.619 0 01-4.4-1.058 2.159 2.159 0 00-.397.047zM20.5 11.657a8.157 8.157 0 10-15.396 3.765c.128.246.144.513.141.7a3.764 3.764 0 01-.075.643 11.85 11.85 0 01-.403 1.447c-.185.55-.402 1.12-.606 1.631a32 32 0 011.684-.62c.495-.165.991-.31 1.417-.392.212-.041.427-.07.627-.074.18-.003.445.012.69.14A8.157 8.157 0 0020.5 11.657z" clip-rule="evenodd"/></g></svg>');
+}
+
+%message-square-16-svg-prop {
+  --message-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M15 3.25A2.25 2.25 0 0012.75 1h-9.5A2.25 2.25 0 001 3.25v11a.75.75 0 001.26.55l2.801-2.6a.75.75 0 01.51-.2h7.179A2.25 2.25 0 0015 9.75v-6.5zm-2.25-.75a.75.75 0 01.75.75v6.5a.75.75 0 01-.75.75H5.572a2.25 2.25 0 00-1.531.6L2.5 12.53V3.25a.75.75 0 01.75-.75h9.5z" clip-rule="evenodd"/></svg>');
+}
+
+%message-square-24-svg-prop {
+  --message-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M22 4.75A2.75 2.75 0 0019.25 2H4.75A2.75 2.75 0 002 4.75v16.5a.75.75 0 001.231.575l4.228-3.534A1.25 1.25 0 018.26 18h10.99A2.75 2.75 0 0022 15.25V4.75zM19.25 3.5c.69 0 1.25.56 1.25 1.25v10.5c0 .69-.56 1.25-1.25 1.25H8.26a2.75 2.75 0 00-1.763.64L3.5 19.645V4.75c0-.69.56-1.25 1.25-1.25h14.5z" clip-rule="evenodd"/></svg>');
+}
+
+%message-square-fill-16-svg-prop {
+  --message-square-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M4 7.75A.75.75 0 014.75 7h3.5a.75.75 0 010 1.5h-3.5A.75.75 0 014 7.75zM4.75 4.5a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5z"/><path fill-rule="evenodd" d="M15 3.25A2.25 2.25 0 0012.75 1h-9.5A2.25 2.25 0 001 3.25v11a.75.75 0 001.26.55l2.801-2.6a.75.75 0 01.51-.2h7.179A2.25 2.25 0 0015 9.75v-6.5zm-2.25-.75a.75.75 0 01.75.75v6.5a.75.75 0 01-.75.75H5.572a2.25 2.25 0 00-1.531.6L2.5 12.53V3.25a.75.75 0 01.75-.75h9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%message-square-fill-24-svg-prop {
+  --message-square-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M6 6.75A.75.75 0 016.75 6h10a.75.75 0 010 1.5h-10A.75.75 0 016 6.75zM6 9.75A.75.75 0 016.75 9h5a.75.75 0 010 1.5h-5A.75.75 0 016 9.75zM6 12.75a.75.75 0 01.75-.75h7a.75.75 0 010 1.5h-7a.75.75 0 01-.75-.75z"/><path fill-rule="evenodd" d="M19.25 2A2.75 2.75 0 0122 4.75v10.5A2.75 2.75 0 0119.25 18H8.26a1.25 1.25 0 00-.801.291L3.23 21.825A.75.75 0 012 21.25V4.75A2.75 2.75 0 014.75 2h14.5zm1.25 2.75c0-.69-.56-1.25-1.25-1.25H4.75c-.69 0-1.25.56-1.25 1.25v14.895l2.997-2.505a2.75 2.75 0 011.763-.64h10.99c.69 0 1.25-.56 1.25-1.25V4.75z" clip-rule="evenodd"/></g></svg>');
+}
+
 %message-svg-prop {
   --message-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M18 0H2C.9 0 .01.9.01 2L0 20l4-4h14c1.1 0 2-.9 2-2V2c0-1.1-.9-2-2-2zM4 7h12v2H4V7zm8 5H4v-2h8v2zm4-6H4V4h12v2z" fill="%23000"/></svg>');
+}
+
+%mic-16-svg-prop {
+  --mic-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M8 0c-.78 0-1.538.29-2.104.821A2.797 2.797 0 005 2.861V8.14c0 .775.328 1.507.896 2.04.566.53 1.323.821 2.104.821.78 0 1.538-.29 2.104-.821A2.797 2.797 0 0011 8.139V2.86c0-.775-.329-1.507-.896-2.04A3.077 3.077 0 008 0zM6.922 1.915A1.578 1.578 0 018 1.5c.413 0 .8.154 1.078.415.276.26.422.601.422.946V8.14c0 .345-.146.686-.422.946A1.578 1.578 0 018 9.5c-.413 0-.8-.154-1.078-.415-.276-.26-.422-.601-.422-.946V2.86c0-.345.146-.686.422-.946z" clip-rule="evenodd"/><path d="M4 6.75a.75.75 0 00-1.5 0v1.385a5.3 5.3 0 001.619 3.801A5.553 5.553 0 007.25 13.45v1.05H5.5a.75.75 0 000 1.5h5a.75.75 0 000-1.5H8.75v-1.05a5.553 5.553 0 003.131-1.514A5.3 5.3 0 0013.5 8.135V6.75a.75.75 0 00-1.5 0v1.385a3.8 3.8 0 01-1.164 2.725A4.071 4.071 0 018 12a4.071 4.071 0 01-2.836-1.14A3.8 3.8 0 014 8.135V6.75z"/></g></svg>');
+}
+
+%mic-24-svg-prop {
+  --mic-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M12 0c-1.05 0-2.064.399-2.816 1.118A3.79 3.79 0 008 3.858v8.285a3.79 3.79 0 001.184 2.739A4.077 4.077 0 0012 16c1.05 0 2.064-.399 2.816-1.118A3.79 3.79 0 0016 12.142V3.858a3.79 3.79 0 00-1.184-2.739A4.077 4.077 0 0012 0zm-1.78 2.202A2.578 2.578 0 0112 1.5c.674 0 1.313.256 1.78.702a2.29 2.29 0 01.72 1.655v8.286a2.29 2.29 0 01-.72 1.655A2.578 2.578 0 0112 14.5a2.578 2.578 0 01-1.78-.702 2.29 2.29 0 01-.72-1.655V3.857c0-.614.255-1.21.72-1.655z" clip-rule="evenodd"/><path d="M5.5 10A.75.75 0 004 10v2a7.63 7.63 0 002.353 5.49 8.112 8.112 0 004.897 2.226V22H8a.75.75 0 000 1.5h8a.75.75 0 000-1.5h-3.25v-2.284a8.112 8.112 0 004.898-2.227A7.63 7.63 0 0020 12v-2a.75.75 0 00-1.5 0v2a6.13 6.13 0 01-1.894 4.41A6.634 6.634 0 0112 18.25a6.633 6.633 0 01-4.606-1.84A6.13 6.13 0 015.5 12v-2z"/></g></svg>');
+}
+
+%mic-off-16-svg-prop {
+  --mic-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 0c-.78 0-1.538.29-2.104.821a2.862 2.862 0 00-.627.857.75.75 0 001.354.644c.07-.147.17-.286.3-.407A1.578 1.578 0 018 1.5c.413 0 .8.154 1.078.415.276.26.422.601.422.946v3.443a.75.75 0 001.5 0V2.861c0-.775-.329-1.507-.896-2.04A3.077 3.077 0 008 0z"/><path fill-rule="evenodd" d="M5 6.06L1.22 2.28a.75.75 0 011.06-1.06l12.5 12.5a.75.75 0 11-1.06 1.06L11.338 12.4a5.575 5.575 0 01-2.588 1.05V14.5h1.75a.75.75 0 010 1.5h-5a.75.75 0 010-1.5h1.75v-1.05a5.553 5.553 0 01-3.131-1.514A5.3 5.3 0 012.5 8.135V6.75a.75.75 0 011.5 0v1.385a3.8 3.8 0 001.164 2.725A4.071 4.071 0 008 12c.815 0 1.602-.24 2.262-.677l-.726-.726A3.113 3.113 0 018 11c-.78 0-1.538-.29-2.104-.821A2.797 2.797 0 015 8.139V6.06zm1.5 1.5v.579c0 .345.146.686.422.946.278.26.665.415 1.078.415.134 0 .266-.016.392-.047L6.5 7.56z" clip-rule="evenodd"/><path d="M12.03 6.75a.75.75 0 011.5 0v1.385c0 .266-.02.53-.06.79a.75.75 0 11-1.483-.227c.029-.185.043-.374.043-.563V6.75z"/></g></svg>');
+}
+
+%mic-off-24-svg-prop {
+  --mic-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9.184 1.118A4.077 4.077 0 0112 0c1.05 0 2.064.399 2.816 1.118A3.79 3.79 0 0116 3.858v6.5a.75.75 0 11-1.5 0v-6.5a2.29 2.29 0 00-.72-1.656A2.578 2.578 0 0012 1.5c-.674 0-1.313.256-1.78.702a2.29 2.29 0 00-.72 1.655.75.75 0 11-1.5 0 3.79 3.79 0 011.184-2.739z"/><path fill-rule="evenodd" d="M12 16c.81 0 1.6-.237 2.263-.676l1.66 1.66A6.671 6.671 0 0112 18.25a6.633 6.633 0 01-4.606-1.84A6.13 6.13 0 015.5 12v-2A.75.75 0 004 10v2a7.63 7.63 0 002.353 5.49 8.112 8.112 0 004.897 2.226V22H8a.75.75 0 000 1.5h8a.75.75 0 000-1.5h-3.25v-2.284a8.145 8.145 0 004.244-1.661l4.726 4.725a.75.75 0 101.06-1.06L2.28 1.22a.75.75 0 00-1.06 1.06L8 9.06v3.083a3.79 3.79 0 001.184 2.739A4.077 4.077 0 0012 16zm-2.5-3.857V10.56l3.667 3.666A2.62 2.62 0 0112 14.5a2.578 2.578 0 01-1.78-.702 2.29 2.29 0 01-.72-1.655z" clip-rule="evenodd"/><path d="M20 10a.75.75 0 00-1.5 0v2c0 .552-.076 1.097-.222 1.62a.75.75 0 001.444.404A7.522 7.522 0 0020 12v-2z"/></g></svg>');
+}
+
+%microsoft-16-svg-prop {
+  --microsoft-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1 1h6.5v6.5H1V1zM8.5 1H15v6.5H8.5V1zM1 8.5h6.5V15H1V8.5zM8.5 8.5H15V15H8.5V8.5z"/></g></svg>');
+}
+
+%microsoft-24-svg-prop {
+  --microsoft-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3 3h8.5v8.5H3V3zM12.5 3H21v8.5h-8.5V3zM3 12.5h8.5V21H3v-8.5zM12.5 12.5H21V21h-8.5v-8.5z"/></g></svg>');
+}
+
+%microsoft-color-16-svg-prop {
+  --microsoft-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23F35325" d="M1 1h6.5v6.5H1V1z"/><path fill="%2381BC06" d="M8.5 1H15v6.5H8.5V1z"/><path fill="%2305A6F0" d="M1 8.5h6.5V15H1V8.5z"/><path fill="%23FFBA08" d="M8.5 8.5H15V15H8.5V8.5z"/></svg>');
+}
+
+%microsoft-color-24-svg-prop {
+  --microsoft-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23F35325" d="M3 3h8.5v8.5H3V3z"/><path fill="%2381BC06" d="M12.5 3H21v8.5h-8.5V3z"/><path fill="%2305A6F0" d="M3 12.5h8.5V21H3v-8.5z"/><path fill="%23FFBA08" d="M12.5 12.5H21V21h-8.5v-8.5z"/></svg>');
+}
+
+%migrate-16-svg-prop {
+  --migrate-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M9.22 3.72a.75.75 0 011.06 0l3.5 3.5a.75.75 0 010 1.06l-3.5 3.5a.75.75 0 11-1.06-1.06l2.97-2.97-2.97-2.97a.75.75 0 010-1.06z"/><path d="M5.22 3.72a.75.75 0 011.06 0l3.5 3.5a.75.75 0 010 1.06l-3.5 3.5a.75.75 0 01-1.06-1.06L7.44 8.5H2A.75.75 0 012 7h5.44L5.22 4.78a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%migrate-24-svg-prop {
+  --migrate-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.207 5.982a.75.75 0 011.06-.025l5.5 5.25a.75.75 0 010 1.085l-5.5 5.25a.75.75 0 11-1.035-1.085l4.146-3.957H4A.75.75 0 014 11h8.378L8.232 7.043a.75.75 0 01-.025-1.06z"/><path d="M14.207 5.982a.75.75 0 011.06-.025l5.5 5.25a.75.75 0 010 1.085l-5.5 5.25a.75.75 0 01-1.035-1.085l4.932-4.707-4.932-4.707a.75.75 0 01-.024-1.06z"/></g></svg>');
+}
+
+%minimize-16-svg-prop {
+  --minimize-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M10 4.94V2.75a.75.75 0 00-1.5 0v4c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-2.19l2.72-2.72a.75.75 0 00-1.06-1.06L10 4.94zM2.75 8.5a.75.75 0 000 1.5h2.19l-2.72 2.72a.75.75 0 101.06 1.06L6 11.06v2.19a.75.75 0 001.5 0v-4a.75.75 0 00-.75-.75h-4z"/></g></svg>');
+}
+
+%minimize-24-svg-prop {
+  --minimize-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M20.78 4.28a.75.75 0 00-1.06-1.06L14.5 8.44V4.75a.75.75 0 00-1.5 0v5.5a.747.747 0 00.75.75h5.5a.75.75 0 000-1.5h-3.69l5.22-5.22zM4 13.75c0 .414.336.75.75.75h3.69l-5.22 5.22a.75.75 0 101.06 1.06l5.22-5.22v3.69a.75.75 0 001.5 0v-5.5a.747.747 0 00-.215-.525l-.01-.01A.747.747 0 0010.25 13h-5.5a.75.75 0 00-.75.75z"/></g></svg>');
+}
+
+%minimize-alt-16-svg-prop {
+  --minimize-alt-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M5.25.953a.75.75 0 01.75.75V3.75A2.25 2.25 0 013.75 6H1.703a.75.75 0 110-1.5H3.75a.75.75 0 00.75-.75V1.703a.75.75 0 01.75-.75zm5.5 0a.75.75 0 01.75.75V3.75c0 .414.336.75.75.75h2.047a.75.75 0 010 1.5H12.25A2.25 2.25 0 0110 3.75V1.703a.75.75 0 01.75-.75zM.953 10.75a.75.75 0 01.75-.75H3.75A2.25 2.25 0 016 12.25v2.047a.75.75 0 01-1.5 0V12.25a.75.75 0 00-.75-.75H1.703a.75.75 0 01-.75-.75zM10 12.25A2.25 2.25 0 0112.25 10h2.047a.75.75 0 110 1.5H12.25a.75.75 0 00-.75.75v2.047a.75.75 0 01-1.5 0V12.25z" clip-rule="evenodd"/></svg>');
+}
+
+%minimize-alt-24-svg-prop {
+  --minimize-alt-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M8.25 2.25A.75.75 0 019 3v3.25A2.75 2.75 0 016.25 9H3a.75.75 0 010-1.5h3.25c.69 0 1.25-.56 1.25-1.25V3a.75.75 0 01.75-.75zm7.5 0a.75.75 0 01.75.75v3.25c0 .69.56 1.25 1.25 1.25H21A.75.75 0 0121 9h-3.25A2.75 2.75 0 0115 6.25V3a.75.75 0 01.75-.75zm-13.5 13.5A.75.75 0 013 15h3.25A2.75 2.75 0 019 17.75V21a.75.75 0 01-1.5 0v-3.25c0-.69-.56-1.25-1.25-1.25H3a.75.75 0 01-.75-.75zm12.75 2A2.75 2.75 0 0117.75 15H21a.75.75 0 010 1.5h-3.25c-.69 0-1.25.56-1.25 1.25V21a.75.75 0 01-1.5 0v-3.25z" clip-rule="evenodd"/></svg>');
+}
+
+%minus-16-svg-prop {
+  --minus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.5 7.75A.75.75 0 014.25 7h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%minus-24-svg-prop {
+  --minus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4.5 11.75a.75.75 0 01.75-.75h13.5a.75.75 0 010 1.5H5.25a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></svg>');
+}
+
+%minus-circle-16-svg-prop {
+  --minus-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M4.75 7a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5z"/><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%minus-circle-24-svg-prop {
+  --minus-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.25 11a.75.75 0 000 1.5h7.5a.75.75 0 000-1.5h-7.5z"/><path fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z" clip-rule="evenodd"/></g></svg>');
 }
 
 %minus-circle-fill-svg-prop {
@@ -494,20 +2526,164 @@
   --minus-plain-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M18 13H6v-2h12v2z" fill="%23000"/></svg>');
 }
 
+%minus-plus-16-svg-prop {
+  --minus-plus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.72 3.22a.75.75 0 111.06 1.06l-8.5 8.5a.75.75 0 01-1.06-1.06l8.5-8.5zM2.25 4a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5zM10 10a.75.75 0 000 1.5h1.5V13a.75.75 0 001.5 0v-1.5h1.5a.75.75 0 000-1.5H13V8.5a.75.75 0 00-1.5 0V10H10z"/></g></svg>');
+}
+
+%minus-plus-24-svg-prop {
+  --minus-plus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M17.72 5.22a.75.75 0 111.06 1.06l-12.5 12.5a.75.75 0 01-1.06-1.06l12.5-12.5zM3.5 6.75A.75.75 0 014.25 6h5.5a.75.75 0 010 1.5h-5.5a.75.75 0 01-.75-.75zM16.5 13.5a.75.75 0 011.5 0V16h2.5a.75.75 0 010 1.5H18V20a.75.75 0 01-1.5 0v-2.5H14a.75.75 0 010-1.5h2.5v-2.5z"/></g></svg>');
+}
+
+%minus-plus-circle-16-svg-prop {
+  --minus-plus-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.75 4.5a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3zM10.25 7.5a.75.75 0 01.75.75V9.5h1.25a.75.75 0 010 1.5H11v1.25a.75.75 0 01-1.5 0V11H8.25a.75.75 0 010-1.5H9.5V8.25a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M5.25 0a5.25 5.25 0 015.244 5.006 5.25 5.25 0 11-5.488 5.488A5.25 5.25 0 015.25 0zM1.5 5.25a3.75 3.75 0 017.499-.1A5.258 5.258 0 005.15 8.999 3.75 3.75 0 011.5 5.25zm8.75 1.25a3.75 3.75 0 100 7.5 3.75 3.75 0 000-7.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%minus-plus-circle-24-svg-prop {
+  --minus-plus-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M6 7a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5H6zM15.75 12.25A.75.75 0 0015 13v2h-2a.75.75 0 000 1.5h2v2a.75.75 0 001.5 0v-2h2a.75.75 0 000-1.5h-2v-2a.75.75 0 00-.75-.75z"/><path fill-rule="evenodd" d="M8.25 15.5c.085 0 .17-.002.254-.004a7.25 7.25 0 106.991-6.991A7.25 7.25 0 108.25 15.5zm0-13a5.75 5.75 0 10.467 11.481 7.262 7.262 0 015.264-5.264A5.75 5.75 0 008.25 2.5zM10 15.75a5.75 5.75 0 1111.5 0 5.75 5.75 0 01-11.5 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%minus-plus-square-16-svg-prop {
+  --minus-plus-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M10.75 8a.75.75 0 01.75.75V10h1.25a.75.75 0 010 1.5H11.5v1.25a.75.75 0 01-1.5 0V11.5H8.75a.75.75 0 010-1.5H10V8.75a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M0 2.25A2.25 2.25 0 012.25 0h6a2.25 2.25 0 012.25 2.25V5.5h3.25A2.25 2.25 0 0116 7.75v6A2.25 2.25 0 0113.75 16h-6a2.25 2.25 0 01-2.25-2.25V10.5H2.25A2.25 2.25 0 010 8.25v-6zm9 0V5.5H7.707A.749.749 0 007 4.5H3.5a.75.75 0 000 1.5h2.836A2.246 2.246 0 005.5 7.75V9H2.25a.75.75 0 01-.75-.75v-6a.75.75 0 01.75-.75h6a.75.75 0 01.75.75zm-2 11.5v-6A.75.75 0 017.75 7h6a.75.75 0 01.75.75v6a.75.75 0 01-.75.75h-6a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%minus-plus-square-24-svg-prop {
+  --minus-plus-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5.25 7.75A.75.75 0 016 7h4.5a.75.75 0 010 1.5H6a.75.75 0 01-.75-.75zM15.75 12.25A.75.75 0 0015 13v2h-2a.75.75 0 000 1.5h2v2a.75.75 0 001.5 0v-2h2a.75.75 0 000-1.5h-2v-2a.75.75 0 00-.75-.75z"/><path fill-rule="evenodd" d="M4.25 1.5A2.75 2.75 0 001.5 4.25v8A2.75 2.75 0 004.25 15H9v4.75a2.75 2.75 0 002.75 2.75h8a2.75 2.75 0 002.75-2.75v-8A2.75 2.75 0 0019.75 9H15V4.25a2.75 2.75 0 00-2.75-2.75h-8zM13.5 9V4.25c0-.69-.56-1.25-1.25-1.25h-8C3.56 3 3 3.56 3 4.25v8c0 .69.56 1.25 1.25 1.25H9v-1.75A2.75 2.75 0 0111.75 9h1.75zm-3 10.75c0 .69.56 1.25 1.25 1.25h8c.69 0 1.25-.56 1.25-1.25v-8c0-.69-.56-1.25-1.25-1.25h-8c-.69 0-1.25.56-1.25 1.25v8z" clip-rule="evenodd"/></g></svg>');
+}
+
+%minus-square-16-svg-prop {
+  --minus-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.25 7a.75.75 0 000 1.5h5.5a.75.75 0 000-1.5h-5.5z"/><path fill-rule="evenodd" d="M3.25 1A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1h-9.5zM2.5 3.25a.75.75 0 01.75-.75h9.5a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75v-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%minus-square-24-svg-prop {
+  --minus-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.25 11a.75.75 0 000 1.5h7.5a.75.75 0 000-1.5h-7.5z"/><path fill-rule="evenodd" d="M4.75 2A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V4.75A2.75 2.75 0 0019.25 2H4.75zM3.5 4.75c0-.69.56-1.25 1.25-1.25h14.5c.69 0 1.25.56 1.25 1.25v14.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25V4.75z" clip-rule="evenodd"/></g></svg>');
+}
+
 %minus-square-fill-svg-prop {
   --minus-square-fill-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10H7v-2h10v2z" fill="%23000"/></svg>');
+}
+
+%module-16-svg-prop {
+  --module-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M11.5 4.75a.75.75 0 00-.897-.735l-5.5 1.1a.75.75 0 00-.603.735v5.4a.75.75 0 00.897.735l5.5-1.1a.75.75 0 00.603-.735v-5.4zM6 10.335v-3.87l4-.8v3.87l-4 .8z"/><path d="M15 2.33A2.25 2.25 0 0012.309.123l-9.5 1.9A2.25 2.25 0 001 4.23v9.44a2.25 2.25 0 002.691 2.207l9.5-1.9A2.25 2.25 0 0015 11.77V2.33zm-2.397-.736a.75.75 0 01.897.736v9.44a.75.75 0 01-.603.736l-9.5 1.9a.75.75 0 01-.897-.736V4.23a.75.75 0 01.603-.736l9.5-1.9z"/></g></svg>');
+}
+
+%module-24-svg-prop {
+  --module-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M17 7.866a1.25 1.25 0 00-1.507-1.223l-7.5 1.578A1.25 1.25 0 007 9.444v7.69c0 .794.73 1.387 1.507 1.223l7.5-1.578A1.25 1.25 0 0017 15.556v-7.69zM8.5 9.647l7-1.473v7.179l-7 1.473V9.647z"/><path d="M21 4.719a2.75 2.75 0 00-3.32-2.69L5.18 4.68A2.75 2.75 0 003 7.37v12.911a2.75 2.75 0 003.32 2.69l12.5-2.651A2.75 2.75 0 0021 17.63V4.719zm-3.01-1.223a1.25 1.25 0 011.51 1.223v12.91c0 .591-.413 1.101-.99 1.224l-12.5 2.651a1.25 1.25 0 01-1.51-1.223V7.371c0-.591.413-1.101.99-1.223l12.5-2.652z"/></g></svg>');
 }
 
 %module-svg-prop {
   --module-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15 8l-6 2.588L9.063 16l5.874-2.623L15 8z" fill="%23000"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 8.47L19 2l-.146 13.443L5.146 22 5 8.47zm2 1.06L17 5l-.104 9.41L7.104 19 7 9.53z" fill="currentColor"/></svg>');
 }
 
+%monitor-16-svg-prop {
+  --monitor-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 3.25A2.25 2.25 0 012.25 1h11.5A2.25 2.25 0 0116 3.25v6.5A2.25 2.25 0 0113.75 12H8.5v1.5H11a.75.75 0 010 1.5H5a.75.75 0 010-1.5h2V12H2.25A2.25 2.25 0 010 9.75v-6.5zm13.75 7.25a.75.75 0 00.75-.75v-6.5a.75.75 0 00-.75-.75H2.25a.75.75 0 00-.75.75v6.5c0 .414.336.75.75.75h11.5z" clip-rule="evenodd"/></svg>');
+}
+
+%monitor-24-svg-prop {
+  --monitor-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M1 4.75A2.75 2.75 0 013.75 2h16.5A2.75 2.75 0 0123 4.75v10.5A2.75 2.75 0 0120.25 18H12.5v2.5H16a.75.75 0 010 1.5H8a.75.75 0 010-1.5h3V18H3.75A2.75 2.75 0 011 15.25V4.75zM20.25 16.5c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H3.75c-.69 0-1.25.56-1.25 1.25v10.5c0 .69.56 1.25 1.25 1.25h16.5z" clip-rule="evenodd"/></svg>');
+}
+
+%moon-16-svg-prop {
+  --moon-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8.09 1.382a.75.75 0 01-.05.814 4.121 4.121 0 005.764 5.764.75.75 0 011.193.672 7.014 7.014 0 11-7.63-7.629.75.75 0 01.723.379zm-2.06 1.46a5.513 5.513 0 107.128 7.128A5.621 5.621 0 016.03 2.843z" clip-rule="evenodd"/></svg>');
+}
+
+%moon-24-svg-prop {
+  --moon-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M11.82 2.382a.75.75 0 01-.05.814 6.46 6.46 0 009.034 9.034.75.75 0 011.193.672 10.02 10.02 0 11-10.9-10.899.75.75 0 01.723.379zm-2.12 1.4A8.52 8.52 0 1020.217 14.3 7.96 7.96 0 019.7 3.783z" clip-rule="evenodd"/></svg>');
+}
+
+%more-horizontal-16-svg-prop {
+  --more-horizontal-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.5 6.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM8 6.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM12.5 6.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3z"/></g></svg>');
+}
+
+%more-horizontal-24-svg-prop {
+  --more-horizontal-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5 10a2 2 0 100 4 2 2 0 000-4zM12 10a2 2 0 100 4 2 2 0 000-4zM19 10a2 2 0 100 4 2 2 0 000-4z"/></g></svg>');
+}
+
 %more-horizontal-svg-prop {
   --more-horizontal-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" fill="%23000"/></svg>');
 }
 
+%more-vertical-16-svg-prop {
+  --more-vertical-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 2a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM8 6.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM8 11a1.5 1.5 0 100 3 1.5 1.5 0 000-3z"/></g></svg>');
+}
+
+%more-vertical-24-svg-prop {
+  --more-vertical-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 3.5a2 2 0 100 4 2 2 0 000-4zM12 10a2 2 0 100 4 2 2 0 000-4zM12 16.5a2 2 0 100 4 2 2 0 000-4z"/></g></svg>');
+}
+
 %more-vertical-svg-prop {
   --more-vertical-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" fill="%23000"/></svg>');
+}
+
+%mouse-pointer-16-svg-prop {
+  --mouse-pointer-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2.538 1.558a.75.75 0 00-.98.98l4.79 11.5a.75.75 0 001.403-.047l1.313-3.866 3.656 3.655a.75.75 0 101.06-1.06l-3.655-3.656 3.866-1.313a.75.75 0 00.048-1.402l-11.5-4.791zm4.432 10.07L3.643 3.643l7.985 3.327-3.127 1.062a.75.75 0 00-.47.469L6.97 11.628z" clip-rule="evenodd"/></svg>');
+}
+
+%mouse-pointer-24-svg-prop {
+  --mouse-pointer-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M3.038 2.058a.75.75 0 00-.98.98l7.29 17.5a.75.75 0 001.403-.047l2.2-6.479 5.769 5.768a.75.75 0 101.06-1.06l-5.768-5.768 6.48-2.201a.75.75 0 00.046-1.402l-17.5-7.291zm6.931 16.07L4.143 4.143l13.985 5.826-5.74 1.95a.75.75 0 00-.469.469l-1.95 5.74z" clip-rule="evenodd"/></svg>');
+}
+
+%move-16-svg-prop {
+  --move-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M7.463.057A.748.748 0 007.22.22l-2 2a.75.75 0 001.06 1.06L7 2.56V7H2.56l.72-.72a.75.75 0 00-1.06-1.06l-2 2a.748.748 0 000 1.06l2 2a.75.75 0 101.06-1.06l-.72-.72H7v4.44l-.72-.72a.75.75 0 00-1.06 1.06l2 2a.748.748 0 001.06 0l2-2a.75.75 0 10-1.06-1.06l-.72.72V8.5h4.44l-.72.72a.75.75 0 101.06 1.06l2-2a.748.748 0 000-1.06l-2-2a.75.75 0 10-1.06 1.06l.72.72H8.5V2.56l.72.72a.75.75 0 101.06-1.06l-2-2a.748.748 0 00-.817-.163z"/></svg>');
+}
+
+%move-24-svg-prop {
+  --move-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M11.463 1.057a.748.748 0 00-.243.163l-3 3a.75.75 0 001.06 1.06L11 3.56V11H3.56l1.72-1.72a.75.75 0 00-1.06-1.06l-3 3a.748.748 0 000 1.06l3 3a.75.75 0 001.06-1.06L3.56 12.5H11v7.44l-1.72-1.72a.75.75 0 00-1.06 1.06l3 3a.748.748 0 001.06 0l3-3a.75.75 0 10-1.06-1.06l-1.72 1.72V12.5h7.44l-1.72 1.72a.75.75 0 101.06 1.06l3-3a.748.748 0 000-1.06l-3-3a.75.75 0 10-1.06 1.06L19.94 11H12.5V3.56l1.72 1.72a.75.75 0 101.06-1.06l-3-3a.748.748 0 00-.817-.163z"/></svg>');
+}
+
+%music-16-svg-prop {
+  --music-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M13.5 3.687a.25.25 0 00-.293-.246l-6.5 1.121a.25.25 0 00-.207.247v7.348a2.75 2.75 0 01-2.318 2.716l-.678.107a2.164 2.164 0 01-.68-4.274L5 10.36V4.809c0-.852.613-1.58 1.452-1.725l6.5-1.121A1.75 1.75 0 0115 3.687v7.47a2.75 2.75 0 01-2.318 2.716l-.678.107a2.164 2.164 0 01-.68-4.274L13.5 9.36V3.687zM5 11.88l-1.94.309a.664.664 0 10.208 1.311l.678-.108A1.25 1.25 0 005 12.157v-.278zm6.56-.691l1.94-.31v.279a1.25 1.25 0 01-1.054 1.234l-.678.108a.664.664 0 11-.208-1.312z" clip-rule="evenodd"/></svg>');
+}
+
+%music-24-svg-prop {
+  --music-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M20.5 4.27a.75.75 0 00-.873-.74l-9 1.5a.75.75 0 00-.627.74v13.286a2.75 2.75 0 01-2.298 2.712l-2 .334A2.75 2.75 0 012.5 19.389v-.445a2.75 2.75 0 012.298-2.712l3.702-.617V5.77c0-1.1.795-2.039 1.88-2.22l9-1.5A2.25 2.25 0 0122 4.271v12.785a2.75 2.75 0 01-2.298 2.712l-2 .334a2.75 2.75 0 01-3.202-2.713v-.445a2.75 2.75 0 012.298-2.712l3.702-.617V4.27zm0 10.865l-3.456.576A1.25 1.25 0 0016 16.944v.445c0 .773.694 1.36 1.456 1.233l2-.333a1.25 1.25 0 001.044-1.233v-1.92zM5.044 17.711l3.456-.576v1.92a1.25 1.25 0 01-1.045 1.234l-2 .333A1.25 1.25 0 014 19.39v-.445a1.25 1.25 0 011.045-1.233z" clip-rule="evenodd"/></svg>');
+}
+
+%navigation-16-svg-prop {
+  --navigation-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M14.78 1.22a.75.75 0 01.148.851l-5.921 12.5a.75.75 0 01-1.406-.14L6.395 9.606 1.568 8.4a.75.75 0 01-.14-1.406l12.5-5.92a.75.75 0 01.852.147zM3.965 7.452l3.23.807a.75.75 0 01.546.546l.807 3.23 4.125-8.708-8.708 4.125z" clip-rule="evenodd"/></svg>');
+}
+
+%navigation-24-svg-prop {
+  --navigation-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M21.78 2.22a.75.75 0 01.148.851l-8.763 18.5a.75.75 0 01-1.406-.14L9.921 14.08l-7.353-1.838a.75.75 0 01-.14-1.406l18.5-8.763a.75.75 0 01.852.148zM4.965 11.294l5.756 1.439a.75.75 0 01.546.546l1.44 5.756 6.966-14.708-14.708 6.967z" clip-rule="evenodd"/></svg>');
+}
+
+%navigation-alt-16-svg-prop {
+  --navigation-alt-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 1a.75.75 0 01.691.46l5.25 12.5a.75.75 0 01-1.027.96L8 12.457 3.086 14.92a.75.75 0 01-1.027-.96l5.25-12.5A.75.75 0 018 1zM4.227 12.67l3.437-1.722a.75.75 0 01.672 0l3.437 1.723L8 3.687 4.227 12.67z" clip-rule="evenodd"/></svg>');
+}
+
+%navigation-alt-24-svg-prop {
+  --navigation-alt-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 2a.75.75 0 01.698.476l7.25 18.5a.75.75 0 01-1.053.935L12 18.207 5.105 21.91a.75.75 0 01-1.053-.935l7.25-18.5A.75.75 0 0112 2zM6.193 19.623l5.452-2.928a.75.75 0 01.71 0l5.452 2.928L12 4.806 6.193 19.623z" clip-rule="evenodd"/></svg>');
+}
+
+%network-16-svg-prop {
+  --network-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M6.25 0C5.56 0 5 .56 5 1.25v3.5C5 5.44 5.56 6 6.25 6H7v1H1a.75.75 0 000 1.5h2.5V10H2.25C1.56 10 1 10.56 1 11.25v3.5c0 .69.56 1.25 1.25 1.25h3.5C6.44 16 7 15.44 7 14.75v-3.5C7 10.56 6.44 10 5.75 10H5V8.5h6V10h-.75C9.56 10 9 10.56 9 11.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5c0-.69-.56-1.25-1.25-1.25H12.5V8.5H15A.75.75 0 0015 7H8.5V6h1.25C10.44 6 11 5.44 11 4.75v-3.5C11 .56 10.44 0 9.75 0h-3.5zm4.25 11.5v3h3v-3h-3zm-8 0v3h3v-3h-3zm7-7v-3h-3v3h3z" clip-rule="evenodd"/></svg>');
+}
+
+%network-24-svg-prop {
+  --network-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M10.25 2.5A1.75 1.75 0 008.5 4.25v3.5c0 .966.784 1.75 1.75 1.75H11V11H3a.75.75 0 000 1.5h3.5v2H5.25a1.75 1.75 0 00-1.75 1.75v3.5c0 .966.784 1.75 1.75 1.75h3.5a1.75 1.75 0 001.75-1.75v-3.5a1.75 1.75 0 00-1.75-1.75H8v-2h8v2h-.75a1.75 1.75 0 00-1.75 1.75v3.5c0 .966.784 1.75 1.75 1.75h3.5a1.75 1.75 0 001.75-1.75v-3.5a1.75 1.75 0 00-1.75-1.75H17.5v-2H21a.75.75 0 000-1.5h-8.5V9.5h1.25a1.75 1.75 0 001.75-1.75v-3.5a1.75 1.75 0 00-1.75-1.75h-3.5zM10 4.25a.25.25 0 01.25-.25h3.5a.25.25 0 01.25.25v3.5a.25.25 0 01-.25.25h-3.5a.25.25 0 01-.25-.25v-3.5zm-5 12a.25.25 0 01.25-.25h3.5a.25.25 0 01.25.25v3.5a.25.25 0 01-.25.25h-3.5a.25.25 0 01-.25-.25v-3.5zM15.25 16a.25.25 0 00-.25.25v3.5c0 .138.112.25.25.25h3.5a.25.25 0 00.25-.25v-3.5a.25.25 0 00-.25-.25h-3.5z" clip-rule="evenodd"/></svg>');
+}
+
+%network-alt-16-svg-prop {
+  --network-alt-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M16 8a.75.75 0 00-.22-.53l-3.5-3.5a.75.75 0 10-1.06 1.06L14.19 8l-2.97 2.97a.75.75 0 101.06 1.06l3.5-3.5A.75.75 0 0016 8zM.22 8.53a.75.75 0 010-1.06l3.5-3.5a.75.75 0 011.06 1.06L1.81 8l2.97 2.97a.75.75 0 11-1.06 1.06l-3.5-3.5z"/><path d="M5 7a1 1 0 000 2h.01a1 1 0 100-2H5zM7 8a1 1 0 011-1h.01a1 1 0 010 2H8a1 1 0 01-1-1zM11 7a1 1 0 100 2h.01a1 1 0 100-2H11z"/></g></svg>');
+}
+
+%network-alt-24-svg-prop {
+  --network-alt-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M23 12a.75.75 0 00-.232-.543l-5.5-5.25a.75.75 0 00-1.036 1.086L21.164 12l-4.932 4.707a.75.75 0 001.036 1.085l5.5-5.25A.75.75 0 0023 12zM1 12a.75.75 0 01.232-.543l5.5-5.25a.75.75 0 111.036 1.086L2.836 12l4.932 4.707a.75.75 0 01-1.036 1.085l-5.5-5.25A.75.75 0 011 12z"/><path d="M8 11a1 1 0 100 2h.01a1 1 0 100-2H8zM11 12a1 1 0 011-1h.01a1 1 0 110 2H12a1 1 0 01-1-1zM16 11a1 1 0 100 2h.01a1 1 0 100-2H16z"/></g></svg>');
+}
+
+%newspaper-16-svg-prop {
+  --newspaper-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.75 9.5a.75.75 0 000 1.5h4.5a.75.75 0 000-1.5h-4.5zM6 12.75a.75.75 0 01.75-.75h2.5a.75.75 0 010 1.5h-2.5a.75.75 0 01-.75-.75z"/><path fill-rule="evenodd" d="M7.25 2.5C6.56 2.5 6 3.06 6 3.75v3.5c0 .69.56 1.25 1.25 1.25h4.5c.69 0 1.25-.56 1.25-1.25v-3.5c0-.69-.56-1.25-1.25-1.25h-4.5zM7.5 7V4h4v3h-4z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M2.75 16h10.5a2.25 2.25 0 002.25-2.25V2.25A2.25 2.25 0 0013.25 0h-7.5A2.25 2.25 0 003.5 2.25V3.5h-.75A2.25 2.25 0 00.5 5.75v8A2.25 2.25 0 002.75 16zM14 2.25v11.5a.75.75 0 01-.75.75H4.872c.083-.235.128-.487.128-.75V2.25a.75.75 0 01.75-.75h7.5a.75.75 0 01.75.75zM2.75 14.5a.75.75 0 00.75-.75V5h-.75a.75.75 0 00-.75.75v8c0 .414.336.75.75.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%newspaper-24-svg-prop {
+  --newspaper-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9.75 13a.75.75 0 000 1.5h7a.75.75 0 000-1.5h-7zM9 16.75a.75.75 0 01.75-.75h4a.75.75 0 010 1.5h-4a.75.75 0 01-.75-.75z"/><path fill-rule="evenodd" d="M10.75 4.5A1.75 1.75 0 009 6.25v3.5c0 .966.784 1.75 1.75 1.75h6.5A1.75 1.75 0 0019 9.75v-3.5a1.75 1.75 0 00-1.75-1.75h-6.5zm-.25 1.75a.25.25 0 01.25-.25h6.5a.25.25 0 01.25.25v3.5a.25.25 0 01-.25.25h-6.5a.25.25 0 01-.25-.25v-3.5z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M19.75 23H4.25a2.75 2.75 0 01-2.75-2.75v-12A2.75 2.75 0 014.25 5.5H5.5V3.75A2.75 2.75 0 018.25 1h11.5a2.75 2.75 0 012.75 2.75v16.5A2.75 2.75 0 0119.75 23zM21 3.75v16.5c0 .69-.56 1.25-1.25 1.25H6.7c.192-.375.3-.8.3-1.25V3.75c0-.69.56-1.25 1.25-1.25h11.5c.69 0 1.25.56 1.25 1.25zM3 20.25a1.25 1.25 0 102.5 0V7H4.25C3.56 7 3 7.56 3 8.25v12z" clip-rule="evenodd"/></g></svg>');
+}
+
+%node-16-svg-prop {
+  --node-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4 6.25A2.25 2.25 0 016.25 4h3a2.25 2.25 0 012.25 2.25V7h3.25a.75.75 0 010 1.5H11.5v.75a2.25 2.25 0 01-2.25 2.25h-3A2.25 2.25 0 014 9.25V8.5H.75a.75.75 0 010-1.5H4v-.75zm6 0a.75.75 0 00-.75-.75h-3a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h3a.75.75 0 00.75-.75v-3z" clip-rule="evenodd"/></svg>');
+}
+
+%node-24-svg-prop {
+  --node-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M7 9.25A2.75 2.75 0 019.75 6.5h5a2.75 2.75 0 012.75 2.75V11h4.75a.75.75 0 010 1.5H17.5v1.75A2.75 2.75 0 0114.75 17h-5A2.75 2.75 0 017 14.25V12.5H2.25a.75.75 0 010-1.5H7V9.25zm9 0C16 8.56 15.44 8 14.75 8h-5c-.69 0-1.25.56-1.25 1.25v5c0 .69.56 1.25 1.25 1.25h5c.69 0 1.25-.56 1.25-1.25v-5z" clip-rule="evenodd"/></svg>');
 }
 
 %notification-disabled-svg-prop {
@@ -522,20 +2698,188 @@
   --notification-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 21.5c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.63-5.64-4.5-6.32V3.5c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 4.86 6 7.42 6 10.5v5l-2 2v1h16v-1l-2-2zm-2 1H8v-6C8 8.02 9.51 6 12 6s4 2.02 4 4.5v6z" fill="%23000"/></svg>');
 }
 
+%octagon-16-svg-prop {
+  --octagon-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.923.659A2.25 2.25 0 015.514 0h4.972c.597 0 1.169.237 1.59.659l3.265 3.264c.422.422.659.994.659 1.591v4.972a2.25 2.25 0 01-.659 1.59l-3.264 3.265a2.25 2.25 0 01-1.591.659H5.514a2.25 2.25 0 01-1.59-.659L.658 12.077A2.25 2.25 0 010 10.486V5.514c0-.597.237-1.169.659-1.59L3.923.658zm1.591.841a.75.75 0 00-.53.22L1.72 4.984a.75.75 0 00-.22.53v4.972c0 .199.079.39.22.53l3.264 3.264c.14.141.331.22.53.22h4.972a.75.75 0 00.53-.22l3.264-3.264a.75.75 0 00.22-.53V5.514a.75.75 0 00-.22-.53L11.016 1.72a.75.75 0 00-.53-.22H5.514z" clip-rule="evenodd"/></svg>');
+}
+
+%octagon-24-svg-prop {
+  --octagon-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M6.64 1.805A2.75 2.75 0 018.585 1h6.83c.73 0 1.429.29 1.945.805l4.835 4.835A2.75 2.75 0 0123 8.585v6.83c0 .73-.29 1.429-.805 1.945l-4.835 4.835a2.75 2.75 0 01-1.945.805h-6.83a2.75 2.75 0 01-1.945-.805L1.805 17.36A2.75 2.75 0 011 15.415v-6.83c0-.73.29-1.429.805-1.945L6.64 1.805zm1.945.695c-.332 0-.65.132-.884.366L2.866 7.701a1.25 1.25 0 00-.366.884v6.83c0 .332.132.65.366.884l4.835 4.835c.234.234.552.366.884.366h6.83c.332 0 .65-.132.884-.366l4.835-4.835a1.25 1.25 0 00.366-.884v-6.83c0-.332-.132-.65-.366-.884l-4.835-4.835a1.25 1.25 0 00-.884-.366h-6.83z" clip-rule="evenodd"/></svg>');
+}
+
+%okta-16-svg-prop {
+  --okta-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M8 1C4.143 1 1 4.12 1 8s3.121 7 7 7 7-3.121 7-7-3.143-7-7-7zm0 10.5c-1.94 0-3.5-1.56-3.5-3.5S6.06 4.5 8 4.5s3.5 1.56 3.5 3.5-1.56 3.5-3.5 3.5z"/></svg>');
+}
+
+%okta-24-svg-prop {
+  --okta-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M12 2C6.49 2 2 6.458 2 12s4.459 10 10 10 10-4.459 10-10S17.51 2 12 2zm0 15c-2.77 0-5-2.23-5-5s2.23-5 5-5 5 2.23 5 5-2.23 5-5 5z"/></svg>');
+}
+
+%okta-color-16-svg-prop {
+  --okta-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23007DC1" d="M8 1C4.143 1 1 4.12 1 8s3.121 7 7 7 7-3.121 7-7-3.143-7-7-7zm0 10.5c-1.94 0-3.5-1.56-3.5-3.5S6.06 4.5 8 4.5s3.5 1.56 3.5 3.5-1.56 3.5-3.5 3.5z"/></svg>');
+}
+
+%okta-color-24-svg-prop {
+  --okta-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23007DC1" d="M12 2C6.49 2 2 6.458 2 12s4.459 10 10 10 10-4.459 10-10S17.51 2 12 2zm0 15c-2.77 0-5-2.23-5-5s2.23-5 5-5 5 2.23 5 5-2.23 5-5 5z"/></svg>');
+}
+
+%oracle-16-svg-prop {
+  --oracle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M.1 8c0 2.761 2.237 5 4.997 5h5.806A4.999 4.999 0 0015.9 8c0-2.761-2.237-5-4.997-5H5.097A4.999 4.999 0 00.1 8zm13.911 0a3.235 3.235 0 01-3.234 3.237H5.226A3.235 3.235 0 011.992 8a3.235 3.235 0 013.234-3.236h5.55A3.235 3.235 0 0114.012 8z" clip-rule="evenodd"/></svg>');
+}
+
+%oracle-24-svg-prop {
+  --oracle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M2 12c0 3.48 2.832 6.3 6.326 6.3h7.348C19.168 18.3 22 15.48 22 12s-2.832-6.3-6.326-6.3H8.326C4.832 5.7 2 8.52 2 12zm17.61 0a4.086 4.086 0 01-4.095 4.078H8.489a4.086 4.086 0 01-4.095-4.077A4.086 4.086 0 018.49 7.923h7.026a4.086 4.086 0 014.094 4.078z" clip-rule="evenodd"/></svg>');
+}
+
+%oracle-color-16-svg-prop {
+  --oracle-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23EA1B22" fill-rule="evenodd" d="M.1 8c0 2.761 2.237 5 4.997 5h5.806A4.999 4.999 0 0015.9 8c0-2.761-2.237-5-4.997-5H5.097A4.999 4.999 0 00.1 8zm13.911 0a3.235 3.235 0 01-3.234 3.237H5.226A3.235 3.235 0 011.992 8a3.235 3.235 0 013.234-3.236h5.55A3.235 3.235 0 0114.012 8z" clip-rule="evenodd"/></svg>');
+}
+
+%oracle-color-24-svg-prop {
+  --oracle-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23EA1B22" fill-rule="evenodd" d="M2 12c0 3.48 2.832 6.3 6.326 6.3h7.348C19.168 18.3 22 15.48 22 12s-2.832-6.3-6.326-6.3H8.326C4.832 5.7 2 8.52 2 12zm17.61 0a4.086 4.086 0 01-4.095 4.078H8.489a4.086 4.086 0 01-4.095-4.077A4.086 4.086 0 018.49 7.923h7.026a4.086 4.086 0 014.094 4.078z" clip-rule="evenodd"/></svg>');
+}
+
+%org-16-svg-prop {
+  --org-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h6.5A2.25 2.25 0 0112 3.25v2.112l2.05 1.453A2.25 2.25 0 0115 8.65v5.1c0 .69-.56 1.25-1.25 1.25h-2.5a.748.748 0 01-.75-.751v-11a.75.75 0 00-.75-.75h-6.5a.75.75 0 00-.75.75v11a.75.75 0 01-1.5 0v-11zM12 13.5V7.2l1.184.839a.75.75 0 01.316.612v4.85H12z" clip-rule="evenodd"/><path d="M4.75 10.55a.7.7 0 00-.7.7v3a.7.7 0 101.4 0v-2.3h2.1v2.3a.7.7 0 101.4 0v-3a.7.7 0 00-.7-.7h-3.5zM4.25 4.75A.75.75 0 015 4h.25a.75.75 0 010 1.5H5a.75.75 0 01-.75-.75zM7.75 4a.75.75 0 000 1.5H8A.75.75 0 008 4h-.25zM4.25 6.75A.75.75 0 015 6h.25a.75.75 0 010 1.5H5a.75.75 0 01-.75-.75zM7.75 6a.75.75 0 000 1.5H8A.75.75 0 008 6h-.25zM4.25 8.75A.75.75 0 015 8h.25a.75.75 0 010 1.5H5a.75.75 0 01-.75-.75zM7.75 8a.75.75 0 000 1.5H8A.75.75 0 008 8h-.25z"/></g></svg>');
+}
+
+%org-24-svg-prop {
+  --org-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2h10.5A2.75 2.75 0 0118 4.75v5.504l2.326.988A2.75 2.75 0 0122 13.773v6.477A1.75 1.75 0 0120.25 22h-3a.746.746 0 01-.622-.33.746.746 0 01-.128-.42V10.769a.81.81 0 010-.039V4.75c0-.69-.56-1.25-1.25-1.25H4.75c-.69 0-1.25.56-1.25 1.25v16.5a.75.75 0 01-1.5 0V4.75zM18 20.5v-8.616l1.739.739c.461.196.76.649.76 1.15v6.477a.25.25 0 01-.25.25H18z" clip-rule="evenodd"/><path d="M8.25 16C7.56 16 7 16.56 7 17.25v4a.75.75 0 001.5 0V17.5h3v3.75a.75.75 0 001.5 0v-4c0-.69-.56-1.25-1.25-1.25h-3.5zM7 6.75A.75.75 0 017.75 6h.5a.75.75 0 010 1.5h-.5A.75.75 0 017 6.75zM11.75 6a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM7 9.75A.75.75 0 017.75 9h.5a.75.75 0 010 1.5h-.5A.75.75 0 017 9.75zM11.75 9a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5zM7 12.75a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5a.75.75 0 01-.75-.75zM11.75 12a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5z"/></g></svg>');
+}
+
+%outline-16-svg-prop {
+  --outline-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.5 7.25a.75.75 0 01.75-.75h4a.75.75 0 010 1.5h-4a.75.75 0 01-.75-.75zM4.75 3.5a.75.75 0 000 1.5h.01a.75.75 0 000-1.5h-.01zM4 7.25a.75.75 0 01.75-.75h.01a.75.75 0 010 1.5h-.01A.75.75 0 014 7.25zM4.75 9.5a.75.75 0 000 1.5h.01a.75.75 0 000-1.5h-.01zM6.5 4.25a.75.75 0 01.75-.75h2.5a.75.75 0 010 1.5h-2.5a.75.75 0 01-.75-.75zM7.25 9.5a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z"/><path fill-rule="evenodd" d="M1 2.25A2.25 2.25 0 013.25 0h9.5A2.25 2.25 0 0115 2.25v11.5A2.25 2.25 0 0112.75 16h-9.5A2.25 2.25 0 011 13.75V2.25zm2.25-.75a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75V2.25a.75.75 0 00-.75-.75h-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%outline-24-svg-prop {
+  --outline-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M6.5 5.75A.75.75 0 017.25 5h.01a.75.75 0 010 1.5h-.01a.75.75 0 01-.75-.75zM7.25 9a.75.75 0 000 1.5h.01a.75.75 0 000-1.5h-.01zM6.5 13.75a.75.75 0 01.75-.75h.01a.75.75 0 010 1.5h-.01a.75.75 0 01-.75-.75zM7.25 17a.75.75 0 000 1.5h.01a.75.75 0 000-1.5h-.01zM9.5 9.75a.75.75 0 01.75-.75h4.5a.75.75 0 010 1.5h-4.5a.75.75 0 01-.75-.75zM10.25 5a.75.75 0 000 1.5h6.5a.75.75 0 000-1.5h-6.5zM9.5 13.75a.75.75 0 01.75-.75h6.5a.75.75 0 010 1.5h-6.5a.75.75 0 01-.75-.75zM10.25 17a.75.75 0 000 1.5h3.5a.75.75 0 000-1.5h-3.5z"/><path fill-rule="evenodd" d="M3 3.75A2.75 2.75 0 015.75 1h12.5A2.75 2.75 0 0121 3.75v16.5A2.75 2.75 0 0118.25 23H5.75A2.75 2.75 0 013 20.25V3.75zM5.75 2.5c-.69 0-1.25.56-1.25 1.25v16.5c0 .69.56 1.25 1.25 1.25h12.5c.69 0 1.25-.56 1.25-1.25V3.75c0-.69-.56-1.25-1.25-1.25H5.75z" clip-rule="evenodd"/></g></svg>');
+}
+
 %outline-svg-prop {
   --outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M19 2c1.05 0 1.918.82 1.994 1.851L21 4v16c0 1.05-.82 1.918-1.851 1.994L19 22H5c-1.05 0-1.918-.82-1.994-1.851L3 20V4c0-1.05.82-1.918 1.851-1.994L5 2h14zm0 2H5v16h14V4zM7.952 15.004a1 1 0 0 1 .998.998 1 1 0 0 1-.998.998 1 1 0 0 1-.998-.998 1 1 0 0 1 .998-.998zM15.944 15v2h-6v-2h6zm-2-4v2h-4v-2h4zm-5.992 0a1 1 0 0 1 .998.998 1 1 0 0 1-.998.998 1 1 0 0 1-.998-.998A1 1 0 0 1 7.952 11zm8.992-4v2h-7V7h7zm-8.992.004a1 1 0 0 1 .998.998A1 1 0 0 1 7.952 9a1 1 0 0 1-.998-.998 1 1 0 0 1 .998-.998z" fill="%23000"/></svg>');
+}
+
+%package-16-svg-prop {
+  --package-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.02.678a2.25 2.25 0 00-2.04 0L1.682 3.374A1.25 1.25 0 001 4.488v6.717c0 .658.37 1.26.956 1.56l5.023 2.557a2.25 2.25 0 002.042 0l5.023-2.557a1.75 1.75 0 00.956-1.56V4.488c0-.47-.264-.9-.683-1.114L9.021.678zM7.66 2.015a.75.75 0 01.68 0l4.436 2.258-1.468.734-4.805-2.403 1.157-.59zM4.84 3.45l-1.617.823L8 6.661l1.631-.815-4.79-2.396zM2.5 5.588v5.617c0 .094.053.18.137.223l4.613 2.348V7.964L2.5 5.588zm10.863 5.84L8.75 13.776V7.964l4.75-2.375v5.617a.25.25 0 01-.137.223z" clip-rule="evenodd"/></svg>');
+}
+
+%package-24-svg-prop {
+  --package-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M10.794.754a2.75 2.75 0 012.412 0l8.811 4.298c.602.293.983.904.983 1.573v9.902a2.75 2.75 0 01-1.496 2.448l-8.25 4.226a2.75 2.75 0 01-2.508 0l-8.25-4.226A2.75 2.75 0 011 16.527V6.625c0-.67.381-1.28.983-1.573L10.794.754zm1.754 1.348a1.25 1.25 0 00-1.096 0l-2.82 1.375 8.505 4.253 3.52-1.672-8.109-3.956zm2.869 6.445L6.934 4.306 3.343 6.058 12 10.17l3.417-1.623zM2.5 16.527v-9.21l8.75 4.157v10.3L3.18 17.64a1.25 1.25 0 01-.68-1.113zm18.32 1.113l-8.07 4.133V11.474l8.75-4.156v9.21c0 .469-.263.898-.68 1.112z" clip-rule="evenodd"/></svg>');
 }
 
 %page-outline-svg-prop {
   --page-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M19.045 2c1.05 0 1.917.82 1.994 1.851l.006.149v16c0 1.05-.82 1.918-1.852 1.994l-.148.006h-14c-1.05 0-1.918-.82-1.995-1.851L3.045 20V4c0-1.05.82-1.918 1.851-1.994L5.045 2h14zm0 2h-14v16h14V4zM7.997 15.004c.549 0 1.003.45 1.003.998a1 1 0 0 1-2.001 0 1 1 0 0 1 .998-.998zM15.989 15v2h-6v-2h6zM15 11v2h-5v-2h5zm-7.003 0c.549 0 1.003.45 1.003.998a1 1 0 0 1-2.001 0A1 1 0 0 1 7.997 11zM17 7.004L16.989 9H10V7.004h7zm-9.003 0a1 1 0 0 1 .998.998A1 1 0 0 1 7.997 9a1 1 0 0 1-.998-.998 1 1 0 0 1 .998-.998z" fill="%23000"/></svg>');
 }
 
+%paperclip-16-svg-prop {
+  --paperclip-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M9.387 2.102a2.034 2.034 0 012.864 0c.776.785.749 2.178 0 2.928-.75.749-6.39 6.465-6.39 6.465a.642.642 0 01-.898 0 .685.685 0 010-.937l5.896-5.966a.75.75 0 10-1.066-1.054L3.896 9.504a2.184 2.184 0 000 3.045 2.142 2.142 0 003.033 0l6.39-6.466c1.36-1.377 1.36-3.658 0-5.035-1.364-1.381-3.636-1.381-5 0L1.938 7.513A5.001 5.001 0 00.5 11.026c0 1.316.516 2.58 1.437 3.514A4.892 4.892 0 005.42 16c1.308 0 2.56-.526 3.482-1.46l6.383-6.466a.75.75 0 10-1.068-1.053l-6.382 6.465A3.392 3.392 0 015.419 14.5a3.392 3.392 0 01-2.414-1.014A3.501 3.501 0 012 11.026c0-.924.363-1.808 1.005-2.46l6.382-6.464z"/></svg>');
+}
+
+%paperclip-24-svg-prop {
+  --paperclip-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M16.072 2.5c-.868 0-1.7.342-2.31.949l-9.22 9.14A5.196 5.196 0 003 16.28c0 1.383.554 2.71 1.542 3.69a5.299 5.299 0 003.73 1.531c1.4 0 2.742-.552 3.73-1.532l9.22-9.14a.75.75 0 011.056 1.065l-9.22 9.14A6.799 6.799 0 018.273 23a6.799 6.799 0 01-4.786-1.966A6.696 6.696 0 011.5 16.279c0-1.785.715-3.495 1.986-4.755l9.219-9.14A4.783 4.783 0 0116.072 1c1.262 0 2.473.497 3.367 1.383a4.714 4.714 0 011.398 3.348c0 1.257-.504 2.46-1.398 3.347l-9.23 9.14a2.766 2.766 0 01-3.894 0 2.732 2.732 0 010-3.88l8.517-8.434a.75.75 0 011.055 1.066l-8.516 8.434a1.232 1.232 0 000 1.75 1.266 1.266 0 001.783 0l9.229-9.141a3.214 3.214 0 00.954-2.282c0-.855-.342-1.676-.954-2.282a3.283 3.283 0 00-2.311-.949z" clip-rule="evenodd"/></svg>');
+}
+
 %partner-svg-prop {
   --partner-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8.478 8.41l2.556-2.339H8.341L5 8.075H2v6.99h4.572l2.441 2.184c.913.779 1.473.779 2.028.54.61-.262.959-.699.959-.699l.613.517c.587.54 1.537.294 2.027-.192.745-.741.724-1.188.724-1.188l.517.43c.39.233.988-.025 1.187-.228.44-.446.54-.944.064-1.395l-4.124-3.669c-.545-.471-.562-.464-1.008-.094l-.491.445c-1.02.765-2.34.775-3.168-.128a2.25 2.25 0 0 1 .137-3.177z" fill="%23000"/><path d="M16.29 6.365l-.706-.294H12.9a1 1 0 0 0-.675.263L9.153 9.145l-.005.006-.004.007a1.242 1.242 0 0 0-.066 1.749c.397.434 1.231.55 1.753.084l.007-.003.006-.003 2.497-2.287a.5.5 0 1 1 .675.737l-.816.747 4.797 4.216H22V8.07h-4.003L16.29 6.365z" fill="currentColor"/></svg>');
 }
 
+%path-16-svg-prop {
+  --path-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M13 0a3 3 0 00-1.65 5.506 7.338 7.338 0 01-.78 1.493c-.22.32-.472.635-.8 1.025a1.509 1.509 0 00-.832.085 12.722 12.722 0 00-1.773-1.124c-.66-.34-1.366-.616-2.215-.871a1.5 1.5 0 10-2.708 1.204c-.9 1.935-1.236 3.607-1.409 5.838a1.5 1.5 0 101.497.095c.162-2.07.464-3.55 1.25-5.253.381-.02.725-.183.979-.435.763.23 1.367.471 1.919.756a11.13 11.13 0 011.536.973 1.5 1.5 0 102.899-.296c.348-.415.64-.779.894-1.148.375-.548.665-1.103.964-1.857A3 3 0 1013 0zm-1.5 3a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/></svg>');
+}
+
+%path-24-svg-prop {
+  --path-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M19.5 1a3.5 3.5 0 00-1.668 6.578c-.665 1.8-1.174 2.997-2.267 4.503a2.001 2.001 0 00-1.605.21c-1.859-1.251-3.599-1.917-5.978-2.56A2 2 0 104.48 11.3c-.616 1.268-1.071 2.439-1.406 3.674-.344 1.267-.556 2.585-.694 4.125a2 2 0 101.497.103c.132-1.465.332-2.682.644-3.835.303-1.115.715-2.186 1.29-3.375a1.997 1.997 0 001.8-.806c2.236.605 3.801 1.208 5.454 2.311A2.002 2.002 0 0015 16a2 2 0 001.74-2.986c1.25-1.71 1.815-3.057 2.537-5.021A3.5 3.5 0 1019.5 1zm-2 3.5a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/></svg>');
+}
+
 %path-svg-prop {
   --path-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.8532 7.87695C20.0944 7.50942 21 6.36046 21 5C21 3.34315 19.6569 2 18 2C16.3431 2 15 3.34315 15 5C15 6.25039 15.765 7.3221 16.8524 7.77269L16.602 10.0262C15.9316 10.115 15.3311 10.4253 14.8763 10.881L8.97505 8.6113C8.78445 7.13807 7.52513 6 6 6C4.34315 6 3 7.34315 3 9C3 10.3062 3.83481 11.4175 5 11.8293V16.1707C3.83481 16.5825 3 17.6938 3 19C3 20.6569 4.34315 22 6 22C7.65685 22 9 20.6569 9 19C9 17.6938 8.16519 16.5825 7 16.1707V11.8293C7.64469 11.6014 8.18824 11.1595 8.54521 10.5888L14.0155 12.6928C14.0053 12.7938 14 12.8963 14 13C14 14.6569 15.3431 16 17 16C18.6569 16 20 14.6569 20 13C20 11.9179 19.4271 10.9697 18.5682 10.442L18.8532 7.87695ZM18 6C18.5523 6 19 5.55228 19 5C19 4.44772 18.5523 4 18 4C17.4477 4 17 4.44772 17 5C17 5.55228 17.4477 6 18 6ZM7 9C7 9.55228 6.55228 10 6 10C5.44772 10 5 9.55228 5 9C5 8.44772 5.44772 8 6 8C6.55228 8 7 8.44772 7 9Z" fill="%23000"/></svg>');
+}
+
+%pause-16-svg-prop {
+  --pause-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6 3.75a.75.75 0 00-1.5 0v8.5a.75.75 0 001.5 0v-8.5zM11.5 3.75a.75.75 0 00-1.5 0v8.5a.75.75 0 001.5 0v-8.5z"/></g></svg>');
+}
+
+%pause-24-svg-prop {
+  --pause-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9 5.25a.75.75 0 00-1.5 0v13.5a.75.75 0 001.5 0V5.25zM16.5 5.25a.75.75 0 00-1.5 0v13.5a.75.75 0 001.5 0V5.25z"/></g></svg>');
+}
+
+%pause-circle-16-svg-prop {
+  --pause-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.25 5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 016.25 5zM10.5 5.75a.75.75 0 00-1.5 0v4.5a.75.75 0 001.5 0v-4.5z"/><path fill-rule="evenodd" d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z" clip-rule="evenodd"/></g></svg>');
+}
+
+%pause-circle-24-svg-prop {
+  --pause-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9.25 7a.75.75 0 01.75.75v8.5a.75.75 0 01-1.5 0v-8.5A.75.75 0 019.25 7zM15.5 7.75a.75.75 0 00-1.5 0v8.5a.75.75 0 001.5 0v-8.5z"/><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z" clip-rule="evenodd"/></g></svg>');
+}
+
+%pen-tool-16-svg-prop {
+  --pen-tool-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M.923.02A.75.75 0 00.02.923l2.476 10.433a.75.75 0 00.587.563l4.245.822a.75.75 0 00.142.864l2.175 2.175a.75.75 0 001.06 0l5.075-5.075a.75.75 0 000-1.06L13.605 7.47a.75.75 0 00-.864-.142l-.822-4.245a.75.75 0 00-.563-.587L.923.02zm10.529 8.542l-.913-4.718L3.15 2.09l3.08 3.08a2.25 2.25 0 11-1.06 1.06l-3.08-3.08 1.753 7.388 4.718.913 2.89-2.89zM9.06 13.075l4.014-4.014 1.114 1.114-4.014 4.014-1.114-1.114zM6.45 7.201a.75.75 0 111.5 0 .75.75 0 01-1.5 0z" clip-rule="evenodd"/></svg>');
+}
+
+%pen-tool-24-svg-prop {
+  --pen-tool-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M1.923 1.02a.75.75 0 00-.903.903l3.5 14.75a.75.75 0 00.588.563l6.51 1.26-.148.149a.75.75 0 000 1.06l3.075 3.075a.75.75 0 001.06 0l7.175-7.175a.75.75 0 000-1.06l-3.075-3.075a.75.75 0 00-1.06 0l-.149.148-1.26-6.51a.75.75 0 00-.563-.588l-14.75-3.5zm15.293 11.878l-1.36-7.03L4.15 3.091l5.325 5.324a3 3 0 11-1.06 1.06L3.09 4.152l2.777 11.705 7.03 1.36 4.318-4.318zm-4.155 6.277l6.114-6.114 2.014 2.014-6.114 6.114-2.014-2.014zM9.5 11a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/></svg>');
+}
+
+%pencil-tool-16-svg-prop {
+  --pencil-tool-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M12.988 2.177a1.75 1.75 0 00-2.475 0L3.26 9.429a2.75 2.75 0 00-.609.923l-1.347 3.37a.75.75 0 00.975.974l3.368-1.347a2.75 2.75 0 00.924-.61l7.252-7.252a1.75 1.75 0 000-2.475l-.835-.835zm-1.415 1.06a.25.25 0 01.354 0l.836.836a.25.25 0 010 .354l-.638.637-1.19-1.19.638-.637zM9.875 4.936L4.32 10.49a1.25 1.25 0 00-.277.42l-.698 1.744 1.744-.698c.157-.063.3-.157.42-.277l5.554-5.554-1.19-1.19z" clip-rule="evenodd"/></svg>');
+}
+
+%pencil-tool-24-svg-prop {
+  --pencil-tool-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M18.945 4.884a2.75 2.75 0 00-3.89 0L6.05 13.89A4.75 4.75 0 005 15.484l-1.695 4.238a.75.75 0 00.975.974l4.237-1.695a4.75 4.75 0 001.595-1.051l9.005-9.005a2.75 2.75 0 000-3.89l-.171-.17zm-2.829 1.06a1.25 1.25 0 011.768 0l.171.172a1.25 1.25 0 010 1.768l-.555.555L15.56 6.5l.556-.555zM14.5 7.562L7.11 14.95a3.25 3.25 0 00-.719 1.091l-1.045 2.613 2.613-1.045c.409-.164.78-.409 1.091-.72L16.44 9.5 14.5 7.56z" clip-rule="evenodd"/></svg>');
+}
+
+%phone-16-svg-prop {
+  --phone-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M4.87 1.671a.71.71 0 00-.469-.171H2.208a.712.712 0 00-.671.48.702.702 0 00-.034.284c.227 2.129.954 4.175 2.12 5.972 1.175 1.81 2.348 2.976 4.153 4.145a13.697 13.697 0 005.957 2.117.711.711 0 00.707-.421c.04-.09.06-.187.06-.285v-.071c-.002-.371-.009-1.792 0-2.134a.703.703 0 00-.606-.715c-.755-.1-1.496-.284-2.209-.55h-.002a.71.71 0 00-.746.158h-.002l-.923.922a.75.75 0 01-.9.121 12.403 12.403 0 01-4.655-4.646.75.75 0 01.122-.902l.924-.923a.704.704 0 00.158-.742L5.66 4.31a10.077 10.077 0 01-.55-2.205.704.704 0 00-.24-.433zM4.39.001a2.21 2.21 0 012.205 1.895v.007c.086.643.243 1.273.47 1.88l-.703.263.702-.264a2.202 2.202 0 01-.497 2.327l-.003.003-.51.509a10.903 10.903 0 003.314 3.306l.514-.514a2.21 2.21 0 012.327-.496c.609.226 1.24.384 1.884.468l.007.001a2.209 2.209 0 011.9 2.239 152.65 152.65 0 000 2.16 2.202 2.202 0 01-1.502 2.099c-.29.098-.6.135-.905.107l-.014-.001a15.196 15.196 0 01-6.618-2.35c-1.981-1.282-3.306-2.6-4.596-4.587A15.131 15.131 0 01.01 2.416L.01 2.404A2.202 2.202 0 011.317.188 2.21 2.21 0 012.207 0H4.39z" clip-rule="evenodd"/></svg>');
+}
+
+%phone-24-svg-prop {
+  --phone-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M7.778 2.817a1.314 1.314 0 00-.869-.317H3.81a1.316 1.316 0 00-1.241.89c-.058.17-.08.351-.064.53.326 3.06 1.37 6 3.047 8.583 1.684 2.595 3.374 4.276 5.963 5.951a19.676 19.676 0 008.56 3.041 1.316 1.316 0 001.315-.78c.073-.166.11-.346.11-.528l-.001-.1c-.002-.528-.011-2.53 0-3.008a1.304 1.304 0 00-1.124-1.326 14.005 14.005 0 01-3.057-.76h-.001a1.315 1.315 0 00-1.383.292l-.002.002-1.306 1.303a.75.75 0 01-.9.122 17.225 17.225 0 01-6.466-6.454.75.75 0 01.122-.902l1.307-1.305a1.306 1.306 0 00.294-1.377v-.001a13.937 13.937 0 01-.763-3.051 1.306 1.306 0 00-.442-.805zM6.898 1a2.814 2.814 0 012.808 2.414v.007c.124.932.352 1.846.681 2.726l-.702.263.702-.264a2.804 2.804 0 01-.633 2.962l-.003.003-.896.895a15.726 15.726 0 005.123 5.112l.9-.899a2.813 2.813 0 012.965-.632c.882.329 1.798.557 2.731.68h.007a2.813 2.813 0 012.418 2.85c-.011.451-.002 2.42 0 2.96v.104a2.803 2.803 0 01-1.91 2.671c-.371.125-.764.172-1.154.137l-.013-.002a21.173 21.173 0 01-9.222-3.274c-2.765-1.79-4.607-3.62-6.406-6.393a21.082 21.082 0 01-3.281-9.248L1.01 4.06a2.803 2.803 0 011.665-2.82A2.815 2.815 0 013.81 1h3.09z" clip-rule="evenodd"/></svg>');
+}
+
+%phone-call-16-svg-prop {
+  --phone-call-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M5.847.533A2.21 2.21 0 004.391 0H2.206a2.21 2.21 0 00-2.09 1.501c-.098.29-.135.598-.107.903l.001.012a15.13 15.13 0 002.355 6.637c1.29 1.987 2.615 3.304 4.596 4.587a15.196 15.196 0 006.618 2.35h.014a2.21 2.21 0 002.406-2.204v-.075c-.002-.383-.008-1.77 0-2.087A2.204 2.204 0 0014.1 9.386h-.007a8.626 8.626 0 01-1.884-.47 2.21 2.21 0 00-2.327.497l-.515.513a10.903 10.903 0 01-3.313-3.305l.51-.509.003-.003a2.204 2.204 0 00.498-2.326 8.577 8.577 0 01-.47-1.88v-.007A2.204 2.204 0 005.847.533zM4.401 1.5a.71.71 0 01.708.604c.1.753.285 1.493.55 2.205l.001.001a.703.703 0 01-.157.742l-.924.923a.75.75 0 00-.122.902 12.403 12.403 0 004.655 4.646.75.75 0 00.9-.121l.923-.921.002-.001a.709.709 0 01.746-.158h.002c.713.266 1.454.45 2.209.55a.709.709 0 01.606.715c-.009.342-.002 1.762 0 2.134v.07a.702.702 0 01-.481.671.711.711 0 01-.286.036 13.697 13.697 0 01-5.957-2.117c-1.805-1.169-2.979-2.336-4.153-4.145a13.631 13.631 0 01-2.12-5.972.702.702 0 01.419-.704c.09-.04.187-.06.286-.06H4.4zm2.664 2.283v-.001l-.703.264.703-.263z" clip-rule="evenodd"/><path d="M10.333.005a.75.75 0 00-.166 1.49 4.91 4.91 0 014.338 4.332.75.75 0 001.49-.167A6.41 6.41 0 0010.333.005z"/><path d="M10.394 2.53a.75.75 0 10-.288 1.472 2.394 2.394 0 011.892 1.892.75.75 0 001.472-.288 3.895 3.895 0 00-3.076-3.076z"/></g></svg>');
+}
+
+%phone-call-24-svg-prop {
+  --phone-call-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M14.833.005a.75.75 0 10-.166 1.49 8.872 8.872 0 017.838 7.828.75.75 0 001.49-.167A10.372 10.372 0 0014.833.005zM14.894 4.29a.75.75 0 00-.288 1.473 4.596 4.596 0 013.631 3.63.75.75 0 101.472-.287 6.096 6.096 0 00-4.815-4.815z"/><path fill-rule="evenodd" d="M8.755 1.678A2.814 2.814 0 006.898 1h-3.09a2.815 2.815 0 00-2.66 1.911c-.125.37-.172.76-.137 1.15l.002.011a21.082 21.082 0 003.28 9.248c1.8 2.773 3.642 4.604 6.407 6.393a21.175 21.175 0 009.221 3.274l.014.002a2.816 2.816 0 002.829-1.671c.157-.359.237-.746.235-1.137v-.105c-.002-.539-.011-2.508 0-2.96a2.804 2.804 0 00-2.418-2.849h-.007a12.51 12.51 0 01-2.732-.68 2.815 2.815 0 00-2.964.632l-.9.899a15.726 15.726 0 01-5.124-5.112l.897-.895.003-.003a2.806 2.806 0 00.633-2.961 12.436 12.436 0 01-.68-2.726l-.001-.007a2.806 2.806 0 00-.951-1.736zM6.909 2.5A1.314 1.314 0 018.22 3.622c.138 1.042.394 2.066.762 3.05v.002a1.304 1.304 0 01-.293 1.377L7.382 9.356a.75.75 0 00-.122.902 17.226 17.226 0 006.466 6.454.75.75 0 00.9-.122l1.306-1.303.001-.002a1.313 1.313 0 011.384-.293h.001c.987.368 2.012.623 3.057.761a1.313 1.313 0 011.125 1.326c-.012.479-.003 2.48-.001 3.007v.101a1.302 1.302 0 01-.424.968 1.313 1.313 0 01-1 .34 19.675 19.675 0 01-8.56-3.041c-2.59-1.676-4.28-3.357-5.963-5.951A19.582 19.582 0 012.505 3.92a1.303 1.303 0 01.776-1.308c.167-.074.347-.112.53-.112h3.098zm3.478 3.647v-.001l-.702.264.702-.263z" clip-rule="evenodd"/></g></svg>');
+}
+
+%phone-off-16-svg-prop {
+  --phone-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M4.401 1.5a.71.71 0 01.708.604c.1.753.285 1.493.55 2.205l.002.001a.703.703 0 01-.158.742l-.924.923a.75.75 0 001.06 1.061l.925-.924.003-.003a2.204 2.204 0 00.498-2.326 8.577 8.577 0 01-.47-1.88v-.007A2.204 2.204 0 004.39 0H2.206a2.21 2.21 0 00-2.09 1.501c-.098.29-.135.598-.107.903l.001.012a15.131 15.131 0 002.355 6.637.75.75 0 101.258-.817 13.631 13.631 0 01-2.12-5.972.702.702 0 01.419-.704c.09-.04.187-.06.286-.06H4.4zM4.91 12.15l-2.63 2.63a.75.75 0 01-1.06-1.06l12.5-12.5a.75.75 0 111.06 1.06L8.05 9.012c.403.334.84.632 1.312.92l.52-.519a2.209 2.209 0 012.327-.496l-.262.703.263-.703c.608.227 1.24.384 1.883.468l.007.001a2.209 2.209 0 011.9 2.239c-.009.315-.002 1.703 0 2.086v.075a2.204 2.204 0 01-2.407 2.205l-.014-.001a15.196 15.196 0 01-6.618-2.35c-.752-.487-1.426-.947-2.05-1.49zm2.075-2.074l-1.01 1.01c.517.44 1.098.84 1.801 1.295a13.696 13.696 0 005.957 2.117l-.005-.001-.068.747.081-.746h-.008a.71.71 0 00.767-.706v-.071c-.002-.372-.009-1.792 0-2.134a.704.704 0 00-.606-.715h.004l.098-.743-.105.743h.003a10.13 10.13 0 01-2.209-.55h-.002a.712.712 0 00-.746.158l.001-.002-.53-.531.527.534-.923.921a.75.75 0 01-.9.121c-.743-.421-1.461-.878-2.127-1.447z"/></g></svg>');
+}
+
+%phone-off-24-svg-prop {
+  --phone-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M6.91 2.5a1.314 1.314 0 011.31 1.122c.138 1.042.394 2.066.762 3.05v.002a1.304 1.304 0 01-.293 1.377L7.382 9.356a.75.75 0 101.06 1.062L9.75 9.11l.003-.003a2.807 2.807 0 00.633-2.962 12.438 12.438 0 01-.68-2.725l-.001-.007A2.806 2.806 0 006.898 1h-3.09a2.815 2.815 0 00-2.66 1.911c-.125.37-.172.76-.137 1.15l.002.011a21.081 21.081 0 003.28 9.248.75.75 0 101.259-.817A19.582 19.582 0 012.505 3.92a1.303 1.303 0 01.776-1.308c.167-.074.347-.112.53-.112h3.098zm3.477 3.646l-.702.264.702-.263zM7.666 17.395L2.28 22.78a.75.75 0 01-1.06-1.06l20.5-20.5a.75.75 0 111.06 1.06L11.673 13.388a15.738 15.738 0 002.305 1.73l.9-.899a2.813 2.813 0 012.965-.631c.882.328 1.798.556 2.731.678l.007.001a2.812 2.812 0 012.418 2.85c-.011.451-.002 2.42 0 2.96v.104a2.803 2.803 0 01-1.91 2.671c-.371.125-.764.172-1.154.137l-.013-.002a21.175 21.175 0 01-9.222-3.274c-1.144-.74-2.135-1.49-3.034-2.319zm2.945-2.945l-1.883 1.883c.814.745 1.722 1.432 2.787 2.12a19.673 19.673 0 008.56 3.042 1.315 1.315 0 001.315-.78c.073-.166.11-.346.11-.528l-.001-.1c-.002-.528-.011-2.53 0-3.008a1.305 1.305 0 00-1.124-1.326 14.007 14.007 0 01-3.057-.76h-.001a1.316 1.316 0 00-1.384.292l-.001.002-1.306 1.303a.75.75 0 01-.9.122 17.233 17.233 0 01-3.115-2.262z"/></g></svg>');
+}
+
+%pie-chart-16-svg-prop {
+  --pie-chart-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M7.75.05a.7.7 0 00-.7.7v7.5a.7.7 0 00.7.7h7.5a.7.7 0 00.7-.7 8.2 8.2 0 00-8.2-8.2zm.7 7.5V1.486a6.8 6.8 0 016.064 6.064H8.45z" clip-rule="evenodd"/><path d="M5.118 2.172A.75.75 0 104.452.828a8 8 0 1010.72 10.72.75.75 0 00-1.344-.666 6.5 6.5 0 11-8.71-8.71z"/></g></svg>');
+}
+
+%pie-chart-24-svg-prop {
+  --pie-chart-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M11.75 1a.75.75 0 00-.75.75v10.5c0 .414.336.75.75.75h10.5a.75.75 0 00.75-.75A11.25 11.25 0 0011.75 1zm.75 10.5V2.529a9.751 9.751 0 018.971 8.971H12.5z" clip-rule="evenodd"/><path d="M8.08 3.344a.75.75 0 10-.62-1.366A11.002 11.002 0 001 12c0 6.075 4.925 11 11 11 4.457 0 8.294-2.65 10.022-6.46a.75.75 0 00-1.366-.619A9.502 9.502 0 0112 21.501 9.5 9.5 0 012.5 12a9.502 9.502 0 015.58-8.657z"/></g></svg>');
+}
+
+%pin-16-svg-prop {
+  --pin-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.121 1.4a1.25 1.25 0 011.76.008l3.707 3.708a1.25 1.25 0 010 1.768l-2.014 2.014a.75.75 0 01-.53.22h-1.16L9.452 10.55l-.248 2.231c-.103.924-1.16 1.435-1.945.88-.578-.409-1.458-1.052-2.18-1.68l-2.799 2.8a.75.75 0 01-1.06-1.061l2.799-2.8c-.628-.721-1.271-1.6-1.68-2.18-.555-.784-.044-1.841.88-1.944l2.23-.248 1.387-1.386V3.956a.75.75 0 01.225-.535L9.12 1.4zm.874 1.244L8.335 4.27v1.202a.75.75 0 01-.219.53L6.324 7.795a.75.75 0 01-.447.215l-2.053.228c.516.713 1.202 1.61 1.765 2.173s1.46 1.25 2.173 1.765l.228-2.053a.75.75 0 01.215-.447l1.838-1.839a.75.75 0 01.53-.22h1.16L13.351 6 9.995 2.644z" clip-rule="evenodd"/></svg>');
+}
+
+%pin-24-svg-prop {
+  --pin-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13.614 3.482a1.75 1.75 0 012.464.012l4.425 4.425a1.75 1.75 0 010 2.475l-2.612 2.612a.75.75 0 01-.53.22h-1.634l-2.025 2.025-.275 2.48c-.144 1.295-1.622 2.005-2.713 1.218-.773-.559-1.768-1.309-2.573-2.026l-3.86 3.86a.75.75 0 11-1.061-1.06l3.86-3.861c-.717-.805-1.467-1.8-2.025-2.573-.788-1.09-.077-2.568 1.217-2.712l2.48-.276 1.964-1.963V6.643a.75.75 0 01.225-.535l2.673-2.626zm1.403 1.072a.25.25 0 00-.352-.001l-2.449 2.404V8.65a.75.75 0 01-.22.53l-2.369 2.369a.75.75 0 01-.447.215l-2.742.305c-.195.021-.257.218-.167.343.692.959 1.621 2.174 2.384 2.937.763.763 1.979 1.692 2.937 2.385.125.09.322.027.344-.168l.304-2.741a.75.75 0 01.216-.448l2.43-2.43a.75.75 0 01.53-.22h1.634l2.393-2.393a.25.25 0 000-.353l-4.426-4.426z" clip-rule="evenodd"/></svg>');
+}
+
+%play-16-svg-prop {
+  --play-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3 3.814C3 2.436 4.52 1.6 5.684 2.334l6.628 4.186a1.75 1.75 0 010 2.96l-6.628 4.185C4.52 14.401 3 13.564 3 12.185v-8.37zm1.883-.211a.25.25 0 00-.383.211v8.372a.25.25 0 00.383.211l6.628-4.186a.25.25 0 000-.422L4.884 3.603z" clip-rule="evenodd"/></svg>');
+}
+
+%play-24-svg-prop {
+  --play-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4 4.814C4 3.436 5.52 2.6 6.684 3.334l11.378 7.186a1.75 1.75 0 010 2.96L6.684 20.665C5.52 21.401 4 20.564 4 19.185V4.816zm1.883-.211a.25.25 0 00-.383.211v14.372a.25.25 0 00.383.211l11.378-7.186a.25.25 0 000-.422L5.884 4.603z" clip-rule="evenodd"/></svg>');
+}
+
+%play-circle-16-svg-prop {
+  --play-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M7.421 4.356A1.25 1.25 0 005.5 5.411v5.178a1.25 1.25 0 001.921 1.055l4.069-2.59a1.25 1.25 0 000-2.109L7.42 4.356zM10.353 8L7 10.134V5.866L10.353 8z"/><path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></g></svg>');
+}
+
+%play-circle-24-svg-prop {
+  --play-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M10.712 6.143C9.548 5.377 8 6.213 8 7.605v8.79c0 1.393 1.548 2.228 2.712 1.462l6.68-4.395a1.75 1.75 0 000-2.924l-6.68-4.395zM9.5 7.605a.25.25 0 01.387-.209l6.681 4.395a.25.25 0 010 .418l-6.68 4.395a.25.25 0 01-.388-.209v-8.79z"/><path d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z"/></g></svg>');
 }
 
 %play-fill-svg-prop {
@@ -550,6 +2894,22 @@
   --play-plain-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 7v10l8.789-5L8 7z" fill="%23000"/></svg>');
 }
 
+%plus-16-svg-prop {
+  --plus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M9 3.5a.75.75 0 00-1.5 0V7H4a.75.75 0 000 1.5h3.5V12A.75.75 0 009 12V8.5h3.5a.75.75 0 000-1.5H9V3.5z"/></svg>');
+}
+
+%plus-24-svg-prop {
+  --plus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M13 5a.75.75 0 00-1.5 0v6.5H5A.75.75 0 005 13h6.5v6.5a.75.75 0 001.5 0V13h6.5a.75.75 0 000-1.5H13V5z"/></svg>');
+}
+
+%plus-circle-16-svg-prop {
+  --plus-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.75 4a.75.75 0 01.75.75V7h2.25a.75.75 0 010 1.5H8.5v2.25a.75.75 0 01-1.5 0V8.5H4.75a.75.75 0 010-1.5H7V4.75A.75.75 0 017.75 4z"/><path fill-rule="evenodd" d="M0 7.75a7.75 7.75 0 1115.5 0 7.75 7.75 0 01-15.5 0zM7.75 1.5a6.25 6.25 0 100 12.5 6.25 6.25 0 000-12.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%plus-circle-24-svg-prop {
+  --plus-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.75 6.75a.75.75 0 01.75.75V11H16a.75.75 0 010 1.5h-3.5V16a.75.75 0 01-1.5 0v-3.5H7.5a.75.75 0 010-1.5H11V7.5a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M1 11.75C1 5.813 5.813 1 11.75 1S22.5 5.813 22.5 11.75 17.687 22.5 11.75 22.5 1 17.687 1 11.75zM11.75 2.5a9.25 9.25 0 100 18.5 9.25 9.25 0 000-18.5z" clip-rule="evenodd"/></g></svg>');
+}
+
 %plus-circle-fill-svg-prop {
   --plus-circle-fill-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 11h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" fill="%23000"/></svg>');
 }
@@ -562,6 +2922,14 @@
   --plus-plain-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" fill="%23000"/></svg>');
 }
 
+%plus-square-16-svg-prop {
+  --plus-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.75 4a.75.75 0 01.75.75V7h2.25a.75.75 0 010 1.5H8.5v2.25a.75.75 0 01-1.5 0V8.5H4.75a.75.75 0 010-1.5H7V4.75A.75.75 0 017.75 4z"/><path fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h9a2.25 2.25 0 012.25 2.25v9a2.25 2.25 0 01-2.25 2.25h-9A2.25 2.25 0 011 12.25v-9zm2.25-.75a.75.75 0 00-.75.75v9c0 .414.336.75.75.75h9a.75.75 0 00.75-.75v-9a.75.75 0 00-.75-.75h-9z" clip-rule="evenodd"/></g></svg>');
+}
+
+%plus-square-24-svg-prop {
+  --plus-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.75 6.75a.75.75 0 01.75.75V11H16a.75.75 0 010 1.5h-3.5V16a.75.75 0 01-1.5 0v-3.5H7.5a.75.75 0 010-1.5H11V7.5a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2h14a2.75 2.75 0 012.75 2.75v14a2.75 2.75 0 01-2.75 2.75h-14A2.75 2.75 0 012 18.75v-14zM4.75 3.5c-.69 0-1.25.56-1.25 1.25v14c0 .69.56 1.25 1.25 1.25h14c.69 0 1.25-.56 1.25-1.25v-14c0-.69-.56-1.25-1.25-1.25h-14z" clip-rule="evenodd"/></g></svg>');
+}
+
 %plus-square-fill-svg-prop {
   --plus-square-fill-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-2 10h-4v4h-2v-4H7v-2h4V7h2v4h4v2z" fill="%23000"/></svg>');
 }
@@ -570,8 +2938,32 @@
   --port-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8.35 3.00001C8.35 2.08874 9.08873 1.35001 10 1.35001H14C14.9113 1.35001 15.65 2.08874 15.65 3.00001V7.00001C15.65 7.91128 14.9113 8.65001 14 8.65001H12.5834C12.5836 8.66071 12.5836 8.67147 12.5833 8.68229L12.5329 10.7L21.35 10.7C21.709 10.7 22 10.991 22 11.35C22 11.709 21.709 12 21.35 12H17.5826C17.594 12.0482 17.6 12.0984 17.6 12.15V14.35H19C19.9113 14.35 20.65 15.0887 20.65 16V20C20.65 20.9113 19.9113 21.65 19 21.65H15C14.0887 21.65 13.35 20.9113 13.35 20V16C13.35 15.0887 14.0887 14.35 15 14.35H16.3V12.15C16.3 12.0984 16.306 12.0482 16.3174 12H12.012C11.96 12.012 11.9056 12.0176 11.8498 12.0162C11.8053 12.0151 11.762 12.0096 11.7202 12H7.58261C7.59398 12.0482 7.6 12.0984 7.6 12.15V14.35H9C9.91127 14.35 10.65 15.0887 10.65 16V20C10.65 20.9113 9.91127 21.65 9 21.65H5C4.08873 21.65 3.35 20.9113 3.35 20V16C3.35 15.0887 4.08873 14.35 5 14.35H6.3V12.15C6.3 12.0984 6.30602 12.0482 6.31739 12H2.65C2.29102 12 2 11.709 2 11.35C2 10.991 2.29101 10.7 2.65 10.7L11.2325 10.7L11.2838 8.65001H10C9.08873 8.65001 8.35 7.91128 8.35 7.00001V3.00001ZM10 2.65001C9.8067 2.65001 9.65 2.80671 9.65 3.00001V7.00001C9.65 7.19331 9.8067 7.35001 10 7.35001H14C14.1933 7.35001 14.35 7.19331 14.35 7.00001V3.00001C14.35 2.80671 14.1933 2.65001 14 2.65001H10ZM5 15.65C4.8067 15.65 4.65 15.8067 4.65 16V20C4.65 20.1933 4.8067 20.35 5 20.35H9C9.1933 20.35 9.35 20.1933 9.35 20V16C9.35 15.8067 9.1933 15.65 9 15.65H5ZM14.65 16C14.65 15.8067 14.8067 15.65 15 15.65H19C19.1933 15.65 19.35 15.8067 19.35 16V20C19.35 20.1933 19.1933 20.35 19 20.35H15C14.8067 20.35 14.65 20.1933 14.65 20V16Z" fill="%236F7682"/></svg>');
 }
 
+%power-16-svg-prop {
+  --power-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.5 1.25a.75.75 0 00-1.5 0v5.5a.75.75 0 001.5 0v-5.5z"/><path d="M3.548 3.825a.75.75 0 00-1.096-1.024 7.25 7.25 0 1010.596 0 .75.75 0 00-1.096 1.024 5.75 5.75 0 11-8.404 0z"/></g></svg>');
+}
+
+%power-24-svg-prop {
+  --power-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.5 2A.75.75 0 0011 2v10a.75.75 0 001.5 0V2z"/><path d="M5.562 7.293a.75.75 0 10-1.124-.992A9.716 9.716 0 002 12.75c0 5.385 4.365 9.75 9.75 9.75s9.75-4.365 9.75-9.75a9.716 9.716 0 00-2.438-6.45.75.75 0 10-1.124.993 8.25 8.25 0 11-12.375 0z"/></g></svg>');
+}
+
+%printer-16-svg-prop {
+  --printer-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2.25 5H3V3.25A2.25 2.25 0 015.25 1h5.5A2.25 2.25 0 0113 3.25V5h.75A2.25 2.25 0 0116 7.25v3.5A2.25 2.25 0 0113.75 13H12.5v.25c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25V13H2.25A2.25 2.25 0 010 10.75v-3.5A2.25 2.25 0 012.25 5zm3-2.5a.75.75 0 00-.75.75V5h7V3.25a.75.75 0 00-.75-.75h-5.5zm-1.75 9V9.75c0-.69.56-1.25 1.25-1.25h6.5c.69 0 1.25.56 1.25 1.25v1.75h1.25a.75.75 0 00.75-.75v-3.5a.75.75 0 00-.75-.75H2.25a.75.75 0 00-.75.75v3.5c0 .414.336.75.75.75H3.5zM11 13H5v-3h6v3z" clip-rule="evenodd"/></svg>');
+}
+
+%printer-24-svg-prop {
+  --printer-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M5 3.75V8H3.75A2.75 2.75 0 001 10.75v5.5A2.75 2.75 0 003.75 19H5v2.25c0 .966.784 1.75 1.75 1.75h10.5A1.75 1.75 0 0019 21.25V19h1.25A2.75 2.75 0 0023 16.25v-5.5A2.75 2.75 0 0020.25 8H19V3.75A2.75 2.75 0 0016.25 1h-8.5A2.75 2.75 0 005 3.75zM7.75 2.5c-.69 0-1.25.56-1.25 1.25V8h11V3.75c0-.69-.56-1.25-1.25-1.25h-8.5zM19 17.5h1.25c.69 0 1.25-.56 1.25-1.25v-5.5c0-.69-.56-1.25-1.25-1.25H3.75c-.69 0-1.25.56-1.25 1.25v5.5c0 .69.56 1.25 1.25 1.25H5v-2.75c0-.966.784-1.75 1.75-1.75h10.5c.966 0 1.75.784 1.75 1.75v2.75zM6.5 14.75a.25.25 0 01.25-.25h10.5a.25.25 0 01.25.25v6.5a.25.25 0 01-.25.25H6.75a.25.25 0 01-.25-.25v-6.5z" clip-rule="evenodd"/></svg>');
+}
+
 %protocol-svg-prop {
   --protocol-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM11.8104 19.9978C11.9269 19.8258 12.0639 19.6117 12.212 19.3572C12.5111 18.8431 12.8544 18.1657 13.1663 17.3382C12.9879 17.3233 12.8084 17.3101 12.6278 17.2987C11.9536 17.2562 11.2715 17.2398 10.5929 17.2563C10.8669 18.1335 11.2168 19.0463 11.6554 19.9927C11.7069 19.9949 11.7586 19.9966 11.8104 19.9978ZM9.897 19.7207C9.55842 18.9089 9.28019 18.1195 9.05511 17.354C8.53381 17.4089 8.01993 17.4871 7.51892 17.5915C7.73118 18.0727 7.97418 18.5653 8.25086 19.0689C8.7684 19.344 9.31972 19.5638 9.897 19.7207ZM5.45938 16.6077C5.48104 16.6001 5.50273 16.5925 5.52445 16.585C4.46623 13.3833 4.62347 10.6454 5.21707 8.50224C5.09245 8.46738 4.97167 8.43251 4.85496 8.39777C4.30807 9.4804 4 10.7042 4 12C4 13.7156 4.54003 15.3051 5.45938 16.6077ZM5.69311 7.07772C5.69614 7.07856 5.69918 7.07939 5.70221 7.08023C5.70623 7.07039 5.71025 7.06056 5.71427 7.05076C5.7072 7.05973 5.70015 7.06872 5.69311 7.07772ZM8.96894 4.59417C8.93129 4.63447 8.8765 4.69478 8.80813 4.77455C8.66145 4.94568 8.45292 5.20563 8.21744 5.5491C7.8904 6.02611 7.51351 6.66107 7.17773 7.44022C7.68086 7.54828 8.21954 7.64986 8.78391 7.73875L8.79848 7.68326C9.18148 6.23496 9.70589 5.06597 10.1744 4.20925C9.75921 4.30615 9.35646 4.43539 8.96894 4.59417ZM12.0548 4.00018C11.938 4.17254 11.8005 4.38729 11.6519 4.64277C11.2113 5.40008 10.6747 6.5116 10.2841 7.93527C10.6414 7.97247 11.0048 8.00331 11.3722 8.02649C12.1215 8.07374 12.8805 8.08863 13.6336 8.06207C13.3315 6.79045 12.8705 5.435 12.2062 4.00261C12.1559 4.00133 12.1054 4.00052 12.0548 4.00018ZM15.0311 19.4058C14.5954 19.5843 14.1406 19.7255 13.6705 19.8253C14.0078 19.2125 14.3757 18.4365 14.6998 17.5098C15.227 17.5833 15.7354 17.6688 16.2175 17.7617C16.0682 18.019 15.9209 18.2491 15.7826 18.4509C15.5471 18.7944 15.3386 19.0543 15.1919 19.2255C15.1235 19.3052 15.0687 19.3655 15.0311 19.4058ZM18.4508 16.7325C19.4247 15.4072 20 13.7708 20 12C20 10.7332 19.7056 9.53525 19.1814 8.47072C19.0626 8.52056 18.9428 8.56843 18.8221 8.61438C19.5339 11.495 19.2703 13.9558 18.6676 15.8898C18.5781 16.1768 18.4814 16.4516 18.3797 16.7138C18.4035 16.72 18.4272 16.7262 18.4508 16.7325ZM15.7491 4.93109C16.2637 5.8677 16.6617 6.76614 16.9623 7.6241C16.3749 7.76946 15.7668 7.87585 15.147 7.94868C14.8822 6.77294 14.493 5.53469 13.9502 4.23938C14.5831 4.39792 15.1861 4.63186 15.7491 4.93109ZM6.67301 8.86539C7.23389 8.98964 7.83778 9.10647 8.47251 9.20809C8.16114 11.101 8.13055 13.3457 8.68042 15.8864C8.10403 15.9541 7.53135 16.0491 6.96921 16.176C5.97706 13.2159 6.14482 10.7469 6.67301 8.86539ZM9.9596 9.4091C9.66322 11.1785 9.63171 13.3152 10.1908 15.7687C11.047 15.7336 11.8982 15.7497 12.7222 15.8017C13.0281 15.8209 13.3313 15.8453 13.6308 15.8739C14.0706 14.1822 14.3018 12.0541 13.9234 9.55152C13.0288 9.59288 12.1384 9.57779 11.2778 9.52351C10.8317 9.49538 10.3912 9.45656 9.9596 9.4091ZM16.9025 16.3689C16.3454 16.2539 15.7517 16.1474 15.1319 16.0564C15.5821 14.232 15.7965 12.0001 15.4213 9.42649C16.0858 9.3447 16.7447 9.22621 17.3877 9.06387C18.0053 11.6354 17.7519 13.7864 17.2355 15.4435C17.1337 15.7703 17.0212 16.0789 16.9025 16.3689Z" fill="%236F7682"/></svg>');
+}
+
+%provider-16-svg-prop {
+  --provider-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zm-.5 1.519a6.464 6.464 0 00-2 .48V5.19l2-1.09V1.518zM1.532 7.356A6.491 6.491 0 014 2.876V6.01L1.532 7.356zm.05 1.68L4 7.719v5.406a6.495 6.495 0 01-2.418-4.087zM7.5 11.423l-2 1.143V6.9l2-1.091v5.613zm1.5-.857V4.991L11 3.9v5.522l-2 1.143zm2 .585l-2 1.143v2.13a6.456 6.456 0 002-.655V11.15zm1.5 1.54v-2.397l1.887-1.079A6.488 6.488 0 0112.5 12.69zm0-4.125V3.31a6.482 6.482 0 011.976 4.126L12.5 8.565zm-5 4.585l-1.697.97a6.47 6.47 0 001.697.361V13.15zM9 3.282V1.576a6.455 6.455 0 011.961.636L9 3.282z" clip-rule="evenodd"/></svg>');
+}
+
+%provider-24-svg-prop {
+  --provider-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zm-1 1.552a9.438 9.438 0 00-3.5 1.08v4.085L11 5.85V2.552zm-8.349 7.75A9.493 9.493 0 016 4.635v3.883l-3.349 1.786zm-.15 1.781L6 10.217v9.149a9.481 9.481 0 01-3.5-7.283zM11 17.02l-3.5 2.032V9.417L11 7.55v9.47zm1.5-.871V6.75L16 4.883v9.234l-3.5 2.032zm3.5-.298l-3.5 2.033v3.603a9.449 9.449 0 003.5-.868v-4.768zm1.5 3.896V14.98l3.977-2.309a9.491 9.491 0 01-3.977 7.076zm0-6.501V4.253a9.494 9.494 0 013.943 6.703l-3.943 2.29zM11 18.754l-3.117 1.81c.96.463 2.01.768 3.117.884v-2.694zM12.5 5.05V2.513c1.168.06 2.28.332 3.3.777l-3.3 1.76z" clip-rule="evenodd"/></svg>');
 }
 
 %provider-svg-prop {
@@ -586,8 +2978,24 @@
   --public-locked-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M21 3v-.5a2.5 2.5 0 0 0-5 0V3c-.55 0-1 .45-1 1v4c0 .55.45 1 1 1h5c.55 0 1-.45 1-1V4c0-.55-.45-1-1-1zm-.8 0h-3.4v-.5c0-.94.76-1.7 1.7-1.7s1.7.76 1.7 1.7V3zm-2.28 8c.04.33.08.66.08 1 0 2.08-.8 3.97-2.1 5.39-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H6v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2V2.46c-.95-.3-1.95-.46-3-.46C4.48 2 0 6.48 0 12s4.48 10 10 10 10-4.48 10-10c0-.34-.02-.67-.05-1h-2.03zM9 19.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L7 15v1c0 1.1.9 2 2 2v1.93z" fill="%23000"/></svg>');
 }
 
+%queue-16-svg-prop {
+  --queue-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M2.23 2.674a.75.75 0 00-.96 1.152L3.578 5.75 1.27 7.674a.75.75 0 00.96 1.152l3-2.5a.75.75 0 000-1.152l-3-2.5zM8.25 5a.75.75 0 000 1.5h6a.75.75 0 000-1.5h-6zM5.5 9.25a.75.75 0 01.75-.75h8a.75.75 0 010 1.5h-8a.75.75 0 01-.75-.75zM6.25 12a.75.75 0 000 1.5h8a.75.75 0 000-1.5h-8z"/></g></svg>');
+}
+
+%queue-24-svg-prop {
+  --queue-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.19 3.892a.75.75 0 10-.88 1.216L5.97 7.75l-3.66 2.642a.75.75 0 00.88 1.216l4.5-3.25a.75.75 0 000-1.216l-4.5-3.25zM11.75 7a.75.75 0 000 1.5h9.5a.75.75 0 000-1.5h-9.5zM8 12.75a.75.75 0 01.75-.75h12.5a.75.75 0 010 1.5H8.75a.75.75 0 01-.75-.75zM8.75 17a.75.75 0 000 1.5h12.5a.75.75 0 000-1.5H8.75z"/></g></svg>');
+}
+
 %queue-svg-prop {
   --queue-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5 15h16v-2H5v2zm0 5h16v-2H5v2zM21 8H9v2h12V8zM2 4v6l5-3-5-3z" fill="%23000"/></svg>');
+}
+
+%radio-16-svg-prop {
+  --radio-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.41 2.476a.75.75 0 01-.013 1.06A6.235 6.235 0 001.5 8c0 1.67.68 3.276 1.897 4.463a.75.75 0 01-1.048 1.074A7.735 7.735 0 010 8c0-2.08.847-4.072 2.35-5.537a.75.75 0 011.06.013zM12.59 2.476a.75.75 0 011.06-.013A7.735 7.735 0 0116 8c0 2.08-.847 4.072-2.35 5.537a.75.75 0 01-1.047-1.074A6.234 6.234 0 0014.5 8c0-1.67-.68-3.276-1.897-4.463a.75.75 0 01-.013-1.06zM7 8a1 1 0 011-1h.01a1 1 0 010 2H8a1 1 0 01-1-1z"/><path d="M5.864 6.046a.75.75 0 10-1.028-1.092c-.42.395-.756.867-.987 1.39a4.1 4.1 0 000 3.307c.23.523.567.994.987 1.39a.75.75 0 001.028-1.093 2.774 2.774 0 01-.642-.902 2.6 2.6 0 010-2.098c.147-.334.365-.641.642-.902zM11.164 4.96a.75.75 0 10-1.028 1.092c.277.26.495.567.642.902a2.601 2.601 0 010 2.098 2.775 2.775 0 01-.642.902.75.75 0 101.028 1.092c.42-.395.756-.866.986-1.39a4.1 4.1 0 000-3.307 4.273 4.273 0 00-.986-1.39z"/></g></svg>');
+}
+
+%radio-24-svg-prop {
+  --radio-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5.282 4.22a.75.75 0 010 1.06 9.502 9.502 0 000 13.436.75.75 0 01-1.06 1.06 11.002 11.002 0 010-15.556.75.75 0 011.06 0zM18.718 4.22a.75.75 0 011.06 0 11.002 11.002 0 010 15.557.75.75 0 11-1.06-1.06 9.502 9.502 0 000-13.437.75.75 0 010-1.06z"/><path fill-rule="evenodd" d="M9 12a3 3 0 116 0 3 3 0 01-6 0zm3-1.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" clip-rule="evenodd"/><path d="M8.117 8.026A.75.75 0 107.05 6.974a7.11 7.11 0 00-1.517 2.305 7.194 7.194 0 000 5.432 7.11 7.11 0 001.517 2.305.75.75 0 001.068-1.053 5.611 5.611 0 01-1.196-1.819 5.694 5.694 0 010-4.299 5.61 5.61 0 011.196-1.819zM16.951 6.984a.75.75 0 10-1.069 1.053c.513.52.92 1.138 1.197 1.819a5.693 5.693 0 010 4.299 5.612 5.612 0 01-1.197 1.819.75.75 0 001.07 1.052 7.11 7.11 0 001.516-2.305 7.194 7.194 0 000-5.432 7.11 7.11 0 00-1.517-2.305z"/></g></svg>');
 }
 
 %radio-button-checked-svg-prop {
@@ -598,12 +3006,28 @@
   --radio-button-unchecked-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" fill="%23000"/></svg>');
 }
 
+%random-16-svg-prop {
+  --random-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5 4a1 1 0 000 2h.01a1 1 0 000-2H5zM7 8a1 1 0 011-1h.01a1 1 0 010 2H8a1 1 0 01-1-1zM11.01 10a1 1 0 100 2h.01a1 1 0 100-2h-.01z"/><path fill-rule="evenodd" d="M3.25 1A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1h-9.5zM2.5 3.25a.75.75 0 01.75-.75h9.5a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75v-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%random-24-svg-prop {
+  --random-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 9.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM11 12a1 1 0 112 0 1 1 0 01-2 0zM5 7.5a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0zm2.5-1a1 1 0 100 2 1 1 0 000-2zM16.5 14a2.5 2.5 0 100 5 2.5 2.5 0 000-5zm-1 2.5a1 1 0 112 0 1 1 0 01-2 0z"/><path d="M4.75 2A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V4.75A2.75 2.75 0 0019.25 2H4.75zM3.5 4.75c0-.69.56-1.25 1.25-1.25h14.5c.69 0 1.25.56 1.25 1.25v14.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25V4.75z"/></g></svg>');
+}
+
 %random-svg-prop {
   --random-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M18.5 2C20.503 2 22 3.5 22 5.5v13c0 2-1.556 3.5-3.5 3.5h-13c-2 0-3.5-1.5-3.5-3.5v-13C2 3.5 3.5 2 5.5 2h13zm0 2h-13C4.71 4 4 4.714 4 5.5v13c0 .781.706 1.5 1.5 1.5h13c.79 0 1.5-.714 1.5-1.5v-13c0-.781-.706-1.5-1.5-1.5zM12 14a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm4-4a2 2 0 1 0 0-4 2 2 0 0 0 0 4zm-8 8a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" fill="%23000"/></svg>');
 }
 
+%redirect-16-svg-prop {
+  --redirect-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 3.517a1 1 0 011.62-.784l5.348 4.233a1 1 0 010 1.568l-5.347 4.233A1 1 0 018 11.983v-1.545c-.76-.043-1.484.003-2.254.218-.994.279-2.118.856-3.506 1.99a.993.993 0 01-1.129.096.962.962 0 01-.445-1.099c.415-1.5 1.425-3.141 2.808-4.412C4.69 6.114 6.244 5.241 8 5.042V3.517zM9.5 4.55v1.2a.75.75 0 01-.75.75c-1.586 0-3.066.739-4.261 1.836a8.995 8.995 0 00-1.635 2.014c.878-.553 1.695-.916 2.488-1.138 1.247-.35 2.377-.331 3.49-.207a.75.75 0 01.668.745v1.2l4.042-3.2L9.5 4.55z" clip-rule="evenodd"/></svg>');
+}
+
+%redirect-24-svg-prop {
+  --redirect-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 5.786c0-1.046 1.209-1.63 2.028-.978l7.45 5.922c.627.498.63 1.45.005 1.952l-7.45 5.997c-.817.659-2.033.077-2.033-.973v-2.754a7.316 7.316 0 00-2.824.427c-1.306.456-2.918 1.342-5.295 2.981-.436.3-.973.287-1.37.029a1.168 1.168 0 01-.479-1.326c.59-2 1.91-4.124 3.743-5.755C7.444 9.824 9.571 8.72 12 8.529V5.786zm1.5.518V9.25a.75.75 0 01-.75.75c-2.296 0-4.35.98-5.978 2.428-1.36 1.21-2.393 2.723-2.994 4.189 2.03-1.357 3.565-2.187 4.903-2.654 1.53-.535 2.769-.584 4.137-.46a.75.75 0 01.682.747v2.933l6.8-5.473-6.8-5.406z" clip-rule="evenodd"/></svg>');
+}
+
 %redirect-svg-prop {
-  --redirect-svg: url('data:image/svg+xml;charset=UTF-8,<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M2 19.833C2.89 13.318 6.712 9.65 13.466 8.83V4L22 11.77l-8.534 7.676v-4.849C8.585 14.344 4.763 16.09 2 19.833z" fill="%236F7682"/></svg>');
+  --redirect-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M2 19.833C2.89 13.318 6.712 9.65 13.466 8.83V4L22 11.77l-8.534 7.676v-4.849C8.585 14.344 4.763 16.09 2 19.833z" fill="%236F7682"/></svg>');
 }
 
 %refresh-alert-svg-prop {
@@ -614,16 +3038,112 @@
   --refresh-default-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" fill="%23000"/></svg>');
 }
 
+%reload-16-svg-prop {
+  --reload-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M7.248 1.307A.75.75 0 118.252.193l2.5 2.25a.75.75 0 010 1.114l-2.5 2.25a.75.75 0 01-1.004-1.114l1.29-1.161a4.5 4.5 0 103.655 2.832.75.75 0 111.398-.546A6 6 0 118.018 2l-.77-.693z"/></svg>');
+}
+
+%reload-24-svg-prop {
+  --reload-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M11.24 1.3A.75.75 0 1112.26.2l3.5 3.25a.75.75 0 010 1.1l-3.5 3.25a.75.75 0 11-1.02-1.1l2.217-2.059a7.5 7.5 0 105.532 4.632.75.75 0 111.397-.546 9 9 0 11-7.237-5.654L11.24 1.3z"/></svg>');
+}
+
 %remix-svg-prop {
   --remix-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M17 5l4 3-4 3 .01-2H15c-.83 0-1.657 1.361-2.692 2.961C13.345 13.595 14.156 15 15 15h2.01L17 13l4 3-4 3 .01-2H15c-1.565 0-2.694-1.593-3.835-3.358C9.863 15.406 8.232 17 6 17H4.067v-2H6c1.737 0 2.979-1.383 4.09-2.999C8.98 10.384 7.737 9 6 9H4.066V7H6c2.283 0 3.913 1.565 5.195 3.311C12.326 8.565 13.45 7 15 7h2.01L17 5z" fill="%23000"/></svg>');
+}
+
+%repeat-16-svg-prop {
+  --repeat-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.238.68a.75.75 0 10-.976 1.14l1.96 1.68H4.418A3.417 3.417 0 001 6.917v.833a.75.75 0 001.5 0v-.833A1.917 1.917 0 014.417 5h7.806l-1.961 1.68a.75.75 0 00.976 1.14l3.5-3a.75.75 0 000-1.14l-3.5-3z"/><path d="M5.82 8.262a.75.75 0 01-.082 1.057L3.778 11h7.805A1.916 1.916 0 0013.5 9.083V8.25a.75.75 0 011.5 0v.833a3.417 3.417 0 01-3.417 3.417H3.777l1.961 1.68a.75.75 0 11-.976 1.14l-3.5-3a.75.75 0 010-1.14l3.5-3a.75.75 0 011.057.082z"/></g></svg>');
+}
+
+%repeat-24-svg-prop {
+  --repeat-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M17.515.455a.75.75 0 00-1.03 1.09L19.614 4.5H6.75A4.75 4.75 0 002 9.25v2a.75.75 0 001.5 0v-2A3.25 3.25 0 016.75 6h12.864l-3.129 2.955a.75.75 0 001.03 1.09l4.5-4.25a.75.75 0 000-1.09l-4.5-4.25zM8.045 13.985a.75.75 0 01-.03 1.06L4.886 18H17.25a3.25 3.25 0 003.25-3.25v-2a.75.75 0 011.5 0v2a4.75 4.75 0 01-4.75 4.75H4.886l3.129 2.955a.75.75 0 01-1.03 1.09l-4.5-4.25a.75.75 0 010-1.09l4.5-4.25a.75.75 0 011.06.03z"/></g></svg>');
+}
+
+%replication-direct-16-svg-prop {
+  --replication-direct-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M0 2.25A2.25 2.25 0 012.25 0h6.5A2.25 2.25 0 0111 2.25v8a.75.75 0 01-.75.75h-8A2.25 2.25 0 010 8.75v-6.5zm2.25-.75a.75.75 0 00-.75.75v6.5c0 .414.336.75.75.75H9.5V2.25a.75.75 0 00-.75-.75h-6.5z" clip-rule="evenodd"/><path d="M12.75 3.55a.7.7 0 01.7.7v8c0 .657-.53 1.2-1.197 1.2H4.25a.7.7 0 110-1.4h7.8v-7.8a.7.7 0 01.7-.7z"/><path d="M15.95 6.75a.7.7 0 00-1.4 0v6.5c0 .718-.581 1.3-1.299 1.3h-6.5a.7.7 0 10-.001 1.4h6.501a2.699 2.699 0 002.699-2.7v-6.5z"/></g></svg>');
+}
+
+%replication-direct-24-svg-prop {
+  --replication-direct-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M1 3.75A2.75 2.75 0 013.75 1h10.5A2.75 2.75 0 0117 3.75v12.5a.75.75 0 01-.75.75H3.75A2.75 2.75 0 011 14.25V3.75zM3.75 2.5c-.69 0-1.25.56-1.25 1.25v10.5c0 .69.56 1.25 1.25 1.25H15.5V3.75c0-.69-.56-1.25-1.25-1.25H3.75z" clip-rule="evenodd"/><path d="M19.25 6a.75.75 0 01.75.75v11.5c0 .964-.778 1.75-1.747 1.75H6.75a.75.75 0 010-1.5h11.503c.135 0 .247-.11.247-.25V6.75a.75.75 0 01.75-.75z"/><path d="M23 9.75a.75.75 0 00-1.5 0v9.5a2.248 2.248 0 01-2.248 2.25H9.75a.75.75 0 000 1.5h9.502A3.748 3.748 0 0023 19.25v-9.5z"/></g></svg>');
+}
+
+%replication-perf-16-svg-prop {
+  --replication-perf-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h6.5A2.25 2.25 0 0112 3.25v1.104a.71.71 0 01.078.067l.667.667A.7.7 0 0112 6.237v1.45a.71.71 0 01.078.068l1.75 1.75a.7.7 0 01-.99.99L12 9.656v.094c0 .417-.113.807-.31 1.141.142.022.279.088.388.197l2.667 2.667a.7.7 0 11-.99.99l-2.667-2.667a.697.697 0 01-.197-.389c-.334.198-.724.311-1.141.311h-.093l.338.338a.7.7 0 01-.99.99l-1.25-1.25A.71.71 0 017.687 12H6.323l1.755 1.755a.7.7 0 11-.99.99l-2.666-2.667A.71.71 0 014.354 12H3.25A2.25 2.25 0 011 9.75v-6.5zm2.25-.75a.75.75 0 00-.75.75v6.5c0 .414.336.75.75.75h6.5a.75.75 0 00.75-.75v-6.5a.75.75 0 00-.75-.75h-6.5z" clip-rule="evenodd"/><path d="M11.495 13.838a.7.7 0 00-.99.99l.583.584a.7.7 0 00.99-.99l-.583-.584zM15.345 11.021a.7.7 0 00-.99.99l.067.067a.7.7 0 00.99-.99l-.067-.067zM13.375 6.705a.7.7 0 01.99 0l.833.833a.7.7 0 01-.99.99l-.833-.833a.7.7 0 010-.99z"/></g></svg>');
+}
+
+%replication-perf-24-svg-prop {
+  --replication-perf-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2h10.5A2.75 2.75 0 0118 4.75v2.19l.78.78A.75.75 0 0118 8.957v2.982l2.78 2.78a.75.75 0 11-1.06 1.061L18 14.06v1.19c0 .495-.13.959-.36 1.36.05.03.097.067.14.11l4 4a.75.75 0 11-1.06 1.06l-4-4a.751.751 0 01-.11-.14c-.401.23-.865.36-1.36.36h-1.19l.72.72a.75.75 0 11-1.06 1.06L11.94 18H9.06l2.72 2.72a.75.75 0 11-1.06 1.06L6.94 18H4.75A2.75 2.75 0 012 15.25V4.75zM4.75 3.5c-.69 0-1.25.56-1.25 1.25v10.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd"/><path d="M16.78 20.72a.75.75 0 10-1.06 1.06l1 1a.75.75 0 101.06-1.06l-1-1zM22.68 16.62a.75.75 0 00-1.06 1.06l.1.1a.75.75 0 001.06-1.06l-.1-.1zM19.72 9.72a.75.75 0 011.06 0l1 1a.75.75 0 11-1.06 1.06l-1-1a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%rewind-16-svg-prop {
+  --rewind-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M7.074 3.364A1.25 1.25 0 019 4.416v1.806l4.039-2.795A1.25 1.25 0 0115 4.454v7.092a1.25 1.25 0 01-1.961 1.027L9 9.778v1.806a1.25 1.25 0 01-1.926 1.051L1.499 9.051a1.25 1.25 0 010-2.103l5.575-3.584zM2.637 8L7.5 11.126V4.874L2.637 8zm6.43 0l4.433 3.069V4.93L9.068 8z" clip-rule="evenodd"/></svg>');
+}
+
+%rewind-24-svg-prop {
+  --rewind-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M10.188 5.38C11.34 4.501 13 5.322 13 6.771v3.332l6.188-4.723C20.34 4.501 22 5.322 22 6.771V17.23c0 1.449-1.66 2.27-2.812 1.391L13 13.898v3.331c0 1.449-1.66 2.27-2.812 1.391l-6.851-5.229a1.75 1.75 0 010-2.782l6.851-5.229zM11.5 6.771a.25.25 0 00-.402-.198L4.247 11.8a.25.25 0 000 .398l6.851 5.229a.25.25 0 00.402-.199V6.771zm9 0a.25.25 0 00-.402-.198l-7.061 5.389v.077l7.061 5.389a.25.25 0 00.402-.199V6.771z" clip-rule="evenodd"/></svg>');
 }
 
 %ribbon-svg-prop {
   --ribbon-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M18.652 13.506c.136-.23.345-.417.812-.87.462-.45.643-1.104.474-1.718-.17-.615-.255-.88-.255-1.145s.084-.53.255-1.147a1.743 1.743 0 0 0-.474-1.717c-.467-.454-.676-.641-.813-.872-.134-.229-.197-.5-.367-1.113a1.804 1.804 0 0 0-1.294-1.257c-.637-.166-.915-.227-1.152-.36-.235-.134-.43-.338-.89-.786a1.866 1.866 0 0 0-1.768-.46c-.636.165-.908.248-1.181.247-.273 0-.545-.082-1.179-.247a1.867 1.867 0 0 0-1.767.46c-.465.452-.66.656-.896.788-.237.133-.515.193-1.147.358a1.806 1.806 0 0 0-1.294 1.257c-.17.616-.233.887-.368 1.115-.136.23-.345.416-.812.87a1.743 1.743 0 0 0-.474 1.717c.171.619.256.884.255 1.15 0 .264-.085.528-.255 1.142-.169.613.012 1.268.474 1.717.466.453.676.641.812.872.135.229.198.5.368 1.113.169.614.662 1.093 1.294 1.257.894.233.99.623.99 1.123v5l4-2.212L16 22v-5c0-.497.095-.89.99-1.122a1.805 1.805 0 0 0 1.294-1.257c.17-.616.233-.887.368-1.115zM9 10a3 3 0 1 1 6 0 3 3 0 0 1-6 0z" fill="%23000"/></svg>');
 }
 
+%rocket-16-svg-prop {
+  --rocket-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M9.78 7.28a.75.75 0 00-1.06-1.06l-.5.5a.75.75 0 001.06 1.06l.5-.5z"/><path fill-rule="evenodd" d="M12.627 1.32a1.731 1.731 0 012.054 2.053c-.27 1.28-.686 3.19-1.103 4.859a3.625 3.625 0 01-.58 1.224c.002.015.002.03.002.044v2.441a1.75 1.75 0 01-.833 1.49l-2.021 1.244a1.75 1.75 0 01-2.284-.397l-1.27-1.587a2.028 2.028 0 01-1.08-.917 3.426 3.426 0 00-.542-.744 3.428 3.428 0 00-.744-.542c-.4-.223-.755-.61-.917-1.08l-1.587-1.27a1.75 1.75 0 01-.398-2.284l1.244-2.021A1.75 1.75 0 014.058 3H6.5l.044.001c.37-.263.777-.467 1.224-.579 1.669-.417 3.58-.833 4.859-1.103zm-5.43 9.956a.754.754 0 00-.167-.025.517.517 0 01-.209-.208 4.913 4.913 0 00-.79-1.073 4.913 4.913 0 00-1.074-.791.516.516 0 01-.208-.21.754.754 0 00-.025-.166l.002-.008c.255-.78.694-1.941 1.307-2.958.634-1.05 1.353-1.773 2.099-1.96 1.641-.41 3.53-.821 4.804-1.09a.231.231 0 01.277.277c-.269 1.274-.68 3.163-1.09 4.804-.187.746-.91 1.465-1.96 2.099-1.017.613-2.177 1.052-2.958 1.307a.173.173 0 01-.008.002zm1.139 1.193l.697.872a.25.25 0 00.327.057l2.021-1.244a.25.25 0 00.119-.213v-1.056c-.186.13-.375.252-.562.366-.88.53-1.832.936-2.602 1.218zM2.659 6.967l.872.697c.282-.77.687-1.722 1.218-2.602.113-.187.235-.376.366-.562H4.059a.25.25 0 00-.213.119L2.602 6.64a.25.25 0 00.057.327z" clip-rule="evenodd"/><path d="M4.442 11.558a.625.625 0 010 .884l-2 2a.625.625 0 11-.884-.884l2-2a.625.625 0 01.884 0zM2.692 10.308a.625.625 0 010 .884l-.75.75a.625.625 0 11-.884-.884l.75-.75a.625.625 0 01.884 0zM5.692 14.192a.625.625 0 10-.884-.884l-.75.75a.625.625 0 10.884.884l.75-.75z"/></g></svg>');
+}
+
+%rocket-24-svg-prop {
+  --rocket-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M14.78 10.28a.75.75 0 10-1.06-1.06l-.5.5a.75.75 0 101.06 1.06l.5-.5z"/><path fill-rule="evenodd" d="M19.63 2.317a1.733 1.733 0 012.053 2.053c-.38 1.827-1.07 5.047-1.76 7.812-.182.723-.542 1.377-1.012 1.964l-.002.015-.457 3.198a1.75 1.75 0 01-.658 1.133l-3.516 2.736a1.75 1.75 0 01-2.456-.307l-1.783-2.293a1.932 1.932 0 01-1.129-.982c-.24-.486-.59-1.07-1.037-1.518-.448-.448-1.033-.799-1.52-1.038a1.932 1.932 0 01-.98-1.129l-2.294-1.783a1.75 1.75 0 01-.307-2.456l2.735-3.517a1.75 1.75 0 011.134-.658l3.197-.456.016-.002c.587-.47 1.24-.83 1.964-1.011 2.765-.691 5.986-1.381 7.812-1.761zM8.234 6.835l-1.38.197a.25.25 0 00-.163.094l-2.735 3.517a.25.25 0 00.044.35l1.6 1.245c.38-1.121.982-2.674 1.813-4.124.247-.43.52-.863.821-1.279zm7.652 9.752c.43-.247.863-.52 1.279-.821l-.197 1.38a.25.25 0 01-.095.162l-3.516 2.736a.25.25 0 01-.351-.044l-1.245-1.6c1.122-.38 2.675-.982 4.125-1.813zm4.329-12.523a.234.234 0 00-.28-.279c-1.821.38-5.018 1.064-7.753 1.748-1.32.33-2.498 1.636-3.467 3.327-.946 1.65-1.586 3.476-1.911 4.53a.22.22 0 00.02.17c.034.069.1.14.192.184.556.274 1.305.71 1.917 1.323.613.612 1.049 1.36 1.323 1.917a.425.425 0 00.185.192.22.22 0 00.169.02c1.054-.325 2.88-.965 4.53-1.91 1.691-.97 2.997-2.148 3.327-3.468.684-2.735 1.369-5.932 1.748-7.754z" clip-rule="evenodd"/><path d="M4.03 15.97a.75.75 0 010 1.06l-1 1a.75.75 0 01-1.06-1.06l1-1a.75.75 0 011.06 0zM6.53 17.47a.75.75 0 010 1.06l-3 3a.75.75 0 01-1.06-1.06l3-3a.75.75 0 011.06 0zM8.03 21.03a.75.75 0 10-1.06-1.06l-1 1a.75.75 0 101.06 1.06l1-1z"/></g></svg>');
+}
+
+%rotate-ccw-16-svg-prop {
+  --rotate-ccw-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M2 .75a.75.75 0 011.5 0v1.888A7 7 0 111 8a.75.75 0 011.5 0 5.5 5.5 0 101.725-4H6.75a.75.75 0 010 1.5h-4A.75.75 0 012 4.75v-4z"/></svg>');
+}
+
+%rotate-ccw-24-svg-prop {
+  --rotate-ccw-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M3 1.75a.75.75 0 011.5 0v3.636A9.977 9.977 0 0112 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12a.75.75 0 011.5 0 8.5 8.5 0 102.019-5.5H9.25a.75.75 0 010 1.5h-5.5A.75.75 0 013 7.25v-5.5z"/></svg>');
+}
+
+%rotate-cw-16-svg-prop {
+  --rotate-cw-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M14 .75a.75.75 0 00-1.5 0v1.888A7 7 0 1015 8a.75.75 0 00-1.5 0 5.5 5.5 0 11-1.725-4H9.25a.75.75 0 000 1.5h4a.75.75 0 00.75-.75v-4z"/></svg>');
+}
+
+%rotate-cw-24-svg-prop {
+  --rotate-cw-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M21 1.75a.75.75 0 00-1.5 0v3.636A9.977 9.977 0 0012 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10a.75.75 0 00-1.5 0 8.5 8.5 0 11-2.019-5.5H14.75a.75.75 0 000 1.5h5.5a.75.75 0 00.75-.75v-5.5z"/></svg>');
+}
+
+%rss-16-svg-prop {
+  --rss-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M2.75 1a.75.75 0 000 1.5A10.75 10.75 0 0113.5 13.25a.75.75 0 001.5 0A12.25 12.25 0 002.75 1z"/><path d="M2.75 6a.75.75 0 000 1.5 5.75 5.75 0 015.75 5.75.75.75 0 001.5 0A7.25 7.25 0 002.75 6zM3.5 11a1.5 1.5 0 100 3 1.5 1.5 0 000-3z"/></g></svg>');
+}
+
+%rss-24-svg-prop {
+  --rss-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.75 3a.75.75 0 000 1.5A15.75 15.75 0 0119.5 20.25a.75.75 0 001.5 0A17.25 17.25 0 003.75 3z"/><path d="M3.75 10a.75.75 0 000 1.5 8.75 8.75 0 018.75 8.75.75.75 0 001.5 0A10.25 10.25 0 003.75 10zM5 17a2 2 0 100 4 2 2 0 000-4z"/></g></svg>');
+}
+
 %run-svg-prop {
-  --run-svg: url('data:image/svg+xml;charset=UTF-8,<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" class="structure-icon-run"><style>.structure-icon-run {animation: structure-icon-run-simple-spin 1s infinite linear;}.structure-icon-run-progress {animation: structure-icon-run-fancy-spin 3s infinite linear;fill: transparent;opacity: 0.66;stroke-dasharray: 16 16;transform-origin: 50% 50%;}@keyframes structure-icon-run-fancy-spin {0% {stroke-dasharray: 4 32;}50% {stroke-dasharray: 24 8;}50% {stroke-dasharray: 4 32;}50% {stroke-dasharray: 24 8;}100% {stroke-dasharray: 4 32;}}@keyframes structure-icon-run-simple-spin {0% {transform: rotate(0deg);}100% {transform: rotate(360deg);}}</style><g fill="none" fill-rule="evenodd"><circle cx="12" cy="12" r="8" stroke="%23000" stroke-width="4"/><circle cx="12" cy="12" r="5" stroke="%23000" stroke-width="2" class="structure-icon-run-progress"/><circle cx="12" cy="12" r="4" fill="currentColor"/></g></svg>');
+  --run-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="structure-icon-run"><style>.structure-icon-run {animation: structure-icon-run-simple-spin 1s infinite linear;}.structure-icon-run-progress {animation: structure-icon-run-fancy-spin 3s infinite linear;fill: transparent;opacity: 0.66;stroke-dasharray: 16 16;transform-origin: 50% 50%;}@keyframes structure-icon-run-fancy-spin {0% {stroke-dasharray: 4 32;}50% {stroke-dasharray: 24 8;}50% {stroke-dasharray: 4 32;}50% {stroke-dasharray: 24 8;}100% {stroke-dasharray: 4 32;}}@keyframes structure-icon-run-simple-spin {0% {transform: rotate(0deg);}100% {transform: rotate(360deg);}}</style><g fill="none" fill-rule="evenodd"><circle cx="12" cy="12" r="8" stroke="%23000" stroke-width="4"/><circle cx="12" cy="12" r="5" stroke="%23000" stroke-width="2" class="structure-icon-run-progress"/><circle cx="12" cy="12" r="4" fill="currentColor"/></g></svg>');
+}
+
+%save-16-svg-prop {
+  --save-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h6.879a2.25 2.25 0 011.59.659l2.622 2.621c.422.422.659.995.659 1.591v6.879A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-9.5zm2.25-.75a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h.8V9.25a1.2 1.2 0 011.2-1.2h5.5a1.2 1.2 0 011.2 1.2v4.25h.8a.75.75 0 00.75-.75V5.871a.75.75 0 00-.22-.53L10.66 2.72a.75.75 0 00-.53-.22H5.45v2.05h3.8a.7.7 0 010 1.4h-4a1.2 1.2 0 01-1.2-1.2V2.5h-.8zm7.3 11h-5.1V9.45h5.1v4.05z" clip-rule="evenodd"/></svg>');
+}
+
+%save-24-svg-prop {
+  --save-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4.75 2A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V9.078c0-.729-.29-1.428-.805-1.944l-4.329-4.329A2.75 2.75 0 0014.922 2H4.75zm0 1.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25H6v-6.75c0-.966.784-1.75 1.75-1.75h8.5c.966 0 1.75.784 1.75 1.75v6.75h1.25c.69 0 1.25-.56 1.25-1.25V9.078c0-.331-.132-.649-.366-.883l-4.329-4.329a1.25 1.25 0 00-.883-.366H7.5v3.75c0 .138.112.25.25.25h7.5a.75.75 0 010 1.5h-7.5A1.75 1.75 0 016 7.25V3.5H4.75zM7.5 13.75v6.75h9v-6.75a.25.25 0 00-.25-.25h-8.5a.25.25 0 00-.25.25z" clip-rule="evenodd"/></svg>');
+}
+
+%scissors-16-svg-prop {
+  --scissors-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M1 4a3 3 0 115.585 1.524L8 6.94l4.803-4.803a.75.75 0 011.06 1.06L8.539 8.523a.678.678 0 01-.016.016l-1.937 1.938a3 3 0 11-1.06-1.06L6.938 8 5.524 6.585A3 3 0 011 4zm3-1.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3zm0 8a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" clip-rule="evenodd"/><path d="M9.116 9.123a.75.75 0 011.06 0l3.687 3.68a.75.75 0 11-1.06 1.061l-3.686-3.68a.75.75 0 01-.001-1.06z"/></g></svg>');
+}
+
+%scissors-24-svg-prop {
+  --scissors-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M5.5 2a3.5 3.5 0 101.99 6.38l3.346 3.12-3.346 3.12a3.5 3.5 0 101.023 1.097l3.93-3.664.009-.008 8.31-7.746A.75.75 0 0019.739 3.2l-7.803 7.274-3.424-3.192A3.5 3.5 0 005.5 2zm-2 3.5a2 2 0 114 0 2 2 0 01-4 0zm0 12a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/><path d="M20.763 18.703a.75.75 0 01-1.026 1.095l-5.5-5.15a.75.75 0 011.026-1.095l5.5 5.15z"/></g></svg>');
+}
+
+%search-16-svg-prop {
+  --search-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M7.25 2a5.25 5.25 0 103.144 9.455l2.326 2.325a.75.75 0 101.06-1.06l-2.325-2.326A5.25 5.25 0 007.25 2zM3.5 7.25a3.75 3.75 0 117.5 0 3.75 3.75 0 01-7.5 0z" clip-rule="evenodd"/></svg>');
+}
+
+%search-24-svg-prop {
+  --search-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M10.5 2a8.5 8.5 0 105.457 15.017l4.763 4.763a.75.75 0 101.06-1.06l-4.763-4.763A8.5 8.5 0 0010.5 2zm-7 8.5a7 7 0 1114 0 7 7 0 01-14 0z" clip-rule="evenodd"/></svg>');
 }
 
 %search-color-svg-prop {
@@ -634,12 +3154,268 @@
   --search-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M15.5 14h-.79l-.28-.27A6.47 6.47 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" fill="%23000"/></svg>');
 }
 
+%send-16-svg-prop {
+  --send-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M15.08 2.526c.368-1.001-.605-1.974-1.606-1.605L1.878 5.193a1.25 1.25 0 00-.295 2.19l4.07 2.907a.25.25 0 01.057.058l2.907 4.069a1.25 1.25 0 002.19-.295l4.272-11.596zM2.84 6.437l10.645-3.922L9.563 13.16l-2.39-3.344 3.072-3.071a.7.7 0 10-.99-.99L6.184 8.826 2.84 6.437z" clip-rule="evenodd"/></svg>');
+}
+
+%send-24-svg-prop {
+  --send-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M21.205 5.042c.516-1.4-.846-2.763-2.247-2.247L3.264 8.577c-1.318.486-1.555 2.25-.412 3.066l5.51 3.936a.252.252 0 01.059.058l3.936 5.51c.817 1.144 2.58.907 3.066-.411l5.782-15.694zm-1.729-.84a.25.25 0 01.321.322l-5.782 15.693a.25.25 0 01-.438.059l-3.663-5.13L15.53 9.53a.75.75 0 00-1.06-1.06l-5.617 5.616-5.129-3.663a.25.25 0 01.059-.438l15.693-5.782z" clip-rule="evenodd"/></svg>');
+}
+
+%server-16-svg-prop {
+  --server-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3 3.25a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 013 3.25z"/><path fill-rule="evenodd" d="M2.25 0A2.25 2.25 0 000 2.25v2.5A2.25 2.25 0 002.25 7h11.5A2.25 2.25 0 0016 4.75v-2.5A2.25 2.25 0 0013.75 0H2.25zM1.5 2.25a.75.75 0 01.75-.75h11.5a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75H2.25a.75.75 0 01-.75-.75v-2.5z" clip-rule="evenodd"/><path d="M3.75 11.5a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5z"/><path fill-rule="evenodd" d="M2.25 9A2.25 2.25 0 000 11.25v2.5A2.25 2.25 0 002.25 16h11.5A2.25 2.25 0 0016 13.75v-2.5A2.25 2.25 0 0013.75 9H2.25zm-.75 2.25a.75.75 0 01.75-.75h11.5a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75H2.25a.75.75 0 01-.75-.75v-2.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%server-24-svg-prop {
+  --server-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5 5.75A.75.75 0 015.75 5h.5a.75.75 0 010 1.5h-.5A.75.75 0 015 5.75z"/><path fill-rule="evenodd" d="M3.75 1A2.75 2.75 0 001 3.75v4.5A2.75 2.75 0 003.75 11h16.5A2.75 2.75 0 0023 8.25v-4.5A2.75 2.75 0 0020.25 1H3.75zM2.5 3.75c0-.69.56-1.25 1.25-1.25h16.5c.69 0 1.25.56 1.25 1.25v4.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25v-4.5z" clip-rule="evenodd"/><path d="M5.75 17a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5z"/><path fill-rule="evenodd" d="M3.75 13A2.75 2.75 0 001 15.75v4.5A2.75 2.75 0 003.75 23h16.5A2.75 2.75 0 0023 20.25v-4.5A2.75 2.75 0 0020.25 13H3.75zM2.5 15.75c0-.69.56-1.25 1.25-1.25h16.5c.69 0 1.25.56 1.25 1.25v4.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25v-4.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%server-cluster-16-svg-prop {
+  --server-cluster-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a2.25 2.25 0 00-.75 4.372v.465a3.25 3.25 0 00-1.797 1.144l-.625-.366a2.25 2.25 0 10-1.038 1.13l1.026.602a3.261 3.261 0 000 1.306l-1.026.601a2.25 2.25 0 101.038 1.13l.625-.366a3.25 3.25 0 001.797 1.145v.465a2.25 2.25 0 101.5 0v-.465a3.25 3.25 0 001.797-1.145l.625.366a2.25 2.25 0 101.038-1.13l-1.026-.6a3.26 3.26 0 000-1.307l1.026-.601a2.25 2.25 0 10-1.038-1.13l-.625.365A3.251 3.251 0 008.75 4.837v-.465A2.25 2.25 0 008 0zm-.75 2.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zM2.75 4a.75.75 0 100 1.5.75.75 0 000-1.5zm0 6.5a.75.75 0 100 1.5.75.75 0 000-1.5zm4.5 3.25a.75.75 0 111.5 0 .75.75 0 01-1.5 0zm6-3.25a.75.75 0 100 1.5.75.75 0 000-1.5zm0-6.5a.75.75 0 100 1.5.75.75 0 000-1.5zM6.395 7.3a1.75 1.75 0 113.21 1.4 1.75 1.75 0 01-3.21-1.4z" clip-rule="evenodd"/></svg>');
+}
+
+%server-cluster-24-svg-prop {
+  --server-cluster-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 .5a2.5 2.5 0 00-.75 4.886v1.67a4.998 4.998 0 00-3.255 1.95l-1.731-.944a2.5 2.5 0 10-1.061 1.13l2.083 1.137A4.993 4.993 0 007 12c0 .615.111 1.206.316 1.752l-1.768 1.285a2.5 2.5 0 10.845 1.24l1.66-1.207a4.996 4.996 0 003.197 1.874v1.67a2.501 2.501 0 101.5 0v-1.67a4.996 4.996 0 003.197-1.874l1.66 1.207a2.5 2.5 0 10.845-1.24l-1.768-1.285A4.991 4.991 0 0017 12c0-.585-.1-1.148-.286-1.671l2.083-1.137a2.5 2.5 0 10-1.06-1.13l-1.732.945a4.998 4.998 0 00-3.255-1.951v-1.67A2.501 2.501 0 0012 .5zM11 3a1 1 0 112 0 1 1 0 01-2 0zM4 6a1 1 0 100 2 1 1 0 000-2zm0 10a1 1 0 100 2 1 1 0 000-2zm7 5a1 1 0 112 0 1 1 0 01-2 0zm9-5a1 1 0 100 2 1 1 0 000-2zm0-10a1 1 0 100 2 1 1 0 000-2zM8.91 10.353a3.5 3.5 0 016.18 0c.261.49.41 1.05.41 1.647s-.149 1.157-.41 1.647a3.5 3.5 0 01-6.18 0A3.482 3.482 0 018.5 12c0-.597.149-1.157.41-1.647z" clip-rule="evenodd"/></svg>');
+}
+
+%serverless-16-svg-prop {
+  --serverless-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.75 11.5a.75.75 0 000 1.5h.5a.75.75 0 000-1.5h-.5z"/><path fill-rule="evenodd" d="M1.28.22A.75.75 0 00.22 1.28c-.141.294-.22.623-.22.97v2.5A2.25 2.25 0 002.25 7h3.69l2 2H2.25A2.25 2.25 0 000 11.25v2.5A2.25 2.25 0 002.25 16h11.5c.347 0 .676-.079.97-.22a.75.75 0 001.06-1.06L1.28.22zm.97 10.28h7.19l4 4H2.25a.75.75 0 01-.75-.75v-2.5a.75.75 0 01.75-.75zm2.19-5L1.5 2.56v2.19c0 .414.336.75.75.75h2.19z" clip-rule="evenodd"/><path d="M13.75 0H5a.75.75 0 000 1.5h8.75a.75.75 0 01.75.75v2.5a.75.75 0 01-.75.75H10.5a.75.75 0 000 1.5h3.25A2.25 2.25 0 0016 4.75v-2.5A2.25 2.25 0 0013.75 0zM13 9.75a.75.75 0 01.75-.75A2.25 2.25 0 0116 11.25a.75.75 0 01-1.5 0 .75.75 0 00-.75-.75.75.75 0 01-.75-.75z"/></g></svg>');
+}
+
+%serverless-24-svg-prop {
+  --serverless-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M5 17.75a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5a.75.75 0 01-.75-.75z"/><path fill-rule="evenodd" d="M1.78.72A.75.75 0 00.72 1.78l.629.63A2.74 2.74 0 001 3.75v4.5A2.75 2.75 0 003.75 11h6.19l2 2H3.75A2.75 2.75 0 001 15.75v4.5A2.75 2.75 0 003.75 23h16.5a2.74 2.74 0 001.34-.349l.63.63a.75.75 0 101.06-1.061L2.866 1.806 1.78.72zm.732 2.853a1.265 1.265 0 00-.012.177v4.5c0 .69.56 1.25 1.25 1.25h4.69L2.511 3.573zm17.915 17.915L13.439 14.5H3.75c-.69 0-1.25.56-1.25 1.25v4.5c0 .69.56 1.25 1.25 1.25h16.5c.06 0 .12-.004.177-.012z" clip-rule="evenodd"/><path d="M6 1a.75.75 0 000 1.5h14.25c.69 0 1.25.56 1.25 1.25v4.5c0 .69-.56 1.25-1.25 1.25H14.5a.75.75 0 000 1.5h5.75A2.75 2.75 0 0023 8.25v-4.5A2.75 2.75 0 0020.25 1H6zM18 13a.75.75 0 000 1.5h2.25c.69 0 1.25.56 1.25 1.25V18a.75.75 0 001.5 0v-2.25A2.75 2.75 0 0020.25 13H18z"/></g></svg>');
+}
+
+%settings-16-svg-prop {
+  --settings-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 5a3 3 0 100 6 3 3 0 000-6zM6.5 8a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z"/><path d="M7.5 0a1.75 1.75 0 00-1.75 1.75v.15c-.16.06-.318.125-.472.196l-.106-.106a1.75 1.75 0 00-2.475 0l-.707.707a1.75 1.75 0 000 2.475l.106.106a6.46 6.46 0 00-.196.472h-.15A1.75 1.75 0 000 7.5v1c0 .966.784 1.75 1.75 1.75h.15c.06.16.125.318.196.472l-.106.107a1.75 1.75 0 000 2.474l.707.708a1.75 1.75 0 002.475 0l.106-.107c.154.071.312.137.472.196v.15c0 .966.784 1.75 1.75 1.75h1a1.75 1.75 0 001.75-1.75v-.15c.16-.06.318-.125.472-.196l.106.107a1.75 1.75 0 002.475 0l.707-.707a1.75 1.75 0 000-2.475l-.106-.107c.071-.154.137-.311.196-.472h.15A1.75 1.75 0 0016 8.5v-1a1.75 1.75 0 00-1.75-1.75h-.15a6.455 6.455 0 00-.196-.472l.106-.106a1.75 1.75 0 000-2.475l-.707-.707a1.75 1.75 0 00-2.475 0l-.106.106a6.46 6.46 0 00-.472-.196v-.15A1.75 1.75 0 008.5 0h-1zm-.25 1.75a.25.25 0 01.25-.25h1a.25.25 0 01.25.25v.698c0 .339.227.636.555.724.42.113.817.28 1.186.492a.75.75 0 00.905-.12l.493-.494a.25.25 0 01.354 0l.707.708a.25.25 0 010 .353l-.494.494a.75.75 0 00-.12.904c.213.369.38.767.492 1.186a.75.75 0 00.724.555h.698a.25.25 0 01.25.25v1a.25.25 0 01-.25.25h-.698a.75.75 0 00-.724.555c-.113.42-.28.817-.492 1.186a.75.75 0 00.12.905l.494.493a.25.25 0 010 .354l-.707.707a.25.25 0 01-.354 0l-.494-.494a.75.75 0 00-.904-.12 4.966 4.966 0 01-1.186.492.75.75 0 00-.555.724v.698a.25.25 0 01-.25.25h-1a.25.25 0 01-.25-.25v-.698a.75.75 0 00-.555-.724 4.966 4.966 0 01-1.186-.491.75.75 0 00-.904.12l-.494.493a.25.25 0 01-.354 0l-.707-.707a.25.25 0 010-.354l.494-.493a.75.75 0 00.12-.905 4.966 4.966 0 01-.492-1.186.75.75 0 00-.724-.555H1.75a.25.25 0 01-.25-.25v-1a.25.25 0 01.25-.25h.698a.75.75 0 00.724-.555c.113-.42.28-.817.491-1.186a.75.75 0 00-.12-.904L3.05 4.11a.25.25 0 010-.353l.707-.708a.25.25 0 01.354 0l.493.494c.24.24.611.289.905.12a4.965 4.965 0 011.186-.492.75.75 0 00.555-.724V1.75z"/></g></svg>');
+}
+
+%settings-24-svg-prop {
+  --settings-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 8a4 4 0 100 8 4 4 0 000-8zm-2.5 4a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0z"/><path d="M11.5 1a2.25 2.25 0 00-2.25 2.25v.178c-.474.152-.93.342-1.366.567l-.127-.127a2.25 2.25 0 00-3.182 0l-.707.707a2.25 2.25 0 000 3.182l.127.127a8.95 8.95 0 00-.567 1.366H3.25A2.25 2.25 0 001 11.5v1a2.25 2.25 0 002.25 2.25h.178c.152.474.342.93.567 1.366l-.127.127a2.25 2.25 0 000 3.182l.707.707a2.25 2.25 0 003.182 0l.127-.127c.435.225.892.415 1.366.567v.178A2.25 2.25 0 0011.5 23h1a2.25 2.25 0 002.25-2.25v-.178c.474-.152.93-.342 1.366-.567l.127.127a2.25 2.25 0 003.182 0l.707-.707a2.25 2.25 0 000-3.182l-.127-.127a8.94 8.94 0 00.567-1.366h.178A2.25 2.25 0 0023 12.5v-1a2.25 2.25 0 00-2.25-2.25h-.178a8.952 8.952 0 00-.567-1.366l.127-.127a2.25 2.25 0 000-3.182l-.707-.707a2.25 2.25 0 00-3.182 0l-.127.127a8.95 8.95 0 00-1.366-.567V3.25A2.25 2.25 0 0012.5 1h-1zm-.75 2.25a.75.75 0 01.75-.75h1a.75.75 0 01.75.75v.744a.75.75 0 00.569.728 7.45 7.45 0 012.04.846.75.75 0 00.918-.112l.526-.527a.75.75 0 011.06 0l.708.707a.75.75 0 010 1.06l-.527.527a.75.75 0 00-.112.917c.377.627.665 1.313.846 2.041a.75.75 0 00.728.569h.744a.75.75 0 01.75.75v1a.75.75 0 01-.75.75h-.744a.75.75 0 00-.728.569 7.449 7.449 0 01-.846 2.04.75.75 0 00.112.918l.527.526a.75.75 0 010 1.06l-.707.708a.75.75 0 01-1.06 0l-.527-.527a.75.75 0 00-.917-.112 7.446 7.446 0 01-2.041.846.75.75 0 00-.569.728v.744a.75.75 0 01-.75.75h-1a.75.75 0 01-.75-.75v-.744a.75.75 0 00-.569-.728 7.447 7.447 0 01-2.04-.846.75.75 0 00-.918.112l-.526.527a.75.75 0 01-1.061 0l-.707-.707a.75.75 0 010-1.06l.527-.527a.75.75 0 00.112-.917 7.45 7.45 0 01-.846-2.041.75.75 0 00-.728-.569H3.25a.75.75 0 01-.75-.75v-1a.75.75 0 01.75-.75h.744a.75.75 0 00.728-.569c.181-.728.469-1.414.846-2.04a.75.75 0 00-.112-.918l-.527-.526a.75.75 0 010-1.061l.707-.707a.75.75 0 011.06 0l.527.527a.75.75 0 00.917.112 7.451 7.451 0 012.041-.846.75.75 0 00.569-.728V3.25z"/></g></svg>');
+}
+
 %settings-svg-prop {
   --settings-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M19.43 12.98c.04-.32.07-.64.07-.98 0-.34-.03-.66-.07-.98l2.11-1.65c.19-.15.24-.42.12-.64l-2-3.46c-.12-.22-.39-.3-.61-.22l-2.49 1c-.52-.4-1.08-.73-1.69-.98l-.38-2.65A.488.488 0 0 0 14 2h-4c-.25 0-.46.18-.49.42l-.38 2.65c-.61.25-1.17.59-1.69.98l-2.49-1c-.23-.09-.49 0-.61.22l-2 3.46c-.13.22-.07.49.12.64l2.11 1.65c-.04.32-.07.65-.07.98 0 .33.03.66.07.98l-2.11 1.65c-.19.15-.24.42-.12.64l2 3.46c.12.22.39.3.61.22l2.49-1c.52.4 1.08.73 1.69.98l.38 2.65c.03.24.24.42.49.42h4c.25 0 .46-.18.49-.42l.38-2.65c.61-.25 1.17-.59 1.69-.98l2.49 1c.23.09.49 0 .61-.22l2-3.46c.12-.22.07-.49-.12-.64l-2.11-1.65zM12 16c-2.206 0-4-1.794-4-4s1.794-4 4-4 4 1.794 4 4-1.794 4-4 4z" fill="%23000"/></svg>');
 }
 
+%share-16-svg-prop {
+  --share-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5.3 5.76a.75.75 0 01-1.1-1.02l3.25-3.5a.75.75 0 011.1 0l3.25 3.5a.75.75 0 11-1.1 1.02l-1.95-2.1v6.59a.75.75 0 01-1.5 0V3.66L5.3 5.76z"/><path d="M2 9.25A2.25 2.25 0 014.25 7H5a.75.75 0 010 1.5h-.75a.75.75 0 00-.75.75v3.5c0 .414.336.75.75.75h7.5a.75.75 0 00.75-.75v-3.5a.75.75 0 00-.75-.75H11A.75.75 0 0111 7h.75A2.25 2.25 0 0114 9.25v3.5A2.25 2.25 0 0111.75 15h-7.5A2.25 2.25 0 012 12.75v-3.5z"/></g></svg>');
+}
+
+%share-24-svg-prop {
+  --share-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.295 6.765a.75.75 0 11-1.09-1.03l4.25-4.5a.75.75 0 011.09 0l4.25 4.5a.75.75 0 01-1.09 1.03L12.75 3.636V14.25a.75.75 0 01-1.5 0V3.636L8.295 6.765z"/><path d="M5.75 10.5c-.69 0-1.25.56-1.25 1.25v8.5c0 .69.56 1.25 1.25 1.25h12.5c.69 0 1.25-.56 1.25-1.25v-8.5c0-.69-.56-1.25-1.25-1.25H15.5a.75.75 0 010-1.5h2.75A2.75 2.75 0 0121 11.75v8.5A2.75 2.75 0 0118.25 23H5.75A2.75 2.75 0 013 20.25v-8.5A2.75 2.75 0 015.75 9H8.5a.75.75 0 010 1.5H5.75z"/></g></svg>');
+}
+
+%shield-16-svg-prop {
+  --shield-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M7.26.213a2.25 2.25 0 011.48 0l4.75 1.653A2.25 2.25 0 0115 3.991v4.01c0 2.048-1.181 3.747-2.45 4.991-1.282 1.255-2.757 2.15-3.573 2.598a2.024 2.024 0 01-1.954 0c-.816-.447-2.291-1.342-3.572-2.598C2.18 11.748 1 10.05 1 8V3.991c0-.957.606-1.81 1.51-2.125L7.26.213zm.986 1.417a.75.75 0 00-.493 0l-4.75 1.653a.75.75 0 00-.503.708v4.01c0 1.455.847 2.79 2 3.92 1.142 1.118 2.483 1.937 3.244 2.353.163.09.35.09.512 0 .761-.416 2.102-1.235 3.244-2.353 1.153-1.13 2-2.465 2-3.92V3.99a.75.75 0 00-.504-.708L8.246 1.63z" clip-rule="evenodd"/></svg>');
+}
+
+%shield-24-svg-prop {
+  --shield-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M11.04 1.307a2.75 2.75 0 011.92 0l6.25 2.33A2.75 2.75 0 0121 6.214V12c0 2.732-1.462 5.038-3.104 6.774-1.65 1.744-3.562 3-4.65 3.642a2.437 2.437 0 01-2.493 0c-1.087-.643-3-1.898-4.65-3.642C4.463 17.038 3 14.732 3 12V6.214a2.75 2.75 0 011.79-2.577l6.25-2.33zm1.397 1.406a1.25 1.25 0 00-.874 0l-6.25 2.33a1.25 1.25 0 00-.813 1.17V12c0 2.182 1.172 4.136 2.693 5.744 1.514 1.6 3.294 2.772 4.323 3.38.304.18.664.18.968 0 1.03-.608 2.809-1.78 4.323-3.38C18.327 16.136 19.5 14.182 19.5 12V6.214a1.25 1.25 0 00-.813-1.171l-6.25-2.33z" clip-rule="evenodd"/></svg>');
+}
+
+%shield-alert-16-svg-prop {
+  --shield-alert-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7 11a1 1 0 011-1h.007a1 1 0 110 2H8a1 1 0 01-1-1zM8.75 4.75a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"/><path fill-rule="evenodd" d="M7.26.213a2.25 2.25 0 011.48 0l4.75 1.653A2.25 2.25 0 0115 3.991v4.01c0 2.048-1.181 3.747-2.45 4.991-1.282 1.255-2.757 2.15-3.573 2.598a2.024 2.024 0 01-1.954 0c-.816-.447-2.291-1.342-3.572-2.598C2.18 11.748 1 10.05 1 8V3.991c0-.957.606-1.81 1.51-2.125L7.26.213zm.986 1.417a.75.75 0 00-.493 0l-4.75 1.653a.75.75 0 00-.503.708v4.01c0 1.455.847 2.79 2 3.92 1.142 1.118 2.483 1.937 3.244 2.353.163.09.35.09.512 0 .761-.416 2.102-1.235 3.244-2.353 1.153-1.13 2-2.465 2-3.92V3.99a.75.75 0 00-.504-.708L8.246 1.63z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shield-alert-24-svg-prop {
+  --shield-alert-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 7a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0112 7zM12 15a1 1 0 100 2h.01a1 1 0 100-2H12z"/><path fill-rule="evenodd" d="M11.04 1.307a2.75 2.75 0 011.92 0l6.25 2.33A2.75 2.75 0 0121 6.214V12c0 2.732-1.462 5.038-3.104 6.774-1.65 1.744-3.562 3-4.65 3.642a2.437 2.437 0 01-2.493 0c-1.087-.643-3-1.898-4.65-3.642C4.463 17.038 3 14.732 3 12V6.214a2.75 2.75 0 011.79-2.577l6.25-2.33zm1.397 1.406a1.25 1.25 0 00-.874 0l-6.25 2.33a1.25 1.25 0 00-.813 1.17V12c0 2.182 1.172 4.136 2.693 5.744 1.514 1.6 3.294 2.772 4.323 3.38.304.18.664.18.968 0 1.03-.608 2.809-1.78 4.323-3.38C18.327 16.136 19.5 14.182 19.5 12V6.214a1.25 1.25 0 00-.813-1.171l-6.25-2.33z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shield-check-16-svg-prop {
+  --shield-check-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.28 5.47a.75.75 0 010 1.06l-4 4a.75.75 0 01-1.06 0l-2-2a.75.75 0 011.06-1.06l1.47 1.47 3.47-3.47a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M7.26.213a2.25 2.25 0 011.48 0l4.75 1.653A2.25 2.25 0 0115 3.991v4.01c0 2.048-1.181 3.747-2.45 4.991-1.282 1.255-2.757 2.15-3.573 2.598a2.024 2.024 0 01-1.954 0c-.816-.447-2.291-1.342-3.572-2.598C2.18 11.748 1 10.05 1 8V3.991c0-.957.606-1.81 1.51-2.125L7.26.213zm.986 1.417a.75.75 0 00-.493 0l-4.75 1.653a.75.75 0 00-.503.708v4.01c0 1.455.847 2.79 2 3.92 1.142 1.118 2.483 1.937 3.244 2.353.163.09.35.09.512 0 .761-.416 2.102-1.235 3.244-2.353 1.153-1.13 2-2.465 2-3.92V3.99a.75.75 0 00-.504-.708L8.246 1.63z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shield-check-24-svg-prop {
+  --shield-check-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M16.78 8.22a.75.75 0 010 1.06l-5.499 5.5a.75.75 0 01-1.061 0l-2.5-2.5a.75.75 0 111.06-1.06l1.97 1.97 4.97-4.97a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M11.04 1.307a2.75 2.75 0 011.92 0l6.25 2.33A2.75 2.75 0 0121 6.214V12c0 2.732-1.462 5.038-3.104 6.774-1.65 1.744-3.562 3-4.65 3.642a2.437 2.437 0 01-2.493 0c-1.087-.643-3-1.898-4.65-3.642C4.463 17.038 3 14.732 3 12V6.214a2.75 2.75 0 011.79-2.577l6.25-2.33zm1.397 1.406a1.25 1.25 0 00-.874 0l-6.25 2.33a1.25 1.25 0 00-.813 1.17V12c0 2.182 1.172 4.136 2.693 5.744 1.514 1.6 3.294 2.772 4.323 3.38.304.18.664.18.968 0 1.03-.608 2.809-1.78 4.323-3.38C18.327 16.136 19.5 14.182 19.5 12V6.214a1.25 1.25 0 00-.813-1.171l-6.25-2.33z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shield-off-16-svg-prop {
+  --shield-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.74.213a2.25 2.25 0 00-1.48 0L6.035.64a.75.75 0 00.493 1.417l1.226-.427a.75.75 0 01.493 0l4.75 1.653a.75.75 0 01.504.708v4.01c0 .334-.044.661-.127.98a.75.75 0 101.453.374C14.938 8.922 15 8.47 15 8V3.991a2.25 2.25 0 00-1.51-2.125L8.74.213z"/><path fill-rule="evenodd" d="M1.447 2.507L.72 1.78A.75.75 0 011.78.72l13.5 13.5a.75.75 0 11-1.06 1.06l-1.988-1.987c-1.2 1.098-2.505 1.886-3.254 2.296a2.026 2.026 0 01-1.955 0c-.816-.446-2.291-1.341-3.572-2.597C2.18 11.748 1 10.05 1 8V3.72c0-.456.165-.882.447-1.213zm1.078 1.079a.366.366 0 00-.025.133V8c0 1.456.847 2.79 2 3.92 1.142 1.12 2.483 1.938 3.244 2.354.162.09.35.09.513 0 .69-.378 1.854-1.084 2.913-2.043L2.525 3.586z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shield-off-24-svg-prop {
+  --shield-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M2.28 1.22a.75.75 0 00-1.06 1.06l2.185 2.185A1.937 1.937 0 003 5.651V12c0 2.732 1.462 5.038 3.104 6.774 1.65 1.744 3.562 3 4.65 3.642a2.442 2.442 0 002.496-.002c1.066-.63 2.928-1.85 4.557-3.546l3.913 3.912a.75.75 0 101.06-1.06L2.28 1.22zm14.466 16.587L4.508 5.568a.44.44 0 00-.008.083V12c0 2.182 1.172 4.136 2.693 5.744 1.514 1.6 3.294 2.772 4.323 3.38a.942.942 0 00.97-.002c1.02-.602 2.763-1.75 4.26-3.315z" clip-rule="evenodd"/><path d="M12.96 1.307a2.75 2.75 0 00-1.92 0l-2.302.858a.75.75 0 10.524 1.406l2.301-.858a1.25 1.25 0 01.874 0l6.25 2.33c.489.182.813.649.813 1.17V12c0 .574-.08 1.13-.227 1.668a.75.75 0 101.448.394c.178-.657.279-1.346.279-2.062V6.214a2.75 2.75 0 00-1.79-2.577l-6.25-2.33z"/></g></svg>');
+}
+
+%shield-x-16-svg-prop {
+  --shield-x-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M10.78 4.72a.75.75 0 010 1.06L9.06 7.5l1.72 1.72a.75.75 0 11-1.06 1.06L8 8.56l-1.72 1.72a.75.75 0 11-1.06-1.06L6.94 7.5 5.22 5.78a.75.75 0 011.06-1.06L8 6.44l1.72-1.72a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M7.26.213a2.25 2.25 0 011.48 0l4.75 1.653A2.25 2.25 0 0115 3.991v4.01c0 2.048-1.181 3.747-2.45 4.991-1.282 1.255-2.757 2.15-3.573 2.598a2.024 2.024 0 01-1.954 0c-.816-.447-2.291-1.342-3.572-2.598C2.18 11.748 1 10.05 1 8V3.991c0-.957.606-1.81 1.51-2.125L7.26.213zm.986 1.417a.75.75 0 00-.493 0l-4.75 1.653a.75.75 0 00-.503.708v4.01c0 1.455.847 2.79 2 3.92 1.142 1.118 2.483 1.937 3.244 2.353.163.09.35.09.512 0 .761-.416 2.102-1.235 3.244-2.353 1.153-1.13 2-2.465 2-3.92V3.99a.75.75 0 00-.504-.708L8.246 1.63z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shield-x-24-svg-prop {
+  --shield-x-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M15.78 7.22a.75.75 0 010 1.06L13.06 11l2.72 2.72a.75.75 0 11-1.06 1.06L12 12.06l-2.72 2.72a.75.75 0 01-1.06-1.06L10.94 11 8.22 8.28a.75.75 0 011.06-1.06L12 9.94l2.72-2.72a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M11.04 1.307a2.75 2.75 0 011.92 0l6.25 2.33A2.75 2.75 0 0121 6.214V12c0 2.732-1.462 5.038-3.104 6.774-1.65 1.744-3.562 3-4.65 3.642a2.437 2.437 0 01-2.493 0c-1.087-.643-3-1.898-4.65-3.642C4.463 17.038 3 14.732 3 12V6.214a2.75 2.75 0 011.79-2.577l6.25-2.33zm1.397 1.406a1.25 1.25 0 00-.874 0l-6.25 2.33a1.25 1.25 0 00-.813 1.17V12c0 2.182 1.172 4.136 2.693 5.744 1.514 1.6 3.294 2.772 4.323 3.38.304.18.664.18.968 0 1.03-.608 2.809-1.78 4.323-3.38C18.327 16.136 19.5 14.182 19.5 12V6.214a1.25 1.25 0 00-.813-1.171l-6.25-2.33z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shopping-bag-16-svg-prop {
+  --shopping-bag-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.5 7.25a.75.75 0 00-1.5 0c0 .76.34 1.468.91 1.975A3.15 3.15 0 008 10a3.15 3.15 0 002.09-.775c.57-.507.91-1.215.91-1.975a.75.75 0 00-1.5 0c0 .301-.134.61-.407.854A1.651 1.651 0 018 8.5c-.424 0-.816-.15-1.093-.396A1.145 1.145 0 016.5 7.25z"/><path fill-rule="evenodd" d="M3.448.746A2.25 2.25 0 015.121 0h5.758a2.25 2.25 0 011.673.746l1.871 2.081c.371.413.577.949.577 1.504v9.419A2.25 2.25 0 0112.75 16h-9.5A2.25 2.25 0 011 13.75V4.331c0-.555.205-1.091.577-1.504L3.448.746zm1.673.754a.75.75 0 00-.558.249L2.99 3.5H13.01l-1.574-1.751a.75.75 0 00-.558-.249H5.12zM2.5 13.75V5h11v8.75a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shopping-bag-24-svg-prop {
+  --shopping-bag-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9 10.5a.75.75 0 00-1.5 0 4.5 4.5 0 109 0 .75.75 0 00-1.5 0 3 3 0 01-6 0z"/><path fill-rule="evenodd" d="M5.612 1.865A2.75 2.75 0 017.614 1h8.772a2.75 2.75 0 012.002.865l2.865 3.043c.48.51.747 1.185.747 1.885V20.25A2.75 2.75 0 0119.25 23H4.75A2.75 2.75 0 012 20.25V6.793c0-.7.267-1.374.747-1.885l2.865-3.043zm2.002.635a1.25 1.25 0 00-.91.393L4.25 5.5h15.498l-2.453-2.607a1.25 1.25 0 00-.91-.393H7.614zM3.5 20.25V7h17v13.25c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%shopping-cart-16-svg-prop {
+  --shopping-cart-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M1.25 1.5a.75.75 0 000 1.5h1.154a.75.75 0 01.736.604l.874 4.413.405 2.15A2.25 2.25 0 006.63 12h6.095a2.25 2.25 0 002.214-1.848l.727-4A2.25 2.25 0 0013.453 3.5H4.648l-.037-.187A2.25 2.25 0 002.404 1.5H1.25zm4.237 6.236L4.945 5h8.508a.75.75 0 01.738.884l-.728 4a.75.75 0 01-.738.616H6.63a.75.75 0 01-.737-.611l-.406-2.153z" clip-rule="evenodd"/><path d="M7.5 13.75c0 .69-.56 1.25-1.25 1.25h-.01a1.25 1.25 0 110-2.5h.01c.69 0 1.25.56 1.25 1.25zM14 13.75c0 .69-.56 1.25-1.25 1.25h-.01a1.25 1.25 0 110-2.5h.01c.69 0 1.25.56 1.25 1.25z"/></g></svg>');
+}
+
+%shopping-cart-24-svg-prop {
+  --shopping-cart-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M1.25 1.5a.75.75 0 000 1.5h2.089a1.25 1.25 0 011.229 1.02l1.444 7.74.706 3.971A2.75 2.75 0 009.426 18h10.142a2.75 2.75 0 002.71-2.279l1.303-7.5A2.75 2.75 0 0020.872 5H6.276l-.234-1.255A2.75 2.75 0 003.34 1.5H1.25zm6.238 9.994L6.556 6.5h14.316c.776 0 1.365.7 1.232 1.464l-1.305 7.5a1.25 1.25 0 01-1.231 1.036H9.426a1.25 1.25 0 01-1.23-1.031l-.708-3.975z" clip-rule="evenodd"/><path d="M11.5 20.75a1.75 1.75 0 01-1.75 1.75h-.01a1.75 1.75 0 110-3.5h.01c.966 0 1.75.784 1.75 1.75zM21.5 20.75a1.75 1.75 0 01-1.75 1.75h-.01a1.75 1.75 0 110-3.5h.01c.966 0 1.75.784 1.75 1.75z"/></g></svg>');
+}
+
+%shuffle-16-svg-prop {
+  --shuffle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M14.943 1.463a.748.748 0 00-.161-.242l-.002-.001-.001-.002A.748.748 0 0014.25 1h-4a.75.75 0 000 1.5h2.19L1.22 13.72a.75.75 0 101.06 1.06L13.5 3.56v2.19a.75.75 0 001.5 0v-4a.747.747 0 00-.057-.287zM9.5 14.25c0 .414.336.75.75.75h4a.747.747 0 00.75-.75v-4a.75.75 0 00-1.5 0v2.19l-2.47-2.47a.75.75 0 10-1.06 1.06l2.47 2.47h-2.19a.75.75 0 00-.75.75zM6.03 4.97a.75.75 0 01-1.06 1.06L1.22 2.28a.75.75 0 011.06-1.06l3.75 3.75z"/></g></svg>');
+}
+
+%shuffle-24-svg-prop {
+  --shuffle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M21.943 2.463A.748.748 0 0021.25 2h-5.5a.75.75 0 000 1.5h3.69L2.22 20.72a.75.75 0 101.06 1.06L20.5 4.56v3.69a.75.75 0 001.5 0v-5.5a.747.747 0 00-.057-.287zM20.5 19.44v-3.69a.75.75 0 011.5 0v5.5a.747.747 0 01-.75.75h-5.5a.75.75 0 010-1.5h3.69l-4.97-4.97a.75.75 0 111.06-1.06l4.97 4.97zM9.53 9.53a.75.75 0 000-1.06L3.28 2.22a.75.75 0 00-1.06 1.06l6.25 6.25a.75.75 0 001.06 0z"/></g></svg>');
+}
+
+%sidebar-16-svg-prop {
+  --sidebar-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.25 1A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1h-9.5zM2.5 3.25a.75.75 0 01.75-.75h1.8v11h-1.8a.75.75 0 01-.75-.75v-9.5zM6.45 13.5h6.3a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75h-6.3v11z" clip-rule="evenodd"/></svg>');
+}
+
+%sidebar-24-svg-prop {
+  --sidebar-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4.75 2A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V4.75A2.75 2.75 0 0019.25 2H4.75zM3.5 4.75c0-.69.56-1.25 1.25-1.25H8v17H4.75c-.69 0-1.25-.56-1.25-1.25V4.75zm6 15.75h9.75c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H9.5v17z" clip-rule="evenodd"/></svg>');
+}
+
+%sidebar-hide-16-svg-prop {
+  --sidebar-hide-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.726 5.263a.7.7 0 10-.952-1.026l-3.5 3.25a.7.7 0 000 1.026l3.5 3.25a.7.7 0 00.952-1.026L8.78 8l2.947-2.737z"/><path fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h9.5A2.25 2.25 0 0115 3.25v9.5A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-9.5zm2.25-.75a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h1.3v-11h-1.3zm9.5 11h-6.8v-11h6.8a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%sidebar-hide-24-svg-prop {
+  --sidebar-hide-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M16.765 8.295a.75.75 0 00-1.03-1.09l-4.5 4.25a.75.75 0 000 1.09l4.5 4.25a.75.75 0 001.03-1.09L12.842 12l3.923-3.705z"/><path fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2h14.5A2.75 2.75 0 0122 4.75v14.5A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25V4.75zM4.75 3.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25H7v-17H4.75zm14.5 17H8.5v-17h10.75c.69 0 1.25.56 1.25 1.25v14.5c0 .69-.56 1.25-1.25 1.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%sidebar-show-16-svg-prop {
+  --sidebar-show-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.774 5.263a.7.7 0 11.952-1.026l3.5 3.25a.7.7 0 010 1.026l-3.5 3.25a.7.7 0 01-.952-1.026L10.72 8 7.774 5.263z"/><path fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h9.5A2.25 2.25 0 0115 3.25v9.5A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-9.5zm2.25-.75a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h1.3v-11h-1.3zm9.5 11h-6.8v-11h6.8a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%sidebar-show-24-svg-prop {
+  --sidebar-show-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M11.735 8.295a.75.75 0 011.03-1.09l4.5 4.25a.75.75 0 010 1.09l-4.5 4.25a.75.75 0 01-1.03-1.09L15.658 12l-3.923-3.705z"/><path fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2h14.5A2.75 2.75 0 0122 4.75v14.5A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25V4.75zM4.75 3.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25H7v-17H4.75zm14.5 17H8.5v-17h10.75c.69 0 1.25.56 1.25 1.25v14.5c0 .69-.56 1.25-1.25 1.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%sign-in-16-svg-prop {
+  --sign-in-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M9.5 1.75a.75.75 0 01.75-.75h2.5A2.25 2.25 0 0115 3.25v9.5A2.25 2.25 0 0112.75 15h-2.5a.75.75 0 010-1.5h2.5a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75h-2.5a.75.75 0 01-.75-.75z"/><path d="M5.97 3.72a.75.75 0 011.06 0l3.5 3.5a.75.75 0 010 1.06l-3.5 3.5a.75.75 0 01-1.06-1.06L8.19 8.5H2A.75.75 0 012 7h6.19L5.97 4.78a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%sign-in-24-svg-prop {
+  --sign-in-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M14.5 2.75a.75.75 0 01.75-.75h4A2.75 2.75 0 0122 4.75v14.5A2.75 2.75 0 0119.25 22h-4a.75.75 0 010-1.5h4c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25h-4a.75.75 0 01-.75-.75z"/><path d="M9.47 6.22a.75.75 0 011.06 0l5 5a.747.747 0 010 1.06l-5 5a.75.75 0 11-1.06-1.06l3.72-3.72H3A.75.75 0 013 11h10.19L9.47 7.28a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%sign-out-16-svg-prop {
+  --sign-out-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.5 1.75A.75.75 0 005.75 1h-2.5A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h2.5a.75.75 0 000-1.5h-2.5a.75.75 0 01-.75-.75v-9.5a.75.75 0 01.75-.75h2.5a.75.75 0 00.75-.75z"/><path d="M9.97 3.72a.75.75 0 011.06 0l3.5 3.5a.75.75 0 010 1.06l-3.5 3.5a.75.75 0 11-1.06-1.06l2.22-2.22H6A.75.75 0 016 7h6.19L9.97 4.78a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%sign-out-24-svg-prop {
+  --sign-out-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9.5 2.75A.75.75 0 008.75 2h-4A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h4a.75.75 0 000-1.5h-4c-.69 0-1.25-.56-1.25-1.25V4.75c0-.69.56-1.25 1.25-1.25h4a.75.75 0 00.75-.75z"/><path d="M15.47 6.22a.75.75 0 011.06 0l5 5a.75.75 0 010 1.06l-5 5a.75.75 0 11-1.06-1.06l3.72-3.72H9A.75.75 0 019 11h10.19l-3.72-3.72a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%skip-16-svg-prop {
+  --skip-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 0110.535-5.096l-9.131 9.131A6.472 6.472 0 011.5 8zm2.465 5.096a6.5 6.5 0 009.131-9.131l-9.131 9.131z" clip-rule="evenodd"/></svg>');
+}
+
+%skip-24-svg-prop {
+  --skip-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4.172 19.728a.744.744 0 00.1.1A10.965 10.965 0 0012 23c6.075 0 11-4.925 11-11 0-3.012-1.21-5.742-3.172-7.728a.769.769 0 00-.1-.1A10.965 10.965 0 0012 1C5.925 1 1 5.925 1 12c0 3.012 1.21 5.742 3.172 7.728zM2.5 12A9.5 9.5 0 0112 2.5c2.353 0 4.507.856 6.166 2.273L4.773 18.166A9.462 9.462 0 012.5 12zm16.727-6.166A9.462 9.462 0 0121.5 12a9.5 9.5 0 01-9.5 9.5 9.462 9.462 0 01-6.166-2.273L19.227 5.834z" clip-rule="evenodd"/></svg>');
+}
+
+%skip-back-16-svg-prop {
+  --skip-back-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M11.24 2.5C12.4 1.682 14 2.51 14 3.93v8.14c0 1.419-1.6 2.248-2.76 1.43L5.476 9.43a1.75 1.75 0 010-2.86L11.24 2.5zm1.26 1.43a.25.25 0 00-.394-.204L6.34 7.796a.25.25 0 000 .408l5.766 4.07a.25.25 0 00.394-.204V3.93z" clip-rule="evenodd"/><path d="M3.5 3A.75.75 0 002 3v10a.75.75 0 001.5 0V3z"/></g></svg>');
+}
+
+%skip-back-24-svg-prop {
+  --skip-back-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M17.236 4.512C18.395 3.688 20 4.516 20 5.938v12.124c0 1.421-1.605 2.25-2.764 1.426L8.71 13.426a1.75 1.75 0 010-2.852l8.525-6.062zM18.5 5.938a.25.25 0 00-.395-.204l-8.524 6.062a.25.25 0 000 .408l8.524 6.061a.25.25 0 00.395-.203V5.938z" clip-rule="evenodd"/><path d="M6 5a.75.75 0 00-1.5 0v14A.75.75 0 006 19V5z"/></g></svg>');
+}
+
+%skip-forward-16-svg-prop {
+  --skip-forward-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M4.76 2.5C3.6 1.682 2 2.51 2 3.93v8.14c0 1.419 1.6 2.248 2.76 1.43l5.765-4.07a1.75 1.75 0 000-2.86L4.76 2.5zM3.5 3.93a.25.25 0 01.394-.204l5.766 4.07a.25.25 0 010 .408l-5.766 4.07a.25.25 0 01-.394-.204V3.93z" clip-rule="evenodd"/><path d="M14 3a.75.75 0 00-1.5 0v10a.75.75 0 001.5 0V3z"/></g></svg>');
+}
+
+%skip-forward-24-svg-prop {
+  --skip-forward-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M6.764 4.512C5.606 3.688 4 4.516 4 5.938v12.124c0 1.421 1.606 2.25 2.764 1.426l8.525-6.062a1.75 1.75 0 000-2.852L6.764 4.512zM5.5 5.938a.25.25 0 01.395-.204l8.524 6.062c.14.1.14.308 0 .408l-8.524 6.061a.25.25 0 01-.395-.203V5.938z" clip-rule="evenodd"/><path d="M19.5 5A.75.75 0 0018 5v14a.75.75 0 001.5 0V5z"/></g></svg>');
+}
+
+%slack-16-svg-prop {
+  --slack-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M2.471 11.318a1.474 1.474 0 001.47-1.471v-1.47h-1.47A1.474 1.474 0 001 9.846c.001.811.659 1.469 1.47 1.47zm3.682-2.942a1.474 1.474 0 00-1.47 1.471v3.683c.002.811.659 1.468 1.47 1.47a1.474 1.474 0 001.47-1.47V9.846a1.474 1.474 0 00-1.47-1.47zM4.683 2.471c.001.811.659 1.469 1.47 1.47h1.47v-1.47A1.474 1.474 0 006.154 1a1.474 1.474 0 00-1.47 1.47zm2.94 3.682a1.474 1.474 0 00-1.47-1.47H2.47A1.474 1.474 0 001 6.153c.002.812.66 1.469 1.47 1.47h3.684a1.474 1.474 0 001.47-1.47zM9.847 7.624a1.474 1.474 0 001.47-1.47V2.47A1.474 1.474 0 009.848 1a1.474 1.474 0 00-1.47 1.47v3.684c.002.81.659 1.468 1.47 1.47zm3.682-2.941a1.474 1.474 0 00-1.47 1.47v1.47h1.47A1.474 1.474 0 0015 6.154a1.474 1.474 0 00-1.47-1.47zM8.377 9.847c.002.811.659 1.469 1.47 1.47h3.683A1.474 1.474 0 0015 9.848a1.474 1.474 0 00-1.47-1.47H9.847a1.474 1.474 0 00-1.47 1.47zm2.94 3.682a1.474 1.474 0 00-1.47-1.47h-1.47v1.47c.002.812.659 1.469 1.47 1.47a1.474 1.474 0 001.47-1.47z"/></g></svg>');
+}
+
+%slack-24-svg-prop {
+  --slack-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M4.101 16.74a2.106 2.106 0 002.101-2.101v-2.101H4.101a2.106 2.106 0 00-2.1 2.1 2.106 2.106 0 002.1 2.102zm5.26-4.202a2.106 2.106 0 00-2.1 2.1V19.9A2.106 2.106 0 009.362 22a2.106 2.106 0 002.1-2.1v-5.262a2.106 2.106 0 00-2.1-2.1zM7.26 4.101a2.106 2.106 0 002.102 2.101h2.1V4.101a2.106 2.106 0 00-2.1-2.1A2.106 2.106 0 007.26 4.1zm4.203 5.26a2.106 2.106 0 00-2.101-2.1H4.1A2.106 2.106 0 002 9.362a2.106 2.106 0 002.1 2.1h5.262a2.106 2.106 0 002.1-2.1zM14.639 11.463a2.106 2.106 0 002.1-2.101V4.1a2.106 2.106 0 00-2.1-2.1 2.106 2.106 0 00-2.101 2.1v5.262a2.106 2.106 0 002.1 2.1zm5.26-4.202a2.106 2.106 0 00-2.1 2.1v2.102h2.1A2.106 2.106 0 0022 9.362a2.106 2.106 0 00-2.1-2.101zM12.538 14.639a2.106 2.106 0 002.1 2.1H19.9a2.106 2.106 0 002.1-2.1 2.106 2.106 0 00-2.1-2.101h-5.262a2.106 2.106 0 00-2.1 2.1zm4.202 5.26a2.106 2.106 0 00-2.101-2.1h-2.101v2.1a2.106 2.106 0 002.1 2.101 2.106 2.106 0 002.102-2.1z"/></g></svg>');
+}
+
+%slack-color-16-svg-prop {
+  --slack-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill-rule="evenodd" clip-rule="evenodd"><path fill="%23E01E5A" d="M2.471 11.318a1.474 1.474 0 001.47-1.471v-1.47h-1.47A1.474 1.474 0 001 9.846c.001.811.659 1.469 1.47 1.47zm3.682-2.942a1.474 1.474 0 00-1.47 1.471v3.683c.002.811.66 1.468 1.47 1.47a1.474 1.474 0 001.47-1.47V9.846a1.474 1.474 0 00-1.47-1.47z"/><path fill="%2336C5F0" d="M4.683 2.471c.001.811.659 1.469 1.47 1.47h1.47v-1.47A1.474 1.474 0 006.154 1a1.474 1.474 0 00-1.47 1.47zm2.94 3.682a1.474 1.474 0 00-1.47-1.47H2.47A1.474 1.474 0 001 6.153c.002.812.66 1.469 1.47 1.47h3.684a1.474 1.474 0 001.47-1.47z"/><path fill="%232EB67D" d="M9.847 7.624a1.474 1.474 0 001.47-1.47V2.47A1.474 1.474 0 009.848 1a1.474 1.474 0 00-1.47 1.47v3.684c.002.81.659 1.468 1.47 1.47zm3.682-2.941a1.474 1.474 0 00-1.47 1.47v1.47h1.47A1.474 1.474 0 0015 6.154a1.474 1.474 0 00-1.47-1.47z"/><path fill="%23ECB22E" d="M8.377 9.847c.002.811.659 1.469 1.47 1.47h3.683A1.474 1.474 0 0015 9.848a1.474 1.474 0 00-1.47-1.47H9.847a1.474 1.474 0 00-1.47 1.47zm2.94 3.682a1.474 1.474 0 00-1.47-1.47h-1.47v1.47c.002.812.659 1.469 1.47 1.47a1.474 1.474 0 001.47-1.47z"/></g></svg>');
+}
+
+%slack-color-24-svg-prop {
+  --slack-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill-rule="evenodd" clip-rule="evenodd"><path fill="%23E01E5A" d="M4.101 16.74a2.106 2.106 0 002.101-2.101v-2.101H4.101a2.106 2.106 0 00-2.1 2.1 2.106 2.106 0 002.1 2.102zm5.26-4.202a2.106 2.106 0 00-2.1 2.1V19.9A2.106 2.106 0 009.362 22a2.106 2.106 0 002.1-2.1v-5.262a2.106 2.106 0 00-2.1-2.1z"/><path fill="%2336C5F0" d="M7.26 4.101a2.106 2.106 0 002.102 2.101h2.1V4.101a2.106 2.106 0 00-2.1-2.1A2.106 2.106 0 007.26 4.1zm4.203 5.26a2.106 2.106 0 00-2.101-2.1H4.1A2.106 2.106 0 002 9.362a2.106 2.106 0 002.1 2.1h5.262a2.106 2.106 0 002.1-2.1z"/><path fill="%232EB67D" d="M14.639 11.463a2.106 2.106 0 002.1-2.101V4.1a2.106 2.106 0 00-2.1-2.1 2.106 2.106 0 00-2.101 2.1v5.262a2.106 2.106 0 002.1 2.1zm5.26-4.202a2.106 2.106 0 00-2.1 2.1v2.101h2.1A2.106 2.106 0 0022 9.363a2.106 2.106 0 00-2.1-2.101z"/><path fill="%23ECB22E" d="M12.538 14.639a2.106 2.106 0 002.1 2.1H19.9a2.106 2.106 0 002.1-2.1 2.106 2.106 0 00-2.1-2.101h-5.262a2.106 2.106 0 00-2.1 2.1zm4.202 5.26a2.106 2.106 0 00-2.101-2.1h-2.101v2.1a2.106 2.106 0 002.1 2.1 2.106 2.106 0 002.102-2.1z"/></g></svg>');
+}
+
+%slash-16-svg-prop {
+  --slash-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M11.126 2.601a.75.75 0 00-1.025.273l-5.5 9.5a.75.75 0 001.298.752l5.5-9.5a.75.75 0 00-.273-1.025z" clip-rule="evenodd"/></svg>');
+}
+
+%slash-24-svg-prop {
+  --slash-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M16.63 4.103a.75.75 0 00-1.027.268l-8.5 14.5a.75.75 0 101.294.758l8.5-14.5a.75.75 0 00-.268-1.026z" clip-rule="evenodd"/></svg>');
+}
+
+%slash-square-16-svg-prop {
+  --slash-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M9.633 4.323a.75.75 0 011.234.854l-4.5 6.5a.75.75 0 01-1.234-.854l4.5-6.5z"/><path fill-rule="evenodd" d="M3.25 1A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1h-9.5zM2.5 3.25a.75.75 0 01.75-.75h9.5a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75v-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%slash-square-24-svg-prop {
+  --slash-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M14.1 6.874a.75.75 0 011.3.752l-5.5 9.5a.75.75 0 11-1.3-.752l5.5-9.5z"/><path fill-rule="evenodd" d="M4.75 2A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V4.75A2.75 2.75 0 0019.25 2H4.75zM3.5 4.75c0-.69.56-1.25 1.25-1.25h14.5c.69 0 1.25.56 1.25 1.25v14.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25V4.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%sliders-16-svg-prop {
+  --sliders-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M2.75 1a.75.75 0 01.75.75v5.5a.75.75 0 01-1.5 0v-5.5A.75.75 0 012.75 1zM2 10.5v3.75a.75.75 0 001.5 0V10.5h1a.75.75 0 000-1.5H1a.75.75 0 000 1.5h1zM8.5 7.75a.75.75 0 00-1.5 0v6.5a.75.75 0 001.5 0v-6.5zM7.75 1a.75.75 0 01.75.75V4.5h1a.75.75 0 010 1.5H6a.75.75 0 010-1.5h1V1.75A.75.75 0 017.75 1zM14.5 10a.75.75 0 010 1.5h-1v2.75a.75.75 0 01-1.5 0V11.5h-1a.75.75 0 010-1.5h3.5zM12.75 1a.75.75 0 01.75.75v6.5a.75.75 0 01-1.5 0v-6.5a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
+%sliders-24-svg-prop {
+  --sliders-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.75 2.5a.75.75 0 01.75.75v7a.75.75 0 01-1.5 0v-7a.75.75 0 01.75-.75zM3 14.5v6.25a.75.75 0 001.5 0V14.5h2a.75.75 0 000-1.5H1a.75.75 0 000 1.5h2zM12.5 11.75a.75.75 0 00-1.5 0v9a.75.75 0 001.5 0v-9zM11.75 2.5a.75.75 0 01.75.75V7.5h2a.75.75 0 010 1.5H9a.75.75 0 010-1.5h2V3.25a.75.75 0 01.75-.75zM22.5 15a.75.75 0 010 1.5h-2v4.25a.75.75 0 01-1.5 0V16.5h-2a.75.75 0 010-1.5h5.5zM19.75 2.5a.75.75 0 01.75.75v9a.75.75 0 01-1.5 0v-9a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
+%smartphone-16-svg-prop {
+  --smartphone-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 12a1 1 0 100 2h.007a1 1 0 100-2H8z"/><path fill-rule="evenodd" d="M4.25 0A2.25 2.25 0 002 2.25v11.5A2.25 2.25 0 004.25 16h7.5A2.25 2.25 0 0014 13.75V2.25A2.25 2.25 0 0011.75 0h-7.5zM3.5 2.25a.75.75 0 01.75-.75h7.5a.75.75 0 01.75.75v11.5a.75.75 0 01-.75.75h-7.5a.75.75 0 01-.75-.75V2.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%smartphone-24-svg-prop {
+  --smartphone-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 19a1 1 0 100 2h.01a1 1 0 100-2H12z"/><path fill-rule="evenodd" d="M6.75 1A2.75 2.75 0 004 3.75v16.5A2.75 2.75 0 006.75 23h10.5A2.75 2.75 0 0020 20.25V3.75A2.75 2.75 0 0017.25 1H6.75zM5.5 3.75c0-.69.56-1.25 1.25-1.25h10.5c.69 0 1.25.56 1.25 1.25v16.5c0 .69-.56 1.25-1.25 1.25H6.75c-.69 0-1.25-.56-1.25-1.25V3.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%smile-16-svg-prop {
+  --smile-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 12c-1.01 0-1.782-.504-2.267-.945a4.72 4.72 0 01-.564-.614 3.31 3.31 0 01-.212-.305.75.75 0 011.284-.775 3.214 3.214 0 00.5.584c.341.31.769.555 1.259.555.49 0 .918-.246 1.258-.555a3.214 3.214 0 00.5-.584.75.75 0 011.285.775l-.212.305c-.128.167-.317.39-.564.614C9.782 11.495 9.01 12 8 12zM5 6a1 1 0 011-1h.007a1 1 0 010 2H6a1 1 0 01-1-1zM10 5a1 1 0 100 2h.007a1 1 0 100-2H10z"/><path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%smile-24-svg-prop {
+  --smile-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M7.362 14.693c.216.265.534.618.948.972.82.7 2.077 1.46 3.69 1.46s2.87-.76 3.69-1.46a7.647 7.647 0 001.199-1.3l.099-.145a.875.875 0 00-1.475-.942c-.071.107-.15.21-.232.31a5.898 5.898 0 01-.729.747c-.641.549-1.509 1.04-2.552 1.04-1.043 0-1.91-.491-2.552-1.04a5.894 5.894 0 01-.73-.747 4.012 4.012 0 01-.232-.31.875.875 0 00-1.474.942c.106.165.227.322.35.473zM8 9a1 1 0 011-1h.01a1 1 0 110 2H9a1 1 0 01-1-1zM15 8a1 1 0 100 2h.01a1 1 0 100-2H15z"/><path fill-rule="evenodd" d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%socket-16-svg-prop {
+  --socket-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5 8a1 1 0 011-1h.01a1 1 0 010 2H6a1 1 0 01-1-1zM10.01 7a1 1 0 000 2h.01a1 1 0 100-2h-.01z"/><path fill-rule="evenodd" d="M8 2.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM4 8a4 4 0 118 0 4 4 0 01-8 0z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M2.25 0A2.25 2.25 0 000 2.25v11.5A2.25 2.25 0 002.25 16h11.5A2.25 2.25 0 0016 13.75V2.25A2.25 2.25 0 0013.75 0H2.25zM1.5 2.25a.75.75 0 01.75-.75h11.5a.75.75 0 01.75.75v11.5a.75.75 0 01-.75.75H2.25a.75.75 0 01-.75-.75V2.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%socket-24-svg-prop {
+  --socket-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9 12a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zM14.01 11a1 1 0 100 2h.01a1 1 0 100-2h-.01z"/><path fill-rule="evenodd" d="M12 4a8 8 0 100 16 8 8 0 000-16zm-6.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/><path fill-rule="evenodd" d="M3.75 1A2.75 2.75 0 001 3.75v16.5A2.75 2.75 0 003.75 23h16.5A2.75 2.75 0 0023 20.25V3.75A2.75 2.75 0 0020.25 1H3.75zM2.5 3.75c0-.69.56-1.25 1.25-1.25h16.5c.69 0 1.25.56 1.25 1.25v16.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25V3.75z" clip-rule="evenodd"/></g></svg>');
+}
+
 %socket-svg-prop {
-  --socket-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20ZM12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22ZM7 11C7 10.4477 7.44772 10 8 10H10C10.5523 10 11 10.4477 11 11V13C11 13.5523 10.5523 14 10 14H8C7.44772 14 7 13.5523 7 13V11ZM14 10C13.4477 10 13 10.4477 13 11V13C13 13.5523 13.4477 14 14 14H16C16.5523 14 17 13.5523 17 13V11C17 10.4477 16.5523 10 16 10H14Z" fill="%23000"/></svg>');
+  --socket-svg: url('data:image/svg+xml;charset=UTF-8,<svg width="16" height="16" fill="%23000" xmlns="http://www.w3.org/2000/svg"><g fill-rule="EVENODD"><path d="M0 2.25A2.25 2.25 0 012.25 0h11.5A2.25 2.25 0 0116 2.25v11.5A2.25 2.25 0 0113.75 16H2.25A2.25 2.25 0 010 13.75V2.25zm2.25-.75a.75.75 0 00-.75.75v11.5c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75V2.25a.75.75 0 00-.75-.75H2.25z"/><path d="M8 4a4 4 0 100 8 4 4 0 000-8zM2.5 8a5.5 5.5 0 1111 0 5.5 5.5 0 01-11 0z"/><path d="M5 8a1 1 0 011-1h.01a1 1 0 010 2H6a1 1 0 01-1-1zM9.01 8a1 1 0 011-1h.01a1 1 0 110 2h-.01a1 1 0 01-1-1z"/></g></svg>');
+}
+
+%sort-asc-16-svg-prop {
+  --sort-asc-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M15.78 5.72a.75.75 0 01-1.06 1.06L13 5.06v4.69a.75.75 0 01-1.5 0V5.06L9.78 6.78a.75.75 0 01-1.06-1.06l3-3a.748.748 0 01.528-.22h.004a.748.748 0 01.528.22l3 3zM3 10.5A.75.75 0 013 9h6a.75.75 0 010 1.5H3zM2.25 12.75c0 .414.336.75.75.75h10a.75.75 0 000-1.5H3a.75.75 0 00-.75.75zM3 7.5A.75.75 0 013 6h3a.75.75 0 010 1.5H3zM2.25 3.75c0 .414.336.75.75.75h3A.75.75 0 006 3H3a.75.75 0 00-.75.75z"/></g></svg>');
+}
+
+%sort-asc-24-svg-prop {
+  --sort-asc-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M16.963 3.057a.748.748 0 01.817.163l4 4a.75.75 0 01-1.06 1.06L18 5.56v8.19a.75.75 0 01-1.5 0V5.56l-2.72 2.72a.75.75 0 11-1.06-1.06l4-4a.748.748 0 01.243-.163zM3.75 14.5a.75.75 0 010-1.5h9.5a.75.75 0 010 1.5h-9.5zM3 17.75c0 .414.336.75.75.75h16.5a.75.75 0 000-1.5H3.75a.75.75 0 00-.75.75zM3.75 10.5a.75.75 0 010-1.5h5.5a.75.75 0 010 1.5h-5.5zM3 5.75c0 .414.336.75.75.75h3.5a.75.75 0 000-1.5h-3.5a.75.75 0 00-.75.75z"/></g></svg>');
+}
+
+%sort-desc-16-svg-prop {
+  --sort-desc-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M2.25 3.75A.75.75 0 013 3h10a.75.75 0 010 1.5H3a.75.75 0 01-.75-.75zM3 6a.75.75 0 000 1.5h6A.75.75 0 009 6H3zM11.963 13.943a.747.747 0 00.817-.163l3-3a.75.75 0 10-1.06-1.06L13 11.44V6.75a.75.75 0 00-1.5 0v4.69L9.78 9.72a.75.75 0 00-1.06 1.06l3 3a.748.748 0 00.243.163zM3 9a.75.75 0 000 1.5h3A.75.75 0 006 9H3zM2.25 12.75A.75.75 0 013 12h3a.75.75 0 010 1.5H3a.75.75 0 01-.75-.75z"/></g></svg>');
+}
+
+%sort-desc-24-svg-prop {
+  --sort-desc-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3 5.75A.75.75 0 013.75 5h16.5a.75.75 0 010 1.5H3.75A.75.75 0 013 5.75zM3.75 9a.75.75 0 000 1.5h9.5a.75.75 0 000-1.5h-9.5zM16.963 20.443a.747.747 0 00.817-.163l4-4a.75.75 0 10-1.06-1.06L18 17.94V9.75a.75.75 0 00-1.5 0v8.19l-2.72-2.72a.75.75 0 10-1.06 1.06l4 4a.748.748 0 00.243.163zM3.75 13a.75.75 0 000 1.5h5.5a.75.75 0 000-1.5h-5.5zM3 17.75a.75.75 0 01.75-.75h3.5a.75.75 0 010 1.5h-3.5a.75.75 0 01-.75-.75z"/></g></svg>');
 }
 
 %sort-svg-prop {
@@ -650,12 +3426,76 @@
   --source-file-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.714 9.143l3.572 3.571-3.572 3.572-.714-1.4 2.143-2.172L13 10.571l.714-1.428zm-3.571 1.4L8 12.714l2.143 2.143-.714 1.429-3.572-3.572L9.43 9.143l.714 1.4zm8.571 10.028H4.43V3.43h10l4.285 4.285v12.857zM15.143 2H4.429C3.643 2 3 2.643 3 3.429V20.57C3 21.357 3.643 22 4.429 22h14.285c.786 0 1.429-.643 1.429-1.429V7l-5-5z" fill="%23000"/></svg>');
 }
 
+%speaker-16-svg-prop {
+  --speaker-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 5.55a3.95 3.95 0 100 7.9 3.95 3.95 0 000-7.9zM5.45 9.5a2.55 2.55 0 115.1 0 2.55 2.55 0 01-5.1 0z"/><path d="M3.25 0A2.25 2.25 0 001 2.25v11.5A2.25 2.25 0 003.25 16h9.5A2.25 2.25 0 0015 13.75V2.25A2.25 2.25 0 0012.75 0h-9.5zM2.5 2.25a.75.75 0 01.75-.75h9.5a.75.75 0 01.75.75v11.5a.75.75 0 01-.75.75h-9.5a.75.75 0 01-.75-.75V2.25z"/></g></svg>');
+}
+
+%speaker-24-svg-prop {
+  --speaker-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 9a5 5 0 100 10 5 5 0 000-10zm-3.5 5a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0z"/><path d="M5.75 1A2.75 2.75 0 003 3.75v16.5A2.75 2.75 0 005.75 23h12.5A2.75 2.75 0 0021 20.25V3.75A2.75 2.75 0 0018.25 1H5.75zM4.5 3.75c0-.69.56-1.25 1.25-1.25h12.5c.69 0 1.25.56 1.25 1.25v16.5c0 .69-.56 1.25-1.25 1.25H5.75c-.69 0-1.25-.56-1.25-1.25V3.75z"/></g></svg>');
+}
+
+%square-16-svg-prop {
+  --square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1 3.25A2.25 2.25 0 013.25 1h9.5A2.25 2.25 0 0115 3.25v9.5A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-9.5zm2.25-.75a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75h-9.5z" clip-rule="evenodd"/></svg>');
+}
+
+%square-24-svg-prop {
+  --square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M2 4.75A2.75 2.75 0 014.75 2h14.5A2.75 2.75 0 0122 4.75v14.5A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25V4.75zM4.75 3.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25h14.5c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H4.75z" clip-rule="evenodd"/></svg>');
+}
+
+%square-fill-16-svg-prop {
+  --square-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M3.25 1A2.25 2.25 0 001 3.25v9.5A2.25 2.25 0 003.25 15h9.5A2.25 2.25 0 0015 12.75v-9.5A2.25 2.25 0 0012.75 1h-9.5z"/></svg>');
+}
+
+%square-fill-24-svg-prop {
+  --square-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M4.75 2A2.75 2.75 0 002 4.75v14.5A2.75 2.75 0 004.75 22h14.5A2.75 2.75 0 0022 19.25V4.75A2.75 2.75 0 0019.25 2H4.75z"/></svg>');
+}
+
+%star-16-svg-prop {
+  --star-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 .5a.75.75 0 01.67.412l2.064 4.094 4.622.662a.75.75 0 01.412 1.285l-3.335 3.18.786 4.488a.75.75 0 01-1.082.796L8 13.287l-4.137 2.13a.75.75 0 01-1.082-.796l.786-4.489-3.335-3.18a.75.75 0 01.412-1.284l4.622-.662L7.33.912A.75.75 0 018 .5zm0 2.416L6.43 6.03a.75.75 0 01-.564.405l-3.48.498 2.507 2.39a.75.75 0 01.22.672l-.594 3.396 3.138-1.616a.75.75 0 01.686 0l3.138 1.616-.595-3.396a.75.75 0 01.221-.672l2.507-2.39-3.48-.498a.75.75 0 01-.563-.405L8 2.916z" clip-rule="evenodd"/></svg>');
+}
+
+%star-24-svg-prop {
+  --star-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1a.75.75 0 01.673.418l2.992 6.065 6.694.978a.75.75 0 01.414 1.28l-4.842 4.717 1.143 6.665a.75.75 0 01-1.089.79L12 18.766l-5.985 3.149a.75.75 0 01-1.089-.79l1.143-6.666-4.842-4.717a.75.75 0 01.415-1.28l6.693-.978 2.992-6.065A.75.75 0 0112 1zm0 2.445L9.505 8.5a.75.75 0 01-.564.41l-5.58.816 4.037 3.933a.75.75 0 01.216.664l-.952 5.556 4.989-2.625a.75.75 0 01.698 0l4.99 2.625-.953-5.556a.75.75 0 01.216-.664l4.037-3.933-5.58-.816a.75.75 0 01-.564-.41L12 3.445z" clip-rule="evenodd"/></svg>');
+}
+
+%star-circle-16-svg-prop {
+  --star-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8.679 2.431a.75.75 0 00-1.358 0L6.023 5.196l-2.887.444a.75.75 0 00-.423 1.265l2.11 2.162-.499 3.062a.75.75 0 001.103.777L8 11.484l2.573 1.422a.75.75 0 001.103-.777l-.5-3.062 2.11-2.162a.75.75 0 00-.422-1.265l-2.887-.444-1.298-2.765zM7.21 6.195L8 4.515l.789 1.68a.75.75 0 00.565.423l1.84.283L9.838 8.29a.75.75 0 00-.203.644l.312 1.912-1.584-.876a.75.75 0 00-.726 0l-1.584.876.312-1.912a.75.75 0 00-.203-.644L4.806 6.9l1.84-.282a.75.75 0 00.565-.423z"/><path d="M8 .05a7.95 7.95 0 100 15.9A7.95 7.95 0 008 .05zM1.45 8a6.55 6.55 0 1113.1 0 6.55 6.55 0 01-13.1 0z"/></g></svg>');
+}
+
+%star-circle-24-svg-prop {
+  --star-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12.669 4.91a.75.75 0 00-1.338 0l-1.91 3.767-4.277.608a.75.75 0 00-.41 1.287l3.082 2.923-.726 4.125a.75.75 0 001.08.798L12 16.457l3.83 1.96a.75.75 0 001.08-.797l-.726-4.125 3.082-2.923a.75.75 0 00-.41-1.287l-4.278-.608L12.67 4.91zm-2.086 4.793L12 6.91l1.417 2.794a.75.75 0 00.563.404l3.128.445-2.25 2.132a.75.75 0 00-.222.675l.535 3.036-2.83-1.448a.75.75 0 00-.683 0l-2.83 1.448.536-3.036a.75.75 0 00-.223-.675l-2.249-2.132 3.128-.445a.75.75 0 00.563-.404z"/><path d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z"/></g></svg>');
+}
+
+%star-fill-16-svg-prop {
+  --star-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M8.67.912a.75.75 0 00-1.34 0L5.266 5.006l-4.622.662a.75.75 0 00-.412 1.285l3.335 3.18-.786 4.488a.75.75 0 001.082.796L8 13.287l4.137 2.13a.75.75 0 001.082-.796l-.786-4.489 3.335-3.18a.75.75 0 00-.412-1.284l-4.622-.662L8.67.912z"/></svg>');
+}
+
+%star-fill-24-svg-prop {
+  --star-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M12.673 1.418a.75.75 0 00-1.345 0L8.335 7.483l-6.693.978a.75.75 0 00-.415 1.28l4.842 4.717-1.143 6.665a.75.75 0 001.089.79L12 18.766l5.985 3.149a.75.75 0 001.089-.79l-1.143-6.666 4.842-4.717a.75.75 0 00-.415-1.28l-6.693-.978-2.992-6.065z"/></svg>');
+}
+
 %star-fill-svg-prop {
   --star-fill-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27z" fill="%23000"/></svg>');
 }
 
+%star-off-16-svg-prop {
+  --star-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8.67.912a.75.75 0 00-1.34 0l-.882 1.75a.75.75 0 001.34.676L8 2.916 9.57 6.03c.11.219.321.37.564.405l3.48.498-1.299 1.238a.75.75 0 101.035 1.086l2.418-2.305a.75.75 0 00-.412-1.285l-4.622-.662L8.67.912z"/><path fill-rule="evenodd" d="M13.147 14.207l.072.413a.75.75 0 01-1.082.797L8 13.287l-4.137 2.13a.75.75 0 01-1.082-.796l.786-4.489-3.335-3.18a.75.75 0 01.412-1.284l3.467-.496L1.22 2.28a.75.75 0 111.06-1.06l12.5 12.5a.75.75 0 01-1.06 1.06l-.573-.572zm-7.71-7.71l-3.051.437 2.507 2.39a.75.75 0 01.22.672l-.594 3.396 3.138-1.616a.75.75 0 01.686 0l3.138 1.616-.18-1.03-5.865-5.865z" clip-rule="evenodd"/></g></svg>');
+}
+
+%star-off-24-svg-prop {
+  --star-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.673 1.418a.75.75 0 00-1.345 0l-1.584 3.21a.75.75 0 101.345.663L12 3.445 14.495 8.5a.75.75 0 00.564.41l5.58.816-2.756 2.685a.75.75 0 001.046 1.075l3.844-3.745a.75.75 0 00-.415-1.28l-6.693-.978-2.992-6.065z"/><path fill-rule="evenodd" d="M18.87 19.93l.204 1.193a.75.75 0 01-1.089.79L12 18.766l-5.985 3.149a.75.75 0 01-1.089-.79l1.143-6.666-4.842-4.717a.75.75 0 01.415-1.28l5.024-.734L1.22 2.28a.75.75 0 011.06-1.06l20.5 20.5a.75.75 0 11-1.06 1.06l-2.85-2.85zM7.988 9.05l-4.628.676 4.037 3.933a.75.75 0 01.216.664l-.952 5.556 4.989-2.625a.75.75 0 01.698 0l4.99 2.625-.307-1.786L7.99 9.049z" clip-rule="evenodd"/></g></svg>');
+}
+
 %star-outline-svg-prop {
   --star-outline-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z" fill="%23000"/></svg>');
+}
+
+%stop-circle-16-svg-prop {
+  --stop-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M6.25 5C5.56 5 5 5.56 5 6.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5C11 5.56 10.44 5 9.75 5h-3.5zm.25 4.5v-3h3v3h-3z"/><path d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"/></g></svg>');
+}
+
+%stop-circle-24-svg-prop {
+  --stop-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8.75 7A1.75 1.75 0 007 8.75v6.5c0 .966.784 1.75 1.75 1.75h6.5A1.75 1.75 0 0017 15.25v-6.5A1.75 1.75 0 0015.25 7h-6.5zM8.5 8.75a.25.25 0 01.25-.25h6.5a.25.25 0 01.25.25v6.5a.25.25 0 01-.25.25h-6.5a.25.25 0 01-.25-.25v-6.5z"/><path d="M12 1C5.925 1 1 5.925 1 12s4.925 11 11 11 11-4.925 11-11S18.075 1 12 1zM2.5 12a9.5 9.5 0 1119 0 9.5 9.5 0 01-19 0z"/></g></svg>');
 }
 
 %sub-left-svg-prop {
@@ -666,28 +3506,260 @@
   --sub-right-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M14 20l-1.42-1.42L16.17 15H4V4h2v9h10.17l-3.59-3.58L14 8l6 6-6 6z" fill="%23000"/></svg>');
 }
 
+%sun-16-svg-prop {
+  --sun-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 .25a.75.75 0 01.75.75v1.273a.75.75 0 01-1.5 0V1A.75.75 0 018 .25z"/><path fill-rule="evenodd" d="M4 8a4 4 0 118 0 4 4 0 01-8 0zm4-2.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5z" clip-rule="evenodd"/><path d="M8.75 13.727a.75.75 0 00-1.5 0V15a.75.75 0 001.5 0v-1.273zM2.519 2.518a.75.75 0 011.06 0l.904.904a.75.75 0 01-1.06 1.06l-.904-.903a.75.75 0 010-1.06zM12.578 11.517a.75.75 0 00-1.061 1.06l.904.904a.75.75 0 101.06-1.06l-.903-.904zM.25 8A.75.75 0 011 7.25h1.273a.75.75 0 010 1.5H1A.75.75 0 01.25 8zM13.727 7.25a.75.75 0 000 1.5H15a.75.75 0 000-1.5h-1.273zM4.483 11.517a.75.75 0 010 1.06l-.904.904a.75.75 0 01-1.06-1.06l.903-.904a.75.75 0 011.061 0zM13.481 3.58a.75.75 0 00-1.06-1.062l-.904.904a.75.75 0 101.06 1.06l.904-.903z"/></g></svg>');
+}
+
+%sun-24-svg-prop {
+  --sun-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 .25a.75.75 0 01.75.75v2a.75.75 0 01-1.5 0V1A.75.75 0 0112 .25z"/><path fill-rule="evenodd" d="M6 12a6 6 0 1112 0 6 6 0 01-12 0zm6-4.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z" clip-rule="evenodd"/><path d="M12.75 21a.75.75 0 00-1.5 0v2a.75.75 0 001.5 0v-2zM3.69 3.69a.75.75 0 011.06 0l1.42 1.42a.75.75 0 01-1.06 1.06L3.69 4.75a.75.75 0 010-1.06zM18.89 17.83a.75.75 0 10-1.06 1.06l1.42 1.42a.75.75 0 101.06-1.06l-1.42-1.42zM.25 12a.75.75 0 01.75-.75h2a.75.75 0 010 1.5H1A.75.75 0 01.25 12zM21 11.25a.75.75 0 000 1.5h2a.75.75 0 000-1.5h-2zM6.17 17.83a.75.75 0 010 1.06l-1.42 1.42a.75.75 0 11-1.06-1.06l1.42-1.42a.75.75 0 011.06 0zM20.31 4.75a.75.75 0 00-1.06-1.06l-1.42 1.42a.75.75 0 001.06 1.06l1.42-1.42z"/></g></svg>');
+}
+
+%support-16-svg-prop {
+  --support-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8c0-1.525.525-2.927 1.404-4.035l1.787 1.787A3.982 3.982 0 004 8c0 .834.255 1.608.691 2.248l-1.787 1.787A6.472 6.472 0 011.5 8zm2.465 5.096l1.787-1.787C6.392 11.745 7.166 12 8 12c.834 0 1.608-.255 2.248-.691l1.787 1.787A6.472 6.472 0 018 14.5a6.473 6.473 0 01-4.035-1.404zm9.131-1.06A6.472 6.472 0 0014.5 8a6.473 6.473 0 00-1.404-4.035l-1.787 1.787C11.745 6.392 12 7.166 12 8c0 .834-.255 1.608-.691 2.248l1.787 1.787zm-1.06-9.132A6.472 6.472 0 008 1.5a6.472 6.472 0 00-4.035 1.404l1.787 1.787A3.982 3.982 0 018 4c.834 0 1.608.255 2.248.691l1.787-1.787zM5.5 8a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0z" clip-rule="evenodd"/></svg>');
+}
+
+%support-24-svg-prop {
+  --support-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M19.828 19.728A10.965 10.965 0 0023 12c0-3.012-1.21-5.742-3.172-7.728a.77.77 0 00-.1-.1A10.965 10.965 0 0012 1C8.988 1 6.258 2.21 4.272 4.172a.767.767 0 00-.1.1A10.965 10.965 0 001 12c0 3.012 1.21 5.742 3.172 7.728a.77.77 0 00.1.1A10.965 10.965 0 0012 23c3.012 0 5.742-1.21 7.728-3.172a.771.771 0 00.1-.1zM2.5 12c0-2.353.856-4.507 2.273-6.166l3.2 3.2A4.978 4.978 0 007 12c0 1.11.362 2.136.974 2.965l-3.201 3.201A9.462 9.462 0 012.5 12zm7.094 2.542A3.488 3.488 0 0012 15.5c.932 0 1.779-.364 2.406-.958a.769.769 0 01.136-.136A3.488 3.488 0 0015.5 12c0-.932-.364-1.779-.958-2.406a.768.768 0 01-.136-.136A3.488 3.488 0 0012 8.5c-.932 0-1.779.364-2.406.958a.768.768 0 01-.136.136A3.488 3.488 0 008.5 12c0 .932.364 1.779.958 2.406.05.039.097.086.136.136zm5.371 1.484A4.978 4.978 0 0112 17a4.978 4.978 0 01-2.965-.974l-3.201 3.201A9.462 9.462 0 0012 21.5a9.462 9.462 0 006.166-2.273l-3.2-3.2zm4.262 2.14l-3.2-3.2c.611-.83.973-1.856.973-2.966s-.362-2.136-.974-2.965l3.201-3.201A9.462 9.462 0 0121.5 12a9.462 9.462 0 01-2.273 6.166zm-1.06-13.393l-3.202 3.2A4.977 4.977 0 0012 7c-1.11 0-2.136.362-2.965.974L5.834 4.773A9.463 9.463 0 0112 2.5c2.353 0 4.507.856 6.166 2.273z" clip-rule="evenodd"/></svg>');
+}
+
 %support-svg-prop {
   --support-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M2 12C2 6.477 6.477 2 12 2c5.52.006 9.994 4.48 10 10 0 5.523-4.477 10-10 10S2 17.523 2 12zm17.83-2.588a.208.208 0 0 0 .027-.19 8.375 8.375 0 0 0-5.079-5.079.209.209 0 0 0-.278.197v3.213c0 .074.04.142.102.18.68.416 1.251.988 1.667 1.667a.21.21 0 0 0 .179.1h3.213a.208.208 0 0 0 .17-.088zM12 15.333a3.333 3.333 0 1 1 0-6.666 3.333 3.333 0 0 1 0 6.666zM9.412 4.17a.21.21 0 0 0-.19-.027A8.376 8.376 0 0 0 4.14 9.227a.206.206 0 0 0 .026.19.21.21 0 0 0 .172.083h3.213a.21.21 0 0 0 .181-.102c.416-.68.988-1.25 1.667-1.666a.21.21 0 0 0 .1-.179V4.34a.21.21 0 0 0-.088-.17zM4.143 14.778a.207.207 0 0 1 .196-.278h3.213a.21.21 0 0 1 .179.1c.416.68.987 1.25 1.666 1.667a.21.21 0 0 1 .1.178v3.213a.208.208 0 0 1-.278.196 8.376 8.376 0 0 1-5.076-5.076zm10.446 5.054a.208.208 0 0 0 .19.026 8.376 8.376 0 0 0 5.072-5.077.208.208 0 0 0-.192-.277h-3.214a.21.21 0 0 0-.178.1A5.042 5.042 0 0 1 14.6 16.27a.209.209 0 0 0-.1.178v3.214c0 .067.033.13.088.17z" fill="%23000"/></svg>');
+}
+
+%swap-horizontal-16-svg-prop {
+  --swap-horizontal-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M12.26 1.45a.75.75 0 10-1.02 1.1l2.1 1.95H7.75a.75.75 0 100 1.5h5.59l-2.1 1.95a.75.75 0 101.02 1.1l3.5-3.25a.75.75 0 000-1.1l-3.5-3.25zM2.66 10l2.1-1.95a.75.75 0 00-1.02-1.1L.24 10.2a.75.75 0 000 1.1l3.5 3.25a.75.75 0 001.02-1.1l-2.1-1.95h5.59a.75.75 0 000-1.5H2.66z"/></g></svg>');
+}
+
+%swap-horizontal-24-svg-prop {
+  --swap-horizontal-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M18.265 5.455a.75.75 0 00-1.03 1.09L20.364 9.5H11.75a.75.75 0 000 1.5h8.614l-3.129 2.955a.75.75 0 001.03 1.09l4.5-4.25a.75.75 0 000-1.09l-4.5-4.25zM3.636 13l3.129-2.955a.75.75 0 00-1.03-1.09l-4.5 4.25a.75.75 0 000 1.09l4.5 4.25a.75.75 0 001.03-1.09L3.636 14.5h8.614a.75.75 0 000-1.5H3.636z"/></g></svg>');
 }
 
 %swap-horizontal-svg-prop {
   --swap-horizontal-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M6.99 11L3 15l3.99 4v-3H14v-2H6.99v-3zM21 9l-3.99-4v3H10v2h7.01v3L21 9z" fill="%23000"/></svg>');
 }
 
+%swap-vertical-16-svg-prop {
+  --swap-vertical-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.45 3.74a.75.75 0 101.1 1.02l1.95-2.1v5.59a.75.75 0 101.5 0V2.66l1.95 2.1a.75.75 0 001.1-1.02L5.8.24a.75.75 0 00-1.1 0l-3.25 3.5zM10.75 7a.75.75 0 00-.75.75v5.59l-1.95-2.1a.75.75 0 10-1.1 1.02l3.25 3.5a.75.75 0 001.1 0l3.25-3.5a.75.75 0 10-1.1-1.02l-1.95 2.1V7.75a.75.75 0 00-.75-.75z"/></g></svg>');
+}
+
+%swap-vertical-24-svg-prop {
+  --swap-vertical-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M4.455 5.735a.75.75 0 001.09 1.03L8.5 3.636v8.614a.75.75 0 001.5 0V3.636l2.955 3.129a.75.75 0 001.09-1.03l-4.25-4.5a.75.75 0 00-1.09 0l-4.25 4.5zM15.5 20.364V11.75a.75.75 0 00-1.5 0v8.614l-2.955-3.129a.75.75 0 00-1.09 1.03l4.25 4.5a.75.75 0 001.09 0l4.25-4.5a.75.75 0 00-1.09-1.03L15.5 20.364z"/></g></svg>');
+}
+
 %swap-vertical-svg-prop {
   --swap-vertical-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16 17.01V10h-2v7.01h-3L15 21l4-3.99h-3zM9 3L5 6.99h3V14h2V6.99h3L9 3z" fill="%23000"/></svg>');
+}
+
+%switcher-16-svg-prop {
+  --switcher-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M.75 0A.75.75 0 000 .75v2.5c0 .414.336.75.75.75h2.5A.75.75 0 004 3.25V.75A.75.75 0 003.25 0H.75zM6.75 0A.75.75 0 006 .75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75V.75A.75.75 0 009.25 0h-2.5zM12.75 0a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75V.75a.75.75 0 00-.75-.75h-2.5zM.75 6a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5A.75.75 0 004 9.25v-2.5A.75.75 0 003.25 6H.75zM6.75 6a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-2.5A.75.75 0 009.25 6h-2.5zM12.75 6a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-2.5a.75.75 0 00-.75-.75h-2.5zM.75 12a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-2.5a.75.75 0 00-.75-.75H.75zM6.75 12a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-2.5a.75.75 0 00-.75-.75h-2.5zM12.75 12a.75.75 0 00-.75.75v2.5c0 .414.336.75.75.75h2.5a.75.75 0 00.75-.75v-2.5a.75.75 0 00-.75-.75h-2.5z"/></g></svg>');
+}
+
+%switcher-24-svg-prop {
+  --switcher-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M2.25 1C1.56 1 1 1.56 1 2.25v3.5C1 6.44 1.56 7 2.25 7h3.5C6.44 7 7 6.44 7 5.75v-3.5C7 1.56 6.44 1 5.75 1h-3.5zM10.25 1C9.56 1 9 1.56 9 2.25v3.5C9 6.44 9.56 7 10.25 7h3.5C14.44 7 15 6.44 15 5.75v-3.5C15 1.56 14.44 1 13.75 1h-3.5zM18.25 1C17.56 1 17 1.56 17 2.25v3.5c0 .69.56 1.25 1.25 1.25h3.5C22.44 7 23 6.44 23 5.75v-3.5C23 1.56 22.44 1 21.75 1h-3.5zM2.25 9C1.56 9 1 9.56 1 10.25v3.5c0 .69.56 1.25 1.25 1.25h3.5C6.44 15 7 14.44 7 13.75v-3.5C7 9.56 6.44 9 5.75 9h-3.5zM10.25 9C9.56 9 9 9.56 9 10.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5C15 9.56 14.44 9 13.75 9h-3.5zM18.25 9c-.69 0-1.25.56-1.25 1.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5C23 9.56 22.44 9 21.75 9h-3.5zM2.25 17C1.56 17 1 17.56 1 18.25v3.5c0 .69.56 1.25 1.25 1.25h3.5C6.44 23 7 22.44 7 21.75v-3.5C7 17.56 6.44 17 5.75 17h-3.5zM10.25 17C9.56 17 9 17.56 9 18.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5c0-.69-.56-1.25-1.25-1.25h-3.5zM18.25 17c-.69 0-1.25.56-1.25 1.25v3.5c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25v-3.5c0-.69-.56-1.25-1.25-1.25h-3.5z"/></g></svg>');
+}
+
+%sync-16-svg-prop {
+  --sync-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 1.5A6.5 6.5 0 001.5 8 .75.75 0 010 8a8 8 0 0113.5-5.81v-.94a.75.75 0 011.5 0v3a.75.75 0 01-.75.75h-3a.75.75 0 010-1.5h1.44A6.479 6.479 0 008 1.5zM15.25 7.25A.75.75 0 0116 8a8 8 0 01-13.5 5.81v.94a.75.75 0 01-1.5 0v-3a.75.75 0 01.75-.75h3a.75.75 0 010 1.5H3.31A6.5 6.5 0 0014.5 8a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
+%sync-24-svg-prop {
+  --sync-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 3.5A8.5 8.5 0 003.5 12 .75.75 0 012 12C2 6.477 6.477 2 12 2a9.977 9.977 0 017.5 3.386V2.75a.75.75 0 011.5 0v4.5a.75.75 0 01-.75.75h-4.5a.75.75 0 010-1.5h2.731A8.48 8.48 0 0012 3.5zM21.25 11.25A.75.75 0 0122 12c0 5.523-4.477 10-10 10a9.977 9.977 0 01-7.5-3.386v2.636a.75.75 0 01-1.5 0v-4.5a.75.75 0 01.75-.75h4.5a.75.75 0 010 1.5H5.519A8.5 8.5 0 0020.5 12a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
+%sync-alert-16-svg-prop {
+  --sync-alert-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 1.5A6.5 6.5 0 001.5 8 .75.75 0 010 8a8 8 0 0113.5-5.81v-.94a.75.75 0 011.5 0v3a.75.75 0 01-.75.75h-3a.75.75 0 010-1.5h1.44A6.479 6.479 0 008 1.5zM15.25 7.25A.75.75 0 0116 8a8 8 0 01-13.5 5.81v.94a.75.75 0 01-1.5 0v-3a.75.75 0 01.75-.75h3a.75.75 0 010 1.5H3.31A6.5 6.5 0 0014.5 8a.75.75 0 01.75-.75z"/><path d="M7 11a1 1 0 011-1h.007a1 1 0 110 2H8a1 1 0 01-1-1zM8.75 4.75a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z"/></g></svg>');
+}
+
+%sync-alert-24-svg-prop {
+  --sync-alert-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 3.5A8.5 8.5 0 003.5 12 .75.75 0 012 12C2 6.477 6.477 2 12 2a9.977 9.977 0 017.5 3.386V2.75a.75.75 0 011.5 0v4.5a.75.75 0 01-.75.75h-4.5a.75.75 0 010-1.5h2.731A8.48 8.48 0 0012 3.5zM21.25 11.25A.75.75 0 0122 12c0 5.523-4.477 10-10 10a9.977 9.977 0 01-7.5-3.386v2.636a.75.75 0 01-1.5 0v-4.5a.75.75 0 01.75-.75h4.5a.75.75 0 010 1.5H5.519A8.5 8.5 0 0020.5 12a.75.75 0 01.75-.75z"/><path d="M12 7a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0112 7zM12 15a1 1 0 100 2h.01a1 1 0 100-2H12z"/></g></svg>');
+}
+
+%sync-reverse-16-svg-prop {
+  --sync-reverse-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 1.5A6.5 6.5 0 0114.5 8 .75.75 0 0016 8 8 8 0 002.5 2.19v-.94a.75.75 0 00-1.5 0v3c0 .414.336.75.75.75h3a.75.75 0 000-1.5H3.31A6.479 6.479 0 018 1.5zM.75 7.25A.75.75 0 000 8a8 8 0 0013.5 5.81v.94a.75.75 0 001.5 0v-3a.75.75 0 00-.75-.75h-3a.75.75 0 000 1.5h1.44A6.5 6.5 0 011.5 8a.75.75 0 00-.75-.75z"/></g></svg>');
+}
+
+%sync-reverse-24-svg-prop {
+  --sync-reverse-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 3.5a8.5 8.5 0 018.5 8.5.75.75 0 001.5 0c0-5.523-4.477-10-10-10a9.977 9.977 0 00-7.5 3.386V2.75a.75.75 0 00-1.5 0v4.5c0 .414.336.75.75.75h4.5a.75.75 0 000-1.5H5.519A8.48 8.48 0 0112 3.5zM2.75 11.25A.75.75 0 002 12c0 5.523 4.477 10 10 10a9.977 9.977 0 007.5-3.386v2.636a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.731A8.5 8.5 0 013.5 12a.75.75 0 00-.75-.75z"/></g></svg>');
+}
+
+%tablet-16-svg-prop {
+  --tablet-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 11a1 1 0 100 2h.01a1 1 0 100-2H8z"/><path fill-rule="evenodd" d="M2.25 1A2.25 2.25 0 000 3.25v9.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-9.5A2.25 2.25 0 0013.75 1H2.25zM1.5 3.25a.75.75 0 01.75-.75h11.5a.75.75 0 01.75.75v9.5a.75.75 0 01-.75.75H2.25a.75.75 0 01-.75-.75v-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%tablet-24-svg-prop {
+  --tablet-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 17a1 1 0 100 2h.01a1 1 0 100-2H12z"/><path fill-rule="evenodd" d="M3.75 3A2.75 2.75 0 001 5.75v12.5A2.75 2.75 0 003.75 21h16.5A2.75 2.75 0 0023 18.25V5.75A2.75 2.75 0 0020.25 3H3.75zM2.5 5.75c0-.69.56-1.25 1.25-1.25h16.5c.69 0 1.25.56 1.25 1.25v12.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25V5.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%tag-16-svg-prop {
+  --tag-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M5 4a1 1 0 000 2h.006a1 1 0 000-2H5z"/><path fill-rule="evenodd" d="M2.25 1C1.56 1 1 1.56 1 2.25v5.246c0 .596.237 1.169.659 1.59l5.383 5.384a2.25 2.25 0 003.182 0l4.246-4.246a2.25 2.25 0 000-3.182L9.087 1.66A2.25 2.25 0 007.496 1H2.25zm.25 6.496V2.5h4.996a.75.75 0 01.53.22l5.383 5.383a.75.75 0 010 1.06L9.163 13.41a.75.75 0 01-1.06 0L2.72 8.026a.75.75 0 01-.22-.53z" clip-rule="evenodd"/></g></svg>');
+}
+
+%tag-24-svg-prop {
+  --tag-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M6 5a1 1 0 000 2h.01a1 1 0 000-2H6z"/><path fill-rule="evenodd" d="M4.75 2A2.75 2.75 0 002 4.75v6.422c0 .729.29 1.428.805 1.944l8 8a2.75 2.75 0 003.89 0l6.421-6.421a2.75 2.75 0 000-3.89l-8-8A2.75 2.75 0 0011.172 2H4.75zM3.5 4.75c0-.69.56-1.25 1.25-1.25h6.422c.331 0 .649.132.883.366l8 8a1.25 1.25 0 010 1.768l-6.421 6.421a1.25 1.25 0 01-1.768 0l-8-8a1.25 1.25 0 01-.366-.883V4.75z" clip-rule="evenodd"/></g></svg>');
 }
 
 %tag-svg-prop {
   --tag-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M11.304 3.195l10.253 10.253-8.031 8.03L3.273 11.227l1.029-7.002 7.002-1.029zM1.86 12.64a2 2 0 01-.564-1.704l1.028-7.003A2 2 0 014.01 2.245l7.003-1.029a2 2 0 011.705.565L22.97 12.034a2 2 0 010 2.828l-8.03 8.031a2 2 0 01-2.83 0L1.86 12.64zM8.5 10a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" fill="%23000"/></svg>');
 }
 
+%target-16-svg-prop {
+  --target-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 6a2 2 0 100 4 2 2 0 000-4zm-.5 2a.5.5 0 111 0 .5.5 0 01-1 0z"/><path d="M3 8a5 5 0 1110 0A5 5 0 013 8zm5-3.5a3.5 3.5 0 100 7 3.5 3.5 0 000-7z"/><path d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13z"/></g></svg>');
+}
+
+%target-24-svg-prop {
+  --target-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 9a3 3 0 100 6 3 3 0 000-6zm-1.5 3a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z"/><path d="M5 12a7 7 0 1114 0 7 7 0 01-14 0zm7-5.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11z"/><path d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm11-9.5a9.5 9.5 0 100 19 9.5 9.5 0 000-19z"/></g></svg>');
+}
+
+%terminal-16-svg-prop {
+  --terminal-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.23 3.174a.75.75 0 00-.96 1.152L6.078 7.5 2.27 10.674a.75.75 0 10.96 1.152l4.5-3.75a.75.75 0 000-1.152l-4.5-3.75zM7.75 12a.75.75 0 000 1.5h5.5a.75.75 0 000-1.5h-5.5z"/></g></svg>');
+}
+
+%terminal-24-svg-prop {
+  --terminal-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M4.23 4.174a.75.75 0 00-.96 1.152L10.078 11 3.27 16.674a.75.75 0 10.96 1.152l7.5-6.25a.75.75 0 000-1.152l-7.5-6.25zM11.75 18a.75.75 0 000 1.5h8.5a.75.75 0 000-1.5h-8.5z"/></g></svg>');
+}
+
+%terminal-screen-16-svg-prop {
+  --terminal-screen-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3.924 5.02a.75.75 0 011.056-.096l3 2.5a.75.75 0 010 1.152l-3 2.5a.75.75 0 11-.96-1.152L6.328 8 4.02 6.076a.75.75 0 01-.096-1.056zM8.25 10.5a.75.75 0 000 1.5h3a.75.75 0 000-1.5h-3z"/><path fill-rule="evenodd" d="M0 3.25A2.25 2.25 0 012.25 1h11.5A2.25 2.25 0 0116 3.25v9.5A2.25 2.25 0 0113.75 15H2.25A2.25 2.25 0 010 12.75v-9.5zm2.25-.75a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75H2.25z" clip-rule="evenodd"/></g></svg>');
+}
+
+%terminal-screen-24-svg-prop {
+  --terminal-screen-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M6.174 7.27a.75.75 0 011.056-.096l4.5 3.75a.75.75 0 010 1.152l-4.5 3.75a.75.75 0 11-.96-1.152l3.809-3.174-3.81-3.174a.75.75 0 01-.095-1.056zM11.75 16a.75.75 0 000 1.5h5.5a.75.75 0 000-1.5h-5.5z"/><path fill-rule="evenodd" d="M1 4.75A2.75 2.75 0 013.75 2h16.5A2.75 2.75 0 0123 4.75v14.5A2.75 2.75 0 0120.25 22H3.75A2.75 2.75 0 011 19.25V4.75zM3.75 3.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25h16.5c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H3.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%thumbs-down-16-svg-prop {
+  --thumbs-down-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8.404 14.484l2.56-5.759V1.5H3.488a.75.75 0 00-.741.637l-.995 6.55a.75.75 0 00.742.862h3.767c.69 0 1.25.56 1.25 1.25v2.626c0 .53.385.972.892 1.06zM12.464 1.5v6.634h1.286a.75.75 0 00.75-.75V2.25a.75.75 0 00-.75-.75h-1.287zM12.2 9.634l-2.511 5.65A1.206 1.206 0 018.588 16a2.575 2.575 0 01-2.576-2.575v-2.376H2.495A2.25 2.25 0 01.27 8.46l.995-6.549A2.25 2.25 0 013.489 0H13.75A2.25 2.25 0 0116 2.25v5.134a2.25 2.25 0 01-2.25 2.25H12.2z" clip-rule="evenodd"/></svg>');
+}
+
+%thumbs-down-24-svg-prop {
+  --thumbs-down-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12.77 21.484l3.73-8.393V2.5H5.52a1.25 1.25 0 00-1.237 1.062l-1.442 9.5A1.25 1.25 0 004.077 14.5H9.25c.966 0 1.75.784 1.75 1.75v3.225c0 1.032.772 1.884 1.77 2.01zM18 2.5v10h2.25c.69 0 1.25-.56 1.25-1.25v-7.5c0-.69-.56-1.25-1.25-1.25H18zM17.737 14l-3.71 8.349a1.097 1.097 0 01-1.002.651A3.525 3.525 0 019.5 19.475V16.25a.25.25 0 00-.25-.25H4.077a2.75 2.75 0 01-2.72-3.163l1.443-9.5A2.75 2.75 0 015.52 1h14.73A2.75 2.75 0 0123 3.75v7.5A2.75 2.75 0 0120.25 14h-2.513z" clip-rule="evenodd"/></svg>');
+}
+
+%thumbs-up-16-svg-prop {
+  --thumbs-up-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M7.596 1.516l-2.56 5.759V14.5h7.475a.75.75 0 00.741-.637l.994-6.55a.75.75 0 00-.741-.862H9.738c-.69 0-1.25-.56-1.25-1.25V2.575c0-.53-.385-.972-.892-1.06zM3.536 14.5V7.866H2.25a.75.75 0 00-.75.75v5.134c0 .414.336.75.75.75h1.287zM3.8 6.366L6.31.716A1.206 1.206 0 017.412 0a2.575 2.575 0 012.576 2.575v2.376h3.517a2.25 2.25 0 012.224 2.588l-.994 6.549A2.25 2.25 0 0112.511 16H2.25A2.25 2.25 0 010 13.75V8.616a2.25 2.25 0 012.25-2.25H3.8z" clip-rule="evenodd"/></svg>');
+}
+
+%thumbs-up-24-svg-prop {
+  --thumbs-up-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M11.23 2.516L7.5 10.909V21.5h10.98a1.25 1.25 0 001.237-1.062l1.442-9.5A1.25 1.25 0 0019.923 9.5H14.75A1.75 1.75 0 0113 7.75V4.525a2.025 2.025 0 00-1.77-2.01zM6 21.5v-10H3.75c-.69 0-1.25.56-1.25 1.25v7.5c0 .69.56 1.25 1.25 1.25H6zM6.263 10l3.71-8.349A1.097 1.097 0 0110.975 1 3.525 3.525 0 0114.5 4.525V7.75c0 .138.112.25.25.25h5.173a2.75 2.75 0 012.72 3.163l-1.443 9.5A2.75 2.75 0 0118.48 23H3.75A2.75 2.75 0 011 20.25v-7.5A2.75 2.75 0 013.75 10h2.513z" clip-rule="evenodd"/></svg>');
+}
+
+%toggle-left-16-svg-prop {
+  --toggle-left-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M3 8a2 2 0 114 0 2 2 0 01-4 0z"/><path fill-rule="evenodd" d="M5 3a5 5 0 000 10h6a5 5 0 000-10H5zM1.5 8A3.5 3.5 0 015 4.5h6a3.5 3.5 0 110 7H5A3.5 3.5 0 011.5 8z" clip-rule="evenodd"/></g></svg>');
+}
+
+%toggle-left-24-svg-prop {
+  --toggle-left-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 8a4 4 0 100 8 4 4 0 000-8zm-2.5 4a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0z"/><path d="M8 5a7 7 0 000 14h8a7 7 0 100-14H8zm-5.5 7A5.5 5.5 0 018 6.5h8a5.5 5.5 0 110 11H8A5.5 5.5 0 012.5 12z"/></g></svg>');
+}
+
+%toggle-right-16-svg-prop {
+  --toggle-right-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M13 8a2 2 0 10-4 0 2 2 0 004 0z"/><path fill-rule="evenodd" d="M11 3a5 5 0 010 10H5A5 5 0 015 3h6zm3.5 5A3.5 3.5 0 0011 4.5H5a3.5 3.5 0 100 7h6A3.5 3.5 0 0014.5 8z" clip-rule="evenodd"/></g></svg>');
+}
+
+%toggle-right-24-svg-prop {
+  --toggle-right-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M16 8a4 4 0 110 8 4 4 0 010-8zm2.5 4a2.5 2.5 0 10-5 0 2.5 2.5 0 005 0z"/><path d="M16 5a7 7 0 110 14H8A7 7 0 118 5h8zm5.5 7A5.5 5.5 0 0016 6.5H8a5.5 5.5 0 100 11h8a5.5 5.5 0 005.5-5.5z"/></g></svg>');
+}
+
+%token-16-svg-prop {
+  --token-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M5.791 3.318L3.316 5.793a1 1 0 000 1.414l2.475 2.475a1 1 0 001.415 0L9.68 7.207a1 1 0 000-1.414L7.206 3.318a1 1 0 00-1.415 0zm.707 4.95L4.731 6.5l1.767-1.768L8.266 6.5 6.498 8.268z"/><path d="M0 6.5a6.5 6.5 0 0112.346-2.845 6.5 6.5 0 11-8.691 8.691A6.5 6.5 0 010 6.5zm6.5-5a5 5 0 100 10 5 5 0 000-10zm6.5 5c0-.201-.01-.4-.027-.597a5 5 0 11-7.07 7.07A6.5 6.5 0 0013 6.5z"/></g></svg>');
+}
+
+%token-24-svg-prop {
+  --token-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8.762 5.228L5.227 8.763a1.75 1.75 0 000 2.475l3.535 3.535a1.75 1.75 0 002.475 0l3.536-3.535a1.75 1.75 0 000-2.475l-3.536-3.535a1.75 1.75 0 00-2.475 0zM6.287 9.824l3.536-3.536a.25.25 0 01.354 0l3.535 3.536a.25.25 0 010 .353l-3.535 3.536a.25.25 0 01-.354 0l-3.536-3.536a.25.25 0 010-.353z"/><path d="M1 10a9 9 0 0117.043-4.043A9 9 0 115.957 18.043 9 9 0 011 10zm9-7.5a7.5 7.5 0 100 15 7.5 7.5 0 000-15zm9 7.5c0-.594-.058-1.174-.167-1.736A7.5 7.5 0 118.264 18.833 9 9 0 0019 10z"/></g></svg>');
+}
+
+%tools-16-svg-prop {
+  --tools-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M5 3v-.75A2.25 2.25 0 017.25 0h1.5A2.25 2.25 0 0111 2.25V3h.79a2.25 2.25 0 011.609.678l1.96 2.007c.411.42.641.985.641 1.573v5.492A2.25 2.25 0 0113.75 15H2.25A2.25 2.25 0 010 12.75V7.258c0-.588.23-1.152.64-1.573l1.961-2.007A2.25 2.25 0 014.211 3H5zm1.5-.75a.75.75 0 01.75-.75h1.5a.75.75 0 01.75.75V3h-3v-.75zM3.674 4.726a.75.75 0 01.537-.226h7.578a.75.75 0 01.537.226l1.96 2.008a.75.75 0 01.214.524V8h-4v-.25c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25V8h-4v-.742a.75.75 0 01.213-.524l1.961-2.008zM5.5 9.5h-4v3.25c0 .414.336.75.75.75h11.5a.75.75 0 00.75-.75V9.5h-4v.25c0 .69-.56 1.25-1.25 1.25h-2.5c-.69 0-1.25-.56-1.25-1.25V9.5zm1.5 0V8h2v1.5H7z" clip-rule="evenodd"/></svg>');
+}
+
+%tools-24-svg-prop {
+  --tools-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M7 6V4.75A2.75 2.75 0 019.75 2h4.5A2.75 2.75 0 0117 4.75V6h.422c.729 0 1.428.29 1.944.805l2.829 2.829A2.75 2.75 0 0123 11.578v7.672A2.75 2.75 0 0120.25 22H3.75A2.75 2.75 0 011 19.25v-7.672c0-.729.29-1.428.805-1.944l2.829-2.829A2.75 2.75 0 016.578 6H7zm1.5-1.25c0-.69.56-1.25 1.25-1.25h4.5c.69 0 1.25.56 1.25 1.25V6h-7V4.75zM6.578 7.5c-.331 0-.649.132-.883.366l-2.829 2.829a1.25 1.25 0 00-.366.883V13H9v-.75c0-.69.56-1.25 1.25-1.25h3.5c.69 0 1.25.56 1.25 1.25V13h6.5v-1.422c0-.331-.132-.649-.366-.883l-2.829-2.829a1.25 1.25 0 00-.883-.366H6.578zM15 15.75V14.5h6.5v4.75c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25V14.5H9v1.25c0 .69.56 1.25 1.25 1.25h3.5c.69 0 1.25-.56 1.25-1.25zm-4.5-3.25v3h3v-3h-3z" clip-rule="evenodd"/></svg>');
+}
+
+%top-16-svg-prop {
+  --top-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M2.5 2.5a.75.75 0 010-1.5H13a.75.75 0 010 1.5H2.5zM2.985 9.795a.75.75 0 001.06-.03L7 6.636v7.614a.75.75 0 001.5 0V6.636l2.955 3.129a.75.75 0 001.09-1.03l-4.25-4.5a.75.75 0 00-1.09 0l-4.25 4.5a.75.75 0 00.03 1.06z"/></g></svg>');
+}
+
+%top-24-svg-prop {
+  --top-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M3.5 3.5a.75.75 0 010-1.5H20a.75.75 0 010 1.5H3.5zM4.98 13.79a.75.75 0 001.06-.02L11 8.612V21.25a.75.75 0 001.5 0V8.612l4.96 5.158a.75.75 0 101.08-1.04l-6.25-6.5a.75.75 0 00-1.08 0l-6.25 6.5a.75.75 0 00.02 1.06z"/></g></svg>');
+}
+
+%trash-16-svg-prop {
+  --trash-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.25 6a.75.75 0 01.75.75v5.5a.75.75 0 01-1.5 0v-5.5A.75.75 0 016.25 6zM10.5 6.75a.75.75 0 00-1.5 0v5.5a.75.75 0 001.5 0v-5.5z"/><path fill-rule="evenodd" d="M4 3v-.75A2.25 2.25 0 016.25 0h3.5A2.25 2.25 0 0112 2.25V3h2.25a.75.75 0 010 1.5H14v9.25A2.25 2.25 0 0111.75 16h-7.5A2.25 2.25 0 012 13.75V4.5h-.25a.75.75 0 010-1.5H4zm1.5-.75a.75.75 0 01.75-.75h3.5a.75.75 0 01.75.75V3h-5v-.75zm-2 2.25v9.25c0 .414.336.75.75.75h7.5a.75.75 0 00.75-.75V4.5h-9z" clip-rule="evenodd"/></g></svg>');
+}
+
+%trash-24-svg-prop {
+  --trash-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M9.75 9a.75.75 0 01.75.75v8.5a.75.75 0 01-1.5 0v-8.5A.75.75 0 019.75 9zM15 9.75a.75.75 0 00-1.5 0v8.5a.75.75 0 001.5 0v-8.5z"/><path fill-rule="evenodd" d="M7 5V3.75A2.75 2.75 0 019.75 1h4.5A2.75 2.75 0 0117 3.75V5h4.25a.75.75 0 010 1.5H20v13.75A2.75 2.75 0 0117.25 23H6.75A2.75 2.75 0 014 20.25V6.5H2.75a.75.75 0 010-1.5H7zm1.5-1.25c0-.69.56-1.25 1.25-1.25h4.5c.69 0 1.25.56 1.25 1.25V5h-7V3.75zm-3 2.75v13.75c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25V6.5h-13z" clip-rule="evenodd"/></g></svg>');
+}
+
 %trash-svg-prop {
   --trash-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M21 4v2H3V4h6l1-1h4l1 1h6zM17 19V7h2v12c0 1.1-.9 2-2 2H7c-1.1 0-2-.9-2-2V7h2v12h10z" fill="%23000"/><path d="M9 17h2V7H9v10zM15 17h-2V7h2v10z" fill="currentColor"/></svg>');
 }
 
+%trend-down-16-svg-prop {
+  --trend-down-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M1.28 3.22A.75.75 0 00.22 4.28l4.5 4.5a.75.75 0 00.894.126l3.96-2.2L13.6 11.5H10.75a.75.75 0 000 1.5h4.5a.75.75 0 00.75-.75v-4.5a.75.75 0 00-1.5 0v2.489l-4.176-4.971a.75.75 0 00-.938-.174L5.38 7.32l-4.1-4.1z"/></svg>');
+}
+
+%trend-down-24-svg-prop {
+  --trend-down-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M1.28 5.22A.75.75 0 00.22 6.28l7.5 7.5a.75.75 0 001.005.05L13.7 9.76l7.74 7.74h-4.69a.75.75 0 000 1.5h6.5a.75.75 0 00.75-.75v-6.5a.75.75 0 00-1.5 0v4.69l-8.22-8.22a.75.75 0 00-1.005-.05L8.3 12.24 1.28 5.22z"/></svg>');
+}
+
+%trend-up-16-svg-prop {
+  --trend-up-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M16 8.25a.75.75 0 01-1.5 0V5.761l-4.176 4.971a.75.75 0 01-.938.174L5.38 8.68l-4.1 4.1a.75.75 0 01-1.06-1.06l4.5-4.5a.75.75 0 01.894-.126l3.96 2.2L13.6 4.5H10.75a.75.75 0 010-1.5h4.5a.75.75 0 01.75.75v4.5z"/></svg>');
+}
+
+%trend-up-24-svg-prop {
+  --trend-up-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M24 12.25a.75.75 0 01-1.5 0V7.56l-8.22 8.22a.75.75 0 01-1.005.05L8.3 11.76l-7.02 7.02a.75.75 0 01-1.06-1.06l7.5-7.5a.75.75 0 011.005-.05l4.975 4.07 7.74-7.74h-4.69a.75.75 0 010-1.5h6.5a.75.75 0 01.75.75v6.5z"/></svg>');
+}
+
+%triangle-16-svg-prop {
+  --triangle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M6.978 1.515a2.101 2.101 0 012.807.731l.002.004 5.681 9.383a2.065 2.065 0 01-.751 2.832c-.314.183-.67.281-1.034.285H2.317a2.101 2.101 0 01-1.791-1.045 2.065 2.065 0 01.006-2.072l.006-.01L6.213 2.25l.002-.004c.187-.305.45-.557.763-.73zm.517 1.514l-.001.001-5.67 9.363a.565.565 0 00.214.776c.088.051.189.08.292.081h11.34a.601.601 0 00.504-.294.564.564 0 00.001-.563L8.506 3.03V3.03A.584.584 0 008 2.75a.601.601 0 00-.505.279z" clip-rule="evenodd"/></svg>');
+}
+
+%triangle-24-svg-prop {
+  --triangle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M10.658 2.366a2.651 2.651 0 012.684 0c.407.239.745.581.984.99l.002.004 8.315 14.46a2.86 2.86 0 01.008 2.758 2.757 2.757 0 01-.976 1.03c-.41.25-.877.386-1.357.392H3.682a2.653 2.653 0 01-1.357-.393 2.757 2.757 0 01-.975-1.029 2.86 2.86 0 01.007-2.758l.006-.01 8.31-14.45.001-.004a2.75 2.75 0 01.984-.99zm.313 1.744v.001L2.665 18.552a1.36 1.36 0 000 1.306c.108.198.262.36.443.47.18.11.382.169.586.172h16.61c.204-.003.406-.061.586-.172.181-.11.335-.272.444-.47a1.361 1.361 0 00-.001-1.306L13.03 4.112l-.001-.002a1.25 1.25 0 00-.446-.45 1.151 1.151 0 00-1.166 0 1.25 1.25 0 00-.446.45z" clip-rule="evenodd"/></svg>');
+}
+
+%triangle-fill-16-svg-prop {
+  --triangle-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M8 1.25a2.101 2.101 0 00-1.785.996l.64.392-.642-.388-5.675 9.373-.006.01a2.065 2.065 0 00.751 2.832c.314.183.67.281 1.034.285h11.366a2.101 2.101 0 001.791-1.045 2.064 2.064 0 00-.006-2.072L9.788 2.25l-.003-.004A2.084 2.084 0 008 1.25z"/></svg>');
+}
+
+%triangle-fill-24-svg-prop {
+  --triangle-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M12 2c-.472 0-.934.127-1.342.366a2.75 2.75 0 00-.984.99l.648.378-.65-.374-8.31 14.45-.005.01a2.86 2.86 0 00-.007 2.758c.23.423.566.778.975 1.03.41.25.877.386 1.357.392h16.637c.479-.006.947-.142 1.356-.393.41-.25.744-.606.976-1.029a2.86 2.86 0 00-.008-2.758L14.328 3.36l-.002-.004a2.75 2.75 0 00-.984-.99A2.651 2.651 0 0012 2z"/></svg>');
+}
+
+%truck-16-svg-prop {
+  --truck-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 3.25A2.25 2.25 0 012.25 1h7a2.25 2.25 0 012.25 2.25v.328h.643a2.25 2.25 0 011.565.634l1.608 1.557A2.25 2.25 0 0116 7.385v2.865A1.75 1.75 0 0114.292 12a2.5 2.5 0 11-4.584 0H6.292a2.5 2.5 0 11-4.584 0A1.75 1.75 0 010 10.25v-7zM12 12a1 1 0 100 2 1 1 0 000-2zm2.25-1.5a.25.25 0 00.25-.25V7.385a.75.75 0 00-.228-.538l-1.608-1.558a.75.75 0 00-.521-.211H11.5V10.5h2.75zm-4.25 0H1.75a.25.25 0 01-.25-.25v-7a.75.75 0 01.75-.75h7a.75.75 0 01.75.75v7.25zM3 13a1 1 0 112 0 1 1 0 01-2 0z" clip-rule="evenodd"/></svg>');
+}
+
+%truck-24-svg-prop {
+  --truck-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M0 4.75A2.75 2.75 0 012.75 2h11.5A2.75 2.75 0 0117 4.75V6h1.245c.74 0 1.447.297 1.965.825l3.004 3.067A2.75 2.75 0 0124 11.817v3.433A1.75 1.75 0 0122.25 17h-1.014a3 3 0 11-4.472 0H7.236a3 3 0 11-4.472 0H1.75A1.75 1.75 0 010 15.25V4.75zm15.5 0c0-.69-.56-1.25-1.25-1.25H2.75c-.69 0-1.25.56-1.25 1.25v10.5c0 .138.112.25.25.25H15.5V4.75zM17 15.5v-8h1.245c.336 0 .658.135.893.375l3.005 3.067c.229.233.357.547.357.874v3.434a.25.25 0 01-.25.25H17zm-12 2a1.5 1.5 0 100 3 1.5 1.5 0 000-3zM17.5 19a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z" clip-rule="evenodd"/></svg>');
+}
+
 %tune-svg-prop {
   --tune-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z" fill="%23000"/></svg>');
+}
+
+%tv-16-svg-prop {
+  --tv-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M6.624.334a.75.75 0 00-1.248.832L6.599 3H2.25A2.25 2.25 0 000 5.25v7.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-7.5A2.25 2.25 0 0013.75 3H9.401l1.223-1.834A.75.75 0 109.376.334L8 2.398 6.624.334zM7.989 4.5a.798.798 0 00.022 0h5.739a.75.75 0 01.75.75v7.5a.75.75 0 01-.75.75H2.25a.75.75 0 01-.75-.75v-7.5a.75.75 0 01.75-.75h5.739z" clip-rule="evenodd"/></svg>');
+}
+
+%tv-24-svg-prop {
+  --tv-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M9.379 1.341a.75.75 0 10-1.258.818L10.618 6H3.75A2.75 2.75 0 001 8.75v11.5A2.75 2.75 0 003.75 23h16.5A2.75 2.75 0 0023 20.25V8.75A2.75 2.75 0 0020.25 6h-6.868l2.497-3.841a.75.75 0 00-1.258-.818L12 5.374 9.379 1.34zm2.61 6.159a.725.725 0 00.022 0h8.239c.69 0 1.25.56 1.25 1.25v11.5c0 .69-.56 1.25-1.25 1.25H3.75c-.69 0-1.25-.56-1.25-1.25V8.75c0-.69.56-1.25 1.25-1.25h8.239z" clip-rule="evenodd"/></svg>');
+}
+
+%type-16-svg-prop {
+  --type-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M2 2.75A.75.75 0 012.75 2h10a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0V3.5H8.5v9H10a.75.75 0 010 1.5H5.5a.75.75 0 010-1.5H7v-9H3.5v.75a.75.75 0 01-1.5 0v-1.5z"/></svg>');
+}
+
+%type-24-svg-prop {
+  --type-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M3 3.75A.75.75 0 013.75 3h16a.75.75 0 01.75.75v2.5a.75.75 0 01-1.5 0V4.5h-6.5v15h2a.75.75 0 010 1.5H9a.75.75 0 010-1.5h2v-15H4.5v1.75a.75.75 0 01-1.5 0v-2.5z"/></svg>');
+}
+
+%unfold-close-16-svg-prop {
+  --unfold-close-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 6a.75.75 0 00.55-.24l3.25-3.5a.75.75 0 10-1.1-1.02L8 4.148 5.3 1.24a.75.75 0 00-1.1 1.02l3.25 3.5A.75.75 0 008 6zM8 10a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L8 11.852 5.3 14.76a.75.75 0 11-1.1-1.02l3.25-3.5A.75.75 0 018 10zM1.75 7.124a.626.626 0 100 1.253h.5a.627.627 0 000-1.253h-.5zM4.75 7.124a.626.626 0 100 1.253h.5a.627.627 0 000-1.253h-.5zM7.75 7.124a.626.626 0 100 1.253h.5a.627.627 0 000-1.253h-.5zM10.75 7.124a.627.627 0 000 1.253h.5a.627.627 0 000-1.253h-.5zM13.75 7.124a.627.627 0 000 1.253h.5a.627.627 0 000-1.253h-.5z"/></g></svg>');
+}
+
+%unfold-close-24-svg-prop {
+  --unfold-close-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 9a.75.75 0 00.543-.232l5.25-5.5a.75.75 0 10-1.085-1.036L12 7.164 7.293 2.232a.75.75 0 00-1.086 1.036l5.25 5.5A.75.75 0 0012 9zM12 15a.75.75 0 01.543.232l5.25 5.5a.75.75 0 01-1.085 1.036L12 16.836l-4.707 4.932a.75.75 0 01-1.086-1.036l5.25-5.5A.75.75 0 0112 15zM1.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM6.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM11.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM16.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM21.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5z"/></g></svg>');
 }
 
 %unfold-less-svg-prop {
@@ -698,12 +3770,76 @@
   --unfold-more-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 5.83L15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z" fill="%23000"/></svg>');
 }
 
+%unfold-open-16-svg-prop {
+  --unfold-open-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M8 1a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L8 2.852 5.3 5.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 018 1zM8 15a.75.75 0 00.55-.24l3.25-3.5a.75.75 0 10-1.1-1.02L8 13.148 5.3 10.24a.75.75 0 10-1.1 1.02l3.25 3.5A.75.75 0 008 15zM1.75 7.124a.626.626 0 100 1.253h.5a.627.627 0 000-1.253h-.5zM4.75 7.124a.626.626 0 100 1.253h.5a.627.627 0 000-1.253h-.5zM7.75 7.124a.626.626 0 100 1.253h.5a.627.627 0 000-1.253h-.5zM10.75 7.124a.627.627 0 000 1.253h.5a.627.627 0 000-1.253h-.5zM13.75 7.124a.627.627 0 000 1.253h.5a.627.627 0 000-1.253h-.5z"/></g></svg>');
+}
+
+%unfold-open-24-svg-prop {
+  --unfold-open-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12 2a.75.75 0 01.543.232l5.25 5.5a.75.75 0 11-1.085 1.036L12 3.836 7.293 8.768a.75.75 0 01-1.086-1.036l5.25-5.5A.75.75 0 0112 2zM12 22a.75.75 0 00.543-.232l5.25-5.5a.75.75 0 00-1.085-1.036L12 20.164l-4.707-4.932a.75.75 0 00-1.086 1.036l5.25 5.5A.75.75 0 0012 22zM1.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM6.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM11.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM16.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5zM21.25 11a.75.75 0 000 1.5h1.5a.75.75 0 000-1.5h-1.5z"/></g></svg>');
+}
+
+%unlock-16-svg-prop {
+  --unlock-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M10.239 2.25A2.46 2.46 0 0112 1.5c.657 0 1.29.267 1.761.75.471.483.739 1.142.739 1.833a.75.75 0 001.5 0 4.127 4.127 0 00-1.165-2.88A3.96 3.96 0 0012 0a3.96 3.96 0 00-2.835 1.203A4.127 4.127 0 008 4.083V5H2.25A2.25 2.25 0 000 7.25v5.5A2.25 2.25 0 002.25 15h7.5A2.25 2.25 0 0012 12.75v-5.5A2.25 2.25 0 009.75 5H9.5v-.917c0-.69.268-1.35.739-1.833zm-8.739 5a.75.75 0 01.75-.75h7.5a.75.75 0 01.75.75v5.5a.75.75 0 01-.75.75h-7.5a.75.75 0 01-.75-.75v-5.5z" clip-rule="evenodd"/></svg>');
+}
+
+%unlock-24-svg-prop {
+  --unlock-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M14.805 3.758A4.636 4.636 0 0118 2.5c1.205 0 2.354.456 3.195 1.258.84.8 1.305 1.877 1.305 2.992a.75.75 0 001.5 0 5.632 5.632 0 00-1.77-4.079A6.136 6.136 0 0018 1c-1.58 0-3.102.597-4.23 1.671A5.632 5.632 0 0012 6.75V10H3.75A2.75 2.75 0 001 12.75v7.5A2.75 2.75 0 003.75 23h10.5A2.75 2.75 0 0017 20.25v-7.5A2.75 2.75 0 0014.25 10h-.75V6.75c0-1.115.465-2.192 1.305-2.992zM3.75 11.5c-.69 0-1.25.56-1.25 1.25v7.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-7.5c0-.69-.56-1.25-1.25-1.25H3.75z" clip-rule="evenodd"/></svg>');
+}
+
+%upload-16-svg-prop {
+  --upload-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M4.24 5.8a.75.75 0 001.06-.04l1.95-2.1v6.59a.75.75 0 001.5 0V3.66l1.95 2.1a.75.75 0 101.1-1.02l-3.25-3.5a.75.75 0 00-1.101.001L4.2 4.74a.75.75 0 00.04 1.06z"/><path d="M1.75 9a.75.75 0 01.75.75v3c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75v-3a.75.75 0 011.5 0v3A2.25 2.25 0 0112.75 15h-9.5A2.25 2.25 0 011 12.75v-3A.75.75 0 011.75 9z"/></g></svg>');
+}
+
+%upload-24-svg-prop {
+  --upload-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M6.232 8.793a.75.75 0 001.06-.025l3.958-4.146V15.25a.75.75 0 001.5 0V4.622l3.957 4.146a.75.75 0 001.085-1.036l-5.25-5.5a.747.747 0 00-1.086.001l-5.249 5.5a.75.75 0 00.025 1.06z"/><path d="M2.75 14a.75.75 0 01.75.75v4.5c0 .69.56 1.25 1.25 1.25h14.5c.69 0 1.25-.56 1.25-1.25v-4.5a.75.75 0 011.5 0v4.5A2.75 2.75 0 0119.25 22H4.75A2.75 2.75 0 012 19.25v-4.5a.75.75 0 01.75-.75z"/></g></svg>');
+}
+
 %upload-svg-prop {
   --upload-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M5 10h4v6h6v-6h4l-7-7-7 7zm0 8v2h14v-2H5zm-2 2h2v-4H3v4zm16 0h2v-4h-2v4z" fill="%23000"/></svg>');
 }
 
+%user-16-svg-prop {
+  --user-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M8 1a4 4 0 100 8 4 4 0 000-8zM5.5 5a2.5 2.5 0 115 0 2.5 2.5 0 01-5 0z" clip-rule="evenodd"/><path d="M5.25 10a3.75 3.75 0 00-3.75 3.75v.5a.75.75 0 001.5 0v-.5a2.25 2.25 0 012.25-2.25h5.5A2.25 2.25 0 0113 13.75v.5a.75.75 0 001.5 0v-.5A3.75 3.75 0 0010.75 10h-5.5z"/></g></svg>');
+}
+
+%user-24-svg-prop {
+  --user-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M12 3a5 5 0 100 10 5 5 0 000-10zM8.5 8a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0z" clip-rule="evenodd"/><path d="M7.75 14.5A4.75 4.75 0 003 19.25v1a.75.75 0 001.5 0v-1A3.25 3.25 0 017.75 16h8.5a3.25 3.25 0 013.25 3.25v1a.75.75 0 001.5 0v-1a4.75 4.75 0 00-4.75-4.75h-8.5z"/></g></svg>');
+}
+
 %user-add-svg-prop {
   --user-add-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M15 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm-9-2V7H4v3H1v2h3v3h2v-3h3v-2H6zm9 4c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" fill="%23000"/></svg>');
+}
+
+%user-check-16-svg-prop {
+  --user-check-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M6 2a3.5 3.5 0 100 7 3.5 3.5 0 000-7zM4 5.5a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/><path d="M4.25 10A3.75 3.75 0 00.5 13.75v.5a.75.75 0 001.5 0v-.5a2.25 2.25 0 012.25-2.25h3.5A2.25 2.25 0 0110 13.75v.5a.75.75 0 001.5 0v-.5A3.75 3.75 0 007.75 10h-3.5zM14.78 6.22a.75.75 0 010 1.06l-2.5 2.5a.75.75 0 01-1.06 0l-1-1a.75.75 0 111.06-1.06l.47.47 1.97-1.97a.75.75 0 011.06 0z"/></g></svg>');
+}
+
+%user-check-24-svg-prop {
+  --user-check-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M9 3a5 5 0 100 10A5 5 0 009 3zM5.5 8a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0z" clip-rule="evenodd"/><path d="M4.75 14.5A4.75 4.75 0 000 19.25v1a.75.75 0 001.5 0v-1A3.25 3.25 0 014.75 16h8.5a3.25 3.25 0 013.25 3.25v1a.75.75 0 001.5 0v-1a4.75 4.75 0 00-4.75-4.75h-8.5zM23.28 8.72a.75.75 0 010 1.06l-4 4a.75.75 0 01-1.06 0l-2-2a.75.75 0 111.06-1.06l1.47 1.47 3.47-3.47a.75.75 0 011.06 0z"/></g></svg>');
+}
+
+%user-circle-16-svg-prop {
+  --user-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M8 3a3 3 0 100 6 3 3 0 000-6zM6.5 6a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z"/><path d="M.25 8a7.75 7.75 0 1115.5 0A7.75 7.75 0 01.25 8zM8 1.75a6.25 6.25 0 00-5.274 9.604c.15-.194.325-.369.514-.533C3.855 10.286 4.67 10 5.5 10h5c.83 0 1.645.286 2.26.82.189.165.365.34.514.534A6.25 6.25 0 008 1.75zm0 12.5a6.228 6.228 0 01-4.238-1.656c.035-.196.153-.372.462-.641.323-.281.78-.453 1.276-.453h5c.495 0 .953.172 1.276.453.31.269.427.445.462.641A6.228 6.228 0 018 14.25z"/></g></svg>');
+}
+
+%user-circle-24-svg-prop {
+  --user-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000" fill-rule="evenodd" clip-rule="evenodd"><path d="M12 4.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9zM9 9a3 3 0 116 0 3 3 0 01-6 0z"/><path d="M.25 12C.25 5.51 5.51.25 12 .25S23.75 5.51 23.75 12 18.49 23.75 12 23.75.25 18.49.25 12zM12 1.75C6.34 1.75 1.75 6.34 1.75 12c0 2.298.756 4.42 2.034 6.13A4.752 4.752 0 018.25 15h7.5a4.752 4.752 0 014.466 3.13A10.204 10.204 0 0022.25 12c0-5.66-4.59-10.25-10.25-10.25zm0 20.5c-2.702 0-5.16-1.045-6.99-2.753A3.25 3.25 0 018.25 16.5h7.5a3.25 3.25 0 013.24 2.997A10.214 10.214 0 0112 22.25z"/></g></svg>');
+}
+
+%user-circle-fill-16-svg-prop {
+  --user-circle-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M.25 8a7.75 7.75 0 1115.5 0A7.75 7.75 0 01.25 8zm3.19 1.833A3.24 3.24 0 015.624 9h4.75a3.24 3.24 0 012.186.833c.528.484.939 1.048.939 1.917a.75.75 0 01-1.5 0c0-.284-.09-.478-.452-.81-.3-.275-.722-.44-1.173-.44h-4.75c-.451 0-.872.165-1.173.44-.363.332-.452.526-.452.81a.75.75 0 01-1.5 0c0-.869.411-1.433.94-1.917zM6.5 5a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zM8 2a3 3 0 100 6 3 3 0 000-6z" clip-rule="evenodd"/></svg>');
+}
+
+%user-circle-fill-24-svg-prop {
+  --user-circle-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M.25 12C.25 5.51 5.51.25 12 .25S23.75 5.51 23.75 12 18.49 23.75 12 23.75.25 18.49.25 12zM4 18a4 4 0 014-4h8a4 4 0 014 4v.25a.75.75 0 01-1.5 0V18a2.5 2.5 0 00-2.5-2.5H8A2.5 2.5 0 005.5 18v.25a.75.75 0 01-1.5 0V18zM9 8a3 3 0 116 0 3 3 0 01-6 0zm3-4.5a4.5 4.5 0 100 9 4.5 4.5 0 000-9z" clip-rule="evenodd"/></svg>');
+}
+
+%user-minus-16-svg-prop {
+  --user-minus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M2.5 5.5a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0zm3.5-2a2 2 0 100 4 2 2 0 000-4z" clip-rule="evenodd"/><path d="M.5 13.75A3.75 3.75 0 014.25 10h3.5a3.75 3.75 0 013.75 3.75v.5a.75.75 0 01-1.5 0v-.5a2.25 2.25 0 00-2.25-2.25h-3.5A2.25 2.25 0 002 13.75v.5a.75.75 0 01-1.5 0v-.5zM11.25 7.5a.75.75 0 000 1.5h3.5a.75.75 0 000-1.5h-3.5z"/></g></svg>');
+}
+
+%user-minus-24-svg-prop {
+  --user-minus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M4 8a5 5 0 1110 0A5 5 0 014 8zm5-3.5a3.5 3.5 0 100 7 3.5 3.5 0 000-7z" clip-rule="evenodd"/><path d="M0 19.25a4.75 4.75 0 014.75-4.75h8.5A4.75 4.75 0 0118 19.25v1a.75.75 0 01-1.5 0v-1A3.25 3.25 0 0013.25 16h-8.5a3.25 3.25 0 00-3.25 3.25v1a.75.75 0 01-1.5 0v-1zM16.75 10.5a.75.75 0 000 1.5h5.5a.75.75 0 000-1.5h-5.5z"/></g></svg>');
 }
 
 %user-organization-svg-prop {
@@ -712,6 +3848,14 @@
 
 %user-plain-svg-prop {
   --user-plain-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" fill="%23000"/></svg>');
+}
+
+%user-plus-16-svg-prop {
+  --user-plus-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M6 2a3.5 3.5 0 100 7 3.5 3.5 0 000-7zM4 5.5a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/><path d="M4.25 10A3.75 3.75 0 00.5 13.75v.5a.75.75 0 001.5 0v-.5a2.25 2.25 0 012.25-2.25h3.5A2.25 2.25 0 0110 13.75v.5a.75.75 0 001.5 0v-.5A3.75 3.75 0 007.75 10h-3.5zM10.25 8.25A.75.75 0 0111 7.5h1v-1a.75.75 0 011.5 0v1h1a.75.75 0 010 1.5h-1v1a.75.75 0 01-1.5 0V9h-1a.75.75 0 01-.75-.75z"/></g></svg>');
+}
+
+%user-plus-24-svg-prop {
+  --user-plus-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M9 3a5 5 0 100 10A5 5 0 009 3zM5.5 8a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0z" clip-rule="evenodd"/><path d="M4.75 14.5A4.75 4.75 0 000 19.25v1a.75.75 0 001.5 0v-1A3.25 3.25 0 014.75 16h8.5a3.25 3.25 0 013.25 3.25v1a.75.75 0 001.5 0v-1a4.75 4.75 0 00-4.75-4.75h-8.5zM15.75 11.25a.75.75 0 01.75-.75h2v-2a.75.75 0 011.5 0v2h2a.75.75 0 010 1.5h-2v2a.75.75 0 01-1.5 0v-2h-2a.75.75 0 01-.75-.75z"/></g></svg>');
 }
 
 %user-square-fill-svg-prop {
@@ -726,6 +3870,54 @@
   --user-team-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M16.5 12c1.38 0 2.49-1.12 2.49-2.5S17.88 7 16.5 7a2.5 2.5 0 0 0 0 5zM9 11c1.66 0 2.99-1.34 2.99-3S10.66 5 9 5C7.34 5 6 6.34 6 8s1.34 3 3 3zm7.5 3c-1.83 0-5.5.92-5.5 2.75V19h11v-2.25c0-1.83-3.67-2.75-5.5-2.75zM9 13c-2.33 0-7 1.17-7 3.5V19h7v-2.25c0-.85.33-2.34 2.37-3.47C10.5 13.1 9.66 13 9 13z" fill="%23000"/></svg>');
 }
 
+%user-x-16-svg-prop {
+  --user-x-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M6 2a3.5 3.5 0 100 7 3.5 3.5 0 000-7zM4 5.5a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/><path d="M4.25 10A3.75 3.75 0 00.5 13.75v.5a.75.75 0 001.5 0v-.5a2.25 2.25 0 012.25-2.25h3.5A2.25 2.25 0 0110 13.75v.5a.75.75 0 001.5 0v-.5A3.75 3.75 0 007.75 10h-3.5zM11.22 5.22a.75.75 0 011.06 0l1.22 1.22 1.22-1.22a.75.75 0 111.06 1.06L14.56 7.5l1.22 1.22a.75.75 0 01-1.06 1.06L13.5 8.56l-1.22 1.22a.75.75 0 11-1.06-1.06l1.22-1.22-1.22-1.22a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%user-x-24-svg-prop {
+  --user-x-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M9 3a5 5 0 100 10A5 5 0 009 3zM5.5 8a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0z" clip-rule="evenodd"/><path d="M4.75 14.5A4.75 4.75 0 000 19.25v1a.75.75 0 001.5 0v-1A3.25 3.25 0 014.75 16h8.5a3.25 3.25 0 013.25 3.25v1a.75.75 0 001.5 0v-1a4.75 4.75 0 00-4.75-4.75h-8.5zM16.22 8.22a.75.75 0 011.06 0L19 9.94l1.72-1.72a.75.75 0 111.06 1.06L20.06 11l1.72 1.72a.75.75 0 11-1.06 1.06L19 12.06l-1.72 1.72a.75.75 0 11-1.06-1.06L17.94 11l-1.72-1.72a.75.75 0 010-1.06z"/></g></svg>');
+}
+
+%users-16-svg-prop {
+  --users-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M6 2a3.5 3.5 0 100 7 3.5 3.5 0 000-7zM4 5.5a2 2 0 114 0 2 2 0 01-4 0z" clip-rule="evenodd"/><path d="M4.25 10A3.75 3.75 0 00.5 13.75v.5a.75.75 0 001.5 0v-.5a2.25 2.25 0 012.25-2.25h3.5A2.25 2.25 0 0110 13.75v.5a.75.75 0 001.5 0v-.5A3.75 3.75 0 007.75 10h-3.5zM11.25 10.75A.75.75 0 0112 10h.25a3.25 3.25 0 013.25 3.25v1a.75.75 0 01-1.5 0v-1a1.75 1.75 0 00-1.75-1.75H12a.75.75 0 01-.75-.75zM11.273 2.24a.75.75 0 00-.546 1.396 2.001 2.001 0 010 3.728.75.75 0 00.546 1.397 3.501 3.501 0 000-6.522z"/></g></svg>');
+}
+
+%users-24-svg-prop {
+  --users-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M9 3a5 5 0 100 10A5 5 0 009 3zM5.5 8a3.5 3.5 0 117 0 3.5 3.5 0 01-7 0z" clip-rule="evenodd"/><path d="M4.75 14.5A4.75 4.75 0 000 19.25v1a.75.75 0 001.5 0v-1A3.25 3.25 0 014.75 16h8.5a3.25 3.25 0 013.25 3.25v1a.75.75 0 001.5 0v-1a4.75 4.75 0 00-4.75-4.75h-8.5zM18.25 15.25a.75.75 0 01.75-.75h.25A4.75 4.75 0 0124 19.25v1a.75.75 0 01-1.5 0v-1A3.25 3.25 0 0019.25 16H19a.75.75 0 01-.75-.75zM15 3a.75.75 0 000 1.5 3.5 3.5 0 110 7 .75.75 0 000 1.5 5 5 0 000-10z"/></g></svg>');
+}
+
+%vault-16-svg-prop {
+  --vault-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M6.035 3.974A4.978 4.978 0 019 3c1.11 0 2.136.362 2.965.974l.005-.004a.75.75 0 111.06 1.06l-.004.005C13.638 5.865 14 6.89 14 8c0 1.11-.362 2.136-.974 2.965l.004.005a.75.75 0 11-1.06 1.06l-.005-.004A4.978 4.978 0 019 13a4.978 4.978 0 01-2.965-.974l-.005.004a.75.75 0 01-1.06-1.06l.004-.005A4.977 4.977 0 014 8c0-1.11.362-2.136.974-2.965L4.97 5.03a.75.75 0 011.06-1.06l.005.004zm1.078 1.078A3.484 3.484 0 019 4.5c.695 0 1.343.203 1.887.552l-.917.918a.75.75 0 001.06 1.06l.918-.917c.35.544.552 1.192.552 1.887 0 .695-.203 1.343-.552 1.887l-.918-.917a.75.75 0 10-1.06 1.06l.917.918A3.484 3.484 0 019 11.5a3.483 3.483 0 01-1.887-.552l.917-.918a.75.75 0 10-1.06-1.06l-.918.917A3.484 3.484 0 015.5 8c0-.695.203-1.343.552-1.887l.918.917a.75.75 0 001.06-1.06l-.917-.918z" clip-rule="evenodd"/><path d="M2.75 3.25A.75.75 0 013.5 4v1.5a.75.75 0 01-1.5 0V4a.75.75 0 01.75-.75zM3.5 10.5a.75.75 0 00-1.5 0V12a.75.75 0 001.5 0v-1.5z"/><path fill-rule="evenodd" d="M2.25 1A2.25 2.25 0 000 3.25v9.5A2.25 2.25 0 002.25 15H3v.25a.75.75 0 001.5 0V15h7v.25a.75.75 0 001.5 0V15h.75A2.25 2.25 0 0016 12.75v-9.5A2.25 2.25 0 0013.75 1H2.25zm11.5 12.5a.75.75 0 00.75-.75v-9.5a.75.75 0 00-.75-.75H2.25a.75.75 0 00-.75.75v9.5c0 .414.336.75.75.75h11.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%vault-24-svg-prop {
+  --vault-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M8 12a6 6 0 1112 0 6 6 0 01-12 0zm2.332-2.607A4.48 4.48 0 009.5 12c0 .972.308 1.872.832 2.607l1.45-1.45A2.49 2.49 0 0111.5 12c0-.417.102-.81.283-1.156l-1.451-1.451zm1.06-1.061l1.452 1.45A2.49 2.49 0 0114 9.5c.417 0 .81.102 1.156.283l1.451-1.451A4.48 4.48 0 0014 7.5a4.48 4.48 0 00-2.607.832zm1.452 5.885l-1.451 1.451A4.48 4.48 0 0014 16.5a4.48 4.48 0 002.607-.832l-1.45-1.45A2.49 2.49 0 0114 14.5a2.49 2.49 0 01-1.156-.283zM18.5 12a4.48 4.48 0 01-.832 2.607l-1.45-1.45c.18-.346.282-.74.282-1.157 0-.417-.102-.81-.283-1.156l1.451-1.451A4.48 4.48 0 0118.5 12zM13 12a1 1 0 112 0 1 1 0 01-2 0z" clip-rule="evenodd"/><path d="M4.75 5a.75.75 0 01.75.75v2.5a.75.75 0 01-1.5 0v-2.5A.75.75 0 014.75 5zM5.5 15.75a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z"/><path fill-rule="evenodd" d="M1 4.75A2.75 2.75 0 013.75 2h16.5A2.75 2.75 0 0123 4.75v14.5A2.75 2.75 0 0120.25 22h-.125v1a.875.875 0 01-1.75 0v-1H5.625v1a.875.875 0 01-1.75 0v-1H3.75A2.75 2.75 0 011 19.25V4.75zM3.75 3.5c-.69 0-1.25.56-1.25 1.25v14.5c0 .69.56 1.25 1.25 1.25h16.5c.69 0 1.25-.56 1.25-1.25V4.75c0-.69-.56-1.25-1.25-1.25H3.75z" clip-rule="evenodd"/></g></svg>');
+}
+
+%verified-16-svg-prop {
+  --verified-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.28 5.72a.75.75 0 010 1.06l-4 4a.75.75 0 01-1.06 0l-1.5-1.5a.75.75 0 011.06-1.06l.97.97 3.47-3.47a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M6.402 1.22a2.75 2.75 0 013.196 0l.69.493c.154.11.332.184.519.215l.865.146a2.75 2.75 0 012.254 2.254l.146.866c.031.187.105.364.215.518l.493.69a2.75 2.75 0 010 3.197l-.493.69c-.11.154-.184.33-.215.518l-.146.865a2.75 2.75 0 01-2.254 2.254l-.865.146a1.25 1.25 0 00-.519.216l-.69.492a2.75 2.75 0 01-3.196 0l-.69-.492a1.25 1.25 0 00-.519-.216l-.865-.146a2.75 2.75 0 01-2.254-2.254l-.146-.865a1.25 1.25 0 00-.215-.519l-.493-.69a2.75 2.75 0 010-3.196l.493-.69a1.25 1.25 0 00.215-.518l.146-.866a2.75 2.75 0 012.254-2.254l.865-.146a1.25 1.25 0 00.519-.215l.69-.493zm2.324 1.22a1.25 1.25 0 00-1.453 0l-.69.493a2.75 2.75 0 01-1.14.474l-.865.146a1.25 1.25 0 00-1.025 1.025l-.146.865a2.75 2.75 0 01-.474 1.141l-.492.69a1.25 1.25 0 000 1.453l.492.69c.243.339.405.729.474 1.14l.146.865c.089.525.5.936 1.025 1.025l.865.146c.411.07.801.232 1.14.474l.69.493a1.25 1.25 0 001.454 0l.69-.493a2.75 2.75 0 011.14-.474l.865-.146a1.25 1.25 0 001.025-1.024l.146-.866a2.75 2.75 0 01.474-1.14l.492-.69a1.25 1.25 0 000-1.453l-.492-.69a2.75 2.75 0 01-.474-1.14l-.146-.866a1.25 1.25 0 00-1.025-1.025l-.865-.146a2.75 2.75 0 01-1.14-.474l-.69-.492z" clip-rule="evenodd"/></g></svg>');
+}
+
+%verified-24-svg-prop {
+  --verified-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M16.78 8.22a.75.75 0 010 1.06l-6.5 6.5a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l2.47 2.47 5.97-5.97a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M9.82 1.635a3.75 3.75 0 014.36 0l1.193.853c.278.198.597.33.934.387l1.492.252a3.75 3.75 0 013.074 3.074l.252 1.492c.056.337.189.656.387.934l.853 1.193a3.75 3.75 0 010 4.36l-.853 1.193a2.248 2.248 0 00-.387.934l-.252 1.492a3.75 3.75 0 01-3.074 3.073l-1.492.252a2.25 2.25 0 00-.934.388l-1.193.853a3.75 3.75 0 01-4.36 0l-1.193-.853a2.25 2.25 0 00-.934-.388l-1.492-.252A3.75 3.75 0 013.127 17.8l-.251-1.492a2.25 2.25 0 00-.388-.934l-.853-1.193a3.75 3.75 0 010-4.36l.853-1.193a2.25 2.25 0 00.388-.934l.251-1.492a3.75 3.75 0 013.074-3.074l1.492-.252a2.25 2.25 0 00.934-.387l1.193-.853zm3.488 1.22a2.25 2.25 0 00-2.616 0L9.5 3.709a3.75 3.75 0 01-1.556.646l-1.492.252A2.25 2.25 0 004.606 6.45l-.251 1.493a3.75 3.75 0 01-.647 1.555l-.852 1.194a2.25 2.25 0 000 2.616l.852 1.193c.331.463.552.995.647 1.556l.251 1.492c.16.945.9 1.685 1.845 1.844l1.492.252c.56.095 1.093.316 1.556.646l1.193.853a2.25 2.25 0 002.616 0l1.193-.852c.463-.331.995-.552 1.556-.647l1.492-.252a2.25 2.25 0 001.845-1.844l.252-1.492a3.75 3.75 0 01.646-1.556l.852-1.193a2.25 2.25 0 000-2.616l-.852-1.194a3.75 3.75 0 01-.647-1.555l-.251-1.493a2.25 2.25 0 00-1.845-1.844l-1.492-.252a3.75 3.75 0 01-1.556-.646l-1.193-.852z" clip-rule="evenodd"/></g></svg>');
+}
+
+%video-16-svg-prop {
+  --video-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M0 5.25A2.25 2.25 0 012.25 3h6.5A2.25 2.25 0 0111 5.25v.818l3.018-2.09C14.843 3.382 16 3.97 16 4.991v6.018c0 1.021-1.157 1.61-1.982 1.013L11 9.932v.818A2.25 2.25 0 018.75 13h-6.5A2.25 2.25 0 010 10.75v-5.5zM11 8c0 .067.033.13.088.168l3.412 2.363V5.47l-3.412 2.363A.204.204 0 0011 8zM9.5 5.25a.75.75 0 00-.75-.75h-6.5a.75.75 0 00-.75.75v5.5c0 .414.336.75.75.75h6.5a.75.75 0 00.75-.75v-5.5z" clip-rule="evenodd"/></svg>');
+}
+
+%video-24-svg-prop {
+  --video-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M0 6.75A2.75 2.75 0 012.75 4h11.5A2.75 2.75 0 0117 6.75v3.138l4.127-3.322C22.264 5.613 24 6.42 24 7.908v8.184c0 1.488-1.738 2.296-2.875 1.34L17 14.078v3.173A2.75 2.75 0 0114.25 20H2.75A2.75 2.75 0 010 17.25V6.75zm17 5.23c0 .103.047.201.127.267l4.95 4.026.011.01a.25.25 0 00.412-.19V7.907a.25.25 0 00-.412-.19l-.014.011-4.945 3.981a.345.345 0 00-.129.27zm-1.5-5.23c0-.69-.56-1.25-1.25-1.25H2.75c-.69 0-1.25.56-1.25 1.25v10.5c0 .69.56 1.25 1.25 1.25h11.5c.69 0 1.25-.56 1.25-1.25V6.75z" clip-rule="evenodd"/></svg>');
+}
+
+%video-off-16-svg-prop {
+  --video-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M2.28 1.22a.75.75 0 00-1.06 1.06l.738.739A2.25 2.25 0 000 5.25v5.5A2.25 2.25 0 002.25 13h6.5a2.25 2.25 0 001.99-1.2l2.98 2.98a.75.75 0 101.06-1.06L2.28 1.22zm7.22 9.34L3.44 4.5H2.25a.75.75 0 00-.75.75v5.5c0 .414.336.75.75.75h6.5a.75.75 0 00.75-.75v-.19z" clip-rule="evenodd"/><path d="M7.688 3a.75.75 0 000 1.5H8.75a.75.75 0 01.75.75v.733a1.544 1.544 0 002.424 1.27L14.5 5.47v5.54a.75.75 0 001.5 0V4.99c0-1.021-1.157-1.61-1.982-1.013L11.07 6.02a.045.045 0 01-.07-.037V5.25A2.25 2.25 0 008.75 3H7.687z"/></g></svg>');
+}
+
+%video-off-24-svg-prop {
+  --video-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M2.28 1.22a.75.75 0 00-1.06 1.06L2.94 4h-.19A2.75 2.75 0 000 6.75v10.5A2.75 2.75 0 002.75 20h11.5c1.271 0 2.34-.862 2.656-2.034l4.814 4.814a.75.75 0 101.06-1.06L2.28 1.22zM15.5 16.56L4.44 5.5H2.75c-.69 0-1.25.56-1.25 1.25v10.5c0 .69.56 1.25 1.25 1.25h11.5c.69 0 1.25-.56 1.25-1.25v-.69z" clip-rule="evenodd"/><path d="M10.5 4a.75.75 0 000 1.5h3.75c.69 0 1.25.56 1.25 1.25v3.514a1.32 1.32 0 002.148 1.028l4.426-3.563.014-.012a.25.25 0 01.412.19v8.185c0 .06-.015.101-.035.133a.253.253 0 01-.096.087.75.75 0 00.708 1.322c.527-.281.923-.84.923-1.542V7.908c0-1.487-1.736-2.295-2.873-1.342L17 9.888V6.75A2.75 2.75 0 0014.25 4H10.5z"/></g></svg>');
+}
+
 %visibility-hide-svg-prop {
   --visibility-hide-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.74 2.74A11.804 11.804 0 0 0 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z" fill="%23000"/></svg>');
 }
@@ -734,6 +3926,206 @@
   --visibility-show-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z" fill="%23000"/></svg>');
 }
 
+%vmware-16-svg-prop {
+  --vmware-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M1.677 5.14c-.201-.46-.698-.67-1.162-.454-.465.216-.636.756-.426 1.218l1.949 4.436c.306.696.63 1.06 1.236 1.06.647 0 .93-.397 1.236-1.06l1.717-3.916a.247.247 0 01.245-.166c.146.001.27.124.27.288v3.79c0 .585.308 1.064.904 1.064.595 0 .916-.48.916-1.064V7.235c0-.599.41-.987.968-.987s.929.402.929.987v3.101c0 .585.31 1.064.905 1.064s.918-.48.918-1.064V7.235c0-.599.408-.987.966-.987.557 0 .93.402.93.987v3.101c0 .585.31 1.064.905 1.064.594 0 .917-.48.917-1.064v-3.53C16 5.51 15.004 4.6 13.805 4.6c-1.197 0-1.947.867-1.947.867-.4-.54-.949-.866-1.878-.866-.982 0-1.84.866-1.84.866-.4-.54-1.078-.866-1.64-.866-.87 0-1.56.4-1.982 1.41L3.274 9.082 1.677 5.14z"/></svg>');
+}
+
+%vmware-24-svg-prop {
+  --vmware-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M4.096 8.468c-.251-.57-.873-.829-1.453-.562-.58.267-.795.934-.532 1.505l2.436 5.48c.383.859.787 1.309 1.545 1.309.81 0 1.163-.49 1.545-1.309l2.147-4.838a.309.309 0 01.306-.204.345.345 0 01.336.355v4.682c0 .722.387 1.314 1.131 1.314s1.146-.592 1.146-1.314v-3.831c0-.74.512-1.22 1.21-1.22.697 0 1.16.498 1.16 1.22v3.831c0 .722.389 1.314 1.132 1.314.743 0 1.147-.592 1.147-1.314v-3.831c0-.74.51-1.22 1.208-1.22.696 0 1.162.498 1.162 1.22v3.831c0 .722.388 1.314 1.131 1.314.744 0 1.147-.592 1.147-1.314v-4.36C22 8.922 20.755 7.8 19.256 7.8c-1.497 0-2.434 1.072-2.434 1.072-.498-.669-1.185-1.07-2.347-1.07-1.227 0-2.3 1.07-2.3 1.07-.499-.669-1.348-1.07-2.05-1.07-1.087 0-1.95.494-2.477 1.74l-1.556 3.795-1.996-4.869z"/></svg>');
+}
+
+%vmware-color-16-svg-prop {
+  --vmware-color-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23696566" d="M1.677 5.14c-.201-.46-.698-.67-1.162-.454-.465.216-.636.756-.426 1.218l1.949 4.436c.306.696.63 1.06 1.236 1.06.647 0 .93-.397 1.236-1.06l1.717-3.916a.247.247 0 01.245-.165c.146 0 .27.123.27.287v3.79c0 .585.308 1.064.904 1.064.595 0 .916-.48.916-1.064V7.235c0-.599.41-.987.968-.987s.929.402.929.987v3.101c0 .585.31 1.064.905 1.064s.918-.48.918-1.064V7.235c0-.599.408-.987.966-.987.557 0 .93.402.93.987v3.101c0 .585.31 1.064.905 1.064.594 0 .917-.48.917-1.064v-3.53C16 5.51 15.004 4.6 13.805 4.6c-1.197 0-1.947.868-1.947.868-.4-.542-.949-.867-1.878-.867-.982 0-1.84.867-1.84.867-.4-.542-1.078-.867-1.64-.867-.87 0-1.56.4-1.982 1.41L3.274 9.082 1.677 5.14z"/></svg>');
+}
+
+%vmware-color-24-svg-prop {
+  --vmware-color-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23696566" d="M4.096 8.468c-.251-.57-.873-.829-1.453-.562-.58.267-.795.934-.532 1.505l2.436 5.48c.383.859.787 1.309 1.545 1.309.81 0 1.163-.49 1.545-1.309l2.147-4.838a.309.309 0 01.306-.204.345.345 0 01.336.355v4.682c0 .722.387 1.314 1.131 1.314s1.146-.592 1.146-1.314v-3.831c0-.74.512-1.22 1.21-1.22.697 0 1.16.498 1.16 1.22v3.831c0 .722.389 1.314 1.132 1.314.743 0 1.147-.592 1.147-1.314v-3.831c0-.74.51-1.22 1.208-1.22.696 0 1.162.498 1.162 1.22v3.831c0 .722.388 1.314 1.131 1.314.744 0 1.147-.592 1.147-1.314v-4.36C22 8.922 20.755 7.8 19.256 7.8c-1.497 0-2.434 1.072-2.434 1.072-.498-.669-1.185-1.07-2.347-1.07-1.227 0-2.3 1.07-2.3 1.07-.499-.669-1.348-1.07-2.05-1.07-1.087 0-1.95.494-2.477 1.74l-1.556 3.795-1.996-4.869z"/></svg>');
+}
+
+%volume-16-svg-prop {
+  --volume-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M7.5 4.19L4.524 6.274a1.25 1.25 0 01-.717.226H1.5v3h2.307c.256 0 .506.079.717.226L7.5 11.809V4.19zm-.467-1.504A1.25 1.25 0 019 3.71v8.58a1.25 1.25 0 01-1.967 1.024L3.728 11H1.25C.56 11 0 10.44 0 9.75v-3.5C0 5.56.56 5 1.25 5h2.478l3.305-2.314z" clip-rule="evenodd"/></svg>');
+}
+
+%volume-2-16-svg-prop {
+  --volume-2-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M13.242 2.184a.75.75 0 00-.984 1.132C13.709 4.578 14.5 6.266 14.5 8s-.79 3.422-2.242 4.684a.75.75 0 10.984 1.132C14.992 12.293 16 10.204 16 8c0-2.204-1.008-4.293-2.758-5.816z"/><path fill-rule="evenodd" d="M7.033 2.686A1.25 1.25 0 019 3.71v8.58a1.25 1.25 0 01-1.967 1.024L3.728 11H1.25C.56 11 0 10.44 0 9.75v-3.5C0 5.56.56 5 1.25 5h2.478l3.305-2.314zM7.5 4.19L4.523 6.274a1.25 1.25 0 01-.716.226H1.5v3h2.307c.256 0 .506.079.716.226L7.5 11.809V4.19z" clip-rule="evenodd"/><path d="M10.701 5.239a.75.75 0 011.06-.038A3.826 3.826 0 0113 8c0 1.06-.453 2.066-1.239 2.799A.75.75 0 1110.74 9.7c.494-.46.761-1.074.761-1.701s-.267-1.24-.761-1.701a.75.75 0 01-.038-1.06z"/></g></svg>');
+}
+
+%volume-2-24-svg-prop {
+  --volume-2-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M18.72 4.22a.75.75 0 011.06 0 11.009 11.009 0 010 15.56.75.75 0 11-1.06-1.06 9.51 9.51 0 000-13.44.75.75 0 010-1.06z"/><path fill-rule="evenodd" d="M9.046 4.804C10.162 3.748 12 4.538 12 6.074v11.851c0 1.536-1.838 2.327-2.954 1.27l-3.3-3.127A.25.25 0 005.574 16H2.75A1.75 1.75 0 011 14.25v-4.5C1 8.783 1.784 8 2.75 8h2.824a.25.25 0 00.172-.069l3.3-3.127zm1.454 1.27a.25.25 0 00-.422-.18l-3.3 3.126a1.75 1.75 0 01-1.204.48H2.75a.25.25 0 00-.25.25v4.5c0 .138.112.25.25.25h2.824c.448 0 .878.171 1.203.48l3.301 3.127a.25.25 0 00.422-.182V6.075z" clip-rule="evenodd"/><path d="M16.271 7.96a.75.75 0 10-1.042 1.08A4.118 4.118 0 0116.5 12c0 1.105-.454 2.17-1.271 2.96a.75.75 0 101.042 1.08A5.617 5.617 0 0018 12c0-1.52-.625-2.972-1.729-4.04z"/></g></svg>');
+}
+
+%volume-24-svg-prop {
+  --volume-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M10.5 6.075a.25.25 0 00-.422-.182l-3.3 3.127a1.75 1.75 0 01-1.204.48H2.75a.25.25 0 00-.25.25v4.5c0 .138.112.25.25.25h2.824c.448 0 .878.171 1.203.48l3.301 3.127a.25.25 0 00.422-.182V6.075zm-1.454-1.27C10.162 3.747 12 4.537 12 6.074v11.85c0 1.536-1.838 2.327-2.954 1.27l-3.3-3.127A.25.25 0 005.574 16H2.75A1.75 1.75 0 011 14.25v-4.5C1 8.783 1.784 8 2.75 8h2.824a.25.25 0 00.172-.069l3.3-3.127z" clip-rule="evenodd"/></svg>');
+}
+
+%volume-down-16-svg-prop {
+  --volume-down-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M9 3.71a1.25 1.25 0 00-1.967-1.024L3.728 5H1.25C.56 5 0 5.56 0 6.25v3.5C0 10.44.56 11 1.25 11h2.478l3.305 2.314A1.25 1.25 0 009 12.29V3.71zM4.524 6.274L7.5 4.19v7.62L4.524 9.725a1.25 1.25 0 00-.717-.226H1.5v-3h2.307c.256 0 .506-.079.717-.226z" clip-rule="evenodd"/><path d="M11.761 5.201A.75.75 0 0010.74 6.3c.494.46.761 1.074.761 1.701s-.267 1.24-.761 1.701A.75.75 0 1011.76 10.8 3.826 3.826 0 0013 8c0-1.06-.453-2.066-1.239-2.799z"/></g></svg>');
+}
+
+%volume-down-24-svg-prop {
+  --volume-down-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M12 6.075c0-1.537-1.838-2.327-2.954-1.27l-3.3 3.126A.25.25 0 015.574 8H2.75A1.75 1.75 0 001 9.75v4.5c0 .966.784 1.75 1.75 1.75h2.824a.25.25 0 01.172.068l3.3 3.127c1.116 1.057 2.954.266 2.954-1.27V6.075zm-1.922-.182a.25.25 0 01.422.182v11.85a.25.25 0 01-.422.181l-3.3-3.127a1.75 1.75 0 00-1.204-.48H2.75a.25.25 0 01-.25-.25v-4.5a.25.25 0 01.25-.25h2.824a1.75 1.75 0 001.203-.479l3.301-3.127z" clip-rule="evenodd"/><path d="M16.271 7.96a.75.75 0 10-1.042 1.08A4.118 4.118 0 0116.5 12c0 1.105-.454 2.17-1.271 2.96a.75.75 0 101.042 1.08A5.617 5.617 0 0018 12c0-1.52-.625-2.972-1.729-4.04z"/></g></svg>');
+}
+
+%volume-x-16-svg-prop {
+  --volume-x-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path fill-rule="evenodd" d="M7.033 2.686A1.25 1.25 0 019 3.71v8.58a1.25 1.25 0 01-1.967 1.024L3.728 11H1.25C.56 11 0 10.44 0 9.75v-3.5C0 5.56.56 5 1.25 5h2.478l3.305-2.314zM7.5 4.19L4.524 6.274a1.25 1.25 0 01-.717.226H1.5v3h2.307c.256 0 .506.079.717.226L7.5 11.809V4.19z" clip-rule="evenodd"/><path d="M15.28 5.72a.75.75 0 010 1.06L14.06 8l1.22 1.22a.75.75 0 11-1.06 1.06L13 9.06l-1.22 1.22a.75.75 0 11-1.06-1.06L11.94 8l-1.22-1.22a.75.75 0 011.06-1.06L13 6.94l1.22-1.22a.75.75 0 011.06 0z"/></g></svg>');
+}
+
+%volume-x-24-svg-prop {
+  --volume-x-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M9.046 4.804C10.162 3.748 12 4.538 12 6.074v11.851c0 1.536-1.838 2.327-2.954 1.27l-3.3-3.127A.25.25 0 005.574 16H2.75A1.75 1.75 0 011 14.25v-4.5C1 8.783 1.784 8 2.75 8h2.824a.25.25 0 00.172-.069l3.3-3.127zm1.454 1.27a.25.25 0 00-.422-.18l-3.3 3.126a1.75 1.75 0 01-1.204.48H2.75a.25.25 0 00-.25.25v4.5c0 .138.112.25.25.25h2.824c.448 0 .878.171 1.203.48l3.301 3.127a.25.25 0 00.422-.182V6.075z" clip-rule="evenodd"/><path d="M22.78 8.22a.75.75 0 010 1.06L20.06 12l2.72 2.72a.75.75 0 11-1.06 1.06L19 13.06l-2.72 2.72a.75.75 0 11-1.06-1.06L17.94 12l-2.72-2.72a.75.75 0 011.06-1.06L19 10.94l2.72-2.72a.75.75 0 011.06 0z"/></g></svg>');
+}
+
+%wall-16-svg-prop {
+  --wall-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M2.25 1A2.25 2.25 0 000 3.25v9.5A2.25 2.25 0 002.25 15h11.5A2.25 2.25 0 0016 12.75v-9.5A2.25 2.25 0 0013.75 1H2.25zM4.5 2.5H2.25a.75.75 0 00-.75.75V5h3V2.5zm-3 4v3H7v-3H1.5zm0 4.5v1.75c0 .414.336.75.75.75H4.5V11h-3zM6 13.5h4V11H6v2.5zm5.5 0h2.25a.75.75 0 00.75-.75V11h-3v2.5zm3-4v-3h-6v3h6zm0-4.5V3.25a.75.75 0 00-.75-.75H11.5V5h3zM10 2.5V5H6V2.5h4z" clip-rule="evenodd"/></svg>');
+}
+
+%wall-24-svg-prop {
+  --wall-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M3.75 2A2.75 2.75 0 001 4.75v14.5A2.75 2.75 0 003.75 22h16.5A2.75 2.75 0 0023 19.25V4.75A2.75 2.75 0 0020.25 2H3.75zM6.5 3.5H3.75c-.69 0-1.25.56-1.25 1.25V8h4V3.5zm-4 6v5H11v-5H2.5zm0 6.5v3.25c0 .69.56 1.25 1.25 1.25H6.5V16h-4zM8 20.5h8V16H8v4.5zm9.5 0h2.75c.69 0 1.25-.56 1.25-1.25V16h-4v4.5zm4-6v-5h-9v5h9zm0-6.5V4.75c0-.69-.56-1.25-1.25-1.25H17.5V8h4zM16 3.5V8H8V3.5h8z" clip-rule="evenodd"/></svg>');
+}
+
+%watch-16-svg-prop {
+  --watch-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M9 6.25a.75.75 0 00-1.5 0V8.5c0 .323.207.61.513.712l1.5.5a.75.75 0 10.474-1.424L9 7.96V6.25z"/><path fill-rule="evenodd" d="M4.574 1.932A2.25 2.25 0 016.8 0h2.398c1.12 0 2.07.823 2.227 1.932l.288 2.011A5.485 5.485 0 0113.5 8a5.485 5.485 0 01-1.786 4.057l-.288 2.011A2.25 2.25 0 019.2 16H6.801a2.25 2.25 0 01-2.227-1.932l-.288-2.011A5.485 5.485 0 012.5 8c0-1.606.688-3.051 1.786-4.057l.288-2.011zM5.95 13.106l.107.75a.75.75 0 00.743.644h2.398a.75.75 0 00.742-.644l.108-.75A5.485 5.485 0 018 13.5c-.724 0-1.416-.14-2.049-.394zm3.99-10.962l.108.75A5.485 5.485 0 008 2.5c-.724 0-1.416.14-2.049.394l.107-.75a.75.75 0 01.743-.644h2.398a.75.75 0 01.742.644zM4 8a4 4 0 118 0 4 4 0 01-8 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%watch-24-svg-prop {
+  --watch-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M12.5 8.25a.75.75 0 00-1.5 0v4.25c0 .284.16.544.415.67l2.5 1.25a.75.75 0 10.67-1.34L12.5 12.036V8.25z"/><path fill-rule="evenodd" d="M7.464 2.258A2.75 2.75 0 0110.169 0h3.662a2.75 2.75 0 012.706 2.258l.666 3.665A7.982 7.982 0 0120 12a7.982 7.982 0 01-2.797 6.077l-.666 3.665A2.75 2.75 0 0113.83 24h-3.662a2.75 2.75 0 01-2.705-2.258l-.667-3.665A7.982 7.982 0 014 12a7.982 7.982 0 012.797-6.077l.667-3.665zM8.528 19.21l.411 2.265a1.25 1.25 0 001.23 1.026h3.662a1.25 1.25 0 001.23-1.026l.411-2.265A7.968 7.968 0 0112 20a7.97 7.97 0 01-3.472-.79zM15.06 2.526l.411 2.265A7.968 7.968 0 0012 4a7.968 7.968 0 00-3.472.79l.411-2.264A1.25 1.25 0 0110.17 1.5h3.662a1.25 1.25 0 011.23 1.026zM5.5 12a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%webhook-16-svg-prop {
+  --webhook-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M6.032 4.132c0-1.039.843-1.882 1.886-1.882.709 0 1.328.39 1.65.97a.75.75 0 101.311-.728A3.385 3.385 0 007.918.75a3.383 3.383 0 00-3.386 3.382c0 .94.385 1.79 1.003 2.402l-2.054 3.594a1.25 1.25 0 00.151 2.49h.007a1.25 1.25 0 001.146-1.75l2.369-4.144a.75.75 0 00-.249-1.005 1.879 1.879 0 01-.873-1.587z"/><path d="M7.793 5.375a1.25 1.25 0 01.125-2.494h.006a1.25 1.25 0 011.157 1.725l2.159 3.572a3.383 3.383 0 014.51 3.19 3.383 3.383 0 01-4.23 3.275.75.75 0 11.373-1.452 1.883 1.883 0 002.357-1.822 1.883 1.883 0 00-2.897-1.588.75.75 0 01-1.045-.245l-2.515-4.16z"/><path d="M2.002 10.429a.75.75 0 00-1.298-.752 3.383 3.383 0 002.932 5.073c1.61 0 2.96-1.124 3.301-2.632h4.42c.229.304.592.5 1.001.5h.007a1.25 1.25 0 000-2.5h-.007c-.409 0-.772.197-1 .5H6.271a.75.75 0 00-.75.75 1.883 1.883 0 01-1.886 1.882 1.883 1.883 0 01-1.633-2.821z"/></g></svg>');
+}
+
+%webhook-24-svg-prop {
+  --webhook-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M8.75 6a3.25 3.25 0 016.094-1.574.75.75 0 101.312-.728 4.75 4.75 0 10-7.307 5.856l-3.485 5.477A2.013 2.013 0 005.01 15H5a2 2 0 100 4h.01a2 2 0 001.623-3.17l3.852-6.052a.75.75 0 00-.23-1.035A3.247 3.247 0 018.75 6z"/><path d="M12.364 7.969c-.115.02-.233.031-.354.031H12a2 2 0 110-4h.01a2 2 0 011.623 3.17l3.481 5.47a4.75 4.75 0 11.7 8.96.75.75 0 11.373-1.452 3.25 3.25 0 10-.931-5.89.75.75 0 01-1.037-.23l-3.855-6.06z"/><path d="M2.184 15.376a.75.75 0 10-1.298-.752A4.75 4.75 0 109.69 17.75h7.454A2 2 0 0019 19h.01a2 2 0 100-4H19a2 2 0 00-1.855 1.25H9a.75.75 0 00-.75.75 3.25 3.25 0 11-6.066-1.624z"/></g></svg>');
+}
+
 %webhook-svg-prop {
   --webhook-svg: url('data:image/svg+xml;charset=UTF-8,<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M12.278 9.313a2.021 2.021 0 0 1-2.01-.951c-.552-.928-.224-2.115.732-2.65.956-.536 2.179-.218 2.732.71.407.684.346 1.54-.155 2.164l2.354 3.955c2.02-.731 4.352.038 5.466 1.91 1.242 2.087.504 4.76-1.647 5.964a4.608 4.608 0 0 1-3.51.41l.474-1.383c.77.204 1.594.1 2.286-.288 1.434-.804 1.925-2.583 1.098-3.975a3.006 3.006 0 0 0-2.193-1.429 3.059 3.059 0 0 0-2.507.807l-3.12-5.244zm3.367 6.592a2.003 2.003 0 0 1 1.855-1.213c1.104 0 2 .87 2 1.94 0 1.072-.896 1.94-2 1.941-.815 0-1.549-.48-1.855-1.213h-4.707C10.58 19.424 8.728 21 6.5 21c-2.484 0-4.5-1.957-4.5-4.366 0-1.24.533-2.358 1.389-3.153l.997 1.088a2.859 2.859 0 0 0-.886 2.065c0 1.607 1.343 2.91 3 2.91.928 0 1.803-.417 2.371-1.128a2.844 2.844 0 0 0 .534-2.51h6.24zm-7.568-.49c.501.623.562 1.479.155 2.164-.553.927-1.775 1.245-2.732.71-.956-.536-1.284-1.723-.732-2.65a2.022 2.022 0 0 1 2.01-.953l2.354-3.955c-1.664-1.332-2.143-3.676-1.03-5.548C9.345 3.096 12.1 2.38 14.25 3.585a4.37 4.37 0 0 1 2.12 2.744l-1.47.293a2.915 2.915 0 0 0-1.4-1.777c-1.435-.802-3.269-.326-4.098 1.065a2.835 2.835 0 0 0-.179 2.557 2.973 2.973 0 0 0 1.974 1.704l-3.12 5.243z" fill="%23000"/></svg>');
+}
+
+%wifi-16-svg-prop {
+  --wifi-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.443 5.978a9.917 9.917 0 0113.114 0 .75.75 0 00.992-1.126 11.417 11.417 0 00-15.098 0 .75.75 0 10.992 1.126z"/><path d="M3.813 8.525a6.583 6.583 0 018.427 0 .75.75 0 00.96-1.153 8.083 8.083 0 00-10.347 0 .75.75 0 00.96 1.153z"/><path d="M8.003 10.5a3.25 3.25 0 00-1.882.6.75.75 0 01-.869-1.222 4.75 4.75 0 015.502 0 .75.75 0 11-.868 1.223 3.25 3.25 0 00-1.883-.601zM8 12a1 1 0 100 2h.007a1 1 0 100-2H8z"/></g></svg>');
+}
+
+%wifi-24-svg-prop {
+  --wifi-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M1.916 9.31a15.25 15.25 0 0120.168 0 .75.75 0 00.992-1.125 16.75 16.75 0 00-22.152 0 .75.75 0 10.992 1.125z"/><path d="M5.48 12.874a10.25 10.25 0 0113.12 0 .75.75 0 00.96-1.152 11.75 11.75 0 00-15.04 0 .75.75 0 00.96 1.152zM12.005 15.5a5.25 5.25 0 00-3.04.97.75.75 0 01-.87-1.223 6.75 6.75 0 017.82 0 .75.75 0 11-.87 1.223 5.25 5.25 0 00-3.04-.97zM12 19a1 1 0 100 2h.01a1 1 0 100-2H12z"/></g></svg>');
+}
+
+%wifi-off-16-svg-prop {
+  --wifi-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M1.22 1.22a.75.75 0 011.06 0l12.5 12.5a.75.75 0 11-1.06 1.06l-3.558-3.557a.749.749 0 01-.276-.122 3.25 3.25 0 00-3.765 0 .75.75 0 01-.869-1.223A4.75 4.75 0 017.94 9L6.198 7.26c-.867.25-1.68.68-2.385 1.266a.75.75 0 01-.96-1.153A8.083 8.083 0 015.02 6.08L3.513 4.573a9.914 9.914 0 00-2.07 1.405.75.75 0 11-.992-1.126c.605-.533 1.26-.997 1.954-1.387L1.22 2.28a.75.75 0 010-1.06zM8 3.5c-.42 0-.837.027-1.25.08a.75.75 0 11-.19-1.489 11.418 11.418 0 018.99 2.761.75.75 0 01-.993 1.126A9.917 9.917 0 008 3.5zM9.794 6.427a.75.75 0 01.959-.453A8.083 8.083 0 0113.2 7.372a.75.75 0 11-.96 1.153 6.583 6.583 0 00-1.993-1.14.75.75 0 01-.453-.958z"/><path d="M8 12a1 1 0 100 2h.007a1 1 0 100-2H8z"/></g></svg>');
+}
+
+%wifi-off-24-svg-prop {
+  --wifi-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M1.22 1.22a.75.75 0 011.06 0l20.5 20.5a.75.75 0 11-1.06 1.06l-6.175-6.174a.747.747 0 01-.5-.136 5.25 5.25 0 00-6.08 0 .75.75 0 01-.87-1.223 6.75 6.75 0 014.92-1.171l-3.307-3.307a10.249 10.249 0 00-4.228 2.105.75.75 0 01-.96-1.152A11.749 11.749 0 018.49 9.55L5.77 6.83a15.247 15.247 0 00-3.854 2.48.75.75 0 11-.992-1.125 16.746 16.746 0 013.718-2.482L1.22 2.28a.75.75 0 010-1.06zM12 5.5c-.72 0-1.436.051-2.142.151a.75.75 0 01-.21-1.485 16.75 16.75 0 0113.428 4.019.75.75 0 01-.992 1.125A15.25 15.25 0 0012 5.5zM14.278 9.954a.75.75 0 01.924-.52 11.75 11.75 0 014.358 2.288.75.75 0 01-.96 1.152 10.248 10.248 0 00-3.802-1.996.75.75 0 01-.52-.924zM12 19a1 1 0 100 2h.01a1 1 0 100-2H12z"/></g></svg>');
+}
+
+%wrench-16-svg-prop {
+  --wrench-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M10.973 1.506a18.57 18.57 0 00-.497-.006A4.024 4.024 0 006.45 5.524c0 .43.095.865.199 1.205.054.18.116.356.192.527v.002a.75.75 0 01-.15.848l-4.937 4.911a.871.871 0 000 1.229.868.868 0 001.227 0L7.896 9.31a.75.75 0 01.847-.151c.17.079.35.139.528.193.34.103.775.198 1.205.198A4.024 4.024 0 0014.5 5.524c0-.177-.002-.338-.006-.483-.208.25-.438.517-.675.774-.32.345-.677.696-1.048.964-.354.257-.82.511-1.339.511-.396 0-.776-.155-1.059-.432L9.142 5.627a1.513 1.513 0 01-.432-1.06c0-.52.256-.985.514-1.34.27-.37.623-.727.97-1.046.258-.237.529-.466.78-.675zm-2.36 9.209l-4.57 4.59a2.37 2.37 0 01-3.35-3.348l.002-.001 4.591-4.568a6.886 6.886 0 01-.072-.223 5.77 5.77 0 01-.263-1.64A5.524 5.524 0 0110.476 0c.675 0 1.167.028 1.525.076.331.044.64.115.873.264a.92.92 0 01.374.45.844.844 0 01-.013.625.922.922 0 01-.241.332c-.26.257-.547.487-.829.72-.315.26-.647.535-.957.82a5.948 5.948 0 00-.771.824c-.197.27-.227.415-.227.457 0 .003 0 .006.003.008l1.211 1.211a.013.013 0 00.008.003c.043 0 .19-.03.46-.226a5.96 5.96 0 00.826-.767c.284-.308.56-.638.82-.951.233-.28.463-.564.72-.822a.927.927 0 01.31-.235.841.841 0 01.628-.033.91.91 0 01.467.376c.15.233.22.543.262.87.047.356.075.847.075 1.522a5.524 5.524 0 01-5.524 5.525c-.631 0-1.221-.136-1.64-.263a6.731 6.731 0 01-.222-.071z" clip-rule="evenodd"/></svg>');
+}
+
+%wrench-24-svg-prop {
+  --wrench-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M15.5 2.5a6 6 0 00-6 6c0 .65.143 1.296.294 1.794a7.667 7.667 0 00.285.78l.003.007a.75.75 0 01-.15.85L2.95 18.873A1.54 1.54 0 004.038 21.5c.408 0 .799-.162 1.087-.45l6.948-6.98a.75.75 0 01.848-.15l.008.003.037.016.156.065c.139.054.34.129.586.203.497.15 1.143.293 1.792.293a6 6 0 006-6c0-.635-.018-1.122-.047-1.492l-.207.248-.034.04c-.362.435-.778.934-1.213 1.404-.446.483-.935.96-1.436 1.323-.483.35-1.075.664-1.71.664-.479 0-.939-.188-1.28-.523l-.006-.005-1.73-1.732a1.829 1.829 0 01-.524-1.28c0-.637.317-1.229.669-1.711.364-.5.844-.989 1.33-1.434.473-.434.975-.85 1.412-1.212l.04-.032.251-.209c-.373-.03-.867-.049-1.515-.049zm3.348.432a.982.982 0 00.266-.363c.07-.165.11-.4.015-.653a.991.991 0 00-.405-.485c-.27-.172-.648-.265-1.108-.327C17.129 1.04 16.449 1 15.5 1A7.5 7.5 0 008 8.5c0 .85.183 1.653.358 2.23.056.184.112.348.163.487L1.89 17.814a3.038 3.038 0 004.297 4.296l6.6-6.63c.138.05.301.107.485.162.576.175 1.377.358 2.228.358A7.5 7.5 0 0023 8.5c0-.948-.039-1.627-.103-2.111-.06-.456-.152-.835-.324-1.104a.978.978 0 00-.5-.406.879.879 0 00-.658.035.989.989 0 00-.34.262c-.287.287-.63.7-.98 1.119l-.026.03c-.368.442-.763.915-1.171 1.357-.42.454-.832.849-1.214 1.125-.399.29-.672.38-.831.38a.329.329 0 01-.228-.092l-1.72-1.72a.328.328 0 01-.091-.228c0-.157.09-.43.38-.828.278-.382.675-.792 1.132-1.212.444-.408.92-.802 1.365-1.17l.029-.023c.423-.35.84-.695 1.128-.982z" clip-rule="evenodd"/></svg>');
+}
+
+%x-16-svg-prop {
+  --x-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" d="M12.78 4.28a.75.75 0 00-1.06-1.06L8 6.94 4.28 3.22a.75.75 0 00-1.06 1.06L6.94 8l-3.72 3.72a.75.75 0 101.06 1.06L8 9.06l3.72 3.72a.75.75 0 101.06-1.06L9.06 8l3.72-3.72z"/></svg>');
+}
+
+%x-24-svg-prop {
+  --x-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" d="M18.78 6.28a.75.75 0 00-1.06-1.06L12 10.94 6.28 5.22a.75.75 0 00-1.06 1.06L10.94 12l-5.72 5.72a.75.75 0 101.06 1.06L12 13.06l5.72 5.72a.75.75 0 101.06-1.06L13.06 12l5.72-5.72z"/></svg>');
+}
+
+%x-circle-16-svg-prop {
+  --x-circle-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M11.28 4.72a.75.75 0 010 1.06L9.06 8l2.22 2.22a.75.75 0 11-1.06 1.06L8 9.06l-2.22 2.22a.75.75 0 01-1.06-1.06L6.94 8 4.72 5.78a.75.75 0 011.06-1.06L8 6.94l2.22-2.22a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M.25 8a7.75 7.75 0 1115.5 0A7.75 7.75 0 01.25 8zM8 1.75a6.25 6.25 0 100 12.5 6.25 6.25 0 000-12.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%x-circle-24-svg-prop {
+  --x-circle-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M16.78 7.22a.75.75 0 010 1.06L13.06 12l3.72 3.72a.75.75 0 11-1.06 1.06L12 13.06l-3.72 3.72a.75.75 0 01-1.06-1.06L10.94 12 7.22 8.28a.75.75 0 011.06-1.06L12 10.94l3.72-3.72a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M1.25 12C1.25 6.063 6.063 1.25 12 1.25S22.75 6.063 22.75 12 17.937 22.75 12 22.75 1.25 17.937 1.25 12zM12 2.75a9.25 9.25 0 100 18.5 9.25 9.25 0 000-18.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%x-circle-fill-16-svg-prop {
+  --x-circle-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M8 .25a7.75 7.75 0 100 15.5A7.75 7.75 0 008 .25zm2.72 3.97a.75.75 0 111.06 1.06L9.06 8l2.72 2.72a.75.75 0 11-1.06 1.06L8 9.06l-2.72 2.72a.75.75 0 01-1.06-1.06L6.94 8 4.22 5.28a.75.75 0 011.06-1.06L8 6.94l2.72-2.72z" clip-rule="evenodd"/></svg>');
+}
+
+%x-circle-fill-24-svg-prop {
+  --x-circle-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M12 1.25C6.063 1.25 1.25 6.063 1.25 12S6.063 22.75 12 22.75 22.75 17.937 22.75 12 17.937 1.25 12 1.25zM7.22 7.22a.75.75 0 011.06 0L12 10.94l3.72-3.72a.75.75 0 111.06 1.06L13.06 12l3.72 3.72a.75.75 0 11-1.06 1.06L12 13.06l-3.72 3.72a.75.75 0 01-1.06-1.06L10.94 12 7.22 8.28a.75.75 0 010-1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%x-diamond-16-svg-prop {
+  --x-diamond-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M10.78 5.22a.75.75 0 010 1.06L9.06 8l1.72 1.72a.75.75 0 01-1.06 1.06L8 9.06l-1.72 1.72a.75.75 0 11-1.06-1.06L6.94 8 5.22 6.28a.75.75 0 011.06-1.06L8 6.94l1.72-1.72a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M.75 6.41L6.407.753a2.25 2.25 0 013.182 0l5.657 5.657a2.25 2.25 0 010 3.182l-5.657 5.656a2.25 2.25 0 01-3.182 0L.75 9.592a2.25 2.25 0 010-3.182zm6.718-4.597L1.81 7.47a.75.75 0 000 1.06l5.657 5.658a.75.75 0 001.06 0l5.657-5.657a.75.75 0 000-1.06L8.53 1.812a.75.75 0 00-1.061 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%x-diamond-24-svg-prop {
+  --x-diamond-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M15.78 8.22a.75.75 0 010 1.06L13.06 12l2.72 2.72a.75.75 0 11-1.06 1.06L12 13.06l-2.72 2.72a.75.75 0 01-1.06-1.06L10.94 12 8.22 9.28a.75.75 0 111.06-1.06L12 10.94l2.72-2.72a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M1.884 10.056l8.171-8.172a2.75 2.75 0 013.89 0l8.171 8.172a2.75 2.75 0 010 3.889l-8.171 8.171a2.75 2.75 0 01-3.89 0l-8.171-8.171a2.75 2.75 0 010-3.89zm9.232-7.111l-8.172 8.171a1.25 1.25 0 000 1.768l8.172 8.172a1.25 1.25 0 001.768 0l8.171-8.172a1.25 1.25 0 000-1.768l-8.171-8.171a1.25 1.25 0 00-1.768 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%x-diamond-fill-16-svg-prop {
+  --x-diamond-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.57.752a2.25 2.25 0 00-3.183 0L.73 6.41a2.25 2.25 0 000 3.182l5.657 5.657a2.25 2.25 0 003.182 0l5.657-5.657a2.25 2.25 0 000-3.182L9.569.752zM5.22 5.22a.75.75 0 011.06 0L8 6.94l1.72-1.72a.75.75 0 111.06 1.06L9.06 8l1.72 1.72a.75.75 0 11-1.06 1.06L8 9.06l-1.72 1.72a.75.75 0 11-1.06-1.06L6.94 8 5.22 6.28a.75.75 0 010-1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%x-diamond-fill-24-svg-prop {
+  --x-diamond-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13.945 1.884a2.75 2.75 0 00-3.89 0l-8.171 8.172a2.75 2.75 0 000 3.889l8.171 8.171a2.75 2.75 0 003.89 0l8.171-8.171a2.75 2.75 0 000-3.89l-8.171-8.17zM8.22 8.22a.75.75 0 011.06 0L12 10.94l2.72-2.72a.75.75 0 111.06 1.06L13.06 12l2.72 2.72a.75.75 0 01-1.06 1.06L12 13.06l-2.72 2.72a.75.75 0 11-1.06-1.06L10.94 12 8.22 9.28a.75.75 0 010-1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%x-hexagon-16-svg-prop {
+  --x-hexagon-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M10.78 5.22a.75.75 0 010 1.06L9.06 8l1.72 1.72a.75.75 0 11-1.06 1.06L8 9.06l-1.72 1.72a.75.75 0 11-1.06-1.06L6.94 8 5.22 6.28a.75.75 0 011.06-1.06L8 6.94l1.72-1.72a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M6.834.33a2.25 2.25 0 012.332 0l5.25 3.182A2.25 2.25 0 0115.5 5.436v5.128a2.25 2.25 0 01-1.084 1.924l-5.25 3.182a2.25 2.25 0 01-2.332 0l-5.25-3.182A2.25 2.25 0 01.5 10.564V5.436a2.25 2.25 0 011.084-1.924L6.834.33zm1.555 1.283a.75.75 0 00-.778 0l-5.25 3.181A.75.75 0 002 5.436v5.128a.75.75 0 00.361.642l5.25 3.181a.75.75 0 00.778 0l5.25-3.181a.75.75 0 00.361-.642V5.436a.75.75 0 00-.361-.642l-5.25-3.181z" clip-rule="evenodd"/></g></svg>');
+}
+
+%x-hexagon-24-svg-prop {
+  --x-hexagon-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M15.78 8.22a.75.75 0 010 1.06L13.06 12l2.72 2.72a.75.75 0 11-1.06 1.06L12 13.06l-2.72 2.72a.75.75 0 01-1.06-1.06L10.94 12 8.22 9.28a.75.75 0 011.06-1.06L12 10.94l2.72-2.72a.75.75 0 011.06 0z"/><path fill-rule="evenodd" d="M10.559 1.006a2.75 2.75 0 012.882 0l7.75 4.77A2.75 2.75 0 0122.5 8.116v7.765a2.75 2.75 0 01-1.309 2.342l-7.75 4.77a2.75 2.75 0 01-2.882 0l-7.75-4.77A2.75 2.75 0 011.5 15.882V8.117a2.75 2.75 0 011.309-2.342l7.75-4.769zm2.096 1.278a1.25 1.25 0 00-1.31 0l-7.75 4.769A1.25 1.25 0 003 8.117v7.765c0 .434.225.837.595 1.065l7.75 4.769a1.25 1.25 0 001.31 0l7.75-4.77c.37-.227.595-.63.595-1.064V8.117a1.25 1.25 0 00-.595-1.064l-7.75-4.77z" clip-rule="evenodd"/></g></svg>');
+}
+
+%x-hexagon-fill-16-svg-prop {
+  --x-hexagon-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.166.33a2.25 2.25 0 00-2.332 0l-5.25 3.182A2.25 2.25 0 00.5 5.436v5.128a2.25 2.25 0 001.084 1.924l5.25 3.182a2.25 2.25 0 002.332 0l5.25-3.182a2.25 2.25 0 001.084-1.924V5.436a2.25 2.25 0 00-1.084-1.924L9.166.33zM5.22 5.22a.75.75 0 011.06 0L8 6.94l1.72-1.72a.75.75 0 111.06 1.06L9.06 8l1.72 1.72a.75.75 0 11-1.06 1.06L8 9.06l-1.72 1.72a.75.75 0 11-1.06-1.06L6.94 8 5.22 6.28a.75.75 0 010-1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%x-hexagon-fill-24-svg-prop {
+  --x-hexagon-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13.441 1.006a2.75 2.75 0 00-2.882 0l-7.75 4.77a2.75 2.75 0 00-1.31 2.341v7.765a2.75 2.75 0 001.31 2.342l7.75 4.77a2.75 2.75 0 002.882 0l7.75-4.77a2.75 2.75 0 001.309-2.342V8.117a2.75 2.75 0 00-1.309-2.342l-7.75-4.769zM14.72 8.22a.75.75 0 011.06 1.061L13.06 12l2.72 2.72a.75.75 0 01-1.06 1.06L12 13.06l-2.72 2.72a.75.75 0 11-1.06-1.06L10.94 12 8.22 9.28a.75.75 0 011.06-1.06L12 10.94l2.72-2.72z" clip-rule="evenodd"/></svg>');
+}
+
+%x-square-16-svg-prop {
+  --x-square-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M3.139 2.5a.639.639 0 00-.639.639v9.722c0 .353.286.639.639.639h9.722a.639.639 0 00.639-.639V3.14a.639.639 0 00-.639-.639H3.14zM1 3.139C1 1.958 1.958 1 3.139 1h9.722C14.042 1 15 1.958 15 3.139v9.722A2.139 2.139 0 0112.861 15H3.14A2.139 2.139 0 011 12.861V3.14zm3.72 1.58a.75.75 0 011.06 0L8 6.94l2.22-2.22a.75.75 0 111.06 1.061L9.06 8l2.22 2.22a.75.75 0 11-1.06 1.06L8 9.06l-2.22 2.22a.75.75 0 01-1.06-1.06L6.94 8 4.72 5.78a.75.75 0 010-1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%x-square-24-svg-prop {
+  --x-square-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M4.806 3.5c-.721 0-1.306.585-1.306 1.306v14.388c0 .722.585 1.306 1.306 1.306h14.388c.722 0 1.306-.584 1.306-1.306V4.806c0-.721-.584-1.306-1.306-1.306H4.806zM2 4.806A2.806 2.806 0 014.806 2h14.388A2.806 2.806 0 0122 4.806v14.388A2.806 2.806 0 0119.194 22H4.806A2.806 2.806 0 012 19.194V4.806zM7.22 7.22a.75.75 0 011.06 0L12 10.94l3.72-3.72a.75.75 0 111.06 1.06L13.06 12l3.72 3.72a.75.75 0 11-1.06 1.06L12 13.06l-3.72 3.72a.75.75 0 01-1.06-1.06L10.94 12 7.22 8.28a.75.75 0 010-1.06z" clip-rule="evenodd"/></svg>');
+}
+
+%x-square-fill-16-svg-prop {
+  --x-square-fill-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M1 3.139C1 1.958 1.958 1 3.139 1h9.722C14.042 1 15 1.958 15 3.139v9.722A2.139 2.139 0 0112.861 15H3.14A2.139 2.139 0 011 12.861V3.14zm4.28 1.08A.75.75 0 004.22 5.28L6.94 8l-2.72 2.72a.75.75 0 101.06 1.06L8 9.06l2.72 2.72a.75.75 0 101.06-1.06L9.06 8l2.72-2.72a.75.75 0 00-1.06-1.06L8 6.94 5.28 4.22z" clip-rule="evenodd"/></svg>');
+}
+
+%x-square-fill-24-svg-prop {
+  --x-square-fill-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M2 4.806A2.806 2.806 0 014.806 2h14.388A2.806 2.806 0 0122 4.806v14.388A2.806 2.806 0 0119.194 22H4.806A2.806 2.806 0 012 19.194V4.806zM8.28 7.22a.75.75 0 00-1.06 1.06L10.94 12l-3.72 3.72a.75.75 0 101.06 1.06L12 13.06l3.72 3.72a.75.75 0 101.06-1.06L13.06 12l3.72-3.72a.75.75 0 00-1.06-1.06L12 10.94 8.28 7.22z" clip-rule="evenodd"/></svg>');
+}
+
+%zap-16-svg-prop {
+  --zap-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><path fill="%23000" fill-rule="evenodd" d="M9.375.078a.75.75 0 01.402.82l-.889 4.418 5.485.908a.75.75 0 01.44 1.236l-7.292 8.285a.75.75 0 01-1.298-.643l.889-4.418-5.485-.908a.75.75 0 01-.44-1.236L8.479.255a.75.75 0 01.896-.177zm-6.17 8.439l4.918.815a.75.75 0 01.612.887l-.489 2.433 4.548-5.169-4.917-.815a.75.75 0 01-.612-.887l.489-2.432-4.548 5.168z" clip-rule="evenodd"/></svg>');
+}
+
+%zap-24-svg-prop {
+  --zap-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><path fill="%23000" fill-rule="evenodd" d="M13.333 1.065a.75.75 0 01.437.791l-.918 6.409 8.48.94a.75.75 0 01.494 1.226l-10.278 12.3a.75.75 0 01-1.318-.587l.918-6.409-8.48-.94a.75.75 0 01-.494-1.226l10.278-12.3a.75.75 0 01.881-.204zM4.222 13.458l7.86.872a.75.75 0 01.66.851l-.653 4.563 7.69-9.202-7.862-.872a.75.75 0 01-.66-.851l.654-4.563-7.69 9.203z" clip-rule="evenodd"/></svg>');
+}
+
+%zap-off-16-svg-prop {
+  --zap-off-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M9.777.898A.75.75 0 008.479.255L6.473 2.533a.75.75 0 001.126.991l.155-.175-.164.814a.75.75 0 101.47.296L9.778.898z"/><path fill-rule="evenodd" d="M10.874 11.935l-3.353 3.81a.75.75 0 01-1.309-.57l.452-4.489-5.047-.912a.75.75 0 01-.43-1.234l2.946-3.347L1.22 2.28a.75.75 0 011.06-1.06l12.5 12.5a.75.75 0 01-1.06 1.06l-2.846-2.845zM5.195 6.256L3.191 8.534l4.422.8a.75.75 0 01.612.813L7.938 13l1.874-2.129-4.617-4.616z" clip-rule="evenodd"/><path d="M11.248 5.707a.75.75 0 10-.246 1.48l1.792.296-.322.367a.75.75 0 101.126.99l1.215-1.38a.75.75 0 00-.44-1.236l-3.125-.517z"/></g></svg>');
+}
+
+%zap-off-24-svg-prop {
+  --zap-off-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path fill-rule="evenodd" d="M2.28 1.22a.75.75 0 00-1.06 1.06l5.659 5.66-4.705 5.63a.75.75 0 00.493 1.226l8.48.94-.917 6.408a.75.75 0 001.318.587l4.608-5.515 5.564 5.564a.75.75 0 101.06-1.06l-6.067-6.067a.753.753 0 00-.154-.154L2.28 1.219zM15.09 16.15L7.945 9.004 4.222 13.46l7.86.87a.75.75 0 01.66.852l-.653 4.563 3.002-3.593z" clip-rule="evenodd"/><path d="M13.77 1.856a.75.75 0 00-1.318-.587l-2.57 3.075a.75.75 0 101.152.962l.877-1.05-.332 2.32a.75.75 0 101.485.213l.706-4.933zM14.973 8.5a.75.75 0 10-.165 1.49l4.97.552-1.673 2.002a.75.75 0 001.151.962l2.57-3.075a.75.75 0 00-.493-1.226l-6.36-.705z"/></g></svg>');
+}
+
+%zoom-in-16-svg-prop {
+  --zoom-in-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M7.25 4a.75.75 0 01.75.75V6.5h1.75a.75.75 0 010 1.5H8v1.75a.75.75 0 01-1.5 0V8H4.75a.75.75 0 010-1.5H6.5V4.75A.75.75 0 017.25 4z"/><path fill-rule="evenodd" d="M7.25 1a6.25 6.25 0 103.857 11.168l2.613 2.612a.75.75 0 101.06-1.06l-2.612-2.613A6.25 6.25 0 007.25 1zM2.5 7.25a4.75 4.75 0 119.5 0 4.75 4.75 0 01-9.5 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%zoom-in-24-svg-prop {
+  --zoom-in-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M10.75 6.5a.75.75 0 01.75.75V10h2.75a.75.75 0 010 1.5H11.5v2.75a.75.75 0 01-1.5 0V11.5H7.25a.75.75 0 010-1.5H10V7.25a.75.75 0 01.75-.75z"/><path fill-rule="evenodd" d="M10.75 2a8.75 8.75 0 105.634 15.445l4.336 4.335a.75.75 0 101.06-1.06l-4.335-4.336A8.75 8.75 0 0010.75 2zM3.5 10.75a7.25 7.25 0 1114.5 0 7.25 7.25 0 01-14.5 0z" clip-rule="evenodd"/></g></svg>');
+}
+
+%zoom-out-16-svg-prop {
+  --zoom-out-16-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="none" viewBox="0 0 16 16"><g fill="%23000"><path d="M4.75 6.5a.75.75 0 000 1.5h5a.75.75 0 000-1.5h-5z"/><path fill-rule="evenodd" d="M1 7.25a6.25 6.25 0 1111.168 3.857l2.612 2.613a.75.75 0 11-1.06 1.06l-2.613-2.612A6.25 6.25 0 011 7.25zM7.25 2.5a4.75 4.75 0 100 9.5 4.75 4.75 0 000-9.5z" clip-rule="evenodd"/></g></svg>');
+}
+
+%zoom-out-24-svg-prop {
+  --zoom-out-24-svg: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" viewBox="0 0 24 24"><g fill="%23000"><path d="M7.25 10a.75.75 0 000 1.5h7a.75.75 0 000-1.5h-7z"/><path fill-rule="evenodd" d="M2 10.75a8.75 8.75 0 1115.445 5.634l4.335 4.336a.75.75 0 11-1.06 1.06l-4.336-4.335A8.75 8.75 0 012 10.75zm8.75-7.25a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5z" clip-rule="evenodd"/></g></svg>');
 }

--- a/ui/packages/consul-ui/app/styles/base/icons/icon-placeholders.scss
+++ b/ui/packages/consul-ui/app/styles/base/icons/icon-placeholders.scss
@@ -1,1849 +1,10329 @@
+%with-activity-16-icon {
+  @extend %with-icon, %activity-16-svg-prop !optional;
+  background-image: var(--activity-16-svg);
+}
+%with-activity-16-mask {
+  @extend %with-mask, %activity-16-svg-prop !optional;
+  -webkit-mask-image: var(--activity-16-svg);
+  mask-image: var(--activity-16-svg);
+}
+
+%with-activity-24-icon {
+  @extend %with-icon, %activity-24-svg-prop !optional;
+  background-image: var(--activity-24-svg);
+}
+%with-activity-24-mask {
+  @extend %with-mask, %activity-24-svg-prop !optional;
+  -webkit-mask-image: var(--activity-24-svg);
+  mask-image: var(--activity-24-svg);
+}
+
+%with-alert-circle-16-icon {
+  @extend %with-icon, %alert-circle-16-svg-prop !optional;
+  background-image: var(--alert-circle-16-svg);
+}
+%with-alert-circle-16-mask {
+  @extend %with-mask, %alert-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--alert-circle-16-svg);
+  mask-image: var(--alert-circle-16-svg);
+}
+
+%with-alert-circle-24-icon {
+  @extend %with-icon, %alert-circle-24-svg-prop !optional;
+  background-image: var(--alert-circle-24-svg);
+}
+%with-alert-circle-24-mask {
+  @extend %with-mask, %alert-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--alert-circle-24-svg);
+  mask-image: var(--alert-circle-24-svg);
+}
+
+%with-alert-circle-fill-16-icon {
+  @extend %with-icon, %alert-circle-fill-16-svg-prop !optional;
+  background-image: var(--alert-circle-fill-16-svg);
+}
+%with-alert-circle-fill-16-mask {
+  @extend %with-mask, %alert-circle-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--alert-circle-fill-16-svg);
+  mask-image: var(--alert-circle-fill-16-svg);
+}
+
+%with-alert-circle-fill-24-icon {
+  @extend %with-icon, %alert-circle-fill-24-svg-prop !optional;
+  background-image: var(--alert-circle-fill-24-svg);
+}
+%with-alert-circle-fill-24-mask {
+  @extend %with-mask, %alert-circle-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--alert-circle-fill-24-svg);
+  mask-image: var(--alert-circle-fill-24-svg);
+}
+
 %with-alert-circle-fill-icon {
-  @extend %with-icon, %alert-circle-fill-svg-prop;
+  @extend %with-icon, %alert-circle-fill-svg-prop !optional;
   background-image: var(--alert-circle-fill-svg);
 }
 %with-alert-circle-fill-mask {
-  @extend %with-mask, %alert-circle-fill-svg-prop;
+  @extend %with-mask, %alert-circle-fill-svg-prop !optional;
   -webkit-mask-image: var(--alert-circle-fill-svg);
   mask-image: var(--alert-circle-fill-svg);
 }
 
 %with-alert-circle-outline-icon {
-  @extend %with-icon, %alert-circle-outline-svg-prop;
+  @extend %with-icon, %alert-circle-outline-svg-prop !optional;
   background-image: var(--alert-circle-outline-svg);
 }
 %with-alert-circle-outline-mask {
-  @extend %with-mask, %alert-circle-outline-svg-prop;
+  @extend %with-mask, %alert-circle-outline-svg-prop !optional;
   -webkit-mask-image: var(--alert-circle-outline-svg);
   mask-image: var(--alert-circle-outline-svg);
 }
 
+%with-alert-octagon-16-icon {
+  @extend %with-icon, %alert-octagon-16-svg-prop !optional;
+  background-image: var(--alert-octagon-16-svg);
+}
+%with-alert-octagon-16-mask {
+  @extend %with-mask, %alert-octagon-16-svg-prop !optional;
+  -webkit-mask-image: var(--alert-octagon-16-svg);
+  mask-image: var(--alert-octagon-16-svg);
+}
+
+%with-alert-octagon-24-icon {
+  @extend %with-icon, %alert-octagon-24-svg-prop !optional;
+  background-image: var(--alert-octagon-24-svg);
+}
+%with-alert-octagon-24-mask {
+  @extend %with-mask, %alert-octagon-24-svg-prop !optional;
+  -webkit-mask-image: var(--alert-octagon-24-svg);
+  mask-image: var(--alert-octagon-24-svg);
+}
+
+%with-alert-octagon-fill-16-icon {
+  @extend %with-icon, %alert-octagon-fill-16-svg-prop !optional;
+  background-image: var(--alert-octagon-fill-16-svg);
+}
+%with-alert-octagon-fill-16-mask {
+  @extend %with-mask, %alert-octagon-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--alert-octagon-fill-16-svg);
+  mask-image: var(--alert-octagon-fill-16-svg);
+}
+
+%with-alert-octagon-fill-24-icon {
+  @extend %with-icon, %alert-octagon-fill-24-svg-prop !optional;
+  background-image: var(--alert-octagon-fill-24-svg);
+}
+%with-alert-octagon-fill-24-mask {
+  @extend %with-mask, %alert-octagon-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--alert-octagon-fill-24-svg);
+  mask-image: var(--alert-octagon-fill-24-svg);
+}
+
+%with-alert-triangle-16-icon {
+  @extend %with-icon, %alert-triangle-16-svg-prop !optional;
+  background-image: var(--alert-triangle-16-svg);
+}
+%with-alert-triangle-16-mask {
+  @extend %with-mask, %alert-triangle-16-svg-prop !optional;
+  -webkit-mask-image: var(--alert-triangle-16-svg);
+  mask-image: var(--alert-triangle-16-svg);
+}
+
+%with-alert-triangle-24-icon {
+  @extend %with-icon, %alert-triangle-24-svg-prop !optional;
+  background-image: var(--alert-triangle-24-svg);
+}
+%with-alert-triangle-24-mask {
+  @extend %with-mask, %alert-triangle-24-svg-prop !optional;
+  -webkit-mask-image: var(--alert-triangle-24-svg);
+  mask-image: var(--alert-triangle-24-svg);
+}
+
+%with-alert-triangle-fill-16-icon {
+  @extend %with-icon, %alert-triangle-fill-16-svg-prop !optional;
+  background-image: var(--alert-triangle-fill-16-svg);
+}
+%with-alert-triangle-fill-16-mask {
+  @extend %with-mask, %alert-triangle-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--alert-triangle-fill-16-svg);
+  mask-image: var(--alert-triangle-fill-16-svg);
+}
+
+%with-alert-triangle-fill-24-icon {
+  @extend %with-icon, %alert-triangle-fill-24-svg-prop !optional;
+  background-image: var(--alert-triangle-fill-24-svg);
+}
+%with-alert-triangle-fill-24-mask {
+  @extend %with-mask, %alert-triangle-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--alert-triangle-fill-24-svg);
+  mask-image: var(--alert-triangle-fill-24-svg);
+}
+
 %with-alert-triangle-icon {
-  @extend %with-icon, %alert-triangle-svg-prop;
+  @extend %with-icon, %alert-triangle-svg-prop !optional;
   background-image: var(--alert-triangle-svg);
 }
 %with-alert-triangle-mask {
-  @extend %with-mask, %alert-triangle-svg-prop;
+  @extend %with-mask, %alert-triangle-svg-prop !optional;
   -webkit-mask-image: var(--alert-triangle-svg);
   mask-image: var(--alert-triangle-svg);
 }
 
+%with-alibaba-16-icon {
+  @extend %with-icon, %alibaba-16-svg-prop !optional;
+  background-image: var(--alibaba-16-svg);
+}
+%with-alibaba-16-mask {
+  @extend %with-mask, %alibaba-16-svg-prop !optional;
+  -webkit-mask-image: var(--alibaba-16-svg);
+  mask-image: var(--alibaba-16-svg);
+}
+
+%with-alibaba-24-icon {
+  @extend %with-icon, %alibaba-24-svg-prop !optional;
+  background-image: var(--alibaba-24-svg);
+}
+%with-alibaba-24-mask {
+  @extend %with-mask, %alibaba-24-svg-prop !optional;
+  -webkit-mask-image: var(--alibaba-24-svg);
+  mask-image: var(--alibaba-24-svg);
+}
+
+%with-alibaba-color-16-icon {
+  @extend %with-icon, %alibaba-color-16-svg-prop !optional;
+  background-image: var(--alibaba-color-16-svg);
+}
+%with-alibaba-color-16-mask {
+  @extend %with-mask, %alibaba-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--alibaba-color-16-svg);
+  mask-image: var(--alibaba-color-16-svg);
+}
+
+%with-alibaba-color-24-icon {
+  @extend %with-icon, %alibaba-color-24-svg-prop !optional;
+  background-image: var(--alibaba-color-24-svg);
+}
+%with-alibaba-color-24-mask {
+  @extend %with-mask, %alibaba-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--alibaba-color-24-svg);
+  mask-image: var(--alibaba-color-24-svg);
+}
+
+%with-align-center-16-icon {
+  @extend %with-icon, %align-center-16-svg-prop !optional;
+  background-image: var(--align-center-16-svg);
+}
+%with-align-center-16-mask {
+  @extend %with-mask, %align-center-16-svg-prop !optional;
+  -webkit-mask-image: var(--align-center-16-svg);
+  mask-image: var(--align-center-16-svg);
+}
+
+%with-align-center-24-icon {
+  @extend %with-icon, %align-center-24-svg-prop !optional;
+  background-image: var(--align-center-24-svg);
+}
+%with-align-center-24-mask {
+  @extend %with-mask, %align-center-24-svg-prop !optional;
+  -webkit-mask-image: var(--align-center-24-svg);
+  mask-image: var(--align-center-24-svg);
+}
+
+%with-align-justify-16-icon {
+  @extend %with-icon, %align-justify-16-svg-prop !optional;
+  background-image: var(--align-justify-16-svg);
+}
+%with-align-justify-16-mask {
+  @extend %with-mask, %align-justify-16-svg-prop !optional;
+  -webkit-mask-image: var(--align-justify-16-svg);
+  mask-image: var(--align-justify-16-svg);
+}
+
+%with-align-justify-24-icon {
+  @extend %with-icon, %align-justify-24-svg-prop !optional;
+  background-image: var(--align-justify-24-svg);
+}
+%with-align-justify-24-mask {
+  @extend %with-mask, %align-justify-24-svg-prop !optional;
+  -webkit-mask-image: var(--align-justify-24-svg);
+  mask-image: var(--align-justify-24-svg);
+}
+
+%with-align-left-16-icon {
+  @extend %with-icon, %align-left-16-svg-prop !optional;
+  background-image: var(--align-left-16-svg);
+}
+%with-align-left-16-mask {
+  @extend %with-mask, %align-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--align-left-16-svg);
+  mask-image: var(--align-left-16-svg);
+}
+
+%with-align-left-24-icon {
+  @extend %with-icon, %align-left-24-svg-prop !optional;
+  background-image: var(--align-left-24-svg);
+}
+%with-align-left-24-mask {
+  @extend %with-mask, %align-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--align-left-24-svg);
+  mask-image: var(--align-left-24-svg);
+}
+
+%with-align-right-16-icon {
+  @extend %with-icon, %align-right-16-svg-prop !optional;
+  background-image: var(--align-right-16-svg);
+}
+%with-align-right-16-mask {
+  @extend %with-mask, %align-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--align-right-16-svg);
+  mask-image: var(--align-right-16-svg);
+}
+
+%with-align-right-24-icon {
+  @extend %with-icon, %align-right-24-svg-prop !optional;
+  background-image: var(--align-right-24-svg);
+}
+%with-align-right-24-mask {
+  @extend %with-mask, %align-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--align-right-24-svg);
+  mask-image: var(--align-right-24-svg);
+}
+
+%with-apple-16-icon {
+  @extend %with-icon, %apple-16-svg-prop !optional;
+  background-image: var(--apple-16-svg);
+}
+%with-apple-16-mask {
+  @extend %with-mask, %apple-16-svg-prop !optional;
+  -webkit-mask-image: var(--apple-16-svg);
+  mask-image: var(--apple-16-svg);
+}
+
+%with-apple-24-icon {
+  @extend %with-icon, %apple-24-svg-prop !optional;
+  background-image: var(--apple-24-svg);
+}
+%with-apple-24-mask {
+  @extend %with-mask, %apple-24-svg-prop !optional;
+  -webkit-mask-image: var(--apple-24-svg);
+  mask-image: var(--apple-24-svg);
+}
+
+%with-apple-color-16-icon {
+  @extend %with-icon, %apple-color-16-svg-prop !optional;
+  background-image: var(--apple-color-16-svg);
+}
+%with-apple-color-16-mask {
+  @extend %with-mask, %apple-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--apple-color-16-svg);
+  mask-image: var(--apple-color-16-svg);
+}
+
+%with-apple-color-24-icon {
+  @extend %with-icon, %apple-color-24-svg-prop !optional;
+  background-image: var(--apple-color-24-svg);
+}
+%with-apple-color-24-mask {
+  @extend %with-mask, %apple-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--apple-color-24-svg);
+  mask-image: var(--apple-color-24-svg);
+}
+
+%with-archive-16-icon {
+  @extend %with-icon, %archive-16-svg-prop !optional;
+  background-image: var(--archive-16-svg);
+}
+%with-archive-16-mask {
+  @extend %with-mask, %archive-16-svg-prop !optional;
+  -webkit-mask-image: var(--archive-16-svg);
+  mask-image: var(--archive-16-svg);
+}
+
+%with-archive-24-icon {
+  @extend %with-icon, %archive-24-svg-prop !optional;
+  background-image: var(--archive-24-svg);
+}
+%with-archive-24-mask {
+  @extend %with-mask, %archive-24-svg-prop !optional;
+  -webkit-mask-image: var(--archive-24-svg);
+  mask-image: var(--archive-24-svg);
+}
+
+%with-arrow-down-16-icon {
+  @extend %with-icon, %arrow-down-16-svg-prop !optional;
+  background-image: var(--arrow-down-16-svg);
+}
+%with-arrow-down-16-mask {
+  @extend %with-mask, %arrow-down-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-down-16-svg);
+  mask-image: var(--arrow-down-16-svg);
+}
+
+%with-arrow-down-24-icon {
+  @extend %with-icon, %arrow-down-24-svg-prop !optional;
+  background-image: var(--arrow-down-24-svg);
+}
+%with-arrow-down-24-mask {
+  @extend %with-mask, %arrow-down-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-down-24-svg);
+  mask-image: var(--arrow-down-24-svg);
+}
+
+%with-arrow-down-circle-16-icon {
+  @extend %with-icon, %arrow-down-circle-16-svg-prop !optional;
+  background-image: var(--arrow-down-circle-16-svg);
+}
+%with-arrow-down-circle-16-mask {
+  @extend %with-mask, %arrow-down-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-down-circle-16-svg);
+  mask-image: var(--arrow-down-circle-16-svg);
+}
+
+%with-arrow-down-circle-24-icon {
+  @extend %with-icon, %arrow-down-circle-24-svg-prop !optional;
+  background-image: var(--arrow-down-circle-24-svg);
+}
+%with-arrow-down-circle-24-mask {
+  @extend %with-mask, %arrow-down-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-down-circle-24-svg);
+  mask-image: var(--arrow-down-circle-24-svg);
+}
+
+%with-arrow-down-left-16-icon {
+  @extend %with-icon, %arrow-down-left-16-svg-prop !optional;
+  background-image: var(--arrow-down-left-16-svg);
+}
+%with-arrow-down-left-16-mask {
+  @extend %with-mask, %arrow-down-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-down-left-16-svg);
+  mask-image: var(--arrow-down-left-16-svg);
+}
+
+%with-arrow-down-left-24-icon {
+  @extend %with-icon, %arrow-down-left-24-svg-prop !optional;
+  background-image: var(--arrow-down-left-24-svg);
+}
+%with-arrow-down-left-24-mask {
+  @extend %with-mask, %arrow-down-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-down-left-24-svg);
+  mask-image: var(--arrow-down-left-24-svg);
+}
+
+%with-arrow-down-right-16-icon {
+  @extend %with-icon, %arrow-down-right-16-svg-prop !optional;
+  background-image: var(--arrow-down-right-16-svg);
+}
+%with-arrow-down-right-16-mask {
+  @extend %with-mask, %arrow-down-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-down-right-16-svg);
+  mask-image: var(--arrow-down-right-16-svg);
+}
+
+%with-arrow-down-right-24-icon {
+  @extend %with-icon, %arrow-down-right-24-svg-prop !optional;
+  background-image: var(--arrow-down-right-24-svg);
+}
+%with-arrow-down-right-24-mask {
+  @extend %with-mask, %arrow-down-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-down-right-24-svg);
+  mask-image: var(--arrow-down-right-24-svg);
+}
+
 %with-arrow-down-icon {
-  @extend %with-icon, %arrow-down-svg-prop;
+  @extend %with-icon, %arrow-down-svg-prop !optional;
   background-image: var(--arrow-down-svg);
 }
 %with-arrow-down-mask {
-  @extend %with-mask, %arrow-down-svg-prop;
+  @extend %with-mask, %arrow-down-svg-prop !optional;
   -webkit-mask-image: var(--arrow-down-svg);
   mask-image: var(--arrow-down-svg);
 }
 
+%with-arrow-left-16-icon {
+  @extend %with-icon, %arrow-left-16-svg-prop !optional;
+  background-image: var(--arrow-left-16-svg);
+}
+%with-arrow-left-16-mask {
+  @extend %with-mask, %arrow-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-left-16-svg);
+  mask-image: var(--arrow-left-16-svg);
+}
+
+%with-arrow-left-24-icon {
+  @extend %with-icon, %arrow-left-24-svg-prop !optional;
+  background-image: var(--arrow-left-24-svg);
+}
+%with-arrow-left-24-mask {
+  @extend %with-mask, %arrow-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-left-24-svg);
+  mask-image: var(--arrow-left-24-svg);
+}
+
+%with-arrow-left-circle-16-icon {
+  @extend %with-icon, %arrow-left-circle-16-svg-prop !optional;
+  background-image: var(--arrow-left-circle-16-svg);
+}
+%with-arrow-left-circle-16-mask {
+  @extend %with-mask, %arrow-left-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-left-circle-16-svg);
+  mask-image: var(--arrow-left-circle-16-svg);
+}
+
+%with-arrow-left-circle-24-icon {
+  @extend %with-icon, %arrow-left-circle-24-svg-prop !optional;
+  background-image: var(--arrow-left-circle-24-svg);
+}
+%with-arrow-left-circle-24-mask {
+  @extend %with-mask, %arrow-left-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-left-circle-24-svg);
+  mask-image: var(--arrow-left-circle-24-svg);
+}
+
 %with-arrow-left-icon {
-  @extend %with-icon, %arrow-left-svg-prop;
+  @extend %with-icon, %arrow-left-svg-prop !optional;
   background-image: var(--arrow-left-svg);
 }
 %with-arrow-left-mask {
-  @extend %with-mask, %arrow-left-svg-prop;
+  @extend %with-mask, %arrow-left-svg-prop !optional;
   -webkit-mask-image: var(--arrow-left-svg);
   mask-image: var(--arrow-left-svg);
 }
 
+%with-arrow-right-16-icon {
+  @extend %with-icon, %arrow-right-16-svg-prop !optional;
+  background-image: var(--arrow-right-16-svg);
+}
+%with-arrow-right-16-mask {
+  @extend %with-mask, %arrow-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-right-16-svg);
+  mask-image: var(--arrow-right-16-svg);
+}
+
+%with-arrow-right-24-icon {
+  @extend %with-icon, %arrow-right-24-svg-prop !optional;
+  background-image: var(--arrow-right-24-svg);
+}
+%with-arrow-right-24-mask {
+  @extend %with-mask, %arrow-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-right-24-svg);
+  mask-image: var(--arrow-right-24-svg);
+}
+
+%with-arrow-right-circle-16-icon {
+  @extend %with-icon, %arrow-right-circle-16-svg-prop !optional;
+  background-image: var(--arrow-right-circle-16-svg);
+}
+%with-arrow-right-circle-16-mask {
+  @extend %with-mask, %arrow-right-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-right-circle-16-svg);
+  mask-image: var(--arrow-right-circle-16-svg);
+}
+
+%with-arrow-right-circle-24-icon {
+  @extend %with-icon, %arrow-right-circle-24-svg-prop !optional;
+  background-image: var(--arrow-right-circle-24-svg);
+}
+%with-arrow-right-circle-24-mask {
+  @extend %with-mask, %arrow-right-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-right-circle-24-svg);
+  mask-image: var(--arrow-right-circle-24-svg);
+}
+
 %with-arrow-right-icon {
-  @extend %with-icon, %arrow-right-svg-prop;
+  @extend %with-icon, %arrow-right-svg-prop !optional;
   background-image: var(--arrow-right-svg);
 }
 %with-arrow-right-mask {
-  @extend %with-mask, %arrow-right-svg-prop;
+  @extend %with-mask, %arrow-right-svg-prop !optional;
   -webkit-mask-image: var(--arrow-right-svg);
   mask-image: var(--arrow-right-svg);
 }
 
+%with-arrow-up-16-icon {
+  @extend %with-icon, %arrow-up-16-svg-prop !optional;
+  background-image: var(--arrow-up-16-svg);
+}
+%with-arrow-up-16-mask {
+  @extend %with-mask, %arrow-up-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-up-16-svg);
+  mask-image: var(--arrow-up-16-svg);
+}
+
+%with-arrow-up-24-icon {
+  @extend %with-icon, %arrow-up-24-svg-prop !optional;
+  background-image: var(--arrow-up-24-svg);
+}
+%with-arrow-up-24-mask {
+  @extend %with-mask, %arrow-up-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-up-24-svg);
+  mask-image: var(--arrow-up-24-svg);
+}
+
+%with-arrow-up-circle-16-icon {
+  @extend %with-icon, %arrow-up-circle-16-svg-prop !optional;
+  background-image: var(--arrow-up-circle-16-svg);
+}
+%with-arrow-up-circle-16-mask {
+  @extend %with-mask, %arrow-up-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-up-circle-16-svg);
+  mask-image: var(--arrow-up-circle-16-svg);
+}
+
+%with-arrow-up-circle-24-icon {
+  @extend %with-icon, %arrow-up-circle-24-svg-prop !optional;
+  background-image: var(--arrow-up-circle-24-svg);
+}
+%with-arrow-up-circle-24-mask {
+  @extend %with-mask, %arrow-up-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-up-circle-24-svg);
+  mask-image: var(--arrow-up-circle-24-svg);
+}
+
+%with-arrow-up-left-16-icon {
+  @extend %with-icon, %arrow-up-left-16-svg-prop !optional;
+  background-image: var(--arrow-up-left-16-svg);
+}
+%with-arrow-up-left-16-mask {
+  @extend %with-mask, %arrow-up-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-up-left-16-svg);
+  mask-image: var(--arrow-up-left-16-svg);
+}
+
+%with-arrow-up-left-24-icon {
+  @extend %with-icon, %arrow-up-left-24-svg-prop !optional;
+  background-image: var(--arrow-up-left-24-svg);
+}
+%with-arrow-up-left-24-mask {
+  @extend %with-mask, %arrow-up-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-up-left-24-svg);
+  mask-image: var(--arrow-up-left-24-svg);
+}
+
+%with-arrow-up-right-16-icon {
+  @extend %with-icon, %arrow-up-right-16-svg-prop !optional;
+  background-image: var(--arrow-up-right-16-svg);
+}
+%with-arrow-up-right-16-mask {
+  @extend %with-mask, %arrow-up-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-up-right-16-svg);
+  mask-image: var(--arrow-up-right-16-svg);
+}
+
+%with-arrow-up-right-24-icon {
+  @extend %with-icon, %arrow-up-right-24-svg-prop !optional;
+  background-image: var(--arrow-up-right-24-svg);
+}
+%with-arrow-up-right-24-mask {
+  @extend %with-mask, %arrow-up-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--arrow-up-right-24-svg);
+  mask-image: var(--arrow-up-right-24-svg);
+}
+
 %with-arrow-up-icon {
-  @extend %with-icon, %arrow-up-svg-prop;
+  @extend %with-icon, %arrow-up-svg-prop !optional;
   background-image: var(--arrow-up-svg);
 }
 %with-arrow-up-mask {
-  @extend %with-mask, %arrow-up-svg-prop;
+  @extend %with-mask, %arrow-up-svg-prop !optional;
   -webkit-mask-image: var(--arrow-up-svg);
   mask-image: var(--arrow-up-svg);
 }
 
+%with-at-sign-16-icon {
+  @extend %with-icon, %at-sign-16-svg-prop !optional;
+  background-image: var(--at-sign-16-svg);
+}
+%with-at-sign-16-mask {
+  @extend %with-mask, %at-sign-16-svg-prop !optional;
+  -webkit-mask-image: var(--at-sign-16-svg);
+  mask-image: var(--at-sign-16-svg);
+}
+
+%with-at-sign-24-icon {
+  @extend %with-icon, %at-sign-24-svg-prop !optional;
+  background-image: var(--at-sign-24-svg);
+}
+%with-at-sign-24-mask {
+  @extend %with-mask, %at-sign-24-svg-prop !optional;
+  -webkit-mask-image: var(--at-sign-24-svg);
+  mask-image: var(--at-sign-24-svg);
+}
+
+%with-auth0-16-icon {
+  @extend %with-icon, %auth0-16-svg-prop !optional;
+  background-image: var(--auth0-16-svg);
+}
+%with-auth0-16-mask {
+  @extend %with-mask, %auth0-16-svg-prop !optional;
+  -webkit-mask-image: var(--auth0-16-svg);
+  mask-image: var(--auth0-16-svg);
+}
+
+%with-auth0-24-icon {
+  @extend %with-icon, %auth0-24-svg-prop !optional;
+  background-image: var(--auth0-24-svg);
+}
+%with-auth0-24-mask {
+  @extend %with-mask, %auth0-24-svg-prop !optional;
+  -webkit-mask-image: var(--auth0-24-svg);
+  mask-image: var(--auth0-24-svg);
+}
+
+%with-auth0-color-16-icon {
+  @extend %with-icon, %auth0-color-16-svg-prop !optional;
+  background-image: var(--auth0-color-16-svg);
+}
+%with-auth0-color-16-mask {
+  @extend %with-mask, %auth0-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--auth0-color-16-svg);
+  mask-image: var(--auth0-color-16-svg);
+}
+
+%with-auth0-color-24-icon {
+  @extend %with-icon, %auth0-color-24-svg-prop !optional;
+  background-image: var(--auth0-color-24-svg);
+}
+%with-auth0-color-24-mask {
+  @extend %with-mask, %auth0-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--auth0-color-24-svg);
+  mask-image: var(--auth0-color-24-svg);
+}
+
+%with-auto-apply-16-icon {
+  @extend %with-icon, %auto-apply-16-svg-prop !optional;
+  background-image: var(--auto-apply-16-svg);
+}
+%with-auto-apply-16-mask {
+  @extend %with-mask, %auto-apply-16-svg-prop !optional;
+  -webkit-mask-image: var(--auto-apply-16-svg);
+  mask-image: var(--auto-apply-16-svg);
+}
+
+%with-auto-apply-24-icon {
+  @extend %with-icon, %auto-apply-24-svg-prop !optional;
+  background-image: var(--auto-apply-24-svg);
+}
+%with-auto-apply-24-mask {
+  @extend %with-mask, %auto-apply-24-svg-prop !optional;
+  -webkit-mask-image: var(--auto-apply-24-svg);
+  mask-image: var(--auto-apply-24-svg);
+}
+
+%with-award-16-icon {
+  @extend %with-icon, %award-16-svg-prop !optional;
+  background-image: var(--award-16-svg);
+}
+%with-award-16-mask {
+  @extend %with-mask, %award-16-svg-prop !optional;
+  -webkit-mask-image: var(--award-16-svg);
+  mask-image: var(--award-16-svg);
+}
+
+%with-award-24-icon {
+  @extend %with-icon, %award-24-svg-prop !optional;
+  background-image: var(--award-24-svg);
+}
+%with-award-24-mask {
+  @extend %with-mask, %award-24-svg-prop !optional;
+  -webkit-mask-image: var(--award-24-svg);
+  mask-image: var(--award-24-svg);
+}
+
+%with-aws-16-icon {
+  @extend %with-icon, %aws-16-svg-prop !optional;
+  background-image: var(--aws-16-svg);
+}
+%with-aws-16-mask {
+  @extend %with-mask, %aws-16-svg-prop !optional;
+  -webkit-mask-image: var(--aws-16-svg);
+  mask-image: var(--aws-16-svg);
+}
+
+%with-aws-24-icon {
+  @extend %with-icon, %aws-24-svg-prop !optional;
+  background-image: var(--aws-24-svg);
+}
+%with-aws-24-mask {
+  @extend %with-mask, %aws-24-svg-prop !optional;
+  -webkit-mask-image: var(--aws-24-svg);
+  mask-image: var(--aws-24-svg);
+}
+
+%with-aws-color-16-icon {
+  @extend %with-icon, %aws-color-16-svg-prop !optional;
+  background-image: var(--aws-color-16-svg);
+}
+%with-aws-color-16-mask {
+  @extend %with-mask, %aws-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--aws-color-16-svg);
+  mask-image: var(--aws-color-16-svg);
+}
+
+%with-aws-color-24-icon {
+  @extend %with-icon, %aws-color-24-svg-prop !optional;
+  background-image: var(--aws-color-24-svg);
+}
+%with-aws-color-24-mask {
+  @extend %with-mask, %aws-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--aws-color-24-svg);
+  mask-image: var(--aws-color-24-svg);
+}
+
+%with-azure-16-icon {
+  @extend %with-icon, %azure-16-svg-prop !optional;
+  background-image: var(--azure-16-svg);
+}
+%with-azure-16-mask {
+  @extend %with-mask, %azure-16-svg-prop !optional;
+  -webkit-mask-image: var(--azure-16-svg);
+  mask-image: var(--azure-16-svg);
+}
+
+%with-azure-24-icon {
+  @extend %with-icon, %azure-24-svg-prop !optional;
+  background-image: var(--azure-24-svg);
+}
+%with-azure-24-mask {
+  @extend %with-mask, %azure-24-svg-prop !optional;
+  -webkit-mask-image: var(--azure-24-svg);
+  mask-image: var(--azure-24-svg);
+}
+
+%with-azure-color-16-icon {
+  @extend %with-icon, %azure-color-16-svg-prop !optional;
+  background-image: var(--azure-color-16-svg);
+}
+%with-azure-color-16-mask {
+  @extend %with-mask, %azure-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--azure-color-16-svg);
+  mask-image: var(--azure-color-16-svg);
+}
+
+%with-azure-color-24-icon {
+  @extend %with-icon, %azure-color-24-svg-prop !optional;
+  background-image: var(--azure-color-24-svg);
+}
+%with-azure-color-24-mask {
+  @extend %with-mask, %azure-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--azure-color-24-svg);
+  mask-image: var(--azure-color-24-svg);
+}
+
+%with-azure-devops-16-icon {
+  @extend %with-icon, %azure-devops-16-svg-prop !optional;
+  background-image: var(--azure-devops-16-svg);
+}
+%with-azure-devops-16-mask {
+  @extend %with-mask, %azure-devops-16-svg-prop !optional;
+  -webkit-mask-image: var(--azure-devops-16-svg);
+  mask-image: var(--azure-devops-16-svg);
+}
+
+%with-azure-devops-24-icon {
+  @extend %with-icon, %azure-devops-24-svg-prop !optional;
+  background-image: var(--azure-devops-24-svg);
+}
+%with-azure-devops-24-mask {
+  @extend %with-mask, %azure-devops-24-svg-prop !optional;
+  -webkit-mask-image: var(--azure-devops-24-svg);
+  mask-image: var(--azure-devops-24-svg);
+}
+
+%with-azure-devops-color-16-icon {
+  @extend %with-icon, %azure-devops-color-16-svg-prop !optional;
+  background-image: var(--azure-devops-color-16-svg);
+}
+%with-azure-devops-color-16-mask {
+  @extend %with-mask, %azure-devops-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--azure-devops-color-16-svg);
+  mask-image: var(--azure-devops-color-16-svg);
+}
+
+%with-azure-devops-color-24-icon {
+  @extend %with-icon, %azure-devops-color-24-svg-prop !optional;
+  background-image: var(--azure-devops-color-24-svg);
+}
+%with-azure-devops-color-24-mask {
+  @extend %with-mask, %azure-devops-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--azure-devops-color-24-svg);
+  mask-image: var(--azure-devops-color-24-svg);
+}
+
+%with-bar-chart-16-icon {
+  @extend %with-icon, %bar-chart-16-svg-prop !optional;
+  background-image: var(--bar-chart-16-svg);
+}
+%with-bar-chart-16-mask {
+  @extend %with-mask, %bar-chart-16-svg-prop !optional;
+  -webkit-mask-image: var(--bar-chart-16-svg);
+  mask-image: var(--bar-chart-16-svg);
+}
+
+%with-bar-chart-24-icon {
+  @extend %with-icon, %bar-chart-24-svg-prop !optional;
+  background-image: var(--bar-chart-24-svg);
+}
+%with-bar-chart-24-mask {
+  @extend %with-mask, %bar-chart-24-svg-prop !optional;
+  -webkit-mask-image: var(--bar-chart-24-svg);
+  mask-image: var(--bar-chart-24-svg);
+}
+
+%with-bar-chart-alt-16-icon {
+  @extend %with-icon, %bar-chart-alt-16-svg-prop !optional;
+  background-image: var(--bar-chart-alt-16-svg);
+}
+%with-bar-chart-alt-16-mask {
+  @extend %with-mask, %bar-chart-alt-16-svg-prop !optional;
+  -webkit-mask-image: var(--bar-chart-alt-16-svg);
+  mask-image: var(--bar-chart-alt-16-svg);
+}
+
+%with-bar-chart-alt-24-icon {
+  @extend %with-icon, %bar-chart-alt-24-svg-prop !optional;
+  background-image: var(--bar-chart-alt-24-svg);
+}
+%with-bar-chart-alt-24-mask {
+  @extend %with-mask, %bar-chart-alt-24-svg-prop !optional;
+  -webkit-mask-image: var(--bar-chart-alt-24-svg);
+  mask-image: var(--bar-chart-alt-24-svg);
+}
+
+%with-battery-16-icon {
+  @extend %with-icon, %battery-16-svg-prop !optional;
+  background-image: var(--battery-16-svg);
+}
+%with-battery-16-mask {
+  @extend %with-mask, %battery-16-svg-prop !optional;
+  -webkit-mask-image: var(--battery-16-svg);
+  mask-image: var(--battery-16-svg);
+}
+
+%with-battery-24-icon {
+  @extend %with-icon, %battery-24-svg-prop !optional;
+  background-image: var(--battery-24-svg);
+}
+%with-battery-24-mask {
+  @extend %with-mask, %battery-24-svg-prop !optional;
+  -webkit-mask-image: var(--battery-24-svg);
+  mask-image: var(--battery-24-svg);
+}
+
+%with-battery-charging-16-icon {
+  @extend %with-icon, %battery-charging-16-svg-prop !optional;
+  background-image: var(--battery-charging-16-svg);
+}
+%with-battery-charging-16-mask {
+  @extend %with-mask, %battery-charging-16-svg-prop !optional;
+  -webkit-mask-image: var(--battery-charging-16-svg);
+  mask-image: var(--battery-charging-16-svg);
+}
+
+%with-battery-charging-24-icon {
+  @extend %with-icon, %battery-charging-24-svg-prop !optional;
+  background-image: var(--battery-charging-24-svg);
+}
+%with-battery-charging-24-mask {
+  @extend %with-mask, %battery-charging-24-svg-prop !optional;
+  -webkit-mask-image: var(--battery-charging-24-svg);
+  mask-image: var(--battery-charging-24-svg);
+}
+
+%with-beaker-16-icon {
+  @extend %with-icon, %beaker-16-svg-prop !optional;
+  background-image: var(--beaker-16-svg);
+}
+%with-beaker-16-mask {
+  @extend %with-mask, %beaker-16-svg-prop !optional;
+  -webkit-mask-image: var(--beaker-16-svg);
+  mask-image: var(--beaker-16-svg);
+}
+
+%with-beaker-24-icon {
+  @extend %with-icon, %beaker-24-svg-prop !optional;
+  background-image: var(--beaker-24-svg);
+}
+%with-beaker-24-mask {
+  @extend %with-mask, %beaker-24-svg-prop !optional;
+  -webkit-mask-image: var(--beaker-24-svg);
+  mask-image: var(--beaker-24-svg);
+}
+
+%with-bell-16-icon {
+  @extend %with-icon, %bell-16-svg-prop !optional;
+  background-image: var(--bell-16-svg);
+}
+%with-bell-16-mask {
+  @extend %with-mask, %bell-16-svg-prop !optional;
+  -webkit-mask-image: var(--bell-16-svg);
+  mask-image: var(--bell-16-svg);
+}
+
+%with-bell-24-icon {
+  @extend %with-icon, %bell-24-svg-prop !optional;
+  background-image: var(--bell-24-svg);
+}
+%with-bell-24-mask {
+  @extend %with-mask, %bell-24-svg-prop !optional;
+  -webkit-mask-image: var(--bell-24-svg);
+  mask-image: var(--bell-24-svg);
+}
+
+%with-bell-active-16-icon {
+  @extend %with-icon, %bell-active-16-svg-prop !optional;
+  background-image: var(--bell-active-16-svg);
+}
+%with-bell-active-16-mask {
+  @extend %with-mask, %bell-active-16-svg-prop !optional;
+  -webkit-mask-image: var(--bell-active-16-svg);
+  mask-image: var(--bell-active-16-svg);
+}
+
+%with-bell-active-24-icon {
+  @extend %with-icon, %bell-active-24-svg-prop !optional;
+  background-image: var(--bell-active-24-svg);
+}
+%with-bell-active-24-mask {
+  @extend %with-mask, %bell-active-24-svg-prop !optional;
+  -webkit-mask-image: var(--bell-active-24-svg);
+  mask-image: var(--bell-active-24-svg);
+}
+
+%with-bell-active-fill-16-icon {
+  @extend %with-icon, %bell-active-fill-16-svg-prop !optional;
+  background-image: var(--bell-active-fill-16-svg);
+}
+%with-bell-active-fill-16-mask {
+  @extend %with-mask, %bell-active-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--bell-active-fill-16-svg);
+  mask-image: var(--bell-active-fill-16-svg);
+}
+
+%with-bell-active-fill-24-icon {
+  @extend %with-icon, %bell-active-fill-24-svg-prop !optional;
+  background-image: var(--bell-active-fill-24-svg);
+}
+%with-bell-active-fill-24-mask {
+  @extend %with-mask, %bell-active-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--bell-active-fill-24-svg);
+  mask-image: var(--bell-active-fill-24-svg);
+}
+
+%with-bell-off-16-icon {
+  @extend %with-icon, %bell-off-16-svg-prop !optional;
+  background-image: var(--bell-off-16-svg);
+}
+%with-bell-off-16-mask {
+  @extend %with-mask, %bell-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--bell-off-16-svg);
+  mask-image: var(--bell-off-16-svg);
+}
+
+%with-bell-off-24-icon {
+  @extend %with-icon, %bell-off-24-svg-prop !optional;
+  background-image: var(--bell-off-24-svg);
+}
+%with-bell-off-24-mask {
+  @extend %with-mask, %bell-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--bell-off-24-svg);
+  mask-image: var(--bell-off-24-svg);
+}
+
+%with-bitbucket-16-icon {
+  @extend %with-icon, %bitbucket-16-svg-prop !optional;
+  background-image: var(--bitbucket-16-svg);
+}
+%with-bitbucket-16-mask {
+  @extend %with-mask, %bitbucket-16-svg-prop !optional;
+  -webkit-mask-image: var(--bitbucket-16-svg);
+  mask-image: var(--bitbucket-16-svg);
+}
+
+%with-bitbucket-24-icon {
+  @extend %with-icon, %bitbucket-24-svg-prop !optional;
+  background-image: var(--bitbucket-24-svg);
+}
+%with-bitbucket-24-mask {
+  @extend %with-mask, %bitbucket-24-svg-prop !optional;
+  -webkit-mask-image: var(--bitbucket-24-svg);
+  mask-image: var(--bitbucket-24-svg);
+}
+
+%with-bitbucket-color-16-icon {
+  @extend %with-icon, %bitbucket-color-16-svg-prop !optional;
+  background-image: var(--bitbucket-color-16-svg);
+}
+%with-bitbucket-color-16-mask {
+  @extend %with-mask, %bitbucket-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--bitbucket-color-16-svg);
+  mask-image: var(--bitbucket-color-16-svg);
+}
+
+%with-bitbucket-color-24-icon {
+  @extend %with-icon, %bitbucket-color-24-svg-prop !optional;
+  background-image: var(--bitbucket-color-24-svg);
+}
+%with-bitbucket-color-24-mask {
+  @extend %with-mask, %bitbucket-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--bitbucket-color-24-svg);
+  mask-image: var(--bitbucket-color-24-svg);
+}
+
 %with-bolt-icon {
-  @extend %with-icon, %bolt-svg-prop;
+  @extend %with-icon, %bolt-svg-prop !optional;
   background-image: var(--bolt-svg);
 }
 %with-bolt-mask {
-  @extend %with-mask, %bolt-svg-prop;
+  @extend %with-mask, %bolt-svg-prop !optional;
   -webkit-mask-image: var(--bolt-svg);
   mask-image: var(--bolt-svg);
 }
 
+%with-bookmark-16-icon {
+  @extend %with-icon, %bookmark-16-svg-prop !optional;
+  background-image: var(--bookmark-16-svg);
+}
+%with-bookmark-16-mask {
+  @extend %with-mask, %bookmark-16-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-16-svg);
+  mask-image: var(--bookmark-16-svg);
+}
+
+%with-bookmark-24-icon {
+  @extend %with-icon, %bookmark-24-svg-prop !optional;
+  background-image: var(--bookmark-24-svg);
+}
+%with-bookmark-24-mask {
+  @extend %with-mask, %bookmark-24-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-24-svg);
+  mask-image: var(--bookmark-24-svg);
+}
+
+%with-bookmark-add-16-icon {
+  @extend %with-icon, %bookmark-add-16-svg-prop !optional;
+  background-image: var(--bookmark-add-16-svg);
+}
+%with-bookmark-add-16-mask {
+  @extend %with-mask, %bookmark-add-16-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-add-16-svg);
+  mask-image: var(--bookmark-add-16-svg);
+}
+
+%with-bookmark-add-24-icon {
+  @extend %with-icon, %bookmark-add-24-svg-prop !optional;
+  background-image: var(--bookmark-add-24-svg);
+}
+%with-bookmark-add-24-mask {
+  @extend %with-mask, %bookmark-add-24-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-add-24-svg);
+  mask-image: var(--bookmark-add-24-svg);
+}
+
+%with-bookmark-add-fill-16-icon {
+  @extend %with-icon, %bookmark-add-fill-16-svg-prop !optional;
+  background-image: var(--bookmark-add-fill-16-svg);
+}
+%with-bookmark-add-fill-16-mask {
+  @extend %with-mask, %bookmark-add-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-add-fill-16-svg);
+  mask-image: var(--bookmark-add-fill-16-svg);
+}
+
+%with-bookmark-add-fill-24-icon {
+  @extend %with-icon, %bookmark-add-fill-24-svg-prop !optional;
+  background-image: var(--bookmark-add-fill-24-svg);
+}
+%with-bookmark-add-fill-24-mask {
+  @extend %with-mask, %bookmark-add-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-add-fill-24-svg);
+  mask-image: var(--bookmark-add-fill-24-svg);
+}
+
+%with-bookmark-fill-16-icon {
+  @extend %with-icon, %bookmark-fill-16-svg-prop !optional;
+  background-image: var(--bookmark-fill-16-svg);
+}
+%with-bookmark-fill-16-mask {
+  @extend %with-mask, %bookmark-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-fill-16-svg);
+  mask-image: var(--bookmark-fill-16-svg);
+}
+
+%with-bookmark-fill-24-icon {
+  @extend %with-icon, %bookmark-fill-24-svg-prop !optional;
+  background-image: var(--bookmark-fill-24-svg);
+}
+%with-bookmark-fill-24-mask {
+  @extend %with-mask, %bookmark-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-fill-24-svg);
+  mask-image: var(--bookmark-fill-24-svg);
+}
+
+%with-bookmark-remove-16-icon {
+  @extend %with-icon, %bookmark-remove-16-svg-prop !optional;
+  background-image: var(--bookmark-remove-16-svg);
+}
+%with-bookmark-remove-16-mask {
+  @extend %with-mask, %bookmark-remove-16-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-remove-16-svg);
+  mask-image: var(--bookmark-remove-16-svg);
+}
+
+%with-bookmark-remove-24-icon {
+  @extend %with-icon, %bookmark-remove-24-svg-prop !optional;
+  background-image: var(--bookmark-remove-24-svg);
+}
+%with-bookmark-remove-24-mask {
+  @extend %with-mask, %bookmark-remove-24-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-remove-24-svg);
+  mask-image: var(--bookmark-remove-24-svg);
+}
+
+%with-bookmark-remove-fill-16-icon {
+  @extend %with-icon, %bookmark-remove-fill-16-svg-prop !optional;
+  background-image: var(--bookmark-remove-fill-16-svg);
+}
+%with-bookmark-remove-fill-16-mask {
+  @extend %with-mask, %bookmark-remove-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-remove-fill-16-svg);
+  mask-image: var(--bookmark-remove-fill-16-svg);
+}
+
+%with-bookmark-remove-fill-24-icon {
+  @extend %with-icon, %bookmark-remove-fill-24-svg-prop !optional;
+  background-image: var(--bookmark-remove-fill-24-svg);
+}
+%with-bookmark-remove-fill-24-mask {
+  @extend %with-mask, %bookmark-remove-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--bookmark-remove-fill-24-svg);
+  mask-image: var(--bookmark-remove-fill-24-svg);
+}
+
+%with-bottom-16-icon {
+  @extend %with-icon, %bottom-16-svg-prop !optional;
+  background-image: var(--bottom-16-svg);
+}
+%with-bottom-16-mask {
+  @extend %with-mask, %bottom-16-svg-prop !optional;
+  -webkit-mask-image: var(--bottom-16-svg);
+  mask-image: var(--bottom-16-svg);
+}
+
+%with-bottom-24-icon {
+  @extend %with-icon, %bottom-24-svg-prop !optional;
+  background-image: var(--bottom-24-svg);
+}
+%with-bottom-24-mask {
+  @extend %with-mask, %bottom-24-svg-prop !optional;
+  -webkit-mask-image: var(--bottom-24-svg);
+  mask-image: var(--bottom-24-svg);
+}
+
+%with-box-16-icon {
+  @extend %with-icon, %box-16-svg-prop !optional;
+  background-image: var(--box-16-svg);
+}
+%with-box-16-mask {
+  @extend %with-mask, %box-16-svg-prop !optional;
+  -webkit-mask-image: var(--box-16-svg);
+  mask-image: var(--box-16-svg);
+}
+
+%with-box-24-icon {
+  @extend %with-icon, %box-24-svg-prop !optional;
+  background-image: var(--box-24-svg);
+}
+%with-box-24-mask {
+  @extend %with-mask, %box-24-svg-prop !optional;
+  -webkit-mask-image: var(--box-24-svg);
+  mask-image: var(--box-24-svg);
+}
+
 %with-box-check-fill-icon {
-  @extend %with-icon, %box-check-fill-svg-prop;
+  @extend %with-icon, %box-check-fill-svg-prop !optional;
   background-image: var(--box-check-fill-svg);
 }
 %with-box-check-fill-mask {
-  @extend %with-mask, %box-check-fill-svg-prop;
+  @extend %with-mask, %box-check-fill-svg-prop !optional;
   -webkit-mask-image: var(--box-check-fill-svg);
   mask-image: var(--box-check-fill-svg);
 }
 
 %with-box-outline-icon {
-  @extend %with-icon, %box-outline-svg-prop;
+  @extend %with-icon, %box-outline-svg-prop !optional;
   background-image: var(--box-outline-svg);
 }
 %with-box-outline-mask {
-  @extend %with-mask, %box-outline-svg-prop;
+  @extend %with-mask, %box-outline-svg-prop !optional;
   -webkit-mask-image: var(--box-outline-svg);
   mask-image: var(--box-outline-svg);
 }
 
+%with-briefcase-16-icon {
+  @extend %with-icon, %briefcase-16-svg-prop !optional;
+  background-image: var(--briefcase-16-svg);
+}
+%with-briefcase-16-mask {
+  @extend %with-mask, %briefcase-16-svg-prop !optional;
+  -webkit-mask-image: var(--briefcase-16-svg);
+  mask-image: var(--briefcase-16-svg);
+}
+
+%with-briefcase-24-icon {
+  @extend %with-icon, %briefcase-24-svg-prop !optional;
+  background-image: var(--briefcase-24-svg);
+}
+%with-briefcase-24-mask {
+  @extend %with-mask, %briefcase-24-svg-prop !optional;
+  -webkit-mask-image: var(--briefcase-24-svg);
+  mask-image: var(--briefcase-24-svg);
+}
+
 %with-broadcast-icon {
-  @extend %with-icon, %broadcast-svg-prop;
+  @extend %with-icon, %broadcast-svg-prop !optional;
   background-image: var(--broadcast-svg);
 }
 %with-broadcast-mask {
-  @extend %with-mask, %broadcast-svg-prop;
+  @extend %with-mask, %broadcast-svg-prop !optional;
   -webkit-mask-image: var(--broadcast-svg);
   mask-image: var(--broadcast-svg);
 }
 
+%with-bug-16-icon {
+  @extend %with-icon, %bug-16-svg-prop !optional;
+  background-image: var(--bug-16-svg);
+}
+%with-bug-16-mask {
+  @extend %with-mask, %bug-16-svg-prop !optional;
+  -webkit-mask-image: var(--bug-16-svg);
+  mask-image: var(--bug-16-svg);
+}
+
+%with-bug-24-icon {
+  @extend %with-icon, %bug-24-svg-prop !optional;
+  background-image: var(--bug-24-svg);
+}
+%with-bug-24-mask {
+  @extend %with-mask, %bug-24-svg-prop !optional;
+  -webkit-mask-image: var(--bug-24-svg);
+  mask-image: var(--bug-24-svg);
+}
+
 %with-bug-icon {
-  @extend %with-icon, %bug-svg-prop;
+  @extend %with-icon, %bug-svg-prop !optional;
   background-image: var(--bug-svg);
 }
 %with-bug-mask {
-  @extend %with-mask, %bug-svg-prop;
+  @extend %with-mask, %bug-svg-prop !optional;
   -webkit-mask-image: var(--bug-svg);
   mask-image: var(--bug-svg);
 }
 
+%with-build-16-icon {
+  @extend %with-icon, %build-16-svg-prop !optional;
+  background-image: var(--build-16-svg);
+}
+%with-build-16-mask {
+  @extend %with-mask, %build-16-svg-prop !optional;
+  -webkit-mask-image: var(--build-16-svg);
+  mask-image: var(--build-16-svg);
+}
+
+%with-build-24-icon {
+  @extend %with-icon, %build-24-svg-prop !optional;
+  background-image: var(--build-24-svg);
+}
+%with-build-24-mask {
+  @extend %with-mask, %build-24-svg-prop !optional;
+  -webkit-mask-image: var(--build-24-svg);
+  mask-image: var(--build-24-svg);
+}
+
+%with-calendar-16-icon {
+  @extend %with-icon, %calendar-16-svg-prop !optional;
+  background-image: var(--calendar-16-svg);
+}
+%with-calendar-16-mask {
+  @extend %with-mask, %calendar-16-svg-prop !optional;
+  -webkit-mask-image: var(--calendar-16-svg);
+  mask-image: var(--calendar-16-svg);
+}
+
+%with-calendar-24-icon {
+  @extend %with-icon, %calendar-24-svg-prop !optional;
+  background-image: var(--calendar-24-svg);
+}
+%with-calendar-24-mask {
+  @extend %with-mask, %calendar-24-svg-prop !optional;
+  -webkit-mask-image: var(--calendar-24-svg);
+  mask-image: var(--calendar-24-svg);
+}
+
 %with-calendar-icon {
-  @extend %with-icon, %calendar-svg-prop;
+  @extend %with-icon, %calendar-svg-prop !optional;
   background-image: var(--calendar-svg);
 }
 %with-calendar-mask {
-  @extend %with-mask, %calendar-svg-prop;
+  @extend %with-mask, %calendar-svg-prop !optional;
   -webkit-mask-image: var(--calendar-svg);
   mask-image: var(--calendar-svg);
 }
 
+%with-camera-16-icon {
+  @extend %with-icon, %camera-16-svg-prop !optional;
+  background-image: var(--camera-16-svg);
+}
+%with-camera-16-mask {
+  @extend %with-mask, %camera-16-svg-prop !optional;
+  -webkit-mask-image: var(--camera-16-svg);
+  mask-image: var(--camera-16-svg);
+}
+
+%with-camera-24-icon {
+  @extend %with-icon, %camera-24-svg-prop !optional;
+  background-image: var(--camera-24-svg);
+}
+%with-camera-24-mask {
+  @extend %with-mask, %camera-24-svg-prop !optional;
+  -webkit-mask-image: var(--camera-24-svg);
+  mask-image: var(--camera-24-svg);
+}
+
+%with-camera-off-16-icon {
+  @extend %with-icon, %camera-off-16-svg-prop !optional;
+  background-image: var(--camera-off-16-svg);
+}
+%with-camera-off-16-mask {
+  @extend %with-mask, %camera-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--camera-off-16-svg);
+  mask-image: var(--camera-off-16-svg);
+}
+
+%with-camera-off-24-icon {
+  @extend %with-icon, %camera-off-24-svg-prop !optional;
+  background-image: var(--camera-off-24-svg);
+}
+%with-camera-off-24-mask {
+  @extend %with-mask, %camera-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--camera-off-24-svg);
+  mask-image: var(--camera-off-24-svg);
+}
+
 %with-cancel-circle-fill-icon {
-  @extend %with-icon, %cancel-circle-fill-svg-prop;
+  @extend %with-icon, %cancel-circle-fill-svg-prop !optional;
   background-image: var(--cancel-circle-fill-svg);
 }
 %with-cancel-circle-fill-mask {
-  @extend %with-mask, %cancel-circle-fill-svg-prop;
+  @extend %with-mask, %cancel-circle-fill-svg-prop !optional;
   -webkit-mask-image: var(--cancel-circle-fill-svg);
   mask-image: var(--cancel-circle-fill-svg);
 }
 
 %with-cancel-circle-outline-icon {
-  @extend %with-icon, %cancel-circle-outline-svg-prop;
+  @extend %with-icon, %cancel-circle-outline-svg-prop !optional;
   background-image: var(--cancel-circle-outline-svg);
 }
 %with-cancel-circle-outline-mask {
-  @extend %with-mask, %cancel-circle-outline-svg-prop;
+  @extend %with-mask, %cancel-circle-outline-svg-prop !optional;
   -webkit-mask-image: var(--cancel-circle-outline-svg);
   mask-image: var(--cancel-circle-outline-svg);
 }
 
 %with-cancel-plain-icon {
-  @extend %with-icon, %cancel-plain-svg-prop;
+  @extend %with-icon, %cancel-plain-svg-prop !optional;
   background-image: var(--cancel-plain-svg);
 }
 %with-cancel-plain-mask {
-  @extend %with-mask, %cancel-plain-svg-prop;
+  @extend %with-mask, %cancel-plain-svg-prop !optional;
   -webkit-mask-image: var(--cancel-plain-svg);
   mask-image: var(--cancel-plain-svg);
 }
 
 %with-cancel-square-fill-icon {
-  @extend %with-icon, %cancel-square-fill-svg-prop;
+  @extend %with-icon, %cancel-square-fill-svg-prop !optional;
   background-image: var(--cancel-square-fill-svg);
 }
 %with-cancel-square-fill-mask {
-  @extend %with-mask, %cancel-square-fill-svg-prop;
+  @extend %with-mask, %cancel-square-fill-svg-prop !optional;
   -webkit-mask-image: var(--cancel-square-fill-svg);
   mask-image: var(--cancel-square-fill-svg);
 }
 
 %with-cancel-square-outline-icon {
-  @extend %with-icon, %cancel-square-outline-svg-prop;
+  @extend %with-icon, %cancel-square-outline-svg-prop !optional;
   background-image: var(--cancel-square-outline-svg);
 }
 %with-cancel-square-outline-mask {
-  @extend %with-mask, %cancel-square-outline-svg-prop;
+  @extend %with-mask, %cancel-square-outline-svg-prop !optional;
   -webkit-mask-image: var(--cancel-square-outline-svg);
   mask-image: var(--cancel-square-outline-svg);
 }
 
+%with-caret-16-icon {
+  @extend %with-icon, %caret-16-svg-prop !optional;
+  background-image: var(--caret-16-svg);
+}
+%with-caret-16-mask {
+  @extend %with-mask, %caret-16-svg-prop !optional;
+  -webkit-mask-image: var(--caret-16-svg);
+  mask-image: var(--caret-16-svg);
+}
+
+%with-caret-24-icon {
+  @extend %with-icon, %caret-24-svg-prop !optional;
+  background-image: var(--caret-24-svg);
+}
+%with-caret-24-mask {
+  @extend %with-mask, %caret-24-svg-prop !optional;
+  -webkit-mask-image: var(--caret-24-svg);
+  mask-image: var(--caret-24-svg);
+}
+
 %with-caret-down-icon {
-  @extend %with-icon, %caret-down-svg-prop;
+  @extend %with-icon, %caret-down-svg-prop !optional;
   background-image: var(--caret-down-svg);
 }
 %with-caret-down-mask {
-  @extend %with-mask, %caret-down-svg-prop;
+  @extend %with-mask, %caret-down-svg-prop !optional;
   -webkit-mask-image: var(--caret-down-svg);
   mask-image: var(--caret-down-svg);
 }
 
 %with-caret-up-icon {
-  @extend %with-icon, %caret-up-svg-prop;
+  @extend %with-icon, %caret-up-svg-prop !optional;
   background-image: var(--caret-up-svg);
 }
 %with-caret-up-mask {
-  @extend %with-mask, %caret-up-svg-prop;
+  @extend %with-mask, %caret-up-svg-prop !optional;
   -webkit-mask-image: var(--caret-up-svg);
   mask-image: var(--caret-up-svg);
 }
 
+%with-cast-16-icon {
+  @extend %with-icon, %cast-16-svg-prop !optional;
+  background-image: var(--cast-16-svg);
+}
+%with-cast-16-mask {
+  @extend %with-mask, %cast-16-svg-prop !optional;
+  -webkit-mask-image: var(--cast-16-svg);
+  mask-image: var(--cast-16-svg);
+}
+
+%with-cast-24-icon {
+  @extend %with-icon, %cast-24-svg-prop !optional;
+  background-image: var(--cast-24-svg);
+}
+%with-cast-24-mask {
+  @extend %with-mask, %cast-24-svg-prop !optional;
+  -webkit-mask-image: var(--cast-24-svg);
+  mask-image: var(--cast-24-svg);
+}
+
+%with-certificate-16-icon {
+  @extend %with-icon, %certificate-16-svg-prop !optional;
+  background-image: var(--certificate-16-svg);
+}
+%with-certificate-16-mask {
+  @extend %with-mask, %certificate-16-svg-prop !optional;
+  -webkit-mask-image: var(--certificate-16-svg);
+  mask-image: var(--certificate-16-svg);
+}
+
+%with-certificate-24-icon {
+  @extend %with-icon, %certificate-24-svg-prop !optional;
+  background-image: var(--certificate-24-svg);
+}
+%with-certificate-24-mask {
+  @extend %with-mask, %certificate-24-svg-prop !optional;
+  -webkit-mask-image: var(--certificate-24-svg);
+  mask-image: var(--certificate-24-svg);
+}
+
+%with-change-16-icon {
+  @extend %with-icon, %change-16-svg-prop !optional;
+  background-image: var(--change-16-svg);
+}
+%with-change-16-mask {
+  @extend %with-mask, %change-16-svg-prop !optional;
+  -webkit-mask-image: var(--change-16-svg);
+  mask-image: var(--change-16-svg);
+}
+
+%with-change-24-icon {
+  @extend %with-icon, %change-24-svg-prop !optional;
+  background-image: var(--change-24-svg);
+}
+%with-change-24-mask {
+  @extend %with-mask, %change-24-svg-prop !optional;
+  -webkit-mask-image: var(--change-24-svg);
+  mask-image: var(--change-24-svg);
+}
+
+%with-change-circle-16-icon {
+  @extend %with-icon, %change-circle-16-svg-prop !optional;
+  background-image: var(--change-circle-16-svg);
+}
+%with-change-circle-16-mask {
+  @extend %with-mask, %change-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--change-circle-16-svg);
+  mask-image: var(--change-circle-16-svg);
+}
+
+%with-change-circle-24-icon {
+  @extend %with-icon, %change-circle-24-svg-prop !optional;
+  background-image: var(--change-circle-24-svg);
+}
+%with-change-circle-24-mask {
+  @extend %with-mask, %change-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--change-circle-24-svg);
+  mask-image: var(--change-circle-24-svg);
+}
+
+%with-change-square-16-icon {
+  @extend %with-icon, %change-square-16-svg-prop !optional;
+  background-image: var(--change-square-16-svg);
+}
+%with-change-square-16-mask {
+  @extend %with-mask, %change-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--change-square-16-svg);
+  mask-image: var(--change-square-16-svg);
+}
+
+%with-change-square-24-icon {
+  @extend %with-icon, %change-square-24-svg-prop !optional;
+  background-image: var(--change-square-24-svg);
+}
+%with-change-square-24-mask {
+  @extend %with-mask, %change-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--change-square-24-svg);
+  mask-image: var(--change-square-24-svg);
+}
+
+%with-check-16-icon {
+  @extend %with-icon, %check-16-svg-prop !optional;
+  background-image: var(--check-16-svg);
+}
+%with-check-16-mask {
+  @extend %with-mask, %check-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-16-svg);
+  mask-image: var(--check-16-svg);
+}
+
+%with-check-24-icon {
+  @extend %with-icon, %check-24-svg-prop !optional;
+  background-image: var(--check-24-svg);
+}
+%with-check-24-mask {
+  @extend %with-mask, %check-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-24-svg);
+  mask-image: var(--check-24-svg);
+}
+
+%with-check-circle-16-icon {
+  @extend %with-icon, %check-circle-16-svg-prop !optional;
+  background-image: var(--check-circle-16-svg);
+}
+%with-check-circle-16-mask {
+  @extend %with-mask, %check-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-circle-16-svg);
+  mask-image: var(--check-circle-16-svg);
+}
+
+%with-check-circle-24-icon {
+  @extend %with-icon, %check-circle-24-svg-prop !optional;
+  background-image: var(--check-circle-24-svg);
+}
+%with-check-circle-24-mask {
+  @extend %with-mask, %check-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-circle-24-svg);
+  mask-image: var(--check-circle-24-svg);
+}
+
+%with-check-circle-fill-16-icon {
+  @extend %with-icon, %check-circle-fill-16-svg-prop !optional;
+  background-image: var(--check-circle-fill-16-svg);
+}
+%with-check-circle-fill-16-mask {
+  @extend %with-mask, %check-circle-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-circle-fill-16-svg);
+  mask-image: var(--check-circle-fill-16-svg);
+}
+
+%with-check-circle-fill-24-icon {
+  @extend %with-icon, %check-circle-fill-24-svg-prop !optional;
+  background-image: var(--check-circle-fill-24-svg);
+}
+%with-check-circle-fill-24-mask {
+  @extend %with-mask, %check-circle-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-circle-fill-24-svg);
+  mask-image: var(--check-circle-fill-24-svg);
+}
+
 %with-check-circle-fill-icon {
-  @extend %with-icon, %check-circle-fill-svg-prop;
+  @extend %with-icon, %check-circle-fill-svg-prop !optional;
   background-image: var(--check-circle-fill-svg);
 }
 %with-check-circle-fill-mask {
-  @extend %with-mask, %check-circle-fill-svg-prop;
+  @extend %with-mask, %check-circle-fill-svg-prop !optional;
   -webkit-mask-image: var(--check-circle-fill-svg);
   mask-image: var(--check-circle-fill-svg);
 }
 
 %with-check-circle-outline-icon {
-  @extend %with-icon, %check-circle-outline-svg-prop;
+  @extend %with-icon, %check-circle-outline-svg-prop !optional;
   background-image: var(--check-circle-outline-svg);
 }
 %with-check-circle-outline-mask {
-  @extend %with-mask, %check-circle-outline-svg-prop;
+  @extend %with-mask, %check-circle-outline-svg-prop !optional;
   -webkit-mask-image: var(--check-circle-outline-svg);
   mask-image: var(--check-circle-outline-svg);
 }
 
+%with-check-diamond-16-icon {
+  @extend %with-icon, %check-diamond-16-svg-prop !optional;
+  background-image: var(--check-diamond-16-svg);
+}
+%with-check-diamond-16-mask {
+  @extend %with-mask, %check-diamond-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-diamond-16-svg);
+  mask-image: var(--check-diamond-16-svg);
+}
+
+%with-check-diamond-24-icon {
+  @extend %with-icon, %check-diamond-24-svg-prop !optional;
+  background-image: var(--check-diamond-24-svg);
+}
+%with-check-diamond-24-mask {
+  @extend %with-mask, %check-diamond-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-diamond-24-svg);
+  mask-image: var(--check-diamond-24-svg);
+}
+
+%with-check-diamond-fill-16-icon {
+  @extend %with-icon, %check-diamond-fill-16-svg-prop !optional;
+  background-image: var(--check-diamond-fill-16-svg);
+}
+%with-check-diamond-fill-16-mask {
+  @extend %with-mask, %check-diamond-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-diamond-fill-16-svg);
+  mask-image: var(--check-diamond-fill-16-svg);
+}
+
+%with-check-diamond-fill-24-icon {
+  @extend %with-icon, %check-diamond-fill-24-svg-prop !optional;
+  background-image: var(--check-diamond-fill-24-svg);
+}
+%with-check-diamond-fill-24-mask {
+  @extend %with-mask, %check-diamond-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-diamond-fill-24-svg);
+  mask-image: var(--check-diamond-fill-24-svg);
+}
+
+%with-check-hexagon-16-icon {
+  @extend %with-icon, %check-hexagon-16-svg-prop !optional;
+  background-image: var(--check-hexagon-16-svg);
+}
+%with-check-hexagon-16-mask {
+  @extend %with-mask, %check-hexagon-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-hexagon-16-svg);
+  mask-image: var(--check-hexagon-16-svg);
+}
+
+%with-check-hexagon-24-icon {
+  @extend %with-icon, %check-hexagon-24-svg-prop !optional;
+  background-image: var(--check-hexagon-24-svg);
+}
+%with-check-hexagon-24-mask {
+  @extend %with-mask, %check-hexagon-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-hexagon-24-svg);
+  mask-image: var(--check-hexagon-24-svg);
+}
+
+%with-check-hexagon-fill-16-icon {
+  @extend %with-icon, %check-hexagon-fill-16-svg-prop !optional;
+  background-image: var(--check-hexagon-fill-16-svg);
+}
+%with-check-hexagon-fill-16-mask {
+  @extend %with-mask, %check-hexagon-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-hexagon-fill-16-svg);
+  mask-image: var(--check-hexagon-fill-16-svg);
+}
+
+%with-check-hexagon-fill-24-icon {
+  @extend %with-icon, %check-hexagon-fill-24-svg-prop !optional;
+  background-image: var(--check-hexagon-fill-24-svg);
+}
+%with-check-hexagon-fill-24-mask {
+  @extend %with-mask, %check-hexagon-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-hexagon-fill-24-svg);
+  mask-image: var(--check-hexagon-fill-24-svg);
+}
+
 %with-check-plain-icon {
-  @extend %with-icon, %check-plain-svg-prop;
+  @extend %with-icon, %check-plain-svg-prop !optional;
   background-image: var(--check-plain-svg);
 }
 %with-check-plain-mask {
-  @extend %with-mask, %check-plain-svg-prop;
+  @extend %with-mask, %check-plain-svg-prop !optional;
   -webkit-mask-image: var(--check-plain-svg);
   mask-image: var(--check-plain-svg);
 }
 
+%with-check-square-16-icon {
+  @extend %with-icon, %check-square-16-svg-prop !optional;
+  background-image: var(--check-square-16-svg);
+}
+%with-check-square-16-mask {
+  @extend %with-mask, %check-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-square-16-svg);
+  mask-image: var(--check-square-16-svg);
+}
+
+%with-check-square-24-icon {
+  @extend %with-icon, %check-square-24-svg-prop !optional;
+  background-image: var(--check-square-24-svg);
+}
+%with-check-square-24-mask {
+  @extend %with-mask, %check-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-square-24-svg);
+  mask-image: var(--check-square-24-svg);
+}
+
+%with-check-square-fill-16-icon {
+  @extend %with-icon, %check-square-fill-16-svg-prop !optional;
+  background-image: var(--check-square-fill-16-svg);
+}
+%with-check-square-fill-16-mask {
+  @extend %with-mask, %check-square-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--check-square-fill-16-svg);
+  mask-image: var(--check-square-fill-16-svg);
+}
+
+%with-check-square-fill-24-icon {
+  @extend %with-icon, %check-square-fill-24-svg-prop !optional;
+  background-image: var(--check-square-fill-24-svg);
+}
+%with-check-square-fill-24-mask {
+  @extend %with-mask, %check-square-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--check-square-fill-24-svg);
+  mask-image: var(--check-square-fill-24-svg);
+}
+
+%with-chevron-down-16-icon {
+  @extend %with-icon, %chevron-down-16-svg-prop !optional;
+  background-image: var(--chevron-down-16-svg);
+}
+%with-chevron-down-16-mask {
+  @extend %with-mask, %chevron-down-16-svg-prop !optional;
+  -webkit-mask-image: var(--chevron-down-16-svg);
+  mask-image: var(--chevron-down-16-svg);
+}
+
+%with-chevron-down-24-icon {
+  @extend %with-icon, %chevron-down-24-svg-prop !optional;
+  background-image: var(--chevron-down-24-svg);
+}
+%with-chevron-down-24-mask {
+  @extend %with-mask, %chevron-down-24-svg-prop !optional;
+  -webkit-mask-image: var(--chevron-down-24-svg);
+  mask-image: var(--chevron-down-24-svg);
+}
+
 %with-chevron-down-icon {
-  @extend %with-icon, %chevron-down-svg-prop;
+  @extend %with-icon, %chevron-down-svg-prop !optional;
   background-image: var(--chevron-down-svg);
 }
 %with-chevron-down-mask {
-  @extend %with-mask, %chevron-down-svg-prop;
+  @extend %with-mask, %chevron-down-svg-prop !optional;
   -webkit-mask-image: var(--chevron-down-svg);
   mask-image: var(--chevron-down-svg);
 }
 
+%with-chevron-left-16-icon {
+  @extend %with-icon, %chevron-left-16-svg-prop !optional;
+  background-image: var(--chevron-left-16-svg);
+}
+%with-chevron-left-16-mask {
+  @extend %with-mask, %chevron-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--chevron-left-16-svg);
+  mask-image: var(--chevron-left-16-svg);
+}
+
+%with-chevron-left-24-icon {
+  @extend %with-icon, %chevron-left-24-svg-prop !optional;
+  background-image: var(--chevron-left-24-svg);
+}
+%with-chevron-left-24-mask {
+  @extend %with-mask, %chevron-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--chevron-left-24-svg);
+  mask-image: var(--chevron-left-24-svg);
+}
+
 %with-chevron-left-icon {
-  @extend %with-icon, %chevron-left-svg-prop;
+  @extend %with-icon, %chevron-left-svg-prop !optional;
   background-image: var(--chevron-left-svg);
 }
 %with-chevron-left-mask {
-  @extend %with-mask, %chevron-left-svg-prop;
+  @extend %with-mask, %chevron-left-svg-prop !optional;
   -webkit-mask-image: var(--chevron-left-svg);
   mask-image: var(--chevron-left-svg);
 }
 
+%with-chevron-right-16-icon {
+  @extend %with-icon, %chevron-right-16-svg-prop !optional;
+  background-image: var(--chevron-right-16-svg);
+}
+%with-chevron-right-16-mask {
+  @extend %with-mask, %chevron-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--chevron-right-16-svg);
+  mask-image: var(--chevron-right-16-svg);
+}
+
+%with-chevron-right-24-icon {
+  @extend %with-icon, %chevron-right-24-svg-prop !optional;
+  background-image: var(--chevron-right-24-svg);
+}
+%with-chevron-right-24-mask {
+  @extend %with-mask, %chevron-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--chevron-right-24-svg);
+  mask-image: var(--chevron-right-24-svg);
+}
+
 %with-chevron-right-icon {
-  @extend %with-icon, %chevron-right-svg-prop;
+  @extend %with-icon, %chevron-right-svg-prop !optional;
   background-image: var(--chevron-right-svg);
 }
 %with-chevron-right-mask {
-  @extend %with-mask, %chevron-right-svg-prop;
+  @extend %with-mask, %chevron-right-svg-prop !optional;
   -webkit-mask-image: var(--chevron-right-svg);
   mask-image: var(--chevron-right-svg);
 }
 
+%with-chevron-up-16-icon {
+  @extend %with-icon, %chevron-up-16-svg-prop !optional;
+  background-image: var(--chevron-up-16-svg);
+}
+%with-chevron-up-16-mask {
+  @extend %with-mask, %chevron-up-16-svg-prop !optional;
+  -webkit-mask-image: var(--chevron-up-16-svg);
+  mask-image: var(--chevron-up-16-svg);
+}
+
+%with-chevron-up-24-icon {
+  @extend %with-icon, %chevron-up-24-svg-prop !optional;
+  background-image: var(--chevron-up-24-svg);
+}
+%with-chevron-up-24-mask {
+  @extend %with-mask, %chevron-up-24-svg-prop !optional;
+  -webkit-mask-image: var(--chevron-up-24-svg);
+  mask-image: var(--chevron-up-24-svg);
+}
+
 %with-chevron-up-icon {
-  @extend %with-icon, %chevron-up-svg-prop;
+  @extend %with-icon, %chevron-up-svg-prop !optional;
   background-image: var(--chevron-up-svg);
 }
 %with-chevron-up-mask {
-  @extend %with-mask, %chevron-up-svg-prop;
+  @extend %with-mask, %chevron-up-svg-prop !optional;
   -webkit-mask-image: var(--chevron-up-svg);
   mask-image: var(--chevron-up-svg);
 }
 
+%with-chevrons-down-16-icon {
+  @extend %with-icon, %chevrons-down-16-svg-prop !optional;
+  background-image: var(--chevrons-down-16-svg);
+}
+%with-chevrons-down-16-mask {
+  @extend %with-mask, %chevrons-down-16-svg-prop !optional;
+  -webkit-mask-image: var(--chevrons-down-16-svg);
+  mask-image: var(--chevrons-down-16-svg);
+}
+
+%with-chevrons-down-24-icon {
+  @extend %with-icon, %chevrons-down-24-svg-prop !optional;
+  background-image: var(--chevrons-down-24-svg);
+}
+%with-chevrons-down-24-mask {
+  @extend %with-mask, %chevrons-down-24-svg-prop !optional;
+  -webkit-mask-image: var(--chevrons-down-24-svg);
+  mask-image: var(--chevrons-down-24-svg);
+}
+
+%with-chevrons-left-16-icon {
+  @extend %with-icon, %chevrons-left-16-svg-prop !optional;
+  background-image: var(--chevrons-left-16-svg);
+}
+%with-chevrons-left-16-mask {
+  @extend %with-mask, %chevrons-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--chevrons-left-16-svg);
+  mask-image: var(--chevrons-left-16-svg);
+}
+
+%with-chevrons-left-24-icon {
+  @extend %with-icon, %chevrons-left-24-svg-prop !optional;
+  background-image: var(--chevrons-left-24-svg);
+}
+%with-chevrons-left-24-mask {
+  @extend %with-mask, %chevrons-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--chevrons-left-24-svg);
+  mask-image: var(--chevrons-left-24-svg);
+}
+
+%with-chevrons-right-16-icon {
+  @extend %with-icon, %chevrons-right-16-svg-prop !optional;
+  background-image: var(--chevrons-right-16-svg);
+}
+%with-chevrons-right-16-mask {
+  @extend %with-mask, %chevrons-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--chevrons-right-16-svg);
+  mask-image: var(--chevrons-right-16-svg);
+}
+
+%with-chevrons-right-24-icon {
+  @extend %with-icon, %chevrons-right-24-svg-prop !optional;
+  background-image: var(--chevrons-right-24-svg);
+}
+%with-chevrons-right-24-mask {
+  @extend %with-mask, %chevrons-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--chevrons-right-24-svg);
+  mask-image: var(--chevrons-right-24-svg);
+}
+
+%with-chevrons-up-16-icon {
+  @extend %with-icon, %chevrons-up-16-svg-prop !optional;
+  background-image: var(--chevrons-up-16-svg);
+}
+%with-chevrons-up-16-mask {
+  @extend %with-mask, %chevrons-up-16-svg-prop !optional;
+  -webkit-mask-image: var(--chevrons-up-16-svg);
+  mask-image: var(--chevrons-up-16-svg);
+}
+
+%with-chevrons-up-24-icon {
+  @extend %with-icon, %chevrons-up-24-svg-prop !optional;
+  background-image: var(--chevrons-up-24-svg);
+}
+%with-chevrons-up-24-mask {
+  @extend %with-mask, %chevrons-up-24-svg-prop !optional;
+  -webkit-mask-image: var(--chevrons-up-24-svg);
+  mask-image: var(--chevrons-up-24-svg);
+}
+
+%with-circle-16-icon {
+  @extend %with-icon, %circle-16-svg-prop !optional;
+  background-image: var(--circle-16-svg);
+}
+%with-circle-16-mask {
+  @extend %with-mask, %circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--circle-16-svg);
+  mask-image: var(--circle-16-svg);
+}
+
+%with-circle-24-icon {
+  @extend %with-icon, %circle-24-svg-prop !optional;
+  background-image: var(--circle-24-svg);
+}
+%with-circle-24-mask {
+  @extend %with-mask, %circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--circle-24-svg);
+  mask-image: var(--circle-24-svg);
+}
+
+%with-circle-dot-16-icon {
+  @extend %with-icon, %circle-dot-16-svg-prop !optional;
+  background-image: var(--circle-dot-16-svg);
+}
+%with-circle-dot-16-mask {
+  @extend %with-mask, %circle-dot-16-svg-prop !optional;
+  -webkit-mask-image: var(--circle-dot-16-svg);
+  mask-image: var(--circle-dot-16-svg);
+}
+
+%with-circle-dot-24-icon {
+  @extend %with-icon, %circle-dot-24-svg-prop !optional;
+  background-image: var(--circle-dot-24-svg);
+}
+%with-circle-dot-24-mask {
+  @extend %with-mask, %circle-dot-24-svg-prop !optional;
+  -webkit-mask-image: var(--circle-dot-24-svg);
+  mask-image: var(--circle-dot-24-svg);
+}
+
+%with-circle-fill-16-icon {
+  @extend %with-icon, %circle-fill-16-svg-prop !optional;
+  background-image: var(--circle-fill-16-svg);
+}
+%with-circle-fill-16-mask {
+  @extend %with-mask, %circle-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--circle-fill-16-svg);
+  mask-image: var(--circle-fill-16-svg);
+}
+
+%with-circle-fill-24-icon {
+  @extend %with-icon, %circle-fill-24-svg-prop !optional;
+  background-image: var(--circle-fill-24-svg);
+}
+%with-circle-fill-24-mask {
+  @extend %with-mask, %circle-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--circle-fill-24-svg);
+  mask-image: var(--circle-fill-24-svg);
+}
+
+%with-circle-half-16-icon {
+  @extend %with-icon, %circle-half-16-svg-prop !optional;
+  background-image: var(--circle-half-16-svg);
+}
+%with-circle-half-16-mask {
+  @extend %with-mask, %circle-half-16-svg-prop !optional;
+  -webkit-mask-image: var(--circle-half-16-svg);
+  mask-image: var(--circle-half-16-svg);
+}
+
+%with-circle-half-24-icon {
+  @extend %with-icon, %circle-half-24-svg-prop !optional;
+  background-image: var(--circle-half-24-svg);
+}
+%with-circle-half-24-mask {
+  @extend %with-mask, %circle-half-24-svg-prop !optional;
+  -webkit-mask-image: var(--circle-half-24-svg);
+  mask-image: var(--circle-half-24-svg);
+}
+
+%with-clipboard-16-icon {
+  @extend %with-icon, %clipboard-16-svg-prop !optional;
+  background-image: var(--clipboard-16-svg);
+}
+%with-clipboard-16-mask {
+  @extend %with-mask, %clipboard-16-svg-prop !optional;
+  -webkit-mask-image: var(--clipboard-16-svg);
+  mask-image: var(--clipboard-16-svg);
+}
+
+%with-clipboard-24-icon {
+  @extend %with-icon, %clipboard-24-svg-prop !optional;
+  background-image: var(--clipboard-24-svg);
+}
+%with-clipboard-24-mask {
+  @extend %with-mask, %clipboard-24-svg-prop !optional;
+  -webkit-mask-image: var(--clipboard-24-svg);
+  mask-image: var(--clipboard-24-svg);
+}
+
+%with-clipboard-checked-16-icon {
+  @extend %with-icon, %clipboard-checked-16-svg-prop !optional;
+  background-image: var(--clipboard-checked-16-svg);
+}
+%with-clipboard-checked-16-mask {
+  @extend %with-mask, %clipboard-checked-16-svg-prop !optional;
+  -webkit-mask-image: var(--clipboard-checked-16-svg);
+  mask-image: var(--clipboard-checked-16-svg);
+}
+
+%with-clipboard-checked-24-icon {
+  @extend %with-icon, %clipboard-checked-24-svg-prop !optional;
+  background-image: var(--clipboard-checked-24-svg);
+}
+%with-clipboard-checked-24-mask {
+  @extend %with-mask, %clipboard-checked-24-svg-prop !optional;
+  -webkit-mask-image: var(--clipboard-checked-24-svg);
+  mask-image: var(--clipboard-checked-24-svg);
+}
+
+%with-clipboard-copy-16-icon {
+  @extend %with-icon, %clipboard-copy-16-svg-prop !optional;
+  background-image: var(--clipboard-copy-16-svg);
+}
+%with-clipboard-copy-16-mask {
+  @extend %with-mask, %clipboard-copy-16-svg-prop !optional;
+  -webkit-mask-image: var(--clipboard-copy-16-svg);
+  mask-image: var(--clipboard-copy-16-svg);
+}
+
+%with-clipboard-copy-24-icon {
+  @extend %with-icon, %clipboard-copy-24-svg-prop !optional;
+  background-image: var(--clipboard-copy-24-svg);
+}
+%with-clipboard-copy-24-mask {
+  @extend %with-mask, %clipboard-copy-24-svg-prop !optional;
+  -webkit-mask-image: var(--clipboard-copy-24-svg);
+  mask-image: var(--clipboard-copy-24-svg);
+}
+
+%with-clock-16-icon {
+  @extend %with-icon, %clock-16-svg-prop !optional;
+  background-image: var(--clock-16-svg);
+}
+%with-clock-16-mask {
+  @extend %with-mask, %clock-16-svg-prop !optional;
+  -webkit-mask-image: var(--clock-16-svg);
+  mask-image: var(--clock-16-svg);
+}
+
+%with-clock-24-icon {
+  @extend %with-icon, %clock-24-svg-prop !optional;
+  background-image: var(--clock-24-svg);
+}
+%with-clock-24-mask {
+  @extend %with-mask, %clock-24-svg-prop !optional;
+  -webkit-mask-image: var(--clock-24-svg);
+  mask-image: var(--clock-24-svg);
+}
+
 %with-clock-fill-icon {
-  @extend %with-icon, %clock-fill-svg-prop;
+  @extend %with-icon, %clock-fill-svg-prop !optional;
   background-image: var(--clock-fill-svg);
 }
 %with-clock-fill-mask {
-  @extend %with-mask, %clock-fill-svg-prop;
+  @extend %with-mask, %clock-fill-svg-prop !optional;
   -webkit-mask-image: var(--clock-fill-svg);
   mask-image: var(--clock-fill-svg);
 }
 
 %with-clock-outline-icon {
-  @extend %with-icon, %clock-outline-svg-prop;
+  @extend %with-icon, %clock-outline-svg-prop !optional;
   background-image: var(--clock-outline-svg);
 }
 %with-clock-outline-mask {
-  @extend %with-mask, %clock-outline-svg-prop;
+  @extend %with-mask, %clock-outline-svg-prop !optional;
   -webkit-mask-image: var(--clock-outline-svg);
   mask-image: var(--clock-outline-svg);
 }
 
+%with-cloud-16-icon {
+  @extend %with-icon, %cloud-16-svg-prop !optional;
+  background-image: var(--cloud-16-svg);
+}
+%with-cloud-16-mask {
+  @extend %with-mask, %cloud-16-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-16-svg);
+  mask-image: var(--cloud-16-svg);
+}
+
+%with-cloud-24-icon {
+  @extend %with-icon, %cloud-24-svg-prop !optional;
+  background-image: var(--cloud-24-svg);
+}
+%with-cloud-24-mask {
+  @extend %with-mask, %cloud-24-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-24-svg);
+  mask-image: var(--cloud-24-svg);
+}
+
+%with-cloud-check-16-icon {
+  @extend %with-icon, %cloud-check-16-svg-prop !optional;
+  background-image: var(--cloud-check-16-svg);
+}
+%with-cloud-check-16-mask {
+  @extend %with-mask, %cloud-check-16-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-check-16-svg);
+  mask-image: var(--cloud-check-16-svg);
+}
+
+%with-cloud-check-24-icon {
+  @extend %with-icon, %cloud-check-24-svg-prop !optional;
+  background-image: var(--cloud-check-24-svg);
+}
+%with-cloud-check-24-mask {
+  @extend %with-mask, %cloud-check-24-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-check-24-svg);
+  mask-image: var(--cloud-check-24-svg);
+}
+
 %with-cloud-cross-icon {
-  @extend %with-icon, %cloud-cross-svg-prop;
+  @extend %with-icon, %cloud-cross-svg-prop !optional;
   background-image: var(--cloud-cross-svg);
 }
 %with-cloud-cross-mask {
-  @extend %with-mask, %cloud-cross-svg-prop;
+  @extend %with-mask, %cloud-cross-svg-prop !optional;
   -webkit-mask-image: var(--cloud-cross-svg);
   mask-image: var(--cloud-cross-svg);
 }
 
+%with-cloud-download-16-icon {
+  @extend %with-icon, %cloud-download-16-svg-prop !optional;
+  background-image: var(--cloud-download-16-svg);
+}
+%with-cloud-download-16-mask {
+  @extend %with-mask, %cloud-download-16-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-download-16-svg);
+  mask-image: var(--cloud-download-16-svg);
+}
+
+%with-cloud-download-24-icon {
+  @extend %with-icon, %cloud-download-24-svg-prop !optional;
+  background-image: var(--cloud-download-24-svg);
+}
+%with-cloud-download-24-mask {
+  @extend %with-mask, %cloud-download-24-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-download-24-svg);
+  mask-image: var(--cloud-download-24-svg);
+}
+
+%with-cloud-lightning-16-icon {
+  @extend %with-icon, %cloud-lightning-16-svg-prop !optional;
+  background-image: var(--cloud-lightning-16-svg);
+}
+%with-cloud-lightning-16-mask {
+  @extend %with-mask, %cloud-lightning-16-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-lightning-16-svg);
+  mask-image: var(--cloud-lightning-16-svg);
+}
+
+%with-cloud-lightning-24-icon {
+  @extend %with-icon, %cloud-lightning-24-svg-prop !optional;
+  background-image: var(--cloud-lightning-24-svg);
+}
+%with-cloud-lightning-24-mask {
+  @extend %with-mask, %cloud-lightning-24-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-lightning-24-svg);
+  mask-image: var(--cloud-lightning-24-svg);
+}
+
+%with-cloud-lock-16-icon {
+  @extend %with-icon, %cloud-lock-16-svg-prop !optional;
+  background-image: var(--cloud-lock-16-svg);
+}
+%with-cloud-lock-16-mask {
+  @extend %with-mask, %cloud-lock-16-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-lock-16-svg);
+  mask-image: var(--cloud-lock-16-svg);
+}
+
+%with-cloud-lock-24-icon {
+  @extend %with-icon, %cloud-lock-24-svg-prop !optional;
+  background-image: var(--cloud-lock-24-svg);
+}
+%with-cloud-lock-24-mask {
+  @extend %with-mask, %cloud-lock-24-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-lock-24-svg);
+  mask-image: var(--cloud-lock-24-svg);
+}
+
+%with-cloud-off-16-icon {
+  @extend %with-icon, %cloud-off-16-svg-prop !optional;
+  background-image: var(--cloud-off-16-svg);
+}
+%with-cloud-off-16-mask {
+  @extend %with-mask, %cloud-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-off-16-svg);
+  mask-image: var(--cloud-off-16-svg);
+}
+
+%with-cloud-off-24-icon {
+  @extend %with-icon, %cloud-off-24-svg-prop !optional;
+  background-image: var(--cloud-off-24-svg);
+}
+%with-cloud-off-24-mask {
+  @extend %with-mask, %cloud-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-off-24-svg);
+  mask-image: var(--cloud-off-24-svg);
+}
+
+%with-cloud-upload-16-icon {
+  @extend %with-icon, %cloud-upload-16-svg-prop !optional;
+  background-image: var(--cloud-upload-16-svg);
+}
+%with-cloud-upload-16-mask {
+  @extend %with-mask, %cloud-upload-16-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-upload-16-svg);
+  mask-image: var(--cloud-upload-16-svg);
+}
+
+%with-cloud-upload-24-icon {
+  @extend %with-icon, %cloud-upload-24-svg-prop !optional;
+  background-image: var(--cloud-upload-24-svg);
+}
+%with-cloud-upload-24-mask {
+  @extend %with-mask, %cloud-upload-24-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-upload-24-svg);
+  mask-image: var(--cloud-upload-24-svg);
+}
+
+%with-cloud-x-16-icon {
+  @extend %with-icon, %cloud-x-16-svg-prop !optional;
+  background-image: var(--cloud-x-16-svg);
+}
+%with-cloud-x-16-mask {
+  @extend %with-mask, %cloud-x-16-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-x-16-svg);
+  mask-image: var(--cloud-x-16-svg);
+}
+
+%with-cloud-x-24-icon {
+  @extend %with-icon, %cloud-x-24-svg-prop !optional;
+  background-image: var(--cloud-x-24-svg);
+}
+%with-cloud-x-24-mask {
+  @extend %with-mask, %cloud-x-24-svg-prop !optional;
+  -webkit-mask-image: var(--cloud-x-24-svg);
+  mask-image: var(--cloud-x-24-svg);
+}
+
+%with-code-16-icon {
+  @extend %with-icon, %code-16-svg-prop !optional;
+  background-image: var(--code-16-svg);
+}
+%with-code-16-mask {
+  @extend %with-mask, %code-16-svg-prop !optional;
+  -webkit-mask-image: var(--code-16-svg);
+  mask-image: var(--code-16-svg);
+}
+
+%with-code-24-icon {
+  @extend %with-icon, %code-24-svg-prop !optional;
+  background-image: var(--code-24-svg);
+}
+%with-code-24-mask {
+  @extend %with-mask, %code-24-svg-prop !optional;
+  -webkit-mask-image: var(--code-24-svg);
+  mask-image: var(--code-24-svg);
+}
+
 %with-code-icon {
-  @extend %with-icon, %code-svg-prop;
+  @extend %with-icon, %code-svg-prop !optional;
   background-image: var(--code-svg);
 }
 %with-code-mask {
-  @extend %with-mask, %code-svg-prop;
+  @extend %with-mask, %code-svg-prop !optional;
   -webkit-mask-image: var(--code-svg);
   mask-image: var(--code-svg);
 }
 
+%with-collections-16-icon {
+  @extend %with-icon, %collections-16-svg-prop !optional;
+  background-image: var(--collections-16-svg);
+}
+%with-collections-16-mask {
+  @extend %with-mask, %collections-16-svg-prop !optional;
+  -webkit-mask-image: var(--collections-16-svg);
+  mask-image: var(--collections-16-svg);
+}
+
+%with-collections-24-icon {
+  @extend %with-icon, %collections-24-svg-prop !optional;
+  background-image: var(--collections-24-svg);
+}
+%with-collections-24-mask {
+  @extend %with-mask, %collections-24-svg-prop !optional;
+  -webkit-mask-image: var(--collections-24-svg);
+  mask-image: var(--collections-24-svg);
+}
+
+%with-command-16-icon {
+  @extend %with-icon, %command-16-svg-prop !optional;
+  background-image: var(--command-16-svg);
+}
+%with-command-16-mask {
+  @extend %with-mask, %command-16-svg-prop !optional;
+  -webkit-mask-image: var(--command-16-svg);
+  mask-image: var(--command-16-svg);
+}
+
+%with-command-24-icon {
+  @extend %with-icon, %command-24-svg-prop !optional;
+  background-image: var(--command-24-svg);
+}
+%with-command-24-mask {
+  @extend %with-mask, %command-24-svg-prop !optional;
+  -webkit-mask-image: var(--command-24-svg);
+  mask-image: var(--command-24-svg);
+}
+
+%with-compass-16-icon {
+  @extend %with-icon, %compass-16-svg-prop !optional;
+  background-image: var(--compass-16-svg);
+}
+%with-compass-16-mask {
+  @extend %with-mask, %compass-16-svg-prop !optional;
+  -webkit-mask-image: var(--compass-16-svg);
+  mask-image: var(--compass-16-svg);
+}
+
+%with-compass-24-icon {
+  @extend %with-icon, %compass-24-svg-prop !optional;
+  background-image: var(--compass-24-svg);
+}
+%with-compass-24-mask {
+  @extend %with-mask, %compass-24-svg-prop !optional;
+  -webkit-mask-image: var(--compass-24-svg);
+  mask-image: var(--compass-24-svg);
+}
+
+%with-connection-16-icon {
+  @extend %with-icon, %connection-16-svg-prop !optional;
+  background-image: var(--connection-16-svg);
+}
+%with-connection-16-mask {
+  @extend %with-mask, %connection-16-svg-prop !optional;
+  -webkit-mask-image: var(--connection-16-svg);
+  mask-image: var(--connection-16-svg);
+}
+
+%with-connection-24-icon {
+  @extend %with-icon, %connection-24-svg-prop !optional;
+  background-image: var(--connection-24-svg);
+}
+%with-connection-24-mask {
+  @extend %with-mask, %connection-24-svg-prop !optional;
+  -webkit-mask-image: var(--connection-24-svg);
+  mask-image: var(--connection-24-svg);
+}
+
+%with-connection-gateway-16-icon {
+  @extend %with-icon, %connection-gateway-16-svg-prop !optional;
+  background-image: var(--connection-gateway-16-svg);
+}
+%with-connection-gateway-16-mask {
+  @extend %with-mask, %connection-gateway-16-svg-prop !optional;
+  -webkit-mask-image: var(--connection-gateway-16-svg);
+  mask-image: var(--connection-gateway-16-svg);
+}
+
+%with-connection-gateway-24-icon {
+  @extend %with-icon, %connection-gateway-24-svg-prop !optional;
+  background-image: var(--connection-gateway-24-svg);
+}
+%with-connection-gateway-24-mask {
+  @extend %with-mask, %connection-gateway-24-svg-prop !optional;
+  -webkit-mask-image: var(--connection-gateway-24-svg);
+  mask-image: var(--connection-gateway-24-svg);
+}
+
 %with-console-icon {
-  @extend %with-icon, %console-svg-prop;
+  @extend %with-icon, %console-svg-prop !optional;
   background-image: var(--console-svg);
 }
 %with-console-mask {
-  @extend %with-mask, %console-svg-prop;
+  @extend %with-mask, %console-svg-prop !optional;
   -webkit-mask-image: var(--console-svg);
   mask-image: var(--console-svg);
 }
 
 %with-copy-action-icon {
-  @extend %with-icon, %copy-action-svg-prop;
+  @extend %with-icon, %copy-action-svg-prop !optional;
   background-image: var(--copy-action-svg);
 }
 %with-copy-action-mask {
-  @extend %with-mask, %copy-action-svg-prop;
+  @extend %with-mask, %copy-action-svg-prop !optional;
   -webkit-mask-image: var(--copy-action-svg);
   mask-image: var(--copy-action-svg);
 }
 
 %with-copy-success-icon {
-  @extend %with-icon, %copy-success-svg-prop;
+  @extend %with-icon, %copy-success-svg-prop !optional;
   background-image: var(--copy-success-svg);
 }
 %with-copy-success-mask {
-  @extend %with-mask, %copy-success-svg-prop;
+  @extend %with-mask, %copy-success-svg-prop !optional;
   -webkit-mask-image: var(--copy-success-svg);
   mask-image: var(--copy-success-svg);
 }
 
+%with-corner-down-left-16-icon {
+  @extend %with-icon, %corner-down-left-16-svg-prop !optional;
+  background-image: var(--corner-down-left-16-svg);
+}
+%with-corner-down-left-16-mask {
+  @extend %with-mask, %corner-down-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--corner-down-left-16-svg);
+  mask-image: var(--corner-down-left-16-svg);
+}
+
+%with-corner-down-left-24-icon {
+  @extend %with-icon, %corner-down-left-24-svg-prop !optional;
+  background-image: var(--corner-down-left-24-svg);
+}
+%with-corner-down-left-24-mask {
+  @extend %with-mask, %corner-down-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--corner-down-left-24-svg);
+  mask-image: var(--corner-down-left-24-svg);
+}
+
+%with-corner-down-right-16-icon {
+  @extend %with-icon, %corner-down-right-16-svg-prop !optional;
+  background-image: var(--corner-down-right-16-svg);
+}
+%with-corner-down-right-16-mask {
+  @extend %with-mask, %corner-down-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--corner-down-right-16-svg);
+  mask-image: var(--corner-down-right-16-svg);
+}
+
+%with-corner-down-right-24-icon {
+  @extend %with-icon, %corner-down-right-24-svg-prop !optional;
+  background-image: var(--corner-down-right-24-svg);
+}
+%with-corner-down-right-24-mask {
+  @extend %with-mask, %corner-down-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--corner-down-right-24-svg);
+  mask-image: var(--corner-down-right-24-svg);
+}
+
+%with-corner-left-down-16-icon {
+  @extend %with-icon, %corner-left-down-16-svg-prop !optional;
+  background-image: var(--corner-left-down-16-svg);
+}
+%with-corner-left-down-16-mask {
+  @extend %with-mask, %corner-left-down-16-svg-prop !optional;
+  -webkit-mask-image: var(--corner-left-down-16-svg);
+  mask-image: var(--corner-left-down-16-svg);
+}
+
+%with-corner-left-down-24-icon {
+  @extend %with-icon, %corner-left-down-24-svg-prop !optional;
+  background-image: var(--corner-left-down-24-svg);
+}
+%with-corner-left-down-24-mask {
+  @extend %with-mask, %corner-left-down-24-svg-prop !optional;
+  -webkit-mask-image: var(--corner-left-down-24-svg);
+  mask-image: var(--corner-left-down-24-svg);
+}
+
+%with-corner-left-up-16-icon {
+  @extend %with-icon, %corner-left-up-16-svg-prop !optional;
+  background-image: var(--corner-left-up-16-svg);
+}
+%with-corner-left-up-16-mask {
+  @extend %with-mask, %corner-left-up-16-svg-prop !optional;
+  -webkit-mask-image: var(--corner-left-up-16-svg);
+  mask-image: var(--corner-left-up-16-svg);
+}
+
+%with-corner-left-up-24-icon {
+  @extend %with-icon, %corner-left-up-24-svg-prop !optional;
+  background-image: var(--corner-left-up-24-svg);
+}
+%with-corner-left-up-24-mask {
+  @extend %with-mask, %corner-left-up-24-svg-prop !optional;
+  -webkit-mask-image: var(--corner-left-up-24-svg);
+  mask-image: var(--corner-left-up-24-svg);
+}
+
+%with-corner-right-down-16-icon {
+  @extend %with-icon, %corner-right-down-16-svg-prop !optional;
+  background-image: var(--corner-right-down-16-svg);
+}
+%with-corner-right-down-16-mask {
+  @extend %with-mask, %corner-right-down-16-svg-prop !optional;
+  -webkit-mask-image: var(--corner-right-down-16-svg);
+  mask-image: var(--corner-right-down-16-svg);
+}
+
+%with-corner-right-down-24-icon {
+  @extend %with-icon, %corner-right-down-24-svg-prop !optional;
+  background-image: var(--corner-right-down-24-svg);
+}
+%with-corner-right-down-24-mask {
+  @extend %with-mask, %corner-right-down-24-svg-prop !optional;
+  -webkit-mask-image: var(--corner-right-down-24-svg);
+  mask-image: var(--corner-right-down-24-svg);
+}
+
+%with-corner-right-up-16-icon {
+  @extend %with-icon, %corner-right-up-16-svg-prop !optional;
+  background-image: var(--corner-right-up-16-svg);
+}
+%with-corner-right-up-16-mask {
+  @extend %with-mask, %corner-right-up-16-svg-prop !optional;
+  -webkit-mask-image: var(--corner-right-up-16-svg);
+  mask-image: var(--corner-right-up-16-svg);
+}
+
+%with-corner-right-up-24-icon {
+  @extend %with-icon, %corner-right-up-24-svg-prop !optional;
+  background-image: var(--corner-right-up-24-svg);
+}
+%with-corner-right-up-24-mask {
+  @extend %with-mask, %corner-right-up-24-svg-prop !optional;
+  -webkit-mask-image: var(--corner-right-up-24-svg);
+  mask-image: var(--corner-right-up-24-svg);
+}
+
+%with-corner-up-left-16-icon {
+  @extend %with-icon, %corner-up-left-16-svg-prop !optional;
+  background-image: var(--corner-up-left-16-svg);
+}
+%with-corner-up-left-16-mask {
+  @extend %with-mask, %corner-up-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--corner-up-left-16-svg);
+  mask-image: var(--corner-up-left-16-svg);
+}
+
+%with-corner-up-left-24-icon {
+  @extend %with-icon, %corner-up-left-24-svg-prop !optional;
+  background-image: var(--corner-up-left-24-svg);
+}
+%with-corner-up-left-24-mask {
+  @extend %with-mask, %corner-up-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--corner-up-left-24-svg);
+  mask-image: var(--corner-up-left-24-svg);
+}
+
+%with-corner-up-right-16-icon {
+  @extend %with-icon, %corner-up-right-16-svg-prop !optional;
+  background-image: var(--corner-up-right-16-svg);
+}
+%with-corner-up-right-16-mask {
+  @extend %with-mask, %corner-up-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--corner-up-right-16-svg);
+  mask-image: var(--corner-up-right-16-svg);
+}
+
+%with-corner-up-right-24-icon {
+  @extend %with-icon, %corner-up-right-24-svg-prop !optional;
+  background-image: var(--corner-up-right-24-svg);
+}
+%with-corner-up-right-24-mask {
+  @extend %with-mask, %corner-up-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--corner-up-right-24-svg);
+  mask-image: var(--corner-up-right-24-svg);
+}
+
+%with-cpu-16-icon {
+  @extend %with-icon, %cpu-16-svg-prop !optional;
+  background-image: var(--cpu-16-svg);
+}
+%with-cpu-16-mask {
+  @extend %with-mask, %cpu-16-svg-prop !optional;
+  -webkit-mask-image: var(--cpu-16-svg);
+  mask-image: var(--cpu-16-svg);
+}
+
+%with-cpu-24-icon {
+  @extend %with-icon, %cpu-24-svg-prop !optional;
+  background-image: var(--cpu-24-svg);
+}
+%with-cpu-24-mask {
+  @extend %with-mask, %cpu-24-svg-prop !optional;
+  -webkit-mask-image: var(--cpu-24-svg);
+  mask-image: var(--cpu-24-svg);
+}
+
+%with-credit-card-16-icon {
+  @extend %with-icon, %credit-card-16-svg-prop !optional;
+  background-image: var(--credit-card-16-svg);
+}
+%with-credit-card-16-mask {
+  @extend %with-mask, %credit-card-16-svg-prop !optional;
+  -webkit-mask-image: var(--credit-card-16-svg);
+  mask-image: var(--credit-card-16-svg);
+}
+
+%with-credit-card-24-icon {
+  @extend %with-icon, %credit-card-24-svg-prop !optional;
+  background-image: var(--credit-card-24-svg);
+}
+%with-credit-card-24-mask {
+  @extend %with-mask, %credit-card-24-svg-prop !optional;
+  -webkit-mask-image: var(--credit-card-24-svg);
+  mask-image: var(--credit-card-24-svg);
+}
+
+%with-crop-16-icon {
+  @extend %with-icon, %crop-16-svg-prop !optional;
+  background-image: var(--crop-16-svg);
+}
+%with-crop-16-mask {
+  @extend %with-mask, %crop-16-svg-prop !optional;
+  -webkit-mask-image: var(--crop-16-svg);
+  mask-image: var(--crop-16-svg);
+}
+
+%with-crop-24-icon {
+  @extend %with-icon, %crop-24-svg-prop !optional;
+  background-image: var(--crop-24-svg);
+}
+%with-crop-24-mask {
+  @extend %with-mask, %crop-24-svg-prop !optional;
+  -webkit-mask-image: var(--crop-24-svg);
+  mask-image: var(--crop-24-svg);
+}
+
+%with-crosshair-16-icon {
+  @extend %with-icon, %crosshair-16-svg-prop !optional;
+  background-image: var(--crosshair-16-svg);
+}
+%with-crosshair-16-mask {
+  @extend %with-mask, %crosshair-16-svg-prop !optional;
+  -webkit-mask-image: var(--crosshair-16-svg);
+  mask-image: var(--crosshair-16-svg);
+}
+
+%with-crosshair-24-icon {
+  @extend %with-icon, %crosshair-24-svg-prop !optional;
+  background-image: var(--crosshair-24-svg);
+}
+%with-crosshair-24-mask {
+  @extend %with-mask, %crosshair-24-svg-prop !optional;
+  -webkit-mask-image: var(--crosshair-24-svg);
+  mask-image: var(--crosshair-24-svg);
+}
+
+%with-dashboard-16-icon {
+  @extend %with-icon, %dashboard-16-svg-prop !optional;
+  background-image: var(--dashboard-16-svg);
+}
+%with-dashboard-16-mask {
+  @extend %with-mask, %dashboard-16-svg-prop !optional;
+  -webkit-mask-image: var(--dashboard-16-svg);
+  mask-image: var(--dashboard-16-svg);
+}
+
+%with-dashboard-24-icon {
+  @extend %with-icon, %dashboard-24-svg-prop !optional;
+  background-image: var(--dashboard-24-svg);
+}
+%with-dashboard-24-mask {
+  @extend %with-mask, %dashboard-24-svg-prop !optional;
+  -webkit-mask-image: var(--dashboard-24-svg);
+  mask-image: var(--dashboard-24-svg);
+}
+
+%with-database-16-icon {
+  @extend %with-icon, %database-16-svg-prop !optional;
+  background-image: var(--database-16-svg);
+}
+%with-database-16-mask {
+  @extend %with-mask, %database-16-svg-prop !optional;
+  -webkit-mask-image: var(--database-16-svg);
+  mask-image: var(--database-16-svg);
+}
+
+%with-database-24-icon {
+  @extend %with-icon, %database-24-svg-prop !optional;
+  background-image: var(--database-24-svg);
+}
+%with-database-24-mask {
+  @extend %with-mask, %database-24-svg-prop !optional;
+  -webkit-mask-image: var(--database-24-svg);
+  mask-image: var(--database-24-svg);
+}
+
 %with-database-icon {
-  @extend %with-icon, %database-svg-prop;
+  @extend %with-icon, %database-svg-prop !optional;
   background-image: var(--database-svg);
 }
 %with-database-mask {
-  @extend %with-mask, %database-svg-prop;
+  @extend %with-mask, %database-svg-prop !optional;
   -webkit-mask-image: var(--database-svg);
   mask-image: var(--database-svg);
 }
 
+%with-delay-16-icon {
+  @extend %with-icon, %delay-16-svg-prop !optional;
+  background-image: var(--delay-16-svg);
+}
+%with-delay-16-mask {
+  @extend %with-mask, %delay-16-svg-prop !optional;
+  -webkit-mask-image: var(--delay-16-svg);
+  mask-image: var(--delay-16-svg);
+}
+
+%with-delay-24-icon {
+  @extend %with-icon, %delay-24-svg-prop !optional;
+  background-image: var(--delay-24-svg);
+}
+%with-delay-24-mask {
+  @extend %with-mask, %delay-24-svg-prop !optional;
+  -webkit-mask-image: var(--delay-24-svg);
+  mask-image: var(--delay-24-svg);
+}
+
 %with-delay-icon {
-  @extend %with-icon, %delay-svg-prop;
+  @extend %with-icon, %delay-svg-prop !optional;
   background-image: var(--delay-svg);
 }
 %with-delay-mask {
-  @extend %with-mask, %delay-svg-prop;
+  @extend %with-mask, %delay-svg-prop !optional;
   -webkit-mask-image: var(--delay-svg);
   mask-image: var(--delay-svg);
 }
 
+%with-delete-16-icon {
+  @extend %with-icon, %delete-16-svg-prop !optional;
+  background-image: var(--delete-16-svg);
+}
+%with-delete-16-mask {
+  @extend %with-mask, %delete-16-svg-prop !optional;
+  -webkit-mask-image: var(--delete-16-svg);
+  mask-image: var(--delete-16-svg);
+}
+
+%with-delete-24-icon {
+  @extend %with-icon, %delete-24-svg-prop !optional;
+  background-image: var(--delete-24-svg);
+}
+%with-delete-24-mask {
+  @extend %with-mask, %delete-24-svg-prop !optional;
+  -webkit-mask-image: var(--delete-24-svg);
+  mask-image: var(--delete-24-svg);
+}
+
 %with-deny-alt-icon {
-  @extend %with-icon, %deny-alt-svg-prop;
+  @extend %with-icon, %deny-alt-svg-prop !optional;
   background-image: var(--deny-alt-svg);
 }
 %with-deny-alt-mask {
-  @extend %with-mask, %deny-alt-svg-prop;
+  @extend %with-mask, %deny-alt-svg-prop !optional;
   -webkit-mask-image: var(--deny-alt-svg);
   mask-image: var(--deny-alt-svg);
 }
 
 %with-deny-color-icon {
-  @extend %with-icon, %deny-color-svg-prop;
+  @extend %with-icon, %deny-color-svg-prop !optional;
   background-image: var(--deny-color-svg);
 }
 %with-deny-color-mask {
-  @extend %with-mask, %deny-color-svg-prop;
+  @extend %with-mask, %deny-color-svg-prop !optional;
   -webkit-mask-image: var(--deny-color-svg);
   mask-image: var(--deny-color-svg);
 }
 
 %with-deny-default-icon {
-  @extend %with-icon, %deny-default-svg-prop;
+  @extend %with-icon, %deny-default-svg-prop !optional;
   background-image: var(--deny-default-svg);
 }
 %with-deny-default-mask {
-  @extend %with-mask, %deny-default-svg-prop;
+  @extend %with-mask, %deny-default-svg-prop !optional;
   -webkit-mask-image: var(--deny-default-svg);
   mask-image: var(--deny-default-svg);
 }
 
+%with-diamond-16-icon {
+  @extend %with-icon, %diamond-16-svg-prop !optional;
+  background-image: var(--diamond-16-svg);
+}
+%with-diamond-16-mask {
+  @extend %with-mask, %diamond-16-svg-prop !optional;
+  -webkit-mask-image: var(--diamond-16-svg);
+  mask-image: var(--diamond-16-svg);
+}
+
+%with-diamond-24-icon {
+  @extend %with-icon, %diamond-24-svg-prop !optional;
+  background-image: var(--diamond-24-svg);
+}
+%with-diamond-24-mask {
+  @extend %with-mask, %diamond-24-svg-prop !optional;
+  -webkit-mask-image: var(--diamond-24-svg);
+  mask-image: var(--diamond-24-svg);
+}
+
+%with-diamond-fill-16-icon {
+  @extend %with-icon, %diamond-fill-16-svg-prop !optional;
+  background-image: var(--diamond-fill-16-svg);
+}
+%with-diamond-fill-16-mask {
+  @extend %with-mask, %diamond-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--diamond-fill-16-svg);
+  mask-image: var(--diamond-fill-16-svg);
+}
+
+%with-diamond-fill-24-icon {
+  @extend %with-icon, %diamond-fill-24-svg-prop !optional;
+  background-image: var(--diamond-fill-24-svg);
+}
+%with-diamond-fill-24-mask {
+  @extend %with-mask, %diamond-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--diamond-fill-24-svg);
+  mask-image: var(--diamond-fill-24-svg);
+}
+
 %with-disabled-icon {
-  @extend %with-icon, %disabled-svg-prop;
+  @extend %with-icon, %disabled-svg-prop !optional;
   background-image: var(--disabled-svg);
 }
 %with-disabled-mask {
-  @extend %with-mask, %disabled-svg-prop;
+  @extend %with-mask, %disabled-svg-prop !optional;
   -webkit-mask-image: var(--disabled-svg);
   mask-image: var(--disabled-svg);
 }
 
+%with-disc-16-icon {
+  @extend %with-icon, %disc-16-svg-prop !optional;
+  background-image: var(--disc-16-svg);
+}
+%with-disc-16-mask {
+  @extend %with-mask, %disc-16-svg-prop !optional;
+  -webkit-mask-image: var(--disc-16-svg);
+  mask-image: var(--disc-16-svg);
+}
+
+%with-disc-24-icon {
+  @extend %with-icon, %disc-24-svg-prop !optional;
+  background-image: var(--disc-24-svg);
+}
+%with-disc-24-mask {
+  @extend %with-mask, %disc-24-svg-prop !optional;
+  -webkit-mask-image: var(--disc-24-svg);
+  mask-image: var(--disc-24-svg);
+}
+
+%with-discussion-circle-16-icon {
+  @extend %with-icon, %discussion-circle-16-svg-prop !optional;
+  background-image: var(--discussion-circle-16-svg);
+}
+%with-discussion-circle-16-mask {
+  @extend %with-mask, %discussion-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--discussion-circle-16-svg);
+  mask-image: var(--discussion-circle-16-svg);
+}
+
+%with-discussion-circle-24-icon {
+  @extend %with-icon, %discussion-circle-24-svg-prop !optional;
+  background-image: var(--discussion-circle-24-svg);
+}
+%with-discussion-circle-24-mask {
+  @extend %with-mask, %discussion-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--discussion-circle-24-svg);
+  mask-image: var(--discussion-circle-24-svg);
+}
+
+%with-discussion-square-16-icon {
+  @extend %with-icon, %discussion-square-16-svg-prop !optional;
+  background-image: var(--discussion-square-16-svg);
+}
+%with-discussion-square-16-mask {
+  @extend %with-mask, %discussion-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--discussion-square-16-svg);
+  mask-image: var(--discussion-square-16-svg);
+}
+
+%with-discussion-square-24-icon {
+  @extend %with-icon, %discussion-square-24-svg-prop !optional;
+  background-image: var(--discussion-square-24-svg);
+}
+%with-discussion-square-24-mask {
+  @extend %with-mask, %discussion-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--discussion-square-24-svg);
+  mask-image: var(--discussion-square-24-svg);
+}
+
+%with-docker-16-icon {
+  @extend %with-icon, %docker-16-svg-prop !optional;
+  background-image: var(--docker-16-svg);
+}
+%with-docker-16-mask {
+  @extend %with-mask, %docker-16-svg-prop !optional;
+  -webkit-mask-image: var(--docker-16-svg);
+  mask-image: var(--docker-16-svg);
+}
+
+%with-docker-24-icon {
+  @extend %with-icon, %docker-24-svg-prop !optional;
+  background-image: var(--docker-24-svg);
+}
+%with-docker-24-mask {
+  @extend %with-mask, %docker-24-svg-prop !optional;
+  -webkit-mask-image: var(--docker-24-svg);
+  mask-image: var(--docker-24-svg);
+}
+
+%with-docker-color-16-icon {
+  @extend %with-icon, %docker-color-16-svg-prop !optional;
+  background-image: var(--docker-color-16-svg);
+}
+%with-docker-color-16-mask {
+  @extend %with-mask, %docker-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--docker-color-16-svg);
+  mask-image: var(--docker-color-16-svg);
+}
+
+%with-docker-color-24-icon {
+  @extend %with-icon, %docker-color-24-svg-prop !optional;
+  background-image: var(--docker-color-24-svg);
+}
+%with-docker-color-24-mask {
+  @extend %with-mask, %docker-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--docker-color-24-svg);
+  mask-image: var(--docker-color-24-svg);
+}
+
+%with-docs-16-icon {
+  @extend %with-icon, %docs-16-svg-prop !optional;
+  background-image: var(--docs-16-svg);
+}
+%with-docs-16-mask {
+  @extend %with-mask, %docs-16-svg-prop !optional;
+  -webkit-mask-image: var(--docs-16-svg);
+  mask-image: var(--docs-16-svg);
+}
+
+%with-docs-24-icon {
+  @extend %with-icon, %docs-24-svg-prop !optional;
+  background-image: var(--docs-24-svg);
+}
+%with-docs-24-mask {
+  @extend %with-mask, %docs-24-svg-prop !optional;
+  -webkit-mask-image: var(--docs-24-svg);
+  mask-image: var(--docs-24-svg);
+}
+
+%with-docs-download-16-icon {
+  @extend %with-icon, %docs-download-16-svg-prop !optional;
+  background-image: var(--docs-download-16-svg);
+}
+%with-docs-download-16-mask {
+  @extend %with-mask, %docs-download-16-svg-prop !optional;
+  -webkit-mask-image: var(--docs-download-16-svg);
+  mask-image: var(--docs-download-16-svg);
+}
+
+%with-docs-download-24-icon {
+  @extend %with-icon, %docs-download-24-svg-prop !optional;
+  background-image: var(--docs-download-24-svg);
+}
+%with-docs-download-24-mask {
+  @extend %with-mask, %docs-download-24-svg-prop !optional;
+  -webkit-mask-image: var(--docs-download-24-svg);
+  mask-image: var(--docs-download-24-svg);
+}
+
+%with-docs-link-16-icon {
+  @extend %with-icon, %docs-link-16-svg-prop !optional;
+  background-image: var(--docs-link-16-svg);
+}
+%with-docs-link-16-mask {
+  @extend %with-mask, %docs-link-16-svg-prop !optional;
+  -webkit-mask-image: var(--docs-link-16-svg);
+  mask-image: var(--docs-link-16-svg);
+}
+
+%with-docs-link-24-icon {
+  @extend %with-icon, %docs-link-24-svg-prop !optional;
+  background-image: var(--docs-link-24-svg);
+}
+%with-docs-link-24-mask {
+  @extend %with-mask, %docs-link-24-svg-prop !optional;
+  -webkit-mask-image: var(--docs-link-24-svg);
+  mask-image: var(--docs-link-24-svg);
+}
+
 %with-docs-icon {
-  @extend %with-icon, %docs-svg-prop;
+  @extend %with-icon, %docs-svg-prop !optional;
   background-image: var(--docs-svg);
 }
 %with-docs-mask {
-  @extend %with-mask, %docs-svg-prop;
+  @extend %with-mask, %docs-svg-prop !optional;
   -webkit-mask-image: var(--docs-svg);
   mask-image: var(--docs-svg);
 }
 
+%with-dollar-sign-16-icon {
+  @extend %with-icon, %dollar-sign-16-svg-prop !optional;
+  background-image: var(--dollar-sign-16-svg);
+}
+%with-dollar-sign-16-mask {
+  @extend %with-mask, %dollar-sign-16-svg-prop !optional;
+  -webkit-mask-image: var(--dollar-sign-16-svg);
+  mask-image: var(--dollar-sign-16-svg);
+}
+
+%with-dollar-sign-24-icon {
+  @extend %with-icon, %dollar-sign-24-svg-prop !optional;
+  background-image: var(--dollar-sign-24-svg);
+}
+%with-dollar-sign-24-mask {
+  @extend %with-mask, %dollar-sign-24-svg-prop !optional;
+  -webkit-mask-image: var(--dollar-sign-24-svg);
+  mask-image: var(--dollar-sign-24-svg);
+}
+
+%with-dot-16-icon {
+  @extend %with-icon, %dot-16-svg-prop !optional;
+  background-image: var(--dot-16-svg);
+}
+%with-dot-16-mask {
+  @extend %with-mask, %dot-16-svg-prop !optional;
+  -webkit-mask-image: var(--dot-16-svg);
+  mask-image: var(--dot-16-svg);
+}
+
+%with-dot-24-icon {
+  @extend %with-icon, %dot-24-svg-prop !optional;
+  background-image: var(--dot-24-svg);
+}
+%with-dot-24-mask {
+  @extend %with-mask, %dot-24-svg-prop !optional;
+  -webkit-mask-image: var(--dot-24-svg);
+  mask-image: var(--dot-24-svg);
+}
+
+%with-dot-half-16-icon {
+  @extend %with-icon, %dot-half-16-svg-prop !optional;
+  background-image: var(--dot-half-16-svg);
+}
+%with-dot-half-16-mask {
+  @extend %with-mask, %dot-half-16-svg-prop !optional;
+  -webkit-mask-image: var(--dot-half-16-svg);
+  mask-image: var(--dot-half-16-svg);
+}
+
+%with-dot-half-24-icon {
+  @extend %with-icon, %dot-half-24-svg-prop !optional;
+  background-image: var(--dot-half-24-svg);
+}
+%with-dot-half-24-mask {
+  @extend %with-mask, %dot-half-24-svg-prop !optional;
+  -webkit-mask-image: var(--dot-half-24-svg);
+  mask-image: var(--dot-half-24-svg);
+}
+
+%with-download-16-icon {
+  @extend %with-icon, %download-16-svg-prop !optional;
+  background-image: var(--download-16-svg);
+}
+%with-download-16-mask {
+  @extend %with-mask, %download-16-svg-prop !optional;
+  -webkit-mask-image: var(--download-16-svg);
+  mask-image: var(--download-16-svg);
+}
+
+%with-download-24-icon {
+  @extend %with-icon, %download-24-svg-prop !optional;
+  background-image: var(--download-24-svg);
+}
+%with-download-24-mask {
+  @extend %with-mask, %download-24-svg-prop !optional;
+  -webkit-mask-image: var(--download-24-svg);
+  mask-image: var(--download-24-svg);
+}
+
 %with-download-icon {
-  @extend %with-icon, %download-svg-prop;
+  @extend %with-icon, %download-svg-prop !optional;
   background-image: var(--download-svg);
 }
 %with-download-mask {
-  @extend %with-mask, %download-svg-prop;
+  @extend %with-mask, %download-svg-prop !optional;
   -webkit-mask-image: var(--download-svg);
   mask-image: var(--download-svg);
 }
 
+%with-droplet-16-icon {
+  @extend %with-icon, %droplet-16-svg-prop !optional;
+  background-image: var(--droplet-16-svg);
+}
+%with-droplet-16-mask {
+  @extend %with-mask, %droplet-16-svg-prop !optional;
+  -webkit-mask-image: var(--droplet-16-svg);
+  mask-image: var(--droplet-16-svg);
+}
+
+%with-droplet-24-icon {
+  @extend %with-icon, %droplet-24-svg-prop !optional;
+  background-image: var(--droplet-24-svg);
+}
+%with-droplet-24-mask {
+  @extend %with-mask, %droplet-24-svg-prop !optional;
+  -webkit-mask-image: var(--droplet-24-svg);
+  mask-image: var(--droplet-24-svg);
+}
+
+%with-duplicate-16-icon {
+  @extend %with-icon, %duplicate-16-svg-prop !optional;
+  background-image: var(--duplicate-16-svg);
+}
+%with-duplicate-16-mask {
+  @extend %with-mask, %duplicate-16-svg-prop !optional;
+  -webkit-mask-image: var(--duplicate-16-svg);
+  mask-image: var(--duplicate-16-svg);
+}
+
+%with-duplicate-24-icon {
+  @extend %with-icon, %duplicate-24-svg-prop !optional;
+  background-image: var(--duplicate-24-svg);
+}
+%with-duplicate-24-mask {
+  @extend %with-mask, %duplicate-24-svg-prop !optional;
+  -webkit-mask-image: var(--duplicate-24-svg);
+  mask-image: var(--duplicate-24-svg);
+}
+
+%with-edit-16-icon {
+  @extend %with-icon, %edit-16-svg-prop !optional;
+  background-image: var(--edit-16-svg);
+}
+%with-edit-16-mask {
+  @extend %with-mask, %edit-16-svg-prop !optional;
+  -webkit-mask-image: var(--edit-16-svg);
+  mask-image: var(--edit-16-svg);
+}
+
+%with-edit-24-icon {
+  @extend %with-icon, %edit-24-svg-prop !optional;
+  background-image: var(--edit-24-svg);
+}
+%with-edit-24-mask {
+  @extend %with-mask, %edit-24-svg-prop !optional;
+  -webkit-mask-image: var(--edit-24-svg);
+  mask-image: var(--edit-24-svg);
+}
+
 %with-edit-icon {
-  @extend %with-icon, %edit-svg-prop;
+  @extend %with-icon, %edit-svg-prop !optional;
   background-image: var(--edit-svg);
 }
 %with-edit-mask {
-  @extend %with-mask, %edit-svg-prop;
+  @extend %with-mask, %edit-svg-prop !optional;
   -webkit-mask-image: var(--edit-svg);
   mask-image: var(--edit-svg);
 }
 
+%with-entry-point-16-icon {
+  @extend %with-icon, %entry-point-16-svg-prop !optional;
+  background-image: var(--entry-point-16-svg);
+}
+%with-entry-point-16-mask {
+  @extend %with-mask, %entry-point-16-svg-prop !optional;
+  -webkit-mask-image: var(--entry-point-16-svg);
+  mask-image: var(--entry-point-16-svg);
+}
+
+%with-entry-point-24-icon {
+  @extend %with-icon, %entry-point-24-svg-prop !optional;
+  background-image: var(--entry-point-24-svg);
+}
+%with-entry-point-24-mask {
+  @extend %with-mask, %entry-point-24-svg-prop !optional;
+  -webkit-mask-image: var(--entry-point-24-svg);
+  mask-image: var(--entry-point-24-svg);
+}
+
 %with-envelope-sealed-fill-icon {
-  @extend %with-icon, %envelope-sealed-fill-svg-prop;
+  @extend %with-icon, %envelope-sealed-fill-svg-prop !optional;
   background-image: var(--envelope-sealed-fill-svg);
 }
 %with-envelope-sealed-fill-mask {
-  @extend %with-mask, %envelope-sealed-fill-svg-prop;
+  @extend %with-mask, %envelope-sealed-fill-svg-prop !optional;
   -webkit-mask-image: var(--envelope-sealed-fill-svg);
   mask-image: var(--envelope-sealed-fill-svg);
 }
 
 %with-envelope-sealed-outline-icon {
-  @extend %with-icon, %envelope-sealed-outline-svg-prop;
+  @extend %with-icon, %envelope-sealed-outline-svg-prop !optional;
   background-image: var(--envelope-sealed-outline-svg);
 }
 %with-envelope-sealed-outline-mask {
-  @extend %with-mask, %envelope-sealed-outline-svg-prop;
+  @extend %with-mask, %envelope-sealed-outline-svg-prop !optional;
   -webkit-mask-image: var(--envelope-sealed-outline-svg);
   mask-image: var(--envelope-sealed-outline-svg);
 }
 
 %with-envelope-unsealed--outline-icon {
-  @extend %with-icon, %envelope-unsealed--outline-svg-prop;
+  @extend %with-icon, %envelope-unsealed--outline-svg-prop !optional;
   background-image: var(--envelope-unsealed--outline-svg);
 }
 %with-envelope-unsealed--outline-mask {
-  @extend %with-mask, %envelope-unsealed--outline-svg-prop;
+  @extend %with-mask, %envelope-unsealed--outline-svg-prop !optional;
   -webkit-mask-image: var(--envelope-unsealed--outline-svg);
   mask-image: var(--envelope-unsealed--outline-svg);
 }
 
 %with-envelope-unsealed-fill-icon {
-  @extend %with-icon, %envelope-unsealed-fill-svg-prop;
+  @extend %with-icon, %envelope-unsealed-fill-svg-prop !optional;
   background-image: var(--envelope-unsealed-fill-svg);
 }
 %with-envelope-unsealed-fill-mask {
-  @extend %with-mask, %envelope-unsealed-fill-svg-prop;
+  @extend %with-mask, %envelope-unsealed-fill-svg-prop !optional;
   -webkit-mask-image: var(--envelope-unsealed-fill-svg);
   mask-image: var(--envelope-unsealed-fill-svg);
 }
 
+%with-event-16-icon {
+  @extend %with-icon, %event-16-svg-prop !optional;
+  background-image: var(--event-16-svg);
+}
+%with-event-16-mask {
+  @extend %with-mask, %event-16-svg-prop !optional;
+  -webkit-mask-image: var(--event-16-svg);
+  mask-image: var(--event-16-svg);
+}
+
+%with-event-24-icon {
+  @extend %with-icon, %event-24-svg-prop !optional;
+  background-image: var(--event-24-svg);
+}
+%with-event-24-mask {
+  @extend %with-mask, %event-24-svg-prop !optional;
+  -webkit-mask-image: var(--event-24-svg);
+  mask-image: var(--event-24-svg);
+}
+
+%with-exit-point-16-icon {
+  @extend %with-icon, %exit-point-16-svg-prop !optional;
+  background-image: var(--exit-point-16-svg);
+}
+%with-exit-point-16-mask {
+  @extend %with-mask, %exit-point-16-svg-prop !optional;
+  -webkit-mask-image: var(--exit-point-16-svg);
+  mask-image: var(--exit-point-16-svg);
+}
+
+%with-exit-point-24-icon {
+  @extend %with-icon, %exit-point-24-svg-prop !optional;
+  background-image: var(--exit-point-24-svg);
+}
+%with-exit-point-24-mask {
+  @extend %with-mask, %exit-point-24-svg-prop !optional;
+  -webkit-mask-image: var(--exit-point-24-svg);
+  mask-image: var(--exit-point-24-svg);
+}
+
 %with-exit-icon {
-  @extend %with-icon, %exit-svg-prop;
+  @extend %with-icon, %exit-svg-prop !optional;
   background-image: var(--exit-svg);
 }
 %with-exit-mask {
-  @extend %with-mask, %exit-svg-prop;
+  @extend %with-mask, %exit-svg-prop !optional;
   -webkit-mask-image: var(--exit-svg);
   mask-image: var(--exit-svg);
 }
 
 %with-expand-less-icon {
-  @extend %with-icon, %expand-less-svg-prop;
+  @extend %with-icon, %expand-less-svg-prop !optional;
   background-image: var(--expand-less-svg);
 }
 %with-expand-less-mask {
-  @extend %with-mask, %expand-less-svg-prop;
+  @extend %with-mask, %expand-less-svg-prop !optional;
   -webkit-mask-image: var(--expand-less-svg);
   mask-image: var(--expand-less-svg);
 }
 
 %with-expand-more-icon {
-  @extend %with-icon, %expand-more-svg-prop;
+  @extend %with-icon, %expand-more-svg-prop !optional;
   background-image: var(--expand-more-svg);
 }
 %with-expand-more-mask {
-  @extend %with-mask, %expand-more-svg-prop;
+  @extend %with-mask, %expand-more-svg-prop !optional;
   -webkit-mask-image: var(--expand-more-svg);
   mask-image: var(--expand-more-svg);
 }
 
+%with-external-link-16-icon {
+  @extend %with-icon, %external-link-16-svg-prop !optional;
+  background-image: var(--external-link-16-svg);
+}
+%with-external-link-16-mask {
+  @extend %with-mask, %external-link-16-svg-prop !optional;
+  -webkit-mask-image: var(--external-link-16-svg);
+  mask-image: var(--external-link-16-svg);
+}
+
+%with-external-link-24-icon {
+  @extend %with-icon, %external-link-24-svg-prop !optional;
+  background-image: var(--external-link-24-svg);
+}
+%with-external-link-24-mask {
+  @extend %with-mask, %external-link-24-svg-prop !optional;
+  -webkit-mask-image: var(--external-link-24-svg);
+  mask-image: var(--external-link-24-svg);
+}
+
+%with-eye-16-icon {
+  @extend %with-icon, %eye-16-svg-prop !optional;
+  background-image: var(--eye-16-svg);
+}
+%with-eye-16-mask {
+  @extend %with-mask, %eye-16-svg-prop !optional;
+  -webkit-mask-image: var(--eye-16-svg);
+  mask-image: var(--eye-16-svg);
+}
+
+%with-eye-24-icon {
+  @extend %with-icon, %eye-24-svg-prop !optional;
+  background-image: var(--eye-24-svg);
+}
+%with-eye-24-mask {
+  @extend %with-mask, %eye-24-svg-prop !optional;
+  -webkit-mask-image: var(--eye-24-svg);
+  mask-image: var(--eye-24-svg);
+}
+
+%with-eye-off-16-icon {
+  @extend %with-icon, %eye-off-16-svg-prop !optional;
+  background-image: var(--eye-off-16-svg);
+}
+%with-eye-off-16-mask {
+  @extend %with-mask, %eye-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--eye-off-16-svg);
+  mask-image: var(--eye-off-16-svg);
+}
+
+%with-eye-off-24-icon {
+  @extend %with-icon, %eye-off-24-svg-prop !optional;
+  background-image: var(--eye-off-24-svg);
+}
+%with-eye-off-24-mask {
+  @extend %with-mask, %eye-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--eye-off-24-svg);
+  mask-image: var(--eye-off-24-svg);
+}
+
+%with-f5-16-icon {
+  @extend %with-icon, %f5-16-svg-prop !optional;
+  background-image: var(--f5-16-svg);
+}
+%with-f5-16-mask {
+  @extend %with-mask, %f5-16-svg-prop !optional;
+  -webkit-mask-image: var(--f5-16-svg);
+  mask-image: var(--f5-16-svg);
+}
+
+%with-f5-24-icon {
+  @extend %with-icon, %f5-24-svg-prop !optional;
+  background-image: var(--f5-24-svg);
+}
+%with-f5-24-mask {
+  @extend %with-mask, %f5-24-svg-prop !optional;
+  -webkit-mask-image: var(--f5-24-svg);
+  mask-image: var(--f5-24-svg);
+}
+
+%with-f5-color-16-icon {
+  @extend %with-icon, %f5-color-16-svg-prop !optional;
+  background-image: var(--f5-color-16-svg);
+}
+%with-f5-color-16-mask {
+  @extend %with-mask, %f5-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--f5-color-16-svg);
+  mask-image: var(--f5-color-16-svg);
+}
+
+%with-f5-color-24-icon {
+  @extend %with-icon, %f5-color-24-svg-prop !optional;
+  background-image: var(--f5-color-24-svg);
+}
+%with-f5-color-24-mask {
+  @extend %with-mask, %f5-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--f5-color-24-svg);
+  mask-image: var(--f5-color-24-svg);
+}
+
+%with-fast-forward-16-icon {
+  @extend %with-icon, %fast-forward-16-svg-prop !optional;
+  background-image: var(--fast-forward-16-svg);
+}
+%with-fast-forward-16-mask {
+  @extend %with-mask, %fast-forward-16-svg-prop !optional;
+  -webkit-mask-image: var(--fast-forward-16-svg);
+  mask-image: var(--fast-forward-16-svg);
+}
+
+%with-fast-forward-24-icon {
+  @extend %with-icon, %fast-forward-24-svg-prop !optional;
+  background-image: var(--fast-forward-24-svg);
+}
+%with-fast-forward-24-mask {
+  @extend %with-mask, %fast-forward-24-svg-prop !optional;
+  -webkit-mask-image: var(--fast-forward-24-svg);
+  mask-image: var(--fast-forward-24-svg);
+}
+
+%with-file-16-icon {
+  @extend %with-icon, %file-16-svg-prop !optional;
+  background-image: var(--file-16-svg);
+}
+%with-file-16-mask {
+  @extend %with-mask, %file-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-16-svg);
+  mask-image: var(--file-16-svg);
+}
+
+%with-file-24-icon {
+  @extend %with-icon, %file-24-svg-prop !optional;
+  background-image: var(--file-24-svg);
+}
+%with-file-24-mask {
+  @extend %with-mask, %file-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-24-svg);
+  mask-image: var(--file-24-svg);
+}
+
+%with-file-change-16-icon {
+  @extend %with-icon, %file-change-16-svg-prop !optional;
+  background-image: var(--file-change-16-svg);
+}
+%with-file-change-16-mask {
+  @extend %with-mask, %file-change-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-change-16-svg);
+  mask-image: var(--file-change-16-svg);
+}
+
+%with-file-change-24-icon {
+  @extend %with-icon, %file-change-24-svg-prop !optional;
+  background-image: var(--file-change-24-svg);
+}
+%with-file-change-24-mask {
+  @extend %with-mask, %file-change-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-change-24-svg);
+  mask-image: var(--file-change-24-svg);
+}
+
+%with-file-check-16-icon {
+  @extend %with-icon, %file-check-16-svg-prop !optional;
+  background-image: var(--file-check-16-svg);
+}
+%with-file-check-16-mask {
+  @extend %with-mask, %file-check-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-check-16-svg);
+  mask-image: var(--file-check-16-svg);
+}
+
+%with-file-check-24-icon {
+  @extend %with-icon, %file-check-24-svg-prop !optional;
+  background-image: var(--file-check-24-svg);
+}
+%with-file-check-24-mask {
+  @extend %with-mask, %file-check-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-check-24-svg);
+  mask-image: var(--file-check-24-svg);
+}
+
+%with-file-diff-16-icon {
+  @extend %with-icon, %file-diff-16-svg-prop !optional;
+  background-image: var(--file-diff-16-svg);
+}
+%with-file-diff-16-mask {
+  @extend %with-mask, %file-diff-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-diff-16-svg);
+  mask-image: var(--file-diff-16-svg);
+}
+
+%with-file-diff-24-icon {
+  @extend %with-icon, %file-diff-24-svg-prop !optional;
+  background-image: var(--file-diff-24-svg);
+}
+%with-file-diff-24-mask {
+  @extend %with-mask, %file-diff-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-diff-24-svg);
+  mask-image: var(--file-diff-24-svg);
+}
+
 %with-file-fill-icon {
-  @extend %with-icon, %file-fill-svg-prop;
+  @extend %with-icon, %file-fill-svg-prop !optional;
   background-image: var(--file-fill-svg);
 }
 %with-file-fill-mask {
-  @extend %with-mask, %file-fill-svg-prop;
+  @extend %with-mask, %file-fill-svg-prop !optional;
   -webkit-mask-image: var(--file-fill-svg);
   mask-image: var(--file-fill-svg);
 }
 
+%with-file-minus-16-icon {
+  @extend %with-icon, %file-minus-16-svg-prop !optional;
+  background-image: var(--file-minus-16-svg);
+}
+%with-file-minus-16-mask {
+  @extend %with-mask, %file-minus-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-minus-16-svg);
+  mask-image: var(--file-minus-16-svg);
+}
+
+%with-file-minus-24-icon {
+  @extend %with-icon, %file-minus-24-svg-prop !optional;
+  background-image: var(--file-minus-24-svg);
+}
+%with-file-minus-24-mask {
+  @extend %with-mask, %file-minus-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-minus-24-svg);
+  mask-image: var(--file-minus-24-svg);
+}
+
 %with-file-outline-icon {
-  @extend %with-icon, %file-outline-svg-prop;
+  @extend %with-icon, %file-outline-svg-prop !optional;
   background-image: var(--file-outline-svg);
 }
 %with-file-outline-mask {
-  @extend %with-mask, %file-outline-svg-prop;
+  @extend %with-mask, %file-outline-svg-prop !optional;
   -webkit-mask-image: var(--file-outline-svg);
   mask-image: var(--file-outline-svg);
 }
 
+%with-file-plus-16-icon {
+  @extend %with-icon, %file-plus-16-svg-prop !optional;
+  background-image: var(--file-plus-16-svg);
+}
+%with-file-plus-16-mask {
+  @extend %with-mask, %file-plus-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-plus-16-svg);
+  mask-image: var(--file-plus-16-svg);
+}
+
+%with-file-plus-24-icon {
+  @extend %with-icon, %file-plus-24-svg-prop !optional;
+  background-image: var(--file-plus-24-svg);
+}
+%with-file-plus-24-mask {
+  @extend %with-mask, %file-plus-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-plus-24-svg);
+  mask-image: var(--file-plus-24-svg);
+}
+
+%with-file-source-16-icon {
+  @extend %with-icon, %file-source-16-svg-prop !optional;
+  background-image: var(--file-source-16-svg);
+}
+%with-file-source-16-mask {
+  @extend %with-mask, %file-source-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-source-16-svg);
+  mask-image: var(--file-source-16-svg);
+}
+
+%with-file-source-24-icon {
+  @extend %with-icon, %file-source-24-svg-prop !optional;
+  background-image: var(--file-source-24-svg);
+}
+%with-file-source-24-mask {
+  @extend %with-mask, %file-source-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-source-24-svg);
+  mask-image: var(--file-source-24-svg);
+}
+
+%with-file-text-16-icon {
+  @extend %with-icon, %file-text-16-svg-prop !optional;
+  background-image: var(--file-text-16-svg);
+}
+%with-file-text-16-mask {
+  @extend %with-mask, %file-text-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-text-16-svg);
+  mask-image: var(--file-text-16-svg);
+}
+
+%with-file-text-24-icon {
+  @extend %with-icon, %file-text-24-svg-prop !optional;
+  background-image: var(--file-text-24-svg);
+}
+%with-file-text-24-mask {
+  @extend %with-mask, %file-text-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-text-24-svg);
+  mask-image: var(--file-text-24-svg);
+}
+
+%with-file-x-16-icon {
+  @extend %with-icon, %file-x-16-svg-prop !optional;
+  background-image: var(--file-x-16-svg);
+}
+%with-file-x-16-mask {
+  @extend %with-mask, %file-x-16-svg-prop !optional;
+  -webkit-mask-image: var(--file-x-16-svg);
+  mask-image: var(--file-x-16-svg);
+}
+
+%with-file-x-24-icon {
+  @extend %with-icon, %file-x-24-svg-prop !optional;
+  background-image: var(--file-x-24-svg);
+}
+%with-file-x-24-mask {
+  @extend %with-mask, %file-x-24-svg-prop !optional;
+  -webkit-mask-image: var(--file-x-24-svg);
+  mask-image: var(--file-x-24-svg);
+}
+
+%with-files-16-icon {
+  @extend %with-icon, %files-16-svg-prop !optional;
+  background-image: var(--files-16-svg);
+}
+%with-files-16-mask {
+  @extend %with-mask, %files-16-svg-prop !optional;
+  -webkit-mask-image: var(--files-16-svg);
+  mask-image: var(--files-16-svg);
+}
+
+%with-files-24-icon {
+  @extend %with-icon, %files-24-svg-prop !optional;
+  background-image: var(--files-24-svg);
+}
+%with-files-24-mask {
+  @extend %with-mask, %files-24-svg-prop !optional;
+  -webkit-mask-image: var(--files-24-svg);
+  mask-image: var(--files-24-svg);
+}
+
+%with-film-16-icon {
+  @extend %with-icon, %film-16-svg-prop !optional;
+  background-image: var(--film-16-svg);
+}
+%with-film-16-mask {
+  @extend %with-mask, %film-16-svg-prop !optional;
+  -webkit-mask-image: var(--film-16-svg);
+  mask-image: var(--film-16-svg);
+}
+
+%with-film-24-icon {
+  @extend %with-icon, %film-24-svg-prop !optional;
+  background-image: var(--film-24-svg);
+}
+%with-film-24-mask {
+  @extend %with-mask, %film-24-svg-prop !optional;
+  -webkit-mask-image: var(--film-24-svg);
+  mask-image: var(--film-24-svg);
+}
+
+%with-filter-16-icon {
+  @extend %with-icon, %filter-16-svg-prop !optional;
+  background-image: var(--filter-16-svg);
+}
+%with-filter-16-mask {
+  @extend %with-mask, %filter-16-svg-prop !optional;
+  -webkit-mask-image: var(--filter-16-svg);
+  mask-image: var(--filter-16-svg);
+}
+
+%with-filter-24-icon {
+  @extend %with-icon, %filter-24-svg-prop !optional;
+  background-image: var(--filter-24-svg);
+}
+%with-filter-24-mask {
+  @extend %with-mask, %filter-24-svg-prop !optional;
+  -webkit-mask-image: var(--filter-24-svg);
+  mask-image: var(--filter-24-svg);
+}
+
+%with-filter-circle-16-icon {
+  @extend %with-icon, %filter-circle-16-svg-prop !optional;
+  background-image: var(--filter-circle-16-svg);
+}
+%with-filter-circle-16-mask {
+  @extend %with-mask, %filter-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--filter-circle-16-svg);
+  mask-image: var(--filter-circle-16-svg);
+}
+
+%with-filter-circle-24-icon {
+  @extend %with-icon, %filter-circle-24-svg-prop !optional;
+  background-image: var(--filter-circle-24-svg);
+}
+%with-filter-circle-24-mask {
+  @extend %with-mask, %filter-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--filter-circle-24-svg);
+  mask-image: var(--filter-circle-24-svg);
+}
+
+%with-filter-fill-16-icon {
+  @extend %with-icon, %filter-fill-16-svg-prop !optional;
+  background-image: var(--filter-fill-16-svg);
+}
+%with-filter-fill-16-mask {
+  @extend %with-mask, %filter-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--filter-fill-16-svg);
+  mask-image: var(--filter-fill-16-svg);
+}
+
+%with-filter-fill-24-icon {
+  @extend %with-icon, %filter-fill-24-svg-prop !optional;
+  background-image: var(--filter-fill-24-svg);
+}
+%with-filter-fill-24-mask {
+  @extend %with-mask, %filter-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--filter-fill-24-svg);
+  mask-image: var(--filter-fill-24-svg);
+}
+
 %with-filter-icon {
-  @extend %with-icon, %filter-svg-prop;
+  @extend %with-icon, %filter-svg-prop !optional;
   background-image: var(--filter-svg);
 }
 %with-filter-mask {
-  @extend %with-mask, %filter-svg-prop;
+  @extend %with-mask, %filter-svg-prop !optional;
   -webkit-mask-image: var(--filter-svg);
   mask-image: var(--filter-svg);
 }
 
+%with-fingerprint-16-icon {
+  @extend %with-icon, %fingerprint-16-svg-prop !optional;
+  background-image: var(--fingerprint-16-svg);
+}
+%with-fingerprint-16-mask {
+  @extend %with-mask, %fingerprint-16-svg-prop !optional;
+  -webkit-mask-image: var(--fingerprint-16-svg);
+  mask-image: var(--fingerprint-16-svg);
+}
+
+%with-fingerprint-24-icon {
+  @extend %with-icon, %fingerprint-24-svg-prop !optional;
+  background-image: var(--fingerprint-24-svg);
+}
+%with-fingerprint-24-mask {
+  @extend %with-mask, %fingerprint-24-svg-prop !optional;
+  -webkit-mask-image: var(--fingerprint-24-svg);
+  mask-image: var(--fingerprint-24-svg);
+}
+
+%with-flag-16-icon {
+  @extend %with-icon, %flag-16-svg-prop !optional;
+  background-image: var(--flag-16-svg);
+}
+%with-flag-16-mask {
+  @extend %with-mask, %flag-16-svg-prop !optional;
+  -webkit-mask-image: var(--flag-16-svg);
+  mask-image: var(--flag-16-svg);
+}
+
+%with-flag-24-icon {
+  @extend %with-icon, %flag-24-svg-prop !optional;
+  background-image: var(--flag-24-svg);
+}
+%with-flag-24-mask {
+  @extend %with-mask, %flag-24-svg-prop !optional;
+  -webkit-mask-image: var(--flag-24-svg);
+  mask-image: var(--flag-24-svg);
+}
+
 %with-flag-icon {
-  @extend %with-icon, %flag-svg-prop;
+  @extend %with-icon, %flag-svg-prop !optional;
   background-image: var(--flag-svg);
 }
 %with-flag-mask {
-  @extend %with-mask, %flag-svg-prop;
+  @extend %with-mask, %flag-svg-prop !optional;
   -webkit-mask-image: var(--flag-svg);
   mask-image: var(--flag-svg);
 }
 
+%with-folder-16-icon {
+  @extend %with-icon, %folder-16-svg-prop !optional;
+  background-image: var(--folder-16-svg);
+}
+%with-folder-16-mask {
+  @extend %with-mask, %folder-16-svg-prop !optional;
+  -webkit-mask-image: var(--folder-16-svg);
+  mask-image: var(--folder-16-svg);
+}
+
+%with-folder-24-icon {
+  @extend %with-icon, %folder-24-svg-prop !optional;
+  background-image: var(--folder-24-svg);
+}
+%with-folder-24-mask {
+  @extend %with-mask, %folder-24-svg-prop !optional;
+  -webkit-mask-image: var(--folder-24-svg);
+  mask-image: var(--folder-24-svg);
+}
+
+%with-folder-fill-16-icon {
+  @extend %with-icon, %folder-fill-16-svg-prop !optional;
+  background-image: var(--folder-fill-16-svg);
+}
+%with-folder-fill-16-mask {
+  @extend %with-mask, %folder-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--folder-fill-16-svg);
+  mask-image: var(--folder-fill-16-svg);
+}
+
+%with-folder-fill-24-icon {
+  @extend %with-icon, %folder-fill-24-svg-prop !optional;
+  background-image: var(--folder-fill-24-svg);
+}
+%with-folder-fill-24-mask {
+  @extend %with-mask, %folder-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--folder-fill-24-svg);
+  mask-image: var(--folder-fill-24-svg);
+}
+
 %with-folder-fill-icon {
-  @extend %with-icon, %folder-fill-svg-prop;
+  @extend %with-icon, %folder-fill-svg-prop !optional;
   background-image: var(--folder-fill-svg);
 }
 %with-folder-fill-mask {
-  @extend %with-mask, %folder-fill-svg-prop;
+  @extend %with-mask, %folder-fill-svg-prop !optional;
   -webkit-mask-image: var(--folder-fill-svg);
   mask-image: var(--folder-fill-svg);
 }
 
+%with-folder-minus-16-icon {
+  @extend %with-icon, %folder-minus-16-svg-prop !optional;
+  background-image: var(--folder-minus-16-svg);
+}
+%with-folder-minus-16-mask {
+  @extend %with-mask, %folder-minus-16-svg-prop !optional;
+  -webkit-mask-image: var(--folder-minus-16-svg);
+  mask-image: var(--folder-minus-16-svg);
+}
+
+%with-folder-minus-24-icon {
+  @extend %with-icon, %folder-minus-24-svg-prop !optional;
+  background-image: var(--folder-minus-24-svg);
+}
+%with-folder-minus-24-mask {
+  @extend %with-mask, %folder-minus-24-svg-prop !optional;
+  -webkit-mask-image: var(--folder-minus-24-svg);
+  mask-image: var(--folder-minus-24-svg);
+}
+
+%with-folder-minus-fill-16-icon {
+  @extend %with-icon, %folder-minus-fill-16-svg-prop !optional;
+  background-image: var(--folder-minus-fill-16-svg);
+}
+%with-folder-minus-fill-16-mask {
+  @extend %with-mask, %folder-minus-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--folder-minus-fill-16-svg);
+  mask-image: var(--folder-minus-fill-16-svg);
+}
+
+%with-folder-minus-fill-24-icon {
+  @extend %with-icon, %folder-minus-fill-24-svg-prop !optional;
+  background-image: var(--folder-minus-fill-24-svg);
+}
+%with-folder-minus-fill-24-mask {
+  @extend %with-mask, %folder-minus-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--folder-minus-fill-24-svg);
+  mask-image: var(--folder-minus-fill-24-svg);
+}
+
 %with-folder-outline-icon {
-  @extend %with-icon, %folder-outline-svg-prop;
+  @extend %with-icon, %folder-outline-svg-prop !optional;
   background-image: var(--folder-outline-svg);
 }
 %with-folder-outline-mask {
-  @extend %with-mask, %folder-outline-svg-prop;
+  @extend %with-mask, %folder-outline-svg-prop !optional;
   -webkit-mask-image: var(--folder-outline-svg);
   mask-image: var(--folder-outline-svg);
 }
 
+%with-folder-plus-16-icon {
+  @extend %with-icon, %folder-plus-16-svg-prop !optional;
+  background-image: var(--folder-plus-16-svg);
+}
+%with-folder-plus-16-mask {
+  @extend %with-mask, %folder-plus-16-svg-prop !optional;
+  -webkit-mask-image: var(--folder-plus-16-svg);
+  mask-image: var(--folder-plus-16-svg);
+}
+
+%with-folder-plus-24-icon {
+  @extend %with-icon, %folder-plus-24-svg-prop !optional;
+  background-image: var(--folder-plus-24-svg);
+}
+%with-folder-plus-24-mask {
+  @extend %with-mask, %folder-plus-24-svg-prop !optional;
+  -webkit-mask-image: var(--folder-plus-24-svg);
+  mask-image: var(--folder-plus-24-svg);
+}
+
+%with-folder-plus-fill-16-icon {
+  @extend %with-icon, %folder-plus-fill-16-svg-prop !optional;
+  background-image: var(--folder-plus-fill-16-svg);
+}
+%with-folder-plus-fill-16-mask {
+  @extend %with-mask, %folder-plus-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--folder-plus-fill-16-svg);
+  mask-image: var(--folder-plus-fill-16-svg);
+}
+
+%with-folder-plus-fill-24-icon {
+  @extend %with-icon, %folder-plus-fill-24-svg-prop !optional;
+  background-image: var(--folder-plus-fill-24-svg);
+}
+%with-folder-plus-fill-24-mask {
+  @extend %with-mask, %folder-plus-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--folder-plus-fill-24-svg);
+  mask-image: var(--folder-plus-fill-24-svg);
+}
+
+%with-folder-star-16-icon {
+  @extend %with-icon, %folder-star-16-svg-prop !optional;
+  background-image: var(--folder-star-16-svg);
+}
+%with-folder-star-16-mask {
+  @extend %with-mask, %folder-star-16-svg-prop !optional;
+  -webkit-mask-image: var(--folder-star-16-svg);
+  mask-image: var(--folder-star-16-svg);
+}
+
+%with-folder-star-24-icon {
+  @extend %with-icon, %folder-star-24-svg-prop !optional;
+  background-image: var(--folder-star-24-svg);
+}
+%with-folder-star-24-mask {
+  @extend %with-mask, %folder-star-24-svg-prop !optional;
+  -webkit-mask-image: var(--folder-star-24-svg);
+  mask-image: var(--folder-star-24-svg);
+}
+
+%with-folder-users-16-icon {
+  @extend %with-icon, %folder-users-16-svg-prop !optional;
+  background-image: var(--folder-users-16-svg);
+}
+%with-folder-users-16-mask {
+  @extend %with-mask, %folder-users-16-svg-prop !optional;
+  -webkit-mask-image: var(--folder-users-16-svg);
+  mask-image: var(--folder-users-16-svg);
+}
+
+%with-folder-users-24-icon {
+  @extend %with-icon, %folder-users-24-svg-prop !optional;
+  background-image: var(--folder-users-24-svg);
+}
+%with-folder-users-24-mask {
+  @extend %with-mask, %folder-users-24-svg-prop !optional;
+  -webkit-mask-image: var(--folder-users-24-svg);
+  mask-image: var(--folder-users-24-svg);
+}
+
+%with-frown-16-icon {
+  @extend %with-icon, %frown-16-svg-prop !optional;
+  background-image: var(--frown-16-svg);
+}
+%with-frown-16-mask {
+  @extend %with-mask, %frown-16-svg-prop !optional;
+  -webkit-mask-image: var(--frown-16-svg);
+  mask-image: var(--frown-16-svg);
+}
+
+%with-frown-24-icon {
+  @extend %with-icon, %frown-24-svg-prop !optional;
+  background-image: var(--frown-24-svg);
+}
+%with-frown-24-mask {
+  @extend %with-mask, %frown-24-svg-prop !optional;
+  -webkit-mask-image: var(--frown-24-svg);
+  mask-image: var(--frown-24-svg);
+}
+
+%with-gateway-16-icon {
+  @extend %with-icon, %gateway-16-svg-prop !optional;
+  background-image: var(--gateway-16-svg);
+}
+%with-gateway-16-mask {
+  @extend %with-mask, %gateway-16-svg-prop !optional;
+  -webkit-mask-image: var(--gateway-16-svg);
+  mask-image: var(--gateway-16-svg);
+}
+
+%with-gateway-24-icon {
+  @extend %with-icon, %gateway-24-svg-prop !optional;
+  background-image: var(--gateway-24-svg);
+}
+%with-gateway-24-mask {
+  @extend %with-mask, %gateway-24-svg-prop !optional;
+  -webkit-mask-image: var(--gateway-24-svg);
+  mask-image: var(--gateway-24-svg);
+}
+
 %with-gateway-icon {
-  @extend %with-icon, %gateway-svg-prop;
+  @extend %with-icon, %gateway-svg-prop !optional;
   background-image: var(--gateway-svg);
 }
 %with-gateway-mask {
-  @extend %with-mask, %gateway-svg-prop;
+  @extend %with-mask, %gateway-svg-prop !optional;
   -webkit-mask-image: var(--gateway-svg);
   mask-image: var(--gateway-svg);
 }
 
+%with-gcp-16-icon {
+  @extend %with-icon, %gcp-16-svg-prop !optional;
+  background-image: var(--gcp-16-svg);
+}
+%with-gcp-16-mask {
+  @extend %with-mask, %gcp-16-svg-prop !optional;
+  -webkit-mask-image: var(--gcp-16-svg);
+  mask-image: var(--gcp-16-svg);
+}
+
+%with-gcp-24-icon {
+  @extend %with-icon, %gcp-24-svg-prop !optional;
+  background-image: var(--gcp-24-svg);
+}
+%with-gcp-24-mask {
+  @extend %with-mask, %gcp-24-svg-prop !optional;
+  -webkit-mask-image: var(--gcp-24-svg);
+  mask-image: var(--gcp-24-svg);
+}
+
+%with-gcp-color-16-icon {
+  @extend %with-icon, %gcp-color-16-svg-prop !optional;
+  background-image: var(--gcp-color-16-svg);
+}
+%with-gcp-color-16-mask {
+  @extend %with-mask, %gcp-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--gcp-color-16-svg);
+  mask-image: var(--gcp-color-16-svg);
+}
+
+%with-gcp-color-24-icon {
+  @extend %with-icon, %gcp-color-24-svg-prop !optional;
+  background-image: var(--gcp-color-24-svg);
+}
+%with-gcp-color-24-mask {
+  @extend %with-mask, %gcp-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--gcp-color-24-svg);
+  mask-image: var(--gcp-color-24-svg);
+}
+
+%with-gift-16-icon {
+  @extend %with-icon, %gift-16-svg-prop !optional;
+  background-image: var(--gift-16-svg);
+}
+%with-gift-16-mask {
+  @extend %with-mask, %gift-16-svg-prop !optional;
+  -webkit-mask-image: var(--gift-16-svg);
+  mask-image: var(--gift-16-svg);
+}
+
+%with-gift-24-icon {
+  @extend %with-icon, %gift-24-svg-prop !optional;
+  background-image: var(--gift-24-svg);
+}
+%with-gift-24-mask {
+  @extend %with-mask, %gift-24-svg-prop !optional;
+  -webkit-mask-image: var(--gift-24-svg);
+  mask-image: var(--gift-24-svg);
+}
+
 %with-gift-fill-icon {
-  @extend %with-icon, %gift-fill-svg-prop;
+  @extend %with-icon, %gift-fill-svg-prop !optional;
   background-image: var(--gift-fill-svg);
 }
 %with-gift-fill-mask {
-  @extend %with-mask, %gift-fill-svg-prop;
+  @extend %with-mask, %gift-fill-svg-prop !optional;
   -webkit-mask-image: var(--gift-fill-svg);
   mask-image: var(--gift-fill-svg);
 }
 
 %with-gift-outline-icon {
-  @extend %with-icon, %gift-outline-svg-prop;
+  @extend %with-icon, %gift-outline-svg-prop !optional;
   background-image: var(--gift-outline-svg);
 }
 %with-gift-outline-mask {
-  @extend %with-mask, %gift-outline-svg-prop;
+  @extend %with-mask, %gift-outline-svg-prop !optional;
   -webkit-mask-image: var(--gift-outline-svg);
   mask-image: var(--gift-outline-svg);
 }
 
+%with-git-branch-16-icon {
+  @extend %with-icon, %git-branch-16-svg-prop !optional;
+  background-image: var(--git-branch-16-svg);
+}
+%with-git-branch-16-mask {
+  @extend %with-mask, %git-branch-16-svg-prop !optional;
+  -webkit-mask-image: var(--git-branch-16-svg);
+  mask-image: var(--git-branch-16-svg);
+}
+
+%with-git-branch-24-icon {
+  @extend %with-icon, %git-branch-24-svg-prop !optional;
+  background-image: var(--git-branch-24-svg);
+}
+%with-git-branch-24-mask {
+  @extend %with-mask, %git-branch-24-svg-prop !optional;
+  -webkit-mask-image: var(--git-branch-24-svg);
+  mask-image: var(--git-branch-24-svg);
+}
+
 %with-git-branch-icon {
-  @extend %with-icon, %git-branch-svg-prop;
+  @extend %with-icon, %git-branch-svg-prop !optional;
   background-image: var(--git-branch-svg);
 }
 %with-git-branch-mask {
-  @extend %with-mask, %git-branch-svg-prop;
+  @extend %with-mask, %git-branch-svg-prop !optional;
   -webkit-mask-image: var(--git-branch-svg);
   mask-image: var(--git-branch-svg);
 }
 
+%with-git-commit-16-icon {
+  @extend %with-icon, %git-commit-16-svg-prop !optional;
+  background-image: var(--git-commit-16-svg);
+}
+%with-git-commit-16-mask {
+  @extend %with-mask, %git-commit-16-svg-prop !optional;
+  -webkit-mask-image: var(--git-commit-16-svg);
+  mask-image: var(--git-commit-16-svg);
+}
+
+%with-git-commit-24-icon {
+  @extend %with-icon, %git-commit-24-svg-prop !optional;
+  background-image: var(--git-commit-24-svg);
+}
+%with-git-commit-24-mask {
+  @extend %with-mask, %git-commit-24-svg-prop !optional;
+  -webkit-mask-image: var(--git-commit-24-svg);
+  mask-image: var(--git-commit-24-svg);
+}
+
 %with-git-commit-icon {
-  @extend %with-icon, %git-commit-svg-prop;
+  @extend %with-icon, %git-commit-svg-prop !optional;
   background-image: var(--git-commit-svg);
 }
 %with-git-commit-mask {
-  @extend %with-mask, %git-commit-svg-prop;
+  @extend %with-mask, %git-commit-svg-prop !optional;
   -webkit-mask-image: var(--git-commit-svg);
   mask-image: var(--git-commit-svg);
 }
 
+%with-git-merge-16-icon {
+  @extend %with-icon, %git-merge-16-svg-prop !optional;
+  background-image: var(--git-merge-16-svg);
+}
+%with-git-merge-16-mask {
+  @extend %with-mask, %git-merge-16-svg-prop !optional;
+  -webkit-mask-image: var(--git-merge-16-svg);
+  mask-image: var(--git-merge-16-svg);
+}
+
+%with-git-merge-24-icon {
+  @extend %with-icon, %git-merge-24-svg-prop !optional;
+  background-image: var(--git-merge-24-svg);
+}
+%with-git-merge-24-mask {
+  @extend %with-mask, %git-merge-24-svg-prop !optional;
+  -webkit-mask-image: var(--git-merge-24-svg);
+  mask-image: var(--git-merge-24-svg);
+}
+
+%with-git-pull-request-16-icon {
+  @extend %with-icon, %git-pull-request-16-svg-prop !optional;
+  background-image: var(--git-pull-request-16-svg);
+}
+%with-git-pull-request-16-mask {
+  @extend %with-mask, %git-pull-request-16-svg-prop !optional;
+  -webkit-mask-image: var(--git-pull-request-16-svg);
+  mask-image: var(--git-pull-request-16-svg);
+}
+
+%with-git-pull-request-24-icon {
+  @extend %with-icon, %git-pull-request-24-svg-prop !optional;
+  background-image: var(--git-pull-request-24-svg);
+}
+%with-git-pull-request-24-mask {
+  @extend %with-mask, %git-pull-request-24-svg-prop !optional;
+  -webkit-mask-image: var(--git-pull-request-24-svg);
+  mask-image: var(--git-pull-request-24-svg);
+}
+
 %with-git-pull-request-icon {
-  @extend %with-icon, %git-pull-request-svg-prop;
+  @extend %with-icon, %git-pull-request-svg-prop !optional;
   background-image: var(--git-pull-request-svg);
 }
 %with-git-pull-request-mask {
-  @extend %with-mask, %git-pull-request-svg-prop;
+  @extend %with-mask, %git-pull-request-svg-prop !optional;
   -webkit-mask-image: var(--git-pull-request-svg);
   mask-image: var(--git-pull-request-svg);
 }
 
+%with-git-repo-16-icon {
+  @extend %with-icon, %git-repo-16-svg-prop !optional;
+  background-image: var(--git-repo-16-svg);
+}
+%with-git-repo-16-mask {
+  @extend %with-mask, %git-repo-16-svg-prop !optional;
+  -webkit-mask-image: var(--git-repo-16-svg);
+  mask-image: var(--git-repo-16-svg);
+}
+
+%with-git-repo-24-icon {
+  @extend %with-icon, %git-repo-24-svg-prop !optional;
+  background-image: var(--git-repo-24-svg);
+}
+%with-git-repo-24-mask {
+  @extend %with-mask, %git-repo-24-svg-prop !optional;
+  -webkit-mask-image: var(--git-repo-24-svg);
+  mask-image: var(--git-repo-24-svg);
+}
+
 %with-git-repository-icon {
-  @extend %with-icon, %git-repository-svg-prop;
+  @extend %with-icon, %git-repository-svg-prop !optional;
   background-image: var(--git-repository-svg);
 }
 %with-git-repository-mask {
-  @extend %with-mask, %git-repository-svg-prop;
+  @extend %with-mask, %git-repository-svg-prop !optional;
   -webkit-mask-image: var(--git-repository-svg);
   mask-image: var(--git-repository-svg);
 }
 
+%with-github-16-icon {
+  @extend %with-icon, %github-16-svg-prop !optional;
+  background-image: var(--github-16-svg);
+}
+%with-github-16-mask {
+  @extend %with-mask, %github-16-svg-prop !optional;
+  -webkit-mask-image: var(--github-16-svg);
+  mask-image: var(--github-16-svg);
+}
+
+%with-github-24-icon {
+  @extend %with-icon, %github-24-svg-prop !optional;
+  background-image: var(--github-24-svg);
+}
+%with-github-24-mask {
+  @extend %with-mask, %github-24-svg-prop !optional;
+  -webkit-mask-image: var(--github-24-svg);
+  mask-image: var(--github-24-svg);
+}
+
+%with-github-color-16-icon {
+  @extend %with-icon, %github-color-16-svg-prop !optional;
+  background-image: var(--github-color-16-svg);
+}
+%with-github-color-16-mask {
+  @extend %with-mask, %github-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--github-color-16-svg);
+  mask-image: var(--github-color-16-svg);
+}
+
+%with-github-color-24-icon {
+  @extend %with-icon, %github-color-24-svg-prop !optional;
+  background-image: var(--github-color-24-svg);
+}
+%with-github-color-24-mask {
+  @extend %with-mask, %github-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--github-color-24-svg);
+  mask-image: var(--github-color-24-svg);
+}
+
+%with-gitlab-16-icon {
+  @extend %with-icon, %gitlab-16-svg-prop !optional;
+  background-image: var(--gitlab-16-svg);
+}
+%with-gitlab-16-mask {
+  @extend %with-mask, %gitlab-16-svg-prop !optional;
+  -webkit-mask-image: var(--gitlab-16-svg);
+  mask-image: var(--gitlab-16-svg);
+}
+
+%with-gitlab-24-icon {
+  @extend %with-icon, %gitlab-24-svg-prop !optional;
+  background-image: var(--gitlab-24-svg);
+}
+%with-gitlab-24-mask {
+  @extend %with-mask, %gitlab-24-svg-prop !optional;
+  -webkit-mask-image: var(--gitlab-24-svg);
+  mask-image: var(--gitlab-24-svg);
+}
+
+%with-gitlab-color-16-icon {
+  @extend %with-icon, %gitlab-color-16-svg-prop !optional;
+  background-image: var(--gitlab-color-16-svg);
+}
+%with-gitlab-color-16-mask {
+  @extend %with-mask, %gitlab-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--gitlab-color-16-svg);
+  mask-image: var(--gitlab-color-16-svg);
+}
+
+%with-gitlab-color-24-icon {
+  @extend %with-icon, %gitlab-color-24-svg-prop !optional;
+  background-image: var(--gitlab-color-24-svg);
+}
+%with-gitlab-color-24-mask {
+  @extend %with-mask, %gitlab-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--gitlab-color-24-svg);
+  mask-image: var(--gitlab-color-24-svg);
+}
+
+%with-globe-16-icon {
+  @extend %with-icon, %globe-16-svg-prop !optional;
+  background-image: var(--globe-16-svg);
+}
+%with-globe-16-mask {
+  @extend %with-mask, %globe-16-svg-prop !optional;
+  -webkit-mask-image: var(--globe-16-svg);
+  mask-image: var(--globe-16-svg);
+}
+
+%with-globe-24-icon {
+  @extend %with-icon, %globe-24-svg-prop !optional;
+  background-image: var(--globe-24-svg);
+}
+%with-globe-24-mask {
+  @extend %with-mask, %globe-24-svg-prop !optional;
+  -webkit-mask-image: var(--globe-24-svg);
+  mask-image: var(--globe-24-svg);
+}
+
+%with-globe-private-16-icon {
+  @extend %with-icon, %globe-private-16-svg-prop !optional;
+  background-image: var(--globe-private-16-svg);
+}
+%with-globe-private-16-mask {
+  @extend %with-mask, %globe-private-16-svg-prop !optional;
+  -webkit-mask-image: var(--globe-private-16-svg);
+  mask-image: var(--globe-private-16-svg);
+}
+
+%with-globe-private-24-icon {
+  @extend %with-icon, %globe-private-24-svg-prop !optional;
+  background-image: var(--globe-private-24-svg);
+}
+%with-globe-private-24-mask {
+  @extend %with-mask, %globe-private-24-svg-prop !optional;
+  -webkit-mask-image: var(--globe-private-24-svg);
+  mask-image: var(--globe-private-24-svg);
+}
+
+%with-google-16-icon {
+  @extend %with-icon, %google-16-svg-prop !optional;
+  background-image: var(--google-16-svg);
+}
+%with-google-16-mask {
+  @extend %with-mask, %google-16-svg-prop !optional;
+  -webkit-mask-image: var(--google-16-svg);
+  mask-image: var(--google-16-svg);
+}
+
+%with-google-24-icon {
+  @extend %with-icon, %google-24-svg-prop !optional;
+  background-image: var(--google-24-svg);
+}
+%with-google-24-mask {
+  @extend %with-mask, %google-24-svg-prop !optional;
+  -webkit-mask-image: var(--google-24-svg);
+  mask-image: var(--google-24-svg);
+}
+
+%with-google-color-16-icon {
+  @extend %with-icon, %google-color-16-svg-prop !optional;
+  background-image: var(--google-color-16-svg);
+}
+%with-google-color-16-mask {
+  @extend %with-mask, %google-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--google-color-16-svg);
+  mask-image: var(--google-color-16-svg);
+}
+
+%with-google-color-24-icon {
+  @extend %with-icon, %google-color-24-svg-prop !optional;
+  background-image: var(--google-color-24-svg);
+}
+%with-google-color-24-mask {
+  @extend %with-mask, %google-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--google-color-24-svg);
+  mask-image: var(--google-color-24-svg);
+}
+
+%with-grid-16-icon {
+  @extend %with-icon, %grid-16-svg-prop !optional;
+  background-image: var(--grid-16-svg);
+}
+%with-grid-16-mask {
+  @extend %with-mask, %grid-16-svg-prop !optional;
+  -webkit-mask-image: var(--grid-16-svg);
+  mask-image: var(--grid-16-svg);
+}
+
+%with-grid-24-icon {
+  @extend %with-icon, %grid-24-svg-prop !optional;
+  background-image: var(--grid-24-svg);
+}
+%with-grid-24-mask {
+  @extend %with-mask, %grid-24-svg-prop !optional;
+  -webkit-mask-image: var(--grid-24-svg);
+  mask-image: var(--grid-24-svg);
+}
+
+%with-grid-alt-16-icon {
+  @extend %with-icon, %grid-alt-16-svg-prop !optional;
+  background-image: var(--grid-alt-16-svg);
+}
+%with-grid-alt-16-mask {
+  @extend %with-mask, %grid-alt-16-svg-prop !optional;
+  -webkit-mask-image: var(--grid-alt-16-svg);
+  mask-image: var(--grid-alt-16-svg);
+}
+
+%with-grid-alt-24-icon {
+  @extend %with-icon, %grid-alt-24-svg-prop !optional;
+  background-image: var(--grid-alt-24-svg);
+}
+%with-grid-alt-24-mask {
+  @extend %with-mask, %grid-alt-24-svg-prop !optional;
+  -webkit-mask-image: var(--grid-alt-24-svg);
+  mask-image: var(--grid-alt-24-svg);
+}
+
+%with-guide-16-icon {
+  @extend %with-icon, %guide-16-svg-prop !optional;
+  background-image: var(--guide-16-svg);
+}
+%with-guide-16-mask {
+  @extend %with-mask, %guide-16-svg-prop !optional;
+  -webkit-mask-image: var(--guide-16-svg);
+  mask-image: var(--guide-16-svg);
+}
+
+%with-guide-24-icon {
+  @extend %with-icon, %guide-24-svg-prop !optional;
+  background-image: var(--guide-24-svg);
+}
+%with-guide-24-mask {
+  @extend %with-mask, %guide-24-svg-prop !optional;
+  -webkit-mask-image: var(--guide-24-svg);
+  mask-image: var(--guide-24-svg);
+}
+
+%with-guide-link-16-icon {
+  @extend %with-icon, %guide-link-16-svg-prop !optional;
+  background-image: var(--guide-link-16-svg);
+}
+%with-guide-link-16-mask {
+  @extend %with-mask, %guide-link-16-svg-prop !optional;
+  -webkit-mask-image: var(--guide-link-16-svg);
+  mask-image: var(--guide-link-16-svg);
+}
+
+%with-guide-link-24-icon {
+  @extend %with-icon, %guide-link-24-svg-prop !optional;
+  background-image: var(--guide-link-24-svg);
+}
+%with-guide-link-24-mask {
+  @extend %with-mask, %guide-link-24-svg-prop !optional;
+  -webkit-mask-image: var(--guide-link-24-svg);
+  mask-image: var(--guide-link-24-svg);
+}
+
 %with-guide-icon {
-  @extend %with-icon, %guide-svg-prop;
+  @extend %with-icon, %guide-svg-prop !optional;
   background-image: var(--guide-svg);
 }
 %with-guide-mask {
-  @extend %with-mask, %guide-svg-prop;
+  @extend %with-mask, %guide-svg-prop !optional;
   -webkit-mask-image: var(--guide-svg);
   mask-image: var(--guide-svg);
 }
 
+%with-hammer-16-icon {
+  @extend %with-icon, %hammer-16-svg-prop !optional;
+  background-image: var(--hammer-16-svg);
+}
+%with-hammer-16-mask {
+  @extend %with-mask, %hammer-16-svg-prop !optional;
+  -webkit-mask-image: var(--hammer-16-svg);
+  mask-image: var(--hammer-16-svg);
+}
+
+%with-hammer-24-icon {
+  @extend %with-icon, %hammer-24-svg-prop !optional;
+  background-image: var(--hammer-24-svg);
+}
+%with-hammer-24-mask {
+  @extend %with-mask, %hammer-24-svg-prop !optional;
+  -webkit-mask-image: var(--hammer-24-svg);
+  mask-image: var(--hammer-24-svg);
+}
+
+%with-hard-drive-16-icon {
+  @extend %with-icon, %hard-drive-16-svg-prop !optional;
+  background-image: var(--hard-drive-16-svg);
+}
+%with-hard-drive-16-mask {
+  @extend %with-mask, %hard-drive-16-svg-prop !optional;
+  -webkit-mask-image: var(--hard-drive-16-svg);
+  mask-image: var(--hard-drive-16-svg);
+}
+
+%with-hard-drive-24-icon {
+  @extend %with-icon, %hard-drive-24-svg-prop !optional;
+  background-image: var(--hard-drive-24-svg);
+}
+%with-hard-drive-24-mask {
+  @extend %with-mask, %hard-drive-24-svg-prop !optional;
+  -webkit-mask-image: var(--hard-drive-24-svg);
+  mask-image: var(--hard-drive-24-svg);
+}
+
+%with-hash-16-icon {
+  @extend %with-icon, %hash-16-svg-prop !optional;
+  background-image: var(--hash-16-svg);
+}
+%with-hash-16-mask {
+  @extend %with-mask, %hash-16-svg-prop !optional;
+  -webkit-mask-image: var(--hash-16-svg);
+  mask-image: var(--hash-16-svg);
+}
+
+%with-hash-24-icon {
+  @extend %with-icon, %hash-24-svg-prop !optional;
+  background-image: var(--hash-24-svg);
+}
+%with-hash-24-mask {
+  @extend %with-mask, %hash-24-svg-prop !optional;
+  -webkit-mask-image: var(--hash-24-svg);
+  mask-image: var(--hash-24-svg);
+}
+
+%with-headphones-16-icon {
+  @extend %with-icon, %headphones-16-svg-prop !optional;
+  background-image: var(--headphones-16-svg);
+}
+%with-headphones-16-mask {
+  @extend %with-mask, %headphones-16-svg-prop !optional;
+  -webkit-mask-image: var(--headphones-16-svg);
+  mask-image: var(--headphones-16-svg);
+}
+
+%with-headphones-24-icon {
+  @extend %with-icon, %headphones-24-svg-prop !optional;
+  background-image: var(--headphones-24-svg);
+}
+%with-headphones-24-mask {
+  @extend %with-mask, %headphones-24-svg-prop !optional;
+  -webkit-mask-image: var(--headphones-24-svg);
+  mask-image: var(--headphones-24-svg);
+}
+
 %with-health-icon {
-  @extend %with-icon, %health-svg-prop;
+  @extend %with-icon, %health-svg-prop !optional;
   background-image: var(--health-svg);
 }
 %with-health-mask {
-  @extend %with-mask, %health-svg-prop;
+  @extend %with-mask, %health-svg-prop !optional;
   -webkit-mask-image: var(--health-svg);
   mask-image: var(--health-svg);
 }
 
+%with-heart-16-icon {
+  @extend %with-icon, %heart-16-svg-prop !optional;
+  background-image: var(--heart-16-svg);
+}
+%with-heart-16-mask {
+  @extend %with-mask, %heart-16-svg-prop !optional;
+  -webkit-mask-image: var(--heart-16-svg);
+  mask-image: var(--heart-16-svg);
+}
+
+%with-heart-24-icon {
+  @extend %with-icon, %heart-24-svg-prop !optional;
+  background-image: var(--heart-24-svg);
+}
+%with-heart-24-mask {
+  @extend %with-mask, %heart-24-svg-prop !optional;
+  -webkit-mask-image: var(--heart-24-svg);
+  mask-image: var(--heart-24-svg);
+}
+
+%with-heart-fill-16-icon {
+  @extend %with-icon, %heart-fill-16-svg-prop !optional;
+  background-image: var(--heart-fill-16-svg);
+}
+%with-heart-fill-16-mask {
+  @extend %with-mask, %heart-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--heart-fill-16-svg);
+  mask-image: var(--heart-fill-16-svg);
+}
+
+%with-heart-fill-24-icon {
+  @extend %with-icon, %heart-fill-24-svg-prop !optional;
+  background-image: var(--heart-fill-24-svg);
+}
+%with-heart-fill-24-mask {
+  @extend %with-mask, %heart-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--heart-fill-24-svg);
+  mask-image: var(--heart-fill-24-svg);
+}
+
+%with-heart-off-16-icon {
+  @extend %with-icon, %heart-off-16-svg-prop !optional;
+  background-image: var(--heart-off-16-svg);
+}
+%with-heart-off-16-mask {
+  @extend %with-mask, %heart-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--heart-off-16-svg);
+  mask-image: var(--heart-off-16-svg);
+}
+
+%with-heart-off-24-icon {
+  @extend %with-icon, %heart-off-24-svg-prop !optional;
+  background-image: var(--heart-off-24-svg);
+}
+%with-heart-off-24-mask {
+  @extend %with-mask, %heart-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--heart-off-24-svg);
+  mask-image: var(--heart-off-24-svg);
+}
+
+%with-help-16-icon {
+  @extend %with-icon, %help-16-svg-prop !optional;
+  background-image: var(--help-16-svg);
+}
+%with-help-16-mask {
+  @extend %with-mask, %help-16-svg-prop !optional;
+  -webkit-mask-image: var(--help-16-svg);
+  mask-image: var(--help-16-svg);
+}
+
+%with-help-24-icon {
+  @extend %with-icon, %help-24-svg-prop !optional;
+  background-image: var(--help-24-svg);
+}
+%with-help-24-mask {
+  @extend %with-mask, %help-24-svg-prop !optional;
+  -webkit-mask-image: var(--help-24-svg);
+  mask-image: var(--help-24-svg);
+}
+
 %with-help-circle-fill-icon {
-  @extend %with-icon, %help-circle-fill-svg-prop;
+  @extend %with-icon, %help-circle-fill-svg-prop !optional;
   background-image: var(--help-circle-fill-svg);
 }
 %with-help-circle-fill-mask {
-  @extend %with-mask, %help-circle-fill-svg-prop;
+  @extend %with-mask, %help-circle-fill-svg-prop !optional;
   -webkit-mask-image: var(--help-circle-fill-svg);
   mask-image: var(--help-circle-fill-svg);
 }
 
 %with-help-circle-outline-icon {
-  @extend %with-icon, %help-circle-outline-svg-prop;
+  @extend %with-icon, %help-circle-outline-svg-prop !optional;
   background-image: var(--help-circle-outline-svg);
 }
 %with-help-circle-outline-mask {
-  @extend %with-mask, %help-circle-outline-svg-prop;
+  @extend %with-mask, %help-circle-outline-svg-prop !optional;
   -webkit-mask-image: var(--help-circle-outline-svg);
   mask-image: var(--help-circle-outline-svg);
 }
 
+%with-hexagon-16-icon {
+  @extend %with-icon, %hexagon-16-svg-prop !optional;
+  background-image: var(--hexagon-16-svg);
+}
+%with-hexagon-16-mask {
+  @extend %with-mask, %hexagon-16-svg-prop !optional;
+  -webkit-mask-image: var(--hexagon-16-svg);
+  mask-image: var(--hexagon-16-svg);
+}
+
+%with-hexagon-24-icon {
+  @extend %with-icon, %hexagon-24-svg-prop !optional;
+  background-image: var(--hexagon-24-svg);
+}
+%with-hexagon-24-mask {
+  @extend %with-mask, %hexagon-24-svg-prop !optional;
+  -webkit-mask-image: var(--hexagon-24-svg);
+  mask-image: var(--hexagon-24-svg);
+}
+
+%with-hexagon-fill-16-icon {
+  @extend %with-icon, %hexagon-fill-16-svg-prop !optional;
+  background-image: var(--hexagon-fill-16-svg);
+}
+%with-hexagon-fill-16-mask {
+  @extend %with-mask, %hexagon-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--hexagon-fill-16-svg);
+  mask-image: var(--hexagon-fill-16-svg);
+}
+
+%with-hexagon-fill-24-icon {
+  @extend %with-icon, %hexagon-fill-24-svg-prop !optional;
+  background-image: var(--hexagon-fill-24-svg);
+}
+%with-hexagon-fill-24-mask {
+  @extend %with-mask, %hexagon-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--hexagon-fill-24-svg);
+  mask-image: var(--hexagon-fill-24-svg);
+}
+
+%with-history-16-icon {
+  @extend %with-icon, %history-16-svg-prop !optional;
+  background-image: var(--history-16-svg);
+}
+%with-history-16-mask {
+  @extend %with-mask, %history-16-svg-prop !optional;
+  -webkit-mask-image: var(--history-16-svg);
+  mask-image: var(--history-16-svg);
+}
+
+%with-history-24-icon {
+  @extend %with-icon, %history-24-svg-prop !optional;
+  background-image: var(--history-24-svg);
+}
+%with-history-24-mask {
+  @extend %with-mask, %history-24-svg-prop !optional;
+  -webkit-mask-image: var(--history-24-svg);
+  mask-image: var(--history-24-svg);
+}
+
 %with-history-icon {
-  @extend %with-icon, %history-svg-prop;
+  @extend %with-icon, %history-svg-prop !optional;
   background-image: var(--history-svg);
 }
 %with-history-mask {
-  @extend %with-mask, %history-svg-prop;
+  @extend %with-mask, %history-svg-prop !optional;
   -webkit-mask-image: var(--history-svg);
   mask-image: var(--history-svg);
 }
 
+%with-home-16-icon {
+  @extend %with-icon, %home-16-svg-prop !optional;
+  background-image: var(--home-16-svg);
+}
+%with-home-16-mask {
+  @extend %with-mask, %home-16-svg-prop !optional;
+  -webkit-mask-image: var(--home-16-svg);
+  mask-image: var(--home-16-svg);
+}
+
+%with-home-24-icon {
+  @extend %with-icon, %home-24-svg-prop !optional;
+  background-image: var(--home-24-svg);
+}
+%with-home-24-mask {
+  @extend %with-mask, %home-24-svg-prop !optional;
+  -webkit-mask-image: var(--home-24-svg);
+  mask-image: var(--home-24-svg);
+}
+
+%with-hourglass-16-icon {
+  @extend %with-icon, %hourglass-16-svg-prop !optional;
+  background-image: var(--hourglass-16-svg);
+}
+%with-hourglass-16-mask {
+  @extend %with-mask, %hourglass-16-svg-prop !optional;
+  -webkit-mask-image: var(--hourglass-16-svg);
+  mask-image: var(--hourglass-16-svg);
+}
+
+%with-hourglass-24-icon {
+  @extend %with-icon, %hourglass-24-svg-prop !optional;
+  background-image: var(--hourglass-24-svg);
+}
+%with-hourglass-24-mask {
+  @extend %with-mask, %hourglass-24-svg-prop !optional;
+  -webkit-mask-image: var(--hourglass-24-svg);
+  mask-image: var(--hourglass-24-svg);
+}
+
+%with-identity-service-16-icon {
+  @extend %with-icon, %identity-service-16-svg-prop !optional;
+  background-image: var(--identity-service-16-svg);
+}
+%with-identity-service-16-mask {
+  @extend %with-mask, %identity-service-16-svg-prop !optional;
+  -webkit-mask-image: var(--identity-service-16-svg);
+  mask-image: var(--identity-service-16-svg);
+}
+
+%with-identity-service-24-icon {
+  @extend %with-icon, %identity-service-24-svg-prop !optional;
+  background-image: var(--identity-service-24-svg);
+}
+%with-identity-service-24-mask {
+  @extend %with-mask, %identity-service-24-svg-prop !optional;
+  -webkit-mask-image: var(--identity-service-24-svg);
+  mask-image: var(--identity-service-24-svg);
+}
+
+%with-identity-user-16-icon {
+  @extend %with-icon, %identity-user-16-svg-prop !optional;
+  background-image: var(--identity-user-16-svg);
+}
+%with-identity-user-16-mask {
+  @extend %with-mask, %identity-user-16-svg-prop !optional;
+  -webkit-mask-image: var(--identity-user-16-svg);
+  mask-image: var(--identity-user-16-svg);
+}
+
+%with-identity-user-24-icon {
+  @extend %with-icon, %identity-user-24-svg-prop !optional;
+  background-image: var(--identity-user-24-svg);
+}
+%with-identity-user-24-mask {
+  @extend %with-mask, %identity-user-24-svg-prop !optional;
+  -webkit-mask-image: var(--identity-user-24-svg);
+  mask-image: var(--identity-user-24-svg);
+}
+
+%with-image-16-icon {
+  @extend %with-icon, %image-16-svg-prop !optional;
+  background-image: var(--image-16-svg);
+}
+%with-image-16-mask {
+  @extend %with-mask, %image-16-svg-prop !optional;
+  -webkit-mask-image: var(--image-16-svg);
+  mask-image: var(--image-16-svg);
+}
+
+%with-image-24-icon {
+  @extend %with-icon, %image-24-svg-prop !optional;
+  background-image: var(--image-24-svg);
+}
+%with-image-24-mask {
+  @extend %with-mask, %image-24-svg-prop !optional;
+  -webkit-mask-image: var(--image-24-svg);
+  mask-image: var(--image-24-svg);
+}
+
+%with-inbox-16-icon {
+  @extend %with-icon, %inbox-16-svg-prop !optional;
+  background-image: var(--inbox-16-svg);
+}
+%with-inbox-16-mask {
+  @extend %with-mask, %inbox-16-svg-prop !optional;
+  -webkit-mask-image: var(--inbox-16-svg);
+  mask-image: var(--inbox-16-svg);
+}
+
+%with-inbox-24-icon {
+  @extend %with-icon, %inbox-24-svg-prop !optional;
+  background-image: var(--inbox-24-svg);
+}
+%with-inbox-24-mask {
+  @extend %with-mask, %inbox-24-svg-prop !optional;
+  -webkit-mask-image: var(--inbox-24-svg);
+  mask-image: var(--inbox-24-svg);
+}
+
+%with-info-16-icon {
+  @extend %with-icon, %info-16-svg-prop !optional;
+  background-image: var(--info-16-svg);
+}
+%with-info-16-mask {
+  @extend %with-mask, %info-16-svg-prop !optional;
+  -webkit-mask-image: var(--info-16-svg);
+  mask-image: var(--info-16-svg);
+}
+
+%with-info-24-icon {
+  @extend %with-icon, %info-24-svg-prop !optional;
+  background-image: var(--info-24-svg);
+}
+%with-info-24-mask {
+  @extend %with-mask, %info-24-svg-prop !optional;
+  -webkit-mask-image: var(--info-24-svg);
+  mask-image: var(--info-24-svg);
+}
+
 %with-info-circle-fill-icon {
-  @extend %with-icon, %info-circle-fill-svg-prop;
+  @extend %with-icon, %info-circle-fill-svg-prop !optional;
   background-image: var(--info-circle-fill-svg);
 }
 %with-info-circle-fill-mask {
-  @extend %with-mask, %info-circle-fill-svg-prop;
+  @extend %with-mask, %info-circle-fill-svg-prop !optional;
   -webkit-mask-image: var(--info-circle-fill-svg);
   mask-image: var(--info-circle-fill-svg);
 }
 
 %with-info-circle-outline-icon {
-  @extend %with-icon, %info-circle-outline-svg-prop;
+  @extend %with-icon, %info-circle-outline-svg-prop !optional;
   background-image: var(--info-circle-outline-svg);
 }
 %with-info-circle-outline-mask {
-  @extend %with-mask, %info-circle-outline-svg-prop;
+  @extend %with-mask, %info-circle-outline-svg-prop !optional;
   -webkit-mask-image: var(--info-circle-outline-svg);
   mask-image: var(--info-circle-outline-svg);
 }
 
+%with-jump-link-16-icon {
+  @extend %with-icon, %jump-link-16-svg-prop !optional;
+  background-image: var(--jump-link-16-svg);
+}
+%with-jump-link-16-mask {
+  @extend %with-mask, %jump-link-16-svg-prop !optional;
+  -webkit-mask-image: var(--jump-link-16-svg);
+  mask-image: var(--jump-link-16-svg);
+}
+
+%with-jump-link-24-icon {
+  @extend %with-icon, %jump-link-24-svg-prop !optional;
+  background-image: var(--jump-link-24-svg);
+}
+%with-jump-link-24-mask {
+  @extend %with-mask, %jump-link-24-svg-prop !optional;
+  -webkit-mask-image: var(--jump-link-24-svg);
+  mask-image: var(--jump-link-24-svg);
+}
+
+%with-key-16-icon {
+  @extend %with-icon, %key-16-svg-prop !optional;
+  background-image: var(--key-16-svg);
+}
+%with-key-16-mask {
+  @extend %with-mask, %key-16-svg-prop !optional;
+  -webkit-mask-image: var(--key-16-svg);
+  mask-image: var(--key-16-svg);
+}
+
+%with-key-24-icon {
+  @extend %with-icon, %key-24-svg-prop !optional;
+  background-image: var(--key-24-svg);
+}
+%with-key-24-mask {
+  @extend %with-mask, %key-24-svg-prop !optional;
+  -webkit-mask-image: var(--key-24-svg);
+  mask-image: var(--key-24-svg);
+}
+
+%with-key-values-16-icon {
+  @extend %with-icon, %key-values-16-svg-prop !optional;
+  background-image: var(--key-values-16-svg);
+}
+%with-key-values-16-mask {
+  @extend %with-mask, %key-values-16-svg-prop !optional;
+  -webkit-mask-image: var(--key-values-16-svg);
+  mask-image: var(--key-values-16-svg);
+}
+
+%with-key-values-24-icon {
+  @extend %with-icon, %key-values-24-svg-prop !optional;
+  background-image: var(--key-values-24-svg);
+}
+%with-key-values-24-mask {
+  @extend %with-mask, %key-values-24-svg-prop !optional;
+  -webkit-mask-image: var(--key-values-24-svg);
+  mask-image: var(--key-values-24-svg);
+}
+
 %with-key-icon {
-  @extend %with-icon, %key-svg-prop;
+  @extend %with-icon, %key-svg-prop !optional;
   background-image: var(--key-svg);
 }
 %with-key-mask {
-  @extend %with-mask, %key-svg-prop;
+  @extend %with-mask, %key-svg-prop !optional;
   -webkit-mask-image: var(--key-svg);
   mask-image: var(--key-svg);
 }
 
+%with-kubernetes-16-icon {
+  @extend %with-icon, %kubernetes-16-svg-prop !optional;
+  background-image: var(--kubernetes-16-svg);
+}
+%with-kubernetes-16-mask {
+  @extend %with-mask, %kubernetes-16-svg-prop !optional;
+  -webkit-mask-image: var(--kubernetes-16-svg);
+  mask-image: var(--kubernetes-16-svg);
+}
+
+%with-kubernetes-24-icon {
+  @extend %with-icon, %kubernetes-24-svg-prop !optional;
+  background-image: var(--kubernetes-24-svg);
+}
+%with-kubernetes-24-mask {
+  @extend %with-mask, %kubernetes-24-svg-prop !optional;
+  -webkit-mask-image: var(--kubernetes-24-svg);
+  mask-image: var(--kubernetes-24-svg);
+}
+
+%with-kubernetes-color-16-icon {
+  @extend %with-icon, %kubernetes-color-16-svg-prop !optional;
+  background-image: var(--kubernetes-color-16-svg);
+}
+%with-kubernetes-color-16-mask {
+  @extend %with-mask, %kubernetes-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--kubernetes-color-16-svg);
+  mask-image: var(--kubernetes-color-16-svg);
+}
+
+%with-kubernetes-color-24-icon {
+  @extend %with-icon, %kubernetes-color-24-svg-prop !optional;
+  background-image: var(--kubernetes-color-24-svg);
+}
+%with-kubernetes-color-24-mask {
+  @extend %with-mask, %kubernetes-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--kubernetes-color-24-svg);
+  mask-image: var(--kubernetes-color-24-svg);
+}
+
+%with-labyrinth-16-icon {
+  @extend %with-icon, %labyrinth-16-svg-prop !optional;
+  background-image: var(--labyrinth-16-svg);
+}
+%with-labyrinth-16-mask {
+  @extend %with-mask, %labyrinth-16-svg-prop !optional;
+  -webkit-mask-image: var(--labyrinth-16-svg);
+  mask-image: var(--labyrinth-16-svg);
+}
+
+%with-labyrinth-24-icon {
+  @extend %with-icon, %labyrinth-24-svg-prop !optional;
+  background-image: var(--labyrinth-24-svg);
+}
+%with-labyrinth-24-mask {
+  @extend %with-mask, %labyrinth-24-svg-prop !optional;
+  -webkit-mask-image: var(--labyrinth-24-svg);
+  mask-image: var(--labyrinth-24-svg);
+}
+
+%with-layers-16-icon {
+  @extend %with-icon, %layers-16-svg-prop !optional;
+  background-image: var(--layers-16-svg);
+}
+%with-layers-16-mask {
+  @extend %with-mask, %layers-16-svg-prop !optional;
+  -webkit-mask-image: var(--layers-16-svg);
+  mask-image: var(--layers-16-svg);
+}
+
+%with-layers-24-icon {
+  @extend %with-icon, %layers-24-svg-prop !optional;
+  background-image: var(--layers-24-svg);
+}
+%with-layers-24-mask {
+  @extend %with-mask, %layers-24-svg-prop !optional;
+  -webkit-mask-image: var(--layers-24-svg);
+  mask-image: var(--layers-24-svg);
+}
+
 %with-layers-icon {
-  @extend %with-icon, %layers-svg-prop;
+  @extend %with-icon, %layers-svg-prop !optional;
   background-image: var(--layers-svg);
 }
 %with-layers-mask {
-  @extend %with-mask, %layers-svg-prop;
+  @extend %with-mask, %layers-svg-prop !optional;
   -webkit-mask-image: var(--layers-svg);
   mask-image: var(--layers-svg);
 }
 
+%with-layout-16-icon {
+  @extend %with-icon, %layout-16-svg-prop !optional;
+  background-image: var(--layout-16-svg);
+}
+%with-layout-16-mask {
+  @extend %with-mask, %layout-16-svg-prop !optional;
+  -webkit-mask-image: var(--layout-16-svg);
+  mask-image: var(--layout-16-svg);
+}
+
+%with-layout-24-icon {
+  @extend %with-icon, %layout-24-svg-prop !optional;
+  background-image: var(--layout-24-svg);
+}
+%with-layout-24-mask {
+  @extend %with-mask, %layout-24-svg-prop !optional;
+  -webkit-mask-image: var(--layout-24-svg);
+  mask-image: var(--layout-24-svg);
+}
+
+%with-learn-16-icon {
+  @extend %with-icon, %learn-16-svg-prop !optional;
+  background-image: var(--learn-16-svg);
+}
+%with-learn-16-mask {
+  @extend %with-mask, %learn-16-svg-prop !optional;
+  -webkit-mask-image: var(--learn-16-svg);
+  mask-image: var(--learn-16-svg);
+}
+
+%with-learn-24-icon {
+  @extend %with-icon, %learn-24-svg-prop !optional;
+  background-image: var(--learn-24-svg);
+}
+%with-learn-24-mask {
+  @extend %with-mask, %learn-24-svg-prop !optional;
+  -webkit-mask-image: var(--learn-24-svg);
+  mask-image: var(--learn-24-svg);
+}
+
+%with-learn-link-16-icon {
+  @extend %with-icon, %learn-link-16-svg-prop !optional;
+  background-image: var(--learn-link-16-svg);
+}
+%with-learn-link-16-mask {
+  @extend %with-mask, %learn-link-16-svg-prop !optional;
+  -webkit-mask-image: var(--learn-link-16-svg);
+  mask-image: var(--learn-link-16-svg);
+}
+
+%with-learn-link-24-icon {
+  @extend %with-icon, %learn-link-24-svg-prop !optional;
+  background-image: var(--learn-link-24-svg);
+}
+%with-learn-link-24-mask {
+  @extend %with-mask, %learn-link-24-svg-prop !optional;
+  -webkit-mask-image: var(--learn-link-24-svg);
+  mask-image: var(--learn-link-24-svg);
+}
+
 %with-learn-icon {
-  @extend %with-icon, %learn-svg-prop;
+  @extend %with-icon, %learn-svg-prop !optional;
   background-image: var(--learn-svg);
 }
 %with-learn-mask {
-  @extend %with-mask, %learn-svg-prop;
+  @extend %with-mask, %learn-svg-prop !optional;
   -webkit-mask-image: var(--learn-svg);
   mask-image: var(--learn-svg);
 }
 
+%with-line-chart-16-icon {
+  @extend %with-icon, %line-chart-16-svg-prop !optional;
+  background-image: var(--line-chart-16-svg);
+}
+%with-line-chart-16-mask {
+  @extend %with-mask, %line-chart-16-svg-prop !optional;
+  -webkit-mask-image: var(--line-chart-16-svg);
+  mask-image: var(--line-chart-16-svg);
+}
+
+%with-line-chart-24-icon {
+  @extend %with-icon, %line-chart-24-svg-prop !optional;
+  background-image: var(--line-chart-24-svg);
+}
+%with-line-chart-24-mask {
+  @extend %with-mask, %line-chart-24-svg-prop !optional;
+  -webkit-mask-image: var(--line-chart-24-svg);
+  mask-image: var(--line-chart-24-svg);
+}
+
+%with-line-chart-up-16-icon {
+  @extend %with-icon, %line-chart-up-16-svg-prop !optional;
+  background-image: var(--line-chart-up-16-svg);
+}
+%with-line-chart-up-16-mask {
+  @extend %with-mask, %line-chart-up-16-svg-prop !optional;
+  -webkit-mask-image: var(--line-chart-up-16-svg);
+  mask-image: var(--line-chart-up-16-svg);
+}
+
+%with-line-chart-up-24-icon {
+  @extend %with-icon, %line-chart-up-24-svg-prop !optional;
+  background-image: var(--line-chart-up-24-svg);
+}
+%with-line-chart-up-24-mask {
+  @extend %with-mask, %line-chart-up-24-svg-prop !optional;
+  -webkit-mask-image: var(--line-chart-up-24-svg);
+  mask-image: var(--line-chart-up-24-svg);
+}
+
+%with-link-16-icon {
+  @extend %with-icon, %link-16-svg-prop !optional;
+  background-image: var(--link-16-svg);
+}
+%with-link-16-mask {
+  @extend %with-mask, %link-16-svg-prop !optional;
+  -webkit-mask-image: var(--link-16-svg);
+  mask-image: var(--link-16-svg);
+}
+
+%with-link-24-icon {
+  @extend %with-icon, %link-24-svg-prop !optional;
+  background-image: var(--link-24-svg);
+}
+%with-link-24-mask {
+  @extend %with-mask, %link-24-svg-prop !optional;
+  -webkit-mask-image: var(--link-24-svg);
+  mask-image: var(--link-24-svg);
+}
+
 %with-link-icon {
-  @extend %with-icon, %link-svg-prop;
+  @extend %with-icon, %link-svg-prop !optional;
   background-image: var(--link-svg);
 }
 %with-link-mask {
-  @extend %with-mask, %link-svg-prop;
+  @extend %with-mask, %link-svg-prop !optional;
   -webkit-mask-image: var(--link-svg);
   mask-image: var(--link-svg);
 }
 
+%with-list-16-icon {
+  @extend %with-icon, %list-16-svg-prop !optional;
+  background-image: var(--list-16-svg);
+}
+%with-list-16-mask {
+  @extend %with-mask, %list-16-svg-prop !optional;
+  -webkit-mask-image: var(--list-16-svg);
+  mask-image: var(--list-16-svg);
+}
+
+%with-list-24-icon {
+  @extend %with-icon, %list-24-svg-prop !optional;
+  background-image: var(--list-24-svg);
+}
+%with-list-24-mask {
+  @extend %with-mask, %list-24-svg-prop !optional;
+  -webkit-mask-image: var(--list-24-svg);
+  mask-image: var(--list-24-svg);
+}
+
 %with-loading-icon {
-  @extend %with-icon, %loading-svg-prop;
+  @extend %with-icon, %loading-svg-prop !optional;
   background-image: var(--loading-svg);
 }
 %with-loading-mask {
-  @extend %with-mask, %loading-svg-prop;
+  @extend %with-mask, %loading-svg-prop !optional;
   -webkit-mask-image: var(--loading-svg);
   mask-image: var(--loading-svg);
 }
 
+%with-lock-16-icon {
+  @extend %with-icon, %lock-16-svg-prop !optional;
+  background-image: var(--lock-16-svg);
+}
+%with-lock-16-mask {
+  @extend %with-mask, %lock-16-svg-prop !optional;
+  -webkit-mask-image: var(--lock-16-svg);
+  mask-image: var(--lock-16-svg);
+}
+
+%with-lock-24-icon {
+  @extend %with-icon, %lock-24-svg-prop !optional;
+  background-image: var(--lock-24-svg);
+}
+%with-lock-24-mask {
+  @extend %with-mask, %lock-24-svg-prop !optional;
+  -webkit-mask-image: var(--lock-24-svg);
+  mask-image: var(--lock-24-svg);
+}
+
 %with-lock-closed-fill-icon {
-  @extend %with-icon, %lock-closed-fill-svg-prop;
+  @extend %with-icon, %lock-closed-fill-svg-prop !optional;
   background-image: var(--lock-closed-fill-svg);
 }
 %with-lock-closed-fill-mask {
-  @extend %with-mask, %lock-closed-fill-svg-prop;
+  @extend %with-mask, %lock-closed-fill-svg-prop !optional;
   -webkit-mask-image: var(--lock-closed-fill-svg);
   mask-image: var(--lock-closed-fill-svg);
 }
 
 %with-lock-closed-outline-icon {
-  @extend %with-icon, %lock-closed-outline-svg-prop;
+  @extend %with-icon, %lock-closed-outline-svg-prop !optional;
   background-image: var(--lock-closed-outline-svg);
 }
 %with-lock-closed-outline-mask {
-  @extend %with-mask, %lock-closed-outline-svg-prop;
+  @extend %with-mask, %lock-closed-outline-svg-prop !optional;
   -webkit-mask-image: var(--lock-closed-outline-svg);
   mask-image: var(--lock-closed-outline-svg);
 }
 
 %with-lock-closed-icon {
-  @extend %with-icon, %lock-closed-svg-prop;
+  @extend %with-icon, %lock-closed-svg-prop !optional;
   background-image: var(--lock-closed-svg);
 }
 %with-lock-closed-mask {
-  @extend %with-mask, %lock-closed-svg-prop;
+  @extend %with-mask, %lock-closed-svg-prop !optional;
   -webkit-mask-image: var(--lock-closed-svg);
   mask-image: var(--lock-closed-svg);
 }
 
 %with-lock-disabled-icon {
-  @extend %with-icon, %lock-disabled-svg-prop;
+  @extend %with-icon, %lock-disabled-svg-prop !optional;
   background-image: var(--lock-disabled-svg);
 }
 %with-lock-disabled-mask {
-  @extend %with-mask, %lock-disabled-svg-prop;
+  @extend %with-mask, %lock-disabled-svg-prop !optional;
   -webkit-mask-image: var(--lock-disabled-svg);
   mask-image: var(--lock-disabled-svg);
 }
 
+%with-lock-fill-16-icon {
+  @extend %with-icon, %lock-fill-16-svg-prop !optional;
+  background-image: var(--lock-fill-16-svg);
+}
+%with-lock-fill-16-mask {
+  @extend %with-mask, %lock-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--lock-fill-16-svg);
+  mask-image: var(--lock-fill-16-svg);
+}
+
+%with-lock-fill-24-icon {
+  @extend %with-icon, %lock-fill-24-svg-prop !optional;
+  background-image: var(--lock-fill-24-svg);
+}
+%with-lock-fill-24-mask {
+  @extend %with-mask, %lock-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--lock-fill-24-svg);
+  mask-image: var(--lock-fill-24-svg);
+}
+
+%with-lock-off-16-icon {
+  @extend %with-icon, %lock-off-16-svg-prop !optional;
+  background-image: var(--lock-off-16-svg);
+}
+%with-lock-off-16-mask {
+  @extend %with-mask, %lock-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--lock-off-16-svg);
+  mask-image: var(--lock-off-16-svg);
+}
+
+%with-lock-off-24-icon {
+  @extend %with-icon, %lock-off-24-svg-prop !optional;
+  background-image: var(--lock-off-24-svg);
+}
+%with-lock-off-24-mask {
+  @extend %with-mask, %lock-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--lock-off-24-svg);
+  mask-image: var(--lock-off-24-svg);
+}
+
 %with-lock-open-icon {
-  @extend %with-icon, %lock-open-svg-prop;
+  @extend %with-icon, %lock-open-svg-prop !optional;
   background-image: var(--lock-open-svg);
 }
 %with-lock-open-mask {
-  @extend %with-mask, %lock-open-svg-prop;
+  @extend %with-mask, %lock-open-svg-prop !optional;
   -webkit-mask-image: var(--lock-open-svg);
   mask-image: var(--lock-open-svg);
 }
 
 %with-logo-alicloud-color-icon {
-  @extend %with-icon, %logo-alicloud-color-svg-prop;
+  @extend %with-icon, %logo-alicloud-color-svg-prop !optional;
   background-image: var(--logo-alicloud-color-svg);
 }
 %with-logo-alicloud-color-mask {
-  @extend %with-mask, %logo-alicloud-color-svg-prop;
+  @extend %with-mask, %logo-alicloud-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-alicloud-color-svg);
   mask-image: var(--logo-alicloud-color-svg);
 }
 
 %with-logo-alicloud-monochrome-icon {
-  @extend %with-icon, %logo-alicloud-monochrome-svg-prop;
+  @extend %with-icon, %logo-alicloud-monochrome-svg-prop !optional;
   background-image: var(--logo-alicloud-monochrome-svg);
 }
 %with-logo-alicloud-monochrome-mask {
-  @extend %with-mask, %logo-alicloud-monochrome-svg-prop;
+  @extend %with-mask, %logo-alicloud-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-alicloud-monochrome-svg);
   mask-image: var(--logo-alicloud-monochrome-svg);
 }
 
 %with-logo-auth0-color-icon {
-  @extend %with-icon, %logo-auth0-color-svg-prop;
+  @extend %with-icon, %logo-auth0-color-svg-prop !optional;
   background-image: var(--logo-auth0-color-svg);
 }
 %with-logo-auth0-color-mask {
-  @extend %with-mask, %logo-auth0-color-svg-prop;
+  @extend %with-mask, %logo-auth0-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-auth0-color-svg);
   mask-image: var(--logo-auth0-color-svg);
 }
 
 %with-logo-aws-color-icon {
-  @extend %with-icon, %logo-aws-color-svg-prop;
+  @extend %with-icon, %logo-aws-color-svg-prop !optional;
   background-image: var(--logo-aws-color-svg);
 }
 %with-logo-aws-color-mask {
-  @extend %with-mask, %logo-aws-color-svg-prop;
+  @extend %with-mask, %logo-aws-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-aws-color-svg);
   mask-image: var(--logo-aws-color-svg);
 }
 
 %with-logo-aws-monochrome-icon {
-  @extend %with-icon, %logo-aws-monochrome-svg-prop;
+  @extend %with-icon, %logo-aws-monochrome-svg-prop !optional;
   background-image: var(--logo-aws-monochrome-svg);
 }
 %with-logo-aws-monochrome-mask {
-  @extend %with-mask, %logo-aws-monochrome-svg-prop;
+  @extend %with-mask, %logo-aws-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-aws-monochrome-svg);
   mask-image: var(--logo-aws-monochrome-svg);
 }
 
 %with-logo-azure-color-icon {
-  @extend %with-icon, %logo-azure-color-svg-prop;
+  @extend %with-icon, %logo-azure-color-svg-prop !optional;
   background-image: var(--logo-azure-color-svg);
 }
 %with-logo-azure-color-mask {
-  @extend %with-mask, %logo-azure-color-svg-prop;
+  @extend %with-mask, %logo-azure-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-azure-color-svg);
   mask-image: var(--logo-azure-color-svg);
 }
 
 %with-logo-azure-dev-ops-color-icon {
-  @extend %with-icon, %logo-azure-dev-ops-color-svg-prop;
+  @extend %with-icon, %logo-azure-dev-ops-color-svg-prop !optional;
   background-image: var(--logo-azure-dev-ops-color-svg);
 }
 %with-logo-azure-dev-ops-color-mask {
-  @extend %with-mask, %logo-azure-dev-ops-color-svg-prop;
+  @extend %with-mask, %logo-azure-dev-ops-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-azure-dev-ops-color-svg);
   mask-image: var(--logo-azure-dev-ops-color-svg);
 }
 
 %with-logo-azure-dev-ops-monochrome-icon {
-  @extend %with-icon, %logo-azure-dev-ops-monochrome-svg-prop;
+  @extend %with-icon, %logo-azure-dev-ops-monochrome-svg-prop !optional;
   background-image: var(--logo-azure-dev-ops-monochrome-svg);
 }
 %with-logo-azure-dev-ops-monochrome-mask {
-  @extend %with-mask, %logo-azure-dev-ops-monochrome-svg-prop;
+  @extend %with-mask, %logo-azure-dev-ops-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-azure-dev-ops-monochrome-svg);
   mask-image: var(--logo-azure-dev-ops-monochrome-svg);
 }
 
 %with-logo-azure-monochrome-icon {
-  @extend %with-icon, %logo-azure-monochrome-svg-prop;
+  @extend %with-icon, %logo-azure-monochrome-svg-prop !optional;
   background-image: var(--logo-azure-monochrome-svg);
 }
 %with-logo-azure-monochrome-mask {
-  @extend %with-mask, %logo-azure-monochrome-svg-prop;
+  @extend %with-mask, %logo-azure-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-azure-monochrome-svg);
   mask-image: var(--logo-azure-monochrome-svg);
 }
 
 %with-logo-bitbucket-color-icon {
-  @extend %with-icon, %logo-bitbucket-color-svg-prop;
+  @extend %with-icon, %logo-bitbucket-color-svg-prop !optional;
   background-image: var(--logo-bitbucket-color-svg);
 }
 %with-logo-bitbucket-color-mask {
-  @extend %with-mask, %logo-bitbucket-color-svg-prop;
+  @extend %with-mask, %logo-bitbucket-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-bitbucket-color-svg);
   mask-image: var(--logo-bitbucket-color-svg);
 }
 
 %with-logo-bitbucket-monochrome-icon {
-  @extend %with-icon, %logo-bitbucket-monochrome-svg-prop;
+  @extend %with-icon, %logo-bitbucket-monochrome-svg-prop !optional;
   background-image: var(--logo-bitbucket-monochrome-svg);
 }
 %with-logo-bitbucket-monochrome-mask {
-  @extend %with-mask, %logo-bitbucket-monochrome-svg-prop;
+  @extend %with-mask, %logo-bitbucket-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-bitbucket-monochrome-svg);
   mask-image: var(--logo-bitbucket-monochrome-svg);
 }
 
 %with-logo-consul-color-icon {
-  @extend %with-icon, %logo-consul-color-svg-prop;
+  @extend %with-icon, %logo-consul-color-svg-prop !optional;
   background-image: var(--logo-consul-color-svg);
 }
 %with-logo-consul-color-mask {
-  @extend %with-mask, %logo-consul-color-svg-prop;
+  @extend %with-mask, %logo-consul-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-consul-color-svg);
   mask-image: var(--logo-consul-color-svg);
 }
 
 %with-logo-ember-circle-color-icon {
-  @extend %with-icon, %logo-ember-circle-color-svg-prop;
+  @extend %with-icon, %logo-ember-circle-color-svg-prop !optional;
   background-image: var(--logo-ember-circle-color-svg);
 }
 %with-logo-ember-circle-color-mask {
-  @extend %with-mask, %logo-ember-circle-color-svg-prop;
+  @extend %with-mask, %logo-ember-circle-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-ember-circle-color-svg);
   mask-image: var(--logo-ember-circle-color-svg);
 }
 
 %with-logo-gcp-color-icon {
-  @extend %with-icon, %logo-gcp-color-svg-prop;
+  @extend %with-icon, %logo-gcp-color-svg-prop !optional;
   background-image: var(--logo-gcp-color-svg);
 }
 %with-logo-gcp-color-mask {
-  @extend %with-mask, %logo-gcp-color-svg-prop;
+  @extend %with-mask, %logo-gcp-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-gcp-color-svg);
   mask-image: var(--logo-gcp-color-svg);
 }
 
 %with-logo-gcp-monochrome-icon {
-  @extend %with-icon, %logo-gcp-monochrome-svg-prop;
+  @extend %with-icon, %logo-gcp-monochrome-svg-prop !optional;
   background-image: var(--logo-gcp-monochrome-svg);
 }
 %with-logo-gcp-monochrome-mask {
-  @extend %with-mask, %logo-gcp-monochrome-svg-prop;
+  @extend %with-mask, %logo-gcp-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-gcp-monochrome-svg);
   mask-image: var(--logo-gcp-monochrome-svg);
 }
 
 %with-logo-github-color-icon {
-  @extend %with-icon, %logo-github-color-svg-prop;
+  @extend %with-icon, %logo-github-color-svg-prop !optional;
   background-image: var(--logo-github-color-svg);
 }
 %with-logo-github-color-mask {
-  @extend %with-mask, %logo-github-color-svg-prop;
+  @extend %with-mask, %logo-github-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-github-color-svg);
   mask-image: var(--logo-github-color-svg);
 }
 
 %with-logo-github-monochrome-icon {
-  @extend %with-icon, %logo-github-monochrome-svg-prop;
+  @extend %with-icon, %logo-github-monochrome-svg-prop !optional;
   background-image: var(--logo-github-monochrome-svg);
 }
 %with-logo-github-monochrome-mask {
-  @extend %with-mask, %logo-github-monochrome-svg-prop;
+  @extend %with-mask, %logo-github-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-github-monochrome-svg);
   mask-image: var(--logo-github-monochrome-svg);
 }
 
 %with-logo-gitlab-color-icon {
-  @extend %with-icon, %logo-gitlab-color-svg-prop;
+  @extend %with-icon, %logo-gitlab-color-svg-prop !optional;
   background-image: var(--logo-gitlab-color-svg);
 }
 %with-logo-gitlab-color-mask {
-  @extend %with-mask, %logo-gitlab-color-svg-prop;
+  @extend %with-mask, %logo-gitlab-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-gitlab-color-svg);
   mask-image: var(--logo-gitlab-color-svg);
 }
 
 %with-logo-gitlab-monochrome-icon {
-  @extend %with-icon, %logo-gitlab-monochrome-svg-prop;
+  @extend %with-icon, %logo-gitlab-monochrome-svg-prop !optional;
   background-image: var(--logo-gitlab-monochrome-svg);
 }
 %with-logo-gitlab-monochrome-mask {
-  @extend %with-mask, %logo-gitlab-monochrome-svg-prop;
+  @extend %with-mask, %logo-gitlab-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-gitlab-monochrome-svg);
   mask-image: var(--logo-gitlab-monochrome-svg);
 }
 
 %with-logo-glimmer-color-icon {
-  @extend %with-icon, %logo-glimmer-color-svg-prop;
+  @extend %with-icon, %logo-glimmer-color-svg-prop !optional;
   background-image: var(--logo-glimmer-color-svg);
 }
 %with-logo-glimmer-color-mask {
-  @extend %with-mask, %logo-glimmer-color-svg-prop;
+  @extend %with-mask, %logo-glimmer-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-glimmer-color-svg);
   mask-image: var(--logo-glimmer-color-svg);
 }
 
 %with-logo-google-color-icon {
-  @extend %with-icon, %logo-google-color-svg-prop;
+  @extend %with-icon, %logo-google-color-svg-prop !optional;
   background-image: var(--logo-google-color-svg);
 }
 %with-logo-google-color-mask {
-  @extend %with-mask, %logo-google-color-svg-prop;
+  @extend %with-mask, %logo-google-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-google-color-svg);
   mask-image: var(--logo-google-color-svg);
 }
 
 %with-logo-google-monochrome-icon {
-  @extend %with-icon, %logo-google-monochrome-svg-prop;
+  @extend %with-icon, %logo-google-monochrome-svg-prop !optional;
   background-image: var(--logo-google-monochrome-svg);
 }
 %with-logo-google-monochrome-mask {
-  @extend %with-mask, %logo-google-monochrome-svg-prop;
+  @extend %with-mask, %logo-google-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-google-monochrome-svg);
   mask-image: var(--logo-google-monochrome-svg);
 }
 
 %with-logo-hashicorp-color-icon {
-  @extend %with-icon, %logo-hashicorp-color-svg-prop;
+  @extend %with-icon, %logo-hashicorp-color-svg-prop !optional;
   background-image: var(--logo-hashicorp-color-svg);
 }
 %with-logo-hashicorp-color-mask {
-  @extend %with-mask, %logo-hashicorp-color-svg-prop;
+  @extend %with-mask, %logo-hashicorp-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-hashicorp-color-svg);
   mask-image: var(--logo-hashicorp-color-svg);
 }
 
 %with-logo-jwt-color-icon {
-  @extend %with-icon, %logo-jwt-color-svg-prop;
+  @extend %with-icon, %logo-jwt-color-svg-prop !optional;
   background-image: var(--logo-jwt-color-svg);
 }
 %with-logo-jwt-color-mask {
-  @extend %with-mask, %logo-jwt-color-svg-prop;
+  @extend %with-mask, %logo-jwt-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-jwt-color-svg);
   mask-image: var(--logo-jwt-color-svg);
 }
 
 %with-logo-kubernetes-color-icon {
-  @extend %with-icon, %logo-kubernetes-color-svg-prop;
+  @extend %with-icon, %logo-kubernetes-color-svg-prop !optional;
   background-image: var(--logo-kubernetes-color-svg);
 }
 %with-logo-kubernetes-color-mask {
-  @extend %with-mask, %logo-kubernetes-color-svg-prop;
+  @extend %with-mask, %logo-kubernetes-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-kubernetes-color-svg);
   mask-image: var(--logo-kubernetes-color-svg);
 }
 
 %with-logo-kubernetes-monochrome-icon {
-  @extend %with-icon, %logo-kubernetes-monochrome-svg-prop;
+  @extend %with-icon, %logo-kubernetes-monochrome-svg-prop !optional;
   background-image: var(--logo-kubernetes-monochrome-svg);
 }
 %with-logo-kubernetes-monochrome-mask {
-  @extend %with-mask, %logo-kubernetes-monochrome-svg-prop;
+  @extend %with-mask, %logo-kubernetes-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-kubernetes-monochrome-svg);
   mask-image: var(--logo-kubernetes-monochrome-svg);
 }
 
 %with-logo-microsoft-color-icon {
-  @extend %with-icon, %logo-microsoft-color-svg-prop;
+  @extend %with-icon, %logo-microsoft-color-svg-prop !optional;
   background-image: var(--logo-microsoft-color-svg);
 }
 %with-logo-microsoft-color-mask {
-  @extend %with-mask, %logo-microsoft-color-svg-prop;
+  @extend %with-mask, %logo-microsoft-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-microsoft-color-svg);
   mask-image: var(--logo-microsoft-color-svg);
 }
 
 %with-logo-nomad-color-icon {
-  @extend %with-icon, %logo-nomad-color-svg-prop;
+  @extend %with-icon, %logo-nomad-color-svg-prop !optional;
   background-image: var(--logo-nomad-color-svg);
 }
 %with-logo-nomad-color-mask {
-  @extend %with-mask, %logo-nomad-color-svg-prop;
+  @extend %with-mask, %logo-nomad-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-nomad-color-svg);
   mask-image: var(--logo-nomad-color-svg);
 }
 
 %with-logo-oidc-color-icon {
-  @extend %with-icon, %logo-oidc-color-svg-prop;
+  @extend %with-icon, %logo-oidc-color-svg-prop !optional;
   background-image: var(--logo-oidc-color-svg);
 }
 %with-logo-oidc-color-mask {
-  @extend %with-mask, %logo-oidc-color-svg-prop;
+  @extend %with-mask, %logo-oidc-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-oidc-color-svg);
   mask-image: var(--logo-oidc-color-svg);
 }
 
 %with-logo-okta-color-icon {
-  @extend %with-icon, %logo-okta-color-svg-prop;
+  @extend %with-icon, %logo-okta-color-svg-prop !optional;
   background-image: var(--logo-okta-color-svg);
 }
 %with-logo-okta-color-mask {
-  @extend %with-mask, %logo-okta-color-svg-prop;
+  @extend %with-mask, %logo-okta-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-okta-color-svg);
   mask-image: var(--logo-okta-color-svg);
 }
 
 %with-logo-oracle-color-icon {
-  @extend %with-icon, %logo-oracle-color-svg-prop;
+  @extend %with-icon, %logo-oracle-color-svg-prop !optional;
   background-image: var(--logo-oracle-color-svg);
 }
 %with-logo-oracle-color-mask {
-  @extend %with-mask, %logo-oracle-color-svg-prop;
+  @extend %with-mask, %logo-oracle-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-oracle-color-svg);
   mask-image: var(--logo-oracle-color-svg);
 }
 
 %with-logo-oracle-monochrome-icon {
-  @extend %with-icon, %logo-oracle-monochrome-svg-prop;
+  @extend %with-icon, %logo-oracle-monochrome-svg-prop !optional;
   background-image: var(--logo-oracle-monochrome-svg);
 }
 %with-logo-oracle-monochrome-mask {
-  @extend %with-mask, %logo-oracle-monochrome-svg-prop;
+  @extend %with-mask, %logo-oracle-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-oracle-monochrome-svg);
   mask-image: var(--logo-oracle-monochrome-svg);
 }
 
 %with-logo-slack-color-icon {
-  @extend %with-icon, %logo-slack-color-svg-prop;
+  @extend %with-icon, %logo-slack-color-svg-prop !optional;
   background-image: var(--logo-slack-color-svg);
 }
 %with-logo-slack-color-mask {
-  @extend %with-mask, %logo-slack-color-svg-prop;
+  @extend %with-mask, %logo-slack-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-slack-color-svg);
   mask-image: var(--logo-slack-color-svg);
 }
 
 %with-logo-slack-monochrome-icon {
-  @extend %with-icon, %logo-slack-monochrome-svg-prop;
+  @extend %with-icon, %logo-slack-monochrome-svg-prop !optional;
   background-image: var(--logo-slack-monochrome-svg);
 }
 %with-logo-slack-monochrome-mask {
-  @extend %with-mask, %logo-slack-monochrome-svg-prop;
+  @extend %with-mask, %logo-slack-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-slack-monochrome-svg);
   mask-image: var(--logo-slack-monochrome-svg);
 }
 
 %with-logo-terraform-color-icon {
-  @extend %with-icon, %logo-terraform-color-svg-prop;
+  @extend %with-icon, %logo-terraform-color-svg-prop !optional;
   background-image: var(--logo-terraform-color-svg);
 }
 %with-logo-terraform-color-mask {
-  @extend %with-mask, %logo-terraform-color-svg-prop;
+  @extend %with-mask, %logo-terraform-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-terraform-color-svg);
   mask-image: var(--logo-terraform-color-svg);
 }
 
 %with-logo-vault-color-icon {
-  @extend %with-icon, %logo-vault-color-svg-prop;
+  @extend %with-icon, %logo-vault-color-svg-prop !optional;
   background-image: var(--logo-vault-color-svg);
 }
 %with-logo-vault-color-mask {
-  @extend %with-mask, %logo-vault-color-svg-prop;
+  @extend %with-mask, %logo-vault-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-vault-color-svg);
   mask-image: var(--logo-vault-color-svg);
 }
 
 %with-logo-vmware-color-icon {
-  @extend %with-icon, %logo-vmware-color-svg-prop;
+  @extend %with-icon, %logo-vmware-color-svg-prop !optional;
   background-image: var(--logo-vmware-color-svg);
 }
 %with-logo-vmware-color-mask {
-  @extend %with-mask, %logo-vmware-color-svg-prop;
+  @extend %with-mask, %logo-vmware-color-svg-prop !optional;
   -webkit-mask-image: var(--logo-vmware-color-svg);
   mask-image: var(--logo-vmware-color-svg);
 }
 
 %with-logo-vmware-monochrome-icon {
-  @extend %with-icon, %logo-vmware-monochrome-svg-prop;
+  @extend %with-icon, %logo-vmware-monochrome-svg-prop !optional;
   background-image: var(--logo-vmware-monochrome-svg);
 }
 %with-logo-vmware-monochrome-mask {
-  @extend %with-mask, %logo-vmware-monochrome-svg-prop;
+  @extend %with-mask, %logo-vmware-monochrome-svg-prop !optional;
   -webkit-mask-image: var(--logo-vmware-monochrome-svg);
   mask-image: var(--logo-vmware-monochrome-svg);
 }
 
+%with-mail-16-icon {
+  @extend %with-icon, %mail-16-svg-prop !optional;
+  background-image: var(--mail-16-svg);
+}
+%with-mail-16-mask {
+  @extend %with-mask, %mail-16-svg-prop !optional;
+  -webkit-mask-image: var(--mail-16-svg);
+  mask-image: var(--mail-16-svg);
+}
+
+%with-mail-24-icon {
+  @extend %with-icon, %mail-24-svg-prop !optional;
+  background-image: var(--mail-24-svg);
+}
+%with-mail-24-mask {
+  @extend %with-mask, %mail-24-svg-prop !optional;
+  -webkit-mask-image: var(--mail-24-svg);
+  mask-image: var(--mail-24-svg);
+}
+
+%with-mail-open-16-icon {
+  @extend %with-icon, %mail-open-16-svg-prop !optional;
+  background-image: var(--mail-open-16-svg);
+}
+%with-mail-open-16-mask {
+  @extend %with-mask, %mail-open-16-svg-prop !optional;
+  -webkit-mask-image: var(--mail-open-16-svg);
+  mask-image: var(--mail-open-16-svg);
+}
+
+%with-mail-open-24-icon {
+  @extend %with-icon, %mail-open-24-svg-prop !optional;
+  background-image: var(--mail-open-24-svg);
+}
+%with-mail-open-24-mask {
+  @extend %with-mask, %mail-open-24-svg-prop !optional;
+  -webkit-mask-image: var(--mail-open-24-svg);
+  mask-image: var(--mail-open-24-svg);
+}
+
+%with-map-16-icon {
+  @extend %with-icon, %map-16-svg-prop !optional;
+  background-image: var(--map-16-svg);
+}
+%with-map-16-mask {
+  @extend %with-mask, %map-16-svg-prop !optional;
+  -webkit-mask-image: var(--map-16-svg);
+  mask-image: var(--map-16-svg);
+}
+
+%with-map-24-icon {
+  @extend %with-icon, %map-24-svg-prop !optional;
+  background-image: var(--map-24-svg);
+}
+%with-map-24-mask {
+  @extend %with-mask, %map-24-svg-prop !optional;
+  -webkit-mask-image: var(--map-24-svg);
+  mask-image: var(--map-24-svg);
+}
+
+%with-map-pin-16-icon {
+  @extend %with-icon, %map-pin-16-svg-prop !optional;
+  background-image: var(--map-pin-16-svg);
+}
+%with-map-pin-16-mask {
+  @extend %with-mask, %map-pin-16-svg-prop !optional;
+  -webkit-mask-image: var(--map-pin-16-svg);
+  mask-image: var(--map-pin-16-svg);
+}
+
+%with-map-pin-24-icon {
+  @extend %with-icon, %map-pin-24-svg-prop !optional;
+  background-image: var(--map-pin-24-svg);
+}
+%with-map-pin-24-mask {
+  @extend %with-mask, %map-pin-24-svg-prop !optional;
+  -webkit-mask-image: var(--map-pin-24-svg);
+  mask-image: var(--map-pin-24-svg);
+}
+
+%with-maximize-16-icon {
+  @extend %with-icon, %maximize-16-svg-prop !optional;
+  background-image: var(--maximize-16-svg);
+}
+%with-maximize-16-mask {
+  @extend %with-mask, %maximize-16-svg-prop !optional;
+  -webkit-mask-image: var(--maximize-16-svg);
+  mask-image: var(--maximize-16-svg);
+}
+
+%with-maximize-24-icon {
+  @extend %with-icon, %maximize-24-svg-prop !optional;
+  background-image: var(--maximize-24-svg);
+}
+%with-maximize-24-mask {
+  @extend %with-mask, %maximize-24-svg-prop !optional;
+  -webkit-mask-image: var(--maximize-24-svg);
+  mask-image: var(--maximize-24-svg);
+}
+
+%with-maximize-alt-16-icon {
+  @extend %with-icon, %maximize-alt-16-svg-prop !optional;
+  background-image: var(--maximize-alt-16-svg);
+}
+%with-maximize-alt-16-mask {
+  @extend %with-mask, %maximize-alt-16-svg-prop !optional;
+  -webkit-mask-image: var(--maximize-alt-16-svg);
+  mask-image: var(--maximize-alt-16-svg);
+}
+
+%with-maximize-alt-24-icon {
+  @extend %with-icon, %maximize-alt-24-svg-prop !optional;
+  background-image: var(--maximize-alt-24-svg);
+}
+%with-maximize-alt-24-mask {
+  @extend %with-mask, %maximize-alt-24-svg-prop !optional;
+  -webkit-mask-image: var(--maximize-alt-24-svg);
+  mask-image: var(--maximize-alt-24-svg);
+}
+
+%with-meh-16-icon {
+  @extend %with-icon, %meh-16-svg-prop !optional;
+  background-image: var(--meh-16-svg);
+}
+%with-meh-16-mask {
+  @extend %with-mask, %meh-16-svg-prop !optional;
+  -webkit-mask-image: var(--meh-16-svg);
+  mask-image: var(--meh-16-svg);
+}
+
+%with-meh-24-icon {
+  @extend %with-icon, %meh-24-svg-prop !optional;
+  background-image: var(--meh-24-svg);
+}
+%with-meh-24-mask {
+  @extend %with-mask, %meh-24-svg-prop !optional;
+  -webkit-mask-image: var(--meh-24-svg);
+  mask-image: var(--meh-24-svg);
+}
+
+%with-menu-16-icon {
+  @extend %with-icon, %menu-16-svg-prop !optional;
+  background-image: var(--menu-16-svg);
+}
+%with-menu-16-mask {
+  @extend %with-mask, %menu-16-svg-prop !optional;
+  -webkit-mask-image: var(--menu-16-svg);
+  mask-image: var(--menu-16-svg);
+}
+
+%with-menu-24-icon {
+  @extend %with-icon, %menu-24-svg-prop !optional;
+  background-image: var(--menu-24-svg);
+}
+%with-menu-24-mask {
+  @extend %with-mask, %menu-24-svg-prop !optional;
+  -webkit-mask-image: var(--menu-24-svg);
+  mask-image: var(--menu-24-svg);
+}
+
 %with-menu-icon {
-  @extend %with-icon, %menu-svg-prop;
+  @extend %with-icon, %menu-svg-prop !optional;
   background-image: var(--menu-svg);
 }
 %with-menu-mask {
-  @extend %with-mask, %menu-svg-prop;
+  @extend %with-mask, %menu-svg-prop !optional;
   -webkit-mask-image: var(--menu-svg);
   mask-image: var(--menu-svg);
 }
 
+%with-mesh-16-icon {
+  @extend %with-icon, %mesh-16-svg-prop !optional;
+  background-image: var(--mesh-16-svg);
+}
+%with-mesh-16-mask {
+  @extend %with-mask, %mesh-16-svg-prop !optional;
+  -webkit-mask-image: var(--mesh-16-svg);
+  mask-image: var(--mesh-16-svg);
+}
+
+%with-mesh-24-icon {
+  @extend %with-icon, %mesh-24-svg-prop !optional;
+  background-image: var(--mesh-24-svg);
+}
+%with-mesh-24-mask {
+  @extend %with-mask, %mesh-24-svg-prop !optional;
+  -webkit-mask-image: var(--mesh-24-svg);
+  mask-image: var(--mesh-24-svg);
+}
+
 %with-mesh-icon {
-  @extend %with-icon, %mesh-svg-prop;
+  @extend %with-icon, %mesh-svg-prop !optional;
   background-image: var(--mesh-svg);
 }
 %with-mesh-mask {
-  @extend %with-mask, %mesh-svg-prop;
+  @extend %with-mask, %mesh-svg-prop !optional;
   -webkit-mask-image: var(--mesh-svg);
   mask-image: var(--mesh-svg);
 }
 
+%with-message-circle-16-icon {
+  @extend %with-icon, %message-circle-16-svg-prop !optional;
+  background-image: var(--message-circle-16-svg);
+}
+%with-message-circle-16-mask {
+  @extend %with-mask, %message-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--message-circle-16-svg);
+  mask-image: var(--message-circle-16-svg);
+}
+
+%with-message-circle-24-icon {
+  @extend %with-icon, %message-circle-24-svg-prop !optional;
+  background-image: var(--message-circle-24-svg);
+}
+%with-message-circle-24-mask {
+  @extend %with-mask, %message-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--message-circle-24-svg);
+  mask-image: var(--message-circle-24-svg);
+}
+
+%with-message-circle-fill-16-icon {
+  @extend %with-icon, %message-circle-fill-16-svg-prop !optional;
+  background-image: var(--message-circle-fill-16-svg);
+}
+%with-message-circle-fill-16-mask {
+  @extend %with-mask, %message-circle-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--message-circle-fill-16-svg);
+  mask-image: var(--message-circle-fill-16-svg);
+}
+
+%with-message-circle-fill-24-icon {
+  @extend %with-icon, %message-circle-fill-24-svg-prop !optional;
+  background-image: var(--message-circle-fill-24-svg);
+}
+%with-message-circle-fill-24-mask {
+  @extend %with-mask, %message-circle-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--message-circle-fill-24-svg);
+  mask-image: var(--message-circle-fill-24-svg);
+}
+
+%with-message-square-16-icon {
+  @extend %with-icon, %message-square-16-svg-prop !optional;
+  background-image: var(--message-square-16-svg);
+}
+%with-message-square-16-mask {
+  @extend %with-mask, %message-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--message-square-16-svg);
+  mask-image: var(--message-square-16-svg);
+}
+
+%with-message-square-24-icon {
+  @extend %with-icon, %message-square-24-svg-prop !optional;
+  background-image: var(--message-square-24-svg);
+}
+%with-message-square-24-mask {
+  @extend %with-mask, %message-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--message-square-24-svg);
+  mask-image: var(--message-square-24-svg);
+}
+
+%with-message-square-fill-16-icon {
+  @extend %with-icon, %message-square-fill-16-svg-prop !optional;
+  background-image: var(--message-square-fill-16-svg);
+}
+%with-message-square-fill-16-mask {
+  @extend %with-mask, %message-square-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--message-square-fill-16-svg);
+  mask-image: var(--message-square-fill-16-svg);
+}
+
+%with-message-square-fill-24-icon {
+  @extend %with-icon, %message-square-fill-24-svg-prop !optional;
+  background-image: var(--message-square-fill-24-svg);
+}
+%with-message-square-fill-24-mask {
+  @extend %with-mask, %message-square-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--message-square-fill-24-svg);
+  mask-image: var(--message-square-fill-24-svg);
+}
+
 %with-message-icon {
-  @extend %with-icon, %message-svg-prop;
+  @extend %with-icon, %message-svg-prop !optional;
   background-image: var(--message-svg);
 }
 %with-message-mask {
-  @extend %with-mask, %message-svg-prop;
+  @extend %with-mask, %message-svg-prop !optional;
   -webkit-mask-image: var(--message-svg);
   mask-image: var(--message-svg);
 }
 
+%with-mic-16-icon {
+  @extend %with-icon, %mic-16-svg-prop !optional;
+  background-image: var(--mic-16-svg);
+}
+%with-mic-16-mask {
+  @extend %with-mask, %mic-16-svg-prop !optional;
+  -webkit-mask-image: var(--mic-16-svg);
+  mask-image: var(--mic-16-svg);
+}
+
+%with-mic-24-icon {
+  @extend %with-icon, %mic-24-svg-prop !optional;
+  background-image: var(--mic-24-svg);
+}
+%with-mic-24-mask {
+  @extend %with-mask, %mic-24-svg-prop !optional;
+  -webkit-mask-image: var(--mic-24-svg);
+  mask-image: var(--mic-24-svg);
+}
+
+%with-mic-off-16-icon {
+  @extend %with-icon, %mic-off-16-svg-prop !optional;
+  background-image: var(--mic-off-16-svg);
+}
+%with-mic-off-16-mask {
+  @extend %with-mask, %mic-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--mic-off-16-svg);
+  mask-image: var(--mic-off-16-svg);
+}
+
+%with-mic-off-24-icon {
+  @extend %with-icon, %mic-off-24-svg-prop !optional;
+  background-image: var(--mic-off-24-svg);
+}
+%with-mic-off-24-mask {
+  @extend %with-mask, %mic-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--mic-off-24-svg);
+  mask-image: var(--mic-off-24-svg);
+}
+
+%with-microsoft-16-icon {
+  @extend %with-icon, %microsoft-16-svg-prop !optional;
+  background-image: var(--microsoft-16-svg);
+}
+%with-microsoft-16-mask {
+  @extend %with-mask, %microsoft-16-svg-prop !optional;
+  -webkit-mask-image: var(--microsoft-16-svg);
+  mask-image: var(--microsoft-16-svg);
+}
+
+%with-microsoft-24-icon {
+  @extend %with-icon, %microsoft-24-svg-prop !optional;
+  background-image: var(--microsoft-24-svg);
+}
+%with-microsoft-24-mask {
+  @extend %with-mask, %microsoft-24-svg-prop !optional;
+  -webkit-mask-image: var(--microsoft-24-svg);
+  mask-image: var(--microsoft-24-svg);
+}
+
+%with-microsoft-color-16-icon {
+  @extend %with-icon, %microsoft-color-16-svg-prop !optional;
+  background-image: var(--microsoft-color-16-svg);
+}
+%with-microsoft-color-16-mask {
+  @extend %with-mask, %microsoft-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--microsoft-color-16-svg);
+  mask-image: var(--microsoft-color-16-svg);
+}
+
+%with-microsoft-color-24-icon {
+  @extend %with-icon, %microsoft-color-24-svg-prop !optional;
+  background-image: var(--microsoft-color-24-svg);
+}
+%with-microsoft-color-24-mask {
+  @extend %with-mask, %microsoft-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--microsoft-color-24-svg);
+  mask-image: var(--microsoft-color-24-svg);
+}
+
+%with-migrate-16-icon {
+  @extend %with-icon, %migrate-16-svg-prop !optional;
+  background-image: var(--migrate-16-svg);
+}
+%with-migrate-16-mask {
+  @extend %with-mask, %migrate-16-svg-prop !optional;
+  -webkit-mask-image: var(--migrate-16-svg);
+  mask-image: var(--migrate-16-svg);
+}
+
+%with-migrate-24-icon {
+  @extend %with-icon, %migrate-24-svg-prop !optional;
+  background-image: var(--migrate-24-svg);
+}
+%with-migrate-24-mask {
+  @extend %with-mask, %migrate-24-svg-prop !optional;
+  -webkit-mask-image: var(--migrate-24-svg);
+  mask-image: var(--migrate-24-svg);
+}
+
+%with-minimize-16-icon {
+  @extend %with-icon, %minimize-16-svg-prop !optional;
+  background-image: var(--minimize-16-svg);
+}
+%with-minimize-16-mask {
+  @extend %with-mask, %minimize-16-svg-prop !optional;
+  -webkit-mask-image: var(--minimize-16-svg);
+  mask-image: var(--minimize-16-svg);
+}
+
+%with-minimize-24-icon {
+  @extend %with-icon, %minimize-24-svg-prop !optional;
+  background-image: var(--minimize-24-svg);
+}
+%with-minimize-24-mask {
+  @extend %with-mask, %minimize-24-svg-prop !optional;
+  -webkit-mask-image: var(--minimize-24-svg);
+  mask-image: var(--minimize-24-svg);
+}
+
+%with-minimize-alt-16-icon {
+  @extend %with-icon, %minimize-alt-16-svg-prop !optional;
+  background-image: var(--minimize-alt-16-svg);
+}
+%with-minimize-alt-16-mask {
+  @extend %with-mask, %minimize-alt-16-svg-prop !optional;
+  -webkit-mask-image: var(--minimize-alt-16-svg);
+  mask-image: var(--minimize-alt-16-svg);
+}
+
+%with-minimize-alt-24-icon {
+  @extend %with-icon, %minimize-alt-24-svg-prop !optional;
+  background-image: var(--minimize-alt-24-svg);
+}
+%with-minimize-alt-24-mask {
+  @extend %with-mask, %minimize-alt-24-svg-prop !optional;
+  -webkit-mask-image: var(--minimize-alt-24-svg);
+  mask-image: var(--minimize-alt-24-svg);
+}
+
+%with-minus-16-icon {
+  @extend %with-icon, %minus-16-svg-prop !optional;
+  background-image: var(--minus-16-svg);
+}
+%with-minus-16-mask {
+  @extend %with-mask, %minus-16-svg-prop !optional;
+  -webkit-mask-image: var(--minus-16-svg);
+  mask-image: var(--minus-16-svg);
+}
+
+%with-minus-24-icon {
+  @extend %with-icon, %minus-24-svg-prop !optional;
+  background-image: var(--minus-24-svg);
+}
+%with-minus-24-mask {
+  @extend %with-mask, %minus-24-svg-prop !optional;
+  -webkit-mask-image: var(--minus-24-svg);
+  mask-image: var(--minus-24-svg);
+}
+
+%with-minus-circle-16-icon {
+  @extend %with-icon, %minus-circle-16-svg-prop !optional;
+  background-image: var(--minus-circle-16-svg);
+}
+%with-minus-circle-16-mask {
+  @extend %with-mask, %minus-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--minus-circle-16-svg);
+  mask-image: var(--minus-circle-16-svg);
+}
+
+%with-minus-circle-24-icon {
+  @extend %with-icon, %minus-circle-24-svg-prop !optional;
+  background-image: var(--minus-circle-24-svg);
+}
+%with-minus-circle-24-mask {
+  @extend %with-mask, %minus-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--minus-circle-24-svg);
+  mask-image: var(--minus-circle-24-svg);
+}
+
 %with-minus-circle-fill-icon {
-  @extend %with-icon, %minus-circle-fill-svg-prop;
+  @extend %with-icon, %minus-circle-fill-svg-prop !optional;
   background-image: var(--minus-circle-fill-svg);
 }
 %with-minus-circle-fill-mask {
-  @extend %with-mask, %minus-circle-fill-svg-prop;
+  @extend %with-mask, %minus-circle-fill-svg-prop !optional;
   -webkit-mask-image: var(--minus-circle-fill-svg);
   mask-image: var(--minus-circle-fill-svg);
 }
 
 %with-minus-circle-outline-icon {
-  @extend %with-icon, %minus-circle-outline-svg-prop;
+  @extend %with-icon, %minus-circle-outline-svg-prop !optional;
   background-image: var(--minus-circle-outline-svg);
 }
 %with-minus-circle-outline-mask {
-  @extend %with-mask, %minus-circle-outline-svg-prop;
+  @extend %with-mask, %minus-circle-outline-svg-prop !optional;
   -webkit-mask-image: var(--minus-circle-outline-svg);
   mask-image: var(--minus-circle-outline-svg);
 }
 
 %with-minus-plain-icon {
-  @extend %with-icon, %minus-plain-svg-prop;
+  @extend %with-icon, %minus-plain-svg-prop !optional;
   background-image: var(--minus-plain-svg);
 }
 %with-minus-plain-mask {
-  @extend %with-mask, %minus-plain-svg-prop;
+  @extend %with-mask, %minus-plain-svg-prop !optional;
   -webkit-mask-image: var(--minus-plain-svg);
   mask-image: var(--minus-plain-svg);
 }
 
+%with-minus-plus-16-icon {
+  @extend %with-icon, %minus-plus-16-svg-prop !optional;
+  background-image: var(--minus-plus-16-svg);
+}
+%with-minus-plus-16-mask {
+  @extend %with-mask, %minus-plus-16-svg-prop !optional;
+  -webkit-mask-image: var(--minus-plus-16-svg);
+  mask-image: var(--minus-plus-16-svg);
+}
+
+%with-minus-plus-24-icon {
+  @extend %with-icon, %minus-plus-24-svg-prop !optional;
+  background-image: var(--minus-plus-24-svg);
+}
+%with-minus-plus-24-mask {
+  @extend %with-mask, %minus-plus-24-svg-prop !optional;
+  -webkit-mask-image: var(--minus-plus-24-svg);
+  mask-image: var(--minus-plus-24-svg);
+}
+
+%with-minus-plus-circle-16-icon {
+  @extend %with-icon, %minus-plus-circle-16-svg-prop !optional;
+  background-image: var(--minus-plus-circle-16-svg);
+}
+%with-minus-plus-circle-16-mask {
+  @extend %with-mask, %minus-plus-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--minus-plus-circle-16-svg);
+  mask-image: var(--minus-plus-circle-16-svg);
+}
+
+%with-minus-plus-circle-24-icon {
+  @extend %with-icon, %minus-plus-circle-24-svg-prop !optional;
+  background-image: var(--minus-plus-circle-24-svg);
+}
+%with-minus-plus-circle-24-mask {
+  @extend %with-mask, %minus-plus-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--minus-plus-circle-24-svg);
+  mask-image: var(--minus-plus-circle-24-svg);
+}
+
+%with-minus-plus-square-16-icon {
+  @extend %with-icon, %minus-plus-square-16-svg-prop !optional;
+  background-image: var(--minus-plus-square-16-svg);
+}
+%with-minus-plus-square-16-mask {
+  @extend %with-mask, %minus-plus-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--minus-plus-square-16-svg);
+  mask-image: var(--minus-plus-square-16-svg);
+}
+
+%with-minus-plus-square-24-icon {
+  @extend %with-icon, %minus-plus-square-24-svg-prop !optional;
+  background-image: var(--minus-plus-square-24-svg);
+}
+%with-minus-plus-square-24-mask {
+  @extend %with-mask, %minus-plus-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--minus-plus-square-24-svg);
+  mask-image: var(--minus-plus-square-24-svg);
+}
+
+%with-minus-square-16-icon {
+  @extend %with-icon, %minus-square-16-svg-prop !optional;
+  background-image: var(--minus-square-16-svg);
+}
+%with-minus-square-16-mask {
+  @extend %with-mask, %minus-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--minus-square-16-svg);
+  mask-image: var(--minus-square-16-svg);
+}
+
+%with-minus-square-24-icon {
+  @extend %with-icon, %minus-square-24-svg-prop !optional;
+  background-image: var(--minus-square-24-svg);
+}
+%with-minus-square-24-mask {
+  @extend %with-mask, %minus-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--minus-square-24-svg);
+  mask-image: var(--minus-square-24-svg);
+}
+
 %with-minus-square-fill-icon {
-  @extend %with-icon, %minus-square-fill-svg-prop;
+  @extend %with-icon, %minus-square-fill-svg-prop !optional;
   background-image: var(--minus-square-fill-svg);
 }
 %with-minus-square-fill-mask {
-  @extend %with-mask, %minus-square-fill-svg-prop;
+  @extend %with-mask, %minus-square-fill-svg-prop !optional;
   -webkit-mask-image: var(--minus-square-fill-svg);
   mask-image: var(--minus-square-fill-svg);
 }
 
+%with-module-16-icon {
+  @extend %with-icon, %module-16-svg-prop !optional;
+  background-image: var(--module-16-svg);
+}
+%with-module-16-mask {
+  @extend %with-mask, %module-16-svg-prop !optional;
+  -webkit-mask-image: var(--module-16-svg);
+  mask-image: var(--module-16-svg);
+}
+
+%with-module-24-icon {
+  @extend %with-icon, %module-24-svg-prop !optional;
+  background-image: var(--module-24-svg);
+}
+%with-module-24-mask {
+  @extend %with-mask, %module-24-svg-prop !optional;
+  -webkit-mask-image: var(--module-24-svg);
+  mask-image: var(--module-24-svg);
+}
+
 %with-module-icon {
-  @extend %with-icon, %module-svg-prop;
+  @extend %with-icon, %module-svg-prop !optional;
   background-image: var(--module-svg);
 }
 %with-module-mask {
-  @extend %with-mask, %module-svg-prop;
+  @extend %with-mask, %module-svg-prop !optional;
   -webkit-mask-image: var(--module-svg);
   mask-image: var(--module-svg);
 }
 
+%with-monitor-16-icon {
+  @extend %with-icon, %monitor-16-svg-prop !optional;
+  background-image: var(--monitor-16-svg);
+}
+%with-monitor-16-mask {
+  @extend %with-mask, %monitor-16-svg-prop !optional;
+  -webkit-mask-image: var(--monitor-16-svg);
+  mask-image: var(--monitor-16-svg);
+}
+
+%with-monitor-24-icon {
+  @extend %with-icon, %monitor-24-svg-prop !optional;
+  background-image: var(--monitor-24-svg);
+}
+%with-monitor-24-mask {
+  @extend %with-mask, %monitor-24-svg-prop !optional;
+  -webkit-mask-image: var(--monitor-24-svg);
+  mask-image: var(--monitor-24-svg);
+}
+
+%with-moon-16-icon {
+  @extend %with-icon, %moon-16-svg-prop !optional;
+  background-image: var(--moon-16-svg);
+}
+%with-moon-16-mask {
+  @extend %with-mask, %moon-16-svg-prop !optional;
+  -webkit-mask-image: var(--moon-16-svg);
+  mask-image: var(--moon-16-svg);
+}
+
+%with-moon-24-icon {
+  @extend %with-icon, %moon-24-svg-prop !optional;
+  background-image: var(--moon-24-svg);
+}
+%with-moon-24-mask {
+  @extend %with-mask, %moon-24-svg-prop !optional;
+  -webkit-mask-image: var(--moon-24-svg);
+  mask-image: var(--moon-24-svg);
+}
+
+%with-more-horizontal-16-icon {
+  @extend %with-icon, %more-horizontal-16-svg-prop !optional;
+  background-image: var(--more-horizontal-16-svg);
+}
+%with-more-horizontal-16-mask {
+  @extend %with-mask, %more-horizontal-16-svg-prop !optional;
+  -webkit-mask-image: var(--more-horizontal-16-svg);
+  mask-image: var(--more-horizontal-16-svg);
+}
+
+%with-more-horizontal-24-icon {
+  @extend %with-icon, %more-horizontal-24-svg-prop !optional;
+  background-image: var(--more-horizontal-24-svg);
+}
+%with-more-horizontal-24-mask {
+  @extend %with-mask, %more-horizontal-24-svg-prop !optional;
+  -webkit-mask-image: var(--more-horizontal-24-svg);
+  mask-image: var(--more-horizontal-24-svg);
+}
+
 %with-more-horizontal-icon {
-  @extend %with-icon, %more-horizontal-svg-prop;
+  @extend %with-icon, %more-horizontal-svg-prop !optional;
   background-image: var(--more-horizontal-svg);
 }
 %with-more-horizontal-mask {
-  @extend %with-mask, %more-horizontal-svg-prop;
+  @extend %with-mask, %more-horizontal-svg-prop !optional;
   -webkit-mask-image: var(--more-horizontal-svg);
   mask-image: var(--more-horizontal-svg);
 }
 
+%with-more-vertical-16-icon {
+  @extend %with-icon, %more-vertical-16-svg-prop !optional;
+  background-image: var(--more-vertical-16-svg);
+}
+%with-more-vertical-16-mask {
+  @extend %with-mask, %more-vertical-16-svg-prop !optional;
+  -webkit-mask-image: var(--more-vertical-16-svg);
+  mask-image: var(--more-vertical-16-svg);
+}
+
+%with-more-vertical-24-icon {
+  @extend %with-icon, %more-vertical-24-svg-prop !optional;
+  background-image: var(--more-vertical-24-svg);
+}
+%with-more-vertical-24-mask {
+  @extend %with-mask, %more-vertical-24-svg-prop !optional;
+  -webkit-mask-image: var(--more-vertical-24-svg);
+  mask-image: var(--more-vertical-24-svg);
+}
+
 %with-more-vertical-icon {
-  @extend %with-icon, %more-vertical-svg-prop;
+  @extend %with-icon, %more-vertical-svg-prop !optional;
   background-image: var(--more-vertical-svg);
 }
 %with-more-vertical-mask {
-  @extend %with-mask, %more-vertical-svg-prop;
+  @extend %with-mask, %more-vertical-svg-prop !optional;
   -webkit-mask-image: var(--more-vertical-svg);
   mask-image: var(--more-vertical-svg);
 }
 
+%with-mouse-pointer-16-icon {
+  @extend %with-icon, %mouse-pointer-16-svg-prop !optional;
+  background-image: var(--mouse-pointer-16-svg);
+}
+%with-mouse-pointer-16-mask {
+  @extend %with-mask, %mouse-pointer-16-svg-prop !optional;
+  -webkit-mask-image: var(--mouse-pointer-16-svg);
+  mask-image: var(--mouse-pointer-16-svg);
+}
+
+%with-mouse-pointer-24-icon {
+  @extend %with-icon, %mouse-pointer-24-svg-prop !optional;
+  background-image: var(--mouse-pointer-24-svg);
+}
+%with-mouse-pointer-24-mask {
+  @extend %with-mask, %mouse-pointer-24-svg-prop !optional;
+  -webkit-mask-image: var(--mouse-pointer-24-svg);
+  mask-image: var(--mouse-pointer-24-svg);
+}
+
+%with-move-16-icon {
+  @extend %with-icon, %move-16-svg-prop !optional;
+  background-image: var(--move-16-svg);
+}
+%with-move-16-mask {
+  @extend %with-mask, %move-16-svg-prop !optional;
+  -webkit-mask-image: var(--move-16-svg);
+  mask-image: var(--move-16-svg);
+}
+
+%with-move-24-icon {
+  @extend %with-icon, %move-24-svg-prop !optional;
+  background-image: var(--move-24-svg);
+}
+%with-move-24-mask {
+  @extend %with-mask, %move-24-svg-prop !optional;
+  -webkit-mask-image: var(--move-24-svg);
+  mask-image: var(--move-24-svg);
+}
+
+%with-music-16-icon {
+  @extend %with-icon, %music-16-svg-prop !optional;
+  background-image: var(--music-16-svg);
+}
+%with-music-16-mask {
+  @extend %with-mask, %music-16-svg-prop !optional;
+  -webkit-mask-image: var(--music-16-svg);
+  mask-image: var(--music-16-svg);
+}
+
+%with-music-24-icon {
+  @extend %with-icon, %music-24-svg-prop !optional;
+  background-image: var(--music-24-svg);
+}
+%with-music-24-mask {
+  @extend %with-mask, %music-24-svg-prop !optional;
+  -webkit-mask-image: var(--music-24-svg);
+  mask-image: var(--music-24-svg);
+}
+
+%with-navigation-16-icon {
+  @extend %with-icon, %navigation-16-svg-prop !optional;
+  background-image: var(--navigation-16-svg);
+}
+%with-navigation-16-mask {
+  @extend %with-mask, %navigation-16-svg-prop !optional;
+  -webkit-mask-image: var(--navigation-16-svg);
+  mask-image: var(--navigation-16-svg);
+}
+
+%with-navigation-24-icon {
+  @extend %with-icon, %navigation-24-svg-prop !optional;
+  background-image: var(--navigation-24-svg);
+}
+%with-navigation-24-mask {
+  @extend %with-mask, %navigation-24-svg-prop !optional;
+  -webkit-mask-image: var(--navigation-24-svg);
+  mask-image: var(--navigation-24-svg);
+}
+
+%with-navigation-alt-16-icon {
+  @extend %with-icon, %navigation-alt-16-svg-prop !optional;
+  background-image: var(--navigation-alt-16-svg);
+}
+%with-navigation-alt-16-mask {
+  @extend %with-mask, %navigation-alt-16-svg-prop !optional;
+  -webkit-mask-image: var(--navigation-alt-16-svg);
+  mask-image: var(--navigation-alt-16-svg);
+}
+
+%with-navigation-alt-24-icon {
+  @extend %with-icon, %navigation-alt-24-svg-prop !optional;
+  background-image: var(--navigation-alt-24-svg);
+}
+%with-navigation-alt-24-mask {
+  @extend %with-mask, %navigation-alt-24-svg-prop !optional;
+  -webkit-mask-image: var(--navigation-alt-24-svg);
+  mask-image: var(--navigation-alt-24-svg);
+}
+
+%with-network-16-icon {
+  @extend %with-icon, %network-16-svg-prop !optional;
+  background-image: var(--network-16-svg);
+}
+%with-network-16-mask {
+  @extend %with-mask, %network-16-svg-prop !optional;
+  -webkit-mask-image: var(--network-16-svg);
+  mask-image: var(--network-16-svg);
+}
+
+%with-network-24-icon {
+  @extend %with-icon, %network-24-svg-prop !optional;
+  background-image: var(--network-24-svg);
+}
+%with-network-24-mask {
+  @extend %with-mask, %network-24-svg-prop !optional;
+  -webkit-mask-image: var(--network-24-svg);
+  mask-image: var(--network-24-svg);
+}
+
+%with-network-alt-16-icon {
+  @extend %with-icon, %network-alt-16-svg-prop !optional;
+  background-image: var(--network-alt-16-svg);
+}
+%with-network-alt-16-mask {
+  @extend %with-mask, %network-alt-16-svg-prop !optional;
+  -webkit-mask-image: var(--network-alt-16-svg);
+  mask-image: var(--network-alt-16-svg);
+}
+
+%with-network-alt-24-icon {
+  @extend %with-icon, %network-alt-24-svg-prop !optional;
+  background-image: var(--network-alt-24-svg);
+}
+%with-network-alt-24-mask {
+  @extend %with-mask, %network-alt-24-svg-prop !optional;
+  -webkit-mask-image: var(--network-alt-24-svg);
+  mask-image: var(--network-alt-24-svg);
+}
+
+%with-newspaper-16-icon {
+  @extend %with-icon, %newspaper-16-svg-prop !optional;
+  background-image: var(--newspaper-16-svg);
+}
+%with-newspaper-16-mask {
+  @extend %with-mask, %newspaper-16-svg-prop !optional;
+  -webkit-mask-image: var(--newspaper-16-svg);
+  mask-image: var(--newspaper-16-svg);
+}
+
+%with-newspaper-24-icon {
+  @extend %with-icon, %newspaper-24-svg-prop !optional;
+  background-image: var(--newspaper-24-svg);
+}
+%with-newspaper-24-mask {
+  @extend %with-mask, %newspaper-24-svg-prop !optional;
+  -webkit-mask-image: var(--newspaper-24-svg);
+  mask-image: var(--newspaper-24-svg);
+}
+
+%with-node-16-icon {
+  @extend %with-icon, %node-16-svg-prop !optional;
+  background-image: var(--node-16-svg);
+}
+%with-node-16-mask {
+  @extend %with-mask, %node-16-svg-prop !optional;
+  -webkit-mask-image: var(--node-16-svg);
+  mask-image: var(--node-16-svg);
+}
+
+%with-node-24-icon {
+  @extend %with-icon, %node-24-svg-prop !optional;
+  background-image: var(--node-24-svg);
+}
+%with-node-24-mask {
+  @extend %with-mask, %node-24-svg-prop !optional;
+  -webkit-mask-image: var(--node-24-svg);
+  mask-image: var(--node-24-svg);
+}
+
 %with-notification-disabled-icon {
-  @extend %with-icon, %notification-disabled-svg-prop;
+  @extend %with-icon, %notification-disabled-svg-prop !optional;
   background-image: var(--notification-disabled-svg);
 }
 %with-notification-disabled-mask {
-  @extend %with-mask, %notification-disabled-svg-prop;
+  @extend %with-mask, %notification-disabled-svg-prop !optional;
   -webkit-mask-image: var(--notification-disabled-svg);
   mask-image: var(--notification-disabled-svg);
 }
 
 %with-notification-fill-icon {
-  @extend %with-icon, %notification-fill-svg-prop;
+  @extend %with-icon, %notification-fill-svg-prop !optional;
   background-image: var(--notification-fill-svg);
 }
 %with-notification-fill-mask {
-  @extend %with-mask, %notification-fill-svg-prop;
+  @extend %with-mask, %notification-fill-svg-prop !optional;
   -webkit-mask-image: var(--notification-fill-svg);
   mask-image: var(--notification-fill-svg);
 }
 
 %with-notification-outline-icon {
-  @extend %with-icon, %notification-outline-svg-prop;
+  @extend %with-icon, %notification-outline-svg-prop !optional;
   background-image: var(--notification-outline-svg);
 }
 %with-notification-outline-mask {
-  @extend %with-mask, %notification-outline-svg-prop;
+  @extend %with-mask, %notification-outline-svg-prop !optional;
   -webkit-mask-image: var(--notification-outline-svg);
   mask-image: var(--notification-outline-svg);
 }
 
+%with-octagon-16-icon {
+  @extend %with-icon, %octagon-16-svg-prop !optional;
+  background-image: var(--octagon-16-svg);
+}
+%with-octagon-16-mask {
+  @extend %with-mask, %octagon-16-svg-prop !optional;
+  -webkit-mask-image: var(--octagon-16-svg);
+  mask-image: var(--octagon-16-svg);
+}
+
+%with-octagon-24-icon {
+  @extend %with-icon, %octagon-24-svg-prop !optional;
+  background-image: var(--octagon-24-svg);
+}
+%with-octagon-24-mask {
+  @extend %with-mask, %octagon-24-svg-prop !optional;
+  -webkit-mask-image: var(--octagon-24-svg);
+  mask-image: var(--octagon-24-svg);
+}
+
+%with-okta-16-icon {
+  @extend %with-icon, %okta-16-svg-prop !optional;
+  background-image: var(--okta-16-svg);
+}
+%with-okta-16-mask {
+  @extend %with-mask, %okta-16-svg-prop !optional;
+  -webkit-mask-image: var(--okta-16-svg);
+  mask-image: var(--okta-16-svg);
+}
+
+%with-okta-24-icon {
+  @extend %with-icon, %okta-24-svg-prop !optional;
+  background-image: var(--okta-24-svg);
+}
+%with-okta-24-mask {
+  @extend %with-mask, %okta-24-svg-prop !optional;
+  -webkit-mask-image: var(--okta-24-svg);
+  mask-image: var(--okta-24-svg);
+}
+
+%with-okta-color-16-icon {
+  @extend %with-icon, %okta-color-16-svg-prop !optional;
+  background-image: var(--okta-color-16-svg);
+}
+%with-okta-color-16-mask {
+  @extend %with-mask, %okta-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--okta-color-16-svg);
+  mask-image: var(--okta-color-16-svg);
+}
+
+%with-okta-color-24-icon {
+  @extend %with-icon, %okta-color-24-svg-prop !optional;
+  background-image: var(--okta-color-24-svg);
+}
+%with-okta-color-24-mask {
+  @extend %with-mask, %okta-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--okta-color-24-svg);
+  mask-image: var(--okta-color-24-svg);
+}
+
+%with-oracle-16-icon {
+  @extend %with-icon, %oracle-16-svg-prop !optional;
+  background-image: var(--oracle-16-svg);
+}
+%with-oracle-16-mask {
+  @extend %with-mask, %oracle-16-svg-prop !optional;
+  -webkit-mask-image: var(--oracle-16-svg);
+  mask-image: var(--oracle-16-svg);
+}
+
+%with-oracle-24-icon {
+  @extend %with-icon, %oracle-24-svg-prop !optional;
+  background-image: var(--oracle-24-svg);
+}
+%with-oracle-24-mask {
+  @extend %with-mask, %oracle-24-svg-prop !optional;
+  -webkit-mask-image: var(--oracle-24-svg);
+  mask-image: var(--oracle-24-svg);
+}
+
+%with-oracle-color-16-icon {
+  @extend %with-icon, %oracle-color-16-svg-prop !optional;
+  background-image: var(--oracle-color-16-svg);
+}
+%with-oracle-color-16-mask {
+  @extend %with-mask, %oracle-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--oracle-color-16-svg);
+  mask-image: var(--oracle-color-16-svg);
+}
+
+%with-oracle-color-24-icon {
+  @extend %with-icon, %oracle-color-24-svg-prop !optional;
+  background-image: var(--oracle-color-24-svg);
+}
+%with-oracle-color-24-mask {
+  @extend %with-mask, %oracle-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--oracle-color-24-svg);
+  mask-image: var(--oracle-color-24-svg);
+}
+
+%with-org-16-icon {
+  @extend %with-icon, %org-16-svg-prop !optional;
+  background-image: var(--org-16-svg);
+}
+%with-org-16-mask {
+  @extend %with-mask, %org-16-svg-prop !optional;
+  -webkit-mask-image: var(--org-16-svg);
+  mask-image: var(--org-16-svg);
+}
+
+%with-org-24-icon {
+  @extend %with-icon, %org-24-svg-prop !optional;
+  background-image: var(--org-24-svg);
+}
+%with-org-24-mask {
+  @extend %with-mask, %org-24-svg-prop !optional;
+  -webkit-mask-image: var(--org-24-svg);
+  mask-image: var(--org-24-svg);
+}
+
+%with-outline-16-icon {
+  @extend %with-icon, %outline-16-svg-prop !optional;
+  background-image: var(--outline-16-svg);
+}
+%with-outline-16-mask {
+  @extend %with-mask, %outline-16-svg-prop !optional;
+  -webkit-mask-image: var(--outline-16-svg);
+  mask-image: var(--outline-16-svg);
+}
+
+%with-outline-24-icon {
+  @extend %with-icon, %outline-24-svg-prop !optional;
+  background-image: var(--outline-24-svg);
+}
+%with-outline-24-mask {
+  @extend %with-mask, %outline-24-svg-prop !optional;
+  -webkit-mask-image: var(--outline-24-svg);
+  mask-image: var(--outline-24-svg);
+}
+
 %with-outline-icon {
-  @extend %with-icon, %outline-svg-prop;
+  @extend %with-icon, %outline-svg-prop !optional;
   background-image: var(--outline-svg);
 }
 %with-outline-mask {
-  @extend %with-mask, %outline-svg-prop;
+  @extend %with-mask, %outline-svg-prop !optional;
   -webkit-mask-image: var(--outline-svg);
   mask-image: var(--outline-svg);
 }
 
+%with-package-16-icon {
+  @extend %with-icon, %package-16-svg-prop !optional;
+  background-image: var(--package-16-svg);
+}
+%with-package-16-mask {
+  @extend %with-mask, %package-16-svg-prop !optional;
+  -webkit-mask-image: var(--package-16-svg);
+  mask-image: var(--package-16-svg);
+}
+
+%with-package-24-icon {
+  @extend %with-icon, %package-24-svg-prop !optional;
+  background-image: var(--package-24-svg);
+}
+%with-package-24-mask {
+  @extend %with-mask, %package-24-svg-prop !optional;
+  -webkit-mask-image: var(--package-24-svg);
+  mask-image: var(--package-24-svg);
+}
+
 %with-page-outline-icon {
-  @extend %with-icon, %page-outline-svg-prop;
+  @extend %with-icon, %page-outline-svg-prop !optional;
   background-image: var(--page-outline-svg);
 }
 %with-page-outline-mask {
-  @extend %with-mask, %page-outline-svg-prop;
+  @extend %with-mask, %page-outline-svg-prop !optional;
   -webkit-mask-image: var(--page-outline-svg);
   mask-image: var(--page-outline-svg);
 }
 
+%with-paperclip-16-icon {
+  @extend %with-icon, %paperclip-16-svg-prop !optional;
+  background-image: var(--paperclip-16-svg);
+}
+%with-paperclip-16-mask {
+  @extend %with-mask, %paperclip-16-svg-prop !optional;
+  -webkit-mask-image: var(--paperclip-16-svg);
+  mask-image: var(--paperclip-16-svg);
+}
+
+%with-paperclip-24-icon {
+  @extend %with-icon, %paperclip-24-svg-prop !optional;
+  background-image: var(--paperclip-24-svg);
+}
+%with-paperclip-24-mask {
+  @extend %with-mask, %paperclip-24-svg-prop !optional;
+  -webkit-mask-image: var(--paperclip-24-svg);
+  mask-image: var(--paperclip-24-svg);
+}
+
 %with-partner-icon {
-  @extend %with-icon, %partner-svg-prop;
+  @extend %with-icon, %partner-svg-prop !optional;
   background-image: var(--partner-svg);
 }
 %with-partner-mask {
-  @extend %with-mask, %partner-svg-prop;
+  @extend %with-mask, %partner-svg-prop !optional;
   -webkit-mask-image: var(--partner-svg);
   mask-image: var(--partner-svg);
 }
 
+%with-path-16-icon {
+  @extend %with-icon, %path-16-svg-prop !optional;
+  background-image: var(--path-16-svg);
+}
+%with-path-16-mask {
+  @extend %with-mask, %path-16-svg-prop !optional;
+  -webkit-mask-image: var(--path-16-svg);
+  mask-image: var(--path-16-svg);
+}
+
+%with-path-24-icon {
+  @extend %with-icon, %path-24-svg-prop !optional;
+  background-image: var(--path-24-svg);
+}
+%with-path-24-mask {
+  @extend %with-mask, %path-24-svg-prop !optional;
+  -webkit-mask-image: var(--path-24-svg);
+  mask-image: var(--path-24-svg);
+}
+
 %with-path-icon {
-  @extend %with-icon, %path-svg-prop;
+  @extend %with-icon, %path-svg-prop !optional;
   background-image: var(--path-svg);
 }
 %with-path-mask {
-  @extend %with-mask, %path-svg-prop;
+  @extend %with-mask, %path-svg-prop !optional;
   -webkit-mask-image: var(--path-svg);
   mask-image: var(--path-svg);
 }
 
+%with-pause-16-icon {
+  @extend %with-icon, %pause-16-svg-prop !optional;
+  background-image: var(--pause-16-svg);
+}
+%with-pause-16-mask {
+  @extend %with-mask, %pause-16-svg-prop !optional;
+  -webkit-mask-image: var(--pause-16-svg);
+  mask-image: var(--pause-16-svg);
+}
+
+%with-pause-24-icon {
+  @extend %with-icon, %pause-24-svg-prop !optional;
+  background-image: var(--pause-24-svg);
+}
+%with-pause-24-mask {
+  @extend %with-mask, %pause-24-svg-prop !optional;
+  -webkit-mask-image: var(--pause-24-svg);
+  mask-image: var(--pause-24-svg);
+}
+
+%with-pause-circle-16-icon {
+  @extend %with-icon, %pause-circle-16-svg-prop !optional;
+  background-image: var(--pause-circle-16-svg);
+}
+%with-pause-circle-16-mask {
+  @extend %with-mask, %pause-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--pause-circle-16-svg);
+  mask-image: var(--pause-circle-16-svg);
+}
+
+%with-pause-circle-24-icon {
+  @extend %with-icon, %pause-circle-24-svg-prop !optional;
+  background-image: var(--pause-circle-24-svg);
+}
+%with-pause-circle-24-mask {
+  @extend %with-mask, %pause-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--pause-circle-24-svg);
+  mask-image: var(--pause-circle-24-svg);
+}
+
+%with-pen-tool-16-icon {
+  @extend %with-icon, %pen-tool-16-svg-prop !optional;
+  background-image: var(--pen-tool-16-svg);
+}
+%with-pen-tool-16-mask {
+  @extend %with-mask, %pen-tool-16-svg-prop !optional;
+  -webkit-mask-image: var(--pen-tool-16-svg);
+  mask-image: var(--pen-tool-16-svg);
+}
+
+%with-pen-tool-24-icon {
+  @extend %with-icon, %pen-tool-24-svg-prop !optional;
+  background-image: var(--pen-tool-24-svg);
+}
+%with-pen-tool-24-mask {
+  @extend %with-mask, %pen-tool-24-svg-prop !optional;
+  -webkit-mask-image: var(--pen-tool-24-svg);
+  mask-image: var(--pen-tool-24-svg);
+}
+
+%with-pencil-tool-16-icon {
+  @extend %with-icon, %pencil-tool-16-svg-prop !optional;
+  background-image: var(--pencil-tool-16-svg);
+}
+%with-pencil-tool-16-mask {
+  @extend %with-mask, %pencil-tool-16-svg-prop !optional;
+  -webkit-mask-image: var(--pencil-tool-16-svg);
+  mask-image: var(--pencil-tool-16-svg);
+}
+
+%with-pencil-tool-24-icon {
+  @extend %with-icon, %pencil-tool-24-svg-prop !optional;
+  background-image: var(--pencil-tool-24-svg);
+}
+%with-pencil-tool-24-mask {
+  @extend %with-mask, %pencil-tool-24-svg-prop !optional;
+  -webkit-mask-image: var(--pencil-tool-24-svg);
+  mask-image: var(--pencil-tool-24-svg);
+}
+
+%with-phone-16-icon {
+  @extend %with-icon, %phone-16-svg-prop !optional;
+  background-image: var(--phone-16-svg);
+}
+%with-phone-16-mask {
+  @extend %with-mask, %phone-16-svg-prop !optional;
+  -webkit-mask-image: var(--phone-16-svg);
+  mask-image: var(--phone-16-svg);
+}
+
+%with-phone-24-icon {
+  @extend %with-icon, %phone-24-svg-prop !optional;
+  background-image: var(--phone-24-svg);
+}
+%with-phone-24-mask {
+  @extend %with-mask, %phone-24-svg-prop !optional;
+  -webkit-mask-image: var(--phone-24-svg);
+  mask-image: var(--phone-24-svg);
+}
+
+%with-phone-call-16-icon {
+  @extend %with-icon, %phone-call-16-svg-prop !optional;
+  background-image: var(--phone-call-16-svg);
+}
+%with-phone-call-16-mask {
+  @extend %with-mask, %phone-call-16-svg-prop !optional;
+  -webkit-mask-image: var(--phone-call-16-svg);
+  mask-image: var(--phone-call-16-svg);
+}
+
+%with-phone-call-24-icon {
+  @extend %with-icon, %phone-call-24-svg-prop !optional;
+  background-image: var(--phone-call-24-svg);
+}
+%with-phone-call-24-mask {
+  @extend %with-mask, %phone-call-24-svg-prop !optional;
+  -webkit-mask-image: var(--phone-call-24-svg);
+  mask-image: var(--phone-call-24-svg);
+}
+
+%with-phone-off-16-icon {
+  @extend %with-icon, %phone-off-16-svg-prop !optional;
+  background-image: var(--phone-off-16-svg);
+}
+%with-phone-off-16-mask {
+  @extend %with-mask, %phone-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--phone-off-16-svg);
+  mask-image: var(--phone-off-16-svg);
+}
+
+%with-phone-off-24-icon {
+  @extend %with-icon, %phone-off-24-svg-prop !optional;
+  background-image: var(--phone-off-24-svg);
+}
+%with-phone-off-24-mask {
+  @extend %with-mask, %phone-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--phone-off-24-svg);
+  mask-image: var(--phone-off-24-svg);
+}
+
+%with-pie-chart-16-icon {
+  @extend %with-icon, %pie-chart-16-svg-prop !optional;
+  background-image: var(--pie-chart-16-svg);
+}
+%with-pie-chart-16-mask {
+  @extend %with-mask, %pie-chart-16-svg-prop !optional;
+  -webkit-mask-image: var(--pie-chart-16-svg);
+  mask-image: var(--pie-chart-16-svg);
+}
+
+%with-pie-chart-24-icon {
+  @extend %with-icon, %pie-chart-24-svg-prop !optional;
+  background-image: var(--pie-chart-24-svg);
+}
+%with-pie-chart-24-mask {
+  @extend %with-mask, %pie-chart-24-svg-prop !optional;
+  -webkit-mask-image: var(--pie-chart-24-svg);
+  mask-image: var(--pie-chart-24-svg);
+}
+
+%with-pin-16-icon {
+  @extend %with-icon, %pin-16-svg-prop !optional;
+  background-image: var(--pin-16-svg);
+}
+%with-pin-16-mask {
+  @extend %with-mask, %pin-16-svg-prop !optional;
+  -webkit-mask-image: var(--pin-16-svg);
+  mask-image: var(--pin-16-svg);
+}
+
+%with-pin-24-icon {
+  @extend %with-icon, %pin-24-svg-prop !optional;
+  background-image: var(--pin-24-svg);
+}
+%with-pin-24-mask {
+  @extend %with-mask, %pin-24-svg-prop !optional;
+  -webkit-mask-image: var(--pin-24-svg);
+  mask-image: var(--pin-24-svg);
+}
+
+%with-play-16-icon {
+  @extend %with-icon, %play-16-svg-prop !optional;
+  background-image: var(--play-16-svg);
+}
+%with-play-16-mask {
+  @extend %with-mask, %play-16-svg-prop !optional;
+  -webkit-mask-image: var(--play-16-svg);
+  mask-image: var(--play-16-svg);
+}
+
+%with-play-24-icon {
+  @extend %with-icon, %play-24-svg-prop !optional;
+  background-image: var(--play-24-svg);
+}
+%with-play-24-mask {
+  @extend %with-mask, %play-24-svg-prop !optional;
+  -webkit-mask-image: var(--play-24-svg);
+  mask-image: var(--play-24-svg);
+}
+
+%with-play-circle-16-icon {
+  @extend %with-icon, %play-circle-16-svg-prop !optional;
+  background-image: var(--play-circle-16-svg);
+}
+%with-play-circle-16-mask {
+  @extend %with-mask, %play-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--play-circle-16-svg);
+  mask-image: var(--play-circle-16-svg);
+}
+
+%with-play-circle-24-icon {
+  @extend %with-icon, %play-circle-24-svg-prop !optional;
+  background-image: var(--play-circle-24-svg);
+}
+%with-play-circle-24-mask {
+  @extend %with-mask, %play-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--play-circle-24-svg);
+  mask-image: var(--play-circle-24-svg);
+}
+
 %with-play-fill-icon {
-  @extend %with-icon, %play-fill-svg-prop;
+  @extend %with-icon, %play-fill-svg-prop !optional;
   background-image: var(--play-fill-svg);
 }
 %with-play-fill-mask {
-  @extend %with-mask, %play-fill-svg-prop;
+  @extend %with-mask, %play-fill-svg-prop !optional;
   -webkit-mask-image: var(--play-fill-svg);
   mask-image: var(--play-fill-svg);
 }
 
 %with-play-outline-icon {
-  @extend %with-icon, %play-outline-svg-prop;
+  @extend %with-icon, %play-outline-svg-prop !optional;
   background-image: var(--play-outline-svg);
 }
 %with-play-outline-mask {
-  @extend %with-mask, %play-outline-svg-prop;
+  @extend %with-mask, %play-outline-svg-prop !optional;
   -webkit-mask-image: var(--play-outline-svg);
   mask-image: var(--play-outline-svg);
 }
 
 %with-play-plain-icon {
-  @extend %with-icon, %play-plain-svg-prop;
+  @extend %with-icon, %play-plain-svg-prop !optional;
   background-image: var(--play-plain-svg);
 }
 %with-play-plain-mask {
-  @extend %with-mask, %play-plain-svg-prop;
+  @extend %with-mask, %play-plain-svg-prop !optional;
   -webkit-mask-image: var(--play-plain-svg);
   mask-image: var(--play-plain-svg);
 }
 
+%with-plus-16-icon {
+  @extend %with-icon, %plus-16-svg-prop !optional;
+  background-image: var(--plus-16-svg);
+}
+%with-plus-16-mask {
+  @extend %with-mask, %plus-16-svg-prop !optional;
+  -webkit-mask-image: var(--plus-16-svg);
+  mask-image: var(--plus-16-svg);
+}
+
+%with-plus-24-icon {
+  @extend %with-icon, %plus-24-svg-prop !optional;
+  background-image: var(--plus-24-svg);
+}
+%with-plus-24-mask {
+  @extend %with-mask, %plus-24-svg-prop !optional;
+  -webkit-mask-image: var(--plus-24-svg);
+  mask-image: var(--plus-24-svg);
+}
+
+%with-plus-circle-16-icon {
+  @extend %with-icon, %plus-circle-16-svg-prop !optional;
+  background-image: var(--plus-circle-16-svg);
+}
+%with-plus-circle-16-mask {
+  @extend %with-mask, %plus-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--plus-circle-16-svg);
+  mask-image: var(--plus-circle-16-svg);
+}
+
+%with-plus-circle-24-icon {
+  @extend %with-icon, %plus-circle-24-svg-prop !optional;
+  background-image: var(--plus-circle-24-svg);
+}
+%with-plus-circle-24-mask {
+  @extend %with-mask, %plus-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--plus-circle-24-svg);
+  mask-image: var(--plus-circle-24-svg);
+}
+
 %with-plus-circle-fill-icon {
-  @extend %with-icon, %plus-circle-fill-svg-prop;
+  @extend %with-icon, %plus-circle-fill-svg-prop !optional;
   background-image: var(--plus-circle-fill-svg);
 }
 %with-plus-circle-fill-mask {
-  @extend %with-mask, %plus-circle-fill-svg-prop;
+  @extend %with-mask, %plus-circle-fill-svg-prop !optional;
   -webkit-mask-image: var(--plus-circle-fill-svg);
   mask-image: var(--plus-circle-fill-svg);
 }
 
 %with-plus-circle-outline-icon {
-  @extend %with-icon, %plus-circle-outline-svg-prop;
+  @extend %with-icon, %plus-circle-outline-svg-prop !optional;
   background-image: var(--plus-circle-outline-svg);
 }
 %with-plus-circle-outline-mask {
-  @extend %with-mask, %plus-circle-outline-svg-prop;
+  @extend %with-mask, %plus-circle-outline-svg-prop !optional;
   -webkit-mask-image: var(--plus-circle-outline-svg);
   mask-image: var(--plus-circle-outline-svg);
 }
 
 %with-plus-plain-icon {
-  @extend %with-icon, %plus-plain-svg-prop;
+  @extend %with-icon, %plus-plain-svg-prop !optional;
   background-image: var(--plus-plain-svg);
 }
 %with-plus-plain-mask {
-  @extend %with-mask, %plus-plain-svg-prop;
+  @extend %with-mask, %plus-plain-svg-prop !optional;
   -webkit-mask-image: var(--plus-plain-svg);
   mask-image: var(--plus-plain-svg);
 }
 
+%with-plus-square-16-icon {
+  @extend %with-icon, %plus-square-16-svg-prop !optional;
+  background-image: var(--plus-square-16-svg);
+}
+%with-plus-square-16-mask {
+  @extend %with-mask, %plus-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--plus-square-16-svg);
+  mask-image: var(--plus-square-16-svg);
+}
+
+%with-plus-square-24-icon {
+  @extend %with-icon, %plus-square-24-svg-prop !optional;
+  background-image: var(--plus-square-24-svg);
+}
+%with-plus-square-24-mask {
+  @extend %with-mask, %plus-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--plus-square-24-svg);
+  mask-image: var(--plus-square-24-svg);
+}
+
 %with-plus-square-fill-icon {
-  @extend %with-icon, %plus-square-fill-svg-prop;
+  @extend %with-icon, %plus-square-fill-svg-prop !optional;
   background-image: var(--plus-square-fill-svg);
 }
 %with-plus-square-fill-mask {
-  @extend %with-mask, %plus-square-fill-svg-prop;
+  @extend %with-mask, %plus-square-fill-svg-prop !optional;
   -webkit-mask-image: var(--plus-square-fill-svg);
   mask-image: var(--plus-square-fill-svg);
 }
 
 %with-port-icon {
-  @extend %with-icon, %port-svg-prop;
+  @extend %with-icon, %port-svg-prop !optional;
   background-image: var(--port-svg);
 }
 %with-port-mask {
-  @extend %with-mask, %port-svg-prop;
+  @extend %with-mask, %port-svg-prop !optional;
   -webkit-mask-image: var(--port-svg);
   mask-image: var(--port-svg);
 }
 
+%with-power-16-icon {
+  @extend %with-icon, %power-16-svg-prop !optional;
+  background-image: var(--power-16-svg);
+}
+%with-power-16-mask {
+  @extend %with-mask, %power-16-svg-prop !optional;
+  -webkit-mask-image: var(--power-16-svg);
+  mask-image: var(--power-16-svg);
+}
+
+%with-power-24-icon {
+  @extend %with-icon, %power-24-svg-prop !optional;
+  background-image: var(--power-24-svg);
+}
+%with-power-24-mask {
+  @extend %with-mask, %power-24-svg-prop !optional;
+  -webkit-mask-image: var(--power-24-svg);
+  mask-image: var(--power-24-svg);
+}
+
+%with-printer-16-icon {
+  @extend %with-icon, %printer-16-svg-prop !optional;
+  background-image: var(--printer-16-svg);
+}
+%with-printer-16-mask {
+  @extend %with-mask, %printer-16-svg-prop !optional;
+  -webkit-mask-image: var(--printer-16-svg);
+  mask-image: var(--printer-16-svg);
+}
+
+%with-printer-24-icon {
+  @extend %with-icon, %printer-24-svg-prop !optional;
+  background-image: var(--printer-24-svg);
+}
+%with-printer-24-mask {
+  @extend %with-mask, %printer-24-svg-prop !optional;
+  -webkit-mask-image: var(--printer-24-svg);
+  mask-image: var(--printer-24-svg);
+}
+
 %with-protocol-icon {
-  @extend %with-icon, %protocol-svg-prop;
+  @extend %with-icon, %protocol-svg-prop !optional;
   background-image: var(--protocol-svg);
 }
 %with-protocol-mask {
-  @extend %with-mask, %protocol-svg-prop;
+  @extend %with-mask, %protocol-svg-prop !optional;
   -webkit-mask-image: var(--protocol-svg);
   mask-image: var(--protocol-svg);
 }
 
+%with-provider-16-icon {
+  @extend %with-icon, %provider-16-svg-prop !optional;
+  background-image: var(--provider-16-svg);
+}
+%with-provider-16-mask {
+  @extend %with-mask, %provider-16-svg-prop !optional;
+  -webkit-mask-image: var(--provider-16-svg);
+  mask-image: var(--provider-16-svg);
+}
+
+%with-provider-24-icon {
+  @extend %with-icon, %provider-24-svg-prop !optional;
+  background-image: var(--provider-24-svg);
+}
+%with-provider-24-mask {
+  @extend %with-mask, %provider-24-svg-prop !optional;
+  -webkit-mask-image: var(--provider-24-svg);
+  mask-image: var(--provider-24-svg);
+}
+
 %with-provider-icon {
-  @extend %with-icon, %provider-svg-prop;
+  @extend %with-icon, %provider-svg-prop !optional;
   background-image: var(--provider-svg);
 }
 %with-provider-mask {
-  @extend %with-mask, %provider-svg-prop;
+  @extend %with-mask, %provider-svg-prop !optional;
   -webkit-mask-image: var(--provider-svg);
   mask-image: var(--provider-svg);
 }
 
 %with-public-default-icon {
-  @extend %with-icon, %public-default-svg-prop;
+  @extend %with-icon, %public-default-svg-prop !optional;
   background-image: var(--public-default-svg);
 }
 %with-public-default-mask {
-  @extend %with-mask, %public-default-svg-prop;
+  @extend %with-mask, %public-default-svg-prop !optional;
   -webkit-mask-image: var(--public-default-svg);
   mask-image: var(--public-default-svg);
 }
 
 %with-public-locked-icon {
-  @extend %with-icon, %public-locked-svg-prop;
+  @extend %with-icon, %public-locked-svg-prop !optional;
   background-image: var(--public-locked-svg);
 }
 %with-public-locked-mask {
-  @extend %with-mask, %public-locked-svg-prop;
+  @extend %with-mask, %public-locked-svg-prop !optional;
   -webkit-mask-image: var(--public-locked-svg);
   mask-image: var(--public-locked-svg);
 }
 
+%with-queue-16-icon {
+  @extend %with-icon, %queue-16-svg-prop !optional;
+  background-image: var(--queue-16-svg);
+}
+%with-queue-16-mask {
+  @extend %with-mask, %queue-16-svg-prop !optional;
+  -webkit-mask-image: var(--queue-16-svg);
+  mask-image: var(--queue-16-svg);
+}
+
+%with-queue-24-icon {
+  @extend %with-icon, %queue-24-svg-prop !optional;
+  background-image: var(--queue-24-svg);
+}
+%with-queue-24-mask {
+  @extend %with-mask, %queue-24-svg-prop !optional;
+  -webkit-mask-image: var(--queue-24-svg);
+  mask-image: var(--queue-24-svg);
+}
+
 %with-queue-icon {
-  @extend %with-icon, %queue-svg-prop;
+  @extend %with-icon, %queue-svg-prop !optional;
   background-image: var(--queue-svg);
 }
 %with-queue-mask {
-  @extend %with-mask, %queue-svg-prop;
+  @extend %with-mask, %queue-svg-prop !optional;
   -webkit-mask-image: var(--queue-svg);
   mask-image: var(--queue-svg);
 }
 
+%with-radio-16-icon {
+  @extend %with-icon, %radio-16-svg-prop !optional;
+  background-image: var(--radio-16-svg);
+}
+%with-radio-16-mask {
+  @extend %with-mask, %radio-16-svg-prop !optional;
+  -webkit-mask-image: var(--radio-16-svg);
+  mask-image: var(--radio-16-svg);
+}
+
+%with-radio-24-icon {
+  @extend %with-icon, %radio-24-svg-prop !optional;
+  background-image: var(--radio-24-svg);
+}
+%with-radio-24-mask {
+  @extend %with-mask, %radio-24-svg-prop !optional;
+  -webkit-mask-image: var(--radio-24-svg);
+  mask-image: var(--radio-24-svg);
+}
+
 %with-radio-button-checked-icon {
-  @extend %with-icon, %radio-button-checked-svg-prop;
+  @extend %with-icon, %radio-button-checked-svg-prop !optional;
   background-image: var(--radio-button-checked-svg);
 }
 %with-radio-button-checked-mask {
-  @extend %with-mask, %radio-button-checked-svg-prop;
+  @extend %with-mask, %radio-button-checked-svg-prop !optional;
   -webkit-mask-image: var(--radio-button-checked-svg);
   mask-image: var(--radio-button-checked-svg);
 }
 
 %with-radio-button-unchecked-icon {
-  @extend %with-icon, %radio-button-unchecked-svg-prop;
+  @extend %with-icon, %radio-button-unchecked-svg-prop !optional;
   background-image: var(--radio-button-unchecked-svg);
 }
 %with-radio-button-unchecked-mask {
-  @extend %with-mask, %radio-button-unchecked-svg-prop;
+  @extend %with-mask, %radio-button-unchecked-svg-prop !optional;
   -webkit-mask-image: var(--radio-button-unchecked-svg);
   mask-image: var(--radio-button-unchecked-svg);
 }
 
+%with-random-16-icon {
+  @extend %with-icon, %random-16-svg-prop !optional;
+  background-image: var(--random-16-svg);
+}
+%with-random-16-mask {
+  @extend %with-mask, %random-16-svg-prop !optional;
+  -webkit-mask-image: var(--random-16-svg);
+  mask-image: var(--random-16-svg);
+}
+
+%with-random-24-icon {
+  @extend %with-icon, %random-24-svg-prop !optional;
+  background-image: var(--random-24-svg);
+}
+%with-random-24-mask {
+  @extend %with-mask, %random-24-svg-prop !optional;
+  -webkit-mask-image: var(--random-24-svg);
+  mask-image: var(--random-24-svg);
+}
+
 %with-random-icon {
-  @extend %with-icon, %random-svg-prop;
+  @extend %with-icon, %random-svg-prop !optional;
   background-image: var(--random-svg);
 }
 %with-random-mask {
-  @extend %with-mask, %random-svg-prop;
+  @extend %with-mask, %random-svg-prop !optional;
   -webkit-mask-image: var(--random-svg);
   mask-image: var(--random-svg);
 }
 
+%with-redirect-16-icon {
+  @extend %with-icon, %redirect-16-svg-prop !optional;
+  background-image: var(--redirect-16-svg);
+}
+%with-redirect-16-mask {
+  @extend %with-mask, %redirect-16-svg-prop !optional;
+  -webkit-mask-image: var(--redirect-16-svg);
+  mask-image: var(--redirect-16-svg);
+}
+
+%with-redirect-24-icon {
+  @extend %with-icon, %redirect-24-svg-prop !optional;
+  background-image: var(--redirect-24-svg);
+}
+%with-redirect-24-mask {
+  @extend %with-mask, %redirect-24-svg-prop !optional;
+  -webkit-mask-image: var(--redirect-24-svg);
+  mask-image: var(--redirect-24-svg);
+}
+
 %with-redirect-icon {
-  @extend %with-icon, %redirect-svg-prop;
+  @extend %with-icon, %redirect-svg-prop !optional;
   background-image: var(--redirect-svg);
 }
 %with-redirect-mask {
-  @extend %with-mask, %redirect-svg-prop;
+  @extend %with-mask, %redirect-svg-prop !optional;
   -webkit-mask-image: var(--redirect-svg);
   mask-image: var(--redirect-svg);
 }
 
 %with-refresh-alert-icon {
-  @extend %with-icon, %refresh-alert-svg-prop;
+  @extend %with-icon, %refresh-alert-svg-prop !optional;
   background-image: var(--refresh-alert-svg);
 }
 %with-refresh-alert-mask {
-  @extend %with-mask, %refresh-alert-svg-prop;
+  @extend %with-mask, %refresh-alert-svg-prop !optional;
   -webkit-mask-image: var(--refresh-alert-svg);
   mask-image: var(--refresh-alert-svg);
 }
 
 %with-refresh-default-icon {
-  @extend %with-icon, %refresh-default-svg-prop;
+  @extend %with-icon, %refresh-default-svg-prop !optional;
   background-image: var(--refresh-default-svg);
 }
 %with-refresh-default-mask {
-  @extend %with-mask, %refresh-default-svg-prop;
+  @extend %with-mask, %refresh-default-svg-prop !optional;
   -webkit-mask-image: var(--refresh-default-svg);
   mask-image: var(--refresh-default-svg);
 }
 
+%with-reload-16-icon {
+  @extend %with-icon, %reload-16-svg-prop !optional;
+  background-image: var(--reload-16-svg);
+}
+%with-reload-16-mask {
+  @extend %with-mask, %reload-16-svg-prop !optional;
+  -webkit-mask-image: var(--reload-16-svg);
+  mask-image: var(--reload-16-svg);
+}
+
+%with-reload-24-icon {
+  @extend %with-icon, %reload-24-svg-prop !optional;
+  background-image: var(--reload-24-svg);
+}
+%with-reload-24-mask {
+  @extend %with-mask, %reload-24-svg-prop !optional;
+  -webkit-mask-image: var(--reload-24-svg);
+  mask-image: var(--reload-24-svg);
+}
+
 %with-remix-icon {
-  @extend %with-icon, %remix-svg-prop;
+  @extend %with-icon, %remix-svg-prop !optional;
   background-image: var(--remix-svg);
 }
 %with-remix-mask {
-  @extend %with-mask, %remix-svg-prop;
+  @extend %with-mask, %remix-svg-prop !optional;
   -webkit-mask-image: var(--remix-svg);
   mask-image: var(--remix-svg);
 }
 
+%with-repeat-16-icon {
+  @extend %with-icon, %repeat-16-svg-prop !optional;
+  background-image: var(--repeat-16-svg);
+}
+%with-repeat-16-mask {
+  @extend %with-mask, %repeat-16-svg-prop !optional;
+  -webkit-mask-image: var(--repeat-16-svg);
+  mask-image: var(--repeat-16-svg);
+}
+
+%with-repeat-24-icon {
+  @extend %with-icon, %repeat-24-svg-prop !optional;
+  background-image: var(--repeat-24-svg);
+}
+%with-repeat-24-mask {
+  @extend %with-mask, %repeat-24-svg-prop !optional;
+  -webkit-mask-image: var(--repeat-24-svg);
+  mask-image: var(--repeat-24-svg);
+}
+
+%with-replication-direct-16-icon {
+  @extend %with-icon, %replication-direct-16-svg-prop !optional;
+  background-image: var(--replication-direct-16-svg);
+}
+%with-replication-direct-16-mask {
+  @extend %with-mask, %replication-direct-16-svg-prop !optional;
+  -webkit-mask-image: var(--replication-direct-16-svg);
+  mask-image: var(--replication-direct-16-svg);
+}
+
+%with-replication-direct-24-icon {
+  @extend %with-icon, %replication-direct-24-svg-prop !optional;
+  background-image: var(--replication-direct-24-svg);
+}
+%with-replication-direct-24-mask {
+  @extend %with-mask, %replication-direct-24-svg-prop !optional;
+  -webkit-mask-image: var(--replication-direct-24-svg);
+  mask-image: var(--replication-direct-24-svg);
+}
+
+%with-replication-perf-16-icon {
+  @extend %with-icon, %replication-perf-16-svg-prop !optional;
+  background-image: var(--replication-perf-16-svg);
+}
+%with-replication-perf-16-mask {
+  @extend %with-mask, %replication-perf-16-svg-prop !optional;
+  -webkit-mask-image: var(--replication-perf-16-svg);
+  mask-image: var(--replication-perf-16-svg);
+}
+
+%with-replication-perf-24-icon {
+  @extend %with-icon, %replication-perf-24-svg-prop !optional;
+  background-image: var(--replication-perf-24-svg);
+}
+%with-replication-perf-24-mask {
+  @extend %with-mask, %replication-perf-24-svg-prop !optional;
+  -webkit-mask-image: var(--replication-perf-24-svg);
+  mask-image: var(--replication-perf-24-svg);
+}
+
+%with-rewind-16-icon {
+  @extend %with-icon, %rewind-16-svg-prop !optional;
+  background-image: var(--rewind-16-svg);
+}
+%with-rewind-16-mask {
+  @extend %with-mask, %rewind-16-svg-prop !optional;
+  -webkit-mask-image: var(--rewind-16-svg);
+  mask-image: var(--rewind-16-svg);
+}
+
+%with-rewind-24-icon {
+  @extend %with-icon, %rewind-24-svg-prop !optional;
+  background-image: var(--rewind-24-svg);
+}
+%with-rewind-24-mask {
+  @extend %with-mask, %rewind-24-svg-prop !optional;
+  -webkit-mask-image: var(--rewind-24-svg);
+  mask-image: var(--rewind-24-svg);
+}
+
 %with-ribbon-icon {
-  @extend %with-icon, %ribbon-svg-prop;
+  @extend %with-icon, %ribbon-svg-prop !optional;
   background-image: var(--ribbon-svg);
 }
 %with-ribbon-mask {
-  @extend %with-mask, %ribbon-svg-prop;
+  @extend %with-mask, %ribbon-svg-prop !optional;
   -webkit-mask-image: var(--ribbon-svg);
   mask-image: var(--ribbon-svg);
 }
 
+%with-rocket-16-icon {
+  @extend %with-icon, %rocket-16-svg-prop !optional;
+  background-image: var(--rocket-16-svg);
+}
+%with-rocket-16-mask {
+  @extend %with-mask, %rocket-16-svg-prop !optional;
+  -webkit-mask-image: var(--rocket-16-svg);
+  mask-image: var(--rocket-16-svg);
+}
+
+%with-rocket-24-icon {
+  @extend %with-icon, %rocket-24-svg-prop !optional;
+  background-image: var(--rocket-24-svg);
+}
+%with-rocket-24-mask {
+  @extend %with-mask, %rocket-24-svg-prop !optional;
+  -webkit-mask-image: var(--rocket-24-svg);
+  mask-image: var(--rocket-24-svg);
+}
+
+%with-rotate-ccw-16-icon {
+  @extend %with-icon, %rotate-ccw-16-svg-prop !optional;
+  background-image: var(--rotate-ccw-16-svg);
+}
+%with-rotate-ccw-16-mask {
+  @extend %with-mask, %rotate-ccw-16-svg-prop !optional;
+  -webkit-mask-image: var(--rotate-ccw-16-svg);
+  mask-image: var(--rotate-ccw-16-svg);
+}
+
+%with-rotate-ccw-24-icon {
+  @extend %with-icon, %rotate-ccw-24-svg-prop !optional;
+  background-image: var(--rotate-ccw-24-svg);
+}
+%with-rotate-ccw-24-mask {
+  @extend %with-mask, %rotate-ccw-24-svg-prop !optional;
+  -webkit-mask-image: var(--rotate-ccw-24-svg);
+  mask-image: var(--rotate-ccw-24-svg);
+}
+
+%with-rotate-cw-16-icon {
+  @extend %with-icon, %rotate-cw-16-svg-prop !optional;
+  background-image: var(--rotate-cw-16-svg);
+}
+%with-rotate-cw-16-mask {
+  @extend %with-mask, %rotate-cw-16-svg-prop !optional;
+  -webkit-mask-image: var(--rotate-cw-16-svg);
+  mask-image: var(--rotate-cw-16-svg);
+}
+
+%with-rotate-cw-24-icon {
+  @extend %with-icon, %rotate-cw-24-svg-prop !optional;
+  background-image: var(--rotate-cw-24-svg);
+}
+%with-rotate-cw-24-mask {
+  @extend %with-mask, %rotate-cw-24-svg-prop !optional;
+  -webkit-mask-image: var(--rotate-cw-24-svg);
+  mask-image: var(--rotate-cw-24-svg);
+}
+
+%with-rss-16-icon {
+  @extend %with-icon, %rss-16-svg-prop !optional;
+  background-image: var(--rss-16-svg);
+}
+%with-rss-16-mask {
+  @extend %with-mask, %rss-16-svg-prop !optional;
+  -webkit-mask-image: var(--rss-16-svg);
+  mask-image: var(--rss-16-svg);
+}
+
+%with-rss-24-icon {
+  @extend %with-icon, %rss-24-svg-prop !optional;
+  background-image: var(--rss-24-svg);
+}
+%with-rss-24-mask {
+  @extend %with-mask, %rss-24-svg-prop !optional;
+  -webkit-mask-image: var(--rss-24-svg);
+  mask-image: var(--rss-24-svg);
+}
+
 %with-run-icon {
-  @extend %with-icon, %run-svg-prop;
+  @extend %with-icon, %run-svg-prop !optional;
   background-image: var(--run-svg);
 }
 %with-run-mask {
-  @extend %with-mask, %run-svg-prop;
+  @extend %with-mask, %run-svg-prop !optional;
   -webkit-mask-image: var(--run-svg);
   mask-image: var(--run-svg);
 }
 
+%with-save-16-icon {
+  @extend %with-icon, %save-16-svg-prop !optional;
+  background-image: var(--save-16-svg);
+}
+%with-save-16-mask {
+  @extend %with-mask, %save-16-svg-prop !optional;
+  -webkit-mask-image: var(--save-16-svg);
+  mask-image: var(--save-16-svg);
+}
+
+%with-save-24-icon {
+  @extend %with-icon, %save-24-svg-prop !optional;
+  background-image: var(--save-24-svg);
+}
+%with-save-24-mask {
+  @extend %with-mask, %save-24-svg-prop !optional;
+  -webkit-mask-image: var(--save-24-svg);
+  mask-image: var(--save-24-svg);
+}
+
+%with-scissors-16-icon {
+  @extend %with-icon, %scissors-16-svg-prop !optional;
+  background-image: var(--scissors-16-svg);
+}
+%with-scissors-16-mask {
+  @extend %with-mask, %scissors-16-svg-prop !optional;
+  -webkit-mask-image: var(--scissors-16-svg);
+  mask-image: var(--scissors-16-svg);
+}
+
+%with-scissors-24-icon {
+  @extend %with-icon, %scissors-24-svg-prop !optional;
+  background-image: var(--scissors-24-svg);
+}
+%with-scissors-24-mask {
+  @extend %with-mask, %scissors-24-svg-prop !optional;
+  -webkit-mask-image: var(--scissors-24-svg);
+  mask-image: var(--scissors-24-svg);
+}
+
+%with-search-16-icon {
+  @extend %with-icon, %search-16-svg-prop !optional;
+  background-image: var(--search-16-svg);
+}
+%with-search-16-mask {
+  @extend %with-mask, %search-16-svg-prop !optional;
+  -webkit-mask-image: var(--search-16-svg);
+  mask-image: var(--search-16-svg);
+}
+
+%with-search-24-icon {
+  @extend %with-icon, %search-24-svg-prop !optional;
+  background-image: var(--search-24-svg);
+}
+%with-search-24-mask {
+  @extend %with-mask, %search-24-svg-prop !optional;
+  -webkit-mask-image: var(--search-24-svg);
+  mask-image: var(--search-24-svg);
+}
+
 %with-search-color-icon {
-  @extend %with-icon, %search-color-svg-prop;
+  @extend %with-icon, %search-color-svg-prop !optional;
   background-image: var(--search-color-svg);
 }
 %with-search-color-mask {
-  @extend %with-mask, %search-color-svg-prop;
+  @extend %with-mask, %search-color-svg-prop !optional;
   -webkit-mask-image: var(--search-color-svg);
   mask-image: var(--search-color-svg);
 }
 
 %with-search-icon {
-  @extend %with-icon, %search-svg-prop;
+  @extend %with-icon, %search-svg-prop !optional;
   background-image: var(--search-svg);
 }
 %with-search-mask {
-  @extend %with-mask, %search-svg-prop;
+  @extend %with-mask, %search-svg-prop !optional;
   -webkit-mask-image: var(--search-svg);
   mask-image: var(--search-svg);
 }
 
+%with-send-16-icon {
+  @extend %with-icon, %send-16-svg-prop !optional;
+  background-image: var(--send-16-svg);
+}
+%with-send-16-mask {
+  @extend %with-mask, %send-16-svg-prop !optional;
+  -webkit-mask-image: var(--send-16-svg);
+  mask-image: var(--send-16-svg);
+}
+
+%with-send-24-icon {
+  @extend %with-icon, %send-24-svg-prop !optional;
+  background-image: var(--send-24-svg);
+}
+%with-send-24-mask {
+  @extend %with-mask, %send-24-svg-prop !optional;
+  -webkit-mask-image: var(--send-24-svg);
+  mask-image: var(--send-24-svg);
+}
+
+%with-server-16-icon {
+  @extend %with-icon, %server-16-svg-prop !optional;
+  background-image: var(--server-16-svg);
+}
+%with-server-16-mask {
+  @extend %with-mask, %server-16-svg-prop !optional;
+  -webkit-mask-image: var(--server-16-svg);
+  mask-image: var(--server-16-svg);
+}
+
+%with-server-24-icon {
+  @extend %with-icon, %server-24-svg-prop !optional;
+  background-image: var(--server-24-svg);
+}
+%with-server-24-mask {
+  @extend %with-mask, %server-24-svg-prop !optional;
+  -webkit-mask-image: var(--server-24-svg);
+  mask-image: var(--server-24-svg);
+}
+
+%with-server-cluster-16-icon {
+  @extend %with-icon, %server-cluster-16-svg-prop !optional;
+  background-image: var(--server-cluster-16-svg);
+}
+%with-server-cluster-16-mask {
+  @extend %with-mask, %server-cluster-16-svg-prop !optional;
+  -webkit-mask-image: var(--server-cluster-16-svg);
+  mask-image: var(--server-cluster-16-svg);
+}
+
+%with-server-cluster-24-icon {
+  @extend %with-icon, %server-cluster-24-svg-prop !optional;
+  background-image: var(--server-cluster-24-svg);
+}
+%with-server-cluster-24-mask {
+  @extend %with-mask, %server-cluster-24-svg-prop !optional;
+  -webkit-mask-image: var(--server-cluster-24-svg);
+  mask-image: var(--server-cluster-24-svg);
+}
+
+%with-serverless-16-icon {
+  @extend %with-icon, %serverless-16-svg-prop !optional;
+  background-image: var(--serverless-16-svg);
+}
+%with-serverless-16-mask {
+  @extend %with-mask, %serverless-16-svg-prop !optional;
+  -webkit-mask-image: var(--serverless-16-svg);
+  mask-image: var(--serverless-16-svg);
+}
+
+%with-serverless-24-icon {
+  @extend %with-icon, %serverless-24-svg-prop !optional;
+  background-image: var(--serverless-24-svg);
+}
+%with-serverless-24-mask {
+  @extend %with-mask, %serverless-24-svg-prop !optional;
+  -webkit-mask-image: var(--serverless-24-svg);
+  mask-image: var(--serverless-24-svg);
+}
+
+%with-settings-16-icon {
+  @extend %with-icon, %settings-16-svg-prop !optional;
+  background-image: var(--settings-16-svg);
+}
+%with-settings-16-mask {
+  @extend %with-mask, %settings-16-svg-prop !optional;
+  -webkit-mask-image: var(--settings-16-svg);
+  mask-image: var(--settings-16-svg);
+}
+
+%with-settings-24-icon {
+  @extend %with-icon, %settings-24-svg-prop !optional;
+  background-image: var(--settings-24-svg);
+}
+%with-settings-24-mask {
+  @extend %with-mask, %settings-24-svg-prop !optional;
+  -webkit-mask-image: var(--settings-24-svg);
+  mask-image: var(--settings-24-svg);
+}
+
 %with-settings-icon {
-  @extend %with-icon, %settings-svg-prop;
+  @extend %with-icon, %settings-svg-prop !optional;
   background-image: var(--settings-svg);
 }
 %with-settings-mask {
-  @extend %with-mask, %settings-svg-prop;
+  @extend %with-mask, %settings-svg-prop !optional;
   -webkit-mask-image: var(--settings-svg);
   mask-image: var(--settings-svg);
 }
 
+%with-share-16-icon {
+  @extend %with-icon, %share-16-svg-prop !optional;
+  background-image: var(--share-16-svg);
+}
+%with-share-16-mask {
+  @extend %with-mask, %share-16-svg-prop !optional;
+  -webkit-mask-image: var(--share-16-svg);
+  mask-image: var(--share-16-svg);
+}
+
+%with-share-24-icon {
+  @extend %with-icon, %share-24-svg-prop !optional;
+  background-image: var(--share-24-svg);
+}
+%with-share-24-mask {
+  @extend %with-mask, %share-24-svg-prop !optional;
+  -webkit-mask-image: var(--share-24-svg);
+  mask-image: var(--share-24-svg);
+}
+
+%with-shield-16-icon {
+  @extend %with-icon, %shield-16-svg-prop !optional;
+  background-image: var(--shield-16-svg);
+}
+%with-shield-16-mask {
+  @extend %with-mask, %shield-16-svg-prop !optional;
+  -webkit-mask-image: var(--shield-16-svg);
+  mask-image: var(--shield-16-svg);
+}
+
+%with-shield-24-icon {
+  @extend %with-icon, %shield-24-svg-prop !optional;
+  background-image: var(--shield-24-svg);
+}
+%with-shield-24-mask {
+  @extend %with-mask, %shield-24-svg-prop !optional;
+  -webkit-mask-image: var(--shield-24-svg);
+  mask-image: var(--shield-24-svg);
+}
+
+%with-shield-alert-16-icon {
+  @extend %with-icon, %shield-alert-16-svg-prop !optional;
+  background-image: var(--shield-alert-16-svg);
+}
+%with-shield-alert-16-mask {
+  @extend %with-mask, %shield-alert-16-svg-prop !optional;
+  -webkit-mask-image: var(--shield-alert-16-svg);
+  mask-image: var(--shield-alert-16-svg);
+}
+
+%with-shield-alert-24-icon {
+  @extend %with-icon, %shield-alert-24-svg-prop !optional;
+  background-image: var(--shield-alert-24-svg);
+}
+%with-shield-alert-24-mask {
+  @extend %with-mask, %shield-alert-24-svg-prop !optional;
+  -webkit-mask-image: var(--shield-alert-24-svg);
+  mask-image: var(--shield-alert-24-svg);
+}
+
+%with-shield-check-16-icon {
+  @extend %with-icon, %shield-check-16-svg-prop !optional;
+  background-image: var(--shield-check-16-svg);
+}
+%with-shield-check-16-mask {
+  @extend %with-mask, %shield-check-16-svg-prop !optional;
+  -webkit-mask-image: var(--shield-check-16-svg);
+  mask-image: var(--shield-check-16-svg);
+}
+
+%with-shield-check-24-icon {
+  @extend %with-icon, %shield-check-24-svg-prop !optional;
+  background-image: var(--shield-check-24-svg);
+}
+%with-shield-check-24-mask {
+  @extend %with-mask, %shield-check-24-svg-prop !optional;
+  -webkit-mask-image: var(--shield-check-24-svg);
+  mask-image: var(--shield-check-24-svg);
+}
+
+%with-shield-off-16-icon {
+  @extend %with-icon, %shield-off-16-svg-prop !optional;
+  background-image: var(--shield-off-16-svg);
+}
+%with-shield-off-16-mask {
+  @extend %with-mask, %shield-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--shield-off-16-svg);
+  mask-image: var(--shield-off-16-svg);
+}
+
+%with-shield-off-24-icon {
+  @extend %with-icon, %shield-off-24-svg-prop !optional;
+  background-image: var(--shield-off-24-svg);
+}
+%with-shield-off-24-mask {
+  @extend %with-mask, %shield-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--shield-off-24-svg);
+  mask-image: var(--shield-off-24-svg);
+}
+
+%with-shield-x-16-icon {
+  @extend %with-icon, %shield-x-16-svg-prop !optional;
+  background-image: var(--shield-x-16-svg);
+}
+%with-shield-x-16-mask {
+  @extend %with-mask, %shield-x-16-svg-prop !optional;
+  -webkit-mask-image: var(--shield-x-16-svg);
+  mask-image: var(--shield-x-16-svg);
+}
+
+%with-shield-x-24-icon {
+  @extend %with-icon, %shield-x-24-svg-prop !optional;
+  background-image: var(--shield-x-24-svg);
+}
+%with-shield-x-24-mask {
+  @extend %with-mask, %shield-x-24-svg-prop !optional;
+  -webkit-mask-image: var(--shield-x-24-svg);
+  mask-image: var(--shield-x-24-svg);
+}
+
+%with-shopping-bag-16-icon {
+  @extend %with-icon, %shopping-bag-16-svg-prop !optional;
+  background-image: var(--shopping-bag-16-svg);
+}
+%with-shopping-bag-16-mask {
+  @extend %with-mask, %shopping-bag-16-svg-prop !optional;
+  -webkit-mask-image: var(--shopping-bag-16-svg);
+  mask-image: var(--shopping-bag-16-svg);
+}
+
+%with-shopping-bag-24-icon {
+  @extend %with-icon, %shopping-bag-24-svg-prop !optional;
+  background-image: var(--shopping-bag-24-svg);
+}
+%with-shopping-bag-24-mask {
+  @extend %with-mask, %shopping-bag-24-svg-prop !optional;
+  -webkit-mask-image: var(--shopping-bag-24-svg);
+  mask-image: var(--shopping-bag-24-svg);
+}
+
+%with-shopping-cart-16-icon {
+  @extend %with-icon, %shopping-cart-16-svg-prop !optional;
+  background-image: var(--shopping-cart-16-svg);
+}
+%with-shopping-cart-16-mask {
+  @extend %with-mask, %shopping-cart-16-svg-prop !optional;
+  -webkit-mask-image: var(--shopping-cart-16-svg);
+  mask-image: var(--shopping-cart-16-svg);
+}
+
+%with-shopping-cart-24-icon {
+  @extend %with-icon, %shopping-cart-24-svg-prop !optional;
+  background-image: var(--shopping-cart-24-svg);
+}
+%with-shopping-cart-24-mask {
+  @extend %with-mask, %shopping-cart-24-svg-prop !optional;
+  -webkit-mask-image: var(--shopping-cart-24-svg);
+  mask-image: var(--shopping-cart-24-svg);
+}
+
+%with-shuffle-16-icon {
+  @extend %with-icon, %shuffle-16-svg-prop !optional;
+  background-image: var(--shuffle-16-svg);
+}
+%with-shuffle-16-mask {
+  @extend %with-mask, %shuffle-16-svg-prop !optional;
+  -webkit-mask-image: var(--shuffle-16-svg);
+  mask-image: var(--shuffle-16-svg);
+}
+
+%with-shuffle-24-icon {
+  @extend %with-icon, %shuffle-24-svg-prop !optional;
+  background-image: var(--shuffle-24-svg);
+}
+%with-shuffle-24-mask {
+  @extend %with-mask, %shuffle-24-svg-prop !optional;
+  -webkit-mask-image: var(--shuffle-24-svg);
+  mask-image: var(--shuffle-24-svg);
+}
+
+%with-sidebar-16-icon {
+  @extend %with-icon, %sidebar-16-svg-prop !optional;
+  background-image: var(--sidebar-16-svg);
+}
+%with-sidebar-16-mask {
+  @extend %with-mask, %sidebar-16-svg-prop !optional;
+  -webkit-mask-image: var(--sidebar-16-svg);
+  mask-image: var(--sidebar-16-svg);
+}
+
+%with-sidebar-24-icon {
+  @extend %with-icon, %sidebar-24-svg-prop !optional;
+  background-image: var(--sidebar-24-svg);
+}
+%with-sidebar-24-mask {
+  @extend %with-mask, %sidebar-24-svg-prop !optional;
+  -webkit-mask-image: var(--sidebar-24-svg);
+  mask-image: var(--sidebar-24-svg);
+}
+
+%with-sidebar-hide-16-icon {
+  @extend %with-icon, %sidebar-hide-16-svg-prop !optional;
+  background-image: var(--sidebar-hide-16-svg);
+}
+%with-sidebar-hide-16-mask {
+  @extend %with-mask, %sidebar-hide-16-svg-prop !optional;
+  -webkit-mask-image: var(--sidebar-hide-16-svg);
+  mask-image: var(--sidebar-hide-16-svg);
+}
+
+%with-sidebar-hide-24-icon {
+  @extend %with-icon, %sidebar-hide-24-svg-prop !optional;
+  background-image: var(--sidebar-hide-24-svg);
+}
+%with-sidebar-hide-24-mask {
+  @extend %with-mask, %sidebar-hide-24-svg-prop !optional;
+  -webkit-mask-image: var(--sidebar-hide-24-svg);
+  mask-image: var(--sidebar-hide-24-svg);
+}
+
+%with-sidebar-show-16-icon {
+  @extend %with-icon, %sidebar-show-16-svg-prop !optional;
+  background-image: var(--sidebar-show-16-svg);
+}
+%with-sidebar-show-16-mask {
+  @extend %with-mask, %sidebar-show-16-svg-prop !optional;
+  -webkit-mask-image: var(--sidebar-show-16-svg);
+  mask-image: var(--sidebar-show-16-svg);
+}
+
+%with-sidebar-show-24-icon {
+  @extend %with-icon, %sidebar-show-24-svg-prop !optional;
+  background-image: var(--sidebar-show-24-svg);
+}
+%with-sidebar-show-24-mask {
+  @extend %with-mask, %sidebar-show-24-svg-prop !optional;
+  -webkit-mask-image: var(--sidebar-show-24-svg);
+  mask-image: var(--sidebar-show-24-svg);
+}
+
+%with-sign-in-16-icon {
+  @extend %with-icon, %sign-in-16-svg-prop !optional;
+  background-image: var(--sign-in-16-svg);
+}
+%with-sign-in-16-mask {
+  @extend %with-mask, %sign-in-16-svg-prop !optional;
+  -webkit-mask-image: var(--sign-in-16-svg);
+  mask-image: var(--sign-in-16-svg);
+}
+
+%with-sign-in-24-icon {
+  @extend %with-icon, %sign-in-24-svg-prop !optional;
+  background-image: var(--sign-in-24-svg);
+}
+%with-sign-in-24-mask {
+  @extend %with-mask, %sign-in-24-svg-prop !optional;
+  -webkit-mask-image: var(--sign-in-24-svg);
+  mask-image: var(--sign-in-24-svg);
+}
+
+%with-sign-out-16-icon {
+  @extend %with-icon, %sign-out-16-svg-prop !optional;
+  background-image: var(--sign-out-16-svg);
+}
+%with-sign-out-16-mask {
+  @extend %with-mask, %sign-out-16-svg-prop !optional;
+  -webkit-mask-image: var(--sign-out-16-svg);
+  mask-image: var(--sign-out-16-svg);
+}
+
+%with-sign-out-24-icon {
+  @extend %with-icon, %sign-out-24-svg-prop !optional;
+  background-image: var(--sign-out-24-svg);
+}
+%with-sign-out-24-mask {
+  @extend %with-mask, %sign-out-24-svg-prop !optional;
+  -webkit-mask-image: var(--sign-out-24-svg);
+  mask-image: var(--sign-out-24-svg);
+}
+
+%with-skip-16-icon {
+  @extend %with-icon, %skip-16-svg-prop !optional;
+  background-image: var(--skip-16-svg);
+}
+%with-skip-16-mask {
+  @extend %with-mask, %skip-16-svg-prop !optional;
+  -webkit-mask-image: var(--skip-16-svg);
+  mask-image: var(--skip-16-svg);
+}
+
+%with-skip-24-icon {
+  @extend %with-icon, %skip-24-svg-prop !optional;
+  background-image: var(--skip-24-svg);
+}
+%with-skip-24-mask {
+  @extend %with-mask, %skip-24-svg-prop !optional;
+  -webkit-mask-image: var(--skip-24-svg);
+  mask-image: var(--skip-24-svg);
+}
+
+%with-skip-back-16-icon {
+  @extend %with-icon, %skip-back-16-svg-prop !optional;
+  background-image: var(--skip-back-16-svg);
+}
+%with-skip-back-16-mask {
+  @extend %with-mask, %skip-back-16-svg-prop !optional;
+  -webkit-mask-image: var(--skip-back-16-svg);
+  mask-image: var(--skip-back-16-svg);
+}
+
+%with-skip-back-24-icon {
+  @extend %with-icon, %skip-back-24-svg-prop !optional;
+  background-image: var(--skip-back-24-svg);
+}
+%with-skip-back-24-mask {
+  @extend %with-mask, %skip-back-24-svg-prop !optional;
+  -webkit-mask-image: var(--skip-back-24-svg);
+  mask-image: var(--skip-back-24-svg);
+}
+
+%with-skip-forward-16-icon {
+  @extend %with-icon, %skip-forward-16-svg-prop !optional;
+  background-image: var(--skip-forward-16-svg);
+}
+%with-skip-forward-16-mask {
+  @extend %with-mask, %skip-forward-16-svg-prop !optional;
+  -webkit-mask-image: var(--skip-forward-16-svg);
+  mask-image: var(--skip-forward-16-svg);
+}
+
+%with-skip-forward-24-icon {
+  @extend %with-icon, %skip-forward-24-svg-prop !optional;
+  background-image: var(--skip-forward-24-svg);
+}
+%with-skip-forward-24-mask {
+  @extend %with-mask, %skip-forward-24-svg-prop !optional;
+  -webkit-mask-image: var(--skip-forward-24-svg);
+  mask-image: var(--skip-forward-24-svg);
+}
+
+%with-slack-16-icon {
+  @extend %with-icon, %slack-16-svg-prop !optional;
+  background-image: var(--slack-16-svg);
+}
+%with-slack-16-mask {
+  @extend %with-mask, %slack-16-svg-prop !optional;
+  -webkit-mask-image: var(--slack-16-svg);
+  mask-image: var(--slack-16-svg);
+}
+
+%with-slack-24-icon {
+  @extend %with-icon, %slack-24-svg-prop !optional;
+  background-image: var(--slack-24-svg);
+}
+%with-slack-24-mask {
+  @extend %with-mask, %slack-24-svg-prop !optional;
+  -webkit-mask-image: var(--slack-24-svg);
+  mask-image: var(--slack-24-svg);
+}
+
+%with-slack-color-16-icon {
+  @extend %with-icon, %slack-color-16-svg-prop !optional;
+  background-image: var(--slack-color-16-svg);
+}
+%with-slack-color-16-mask {
+  @extend %with-mask, %slack-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--slack-color-16-svg);
+  mask-image: var(--slack-color-16-svg);
+}
+
+%with-slack-color-24-icon {
+  @extend %with-icon, %slack-color-24-svg-prop !optional;
+  background-image: var(--slack-color-24-svg);
+}
+%with-slack-color-24-mask {
+  @extend %with-mask, %slack-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--slack-color-24-svg);
+  mask-image: var(--slack-color-24-svg);
+}
+
+%with-slash-16-icon {
+  @extend %with-icon, %slash-16-svg-prop !optional;
+  background-image: var(--slash-16-svg);
+}
+%with-slash-16-mask {
+  @extend %with-mask, %slash-16-svg-prop !optional;
+  -webkit-mask-image: var(--slash-16-svg);
+  mask-image: var(--slash-16-svg);
+}
+
+%with-slash-24-icon {
+  @extend %with-icon, %slash-24-svg-prop !optional;
+  background-image: var(--slash-24-svg);
+}
+%with-slash-24-mask {
+  @extend %with-mask, %slash-24-svg-prop !optional;
+  -webkit-mask-image: var(--slash-24-svg);
+  mask-image: var(--slash-24-svg);
+}
+
+%with-slash-square-16-icon {
+  @extend %with-icon, %slash-square-16-svg-prop !optional;
+  background-image: var(--slash-square-16-svg);
+}
+%with-slash-square-16-mask {
+  @extend %with-mask, %slash-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--slash-square-16-svg);
+  mask-image: var(--slash-square-16-svg);
+}
+
+%with-slash-square-24-icon {
+  @extend %with-icon, %slash-square-24-svg-prop !optional;
+  background-image: var(--slash-square-24-svg);
+}
+%with-slash-square-24-mask {
+  @extend %with-mask, %slash-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--slash-square-24-svg);
+  mask-image: var(--slash-square-24-svg);
+}
+
+%with-sliders-16-icon {
+  @extend %with-icon, %sliders-16-svg-prop !optional;
+  background-image: var(--sliders-16-svg);
+}
+%with-sliders-16-mask {
+  @extend %with-mask, %sliders-16-svg-prop !optional;
+  -webkit-mask-image: var(--sliders-16-svg);
+  mask-image: var(--sliders-16-svg);
+}
+
+%with-sliders-24-icon {
+  @extend %with-icon, %sliders-24-svg-prop !optional;
+  background-image: var(--sliders-24-svg);
+}
+%with-sliders-24-mask {
+  @extend %with-mask, %sliders-24-svg-prop !optional;
+  -webkit-mask-image: var(--sliders-24-svg);
+  mask-image: var(--sliders-24-svg);
+}
+
+%with-smartphone-16-icon {
+  @extend %with-icon, %smartphone-16-svg-prop !optional;
+  background-image: var(--smartphone-16-svg);
+}
+%with-smartphone-16-mask {
+  @extend %with-mask, %smartphone-16-svg-prop !optional;
+  -webkit-mask-image: var(--smartphone-16-svg);
+  mask-image: var(--smartphone-16-svg);
+}
+
+%with-smartphone-24-icon {
+  @extend %with-icon, %smartphone-24-svg-prop !optional;
+  background-image: var(--smartphone-24-svg);
+}
+%with-smartphone-24-mask {
+  @extend %with-mask, %smartphone-24-svg-prop !optional;
+  -webkit-mask-image: var(--smartphone-24-svg);
+  mask-image: var(--smartphone-24-svg);
+}
+
+%with-smile-16-icon {
+  @extend %with-icon, %smile-16-svg-prop !optional;
+  background-image: var(--smile-16-svg);
+}
+%with-smile-16-mask {
+  @extend %with-mask, %smile-16-svg-prop !optional;
+  -webkit-mask-image: var(--smile-16-svg);
+  mask-image: var(--smile-16-svg);
+}
+
+%with-smile-24-icon {
+  @extend %with-icon, %smile-24-svg-prop !optional;
+  background-image: var(--smile-24-svg);
+}
+%with-smile-24-mask {
+  @extend %with-mask, %smile-24-svg-prop !optional;
+  -webkit-mask-image: var(--smile-24-svg);
+  mask-image: var(--smile-24-svg);
+}
+
+%with-socket-16-icon {
+  @extend %with-icon, %socket-16-svg-prop !optional;
+  background-image: var(--socket-16-svg);
+}
+%with-socket-16-mask {
+  @extend %with-mask, %socket-16-svg-prop !optional;
+  -webkit-mask-image: var(--socket-16-svg);
+  mask-image: var(--socket-16-svg);
+}
+
+%with-socket-24-icon {
+  @extend %with-icon, %socket-24-svg-prop !optional;
+  background-image: var(--socket-24-svg);
+}
+%with-socket-24-mask {
+  @extend %with-mask, %socket-24-svg-prop !optional;
+  -webkit-mask-image: var(--socket-24-svg);
+  mask-image: var(--socket-24-svg);
+}
+
 %with-socket-icon {
-  @extend %with-icon, %socket-svg-prop;
+  @extend %with-icon, %socket-svg-prop !optional;
   background-image: var(--socket-svg);
 }
 %with-socket-mask {
-  @extend %with-mask, %socket-svg-prop;
+  @extend %with-mask, %socket-svg-prop !optional;
   -webkit-mask-image: var(--socket-svg);
   mask-image: var(--socket-svg);
 }
 
+%with-sort-asc-16-icon {
+  @extend %with-icon, %sort-asc-16-svg-prop !optional;
+  background-image: var(--sort-asc-16-svg);
+}
+%with-sort-asc-16-mask {
+  @extend %with-mask, %sort-asc-16-svg-prop !optional;
+  -webkit-mask-image: var(--sort-asc-16-svg);
+  mask-image: var(--sort-asc-16-svg);
+}
+
+%with-sort-asc-24-icon {
+  @extend %with-icon, %sort-asc-24-svg-prop !optional;
+  background-image: var(--sort-asc-24-svg);
+}
+%with-sort-asc-24-mask {
+  @extend %with-mask, %sort-asc-24-svg-prop !optional;
+  -webkit-mask-image: var(--sort-asc-24-svg);
+  mask-image: var(--sort-asc-24-svg);
+}
+
+%with-sort-desc-16-icon {
+  @extend %with-icon, %sort-desc-16-svg-prop !optional;
+  background-image: var(--sort-desc-16-svg);
+}
+%with-sort-desc-16-mask {
+  @extend %with-mask, %sort-desc-16-svg-prop !optional;
+  -webkit-mask-image: var(--sort-desc-16-svg);
+  mask-image: var(--sort-desc-16-svg);
+}
+
+%with-sort-desc-24-icon {
+  @extend %with-icon, %sort-desc-24-svg-prop !optional;
+  background-image: var(--sort-desc-24-svg);
+}
+%with-sort-desc-24-mask {
+  @extend %with-mask, %sort-desc-24-svg-prop !optional;
+  -webkit-mask-image: var(--sort-desc-24-svg);
+  mask-image: var(--sort-desc-24-svg);
+}
+
 %with-sort-icon {
-  @extend %with-icon, %sort-svg-prop;
+  @extend %with-icon, %sort-svg-prop !optional;
   background-image: var(--sort-svg);
 }
 %with-sort-mask {
-  @extend %with-mask, %sort-svg-prop;
+  @extend %with-mask, %sort-svg-prop !optional;
   -webkit-mask-image: var(--sort-svg);
   mask-image: var(--sort-svg);
 }
 
 %with-source-file-icon {
-  @extend %with-icon, %source-file-svg-prop;
+  @extend %with-icon, %source-file-svg-prop !optional;
   background-image: var(--source-file-svg);
 }
 %with-source-file-mask {
-  @extend %with-mask, %source-file-svg-prop;
+  @extend %with-mask, %source-file-svg-prop !optional;
   -webkit-mask-image: var(--source-file-svg);
   mask-image: var(--source-file-svg);
 }
 
+%with-speaker-16-icon {
+  @extend %with-icon, %speaker-16-svg-prop !optional;
+  background-image: var(--speaker-16-svg);
+}
+%with-speaker-16-mask {
+  @extend %with-mask, %speaker-16-svg-prop !optional;
+  -webkit-mask-image: var(--speaker-16-svg);
+  mask-image: var(--speaker-16-svg);
+}
+
+%with-speaker-24-icon {
+  @extend %with-icon, %speaker-24-svg-prop !optional;
+  background-image: var(--speaker-24-svg);
+}
+%with-speaker-24-mask {
+  @extend %with-mask, %speaker-24-svg-prop !optional;
+  -webkit-mask-image: var(--speaker-24-svg);
+  mask-image: var(--speaker-24-svg);
+}
+
+%with-square-16-icon {
+  @extend %with-icon, %square-16-svg-prop !optional;
+  background-image: var(--square-16-svg);
+}
+%with-square-16-mask {
+  @extend %with-mask, %square-16-svg-prop !optional;
+  -webkit-mask-image: var(--square-16-svg);
+  mask-image: var(--square-16-svg);
+}
+
+%with-square-24-icon {
+  @extend %with-icon, %square-24-svg-prop !optional;
+  background-image: var(--square-24-svg);
+}
+%with-square-24-mask {
+  @extend %with-mask, %square-24-svg-prop !optional;
+  -webkit-mask-image: var(--square-24-svg);
+  mask-image: var(--square-24-svg);
+}
+
+%with-square-fill-16-icon {
+  @extend %with-icon, %square-fill-16-svg-prop !optional;
+  background-image: var(--square-fill-16-svg);
+}
+%with-square-fill-16-mask {
+  @extend %with-mask, %square-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--square-fill-16-svg);
+  mask-image: var(--square-fill-16-svg);
+}
+
+%with-square-fill-24-icon {
+  @extend %with-icon, %square-fill-24-svg-prop !optional;
+  background-image: var(--square-fill-24-svg);
+}
+%with-square-fill-24-mask {
+  @extend %with-mask, %square-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--square-fill-24-svg);
+  mask-image: var(--square-fill-24-svg);
+}
+
+%with-star-16-icon {
+  @extend %with-icon, %star-16-svg-prop !optional;
+  background-image: var(--star-16-svg);
+}
+%with-star-16-mask {
+  @extend %with-mask, %star-16-svg-prop !optional;
+  -webkit-mask-image: var(--star-16-svg);
+  mask-image: var(--star-16-svg);
+}
+
+%with-star-24-icon {
+  @extend %with-icon, %star-24-svg-prop !optional;
+  background-image: var(--star-24-svg);
+}
+%with-star-24-mask {
+  @extend %with-mask, %star-24-svg-prop !optional;
+  -webkit-mask-image: var(--star-24-svg);
+  mask-image: var(--star-24-svg);
+}
+
+%with-star-circle-16-icon {
+  @extend %with-icon, %star-circle-16-svg-prop !optional;
+  background-image: var(--star-circle-16-svg);
+}
+%with-star-circle-16-mask {
+  @extend %with-mask, %star-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--star-circle-16-svg);
+  mask-image: var(--star-circle-16-svg);
+}
+
+%with-star-circle-24-icon {
+  @extend %with-icon, %star-circle-24-svg-prop !optional;
+  background-image: var(--star-circle-24-svg);
+}
+%with-star-circle-24-mask {
+  @extend %with-mask, %star-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--star-circle-24-svg);
+  mask-image: var(--star-circle-24-svg);
+}
+
+%with-star-fill-16-icon {
+  @extend %with-icon, %star-fill-16-svg-prop !optional;
+  background-image: var(--star-fill-16-svg);
+}
+%with-star-fill-16-mask {
+  @extend %with-mask, %star-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--star-fill-16-svg);
+  mask-image: var(--star-fill-16-svg);
+}
+
+%with-star-fill-24-icon {
+  @extend %with-icon, %star-fill-24-svg-prop !optional;
+  background-image: var(--star-fill-24-svg);
+}
+%with-star-fill-24-mask {
+  @extend %with-mask, %star-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--star-fill-24-svg);
+  mask-image: var(--star-fill-24-svg);
+}
+
 %with-star-fill-icon {
-  @extend %with-icon, %star-fill-svg-prop;
+  @extend %with-icon, %star-fill-svg-prop !optional;
   background-image: var(--star-fill-svg);
 }
 %with-star-fill-mask {
-  @extend %with-mask, %star-fill-svg-prop;
+  @extend %with-mask, %star-fill-svg-prop !optional;
   -webkit-mask-image: var(--star-fill-svg);
   mask-image: var(--star-fill-svg);
 }
 
+%with-star-off-16-icon {
+  @extend %with-icon, %star-off-16-svg-prop !optional;
+  background-image: var(--star-off-16-svg);
+}
+%with-star-off-16-mask {
+  @extend %with-mask, %star-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--star-off-16-svg);
+  mask-image: var(--star-off-16-svg);
+}
+
+%with-star-off-24-icon {
+  @extend %with-icon, %star-off-24-svg-prop !optional;
+  background-image: var(--star-off-24-svg);
+}
+%with-star-off-24-mask {
+  @extend %with-mask, %star-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--star-off-24-svg);
+  mask-image: var(--star-off-24-svg);
+}
+
 %with-star-outline-icon {
-  @extend %with-icon, %star-outline-svg-prop;
+  @extend %with-icon, %star-outline-svg-prop !optional;
   background-image: var(--star-outline-svg);
 }
 %with-star-outline-mask {
-  @extend %with-mask, %star-outline-svg-prop;
+  @extend %with-mask, %star-outline-svg-prop !optional;
   -webkit-mask-image: var(--star-outline-svg);
   mask-image: var(--star-outline-svg);
 }
 
+%with-stop-circle-16-icon {
+  @extend %with-icon, %stop-circle-16-svg-prop !optional;
+  background-image: var(--stop-circle-16-svg);
+}
+%with-stop-circle-16-mask {
+  @extend %with-mask, %stop-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--stop-circle-16-svg);
+  mask-image: var(--stop-circle-16-svg);
+}
+
+%with-stop-circle-24-icon {
+  @extend %with-icon, %stop-circle-24-svg-prop !optional;
+  background-image: var(--stop-circle-24-svg);
+}
+%with-stop-circle-24-mask {
+  @extend %with-mask, %stop-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--stop-circle-24-svg);
+  mask-image: var(--stop-circle-24-svg);
+}
+
 %with-sub-left-icon {
-  @extend %with-icon, %sub-left-svg-prop;
+  @extend %with-icon, %sub-left-svg-prop !optional;
   background-image: var(--sub-left-svg);
 }
 %with-sub-left-mask {
-  @extend %with-mask, %sub-left-svg-prop;
+  @extend %with-mask, %sub-left-svg-prop !optional;
   -webkit-mask-image: var(--sub-left-svg);
   mask-image: var(--sub-left-svg);
 }
 
 %with-sub-right-icon {
-  @extend %with-icon, %sub-right-svg-prop;
+  @extend %with-icon, %sub-right-svg-prop !optional;
   background-image: var(--sub-right-svg);
 }
 %with-sub-right-mask {
-  @extend %with-mask, %sub-right-svg-prop;
+  @extend %with-mask, %sub-right-svg-prop !optional;
   -webkit-mask-image: var(--sub-right-svg);
   mask-image: var(--sub-right-svg);
 }
 
+%with-sun-16-icon {
+  @extend %with-icon, %sun-16-svg-prop !optional;
+  background-image: var(--sun-16-svg);
+}
+%with-sun-16-mask {
+  @extend %with-mask, %sun-16-svg-prop !optional;
+  -webkit-mask-image: var(--sun-16-svg);
+  mask-image: var(--sun-16-svg);
+}
+
+%with-sun-24-icon {
+  @extend %with-icon, %sun-24-svg-prop !optional;
+  background-image: var(--sun-24-svg);
+}
+%with-sun-24-mask {
+  @extend %with-mask, %sun-24-svg-prop !optional;
+  -webkit-mask-image: var(--sun-24-svg);
+  mask-image: var(--sun-24-svg);
+}
+
+%with-support-16-icon {
+  @extend %with-icon, %support-16-svg-prop !optional;
+  background-image: var(--support-16-svg);
+}
+%with-support-16-mask {
+  @extend %with-mask, %support-16-svg-prop !optional;
+  -webkit-mask-image: var(--support-16-svg);
+  mask-image: var(--support-16-svg);
+}
+
+%with-support-24-icon {
+  @extend %with-icon, %support-24-svg-prop !optional;
+  background-image: var(--support-24-svg);
+}
+%with-support-24-mask {
+  @extend %with-mask, %support-24-svg-prop !optional;
+  -webkit-mask-image: var(--support-24-svg);
+  mask-image: var(--support-24-svg);
+}
+
 %with-support-icon {
-  @extend %with-icon, %support-svg-prop;
+  @extend %with-icon, %support-svg-prop !optional;
   background-image: var(--support-svg);
 }
 %with-support-mask {
-  @extend %with-mask, %support-svg-prop;
+  @extend %with-mask, %support-svg-prop !optional;
   -webkit-mask-image: var(--support-svg);
   mask-image: var(--support-svg);
 }
 
+%with-swap-horizontal-16-icon {
+  @extend %with-icon, %swap-horizontal-16-svg-prop !optional;
+  background-image: var(--swap-horizontal-16-svg);
+}
+%with-swap-horizontal-16-mask {
+  @extend %with-mask, %swap-horizontal-16-svg-prop !optional;
+  -webkit-mask-image: var(--swap-horizontal-16-svg);
+  mask-image: var(--swap-horizontal-16-svg);
+}
+
+%with-swap-horizontal-24-icon {
+  @extend %with-icon, %swap-horizontal-24-svg-prop !optional;
+  background-image: var(--swap-horizontal-24-svg);
+}
+%with-swap-horizontal-24-mask {
+  @extend %with-mask, %swap-horizontal-24-svg-prop !optional;
+  -webkit-mask-image: var(--swap-horizontal-24-svg);
+  mask-image: var(--swap-horizontal-24-svg);
+}
+
 %with-swap-horizontal-icon {
-  @extend %with-icon, %swap-horizontal-svg-prop;
+  @extend %with-icon, %swap-horizontal-svg-prop !optional;
   background-image: var(--swap-horizontal-svg);
 }
 %with-swap-horizontal-mask {
-  @extend %with-mask, %swap-horizontal-svg-prop;
+  @extend %with-mask, %swap-horizontal-svg-prop !optional;
   -webkit-mask-image: var(--swap-horizontal-svg);
   mask-image: var(--swap-horizontal-svg);
 }
 
+%with-swap-vertical-16-icon {
+  @extend %with-icon, %swap-vertical-16-svg-prop !optional;
+  background-image: var(--swap-vertical-16-svg);
+}
+%with-swap-vertical-16-mask {
+  @extend %with-mask, %swap-vertical-16-svg-prop !optional;
+  -webkit-mask-image: var(--swap-vertical-16-svg);
+  mask-image: var(--swap-vertical-16-svg);
+}
+
+%with-swap-vertical-24-icon {
+  @extend %with-icon, %swap-vertical-24-svg-prop !optional;
+  background-image: var(--swap-vertical-24-svg);
+}
+%with-swap-vertical-24-mask {
+  @extend %with-mask, %swap-vertical-24-svg-prop !optional;
+  -webkit-mask-image: var(--swap-vertical-24-svg);
+  mask-image: var(--swap-vertical-24-svg);
+}
+
 %with-swap-vertical-icon {
-  @extend %with-icon, %swap-vertical-svg-prop;
+  @extend %with-icon, %swap-vertical-svg-prop !optional;
   background-image: var(--swap-vertical-svg);
 }
 %with-swap-vertical-mask {
-  @extend %with-mask, %swap-vertical-svg-prop;
+  @extend %with-mask, %swap-vertical-svg-prop !optional;
   -webkit-mask-image: var(--swap-vertical-svg);
   mask-image: var(--swap-vertical-svg);
 }
 
+%with-switcher-16-icon {
+  @extend %with-icon, %switcher-16-svg-prop !optional;
+  background-image: var(--switcher-16-svg);
+}
+%with-switcher-16-mask {
+  @extend %with-mask, %switcher-16-svg-prop !optional;
+  -webkit-mask-image: var(--switcher-16-svg);
+  mask-image: var(--switcher-16-svg);
+}
+
+%with-switcher-24-icon {
+  @extend %with-icon, %switcher-24-svg-prop !optional;
+  background-image: var(--switcher-24-svg);
+}
+%with-switcher-24-mask {
+  @extend %with-mask, %switcher-24-svg-prop !optional;
+  -webkit-mask-image: var(--switcher-24-svg);
+  mask-image: var(--switcher-24-svg);
+}
+
+%with-sync-16-icon {
+  @extend %with-icon, %sync-16-svg-prop !optional;
+  background-image: var(--sync-16-svg);
+}
+%with-sync-16-mask {
+  @extend %with-mask, %sync-16-svg-prop !optional;
+  -webkit-mask-image: var(--sync-16-svg);
+  mask-image: var(--sync-16-svg);
+}
+
+%with-sync-24-icon {
+  @extend %with-icon, %sync-24-svg-prop !optional;
+  background-image: var(--sync-24-svg);
+}
+%with-sync-24-mask {
+  @extend %with-mask, %sync-24-svg-prop !optional;
+  -webkit-mask-image: var(--sync-24-svg);
+  mask-image: var(--sync-24-svg);
+}
+
+%with-sync-alert-16-icon {
+  @extend %with-icon, %sync-alert-16-svg-prop !optional;
+  background-image: var(--sync-alert-16-svg);
+}
+%with-sync-alert-16-mask {
+  @extend %with-mask, %sync-alert-16-svg-prop !optional;
+  -webkit-mask-image: var(--sync-alert-16-svg);
+  mask-image: var(--sync-alert-16-svg);
+}
+
+%with-sync-alert-24-icon {
+  @extend %with-icon, %sync-alert-24-svg-prop !optional;
+  background-image: var(--sync-alert-24-svg);
+}
+%with-sync-alert-24-mask {
+  @extend %with-mask, %sync-alert-24-svg-prop !optional;
+  -webkit-mask-image: var(--sync-alert-24-svg);
+  mask-image: var(--sync-alert-24-svg);
+}
+
+%with-sync-reverse-16-icon {
+  @extend %with-icon, %sync-reverse-16-svg-prop !optional;
+  background-image: var(--sync-reverse-16-svg);
+}
+%with-sync-reverse-16-mask {
+  @extend %with-mask, %sync-reverse-16-svg-prop !optional;
+  -webkit-mask-image: var(--sync-reverse-16-svg);
+  mask-image: var(--sync-reverse-16-svg);
+}
+
+%with-sync-reverse-24-icon {
+  @extend %with-icon, %sync-reverse-24-svg-prop !optional;
+  background-image: var(--sync-reverse-24-svg);
+}
+%with-sync-reverse-24-mask {
+  @extend %with-mask, %sync-reverse-24-svg-prop !optional;
+  -webkit-mask-image: var(--sync-reverse-24-svg);
+  mask-image: var(--sync-reverse-24-svg);
+}
+
+%with-tablet-16-icon {
+  @extend %with-icon, %tablet-16-svg-prop !optional;
+  background-image: var(--tablet-16-svg);
+}
+%with-tablet-16-mask {
+  @extend %with-mask, %tablet-16-svg-prop !optional;
+  -webkit-mask-image: var(--tablet-16-svg);
+  mask-image: var(--tablet-16-svg);
+}
+
+%with-tablet-24-icon {
+  @extend %with-icon, %tablet-24-svg-prop !optional;
+  background-image: var(--tablet-24-svg);
+}
+%with-tablet-24-mask {
+  @extend %with-mask, %tablet-24-svg-prop !optional;
+  -webkit-mask-image: var(--tablet-24-svg);
+  mask-image: var(--tablet-24-svg);
+}
+
+%with-tag-16-icon {
+  @extend %with-icon, %tag-16-svg-prop !optional;
+  background-image: var(--tag-16-svg);
+}
+%with-tag-16-mask {
+  @extend %with-mask, %tag-16-svg-prop !optional;
+  -webkit-mask-image: var(--tag-16-svg);
+  mask-image: var(--tag-16-svg);
+}
+
+%with-tag-24-icon {
+  @extend %with-icon, %tag-24-svg-prop !optional;
+  background-image: var(--tag-24-svg);
+}
+%with-tag-24-mask {
+  @extend %with-mask, %tag-24-svg-prop !optional;
+  -webkit-mask-image: var(--tag-24-svg);
+  mask-image: var(--tag-24-svg);
+}
+
 %with-tag-icon {
-  @extend %with-icon, %tag-svg-prop;
+  @extend %with-icon, %tag-svg-prop !optional;
   background-image: var(--tag-svg);
 }
 %with-tag-mask {
-  @extend %with-mask, %tag-svg-prop;
+  @extend %with-mask, %tag-svg-prop !optional;
   -webkit-mask-image: var(--tag-svg);
   mask-image: var(--tag-svg);
 }
 
+%with-target-16-icon {
+  @extend %with-icon, %target-16-svg-prop !optional;
+  background-image: var(--target-16-svg);
+}
+%with-target-16-mask {
+  @extend %with-mask, %target-16-svg-prop !optional;
+  -webkit-mask-image: var(--target-16-svg);
+  mask-image: var(--target-16-svg);
+}
+
+%with-target-24-icon {
+  @extend %with-icon, %target-24-svg-prop !optional;
+  background-image: var(--target-24-svg);
+}
+%with-target-24-mask {
+  @extend %with-mask, %target-24-svg-prop !optional;
+  -webkit-mask-image: var(--target-24-svg);
+  mask-image: var(--target-24-svg);
+}
+
+%with-terminal-16-icon {
+  @extend %with-icon, %terminal-16-svg-prop !optional;
+  background-image: var(--terminal-16-svg);
+}
+%with-terminal-16-mask {
+  @extend %with-mask, %terminal-16-svg-prop !optional;
+  -webkit-mask-image: var(--terminal-16-svg);
+  mask-image: var(--terminal-16-svg);
+}
+
+%with-terminal-24-icon {
+  @extend %with-icon, %terminal-24-svg-prop !optional;
+  background-image: var(--terminal-24-svg);
+}
+%with-terminal-24-mask {
+  @extend %with-mask, %terminal-24-svg-prop !optional;
+  -webkit-mask-image: var(--terminal-24-svg);
+  mask-image: var(--terminal-24-svg);
+}
+
+%with-terminal-screen-16-icon {
+  @extend %with-icon, %terminal-screen-16-svg-prop !optional;
+  background-image: var(--terminal-screen-16-svg);
+}
+%with-terminal-screen-16-mask {
+  @extend %with-mask, %terminal-screen-16-svg-prop !optional;
+  -webkit-mask-image: var(--terminal-screen-16-svg);
+  mask-image: var(--terminal-screen-16-svg);
+}
+
+%with-terminal-screen-24-icon {
+  @extend %with-icon, %terminal-screen-24-svg-prop !optional;
+  background-image: var(--terminal-screen-24-svg);
+}
+%with-terminal-screen-24-mask {
+  @extend %with-mask, %terminal-screen-24-svg-prop !optional;
+  -webkit-mask-image: var(--terminal-screen-24-svg);
+  mask-image: var(--terminal-screen-24-svg);
+}
+
+%with-thumbs-down-16-icon {
+  @extend %with-icon, %thumbs-down-16-svg-prop !optional;
+  background-image: var(--thumbs-down-16-svg);
+}
+%with-thumbs-down-16-mask {
+  @extend %with-mask, %thumbs-down-16-svg-prop !optional;
+  -webkit-mask-image: var(--thumbs-down-16-svg);
+  mask-image: var(--thumbs-down-16-svg);
+}
+
+%with-thumbs-down-24-icon {
+  @extend %with-icon, %thumbs-down-24-svg-prop !optional;
+  background-image: var(--thumbs-down-24-svg);
+}
+%with-thumbs-down-24-mask {
+  @extend %with-mask, %thumbs-down-24-svg-prop !optional;
+  -webkit-mask-image: var(--thumbs-down-24-svg);
+  mask-image: var(--thumbs-down-24-svg);
+}
+
+%with-thumbs-up-16-icon {
+  @extend %with-icon, %thumbs-up-16-svg-prop !optional;
+  background-image: var(--thumbs-up-16-svg);
+}
+%with-thumbs-up-16-mask {
+  @extend %with-mask, %thumbs-up-16-svg-prop !optional;
+  -webkit-mask-image: var(--thumbs-up-16-svg);
+  mask-image: var(--thumbs-up-16-svg);
+}
+
+%with-thumbs-up-24-icon {
+  @extend %with-icon, %thumbs-up-24-svg-prop !optional;
+  background-image: var(--thumbs-up-24-svg);
+}
+%with-thumbs-up-24-mask {
+  @extend %with-mask, %thumbs-up-24-svg-prop !optional;
+  -webkit-mask-image: var(--thumbs-up-24-svg);
+  mask-image: var(--thumbs-up-24-svg);
+}
+
+%with-toggle-left-16-icon {
+  @extend %with-icon, %toggle-left-16-svg-prop !optional;
+  background-image: var(--toggle-left-16-svg);
+}
+%with-toggle-left-16-mask {
+  @extend %with-mask, %toggle-left-16-svg-prop !optional;
+  -webkit-mask-image: var(--toggle-left-16-svg);
+  mask-image: var(--toggle-left-16-svg);
+}
+
+%with-toggle-left-24-icon {
+  @extend %with-icon, %toggle-left-24-svg-prop !optional;
+  background-image: var(--toggle-left-24-svg);
+}
+%with-toggle-left-24-mask {
+  @extend %with-mask, %toggle-left-24-svg-prop !optional;
+  -webkit-mask-image: var(--toggle-left-24-svg);
+  mask-image: var(--toggle-left-24-svg);
+}
+
+%with-toggle-right-16-icon {
+  @extend %with-icon, %toggle-right-16-svg-prop !optional;
+  background-image: var(--toggle-right-16-svg);
+}
+%with-toggle-right-16-mask {
+  @extend %with-mask, %toggle-right-16-svg-prop !optional;
+  -webkit-mask-image: var(--toggle-right-16-svg);
+  mask-image: var(--toggle-right-16-svg);
+}
+
+%with-toggle-right-24-icon {
+  @extend %with-icon, %toggle-right-24-svg-prop !optional;
+  background-image: var(--toggle-right-24-svg);
+}
+%with-toggle-right-24-mask {
+  @extend %with-mask, %toggle-right-24-svg-prop !optional;
+  -webkit-mask-image: var(--toggle-right-24-svg);
+  mask-image: var(--toggle-right-24-svg);
+}
+
+%with-token-16-icon {
+  @extend %with-icon, %token-16-svg-prop !optional;
+  background-image: var(--token-16-svg);
+}
+%with-token-16-mask {
+  @extend %with-mask, %token-16-svg-prop !optional;
+  -webkit-mask-image: var(--token-16-svg);
+  mask-image: var(--token-16-svg);
+}
+
+%with-token-24-icon {
+  @extend %with-icon, %token-24-svg-prop !optional;
+  background-image: var(--token-24-svg);
+}
+%with-token-24-mask {
+  @extend %with-mask, %token-24-svg-prop !optional;
+  -webkit-mask-image: var(--token-24-svg);
+  mask-image: var(--token-24-svg);
+}
+
+%with-tools-16-icon {
+  @extend %with-icon, %tools-16-svg-prop !optional;
+  background-image: var(--tools-16-svg);
+}
+%with-tools-16-mask {
+  @extend %with-mask, %tools-16-svg-prop !optional;
+  -webkit-mask-image: var(--tools-16-svg);
+  mask-image: var(--tools-16-svg);
+}
+
+%with-tools-24-icon {
+  @extend %with-icon, %tools-24-svg-prop !optional;
+  background-image: var(--tools-24-svg);
+}
+%with-tools-24-mask {
+  @extend %with-mask, %tools-24-svg-prop !optional;
+  -webkit-mask-image: var(--tools-24-svg);
+  mask-image: var(--tools-24-svg);
+}
+
+%with-top-16-icon {
+  @extend %with-icon, %top-16-svg-prop !optional;
+  background-image: var(--top-16-svg);
+}
+%with-top-16-mask {
+  @extend %with-mask, %top-16-svg-prop !optional;
+  -webkit-mask-image: var(--top-16-svg);
+  mask-image: var(--top-16-svg);
+}
+
+%with-top-24-icon {
+  @extend %with-icon, %top-24-svg-prop !optional;
+  background-image: var(--top-24-svg);
+}
+%with-top-24-mask {
+  @extend %with-mask, %top-24-svg-prop !optional;
+  -webkit-mask-image: var(--top-24-svg);
+  mask-image: var(--top-24-svg);
+}
+
+%with-trash-16-icon {
+  @extend %with-icon, %trash-16-svg-prop !optional;
+  background-image: var(--trash-16-svg);
+}
+%with-trash-16-mask {
+  @extend %with-mask, %trash-16-svg-prop !optional;
+  -webkit-mask-image: var(--trash-16-svg);
+  mask-image: var(--trash-16-svg);
+}
+
+%with-trash-24-icon {
+  @extend %with-icon, %trash-24-svg-prop !optional;
+  background-image: var(--trash-24-svg);
+}
+%with-trash-24-mask {
+  @extend %with-mask, %trash-24-svg-prop !optional;
+  -webkit-mask-image: var(--trash-24-svg);
+  mask-image: var(--trash-24-svg);
+}
+
 %with-trash-icon {
-  @extend %with-icon, %trash-svg-prop;
+  @extend %with-icon, %trash-svg-prop !optional;
   background-image: var(--trash-svg);
 }
 %with-trash-mask {
-  @extend %with-mask, %trash-svg-prop;
+  @extend %with-mask, %trash-svg-prop !optional;
   -webkit-mask-image: var(--trash-svg);
   mask-image: var(--trash-svg);
 }
 
+%with-trend-down-16-icon {
+  @extend %with-icon, %trend-down-16-svg-prop !optional;
+  background-image: var(--trend-down-16-svg);
+}
+%with-trend-down-16-mask {
+  @extend %with-mask, %trend-down-16-svg-prop !optional;
+  -webkit-mask-image: var(--trend-down-16-svg);
+  mask-image: var(--trend-down-16-svg);
+}
+
+%with-trend-down-24-icon {
+  @extend %with-icon, %trend-down-24-svg-prop !optional;
+  background-image: var(--trend-down-24-svg);
+}
+%with-trend-down-24-mask {
+  @extend %with-mask, %trend-down-24-svg-prop !optional;
+  -webkit-mask-image: var(--trend-down-24-svg);
+  mask-image: var(--trend-down-24-svg);
+}
+
+%with-trend-up-16-icon {
+  @extend %with-icon, %trend-up-16-svg-prop !optional;
+  background-image: var(--trend-up-16-svg);
+}
+%with-trend-up-16-mask {
+  @extend %with-mask, %trend-up-16-svg-prop !optional;
+  -webkit-mask-image: var(--trend-up-16-svg);
+  mask-image: var(--trend-up-16-svg);
+}
+
+%with-trend-up-24-icon {
+  @extend %with-icon, %trend-up-24-svg-prop !optional;
+  background-image: var(--trend-up-24-svg);
+}
+%with-trend-up-24-mask {
+  @extend %with-mask, %trend-up-24-svg-prop !optional;
+  -webkit-mask-image: var(--trend-up-24-svg);
+  mask-image: var(--trend-up-24-svg);
+}
+
+%with-triangle-16-icon {
+  @extend %with-icon, %triangle-16-svg-prop !optional;
+  background-image: var(--triangle-16-svg);
+}
+%with-triangle-16-mask {
+  @extend %with-mask, %triangle-16-svg-prop !optional;
+  -webkit-mask-image: var(--triangle-16-svg);
+  mask-image: var(--triangle-16-svg);
+}
+
+%with-triangle-24-icon {
+  @extend %with-icon, %triangle-24-svg-prop !optional;
+  background-image: var(--triangle-24-svg);
+}
+%with-triangle-24-mask {
+  @extend %with-mask, %triangle-24-svg-prop !optional;
+  -webkit-mask-image: var(--triangle-24-svg);
+  mask-image: var(--triangle-24-svg);
+}
+
+%with-triangle-fill-16-icon {
+  @extend %with-icon, %triangle-fill-16-svg-prop !optional;
+  background-image: var(--triangle-fill-16-svg);
+}
+%with-triangle-fill-16-mask {
+  @extend %with-mask, %triangle-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--triangle-fill-16-svg);
+  mask-image: var(--triangle-fill-16-svg);
+}
+
+%with-triangle-fill-24-icon {
+  @extend %with-icon, %triangle-fill-24-svg-prop !optional;
+  background-image: var(--triangle-fill-24-svg);
+}
+%with-triangle-fill-24-mask {
+  @extend %with-mask, %triangle-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--triangle-fill-24-svg);
+  mask-image: var(--triangle-fill-24-svg);
+}
+
+%with-truck-16-icon {
+  @extend %with-icon, %truck-16-svg-prop !optional;
+  background-image: var(--truck-16-svg);
+}
+%with-truck-16-mask {
+  @extend %with-mask, %truck-16-svg-prop !optional;
+  -webkit-mask-image: var(--truck-16-svg);
+  mask-image: var(--truck-16-svg);
+}
+
+%with-truck-24-icon {
+  @extend %with-icon, %truck-24-svg-prop !optional;
+  background-image: var(--truck-24-svg);
+}
+%with-truck-24-mask {
+  @extend %with-mask, %truck-24-svg-prop !optional;
+  -webkit-mask-image: var(--truck-24-svg);
+  mask-image: var(--truck-24-svg);
+}
+
 %with-tune-icon {
-  @extend %with-icon, %tune-svg-prop;
+  @extend %with-icon, %tune-svg-prop !optional;
   background-image: var(--tune-svg);
 }
 %with-tune-mask {
-  @extend %with-mask, %tune-svg-prop;
+  @extend %with-mask, %tune-svg-prop !optional;
   -webkit-mask-image: var(--tune-svg);
   mask-image: var(--tune-svg);
 }
 
+%with-tv-16-icon {
+  @extend %with-icon, %tv-16-svg-prop !optional;
+  background-image: var(--tv-16-svg);
+}
+%with-tv-16-mask {
+  @extend %with-mask, %tv-16-svg-prop !optional;
+  -webkit-mask-image: var(--tv-16-svg);
+  mask-image: var(--tv-16-svg);
+}
+
+%with-tv-24-icon {
+  @extend %with-icon, %tv-24-svg-prop !optional;
+  background-image: var(--tv-24-svg);
+}
+%with-tv-24-mask {
+  @extend %with-mask, %tv-24-svg-prop !optional;
+  -webkit-mask-image: var(--tv-24-svg);
+  mask-image: var(--tv-24-svg);
+}
+
+%with-type-16-icon {
+  @extend %with-icon, %type-16-svg-prop !optional;
+  background-image: var(--type-16-svg);
+}
+%with-type-16-mask {
+  @extend %with-mask, %type-16-svg-prop !optional;
+  -webkit-mask-image: var(--type-16-svg);
+  mask-image: var(--type-16-svg);
+}
+
+%with-type-24-icon {
+  @extend %with-icon, %type-24-svg-prop !optional;
+  background-image: var(--type-24-svg);
+}
+%with-type-24-mask {
+  @extend %with-mask, %type-24-svg-prop !optional;
+  -webkit-mask-image: var(--type-24-svg);
+  mask-image: var(--type-24-svg);
+}
+
+%with-unfold-close-16-icon {
+  @extend %with-icon, %unfold-close-16-svg-prop !optional;
+  background-image: var(--unfold-close-16-svg);
+}
+%with-unfold-close-16-mask {
+  @extend %with-mask, %unfold-close-16-svg-prop !optional;
+  -webkit-mask-image: var(--unfold-close-16-svg);
+  mask-image: var(--unfold-close-16-svg);
+}
+
+%with-unfold-close-24-icon {
+  @extend %with-icon, %unfold-close-24-svg-prop !optional;
+  background-image: var(--unfold-close-24-svg);
+}
+%with-unfold-close-24-mask {
+  @extend %with-mask, %unfold-close-24-svg-prop !optional;
+  -webkit-mask-image: var(--unfold-close-24-svg);
+  mask-image: var(--unfold-close-24-svg);
+}
+
 %with-unfold-less-icon {
-  @extend %with-icon, %unfold-less-svg-prop;
+  @extend %with-icon, %unfold-less-svg-prop !optional;
   background-image: var(--unfold-less-svg);
 }
 %with-unfold-less-mask {
-  @extend %with-mask, %unfold-less-svg-prop;
+  @extend %with-mask, %unfold-less-svg-prop !optional;
   -webkit-mask-image: var(--unfold-less-svg);
   mask-image: var(--unfold-less-svg);
 }
 
 %with-unfold-more-icon {
-  @extend %with-icon, %unfold-more-svg-prop;
+  @extend %with-icon, %unfold-more-svg-prop !optional;
   background-image: var(--unfold-more-svg);
 }
 %with-unfold-more-mask {
-  @extend %with-mask, %unfold-more-svg-prop;
+  @extend %with-mask, %unfold-more-svg-prop !optional;
   -webkit-mask-image: var(--unfold-more-svg);
   mask-image: var(--unfold-more-svg);
 }
 
+%with-unfold-open-16-icon {
+  @extend %with-icon, %unfold-open-16-svg-prop !optional;
+  background-image: var(--unfold-open-16-svg);
+}
+%with-unfold-open-16-mask {
+  @extend %with-mask, %unfold-open-16-svg-prop !optional;
+  -webkit-mask-image: var(--unfold-open-16-svg);
+  mask-image: var(--unfold-open-16-svg);
+}
+
+%with-unfold-open-24-icon {
+  @extend %with-icon, %unfold-open-24-svg-prop !optional;
+  background-image: var(--unfold-open-24-svg);
+}
+%with-unfold-open-24-mask {
+  @extend %with-mask, %unfold-open-24-svg-prop !optional;
+  -webkit-mask-image: var(--unfold-open-24-svg);
+  mask-image: var(--unfold-open-24-svg);
+}
+
+%with-unlock-16-icon {
+  @extend %with-icon, %unlock-16-svg-prop !optional;
+  background-image: var(--unlock-16-svg);
+}
+%with-unlock-16-mask {
+  @extend %with-mask, %unlock-16-svg-prop !optional;
+  -webkit-mask-image: var(--unlock-16-svg);
+  mask-image: var(--unlock-16-svg);
+}
+
+%with-unlock-24-icon {
+  @extend %with-icon, %unlock-24-svg-prop !optional;
+  background-image: var(--unlock-24-svg);
+}
+%with-unlock-24-mask {
+  @extend %with-mask, %unlock-24-svg-prop !optional;
+  -webkit-mask-image: var(--unlock-24-svg);
+  mask-image: var(--unlock-24-svg);
+}
+
+%with-upload-16-icon {
+  @extend %with-icon, %upload-16-svg-prop !optional;
+  background-image: var(--upload-16-svg);
+}
+%with-upload-16-mask {
+  @extend %with-mask, %upload-16-svg-prop !optional;
+  -webkit-mask-image: var(--upload-16-svg);
+  mask-image: var(--upload-16-svg);
+}
+
+%with-upload-24-icon {
+  @extend %with-icon, %upload-24-svg-prop !optional;
+  background-image: var(--upload-24-svg);
+}
+%with-upload-24-mask {
+  @extend %with-mask, %upload-24-svg-prop !optional;
+  -webkit-mask-image: var(--upload-24-svg);
+  mask-image: var(--upload-24-svg);
+}
+
 %with-upload-icon {
-  @extend %with-icon, %upload-svg-prop;
+  @extend %with-icon, %upload-svg-prop !optional;
   background-image: var(--upload-svg);
 }
 %with-upload-mask {
-  @extend %with-mask, %upload-svg-prop;
+  @extend %with-mask, %upload-svg-prop !optional;
   -webkit-mask-image: var(--upload-svg);
   mask-image: var(--upload-svg);
 }
 
+%with-user-16-icon {
+  @extend %with-icon, %user-16-svg-prop !optional;
+  background-image: var(--user-16-svg);
+}
+%with-user-16-mask {
+  @extend %with-mask, %user-16-svg-prop !optional;
+  -webkit-mask-image: var(--user-16-svg);
+  mask-image: var(--user-16-svg);
+}
+
+%with-user-24-icon {
+  @extend %with-icon, %user-24-svg-prop !optional;
+  background-image: var(--user-24-svg);
+}
+%with-user-24-mask {
+  @extend %with-mask, %user-24-svg-prop !optional;
+  -webkit-mask-image: var(--user-24-svg);
+  mask-image: var(--user-24-svg);
+}
+
 %with-user-add-icon {
-  @extend %with-icon, %user-add-svg-prop;
+  @extend %with-icon, %user-add-svg-prop !optional;
   background-image: var(--user-add-svg);
 }
 %with-user-add-mask {
-  @extend %with-mask, %user-add-svg-prop;
+  @extend %with-mask, %user-add-svg-prop !optional;
   -webkit-mask-image: var(--user-add-svg);
   mask-image: var(--user-add-svg);
 }
 
+%with-user-check-16-icon {
+  @extend %with-icon, %user-check-16-svg-prop !optional;
+  background-image: var(--user-check-16-svg);
+}
+%with-user-check-16-mask {
+  @extend %with-mask, %user-check-16-svg-prop !optional;
+  -webkit-mask-image: var(--user-check-16-svg);
+  mask-image: var(--user-check-16-svg);
+}
+
+%with-user-check-24-icon {
+  @extend %with-icon, %user-check-24-svg-prop !optional;
+  background-image: var(--user-check-24-svg);
+}
+%with-user-check-24-mask {
+  @extend %with-mask, %user-check-24-svg-prop !optional;
+  -webkit-mask-image: var(--user-check-24-svg);
+  mask-image: var(--user-check-24-svg);
+}
+
+%with-user-circle-16-icon {
+  @extend %with-icon, %user-circle-16-svg-prop !optional;
+  background-image: var(--user-circle-16-svg);
+}
+%with-user-circle-16-mask {
+  @extend %with-mask, %user-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--user-circle-16-svg);
+  mask-image: var(--user-circle-16-svg);
+}
+
+%with-user-circle-24-icon {
+  @extend %with-icon, %user-circle-24-svg-prop !optional;
+  background-image: var(--user-circle-24-svg);
+}
+%with-user-circle-24-mask {
+  @extend %with-mask, %user-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--user-circle-24-svg);
+  mask-image: var(--user-circle-24-svg);
+}
+
+%with-user-circle-fill-16-icon {
+  @extend %with-icon, %user-circle-fill-16-svg-prop !optional;
+  background-image: var(--user-circle-fill-16-svg);
+}
+%with-user-circle-fill-16-mask {
+  @extend %with-mask, %user-circle-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--user-circle-fill-16-svg);
+  mask-image: var(--user-circle-fill-16-svg);
+}
+
+%with-user-circle-fill-24-icon {
+  @extend %with-icon, %user-circle-fill-24-svg-prop !optional;
+  background-image: var(--user-circle-fill-24-svg);
+}
+%with-user-circle-fill-24-mask {
+  @extend %with-mask, %user-circle-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--user-circle-fill-24-svg);
+  mask-image: var(--user-circle-fill-24-svg);
+}
+
+%with-user-minus-16-icon {
+  @extend %with-icon, %user-minus-16-svg-prop !optional;
+  background-image: var(--user-minus-16-svg);
+}
+%with-user-minus-16-mask {
+  @extend %with-mask, %user-minus-16-svg-prop !optional;
+  -webkit-mask-image: var(--user-minus-16-svg);
+  mask-image: var(--user-minus-16-svg);
+}
+
+%with-user-minus-24-icon {
+  @extend %with-icon, %user-minus-24-svg-prop !optional;
+  background-image: var(--user-minus-24-svg);
+}
+%with-user-minus-24-mask {
+  @extend %with-mask, %user-minus-24-svg-prop !optional;
+  -webkit-mask-image: var(--user-minus-24-svg);
+  mask-image: var(--user-minus-24-svg);
+}
+
 %with-user-organization-icon {
-  @extend %with-icon, %user-organization-svg-prop;
+  @extend %with-icon, %user-organization-svg-prop !optional;
   background-image: var(--user-organization-svg);
 }
 %with-user-organization-mask {
-  @extend %with-mask, %user-organization-svg-prop;
+  @extend %with-mask, %user-organization-svg-prop !optional;
   -webkit-mask-image: var(--user-organization-svg);
   mask-image: var(--user-organization-svg);
 }
 
 %with-user-plain-icon {
-  @extend %with-icon, %user-plain-svg-prop;
+  @extend %with-icon, %user-plain-svg-prop !optional;
   background-image: var(--user-plain-svg);
 }
 %with-user-plain-mask {
-  @extend %with-mask, %user-plain-svg-prop;
+  @extend %with-mask, %user-plain-svg-prop !optional;
   -webkit-mask-image: var(--user-plain-svg);
   mask-image: var(--user-plain-svg);
 }
 
+%with-user-plus-16-icon {
+  @extend %with-icon, %user-plus-16-svg-prop !optional;
+  background-image: var(--user-plus-16-svg);
+}
+%with-user-plus-16-mask {
+  @extend %with-mask, %user-plus-16-svg-prop !optional;
+  -webkit-mask-image: var(--user-plus-16-svg);
+  mask-image: var(--user-plus-16-svg);
+}
+
+%with-user-plus-24-icon {
+  @extend %with-icon, %user-plus-24-svg-prop !optional;
+  background-image: var(--user-plus-24-svg);
+}
+%with-user-plus-24-mask {
+  @extend %with-mask, %user-plus-24-svg-prop !optional;
+  -webkit-mask-image: var(--user-plus-24-svg);
+  mask-image: var(--user-plus-24-svg);
+}
+
 %with-user-square-fill-icon {
-  @extend %with-icon, %user-square-fill-svg-prop;
+  @extend %with-icon, %user-square-fill-svg-prop !optional;
   background-image: var(--user-square-fill-svg);
 }
 %with-user-square-fill-mask {
-  @extend %with-mask, %user-square-fill-svg-prop;
+  @extend %with-mask, %user-square-fill-svg-prop !optional;
   -webkit-mask-image: var(--user-square-fill-svg);
   mask-image: var(--user-square-fill-svg);
 }
 
 %with-user-square-outline-icon {
-  @extend %with-icon, %user-square-outline-svg-prop;
+  @extend %with-icon, %user-square-outline-svg-prop !optional;
   background-image: var(--user-square-outline-svg);
 }
 %with-user-square-outline-mask {
-  @extend %with-mask, %user-square-outline-svg-prop;
+  @extend %with-mask, %user-square-outline-svg-prop !optional;
   -webkit-mask-image: var(--user-square-outline-svg);
   mask-image: var(--user-square-outline-svg);
 }
 
 %with-user-team-icon {
-  @extend %with-icon, %user-team-svg-prop;
+  @extend %with-icon, %user-team-svg-prop !optional;
   background-image: var(--user-team-svg);
 }
 %with-user-team-mask {
-  @extend %with-mask, %user-team-svg-prop;
+  @extend %with-mask, %user-team-svg-prop !optional;
   -webkit-mask-image: var(--user-team-svg);
   mask-image: var(--user-team-svg);
 }
 
+%with-user-x-16-icon {
+  @extend %with-icon, %user-x-16-svg-prop !optional;
+  background-image: var(--user-x-16-svg);
+}
+%with-user-x-16-mask {
+  @extend %with-mask, %user-x-16-svg-prop !optional;
+  -webkit-mask-image: var(--user-x-16-svg);
+  mask-image: var(--user-x-16-svg);
+}
+
+%with-user-x-24-icon {
+  @extend %with-icon, %user-x-24-svg-prop !optional;
+  background-image: var(--user-x-24-svg);
+}
+%with-user-x-24-mask {
+  @extend %with-mask, %user-x-24-svg-prop !optional;
+  -webkit-mask-image: var(--user-x-24-svg);
+  mask-image: var(--user-x-24-svg);
+}
+
+%with-users-16-icon {
+  @extend %with-icon, %users-16-svg-prop !optional;
+  background-image: var(--users-16-svg);
+}
+%with-users-16-mask {
+  @extend %with-mask, %users-16-svg-prop !optional;
+  -webkit-mask-image: var(--users-16-svg);
+  mask-image: var(--users-16-svg);
+}
+
+%with-users-24-icon {
+  @extend %with-icon, %users-24-svg-prop !optional;
+  background-image: var(--users-24-svg);
+}
+%with-users-24-mask {
+  @extend %with-mask, %users-24-svg-prop !optional;
+  -webkit-mask-image: var(--users-24-svg);
+  mask-image: var(--users-24-svg);
+}
+
+%with-vault-16-icon {
+  @extend %with-icon, %vault-16-svg-prop !optional;
+  background-image: var(--vault-16-svg);
+}
+%with-vault-16-mask {
+  @extend %with-mask, %vault-16-svg-prop !optional;
+  -webkit-mask-image: var(--vault-16-svg);
+  mask-image: var(--vault-16-svg);
+}
+
+%with-vault-24-icon {
+  @extend %with-icon, %vault-24-svg-prop !optional;
+  background-image: var(--vault-24-svg);
+}
+%with-vault-24-mask {
+  @extend %with-mask, %vault-24-svg-prop !optional;
+  -webkit-mask-image: var(--vault-24-svg);
+  mask-image: var(--vault-24-svg);
+}
+
+%with-verified-16-icon {
+  @extend %with-icon, %verified-16-svg-prop !optional;
+  background-image: var(--verified-16-svg);
+}
+%with-verified-16-mask {
+  @extend %with-mask, %verified-16-svg-prop !optional;
+  -webkit-mask-image: var(--verified-16-svg);
+  mask-image: var(--verified-16-svg);
+}
+
+%with-verified-24-icon {
+  @extend %with-icon, %verified-24-svg-prop !optional;
+  background-image: var(--verified-24-svg);
+}
+%with-verified-24-mask {
+  @extend %with-mask, %verified-24-svg-prop !optional;
+  -webkit-mask-image: var(--verified-24-svg);
+  mask-image: var(--verified-24-svg);
+}
+
+%with-video-16-icon {
+  @extend %with-icon, %video-16-svg-prop !optional;
+  background-image: var(--video-16-svg);
+}
+%with-video-16-mask {
+  @extend %with-mask, %video-16-svg-prop !optional;
+  -webkit-mask-image: var(--video-16-svg);
+  mask-image: var(--video-16-svg);
+}
+
+%with-video-24-icon {
+  @extend %with-icon, %video-24-svg-prop !optional;
+  background-image: var(--video-24-svg);
+}
+%with-video-24-mask {
+  @extend %with-mask, %video-24-svg-prop !optional;
+  -webkit-mask-image: var(--video-24-svg);
+  mask-image: var(--video-24-svg);
+}
+
+%with-video-off-16-icon {
+  @extend %with-icon, %video-off-16-svg-prop !optional;
+  background-image: var(--video-off-16-svg);
+}
+%with-video-off-16-mask {
+  @extend %with-mask, %video-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--video-off-16-svg);
+  mask-image: var(--video-off-16-svg);
+}
+
+%with-video-off-24-icon {
+  @extend %with-icon, %video-off-24-svg-prop !optional;
+  background-image: var(--video-off-24-svg);
+}
+%with-video-off-24-mask {
+  @extend %with-mask, %video-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--video-off-24-svg);
+  mask-image: var(--video-off-24-svg);
+}
+
 %with-visibility-hide-icon {
-  @extend %with-icon, %visibility-hide-svg-prop;
+  @extend %with-icon, %visibility-hide-svg-prop !optional;
   background-image: var(--visibility-hide-svg);
 }
 %with-visibility-hide-mask {
-  @extend %with-mask, %visibility-hide-svg-prop;
+  @extend %with-mask, %visibility-hide-svg-prop !optional;
   -webkit-mask-image: var(--visibility-hide-svg);
   mask-image: var(--visibility-hide-svg);
 }
 
 %with-visibility-show-icon {
-  @extend %with-icon, %visibility-show-svg-prop;
+  @extend %with-icon, %visibility-show-svg-prop !optional;
   background-image: var(--visibility-show-svg);
 }
 %with-visibility-show-mask {
-  @extend %with-mask, %visibility-show-svg-prop;
+  @extend %with-mask, %visibility-show-svg-prop !optional;
   -webkit-mask-image: var(--visibility-show-svg);
   mask-image: var(--visibility-show-svg);
 }
 
+%with-vmware-16-icon {
+  @extend %with-icon, %vmware-16-svg-prop !optional;
+  background-image: var(--vmware-16-svg);
+}
+%with-vmware-16-mask {
+  @extend %with-mask, %vmware-16-svg-prop !optional;
+  -webkit-mask-image: var(--vmware-16-svg);
+  mask-image: var(--vmware-16-svg);
+}
+
+%with-vmware-24-icon {
+  @extend %with-icon, %vmware-24-svg-prop !optional;
+  background-image: var(--vmware-24-svg);
+}
+%with-vmware-24-mask {
+  @extend %with-mask, %vmware-24-svg-prop !optional;
+  -webkit-mask-image: var(--vmware-24-svg);
+  mask-image: var(--vmware-24-svg);
+}
+
+%with-vmware-color-16-icon {
+  @extend %with-icon, %vmware-color-16-svg-prop !optional;
+  background-image: var(--vmware-color-16-svg);
+}
+%with-vmware-color-16-mask {
+  @extend %with-mask, %vmware-color-16-svg-prop !optional;
+  -webkit-mask-image: var(--vmware-color-16-svg);
+  mask-image: var(--vmware-color-16-svg);
+}
+
+%with-vmware-color-24-icon {
+  @extend %with-icon, %vmware-color-24-svg-prop !optional;
+  background-image: var(--vmware-color-24-svg);
+}
+%with-vmware-color-24-mask {
+  @extend %with-mask, %vmware-color-24-svg-prop !optional;
+  -webkit-mask-image: var(--vmware-color-24-svg);
+  mask-image: var(--vmware-color-24-svg);
+}
+
+%with-volume-16-icon {
+  @extend %with-icon, %volume-16-svg-prop !optional;
+  background-image: var(--volume-16-svg);
+}
+%with-volume-16-mask {
+  @extend %with-mask, %volume-16-svg-prop !optional;
+  -webkit-mask-image: var(--volume-16-svg);
+  mask-image: var(--volume-16-svg);
+}
+
+%with-volume-2-16-icon {
+  @extend %with-icon, %volume-2-16-svg-prop !optional;
+  background-image: var(--volume-2-16-svg);
+}
+%with-volume-2-16-mask {
+  @extend %with-mask, %volume-2-16-svg-prop !optional;
+  -webkit-mask-image: var(--volume-2-16-svg);
+  mask-image: var(--volume-2-16-svg);
+}
+
+%with-volume-2-24-icon {
+  @extend %with-icon, %volume-2-24-svg-prop !optional;
+  background-image: var(--volume-2-24-svg);
+}
+%with-volume-2-24-mask {
+  @extend %with-mask, %volume-2-24-svg-prop !optional;
+  -webkit-mask-image: var(--volume-2-24-svg);
+  mask-image: var(--volume-2-24-svg);
+}
+
+%with-volume-24-icon {
+  @extend %with-icon, %volume-24-svg-prop !optional;
+  background-image: var(--volume-24-svg);
+}
+%with-volume-24-mask {
+  @extend %with-mask, %volume-24-svg-prop !optional;
+  -webkit-mask-image: var(--volume-24-svg);
+  mask-image: var(--volume-24-svg);
+}
+
+%with-volume-down-16-icon {
+  @extend %with-icon, %volume-down-16-svg-prop !optional;
+  background-image: var(--volume-down-16-svg);
+}
+%with-volume-down-16-mask {
+  @extend %with-mask, %volume-down-16-svg-prop !optional;
+  -webkit-mask-image: var(--volume-down-16-svg);
+  mask-image: var(--volume-down-16-svg);
+}
+
+%with-volume-down-24-icon {
+  @extend %with-icon, %volume-down-24-svg-prop !optional;
+  background-image: var(--volume-down-24-svg);
+}
+%with-volume-down-24-mask {
+  @extend %with-mask, %volume-down-24-svg-prop !optional;
+  -webkit-mask-image: var(--volume-down-24-svg);
+  mask-image: var(--volume-down-24-svg);
+}
+
+%with-volume-x-16-icon {
+  @extend %with-icon, %volume-x-16-svg-prop !optional;
+  background-image: var(--volume-x-16-svg);
+}
+%with-volume-x-16-mask {
+  @extend %with-mask, %volume-x-16-svg-prop !optional;
+  -webkit-mask-image: var(--volume-x-16-svg);
+  mask-image: var(--volume-x-16-svg);
+}
+
+%with-volume-x-24-icon {
+  @extend %with-icon, %volume-x-24-svg-prop !optional;
+  background-image: var(--volume-x-24-svg);
+}
+%with-volume-x-24-mask {
+  @extend %with-mask, %volume-x-24-svg-prop !optional;
+  -webkit-mask-image: var(--volume-x-24-svg);
+  mask-image: var(--volume-x-24-svg);
+}
+
+%with-wall-16-icon {
+  @extend %with-icon, %wall-16-svg-prop !optional;
+  background-image: var(--wall-16-svg);
+}
+%with-wall-16-mask {
+  @extend %with-mask, %wall-16-svg-prop !optional;
+  -webkit-mask-image: var(--wall-16-svg);
+  mask-image: var(--wall-16-svg);
+}
+
+%with-wall-24-icon {
+  @extend %with-icon, %wall-24-svg-prop !optional;
+  background-image: var(--wall-24-svg);
+}
+%with-wall-24-mask {
+  @extend %with-mask, %wall-24-svg-prop !optional;
+  -webkit-mask-image: var(--wall-24-svg);
+  mask-image: var(--wall-24-svg);
+}
+
+%with-watch-16-icon {
+  @extend %with-icon, %watch-16-svg-prop !optional;
+  background-image: var(--watch-16-svg);
+}
+%with-watch-16-mask {
+  @extend %with-mask, %watch-16-svg-prop !optional;
+  -webkit-mask-image: var(--watch-16-svg);
+  mask-image: var(--watch-16-svg);
+}
+
+%with-watch-24-icon {
+  @extend %with-icon, %watch-24-svg-prop !optional;
+  background-image: var(--watch-24-svg);
+}
+%with-watch-24-mask {
+  @extend %with-mask, %watch-24-svg-prop !optional;
+  -webkit-mask-image: var(--watch-24-svg);
+  mask-image: var(--watch-24-svg);
+}
+
+%with-webhook-16-icon {
+  @extend %with-icon, %webhook-16-svg-prop !optional;
+  background-image: var(--webhook-16-svg);
+}
+%with-webhook-16-mask {
+  @extend %with-mask, %webhook-16-svg-prop !optional;
+  -webkit-mask-image: var(--webhook-16-svg);
+  mask-image: var(--webhook-16-svg);
+}
+
+%with-webhook-24-icon {
+  @extend %with-icon, %webhook-24-svg-prop !optional;
+  background-image: var(--webhook-24-svg);
+}
+%with-webhook-24-mask {
+  @extend %with-mask, %webhook-24-svg-prop !optional;
+  -webkit-mask-image: var(--webhook-24-svg);
+  mask-image: var(--webhook-24-svg);
+}
+
 %with-webhook-icon {
-  @extend %with-icon, %webhook-svg-prop;
+  @extend %with-icon, %webhook-svg-prop !optional;
   background-image: var(--webhook-svg);
 }
 %with-webhook-mask {
-  @extend %with-mask, %webhook-svg-prop;
+  @extend %with-mask, %webhook-svg-prop !optional;
   -webkit-mask-image: var(--webhook-svg);
   mask-image: var(--webhook-svg);
+}
+
+%with-wifi-16-icon {
+  @extend %with-icon, %wifi-16-svg-prop !optional;
+  background-image: var(--wifi-16-svg);
+}
+%with-wifi-16-mask {
+  @extend %with-mask, %wifi-16-svg-prop !optional;
+  -webkit-mask-image: var(--wifi-16-svg);
+  mask-image: var(--wifi-16-svg);
+}
+
+%with-wifi-24-icon {
+  @extend %with-icon, %wifi-24-svg-prop !optional;
+  background-image: var(--wifi-24-svg);
+}
+%with-wifi-24-mask {
+  @extend %with-mask, %wifi-24-svg-prop !optional;
+  -webkit-mask-image: var(--wifi-24-svg);
+  mask-image: var(--wifi-24-svg);
+}
+
+%with-wifi-off-16-icon {
+  @extend %with-icon, %wifi-off-16-svg-prop !optional;
+  background-image: var(--wifi-off-16-svg);
+}
+%with-wifi-off-16-mask {
+  @extend %with-mask, %wifi-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--wifi-off-16-svg);
+  mask-image: var(--wifi-off-16-svg);
+}
+
+%with-wifi-off-24-icon {
+  @extend %with-icon, %wifi-off-24-svg-prop !optional;
+  background-image: var(--wifi-off-24-svg);
+}
+%with-wifi-off-24-mask {
+  @extend %with-mask, %wifi-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--wifi-off-24-svg);
+  mask-image: var(--wifi-off-24-svg);
+}
+
+%with-wrench-16-icon {
+  @extend %with-icon, %wrench-16-svg-prop !optional;
+  background-image: var(--wrench-16-svg);
+}
+%with-wrench-16-mask {
+  @extend %with-mask, %wrench-16-svg-prop !optional;
+  -webkit-mask-image: var(--wrench-16-svg);
+  mask-image: var(--wrench-16-svg);
+}
+
+%with-wrench-24-icon {
+  @extend %with-icon, %wrench-24-svg-prop !optional;
+  background-image: var(--wrench-24-svg);
+}
+%with-wrench-24-mask {
+  @extend %with-mask, %wrench-24-svg-prop !optional;
+  -webkit-mask-image: var(--wrench-24-svg);
+  mask-image: var(--wrench-24-svg);
+}
+
+%with-x-16-icon {
+  @extend %with-icon, %x-16-svg-prop !optional;
+  background-image: var(--x-16-svg);
+}
+%with-x-16-mask {
+  @extend %with-mask, %x-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-16-svg);
+  mask-image: var(--x-16-svg);
+}
+
+%with-x-24-icon {
+  @extend %with-icon, %x-24-svg-prop !optional;
+  background-image: var(--x-24-svg);
+}
+%with-x-24-mask {
+  @extend %with-mask, %x-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-24-svg);
+  mask-image: var(--x-24-svg);
+}
+
+%with-x-circle-16-icon {
+  @extend %with-icon, %x-circle-16-svg-prop !optional;
+  background-image: var(--x-circle-16-svg);
+}
+%with-x-circle-16-mask {
+  @extend %with-mask, %x-circle-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-circle-16-svg);
+  mask-image: var(--x-circle-16-svg);
+}
+
+%with-x-circle-24-icon {
+  @extend %with-icon, %x-circle-24-svg-prop !optional;
+  background-image: var(--x-circle-24-svg);
+}
+%with-x-circle-24-mask {
+  @extend %with-mask, %x-circle-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-circle-24-svg);
+  mask-image: var(--x-circle-24-svg);
+}
+
+%with-x-circle-fill-16-icon {
+  @extend %with-icon, %x-circle-fill-16-svg-prop !optional;
+  background-image: var(--x-circle-fill-16-svg);
+}
+%with-x-circle-fill-16-mask {
+  @extend %with-mask, %x-circle-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-circle-fill-16-svg);
+  mask-image: var(--x-circle-fill-16-svg);
+}
+
+%with-x-circle-fill-24-icon {
+  @extend %with-icon, %x-circle-fill-24-svg-prop !optional;
+  background-image: var(--x-circle-fill-24-svg);
+}
+%with-x-circle-fill-24-mask {
+  @extend %with-mask, %x-circle-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-circle-fill-24-svg);
+  mask-image: var(--x-circle-fill-24-svg);
+}
+
+%with-x-diamond-16-icon {
+  @extend %with-icon, %x-diamond-16-svg-prop !optional;
+  background-image: var(--x-diamond-16-svg);
+}
+%with-x-diamond-16-mask {
+  @extend %with-mask, %x-diamond-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-diamond-16-svg);
+  mask-image: var(--x-diamond-16-svg);
+}
+
+%with-x-diamond-24-icon {
+  @extend %with-icon, %x-diamond-24-svg-prop !optional;
+  background-image: var(--x-diamond-24-svg);
+}
+%with-x-diamond-24-mask {
+  @extend %with-mask, %x-diamond-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-diamond-24-svg);
+  mask-image: var(--x-diamond-24-svg);
+}
+
+%with-x-diamond-fill-16-icon {
+  @extend %with-icon, %x-diamond-fill-16-svg-prop !optional;
+  background-image: var(--x-diamond-fill-16-svg);
+}
+%with-x-diamond-fill-16-mask {
+  @extend %with-mask, %x-diamond-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-diamond-fill-16-svg);
+  mask-image: var(--x-diamond-fill-16-svg);
+}
+
+%with-x-diamond-fill-24-icon {
+  @extend %with-icon, %x-diamond-fill-24-svg-prop !optional;
+  background-image: var(--x-diamond-fill-24-svg);
+}
+%with-x-diamond-fill-24-mask {
+  @extend %with-mask, %x-diamond-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-diamond-fill-24-svg);
+  mask-image: var(--x-diamond-fill-24-svg);
+}
+
+%with-x-hexagon-16-icon {
+  @extend %with-icon, %x-hexagon-16-svg-prop !optional;
+  background-image: var(--x-hexagon-16-svg);
+}
+%with-x-hexagon-16-mask {
+  @extend %with-mask, %x-hexagon-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-hexagon-16-svg);
+  mask-image: var(--x-hexagon-16-svg);
+}
+
+%with-x-hexagon-24-icon {
+  @extend %with-icon, %x-hexagon-24-svg-prop !optional;
+  background-image: var(--x-hexagon-24-svg);
+}
+%with-x-hexagon-24-mask {
+  @extend %with-mask, %x-hexagon-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-hexagon-24-svg);
+  mask-image: var(--x-hexagon-24-svg);
+}
+
+%with-x-hexagon-fill-16-icon {
+  @extend %with-icon, %x-hexagon-fill-16-svg-prop !optional;
+  background-image: var(--x-hexagon-fill-16-svg);
+}
+%with-x-hexagon-fill-16-mask {
+  @extend %with-mask, %x-hexagon-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-hexagon-fill-16-svg);
+  mask-image: var(--x-hexagon-fill-16-svg);
+}
+
+%with-x-hexagon-fill-24-icon {
+  @extend %with-icon, %x-hexagon-fill-24-svg-prop !optional;
+  background-image: var(--x-hexagon-fill-24-svg);
+}
+%with-x-hexagon-fill-24-mask {
+  @extend %with-mask, %x-hexagon-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-hexagon-fill-24-svg);
+  mask-image: var(--x-hexagon-fill-24-svg);
+}
+
+%with-x-square-16-icon {
+  @extend %with-icon, %x-square-16-svg-prop !optional;
+  background-image: var(--x-square-16-svg);
+}
+%with-x-square-16-mask {
+  @extend %with-mask, %x-square-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-square-16-svg);
+  mask-image: var(--x-square-16-svg);
+}
+
+%with-x-square-24-icon {
+  @extend %with-icon, %x-square-24-svg-prop !optional;
+  background-image: var(--x-square-24-svg);
+}
+%with-x-square-24-mask {
+  @extend %with-mask, %x-square-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-square-24-svg);
+  mask-image: var(--x-square-24-svg);
+}
+
+%with-x-square-fill-16-icon {
+  @extend %with-icon, %x-square-fill-16-svg-prop !optional;
+  background-image: var(--x-square-fill-16-svg);
+}
+%with-x-square-fill-16-mask {
+  @extend %with-mask, %x-square-fill-16-svg-prop !optional;
+  -webkit-mask-image: var(--x-square-fill-16-svg);
+  mask-image: var(--x-square-fill-16-svg);
+}
+
+%with-x-square-fill-24-icon {
+  @extend %with-icon, %x-square-fill-24-svg-prop !optional;
+  background-image: var(--x-square-fill-24-svg);
+}
+%with-x-square-fill-24-mask {
+  @extend %with-mask, %x-square-fill-24-svg-prop !optional;
+  -webkit-mask-image: var(--x-square-fill-24-svg);
+  mask-image: var(--x-square-fill-24-svg);
+}
+
+%with-zap-16-icon {
+  @extend %with-icon, %zap-16-svg-prop !optional;
+  background-image: var(--zap-16-svg);
+}
+%with-zap-16-mask {
+  @extend %with-mask, %zap-16-svg-prop !optional;
+  -webkit-mask-image: var(--zap-16-svg);
+  mask-image: var(--zap-16-svg);
+}
+
+%with-zap-24-icon {
+  @extend %with-icon, %zap-24-svg-prop !optional;
+  background-image: var(--zap-24-svg);
+}
+%with-zap-24-mask {
+  @extend %with-mask, %zap-24-svg-prop !optional;
+  -webkit-mask-image: var(--zap-24-svg);
+  mask-image: var(--zap-24-svg);
+}
+
+%with-zap-off-16-icon {
+  @extend %with-icon, %zap-off-16-svg-prop !optional;
+  background-image: var(--zap-off-16-svg);
+}
+%with-zap-off-16-mask {
+  @extend %with-mask, %zap-off-16-svg-prop !optional;
+  -webkit-mask-image: var(--zap-off-16-svg);
+  mask-image: var(--zap-off-16-svg);
+}
+
+%with-zap-off-24-icon {
+  @extend %with-icon, %zap-off-24-svg-prop !optional;
+  background-image: var(--zap-off-24-svg);
+}
+%with-zap-off-24-mask {
+  @extend %with-mask, %zap-off-24-svg-prop !optional;
+  -webkit-mask-image: var(--zap-off-24-svg);
+  mask-image: var(--zap-off-24-svg);
+}
+
+%with-zoom-in-16-icon {
+  @extend %with-icon, %zoom-in-16-svg-prop !optional;
+  background-image: var(--zoom-in-16-svg);
+}
+%with-zoom-in-16-mask {
+  @extend %with-mask, %zoom-in-16-svg-prop !optional;
+  -webkit-mask-image: var(--zoom-in-16-svg);
+  mask-image: var(--zoom-in-16-svg);
+}
+
+%with-zoom-in-24-icon {
+  @extend %with-icon, %zoom-in-24-svg-prop !optional;
+  background-image: var(--zoom-in-24-svg);
+}
+%with-zoom-in-24-mask {
+  @extend %with-mask, %zoom-in-24-svg-prop !optional;
+  -webkit-mask-image: var(--zoom-in-24-svg);
+  mask-image: var(--zoom-in-24-svg);
+}
+
+%with-zoom-out-16-icon {
+  @extend %with-icon, %zoom-out-16-svg-prop !optional;
+  background-image: var(--zoom-out-16-svg);
+}
+%with-zoom-out-16-mask {
+  @extend %with-mask, %zoom-out-16-svg-prop !optional;
+  -webkit-mask-image: var(--zoom-out-16-svg);
+  mask-image: var(--zoom-out-16-svg);
+}
+
+%with-zoom-out-24-icon {
+  @extend %with-icon, %zoom-out-24-svg-prop !optional;
+  background-image: var(--zoom-out-24-svg);
+}
+%with-zoom-out-24-mask {
+  @extend %with-mask, %zoom-out-24-svg-prop !optional;
+  -webkit-mask-image: var(--zoom-out-24-svg);
+  mask-image: var(--zoom-out-24-svg);
 }

--- a/ui/packages/consul-ui/app/styles/base/icons/icon-placeholders.scss
+++ b/ui/packages/consul-ui/app/styles/base/icons/icon-placeholders.scss
@@ -1,10329 +1,10329 @@
 %with-activity-16-icon {
-  @extend %with-icon, %activity-16-svg-prop !optional;
+  @extend %with-icon, %activity-16-svg-prop;
   background-image: var(--activity-16-svg);
 }
 %with-activity-16-mask {
-  @extend %with-mask, %activity-16-svg-prop !optional;
+  @extend %with-mask, %activity-16-svg-prop;
   -webkit-mask-image: var(--activity-16-svg);
   mask-image: var(--activity-16-svg);
 }
 
 %with-activity-24-icon {
-  @extend %with-icon, %activity-24-svg-prop !optional;
+  @extend %with-icon, %activity-24-svg-prop;
   background-image: var(--activity-24-svg);
 }
 %with-activity-24-mask {
-  @extend %with-mask, %activity-24-svg-prop !optional;
+  @extend %with-mask, %activity-24-svg-prop;
   -webkit-mask-image: var(--activity-24-svg);
   mask-image: var(--activity-24-svg);
 }
 
 %with-alert-circle-16-icon {
-  @extend %with-icon, %alert-circle-16-svg-prop !optional;
+  @extend %with-icon, %alert-circle-16-svg-prop;
   background-image: var(--alert-circle-16-svg);
 }
 %with-alert-circle-16-mask {
-  @extend %with-mask, %alert-circle-16-svg-prop !optional;
+  @extend %with-mask, %alert-circle-16-svg-prop;
   -webkit-mask-image: var(--alert-circle-16-svg);
   mask-image: var(--alert-circle-16-svg);
 }
 
 %with-alert-circle-24-icon {
-  @extend %with-icon, %alert-circle-24-svg-prop !optional;
+  @extend %with-icon, %alert-circle-24-svg-prop;
   background-image: var(--alert-circle-24-svg);
 }
 %with-alert-circle-24-mask {
-  @extend %with-mask, %alert-circle-24-svg-prop !optional;
+  @extend %with-mask, %alert-circle-24-svg-prop;
   -webkit-mask-image: var(--alert-circle-24-svg);
   mask-image: var(--alert-circle-24-svg);
 }
 
 %with-alert-circle-fill-16-icon {
-  @extend %with-icon, %alert-circle-fill-16-svg-prop !optional;
+  @extend %with-icon, %alert-circle-fill-16-svg-prop;
   background-image: var(--alert-circle-fill-16-svg);
 }
 %with-alert-circle-fill-16-mask {
-  @extend %with-mask, %alert-circle-fill-16-svg-prop !optional;
+  @extend %with-mask, %alert-circle-fill-16-svg-prop;
   -webkit-mask-image: var(--alert-circle-fill-16-svg);
   mask-image: var(--alert-circle-fill-16-svg);
 }
 
 %with-alert-circle-fill-24-icon {
-  @extend %with-icon, %alert-circle-fill-24-svg-prop !optional;
+  @extend %with-icon, %alert-circle-fill-24-svg-prop;
   background-image: var(--alert-circle-fill-24-svg);
 }
 %with-alert-circle-fill-24-mask {
-  @extend %with-mask, %alert-circle-fill-24-svg-prop !optional;
+  @extend %with-mask, %alert-circle-fill-24-svg-prop;
   -webkit-mask-image: var(--alert-circle-fill-24-svg);
   mask-image: var(--alert-circle-fill-24-svg);
 }
 
 %with-alert-circle-fill-icon {
-  @extend %with-icon, %alert-circle-fill-svg-prop !optional;
+  @extend %with-icon, %alert-circle-fill-svg-prop;
   background-image: var(--alert-circle-fill-svg);
 }
 %with-alert-circle-fill-mask {
-  @extend %with-mask, %alert-circle-fill-svg-prop !optional;
+  @extend %with-mask, %alert-circle-fill-svg-prop;
   -webkit-mask-image: var(--alert-circle-fill-svg);
   mask-image: var(--alert-circle-fill-svg);
 }
 
 %with-alert-circle-outline-icon {
-  @extend %with-icon, %alert-circle-outline-svg-prop !optional;
+  @extend %with-icon, %alert-circle-outline-svg-prop;
   background-image: var(--alert-circle-outline-svg);
 }
 %with-alert-circle-outline-mask {
-  @extend %with-mask, %alert-circle-outline-svg-prop !optional;
+  @extend %with-mask, %alert-circle-outline-svg-prop;
   -webkit-mask-image: var(--alert-circle-outline-svg);
   mask-image: var(--alert-circle-outline-svg);
 }
 
 %with-alert-octagon-16-icon {
-  @extend %with-icon, %alert-octagon-16-svg-prop !optional;
+  @extend %with-icon, %alert-octagon-16-svg-prop;
   background-image: var(--alert-octagon-16-svg);
 }
 %with-alert-octagon-16-mask {
-  @extend %with-mask, %alert-octagon-16-svg-prop !optional;
+  @extend %with-mask, %alert-octagon-16-svg-prop;
   -webkit-mask-image: var(--alert-octagon-16-svg);
   mask-image: var(--alert-octagon-16-svg);
 }
 
 %with-alert-octagon-24-icon {
-  @extend %with-icon, %alert-octagon-24-svg-prop !optional;
+  @extend %with-icon, %alert-octagon-24-svg-prop;
   background-image: var(--alert-octagon-24-svg);
 }
 %with-alert-octagon-24-mask {
-  @extend %with-mask, %alert-octagon-24-svg-prop !optional;
+  @extend %with-mask, %alert-octagon-24-svg-prop;
   -webkit-mask-image: var(--alert-octagon-24-svg);
   mask-image: var(--alert-octagon-24-svg);
 }
 
 %with-alert-octagon-fill-16-icon {
-  @extend %with-icon, %alert-octagon-fill-16-svg-prop !optional;
+  @extend %with-icon, %alert-octagon-fill-16-svg-prop;
   background-image: var(--alert-octagon-fill-16-svg);
 }
 %with-alert-octagon-fill-16-mask {
-  @extend %with-mask, %alert-octagon-fill-16-svg-prop !optional;
+  @extend %with-mask, %alert-octagon-fill-16-svg-prop;
   -webkit-mask-image: var(--alert-octagon-fill-16-svg);
   mask-image: var(--alert-octagon-fill-16-svg);
 }
 
 %with-alert-octagon-fill-24-icon {
-  @extend %with-icon, %alert-octagon-fill-24-svg-prop !optional;
+  @extend %with-icon, %alert-octagon-fill-24-svg-prop;
   background-image: var(--alert-octagon-fill-24-svg);
 }
 %with-alert-octagon-fill-24-mask {
-  @extend %with-mask, %alert-octagon-fill-24-svg-prop !optional;
+  @extend %with-mask, %alert-octagon-fill-24-svg-prop;
   -webkit-mask-image: var(--alert-octagon-fill-24-svg);
   mask-image: var(--alert-octagon-fill-24-svg);
 }
 
 %with-alert-triangle-16-icon {
-  @extend %with-icon, %alert-triangle-16-svg-prop !optional;
+  @extend %with-icon, %alert-triangle-16-svg-prop;
   background-image: var(--alert-triangle-16-svg);
 }
 %with-alert-triangle-16-mask {
-  @extend %with-mask, %alert-triangle-16-svg-prop !optional;
+  @extend %with-mask, %alert-triangle-16-svg-prop;
   -webkit-mask-image: var(--alert-triangle-16-svg);
   mask-image: var(--alert-triangle-16-svg);
 }
 
 %with-alert-triangle-24-icon {
-  @extend %with-icon, %alert-triangle-24-svg-prop !optional;
+  @extend %with-icon, %alert-triangle-24-svg-prop;
   background-image: var(--alert-triangle-24-svg);
 }
 %with-alert-triangle-24-mask {
-  @extend %with-mask, %alert-triangle-24-svg-prop !optional;
+  @extend %with-mask, %alert-triangle-24-svg-prop;
   -webkit-mask-image: var(--alert-triangle-24-svg);
   mask-image: var(--alert-triangle-24-svg);
 }
 
 %with-alert-triangle-fill-16-icon {
-  @extend %with-icon, %alert-triangle-fill-16-svg-prop !optional;
+  @extend %with-icon, %alert-triangle-fill-16-svg-prop;
   background-image: var(--alert-triangle-fill-16-svg);
 }
 %with-alert-triangle-fill-16-mask {
-  @extend %with-mask, %alert-triangle-fill-16-svg-prop !optional;
+  @extend %with-mask, %alert-triangle-fill-16-svg-prop;
   -webkit-mask-image: var(--alert-triangle-fill-16-svg);
   mask-image: var(--alert-triangle-fill-16-svg);
 }
 
 %with-alert-triangle-fill-24-icon {
-  @extend %with-icon, %alert-triangle-fill-24-svg-prop !optional;
+  @extend %with-icon, %alert-triangle-fill-24-svg-prop;
   background-image: var(--alert-triangle-fill-24-svg);
 }
 %with-alert-triangle-fill-24-mask {
-  @extend %with-mask, %alert-triangle-fill-24-svg-prop !optional;
+  @extend %with-mask, %alert-triangle-fill-24-svg-prop;
   -webkit-mask-image: var(--alert-triangle-fill-24-svg);
   mask-image: var(--alert-triangle-fill-24-svg);
 }
 
 %with-alert-triangle-icon {
-  @extend %with-icon, %alert-triangle-svg-prop !optional;
+  @extend %with-icon, %alert-triangle-svg-prop;
   background-image: var(--alert-triangle-svg);
 }
 %with-alert-triangle-mask {
-  @extend %with-mask, %alert-triangle-svg-prop !optional;
+  @extend %with-mask, %alert-triangle-svg-prop;
   -webkit-mask-image: var(--alert-triangle-svg);
   mask-image: var(--alert-triangle-svg);
 }
 
 %with-alibaba-16-icon {
-  @extend %with-icon, %alibaba-16-svg-prop !optional;
+  @extend %with-icon, %alibaba-16-svg-prop;
   background-image: var(--alibaba-16-svg);
 }
 %with-alibaba-16-mask {
-  @extend %with-mask, %alibaba-16-svg-prop !optional;
+  @extend %with-mask, %alibaba-16-svg-prop;
   -webkit-mask-image: var(--alibaba-16-svg);
   mask-image: var(--alibaba-16-svg);
 }
 
 %with-alibaba-24-icon {
-  @extend %with-icon, %alibaba-24-svg-prop !optional;
+  @extend %with-icon, %alibaba-24-svg-prop;
   background-image: var(--alibaba-24-svg);
 }
 %with-alibaba-24-mask {
-  @extend %with-mask, %alibaba-24-svg-prop !optional;
+  @extend %with-mask, %alibaba-24-svg-prop;
   -webkit-mask-image: var(--alibaba-24-svg);
   mask-image: var(--alibaba-24-svg);
 }
 
 %with-alibaba-color-16-icon {
-  @extend %with-icon, %alibaba-color-16-svg-prop !optional;
+  @extend %with-icon, %alibaba-color-16-svg-prop;
   background-image: var(--alibaba-color-16-svg);
 }
 %with-alibaba-color-16-mask {
-  @extend %with-mask, %alibaba-color-16-svg-prop !optional;
+  @extend %with-mask, %alibaba-color-16-svg-prop;
   -webkit-mask-image: var(--alibaba-color-16-svg);
   mask-image: var(--alibaba-color-16-svg);
 }
 
 %with-alibaba-color-24-icon {
-  @extend %with-icon, %alibaba-color-24-svg-prop !optional;
+  @extend %with-icon, %alibaba-color-24-svg-prop;
   background-image: var(--alibaba-color-24-svg);
 }
 %with-alibaba-color-24-mask {
-  @extend %with-mask, %alibaba-color-24-svg-prop !optional;
+  @extend %with-mask, %alibaba-color-24-svg-prop;
   -webkit-mask-image: var(--alibaba-color-24-svg);
   mask-image: var(--alibaba-color-24-svg);
 }
 
 %with-align-center-16-icon {
-  @extend %with-icon, %align-center-16-svg-prop !optional;
+  @extend %with-icon, %align-center-16-svg-prop;
   background-image: var(--align-center-16-svg);
 }
 %with-align-center-16-mask {
-  @extend %with-mask, %align-center-16-svg-prop !optional;
+  @extend %with-mask, %align-center-16-svg-prop;
   -webkit-mask-image: var(--align-center-16-svg);
   mask-image: var(--align-center-16-svg);
 }
 
 %with-align-center-24-icon {
-  @extend %with-icon, %align-center-24-svg-prop !optional;
+  @extend %with-icon, %align-center-24-svg-prop;
   background-image: var(--align-center-24-svg);
 }
 %with-align-center-24-mask {
-  @extend %with-mask, %align-center-24-svg-prop !optional;
+  @extend %with-mask, %align-center-24-svg-prop;
   -webkit-mask-image: var(--align-center-24-svg);
   mask-image: var(--align-center-24-svg);
 }
 
 %with-align-justify-16-icon {
-  @extend %with-icon, %align-justify-16-svg-prop !optional;
+  @extend %with-icon, %align-justify-16-svg-prop;
   background-image: var(--align-justify-16-svg);
 }
 %with-align-justify-16-mask {
-  @extend %with-mask, %align-justify-16-svg-prop !optional;
+  @extend %with-mask, %align-justify-16-svg-prop;
   -webkit-mask-image: var(--align-justify-16-svg);
   mask-image: var(--align-justify-16-svg);
 }
 
 %with-align-justify-24-icon {
-  @extend %with-icon, %align-justify-24-svg-prop !optional;
+  @extend %with-icon, %align-justify-24-svg-prop;
   background-image: var(--align-justify-24-svg);
 }
 %with-align-justify-24-mask {
-  @extend %with-mask, %align-justify-24-svg-prop !optional;
+  @extend %with-mask, %align-justify-24-svg-prop;
   -webkit-mask-image: var(--align-justify-24-svg);
   mask-image: var(--align-justify-24-svg);
 }
 
 %with-align-left-16-icon {
-  @extend %with-icon, %align-left-16-svg-prop !optional;
+  @extend %with-icon, %align-left-16-svg-prop;
   background-image: var(--align-left-16-svg);
 }
 %with-align-left-16-mask {
-  @extend %with-mask, %align-left-16-svg-prop !optional;
+  @extend %with-mask, %align-left-16-svg-prop;
   -webkit-mask-image: var(--align-left-16-svg);
   mask-image: var(--align-left-16-svg);
 }
 
 %with-align-left-24-icon {
-  @extend %with-icon, %align-left-24-svg-prop !optional;
+  @extend %with-icon, %align-left-24-svg-prop;
   background-image: var(--align-left-24-svg);
 }
 %with-align-left-24-mask {
-  @extend %with-mask, %align-left-24-svg-prop !optional;
+  @extend %with-mask, %align-left-24-svg-prop;
   -webkit-mask-image: var(--align-left-24-svg);
   mask-image: var(--align-left-24-svg);
 }
 
 %with-align-right-16-icon {
-  @extend %with-icon, %align-right-16-svg-prop !optional;
+  @extend %with-icon, %align-right-16-svg-prop;
   background-image: var(--align-right-16-svg);
 }
 %with-align-right-16-mask {
-  @extend %with-mask, %align-right-16-svg-prop !optional;
+  @extend %with-mask, %align-right-16-svg-prop;
   -webkit-mask-image: var(--align-right-16-svg);
   mask-image: var(--align-right-16-svg);
 }
 
 %with-align-right-24-icon {
-  @extend %with-icon, %align-right-24-svg-prop !optional;
+  @extend %with-icon, %align-right-24-svg-prop;
   background-image: var(--align-right-24-svg);
 }
 %with-align-right-24-mask {
-  @extend %with-mask, %align-right-24-svg-prop !optional;
+  @extend %with-mask, %align-right-24-svg-prop;
   -webkit-mask-image: var(--align-right-24-svg);
   mask-image: var(--align-right-24-svg);
 }
 
 %with-apple-16-icon {
-  @extend %with-icon, %apple-16-svg-prop !optional;
+  @extend %with-icon, %apple-16-svg-prop;
   background-image: var(--apple-16-svg);
 }
 %with-apple-16-mask {
-  @extend %with-mask, %apple-16-svg-prop !optional;
+  @extend %with-mask, %apple-16-svg-prop;
   -webkit-mask-image: var(--apple-16-svg);
   mask-image: var(--apple-16-svg);
 }
 
 %with-apple-24-icon {
-  @extend %with-icon, %apple-24-svg-prop !optional;
+  @extend %with-icon, %apple-24-svg-prop;
   background-image: var(--apple-24-svg);
 }
 %with-apple-24-mask {
-  @extend %with-mask, %apple-24-svg-prop !optional;
+  @extend %with-mask, %apple-24-svg-prop;
   -webkit-mask-image: var(--apple-24-svg);
   mask-image: var(--apple-24-svg);
 }
 
 %with-apple-color-16-icon {
-  @extend %with-icon, %apple-color-16-svg-prop !optional;
+  @extend %with-icon, %apple-color-16-svg-prop;
   background-image: var(--apple-color-16-svg);
 }
 %with-apple-color-16-mask {
-  @extend %with-mask, %apple-color-16-svg-prop !optional;
+  @extend %with-mask, %apple-color-16-svg-prop;
   -webkit-mask-image: var(--apple-color-16-svg);
   mask-image: var(--apple-color-16-svg);
 }
 
 %with-apple-color-24-icon {
-  @extend %with-icon, %apple-color-24-svg-prop !optional;
+  @extend %with-icon, %apple-color-24-svg-prop;
   background-image: var(--apple-color-24-svg);
 }
 %with-apple-color-24-mask {
-  @extend %with-mask, %apple-color-24-svg-prop !optional;
+  @extend %with-mask, %apple-color-24-svg-prop;
   -webkit-mask-image: var(--apple-color-24-svg);
   mask-image: var(--apple-color-24-svg);
 }
 
 %with-archive-16-icon {
-  @extend %with-icon, %archive-16-svg-prop !optional;
+  @extend %with-icon, %archive-16-svg-prop;
   background-image: var(--archive-16-svg);
 }
 %with-archive-16-mask {
-  @extend %with-mask, %archive-16-svg-prop !optional;
+  @extend %with-mask, %archive-16-svg-prop;
   -webkit-mask-image: var(--archive-16-svg);
   mask-image: var(--archive-16-svg);
 }
 
 %with-archive-24-icon {
-  @extend %with-icon, %archive-24-svg-prop !optional;
+  @extend %with-icon, %archive-24-svg-prop;
   background-image: var(--archive-24-svg);
 }
 %with-archive-24-mask {
-  @extend %with-mask, %archive-24-svg-prop !optional;
+  @extend %with-mask, %archive-24-svg-prop;
   -webkit-mask-image: var(--archive-24-svg);
   mask-image: var(--archive-24-svg);
 }
 
 %with-arrow-down-16-icon {
-  @extend %with-icon, %arrow-down-16-svg-prop !optional;
+  @extend %with-icon, %arrow-down-16-svg-prop;
   background-image: var(--arrow-down-16-svg);
 }
 %with-arrow-down-16-mask {
-  @extend %with-mask, %arrow-down-16-svg-prop !optional;
+  @extend %with-mask, %arrow-down-16-svg-prop;
   -webkit-mask-image: var(--arrow-down-16-svg);
   mask-image: var(--arrow-down-16-svg);
 }
 
 %with-arrow-down-24-icon {
-  @extend %with-icon, %arrow-down-24-svg-prop !optional;
+  @extend %with-icon, %arrow-down-24-svg-prop;
   background-image: var(--arrow-down-24-svg);
 }
 %with-arrow-down-24-mask {
-  @extend %with-mask, %arrow-down-24-svg-prop !optional;
+  @extend %with-mask, %arrow-down-24-svg-prop;
   -webkit-mask-image: var(--arrow-down-24-svg);
   mask-image: var(--arrow-down-24-svg);
 }
 
 %with-arrow-down-circle-16-icon {
-  @extend %with-icon, %arrow-down-circle-16-svg-prop !optional;
+  @extend %with-icon, %arrow-down-circle-16-svg-prop;
   background-image: var(--arrow-down-circle-16-svg);
 }
 %with-arrow-down-circle-16-mask {
-  @extend %with-mask, %arrow-down-circle-16-svg-prop !optional;
+  @extend %with-mask, %arrow-down-circle-16-svg-prop;
   -webkit-mask-image: var(--arrow-down-circle-16-svg);
   mask-image: var(--arrow-down-circle-16-svg);
 }
 
 %with-arrow-down-circle-24-icon {
-  @extend %with-icon, %arrow-down-circle-24-svg-prop !optional;
+  @extend %with-icon, %arrow-down-circle-24-svg-prop;
   background-image: var(--arrow-down-circle-24-svg);
 }
 %with-arrow-down-circle-24-mask {
-  @extend %with-mask, %arrow-down-circle-24-svg-prop !optional;
+  @extend %with-mask, %arrow-down-circle-24-svg-prop;
   -webkit-mask-image: var(--arrow-down-circle-24-svg);
   mask-image: var(--arrow-down-circle-24-svg);
 }
 
 %with-arrow-down-left-16-icon {
-  @extend %with-icon, %arrow-down-left-16-svg-prop !optional;
+  @extend %with-icon, %arrow-down-left-16-svg-prop;
   background-image: var(--arrow-down-left-16-svg);
 }
 %with-arrow-down-left-16-mask {
-  @extend %with-mask, %arrow-down-left-16-svg-prop !optional;
+  @extend %with-mask, %arrow-down-left-16-svg-prop;
   -webkit-mask-image: var(--arrow-down-left-16-svg);
   mask-image: var(--arrow-down-left-16-svg);
 }
 
 %with-arrow-down-left-24-icon {
-  @extend %with-icon, %arrow-down-left-24-svg-prop !optional;
+  @extend %with-icon, %arrow-down-left-24-svg-prop;
   background-image: var(--arrow-down-left-24-svg);
 }
 %with-arrow-down-left-24-mask {
-  @extend %with-mask, %arrow-down-left-24-svg-prop !optional;
+  @extend %with-mask, %arrow-down-left-24-svg-prop;
   -webkit-mask-image: var(--arrow-down-left-24-svg);
   mask-image: var(--arrow-down-left-24-svg);
 }
 
 %with-arrow-down-right-16-icon {
-  @extend %with-icon, %arrow-down-right-16-svg-prop !optional;
+  @extend %with-icon, %arrow-down-right-16-svg-prop;
   background-image: var(--arrow-down-right-16-svg);
 }
 %with-arrow-down-right-16-mask {
-  @extend %with-mask, %arrow-down-right-16-svg-prop !optional;
+  @extend %with-mask, %arrow-down-right-16-svg-prop;
   -webkit-mask-image: var(--arrow-down-right-16-svg);
   mask-image: var(--arrow-down-right-16-svg);
 }
 
 %with-arrow-down-right-24-icon {
-  @extend %with-icon, %arrow-down-right-24-svg-prop !optional;
+  @extend %with-icon, %arrow-down-right-24-svg-prop;
   background-image: var(--arrow-down-right-24-svg);
 }
 %with-arrow-down-right-24-mask {
-  @extend %with-mask, %arrow-down-right-24-svg-prop !optional;
+  @extend %with-mask, %arrow-down-right-24-svg-prop;
   -webkit-mask-image: var(--arrow-down-right-24-svg);
   mask-image: var(--arrow-down-right-24-svg);
 }
 
 %with-arrow-down-icon {
-  @extend %with-icon, %arrow-down-svg-prop !optional;
+  @extend %with-icon, %arrow-down-svg-prop;
   background-image: var(--arrow-down-svg);
 }
 %with-arrow-down-mask {
-  @extend %with-mask, %arrow-down-svg-prop !optional;
+  @extend %with-mask, %arrow-down-svg-prop;
   -webkit-mask-image: var(--arrow-down-svg);
   mask-image: var(--arrow-down-svg);
 }
 
 %with-arrow-left-16-icon {
-  @extend %with-icon, %arrow-left-16-svg-prop !optional;
+  @extend %with-icon, %arrow-left-16-svg-prop;
   background-image: var(--arrow-left-16-svg);
 }
 %with-arrow-left-16-mask {
-  @extend %with-mask, %arrow-left-16-svg-prop !optional;
+  @extend %with-mask, %arrow-left-16-svg-prop;
   -webkit-mask-image: var(--arrow-left-16-svg);
   mask-image: var(--arrow-left-16-svg);
 }
 
 %with-arrow-left-24-icon {
-  @extend %with-icon, %arrow-left-24-svg-prop !optional;
+  @extend %with-icon, %arrow-left-24-svg-prop;
   background-image: var(--arrow-left-24-svg);
 }
 %with-arrow-left-24-mask {
-  @extend %with-mask, %arrow-left-24-svg-prop !optional;
+  @extend %with-mask, %arrow-left-24-svg-prop;
   -webkit-mask-image: var(--arrow-left-24-svg);
   mask-image: var(--arrow-left-24-svg);
 }
 
 %with-arrow-left-circle-16-icon {
-  @extend %with-icon, %arrow-left-circle-16-svg-prop !optional;
+  @extend %with-icon, %arrow-left-circle-16-svg-prop;
   background-image: var(--arrow-left-circle-16-svg);
 }
 %with-arrow-left-circle-16-mask {
-  @extend %with-mask, %arrow-left-circle-16-svg-prop !optional;
+  @extend %with-mask, %arrow-left-circle-16-svg-prop;
   -webkit-mask-image: var(--arrow-left-circle-16-svg);
   mask-image: var(--arrow-left-circle-16-svg);
 }
 
 %with-arrow-left-circle-24-icon {
-  @extend %with-icon, %arrow-left-circle-24-svg-prop !optional;
+  @extend %with-icon, %arrow-left-circle-24-svg-prop;
   background-image: var(--arrow-left-circle-24-svg);
 }
 %with-arrow-left-circle-24-mask {
-  @extend %with-mask, %arrow-left-circle-24-svg-prop !optional;
+  @extend %with-mask, %arrow-left-circle-24-svg-prop;
   -webkit-mask-image: var(--arrow-left-circle-24-svg);
   mask-image: var(--arrow-left-circle-24-svg);
 }
 
 %with-arrow-left-icon {
-  @extend %with-icon, %arrow-left-svg-prop !optional;
+  @extend %with-icon, %arrow-left-svg-prop;
   background-image: var(--arrow-left-svg);
 }
 %with-arrow-left-mask {
-  @extend %with-mask, %arrow-left-svg-prop !optional;
+  @extend %with-mask, %arrow-left-svg-prop;
   -webkit-mask-image: var(--arrow-left-svg);
   mask-image: var(--arrow-left-svg);
 }
 
 %with-arrow-right-16-icon {
-  @extend %with-icon, %arrow-right-16-svg-prop !optional;
+  @extend %with-icon, %arrow-right-16-svg-prop;
   background-image: var(--arrow-right-16-svg);
 }
 %with-arrow-right-16-mask {
-  @extend %with-mask, %arrow-right-16-svg-prop !optional;
+  @extend %with-mask, %arrow-right-16-svg-prop;
   -webkit-mask-image: var(--arrow-right-16-svg);
   mask-image: var(--arrow-right-16-svg);
 }
 
 %with-arrow-right-24-icon {
-  @extend %with-icon, %arrow-right-24-svg-prop !optional;
+  @extend %with-icon, %arrow-right-24-svg-prop;
   background-image: var(--arrow-right-24-svg);
 }
 %with-arrow-right-24-mask {
-  @extend %with-mask, %arrow-right-24-svg-prop !optional;
+  @extend %with-mask, %arrow-right-24-svg-prop;
   -webkit-mask-image: var(--arrow-right-24-svg);
   mask-image: var(--arrow-right-24-svg);
 }
 
 %with-arrow-right-circle-16-icon {
-  @extend %with-icon, %arrow-right-circle-16-svg-prop !optional;
+  @extend %with-icon, %arrow-right-circle-16-svg-prop;
   background-image: var(--arrow-right-circle-16-svg);
 }
 %with-arrow-right-circle-16-mask {
-  @extend %with-mask, %arrow-right-circle-16-svg-prop !optional;
+  @extend %with-mask, %arrow-right-circle-16-svg-prop;
   -webkit-mask-image: var(--arrow-right-circle-16-svg);
   mask-image: var(--arrow-right-circle-16-svg);
 }
 
 %with-arrow-right-circle-24-icon {
-  @extend %with-icon, %arrow-right-circle-24-svg-prop !optional;
+  @extend %with-icon, %arrow-right-circle-24-svg-prop;
   background-image: var(--arrow-right-circle-24-svg);
 }
 %with-arrow-right-circle-24-mask {
-  @extend %with-mask, %arrow-right-circle-24-svg-prop !optional;
+  @extend %with-mask, %arrow-right-circle-24-svg-prop;
   -webkit-mask-image: var(--arrow-right-circle-24-svg);
   mask-image: var(--arrow-right-circle-24-svg);
 }
 
 %with-arrow-right-icon {
-  @extend %with-icon, %arrow-right-svg-prop !optional;
+  @extend %with-icon, %arrow-right-svg-prop;
   background-image: var(--arrow-right-svg);
 }
 %with-arrow-right-mask {
-  @extend %with-mask, %arrow-right-svg-prop !optional;
+  @extend %with-mask, %arrow-right-svg-prop;
   -webkit-mask-image: var(--arrow-right-svg);
   mask-image: var(--arrow-right-svg);
 }
 
 %with-arrow-up-16-icon {
-  @extend %with-icon, %arrow-up-16-svg-prop !optional;
+  @extend %with-icon, %arrow-up-16-svg-prop;
   background-image: var(--arrow-up-16-svg);
 }
 %with-arrow-up-16-mask {
-  @extend %with-mask, %arrow-up-16-svg-prop !optional;
+  @extend %with-mask, %arrow-up-16-svg-prop;
   -webkit-mask-image: var(--arrow-up-16-svg);
   mask-image: var(--arrow-up-16-svg);
 }
 
 %with-arrow-up-24-icon {
-  @extend %with-icon, %arrow-up-24-svg-prop !optional;
+  @extend %with-icon, %arrow-up-24-svg-prop;
   background-image: var(--arrow-up-24-svg);
 }
 %with-arrow-up-24-mask {
-  @extend %with-mask, %arrow-up-24-svg-prop !optional;
+  @extend %with-mask, %arrow-up-24-svg-prop;
   -webkit-mask-image: var(--arrow-up-24-svg);
   mask-image: var(--arrow-up-24-svg);
 }
 
 %with-arrow-up-circle-16-icon {
-  @extend %with-icon, %arrow-up-circle-16-svg-prop !optional;
+  @extend %with-icon, %arrow-up-circle-16-svg-prop;
   background-image: var(--arrow-up-circle-16-svg);
 }
 %with-arrow-up-circle-16-mask {
-  @extend %with-mask, %arrow-up-circle-16-svg-prop !optional;
+  @extend %with-mask, %arrow-up-circle-16-svg-prop;
   -webkit-mask-image: var(--arrow-up-circle-16-svg);
   mask-image: var(--arrow-up-circle-16-svg);
 }
 
 %with-arrow-up-circle-24-icon {
-  @extend %with-icon, %arrow-up-circle-24-svg-prop !optional;
+  @extend %with-icon, %arrow-up-circle-24-svg-prop;
   background-image: var(--arrow-up-circle-24-svg);
 }
 %with-arrow-up-circle-24-mask {
-  @extend %with-mask, %arrow-up-circle-24-svg-prop !optional;
+  @extend %with-mask, %arrow-up-circle-24-svg-prop;
   -webkit-mask-image: var(--arrow-up-circle-24-svg);
   mask-image: var(--arrow-up-circle-24-svg);
 }
 
 %with-arrow-up-left-16-icon {
-  @extend %with-icon, %arrow-up-left-16-svg-prop !optional;
+  @extend %with-icon, %arrow-up-left-16-svg-prop;
   background-image: var(--arrow-up-left-16-svg);
 }
 %with-arrow-up-left-16-mask {
-  @extend %with-mask, %arrow-up-left-16-svg-prop !optional;
+  @extend %with-mask, %arrow-up-left-16-svg-prop;
   -webkit-mask-image: var(--arrow-up-left-16-svg);
   mask-image: var(--arrow-up-left-16-svg);
 }
 
 %with-arrow-up-left-24-icon {
-  @extend %with-icon, %arrow-up-left-24-svg-prop !optional;
+  @extend %with-icon, %arrow-up-left-24-svg-prop;
   background-image: var(--arrow-up-left-24-svg);
 }
 %with-arrow-up-left-24-mask {
-  @extend %with-mask, %arrow-up-left-24-svg-prop !optional;
+  @extend %with-mask, %arrow-up-left-24-svg-prop;
   -webkit-mask-image: var(--arrow-up-left-24-svg);
   mask-image: var(--arrow-up-left-24-svg);
 }
 
 %with-arrow-up-right-16-icon {
-  @extend %with-icon, %arrow-up-right-16-svg-prop !optional;
+  @extend %with-icon, %arrow-up-right-16-svg-prop;
   background-image: var(--arrow-up-right-16-svg);
 }
 %with-arrow-up-right-16-mask {
-  @extend %with-mask, %arrow-up-right-16-svg-prop !optional;
+  @extend %with-mask, %arrow-up-right-16-svg-prop;
   -webkit-mask-image: var(--arrow-up-right-16-svg);
   mask-image: var(--arrow-up-right-16-svg);
 }
 
 %with-arrow-up-right-24-icon {
-  @extend %with-icon, %arrow-up-right-24-svg-prop !optional;
+  @extend %with-icon, %arrow-up-right-24-svg-prop;
   background-image: var(--arrow-up-right-24-svg);
 }
 %with-arrow-up-right-24-mask {
-  @extend %with-mask, %arrow-up-right-24-svg-prop !optional;
+  @extend %with-mask, %arrow-up-right-24-svg-prop;
   -webkit-mask-image: var(--arrow-up-right-24-svg);
   mask-image: var(--arrow-up-right-24-svg);
 }
 
 %with-arrow-up-icon {
-  @extend %with-icon, %arrow-up-svg-prop !optional;
+  @extend %with-icon, %arrow-up-svg-prop;
   background-image: var(--arrow-up-svg);
 }
 %with-arrow-up-mask {
-  @extend %with-mask, %arrow-up-svg-prop !optional;
+  @extend %with-mask, %arrow-up-svg-prop;
   -webkit-mask-image: var(--arrow-up-svg);
   mask-image: var(--arrow-up-svg);
 }
 
 %with-at-sign-16-icon {
-  @extend %with-icon, %at-sign-16-svg-prop !optional;
+  @extend %with-icon, %at-sign-16-svg-prop;
   background-image: var(--at-sign-16-svg);
 }
 %with-at-sign-16-mask {
-  @extend %with-mask, %at-sign-16-svg-prop !optional;
+  @extend %with-mask, %at-sign-16-svg-prop;
   -webkit-mask-image: var(--at-sign-16-svg);
   mask-image: var(--at-sign-16-svg);
 }
 
 %with-at-sign-24-icon {
-  @extend %with-icon, %at-sign-24-svg-prop !optional;
+  @extend %with-icon, %at-sign-24-svg-prop;
   background-image: var(--at-sign-24-svg);
 }
 %with-at-sign-24-mask {
-  @extend %with-mask, %at-sign-24-svg-prop !optional;
+  @extend %with-mask, %at-sign-24-svg-prop;
   -webkit-mask-image: var(--at-sign-24-svg);
   mask-image: var(--at-sign-24-svg);
 }
 
 %with-auth0-16-icon {
-  @extend %with-icon, %auth0-16-svg-prop !optional;
+  @extend %with-icon, %auth0-16-svg-prop;
   background-image: var(--auth0-16-svg);
 }
 %with-auth0-16-mask {
-  @extend %with-mask, %auth0-16-svg-prop !optional;
+  @extend %with-mask, %auth0-16-svg-prop;
   -webkit-mask-image: var(--auth0-16-svg);
   mask-image: var(--auth0-16-svg);
 }
 
 %with-auth0-24-icon {
-  @extend %with-icon, %auth0-24-svg-prop !optional;
+  @extend %with-icon, %auth0-24-svg-prop;
   background-image: var(--auth0-24-svg);
 }
 %with-auth0-24-mask {
-  @extend %with-mask, %auth0-24-svg-prop !optional;
+  @extend %with-mask, %auth0-24-svg-prop;
   -webkit-mask-image: var(--auth0-24-svg);
   mask-image: var(--auth0-24-svg);
 }
 
 %with-auth0-color-16-icon {
-  @extend %with-icon, %auth0-color-16-svg-prop !optional;
+  @extend %with-icon, %auth0-color-16-svg-prop;
   background-image: var(--auth0-color-16-svg);
 }
 %with-auth0-color-16-mask {
-  @extend %with-mask, %auth0-color-16-svg-prop !optional;
+  @extend %with-mask, %auth0-color-16-svg-prop;
   -webkit-mask-image: var(--auth0-color-16-svg);
   mask-image: var(--auth0-color-16-svg);
 }
 
 %with-auth0-color-24-icon {
-  @extend %with-icon, %auth0-color-24-svg-prop !optional;
+  @extend %with-icon, %auth0-color-24-svg-prop;
   background-image: var(--auth0-color-24-svg);
 }
 %with-auth0-color-24-mask {
-  @extend %with-mask, %auth0-color-24-svg-prop !optional;
+  @extend %with-mask, %auth0-color-24-svg-prop;
   -webkit-mask-image: var(--auth0-color-24-svg);
   mask-image: var(--auth0-color-24-svg);
 }
 
 %with-auto-apply-16-icon {
-  @extend %with-icon, %auto-apply-16-svg-prop !optional;
+  @extend %with-icon, %auto-apply-16-svg-prop;
   background-image: var(--auto-apply-16-svg);
 }
 %with-auto-apply-16-mask {
-  @extend %with-mask, %auto-apply-16-svg-prop !optional;
+  @extend %with-mask, %auto-apply-16-svg-prop;
   -webkit-mask-image: var(--auto-apply-16-svg);
   mask-image: var(--auto-apply-16-svg);
 }
 
 %with-auto-apply-24-icon {
-  @extend %with-icon, %auto-apply-24-svg-prop !optional;
+  @extend %with-icon, %auto-apply-24-svg-prop;
   background-image: var(--auto-apply-24-svg);
 }
 %with-auto-apply-24-mask {
-  @extend %with-mask, %auto-apply-24-svg-prop !optional;
+  @extend %with-mask, %auto-apply-24-svg-prop;
   -webkit-mask-image: var(--auto-apply-24-svg);
   mask-image: var(--auto-apply-24-svg);
 }
 
 %with-award-16-icon {
-  @extend %with-icon, %award-16-svg-prop !optional;
+  @extend %with-icon, %award-16-svg-prop;
   background-image: var(--award-16-svg);
 }
 %with-award-16-mask {
-  @extend %with-mask, %award-16-svg-prop !optional;
+  @extend %with-mask, %award-16-svg-prop;
   -webkit-mask-image: var(--award-16-svg);
   mask-image: var(--award-16-svg);
 }
 
 %with-award-24-icon {
-  @extend %with-icon, %award-24-svg-prop !optional;
+  @extend %with-icon, %award-24-svg-prop;
   background-image: var(--award-24-svg);
 }
 %with-award-24-mask {
-  @extend %with-mask, %award-24-svg-prop !optional;
+  @extend %with-mask, %award-24-svg-prop;
   -webkit-mask-image: var(--award-24-svg);
   mask-image: var(--award-24-svg);
 }
 
 %with-aws-16-icon {
-  @extend %with-icon, %aws-16-svg-prop !optional;
+  @extend %with-icon, %aws-16-svg-prop;
   background-image: var(--aws-16-svg);
 }
 %with-aws-16-mask {
-  @extend %with-mask, %aws-16-svg-prop !optional;
+  @extend %with-mask, %aws-16-svg-prop;
   -webkit-mask-image: var(--aws-16-svg);
   mask-image: var(--aws-16-svg);
 }
 
 %with-aws-24-icon {
-  @extend %with-icon, %aws-24-svg-prop !optional;
+  @extend %with-icon, %aws-24-svg-prop;
   background-image: var(--aws-24-svg);
 }
 %with-aws-24-mask {
-  @extend %with-mask, %aws-24-svg-prop !optional;
+  @extend %with-mask, %aws-24-svg-prop;
   -webkit-mask-image: var(--aws-24-svg);
   mask-image: var(--aws-24-svg);
 }
 
 %with-aws-color-16-icon {
-  @extend %with-icon, %aws-color-16-svg-prop !optional;
+  @extend %with-icon, %aws-color-16-svg-prop;
   background-image: var(--aws-color-16-svg);
 }
 %with-aws-color-16-mask {
-  @extend %with-mask, %aws-color-16-svg-prop !optional;
+  @extend %with-mask, %aws-color-16-svg-prop;
   -webkit-mask-image: var(--aws-color-16-svg);
   mask-image: var(--aws-color-16-svg);
 }
 
 %with-aws-color-24-icon {
-  @extend %with-icon, %aws-color-24-svg-prop !optional;
+  @extend %with-icon, %aws-color-24-svg-prop;
   background-image: var(--aws-color-24-svg);
 }
 %with-aws-color-24-mask {
-  @extend %with-mask, %aws-color-24-svg-prop !optional;
+  @extend %with-mask, %aws-color-24-svg-prop;
   -webkit-mask-image: var(--aws-color-24-svg);
   mask-image: var(--aws-color-24-svg);
 }
 
 %with-azure-16-icon {
-  @extend %with-icon, %azure-16-svg-prop !optional;
+  @extend %with-icon, %azure-16-svg-prop;
   background-image: var(--azure-16-svg);
 }
 %with-azure-16-mask {
-  @extend %with-mask, %azure-16-svg-prop !optional;
+  @extend %with-mask, %azure-16-svg-prop;
   -webkit-mask-image: var(--azure-16-svg);
   mask-image: var(--azure-16-svg);
 }
 
 %with-azure-24-icon {
-  @extend %with-icon, %azure-24-svg-prop !optional;
+  @extend %with-icon, %azure-24-svg-prop;
   background-image: var(--azure-24-svg);
 }
 %with-azure-24-mask {
-  @extend %with-mask, %azure-24-svg-prop !optional;
+  @extend %with-mask, %azure-24-svg-prop;
   -webkit-mask-image: var(--azure-24-svg);
   mask-image: var(--azure-24-svg);
 }
 
 %with-azure-color-16-icon {
-  @extend %with-icon, %azure-color-16-svg-prop !optional;
+  @extend %with-icon, %azure-color-16-svg-prop;
   background-image: var(--azure-color-16-svg);
 }
 %with-azure-color-16-mask {
-  @extend %with-mask, %azure-color-16-svg-prop !optional;
+  @extend %with-mask, %azure-color-16-svg-prop;
   -webkit-mask-image: var(--azure-color-16-svg);
   mask-image: var(--azure-color-16-svg);
 }
 
 %with-azure-color-24-icon {
-  @extend %with-icon, %azure-color-24-svg-prop !optional;
+  @extend %with-icon, %azure-color-24-svg-prop;
   background-image: var(--azure-color-24-svg);
 }
 %with-azure-color-24-mask {
-  @extend %with-mask, %azure-color-24-svg-prop !optional;
+  @extend %with-mask, %azure-color-24-svg-prop;
   -webkit-mask-image: var(--azure-color-24-svg);
   mask-image: var(--azure-color-24-svg);
 }
 
 %with-azure-devops-16-icon {
-  @extend %with-icon, %azure-devops-16-svg-prop !optional;
+  @extend %with-icon, %azure-devops-16-svg-prop;
   background-image: var(--azure-devops-16-svg);
 }
 %with-azure-devops-16-mask {
-  @extend %with-mask, %azure-devops-16-svg-prop !optional;
+  @extend %with-mask, %azure-devops-16-svg-prop;
   -webkit-mask-image: var(--azure-devops-16-svg);
   mask-image: var(--azure-devops-16-svg);
 }
 
 %with-azure-devops-24-icon {
-  @extend %with-icon, %azure-devops-24-svg-prop !optional;
+  @extend %with-icon, %azure-devops-24-svg-prop;
   background-image: var(--azure-devops-24-svg);
 }
 %with-azure-devops-24-mask {
-  @extend %with-mask, %azure-devops-24-svg-prop !optional;
+  @extend %with-mask, %azure-devops-24-svg-prop;
   -webkit-mask-image: var(--azure-devops-24-svg);
   mask-image: var(--azure-devops-24-svg);
 }
 
 %with-azure-devops-color-16-icon {
-  @extend %with-icon, %azure-devops-color-16-svg-prop !optional;
+  @extend %with-icon, %azure-devops-color-16-svg-prop;
   background-image: var(--azure-devops-color-16-svg);
 }
 %with-azure-devops-color-16-mask {
-  @extend %with-mask, %azure-devops-color-16-svg-prop !optional;
+  @extend %with-mask, %azure-devops-color-16-svg-prop;
   -webkit-mask-image: var(--azure-devops-color-16-svg);
   mask-image: var(--azure-devops-color-16-svg);
 }
 
 %with-azure-devops-color-24-icon {
-  @extend %with-icon, %azure-devops-color-24-svg-prop !optional;
+  @extend %with-icon, %azure-devops-color-24-svg-prop;
   background-image: var(--azure-devops-color-24-svg);
 }
 %with-azure-devops-color-24-mask {
-  @extend %with-mask, %azure-devops-color-24-svg-prop !optional;
+  @extend %with-mask, %azure-devops-color-24-svg-prop;
   -webkit-mask-image: var(--azure-devops-color-24-svg);
   mask-image: var(--azure-devops-color-24-svg);
 }
 
 %with-bar-chart-16-icon {
-  @extend %with-icon, %bar-chart-16-svg-prop !optional;
+  @extend %with-icon, %bar-chart-16-svg-prop;
   background-image: var(--bar-chart-16-svg);
 }
 %with-bar-chart-16-mask {
-  @extend %with-mask, %bar-chart-16-svg-prop !optional;
+  @extend %with-mask, %bar-chart-16-svg-prop;
   -webkit-mask-image: var(--bar-chart-16-svg);
   mask-image: var(--bar-chart-16-svg);
 }
 
 %with-bar-chart-24-icon {
-  @extend %with-icon, %bar-chart-24-svg-prop !optional;
+  @extend %with-icon, %bar-chart-24-svg-prop;
   background-image: var(--bar-chart-24-svg);
 }
 %with-bar-chart-24-mask {
-  @extend %with-mask, %bar-chart-24-svg-prop !optional;
+  @extend %with-mask, %bar-chart-24-svg-prop;
   -webkit-mask-image: var(--bar-chart-24-svg);
   mask-image: var(--bar-chart-24-svg);
 }
 
 %with-bar-chart-alt-16-icon {
-  @extend %with-icon, %bar-chart-alt-16-svg-prop !optional;
+  @extend %with-icon, %bar-chart-alt-16-svg-prop;
   background-image: var(--bar-chart-alt-16-svg);
 }
 %with-bar-chart-alt-16-mask {
-  @extend %with-mask, %bar-chart-alt-16-svg-prop !optional;
+  @extend %with-mask, %bar-chart-alt-16-svg-prop;
   -webkit-mask-image: var(--bar-chart-alt-16-svg);
   mask-image: var(--bar-chart-alt-16-svg);
 }
 
 %with-bar-chart-alt-24-icon {
-  @extend %with-icon, %bar-chart-alt-24-svg-prop !optional;
+  @extend %with-icon, %bar-chart-alt-24-svg-prop;
   background-image: var(--bar-chart-alt-24-svg);
 }
 %with-bar-chart-alt-24-mask {
-  @extend %with-mask, %bar-chart-alt-24-svg-prop !optional;
+  @extend %with-mask, %bar-chart-alt-24-svg-prop;
   -webkit-mask-image: var(--bar-chart-alt-24-svg);
   mask-image: var(--bar-chart-alt-24-svg);
 }
 
 %with-battery-16-icon {
-  @extend %with-icon, %battery-16-svg-prop !optional;
+  @extend %with-icon, %battery-16-svg-prop;
   background-image: var(--battery-16-svg);
 }
 %with-battery-16-mask {
-  @extend %with-mask, %battery-16-svg-prop !optional;
+  @extend %with-mask, %battery-16-svg-prop;
   -webkit-mask-image: var(--battery-16-svg);
   mask-image: var(--battery-16-svg);
 }
 
 %with-battery-24-icon {
-  @extend %with-icon, %battery-24-svg-prop !optional;
+  @extend %with-icon, %battery-24-svg-prop;
   background-image: var(--battery-24-svg);
 }
 %with-battery-24-mask {
-  @extend %with-mask, %battery-24-svg-prop !optional;
+  @extend %with-mask, %battery-24-svg-prop;
   -webkit-mask-image: var(--battery-24-svg);
   mask-image: var(--battery-24-svg);
 }
 
 %with-battery-charging-16-icon {
-  @extend %with-icon, %battery-charging-16-svg-prop !optional;
+  @extend %with-icon, %battery-charging-16-svg-prop;
   background-image: var(--battery-charging-16-svg);
 }
 %with-battery-charging-16-mask {
-  @extend %with-mask, %battery-charging-16-svg-prop !optional;
+  @extend %with-mask, %battery-charging-16-svg-prop;
   -webkit-mask-image: var(--battery-charging-16-svg);
   mask-image: var(--battery-charging-16-svg);
 }
 
 %with-battery-charging-24-icon {
-  @extend %with-icon, %battery-charging-24-svg-prop !optional;
+  @extend %with-icon, %battery-charging-24-svg-prop;
   background-image: var(--battery-charging-24-svg);
 }
 %with-battery-charging-24-mask {
-  @extend %with-mask, %battery-charging-24-svg-prop !optional;
+  @extend %with-mask, %battery-charging-24-svg-prop;
   -webkit-mask-image: var(--battery-charging-24-svg);
   mask-image: var(--battery-charging-24-svg);
 }
 
 %with-beaker-16-icon {
-  @extend %with-icon, %beaker-16-svg-prop !optional;
+  @extend %with-icon, %beaker-16-svg-prop;
   background-image: var(--beaker-16-svg);
 }
 %with-beaker-16-mask {
-  @extend %with-mask, %beaker-16-svg-prop !optional;
+  @extend %with-mask, %beaker-16-svg-prop;
   -webkit-mask-image: var(--beaker-16-svg);
   mask-image: var(--beaker-16-svg);
 }
 
 %with-beaker-24-icon {
-  @extend %with-icon, %beaker-24-svg-prop !optional;
+  @extend %with-icon, %beaker-24-svg-prop;
   background-image: var(--beaker-24-svg);
 }
 %with-beaker-24-mask {
-  @extend %with-mask, %beaker-24-svg-prop !optional;
+  @extend %with-mask, %beaker-24-svg-prop;
   -webkit-mask-image: var(--beaker-24-svg);
   mask-image: var(--beaker-24-svg);
 }
 
 %with-bell-16-icon {
-  @extend %with-icon, %bell-16-svg-prop !optional;
+  @extend %with-icon, %bell-16-svg-prop;
   background-image: var(--bell-16-svg);
 }
 %with-bell-16-mask {
-  @extend %with-mask, %bell-16-svg-prop !optional;
+  @extend %with-mask, %bell-16-svg-prop;
   -webkit-mask-image: var(--bell-16-svg);
   mask-image: var(--bell-16-svg);
 }
 
 %with-bell-24-icon {
-  @extend %with-icon, %bell-24-svg-prop !optional;
+  @extend %with-icon, %bell-24-svg-prop;
   background-image: var(--bell-24-svg);
 }
 %with-bell-24-mask {
-  @extend %with-mask, %bell-24-svg-prop !optional;
+  @extend %with-mask, %bell-24-svg-prop;
   -webkit-mask-image: var(--bell-24-svg);
   mask-image: var(--bell-24-svg);
 }
 
 %with-bell-active-16-icon {
-  @extend %with-icon, %bell-active-16-svg-prop !optional;
+  @extend %with-icon, %bell-active-16-svg-prop;
   background-image: var(--bell-active-16-svg);
 }
 %with-bell-active-16-mask {
-  @extend %with-mask, %bell-active-16-svg-prop !optional;
+  @extend %with-mask, %bell-active-16-svg-prop;
   -webkit-mask-image: var(--bell-active-16-svg);
   mask-image: var(--bell-active-16-svg);
 }
 
 %with-bell-active-24-icon {
-  @extend %with-icon, %bell-active-24-svg-prop !optional;
+  @extend %with-icon, %bell-active-24-svg-prop;
   background-image: var(--bell-active-24-svg);
 }
 %with-bell-active-24-mask {
-  @extend %with-mask, %bell-active-24-svg-prop !optional;
+  @extend %with-mask, %bell-active-24-svg-prop;
   -webkit-mask-image: var(--bell-active-24-svg);
   mask-image: var(--bell-active-24-svg);
 }
 
 %with-bell-active-fill-16-icon {
-  @extend %with-icon, %bell-active-fill-16-svg-prop !optional;
+  @extend %with-icon, %bell-active-fill-16-svg-prop;
   background-image: var(--bell-active-fill-16-svg);
 }
 %with-bell-active-fill-16-mask {
-  @extend %with-mask, %bell-active-fill-16-svg-prop !optional;
+  @extend %with-mask, %bell-active-fill-16-svg-prop;
   -webkit-mask-image: var(--bell-active-fill-16-svg);
   mask-image: var(--bell-active-fill-16-svg);
 }
 
 %with-bell-active-fill-24-icon {
-  @extend %with-icon, %bell-active-fill-24-svg-prop !optional;
+  @extend %with-icon, %bell-active-fill-24-svg-prop;
   background-image: var(--bell-active-fill-24-svg);
 }
 %with-bell-active-fill-24-mask {
-  @extend %with-mask, %bell-active-fill-24-svg-prop !optional;
+  @extend %with-mask, %bell-active-fill-24-svg-prop;
   -webkit-mask-image: var(--bell-active-fill-24-svg);
   mask-image: var(--bell-active-fill-24-svg);
 }
 
 %with-bell-off-16-icon {
-  @extend %with-icon, %bell-off-16-svg-prop !optional;
+  @extend %with-icon, %bell-off-16-svg-prop;
   background-image: var(--bell-off-16-svg);
 }
 %with-bell-off-16-mask {
-  @extend %with-mask, %bell-off-16-svg-prop !optional;
+  @extend %with-mask, %bell-off-16-svg-prop;
   -webkit-mask-image: var(--bell-off-16-svg);
   mask-image: var(--bell-off-16-svg);
 }
 
 %with-bell-off-24-icon {
-  @extend %with-icon, %bell-off-24-svg-prop !optional;
+  @extend %with-icon, %bell-off-24-svg-prop;
   background-image: var(--bell-off-24-svg);
 }
 %with-bell-off-24-mask {
-  @extend %with-mask, %bell-off-24-svg-prop !optional;
+  @extend %with-mask, %bell-off-24-svg-prop;
   -webkit-mask-image: var(--bell-off-24-svg);
   mask-image: var(--bell-off-24-svg);
 }
 
 %with-bitbucket-16-icon {
-  @extend %with-icon, %bitbucket-16-svg-prop !optional;
+  @extend %with-icon, %bitbucket-16-svg-prop;
   background-image: var(--bitbucket-16-svg);
 }
 %with-bitbucket-16-mask {
-  @extend %with-mask, %bitbucket-16-svg-prop !optional;
+  @extend %with-mask, %bitbucket-16-svg-prop;
   -webkit-mask-image: var(--bitbucket-16-svg);
   mask-image: var(--bitbucket-16-svg);
 }
 
 %with-bitbucket-24-icon {
-  @extend %with-icon, %bitbucket-24-svg-prop !optional;
+  @extend %with-icon, %bitbucket-24-svg-prop;
   background-image: var(--bitbucket-24-svg);
 }
 %with-bitbucket-24-mask {
-  @extend %with-mask, %bitbucket-24-svg-prop !optional;
+  @extend %with-mask, %bitbucket-24-svg-prop;
   -webkit-mask-image: var(--bitbucket-24-svg);
   mask-image: var(--bitbucket-24-svg);
 }
 
 %with-bitbucket-color-16-icon {
-  @extend %with-icon, %bitbucket-color-16-svg-prop !optional;
+  @extend %with-icon, %bitbucket-color-16-svg-prop;
   background-image: var(--bitbucket-color-16-svg);
 }
 %with-bitbucket-color-16-mask {
-  @extend %with-mask, %bitbucket-color-16-svg-prop !optional;
+  @extend %with-mask, %bitbucket-color-16-svg-prop;
   -webkit-mask-image: var(--bitbucket-color-16-svg);
   mask-image: var(--bitbucket-color-16-svg);
 }
 
 %with-bitbucket-color-24-icon {
-  @extend %with-icon, %bitbucket-color-24-svg-prop !optional;
+  @extend %with-icon, %bitbucket-color-24-svg-prop;
   background-image: var(--bitbucket-color-24-svg);
 }
 %with-bitbucket-color-24-mask {
-  @extend %with-mask, %bitbucket-color-24-svg-prop !optional;
+  @extend %with-mask, %bitbucket-color-24-svg-prop;
   -webkit-mask-image: var(--bitbucket-color-24-svg);
   mask-image: var(--bitbucket-color-24-svg);
 }
 
 %with-bolt-icon {
-  @extend %with-icon, %bolt-svg-prop !optional;
+  @extend %with-icon, %bolt-svg-prop;
   background-image: var(--bolt-svg);
 }
 %with-bolt-mask {
-  @extend %with-mask, %bolt-svg-prop !optional;
+  @extend %with-mask, %bolt-svg-prop;
   -webkit-mask-image: var(--bolt-svg);
   mask-image: var(--bolt-svg);
 }
 
 %with-bookmark-16-icon {
-  @extend %with-icon, %bookmark-16-svg-prop !optional;
+  @extend %with-icon, %bookmark-16-svg-prop;
   background-image: var(--bookmark-16-svg);
 }
 %with-bookmark-16-mask {
-  @extend %with-mask, %bookmark-16-svg-prop !optional;
+  @extend %with-mask, %bookmark-16-svg-prop;
   -webkit-mask-image: var(--bookmark-16-svg);
   mask-image: var(--bookmark-16-svg);
 }
 
 %with-bookmark-24-icon {
-  @extend %with-icon, %bookmark-24-svg-prop !optional;
+  @extend %with-icon, %bookmark-24-svg-prop;
   background-image: var(--bookmark-24-svg);
 }
 %with-bookmark-24-mask {
-  @extend %with-mask, %bookmark-24-svg-prop !optional;
+  @extend %with-mask, %bookmark-24-svg-prop;
   -webkit-mask-image: var(--bookmark-24-svg);
   mask-image: var(--bookmark-24-svg);
 }
 
 %with-bookmark-add-16-icon {
-  @extend %with-icon, %bookmark-add-16-svg-prop !optional;
+  @extend %with-icon, %bookmark-add-16-svg-prop;
   background-image: var(--bookmark-add-16-svg);
 }
 %with-bookmark-add-16-mask {
-  @extend %with-mask, %bookmark-add-16-svg-prop !optional;
+  @extend %with-mask, %bookmark-add-16-svg-prop;
   -webkit-mask-image: var(--bookmark-add-16-svg);
   mask-image: var(--bookmark-add-16-svg);
 }
 
 %with-bookmark-add-24-icon {
-  @extend %with-icon, %bookmark-add-24-svg-prop !optional;
+  @extend %with-icon, %bookmark-add-24-svg-prop;
   background-image: var(--bookmark-add-24-svg);
 }
 %with-bookmark-add-24-mask {
-  @extend %with-mask, %bookmark-add-24-svg-prop !optional;
+  @extend %with-mask, %bookmark-add-24-svg-prop;
   -webkit-mask-image: var(--bookmark-add-24-svg);
   mask-image: var(--bookmark-add-24-svg);
 }
 
 %with-bookmark-add-fill-16-icon {
-  @extend %with-icon, %bookmark-add-fill-16-svg-prop !optional;
+  @extend %with-icon, %bookmark-add-fill-16-svg-prop;
   background-image: var(--bookmark-add-fill-16-svg);
 }
 %with-bookmark-add-fill-16-mask {
-  @extend %with-mask, %bookmark-add-fill-16-svg-prop !optional;
+  @extend %with-mask, %bookmark-add-fill-16-svg-prop;
   -webkit-mask-image: var(--bookmark-add-fill-16-svg);
   mask-image: var(--bookmark-add-fill-16-svg);
 }
 
 %with-bookmark-add-fill-24-icon {
-  @extend %with-icon, %bookmark-add-fill-24-svg-prop !optional;
+  @extend %with-icon, %bookmark-add-fill-24-svg-prop;
   background-image: var(--bookmark-add-fill-24-svg);
 }
 %with-bookmark-add-fill-24-mask {
-  @extend %with-mask, %bookmark-add-fill-24-svg-prop !optional;
+  @extend %with-mask, %bookmark-add-fill-24-svg-prop;
   -webkit-mask-image: var(--bookmark-add-fill-24-svg);
   mask-image: var(--bookmark-add-fill-24-svg);
 }
 
 %with-bookmark-fill-16-icon {
-  @extend %with-icon, %bookmark-fill-16-svg-prop !optional;
+  @extend %with-icon, %bookmark-fill-16-svg-prop;
   background-image: var(--bookmark-fill-16-svg);
 }
 %with-bookmark-fill-16-mask {
-  @extend %with-mask, %bookmark-fill-16-svg-prop !optional;
+  @extend %with-mask, %bookmark-fill-16-svg-prop;
   -webkit-mask-image: var(--bookmark-fill-16-svg);
   mask-image: var(--bookmark-fill-16-svg);
 }
 
 %with-bookmark-fill-24-icon {
-  @extend %with-icon, %bookmark-fill-24-svg-prop !optional;
+  @extend %with-icon, %bookmark-fill-24-svg-prop;
   background-image: var(--bookmark-fill-24-svg);
 }
 %with-bookmark-fill-24-mask {
-  @extend %with-mask, %bookmark-fill-24-svg-prop !optional;
+  @extend %with-mask, %bookmark-fill-24-svg-prop;
   -webkit-mask-image: var(--bookmark-fill-24-svg);
   mask-image: var(--bookmark-fill-24-svg);
 }
 
 %with-bookmark-remove-16-icon {
-  @extend %with-icon, %bookmark-remove-16-svg-prop !optional;
+  @extend %with-icon, %bookmark-remove-16-svg-prop;
   background-image: var(--bookmark-remove-16-svg);
 }
 %with-bookmark-remove-16-mask {
-  @extend %with-mask, %bookmark-remove-16-svg-prop !optional;
+  @extend %with-mask, %bookmark-remove-16-svg-prop;
   -webkit-mask-image: var(--bookmark-remove-16-svg);
   mask-image: var(--bookmark-remove-16-svg);
 }
 
 %with-bookmark-remove-24-icon {
-  @extend %with-icon, %bookmark-remove-24-svg-prop !optional;
+  @extend %with-icon, %bookmark-remove-24-svg-prop;
   background-image: var(--bookmark-remove-24-svg);
 }
 %with-bookmark-remove-24-mask {
-  @extend %with-mask, %bookmark-remove-24-svg-prop !optional;
+  @extend %with-mask, %bookmark-remove-24-svg-prop;
   -webkit-mask-image: var(--bookmark-remove-24-svg);
   mask-image: var(--bookmark-remove-24-svg);
 }
 
 %with-bookmark-remove-fill-16-icon {
-  @extend %with-icon, %bookmark-remove-fill-16-svg-prop !optional;
+  @extend %with-icon, %bookmark-remove-fill-16-svg-prop;
   background-image: var(--bookmark-remove-fill-16-svg);
 }
 %with-bookmark-remove-fill-16-mask {
-  @extend %with-mask, %bookmark-remove-fill-16-svg-prop !optional;
+  @extend %with-mask, %bookmark-remove-fill-16-svg-prop;
   -webkit-mask-image: var(--bookmark-remove-fill-16-svg);
   mask-image: var(--bookmark-remove-fill-16-svg);
 }
 
 %with-bookmark-remove-fill-24-icon {
-  @extend %with-icon, %bookmark-remove-fill-24-svg-prop !optional;
+  @extend %with-icon, %bookmark-remove-fill-24-svg-prop;
   background-image: var(--bookmark-remove-fill-24-svg);
 }
 %with-bookmark-remove-fill-24-mask {
-  @extend %with-mask, %bookmark-remove-fill-24-svg-prop !optional;
+  @extend %with-mask, %bookmark-remove-fill-24-svg-prop;
   -webkit-mask-image: var(--bookmark-remove-fill-24-svg);
   mask-image: var(--bookmark-remove-fill-24-svg);
 }
 
 %with-bottom-16-icon {
-  @extend %with-icon, %bottom-16-svg-prop !optional;
+  @extend %with-icon, %bottom-16-svg-prop;
   background-image: var(--bottom-16-svg);
 }
 %with-bottom-16-mask {
-  @extend %with-mask, %bottom-16-svg-prop !optional;
+  @extend %with-mask, %bottom-16-svg-prop;
   -webkit-mask-image: var(--bottom-16-svg);
   mask-image: var(--bottom-16-svg);
 }
 
 %with-bottom-24-icon {
-  @extend %with-icon, %bottom-24-svg-prop !optional;
+  @extend %with-icon, %bottom-24-svg-prop;
   background-image: var(--bottom-24-svg);
 }
 %with-bottom-24-mask {
-  @extend %with-mask, %bottom-24-svg-prop !optional;
+  @extend %with-mask, %bottom-24-svg-prop;
   -webkit-mask-image: var(--bottom-24-svg);
   mask-image: var(--bottom-24-svg);
 }
 
 %with-box-16-icon {
-  @extend %with-icon, %box-16-svg-prop !optional;
+  @extend %with-icon, %box-16-svg-prop;
   background-image: var(--box-16-svg);
 }
 %with-box-16-mask {
-  @extend %with-mask, %box-16-svg-prop !optional;
+  @extend %with-mask, %box-16-svg-prop;
   -webkit-mask-image: var(--box-16-svg);
   mask-image: var(--box-16-svg);
 }
 
 %with-box-24-icon {
-  @extend %with-icon, %box-24-svg-prop !optional;
+  @extend %with-icon, %box-24-svg-prop;
   background-image: var(--box-24-svg);
 }
 %with-box-24-mask {
-  @extend %with-mask, %box-24-svg-prop !optional;
+  @extend %with-mask, %box-24-svg-prop;
   -webkit-mask-image: var(--box-24-svg);
   mask-image: var(--box-24-svg);
 }
 
 %with-box-check-fill-icon {
-  @extend %with-icon, %box-check-fill-svg-prop !optional;
+  @extend %with-icon, %box-check-fill-svg-prop;
   background-image: var(--box-check-fill-svg);
 }
 %with-box-check-fill-mask {
-  @extend %with-mask, %box-check-fill-svg-prop !optional;
+  @extend %with-mask, %box-check-fill-svg-prop;
   -webkit-mask-image: var(--box-check-fill-svg);
   mask-image: var(--box-check-fill-svg);
 }
 
 %with-box-outline-icon {
-  @extend %with-icon, %box-outline-svg-prop !optional;
+  @extend %with-icon, %box-outline-svg-prop;
   background-image: var(--box-outline-svg);
 }
 %with-box-outline-mask {
-  @extend %with-mask, %box-outline-svg-prop !optional;
+  @extend %with-mask, %box-outline-svg-prop;
   -webkit-mask-image: var(--box-outline-svg);
   mask-image: var(--box-outline-svg);
 }
 
 %with-briefcase-16-icon {
-  @extend %with-icon, %briefcase-16-svg-prop !optional;
+  @extend %with-icon, %briefcase-16-svg-prop;
   background-image: var(--briefcase-16-svg);
 }
 %with-briefcase-16-mask {
-  @extend %with-mask, %briefcase-16-svg-prop !optional;
+  @extend %with-mask, %briefcase-16-svg-prop;
   -webkit-mask-image: var(--briefcase-16-svg);
   mask-image: var(--briefcase-16-svg);
 }
 
 %with-briefcase-24-icon {
-  @extend %with-icon, %briefcase-24-svg-prop !optional;
+  @extend %with-icon, %briefcase-24-svg-prop;
   background-image: var(--briefcase-24-svg);
 }
 %with-briefcase-24-mask {
-  @extend %with-mask, %briefcase-24-svg-prop !optional;
+  @extend %with-mask, %briefcase-24-svg-prop;
   -webkit-mask-image: var(--briefcase-24-svg);
   mask-image: var(--briefcase-24-svg);
 }
 
 %with-broadcast-icon {
-  @extend %with-icon, %broadcast-svg-prop !optional;
+  @extend %with-icon, %broadcast-svg-prop;
   background-image: var(--broadcast-svg);
 }
 %with-broadcast-mask {
-  @extend %with-mask, %broadcast-svg-prop !optional;
+  @extend %with-mask, %broadcast-svg-prop;
   -webkit-mask-image: var(--broadcast-svg);
   mask-image: var(--broadcast-svg);
 }
 
 %with-bug-16-icon {
-  @extend %with-icon, %bug-16-svg-prop !optional;
+  @extend %with-icon, %bug-16-svg-prop;
   background-image: var(--bug-16-svg);
 }
 %with-bug-16-mask {
-  @extend %with-mask, %bug-16-svg-prop !optional;
+  @extend %with-mask, %bug-16-svg-prop;
   -webkit-mask-image: var(--bug-16-svg);
   mask-image: var(--bug-16-svg);
 }
 
 %with-bug-24-icon {
-  @extend %with-icon, %bug-24-svg-prop !optional;
+  @extend %with-icon, %bug-24-svg-prop;
   background-image: var(--bug-24-svg);
 }
 %with-bug-24-mask {
-  @extend %with-mask, %bug-24-svg-prop !optional;
+  @extend %with-mask, %bug-24-svg-prop;
   -webkit-mask-image: var(--bug-24-svg);
   mask-image: var(--bug-24-svg);
 }
 
 %with-bug-icon {
-  @extend %with-icon, %bug-svg-prop !optional;
+  @extend %with-icon, %bug-svg-prop;
   background-image: var(--bug-svg);
 }
 %with-bug-mask {
-  @extend %with-mask, %bug-svg-prop !optional;
+  @extend %with-mask, %bug-svg-prop;
   -webkit-mask-image: var(--bug-svg);
   mask-image: var(--bug-svg);
 }
 
 %with-build-16-icon {
-  @extend %with-icon, %build-16-svg-prop !optional;
+  @extend %with-icon, %build-16-svg-prop;
   background-image: var(--build-16-svg);
 }
 %with-build-16-mask {
-  @extend %with-mask, %build-16-svg-prop !optional;
+  @extend %with-mask, %build-16-svg-prop;
   -webkit-mask-image: var(--build-16-svg);
   mask-image: var(--build-16-svg);
 }
 
 %with-build-24-icon {
-  @extend %with-icon, %build-24-svg-prop !optional;
+  @extend %with-icon, %build-24-svg-prop;
   background-image: var(--build-24-svg);
 }
 %with-build-24-mask {
-  @extend %with-mask, %build-24-svg-prop !optional;
+  @extend %with-mask, %build-24-svg-prop;
   -webkit-mask-image: var(--build-24-svg);
   mask-image: var(--build-24-svg);
 }
 
 %with-calendar-16-icon {
-  @extend %with-icon, %calendar-16-svg-prop !optional;
+  @extend %with-icon, %calendar-16-svg-prop;
   background-image: var(--calendar-16-svg);
 }
 %with-calendar-16-mask {
-  @extend %with-mask, %calendar-16-svg-prop !optional;
+  @extend %with-mask, %calendar-16-svg-prop;
   -webkit-mask-image: var(--calendar-16-svg);
   mask-image: var(--calendar-16-svg);
 }
 
 %with-calendar-24-icon {
-  @extend %with-icon, %calendar-24-svg-prop !optional;
+  @extend %with-icon, %calendar-24-svg-prop;
   background-image: var(--calendar-24-svg);
 }
 %with-calendar-24-mask {
-  @extend %with-mask, %calendar-24-svg-prop !optional;
+  @extend %with-mask, %calendar-24-svg-prop;
   -webkit-mask-image: var(--calendar-24-svg);
   mask-image: var(--calendar-24-svg);
 }
 
 %with-calendar-icon {
-  @extend %with-icon, %calendar-svg-prop !optional;
+  @extend %with-icon, %calendar-svg-prop;
   background-image: var(--calendar-svg);
 }
 %with-calendar-mask {
-  @extend %with-mask, %calendar-svg-prop !optional;
+  @extend %with-mask, %calendar-svg-prop;
   -webkit-mask-image: var(--calendar-svg);
   mask-image: var(--calendar-svg);
 }
 
 %with-camera-16-icon {
-  @extend %with-icon, %camera-16-svg-prop !optional;
+  @extend %with-icon, %camera-16-svg-prop;
   background-image: var(--camera-16-svg);
 }
 %with-camera-16-mask {
-  @extend %with-mask, %camera-16-svg-prop !optional;
+  @extend %with-mask, %camera-16-svg-prop;
   -webkit-mask-image: var(--camera-16-svg);
   mask-image: var(--camera-16-svg);
 }
 
 %with-camera-24-icon {
-  @extend %with-icon, %camera-24-svg-prop !optional;
+  @extend %with-icon, %camera-24-svg-prop;
   background-image: var(--camera-24-svg);
 }
 %with-camera-24-mask {
-  @extend %with-mask, %camera-24-svg-prop !optional;
+  @extend %with-mask, %camera-24-svg-prop;
   -webkit-mask-image: var(--camera-24-svg);
   mask-image: var(--camera-24-svg);
 }
 
 %with-camera-off-16-icon {
-  @extend %with-icon, %camera-off-16-svg-prop !optional;
+  @extend %with-icon, %camera-off-16-svg-prop;
   background-image: var(--camera-off-16-svg);
 }
 %with-camera-off-16-mask {
-  @extend %with-mask, %camera-off-16-svg-prop !optional;
+  @extend %with-mask, %camera-off-16-svg-prop;
   -webkit-mask-image: var(--camera-off-16-svg);
   mask-image: var(--camera-off-16-svg);
 }
 
 %with-camera-off-24-icon {
-  @extend %with-icon, %camera-off-24-svg-prop !optional;
+  @extend %with-icon, %camera-off-24-svg-prop;
   background-image: var(--camera-off-24-svg);
 }
 %with-camera-off-24-mask {
-  @extend %with-mask, %camera-off-24-svg-prop !optional;
+  @extend %with-mask, %camera-off-24-svg-prop;
   -webkit-mask-image: var(--camera-off-24-svg);
   mask-image: var(--camera-off-24-svg);
 }
 
 %with-cancel-circle-fill-icon {
-  @extend %with-icon, %cancel-circle-fill-svg-prop !optional;
+  @extend %with-icon, %cancel-circle-fill-svg-prop;
   background-image: var(--cancel-circle-fill-svg);
 }
 %with-cancel-circle-fill-mask {
-  @extend %with-mask, %cancel-circle-fill-svg-prop !optional;
+  @extend %with-mask, %cancel-circle-fill-svg-prop;
   -webkit-mask-image: var(--cancel-circle-fill-svg);
   mask-image: var(--cancel-circle-fill-svg);
 }
 
 %with-cancel-circle-outline-icon {
-  @extend %with-icon, %cancel-circle-outline-svg-prop !optional;
+  @extend %with-icon, %cancel-circle-outline-svg-prop;
   background-image: var(--cancel-circle-outline-svg);
 }
 %with-cancel-circle-outline-mask {
-  @extend %with-mask, %cancel-circle-outline-svg-prop !optional;
+  @extend %with-mask, %cancel-circle-outline-svg-prop;
   -webkit-mask-image: var(--cancel-circle-outline-svg);
   mask-image: var(--cancel-circle-outline-svg);
 }
 
 %with-cancel-plain-icon {
-  @extend %with-icon, %cancel-plain-svg-prop !optional;
+  @extend %with-icon, %cancel-plain-svg-prop;
   background-image: var(--cancel-plain-svg);
 }
 %with-cancel-plain-mask {
-  @extend %with-mask, %cancel-plain-svg-prop !optional;
+  @extend %with-mask, %cancel-plain-svg-prop;
   -webkit-mask-image: var(--cancel-plain-svg);
   mask-image: var(--cancel-plain-svg);
 }
 
 %with-cancel-square-fill-icon {
-  @extend %with-icon, %cancel-square-fill-svg-prop !optional;
+  @extend %with-icon, %cancel-square-fill-svg-prop;
   background-image: var(--cancel-square-fill-svg);
 }
 %with-cancel-square-fill-mask {
-  @extend %with-mask, %cancel-square-fill-svg-prop !optional;
+  @extend %with-mask, %cancel-square-fill-svg-prop;
   -webkit-mask-image: var(--cancel-square-fill-svg);
   mask-image: var(--cancel-square-fill-svg);
 }
 
 %with-cancel-square-outline-icon {
-  @extend %with-icon, %cancel-square-outline-svg-prop !optional;
+  @extend %with-icon, %cancel-square-outline-svg-prop;
   background-image: var(--cancel-square-outline-svg);
 }
 %with-cancel-square-outline-mask {
-  @extend %with-mask, %cancel-square-outline-svg-prop !optional;
+  @extend %with-mask, %cancel-square-outline-svg-prop;
   -webkit-mask-image: var(--cancel-square-outline-svg);
   mask-image: var(--cancel-square-outline-svg);
 }
 
 %with-caret-16-icon {
-  @extend %with-icon, %caret-16-svg-prop !optional;
+  @extend %with-icon, %caret-16-svg-prop;
   background-image: var(--caret-16-svg);
 }
 %with-caret-16-mask {
-  @extend %with-mask, %caret-16-svg-prop !optional;
+  @extend %with-mask, %caret-16-svg-prop;
   -webkit-mask-image: var(--caret-16-svg);
   mask-image: var(--caret-16-svg);
 }
 
 %with-caret-24-icon {
-  @extend %with-icon, %caret-24-svg-prop !optional;
+  @extend %with-icon, %caret-24-svg-prop;
   background-image: var(--caret-24-svg);
 }
 %with-caret-24-mask {
-  @extend %with-mask, %caret-24-svg-prop !optional;
+  @extend %with-mask, %caret-24-svg-prop;
   -webkit-mask-image: var(--caret-24-svg);
   mask-image: var(--caret-24-svg);
 }
 
 %with-caret-down-icon {
-  @extend %with-icon, %caret-down-svg-prop !optional;
+  @extend %with-icon, %caret-down-svg-prop;
   background-image: var(--caret-down-svg);
 }
 %with-caret-down-mask {
-  @extend %with-mask, %caret-down-svg-prop !optional;
+  @extend %with-mask, %caret-down-svg-prop;
   -webkit-mask-image: var(--caret-down-svg);
   mask-image: var(--caret-down-svg);
 }
 
 %with-caret-up-icon {
-  @extend %with-icon, %caret-up-svg-prop !optional;
+  @extend %with-icon, %caret-up-svg-prop;
   background-image: var(--caret-up-svg);
 }
 %with-caret-up-mask {
-  @extend %with-mask, %caret-up-svg-prop !optional;
+  @extend %with-mask, %caret-up-svg-prop;
   -webkit-mask-image: var(--caret-up-svg);
   mask-image: var(--caret-up-svg);
 }
 
 %with-cast-16-icon {
-  @extend %with-icon, %cast-16-svg-prop !optional;
+  @extend %with-icon, %cast-16-svg-prop;
   background-image: var(--cast-16-svg);
 }
 %with-cast-16-mask {
-  @extend %with-mask, %cast-16-svg-prop !optional;
+  @extend %with-mask, %cast-16-svg-prop;
   -webkit-mask-image: var(--cast-16-svg);
   mask-image: var(--cast-16-svg);
 }
 
 %with-cast-24-icon {
-  @extend %with-icon, %cast-24-svg-prop !optional;
+  @extend %with-icon, %cast-24-svg-prop;
   background-image: var(--cast-24-svg);
 }
 %with-cast-24-mask {
-  @extend %with-mask, %cast-24-svg-prop !optional;
+  @extend %with-mask, %cast-24-svg-prop;
   -webkit-mask-image: var(--cast-24-svg);
   mask-image: var(--cast-24-svg);
 }
 
 %with-certificate-16-icon {
-  @extend %with-icon, %certificate-16-svg-prop !optional;
+  @extend %with-icon, %certificate-16-svg-prop;
   background-image: var(--certificate-16-svg);
 }
 %with-certificate-16-mask {
-  @extend %with-mask, %certificate-16-svg-prop !optional;
+  @extend %with-mask, %certificate-16-svg-prop;
   -webkit-mask-image: var(--certificate-16-svg);
   mask-image: var(--certificate-16-svg);
 }
 
 %with-certificate-24-icon {
-  @extend %with-icon, %certificate-24-svg-prop !optional;
+  @extend %with-icon, %certificate-24-svg-prop;
   background-image: var(--certificate-24-svg);
 }
 %with-certificate-24-mask {
-  @extend %with-mask, %certificate-24-svg-prop !optional;
+  @extend %with-mask, %certificate-24-svg-prop;
   -webkit-mask-image: var(--certificate-24-svg);
   mask-image: var(--certificate-24-svg);
 }
 
 %with-change-16-icon {
-  @extend %with-icon, %change-16-svg-prop !optional;
+  @extend %with-icon, %change-16-svg-prop;
   background-image: var(--change-16-svg);
 }
 %with-change-16-mask {
-  @extend %with-mask, %change-16-svg-prop !optional;
+  @extend %with-mask, %change-16-svg-prop;
   -webkit-mask-image: var(--change-16-svg);
   mask-image: var(--change-16-svg);
 }
 
 %with-change-24-icon {
-  @extend %with-icon, %change-24-svg-prop !optional;
+  @extend %with-icon, %change-24-svg-prop;
   background-image: var(--change-24-svg);
 }
 %with-change-24-mask {
-  @extend %with-mask, %change-24-svg-prop !optional;
+  @extend %with-mask, %change-24-svg-prop;
   -webkit-mask-image: var(--change-24-svg);
   mask-image: var(--change-24-svg);
 }
 
 %with-change-circle-16-icon {
-  @extend %with-icon, %change-circle-16-svg-prop !optional;
+  @extend %with-icon, %change-circle-16-svg-prop;
   background-image: var(--change-circle-16-svg);
 }
 %with-change-circle-16-mask {
-  @extend %with-mask, %change-circle-16-svg-prop !optional;
+  @extend %with-mask, %change-circle-16-svg-prop;
   -webkit-mask-image: var(--change-circle-16-svg);
   mask-image: var(--change-circle-16-svg);
 }
 
 %with-change-circle-24-icon {
-  @extend %with-icon, %change-circle-24-svg-prop !optional;
+  @extend %with-icon, %change-circle-24-svg-prop;
   background-image: var(--change-circle-24-svg);
 }
 %with-change-circle-24-mask {
-  @extend %with-mask, %change-circle-24-svg-prop !optional;
+  @extend %with-mask, %change-circle-24-svg-prop;
   -webkit-mask-image: var(--change-circle-24-svg);
   mask-image: var(--change-circle-24-svg);
 }
 
 %with-change-square-16-icon {
-  @extend %with-icon, %change-square-16-svg-prop !optional;
+  @extend %with-icon, %change-square-16-svg-prop;
   background-image: var(--change-square-16-svg);
 }
 %with-change-square-16-mask {
-  @extend %with-mask, %change-square-16-svg-prop !optional;
+  @extend %with-mask, %change-square-16-svg-prop;
   -webkit-mask-image: var(--change-square-16-svg);
   mask-image: var(--change-square-16-svg);
 }
 
 %with-change-square-24-icon {
-  @extend %with-icon, %change-square-24-svg-prop !optional;
+  @extend %with-icon, %change-square-24-svg-prop;
   background-image: var(--change-square-24-svg);
 }
 %with-change-square-24-mask {
-  @extend %with-mask, %change-square-24-svg-prop !optional;
+  @extend %with-mask, %change-square-24-svg-prop;
   -webkit-mask-image: var(--change-square-24-svg);
   mask-image: var(--change-square-24-svg);
 }
 
 %with-check-16-icon {
-  @extend %with-icon, %check-16-svg-prop !optional;
+  @extend %with-icon, %check-16-svg-prop;
   background-image: var(--check-16-svg);
 }
 %with-check-16-mask {
-  @extend %with-mask, %check-16-svg-prop !optional;
+  @extend %with-mask, %check-16-svg-prop;
   -webkit-mask-image: var(--check-16-svg);
   mask-image: var(--check-16-svg);
 }
 
 %with-check-24-icon {
-  @extend %with-icon, %check-24-svg-prop !optional;
+  @extend %with-icon, %check-24-svg-prop;
   background-image: var(--check-24-svg);
 }
 %with-check-24-mask {
-  @extend %with-mask, %check-24-svg-prop !optional;
+  @extend %with-mask, %check-24-svg-prop;
   -webkit-mask-image: var(--check-24-svg);
   mask-image: var(--check-24-svg);
 }
 
 %with-check-circle-16-icon {
-  @extend %with-icon, %check-circle-16-svg-prop !optional;
+  @extend %with-icon, %check-circle-16-svg-prop;
   background-image: var(--check-circle-16-svg);
 }
 %with-check-circle-16-mask {
-  @extend %with-mask, %check-circle-16-svg-prop !optional;
+  @extend %with-mask, %check-circle-16-svg-prop;
   -webkit-mask-image: var(--check-circle-16-svg);
   mask-image: var(--check-circle-16-svg);
 }
 
 %with-check-circle-24-icon {
-  @extend %with-icon, %check-circle-24-svg-prop !optional;
+  @extend %with-icon, %check-circle-24-svg-prop;
   background-image: var(--check-circle-24-svg);
 }
 %with-check-circle-24-mask {
-  @extend %with-mask, %check-circle-24-svg-prop !optional;
+  @extend %with-mask, %check-circle-24-svg-prop;
   -webkit-mask-image: var(--check-circle-24-svg);
   mask-image: var(--check-circle-24-svg);
 }
 
 %with-check-circle-fill-16-icon {
-  @extend %with-icon, %check-circle-fill-16-svg-prop !optional;
+  @extend %with-icon, %check-circle-fill-16-svg-prop;
   background-image: var(--check-circle-fill-16-svg);
 }
 %with-check-circle-fill-16-mask {
-  @extend %with-mask, %check-circle-fill-16-svg-prop !optional;
+  @extend %with-mask, %check-circle-fill-16-svg-prop;
   -webkit-mask-image: var(--check-circle-fill-16-svg);
   mask-image: var(--check-circle-fill-16-svg);
 }
 
 %with-check-circle-fill-24-icon {
-  @extend %with-icon, %check-circle-fill-24-svg-prop !optional;
+  @extend %with-icon, %check-circle-fill-24-svg-prop;
   background-image: var(--check-circle-fill-24-svg);
 }
 %with-check-circle-fill-24-mask {
-  @extend %with-mask, %check-circle-fill-24-svg-prop !optional;
+  @extend %with-mask, %check-circle-fill-24-svg-prop;
   -webkit-mask-image: var(--check-circle-fill-24-svg);
   mask-image: var(--check-circle-fill-24-svg);
 }
 
 %with-check-circle-fill-icon {
-  @extend %with-icon, %check-circle-fill-svg-prop !optional;
+  @extend %with-icon, %check-circle-fill-svg-prop;
   background-image: var(--check-circle-fill-svg);
 }
 %with-check-circle-fill-mask {
-  @extend %with-mask, %check-circle-fill-svg-prop !optional;
+  @extend %with-mask, %check-circle-fill-svg-prop;
   -webkit-mask-image: var(--check-circle-fill-svg);
   mask-image: var(--check-circle-fill-svg);
 }
 
 %with-check-circle-outline-icon {
-  @extend %with-icon, %check-circle-outline-svg-prop !optional;
+  @extend %with-icon, %check-circle-outline-svg-prop;
   background-image: var(--check-circle-outline-svg);
 }
 %with-check-circle-outline-mask {
-  @extend %with-mask, %check-circle-outline-svg-prop !optional;
+  @extend %with-mask, %check-circle-outline-svg-prop;
   -webkit-mask-image: var(--check-circle-outline-svg);
   mask-image: var(--check-circle-outline-svg);
 }
 
 %with-check-diamond-16-icon {
-  @extend %with-icon, %check-diamond-16-svg-prop !optional;
+  @extend %with-icon, %check-diamond-16-svg-prop;
   background-image: var(--check-diamond-16-svg);
 }
 %with-check-diamond-16-mask {
-  @extend %with-mask, %check-diamond-16-svg-prop !optional;
+  @extend %with-mask, %check-diamond-16-svg-prop;
   -webkit-mask-image: var(--check-diamond-16-svg);
   mask-image: var(--check-diamond-16-svg);
 }
 
 %with-check-diamond-24-icon {
-  @extend %with-icon, %check-diamond-24-svg-prop !optional;
+  @extend %with-icon, %check-diamond-24-svg-prop;
   background-image: var(--check-diamond-24-svg);
 }
 %with-check-diamond-24-mask {
-  @extend %with-mask, %check-diamond-24-svg-prop !optional;
+  @extend %with-mask, %check-diamond-24-svg-prop;
   -webkit-mask-image: var(--check-diamond-24-svg);
   mask-image: var(--check-diamond-24-svg);
 }
 
 %with-check-diamond-fill-16-icon {
-  @extend %with-icon, %check-diamond-fill-16-svg-prop !optional;
+  @extend %with-icon, %check-diamond-fill-16-svg-prop;
   background-image: var(--check-diamond-fill-16-svg);
 }
 %with-check-diamond-fill-16-mask {
-  @extend %with-mask, %check-diamond-fill-16-svg-prop !optional;
+  @extend %with-mask, %check-diamond-fill-16-svg-prop;
   -webkit-mask-image: var(--check-diamond-fill-16-svg);
   mask-image: var(--check-diamond-fill-16-svg);
 }
 
 %with-check-diamond-fill-24-icon {
-  @extend %with-icon, %check-diamond-fill-24-svg-prop !optional;
+  @extend %with-icon, %check-diamond-fill-24-svg-prop;
   background-image: var(--check-diamond-fill-24-svg);
 }
 %with-check-diamond-fill-24-mask {
-  @extend %with-mask, %check-diamond-fill-24-svg-prop !optional;
+  @extend %with-mask, %check-diamond-fill-24-svg-prop;
   -webkit-mask-image: var(--check-diamond-fill-24-svg);
   mask-image: var(--check-diamond-fill-24-svg);
 }
 
 %with-check-hexagon-16-icon {
-  @extend %with-icon, %check-hexagon-16-svg-prop !optional;
+  @extend %with-icon, %check-hexagon-16-svg-prop;
   background-image: var(--check-hexagon-16-svg);
 }
 %with-check-hexagon-16-mask {
-  @extend %with-mask, %check-hexagon-16-svg-prop !optional;
+  @extend %with-mask, %check-hexagon-16-svg-prop;
   -webkit-mask-image: var(--check-hexagon-16-svg);
   mask-image: var(--check-hexagon-16-svg);
 }
 
 %with-check-hexagon-24-icon {
-  @extend %with-icon, %check-hexagon-24-svg-prop !optional;
+  @extend %with-icon, %check-hexagon-24-svg-prop;
   background-image: var(--check-hexagon-24-svg);
 }
 %with-check-hexagon-24-mask {
-  @extend %with-mask, %check-hexagon-24-svg-prop !optional;
+  @extend %with-mask, %check-hexagon-24-svg-prop;
   -webkit-mask-image: var(--check-hexagon-24-svg);
   mask-image: var(--check-hexagon-24-svg);
 }
 
 %with-check-hexagon-fill-16-icon {
-  @extend %with-icon, %check-hexagon-fill-16-svg-prop !optional;
+  @extend %with-icon, %check-hexagon-fill-16-svg-prop;
   background-image: var(--check-hexagon-fill-16-svg);
 }
 %with-check-hexagon-fill-16-mask {
-  @extend %with-mask, %check-hexagon-fill-16-svg-prop !optional;
+  @extend %with-mask, %check-hexagon-fill-16-svg-prop;
   -webkit-mask-image: var(--check-hexagon-fill-16-svg);
   mask-image: var(--check-hexagon-fill-16-svg);
 }
 
 %with-check-hexagon-fill-24-icon {
-  @extend %with-icon, %check-hexagon-fill-24-svg-prop !optional;
+  @extend %with-icon, %check-hexagon-fill-24-svg-prop;
   background-image: var(--check-hexagon-fill-24-svg);
 }
 %with-check-hexagon-fill-24-mask {
-  @extend %with-mask, %check-hexagon-fill-24-svg-prop !optional;
+  @extend %with-mask, %check-hexagon-fill-24-svg-prop;
   -webkit-mask-image: var(--check-hexagon-fill-24-svg);
   mask-image: var(--check-hexagon-fill-24-svg);
 }
 
 %with-check-plain-icon {
-  @extend %with-icon, %check-plain-svg-prop !optional;
+  @extend %with-icon, %check-plain-svg-prop;
   background-image: var(--check-plain-svg);
 }
 %with-check-plain-mask {
-  @extend %with-mask, %check-plain-svg-prop !optional;
+  @extend %with-mask, %check-plain-svg-prop;
   -webkit-mask-image: var(--check-plain-svg);
   mask-image: var(--check-plain-svg);
 }
 
 %with-check-square-16-icon {
-  @extend %with-icon, %check-square-16-svg-prop !optional;
+  @extend %with-icon, %check-square-16-svg-prop;
   background-image: var(--check-square-16-svg);
 }
 %with-check-square-16-mask {
-  @extend %with-mask, %check-square-16-svg-prop !optional;
+  @extend %with-mask, %check-square-16-svg-prop;
   -webkit-mask-image: var(--check-square-16-svg);
   mask-image: var(--check-square-16-svg);
 }
 
 %with-check-square-24-icon {
-  @extend %with-icon, %check-square-24-svg-prop !optional;
+  @extend %with-icon, %check-square-24-svg-prop;
   background-image: var(--check-square-24-svg);
 }
 %with-check-square-24-mask {
-  @extend %with-mask, %check-square-24-svg-prop !optional;
+  @extend %with-mask, %check-square-24-svg-prop;
   -webkit-mask-image: var(--check-square-24-svg);
   mask-image: var(--check-square-24-svg);
 }
 
 %with-check-square-fill-16-icon {
-  @extend %with-icon, %check-square-fill-16-svg-prop !optional;
+  @extend %with-icon, %check-square-fill-16-svg-prop;
   background-image: var(--check-square-fill-16-svg);
 }
 %with-check-square-fill-16-mask {
-  @extend %with-mask, %check-square-fill-16-svg-prop !optional;
+  @extend %with-mask, %check-square-fill-16-svg-prop;
   -webkit-mask-image: var(--check-square-fill-16-svg);
   mask-image: var(--check-square-fill-16-svg);
 }
 
 %with-check-square-fill-24-icon {
-  @extend %with-icon, %check-square-fill-24-svg-prop !optional;
+  @extend %with-icon, %check-square-fill-24-svg-prop;
   background-image: var(--check-square-fill-24-svg);
 }
 %with-check-square-fill-24-mask {
-  @extend %with-mask, %check-square-fill-24-svg-prop !optional;
+  @extend %with-mask, %check-square-fill-24-svg-prop;
   -webkit-mask-image: var(--check-square-fill-24-svg);
   mask-image: var(--check-square-fill-24-svg);
 }
 
 %with-chevron-down-16-icon {
-  @extend %with-icon, %chevron-down-16-svg-prop !optional;
+  @extend %with-icon, %chevron-down-16-svg-prop;
   background-image: var(--chevron-down-16-svg);
 }
 %with-chevron-down-16-mask {
-  @extend %with-mask, %chevron-down-16-svg-prop !optional;
+  @extend %with-mask, %chevron-down-16-svg-prop;
   -webkit-mask-image: var(--chevron-down-16-svg);
   mask-image: var(--chevron-down-16-svg);
 }
 
 %with-chevron-down-24-icon {
-  @extend %with-icon, %chevron-down-24-svg-prop !optional;
+  @extend %with-icon, %chevron-down-24-svg-prop;
   background-image: var(--chevron-down-24-svg);
 }
 %with-chevron-down-24-mask {
-  @extend %with-mask, %chevron-down-24-svg-prop !optional;
+  @extend %with-mask, %chevron-down-24-svg-prop;
   -webkit-mask-image: var(--chevron-down-24-svg);
   mask-image: var(--chevron-down-24-svg);
 }
 
 %with-chevron-down-icon {
-  @extend %with-icon, %chevron-down-svg-prop !optional;
+  @extend %with-icon, %chevron-down-svg-prop;
   background-image: var(--chevron-down-svg);
 }
 %with-chevron-down-mask {
-  @extend %with-mask, %chevron-down-svg-prop !optional;
+  @extend %with-mask, %chevron-down-svg-prop;
   -webkit-mask-image: var(--chevron-down-svg);
   mask-image: var(--chevron-down-svg);
 }
 
 %with-chevron-left-16-icon {
-  @extend %with-icon, %chevron-left-16-svg-prop !optional;
+  @extend %with-icon, %chevron-left-16-svg-prop;
   background-image: var(--chevron-left-16-svg);
 }
 %with-chevron-left-16-mask {
-  @extend %with-mask, %chevron-left-16-svg-prop !optional;
+  @extend %with-mask, %chevron-left-16-svg-prop;
   -webkit-mask-image: var(--chevron-left-16-svg);
   mask-image: var(--chevron-left-16-svg);
 }
 
 %with-chevron-left-24-icon {
-  @extend %with-icon, %chevron-left-24-svg-prop !optional;
+  @extend %with-icon, %chevron-left-24-svg-prop;
   background-image: var(--chevron-left-24-svg);
 }
 %with-chevron-left-24-mask {
-  @extend %with-mask, %chevron-left-24-svg-prop !optional;
+  @extend %with-mask, %chevron-left-24-svg-prop;
   -webkit-mask-image: var(--chevron-left-24-svg);
   mask-image: var(--chevron-left-24-svg);
 }
 
 %with-chevron-left-icon {
-  @extend %with-icon, %chevron-left-svg-prop !optional;
+  @extend %with-icon, %chevron-left-svg-prop;
   background-image: var(--chevron-left-svg);
 }
 %with-chevron-left-mask {
-  @extend %with-mask, %chevron-left-svg-prop !optional;
+  @extend %with-mask, %chevron-left-svg-prop;
   -webkit-mask-image: var(--chevron-left-svg);
   mask-image: var(--chevron-left-svg);
 }
 
 %with-chevron-right-16-icon {
-  @extend %with-icon, %chevron-right-16-svg-prop !optional;
+  @extend %with-icon, %chevron-right-16-svg-prop;
   background-image: var(--chevron-right-16-svg);
 }
 %with-chevron-right-16-mask {
-  @extend %with-mask, %chevron-right-16-svg-prop !optional;
+  @extend %with-mask, %chevron-right-16-svg-prop;
   -webkit-mask-image: var(--chevron-right-16-svg);
   mask-image: var(--chevron-right-16-svg);
 }
 
 %with-chevron-right-24-icon {
-  @extend %with-icon, %chevron-right-24-svg-prop !optional;
+  @extend %with-icon, %chevron-right-24-svg-prop;
   background-image: var(--chevron-right-24-svg);
 }
 %with-chevron-right-24-mask {
-  @extend %with-mask, %chevron-right-24-svg-prop !optional;
+  @extend %with-mask, %chevron-right-24-svg-prop;
   -webkit-mask-image: var(--chevron-right-24-svg);
   mask-image: var(--chevron-right-24-svg);
 }
 
 %with-chevron-right-icon {
-  @extend %with-icon, %chevron-right-svg-prop !optional;
+  @extend %with-icon, %chevron-right-svg-prop;
   background-image: var(--chevron-right-svg);
 }
 %with-chevron-right-mask {
-  @extend %with-mask, %chevron-right-svg-prop !optional;
+  @extend %with-mask, %chevron-right-svg-prop;
   -webkit-mask-image: var(--chevron-right-svg);
   mask-image: var(--chevron-right-svg);
 }
 
 %with-chevron-up-16-icon {
-  @extend %with-icon, %chevron-up-16-svg-prop !optional;
+  @extend %with-icon, %chevron-up-16-svg-prop;
   background-image: var(--chevron-up-16-svg);
 }
 %with-chevron-up-16-mask {
-  @extend %with-mask, %chevron-up-16-svg-prop !optional;
+  @extend %with-mask, %chevron-up-16-svg-prop;
   -webkit-mask-image: var(--chevron-up-16-svg);
   mask-image: var(--chevron-up-16-svg);
 }
 
 %with-chevron-up-24-icon {
-  @extend %with-icon, %chevron-up-24-svg-prop !optional;
+  @extend %with-icon, %chevron-up-24-svg-prop;
   background-image: var(--chevron-up-24-svg);
 }
 %with-chevron-up-24-mask {
-  @extend %with-mask, %chevron-up-24-svg-prop !optional;
+  @extend %with-mask, %chevron-up-24-svg-prop;
   -webkit-mask-image: var(--chevron-up-24-svg);
   mask-image: var(--chevron-up-24-svg);
 }
 
 %with-chevron-up-icon {
-  @extend %with-icon, %chevron-up-svg-prop !optional;
+  @extend %with-icon, %chevron-up-svg-prop;
   background-image: var(--chevron-up-svg);
 }
 %with-chevron-up-mask {
-  @extend %with-mask, %chevron-up-svg-prop !optional;
+  @extend %with-mask, %chevron-up-svg-prop;
   -webkit-mask-image: var(--chevron-up-svg);
   mask-image: var(--chevron-up-svg);
 }
 
 %with-chevrons-down-16-icon {
-  @extend %with-icon, %chevrons-down-16-svg-prop !optional;
+  @extend %with-icon, %chevrons-down-16-svg-prop;
   background-image: var(--chevrons-down-16-svg);
 }
 %with-chevrons-down-16-mask {
-  @extend %with-mask, %chevrons-down-16-svg-prop !optional;
+  @extend %with-mask, %chevrons-down-16-svg-prop;
   -webkit-mask-image: var(--chevrons-down-16-svg);
   mask-image: var(--chevrons-down-16-svg);
 }
 
 %with-chevrons-down-24-icon {
-  @extend %with-icon, %chevrons-down-24-svg-prop !optional;
+  @extend %with-icon, %chevrons-down-24-svg-prop;
   background-image: var(--chevrons-down-24-svg);
 }
 %with-chevrons-down-24-mask {
-  @extend %with-mask, %chevrons-down-24-svg-prop !optional;
+  @extend %with-mask, %chevrons-down-24-svg-prop;
   -webkit-mask-image: var(--chevrons-down-24-svg);
   mask-image: var(--chevrons-down-24-svg);
 }
 
 %with-chevrons-left-16-icon {
-  @extend %with-icon, %chevrons-left-16-svg-prop !optional;
+  @extend %with-icon, %chevrons-left-16-svg-prop;
   background-image: var(--chevrons-left-16-svg);
 }
 %with-chevrons-left-16-mask {
-  @extend %with-mask, %chevrons-left-16-svg-prop !optional;
+  @extend %with-mask, %chevrons-left-16-svg-prop;
   -webkit-mask-image: var(--chevrons-left-16-svg);
   mask-image: var(--chevrons-left-16-svg);
 }
 
 %with-chevrons-left-24-icon {
-  @extend %with-icon, %chevrons-left-24-svg-prop !optional;
+  @extend %with-icon, %chevrons-left-24-svg-prop;
   background-image: var(--chevrons-left-24-svg);
 }
 %with-chevrons-left-24-mask {
-  @extend %with-mask, %chevrons-left-24-svg-prop !optional;
+  @extend %with-mask, %chevrons-left-24-svg-prop;
   -webkit-mask-image: var(--chevrons-left-24-svg);
   mask-image: var(--chevrons-left-24-svg);
 }
 
 %with-chevrons-right-16-icon {
-  @extend %with-icon, %chevrons-right-16-svg-prop !optional;
+  @extend %with-icon, %chevrons-right-16-svg-prop;
   background-image: var(--chevrons-right-16-svg);
 }
 %with-chevrons-right-16-mask {
-  @extend %with-mask, %chevrons-right-16-svg-prop !optional;
+  @extend %with-mask, %chevrons-right-16-svg-prop;
   -webkit-mask-image: var(--chevrons-right-16-svg);
   mask-image: var(--chevrons-right-16-svg);
 }
 
 %with-chevrons-right-24-icon {
-  @extend %with-icon, %chevrons-right-24-svg-prop !optional;
+  @extend %with-icon, %chevrons-right-24-svg-prop;
   background-image: var(--chevrons-right-24-svg);
 }
 %with-chevrons-right-24-mask {
-  @extend %with-mask, %chevrons-right-24-svg-prop !optional;
+  @extend %with-mask, %chevrons-right-24-svg-prop;
   -webkit-mask-image: var(--chevrons-right-24-svg);
   mask-image: var(--chevrons-right-24-svg);
 }
 
 %with-chevrons-up-16-icon {
-  @extend %with-icon, %chevrons-up-16-svg-prop !optional;
+  @extend %with-icon, %chevrons-up-16-svg-prop;
   background-image: var(--chevrons-up-16-svg);
 }
 %with-chevrons-up-16-mask {
-  @extend %with-mask, %chevrons-up-16-svg-prop !optional;
+  @extend %with-mask, %chevrons-up-16-svg-prop;
   -webkit-mask-image: var(--chevrons-up-16-svg);
   mask-image: var(--chevrons-up-16-svg);
 }
 
 %with-chevrons-up-24-icon {
-  @extend %with-icon, %chevrons-up-24-svg-prop !optional;
+  @extend %with-icon, %chevrons-up-24-svg-prop;
   background-image: var(--chevrons-up-24-svg);
 }
 %with-chevrons-up-24-mask {
-  @extend %with-mask, %chevrons-up-24-svg-prop !optional;
+  @extend %with-mask, %chevrons-up-24-svg-prop;
   -webkit-mask-image: var(--chevrons-up-24-svg);
   mask-image: var(--chevrons-up-24-svg);
 }
 
 %with-circle-16-icon {
-  @extend %with-icon, %circle-16-svg-prop !optional;
+  @extend %with-icon, %circle-16-svg-prop;
   background-image: var(--circle-16-svg);
 }
 %with-circle-16-mask {
-  @extend %with-mask, %circle-16-svg-prop !optional;
+  @extend %with-mask, %circle-16-svg-prop;
   -webkit-mask-image: var(--circle-16-svg);
   mask-image: var(--circle-16-svg);
 }
 
 %with-circle-24-icon {
-  @extend %with-icon, %circle-24-svg-prop !optional;
+  @extend %with-icon, %circle-24-svg-prop;
   background-image: var(--circle-24-svg);
 }
 %with-circle-24-mask {
-  @extend %with-mask, %circle-24-svg-prop !optional;
+  @extend %with-mask, %circle-24-svg-prop;
   -webkit-mask-image: var(--circle-24-svg);
   mask-image: var(--circle-24-svg);
 }
 
 %with-circle-dot-16-icon {
-  @extend %with-icon, %circle-dot-16-svg-prop !optional;
+  @extend %with-icon, %circle-dot-16-svg-prop;
   background-image: var(--circle-dot-16-svg);
 }
 %with-circle-dot-16-mask {
-  @extend %with-mask, %circle-dot-16-svg-prop !optional;
+  @extend %with-mask, %circle-dot-16-svg-prop;
   -webkit-mask-image: var(--circle-dot-16-svg);
   mask-image: var(--circle-dot-16-svg);
 }
 
 %with-circle-dot-24-icon {
-  @extend %with-icon, %circle-dot-24-svg-prop !optional;
+  @extend %with-icon, %circle-dot-24-svg-prop;
   background-image: var(--circle-dot-24-svg);
 }
 %with-circle-dot-24-mask {
-  @extend %with-mask, %circle-dot-24-svg-prop !optional;
+  @extend %with-mask, %circle-dot-24-svg-prop;
   -webkit-mask-image: var(--circle-dot-24-svg);
   mask-image: var(--circle-dot-24-svg);
 }
 
 %with-circle-fill-16-icon {
-  @extend %with-icon, %circle-fill-16-svg-prop !optional;
+  @extend %with-icon, %circle-fill-16-svg-prop;
   background-image: var(--circle-fill-16-svg);
 }
 %with-circle-fill-16-mask {
-  @extend %with-mask, %circle-fill-16-svg-prop !optional;
+  @extend %with-mask, %circle-fill-16-svg-prop;
   -webkit-mask-image: var(--circle-fill-16-svg);
   mask-image: var(--circle-fill-16-svg);
 }
 
 %with-circle-fill-24-icon {
-  @extend %with-icon, %circle-fill-24-svg-prop !optional;
+  @extend %with-icon, %circle-fill-24-svg-prop;
   background-image: var(--circle-fill-24-svg);
 }
 %with-circle-fill-24-mask {
-  @extend %with-mask, %circle-fill-24-svg-prop !optional;
+  @extend %with-mask, %circle-fill-24-svg-prop;
   -webkit-mask-image: var(--circle-fill-24-svg);
   mask-image: var(--circle-fill-24-svg);
 }
 
 %with-circle-half-16-icon {
-  @extend %with-icon, %circle-half-16-svg-prop !optional;
+  @extend %with-icon, %circle-half-16-svg-prop;
   background-image: var(--circle-half-16-svg);
 }
 %with-circle-half-16-mask {
-  @extend %with-mask, %circle-half-16-svg-prop !optional;
+  @extend %with-mask, %circle-half-16-svg-prop;
   -webkit-mask-image: var(--circle-half-16-svg);
   mask-image: var(--circle-half-16-svg);
 }
 
 %with-circle-half-24-icon {
-  @extend %with-icon, %circle-half-24-svg-prop !optional;
+  @extend %with-icon, %circle-half-24-svg-prop;
   background-image: var(--circle-half-24-svg);
 }
 %with-circle-half-24-mask {
-  @extend %with-mask, %circle-half-24-svg-prop !optional;
+  @extend %with-mask, %circle-half-24-svg-prop;
   -webkit-mask-image: var(--circle-half-24-svg);
   mask-image: var(--circle-half-24-svg);
 }
 
 %with-clipboard-16-icon {
-  @extend %with-icon, %clipboard-16-svg-prop !optional;
+  @extend %with-icon, %clipboard-16-svg-prop;
   background-image: var(--clipboard-16-svg);
 }
 %with-clipboard-16-mask {
-  @extend %with-mask, %clipboard-16-svg-prop !optional;
+  @extend %with-mask, %clipboard-16-svg-prop;
   -webkit-mask-image: var(--clipboard-16-svg);
   mask-image: var(--clipboard-16-svg);
 }
 
 %with-clipboard-24-icon {
-  @extend %with-icon, %clipboard-24-svg-prop !optional;
+  @extend %with-icon, %clipboard-24-svg-prop;
   background-image: var(--clipboard-24-svg);
 }
 %with-clipboard-24-mask {
-  @extend %with-mask, %clipboard-24-svg-prop !optional;
+  @extend %with-mask, %clipboard-24-svg-prop;
   -webkit-mask-image: var(--clipboard-24-svg);
   mask-image: var(--clipboard-24-svg);
 }
 
 %with-clipboard-checked-16-icon {
-  @extend %with-icon, %clipboard-checked-16-svg-prop !optional;
+  @extend %with-icon, %clipboard-checked-16-svg-prop;
   background-image: var(--clipboard-checked-16-svg);
 }
 %with-clipboard-checked-16-mask {
-  @extend %with-mask, %clipboard-checked-16-svg-prop !optional;
+  @extend %with-mask, %clipboard-checked-16-svg-prop;
   -webkit-mask-image: var(--clipboard-checked-16-svg);
   mask-image: var(--clipboard-checked-16-svg);
 }
 
 %with-clipboard-checked-24-icon {
-  @extend %with-icon, %clipboard-checked-24-svg-prop !optional;
+  @extend %with-icon, %clipboard-checked-24-svg-prop;
   background-image: var(--clipboard-checked-24-svg);
 }
 %with-clipboard-checked-24-mask {
-  @extend %with-mask, %clipboard-checked-24-svg-prop !optional;
+  @extend %with-mask, %clipboard-checked-24-svg-prop;
   -webkit-mask-image: var(--clipboard-checked-24-svg);
   mask-image: var(--clipboard-checked-24-svg);
 }
 
 %with-clipboard-copy-16-icon {
-  @extend %with-icon, %clipboard-copy-16-svg-prop !optional;
+  @extend %with-icon, %clipboard-copy-16-svg-prop;
   background-image: var(--clipboard-copy-16-svg);
 }
 %with-clipboard-copy-16-mask {
-  @extend %with-mask, %clipboard-copy-16-svg-prop !optional;
+  @extend %with-mask, %clipboard-copy-16-svg-prop;
   -webkit-mask-image: var(--clipboard-copy-16-svg);
   mask-image: var(--clipboard-copy-16-svg);
 }
 
 %with-clipboard-copy-24-icon {
-  @extend %with-icon, %clipboard-copy-24-svg-prop !optional;
+  @extend %with-icon, %clipboard-copy-24-svg-prop;
   background-image: var(--clipboard-copy-24-svg);
 }
 %with-clipboard-copy-24-mask {
-  @extend %with-mask, %clipboard-copy-24-svg-prop !optional;
+  @extend %with-mask, %clipboard-copy-24-svg-prop;
   -webkit-mask-image: var(--clipboard-copy-24-svg);
   mask-image: var(--clipboard-copy-24-svg);
 }
 
 %with-clock-16-icon {
-  @extend %with-icon, %clock-16-svg-prop !optional;
+  @extend %with-icon, %clock-16-svg-prop;
   background-image: var(--clock-16-svg);
 }
 %with-clock-16-mask {
-  @extend %with-mask, %clock-16-svg-prop !optional;
+  @extend %with-mask, %clock-16-svg-prop;
   -webkit-mask-image: var(--clock-16-svg);
   mask-image: var(--clock-16-svg);
 }
 
 %with-clock-24-icon {
-  @extend %with-icon, %clock-24-svg-prop !optional;
+  @extend %with-icon, %clock-24-svg-prop;
   background-image: var(--clock-24-svg);
 }
 %with-clock-24-mask {
-  @extend %with-mask, %clock-24-svg-prop !optional;
+  @extend %with-mask, %clock-24-svg-prop;
   -webkit-mask-image: var(--clock-24-svg);
   mask-image: var(--clock-24-svg);
 }
 
 %with-clock-fill-icon {
-  @extend %with-icon, %clock-fill-svg-prop !optional;
+  @extend %with-icon, %clock-fill-svg-prop;
   background-image: var(--clock-fill-svg);
 }
 %with-clock-fill-mask {
-  @extend %with-mask, %clock-fill-svg-prop !optional;
+  @extend %with-mask, %clock-fill-svg-prop;
   -webkit-mask-image: var(--clock-fill-svg);
   mask-image: var(--clock-fill-svg);
 }
 
 %with-clock-outline-icon {
-  @extend %with-icon, %clock-outline-svg-prop !optional;
+  @extend %with-icon, %clock-outline-svg-prop;
   background-image: var(--clock-outline-svg);
 }
 %with-clock-outline-mask {
-  @extend %with-mask, %clock-outline-svg-prop !optional;
+  @extend %with-mask, %clock-outline-svg-prop;
   -webkit-mask-image: var(--clock-outline-svg);
   mask-image: var(--clock-outline-svg);
 }
 
 %with-cloud-16-icon {
-  @extend %with-icon, %cloud-16-svg-prop !optional;
+  @extend %with-icon, %cloud-16-svg-prop;
   background-image: var(--cloud-16-svg);
 }
 %with-cloud-16-mask {
-  @extend %with-mask, %cloud-16-svg-prop !optional;
+  @extend %with-mask, %cloud-16-svg-prop;
   -webkit-mask-image: var(--cloud-16-svg);
   mask-image: var(--cloud-16-svg);
 }
 
 %with-cloud-24-icon {
-  @extend %with-icon, %cloud-24-svg-prop !optional;
+  @extend %with-icon, %cloud-24-svg-prop;
   background-image: var(--cloud-24-svg);
 }
 %with-cloud-24-mask {
-  @extend %with-mask, %cloud-24-svg-prop !optional;
+  @extend %with-mask, %cloud-24-svg-prop;
   -webkit-mask-image: var(--cloud-24-svg);
   mask-image: var(--cloud-24-svg);
 }
 
 %with-cloud-check-16-icon {
-  @extend %with-icon, %cloud-check-16-svg-prop !optional;
+  @extend %with-icon, %cloud-check-16-svg-prop;
   background-image: var(--cloud-check-16-svg);
 }
 %with-cloud-check-16-mask {
-  @extend %with-mask, %cloud-check-16-svg-prop !optional;
+  @extend %with-mask, %cloud-check-16-svg-prop;
   -webkit-mask-image: var(--cloud-check-16-svg);
   mask-image: var(--cloud-check-16-svg);
 }
 
 %with-cloud-check-24-icon {
-  @extend %with-icon, %cloud-check-24-svg-prop !optional;
+  @extend %with-icon, %cloud-check-24-svg-prop;
   background-image: var(--cloud-check-24-svg);
 }
 %with-cloud-check-24-mask {
-  @extend %with-mask, %cloud-check-24-svg-prop !optional;
+  @extend %with-mask, %cloud-check-24-svg-prop;
   -webkit-mask-image: var(--cloud-check-24-svg);
   mask-image: var(--cloud-check-24-svg);
 }
 
 %with-cloud-cross-icon {
-  @extend %with-icon, %cloud-cross-svg-prop !optional;
+  @extend %with-icon, %cloud-cross-svg-prop;
   background-image: var(--cloud-cross-svg);
 }
 %with-cloud-cross-mask {
-  @extend %with-mask, %cloud-cross-svg-prop !optional;
+  @extend %with-mask, %cloud-cross-svg-prop;
   -webkit-mask-image: var(--cloud-cross-svg);
   mask-image: var(--cloud-cross-svg);
 }
 
 %with-cloud-download-16-icon {
-  @extend %with-icon, %cloud-download-16-svg-prop !optional;
+  @extend %with-icon, %cloud-download-16-svg-prop;
   background-image: var(--cloud-download-16-svg);
 }
 %with-cloud-download-16-mask {
-  @extend %with-mask, %cloud-download-16-svg-prop !optional;
+  @extend %with-mask, %cloud-download-16-svg-prop;
   -webkit-mask-image: var(--cloud-download-16-svg);
   mask-image: var(--cloud-download-16-svg);
 }
 
 %with-cloud-download-24-icon {
-  @extend %with-icon, %cloud-download-24-svg-prop !optional;
+  @extend %with-icon, %cloud-download-24-svg-prop;
   background-image: var(--cloud-download-24-svg);
 }
 %with-cloud-download-24-mask {
-  @extend %with-mask, %cloud-download-24-svg-prop !optional;
+  @extend %with-mask, %cloud-download-24-svg-prop;
   -webkit-mask-image: var(--cloud-download-24-svg);
   mask-image: var(--cloud-download-24-svg);
 }
 
 %with-cloud-lightning-16-icon {
-  @extend %with-icon, %cloud-lightning-16-svg-prop !optional;
+  @extend %with-icon, %cloud-lightning-16-svg-prop;
   background-image: var(--cloud-lightning-16-svg);
 }
 %with-cloud-lightning-16-mask {
-  @extend %with-mask, %cloud-lightning-16-svg-prop !optional;
+  @extend %with-mask, %cloud-lightning-16-svg-prop;
   -webkit-mask-image: var(--cloud-lightning-16-svg);
   mask-image: var(--cloud-lightning-16-svg);
 }
 
 %with-cloud-lightning-24-icon {
-  @extend %with-icon, %cloud-lightning-24-svg-prop !optional;
+  @extend %with-icon, %cloud-lightning-24-svg-prop;
   background-image: var(--cloud-lightning-24-svg);
 }
 %with-cloud-lightning-24-mask {
-  @extend %with-mask, %cloud-lightning-24-svg-prop !optional;
+  @extend %with-mask, %cloud-lightning-24-svg-prop;
   -webkit-mask-image: var(--cloud-lightning-24-svg);
   mask-image: var(--cloud-lightning-24-svg);
 }
 
 %with-cloud-lock-16-icon {
-  @extend %with-icon, %cloud-lock-16-svg-prop !optional;
+  @extend %with-icon, %cloud-lock-16-svg-prop;
   background-image: var(--cloud-lock-16-svg);
 }
 %with-cloud-lock-16-mask {
-  @extend %with-mask, %cloud-lock-16-svg-prop !optional;
+  @extend %with-mask, %cloud-lock-16-svg-prop;
   -webkit-mask-image: var(--cloud-lock-16-svg);
   mask-image: var(--cloud-lock-16-svg);
 }
 
 %with-cloud-lock-24-icon {
-  @extend %with-icon, %cloud-lock-24-svg-prop !optional;
+  @extend %with-icon, %cloud-lock-24-svg-prop;
   background-image: var(--cloud-lock-24-svg);
 }
 %with-cloud-lock-24-mask {
-  @extend %with-mask, %cloud-lock-24-svg-prop !optional;
+  @extend %with-mask, %cloud-lock-24-svg-prop;
   -webkit-mask-image: var(--cloud-lock-24-svg);
   mask-image: var(--cloud-lock-24-svg);
 }
 
 %with-cloud-off-16-icon {
-  @extend %with-icon, %cloud-off-16-svg-prop !optional;
+  @extend %with-icon, %cloud-off-16-svg-prop;
   background-image: var(--cloud-off-16-svg);
 }
 %with-cloud-off-16-mask {
-  @extend %with-mask, %cloud-off-16-svg-prop !optional;
+  @extend %with-mask, %cloud-off-16-svg-prop;
   -webkit-mask-image: var(--cloud-off-16-svg);
   mask-image: var(--cloud-off-16-svg);
 }
 
 %with-cloud-off-24-icon {
-  @extend %with-icon, %cloud-off-24-svg-prop !optional;
+  @extend %with-icon, %cloud-off-24-svg-prop;
   background-image: var(--cloud-off-24-svg);
 }
 %with-cloud-off-24-mask {
-  @extend %with-mask, %cloud-off-24-svg-prop !optional;
+  @extend %with-mask, %cloud-off-24-svg-prop;
   -webkit-mask-image: var(--cloud-off-24-svg);
   mask-image: var(--cloud-off-24-svg);
 }
 
 %with-cloud-upload-16-icon {
-  @extend %with-icon, %cloud-upload-16-svg-prop !optional;
+  @extend %with-icon, %cloud-upload-16-svg-prop;
   background-image: var(--cloud-upload-16-svg);
 }
 %with-cloud-upload-16-mask {
-  @extend %with-mask, %cloud-upload-16-svg-prop !optional;
+  @extend %with-mask, %cloud-upload-16-svg-prop;
   -webkit-mask-image: var(--cloud-upload-16-svg);
   mask-image: var(--cloud-upload-16-svg);
 }
 
 %with-cloud-upload-24-icon {
-  @extend %with-icon, %cloud-upload-24-svg-prop !optional;
+  @extend %with-icon, %cloud-upload-24-svg-prop;
   background-image: var(--cloud-upload-24-svg);
 }
 %with-cloud-upload-24-mask {
-  @extend %with-mask, %cloud-upload-24-svg-prop !optional;
+  @extend %with-mask, %cloud-upload-24-svg-prop;
   -webkit-mask-image: var(--cloud-upload-24-svg);
   mask-image: var(--cloud-upload-24-svg);
 }
 
 %with-cloud-x-16-icon {
-  @extend %with-icon, %cloud-x-16-svg-prop !optional;
+  @extend %with-icon, %cloud-x-16-svg-prop;
   background-image: var(--cloud-x-16-svg);
 }
 %with-cloud-x-16-mask {
-  @extend %with-mask, %cloud-x-16-svg-prop !optional;
+  @extend %with-mask, %cloud-x-16-svg-prop;
   -webkit-mask-image: var(--cloud-x-16-svg);
   mask-image: var(--cloud-x-16-svg);
 }
 
 %with-cloud-x-24-icon {
-  @extend %with-icon, %cloud-x-24-svg-prop !optional;
+  @extend %with-icon, %cloud-x-24-svg-prop;
   background-image: var(--cloud-x-24-svg);
 }
 %with-cloud-x-24-mask {
-  @extend %with-mask, %cloud-x-24-svg-prop !optional;
+  @extend %with-mask, %cloud-x-24-svg-prop;
   -webkit-mask-image: var(--cloud-x-24-svg);
   mask-image: var(--cloud-x-24-svg);
 }
 
 %with-code-16-icon {
-  @extend %with-icon, %code-16-svg-prop !optional;
+  @extend %with-icon, %code-16-svg-prop;
   background-image: var(--code-16-svg);
 }
 %with-code-16-mask {
-  @extend %with-mask, %code-16-svg-prop !optional;
+  @extend %with-mask, %code-16-svg-prop;
   -webkit-mask-image: var(--code-16-svg);
   mask-image: var(--code-16-svg);
 }
 
 %with-code-24-icon {
-  @extend %with-icon, %code-24-svg-prop !optional;
+  @extend %with-icon, %code-24-svg-prop;
   background-image: var(--code-24-svg);
 }
 %with-code-24-mask {
-  @extend %with-mask, %code-24-svg-prop !optional;
+  @extend %with-mask, %code-24-svg-prop;
   -webkit-mask-image: var(--code-24-svg);
   mask-image: var(--code-24-svg);
 }
 
 %with-code-icon {
-  @extend %with-icon, %code-svg-prop !optional;
+  @extend %with-icon, %code-svg-prop;
   background-image: var(--code-svg);
 }
 %with-code-mask {
-  @extend %with-mask, %code-svg-prop !optional;
+  @extend %with-mask, %code-svg-prop;
   -webkit-mask-image: var(--code-svg);
   mask-image: var(--code-svg);
 }
 
 %with-collections-16-icon {
-  @extend %with-icon, %collections-16-svg-prop !optional;
+  @extend %with-icon, %collections-16-svg-prop;
   background-image: var(--collections-16-svg);
 }
 %with-collections-16-mask {
-  @extend %with-mask, %collections-16-svg-prop !optional;
+  @extend %with-mask, %collections-16-svg-prop;
   -webkit-mask-image: var(--collections-16-svg);
   mask-image: var(--collections-16-svg);
 }
 
 %with-collections-24-icon {
-  @extend %with-icon, %collections-24-svg-prop !optional;
+  @extend %with-icon, %collections-24-svg-prop;
   background-image: var(--collections-24-svg);
 }
 %with-collections-24-mask {
-  @extend %with-mask, %collections-24-svg-prop !optional;
+  @extend %with-mask, %collections-24-svg-prop;
   -webkit-mask-image: var(--collections-24-svg);
   mask-image: var(--collections-24-svg);
 }
 
 %with-command-16-icon {
-  @extend %with-icon, %command-16-svg-prop !optional;
+  @extend %with-icon, %command-16-svg-prop;
   background-image: var(--command-16-svg);
 }
 %with-command-16-mask {
-  @extend %with-mask, %command-16-svg-prop !optional;
+  @extend %with-mask, %command-16-svg-prop;
   -webkit-mask-image: var(--command-16-svg);
   mask-image: var(--command-16-svg);
 }
 
 %with-command-24-icon {
-  @extend %with-icon, %command-24-svg-prop !optional;
+  @extend %with-icon, %command-24-svg-prop;
   background-image: var(--command-24-svg);
 }
 %with-command-24-mask {
-  @extend %with-mask, %command-24-svg-prop !optional;
+  @extend %with-mask, %command-24-svg-prop;
   -webkit-mask-image: var(--command-24-svg);
   mask-image: var(--command-24-svg);
 }
 
 %with-compass-16-icon {
-  @extend %with-icon, %compass-16-svg-prop !optional;
+  @extend %with-icon, %compass-16-svg-prop;
   background-image: var(--compass-16-svg);
 }
 %with-compass-16-mask {
-  @extend %with-mask, %compass-16-svg-prop !optional;
+  @extend %with-mask, %compass-16-svg-prop;
   -webkit-mask-image: var(--compass-16-svg);
   mask-image: var(--compass-16-svg);
 }
 
 %with-compass-24-icon {
-  @extend %with-icon, %compass-24-svg-prop !optional;
+  @extend %with-icon, %compass-24-svg-prop;
   background-image: var(--compass-24-svg);
 }
 %with-compass-24-mask {
-  @extend %with-mask, %compass-24-svg-prop !optional;
+  @extend %with-mask, %compass-24-svg-prop;
   -webkit-mask-image: var(--compass-24-svg);
   mask-image: var(--compass-24-svg);
 }
 
 %with-connection-16-icon {
-  @extend %with-icon, %connection-16-svg-prop !optional;
+  @extend %with-icon, %connection-16-svg-prop;
   background-image: var(--connection-16-svg);
 }
 %with-connection-16-mask {
-  @extend %with-mask, %connection-16-svg-prop !optional;
+  @extend %with-mask, %connection-16-svg-prop;
   -webkit-mask-image: var(--connection-16-svg);
   mask-image: var(--connection-16-svg);
 }
 
 %with-connection-24-icon {
-  @extend %with-icon, %connection-24-svg-prop !optional;
+  @extend %with-icon, %connection-24-svg-prop;
   background-image: var(--connection-24-svg);
 }
 %with-connection-24-mask {
-  @extend %with-mask, %connection-24-svg-prop !optional;
+  @extend %with-mask, %connection-24-svg-prop;
   -webkit-mask-image: var(--connection-24-svg);
   mask-image: var(--connection-24-svg);
 }
 
 %with-connection-gateway-16-icon {
-  @extend %with-icon, %connection-gateway-16-svg-prop !optional;
+  @extend %with-icon, %connection-gateway-16-svg-prop;
   background-image: var(--connection-gateway-16-svg);
 }
 %with-connection-gateway-16-mask {
-  @extend %with-mask, %connection-gateway-16-svg-prop !optional;
+  @extend %with-mask, %connection-gateway-16-svg-prop;
   -webkit-mask-image: var(--connection-gateway-16-svg);
   mask-image: var(--connection-gateway-16-svg);
 }
 
 %with-connection-gateway-24-icon {
-  @extend %with-icon, %connection-gateway-24-svg-prop !optional;
+  @extend %with-icon, %connection-gateway-24-svg-prop;
   background-image: var(--connection-gateway-24-svg);
 }
 %with-connection-gateway-24-mask {
-  @extend %with-mask, %connection-gateway-24-svg-prop !optional;
+  @extend %with-mask, %connection-gateway-24-svg-prop;
   -webkit-mask-image: var(--connection-gateway-24-svg);
   mask-image: var(--connection-gateway-24-svg);
 }
 
 %with-console-icon {
-  @extend %with-icon, %console-svg-prop !optional;
+  @extend %with-icon, %console-svg-prop;
   background-image: var(--console-svg);
 }
 %with-console-mask {
-  @extend %with-mask, %console-svg-prop !optional;
+  @extend %with-mask, %console-svg-prop;
   -webkit-mask-image: var(--console-svg);
   mask-image: var(--console-svg);
 }
 
 %with-copy-action-icon {
-  @extend %with-icon, %copy-action-svg-prop !optional;
+  @extend %with-icon, %copy-action-svg-prop;
   background-image: var(--copy-action-svg);
 }
 %with-copy-action-mask {
-  @extend %with-mask, %copy-action-svg-prop !optional;
+  @extend %with-mask, %copy-action-svg-prop;
   -webkit-mask-image: var(--copy-action-svg);
   mask-image: var(--copy-action-svg);
 }
 
 %with-copy-success-icon {
-  @extend %with-icon, %copy-success-svg-prop !optional;
+  @extend %with-icon, %copy-success-svg-prop;
   background-image: var(--copy-success-svg);
 }
 %with-copy-success-mask {
-  @extend %with-mask, %copy-success-svg-prop !optional;
+  @extend %with-mask, %copy-success-svg-prop;
   -webkit-mask-image: var(--copy-success-svg);
   mask-image: var(--copy-success-svg);
 }
 
 %with-corner-down-left-16-icon {
-  @extend %with-icon, %corner-down-left-16-svg-prop !optional;
+  @extend %with-icon, %corner-down-left-16-svg-prop;
   background-image: var(--corner-down-left-16-svg);
 }
 %with-corner-down-left-16-mask {
-  @extend %with-mask, %corner-down-left-16-svg-prop !optional;
+  @extend %with-mask, %corner-down-left-16-svg-prop;
   -webkit-mask-image: var(--corner-down-left-16-svg);
   mask-image: var(--corner-down-left-16-svg);
 }
 
 %with-corner-down-left-24-icon {
-  @extend %with-icon, %corner-down-left-24-svg-prop !optional;
+  @extend %with-icon, %corner-down-left-24-svg-prop;
   background-image: var(--corner-down-left-24-svg);
 }
 %with-corner-down-left-24-mask {
-  @extend %with-mask, %corner-down-left-24-svg-prop !optional;
+  @extend %with-mask, %corner-down-left-24-svg-prop;
   -webkit-mask-image: var(--corner-down-left-24-svg);
   mask-image: var(--corner-down-left-24-svg);
 }
 
 %with-corner-down-right-16-icon {
-  @extend %with-icon, %corner-down-right-16-svg-prop !optional;
+  @extend %with-icon, %corner-down-right-16-svg-prop;
   background-image: var(--corner-down-right-16-svg);
 }
 %with-corner-down-right-16-mask {
-  @extend %with-mask, %corner-down-right-16-svg-prop !optional;
+  @extend %with-mask, %corner-down-right-16-svg-prop;
   -webkit-mask-image: var(--corner-down-right-16-svg);
   mask-image: var(--corner-down-right-16-svg);
 }
 
 %with-corner-down-right-24-icon {
-  @extend %with-icon, %corner-down-right-24-svg-prop !optional;
+  @extend %with-icon, %corner-down-right-24-svg-prop;
   background-image: var(--corner-down-right-24-svg);
 }
 %with-corner-down-right-24-mask {
-  @extend %with-mask, %corner-down-right-24-svg-prop !optional;
+  @extend %with-mask, %corner-down-right-24-svg-prop;
   -webkit-mask-image: var(--corner-down-right-24-svg);
   mask-image: var(--corner-down-right-24-svg);
 }
 
 %with-corner-left-down-16-icon {
-  @extend %with-icon, %corner-left-down-16-svg-prop !optional;
+  @extend %with-icon, %corner-left-down-16-svg-prop;
   background-image: var(--corner-left-down-16-svg);
 }
 %with-corner-left-down-16-mask {
-  @extend %with-mask, %corner-left-down-16-svg-prop !optional;
+  @extend %with-mask, %corner-left-down-16-svg-prop;
   -webkit-mask-image: var(--corner-left-down-16-svg);
   mask-image: var(--corner-left-down-16-svg);
 }
 
 %with-corner-left-down-24-icon {
-  @extend %with-icon, %corner-left-down-24-svg-prop !optional;
+  @extend %with-icon, %corner-left-down-24-svg-prop;
   background-image: var(--corner-left-down-24-svg);
 }
 %with-corner-left-down-24-mask {
-  @extend %with-mask, %corner-left-down-24-svg-prop !optional;
+  @extend %with-mask, %corner-left-down-24-svg-prop;
   -webkit-mask-image: var(--corner-left-down-24-svg);
   mask-image: var(--corner-left-down-24-svg);
 }
 
 %with-corner-left-up-16-icon {
-  @extend %with-icon, %corner-left-up-16-svg-prop !optional;
+  @extend %with-icon, %corner-left-up-16-svg-prop;
   background-image: var(--corner-left-up-16-svg);
 }
 %with-corner-left-up-16-mask {
-  @extend %with-mask, %corner-left-up-16-svg-prop !optional;
+  @extend %with-mask, %corner-left-up-16-svg-prop;
   -webkit-mask-image: var(--corner-left-up-16-svg);
   mask-image: var(--corner-left-up-16-svg);
 }
 
 %with-corner-left-up-24-icon {
-  @extend %with-icon, %corner-left-up-24-svg-prop !optional;
+  @extend %with-icon, %corner-left-up-24-svg-prop;
   background-image: var(--corner-left-up-24-svg);
 }
 %with-corner-left-up-24-mask {
-  @extend %with-mask, %corner-left-up-24-svg-prop !optional;
+  @extend %with-mask, %corner-left-up-24-svg-prop;
   -webkit-mask-image: var(--corner-left-up-24-svg);
   mask-image: var(--corner-left-up-24-svg);
 }
 
 %with-corner-right-down-16-icon {
-  @extend %with-icon, %corner-right-down-16-svg-prop !optional;
+  @extend %with-icon, %corner-right-down-16-svg-prop;
   background-image: var(--corner-right-down-16-svg);
 }
 %with-corner-right-down-16-mask {
-  @extend %with-mask, %corner-right-down-16-svg-prop !optional;
+  @extend %with-mask, %corner-right-down-16-svg-prop;
   -webkit-mask-image: var(--corner-right-down-16-svg);
   mask-image: var(--corner-right-down-16-svg);
 }
 
 %with-corner-right-down-24-icon {
-  @extend %with-icon, %corner-right-down-24-svg-prop !optional;
+  @extend %with-icon, %corner-right-down-24-svg-prop;
   background-image: var(--corner-right-down-24-svg);
 }
 %with-corner-right-down-24-mask {
-  @extend %with-mask, %corner-right-down-24-svg-prop !optional;
+  @extend %with-mask, %corner-right-down-24-svg-prop;
   -webkit-mask-image: var(--corner-right-down-24-svg);
   mask-image: var(--corner-right-down-24-svg);
 }
 
 %with-corner-right-up-16-icon {
-  @extend %with-icon, %corner-right-up-16-svg-prop !optional;
+  @extend %with-icon, %corner-right-up-16-svg-prop;
   background-image: var(--corner-right-up-16-svg);
 }
 %with-corner-right-up-16-mask {
-  @extend %with-mask, %corner-right-up-16-svg-prop !optional;
+  @extend %with-mask, %corner-right-up-16-svg-prop;
   -webkit-mask-image: var(--corner-right-up-16-svg);
   mask-image: var(--corner-right-up-16-svg);
 }
 
 %with-corner-right-up-24-icon {
-  @extend %with-icon, %corner-right-up-24-svg-prop !optional;
+  @extend %with-icon, %corner-right-up-24-svg-prop;
   background-image: var(--corner-right-up-24-svg);
 }
 %with-corner-right-up-24-mask {
-  @extend %with-mask, %corner-right-up-24-svg-prop !optional;
+  @extend %with-mask, %corner-right-up-24-svg-prop;
   -webkit-mask-image: var(--corner-right-up-24-svg);
   mask-image: var(--corner-right-up-24-svg);
 }
 
 %with-corner-up-left-16-icon {
-  @extend %with-icon, %corner-up-left-16-svg-prop !optional;
+  @extend %with-icon, %corner-up-left-16-svg-prop;
   background-image: var(--corner-up-left-16-svg);
 }
 %with-corner-up-left-16-mask {
-  @extend %with-mask, %corner-up-left-16-svg-prop !optional;
+  @extend %with-mask, %corner-up-left-16-svg-prop;
   -webkit-mask-image: var(--corner-up-left-16-svg);
   mask-image: var(--corner-up-left-16-svg);
 }
 
 %with-corner-up-left-24-icon {
-  @extend %with-icon, %corner-up-left-24-svg-prop !optional;
+  @extend %with-icon, %corner-up-left-24-svg-prop;
   background-image: var(--corner-up-left-24-svg);
 }
 %with-corner-up-left-24-mask {
-  @extend %with-mask, %corner-up-left-24-svg-prop !optional;
+  @extend %with-mask, %corner-up-left-24-svg-prop;
   -webkit-mask-image: var(--corner-up-left-24-svg);
   mask-image: var(--corner-up-left-24-svg);
 }
 
 %with-corner-up-right-16-icon {
-  @extend %with-icon, %corner-up-right-16-svg-prop !optional;
+  @extend %with-icon, %corner-up-right-16-svg-prop;
   background-image: var(--corner-up-right-16-svg);
 }
 %with-corner-up-right-16-mask {
-  @extend %with-mask, %corner-up-right-16-svg-prop !optional;
+  @extend %with-mask, %corner-up-right-16-svg-prop;
   -webkit-mask-image: var(--corner-up-right-16-svg);
   mask-image: var(--corner-up-right-16-svg);
 }
 
 %with-corner-up-right-24-icon {
-  @extend %with-icon, %corner-up-right-24-svg-prop !optional;
+  @extend %with-icon, %corner-up-right-24-svg-prop;
   background-image: var(--corner-up-right-24-svg);
 }
 %with-corner-up-right-24-mask {
-  @extend %with-mask, %corner-up-right-24-svg-prop !optional;
+  @extend %with-mask, %corner-up-right-24-svg-prop;
   -webkit-mask-image: var(--corner-up-right-24-svg);
   mask-image: var(--corner-up-right-24-svg);
 }
 
 %with-cpu-16-icon {
-  @extend %with-icon, %cpu-16-svg-prop !optional;
+  @extend %with-icon, %cpu-16-svg-prop;
   background-image: var(--cpu-16-svg);
 }
 %with-cpu-16-mask {
-  @extend %with-mask, %cpu-16-svg-prop !optional;
+  @extend %with-mask, %cpu-16-svg-prop;
   -webkit-mask-image: var(--cpu-16-svg);
   mask-image: var(--cpu-16-svg);
 }
 
 %with-cpu-24-icon {
-  @extend %with-icon, %cpu-24-svg-prop !optional;
+  @extend %with-icon, %cpu-24-svg-prop;
   background-image: var(--cpu-24-svg);
 }
 %with-cpu-24-mask {
-  @extend %with-mask, %cpu-24-svg-prop !optional;
+  @extend %with-mask, %cpu-24-svg-prop;
   -webkit-mask-image: var(--cpu-24-svg);
   mask-image: var(--cpu-24-svg);
 }
 
 %with-credit-card-16-icon {
-  @extend %with-icon, %credit-card-16-svg-prop !optional;
+  @extend %with-icon, %credit-card-16-svg-prop;
   background-image: var(--credit-card-16-svg);
 }
 %with-credit-card-16-mask {
-  @extend %with-mask, %credit-card-16-svg-prop !optional;
+  @extend %with-mask, %credit-card-16-svg-prop;
   -webkit-mask-image: var(--credit-card-16-svg);
   mask-image: var(--credit-card-16-svg);
 }
 
 %with-credit-card-24-icon {
-  @extend %with-icon, %credit-card-24-svg-prop !optional;
+  @extend %with-icon, %credit-card-24-svg-prop;
   background-image: var(--credit-card-24-svg);
 }
 %with-credit-card-24-mask {
-  @extend %with-mask, %credit-card-24-svg-prop !optional;
+  @extend %with-mask, %credit-card-24-svg-prop;
   -webkit-mask-image: var(--credit-card-24-svg);
   mask-image: var(--credit-card-24-svg);
 }
 
 %with-crop-16-icon {
-  @extend %with-icon, %crop-16-svg-prop !optional;
+  @extend %with-icon, %crop-16-svg-prop;
   background-image: var(--crop-16-svg);
 }
 %with-crop-16-mask {
-  @extend %with-mask, %crop-16-svg-prop !optional;
+  @extend %with-mask, %crop-16-svg-prop;
   -webkit-mask-image: var(--crop-16-svg);
   mask-image: var(--crop-16-svg);
 }
 
 %with-crop-24-icon {
-  @extend %with-icon, %crop-24-svg-prop !optional;
+  @extend %with-icon, %crop-24-svg-prop;
   background-image: var(--crop-24-svg);
 }
 %with-crop-24-mask {
-  @extend %with-mask, %crop-24-svg-prop !optional;
+  @extend %with-mask, %crop-24-svg-prop;
   -webkit-mask-image: var(--crop-24-svg);
   mask-image: var(--crop-24-svg);
 }
 
 %with-crosshair-16-icon {
-  @extend %with-icon, %crosshair-16-svg-prop !optional;
+  @extend %with-icon, %crosshair-16-svg-prop;
   background-image: var(--crosshair-16-svg);
 }
 %with-crosshair-16-mask {
-  @extend %with-mask, %crosshair-16-svg-prop !optional;
+  @extend %with-mask, %crosshair-16-svg-prop;
   -webkit-mask-image: var(--crosshair-16-svg);
   mask-image: var(--crosshair-16-svg);
 }
 
 %with-crosshair-24-icon {
-  @extend %with-icon, %crosshair-24-svg-prop !optional;
+  @extend %with-icon, %crosshair-24-svg-prop;
   background-image: var(--crosshair-24-svg);
 }
 %with-crosshair-24-mask {
-  @extend %with-mask, %crosshair-24-svg-prop !optional;
+  @extend %with-mask, %crosshair-24-svg-prop;
   -webkit-mask-image: var(--crosshair-24-svg);
   mask-image: var(--crosshair-24-svg);
 }
 
 %with-dashboard-16-icon {
-  @extend %with-icon, %dashboard-16-svg-prop !optional;
+  @extend %with-icon, %dashboard-16-svg-prop;
   background-image: var(--dashboard-16-svg);
 }
 %with-dashboard-16-mask {
-  @extend %with-mask, %dashboard-16-svg-prop !optional;
+  @extend %with-mask, %dashboard-16-svg-prop;
   -webkit-mask-image: var(--dashboard-16-svg);
   mask-image: var(--dashboard-16-svg);
 }
 
 %with-dashboard-24-icon {
-  @extend %with-icon, %dashboard-24-svg-prop !optional;
+  @extend %with-icon, %dashboard-24-svg-prop;
   background-image: var(--dashboard-24-svg);
 }
 %with-dashboard-24-mask {
-  @extend %with-mask, %dashboard-24-svg-prop !optional;
+  @extend %with-mask, %dashboard-24-svg-prop;
   -webkit-mask-image: var(--dashboard-24-svg);
   mask-image: var(--dashboard-24-svg);
 }
 
 %with-database-16-icon {
-  @extend %with-icon, %database-16-svg-prop !optional;
+  @extend %with-icon, %database-16-svg-prop;
   background-image: var(--database-16-svg);
 }
 %with-database-16-mask {
-  @extend %with-mask, %database-16-svg-prop !optional;
+  @extend %with-mask, %database-16-svg-prop;
   -webkit-mask-image: var(--database-16-svg);
   mask-image: var(--database-16-svg);
 }
 
 %with-database-24-icon {
-  @extend %with-icon, %database-24-svg-prop !optional;
+  @extend %with-icon, %database-24-svg-prop;
   background-image: var(--database-24-svg);
 }
 %with-database-24-mask {
-  @extend %with-mask, %database-24-svg-prop !optional;
+  @extend %with-mask, %database-24-svg-prop;
   -webkit-mask-image: var(--database-24-svg);
   mask-image: var(--database-24-svg);
 }
 
 %with-database-icon {
-  @extend %with-icon, %database-svg-prop !optional;
+  @extend %with-icon, %database-svg-prop;
   background-image: var(--database-svg);
 }
 %with-database-mask {
-  @extend %with-mask, %database-svg-prop !optional;
+  @extend %with-mask, %database-svg-prop;
   -webkit-mask-image: var(--database-svg);
   mask-image: var(--database-svg);
 }
 
 %with-delay-16-icon {
-  @extend %with-icon, %delay-16-svg-prop !optional;
+  @extend %with-icon, %delay-16-svg-prop;
   background-image: var(--delay-16-svg);
 }
 %with-delay-16-mask {
-  @extend %with-mask, %delay-16-svg-prop !optional;
+  @extend %with-mask, %delay-16-svg-prop;
   -webkit-mask-image: var(--delay-16-svg);
   mask-image: var(--delay-16-svg);
 }
 
 %with-delay-24-icon {
-  @extend %with-icon, %delay-24-svg-prop !optional;
+  @extend %with-icon, %delay-24-svg-prop;
   background-image: var(--delay-24-svg);
 }
 %with-delay-24-mask {
-  @extend %with-mask, %delay-24-svg-prop !optional;
+  @extend %with-mask, %delay-24-svg-prop;
   -webkit-mask-image: var(--delay-24-svg);
   mask-image: var(--delay-24-svg);
 }
 
 %with-delay-icon {
-  @extend %with-icon, %delay-svg-prop !optional;
+  @extend %with-icon, %delay-svg-prop;
   background-image: var(--delay-svg);
 }
 %with-delay-mask {
-  @extend %with-mask, %delay-svg-prop !optional;
+  @extend %with-mask, %delay-svg-prop;
   -webkit-mask-image: var(--delay-svg);
   mask-image: var(--delay-svg);
 }
 
 %with-delete-16-icon {
-  @extend %with-icon, %delete-16-svg-prop !optional;
+  @extend %with-icon, %delete-16-svg-prop;
   background-image: var(--delete-16-svg);
 }
 %with-delete-16-mask {
-  @extend %with-mask, %delete-16-svg-prop !optional;
+  @extend %with-mask, %delete-16-svg-prop;
   -webkit-mask-image: var(--delete-16-svg);
   mask-image: var(--delete-16-svg);
 }
 
 %with-delete-24-icon {
-  @extend %with-icon, %delete-24-svg-prop !optional;
+  @extend %with-icon, %delete-24-svg-prop;
   background-image: var(--delete-24-svg);
 }
 %with-delete-24-mask {
-  @extend %with-mask, %delete-24-svg-prop !optional;
+  @extend %with-mask, %delete-24-svg-prop;
   -webkit-mask-image: var(--delete-24-svg);
   mask-image: var(--delete-24-svg);
 }
 
 %with-deny-alt-icon {
-  @extend %with-icon, %deny-alt-svg-prop !optional;
+  @extend %with-icon, %deny-alt-svg-prop;
   background-image: var(--deny-alt-svg);
 }
 %with-deny-alt-mask {
-  @extend %with-mask, %deny-alt-svg-prop !optional;
+  @extend %with-mask, %deny-alt-svg-prop;
   -webkit-mask-image: var(--deny-alt-svg);
   mask-image: var(--deny-alt-svg);
 }
 
 %with-deny-color-icon {
-  @extend %with-icon, %deny-color-svg-prop !optional;
+  @extend %with-icon, %deny-color-svg-prop;
   background-image: var(--deny-color-svg);
 }
 %with-deny-color-mask {
-  @extend %with-mask, %deny-color-svg-prop !optional;
+  @extend %with-mask, %deny-color-svg-prop;
   -webkit-mask-image: var(--deny-color-svg);
   mask-image: var(--deny-color-svg);
 }
 
 %with-deny-default-icon {
-  @extend %with-icon, %deny-default-svg-prop !optional;
+  @extend %with-icon, %deny-default-svg-prop;
   background-image: var(--deny-default-svg);
 }
 %with-deny-default-mask {
-  @extend %with-mask, %deny-default-svg-prop !optional;
+  @extend %with-mask, %deny-default-svg-prop;
   -webkit-mask-image: var(--deny-default-svg);
   mask-image: var(--deny-default-svg);
 }
 
 %with-diamond-16-icon {
-  @extend %with-icon, %diamond-16-svg-prop !optional;
+  @extend %with-icon, %diamond-16-svg-prop;
   background-image: var(--diamond-16-svg);
 }
 %with-diamond-16-mask {
-  @extend %with-mask, %diamond-16-svg-prop !optional;
+  @extend %with-mask, %diamond-16-svg-prop;
   -webkit-mask-image: var(--diamond-16-svg);
   mask-image: var(--diamond-16-svg);
 }
 
 %with-diamond-24-icon {
-  @extend %with-icon, %diamond-24-svg-prop !optional;
+  @extend %with-icon, %diamond-24-svg-prop;
   background-image: var(--diamond-24-svg);
 }
 %with-diamond-24-mask {
-  @extend %with-mask, %diamond-24-svg-prop !optional;
+  @extend %with-mask, %diamond-24-svg-prop;
   -webkit-mask-image: var(--diamond-24-svg);
   mask-image: var(--diamond-24-svg);
 }
 
 %with-diamond-fill-16-icon {
-  @extend %with-icon, %diamond-fill-16-svg-prop !optional;
+  @extend %with-icon, %diamond-fill-16-svg-prop;
   background-image: var(--diamond-fill-16-svg);
 }
 %with-diamond-fill-16-mask {
-  @extend %with-mask, %diamond-fill-16-svg-prop !optional;
+  @extend %with-mask, %diamond-fill-16-svg-prop;
   -webkit-mask-image: var(--diamond-fill-16-svg);
   mask-image: var(--diamond-fill-16-svg);
 }
 
 %with-diamond-fill-24-icon {
-  @extend %with-icon, %diamond-fill-24-svg-prop !optional;
+  @extend %with-icon, %diamond-fill-24-svg-prop;
   background-image: var(--diamond-fill-24-svg);
 }
 %with-diamond-fill-24-mask {
-  @extend %with-mask, %diamond-fill-24-svg-prop !optional;
+  @extend %with-mask, %diamond-fill-24-svg-prop;
   -webkit-mask-image: var(--diamond-fill-24-svg);
   mask-image: var(--diamond-fill-24-svg);
 }
 
 %with-disabled-icon {
-  @extend %with-icon, %disabled-svg-prop !optional;
+  @extend %with-icon, %disabled-svg-prop;
   background-image: var(--disabled-svg);
 }
 %with-disabled-mask {
-  @extend %with-mask, %disabled-svg-prop !optional;
+  @extend %with-mask, %disabled-svg-prop;
   -webkit-mask-image: var(--disabled-svg);
   mask-image: var(--disabled-svg);
 }
 
 %with-disc-16-icon {
-  @extend %with-icon, %disc-16-svg-prop !optional;
+  @extend %with-icon, %disc-16-svg-prop;
   background-image: var(--disc-16-svg);
 }
 %with-disc-16-mask {
-  @extend %with-mask, %disc-16-svg-prop !optional;
+  @extend %with-mask, %disc-16-svg-prop;
   -webkit-mask-image: var(--disc-16-svg);
   mask-image: var(--disc-16-svg);
 }
 
 %with-disc-24-icon {
-  @extend %with-icon, %disc-24-svg-prop !optional;
+  @extend %with-icon, %disc-24-svg-prop;
   background-image: var(--disc-24-svg);
 }
 %with-disc-24-mask {
-  @extend %with-mask, %disc-24-svg-prop !optional;
+  @extend %with-mask, %disc-24-svg-prop;
   -webkit-mask-image: var(--disc-24-svg);
   mask-image: var(--disc-24-svg);
 }
 
 %with-discussion-circle-16-icon {
-  @extend %with-icon, %discussion-circle-16-svg-prop !optional;
+  @extend %with-icon, %discussion-circle-16-svg-prop;
   background-image: var(--discussion-circle-16-svg);
 }
 %with-discussion-circle-16-mask {
-  @extend %with-mask, %discussion-circle-16-svg-prop !optional;
+  @extend %with-mask, %discussion-circle-16-svg-prop;
   -webkit-mask-image: var(--discussion-circle-16-svg);
   mask-image: var(--discussion-circle-16-svg);
 }
 
 %with-discussion-circle-24-icon {
-  @extend %with-icon, %discussion-circle-24-svg-prop !optional;
+  @extend %with-icon, %discussion-circle-24-svg-prop;
   background-image: var(--discussion-circle-24-svg);
 }
 %with-discussion-circle-24-mask {
-  @extend %with-mask, %discussion-circle-24-svg-prop !optional;
+  @extend %with-mask, %discussion-circle-24-svg-prop;
   -webkit-mask-image: var(--discussion-circle-24-svg);
   mask-image: var(--discussion-circle-24-svg);
 }
 
 %with-discussion-square-16-icon {
-  @extend %with-icon, %discussion-square-16-svg-prop !optional;
+  @extend %with-icon, %discussion-square-16-svg-prop;
   background-image: var(--discussion-square-16-svg);
 }
 %with-discussion-square-16-mask {
-  @extend %with-mask, %discussion-square-16-svg-prop !optional;
+  @extend %with-mask, %discussion-square-16-svg-prop;
   -webkit-mask-image: var(--discussion-square-16-svg);
   mask-image: var(--discussion-square-16-svg);
 }
 
 %with-discussion-square-24-icon {
-  @extend %with-icon, %discussion-square-24-svg-prop !optional;
+  @extend %with-icon, %discussion-square-24-svg-prop;
   background-image: var(--discussion-square-24-svg);
 }
 %with-discussion-square-24-mask {
-  @extend %with-mask, %discussion-square-24-svg-prop !optional;
+  @extend %with-mask, %discussion-square-24-svg-prop;
   -webkit-mask-image: var(--discussion-square-24-svg);
   mask-image: var(--discussion-square-24-svg);
 }
 
 %with-docker-16-icon {
-  @extend %with-icon, %docker-16-svg-prop !optional;
+  @extend %with-icon, %docker-16-svg-prop;
   background-image: var(--docker-16-svg);
 }
 %with-docker-16-mask {
-  @extend %with-mask, %docker-16-svg-prop !optional;
+  @extend %with-mask, %docker-16-svg-prop;
   -webkit-mask-image: var(--docker-16-svg);
   mask-image: var(--docker-16-svg);
 }
 
 %with-docker-24-icon {
-  @extend %with-icon, %docker-24-svg-prop !optional;
+  @extend %with-icon, %docker-24-svg-prop;
   background-image: var(--docker-24-svg);
 }
 %with-docker-24-mask {
-  @extend %with-mask, %docker-24-svg-prop !optional;
+  @extend %with-mask, %docker-24-svg-prop;
   -webkit-mask-image: var(--docker-24-svg);
   mask-image: var(--docker-24-svg);
 }
 
 %with-docker-color-16-icon {
-  @extend %with-icon, %docker-color-16-svg-prop !optional;
+  @extend %with-icon, %docker-color-16-svg-prop;
   background-image: var(--docker-color-16-svg);
 }
 %with-docker-color-16-mask {
-  @extend %with-mask, %docker-color-16-svg-prop !optional;
+  @extend %with-mask, %docker-color-16-svg-prop;
   -webkit-mask-image: var(--docker-color-16-svg);
   mask-image: var(--docker-color-16-svg);
 }
 
 %with-docker-color-24-icon {
-  @extend %with-icon, %docker-color-24-svg-prop !optional;
+  @extend %with-icon, %docker-color-24-svg-prop;
   background-image: var(--docker-color-24-svg);
 }
 %with-docker-color-24-mask {
-  @extend %with-mask, %docker-color-24-svg-prop !optional;
+  @extend %with-mask, %docker-color-24-svg-prop;
   -webkit-mask-image: var(--docker-color-24-svg);
   mask-image: var(--docker-color-24-svg);
 }
 
 %with-docs-16-icon {
-  @extend %with-icon, %docs-16-svg-prop !optional;
+  @extend %with-icon, %docs-16-svg-prop;
   background-image: var(--docs-16-svg);
 }
 %with-docs-16-mask {
-  @extend %with-mask, %docs-16-svg-prop !optional;
+  @extend %with-mask, %docs-16-svg-prop;
   -webkit-mask-image: var(--docs-16-svg);
   mask-image: var(--docs-16-svg);
 }
 
 %with-docs-24-icon {
-  @extend %with-icon, %docs-24-svg-prop !optional;
+  @extend %with-icon, %docs-24-svg-prop;
   background-image: var(--docs-24-svg);
 }
 %with-docs-24-mask {
-  @extend %with-mask, %docs-24-svg-prop !optional;
+  @extend %with-mask, %docs-24-svg-prop;
   -webkit-mask-image: var(--docs-24-svg);
   mask-image: var(--docs-24-svg);
 }
 
 %with-docs-download-16-icon {
-  @extend %with-icon, %docs-download-16-svg-prop !optional;
+  @extend %with-icon, %docs-download-16-svg-prop;
   background-image: var(--docs-download-16-svg);
 }
 %with-docs-download-16-mask {
-  @extend %with-mask, %docs-download-16-svg-prop !optional;
+  @extend %with-mask, %docs-download-16-svg-prop;
   -webkit-mask-image: var(--docs-download-16-svg);
   mask-image: var(--docs-download-16-svg);
 }
 
 %with-docs-download-24-icon {
-  @extend %with-icon, %docs-download-24-svg-prop !optional;
+  @extend %with-icon, %docs-download-24-svg-prop;
   background-image: var(--docs-download-24-svg);
 }
 %with-docs-download-24-mask {
-  @extend %with-mask, %docs-download-24-svg-prop !optional;
+  @extend %with-mask, %docs-download-24-svg-prop;
   -webkit-mask-image: var(--docs-download-24-svg);
   mask-image: var(--docs-download-24-svg);
 }
 
 %with-docs-link-16-icon {
-  @extend %with-icon, %docs-link-16-svg-prop !optional;
+  @extend %with-icon, %docs-link-16-svg-prop;
   background-image: var(--docs-link-16-svg);
 }
 %with-docs-link-16-mask {
-  @extend %with-mask, %docs-link-16-svg-prop !optional;
+  @extend %with-mask, %docs-link-16-svg-prop;
   -webkit-mask-image: var(--docs-link-16-svg);
   mask-image: var(--docs-link-16-svg);
 }
 
 %with-docs-link-24-icon {
-  @extend %with-icon, %docs-link-24-svg-prop !optional;
+  @extend %with-icon, %docs-link-24-svg-prop;
   background-image: var(--docs-link-24-svg);
 }
 %with-docs-link-24-mask {
-  @extend %with-mask, %docs-link-24-svg-prop !optional;
+  @extend %with-mask, %docs-link-24-svg-prop;
   -webkit-mask-image: var(--docs-link-24-svg);
   mask-image: var(--docs-link-24-svg);
 }
 
 %with-docs-icon {
-  @extend %with-icon, %docs-svg-prop !optional;
+  @extend %with-icon, %docs-svg-prop;
   background-image: var(--docs-svg);
 }
 %with-docs-mask {
-  @extend %with-mask, %docs-svg-prop !optional;
+  @extend %with-mask, %docs-svg-prop;
   -webkit-mask-image: var(--docs-svg);
   mask-image: var(--docs-svg);
 }
 
 %with-dollar-sign-16-icon {
-  @extend %with-icon, %dollar-sign-16-svg-prop !optional;
+  @extend %with-icon, %dollar-sign-16-svg-prop;
   background-image: var(--dollar-sign-16-svg);
 }
 %with-dollar-sign-16-mask {
-  @extend %with-mask, %dollar-sign-16-svg-prop !optional;
+  @extend %with-mask, %dollar-sign-16-svg-prop;
   -webkit-mask-image: var(--dollar-sign-16-svg);
   mask-image: var(--dollar-sign-16-svg);
 }
 
 %with-dollar-sign-24-icon {
-  @extend %with-icon, %dollar-sign-24-svg-prop !optional;
+  @extend %with-icon, %dollar-sign-24-svg-prop;
   background-image: var(--dollar-sign-24-svg);
 }
 %with-dollar-sign-24-mask {
-  @extend %with-mask, %dollar-sign-24-svg-prop !optional;
+  @extend %with-mask, %dollar-sign-24-svg-prop;
   -webkit-mask-image: var(--dollar-sign-24-svg);
   mask-image: var(--dollar-sign-24-svg);
 }
 
 %with-dot-16-icon {
-  @extend %with-icon, %dot-16-svg-prop !optional;
+  @extend %with-icon, %dot-16-svg-prop;
   background-image: var(--dot-16-svg);
 }
 %with-dot-16-mask {
-  @extend %with-mask, %dot-16-svg-prop !optional;
+  @extend %with-mask, %dot-16-svg-prop;
   -webkit-mask-image: var(--dot-16-svg);
   mask-image: var(--dot-16-svg);
 }
 
 %with-dot-24-icon {
-  @extend %with-icon, %dot-24-svg-prop !optional;
+  @extend %with-icon, %dot-24-svg-prop;
   background-image: var(--dot-24-svg);
 }
 %with-dot-24-mask {
-  @extend %with-mask, %dot-24-svg-prop !optional;
+  @extend %with-mask, %dot-24-svg-prop;
   -webkit-mask-image: var(--dot-24-svg);
   mask-image: var(--dot-24-svg);
 }
 
 %with-dot-half-16-icon {
-  @extend %with-icon, %dot-half-16-svg-prop !optional;
+  @extend %with-icon, %dot-half-16-svg-prop;
   background-image: var(--dot-half-16-svg);
 }
 %with-dot-half-16-mask {
-  @extend %with-mask, %dot-half-16-svg-prop !optional;
+  @extend %with-mask, %dot-half-16-svg-prop;
   -webkit-mask-image: var(--dot-half-16-svg);
   mask-image: var(--dot-half-16-svg);
 }
 
 %with-dot-half-24-icon {
-  @extend %with-icon, %dot-half-24-svg-prop !optional;
+  @extend %with-icon, %dot-half-24-svg-prop;
   background-image: var(--dot-half-24-svg);
 }
 %with-dot-half-24-mask {
-  @extend %with-mask, %dot-half-24-svg-prop !optional;
+  @extend %with-mask, %dot-half-24-svg-prop;
   -webkit-mask-image: var(--dot-half-24-svg);
   mask-image: var(--dot-half-24-svg);
 }
 
 %with-download-16-icon {
-  @extend %with-icon, %download-16-svg-prop !optional;
+  @extend %with-icon, %download-16-svg-prop;
   background-image: var(--download-16-svg);
 }
 %with-download-16-mask {
-  @extend %with-mask, %download-16-svg-prop !optional;
+  @extend %with-mask, %download-16-svg-prop;
   -webkit-mask-image: var(--download-16-svg);
   mask-image: var(--download-16-svg);
 }
 
 %with-download-24-icon {
-  @extend %with-icon, %download-24-svg-prop !optional;
+  @extend %with-icon, %download-24-svg-prop;
   background-image: var(--download-24-svg);
 }
 %with-download-24-mask {
-  @extend %with-mask, %download-24-svg-prop !optional;
+  @extend %with-mask, %download-24-svg-prop;
   -webkit-mask-image: var(--download-24-svg);
   mask-image: var(--download-24-svg);
 }
 
 %with-download-icon {
-  @extend %with-icon, %download-svg-prop !optional;
+  @extend %with-icon, %download-svg-prop;
   background-image: var(--download-svg);
 }
 %with-download-mask {
-  @extend %with-mask, %download-svg-prop !optional;
+  @extend %with-mask, %download-svg-prop;
   -webkit-mask-image: var(--download-svg);
   mask-image: var(--download-svg);
 }
 
 %with-droplet-16-icon {
-  @extend %with-icon, %droplet-16-svg-prop !optional;
+  @extend %with-icon, %droplet-16-svg-prop;
   background-image: var(--droplet-16-svg);
 }
 %with-droplet-16-mask {
-  @extend %with-mask, %droplet-16-svg-prop !optional;
+  @extend %with-mask, %droplet-16-svg-prop;
   -webkit-mask-image: var(--droplet-16-svg);
   mask-image: var(--droplet-16-svg);
 }
 
 %with-droplet-24-icon {
-  @extend %with-icon, %droplet-24-svg-prop !optional;
+  @extend %with-icon, %droplet-24-svg-prop;
   background-image: var(--droplet-24-svg);
 }
 %with-droplet-24-mask {
-  @extend %with-mask, %droplet-24-svg-prop !optional;
+  @extend %with-mask, %droplet-24-svg-prop;
   -webkit-mask-image: var(--droplet-24-svg);
   mask-image: var(--droplet-24-svg);
 }
 
 %with-duplicate-16-icon {
-  @extend %with-icon, %duplicate-16-svg-prop !optional;
+  @extend %with-icon, %duplicate-16-svg-prop;
   background-image: var(--duplicate-16-svg);
 }
 %with-duplicate-16-mask {
-  @extend %with-mask, %duplicate-16-svg-prop !optional;
+  @extend %with-mask, %duplicate-16-svg-prop;
   -webkit-mask-image: var(--duplicate-16-svg);
   mask-image: var(--duplicate-16-svg);
 }
 
 %with-duplicate-24-icon {
-  @extend %with-icon, %duplicate-24-svg-prop !optional;
+  @extend %with-icon, %duplicate-24-svg-prop;
   background-image: var(--duplicate-24-svg);
 }
 %with-duplicate-24-mask {
-  @extend %with-mask, %duplicate-24-svg-prop !optional;
+  @extend %with-mask, %duplicate-24-svg-prop;
   -webkit-mask-image: var(--duplicate-24-svg);
   mask-image: var(--duplicate-24-svg);
 }
 
 %with-edit-16-icon {
-  @extend %with-icon, %edit-16-svg-prop !optional;
+  @extend %with-icon, %edit-16-svg-prop;
   background-image: var(--edit-16-svg);
 }
 %with-edit-16-mask {
-  @extend %with-mask, %edit-16-svg-prop !optional;
+  @extend %with-mask, %edit-16-svg-prop;
   -webkit-mask-image: var(--edit-16-svg);
   mask-image: var(--edit-16-svg);
 }
 
 %with-edit-24-icon {
-  @extend %with-icon, %edit-24-svg-prop !optional;
+  @extend %with-icon, %edit-24-svg-prop;
   background-image: var(--edit-24-svg);
 }
 %with-edit-24-mask {
-  @extend %with-mask, %edit-24-svg-prop !optional;
+  @extend %with-mask, %edit-24-svg-prop;
   -webkit-mask-image: var(--edit-24-svg);
   mask-image: var(--edit-24-svg);
 }
 
 %with-edit-icon {
-  @extend %with-icon, %edit-svg-prop !optional;
+  @extend %with-icon, %edit-svg-prop;
   background-image: var(--edit-svg);
 }
 %with-edit-mask {
-  @extend %with-mask, %edit-svg-prop !optional;
+  @extend %with-mask, %edit-svg-prop;
   -webkit-mask-image: var(--edit-svg);
   mask-image: var(--edit-svg);
 }
 
 %with-entry-point-16-icon {
-  @extend %with-icon, %entry-point-16-svg-prop !optional;
+  @extend %with-icon, %entry-point-16-svg-prop;
   background-image: var(--entry-point-16-svg);
 }
 %with-entry-point-16-mask {
-  @extend %with-mask, %entry-point-16-svg-prop !optional;
+  @extend %with-mask, %entry-point-16-svg-prop;
   -webkit-mask-image: var(--entry-point-16-svg);
   mask-image: var(--entry-point-16-svg);
 }
 
 %with-entry-point-24-icon {
-  @extend %with-icon, %entry-point-24-svg-prop !optional;
+  @extend %with-icon, %entry-point-24-svg-prop;
   background-image: var(--entry-point-24-svg);
 }
 %with-entry-point-24-mask {
-  @extend %with-mask, %entry-point-24-svg-prop !optional;
+  @extend %with-mask, %entry-point-24-svg-prop;
   -webkit-mask-image: var(--entry-point-24-svg);
   mask-image: var(--entry-point-24-svg);
 }
 
 %with-envelope-sealed-fill-icon {
-  @extend %with-icon, %envelope-sealed-fill-svg-prop !optional;
+  @extend %with-icon, %envelope-sealed-fill-svg-prop;
   background-image: var(--envelope-sealed-fill-svg);
 }
 %with-envelope-sealed-fill-mask {
-  @extend %with-mask, %envelope-sealed-fill-svg-prop !optional;
+  @extend %with-mask, %envelope-sealed-fill-svg-prop;
   -webkit-mask-image: var(--envelope-sealed-fill-svg);
   mask-image: var(--envelope-sealed-fill-svg);
 }
 
 %with-envelope-sealed-outline-icon {
-  @extend %with-icon, %envelope-sealed-outline-svg-prop !optional;
+  @extend %with-icon, %envelope-sealed-outline-svg-prop;
   background-image: var(--envelope-sealed-outline-svg);
 }
 %with-envelope-sealed-outline-mask {
-  @extend %with-mask, %envelope-sealed-outline-svg-prop !optional;
+  @extend %with-mask, %envelope-sealed-outline-svg-prop;
   -webkit-mask-image: var(--envelope-sealed-outline-svg);
   mask-image: var(--envelope-sealed-outline-svg);
 }
 
 %with-envelope-unsealed--outline-icon {
-  @extend %with-icon, %envelope-unsealed--outline-svg-prop !optional;
+  @extend %with-icon, %envelope-unsealed--outline-svg-prop;
   background-image: var(--envelope-unsealed--outline-svg);
 }
 %with-envelope-unsealed--outline-mask {
-  @extend %with-mask, %envelope-unsealed--outline-svg-prop !optional;
+  @extend %with-mask, %envelope-unsealed--outline-svg-prop;
   -webkit-mask-image: var(--envelope-unsealed--outline-svg);
   mask-image: var(--envelope-unsealed--outline-svg);
 }
 
 %with-envelope-unsealed-fill-icon {
-  @extend %with-icon, %envelope-unsealed-fill-svg-prop !optional;
+  @extend %with-icon, %envelope-unsealed-fill-svg-prop;
   background-image: var(--envelope-unsealed-fill-svg);
 }
 %with-envelope-unsealed-fill-mask {
-  @extend %with-mask, %envelope-unsealed-fill-svg-prop !optional;
+  @extend %with-mask, %envelope-unsealed-fill-svg-prop;
   -webkit-mask-image: var(--envelope-unsealed-fill-svg);
   mask-image: var(--envelope-unsealed-fill-svg);
 }
 
 %with-event-16-icon {
-  @extend %with-icon, %event-16-svg-prop !optional;
+  @extend %with-icon, %event-16-svg-prop;
   background-image: var(--event-16-svg);
 }
 %with-event-16-mask {
-  @extend %with-mask, %event-16-svg-prop !optional;
+  @extend %with-mask, %event-16-svg-prop;
   -webkit-mask-image: var(--event-16-svg);
   mask-image: var(--event-16-svg);
 }
 
 %with-event-24-icon {
-  @extend %with-icon, %event-24-svg-prop !optional;
+  @extend %with-icon, %event-24-svg-prop;
   background-image: var(--event-24-svg);
 }
 %with-event-24-mask {
-  @extend %with-mask, %event-24-svg-prop !optional;
+  @extend %with-mask, %event-24-svg-prop;
   -webkit-mask-image: var(--event-24-svg);
   mask-image: var(--event-24-svg);
 }
 
 %with-exit-point-16-icon {
-  @extend %with-icon, %exit-point-16-svg-prop !optional;
+  @extend %with-icon, %exit-point-16-svg-prop;
   background-image: var(--exit-point-16-svg);
 }
 %with-exit-point-16-mask {
-  @extend %with-mask, %exit-point-16-svg-prop !optional;
+  @extend %with-mask, %exit-point-16-svg-prop;
   -webkit-mask-image: var(--exit-point-16-svg);
   mask-image: var(--exit-point-16-svg);
 }
 
 %with-exit-point-24-icon {
-  @extend %with-icon, %exit-point-24-svg-prop !optional;
+  @extend %with-icon, %exit-point-24-svg-prop;
   background-image: var(--exit-point-24-svg);
 }
 %with-exit-point-24-mask {
-  @extend %with-mask, %exit-point-24-svg-prop !optional;
+  @extend %with-mask, %exit-point-24-svg-prop;
   -webkit-mask-image: var(--exit-point-24-svg);
   mask-image: var(--exit-point-24-svg);
 }
 
 %with-exit-icon {
-  @extend %with-icon, %exit-svg-prop !optional;
+  @extend %with-icon, %exit-svg-prop;
   background-image: var(--exit-svg);
 }
 %with-exit-mask {
-  @extend %with-mask, %exit-svg-prop !optional;
+  @extend %with-mask, %exit-svg-prop;
   -webkit-mask-image: var(--exit-svg);
   mask-image: var(--exit-svg);
 }
 
 %with-expand-less-icon {
-  @extend %with-icon, %expand-less-svg-prop !optional;
+  @extend %with-icon, %expand-less-svg-prop;
   background-image: var(--expand-less-svg);
 }
 %with-expand-less-mask {
-  @extend %with-mask, %expand-less-svg-prop !optional;
+  @extend %with-mask, %expand-less-svg-prop;
   -webkit-mask-image: var(--expand-less-svg);
   mask-image: var(--expand-less-svg);
 }
 
 %with-expand-more-icon {
-  @extend %with-icon, %expand-more-svg-prop !optional;
+  @extend %with-icon, %expand-more-svg-prop;
   background-image: var(--expand-more-svg);
 }
 %with-expand-more-mask {
-  @extend %with-mask, %expand-more-svg-prop !optional;
+  @extend %with-mask, %expand-more-svg-prop;
   -webkit-mask-image: var(--expand-more-svg);
   mask-image: var(--expand-more-svg);
 }
 
 %with-external-link-16-icon {
-  @extend %with-icon, %external-link-16-svg-prop !optional;
+  @extend %with-icon, %external-link-16-svg-prop;
   background-image: var(--external-link-16-svg);
 }
 %with-external-link-16-mask {
-  @extend %with-mask, %external-link-16-svg-prop !optional;
+  @extend %with-mask, %external-link-16-svg-prop;
   -webkit-mask-image: var(--external-link-16-svg);
   mask-image: var(--external-link-16-svg);
 }
 
 %with-external-link-24-icon {
-  @extend %with-icon, %external-link-24-svg-prop !optional;
+  @extend %with-icon, %external-link-24-svg-prop;
   background-image: var(--external-link-24-svg);
 }
 %with-external-link-24-mask {
-  @extend %with-mask, %external-link-24-svg-prop !optional;
+  @extend %with-mask, %external-link-24-svg-prop;
   -webkit-mask-image: var(--external-link-24-svg);
   mask-image: var(--external-link-24-svg);
 }
 
 %with-eye-16-icon {
-  @extend %with-icon, %eye-16-svg-prop !optional;
+  @extend %with-icon, %eye-16-svg-prop;
   background-image: var(--eye-16-svg);
 }
 %with-eye-16-mask {
-  @extend %with-mask, %eye-16-svg-prop !optional;
+  @extend %with-mask, %eye-16-svg-prop;
   -webkit-mask-image: var(--eye-16-svg);
   mask-image: var(--eye-16-svg);
 }
 
 %with-eye-24-icon {
-  @extend %with-icon, %eye-24-svg-prop !optional;
+  @extend %with-icon, %eye-24-svg-prop;
   background-image: var(--eye-24-svg);
 }
 %with-eye-24-mask {
-  @extend %with-mask, %eye-24-svg-prop !optional;
+  @extend %with-mask, %eye-24-svg-prop;
   -webkit-mask-image: var(--eye-24-svg);
   mask-image: var(--eye-24-svg);
 }
 
 %with-eye-off-16-icon {
-  @extend %with-icon, %eye-off-16-svg-prop !optional;
+  @extend %with-icon, %eye-off-16-svg-prop;
   background-image: var(--eye-off-16-svg);
 }
 %with-eye-off-16-mask {
-  @extend %with-mask, %eye-off-16-svg-prop !optional;
+  @extend %with-mask, %eye-off-16-svg-prop;
   -webkit-mask-image: var(--eye-off-16-svg);
   mask-image: var(--eye-off-16-svg);
 }
 
 %with-eye-off-24-icon {
-  @extend %with-icon, %eye-off-24-svg-prop !optional;
+  @extend %with-icon, %eye-off-24-svg-prop;
   background-image: var(--eye-off-24-svg);
 }
 %with-eye-off-24-mask {
-  @extend %with-mask, %eye-off-24-svg-prop !optional;
+  @extend %with-mask, %eye-off-24-svg-prop;
   -webkit-mask-image: var(--eye-off-24-svg);
   mask-image: var(--eye-off-24-svg);
 }
 
 %with-f5-16-icon {
-  @extend %with-icon, %f5-16-svg-prop !optional;
+  @extend %with-icon, %f5-16-svg-prop;
   background-image: var(--f5-16-svg);
 }
 %with-f5-16-mask {
-  @extend %with-mask, %f5-16-svg-prop !optional;
+  @extend %with-mask, %f5-16-svg-prop;
   -webkit-mask-image: var(--f5-16-svg);
   mask-image: var(--f5-16-svg);
 }
 
 %with-f5-24-icon {
-  @extend %with-icon, %f5-24-svg-prop !optional;
+  @extend %with-icon, %f5-24-svg-prop;
   background-image: var(--f5-24-svg);
 }
 %with-f5-24-mask {
-  @extend %with-mask, %f5-24-svg-prop !optional;
+  @extend %with-mask, %f5-24-svg-prop;
   -webkit-mask-image: var(--f5-24-svg);
   mask-image: var(--f5-24-svg);
 }
 
 %with-f5-color-16-icon {
-  @extend %with-icon, %f5-color-16-svg-prop !optional;
+  @extend %with-icon, %f5-color-16-svg-prop;
   background-image: var(--f5-color-16-svg);
 }
 %with-f5-color-16-mask {
-  @extend %with-mask, %f5-color-16-svg-prop !optional;
+  @extend %with-mask, %f5-color-16-svg-prop;
   -webkit-mask-image: var(--f5-color-16-svg);
   mask-image: var(--f5-color-16-svg);
 }
 
 %with-f5-color-24-icon {
-  @extend %with-icon, %f5-color-24-svg-prop !optional;
+  @extend %with-icon, %f5-color-24-svg-prop;
   background-image: var(--f5-color-24-svg);
 }
 %with-f5-color-24-mask {
-  @extend %with-mask, %f5-color-24-svg-prop !optional;
+  @extend %with-mask, %f5-color-24-svg-prop;
   -webkit-mask-image: var(--f5-color-24-svg);
   mask-image: var(--f5-color-24-svg);
 }
 
 %with-fast-forward-16-icon {
-  @extend %with-icon, %fast-forward-16-svg-prop !optional;
+  @extend %with-icon, %fast-forward-16-svg-prop;
   background-image: var(--fast-forward-16-svg);
 }
 %with-fast-forward-16-mask {
-  @extend %with-mask, %fast-forward-16-svg-prop !optional;
+  @extend %with-mask, %fast-forward-16-svg-prop;
   -webkit-mask-image: var(--fast-forward-16-svg);
   mask-image: var(--fast-forward-16-svg);
 }
 
 %with-fast-forward-24-icon {
-  @extend %with-icon, %fast-forward-24-svg-prop !optional;
+  @extend %with-icon, %fast-forward-24-svg-prop;
   background-image: var(--fast-forward-24-svg);
 }
 %with-fast-forward-24-mask {
-  @extend %with-mask, %fast-forward-24-svg-prop !optional;
+  @extend %with-mask, %fast-forward-24-svg-prop;
   -webkit-mask-image: var(--fast-forward-24-svg);
   mask-image: var(--fast-forward-24-svg);
 }
 
 %with-file-16-icon {
-  @extend %with-icon, %file-16-svg-prop !optional;
+  @extend %with-icon, %file-16-svg-prop;
   background-image: var(--file-16-svg);
 }
 %with-file-16-mask {
-  @extend %with-mask, %file-16-svg-prop !optional;
+  @extend %with-mask, %file-16-svg-prop;
   -webkit-mask-image: var(--file-16-svg);
   mask-image: var(--file-16-svg);
 }
 
 %with-file-24-icon {
-  @extend %with-icon, %file-24-svg-prop !optional;
+  @extend %with-icon, %file-24-svg-prop;
   background-image: var(--file-24-svg);
 }
 %with-file-24-mask {
-  @extend %with-mask, %file-24-svg-prop !optional;
+  @extend %with-mask, %file-24-svg-prop;
   -webkit-mask-image: var(--file-24-svg);
   mask-image: var(--file-24-svg);
 }
 
 %with-file-change-16-icon {
-  @extend %with-icon, %file-change-16-svg-prop !optional;
+  @extend %with-icon, %file-change-16-svg-prop;
   background-image: var(--file-change-16-svg);
 }
 %with-file-change-16-mask {
-  @extend %with-mask, %file-change-16-svg-prop !optional;
+  @extend %with-mask, %file-change-16-svg-prop;
   -webkit-mask-image: var(--file-change-16-svg);
   mask-image: var(--file-change-16-svg);
 }
 
 %with-file-change-24-icon {
-  @extend %with-icon, %file-change-24-svg-prop !optional;
+  @extend %with-icon, %file-change-24-svg-prop;
   background-image: var(--file-change-24-svg);
 }
 %with-file-change-24-mask {
-  @extend %with-mask, %file-change-24-svg-prop !optional;
+  @extend %with-mask, %file-change-24-svg-prop;
   -webkit-mask-image: var(--file-change-24-svg);
   mask-image: var(--file-change-24-svg);
 }
 
 %with-file-check-16-icon {
-  @extend %with-icon, %file-check-16-svg-prop !optional;
+  @extend %with-icon, %file-check-16-svg-prop;
   background-image: var(--file-check-16-svg);
 }
 %with-file-check-16-mask {
-  @extend %with-mask, %file-check-16-svg-prop !optional;
+  @extend %with-mask, %file-check-16-svg-prop;
   -webkit-mask-image: var(--file-check-16-svg);
   mask-image: var(--file-check-16-svg);
 }
 
 %with-file-check-24-icon {
-  @extend %with-icon, %file-check-24-svg-prop !optional;
+  @extend %with-icon, %file-check-24-svg-prop;
   background-image: var(--file-check-24-svg);
 }
 %with-file-check-24-mask {
-  @extend %with-mask, %file-check-24-svg-prop !optional;
+  @extend %with-mask, %file-check-24-svg-prop;
   -webkit-mask-image: var(--file-check-24-svg);
   mask-image: var(--file-check-24-svg);
 }
 
 %with-file-diff-16-icon {
-  @extend %with-icon, %file-diff-16-svg-prop !optional;
+  @extend %with-icon, %file-diff-16-svg-prop;
   background-image: var(--file-diff-16-svg);
 }
 %with-file-diff-16-mask {
-  @extend %with-mask, %file-diff-16-svg-prop !optional;
+  @extend %with-mask, %file-diff-16-svg-prop;
   -webkit-mask-image: var(--file-diff-16-svg);
   mask-image: var(--file-diff-16-svg);
 }
 
 %with-file-diff-24-icon {
-  @extend %with-icon, %file-diff-24-svg-prop !optional;
+  @extend %with-icon, %file-diff-24-svg-prop;
   background-image: var(--file-diff-24-svg);
 }
 %with-file-diff-24-mask {
-  @extend %with-mask, %file-diff-24-svg-prop !optional;
+  @extend %with-mask, %file-diff-24-svg-prop;
   -webkit-mask-image: var(--file-diff-24-svg);
   mask-image: var(--file-diff-24-svg);
 }
 
 %with-file-fill-icon {
-  @extend %with-icon, %file-fill-svg-prop !optional;
+  @extend %with-icon, %file-fill-svg-prop;
   background-image: var(--file-fill-svg);
 }
 %with-file-fill-mask {
-  @extend %with-mask, %file-fill-svg-prop !optional;
+  @extend %with-mask, %file-fill-svg-prop;
   -webkit-mask-image: var(--file-fill-svg);
   mask-image: var(--file-fill-svg);
 }
 
 %with-file-minus-16-icon {
-  @extend %with-icon, %file-minus-16-svg-prop !optional;
+  @extend %with-icon, %file-minus-16-svg-prop;
   background-image: var(--file-minus-16-svg);
 }
 %with-file-minus-16-mask {
-  @extend %with-mask, %file-minus-16-svg-prop !optional;
+  @extend %with-mask, %file-minus-16-svg-prop;
   -webkit-mask-image: var(--file-minus-16-svg);
   mask-image: var(--file-minus-16-svg);
 }
 
 %with-file-minus-24-icon {
-  @extend %with-icon, %file-minus-24-svg-prop !optional;
+  @extend %with-icon, %file-minus-24-svg-prop;
   background-image: var(--file-minus-24-svg);
 }
 %with-file-minus-24-mask {
-  @extend %with-mask, %file-minus-24-svg-prop !optional;
+  @extend %with-mask, %file-minus-24-svg-prop;
   -webkit-mask-image: var(--file-minus-24-svg);
   mask-image: var(--file-minus-24-svg);
 }
 
 %with-file-outline-icon {
-  @extend %with-icon, %file-outline-svg-prop !optional;
+  @extend %with-icon, %file-outline-svg-prop;
   background-image: var(--file-outline-svg);
 }
 %with-file-outline-mask {
-  @extend %with-mask, %file-outline-svg-prop !optional;
+  @extend %with-mask, %file-outline-svg-prop;
   -webkit-mask-image: var(--file-outline-svg);
   mask-image: var(--file-outline-svg);
 }
 
 %with-file-plus-16-icon {
-  @extend %with-icon, %file-plus-16-svg-prop !optional;
+  @extend %with-icon, %file-plus-16-svg-prop;
   background-image: var(--file-plus-16-svg);
 }
 %with-file-plus-16-mask {
-  @extend %with-mask, %file-plus-16-svg-prop !optional;
+  @extend %with-mask, %file-plus-16-svg-prop;
   -webkit-mask-image: var(--file-plus-16-svg);
   mask-image: var(--file-plus-16-svg);
 }
 
 %with-file-plus-24-icon {
-  @extend %with-icon, %file-plus-24-svg-prop !optional;
+  @extend %with-icon, %file-plus-24-svg-prop;
   background-image: var(--file-plus-24-svg);
 }
 %with-file-plus-24-mask {
-  @extend %with-mask, %file-plus-24-svg-prop !optional;
+  @extend %with-mask, %file-plus-24-svg-prop;
   -webkit-mask-image: var(--file-plus-24-svg);
   mask-image: var(--file-plus-24-svg);
 }
 
 %with-file-source-16-icon {
-  @extend %with-icon, %file-source-16-svg-prop !optional;
+  @extend %with-icon, %file-source-16-svg-prop;
   background-image: var(--file-source-16-svg);
 }
 %with-file-source-16-mask {
-  @extend %with-mask, %file-source-16-svg-prop !optional;
+  @extend %with-mask, %file-source-16-svg-prop;
   -webkit-mask-image: var(--file-source-16-svg);
   mask-image: var(--file-source-16-svg);
 }
 
 %with-file-source-24-icon {
-  @extend %with-icon, %file-source-24-svg-prop !optional;
+  @extend %with-icon, %file-source-24-svg-prop;
   background-image: var(--file-source-24-svg);
 }
 %with-file-source-24-mask {
-  @extend %with-mask, %file-source-24-svg-prop !optional;
+  @extend %with-mask, %file-source-24-svg-prop;
   -webkit-mask-image: var(--file-source-24-svg);
   mask-image: var(--file-source-24-svg);
 }
 
 %with-file-text-16-icon {
-  @extend %with-icon, %file-text-16-svg-prop !optional;
+  @extend %with-icon, %file-text-16-svg-prop;
   background-image: var(--file-text-16-svg);
 }
 %with-file-text-16-mask {
-  @extend %with-mask, %file-text-16-svg-prop !optional;
+  @extend %with-mask, %file-text-16-svg-prop;
   -webkit-mask-image: var(--file-text-16-svg);
   mask-image: var(--file-text-16-svg);
 }
 
 %with-file-text-24-icon {
-  @extend %with-icon, %file-text-24-svg-prop !optional;
+  @extend %with-icon, %file-text-24-svg-prop;
   background-image: var(--file-text-24-svg);
 }
 %with-file-text-24-mask {
-  @extend %with-mask, %file-text-24-svg-prop !optional;
+  @extend %with-mask, %file-text-24-svg-prop;
   -webkit-mask-image: var(--file-text-24-svg);
   mask-image: var(--file-text-24-svg);
 }
 
 %with-file-x-16-icon {
-  @extend %with-icon, %file-x-16-svg-prop !optional;
+  @extend %with-icon, %file-x-16-svg-prop;
   background-image: var(--file-x-16-svg);
 }
 %with-file-x-16-mask {
-  @extend %with-mask, %file-x-16-svg-prop !optional;
+  @extend %with-mask, %file-x-16-svg-prop;
   -webkit-mask-image: var(--file-x-16-svg);
   mask-image: var(--file-x-16-svg);
 }
 
 %with-file-x-24-icon {
-  @extend %with-icon, %file-x-24-svg-prop !optional;
+  @extend %with-icon, %file-x-24-svg-prop;
   background-image: var(--file-x-24-svg);
 }
 %with-file-x-24-mask {
-  @extend %with-mask, %file-x-24-svg-prop !optional;
+  @extend %with-mask, %file-x-24-svg-prop;
   -webkit-mask-image: var(--file-x-24-svg);
   mask-image: var(--file-x-24-svg);
 }
 
 %with-files-16-icon {
-  @extend %with-icon, %files-16-svg-prop !optional;
+  @extend %with-icon, %files-16-svg-prop;
   background-image: var(--files-16-svg);
 }
 %with-files-16-mask {
-  @extend %with-mask, %files-16-svg-prop !optional;
+  @extend %with-mask, %files-16-svg-prop;
   -webkit-mask-image: var(--files-16-svg);
   mask-image: var(--files-16-svg);
 }
 
 %with-files-24-icon {
-  @extend %with-icon, %files-24-svg-prop !optional;
+  @extend %with-icon, %files-24-svg-prop;
   background-image: var(--files-24-svg);
 }
 %with-files-24-mask {
-  @extend %with-mask, %files-24-svg-prop !optional;
+  @extend %with-mask, %files-24-svg-prop;
   -webkit-mask-image: var(--files-24-svg);
   mask-image: var(--files-24-svg);
 }
 
 %with-film-16-icon {
-  @extend %with-icon, %film-16-svg-prop !optional;
+  @extend %with-icon, %film-16-svg-prop;
   background-image: var(--film-16-svg);
 }
 %with-film-16-mask {
-  @extend %with-mask, %film-16-svg-prop !optional;
+  @extend %with-mask, %film-16-svg-prop;
   -webkit-mask-image: var(--film-16-svg);
   mask-image: var(--film-16-svg);
 }
 
 %with-film-24-icon {
-  @extend %with-icon, %film-24-svg-prop !optional;
+  @extend %with-icon, %film-24-svg-prop;
   background-image: var(--film-24-svg);
 }
 %with-film-24-mask {
-  @extend %with-mask, %film-24-svg-prop !optional;
+  @extend %with-mask, %film-24-svg-prop;
   -webkit-mask-image: var(--film-24-svg);
   mask-image: var(--film-24-svg);
 }
 
 %with-filter-16-icon {
-  @extend %with-icon, %filter-16-svg-prop !optional;
+  @extend %with-icon, %filter-16-svg-prop;
   background-image: var(--filter-16-svg);
 }
 %with-filter-16-mask {
-  @extend %with-mask, %filter-16-svg-prop !optional;
+  @extend %with-mask, %filter-16-svg-prop;
   -webkit-mask-image: var(--filter-16-svg);
   mask-image: var(--filter-16-svg);
 }
 
 %with-filter-24-icon {
-  @extend %with-icon, %filter-24-svg-prop !optional;
+  @extend %with-icon, %filter-24-svg-prop;
   background-image: var(--filter-24-svg);
 }
 %with-filter-24-mask {
-  @extend %with-mask, %filter-24-svg-prop !optional;
+  @extend %with-mask, %filter-24-svg-prop;
   -webkit-mask-image: var(--filter-24-svg);
   mask-image: var(--filter-24-svg);
 }
 
 %with-filter-circle-16-icon {
-  @extend %with-icon, %filter-circle-16-svg-prop !optional;
+  @extend %with-icon, %filter-circle-16-svg-prop;
   background-image: var(--filter-circle-16-svg);
 }
 %with-filter-circle-16-mask {
-  @extend %with-mask, %filter-circle-16-svg-prop !optional;
+  @extend %with-mask, %filter-circle-16-svg-prop;
   -webkit-mask-image: var(--filter-circle-16-svg);
   mask-image: var(--filter-circle-16-svg);
 }
 
 %with-filter-circle-24-icon {
-  @extend %with-icon, %filter-circle-24-svg-prop !optional;
+  @extend %with-icon, %filter-circle-24-svg-prop;
   background-image: var(--filter-circle-24-svg);
 }
 %with-filter-circle-24-mask {
-  @extend %with-mask, %filter-circle-24-svg-prop !optional;
+  @extend %with-mask, %filter-circle-24-svg-prop;
   -webkit-mask-image: var(--filter-circle-24-svg);
   mask-image: var(--filter-circle-24-svg);
 }
 
 %with-filter-fill-16-icon {
-  @extend %with-icon, %filter-fill-16-svg-prop !optional;
+  @extend %with-icon, %filter-fill-16-svg-prop;
   background-image: var(--filter-fill-16-svg);
 }
 %with-filter-fill-16-mask {
-  @extend %with-mask, %filter-fill-16-svg-prop !optional;
+  @extend %with-mask, %filter-fill-16-svg-prop;
   -webkit-mask-image: var(--filter-fill-16-svg);
   mask-image: var(--filter-fill-16-svg);
 }
 
 %with-filter-fill-24-icon {
-  @extend %with-icon, %filter-fill-24-svg-prop !optional;
+  @extend %with-icon, %filter-fill-24-svg-prop;
   background-image: var(--filter-fill-24-svg);
 }
 %with-filter-fill-24-mask {
-  @extend %with-mask, %filter-fill-24-svg-prop !optional;
+  @extend %with-mask, %filter-fill-24-svg-prop;
   -webkit-mask-image: var(--filter-fill-24-svg);
   mask-image: var(--filter-fill-24-svg);
 }
 
 %with-filter-icon {
-  @extend %with-icon, %filter-svg-prop !optional;
+  @extend %with-icon, %filter-svg-prop;
   background-image: var(--filter-svg);
 }
 %with-filter-mask {
-  @extend %with-mask, %filter-svg-prop !optional;
+  @extend %with-mask, %filter-svg-prop;
   -webkit-mask-image: var(--filter-svg);
   mask-image: var(--filter-svg);
 }
 
 %with-fingerprint-16-icon {
-  @extend %with-icon, %fingerprint-16-svg-prop !optional;
+  @extend %with-icon, %fingerprint-16-svg-prop;
   background-image: var(--fingerprint-16-svg);
 }
 %with-fingerprint-16-mask {
-  @extend %with-mask, %fingerprint-16-svg-prop !optional;
+  @extend %with-mask, %fingerprint-16-svg-prop;
   -webkit-mask-image: var(--fingerprint-16-svg);
   mask-image: var(--fingerprint-16-svg);
 }
 
 %with-fingerprint-24-icon {
-  @extend %with-icon, %fingerprint-24-svg-prop !optional;
+  @extend %with-icon, %fingerprint-24-svg-prop;
   background-image: var(--fingerprint-24-svg);
 }
 %with-fingerprint-24-mask {
-  @extend %with-mask, %fingerprint-24-svg-prop !optional;
+  @extend %with-mask, %fingerprint-24-svg-prop;
   -webkit-mask-image: var(--fingerprint-24-svg);
   mask-image: var(--fingerprint-24-svg);
 }
 
 %with-flag-16-icon {
-  @extend %with-icon, %flag-16-svg-prop !optional;
+  @extend %with-icon, %flag-16-svg-prop;
   background-image: var(--flag-16-svg);
 }
 %with-flag-16-mask {
-  @extend %with-mask, %flag-16-svg-prop !optional;
+  @extend %with-mask, %flag-16-svg-prop;
   -webkit-mask-image: var(--flag-16-svg);
   mask-image: var(--flag-16-svg);
 }
 
 %with-flag-24-icon {
-  @extend %with-icon, %flag-24-svg-prop !optional;
+  @extend %with-icon, %flag-24-svg-prop;
   background-image: var(--flag-24-svg);
 }
 %with-flag-24-mask {
-  @extend %with-mask, %flag-24-svg-prop !optional;
+  @extend %with-mask, %flag-24-svg-prop;
   -webkit-mask-image: var(--flag-24-svg);
   mask-image: var(--flag-24-svg);
 }
 
 %with-flag-icon {
-  @extend %with-icon, %flag-svg-prop !optional;
+  @extend %with-icon, %flag-svg-prop;
   background-image: var(--flag-svg);
 }
 %with-flag-mask {
-  @extend %with-mask, %flag-svg-prop !optional;
+  @extend %with-mask, %flag-svg-prop;
   -webkit-mask-image: var(--flag-svg);
   mask-image: var(--flag-svg);
 }
 
 %with-folder-16-icon {
-  @extend %with-icon, %folder-16-svg-prop !optional;
+  @extend %with-icon, %folder-16-svg-prop;
   background-image: var(--folder-16-svg);
 }
 %with-folder-16-mask {
-  @extend %with-mask, %folder-16-svg-prop !optional;
+  @extend %with-mask, %folder-16-svg-prop;
   -webkit-mask-image: var(--folder-16-svg);
   mask-image: var(--folder-16-svg);
 }
 
 %with-folder-24-icon {
-  @extend %with-icon, %folder-24-svg-prop !optional;
+  @extend %with-icon, %folder-24-svg-prop;
   background-image: var(--folder-24-svg);
 }
 %with-folder-24-mask {
-  @extend %with-mask, %folder-24-svg-prop !optional;
+  @extend %with-mask, %folder-24-svg-prop;
   -webkit-mask-image: var(--folder-24-svg);
   mask-image: var(--folder-24-svg);
 }
 
 %with-folder-fill-16-icon {
-  @extend %with-icon, %folder-fill-16-svg-prop !optional;
+  @extend %with-icon, %folder-fill-16-svg-prop;
   background-image: var(--folder-fill-16-svg);
 }
 %with-folder-fill-16-mask {
-  @extend %with-mask, %folder-fill-16-svg-prop !optional;
+  @extend %with-mask, %folder-fill-16-svg-prop;
   -webkit-mask-image: var(--folder-fill-16-svg);
   mask-image: var(--folder-fill-16-svg);
 }
 
 %with-folder-fill-24-icon {
-  @extend %with-icon, %folder-fill-24-svg-prop !optional;
+  @extend %with-icon, %folder-fill-24-svg-prop;
   background-image: var(--folder-fill-24-svg);
 }
 %with-folder-fill-24-mask {
-  @extend %with-mask, %folder-fill-24-svg-prop !optional;
+  @extend %with-mask, %folder-fill-24-svg-prop;
   -webkit-mask-image: var(--folder-fill-24-svg);
   mask-image: var(--folder-fill-24-svg);
 }
 
 %with-folder-fill-icon {
-  @extend %with-icon, %folder-fill-svg-prop !optional;
+  @extend %with-icon, %folder-fill-svg-prop;
   background-image: var(--folder-fill-svg);
 }
 %with-folder-fill-mask {
-  @extend %with-mask, %folder-fill-svg-prop !optional;
+  @extend %with-mask, %folder-fill-svg-prop;
   -webkit-mask-image: var(--folder-fill-svg);
   mask-image: var(--folder-fill-svg);
 }
 
 %with-folder-minus-16-icon {
-  @extend %with-icon, %folder-minus-16-svg-prop !optional;
+  @extend %with-icon, %folder-minus-16-svg-prop;
   background-image: var(--folder-minus-16-svg);
 }
 %with-folder-minus-16-mask {
-  @extend %with-mask, %folder-minus-16-svg-prop !optional;
+  @extend %with-mask, %folder-minus-16-svg-prop;
   -webkit-mask-image: var(--folder-minus-16-svg);
   mask-image: var(--folder-minus-16-svg);
 }
 
 %with-folder-minus-24-icon {
-  @extend %with-icon, %folder-minus-24-svg-prop !optional;
+  @extend %with-icon, %folder-minus-24-svg-prop;
   background-image: var(--folder-minus-24-svg);
 }
 %with-folder-minus-24-mask {
-  @extend %with-mask, %folder-minus-24-svg-prop !optional;
+  @extend %with-mask, %folder-minus-24-svg-prop;
   -webkit-mask-image: var(--folder-minus-24-svg);
   mask-image: var(--folder-minus-24-svg);
 }
 
 %with-folder-minus-fill-16-icon {
-  @extend %with-icon, %folder-minus-fill-16-svg-prop !optional;
+  @extend %with-icon, %folder-minus-fill-16-svg-prop;
   background-image: var(--folder-minus-fill-16-svg);
 }
 %with-folder-minus-fill-16-mask {
-  @extend %with-mask, %folder-minus-fill-16-svg-prop !optional;
+  @extend %with-mask, %folder-minus-fill-16-svg-prop;
   -webkit-mask-image: var(--folder-minus-fill-16-svg);
   mask-image: var(--folder-minus-fill-16-svg);
 }
 
 %with-folder-minus-fill-24-icon {
-  @extend %with-icon, %folder-minus-fill-24-svg-prop !optional;
+  @extend %with-icon, %folder-minus-fill-24-svg-prop;
   background-image: var(--folder-minus-fill-24-svg);
 }
 %with-folder-minus-fill-24-mask {
-  @extend %with-mask, %folder-minus-fill-24-svg-prop !optional;
+  @extend %with-mask, %folder-minus-fill-24-svg-prop;
   -webkit-mask-image: var(--folder-minus-fill-24-svg);
   mask-image: var(--folder-minus-fill-24-svg);
 }
 
 %with-folder-outline-icon {
-  @extend %with-icon, %folder-outline-svg-prop !optional;
+  @extend %with-icon, %folder-outline-svg-prop;
   background-image: var(--folder-outline-svg);
 }
 %with-folder-outline-mask {
-  @extend %with-mask, %folder-outline-svg-prop !optional;
+  @extend %with-mask, %folder-outline-svg-prop;
   -webkit-mask-image: var(--folder-outline-svg);
   mask-image: var(--folder-outline-svg);
 }
 
 %with-folder-plus-16-icon {
-  @extend %with-icon, %folder-plus-16-svg-prop !optional;
+  @extend %with-icon, %folder-plus-16-svg-prop;
   background-image: var(--folder-plus-16-svg);
 }
 %with-folder-plus-16-mask {
-  @extend %with-mask, %folder-plus-16-svg-prop !optional;
+  @extend %with-mask, %folder-plus-16-svg-prop;
   -webkit-mask-image: var(--folder-plus-16-svg);
   mask-image: var(--folder-plus-16-svg);
 }
 
 %with-folder-plus-24-icon {
-  @extend %with-icon, %folder-plus-24-svg-prop !optional;
+  @extend %with-icon, %folder-plus-24-svg-prop;
   background-image: var(--folder-plus-24-svg);
 }
 %with-folder-plus-24-mask {
-  @extend %with-mask, %folder-plus-24-svg-prop !optional;
+  @extend %with-mask, %folder-plus-24-svg-prop;
   -webkit-mask-image: var(--folder-plus-24-svg);
   mask-image: var(--folder-plus-24-svg);
 }
 
 %with-folder-plus-fill-16-icon {
-  @extend %with-icon, %folder-plus-fill-16-svg-prop !optional;
+  @extend %with-icon, %folder-plus-fill-16-svg-prop;
   background-image: var(--folder-plus-fill-16-svg);
 }
 %with-folder-plus-fill-16-mask {
-  @extend %with-mask, %folder-plus-fill-16-svg-prop !optional;
+  @extend %with-mask, %folder-plus-fill-16-svg-prop;
   -webkit-mask-image: var(--folder-plus-fill-16-svg);
   mask-image: var(--folder-plus-fill-16-svg);
 }
 
 %with-folder-plus-fill-24-icon {
-  @extend %with-icon, %folder-plus-fill-24-svg-prop !optional;
+  @extend %with-icon, %folder-plus-fill-24-svg-prop;
   background-image: var(--folder-plus-fill-24-svg);
 }
 %with-folder-plus-fill-24-mask {
-  @extend %with-mask, %folder-plus-fill-24-svg-prop !optional;
+  @extend %with-mask, %folder-plus-fill-24-svg-prop;
   -webkit-mask-image: var(--folder-plus-fill-24-svg);
   mask-image: var(--folder-plus-fill-24-svg);
 }
 
 %with-folder-star-16-icon {
-  @extend %with-icon, %folder-star-16-svg-prop !optional;
+  @extend %with-icon, %folder-star-16-svg-prop;
   background-image: var(--folder-star-16-svg);
 }
 %with-folder-star-16-mask {
-  @extend %with-mask, %folder-star-16-svg-prop !optional;
+  @extend %with-mask, %folder-star-16-svg-prop;
   -webkit-mask-image: var(--folder-star-16-svg);
   mask-image: var(--folder-star-16-svg);
 }
 
 %with-folder-star-24-icon {
-  @extend %with-icon, %folder-star-24-svg-prop !optional;
+  @extend %with-icon, %folder-star-24-svg-prop;
   background-image: var(--folder-star-24-svg);
 }
 %with-folder-star-24-mask {
-  @extend %with-mask, %folder-star-24-svg-prop !optional;
+  @extend %with-mask, %folder-star-24-svg-prop;
   -webkit-mask-image: var(--folder-star-24-svg);
   mask-image: var(--folder-star-24-svg);
 }
 
 %with-folder-users-16-icon {
-  @extend %with-icon, %folder-users-16-svg-prop !optional;
+  @extend %with-icon, %folder-users-16-svg-prop;
   background-image: var(--folder-users-16-svg);
 }
 %with-folder-users-16-mask {
-  @extend %with-mask, %folder-users-16-svg-prop !optional;
+  @extend %with-mask, %folder-users-16-svg-prop;
   -webkit-mask-image: var(--folder-users-16-svg);
   mask-image: var(--folder-users-16-svg);
 }
 
 %with-folder-users-24-icon {
-  @extend %with-icon, %folder-users-24-svg-prop !optional;
+  @extend %with-icon, %folder-users-24-svg-prop;
   background-image: var(--folder-users-24-svg);
 }
 %with-folder-users-24-mask {
-  @extend %with-mask, %folder-users-24-svg-prop !optional;
+  @extend %with-mask, %folder-users-24-svg-prop;
   -webkit-mask-image: var(--folder-users-24-svg);
   mask-image: var(--folder-users-24-svg);
 }
 
 %with-frown-16-icon {
-  @extend %with-icon, %frown-16-svg-prop !optional;
+  @extend %with-icon, %frown-16-svg-prop;
   background-image: var(--frown-16-svg);
 }
 %with-frown-16-mask {
-  @extend %with-mask, %frown-16-svg-prop !optional;
+  @extend %with-mask, %frown-16-svg-prop;
   -webkit-mask-image: var(--frown-16-svg);
   mask-image: var(--frown-16-svg);
 }
 
 %with-frown-24-icon {
-  @extend %with-icon, %frown-24-svg-prop !optional;
+  @extend %with-icon, %frown-24-svg-prop;
   background-image: var(--frown-24-svg);
 }
 %with-frown-24-mask {
-  @extend %with-mask, %frown-24-svg-prop !optional;
+  @extend %with-mask, %frown-24-svg-prop;
   -webkit-mask-image: var(--frown-24-svg);
   mask-image: var(--frown-24-svg);
 }
 
 %with-gateway-16-icon {
-  @extend %with-icon, %gateway-16-svg-prop !optional;
+  @extend %with-icon, %gateway-16-svg-prop;
   background-image: var(--gateway-16-svg);
 }
 %with-gateway-16-mask {
-  @extend %with-mask, %gateway-16-svg-prop !optional;
+  @extend %with-mask, %gateway-16-svg-prop;
   -webkit-mask-image: var(--gateway-16-svg);
   mask-image: var(--gateway-16-svg);
 }
 
 %with-gateway-24-icon {
-  @extend %with-icon, %gateway-24-svg-prop !optional;
+  @extend %with-icon, %gateway-24-svg-prop;
   background-image: var(--gateway-24-svg);
 }
 %with-gateway-24-mask {
-  @extend %with-mask, %gateway-24-svg-prop !optional;
+  @extend %with-mask, %gateway-24-svg-prop;
   -webkit-mask-image: var(--gateway-24-svg);
   mask-image: var(--gateway-24-svg);
 }
 
 %with-gateway-icon {
-  @extend %with-icon, %gateway-svg-prop !optional;
+  @extend %with-icon, %gateway-svg-prop;
   background-image: var(--gateway-svg);
 }
 %with-gateway-mask {
-  @extend %with-mask, %gateway-svg-prop !optional;
+  @extend %with-mask, %gateway-svg-prop;
   -webkit-mask-image: var(--gateway-svg);
   mask-image: var(--gateway-svg);
 }
 
 %with-gcp-16-icon {
-  @extend %with-icon, %gcp-16-svg-prop !optional;
+  @extend %with-icon, %gcp-16-svg-prop;
   background-image: var(--gcp-16-svg);
 }
 %with-gcp-16-mask {
-  @extend %with-mask, %gcp-16-svg-prop !optional;
+  @extend %with-mask, %gcp-16-svg-prop;
   -webkit-mask-image: var(--gcp-16-svg);
   mask-image: var(--gcp-16-svg);
 }
 
 %with-gcp-24-icon {
-  @extend %with-icon, %gcp-24-svg-prop !optional;
+  @extend %with-icon, %gcp-24-svg-prop;
   background-image: var(--gcp-24-svg);
 }
 %with-gcp-24-mask {
-  @extend %with-mask, %gcp-24-svg-prop !optional;
+  @extend %with-mask, %gcp-24-svg-prop;
   -webkit-mask-image: var(--gcp-24-svg);
   mask-image: var(--gcp-24-svg);
 }
 
 %with-gcp-color-16-icon {
-  @extend %with-icon, %gcp-color-16-svg-prop !optional;
+  @extend %with-icon, %gcp-color-16-svg-prop;
   background-image: var(--gcp-color-16-svg);
 }
 %with-gcp-color-16-mask {
-  @extend %with-mask, %gcp-color-16-svg-prop !optional;
+  @extend %with-mask, %gcp-color-16-svg-prop;
   -webkit-mask-image: var(--gcp-color-16-svg);
   mask-image: var(--gcp-color-16-svg);
 }
 
 %with-gcp-color-24-icon {
-  @extend %with-icon, %gcp-color-24-svg-prop !optional;
+  @extend %with-icon, %gcp-color-24-svg-prop;
   background-image: var(--gcp-color-24-svg);
 }
 %with-gcp-color-24-mask {
-  @extend %with-mask, %gcp-color-24-svg-prop !optional;
+  @extend %with-mask, %gcp-color-24-svg-prop;
   -webkit-mask-image: var(--gcp-color-24-svg);
   mask-image: var(--gcp-color-24-svg);
 }
 
 %with-gift-16-icon {
-  @extend %with-icon, %gift-16-svg-prop !optional;
+  @extend %with-icon, %gift-16-svg-prop;
   background-image: var(--gift-16-svg);
 }
 %with-gift-16-mask {
-  @extend %with-mask, %gift-16-svg-prop !optional;
+  @extend %with-mask, %gift-16-svg-prop;
   -webkit-mask-image: var(--gift-16-svg);
   mask-image: var(--gift-16-svg);
 }
 
 %with-gift-24-icon {
-  @extend %with-icon, %gift-24-svg-prop !optional;
+  @extend %with-icon, %gift-24-svg-prop;
   background-image: var(--gift-24-svg);
 }
 %with-gift-24-mask {
-  @extend %with-mask, %gift-24-svg-prop !optional;
+  @extend %with-mask, %gift-24-svg-prop;
   -webkit-mask-image: var(--gift-24-svg);
   mask-image: var(--gift-24-svg);
 }
 
 %with-gift-fill-icon {
-  @extend %with-icon, %gift-fill-svg-prop !optional;
+  @extend %with-icon, %gift-fill-svg-prop;
   background-image: var(--gift-fill-svg);
 }
 %with-gift-fill-mask {
-  @extend %with-mask, %gift-fill-svg-prop !optional;
+  @extend %with-mask, %gift-fill-svg-prop;
   -webkit-mask-image: var(--gift-fill-svg);
   mask-image: var(--gift-fill-svg);
 }
 
 %with-gift-outline-icon {
-  @extend %with-icon, %gift-outline-svg-prop !optional;
+  @extend %with-icon, %gift-outline-svg-prop;
   background-image: var(--gift-outline-svg);
 }
 %with-gift-outline-mask {
-  @extend %with-mask, %gift-outline-svg-prop !optional;
+  @extend %with-mask, %gift-outline-svg-prop;
   -webkit-mask-image: var(--gift-outline-svg);
   mask-image: var(--gift-outline-svg);
 }
 
 %with-git-branch-16-icon {
-  @extend %with-icon, %git-branch-16-svg-prop !optional;
+  @extend %with-icon, %git-branch-16-svg-prop;
   background-image: var(--git-branch-16-svg);
 }
 %with-git-branch-16-mask {
-  @extend %with-mask, %git-branch-16-svg-prop !optional;
+  @extend %with-mask, %git-branch-16-svg-prop;
   -webkit-mask-image: var(--git-branch-16-svg);
   mask-image: var(--git-branch-16-svg);
 }
 
 %with-git-branch-24-icon {
-  @extend %with-icon, %git-branch-24-svg-prop !optional;
+  @extend %with-icon, %git-branch-24-svg-prop;
   background-image: var(--git-branch-24-svg);
 }
 %with-git-branch-24-mask {
-  @extend %with-mask, %git-branch-24-svg-prop !optional;
+  @extend %with-mask, %git-branch-24-svg-prop;
   -webkit-mask-image: var(--git-branch-24-svg);
   mask-image: var(--git-branch-24-svg);
 }
 
 %with-git-branch-icon {
-  @extend %with-icon, %git-branch-svg-prop !optional;
+  @extend %with-icon, %git-branch-svg-prop;
   background-image: var(--git-branch-svg);
 }
 %with-git-branch-mask {
-  @extend %with-mask, %git-branch-svg-prop !optional;
+  @extend %with-mask, %git-branch-svg-prop;
   -webkit-mask-image: var(--git-branch-svg);
   mask-image: var(--git-branch-svg);
 }
 
 %with-git-commit-16-icon {
-  @extend %with-icon, %git-commit-16-svg-prop !optional;
+  @extend %with-icon, %git-commit-16-svg-prop;
   background-image: var(--git-commit-16-svg);
 }
 %with-git-commit-16-mask {
-  @extend %with-mask, %git-commit-16-svg-prop !optional;
+  @extend %with-mask, %git-commit-16-svg-prop;
   -webkit-mask-image: var(--git-commit-16-svg);
   mask-image: var(--git-commit-16-svg);
 }
 
 %with-git-commit-24-icon {
-  @extend %with-icon, %git-commit-24-svg-prop !optional;
+  @extend %with-icon, %git-commit-24-svg-prop;
   background-image: var(--git-commit-24-svg);
 }
 %with-git-commit-24-mask {
-  @extend %with-mask, %git-commit-24-svg-prop !optional;
+  @extend %with-mask, %git-commit-24-svg-prop;
   -webkit-mask-image: var(--git-commit-24-svg);
   mask-image: var(--git-commit-24-svg);
 }
 
 %with-git-commit-icon {
-  @extend %with-icon, %git-commit-svg-prop !optional;
+  @extend %with-icon, %git-commit-svg-prop;
   background-image: var(--git-commit-svg);
 }
 %with-git-commit-mask {
-  @extend %with-mask, %git-commit-svg-prop !optional;
+  @extend %with-mask, %git-commit-svg-prop;
   -webkit-mask-image: var(--git-commit-svg);
   mask-image: var(--git-commit-svg);
 }
 
 %with-git-merge-16-icon {
-  @extend %with-icon, %git-merge-16-svg-prop !optional;
+  @extend %with-icon, %git-merge-16-svg-prop;
   background-image: var(--git-merge-16-svg);
 }
 %with-git-merge-16-mask {
-  @extend %with-mask, %git-merge-16-svg-prop !optional;
+  @extend %with-mask, %git-merge-16-svg-prop;
   -webkit-mask-image: var(--git-merge-16-svg);
   mask-image: var(--git-merge-16-svg);
 }
 
 %with-git-merge-24-icon {
-  @extend %with-icon, %git-merge-24-svg-prop !optional;
+  @extend %with-icon, %git-merge-24-svg-prop;
   background-image: var(--git-merge-24-svg);
 }
 %with-git-merge-24-mask {
-  @extend %with-mask, %git-merge-24-svg-prop !optional;
+  @extend %with-mask, %git-merge-24-svg-prop;
   -webkit-mask-image: var(--git-merge-24-svg);
   mask-image: var(--git-merge-24-svg);
 }
 
 %with-git-pull-request-16-icon {
-  @extend %with-icon, %git-pull-request-16-svg-prop !optional;
+  @extend %with-icon, %git-pull-request-16-svg-prop;
   background-image: var(--git-pull-request-16-svg);
 }
 %with-git-pull-request-16-mask {
-  @extend %with-mask, %git-pull-request-16-svg-prop !optional;
+  @extend %with-mask, %git-pull-request-16-svg-prop;
   -webkit-mask-image: var(--git-pull-request-16-svg);
   mask-image: var(--git-pull-request-16-svg);
 }
 
 %with-git-pull-request-24-icon {
-  @extend %with-icon, %git-pull-request-24-svg-prop !optional;
+  @extend %with-icon, %git-pull-request-24-svg-prop;
   background-image: var(--git-pull-request-24-svg);
 }
 %with-git-pull-request-24-mask {
-  @extend %with-mask, %git-pull-request-24-svg-prop !optional;
+  @extend %with-mask, %git-pull-request-24-svg-prop;
   -webkit-mask-image: var(--git-pull-request-24-svg);
   mask-image: var(--git-pull-request-24-svg);
 }
 
 %with-git-pull-request-icon {
-  @extend %with-icon, %git-pull-request-svg-prop !optional;
+  @extend %with-icon, %git-pull-request-svg-prop;
   background-image: var(--git-pull-request-svg);
 }
 %with-git-pull-request-mask {
-  @extend %with-mask, %git-pull-request-svg-prop !optional;
+  @extend %with-mask, %git-pull-request-svg-prop;
   -webkit-mask-image: var(--git-pull-request-svg);
   mask-image: var(--git-pull-request-svg);
 }
 
 %with-git-repo-16-icon {
-  @extend %with-icon, %git-repo-16-svg-prop !optional;
+  @extend %with-icon, %git-repo-16-svg-prop;
   background-image: var(--git-repo-16-svg);
 }
 %with-git-repo-16-mask {
-  @extend %with-mask, %git-repo-16-svg-prop !optional;
+  @extend %with-mask, %git-repo-16-svg-prop;
   -webkit-mask-image: var(--git-repo-16-svg);
   mask-image: var(--git-repo-16-svg);
 }
 
 %with-git-repo-24-icon {
-  @extend %with-icon, %git-repo-24-svg-prop !optional;
+  @extend %with-icon, %git-repo-24-svg-prop;
   background-image: var(--git-repo-24-svg);
 }
 %with-git-repo-24-mask {
-  @extend %with-mask, %git-repo-24-svg-prop !optional;
+  @extend %with-mask, %git-repo-24-svg-prop;
   -webkit-mask-image: var(--git-repo-24-svg);
   mask-image: var(--git-repo-24-svg);
 }
 
 %with-git-repository-icon {
-  @extend %with-icon, %git-repository-svg-prop !optional;
+  @extend %with-icon, %git-repository-svg-prop;
   background-image: var(--git-repository-svg);
 }
 %with-git-repository-mask {
-  @extend %with-mask, %git-repository-svg-prop !optional;
+  @extend %with-mask, %git-repository-svg-prop;
   -webkit-mask-image: var(--git-repository-svg);
   mask-image: var(--git-repository-svg);
 }
 
 %with-github-16-icon {
-  @extend %with-icon, %github-16-svg-prop !optional;
+  @extend %with-icon, %github-16-svg-prop;
   background-image: var(--github-16-svg);
 }
 %with-github-16-mask {
-  @extend %with-mask, %github-16-svg-prop !optional;
+  @extend %with-mask, %github-16-svg-prop;
   -webkit-mask-image: var(--github-16-svg);
   mask-image: var(--github-16-svg);
 }
 
 %with-github-24-icon {
-  @extend %with-icon, %github-24-svg-prop !optional;
+  @extend %with-icon, %github-24-svg-prop;
   background-image: var(--github-24-svg);
 }
 %with-github-24-mask {
-  @extend %with-mask, %github-24-svg-prop !optional;
+  @extend %with-mask, %github-24-svg-prop;
   -webkit-mask-image: var(--github-24-svg);
   mask-image: var(--github-24-svg);
 }
 
 %with-github-color-16-icon {
-  @extend %with-icon, %github-color-16-svg-prop !optional;
+  @extend %with-icon, %github-color-16-svg-prop;
   background-image: var(--github-color-16-svg);
 }
 %with-github-color-16-mask {
-  @extend %with-mask, %github-color-16-svg-prop !optional;
+  @extend %with-mask, %github-color-16-svg-prop;
   -webkit-mask-image: var(--github-color-16-svg);
   mask-image: var(--github-color-16-svg);
 }
 
 %with-github-color-24-icon {
-  @extend %with-icon, %github-color-24-svg-prop !optional;
+  @extend %with-icon, %github-color-24-svg-prop;
   background-image: var(--github-color-24-svg);
 }
 %with-github-color-24-mask {
-  @extend %with-mask, %github-color-24-svg-prop !optional;
+  @extend %with-mask, %github-color-24-svg-prop;
   -webkit-mask-image: var(--github-color-24-svg);
   mask-image: var(--github-color-24-svg);
 }
 
 %with-gitlab-16-icon {
-  @extend %with-icon, %gitlab-16-svg-prop !optional;
+  @extend %with-icon, %gitlab-16-svg-prop;
   background-image: var(--gitlab-16-svg);
 }
 %with-gitlab-16-mask {
-  @extend %with-mask, %gitlab-16-svg-prop !optional;
+  @extend %with-mask, %gitlab-16-svg-prop;
   -webkit-mask-image: var(--gitlab-16-svg);
   mask-image: var(--gitlab-16-svg);
 }
 
 %with-gitlab-24-icon {
-  @extend %with-icon, %gitlab-24-svg-prop !optional;
+  @extend %with-icon, %gitlab-24-svg-prop;
   background-image: var(--gitlab-24-svg);
 }
 %with-gitlab-24-mask {
-  @extend %with-mask, %gitlab-24-svg-prop !optional;
+  @extend %with-mask, %gitlab-24-svg-prop;
   -webkit-mask-image: var(--gitlab-24-svg);
   mask-image: var(--gitlab-24-svg);
 }
 
 %with-gitlab-color-16-icon {
-  @extend %with-icon, %gitlab-color-16-svg-prop !optional;
+  @extend %with-icon, %gitlab-color-16-svg-prop;
   background-image: var(--gitlab-color-16-svg);
 }
 %with-gitlab-color-16-mask {
-  @extend %with-mask, %gitlab-color-16-svg-prop !optional;
+  @extend %with-mask, %gitlab-color-16-svg-prop;
   -webkit-mask-image: var(--gitlab-color-16-svg);
   mask-image: var(--gitlab-color-16-svg);
 }
 
 %with-gitlab-color-24-icon {
-  @extend %with-icon, %gitlab-color-24-svg-prop !optional;
+  @extend %with-icon, %gitlab-color-24-svg-prop;
   background-image: var(--gitlab-color-24-svg);
 }
 %with-gitlab-color-24-mask {
-  @extend %with-mask, %gitlab-color-24-svg-prop !optional;
+  @extend %with-mask, %gitlab-color-24-svg-prop;
   -webkit-mask-image: var(--gitlab-color-24-svg);
   mask-image: var(--gitlab-color-24-svg);
 }
 
 %with-globe-16-icon {
-  @extend %with-icon, %globe-16-svg-prop !optional;
+  @extend %with-icon, %globe-16-svg-prop;
   background-image: var(--globe-16-svg);
 }
 %with-globe-16-mask {
-  @extend %with-mask, %globe-16-svg-prop !optional;
+  @extend %with-mask, %globe-16-svg-prop;
   -webkit-mask-image: var(--globe-16-svg);
   mask-image: var(--globe-16-svg);
 }
 
 %with-globe-24-icon {
-  @extend %with-icon, %globe-24-svg-prop !optional;
+  @extend %with-icon, %globe-24-svg-prop;
   background-image: var(--globe-24-svg);
 }
 %with-globe-24-mask {
-  @extend %with-mask, %globe-24-svg-prop !optional;
+  @extend %with-mask, %globe-24-svg-prop;
   -webkit-mask-image: var(--globe-24-svg);
   mask-image: var(--globe-24-svg);
 }
 
 %with-globe-private-16-icon {
-  @extend %with-icon, %globe-private-16-svg-prop !optional;
+  @extend %with-icon, %globe-private-16-svg-prop;
   background-image: var(--globe-private-16-svg);
 }
 %with-globe-private-16-mask {
-  @extend %with-mask, %globe-private-16-svg-prop !optional;
+  @extend %with-mask, %globe-private-16-svg-prop;
   -webkit-mask-image: var(--globe-private-16-svg);
   mask-image: var(--globe-private-16-svg);
 }
 
 %with-globe-private-24-icon {
-  @extend %with-icon, %globe-private-24-svg-prop !optional;
+  @extend %with-icon, %globe-private-24-svg-prop;
   background-image: var(--globe-private-24-svg);
 }
 %with-globe-private-24-mask {
-  @extend %with-mask, %globe-private-24-svg-prop !optional;
+  @extend %with-mask, %globe-private-24-svg-prop;
   -webkit-mask-image: var(--globe-private-24-svg);
   mask-image: var(--globe-private-24-svg);
 }
 
 %with-google-16-icon {
-  @extend %with-icon, %google-16-svg-prop !optional;
+  @extend %with-icon, %google-16-svg-prop;
   background-image: var(--google-16-svg);
 }
 %with-google-16-mask {
-  @extend %with-mask, %google-16-svg-prop !optional;
+  @extend %with-mask, %google-16-svg-prop;
   -webkit-mask-image: var(--google-16-svg);
   mask-image: var(--google-16-svg);
 }
 
 %with-google-24-icon {
-  @extend %with-icon, %google-24-svg-prop !optional;
+  @extend %with-icon, %google-24-svg-prop;
   background-image: var(--google-24-svg);
 }
 %with-google-24-mask {
-  @extend %with-mask, %google-24-svg-prop !optional;
+  @extend %with-mask, %google-24-svg-prop;
   -webkit-mask-image: var(--google-24-svg);
   mask-image: var(--google-24-svg);
 }
 
 %with-google-color-16-icon {
-  @extend %with-icon, %google-color-16-svg-prop !optional;
+  @extend %with-icon, %google-color-16-svg-prop;
   background-image: var(--google-color-16-svg);
 }
 %with-google-color-16-mask {
-  @extend %with-mask, %google-color-16-svg-prop !optional;
+  @extend %with-mask, %google-color-16-svg-prop;
   -webkit-mask-image: var(--google-color-16-svg);
   mask-image: var(--google-color-16-svg);
 }
 
 %with-google-color-24-icon {
-  @extend %with-icon, %google-color-24-svg-prop !optional;
+  @extend %with-icon, %google-color-24-svg-prop;
   background-image: var(--google-color-24-svg);
 }
 %with-google-color-24-mask {
-  @extend %with-mask, %google-color-24-svg-prop !optional;
+  @extend %with-mask, %google-color-24-svg-prop;
   -webkit-mask-image: var(--google-color-24-svg);
   mask-image: var(--google-color-24-svg);
 }
 
 %with-grid-16-icon {
-  @extend %with-icon, %grid-16-svg-prop !optional;
+  @extend %with-icon, %grid-16-svg-prop;
   background-image: var(--grid-16-svg);
 }
 %with-grid-16-mask {
-  @extend %with-mask, %grid-16-svg-prop !optional;
+  @extend %with-mask, %grid-16-svg-prop;
   -webkit-mask-image: var(--grid-16-svg);
   mask-image: var(--grid-16-svg);
 }
 
 %with-grid-24-icon {
-  @extend %with-icon, %grid-24-svg-prop !optional;
+  @extend %with-icon, %grid-24-svg-prop;
   background-image: var(--grid-24-svg);
 }
 %with-grid-24-mask {
-  @extend %with-mask, %grid-24-svg-prop !optional;
+  @extend %with-mask, %grid-24-svg-prop;
   -webkit-mask-image: var(--grid-24-svg);
   mask-image: var(--grid-24-svg);
 }
 
 %with-grid-alt-16-icon {
-  @extend %with-icon, %grid-alt-16-svg-prop !optional;
+  @extend %with-icon, %grid-alt-16-svg-prop;
   background-image: var(--grid-alt-16-svg);
 }
 %with-grid-alt-16-mask {
-  @extend %with-mask, %grid-alt-16-svg-prop !optional;
+  @extend %with-mask, %grid-alt-16-svg-prop;
   -webkit-mask-image: var(--grid-alt-16-svg);
   mask-image: var(--grid-alt-16-svg);
 }
 
 %with-grid-alt-24-icon {
-  @extend %with-icon, %grid-alt-24-svg-prop !optional;
+  @extend %with-icon, %grid-alt-24-svg-prop;
   background-image: var(--grid-alt-24-svg);
 }
 %with-grid-alt-24-mask {
-  @extend %with-mask, %grid-alt-24-svg-prop !optional;
+  @extend %with-mask, %grid-alt-24-svg-prop;
   -webkit-mask-image: var(--grid-alt-24-svg);
   mask-image: var(--grid-alt-24-svg);
 }
 
 %with-guide-16-icon {
-  @extend %with-icon, %guide-16-svg-prop !optional;
+  @extend %with-icon, %guide-16-svg-prop;
   background-image: var(--guide-16-svg);
 }
 %with-guide-16-mask {
-  @extend %with-mask, %guide-16-svg-prop !optional;
+  @extend %with-mask, %guide-16-svg-prop;
   -webkit-mask-image: var(--guide-16-svg);
   mask-image: var(--guide-16-svg);
 }
 
 %with-guide-24-icon {
-  @extend %with-icon, %guide-24-svg-prop !optional;
+  @extend %with-icon, %guide-24-svg-prop;
   background-image: var(--guide-24-svg);
 }
 %with-guide-24-mask {
-  @extend %with-mask, %guide-24-svg-prop !optional;
+  @extend %with-mask, %guide-24-svg-prop;
   -webkit-mask-image: var(--guide-24-svg);
   mask-image: var(--guide-24-svg);
 }
 
 %with-guide-link-16-icon {
-  @extend %with-icon, %guide-link-16-svg-prop !optional;
+  @extend %with-icon, %guide-link-16-svg-prop;
   background-image: var(--guide-link-16-svg);
 }
 %with-guide-link-16-mask {
-  @extend %with-mask, %guide-link-16-svg-prop !optional;
+  @extend %with-mask, %guide-link-16-svg-prop;
   -webkit-mask-image: var(--guide-link-16-svg);
   mask-image: var(--guide-link-16-svg);
 }
 
 %with-guide-link-24-icon {
-  @extend %with-icon, %guide-link-24-svg-prop !optional;
+  @extend %with-icon, %guide-link-24-svg-prop;
   background-image: var(--guide-link-24-svg);
 }
 %with-guide-link-24-mask {
-  @extend %with-mask, %guide-link-24-svg-prop !optional;
+  @extend %with-mask, %guide-link-24-svg-prop;
   -webkit-mask-image: var(--guide-link-24-svg);
   mask-image: var(--guide-link-24-svg);
 }
 
 %with-guide-icon {
-  @extend %with-icon, %guide-svg-prop !optional;
+  @extend %with-icon, %guide-svg-prop;
   background-image: var(--guide-svg);
 }
 %with-guide-mask {
-  @extend %with-mask, %guide-svg-prop !optional;
+  @extend %with-mask, %guide-svg-prop;
   -webkit-mask-image: var(--guide-svg);
   mask-image: var(--guide-svg);
 }
 
 %with-hammer-16-icon {
-  @extend %with-icon, %hammer-16-svg-prop !optional;
+  @extend %with-icon, %hammer-16-svg-prop;
   background-image: var(--hammer-16-svg);
 }
 %with-hammer-16-mask {
-  @extend %with-mask, %hammer-16-svg-prop !optional;
+  @extend %with-mask, %hammer-16-svg-prop;
   -webkit-mask-image: var(--hammer-16-svg);
   mask-image: var(--hammer-16-svg);
 }
 
 %with-hammer-24-icon {
-  @extend %with-icon, %hammer-24-svg-prop !optional;
+  @extend %with-icon, %hammer-24-svg-prop;
   background-image: var(--hammer-24-svg);
 }
 %with-hammer-24-mask {
-  @extend %with-mask, %hammer-24-svg-prop !optional;
+  @extend %with-mask, %hammer-24-svg-prop;
   -webkit-mask-image: var(--hammer-24-svg);
   mask-image: var(--hammer-24-svg);
 }
 
 %with-hard-drive-16-icon {
-  @extend %with-icon, %hard-drive-16-svg-prop !optional;
+  @extend %with-icon, %hard-drive-16-svg-prop;
   background-image: var(--hard-drive-16-svg);
 }
 %with-hard-drive-16-mask {
-  @extend %with-mask, %hard-drive-16-svg-prop !optional;
+  @extend %with-mask, %hard-drive-16-svg-prop;
   -webkit-mask-image: var(--hard-drive-16-svg);
   mask-image: var(--hard-drive-16-svg);
 }
 
 %with-hard-drive-24-icon {
-  @extend %with-icon, %hard-drive-24-svg-prop !optional;
+  @extend %with-icon, %hard-drive-24-svg-prop;
   background-image: var(--hard-drive-24-svg);
 }
 %with-hard-drive-24-mask {
-  @extend %with-mask, %hard-drive-24-svg-prop !optional;
+  @extend %with-mask, %hard-drive-24-svg-prop;
   -webkit-mask-image: var(--hard-drive-24-svg);
   mask-image: var(--hard-drive-24-svg);
 }
 
 %with-hash-16-icon {
-  @extend %with-icon, %hash-16-svg-prop !optional;
+  @extend %with-icon, %hash-16-svg-prop;
   background-image: var(--hash-16-svg);
 }
 %with-hash-16-mask {
-  @extend %with-mask, %hash-16-svg-prop !optional;
+  @extend %with-mask, %hash-16-svg-prop;
   -webkit-mask-image: var(--hash-16-svg);
   mask-image: var(--hash-16-svg);
 }
 
 %with-hash-24-icon {
-  @extend %with-icon, %hash-24-svg-prop !optional;
+  @extend %with-icon, %hash-24-svg-prop;
   background-image: var(--hash-24-svg);
 }
 %with-hash-24-mask {
-  @extend %with-mask, %hash-24-svg-prop !optional;
+  @extend %with-mask, %hash-24-svg-prop;
   -webkit-mask-image: var(--hash-24-svg);
   mask-image: var(--hash-24-svg);
 }
 
 %with-headphones-16-icon {
-  @extend %with-icon, %headphones-16-svg-prop !optional;
+  @extend %with-icon, %headphones-16-svg-prop;
   background-image: var(--headphones-16-svg);
 }
 %with-headphones-16-mask {
-  @extend %with-mask, %headphones-16-svg-prop !optional;
+  @extend %with-mask, %headphones-16-svg-prop;
   -webkit-mask-image: var(--headphones-16-svg);
   mask-image: var(--headphones-16-svg);
 }
 
 %with-headphones-24-icon {
-  @extend %with-icon, %headphones-24-svg-prop !optional;
+  @extend %with-icon, %headphones-24-svg-prop;
   background-image: var(--headphones-24-svg);
 }
 %with-headphones-24-mask {
-  @extend %with-mask, %headphones-24-svg-prop !optional;
+  @extend %with-mask, %headphones-24-svg-prop;
   -webkit-mask-image: var(--headphones-24-svg);
   mask-image: var(--headphones-24-svg);
 }
 
 %with-health-icon {
-  @extend %with-icon, %health-svg-prop !optional;
+  @extend %with-icon, %health-svg-prop;
   background-image: var(--health-svg);
 }
 %with-health-mask {
-  @extend %with-mask, %health-svg-prop !optional;
+  @extend %with-mask, %health-svg-prop;
   -webkit-mask-image: var(--health-svg);
   mask-image: var(--health-svg);
 }
 
 %with-heart-16-icon {
-  @extend %with-icon, %heart-16-svg-prop !optional;
+  @extend %with-icon, %heart-16-svg-prop;
   background-image: var(--heart-16-svg);
 }
 %with-heart-16-mask {
-  @extend %with-mask, %heart-16-svg-prop !optional;
+  @extend %with-mask, %heart-16-svg-prop;
   -webkit-mask-image: var(--heart-16-svg);
   mask-image: var(--heart-16-svg);
 }
 
 %with-heart-24-icon {
-  @extend %with-icon, %heart-24-svg-prop !optional;
+  @extend %with-icon, %heart-24-svg-prop;
   background-image: var(--heart-24-svg);
 }
 %with-heart-24-mask {
-  @extend %with-mask, %heart-24-svg-prop !optional;
+  @extend %with-mask, %heart-24-svg-prop;
   -webkit-mask-image: var(--heart-24-svg);
   mask-image: var(--heart-24-svg);
 }
 
 %with-heart-fill-16-icon {
-  @extend %with-icon, %heart-fill-16-svg-prop !optional;
+  @extend %with-icon, %heart-fill-16-svg-prop;
   background-image: var(--heart-fill-16-svg);
 }
 %with-heart-fill-16-mask {
-  @extend %with-mask, %heart-fill-16-svg-prop !optional;
+  @extend %with-mask, %heart-fill-16-svg-prop;
   -webkit-mask-image: var(--heart-fill-16-svg);
   mask-image: var(--heart-fill-16-svg);
 }
 
 %with-heart-fill-24-icon {
-  @extend %with-icon, %heart-fill-24-svg-prop !optional;
+  @extend %with-icon, %heart-fill-24-svg-prop;
   background-image: var(--heart-fill-24-svg);
 }
 %with-heart-fill-24-mask {
-  @extend %with-mask, %heart-fill-24-svg-prop !optional;
+  @extend %with-mask, %heart-fill-24-svg-prop;
   -webkit-mask-image: var(--heart-fill-24-svg);
   mask-image: var(--heart-fill-24-svg);
 }
 
 %with-heart-off-16-icon {
-  @extend %with-icon, %heart-off-16-svg-prop !optional;
+  @extend %with-icon, %heart-off-16-svg-prop;
   background-image: var(--heart-off-16-svg);
 }
 %with-heart-off-16-mask {
-  @extend %with-mask, %heart-off-16-svg-prop !optional;
+  @extend %with-mask, %heart-off-16-svg-prop;
   -webkit-mask-image: var(--heart-off-16-svg);
   mask-image: var(--heart-off-16-svg);
 }
 
 %with-heart-off-24-icon {
-  @extend %with-icon, %heart-off-24-svg-prop !optional;
+  @extend %with-icon, %heart-off-24-svg-prop;
   background-image: var(--heart-off-24-svg);
 }
 %with-heart-off-24-mask {
-  @extend %with-mask, %heart-off-24-svg-prop !optional;
+  @extend %with-mask, %heart-off-24-svg-prop;
   -webkit-mask-image: var(--heart-off-24-svg);
   mask-image: var(--heart-off-24-svg);
 }
 
 %with-help-16-icon {
-  @extend %with-icon, %help-16-svg-prop !optional;
+  @extend %with-icon, %help-16-svg-prop;
   background-image: var(--help-16-svg);
 }
 %with-help-16-mask {
-  @extend %with-mask, %help-16-svg-prop !optional;
+  @extend %with-mask, %help-16-svg-prop;
   -webkit-mask-image: var(--help-16-svg);
   mask-image: var(--help-16-svg);
 }
 
 %with-help-24-icon {
-  @extend %with-icon, %help-24-svg-prop !optional;
+  @extend %with-icon, %help-24-svg-prop;
   background-image: var(--help-24-svg);
 }
 %with-help-24-mask {
-  @extend %with-mask, %help-24-svg-prop !optional;
+  @extend %with-mask, %help-24-svg-prop;
   -webkit-mask-image: var(--help-24-svg);
   mask-image: var(--help-24-svg);
 }
 
 %with-help-circle-fill-icon {
-  @extend %with-icon, %help-circle-fill-svg-prop !optional;
+  @extend %with-icon, %help-circle-fill-svg-prop;
   background-image: var(--help-circle-fill-svg);
 }
 %with-help-circle-fill-mask {
-  @extend %with-mask, %help-circle-fill-svg-prop !optional;
+  @extend %with-mask, %help-circle-fill-svg-prop;
   -webkit-mask-image: var(--help-circle-fill-svg);
   mask-image: var(--help-circle-fill-svg);
 }
 
 %with-help-circle-outline-icon {
-  @extend %with-icon, %help-circle-outline-svg-prop !optional;
+  @extend %with-icon, %help-circle-outline-svg-prop;
   background-image: var(--help-circle-outline-svg);
 }
 %with-help-circle-outline-mask {
-  @extend %with-mask, %help-circle-outline-svg-prop !optional;
+  @extend %with-mask, %help-circle-outline-svg-prop;
   -webkit-mask-image: var(--help-circle-outline-svg);
   mask-image: var(--help-circle-outline-svg);
 }
 
 %with-hexagon-16-icon {
-  @extend %with-icon, %hexagon-16-svg-prop !optional;
+  @extend %with-icon, %hexagon-16-svg-prop;
   background-image: var(--hexagon-16-svg);
 }
 %with-hexagon-16-mask {
-  @extend %with-mask, %hexagon-16-svg-prop !optional;
+  @extend %with-mask, %hexagon-16-svg-prop;
   -webkit-mask-image: var(--hexagon-16-svg);
   mask-image: var(--hexagon-16-svg);
 }
 
 %with-hexagon-24-icon {
-  @extend %with-icon, %hexagon-24-svg-prop !optional;
+  @extend %with-icon, %hexagon-24-svg-prop;
   background-image: var(--hexagon-24-svg);
 }
 %with-hexagon-24-mask {
-  @extend %with-mask, %hexagon-24-svg-prop !optional;
+  @extend %with-mask, %hexagon-24-svg-prop;
   -webkit-mask-image: var(--hexagon-24-svg);
   mask-image: var(--hexagon-24-svg);
 }
 
 %with-hexagon-fill-16-icon {
-  @extend %with-icon, %hexagon-fill-16-svg-prop !optional;
+  @extend %with-icon, %hexagon-fill-16-svg-prop;
   background-image: var(--hexagon-fill-16-svg);
 }
 %with-hexagon-fill-16-mask {
-  @extend %with-mask, %hexagon-fill-16-svg-prop !optional;
+  @extend %with-mask, %hexagon-fill-16-svg-prop;
   -webkit-mask-image: var(--hexagon-fill-16-svg);
   mask-image: var(--hexagon-fill-16-svg);
 }
 
 %with-hexagon-fill-24-icon {
-  @extend %with-icon, %hexagon-fill-24-svg-prop !optional;
+  @extend %with-icon, %hexagon-fill-24-svg-prop;
   background-image: var(--hexagon-fill-24-svg);
 }
 %with-hexagon-fill-24-mask {
-  @extend %with-mask, %hexagon-fill-24-svg-prop !optional;
+  @extend %with-mask, %hexagon-fill-24-svg-prop;
   -webkit-mask-image: var(--hexagon-fill-24-svg);
   mask-image: var(--hexagon-fill-24-svg);
 }
 
 %with-history-16-icon {
-  @extend %with-icon, %history-16-svg-prop !optional;
+  @extend %with-icon, %history-16-svg-prop;
   background-image: var(--history-16-svg);
 }
 %with-history-16-mask {
-  @extend %with-mask, %history-16-svg-prop !optional;
+  @extend %with-mask, %history-16-svg-prop;
   -webkit-mask-image: var(--history-16-svg);
   mask-image: var(--history-16-svg);
 }
 
 %with-history-24-icon {
-  @extend %with-icon, %history-24-svg-prop !optional;
+  @extend %with-icon, %history-24-svg-prop;
   background-image: var(--history-24-svg);
 }
 %with-history-24-mask {
-  @extend %with-mask, %history-24-svg-prop !optional;
+  @extend %with-mask, %history-24-svg-prop;
   -webkit-mask-image: var(--history-24-svg);
   mask-image: var(--history-24-svg);
 }
 
 %with-history-icon {
-  @extend %with-icon, %history-svg-prop !optional;
+  @extend %with-icon, %history-svg-prop;
   background-image: var(--history-svg);
 }
 %with-history-mask {
-  @extend %with-mask, %history-svg-prop !optional;
+  @extend %with-mask, %history-svg-prop;
   -webkit-mask-image: var(--history-svg);
   mask-image: var(--history-svg);
 }
 
 %with-home-16-icon {
-  @extend %with-icon, %home-16-svg-prop !optional;
+  @extend %with-icon, %home-16-svg-prop;
   background-image: var(--home-16-svg);
 }
 %with-home-16-mask {
-  @extend %with-mask, %home-16-svg-prop !optional;
+  @extend %with-mask, %home-16-svg-prop;
   -webkit-mask-image: var(--home-16-svg);
   mask-image: var(--home-16-svg);
 }
 
 %with-home-24-icon {
-  @extend %with-icon, %home-24-svg-prop !optional;
+  @extend %with-icon, %home-24-svg-prop;
   background-image: var(--home-24-svg);
 }
 %with-home-24-mask {
-  @extend %with-mask, %home-24-svg-prop !optional;
+  @extend %with-mask, %home-24-svg-prop;
   -webkit-mask-image: var(--home-24-svg);
   mask-image: var(--home-24-svg);
 }
 
 %with-hourglass-16-icon {
-  @extend %with-icon, %hourglass-16-svg-prop !optional;
+  @extend %with-icon, %hourglass-16-svg-prop;
   background-image: var(--hourglass-16-svg);
 }
 %with-hourglass-16-mask {
-  @extend %with-mask, %hourglass-16-svg-prop !optional;
+  @extend %with-mask, %hourglass-16-svg-prop;
   -webkit-mask-image: var(--hourglass-16-svg);
   mask-image: var(--hourglass-16-svg);
 }
 
 %with-hourglass-24-icon {
-  @extend %with-icon, %hourglass-24-svg-prop !optional;
+  @extend %with-icon, %hourglass-24-svg-prop;
   background-image: var(--hourglass-24-svg);
 }
 %with-hourglass-24-mask {
-  @extend %with-mask, %hourglass-24-svg-prop !optional;
+  @extend %with-mask, %hourglass-24-svg-prop;
   -webkit-mask-image: var(--hourglass-24-svg);
   mask-image: var(--hourglass-24-svg);
 }
 
 %with-identity-service-16-icon {
-  @extend %with-icon, %identity-service-16-svg-prop !optional;
+  @extend %with-icon, %identity-service-16-svg-prop;
   background-image: var(--identity-service-16-svg);
 }
 %with-identity-service-16-mask {
-  @extend %with-mask, %identity-service-16-svg-prop !optional;
+  @extend %with-mask, %identity-service-16-svg-prop;
   -webkit-mask-image: var(--identity-service-16-svg);
   mask-image: var(--identity-service-16-svg);
 }
 
 %with-identity-service-24-icon {
-  @extend %with-icon, %identity-service-24-svg-prop !optional;
+  @extend %with-icon, %identity-service-24-svg-prop;
   background-image: var(--identity-service-24-svg);
 }
 %with-identity-service-24-mask {
-  @extend %with-mask, %identity-service-24-svg-prop !optional;
+  @extend %with-mask, %identity-service-24-svg-prop;
   -webkit-mask-image: var(--identity-service-24-svg);
   mask-image: var(--identity-service-24-svg);
 }
 
 %with-identity-user-16-icon {
-  @extend %with-icon, %identity-user-16-svg-prop !optional;
+  @extend %with-icon, %identity-user-16-svg-prop;
   background-image: var(--identity-user-16-svg);
 }
 %with-identity-user-16-mask {
-  @extend %with-mask, %identity-user-16-svg-prop !optional;
+  @extend %with-mask, %identity-user-16-svg-prop;
   -webkit-mask-image: var(--identity-user-16-svg);
   mask-image: var(--identity-user-16-svg);
 }
 
 %with-identity-user-24-icon {
-  @extend %with-icon, %identity-user-24-svg-prop !optional;
+  @extend %with-icon, %identity-user-24-svg-prop;
   background-image: var(--identity-user-24-svg);
 }
 %with-identity-user-24-mask {
-  @extend %with-mask, %identity-user-24-svg-prop !optional;
+  @extend %with-mask, %identity-user-24-svg-prop;
   -webkit-mask-image: var(--identity-user-24-svg);
   mask-image: var(--identity-user-24-svg);
 }
 
 %with-image-16-icon {
-  @extend %with-icon, %image-16-svg-prop !optional;
+  @extend %with-icon, %image-16-svg-prop;
   background-image: var(--image-16-svg);
 }
 %with-image-16-mask {
-  @extend %with-mask, %image-16-svg-prop !optional;
+  @extend %with-mask, %image-16-svg-prop;
   -webkit-mask-image: var(--image-16-svg);
   mask-image: var(--image-16-svg);
 }
 
 %with-image-24-icon {
-  @extend %with-icon, %image-24-svg-prop !optional;
+  @extend %with-icon, %image-24-svg-prop;
   background-image: var(--image-24-svg);
 }
 %with-image-24-mask {
-  @extend %with-mask, %image-24-svg-prop !optional;
+  @extend %with-mask, %image-24-svg-prop;
   -webkit-mask-image: var(--image-24-svg);
   mask-image: var(--image-24-svg);
 }
 
 %with-inbox-16-icon {
-  @extend %with-icon, %inbox-16-svg-prop !optional;
+  @extend %with-icon, %inbox-16-svg-prop;
   background-image: var(--inbox-16-svg);
 }
 %with-inbox-16-mask {
-  @extend %with-mask, %inbox-16-svg-prop !optional;
+  @extend %with-mask, %inbox-16-svg-prop;
   -webkit-mask-image: var(--inbox-16-svg);
   mask-image: var(--inbox-16-svg);
 }
 
 %with-inbox-24-icon {
-  @extend %with-icon, %inbox-24-svg-prop !optional;
+  @extend %with-icon, %inbox-24-svg-prop;
   background-image: var(--inbox-24-svg);
 }
 %with-inbox-24-mask {
-  @extend %with-mask, %inbox-24-svg-prop !optional;
+  @extend %with-mask, %inbox-24-svg-prop;
   -webkit-mask-image: var(--inbox-24-svg);
   mask-image: var(--inbox-24-svg);
 }
 
 %with-info-16-icon {
-  @extend %with-icon, %info-16-svg-prop !optional;
+  @extend %with-icon, %info-16-svg-prop;
   background-image: var(--info-16-svg);
 }
 %with-info-16-mask {
-  @extend %with-mask, %info-16-svg-prop !optional;
+  @extend %with-mask, %info-16-svg-prop;
   -webkit-mask-image: var(--info-16-svg);
   mask-image: var(--info-16-svg);
 }
 
 %with-info-24-icon {
-  @extend %with-icon, %info-24-svg-prop !optional;
+  @extend %with-icon, %info-24-svg-prop;
   background-image: var(--info-24-svg);
 }
 %with-info-24-mask {
-  @extend %with-mask, %info-24-svg-prop !optional;
+  @extend %with-mask, %info-24-svg-prop;
   -webkit-mask-image: var(--info-24-svg);
   mask-image: var(--info-24-svg);
 }
 
 %with-info-circle-fill-icon {
-  @extend %with-icon, %info-circle-fill-svg-prop !optional;
+  @extend %with-icon, %info-circle-fill-svg-prop;
   background-image: var(--info-circle-fill-svg);
 }
 %with-info-circle-fill-mask {
-  @extend %with-mask, %info-circle-fill-svg-prop !optional;
+  @extend %with-mask, %info-circle-fill-svg-prop;
   -webkit-mask-image: var(--info-circle-fill-svg);
   mask-image: var(--info-circle-fill-svg);
 }
 
 %with-info-circle-outline-icon {
-  @extend %with-icon, %info-circle-outline-svg-prop !optional;
+  @extend %with-icon, %info-circle-outline-svg-prop;
   background-image: var(--info-circle-outline-svg);
 }
 %with-info-circle-outline-mask {
-  @extend %with-mask, %info-circle-outline-svg-prop !optional;
+  @extend %with-mask, %info-circle-outline-svg-prop;
   -webkit-mask-image: var(--info-circle-outline-svg);
   mask-image: var(--info-circle-outline-svg);
 }
 
 %with-jump-link-16-icon {
-  @extend %with-icon, %jump-link-16-svg-prop !optional;
+  @extend %with-icon, %jump-link-16-svg-prop;
   background-image: var(--jump-link-16-svg);
 }
 %with-jump-link-16-mask {
-  @extend %with-mask, %jump-link-16-svg-prop !optional;
+  @extend %with-mask, %jump-link-16-svg-prop;
   -webkit-mask-image: var(--jump-link-16-svg);
   mask-image: var(--jump-link-16-svg);
 }
 
 %with-jump-link-24-icon {
-  @extend %with-icon, %jump-link-24-svg-prop !optional;
+  @extend %with-icon, %jump-link-24-svg-prop;
   background-image: var(--jump-link-24-svg);
 }
 %with-jump-link-24-mask {
-  @extend %with-mask, %jump-link-24-svg-prop !optional;
+  @extend %with-mask, %jump-link-24-svg-prop;
   -webkit-mask-image: var(--jump-link-24-svg);
   mask-image: var(--jump-link-24-svg);
 }
 
 %with-key-16-icon {
-  @extend %with-icon, %key-16-svg-prop !optional;
+  @extend %with-icon, %key-16-svg-prop;
   background-image: var(--key-16-svg);
 }
 %with-key-16-mask {
-  @extend %with-mask, %key-16-svg-prop !optional;
+  @extend %with-mask, %key-16-svg-prop;
   -webkit-mask-image: var(--key-16-svg);
   mask-image: var(--key-16-svg);
 }
 
 %with-key-24-icon {
-  @extend %with-icon, %key-24-svg-prop !optional;
+  @extend %with-icon, %key-24-svg-prop;
   background-image: var(--key-24-svg);
 }
 %with-key-24-mask {
-  @extend %with-mask, %key-24-svg-prop !optional;
+  @extend %with-mask, %key-24-svg-prop;
   -webkit-mask-image: var(--key-24-svg);
   mask-image: var(--key-24-svg);
 }
 
 %with-key-values-16-icon {
-  @extend %with-icon, %key-values-16-svg-prop !optional;
+  @extend %with-icon, %key-values-16-svg-prop;
   background-image: var(--key-values-16-svg);
 }
 %with-key-values-16-mask {
-  @extend %with-mask, %key-values-16-svg-prop !optional;
+  @extend %with-mask, %key-values-16-svg-prop;
   -webkit-mask-image: var(--key-values-16-svg);
   mask-image: var(--key-values-16-svg);
 }
 
 %with-key-values-24-icon {
-  @extend %with-icon, %key-values-24-svg-prop !optional;
+  @extend %with-icon, %key-values-24-svg-prop;
   background-image: var(--key-values-24-svg);
 }
 %with-key-values-24-mask {
-  @extend %with-mask, %key-values-24-svg-prop !optional;
+  @extend %with-mask, %key-values-24-svg-prop;
   -webkit-mask-image: var(--key-values-24-svg);
   mask-image: var(--key-values-24-svg);
 }
 
 %with-key-icon {
-  @extend %with-icon, %key-svg-prop !optional;
+  @extend %with-icon, %key-svg-prop;
   background-image: var(--key-svg);
 }
 %with-key-mask {
-  @extend %with-mask, %key-svg-prop !optional;
+  @extend %with-mask, %key-svg-prop;
   -webkit-mask-image: var(--key-svg);
   mask-image: var(--key-svg);
 }
 
 %with-kubernetes-16-icon {
-  @extend %with-icon, %kubernetes-16-svg-prop !optional;
+  @extend %with-icon, %kubernetes-16-svg-prop;
   background-image: var(--kubernetes-16-svg);
 }
 %with-kubernetes-16-mask {
-  @extend %with-mask, %kubernetes-16-svg-prop !optional;
+  @extend %with-mask, %kubernetes-16-svg-prop;
   -webkit-mask-image: var(--kubernetes-16-svg);
   mask-image: var(--kubernetes-16-svg);
 }
 
 %with-kubernetes-24-icon {
-  @extend %with-icon, %kubernetes-24-svg-prop !optional;
+  @extend %with-icon, %kubernetes-24-svg-prop;
   background-image: var(--kubernetes-24-svg);
 }
 %with-kubernetes-24-mask {
-  @extend %with-mask, %kubernetes-24-svg-prop !optional;
+  @extend %with-mask, %kubernetes-24-svg-prop;
   -webkit-mask-image: var(--kubernetes-24-svg);
   mask-image: var(--kubernetes-24-svg);
 }
 
 %with-kubernetes-color-16-icon {
-  @extend %with-icon, %kubernetes-color-16-svg-prop !optional;
+  @extend %with-icon, %kubernetes-color-16-svg-prop;
   background-image: var(--kubernetes-color-16-svg);
 }
 %with-kubernetes-color-16-mask {
-  @extend %with-mask, %kubernetes-color-16-svg-prop !optional;
+  @extend %with-mask, %kubernetes-color-16-svg-prop;
   -webkit-mask-image: var(--kubernetes-color-16-svg);
   mask-image: var(--kubernetes-color-16-svg);
 }
 
 %with-kubernetes-color-24-icon {
-  @extend %with-icon, %kubernetes-color-24-svg-prop !optional;
+  @extend %with-icon, %kubernetes-color-24-svg-prop;
   background-image: var(--kubernetes-color-24-svg);
 }
 %with-kubernetes-color-24-mask {
-  @extend %with-mask, %kubernetes-color-24-svg-prop !optional;
+  @extend %with-mask, %kubernetes-color-24-svg-prop;
   -webkit-mask-image: var(--kubernetes-color-24-svg);
   mask-image: var(--kubernetes-color-24-svg);
 }
 
 %with-labyrinth-16-icon {
-  @extend %with-icon, %labyrinth-16-svg-prop !optional;
+  @extend %with-icon, %labyrinth-16-svg-prop;
   background-image: var(--labyrinth-16-svg);
 }
 %with-labyrinth-16-mask {
-  @extend %with-mask, %labyrinth-16-svg-prop !optional;
+  @extend %with-mask, %labyrinth-16-svg-prop;
   -webkit-mask-image: var(--labyrinth-16-svg);
   mask-image: var(--labyrinth-16-svg);
 }
 
 %with-labyrinth-24-icon {
-  @extend %with-icon, %labyrinth-24-svg-prop !optional;
+  @extend %with-icon, %labyrinth-24-svg-prop;
   background-image: var(--labyrinth-24-svg);
 }
 %with-labyrinth-24-mask {
-  @extend %with-mask, %labyrinth-24-svg-prop !optional;
+  @extend %with-mask, %labyrinth-24-svg-prop;
   -webkit-mask-image: var(--labyrinth-24-svg);
   mask-image: var(--labyrinth-24-svg);
 }
 
 %with-layers-16-icon {
-  @extend %with-icon, %layers-16-svg-prop !optional;
+  @extend %with-icon, %layers-16-svg-prop;
   background-image: var(--layers-16-svg);
 }
 %with-layers-16-mask {
-  @extend %with-mask, %layers-16-svg-prop !optional;
+  @extend %with-mask, %layers-16-svg-prop;
   -webkit-mask-image: var(--layers-16-svg);
   mask-image: var(--layers-16-svg);
 }
 
 %with-layers-24-icon {
-  @extend %with-icon, %layers-24-svg-prop !optional;
+  @extend %with-icon, %layers-24-svg-prop;
   background-image: var(--layers-24-svg);
 }
 %with-layers-24-mask {
-  @extend %with-mask, %layers-24-svg-prop !optional;
+  @extend %with-mask, %layers-24-svg-prop;
   -webkit-mask-image: var(--layers-24-svg);
   mask-image: var(--layers-24-svg);
 }
 
 %with-layers-icon {
-  @extend %with-icon, %layers-svg-prop !optional;
+  @extend %with-icon, %layers-svg-prop;
   background-image: var(--layers-svg);
 }
 %with-layers-mask {
-  @extend %with-mask, %layers-svg-prop !optional;
+  @extend %with-mask, %layers-svg-prop;
   -webkit-mask-image: var(--layers-svg);
   mask-image: var(--layers-svg);
 }
 
 %with-layout-16-icon {
-  @extend %with-icon, %layout-16-svg-prop !optional;
+  @extend %with-icon, %layout-16-svg-prop;
   background-image: var(--layout-16-svg);
 }
 %with-layout-16-mask {
-  @extend %with-mask, %layout-16-svg-prop !optional;
+  @extend %with-mask, %layout-16-svg-prop;
   -webkit-mask-image: var(--layout-16-svg);
   mask-image: var(--layout-16-svg);
 }
 
 %with-layout-24-icon {
-  @extend %with-icon, %layout-24-svg-prop !optional;
+  @extend %with-icon, %layout-24-svg-prop;
   background-image: var(--layout-24-svg);
 }
 %with-layout-24-mask {
-  @extend %with-mask, %layout-24-svg-prop !optional;
+  @extend %with-mask, %layout-24-svg-prop;
   -webkit-mask-image: var(--layout-24-svg);
   mask-image: var(--layout-24-svg);
 }
 
 %with-learn-16-icon {
-  @extend %with-icon, %learn-16-svg-prop !optional;
+  @extend %with-icon, %learn-16-svg-prop;
   background-image: var(--learn-16-svg);
 }
 %with-learn-16-mask {
-  @extend %with-mask, %learn-16-svg-prop !optional;
+  @extend %with-mask, %learn-16-svg-prop;
   -webkit-mask-image: var(--learn-16-svg);
   mask-image: var(--learn-16-svg);
 }
 
 %with-learn-24-icon {
-  @extend %with-icon, %learn-24-svg-prop !optional;
+  @extend %with-icon, %learn-24-svg-prop;
   background-image: var(--learn-24-svg);
 }
 %with-learn-24-mask {
-  @extend %with-mask, %learn-24-svg-prop !optional;
+  @extend %with-mask, %learn-24-svg-prop;
   -webkit-mask-image: var(--learn-24-svg);
   mask-image: var(--learn-24-svg);
 }
 
 %with-learn-link-16-icon {
-  @extend %with-icon, %learn-link-16-svg-prop !optional;
+  @extend %with-icon, %learn-link-16-svg-prop;
   background-image: var(--learn-link-16-svg);
 }
 %with-learn-link-16-mask {
-  @extend %with-mask, %learn-link-16-svg-prop !optional;
+  @extend %with-mask, %learn-link-16-svg-prop;
   -webkit-mask-image: var(--learn-link-16-svg);
   mask-image: var(--learn-link-16-svg);
 }
 
 %with-learn-link-24-icon {
-  @extend %with-icon, %learn-link-24-svg-prop !optional;
+  @extend %with-icon, %learn-link-24-svg-prop;
   background-image: var(--learn-link-24-svg);
 }
 %with-learn-link-24-mask {
-  @extend %with-mask, %learn-link-24-svg-prop !optional;
+  @extend %with-mask, %learn-link-24-svg-prop;
   -webkit-mask-image: var(--learn-link-24-svg);
   mask-image: var(--learn-link-24-svg);
 }
 
 %with-learn-icon {
-  @extend %with-icon, %learn-svg-prop !optional;
+  @extend %with-icon, %learn-svg-prop;
   background-image: var(--learn-svg);
 }
 %with-learn-mask {
-  @extend %with-mask, %learn-svg-prop !optional;
+  @extend %with-mask, %learn-svg-prop;
   -webkit-mask-image: var(--learn-svg);
   mask-image: var(--learn-svg);
 }
 
 %with-line-chart-16-icon {
-  @extend %with-icon, %line-chart-16-svg-prop !optional;
+  @extend %with-icon, %line-chart-16-svg-prop;
   background-image: var(--line-chart-16-svg);
 }
 %with-line-chart-16-mask {
-  @extend %with-mask, %line-chart-16-svg-prop !optional;
+  @extend %with-mask, %line-chart-16-svg-prop;
   -webkit-mask-image: var(--line-chart-16-svg);
   mask-image: var(--line-chart-16-svg);
 }
 
 %with-line-chart-24-icon {
-  @extend %with-icon, %line-chart-24-svg-prop !optional;
+  @extend %with-icon, %line-chart-24-svg-prop;
   background-image: var(--line-chart-24-svg);
 }
 %with-line-chart-24-mask {
-  @extend %with-mask, %line-chart-24-svg-prop !optional;
+  @extend %with-mask, %line-chart-24-svg-prop;
   -webkit-mask-image: var(--line-chart-24-svg);
   mask-image: var(--line-chart-24-svg);
 }
 
 %with-line-chart-up-16-icon {
-  @extend %with-icon, %line-chart-up-16-svg-prop !optional;
+  @extend %with-icon, %line-chart-up-16-svg-prop;
   background-image: var(--line-chart-up-16-svg);
 }
 %with-line-chart-up-16-mask {
-  @extend %with-mask, %line-chart-up-16-svg-prop !optional;
+  @extend %with-mask, %line-chart-up-16-svg-prop;
   -webkit-mask-image: var(--line-chart-up-16-svg);
   mask-image: var(--line-chart-up-16-svg);
 }
 
 %with-line-chart-up-24-icon {
-  @extend %with-icon, %line-chart-up-24-svg-prop !optional;
+  @extend %with-icon, %line-chart-up-24-svg-prop;
   background-image: var(--line-chart-up-24-svg);
 }
 %with-line-chart-up-24-mask {
-  @extend %with-mask, %line-chart-up-24-svg-prop !optional;
+  @extend %with-mask, %line-chart-up-24-svg-prop;
   -webkit-mask-image: var(--line-chart-up-24-svg);
   mask-image: var(--line-chart-up-24-svg);
 }
 
 %with-link-16-icon {
-  @extend %with-icon, %link-16-svg-prop !optional;
+  @extend %with-icon, %link-16-svg-prop;
   background-image: var(--link-16-svg);
 }
 %with-link-16-mask {
-  @extend %with-mask, %link-16-svg-prop !optional;
+  @extend %with-mask, %link-16-svg-prop;
   -webkit-mask-image: var(--link-16-svg);
   mask-image: var(--link-16-svg);
 }
 
 %with-link-24-icon {
-  @extend %with-icon, %link-24-svg-prop !optional;
+  @extend %with-icon, %link-24-svg-prop;
   background-image: var(--link-24-svg);
 }
 %with-link-24-mask {
-  @extend %with-mask, %link-24-svg-prop !optional;
+  @extend %with-mask, %link-24-svg-prop;
   -webkit-mask-image: var(--link-24-svg);
   mask-image: var(--link-24-svg);
 }
 
 %with-link-icon {
-  @extend %with-icon, %link-svg-prop !optional;
+  @extend %with-icon, %link-svg-prop;
   background-image: var(--link-svg);
 }
 %with-link-mask {
-  @extend %with-mask, %link-svg-prop !optional;
+  @extend %with-mask, %link-svg-prop;
   -webkit-mask-image: var(--link-svg);
   mask-image: var(--link-svg);
 }
 
 %with-list-16-icon {
-  @extend %with-icon, %list-16-svg-prop !optional;
+  @extend %with-icon, %list-16-svg-prop;
   background-image: var(--list-16-svg);
 }
 %with-list-16-mask {
-  @extend %with-mask, %list-16-svg-prop !optional;
+  @extend %with-mask, %list-16-svg-prop;
   -webkit-mask-image: var(--list-16-svg);
   mask-image: var(--list-16-svg);
 }
 
 %with-list-24-icon {
-  @extend %with-icon, %list-24-svg-prop !optional;
+  @extend %with-icon, %list-24-svg-prop;
   background-image: var(--list-24-svg);
 }
 %with-list-24-mask {
-  @extend %with-mask, %list-24-svg-prop !optional;
+  @extend %with-mask, %list-24-svg-prop;
   -webkit-mask-image: var(--list-24-svg);
   mask-image: var(--list-24-svg);
 }
 
 %with-loading-icon {
-  @extend %with-icon, %loading-svg-prop !optional;
+  @extend %with-icon, %loading-svg-prop;
   background-image: var(--loading-svg);
 }
 %with-loading-mask {
-  @extend %with-mask, %loading-svg-prop !optional;
+  @extend %with-mask, %loading-svg-prop;
   -webkit-mask-image: var(--loading-svg);
   mask-image: var(--loading-svg);
 }
 
 %with-lock-16-icon {
-  @extend %with-icon, %lock-16-svg-prop !optional;
+  @extend %with-icon, %lock-16-svg-prop;
   background-image: var(--lock-16-svg);
 }
 %with-lock-16-mask {
-  @extend %with-mask, %lock-16-svg-prop !optional;
+  @extend %with-mask, %lock-16-svg-prop;
   -webkit-mask-image: var(--lock-16-svg);
   mask-image: var(--lock-16-svg);
 }
 
 %with-lock-24-icon {
-  @extend %with-icon, %lock-24-svg-prop !optional;
+  @extend %with-icon, %lock-24-svg-prop;
   background-image: var(--lock-24-svg);
 }
 %with-lock-24-mask {
-  @extend %with-mask, %lock-24-svg-prop !optional;
+  @extend %with-mask, %lock-24-svg-prop;
   -webkit-mask-image: var(--lock-24-svg);
   mask-image: var(--lock-24-svg);
 }
 
 %with-lock-closed-fill-icon {
-  @extend %with-icon, %lock-closed-fill-svg-prop !optional;
+  @extend %with-icon, %lock-closed-fill-svg-prop;
   background-image: var(--lock-closed-fill-svg);
 }
 %with-lock-closed-fill-mask {
-  @extend %with-mask, %lock-closed-fill-svg-prop !optional;
+  @extend %with-mask, %lock-closed-fill-svg-prop;
   -webkit-mask-image: var(--lock-closed-fill-svg);
   mask-image: var(--lock-closed-fill-svg);
 }
 
 %with-lock-closed-outline-icon {
-  @extend %with-icon, %lock-closed-outline-svg-prop !optional;
+  @extend %with-icon, %lock-closed-outline-svg-prop;
   background-image: var(--lock-closed-outline-svg);
 }
 %with-lock-closed-outline-mask {
-  @extend %with-mask, %lock-closed-outline-svg-prop !optional;
+  @extend %with-mask, %lock-closed-outline-svg-prop;
   -webkit-mask-image: var(--lock-closed-outline-svg);
   mask-image: var(--lock-closed-outline-svg);
 }
 
 %with-lock-closed-icon {
-  @extend %with-icon, %lock-closed-svg-prop !optional;
+  @extend %with-icon, %lock-closed-svg-prop;
   background-image: var(--lock-closed-svg);
 }
 %with-lock-closed-mask {
-  @extend %with-mask, %lock-closed-svg-prop !optional;
+  @extend %with-mask, %lock-closed-svg-prop;
   -webkit-mask-image: var(--lock-closed-svg);
   mask-image: var(--lock-closed-svg);
 }
 
 %with-lock-disabled-icon {
-  @extend %with-icon, %lock-disabled-svg-prop !optional;
+  @extend %with-icon, %lock-disabled-svg-prop;
   background-image: var(--lock-disabled-svg);
 }
 %with-lock-disabled-mask {
-  @extend %with-mask, %lock-disabled-svg-prop !optional;
+  @extend %with-mask, %lock-disabled-svg-prop;
   -webkit-mask-image: var(--lock-disabled-svg);
   mask-image: var(--lock-disabled-svg);
 }
 
 %with-lock-fill-16-icon {
-  @extend %with-icon, %lock-fill-16-svg-prop !optional;
+  @extend %with-icon, %lock-fill-16-svg-prop;
   background-image: var(--lock-fill-16-svg);
 }
 %with-lock-fill-16-mask {
-  @extend %with-mask, %lock-fill-16-svg-prop !optional;
+  @extend %with-mask, %lock-fill-16-svg-prop;
   -webkit-mask-image: var(--lock-fill-16-svg);
   mask-image: var(--lock-fill-16-svg);
 }
 
 %with-lock-fill-24-icon {
-  @extend %with-icon, %lock-fill-24-svg-prop !optional;
+  @extend %with-icon, %lock-fill-24-svg-prop;
   background-image: var(--lock-fill-24-svg);
 }
 %with-lock-fill-24-mask {
-  @extend %with-mask, %lock-fill-24-svg-prop !optional;
+  @extend %with-mask, %lock-fill-24-svg-prop;
   -webkit-mask-image: var(--lock-fill-24-svg);
   mask-image: var(--lock-fill-24-svg);
 }
 
 %with-lock-off-16-icon {
-  @extend %with-icon, %lock-off-16-svg-prop !optional;
+  @extend %with-icon, %lock-off-16-svg-prop;
   background-image: var(--lock-off-16-svg);
 }
 %with-lock-off-16-mask {
-  @extend %with-mask, %lock-off-16-svg-prop !optional;
+  @extend %with-mask, %lock-off-16-svg-prop;
   -webkit-mask-image: var(--lock-off-16-svg);
   mask-image: var(--lock-off-16-svg);
 }
 
 %with-lock-off-24-icon {
-  @extend %with-icon, %lock-off-24-svg-prop !optional;
+  @extend %with-icon, %lock-off-24-svg-prop;
   background-image: var(--lock-off-24-svg);
 }
 %with-lock-off-24-mask {
-  @extend %with-mask, %lock-off-24-svg-prop !optional;
+  @extend %with-mask, %lock-off-24-svg-prop;
   -webkit-mask-image: var(--lock-off-24-svg);
   mask-image: var(--lock-off-24-svg);
 }
 
 %with-lock-open-icon {
-  @extend %with-icon, %lock-open-svg-prop !optional;
+  @extend %with-icon, %lock-open-svg-prop;
   background-image: var(--lock-open-svg);
 }
 %with-lock-open-mask {
-  @extend %with-mask, %lock-open-svg-prop !optional;
+  @extend %with-mask, %lock-open-svg-prop;
   -webkit-mask-image: var(--lock-open-svg);
   mask-image: var(--lock-open-svg);
 }
 
 %with-logo-alicloud-color-icon {
-  @extend %with-icon, %logo-alicloud-color-svg-prop !optional;
+  @extend %with-icon, %logo-alicloud-color-svg-prop;
   background-image: var(--logo-alicloud-color-svg);
 }
 %with-logo-alicloud-color-mask {
-  @extend %with-mask, %logo-alicloud-color-svg-prop !optional;
+  @extend %with-mask, %logo-alicloud-color-svg-prop;
   -webkit-mask-image: var(--logo-alicloud-color-svg);
   mask-image: var(--logo-alicloud-color-svg);
 }
 
 %with-logo-alicloud-monochrome-icon {
-  @extend %with-icon, %logo-alicloud-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-alicloud-monochrome-svg-prop;
   background-image: var(--logo-alicloud-monochrome-svg);
 }
 %with-logo-alicloud-monochrome-mask {
-  @extend %with-mask, %logo-alicloud-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-alicloud-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-alicloud-monochrome-svg);
   mask-image: var(--logo-alicloud-monochrome-svg);
 }
 
 %with-logo-auth0-color-icon {
-  @extend %with-icon, %logo-auth0-color-svg-prop !optional;
+  @extend %with-icon, %logo-auth0-color-svg-prop;
   background-image: var(--logo-auth0-color-svg);
 }
 %with-logo-auth0-color-mask {
-  @extend %with-mask, %logo-auth0-color-svg-prop !optional;
+  @extend %with-mask, %logo-auth0-color-svg-prop;
   -webkit-mask-image: var(--logo-auth0-color-svg);
   mask-image: var(--logo-auth0-color-svg);
 }
 
 %with-logo-aws-color-icon {
-  @extend %with-icon, %logo-aws-color-svg-prop !optional;
+  @extend %with-icon, %logo-aws-color-svg-prop;
   background-image: var(--logo-aws-color-svg);
 }
 %with-logo-aws-color-mask {
-  @extend %with-mask, %logo-aws-color-svg-prop !optional;
+  @extend %with-mask, %logo-aws-color-svg-prop;
   -webkit-mask-image: var(--logo-aws-color-svg);
   mask-image: var(--logo-aws-color-svg);
 }
 
 %with-logo-aws-monochrome-icon {
-  @extend %with-icon, %logo-aws-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-aws-monochrome-svg-prop;
   background-image: var(--logo-aws-monochrome-svg);
 }
 %with-logo-aws-monochrome-mask {
-  @extend %with-mask, %logo-aws-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-aws-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-aws-monochrome-svg);
   mask-image: var(--logo-aws-monochrome-svg);
 }
 
 %with-logo-azure-color-icon {
-  @extend %with-icon, %logo-azure-color-svg-prop !optional;
+  @extend %with-icon, %logo-azure-color-svg-prop;
   background-image: var(--logo-azure-color-svg);
 }
 %with-logo-azure-color-mask {
-  @extend %with-mask, %logo-azure-color-svg-prop !optional;
+  @extend %with-mask, %logo-azure-color-svg-prop;
   -webkit-mask-image: var(--logo-azure-color-svg);
   mask-image: var(--logo-azure-color-svg);
 }
 
 %with-logo-azure-dev-ops-color-icon {
-  @extend %with-icon, %logo-azure-dev-ops-color-svg-prop !optional;
+  @extend %with-icon, %logo-azure-dev-ops-color-svg-prop;
   background-image: var(--logo-azure-dev-ops-color-svg);
 }
 %with-logo-azure-dev-ops-color-mask {
-  @extend %with-mask, %logo-azure-dev-ops-color-svg-prop !optional;
+  @extend %with-mask, %logo-azure-dev-ops-color-svg-prop;
   -webkit-mask-image: var(--logo-azure-dev-ops-color-svg);
   mask-image: var(--logo-azure-dev-ops-color-svg);
 }
 
 %with-logo-azure-dev-ops-monochrome-icon {
-  @extend %with-icon, %logo-azure-dev-ops-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-azure-dev-ops-monochrome-svg-prop;
   background-image: var(--logo-azure-dev-ops-monochrome-svg);
 }
 %with-logo-azure-dev-ops-monochrome-mask {
-  @extend %with-mask, %logo-azure-dev-ops-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-azure-dev-ops-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-azure-dev-ops-monochrome-svg);
   mask-image: var(--logo-azure-dev-ops-monochrome-svg);
 }
 
 %with-logo-azure-monochrome-icon {
-  @extend %with-icon, %logo-azure-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-azure-monochrome-svg-prop;
   background-image: var(--logo-azure-monochrome-svg);
 }
 %with-logo-azure-monochrome-mask {
-  @extend %with-mask, %logo-azure-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-azure-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-azure-monochrome-svg);
   mask-image: var(--logo-azure-monochrome-svg);
 }
 
 %with-logo-bitbucket-color-icon {
-  @extend %with-icon, %logo-bitbucket-color-svg-prop !optional;
+  @extend %with-icon, %logo-bitbucket-color-svg-prop;
   background-image: var(--logo-bitbucket-color-svg);
 }
 %with-logo-bitbucket-color-mask {
-  @extend %with-mask, %logo-bitbucket-color-svg-prop !optional;
+  @extend %with-mask, %logo-bitbucket-color-svg-prop;
   -webkit-mask-image: var(--logo-bitbucket-color-svg);
   mask-image: var(--logo-bitbucket-color-svg);
 }
 
 %with-logo-bitbucket-monochrome-icon {
-  @extend %with-icon, %logo-bitbucket-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-bitbucket-monochrome-svg-prop;
   background-image: var(--logo-bitbucket-monochrome-svg);
 }
 %with-logo-bitbucket-monochrome-mask {
-  @extend %with-mask, %logo-bitbucket-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-bitbucket-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-bitbucket-monochrome-svg);
   mask-image: var(--logo-bitbucket-monochrome-svg);
 }
 
 %with-logo-consul-color-icon {
-  @extend %with-icon, %logo-consul-color-svg-prop !optional;
+  @extend %with-icon, %logo-consul-color-svg-prop;
   background-image: var(--logo-consul-color-svg);
 }
 %with-logo-consul-color-mask {
-  @extend %with-mask, %logo-consul-color-svg-prop !optional;
+  @extend %with-mask, %logo-consul-color-svg-prop;
   -webkit-mask-image: var(--logo-consul-color-svg);
   mask-image: var(--logo-consul-color-svg);
 }
 
 %with-logo-ember-circle-color-icon {
-  @extend %with-icon, %logo-ember-circle-color-svg-prop !optional;
+  @extend %with-icon, %logo-ember-circle-color-svg-prop;
   background-image: var(--logo-ember-circle-color-svg);
 }
 %with-logo-ember-circle-color-mask {
-  @extend %with-mask, %logo-ember-circle-color-svg-prop !optional;
+  @extend %with-mask, %logo-ember-circle-color-svg-prop;
   -webkit-mask-image: var(--logo-ember-circle-color-svg);
   mask-image: var(--logo-ember-circle-color-svg);
 }
 
 %with-logo-gcp-color-icon {
-  @extend %with-icon, %logo-gcp-color-svg-prop !optional;
+  @extend %with-icon, %logo-gcp-color-svg-prop;
   background-image: var(--logo-gcp-color-svg);
 }
 %with-logo-gcp-color-mask {
-  @extend %with-mask, %logo-gcp-color-svg-prop !optional;
+  @extend %with-mask, %logo-gcp-color-svg-prop;
   -webkit-mask-image: var(--logo-gcp-color-svg);
   mask-image: var(--logo-gcp-color-svg);
 }
 
 %with-logo-gcp-monochrome-icon {
-  @extend %with-icon, %logo-gcp-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-gcp-monochrome-svg-prop;
   background-image: var(--logo-gcp-monochrome-svg);
 }
 %with-logo-gcp-monochrome-mask {
-  @extend %with-mask, %logo-gcp-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-gcp-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-gcp-monochrome-svg);
   mask-image: var(--logo-gcp-monochrome-svg);
 }
 
 %with-logo-github-color-icon {
-  @extend %with-icon, %logo-github-color-svg-prop !optional;
+  @extend %with-icon, %logo-github-color-svg-prop;
   background-image: var(--logo-github-color-svg);
 }
 %with-logo-github-color-mask {
-  @extend %with-mask, %logo-github-color-svg-prop !optional;
+  @extend %with-mask, %logo-github-color-svg-prop;
   -webkit-mask-image: var(--logo-github-color-svg);
   mask-image: var(--logo-github-color-svg);
 }
 
 %with-logo-github-monochrome-icon {
-  @extend %with-icon, %logo-github-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-github-monochrome-svg-prop;
   background-image: var(--logo-github-monochrome-svg);
 }
 %with-logo-github-monochrome-mask {
-  @extend %with-mask, %logo-github-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-github-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-github-monochrome-svg);
   mask-image: var(--logo-github-monochrome-svg);
 }
 
 %with-logo-gitlab-color-icon {
-  @extend %with-icon, %logo-gitlab-color-svg-prop !optional;
+  @extend %with-icon, %logo-gitlab-color-svg-prop;
   background-image: var(--logo-gitlab-color-svg);
 }
 %with-logo-gitlab-color-mask {
-  @extend %with-mask, %logo-gitlab-color-svg-prop !optional;
+  @extend %with-mask, %logo-gitlab-color-svg-prop;
   -webkit-mask-image: var(--logo-gitlab-color-svg);
   mask-image: var(--logo-gitlab-color-svg);
 }
 
 %with-logo-gitlab-monochrome-icon {
-  @extend %with-icon, %logo-gitlab-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-gitlab-monochrome-svg-prop;
   background-image: var(--logo-gitlab-monochrome-svg);
 }
 %with-logo-gitlab-monochrome-mask {
-  @extend %with-mask, %logo-gitlab-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-gitlab-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-gitlab-monochrome-svg);
   mask-image: var(--logo-gitlab-monochrome-svg);
 }
 
 %with-logo-glimmer-color-icon {
-  @extend %with-icon, %logo-glimmer-color-svg-prop !optional;
+  @extend %with-icon, %logo-glimmer-color-svg-prop;
   background-image: var(--logo-glimmer-color-svg);
 }
 %with-logo-glimmer-color-mask {
-  @extend %with-mask, %logo-glimmer-color-svg-prop !optional;
+  @extend %with-mask, %logo-glimmer-color-svg-prop;
   -webkit-mask-image: var(--logo-glimmer-color-svg);
   mask-image: var(--logo-glimmer-color-svg);
 }
 
 %with-logo-google-color-icon {
-  @extend %with-icon, %logo-google-color-svg-prop !optional;
+  @extend %with-icon, %logo-google-color-svg-prop;
   background-image: var(--logo-google-color-svg);
 }
 %with-logo-google-color-mask {
-  @extend %with-mask, %logo-google-color-svg-prop !optional;
+  @extend %with-mask, %logo-google-color-svg-prop;
   -webkit-mask-image: var(--logo-google-color-svg);
   mask-image: var(--logo-google-color-svg);
 }
 
 %with-logo-google-monochrome-icon {
-  @extend %with-icon, %logo-google-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-google-monochrome-svg-prop;
   background-image: var(--logo-google-monochrome-svg);
 }
 %with-logo-google-monochrome-mask {
-  @extend %with-mask, %logo-google-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-google-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-google-monochrome-svg);
   mask-image: var(--logo-google-monochrome-svg);
 }
 
 %with-logo-hashicorp-color-icon {
-  @extend %with-icon, %logo-hashicorp-color-svg-prop !optional;
+  @extend %with-icon, %logo-hashicorp-color-svg-prop;
   background-image: var(--logo-hashicorp-color-svg);
 }
 %with-logo-hashicorp-color-mask {
-  @extend %with-mask, %logo-hashicorp-color-svg-prop !optional;
+  @extend %with-mask, %logo-hashicorp-color-svg-prop;
   -webkit-mask-image: var(--logo-hashicorp-color-svg);
   mask-image: var(--logo-hashicorp-color-svg);
 }
 
 %with-logo-jwt-color-icon {
-  @extend %with-icon, %logo-jwt-color-svg-prop !optional;
+  @extend %with-icon, %logo-jwt-color-svg-prop;
   background-image: var(--logo-jwt-color-svg);
 }
 %with-logo-jwt-color-mask {
-  @extend %with-mask, %logo-jwt-color-svg-prop !optional;
+  @extend %with-mask, %logo-jwt-color-svg-prop;
   -webkit-mask-image: var(--logo-jwt-color-svg);
   mask-image: var(--logo-jwt-color-svg);
 }
 
 %with-logo-kubernetes-color-icon {
-  @extend %with-icon, %logo-kubernetes-color-svg-prop !optional;
+  @extend %with-icon, %logo-kubernetes-color-svg-prop;
   background-image: var(--logo-kubernetes-color-svg);
 }
 %with-logo-kubernetes-color-mask {
-  @extend %with-mask, %logo-kubernetes-color-svg-prop !optional;
+  @extend %with-mask, %logo-kubernetes-color-svg-prop;
   -webkit-mask-image: var(--logo-kubernetes-color-svg);
   mask-image: var(--logo-kubernetes-color-svg);
 }
 
 %with-logo-kubernetes-monochrome-icon {
-  @extend %with-icon, %logo-kubernetes-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-kubernetes-monochrome-svg-prop;
   background-image: var(--logo-kubernetes-monochrome-svg);
 }
 %with-logo-kubernetes-monochrome-mask {
-  @extend %with-mask, %logo-kubernetes-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-kubernetes-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-kubernetes-monochrome-svg);
   mask-image: var(--logo-kubernetes-monochrome-svg);
 }
 
 %with-logo-microsoft-color-icon {
-  @extend %with-icon, %logo-microsoft-color-svg-prop !optional;
+  @extend %with-icon, %logo-microsoft-color-svg-prop;
   background-image: var(--logo-microsoft-color-svg);
 }
 %with-logo-microsoft-color-mask {
-  @extend %with-mask, %logo-microsoft-color-svg-prop !optional;
+  @extend %with-mask, %logo-microsoft-color-svg-prop;
   -webkit-mask-image: var(--logo-microsoft-color-svg);
   mask-image: var(--logo-microsoft-color-svg);
 }
 
 %with-logo-nomad-color-icon {
-  @extend %with-icon, %logo-nomad-color-svg-prop !optional;
+  @extend %with-icon, %logo-nomad-color-svg-prop;
   background-image: var(--logo-nomad-color-svg);
 }
 %with-logo-nomad-color-mask {
-  @extend %with-mask, %logo-nomad-color-svg-prop !optional;
+  @extend %with-mask, %logo-nomad-color-svg-prop;
   -webkit-mask-image: var(--logo-nomad-color-svg);
   mask-image: var(--logo-nomad-color-svg);
 }
 
 %with-logo-oidc-color-icon {
-  @extend %with-icon, %logo-oidc-color-svg-prop !optional;
+  @extend %with-icon, %logo-oidc-color-svg-prop;
   background-image: var(--logo-oidc-color-svg);
 }
 %with-logo-oidc-color-mask {
-  @extend %with-mask, %logo-oidc-color-svg-prop !optional;
+  @extend %with-mask, %logo-oidc-color-svg-prop;
   -webkit-mask-image: var(--logo-oidc-color-svg);
   mask-image: var(--logo-oidc-color-svg);
 }
 
 %with-logo-okta-color-icon {
-  @extend %with-icon, %logo-okta-color-svg-prop !optional;
+  @extend %with-icon, %logo-okta-color-svg-prop;
   background-image: var(--logo-okta-color-svg);
 }
 %with-logo-okta-color-mask {
-  @extend %with-mask, %logo-okta-color-svg-prop !optional;
+  @extend %with-mask, %logo-okta-color-svg-prop;
   -webkit-mask-image: var(--logo-okta-color-svg);
   mask-image: var(--logo-okta-color-svg);
 }
 
 %with-logo-oracle-color-icon {
-  @extend %with-icon, %logo-oracle-color-svg-prop !optional;
+  @extend %with-icon, %logo-oracle-color-svg-prop;
   background-image: var(--logo-oracle-color-svg);
 }
 %with-logo-oracle-color-mask {
-  @extend %with-mask, %logo-oracle-color-svg-prop !optional;
+  @extend %with-mask, %logo-oracle-color-svg-prop;
   -webkit-mask-image: var(--logo-oracle-color-svg);
   mask-image: var(--logo-oracle-color-svg);
 }
 
 %with-logo-oracle-monochrome-icon {
-  @extend %with-icon, %logo-oracle-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-oracle-monochrome-svg-prop;
   background-image: var(--logo-oracle-monochrome-svg);
 }
 %with-logo-oracle-monochrome-mask {
-  @extend %with-mask, %logo-oracle-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-oracle-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-oracle-monochrome-svg);
   mask-image: var(--logo-oracle-monochrome-svg);
 }
 
 %with-logo-slack-color-icon {
-  @extend %with-icon, %logo-slack-color-svg-prop !optional;
+  @extend %with-icon, %logo-slack-color-svg-prop;
   background-image: var(--logo-slack-color-svg);
 }
 %with-logo-slack-color-mask {
-  @extend %with-mask, %logo-slack-color-svg-prop !optional;
+  @extend %with-mask, %logo-slack-color-svg-prop;
   -webkit-mask-image: var(--logo-slack-color-svg);
   mask-image: var(--logo-slack-color-svg);
 }
 
 %with-logo-slack-monochrome-icon {
-  @extend %with-icon, %logo-slack-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-slack-monochrome-svg-prop;
   background-image: var(--logo-slack-monochrome-svg);
 }
 %with-logo-slack-monochrome-mask {
-  @extend %with-mask, %logo-slack-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-slack-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-slack-monochrome-svg);
   mask-image: var(--logo-slack-monochrome-svg);
 }
 
 %with-logo-terraform-color-icon {
-  @extend %with-icon, %logo-terraform-color-svg-prop !optional;
+  @extend %with-icon, %logo-terraform-color-svg-prop;
   background-image: var(--logo-terraform-color-svg);
 }
 %with-logo-terraform-color-mask {
-  @extend %with-mask, %logo-terraform-color-svg-prop !optional;
+  @extend %with-mask, %logo-terraform-color-svg-prop;
   -webkit-mask-image: var(--logo-terraform-color-svg);
   mask-image: var(--logo-terraform-color-svg);
 }
 
 %with-logo-vault-color-icon {
-  @extend %with-icon, %logo-vault-color-svg-prop !optional;
+  @extend %with-icon, %logo-vault-color-svg-prop;
   background-image: var(--logo-vault-color-svg);
 }
 %with-logo-vault-color-mask {
-  @extend %with-mask, %logo-vault-color-svg-prop !optional;
+  @extend %with-mask, %logo-vault-color-svg-prop;
   -webkit-mask-image: var(--logo-vault-color-svg);
   mask-image: var(--logo-vault-color-svg);
 }
 
 %with-logo-vmware-color-icon {
-  @extend %with-icon, %logo-vmware-color-svg-prop !optional;
+  @extend %with-icon, %logo-vmware-color-svg-prop;
   background-image: var(--logo-vmware-color-svg);
 }
 %with-logo-vmware-color-mask {
-  @extend %with-mask, %logo-vmware-color-svg-prop !optional;
+  @extend %with-mask, %logo-vmware-color-svg-prop;
   -webkit-mask-image: var(--logo-vmware-color-svg);
   mask-image: var(--logo-vmware-color-svg);
 }
 
 %with-logo-vmware-monochrome-icon {
-  @extend %with-icon, %logo-vmware-monochrome-svg-prop !optional;
+  @extend %with-icon, %logo-vmware-monochrome-svg-prop;
   background-image: var(--logo-vmware-monochrome-svg);
 }
 %with-logo-vmware-monochrome-mask {
-  @extend %with-mask, %logo-vmware-monochrome-svg-prop !optional;
+  @extend %with-mask, %logo-vmware-monochrome-svg-prop;
   -webkit-mask-image: var(--logo-vmware-monochrome-svg);
   mask-image: var(--logo-vmware-monochrome-svg);
 }
 
 %with-mail-16-icon {
-  @extend %with-icon, %mail-16-svg-prop !optional;
+  @extend %with-icon, %mail-16-svg-prop;
   background-image: var(--mail-16-svg);
 }
 %with-mail-16-mask {
-  @extend %with-mask, %mail-16-svg-prop !optional;
+  @extend %with-mask, %mail-16-svg-prop;
   -webkit-mask-image: var(--mail-16-svg);
   mask-image: var(--mail-16-svg);
 }
 
 %with-mail-24-icon {
-  @extend %with-icon, %mail-24-svg-prop !optional;
+  @extend %with-icon, %mail-24-svg-prop;
   background-image: var(--mail-24-svg);
 }
 %with-mail-24-mask {
-  @extend %with-mask, %mail-24-svg-prop !optional;
+  @extend %with-mask, %mail-24-svg-prop;
   -webkit-mask-image: var(--mail-24-svg);
   mask-image: var(--mail-24-svg);
 }
 
 %with-mail-open-16-icon {
-  @extend %with-icon, %mail-open-16-svg-prop !optional;
+  @extend %with-icon, %mail-open-16-svg-prop;
   background-image: var(--mail-open-16-svg);
 }
 %with-mail-open-16-mask {
-  @extend %with-mask, %mail-open-16-svg-prop !optional;
+  @extend %with-mask, %mail-open-16-svg-prop;
   -webkit-mask-image: var(--mail-open-16-svg);
   mask-image: var(--mail-open-16-svg);
 }
 
 %with-mail-open-24-icon {
-  @extend %with-icon, %mail-open-24-svg-prop !optional;
+  @extend %with-icon, %mail-open-24-svg-prop;
   background-image: var(--mail-open-24-svg);
 }
 %with-mail-open-24-mask {
-  @extend %with-mask, %mail-open-24-svg-prop !optional;
+  @extend %with-mask, %mail-open-24-svg-prop;
   -webkit-mask-image: var(--mail-open-24-svg);
   mask-image: var(--mail-open-24-svg);
 }
 
 %with-map-16-icon {
-  @extend %with-icon, %map-16-svg-prop !optional;
+  @extend %with-icon, %map-16-svg-prop;
   background-image: var(--map-16-svg);
 }
 %with-map-16-mask {
-  @extend %with-mask, %map-16-svg-prop !optional;
+  @extend %with-mask, %map-16-svg-prop;
   -webkit-mask-image: var(--map-16-svg);
   mask-image: var(--map-16-svg);
 }
 
 %with-map-24-icon {
-  @extend %with-icon, %map-24-svg-prop !optional;
+  @extend %with-icon, %map-24-svg-prop;
   background-image: var(--map-24-svg);
 }
 %with-map-24-mask {
-  @extend %with-mask, %map-24-svg-prop !optional;
+  @extend %with-mask, %map-24-svg-prop;
   -webkit-mask-image: var(--map-24-svg);
   mask-image: var(--map-24-svg);
 }
 
 %with-map-pin-16-icon {
-  @extend %with-icon, %map-pin-16-svg-prop !optional;
+  @extend %with-icon, %map-pin-16-svg-prop;
   background-image: var(--map-pin-16-svg);
 }
 %with-map-pin-16-mask {
-  @extend %with-mask, %map-pin-16-svg-prop !optional;
+  @extend %with-mask, %map-pin-16-svg-prop;
   -webkit-mask-image: var(--map-pin-16-svg);
   mask-image: var(--map-pin-16-svg);
 }
 
 %with-map-pin-24-icon {
-  @extend %with-icon, %map-pin-24-svg-prop !optional;
+  @extend %with-icon, %map-pin-24-svg-prop;
   background-image: var(--map-pin-24-svg);
 }
 %with-map-pin-24-mask {
-  @extend %with-mask, %map-pin-24-svg-prop !optional;
+  @extend %with-mask, %map-pin-24-svg-prop;
   -webkit-mask-image: var(--map-pin-24-svg);
   mask-image: var(--map-pin-24-svg);
 }
 
 %with-maximize-16-icon {
-  @extend %with-icon, %maximize-16-svg-prop !optional;
+  @extend %with-icon, %maximize-16-svg-prop;
   background-image: var(--maximize-16-svg);
 }
 %with-maximize-16-mask {
-  @extend %with-mask, %maximize-16-svg-prop !optional;
+  @extend %with-mask, %maximize-16-svg-prop;
   -webkit-mask-image: var(--maximize-16-svg);
   mask-image: var(--maximize-16-svg);
 }
 
 %with-maximize-24-icon {
-  @extend %with-icon, %maximize-24-svg-prop !optional;
+  @extend %with-icon, %maximize-24-svg-prop;
   background-image: var(--maximize-24-svg);
 }
 %with-maximize-24-mask {
-  @extend %with-mask, %maximize-24-svg-prop !optional;
+  @extend %with-mask, %maximize-24-svg-prop;
   -webkit-mask-image: var(--maximize-24-svg);
   mask-image: var(--maximize-24-svg);
 }
 
 %with-maximize-alt-16-icon {
-  @extend %with-icon, %maximize-alt-16-svg-prop !optional;
+  @extend %with-icon, %maximize-alt-16-svg-prop;
   background-image: var(--maximize-alt-16-svg);
 }
 %with-maximize-alt-16-mask {
-  @extend %with-mask, %maximize-alt-16-svg-prop !optional;
+  @extend %with-mask, %maximize-alt-16-svg-prop;
   -webkit-mask-image: var(--maximize-alt-16-svg);
   mask-image: var(--maximize-alt-16-svg);
 }
 
 %with-maximize-alt-24-icon {
-  @extend %with-icon, %maximize-alt-24-svg-prop !optional;
+  @extend %with-icon, %maximize-alt-24-svg-prop;
   background-image: var(--maximize-alt-24-svg);
 }
 %with-maximize-alt-24-mask {
-  @extend %with-mask, %maximize-alt-24-svg-prop !optional;
+  @extend %with-mask, %maximize-alt-24-svg-prop;
   -webkit-mask-image: var(--maximize-alt-24-svg);
   mask-image: var(--maximize-alt-24-svg);
 }
 
 %with-meh-16-icon {
-  @extend %with-icon, %meh-16-svg-prop !optional;
+  @extend %with-icon, %meh-16-svg-prop;
   background-image: var(--meh-16-svg);
 }
 %with-meh-16-mask {
-  @extend %with-mask, %meh-16-svg-prop !optional;
+  @extend %with-mask, %meh-16-svg-prop;
   -webkit-mask-image: var(--meh-16-svg);
   mask-image: var(--meh-16-svg);
 }
 
 %with-meh-24-icon {
-  @extend %with-icon, %meh-24-svg-prop !optional;
+  @extend %with-icon, %meh-24-svg-prop;
   background-image: var(--meh-24-svg);
 }
 %with-meh-24-mask {
-  @extend %with-mask, %meh-24-svg-prop !optional;
+  @extend %with-mask, %meh-24-svg-prop;
   -webkit-mask-image: var(--meh-24-svg);
   mask-image: var(--meh-24-svg);
 }
 
 %with-menu-16-icon {
-  @extend %with-icon, %menu-16-svg-prop !optional;
+  @extend %with-icon, %menu-16-svg-prop;
   background-image: var(--menu-16-svg);
 }
 %with-menu-16-mask {
-  @extend %with-mask, %menu-16-svg-prop !optional;
+  @extend %with-mask, %menu-16-svg-prop;
   -webkit-mask-image: var(--menu-16-svg);
   mask-image: var(--menu-16-svg);
 }
 
 %with-menu-24-icon {
-  @extend %with-icon, %menu-24-svg-prop !optional;
+  @extend %with-icon, %menu-24-svg-prop;
   background-image: var(--menu-24-svg);
 }
 %with-menu-24-mask {
-  @extend %with-mask, %menu-24-svg-prop !optional;
+  @extend %with-mask, %menu-24-svg-prop;
   -webkit-mask-image: var(--menu-24-svg);
   mask-image: var(--menu-24-svg);
 }
 
 %with-menu-icon {
-  @extend %with-icon, %menu-svg-prop !optional;
+  @extend %with-icon, %menu-svg-prop;
   background-image: var(--menu-svg);
 }
 %with-menu-mask {
-  @extend %with-mask, %menu-svg-prop !optional;
+  @extend %with-mask, %menu-svg-prop;
   -webkit-mask-image: var(--menu-svg);
   mask-image: var(--menu-svg);
 }
 
 %with-mesh-16-icon {
-  @extend %with-icon, %mesh-16-svg-prop !optional;
+  @extend %with-icon, %mesh-16-svg-prop;
   background-image: var(--mesh-16-svg);
 }
 %with-mesh-16-mask {
-  @extend %with-mask, %mesh-16-svg-prop !optional;
+  @extend %with-mask, %mesh-16-svg-prop;
   -webkit-mask-image: var(--mesh-16-svg);
   mask-image: var(--mesh-16-svg);
 }
 
 %with-mesh-24-icon {
-  @extend %with-icon, %mesh-24-svg-prop !optional;
+  @extend %with-icon, %mesh-24-svg-prop;
   background-image: var(--mesh-24-svg);
 }
 %with-mesh-24-mask {
-  @extend %with-mask, %mesh-24-svg-prop !optional;
+  @extend %with-mask, %mesh-24-svg-prop;
   -webkit-mask-image: var(--mesh-24-svg);
   mask-image: var(--mesh-24-svg);
 }
 
 %with-mesh-icon {
-  @extend %with-icon, %mesh-svg-prop !optional;
+  @extend %with-icon, %mesh-svg-prop;
   background-image: var(--mesh-svg);
 }
 %with-mesh-mask {
-  @extend %with-mask, %mesh-svg-prop !optional;
+  @extend %with-mask, %mesh-svg-prop;
   -webkit-mask-image: var(--mesh-svg);
   mask-image: var(--mesh-svg);
 }
 
 %with-message-circle-16-icon {
-  @extend %with-icon, %message-circle-16-svg-prop !optional;
+  @extend %with-icon, %message-circle-16-svg-prop;
   background-image: var(--message-circle-16-svg);
 }
 %with-message-circle-16-mask {
-  @extend %with-mask, %message-circle-16-svg-prop !optional;
+  @extend %with-mask, %message-circle-16-svg-prop;
   -webkit-mask-image: var(--message-circle-16-svg);
   mask-image: var(--message-circle-16-svg);
 }
 
 %with-message-circle-24-icon {
-  @extend %with-icon, %message-circle-24-svg-prop !optional;
+  @extend %with-icon, %message-circle-24-svg-prop;
   background-image: var(--message-circle-24-svg);
 }
 %with-message-circle-24-mask {
-  @extend %with-mask, %message-circle-24-svg-prop !optional;
+  @extend %with-mask, %message-circle-24-svg-prop;
   -webkit-mask-image: var(--message-circle-24-svg);
   mask-image: var(--message-circle-24-svg);
 }
 
 %with-message-circle-fill-16-icon {
-  @extend %with-icon, %message-circle-fill-16-svg-prop !optional;
+  @extend %with-icon, %message-circle-fill-16-svg-prop;
   background-image: var(--message-circle-fill-16-svg);
 }
 %with-message-circle-fill-16-mask {
-  @extend %with-mask, %message-circle-fill-16-svg-prop !optional;
+  @extend %with-mask, %message-circle-fill-16-svg-prop;
   -webkit-mask-image: var(--message-circle-fill-16-svg);
   mask-image: var(--message-circle-fill-16-svg);
 }
 
 %with-message-circle-fill-24-icon {
-  @extend %with-icon, %message-circle-fill-24-svg-prop !optional;
+  @extend %with-icon, %message-circle-fill-24-svg-prop;
   background-image: var(--message-circle-fill-24-svg);
 }
 %with-message-circle-fill-24-mask {
-  @extend %with-mask, %message-circle-fill-24-svg-prop !optional;
+  @extend %with-mask, %message-circle-fill-24-svg-prop;
   -webkit-mask-image: var(--message-circle-fill-24-svg);
   mask-image: var(--message-circle-fill-24-svg);
 }
 
 %with-message-square-16-icon {
-  @extend %with-icon, %message-square-16-svg-prop !optional;
+  @extend %with-icon, %message-square-16-svg-prop;
   background-image: var(--message-square-16-svg);
 }
 %with-message-square-16-mask {
-  @extend %with-mask, %message-square-16-svg-prop !optional;
+  @extend %with-mask, %message-square-16-svg-prop;
   -webkit-mask-image: var(--message-square-16-svg);
   mask-image: var(--message-square-16-svg);
 }
 
 %with-message-square-24-icon {
-  @extend %with-icon, %message-square-24-svg-prop !optional;
+  @extend %with-icon, %message-square-24-svg-prop;
   background-image: var(--message-square-24-svg);
 }
 %with-message-square-24-mask {
-  @extend %with-mask, %message-square-24-svg-prop !optional;
+  @extend %with-mask, %message-square-24-svg-prop;
   -webkit-mask-image: var(--message-square-24-svg);
   mask-image: var(--message-square-24-svg);
 }
 
 %with-message-square-fill-16-icon {
-  @extend %with-icon, %message-square-fill-16-svg-prop !optional;
+  @extend %with-icon, %message-square-fill-16-svg-prop;
   background-image: var(--message-square-fill-16-svg);
 }
 %with-message-square-fill-16-mask {
-  @extend %with-mask, %message-square-fill-16-svg-prop !optional;
+  @extend %with-mask, %message-square-fill-16-svg-prop;
   -webkit-mask-image: var(--message-square-fill-16-svg);
   mask-image: var(--message-square-fill-16-svg);
 }
 
 %with-message-square-fill-24-icon {
-  @extend %with-icon, %message-square-fill-24-svg-prop !optional;
+  @extend %with-icon, %message-square-fill-24-svg-prop;
   background-image: var(--message-square-fill-24-svg);
 }
 %with-message-square-fill-24-mask {
-  @extend %with-mask, %message-square-fill-24-svg-prop !optional;
+  @extend %with-mask, %message-square-fill-24-svg-prop;
   -webkit-mask-image: var(--message-square-fill-24-svg);
   mask-image: var(--message-square-fill-24-svg);
 }
 
 %with-message-icon {
-  @extend %with-icon, %message-svg-prop !optional;
+  @extend %with-icon, %message-svg-prop;
   background-image: var(--message-svg);
 }
 %with-message-mask {
-  @extend %with-mask, %message-svg-prop !optional;
+  @extend %with-mask, %message-svg-prop;
   -webkit-mask-image: var(--message-svg);
   mask-image: var(--message-svg);
 }
 
 %with-mic-16-icon {
-  @extend %with-icon, %mic-16-svg-prop !optional;
+  @extend %with-icon, %mic-16-svg-prop;
   background-image: var(--mic-16-svg);
 }
 %with-mic-16-mask {
-  @extend %with-mask, %mic-16-svg-prop !optional;
+  @extend %with-mask, %mic-16-svg-prop;
   -webkit-mask-image: var(--mic-16-svg);
   mask-image: var(--mic-16-svg);
 }
 
 %with-mic-24-icon {
-  @extend %with-icon, %mic-24-svg-prop !optional;
+  @extend %with-icon, %mic-24-svg-prop;
   background-image: var(--mic-24-svg);
 }
 %with-mic-24-mask {
-  @extend %with-mask, %mic-24-svg-prop !optional;
+  @extend %with-mask, %mic-24-svg-prop;
   -webkit-mask-image: var(--mic-24-svg);
   mask-image: var(--mic-24-svg);
 }
 
 %with-mic-off-16-icon {
-  @extend %with-icon, %mic-off-16-svg-prop !optional;
+  @extend %with-icon, %mic-off-16-svg-prop;
   background-image: var(--mic-off-16-svg);
 }
 %with-mic-off-16-mask {
-  @extend %with-mask, %mic-off-16-svg-prop !optional;
+  @extend %with-mask, %mic-off-16-svg-prop;
   -webkit-mask-image: var(--mic-off-16-svg);
   mask-image: var(--mic-off-16-svg);
 }
 
 %with-mic-off-24-icon {
-  @extend %with-icon, %mic-off-24-svg-prop !optional;
+  @extend %with-icon, %mic-off-24-svg-prop;
   background-image: var(--mic-off-24-svg);
 }
 %with-mic-off-24-mask {
-  @extend %with-mask, %mic-off-24-svg-prop !optional;
+  @extend %with-mask, %mic-off-24-svg-prop;
   -webkit-mask-image: var(--mic-off-24-svg);
   mask-image: var(--mic-off-24-svg);
 }
 
 %with-microsoft-16-icon {
-  @extend %with-icon, %microsoft-16-svg-prop !optional;
+  @extend %with-icon, %microsoft-16-svg-prop;
   background-image: var(--microsoft-16-svg);
 }
 %with-microsoft-16-mask {
-  @extend %with-mask, %microsoft-16-svg-prop !optional;
+  @extend %with-mask, %microsoft-16-svg-prop;
   -webkit-mask-image: var(--microsoft-16-svg);
   mask-image: var(--microsoft-16-svg);
 }
 
 %with-microsoft-24-icon {
-  @extend %with-icon, %microsoft-24-svg-prop !optional;
+  @extend %with-icon, %microsoft-24-svg-prop;
   background-image: var(--microsoft-24-svg);
 }
 %with-microsoft-24-mask {
-  @extend %with-mask, %microsoft-24-svg-prop !optional;
+  @extend %with-mask, %microsoft-24-svg-prop;
   -webkit-mask-image: var(--microsoft-24-svg);
   mask-image: var(--microsoft-24-svg);
 }
 
 %with-microsoft-color-16-icon {
-  @extend %with-icon, %microsoft-color-16-svg-prop !optional;
+  @extend %with-icon, %microsoft-color-16-svg-prop;
   background-image: var(--microsoft-color-16-svg);
 }
 %with-microsoft-color-16-mask {
-  @extend %with-mask, %microsoft-color-16-svg-prop !optional;
+  @extend %with-mask, %microsoft-color-16-svg-prop;
   -webkit-mask-image: var(--microsoft-color-16-svg);
   mask-image: var(--microsoft-color-16-svg);
 }
 
 %with-microsoft-color-24-icon {
-  @extend %with-icon, %microsoft-color-24-svg-prop !optional;
+  @extend %with-icon, %microsoft-color-24-svg-prop;
   background-image: var(--microsoft-color-24-svg);
 }
 %with-microsoft-color-24-mask {
-  @extend %with-mask, %microsoft-color-24-svg-prop !optional;
+  @extend %with-mask, %microsoft-color-24-svg-prop;
   -webkit-mask-image: var(--microsoft-color-24-svg);
   mask-image: var(--microsoft-color-24-svg);
 }
 
 %with-migrate-16-icon {
-  @extend %with-icon, %migrate-16-svg-prop !optional;
+  @extend %with-icon, %migrate-16-svg-prop;
   background-image: var(--migrate-16-svg);
 }
 %with-migrate-16-mask {
-  @extend %with-mask, %migrate-16-svg-prop !optional;
+  @extend %with-mask, %migrate-16-svg-prop;
   -webkit-mask-image: var(--migrate-16-svg);
   mask-image: var(--migrate-16-svg);
 }
 
 %with-migrate-24-icon {
-  @extend %with-icon, %migrate-24-svg-prop !optional;
+  @extend %with-icon, %migrate-24-svg-prop;
   background-image: var(--migrate-24-svg);
 }
 %with-migrate-24-mask {
-  @extend %with-mask, %migrate-24-svg-prop !optional;
+  @extend %with-mask, %migrate-24-svg-prop;
   -webkit-mask-image: var(--migrate-24-svg);
   mask-image: var(--migrate-24-svg);
 }
 
 %with-minimize-16-icon {
-  @extend %with-icon, %minimize-16-svg-prop !optional;
+  @extend %with-icon, %minimize-16-svg-prop;
   background-image: var(--minimize-16-svg);
 }
 %with-minimize-16-mask {
-  @extend %with-mask, %minimize-16-svg-prop !optional;
+  @extend %with-mask, %minimize-16-svg-prop;
   -webkit-mask-image: var(--minimize-16-svg);
   mask-image: var(--minimize-16-svg);
 }
 
 %with-minimize-24-icon {
-  @extend %with-icon, %minimize-24-svg-prop !optional;
+  @extend %with-icon, %minimize-24-svg-prop;
   background-image: var(--minimize-24-svg);
 }
 %with-minimize-24-mask {
-  @extend %with-mask, %minimize-24-svg-prop !optional;
+  @extend %with-mask, %minimize-24-svg-prop;
   -webkit-mask-image: var(--minimize-24-svg);
   mask-image: var(--minimize-24-svg);
 }
 
 %with-minimize-alt-16-icon {
-  @extend %with-icon, %minimize-alt-16-svg-prop !optional;
+  @extend %with-icon, %minimize-alt-16-svg-prop;
   background-image: var(--minimize-alt-16-svg);
 }
 %with-minimize-alt-16-mask {
-  @extend %with-mask, %minimize-alt-16-svg-prop !optional;
+  @extend %with-mask, %minimize-alt-16-svg-prop;
   -webkit-mask-image: var(--minimize-alt-16-svg);
   mask-image: var(--minimize-alt-16-svg);
 }
 
 %with-minimize-alt-24-icon {
-  @extend %with-icon, %minimize-alt-24-svg-prop !optional;
+  @extend %with-icon, %minimize-alt-24-svg-prop;
   background-image: var(--minimize-alt-24-svg);
 }
 %with-minimize-alt-24-mask {
-  @extend %with-mask, %minimize-alt-24-svg-prop !optional;
+  @extend %with-mask, %minimize-alt-24-svg-prop;
   -webkit-mask-image: var(--minimize-alt-24-svg);
   mask-image: var(--minimize-alt-24-svg);
 }
 
 %with-minus-16-icon {
-  @extend %with-icon, %minus-16-svg-prop !optional;
+  @extend %with-icon, %minus-16-svg-prop;
   background-image: var(--minus-16-svg);
 }
 %with-minus-16-mask {
-  @extend %with-mask, %minus-16-svg-prop !optional;
+  @extend %with-mask, %minus-16-svg-prop;
   -webkit-mask-image: var(--minus-16-svg);
   mask-image: var(--minus-16-svg);
 }
 
 %with-minus-24-icon {
-  @extend %with-icon, %minus-24-svg-prop !optional;
+  @extend %with-icon, %minus-24-svg-prop;
   background-image: var(--minus-24-svg);
 }
 %with-minus-24-mask {
-  @extend %with-mask, %minus-24-svg-prop !optional;
+  @extend %with-mask, %minus-24-svg-prop;
   -webkit-mask-image: var(--minus-24-svg);
   mask-image: var(--minus-24-svg);
 }
 
 %with-minus-circle-16-icon {
-  @extend %with-icon, %minus-circle-16-svg-prop !optional;
+  @extend %with-icon, %minus-circle-16-svg-prop;
   background-image: var(--minus-circle-16-svg);
 }
 %with-minus-circle-16-mask {
-  @extend %with-mask, %minus-circle-16-svg-prop !optional;
+  @extend %with-mask, %minus-circle-16-svg-prop;
   -webkit-mask-image: var(--minus-circle-16-svg);
   mask-image: var(--minus-circle-16-svg);
 }
 
 %with-minus-circle-24-icon {
-  @extend %with-icon, %minus-circle-24-svg-prop !optional;
+  @extend %with-icon, %minus-circle-24-svg-prop;
   background-image: var(--minus-circle-24-svg);
 }
 %with-minus-circle-24-mask {
-  @extend %with-mask, %minus-circle-24-svg-prop !optional;
+  @extend %with-mask, %minus-circle-24-svg-prop;
   -webkit-mask-image: var(--minus-circle-24-svg);
   mask-image: var(--minus-circle-24-svg);
 }
 
 %with-minus-circle-fill-icon {
-  @extend %with-icon, %minus-circle-fill-svg-prop !optional;
+  @extend %with-icon, %minus-circle-fill-svg-prop;
   background-image: var(--minus-circle-fill-svg);
 }
 %with-minus-circle-fill-mask {
-  @extend %with-mask, %minus-circle-fill-svg-prop !optional;
+  @extend %with-mask, %minus-circle-fill-svg-prop;
   -webkit-mask-image: var(--minus-circle-fill-svg);
   mask-image: var(--minus-circle-fill-svg);
 }
 
 %with-minus-circle-outline-icon {
-  @extend %with-icon, %minus-circle-outline-svg-prop !optional;
+  @extend %with-icon, %minus-circle-outline-svg-prop;
   background-image: var(--minus-circle-outline-svg);
 }
 %with-minus-circle-outline-mask {
-  @extend %with-mask, %minus-circle-outline-svg-prop !optional;
+  @extend %with-mask, %minus-circle-outline-svg-prop;
   -webkit-mask-image: var(--minus-circle-outline-svg);
   mask-image: var(--minus-circle-outline-svg);
 }
 
 %with-minus-plain-icon {
-  @extend %with-icon, %minus-plain-svg-prop !optional;
+  @extend %with-icon, %minus-plain-svg-prop;
   background-image: var(--minus-plain-svg);
 }
 %with-minus-plain-mask {
-  @extend %with-mask, %minus-plain-svg-prop !optional;
+  @extend %with-mask, %minus-plain-svg-prop;
   -webkit-mask-image: var(--minus-plain-svg);
   mask-image: var(--minus-plain-svg);
 }
 
 %with-minus-plus-16-icon {
-  @extend %with-icon, %minus-plus-16-svg-prop !optional;
+  @extend %with-icon, %minus-plus-16-svg-prop;
   background-image: var(--minus-plus-16-svg);
 }
 %with-minus-plus-16-mask {
-  @extend %with-mask, %minus-plus-16-svg-prop !optional;
+  @extend %with-mask, %minus-plus-16-svg-prop;
   -webkit-mask-image: var(--minus-plus-16-svg);
   mask-image: var(--minus-plus-16-svg);
 }
 
 %with-minus-plus-24-icon {
-  @extend %with-icon, %minus-plus-24-svg-prop !optional;
+  @extend %with-icon, %minus-plus-24-svg-prop;
   background-image: var(--minus-plus-24-svg);
 }
 %with-minus-plus-24-mask {
-  @extend %with-mask, %minus-plus-24-svg-prop !optional;
+  @extend %with-mask, %minus-plus-24-svg-prop;
   -webkit-mask-image: var(--minus-plus-24-svg);
   mask-image: var(--minus-plus-24-svg);
 }
 
 %with-minus-plus-circle-16-icon {
-  @extend %with-icon, %minus-plus-circle-16-svg-prop !optional;
+  @extend %with-icon, %minus-plus-circle-16-svg-prop;
   background-image: var(--minus-plus-circle-16-svg);
 }
 %with-minus-plus-circle-16-mask {
-  @extend %with-mask, %minus-plus-circle-16-svg-prop !optional;
+  @extend %with-mask, %minus-plus-circle-16-svg-prop;
   -webkit-mask-image: var(--minus-plus-circle-16-svg);
   mask-image: var(--minus-plus-circle-16-svg);
 }
 
 %with-minus-plus-circle-24-icon {
-  @extend %with-icon, %minus-plus-circle-24-svg-prop !optional;
+  @extend %with-icon, %minus-plus-circle-24-svg-prop;
   background-image: var(--minus-plus-circle-24-svg);
 }
 %with-minus-plus-circle-24-mask {
-  @extend %with-mask, %minus-plus-circle-24-svg-prop !optional;
+  @extend %with-mask, %minus-plus-circle-24-svg-prop;
   -webkit-mask-image: var(--minus-plus-circle-24-svg);
   mask-image: var(--minus-plus-circle-24-svg);
 }
 
 %with-minus-plus-square-16-icon {
-  @extend %with-icon, %minus-plus-square-16-svg-prop !optional;
+  @extend %with-icon, %minus-plus-square-16-svg-prop;
   background-image: var(--minus-plus-square-16-svg);
 }
 %with-minus-plus-square-16-mask {
-  @extend %with-mask, %minus-plus-square-16-svg-prop !optional;
+  @extend %with-mask, %minus-plus-square-16-svg-prop;
   -webkit-mask-image: var(--minus-plus-square-16-svg);
   mask-image: var(--minus-plus-square-16-svg);
 }
 
 %with-minus-plus-square-24-icon {
-  @extend %with-icon, %minus-plus-square-24-svg-prop !optional;
+  @extend %with-icon, %minus-plus-square-24-svg-prop;
   background-image: var(--minus-plus-square-24-svg);
 }
 %with-minus-plus-square-24-mask {
-  @extend %with-mask, %minus-plus-square-24-svg-prop !optional;
+  @extend %with-mask, %minus-plus-square-24-svg-prop;
   -webkit-mask-image: var(--minus-plus-square-24-svg);
   mask-image: var(--minus-plus-square-24-svg);
 }
 
 %with-minus-square-16-icon {
-  @extend %with-icon, %minus-square-16-svg-prop !optional;
+  @extend %with-icon, %minus-square-16-svg-prop;
   background-image: var(--minus-square-16-svg);
 }
 %with-minus-square-16-mask {
-  @extend %with-mask, %minus-square-16-svg-prop !optional;
+  @extend %with-mask, %minus-square-16-svg-prop;
   -webkit-mask-image: var(--minus-square-16-svg);
   mask-image: var(--minus-square-16-svg);
 }
 
 %with-minus-square-24-icon {
-  @extend %with-icon, %minus-square-24-svg-prop !optional;
+  @extend %with-icon, %minus-square-24-svg-prop;
   background-image: var(--minus-square-24-svg);
 }
 %with-minus-square-24-mask {
-  @extend %with-mask, %minus-square-24-svg-prop !optional;
+  @extend %with-mask, %minus-square-24-svg-prop;
   -webkit-mask-image: var(--minus-square-24-svg);
   mask-image: var(--minus-square-24-svg);
 }
 
 %with-minus-square-fill-icon {
-  @extend %with-icon, %minus-square-fill-svg-prop !optional;
+  @extend %with-icon, %minus-square-fill-svg-prop;
   background-image: var(--minus-square-fill-svg);
 }
 %with-minus-square-fill-mask {
-  @extend %with-mask, %minus-square-fill-svg-prop !optional;
+  @extend %with-mask, %minus-square-fill-svg-prop;
   -webkit-mask-image: var(--minus-square-fill-svg);
   mask-image: var(--minus-square-fill-svg);
 }
 
 %with-module-16-icon {
-  @extend %with-icon, %module-16-svg-prop !optional;
+  @extend %with-icon, %module-16-svg-prop;
   background-image: var(--module-16-svg);
 }
 %with-module-16-mask {
-  @extend %with-mask, %module-16-svg-prop !optional;
+  @extend %with-mask, %module-16-svg-prop;
   -webkit-mask-image: var(--module-16-svg);
   mask-image: var(--module-16-svg);
 }
 
 %with-module-24-icon {
-  @extend %with-icon, %module-24-svg-prop !optional;
+  @extend %with-icon, %module-24-svg-prop;
   background-image: var(--module-24-svg);
 }
 %with-module-24-mask {
-  @extend %with-mask, %module-24-svg-prop !optional;
+  @extend %with-mask, %module-24-svg-prop;
   -webkit-mask-image: var(--module-24-svg);
   mask-image: var(--module-24-svg);
 }
 
 %with-module-icon {
-  @extend %with-icon, %module-svg-prop !optional;
+  @extend %with-icon, %module-svg-prop;
   background-image: var(--module-svg);
 }
 %with-module-mask {
-  @extend %with-mask, %module-svg-prop !optional;
+  @extend %with-mask, %module-svg-prop;
   -webkit-mask-image: var(--module-svg);
   mask-image: var(--module-svg);
 }
 
 %with-monitor-16-icon {
-  @extend %with-icon, %monitor-16-svg-prop !optional;
+  @extend %with-icon, %monitor-16-svg-prop;
   background-image: var(--monitor-16-svg);
 }
 %with-monitor-16-mask {
-  @extend %with-mask, %monitor-16-svg-prop !optional;
+  @extend %with-mask, %monitor-16-svg-prop;
   -webkit-mask-image: var(--monitor-16-svg);
   mask-image: var(--monitor-16-svg);
 }
 
 %with-monitor-24-icon {
-  @extend %with-icon, %monitor-24-svg-prop !optional;
+  @extend %with-icon, %monitor-24-svg-prop;
   background-image: var(--monitor-24-svg);
 }
 %with-monitor-24-mask {
-  @extend %with-mask, %monitor-24-svg-prop !optional;
+  @extend %with-mask, %monitor-24-svg-prop;
   -webkit-mask-image: var(--monitor-24-svg);
   mask-image: var(--monitor-24-svg);
 }
 
 %with-moon-16-icon {
-  @extend %with-icon, %moon-16-svg-prop !optional;
+  @extend %with-icon, %moon-16-svg-prop;
   background-image: var(--moon-16-svg);
 }
 %with-moon-16-mask {
-  @extend %with-mask, %moon-16-svg-prop !optional;
+  @extend %with-mask, %moon-16-svg-prop;
   -webkit-mask-image: var(--moon-16-svg);
   mask-image: var(--moon-16-svg);
 }
 
 %with-moon-24-icon {
-  @extend %with-icon, %moon-24-svg-prop !optional;
+  @extend %with-icon, %moon-24-svg-prop;
   background-image: var(--moon-24-svg);
 }
 %with-moon-24-mask {
-  @extend %with-mask, %moon-24-svg-prop !optional;
+  @extend %with-mask, %moon-24-svg-prop;
   -webkit-mask-image: var(--moon-24-svg);
   mask-image: var(--moon-24-svg);
 }
 
 %with-more-horizontal-16-icon {
-  @extend %with-icon, %more-horizontal-16-svg-prop !optional;
+  @extend %with-icon, %more-horizontal-16-svg-prop;
   background-image: var(--more-horizontal-16-svg);
 }
 %with-more-horizontal-16-mask {
-  @extend %with-mask, %more-horizontal-16-svg-prop !optional;
+  @extend %with-mask, %more-horizontal-16-svg-prop;
   -webkit-mask-image: var(--more-horizontal-16-svg);
   mask-image: var(--more-horizontal-16-svg);
 }
 
 %with-more-horizontal-24-icon {
-  @extend %with-icon, %more-horizontal-24-svg-prop !optional;
+  @extend %with-icon, %more-horizontal-24-svg-prop;
   background-image: var(--more-horizontal-24-svg);
 }
 %with-more-horizontal-24-mask {
-  @extend %with-mask, %more-horizontal-24-svg-prop !optional;
+  @extend %with-mask, %more-horizontal-24-svg-prop;
   -webkit-mask-image: var(--more-horizontal-24-svg);
   mask-image: var(--more-horizontal-24-svg);
 }
 
 %with-more-horizontal-icon {
-  @extend %with-icon, %more-horizontal-svg-prop !optional;
+  @extend %with-icon, %more-horizontal-svg-prop;
   background-image: var(--more-horizontal-svg);
 }
 %with-more-horizontal-mask {
-  @extend %with-mask, %more-horizontal-svg-prop !optional;
+  @extend %with-mask, %more-horizontal-svg-prop;
   -webkit-mask-image: var(--more-horizontal-svg);
   mask-image: var(--more-horizontal-svg);
 }
 
 %with-more-vertical-16-icon {
-  @extend %with-icon, %more-vertical-16-svg-prop !optional;
+  @extend %with-icon, %more-vertical-16-svg-prop;
   background-image: var(--more-vertical-16-svg);
 }
 %with-more-vertical-16-mask {
-  @extend %with-mask, %more-vertical-16-svg-prop !optional;
+  @extend %with-mask, %more-vertical-16-svg-prop;
   -webkit-mask-image: var(--more-vertical-16-svg);
   mask-image: var(--more-vertical-16-svg);
 }
 
 %with-more-vertical-24-icon {
-  @extend %with-icon, %more-vertical-24-svg-prop !optional;
+  @extend %with-icon, %more-vertical-24-svg-prop;
   background-image: var(--more-vertical-24-svg);
 }
 %with-more-vertical-24-mask {
-  @extend %with-mask, %more-vertical-24-svg-prop !optional;
+  @extend %with-mask, %more-vertical-24-svg-prop;
   -webkit-mask-image: var(--more-vertical-24-svg);
   mask-image: var(--more-vertical-24-svg);
 }
 
 %with-more-vertical-icon {
-  @extend %with-icon, %more-vertical-svg-prop !optional;
+  @extend %with-icon, %more-vertical-svg-prop;
   background-image: var(--more-vertical-svg);
 }
 %with-more-vertical-mask {
-  @extend %with-mask, %more-vertical-svg-prop !optional;
+  @extend %with-mask, %more-vertical-svg-prop;
   -webkit-mask-image: var(--more-vertical-svg);
   mask-image: var(--more-vertical-svg);
 }
 
 %with-mouse-pointer-16-icon {
-  @extend %with-icon, %mouse-pointer-16-svg-prop !optional;
+  @extend %with-icon, %mouse-pointer-16-svg-prop;
   background-image: var(--mouse-pointer-16-svg);
 }
 %with-mouse-pointer-16-mask {
-  @extend %with-mask, %mouse-pointer-16-svg-prop !optional;
+  @extend %with-mask, %mouse-pointer-16-svg-prop;
   -webkit-mask-image: var(--mouse-pointer-16-svg);
   mask-image: var(--mouse-pointer-16-svg);
 }
 
 %with-mouse-pointer-24-icon {
-  @extend %with-icon, %mouse-pointer-24-svg-prop !optional;
+  @extend %with-icon, %mouse-pointer-24-svg-prop;
   background-image: var(--mouse-pointer-24-svg);
 }
 %with-mouse-pointer-24-mask {
-  @extend %with-mask, %mouse-pointer-24-svg-prop !optional;
+  @extend %with-mask, %mouse-pointer-24-svg-prop;
   -webkit-mask-image: var(--mouse-pointer-24-svg);
   mask-image: var(--mouse-pointer-24-svg);
 }
 
 %with-move-16-icon {
-  @extend %with-icon, %move-16-svg-prop !optional;
+  @extend %with-icon, %move-16-svg-prop;
   background-image: var(--move-16-svg);
 }
 %with-move-16-mask {
-  @extend %with-mask, %move-16-svg-prop !optional;
+  @extend %with-mask, %move-16-svg-prop;
   -webkit-mask-image: var(--move-16-svg);
   mask-image: var(--move-16-svg);
 }
 
 %with-move-24-icon {
-  @extend %with-icon, %move-24-svg-prop !optional;
+  @extend %with-icon, %move-24-svg-prop;
   background-image: var(--move-24-svg);
 }
 %with-move-24-mask {
-  @extend %with-mask, %move-24-svg-prop !optional;
+  @extend %with-mask, %move-24-svg-prop;
   -webkit-mask-image: var(--move-24-svg);
   mask-image: var(--move-24-svg);
 }
 
 %with-music-16-icon {
-  @extend %with-icon, %music-16-svg-prop !optional;
+  @extend %with-icon, %music-16-svg-prop;
   background-image: var(--music-16-svg);
 }
 %with-music-16-mask {
-  @extend %with-mask, %music-16-svg-prop !optional;
+  @extend %with-mask, %music-16-svg-prop;
   -webkit-mask-image: var(--music-16-svg);
   mask-image: var(--music-16-svg);
 }
 
 %with-music-24-icon {
-  @extend %with-icon, %music-24-svg-prop !optional;
+  @extend %with-icon, %music-24-svg-prop;
   background-image: var(--music-24-svg);
 }
 %with-music-24-mask {
-  @extend %with-mask, %music-24-svg-prop !optional;
+  @extend %with-mask, %music-24-svg-prop;
   -webkit-mask-image: var(--music-24-svg);
   mask-image: var(--music-24-svg);
 }
 
 %with-navigation-16-icon {
-  @extend %with-icon, %navigation-16-svg-prop !optional;
+  @extend %with-icon, %navigation-16-svg-prop;
   background-image: var(--navigation-16-svg);
 }
 %with-navigation-16-mask {
-  @extend %with-mask, %navigation-16-svg-prop !optional;
+  @extend %with-mask, %navigation-16-svg-prop;
   -webkit-mask-image: var(--navigation-16-svg);
   mask-image: var(--navigation-16-svg);
 }
 
 %with-navigation-24-icon {
-  @extend %with-icon, %navigation-24-svg-prop !optional;
+  @extend %with-icon, %navigation-24-svg-prop;
   background-image: var(--navigation-24-svg);
 }
 %with-navigation-24-mask {
-  @extend %with-mask, %navigation-24-svg-prop !optional;
+  @extend %with-mask, %navigation-24-svg-prop;
   -webkit-mask-image: var(--navigation-24-svg);
   mask-image: var(--navigation-24-svg);
 }
 
 %with-navigation-alt-16-icon {
-  @extend %with-icon, %navigation-alt-16-svg-prop !optional;
+  @extend %with-icon, %navigation-alt-16-svg-prop;
   background-image: var(--navigation-alt-16-svg);
 }
 %with-navigation-alt-16-mask {
-  @extend %with-mask, %navigation-alt-16-svg-prop !optional;
+  @extend %with-mask, %navigation-alt-16-svg-prop;
   -webkit-mask-image: var(--navigation-alt-16-svg);
   mask-image: var(--navigation-alt-16-svg);
 }
 
 %with-navigation-alt-24-icon {
-  @extend %with-icon, %navigation-alt-24-svg-prop !optional;
+  @extend %with-icon, %navigation-alt-24-svg-prop;
   background-image: var(--navigation-alt-24-svg);
 }
 %with-navigation-alt-24-mask {
-  @extend %with-mask, %navigation-alt-24-svg-prop !optional;
+  @extend %with-mask, %navigation-alt-24-svg-prop;
   -webkit-mask-image: var(--navigation-alt-24-svg);
   mask-image: var(--navigation-alt-24-svg);
 }
 
 %with-network-16-icon {
-  @extend %with-icon, %network-16-svg-prop !optional;
+  @extend %with-icon, %network-16-svg-prop;
   background-image: var(--network-16-svg);
 }
 %with-network-16-mask {
-  @extend %with-mask, %network-16-svg-prop !optional;
+  @extend %with-mask, %network-16-svg-prop;
   -webkit-mask-image: var(--network-16-svg);
   mask-image: var(--network-16-svg);
 }
 
 %with-network-24-icon {
-  @extend %with-icon, %network-24-svg-prop !optional;
+  @extend %with-icon, %network-24-svg-prop;
   background-image: var(--network-24-svg);
 }
 %with-network-24-mask {
-  @extend %with-mask, %network-24-svg-prop !optional;
+  @extend %with-mask, %network-24-svg-prop;
   -webkit-mask-image: var(--network-24-svg);
   mask-image: var(--network-24-svg);
 }
 
 %with-network-alt-16-icon {
-  @extend %with-icon, %network-alt-16-svg-prop !optional;
+  @extend %with-icon, %network-alt-16-svg-prop;
   background-image: var(--network-alt-16-svg);
 }
 %with-network-alt-16-mask {
-  @extend %with-mask, %network-alt-16-svg-prop !optional;
+  @extend %with-mask, %network-alt-16-svg-prop;
   -webkit-mask-image: var(--network-alt-16-svg);
   mask-image: var(--network-alt-16-svg);
 }
 
 %with-network-alt-24-icon {
-  @extend %with-icon, %network-alt-24-svg-prop !optional;
+  @extend %with-icon, %network-alt-24-svg-prop;
   background-image: var(--network-alt-24-svg);
 }
 %with-network-alt-24-mask {
-  @extend %with-mask, %network-alt-24-svg-prop !optional;
+  @extend %with-mask, %network-alt-24-svg-prop;
   -webkit-mask-image: var(--network-alt-24-svg);
   mask-image: var(--network-alt-24-svg);
 }
 
 %with-newspaper-16-icon {
-  @extend %with-icon, %newspaper-16-svg-prop !optional;
+  @extend %with-icon, %newspaper-16-svg-prop;
   background-image: var(--newspaper-16-svg);
 }
 %with-newspaper-16-mask {
-  @extend %with-mask, %newspaper-16-svg-prop !optional;
+  @extend %with-mask, %newspaper-16-svg-prop;
   -webkit-mask-image: var(--newspaper-16-svg);
   mask-image: var(--newspaper-16-svg);
 }
 
 %with-newspaper-24-icon {
-  @extend %with-icon, %newspaper-24-svg-prop !optional;
+  @extend %with-icon, %newspaper-24-svg-prop;
   background-image: var(--newspaper-24-svg);
 }
 %with-newspaper-24-mask {
-  @extend %with-mask, %newspaper-24-svg-prop !optional;
+  @extend %with-mask, %newspaper-24-svg-prop;
   -webkit-mask-image: var(--newspaper-24-svg);
   mask-image: var(--newspaper-24-svg);
 }
 
 %with-node-16-icon {
-  @extend %with-icon, %node-16-svg-prop !optional;
+  @extend %with-icon, %node-16-svg-prop;
   background-image: var(--node-16-svg);
 }
 %with-node-16-mask {
-  @extend %with-mask, %node-16-svg-prop !optional;
+  @extend %with-mask, %node-16-svg-prop;
   -webkit-mask-image: var(--node-16-svg);
   mask-image: var(--node-16-svg);
 }
 
 %with-node-24-icon {
-  @extend %with-icon, %node-24-svg-prop !optional;
+  @extend %with-icon, %node-24-svg-prop;
   background-image: var(--node-24-svg);
 }
 %with-node-24-mask {
-  @extend %with-mask, %node-24-svg-prop !optional;
+  @extend %with-mask, %node-24-svg-prop;
   -webkit-mask-image: var(--node-24-svg);
   mask-image: var(--node-24-svg);
 }
 
 %with-notification-disabled-icon {
-  @extend %with-icon, %notification-disabled-svg-prop !optional;
+  @extend %with-icon, %notification-disabled-svg-prop;
   background-image: var(--notification-disabled-svg);
 }
 %with-notification-disabled-mask {
-  @extend %with-mask, %notification-disabled-svg-prop !optional;
+  @extend %with-mask, %notification-disabled-svg-prop;
   -webkit-mask-image: var(--notification-disabled-svg);
   mask-image: var(--notification-disabled-svg);
 }
 
 %with-notification-fill-icon {
-  @extend %with-icon, %notification-fill-svg-prop !optional;
+  @extend %with-icon, %notification-fill-svg-prop;
   background-image: var(--notification-fill-svg);
 }
 %with-notification-fill-mask {
-  @extend %with-mask, %notification-fill-svg-prop !optional;
+  @extend %with-mask, %notification-fill-svg-prop;
   -webkit-mask-image: var(--notification-fill-svg);
   mask-image: var(--notification-fill-svg);
 }
 
 %with-notification-outline-icon {
-  @extend %with-icon, %notification-outline-svg-prop !optional;
+  @extend %with-icon, %notification-outline-svg-prop;
   background-image: var(--notification-outline-svg);
 }
 %with-notification-outline-mask {
-  @extend %with-mask, %notification-outline-svg-prop !optional;
+  @extend %with-mask, %notification-outline-svg-prop;
   -webkit-mask-image: var(--notification-outline-svg);
   mask-image: var(--notification-outline-svg);
 }
 
 %with-octagon-16-icon {
-  @extend %with-icon, %octagon-16-svg-prop !optional;
+  @extend %with-icon, %octagon-16-svg-prop;
   background-image: var(--octagon-16-svg);
 }
 %with-octagon-16-mask {
-  @extend %with-mask, %octagon-16-svg-prop !optional;
+  @extend %with-mask, %octagon-16-svg-prop;
   -webkit-mask-image: var(--octagon-16-svg);
   mask-image: var(--octagon-16-svg);
 }
 
 %with-octagon-24-icon {
-  @extend %with-icon, %octagon-24-svg-prop !optional;
+  @extend %with-icon, %octagon-24-svg-prop;
   background-image: var(--octagon-24-svg);
 }
 %with-octagon-24-mask {
-  @extend %with-mask, %octagon-24-svg-prop !optional;
+  @extend %with-mask, %octagon-24-svg-prop;
   -webkit-mask-image: var(--octagon-24-svg);
   mask-image: var(--octagon-24-svg);
 }
 
 %with-okta-16-icon {
-  @extend %with-icon, %okta-16-svg-prop !optional;
+  @extend %with-icon, %okta-16-svg-prop;
   background-image: var(--okta-16-svg);
 }
 %with-okta-16-mask {
-  @extend %with-mask, %okta-16-svg-prop !optional;
+  @extend %with-mask, %okta-16-svg-prop;
   -webkit-mask-image: var(--okta-16-svg);
   mask-image: var(--okta-16-svg);
 }
 
 %with-okta-24-icon {
-  @extend %with-icon, %okta-24-svg-prop !optional;
+  @extend %with-icon, %okta-24-svg-prop;
   background-image: var(--okta-24-svg);
 }
 %with-okta-24-mask {
-  @extend %with-mask, %okta-24-svg-prop !optional;
+  @extend %with-mask, %okta-24-svg-prop;
   -webkit-mask-image: var(--okta-24-svg);
   mask-image: var(--okta-24-svg);
 }
 
 %with-okta-color-16-icon {
-  @extend %with-icon, %okta-color-16-svg-prop !optional;
+  @extend %with-icon, %okta-color-16-svg-prop;
   background-image: var(--okta-color-16-svg);
 }
 %with-okta-color-16-mask {
-  @extend %with-mask, %okta-color-16-svg-prop !optional;
+  @extend %with-mask, %okta-color-16-svg-prop;
   -webkit-mask-image: var(--okta-color-16-svg);
   mask-image: var(--okta-color-16-svg);
 }
 
 %with-okta-color-24-icon {
-  @extend %with-icon, %okta-color-24-svg-prop !optional;
+  @extend %with-icon, %okta-color-24-svg-prop;
   background-image: var(--okta-color-24-svg);
 }
 %with-okta-color-24-mask {
-  @extend %with-mask, %okta-color-24-svg-prop !optional;
+  @extend %with-mask, %okta-color-24-svg-prop;
   -webkit-mask-image: var(--okta-color-24-svg);
   mask-image: var(--okta-color-24-svg);
 }
 
 %with-oracle-16-icon {
-  @extend %with-icon, %oracle-16-svg-prop !optional;
+  @extend %with-icon, %oracle-16-svg-prop;
   background-image: var(--oracle-16-svg);
 }
 %with-oracle-16-mask {
-  @extend %with-mask, %oracle-16-svg-prop !optional;
+  @extend %with-mask, %oracle-16-svg-prop;
   -webkit-mask-image: var(--oracle-16-svg);
   mask-image: var(--oracle-16-svg);
 }
 
 %with-oracle-24-icon {
-  @extend %with-icon, %oracle-24-svg-prop !optional;
+  @extend %with-icon, %oracle-24-svg-prop;
   background-image: var(--oracle-24-svg);
 }
 %with-oracle-24-mask {
-  @extend %with-mask, %oracle-24-svg-prop !optional;
+  @extend %with-mask, %oracle-24-svg-prop;
   -webkit-mask-image: var(--oracle-24-svg);
   mask-image: var(--oracle-24-svg);
 }
 
 %with-oracle-color-16-icon {
-  @extend %with-icon, %oracle-color-16-svg-prop !optional;
+  @extend %with-icon, %oracle-color-16-svg-prop;
   background-image: var(--oracle-color-16-svg);
 }
 %with-oracle-color-16-mask {
-  @extend %with-mask, %oracle-color-16-svg-prop !optional;
+  @extend %with-mask, %oracle-color-16-svg-prop;
   -webkit-mask-image: var(--oracle-color-16-svg);
   mask-image: var(--oracle-color-16-svg);
 }
 
 %with-oracle-color-24-icon {
-  @extend %with-icon, %oracle-color-24-svg-prop !optional;
+  @extend %with-icon, %oracle-color-24-svg-prop;
   background-image: var(--oracle-color-24-svg);
 }
 %with-oracle-color-24-mask {
-  @extend %with-mask, %oracle-color-24-svg-prop !optional;
+  @extend %with-mask, %oracle-color-24-svg-prop;
   -webkit-mask-image: var(--oracle-color-24-svg);
   mask-image: var(--oracle-color-24-svg);
 }
 
 %with-org-16-icon {
-  @extend %with-icon, %org-16-svg-prop !optional;
+  @extend %with-icon, %org-16-svg-prop;
   background-image: var(--org-16-svg);
 }
 %with-org-16-mask {
-  @extend %with-mask, %org-16-svg-prop !optional;
+  @extend %with-mask, %org-16-svg-prop;
   -webkit-mask-image: var(--org-16-svg);
   mask-image: var(--org-16-svg);
 }
 
 %with-org-24-icon {
-  @extend %with-icon, %org-24-svg-prop !optional;
+  @extend %with-icon, %org-24-svg-prop;
   background-image: var(--org-24-svg);
 }
 %with-org-24-mask {
-  @extend %with-mask, %org-24-svg-prop !optional;
+  @extend %with-mask, %org-24-svg-prop;
   -webkit-mask-image: var(--org-24-svg);
   mask-image: var(--org-24-svg);
 }
 
 %with-outline-16-icon {
-  @extend %with-icon, %outline-16-svg-prop !optional;
+  @extend %with-icon, %outline-16-svg-prop;
   background-image: var(--outline-16-svg);
 }
 %with-outline-16-mask {
-  @extend %with-mask, %outline-16-svg-prop !optional;
+  @extend %with-mask, %outline-16-svg-prop;
   -webkit-mask-image: var(--outline-16-svg);
   mask-image: var(--outline-16-svg);
 }
 
 %with-outline-24-icon {
-  @extend %with-icon, %outline-24-svg-prop !optional;
+  @extend %with-icon, %outline-24-svg-prop;
   background-image: var(--outline-24-svg);
 }
 %with-outline-24-mask {
-  @extend %with-mask, %outline-24-svg-prop !optional;
+  @extend %with-mask, %outline-24-svg-prop;
   -webkit-mask-image: var(--outline-24-svg);
   mask-image: var(--outline-24-svg);
 }
 
 %with-outline-icon {
-  @extend %with-icon, %outline-svg-prop !optional;
+  @extend %with-icon, %outline-svg-prop;
   background-image: var(--outline-svg);
 }
 %with-outline-mask {
-  @extend %with-mask, %outline-svg-prop !optional;
+  @extend %with-mask, %outline-svg-prop;
   -webkit-mask-image: var(--outline-svg);
   mask-image: var(--outline-svg);
 }
 
 %with-package-16-icon {
-  @extend %with-icon, %package-16-svg-prop !optional;
+  @extend %with-icon, %package-16-svg-prop;
   background-image: var(--package-16-svg);
 }
 %with-package-16-mask {
-  @extend %with-mask, %package-16-svg-prop !optional;
+  @extend %with-mask, %package-16-svg-prop;
   -webkit-mask-image: var(--package-16-svg);
   mask-image: var(--package-16-svg);
 }
 
 %with-package-24-icon {
-  @extend %with-icon, %package-24-svg-prop !optional;
+  @extend %with-icon, %package-24-svg-prop;
   background-image: var(--package-24-svg);
 }
 %with-package-24-mask {
-  @extend %with-mask, %package-24-svg-prop !optional;
+  @extend %with-mask, %package-24-svg-prop;
   -webkit-mask-image: var(--package-24-svg);
   mask-image: var(--package-24-svg);
 }
 
 %with-page-outline-icon {
-  @extend %with-icon, %page-outline-svg-prop !optional;
+  @extend %with-icon, %page-outline-svg-prop;
   background-image: var(--page-outline-svg);
 }
 %with-page-outline-mask {
-  @extend %with-mask, %page-outline-svg-prop !optional;
+  @extend %with-mask, %page-outline-svg-prop;
   -webkit-mask-image: var(--page-outline-svg);
   mask-image: var(--page-outline-svg);
 }
 
 %with-paperclip-16-icon {
-  @extend %with-icon, %paperclip-16-svg-prop !optional;
+  @extend %with-icon, %paperclip-16-svg-prop;
   background-image: var(--paperclip-16-svg);
 }
 %with-paperclip-16-mask {
-  @extend %with-mask, %paperclip-16-svg-prop !optional;
+  @extend %with-mask, %paperclip-16-svg-prop;
   -webkit-mask-image: var(--paperclip-16-svg);
   mask-image: var(--paperclip-16-svg);
 }
 
 %with-paperclip-24-icon {
-  @extend %with-icon, %paperclip-24-svg-prop !optional;
+  @extend %with-icon, %paperclip-24-svg-prop;
   background-image: var(--paperclip-24-svg);
 }
 %with-paperclip-24-mask {
-  @extend %with-mask, %paperclip-24-svg-prop !optional;
+  @extend %with-mask, %paperclip-24-svg-prop;
   -webkit-mask-image: var(--paperclip-24-svg);
   mask-image: var(--paperclip-24-svg);
 }
 
 %with-partner-icon {
-  @extend %with-icon, %partner-svg-prop !optional;
+  @extend %with-icon, %partner-svg-prop;
   background-image: var(--partner-svg);
 }
 %with-partner-mask {
-  @extend %with-mask, %partner-svg-prop !optional;
+  @extend %with-mask, %partner-svg-prop;
   -webkit-mask-image: var(--partner-svg);
   mask-image: var(--partner-svg);
 }
 
 %with-path-16-icon {
-  @extend %with-icon, %path-16-svg-prop !optional;
+  @extend %with-icon, %path-16-svg-prop;
   background-image: var(--path-16-svg);
 }
 %with-path-16-mask {
-  @extend %with-mask, %path-16-svg-prop !optional;
+  @extend %with-mask, %path-16-svg-prop;
   -webkit-mask-image: var(--path-16-svg);
   mask-image: var(--path-16-svg);
 }
 
 %with-path-24-icon {
-  @extend %with-icon, %path-24-svg-prop !optional;
+  @extend %with-icon, %path-24-svg-prop;
   background-image: var(--path-24-svg);
 }
 %with-path-24-mask {
-  @extend %with-mask, %path-24-svg-prop !optional;
+  @extend %with-mask, %path-24-svg-prop;
   -webkit-mask-image: var(--path-24-svg);
   mask-image: var(--path-24-svg);
 }
 
 %with-path-icon {
-  @extend %with-icon, %path-svg-prop !optional;
+  @extend %with-icon, %path-svg-prop;
   background-image: var(--path-svg);
 }
 %with-path-mask {
-  @extend %with-mask, %path-svg-prop !optional;
+  @extend %with-mask, %path-svg-prop;
   -webkit-mask-image: var(--path-svg);
   mask-image: var(--path-svg);
 }
 
 %with-pause-16-icon {
-  @extend %with-icon, %pause-16-svg-prop !optional;
+  @extend %with-icon, %pause-16-svg-prop;
   background-image: var(--pause-16-svg);
 }
 %with-pause-16-mask {
-  @extend %with-mask, %pause-16-svg-prop !optional;
+  @extend %with-mask, %pause-16-svg-prop;
   -webkit-mask-image: var(--pause-16-svg);
   mask-image: var(--pause-16-svg);
 }
 
 %with-pause-24-icon {
-  @extend %with-icon, %pause-24-svg-prop !optional;
+  @extend %with-icon, %pause-24-svg-prop;
   background-image: var(--pause-24-svg);
 }
 %with-pause-24-mask {
-  @extend %with-mask, %pause-24-svg-prop !optional;
+  @extend %with-mask, %pause-24-svg-prop;
   -webkit-mask-image: var(--pause-24-svg);
   mask-image: var(--pause-24-svg);
 }
 
 %with-pause-circle-16-icon {
-  @extend %with-icon, %pause-circle-16-svg-prop !optional;
+  @extend %with-icon, %pause-circle-16-svg-prop;
   background-image: var(--pause-circle-16-svg);
 }
 %with-pause-circle-16-mask {
-  @extend %with-mask, %pause-circle-16-svg-prop !optional;
+  @extend %with-mask, %pause-circle-16-svg-prop;
   -webkit-mask-image: var(--pause-circle-16-svg);
   mask-image: var(--pause-circle-16-svg);
 }
 
 %with-pause-circle-24-icon {
-  @extend %with-icon, %pause-circle-24-svg-prop !optional;
+  @extend %with-icon, %pause-circle-24-svg-prop;
   background-image: var(--pause-circle-24-svg);
 }
 %with-pause-circle-24-mask {
-  @extend %with-mask, %pause-circle-24-svg-prop !optional;
+  @extend %with-mask, %pause-circle-24-svg-prop;
   -webkit-mask-image: var(--pause-circle-24-svg);
   mask-image: var(--pause-circle-24-svg);
 }
 
 %with-pen-tool-16-icon {
-  @extend %with-icon, %pen-tool-16-svg-prop !optional;
+  @extend %with-icon, %pen-tool-16-svg-prop;
   background-image: var(--pen-tool-16-svg);
 }
 %with-pen-tool-16-mask {
-  @extend %with-mask, %pen-tool-16-svg-prop !optional;
+  @extend %with-mask, %pen-tool-16-svg-prop;
   -webkit-mask-image: var(--pen-tool-16-svg);
   mask-image: var(--pen-tool-16-svg);
 }
 
 %with-pen-tool-24-icon {
-  @extend %with-icon, %pen-tool-24-svg-prop !optional;
+  @extend %with-icon, %pen-tool-24-svg-prop;
   background-image: var(--pen-tool-24-svg);
 }
 %with-pen-tool-24-mask {
-  @extend %with-mask, %pen-tool-24-svg-prop !optional;
+  @extend %with-mask, %pen-tool-24-svg-prop;
   -webkit-mask-image: var(--pen-tool-24-svg);
   mask-image: var(--pen-tool-24-svg);
 }
 
 %with-pencil-tool-16-icon {
-  @extend %with-icon, %pencil-tool-16-svg-prop !optional;
+  @extend %with-icon, %pencil-tool-16-svg-prop;
   background-image: var(--pencil-tool-16-svg);
 }
 %with-pencil-tool-16-mask {
-  @extend %with-mask, %pencil-tool-16-svg-prop !optional;
+  @extend %with-mask, %pencil-tool-16-svg-prop;
   -webkit-mask-image: var(--pencil-tool-16-svg);
   mask-image: var(--pencil-tool-16-svg);
 }
 
 %with-pencil-tool-24-icon {
-  @extend %with-icon, %pencil-tool-24-svg-prop !optional;
+  @extend %with-icon, %pencil-tool-24-svg-prop;
   background-image: var(--pencil-tool-24-svg);
 }
 %with-pencil-tool-24-mask {
-  @extend %with-mask, %pencil-tool-24-svg-prop !optional;
+  @extend %with-mask, %pencil-tool-24-svg-prop;
   -webkit-mask-image: var(--pencil-tool-24-svg);
   mask-image: var(--pencil-tool-24-svg);
 }
 
 %with-phone-16-icon {
-  @extend %with-icon, %phone-16-svg-prop !optional;
+  @extend %with-icon, %phone-16-svg-prop;
   background-image: var(--phone-16-svg);
 }
 %with-phone-16-mask {
-  @extend %with-mask, %phone-16-svg-prop !optional;
+  @extend %with-mask, %phone-16-svg-prop;
   -webkit-mask-image: var(--phone-16-svg);
   mask-image: var(--phone-16-svg);
 }
 
 %with-phone-24-icon {
-  @extend %with-icon, %phone-24-svg-prop !optional;
+  @extend %with-icon, %phone-24-svg-prop;
   background-image: var(--phone-24-svg);
 }
 %with-phone-24-mask {
-  @extend %with-mask, %phone-24-svg-prop !optional;
+  @extend %with-mask, %phone-24-svg-prop;
   -webkit-mask-image: var(--phone-24-svg);
   mask-image: var(--phone-24-svg);
 }
 
 %with-phone-call-16-icon {
-  @extend %with-icon, %phone-call-16-svg-prop !optional;
+  @extend %with-icon, %phone-call-16-svg-prop;
   background-image: var(--phone-call-16-svg);
 }
 %with-phone-call-16-mask {
-  @extend %with-mask, %phone-call-16-svg-prop !optional;
+  @extend %with-mask, %phone-call-16-svg-prop;
   -webkit-mask-image: var(--phone-call-16-svg);
   mask-image: var(--phone-call-16-svg);
 }
 
 %with-phone-call-24-icon {
-  @extend %with-icon, %phone-call-24-svg-prop !optional;
+  @extend %with-icon, %phone-call-24-svg-prop;
   background-image: var(--phone-call-24-svg);
 }
 %with-phone-call-24-mask {
-  @extend %with-mask, %phone-call-24-svg-prop !optional;
+  @extend %with-mask, %phone-call-24-svg-prop;
   -webkit-mask-image: var(--phone-call-24-svg);
   mask-image: var(--phone-call-24-svg);
 }
 
 %with-phone-off-16-icon {
-  @extend %with-icon, %phone-off-16-svg-prop !optional;
+  @extend %with-icon, %phone-off-16-svg-prop;
   background-image: var(--phone-off-16-svg);
 }
 %with-phone-off-16-mask {
-  @extend %with-mask, %phone-off-16-svg-prop !optional;
+  @extend %with-mask, %phone-off-16-svg-prop;
   -webkit-mask-image: var(--phone-off-16-svg);
   mask-image: var(--phone-off-16-svg);
 }
 
 %with-phone-off-24-icon {
-  @extend %with-icon, %phone-off-24-svg-prop !optional;
+  @extend %with-icon, %phone-off-24-svg-prop;
   background-image: var(--phone-off-24-svg);
 }
 %with-phone-off-24-mask {
-  @extend %with-mask, %phone-off-24-svg-prop !optional;
+  @extend %with-mask, %phone-off-24-svg-prop;
   -webkit-mask-image: var(--phone-off-24-svg);
   mask-image: var(--phone-off-24-svg);
 }
 
 %with-pie-chart-16-icon {
-  @extend %with-icon, %pie-chart-16-svg-prop !optional;
+  @extend %with-icon, %pie-chart-16-svg-prop;
   background-image: var(--pie-chart-16-svg);
 }
 %with-pie-chart-16-mask {
-  @extend %with-mask, %pie-chart-16-svg-prop !optional;
+  @extend %with-mask, %pie-chart-16-svg-prop;
   -webkit-mask-image: var(--pie-chart-16-svg);
   mask-image: var(--pie-chart-16-svg);
 }
 
 %with-pie-chart-24-icon {
-  @extend %with-icon, %pie-chart-24-svg-prop !optional;
+  @extend %with-icon, %pie-chart-24-svg-prop;
   background-image: var(--pie-chart-24-svg);
 }
 %with-pie-chart-24-mask {
-  @extend %with-mask, %pie-chart-24-svg-prop !optional;
+  @extend %with-mask, %pie-chart-24-svg-prop;
   -webkit-mask-image: var(--pie-chart-24-svg);
   mask-image: var(--pie-chart-24-svg);
 }
 
 %with-pin-16-icon {
-  @extend %with-icon, %pin-16-svg-prop !optional;
+  @extend %with-icon, %pin-16-svg-prop;
   background-image: var(--pin-16-svg);
 }
 %with-pin-16-mask {
-  @extend %with-mask, %pin-16-svg-prop !optional;
+  @extend %with-mask, %pin-16-svg-prop;
   -webkit-mask-image: var(--pin-16-svg);
   mask-image: var(--pin-16-svg);
 }
 
 %with-pin-24-icon {
-  @extend %with-icon, %pin-24-svg-prop !optional;
+  @extend %with-icon, %pin-24-svg-prop;
   background-image: var(--pin-24-svg);
 }
 %with-pin-24-mask {
-  @extend %with-mask, %pin-24-svg-prop !optional;
+  @extend %with-mask, %pin-24-svg-prop;
   -webkit-mask-image: var(--pin-24-svg);
   mask-image: var(--pin-24-svg);
 }
 
 %with-play-16-icon {
-  @extend %with-icon, %play-16-svg-prop !optional;
+  @extend %with-icon, %play-16-svg-prop;
   background-image: var(--play-16-svg);
 }
 %with-play-16-mask {
-  @extend %with-mask, %play-16-svg-prop !optional;
+  @extend %with-mask, %play-16-svg-prop;
   -webkit-mask-image: var(--play-16-svg);
   mask-image: var(--play-16-svg);
 }
 
 %with-play-24-icon {
-  @extend %with-icon, %play-24-svg-prop !optional;
+  @extend %with-icon, %play-24-svg-prop;
   background-image: var(--play-24-svg);
 }
 %with-play-24-mask {
-  @extend %with-mask, %play-24-svg-prop !optional;
+  @extend %with-mask, %play-24-svg-prop;
   -webkit-mask-image: var(--play-24-svg);
   mask-image: var(--play-24-svg);
 }
 
 %with-play-circle-16-icon {
-  @extend %with-icon, %play-circle-16-svg-prop !optional;
+  @extend %with-icon, %play-circle-16-svg-prop;
   background-image: var(--play-circle-16-svg);
 }
 %with-play-circle-16-mask {
-  @extend %with-mask, %play-circle-16-svg-prop !optional;
+  @extend %with-mask, %play-circle-16-svg-prop;
   -webkit-mask-image: var(--play-circle-16-svg);
   mask-image: var(--play-circle-16-svg);
 }
 
 %with-play-circle-24-icon {
-  @extend %with-icon, %play-circle-24-svg-prop !optional;
+  @extend %with-icon, %play-circle-24-svg-prop;
   background-image: var(--play-circle-24-svg);
 }
 %with-play-circle-24-mask {
-  @extend %with-mask, %play-circle-24-svg-prop !optional;
+  @extend %with-mask, %play-circle-24-svg-prop;
   -webkit-mask-image: var(--play-circle-24-svg);
   mask-image: var(--play-circle-24-svg);
 }
 
 %with-play-fill-icon {
-  @extend %with-icon, %play-fill-svg-prop !optional;
+  @extend %with-icon, %play-fill-svg-prop;
   background-image: var(--play-fill-svg);
 }
 %with-play-fill-mask {
-  @extend %with-mask, %play-fill-svg-prop !optional;
+  @extend %with-mask, %play-fill-svg-prop;
   -webkit-mask-image: var(--play-fill-svg);
   mask-image: var(--play-fill-svg);
 }
 
 %with-play-outline-icon {
-  @extend %with-icon, %play-outline-svg-prop !optional;
+  @extend %with-icon, %play-outline-svg-prop;
   background-image: var(--play-outline-svg);
 }
 %with-play-outline-mask {
-  @extend %with-mask, %play-outline-svg-prop !optional;
+  @extend %with-mask, %play-outline-svg-prop;
   -webkit-mask-image: var(--play-outline-svg);
   mask-image: var(--play-outline-svg);
 }
 
 %with-play-plain-icon {
-  @extend %with-icon, %play-plain-svg-prop !optional;
+  @extend %with-icon, %play-plain-svg-prop;
   background-image: var(--play-plain-svg);
 }
 %with-play-plain-mask {
-  @extend %with-mask, %play-plain-svg-prop !optional;
+  @extend %with-mask, %play-plain-svg-prop;
   -webkit-mask-image: var(--play-plain-svg);
   mask-image: var(--play-plain-svg);
 }
 
 %with-plus-16-icon {
-  @extend %with-icon, %plus-16-svg-prop !optional;
+  @extend %with-icon, %plus-16-svg-prop;
   background-image: var(--plus-16-svg);
 }
 %with-plus-16-mask {
-  @extend %with-mask, %plus-16-svg-prop !optional;
+  @extend %with-mask, %plus-16-svg-prop;
   -webkit-mask-image: var(--plus-16-svg);
   mask-image: var(--plus-16-svg);
 }
 
 %with-plus-24-icon {
-  @extend %with-icon, %plus-24-svg-prop !optional;
+  @extend %with-icon, %plus-24-svg-prop;
   background-image: var(--plus-24-svg);
 }
 %with-plus-24-mask {
-  @extend %with-mask, %plus-24-svg-prop !optional;
+  @extend %with-mask, %plus-24-svg-prop;
   -webkit-mask-image: var(--plus-24-svg);
   mask-image: var(--plus-24-svg);
 }
 
 %with-plus-circle-16-icon {
-  @extend %with-icon, %plus-circle-16-svg-prop !optional;
+  @extend %with-icon, %plus-circle-16-svg-prop;
   background-image: var(--plus-circle-16-svg);
 }
 %with-plus-circle-16-mask {
-  @extend %with-mask, %plus-circle-16-svg-prop !optional;
+  @extend %with-mask, %plus-circle-16-svg-prop;
   -webkit-mask-image: var(--plus-circle-16-svg);
   mask-image: var(--plus-circle-16-svg);
 }
 
 %with-plus-circle-24-icon {
-  @extend %with-icon, %plus-circle-24-svg-prop !optional;
+  @extend %with-icon, %plus-circle-24-svg-prop;
   background-image: var(--plus-circle-24-svg);
 }
 %with-plus-circle-24-mask {
-  @extend %with-mask, %plus-circle-24-svg-prop !optional;
+  @extend %with-mask, %plus-circle-24-svg-prop;
   -webkit-mask-image: var(--plus-circle-24-svg);
   mask-image: var(--plus-circle-24-svg);
 }
 
 %with-plus-circle-fill-icon {
-  @extend %with-icon, %plus-circle-fill-svg-prop !optional;
+  @extend %with-icon, %plus-circle-fill-svg-prop;
   background-image: var(--plus-circle-fill-svg);
 }
 %with-plus-circle-fill-mask {
-  @extend %with-mask, %plus-circle-fill-svg-prop !optional;
+  @extend %with-mask, %plus-circle-fill-svg-prop;
   -webkit-mask-image: var(--plus-circle-fill-svg);
   mask-image: var(--plus-circle-fill-svg);
 }
 
 %with-plus-circle-outline-icon {
-  @extend %with-icon, %plus-circle-outline-svg-prop !optional;
+  @extend %with-icon, %plus-circle-outline-svg-prop;
   background-image: var(--plus-circle-outline-svg);
 }
 %with-plus-circle-outline-mask {
-  @extend %with-mask, %plus-circle-outline-svg-prop !optional;
+  @extend %with-mask, %plus-circle-outline-svg-prop;
   -webkit-mask-image: var(--plus-circle-outline-svg);
   mask-image: var(--plus-circle-outline-svg);
 }
 
 %with-plus-plain-icon {
-  @extend %with-icon, %plus-plain-svg-prop !optional;
+  @extend %with-icon, %plus-plain-svg-prop;
   background-image: var(--plus-plain-svg);
 }
 %with-plus-plain-mask {
-  @extend %with-mask, %plus-plain-svg-prop !optional;
+  @extend %with-mask, %plus-plain-svg-prop;
   -webkit-mask-image: var(--plus-plain-svg);
   mask-image: var(--plus-plain-svg);
 }
 
 %with-plus-square-16-icon {
-  @extend %with-icon, %plus-square-16-svg-prop !optional;
+  @extend %with-icon, %plus-square-16-svg-prop;
   background-image: var(--plus-square-16-svg);
 }
 %with-plus-square-16-mask {
-  @extend %with-mask, %plus-square-16-svg-prop !optional;
+  @extend %with-mask, %plus-square-16-svg-prop;
   -webkit-mask-image: var(--plus-square-16-svg);
   mask-image: var(--plus-square-16-svg);
 }
 
 %with-plus-square-24-icon {
-  @extend %with-icon, %plus-square-24-svg-prop !optional;
+  @extend %with-icon, %plus-square-24-svg-prop;
   background-image: var(--plus-square-24-svg);
 }
 %with-plus-square-24-mask {
-  @extend %with-mask, %plus-square-24-svg-prop !optional;
+  @extend %with-mask, %plus-square-24-svg-prop;
   -webkit-mask-image: var(--plus-square-24-svg);
   mask-image: var(--plus-square-24-svg);
 }
 
 %with-plus-square-fill-icon {
-  @extend %with-icon, %plus-square-fill-svg-prop !optional;
+  @extend %with-icon, %plus-square-fill-svg-prop;
   background-image: var(--plus-square-fill-svg);
 }
 %with-plus-square-fill-mask {
-  @extend %with-mask, %plus-square-fill-svg-prop !optional;
+  @extend %with-mask, %plus-square-fill-svg-prop;
   -webkit-mask-image: var(--plus-square-fill-svg);
   mask-image: var(--plus-square-fill-svg);
 }
 
 %with-port-icon {
-  @extend %with-icon, %port-svg-prop !optional;
+  @extend %with-icon, %port-svg-prop;
   background-image: var(--port-svg);
 }
 %with-port-mask {
-  @extend %with-mask, %port-svg-prop !optional;
+  @extend %with-mask, %port-svg-prop;
   -webkit-mask-image: var(--port-svg);
   mask-image: var(--port-svg);
 }
 
 %with-power-16-icon {
-  @extend %with-icon, %power-16-svg-prop !optional;
+  @extend %with-icon, %power-16-svg-prop;
   background-image: var(--power-16-svg);
 }
 %with-power-16-mask {
-  @extend %with-mask, %power-16-svg-prop !optional;
+  @extend %with-mask, %power-16-svg-prop;
   -webkit-mask-image: var(--power-16-svg);
   mask-image: var(--power-16-svg);
 }
 
 %with-power-24-icon {
-  @extend %with-icon, %power-24-svg-prop !optional;
+  @extend %with-icon, %power-24-svg-prop;
   background-image: var(--power-24-svg);
 }
 %with-power-24-mask {
-  @extend %with-mask, %power-24-svg-prop !optional;
+  @extend %with-mask, %power-24-svg-prop;
   -webkit-mask-image: var(--power-24-svg);
   mask-image: var(--power-24-svg);
 }
 
 %with-printer-16-icon {
-  @extend %with-icon, %printer-16-svg-prop !optional;
+  @extend %with-icon, %printer-16-svg-prop;
   background-image: var(--printer-16-svg);
 }
 %with-printer-16-mask {
-  @extend %with-mask, %printer-16-svg-prop !optional;
+  @extend %with-mask, %printer-16-svg-prop;
   -webkit-mask-image: var(--printer-16-svg);
   mask-image: var(--printer-16-svg);
 }
 
 %with-printer-24-icon {
-  @extend %with-icon, %printer-24-svg-prop !optional;
+  @extend %with-icon, %printer-24-svg-prop;
   background-image: var(--printer-24-svg);
 }
 %with-printer-24-mask {
-  @extend %with-mask, %printer-24-svg-prop !optional;
+  @extend %with-mask, %printer-24-svg-prop;
   -webkit-mask-image: var(--printer-24-svg);
   mask-image: var(--printer-24-svg);
 }
 
 %with-protocol-icon {
-  @extend %with-icon, %protocol-svg-prop !optional;
+  @extend %with-icon, %protocol-svg-prop;
   background-image: var(--protocol-svg);
 }
 %with-protocol-mask {
-  @extend %with-mask, %protocol-svg-prop !optional;
+  @extend %with-mask, %protocol-svg-prop;
   -webkit-mask-image: var(--protocol-svg);
   mask-image: var(--protocol-svg);
 }
 
 %with-provider-16-icon {
-  @extend %with-icon, %provider-16-svg-prop !optional;
+  @extend %with-icon, %provider-16-svg-prop;
   background-image: var(--provider-16-svg);
 }
 %with-provider-16-mask {
-  @extend %with-mask, %provider-16-svg-prop !optional;
+  @extend %with-mask, %provider-16-svg-prop;
   -webkit-mask-image: var(--provider-16-svg);
   mask-image: var(--provider-16-svg);
 }
 
 %with-provider-24-icon {
-  @extend %with-icon, %provider-24-svg-prop !optional;
+  @extend %with-icon, %provider-24-svg-prop;
   background-image: var(--provider-24-svg);
 }
 %with-provider-24-mask {
-  @extend %with-mask, %provider-24-svg-prop !optional;
+  @extend %with-mask, %provider-24-svg-prop;
   -webkit-mask-image: var(--provider-24-svg);
   mask-image: var(--provider-24-svg);
 }
 
 %with-provider-icon {
-  @extend %with-icon, %provider-svg-prop !optional;
+  @extend %with-icon, %provider-svg-prop;
   background-image: var(--provider-svg);
 }
 %with-provider-mask {
-  @extend %with-mask, %provider-svg-prop !optional;
+  @extend %with-mask, %provider-svg-prop;
   -webkit-mask-image: var(--provider-svg);
   mask-image: var(--provider-svg);
 }
 
 %with-public-default-icon {
-  @extend %with-icon, %public-default-svg-prop !optional;
+  @extend %with-icon, %public-default-svg-prop;
   background-image: var(--public-default-svg);
 }
 %with-public-default-mask {
-  @extend %with-mask, %public-default-svg-prop !optional;
+  @extend %with-mask, %public-default-svg-prop;
   -webkit-mask-image: var(--public-default-svg);
   mask-image: var(--public-default-svg);
 }
 
 %with-public-locked-icon {
-  @extend %with-icon, %public-locked-svg-prop !optional;
+  @extend %with-icon, %public-locked-svg-prop;
   background-image: var(--public-locked-svg);
 }
 %with-public-locked-mask {
-  @extend %with-mask, %public-locked-svg-prop !optional;
+  @extend %with-mask, %public-locked-svg-prop;
   -webkit-mask-image: var(--public-locked-svg);
   mask-image: var(--public-locked-svg);
 }
 
 %with-queue-16-icon {
-  @extend %with-icon, %queue-16-svg-prop !optional;
+  @extend %with-icon, %queue-16-svg-prop;
   background-image: var(--queue-16-svg);
 }
 %with-queue-16-mask {
-  @extend %with-mask, %queue-16-svg-prop !optional;
+  @extend %with-mask, %queue-16-svg-prop;
   -webkit-mask-image: var(--queue-16-svg);
   mask-image: var(--queue-16-svg);
 }
 
 %with-queue-24-icon {
-  @extend %with-icon, %queue-24-svg-prop !optional;
+  @extend %with-icon, %queue-24-svg-prop;
   background-image: var(--queue-24-svg);
 }
 %with-queue-24-mask {
-  @extend %with-mask, %queue-24-svg-prop !optional;
+  @extend %with-mask, %queue-24-svg-prop;
   -webkit-mask-image: var(--queue-24-svg);
   mask-image: var(--queue-24-svg);
 }
 
 %with-queue-icon {
-  @extend %with-icon, %queue-svg-prop !optional;
+  @extend %with-icon, %queue-svg-prop;
   background-image: var(--queue-svg);
 }
 %with-queue-mask {
-  @extend %with-mask, %queue-svg-prop !optional;
+  @extend %with-mask, %queue-svg-prop;
   -webkit-mask-image: var(--queue-svg);
   mask-image: var(--queue-svg);
 }
 
 %with-radio-16-icon {
-  @extend %with-icon, %radio-16-svg-prop !optional;
+  @extend %with-icon, %radio-16-svg-prop;
   background-image: var(--radio-16-svg);
 }
 %with-radio-16-mask {
-  @extend %with-mask, %radio-16-svg-prop !optional;
+  @extend %with-mask, %radio-16-svg-prop;
   -webkit-mask-image: var(--radio-16-svg);
   mask-image: var(--radio-16-svg);
 }
 
 %with-radio-24-icon {
-  @extend %with-icon, %radio-24-svg-prop !optional;
+  @extend %with-icon, %radio-24-svg-prop;
   background-image: var(--radio-24-svg);
 }
 %with-radio-24-mask {
-  @extend %with-mask, %radio-24-svg-prop !optional;
+  @extend %with-mask, %radio-24-svg-prop;
   -webkit-mask-image: var(--radio-24-svg);
   mask-image: var(--radio-24-svg);
 }
 
 %with-radio-button-checked-icon {
-  @extend %with-icon, %radio-button-checked-svg-prop !optional;
+  @extend %with-icon, %radio-button-checked-svg-prop;
   background-image: var(--radio-button-checked-svg);
 }
 %with-radio-button-checked-mask {
-  @extend %with-mask, %radio-button-checked-svg-prop !optional;
+  @extend %with-mask, %radio-button-checked-svg-prop;
   -webkit-mask-image: var(--radio-button-checked-svg);
   mask-image: var(--radio-button-checked-svg);
 }
 
 %with-radio-button-unchecked-icon {
-  @extend %with-icon, %radio-button-unchecked-svg-prop !optional;
+  @extend %with-icon, %radio-button-unchecked-svg-prop;
   background-image: var(--radio-button-unchecked-svg);
 }
 %with-radio-button-unchecked-mask {
-  @extend %with-mask, %radio-button-unchecked-svg-prop !optional;
+  @extend %with-mask, %radio-button-unchecked-svg-prop;
   -webkit-mask-image: var(--radio-button-unchecked-svg);
   mask-image: var(--radio-button-unchecked-svg);
 }
 
 %with-random-16-icon {
-  @extend %with-icon, %random-16-svg-prop !optional;
+  @extend %with-icon, %random-16-svg-prop;
   background-image: var(--random-16-svg);
 }
 %with-random-16-mask {
-  @extend %with-mask, %random-16-svg-prop !optional;
+  @extend %with-mask, %random-16-svg-prop;
   -webkit-mask-image: var(--random-16-svg);
   mask-image: var(--random-16-svg);
 }
 
 %with-random-24-icon {
-  @extend %with-icon, %random-24-svg-prop !optional;
+  @extend %with-icon, %random-24-svg-prop;
   background-image: var(--random-24-svg);
 }
 %with-random-24-mask {
-  @extend %with-mask, %random-24-svg-prop !optional;
+  @extend %with-mask, %random-24-svg-prop;
   -webkit-mask-image: var(--random-24-svg);
   mask-image: var(--random-24-svg);
 }
 
 %with-random-icon {
-  @extend %with-icon, %random-svg-prop !optional;
+  @extend %with-icon, %random-svg-prop;
   background-image: var(--random-svg);
 }
 %with-random-mask {
-  @extend %with-mask, %random-svg-prop !optional;
+  @extend %with-mask, %random-svg-prop;
   -webkit-mask-image: var(--random-svg);
   mask-image: var(--random-svg);
 }
 
 %with-redirect-16-icon {
-  @extend %with-icon, %redirect-16-svg-prop !optional;
+  @extend %with-icon, %redirect-16-svg-prop;
   background-image: var(--redirect-16-svg);
 }
 %with-redirect-16-mask {
-  @extend %with-mask, %redirect-16-svg-prop !optional;
+  @extend %with-mask, %redirect-16-svg-prop;
   -webkit-mask-image: var(--redirect-16-svg);
   mask-image: var(--redirect-16-svg);
 }
 
 %with-redirect-24-icon {
-  @extend %with-icon, %redirect-24-svg-prop !optional;
+  @extend %with-icon, %redirect-24-svg-prop;
   background-image: var(--redirect-24-svg);
 }
 %with-redirect-24-mask {
-  @extend %with-mask, %redirect-24-svg-prop !optional;
+  @extend %with-mask, %redirect-24-svg-prop;
   -webkit-mask-image: var(--redirect-24-svg);
   mask-image: var(--redirect-24-svg);
 }
 
 %with-redirect-icon {
-  @extend %with-icon, %redirect-svg-prop !optional;
+  @extend %with-icon, %redirect-svg-prop;
   background-image: var(--redirect-svg);
 }
 %with-redirect-mask {
-  @extend %with-mask, %redirect-svg-prop !optional;
+  @extend %with-mask, %redirect-svg-prop;
   -webkit-mask-image: var(--redirect-svg);
   mask-image: var(--redirect-svg);
 }
 
 %with-refresh-alert-icon {
-  @extend %with-icon, %refresh-alert-svg-prop !optional;
+  @extend %with-icon, %refresh-alert-svg-prop;
   background-image: var(--refresh-alert-svg);
 }
 %with-refresh-alert-mask {
-  @extend %with-mask, %refresh-alert-svg-prop !optional;
+  @extend %with-mask, %refresh-alert-svg-prop;
   -webkit-mask-image: var(--refresh-alert-svg);
   mask-image: var(--refresh-alert-svg);
 }
 
 %with-refresh-default-icon {
-  @extend %with-icon, %refresh-default-svg-prop !optional;
+  @extend %with-icon, %refresh-default-svg-prop;
   background-image: var(--refresh-default-svg);
 }
 %with-refresh-default-mask {
-  @extend %with-mask, %refresh-default-svg-prop !optional;
+  @extend %with-mask, %refresh-default-svg-prop;
   -webkit-mask-image: var(--refresh-default-svg);
   mask-image: var(--refresh-default-svg);
 }
 
 %with-reload-16-icon {
-  @extend %with-icon, %reload-16-svg-prop !optional;
+  @extend %with-icon, %reload-16-svg-prop;
   background-image: var(--reload-16-svg);
 }
 %with-reload-16-mask {
-  @extend %with-mask, %reload-16-svg-prop !optional;
+  @extend %with-mask, %reload-16-svg-prop;
   -webkit-mask-image: var(--reload-16-svg);
   mask-image: var(--reload-16-svg);
 }
 
 %with-reload-24-icon {
-  @extend %with-icon, %reload-24-svg-prop !optional;
+  @extend %with-icon, %reload-24-svg-prop;
   background-image: var(--reload-24-svg);
 }
 %with-reload-24-mask {
-  @extend %with-mask, %reload-24-svg-prop !optional;
+  @extend %with-mask, %reload-24-svg-prop;
   -webkit-mask-image: var(--reload-24-svg);
   mask-image: var(--reload-24-svg);
 }
 
 %with-remix-icon {
-  @extend %with-icon, %remix-svg-prop !optional;
+  @extend %with-icon, %remix-svg-prop;
   background-image: var(--remix-svg);
 }
 %with-remix-mask {
-  @extend %with-mask, %remix-svg-prop !optional;
+  @extend %with-mask, %remix-svg-prop;
   -webkit-mask-image: var(--remix-svg);
   mask-image: var(--remix-svg);
 }
 
 %with-repeat-16-icon {
-  @extend %with-icon, %repeat-16-svg-prop !optional;
+  @extend %with-icon, %repeat-16-svg-prop;
   background-image: var(--repeat-16-svg);
 }
 %with-repeat-16-mask {
-  @extend %with-mask, %repeat-16-svg-prop !optional;
+  @extend %with-mask, %repeat-16-svg-prop;
   -webkit-mask-image: var(--repeat-16-svg);
   mask-image: var(--repeat-16-svg);
 }
 
 %with-repeat-24-icon {
-  @extend %with-icon, %repeat-24-svg-prop !optional;
+  @extend %with-icon, %repeat-24-svg-prop;
   background-image: var(--repeat-24-svg);
 }
 %with-repeat-24-mask {
-  @extend %with-mask, %repeat-24-svg-prop !optional;
+  @extend %with-mask, %repeat-24-svg-prop;
   -webkit-mask-image: var(--repeat-24-svg);
   mask-image: var(--repeat-24-svg);
 }
 
 %with-replication-direct-16-icon {
-  @extend %with-icon, %replication-direct-16-svg-prop !optional;
+  @extend %with-icon, %replication-direct-16-svg-prop;
   background-image: var(--replication-direct-16-svg);
 }
 %with-replication-direct-16-mask {
-  @extend %with-mask, %replication-direct-16-svg-prop !optional;
+  @extend %with-mask, %replication-direct-16-svg-prop;
   -webkit-mask-image: var(--replication-direct-16-svg);
   mask-image: var(--replication-direct-16-svg);
 }
 
 %with-replication-direct-24-icon {
-  @extend %with-icon, %replication-direct-24-svg-prop !optional;
+  @extend %with-icon, %replication-direct-24-svg-prop;
   background-image: var(--replication-direct-24-svg);
 }
 %with-replication-direct-24-mask {
-  @extend %with-mask, %replication-direct-24-svg-prop !optional;
+  @extend %with-mask, %replication-direct-24-svg-prop;
   -webkit-mask-image: var(--replication-direct-24-svg);
   mask-image: var(--replication-direct-24-svg);
 }
 
 %with-replication-perf-16-icon {
-  @extend %with-icon, %replication-perf-16-svg-prop !optional;
+  @extend %with-icon, %replication-perf-16-svg-prop;
   background-image: var(--replication-perf-16-svg);
 }
 %with-replication-perf-16-mask {
-  @extend %with-mask, %replication-perf-16-svg-prop !optional;
+  @extend %with-mask, %replication-perf-16-svg-prop;
   -webkit-mask-image: var(--replication-perf-16-svg);
   mask-image: var(--replication-perf-16-svg);
 }
 
 %with-replication-perf-24-icon {
-  @extend %with-icon, %replication-perf-24-svg-prop !optional;
+  @extend %with-icon, %replication-perf-24-svg-prop;
   background-image: var(--replication-perf-24-svg);
 }
 %with-replication-perf-24-mask {
-  @extend %with-mask, %replication-perf-24-svg-prop !optional;
+  @extend %with-mask, %replication-perf-24-svg-prop;
   -webkit-mask-image: var(--replication-perf-24-svg);
   mask-image: var(--replication-perf-24-svg);
 }
 
 %with-rewind-16-icon {
-  @extend %with-icon, %rewind-16-svg-prop !optional;
+  @extend %with-icon, %rewind-16-svg-prop;
   background-image: var(--rewind-16-svg);
 }
 %with-rewind-16-mask {
-  @extend %with-mask, %rewind-16-svg-prop !optional;
+  @extend %with-mask, %rewind-16-svg-prop;
   -webkit-mask-image: var(--rewind-16-svg);
   mask-image: var(--rewind-16-svg);
 }
 
 %with-rewind-24-icon {
-  @extend %with-icon, %rewind-24-svg-prop !optional;
+  @extend %with-icon, %rewind-24-svg-prop;
   background-image: var(--rewind-24-svg);
 }
 %with-rewind-24-mask {
-  @extend %with-mask, %rewind-24-svg-prop !optional;
+  @extend %with-mask, %rewind-24-svg-prop;
   -webkit-mask-image: var(--rewind-24-svg);
   mask-image: var(--rewind-24-svg);
 }
 
 %with-ribbon-icon {
-  @extend %with-icon, %ribbon-svg-prop !optional;
+  @extend %with-icon, %ribbon-svg-prop;
   background-image: var(--ribbon-svg);
 }
 %with-ribbon-mask {
-  @extend %with-mask, %ribbon-svg-prop !optional;
+  @extend %with-mask, %ribbon-svg-prop;
   -webkit-mask-image: var(--ribbon-svg);
   mask-image: var(--ribbon-svg);
 }
 
 %with-rocket-16-icon {
-  @extend %with-icon, %rocket-16-svg-prop !optional;
+  @extend %with-icon, %rocket-16-svg-prop;
   background-image: var(--rocket-16-svg);
 }
 %with-rocket-16-mask {
-  @extend %with-mask, %rocket-16-svg-prop !optional;
+  @extend %with-mask, %rocket-16-svg-prop;
   -webkit-mask-image: var(--rocket-16-svg);
   mask-image: var(--rocket-16-svg);
 }
 
 %with-rocket-24-icon {
-  @extend %with-icon, %rocket-24-svg-prop !optional;
+  @extend %with-icon, %rocket-24-svg-prop;
   background-image: var(--rocket-24-svg);
 }
 %with-rocket-24-mask {
-  @extend %with-mask, %rocket-24-svg-prop !optional;
+  @extend %with-mask, %rocket-24-svg-prop;
   -webkit-mask-image: var(--rocket-24-svg);
   mask-image: var(--rocket-24-svg);
 }
 
 %with-rotate-ccw-16-icon {
-  @extend %with-icon, %rotate-ccw-16-svg-prop !optional;
+  @extend %with-icon, %rotate-ccw-16-svg-prop;
   background-image: var(--rotate-ccw-16-svg);
 }
 %with-rotate-ccw-16-mask {
-  @extend %with-mask, %rotate-ccw-16-svg-prop !optional;
+  @extend %with-mask, %rotate-ccw-16-svg-prop;
   -webkit-mask-image: var(--rotate-ccw-16-svg);
   mask-image: var(--rotate-ccw-16-svg);
 }
 
 %with-rotate-ccw-24-icon {
-  @extend %with-icon, %rotate-ccw-24-svg-prop !optional;
+  @extend %with-icon, %rotate-ccw-24-svg-prop;
   background-image: var(--rotate-ccw-24-svg);
 }
 %with-rotate-ccw-24-mask {
-  @extend %with-mask, %rotate-ccw-24-svg-prop !optional;
+  @extend %with-mask, %rotate-ccw-24-svg-prop;
   -webkit-mask-image: var(--rotate-ccw-24-svg);
   mask-image: var(--rotate-ccw-24-svg);
 }
 
 %with-rotate-cw-16-icon {
-  @extend %with-icon, %rotate-cw-16-svg-prop !optional;
+  @extend %with-icon, %rotate-cw-16-svg-prop;
   background-image: var(--rotate-cw-16-svg);
 }
 %with-rotate-cw-16-mask {
-  @extend %with-mask, %rotate-cw-16-svg-prop !optional;
+  @extend %with-mask, %rotate-cw-16-svg-prop;
   -webkit-mask-image: var(--rotate-cw-16-svg);
   mask-image: var(--rotate-cw-16-svg);
 }
 
 %with-rotate-cw-24-icon {
-  @extend %with-icon, %rotate-cw-24-svg-prop !optional;
+  @extend %with-icon, %rotate-cw-24-svg-prop;
   background-image: var(--rotate-cw-24-svg);
 }
 %with-rotate-cw-24-mask {
-  @extend %with-mask, %rotate-cw-24-svg-prop !optional;
+  @extend %with-mask, %rotate-cw-24-svg-prop;
   -webkit-mask-image: var(--rotate-cw-24-svg);
   mask-image: var(--rotate-cw-24-svg);
 }
 
 %with-rss-16-icon {
-  @extend %with-icon, %rss-16-svg-prop !optional;
+  @extend %with-icon, %rss-16-svg-prop;
   background-image: var(--rss-16-svg);
 }
 %with-rss-16-mask {
-  @extend %with-mask, %rss-16-svg-prop !optional;
+  @extend %with-mask, %rss-16-svg-prop;
   -webkit-mask-image: var(--rss-16-svg);
   mask-image: var(--rss-16-svg);
 }
 
 %with-rss-24-icon {
-  @extend %with-icon, %rss-24-svg-prop !optional;
+  @extend %with-icon, %rss-24-svg-prop;
   background-image: var(--rss-24-svg);
 }
 %with-rss-24-mask {
-  @extend %with-mask, %rss-24-svg-prop !optional;
+  @extend %with-mask, %rss-24-svg-prop;
   -webkit-mask-image: var(--rss-24-svg);
   mask-image: var(--rss-24-svg);
 }
 
 %with-run-icon {
-  @extend %with-icon, %run-svg-prop !optional;
+  @extend %with-icon, %run-svg-prop;
   background-image: var(--run-svg);
 }
 %with-run-mask {
-  @extend %with-mask, %run-svg-prop !optional;
+  @extend %with-mask, %run-svg-prop;
   -webkit-mask-image: var(--run-svg);
   mask-image: var(--run-svg);
 }
 
 %with-save-16-icon {
-  @extend %with-icon, %save-16-svg-prop !optional;
+  @extend %with-icon, %save-16-svg-prop;
   background-image: var(--save-16-svg);
 }
 %with-save-16-mask {
-  @extend %with-mask, %save-16-svg-prop !optional;
+  @extend %with-mask, %save-16-svg-prop;
   -webkit-mask-image: var(--save-16-svg);
   mask-image: var(--save-16-svg);
 }
 
 %with-save-24-icon {
-  @extend %with-icon, %save-24-svg-prop !optional;
+  @extend %with-icon, %save-24-svg-prop;
   background-image: var(--save-24-svg);
 }
 %with-save-24-mask {
-  @extend %with-mask, %save-24-svg-prop !optional;
+  @extend %with-mask, %save-24-svg-prop;
   -webkit-mask-image: var(--save-24-svg);
   mask-image: var(--save-24-svg);
 }
 
 %with-scissors-16-icon {
-  @extend %with-icon, %scissors-16-svg-prop !optional;
+  @extend %with-icon, %scissors-16-svg-prop;
   background-image: var(--scissors-16-svg);
 }
 %with-scissors-16-mask {
-  @extend %with-mask, %scissors-16-svg-prop !optional;
+  @extend %with-mask, %scissors-16-svg-prop;
   -webkit-mask-image: var(--scissors-16-svg);
   mask-image: var(--scissors-16-svg);
 }
 
 %with-scissors-24-icon {
-  @extend %with-icon, %scissors-24-svg-prop !optional;
+  @extend %with-icon, %scissors-24-svg-prop;
   background-image: var(--scissors-24-svg);
 }
 %with-scissors-24-mask {
-  @extend %with-mask, %scissors-24-svg-prop !optional;
+  @extend %with-mask, %scissors-24-svg-prop;
   -webkit-mask-image: var(--scissors-24-svg);
   mask-image: var(--scissors-24-svg);
 }
 
 %with-search-16-icon {
-  @extend %with-icon, %search-16-svg-prop !optional;
+  @extend %with-icon, %search-16-svg-prop;
   background-image: var(--search-16-svg);
 }
 %with-search-16-mask {
-  @extend %with-mask, %search-16-svg-prop !optional;
+  @extend %with-mask, %search-16-svg-prop;
   -webkit-mask-image: var(--search-16-svg);
   mask-image: var(--search-16-svg);
 }
 
 %with-search-24-icon {
-  @extend %with-icon, %search-24-svg-prop !optional;
+  @extend %with-icon, %search-24-svg-prop;
   background-image: var(--search-24-svg);
 }
 %with-search-24-mask {
-  @extend %with-mask, %search-24-svg-prop !optional;
+  @extend %with-mask, %search-24-svg-prop;
   -webkit-mask-image: var(--search-24-svg);
   mask-image: var(--search-24-svg);
 }
 
 %with-search-color-icon {
-  @extend %with-icon, %search-color-svg-prop !optional;
+  @extend %with-icon, %search-color-svg-prop;
   background-image: var(--search-color-svg);
 }
 %with-search-color-mask {
-  @extend %with-mask, %search-color-svg-prop !optional;
+  @extend %with-mask, %search-color-svg-prop;
   -webkit-mask-image: var(--search-color-svg);
   mask-image: var(--search-color-svg);
 }
 
 %with-search-icon {
-  @extend %with-icon, %search-svg-prop !optional;
+  @extend %with-icon, %search-svg-prop;
   background-image: var(--search-svg);
 }
 %with-search-mask {
-  @extend %with-mask, %search-svg-prop !optional;
+  @extend %with-mask, %search-svg-prop;
   -webkit-mask-image: var(--search-svg);
   mask-image: var(--search-svg);
 }
 
 %with-send-16-icon {
-  @extend %with-icon, %send-16-svg-prop !optional;
+  @extend %with-icon, %send-16-svg-prop;
   background-image: var(--send-16-svg);
 }
 %with-send-16-mask {
-  @extend %with-mask, %send-16-svg-prop !optional;
+  @extend %with-mask, %send-16-svg-prop;
   -webkit-mask-image: var(--send-16-svg);
   mask-image: var(--send-16-svg);
 }
 
 %with-send-24-icon {
-  @extend %with-icon, %send-24-svg-prop !optional;
+  @extend %with-icon, %send-24-svg-prop;
   background-image: var(--send-24-svg);
 }
 %with-send-24-mask {
-  @extend %with-mask, %send-24-svg-prop !optional;
+  @extend %with-mask, %send-24-svg-prop;
   -webkit-mask-image: var(--send-24-svg);
   mask-image: var(--send-24-svg);
 }
 
 %with-server-16-icon {
-  @extend %with-icon, %server-16-svg-prop !optional;
+  @extend %with-icon, %server-16-svg-prop;
   background-image: var(--server-16-svg);
 }
 %with-server-16-mask {
-  @extend %with-mask, %server-16-svg-prop !optional;
+  @extend %with-mask, %server-16-svg-prop;
   -webkit-mask-image: var(--server-16-svg);
   mask-image: var(--server-16-svg);
 }
 
 %with-server-24-icon {
-  @extend %with-icon, %server-24-svg-prop !optional;
+  @extend %with-icon, %server-24-svg-prop;
   background-image: var(--server-24-svg);
 }
 %with-server-24-mask {
-  @extend %with-mask, %server-24-svg-prop !optional;
+  @extend %with-mask, %server-24-svg-prop;
   -webkit-mask-image: var(--server-24-svg);
   mask-image: var(--server-24-svg);
 }
 
 %with-server-cluster-16-icon {
-  @extend %with-icon, %server-cluster-16-svg-prop !optional;
+  @extend %with-icon, %server-cluster-16-svg-prop;
   background-image: var(--server-cluster-16-svg);
 }
 %with-server-cluster-16-mask {
-  @extend %with-mask, %server-cluster-16-svg-prop !optional;
+  @extend %with-mask, %server-cluster-16-svg-prop;
   -webkit-mask-image: var(--server-cluster-16-svg);
   mask-image: var(--server-cluster-16-svg);
 }
 
 %with-server-cluster-24-icon {
-  @extend %with-icon, %server-cluster-24-svg-prop !optional;
+  @extend %with-icon, %server-cluster-24-svg-prop;
   background-image: var(--server-cluster-24-svg);
 }
 %with-server-cluster-24-mask {
-  @extend %with-mask, %server-cluster-24-svg-prop !optional;
+  @extend %with-mask, %server-cluster-24-svg-prop;
   -webkit-mask-image: var(--server-cluster-24-svg);
   mask-image: var(--server-cluster-24-svg);
 }
 
 %with-serverless-16-icon {
-  @extend %with-icon, %serverless-16-svg-prop !optional;
+  @extend %with-icon, %serverless-16-svg-prop;
   background-image: var(--serverless-16-svg);
 }
 %with-serverless-16-mask {
-  @extend %with-mask, %serverless-16-svg-prop !optional;
+  @extend %with-mask, %serverless-16-svg-prop;
   -webkit-mask-image: var(--serverless-16-svg);
   mask-image: var(--serverless-16-svg);
 }
 
 %with-serverless-24-icon {
-  @extend %with-icon, %serverless-24-svg-prop !optional;
+  @extend %with-icon, %serverless-24-svg-prop;
   background-image: var(--serverless-24-svg);
 }
 %with-serverless-24-mask {
-  @extend %with-mask, %serverless-24-svg-prop !optional;
+  @extend %with-mask, %serverless-24-svg-prop;
   -webkit-mask-image: var(--serverless-24-svg);
   mask-image: var(--serverless-24-svg);
 }
 
 %with-settings-16-icon {
-  @extend %with-icon, %settings-16-svg-prop !optional;
+  @extend %with-icon, %settings-16-svg-prop;
   background-image: var(--settings-16-svg);
 }
 %with-settings-16-mask {
-  @extend %with-mask, %settings-16-svg-prop !optional;
+  @extend %with-mask, %settings-16-svg-prop;
   -webkit-mask-image: var(--settings-16-svg);
   mask-image: var(--settings-16-svg);
 }
 
 %with-settings-24-icon {
-  @extend %with-icon, %settings-24-svg-prop !optional;
+  @extend %with-icon, %settings-24-svg-prop;
   background-image: var(--settings-24-svg);
 }
 %with-settings-24-mask {
-  @extend %with-mask, %settings-24-svg-prop !optional;
+  @extend %with-mask, %settings-24-svg-prop;
   -webkit-mask-image: var(--settings-24-svg);
   mask-image: var(--settings-24-svg);
 }
 
 %with-settings-icon {
-  @extend %with-icon, %settings-svg-prop !optional;
+  @extend %with-icon, %settings-svg-prop;
   background-image: var(--settings-svg);
 }
 %with-settings-mask {
-  @extend %with-mask, %settings-svg-prop !optional;
+  @extend %with-mask, %settings-svg-prop;
   -webkit-mask-image: var(--settings-svg);
   mask-image: var(--settings-svg);
 }
 
 %with-share-16-icon {
-  @extend %with-icon, %share-16-svg-prop !optional;
+  @extend %with-icon, %share-16-svg-prop;
   background-image: var(--share-16-svg);
 }
 %with-share-16-mask {
-  @extend %with-mask, %share-16-svg-prop !optional;
+  @extend %with-mask, %share-16-svg-prop;
   -webkit-mask-image: var(--share-16-svg);
   mask-image: var(--share-16-svg);
 }
 
 %with-share-24-icon {
-  @extend %with-icon, %share-24-svg-prop !optional;
+  @extend %with-icon, %share-24-svg-prop;
   background-image: var(--share-24-svg);
 }
 %with-share-24-mask {
-  @extend %with-mask, %share-24-svg-prop !optional;
+  @extend %with-mask, %share-24-svg-prop;
   -webkit-mask-image: var(--share-24-svg);
   mask-image: var(--share-24-svg);
 }
 
 %with-shield-16-icon {
-  @extend %with-icon, %shield-16-svg-prop !optional;
+  @extend %with-icon, %shield-16-svg-prop;
   background-image: var(--shield-16-svg);
 }
 %with-shield-16-mask {
-  @extend %with-mask, %shield-16-svg-prop !optional;
+  @extend %with-mask, %shield-16-svg-prop;
   -webkit-mask-image: var(--shield-16-svg);
   mask-image: var(--shield-16-svg);
 }
 
 %with-shield-24-icon {
-  @extend %with-icon, %shield-24-svg-prop !optional;
+  @extend %with-icon, %shield-24-svg-prop;
   background-image: var(--shield-24-svg);
 }
 %with-shield-24-mask {
-  @extend %with-mask, %shield-24-svg-prop !optional;
+  @extend %with-mask, %shield-24-svg-prop;
   -webkit-mask-image: var(--shield-24-svg);
   mask-image: var(--shield-24-svg);
 }
 
 %with-shield-alert-16-icon {
-  @extend %with-icon, %shield-alert-16-svg-prop !optional;
+  @extend %with-icon, %shield-alert-16-svg-prop;
   background-image: var(--shield-alert-16-svg);
 }
 %with-shield-alert-16-mask {
-  @extend %with-mask, %shield-alert-16-svg-prop !optional;
+  @extend %with-mask, %shield-alert-16-svg-prop;
   -webkit-mask-image: var(--shield-alert-16-svg);
   mask-image: var(--shield-alert-16-svg);
 }
 
 %with-shield-alert-24-icon {
-  @extend %with-icon, %shield-alert-24-svg-prop !optional;
+  @extend %with-icon, %shield-alert-24-svg-prop;
   background-image: var(--shield-alert-24-svg);
 }
 %with-shield-alert-24-mask {
-  @extend %with-mask, %shield-alert-24-svg-prop !optional;
+  @extend %with-mask, %shield-alert-24-svg-prop;
   -webkit-mask-image: var(--shield-alert-24-svg);
   mask-image: var(--shield-alert-24-svg);
 }
 
 %with-shield-check-16-icon {
-  @extend %with-icon, %shield-check-16-svg-prop !optional;
+  @extend %with-icon, %shield-check-16-svg-prop;
   background-image: var(--shield-check-16-svg);
 }
 %with-shield-check-16-mask {
-  @extend %with-mask, %shield-check-16-svg-prop !optional;
+  @extend %with-mask, %shield-check-16-svg-prop;
   -webkit-mask-image: var(--shield-check-16-svg);
   mask-image: var(--shield-check-16-svg);
 }
 
 %with-shield-check-24-icon {
-  @extend %with-icon, %shield-check-24-svg-prop !optional;
+  @extend %with-icon, %shield-check-24-svg-prop;
   background-image: var(--shield-check-24-svg);
 }
 %with-shield-check-24-mask {
-  @extend %with-mask, %shield-check-24-svg-prop !optional;
+  @extend %with-mask, %shield-check-24-svg-prop;
   -webkit-mask-image: var(--shield-check-24-svg);
   mask-image: var(--shield-check-24-svg);
 }
 
 %with-shield-off-16-icon {
-  @extend %with-icon, %shield-off-16-svg-prop !optional;
+  @extend %with-icon, %shield-off-16-svg-prop;
   background-image: var(--shield-off-16-svg);
 }
 %with-shield-off-16-mask {
-  @extend %with-mask, %shield-off-16-svg-prop !optional;
+  @extend %with-mask, %shield-off-16-svg-prop;
   -webkit-mask-image: var(--shield-off-16-svg);
   mask-image: var(--shield-off-16-svg);
 }
 
 %with-shield-off-24-icon {
-  @extend %with-icon, %shield-off-24-svg-prop !optional;
+  @extend %with-icon, %shield-off-24-svg-prop;
   background-image: var(--shield-off-24-svg);
 }
 %with-shield-off-24-mask {
-  @extend %with-mask, %shield-off-24-svg-prop !optional;
+  @extend %with-mask, %shield-off-24-svg-prop;
   -webkit-mask-image: var(--shield-off-24-svg);
   mask-image: var(--shield-off-24-svg);
 }
 
 %with-shield-x-16-icon {
-  @extend %with-icon, %shield-x-16-svg-prop !optional;
+  @extend %with-icon, %shield-x-16-svg-prop;
   background-image: var(--shield-x-16-svg);
 }
 %with-shield-x-16-mask {
-  @extend %with-mask, %shield-x-16-svg-prop !optional;
+  @extend %with-mask, %shield-x-16-svg-prop;
   -webkit-mask-image: var(--shield-x-16-svg);
   mask-image: var(--shield-x-16-svg);
 }
 
 %with-shield-x-24-icon {
-  @extend %with-icon, %shield-x-24-svg-prop !optional;
+  @extend %with-icon, %shield-x-24-svg-prop;
   background-image: var(--shield-x-24-svg);
 }
 %with-shield-x-24-mask {
-  @extend %with-mask, %shield-x-24-svg-prop !optional;
+  @extend %with-mask, %shield-x-24-svg-prop;
   -webkit-mask-image: var(--shield-x-24-svg);
   mask-image: var(--shield-x-24-svg);
 }
 
 %with-shopping-bag-16-icon {
-  @extend %with-icon, %shopping-bag-16-svg-prop !optional;
+  @extend %with-icon, %shopping-bag-16-svg-prop;
   background-image: var(--shopping-bag-16-svg);
 }
 %with-shopping-bag-16-mask {
-  @extend %with-mask, %shopping-bag-16-svg-prop !optional;
+  @extend %with-mask, %shopping-bag-16-svg-prop;
   -webkit-mask-image: var(--shopping-bag-16-svg);
   mask-image: var(--shopping-bag-16-svg);
 }
 
 %with-shopping-bag-24-icon {
-  @extend %with-icon, %shopping-bag-24-svg-prop !optional;
+  @extend %with-icon, %shopping-bag-24-svg-prop;
   background-image: var(--shopping-bag-24-svg);
 }
 %with-shopping-bag-24-mask {
-  @extend %with-mask, %shopping-bag-24-svg-prop !optional;
+  @extend %with-mask, %shopping-bag-24-svg-prop;
   -webkit-mask-image: var(--shopping-bag-24-svg);
   mask-image: var(--shopping-bag-24-svg);
 }
 
 %with-shopping-cart-16-icon {
-  @extend %with-icon, %shopping-cart-16-svg-prop !optional;
+  @extend %with-icon, %shopping-cart-16-svg-prop;
   background-image: var(--shopping-cart-16-svg);
 }
 %with-shopping-cart-16-mask {
-  @extend %with-mask, %shopping-cart-16-svg-prop !optional;
+  @extend %with-mask, %shopping-cart-16-svg-prop;
   -webkit-mask-image: var(--shopping-cart-16-svg);
   mask-image: var(--shopping-cart-16-svg);
 }
 
 %with-shopping-cart-24-icon {
-  @extend %with-icon, %shopping-cart-24-svg-prop !optional;
+  @extend %with-icon, %shopping-cart-24-svg-prop;
   background-image: var(--shopping-cart-24-svg);
 }
 %with-shopping-cart-24-mask {
-  @extend %with-mask, %shopping-cart-24-svg-prop !optional;
+  @extend %with-mask, %shopping-cart-24-svg-prop;
   -webkit-mask-image: var(--shopping-cart-24-svg);
   mask-image: var(--shopping-cart-24-svg);
 }
 
 %with-shuffle-16-icon {
-  @extend %with-icon, %shuffle-16-svg-prop !optional;
+  @extend %with-icon, %shuffle-16-svg-prop;
   background-image: var(--shuffle-16-svg);
 }
 %with-shuffle-16-mask {
-  @extend %with-mask, %shuffle-16-svg-prop !optional;
+  @extend %with-mask, %shuffle-16-svg-prop;
   -webkit-mask-image: var(--shuffle-16-svg);
   mask-image: var(--shuffle-16-svg);
 }
 
 %with-shuffle-24-icon {
-  @extend %with-icon, %shuffle-24-svg-prop !optional;
+  @extend %with-icon, %shuffle-24-svg-prop;
   background-image: var(--shuffle-24-svg);
 }
 %with-shuffle-24-mask {
-  @extend %with-mask, %shuffle-24-svg-prop !optional;
+  @extend %with-mask, %shuffle-24-svg-prop;
   -webkit-mask-image: var(--shuffle-24-svg);
   mask-image: var(--shuffle-24-svg);
 }
 
 %with-sidebar-16-icon {
-  @extend %with-icon, %sidebar-16-svg-prop !optional;
+  @extend %with-icon, %sidebar-16-svg-prop;
   background-image: var(--sidebar-16-svg);
 }
 %with-sidebar-16-mask {
-  @extend %with-mask, %sidebar-16-svg-prop !optional;
+  @extend %with-mask, %sidebar-16-svg-prop;
   -webkit-mask-image: var(--sidebar-16-svg);
   mask-image: var(--sidebar-16-svg);
 }
 
 %with-sidebar-24-icon {
-  @extend %with-icon, %sidebar-24-svg-prop !optional;
+  @extend %with-icon, %sidebar-24-svg-prop;
   background-image: var(--sidebar-24-svg);
 }
 %with-sidebar-24-mask {
-  @extend %with-mask, %sidebar-24-svg-prop !optional;
+  @extend %with-mask, %sidebar-24-svg-prop;
   -webkit-mask-image: var(--sidebar-24-svg);
   mask-image: var(--sidebar-24-svg);
 }
 
 %with-sidebar-hide-16-icon {
-  @extend %with-icon, %sidebar-hide-16-svg-prop !optional;
+  @extend %with-icon, %sidebar-hide-16-svg-prop;
   background-image: var(--sidebar-hide-16-svg);
 }
 %with-sidebar-hide-16-mask {
-  @extend %with-mask, %sidebar-hide-16-svg-prop !optional;
+  @extend %with-mask, %sidebar-hide-16-svg-prop;
   -webkit-mask-image: var(--sidebar-hide-16-svg);
   mask-image: var(--sidebar-hide-16-svg);
 }
 
 %with-sidebar-hide-24-icon {
-  @extend %with-icon, %sidebar-hide-24-svg-prop !optional;
+  @extend %with-icon, %sidebar-hide-24-svg-prop;
   background-image: var(--sidebar-hide-24-svg);
 }
 %with-sidebar-hide-24-mask {
-  @extend %with-mask, %sidebar-hide-24-svg-prop !optional;
+  @extend %with-mask, %sidebar-hide-24-svg-prop;
   -webkit-mask-image: var(--sidebar-hide-24-svg);
   mask-image: var(--sidebar-hide-24-svg);
 }
 
 %with-sidebar-show-16-icon {
-  @extend %with-icon, %sidebar-show-16-svg-prop !optional;
+  @extend %with-icon, %sidebar-show-16-svg-prop;
   background-image: var(--sidebar-show-16-svg);
 }
 %with-sidebar-show-16-mask {
-  @extend %with-mask, %sidebar-show-16-svg-prop !optional;
+  @extend %with-mask, %sidebar-show-16-svg-prop;
   -webkit-mask-image: var(--sidebar-show-16-svg);
   mask-image: var(--sidebar-show-16-svg);
 }
 
 %with-sidebar-show-24-icon {
-  @extend %with-icon, %sidebar-show-24-svg-prop !optional;
+  @extend %with-icon, %sidebar-show-24-svg-prop;
   background-image: var(--sidebar-show-24-svg);
 }
 %with-sidebar-show-24-mask {
-  @extend %with-mask, %sidebar-show-24-svg-prop !optional;
+  @extend %with-mask, %sidebar-show-24-svg-prop;
   -webkit-mask-image: var(--sidebar-show-24-svg);
   mask-image: var(--sidebar-show-24-svg);
 }
 
 %with-sign-in-16-icon {
-  @extend %with-icon, %sign-in-16-svg-prop !optional;
+  @extend %with-icon, %sign-in-16-svg-prop;
   background-image: var(--sign-in-16-svg);
 }
 %with-sign-in-16-mask {
-  @extend %with-mask, %sign-in-16-svg-prop !optional;
+  @extend %with-mask, %sign-in-16-svg-prop;
   -webkit-mask-image: var(--sign-in-16-svg);
   mask-image: var(--sign-in-16-svg);
 }
 
 %with-sign-in-24-icon {
-  @extend %with-icon, %sign-in-24-svg-prop !optional;
+  @extend %with-icon, %sign-in-24-svg-prop;
   background-image: var(--sign-in-24-svg);
 }
 %with-sign-in-24-mask {
-  @extend %with-mask, %sign-in-24-svg-prop !optional;
+  @extend %with-mask, %sign-in-24-svg-prop;
   -webkit-mask-image: var(--sign-in-24-svg);
   mask-image: var(--sign-in-24-svg);
 }
 
 %with-sign-out-16-icon {
-  @extend %with-icon, %sign-out-16-svg-prop !optional;
+  @extend %with-icon, %sign-out-16-svg-prop;
   background-image: var(--sign-out-16-svg);
 }
 %with-sign-out-16-mask {
-  @extend %with-mask, %sign-out-16-svg-prop !optional;
+  @extend %with-mask, %sign-out-16-svg-prop;
   -webkit-mask-image: var(--sign-out-16-svg);
   mask-image: var(--sign-out-16-svg);
 }
 
 %with-sign-out-24-icon {
-  @extend %with-icon, %sign-out-24-svg-prop !optional;
+  @extend %with-icon, %sign-out-24-svg-prop;
   background-image: var(--sign-out-24-svg);
 }
 %with-sign-out-24-mask {
-  @extend %with-mask, %sign-out-24-svg-prop !optional;
+  @extend %with-mask, %sign-out-24-svg-prop;
   -webkit-mask-image: var(--sign-out-24-svg);
   mask-image: var(--sign-out-24-svg);
 }
 
 %with-skip-16-icon {
-  @extend %with-icon, %skip-16-svg-prop !optional;
+  @extend %with-icon, %skip-16-svg-prop;
   background-image: var(--skip-16-svg);
 }
 %with-skip-16-mask {
-  @extend %with-mask, %skip-16-svg-prop !optional;
+  @extend %with-mask, %skip-16-svg-prop;
   -webkit-mask-image: var(--skip-16-svg);
   mask-image: var(--skip-16-svg);
 }
 
 %with-skip-24-icon {
-  @extend %with-icon, %skip-24-svg-prop !optional;
+  @extend %with-icon, %skip-24-svg-prop;
   background-image: var(--skip-24-svg);
 }
 %with-skip-24-mask {
-  @extend %with-mask, %skip-24-svg-prop !optional;
+  @extend %with-mask, %skip-24-svg-prop;
   -webkit-mask-image: var(--skip-24-svg);
   mask-image: var(--skip-24-svg);
 }
 
 %with-skip-back-16-icon {
-  @extend %with-icon, %skip-back-16-svg-prop !optional;
+  @extend %with-icon, %skip-back-16-svg-prop;
   background-image: var(--skip-back-16-svg);
 }
 %with-skip-back-16-mask {
-  @extend %with-mask, %skip-back-16-svg-prop !optional;
+  @extend %with-mask, %skip-back-16-svg-prop;
   -webkit-mask-image: var(--skip-back-16-svg);
   mask-image: var(--skip-back-16-svg);
 }
 
 %with-skip-back-24-icon {
-  @extend %with-icon, %skip-back-24-svg-prop !optional;
+  @extend %with-icon, %skip-back-24-svg-prop;
   background-image: var(--skip-back-24-svg);
 }
 %with-skip-back-24-mask {
-  @extend %with-mask, %skip-back-24-svg-prop !optional;
+  @extend %with-mask, %skip-back-24-svg-prop;
   -webkit-mask-image: var(--skip-back-24-svg);
   mask-image: var(--skip-back-24-svg);
 }
 
 %with-skip-forward-16-icon {
-  @extend %with-icon, %skip-forward-16-svg-prop !optional;
+  @extend %with-icon, %skip-forward-16-svg-prop;
   background-image: var(--skip-forward-16-svg);
 }
 %with-skip-forward-16-mask {
-  @extend %with-mask, %skip-forward-16-svg-prop !optional;
+  @extend %with-mask, %skip-forward-16-svg-prop;
   -webkit-mask-image: var(--skip-forward-16-svg);
   mask-image: var(--skip-forward-16-svg);
 }
 
 %with-skip-forward-24-icon {
-  @extend %with-icon, %skip-forward-24-svg-prop !optional;
+  @extend %with-icon, %skip-forward-24-svg-prop;
   background-image: var(--skip-forward-24-svg);
 }
 %with-skip-forward-24-mask {
-  @extend %with-mask, %skip-forward-24-svg-prop !optional;
+  @extend %with-mask, %skip-forward-24-svg-prop;
   -webkit-mask-image: var(--skip-forward-24-svg);
   mask-image: var(--skip-forward-24-svg);
 }
 
 %with-slack-16-icon {
-  @extend %with-icon, %slack-16-svg-prop !optional;
+  @extend %with-icon, %slack-16-svg-prop;
   background-image: var(--slack-16-svg);
 }
 %with-slack-16-mask {
-  @extend %with-mask, %slack-16-svg-prop !optional;
+  @extend %with-mask, %slack-16-svg-prop;
   -webkit-mask-image: var(--slack-16-svg);
   mask-image: var(--slack-16-svg);
 }
 
 %with-slack-24-icon {
-  @extend %with-icon, %slack-24-svg-prop !optional;
+  @extend %with-icon, %slack-24-svg-prop;
   background-image: var(--slack-24-svg);
 }
 %with-slack-24-mask {
-  @extend %with-mask, %slack-24-svg-prop !optional;
+  @extend %with-mask, %slack-24-svg-prop;
   -webkit-mask-image: var(--slack-24-svg);
   mask-image: var(--slack-24-svg);
 }
 
 %with-slack-color-16-icon {
-  @extend %with-icon, %slack-color-16-svg-prop !optional;
+  @extend %with-icon, %slack-color-16-svg-prop;
   background-image: var(--slack-color-16-svg);
 }
 %with-slack-color-16-mask {
-  @extend %with-mask, %slack-color-16-svg-prop !optional;
+  @extend %with-mask, %slack-color-16-svg-prop;
   -webkit-mask-image: var(--slack-color-16-svg);
   mask-image: var(--slack-color-16-svg);
 }
 
 %with-slack-color-24-icon {
-  @extend %with-icon, %slack-color-24-svg-prop !optional;
+  @extend %with-icon, %slack-color-24-svg-prop;
   background-image: var(--slack-color-24-svg);
 }
 %with-slack-color-24-mask {
-  @extend %with-mask, %slack-color-24-svg-prop !optional;
+  @extend %with-mask, %slack-color-24-svg-prop;
   -webkit-mask-image: var(--slack-color-24-svg);
   mask-image: var(--slack-color-24-svg);
 }
 
 %with-slash-16-icon {
-  @extend %with-icon, %slash-16-svg-prop !optional;
+  @extend %with-icon, %slash-16-svg-prop;
   background-image: var(--slash-16-svg);
 }
 %with-slash-16-mask {
-  @extend %with-mask, %slash-16-svg-prop !optional;
+  @extend %with-mask, %slash-16-svg-prop;
   -webkit-mask-image: var(--slash-16-svg);
   mask-image: var(--slash-16-svg);
 }
 
 %with-slash-24-icon {
-  @extend %with-icon, %slash-24-svg-prop !optional;
+  @extend %with-icon, %slash-24-svg-prop;
   background-image: var(--slash-24-svg);
 }
 %with-slash-24-mask {
-  @extend %with-mask, %slash-24-svg-prop !optional;
+  @extend %with-mask, %slash-24-svg-prop;
   -webkit-mask-image: var(--slash-24-svg);
   mask-image: var(--slash-24-svg);
 }
 
 %with-slash-square-16-icon {
-  @extend %with-icon, %slash-square-16-svg-prop !optional;
+  @extend %with-icon, %slash-square-16-svg-prop;
   background-image: var(--slash-square-16-svg);
 }
 %with-slash-square-16-mask {
-  @extend %with-mask, %slash-square-16-svg-prop !optional;
+  @extend %with-mask, %slash-square-16-svg-prop;
   -webkit-mask-image: var(--slash-square-16-svg);
   mask-image: var(--slash-square-16-svg);
 }
 
 %with-slash-square-24-icon {
-  @extend %with-icon, %slash-square-24-svg-prop !optional;
+  @extend %with-icon, %slash-square-24-svg-prop;
   background-image: var(--slash-square-24-svg);
 }
 %with-slash-square-24-mask {
-  @extend %with-mask, %slash-square-24-svg-prop !optional;
+  @extend %with-mask, %slash-square-24-svg-prop;
   -webkit-mask-image: var(--slash-square-24-svg);
   mask-image: var(--slash-square-24-svg);
 }
 
 %with-sliders-16-icon {
-  @extend %with-icon, %sliders-16-svg-prop !optional;
+  @extend %with-icon, %sliders-16-svg-prop;
   background-image: var(--sliders-16-svg);
 }
 %with-sliders-16-mask {
-  @extend %with-mask, %sliders-16-svg-prop !optional;
+  @extend %with-mask, %sliders-16-svg-prop;
   -webkit-mask-image: var(--sliders-16-svg);
   mask-image: var(--sliders-16-svg);
 }
 
 %with-sliders-24-icon {
-  @extend %with-icon, %sliders-24-svg-prop !optional;
+  @extend %with-icon, %sliders-24-svg-prop;
   background-image: var(--sliders-24-svg);
 }
 %with-sliders-24-mask {
-  @extend %with-mask, %sliders-24-svg-prop !optional;
+  @extend %with-mask, %sliders-24-svg-prop;
   -webkit-mask-image: var(--sliders-24-svg);
   mask-image: var(--sliders-24-svg);
 }
 
 %with-smartphone-16-icon {
-  @extend %with-icon, %smartphone-16-svg-prop !optional;
+  @extend %with-icon, %smartphone-16-svg-prop;
   background-image: var(--smartphone-16-svg);
 }
 %with-smartphone-16-mask {
-  @extend %with-mask, %smartphone-16-svg-prop !optional;
+  @extend %with-mask, %smartphone-16-svg-prop;
   -webkit-mask-image: var(--smartphone-16-svg);
   mask-image: var(--smartphone-16-svg);
 }
 
 %with-smartphone-24-icon {
-  @extend %with-icon, %smartphone-24-svg-prop !optional;
+  @extend %with-icon, %smartphone-24-svg-prop;
   background-image: var(--smartphone-24-svg);
 }
 %with-smartphone-24-mask {
-  @extend %with-mask, %smartphone-24-svg-prop !optional;
+  @extend %with-mask, %smartphone-24-svg-prop;
   -webkit-mask-image: var(--smartphone-24-svg);
   mask-image: var(--smartphone-24-svg);
 }
 
 %with-smile-16-icon {
-  @extend %with-icon, %smile-16-svg-prop !optional;
+  @extend %with-icon, %smile-16-svg-prop;
   background-image: var(--smile-16-svg);
 }
 %with-smile-16-mask {
-  @extend %with-mask, %smile-16-svg-prop !optional;
+  @extend %with-mask, %smile-16-svg-prop;
   -webkit-mask-image: var(--smile-16-svg);
   mask-image: var(--smile-16-svg);
 }
 
 %with-smile-24-icon {
-  @extend %with-icon, %smile-24-svg-prop !optional;
+  @extend %with-icon, %smile-24-svg-prop;
   background-image: var(--smile-24-svg);
 }
 %with-smile-24-mask {
-  @extend %with-mask, %smile-24-svg-prop !optional;
+  @extend %with-mask, %smile-24-svg-prop;
   -webkit-mask-image: var(--smile-24-svg);
   mask-image: var(--smile-24-svg);
 }
 
 %with-socket-16-icon {
-  @extend %with-icon, %socket-16-svg-prop !optional;
+  @extend %with-icon, %socket-16-svg-prop;
   background-image: var(--socket-16-svg);
 }
 %with-socket-16-mask {
-  @extend %with-mask, %socket-16-svg-prop !optional;
+  @extend %with-mask, %socket-16-svg-prop;
   -webkit-mask-image: var(--socket-16-svg);
   mask-image: var(--socket-16-svg);
 }
 
 %with-socket-24-icon {
-  @extend %with-icon, %socket-24-svg-prop !optional;
+  @extend %with-icon, %socket-24-svg-prop;
   background-image: var(--socket-24-svg);
 }
 %with-socket-24-mask {
-  @extend %with-mask, %socket-24-svg-prop !optional;
+  @extend %with-mask, %socket-24-svg-prop;
   -webkit-mask-image: var(--socket-24-svg);
   mask-image: var(--socket-24-svg);
 }
 
 %with-socket-icon {
-  @extend %with-icon, %socket-svg-prop !optional;
+  @extend %with-icon, %socket-svg-prop;
   background-image: var(--socket-svg);
 }
 %with-socket-mask {
-  @extend %with-mask, %socket-svg-prop !optional;
+  @extend %with-mask, %socket-svg-prop;
   -webkit-mask-image: var(--socket-svg);
   mask-image: var(--socket-svg);
 }
 
 %with-sort-asc-16-icon {
-  @extend %with-icon, %sort-asc-16-svg-prop !optional;
+  @extend %with-icon, %sort-asc-16-svg-prop;
   background-image: var(--sort-asc-16-svg);
 }
 %with-sort-asc-16-mask {
-  @extend %with-mask, %sort-asc-16-svg-prop !optional;
+  @extend %with-mask, %sort-asc-16-svg-prop;
   -webkit-mask-image: var(--sort-asc-16-svg);
   mask-image: var(--sort-asc-16-svg);
 }
 
 %with-sort-asc-24-icon {
-  @extend %with-icon, %sort-asc-24-svg-prop !optional;
+  @extend %with-icon, %sort-asc-24-svg-prop;
   background-image: var(--sort-asc-24-svg);
 }
 %with-sort-asc-24-mask {
-  @extend %with-mask, %sort-asc-24-svg-prop !optional;
+  @extend %with-mask, %sort-asc-24-svg-prop;
   -webkit-mask-image: var(--sort-asc-24-svg);
   mask-image: var(--sort-asc-24-svg);
 }
 
 %with-sort-desc-16-icon {
-  @extend %with-icon, %sort-desc-16-svg-prop !optional;
+  @extend %with-icon, %sort-desc-16-svg-prop;
   background-image: var(--sort-desc-16-svg);
 }
 %with-sort-desc-16-mask {
-  @extend %with-mask, %sort-desc-16-svg-prop !optional;
+  @extend %with-mask, %sort-desc-16-svg-prop;
   -webkit-mask-image: var(--sort-desc-16-svg);
   mask-image: var(--sort-desc-16-svg);
 }
 
 %with-sort-desc-24-icon {
-  @extend %with-icon, %sort-desc-24-svg-prop !optional;
+  @extend %with-icon, %sort-desc-24-svg-prop;
   background-image: var(--sort-desc-24-svg);
 }
 %with-sort-desc-24-mask {
-  @extend %with-mask, %sort-desc-24-svg-prop !optional;
+  @extend %with-mask, %sort-desc-24-svg-prop;
   -webkit-mask-image: var(--sort-desc-24-svg);
   mask-image: var(--sort-desc-24-svg);
 }
 
 %with-sort-icon {
-  @extend %with-icon, %sort-svg-prop !optional;
+  @extend %with-icon, %sort-svg-prop;
   background-image: var(--sort-svg);
 }
 %with-sort-mask {
-  @extend %with-mask, %sort-svg-prop !optional;
+  @extend %with-mask, %sort-svg-prop;
   -webkit-mask-image: var(--sort-svg);
   mask-image: var(--sort-svg);
 }
 
 %with-source-file-icon {
-  @extend %with-icon, %source-file-svg-prop !optional;
+  @extend %with-icon, %source-file-svg-prop;
   background-image: var(--source-file-svg);
 }
 %with-source-file-mask {
-  @extend %with-mask, %source-file-svg-prop !optional;
+  @extend %with-mask, %source-file-svg-prop;
   -webkit-mask-image: var(--source-file-svg);
   mask-image: var(--source-file-svg);
 }
 
 %with-speaker-16-icon {
-  @extend %with-icon, %speaker-16-svg-prop !optional;
+  @extend %with-icon, %speaker-16-svg-prop;
   background-image: var(--speaker-16-svg);
 }
 %with-speaker-16-mask {
-  @extend %with-mask, %speaker-16-svg-prop !optional;
+  @extend %with-mask, %speaker-16-svg-prop;
   -webkit-mask-image: var(--speaker-16-svg);
   mask-image: var(--speaker-16-svg);
 }
 
 %with-speaker-24-icon {
-  @extend %with-icon, %speaker-24-svg-prop !optional;
+  @extend %with-icon, %speaker-24-svg-prop;
   background-image: var(--speaker-24-svg);
 }
 %with-speaker-24-mask {
-  @extend %with-mask, %speaker-24-svg-prop !optional;
+  @extend %with-mask, %speaker-24-svg-prop;
   -webkit-mask-image: var(--speaker-24-svg);
   mask-image: var(--speaker-24-svg);
 }
 
 %with-square-16-icon {
-  @extend %with-icon, %square-16-svg-prop !optional;
+  @extend %with-icon, %square-16-svg-prop;
   background-image: var(--square-16-svg);
 }
 %with-square-16-mask {
-  @extend %with-mask, %square-16-svg-prop !optional;
+  @extend %with-mask, %square-16-svg-prop;
   -webkit-mask-image: var(--square-16-svg);
   mask-image: var(--square-16-svg);
 }
 
 %with-square-24-icon {
-  @extend %with-icon, %square-24-svg-prop !optional;
+  @extend %with-icon, %square-24-svg-prop;
   background-image: var(--square-24-svg);
 }
 %with-square-24-mask {
-  @extend %with-mask, %square-24-svg-prop !optional;
+  @extend %with-mask, %square-24-svg-prop;
   -webkit-mask-image: var(--square-24-svg);
   mask-image: var(--square-24-svg);
 }
 
 %with-square-fill-16-icon {
-  @extend %with-icon, %square-fill-16-svg-prop !optional;
+  @extend %with-icon, %square-fill-16-svg-prop;
   background-image: var(--square-fill-16-svg);
 }
 %with-square-fill-16-mask {
-  @extend %with-mask, %square-fill-16-svg-prop !optional;
+  @extend %with-mask, %square-fill-16-svg-prop;
   -webkit-mask-image: var(--square-fill-16-svg);
   mask-image: var(--square-fill-16-svg);
 }
 
 %with-square-fill-24-icon {
-  @extend %with-icon, %square-fill-24-svg-prop !optional;
+  @extend %with-icon, %square-fill-24-svg-prop;
   background-image: var(--square-fill-24-svg);
 }
 %with-square-fill-24-mask {
-  @extend %with-mask, %square-fill-24-svg-prop !optional;
+  @extend %with-mask, %square-fill-24-svg-prop;
   -webkit-mask-image: var(--square-fill-24-svg);
   mask-image: var(--square-fill-24-svg);
 }
 
 %with-star-16-icon {
-  @extend %with-icon, %star-16-svg-prop !optional;
+  @extend %with-icon, %star-16-svg-prop;
   background-image: var(--star-16-svg);
 }
 %with-star-16-mask {
-  @extend %with-mask, %star-16-svg-prop !optional;
+  @extend %with-mask, %star-16-svg-prop;
   -webkit-mask-image: var(--star-16-svg);
   mask-image: var(--star-16-svg);
 }
 
 %with-star-24-icon {
-  @extend %with-icon, %star-24-svg-prop !optional;
+  @extend %with-icon, %star-24-svg-prop;
   background-image: var(--star-24-svg);
 }
 %with-star-24-mask {
-  @extend %with-mask, %star-24-svg-prop !optional;
+  @extend %with-mask, %star-24-svg-prop;
   -webkit-mask-image: var(--star-24-svg);
   mask-image: var(--star-24-svg);
 }
 
 %with-star-circle-16-icon {
-  @extend %with-icon, %star-circle-16-svg-prop !optional;
+  @extend %with-icon, %star-circle-16-svg-prop;
   background-image: var(--star-circle-16-svg);
 }
 %with-star-circle-16-mask {
-  @extend %with-mask, %star-circle-16-svg-prop !optional;
+  @extend %with-mask, %star-circle-16-svg-prop;
   -webkit-mask-image: var(--star-circle-16-svg);
   mask-image: var(--star-circle-16-svg);
 }
 
 %with-star-circle-24-icon {
-  @extend %with-icon, %star-circle-24-svg-prop !optional;
+  @extend %with-icon, %star-circle-24-svg-prop;
   background-image: var(--star-circle-24-svg);
 }
 %with-star-circle-24-mask {
-  @extend %with-mask, %star-circle-24-svg-prop !optional;
+  @extend %with-mask, %star-circle-24-svg-prop;
   -webkit-mask-image: var(--star-circle-24-svg);
   mask-image: var(--star-circle-24-svg);
 }
 
 %with-star-fill-16-icon {
-  @extend %with-icon, %star-fill-16-svg-prop !optional;
+  @extend %with-icon, %star-fill-16-svg-prop;
   background-image: var(--star-fill-16-svg);
 }
 %with-star-fill-16-mask {
-  @extend %with-mask, %star-fill-16-svg-prop !optional;
+  @extend %with-mask, %star-fill-16-svg-prop;
   -webkit-mask-image: var(--star-fill-16-svg);
   mask-image: var(--star-fill-16-svg);
 }
 
 %with-star-fill-24-icon {
-  @extend %with-icon, %star-fill-24-svg-prop !optional;
+  @extend %with-icon, %star-fill-24-svg-prop;
   background-image: var(--star-fill-24-svg);
 }
 %with-star-fill-24-mask {
-  @extend %with-mask, %star-fill-24-svg-prop !optional;
+  @extend %with-mask, %star-fill-24-svg-prop;
   -webkit-mask-image: var(--star-fill-24-svg);
   mask-image: var(--star-fill-24-svg);
 }
 
 %with-star-fill-icon {
-  @extend %with-icon, %star-fill-svg-prop !optional;
+  @extend %with-icon, %star-fill-svg-prop;
   background-image: var(--star-fill-svg);
 }
 %with-star-fill-mask {
-  @extend %with-mask, %star-fill-svg-prop !optional;
+  @extend %with-mask, %star-fill-svg-prop;
   -webkit-mask-image: var(--star-fill-svg);
   mask-image: var(--star-fill-svg);
 }
 
 %with-star-off-16-icon {
-  @extend %with-icon, %star-off-16-svg-prop !optional;
+  @extend %with-icon, %star-off-16-svg-prop;
   background-image: var(--star-off-16-svg);
 }
 %with-star-off-16-mask {
-  @extend %with-mask, %star-off-16-svg-prop !optional;
+  @extend %with-mask, %star-off-16-svg-prop;
   -webkit-mask-image: var(--star-off-16-svg);
   mask-image: var(--star-off-16-svg);
 }
 
 %with-star-off-24-icon {
-  @extend %with-icon, %star-off-24-svg-prop !optional;
+  @extend %with-icon, %star-off-24-svg-prop;
   background-image: var(--star-off-24-svg);
 }
 %with-star-off-24-mask {
-  @extend %with-mask, %star-off-24-svg-prop !optional;
+  @extend %with-mask, %star-off-24-svg-prop;
   -webkit-mask-image: var(--star-off-24-svg);
   mask-image: var(--star-off-24-svg);
 }
 
 %with-star-outline-icon {
-  @extend %with-icon, %star-outline-svg-prop !optional;
+  @extend %with-icon, %star-outline-svg-prop;
   background-image: var(--star-outline-svg);
 }
 %with-star-outline-mask {
-  @extend %with-mask, %star-outline-svg-prop !optional;
+  @extend %with-mask, %star-outline-svg-prop;
   -webkit-mask-image: var(--star-outline-svg);
   mask-image: var(--star-outline-svg);
 }
 
 %with-stop-circle-16-icon {
-  @extend %with-icon, %stop-circle-16-svg-prop !optional;
+  @extend %with-icon, %stop-circle-16-svg-prop;
   background-image: var(--stop-circle-16-svg);
 }
 %with-stop-circle-16-mask {
-  @extend %with-mask, %stop-circle-16-svg-prop !optional;
+  @extend %with-mask, %stop-circle-16-svg-prop;
   -webkit-mask-image: var(--stop-circle-16-svg);
   mask-image: var(--stop-circle-16-svg);
 }
 
 %with-stop-circle-24-icon {
-  @extend %with-icon, %stop-circle-24-svg-prop !optional;
+  @extend %with-icon, %stop-circle-24-svg-prop;
   background-image: var(--stop-circle-24-svg);
 }
 %with-stop-circle-24-mask {
-  @extend %with-mask, %stop-circle-24-svg-prop !optional;
+  @extend %with-mask, %stop-circle-24-svg-prop;
   -webkit-mask-image: var(--stop-circle-24-svg);
   mask-image: var(--stop-circle-24-svg);
 }
 
 %with-sub-left-icon {
-  @extend %with-icon, %sub-left-svg-prop !optional;
+  @extend %with-icon, %sub-left-svg-prop;
   background-image: var(--sub-left-svg);
 }
 %with-sub-left-mask {
-  @extend %with-mask, %sub-left-svg-prop !optional;
+  @extend %with-mask, %sub-left-svg-prop;
   -webkit-mask-image: var(--sub-left-svg);
   mask-image: var(--sub-left-svg);
 }
 
 %with-sub-right-icon {
-  @extend %with-icon, %sub-right-svg-prop !optional;
+  @extend %with-icon, %sub-right-svg-prop;
   background-image: var(--sub-right-svg);
 }
 %with-sub-right-mask {
-  @extend %with-mask, %sub-right-svg-prop !optional;
+  @extend %with-mask, %sub-right-svg-prop;
   -webkit-mask-image: var(--sub-right-svg);
   mask-image: var(--sub-right-svg);
 }
 
 %with-sun-16-icon {
-  @extend %with-icon, %sun-16-svg-prop !optional;
+  @extend %with-icon, %sun-16-svg-prop;
   background-image: var(--sun-16-svg);
 }
 %with-sun-16-mask {
-  @extend %with-mask, %sun-16-svg-prop !optional;
+  @extend %with-mask, %sun-16-svg-prop;
   -webkit-mask-image: var(--sun-16-svg);
   mask-image: var(--sun-16-svg);
 }
 
 %with-sun-24-icon {
-  @extend %with-icon, %sun-24-svg-prop !optional;
+  @extend %with-icon, %sun-24-svg-prop;
   background-image: var(--sun-24-svg);
 }
 %with-sun-24-mask {
-  @extend %with-mask, %sun-24-svg-prop !optional;
+  @extend %with-mask, %sun-24-svg-prop;
   -webkit-mask-image: var(--sun-24-svg);
   mask-image: var(--sun-24-svg);
 }
 
 %with-support-16-icon {
-  @extend %with-icon, %support-16-svg-prop !optional;
+  @extend %with-icon, %support-16-svg-prop;
   background-image: var(--support-16-svg);
 }
 %with-support-16-mask {
-  @extend %with-mask, %support-16-svg-prop !optional;
+  @extend %with-mask, %support-16-svg-prop;
   -webkit-mask-image: var(--support-16-svg);
   mask-image: var(--support-16-svg);
 }
 
 %with-support-24-icon {
-  @extend %with-icon, %support-24-svg-prop !optional;
+  @extend %with-icon, %support-24-svg-prop;
   background-image: var(--support-24-svg);
 }
 %with-support-24-mask {
-  @extend %with-mask, %support-24-svg-prop !optional;
+  @extend %with-mask, %support-24-svg-prop;
   -webkit-mask-image: var(--support-24-svg);
   mask-image: var(--support-24-svg);
 }
 
 %with-support-icon {
-  @extend %with-icon, %support-svg-prop !optional;
+  @extend %with-icon, %support-svg-prop;
   background-image: var(--support-svg);
 }
 %with-support-mask {
-  @extend %with-mask, %support-svg-prop !optional;
+  @extend %with-mask, %support-svg-prop;
   -webkit-mask-image: var(--support-svg);
   mask-image: var(--support-svg);
 }
 
 %with-swap-horizontal-16-icon {
-  @extend %with-icon, %swap-horizontal-16-svg-prop !optional;
+  @extend %with-icon, %swap-horizontal-16-svg-prop;
   background-image: var(--swap-horizontal-16-svg);
 }
 %with-swap-horizontal-16-mask {
-  @extend %with-mask, %swap-horizontal-16-svg-prop !optional;
+  @extend %with-mask, %swap-horizontal-16-svg-prop;
   -webkit-mask-image: var(--swap-horizontal-16-svg);
   mask-image: var(--swap-horizontal-16-svg);
 }
 
 %with-swap-horizontal-24-icon {
-  @extend %with-icon, %swap-horizontal-24-svg-prop !optional;
+  @extend %with-icon, %swap-horizontal-24-svg-prop;
   background-image: var(--swap-horizontal-24-svg);
 }
 %with-swap-horizontal-24-mask {
-  @extend %with-mask, %swap-horizontal-24-svg-prop !optional;
+  @extend %with-mask, %swap-horizontal-24-svg-prop;
   -webkit-mask-image: var(--swap-horizontal-24-svg);
   mask-image: var(--swap-horizontal-24-svg);
 }
 
 %with-swap-horizontal-icon {
-  @extend %with-icon, %swap-horizontal-svg-prop !optional;
+  @extend %with-icon, %swap-horizontal-svg-prop;
   background-image: var(--swap-horizontal-svg);
 }
 %with-swap-horizontal-mask {
-  @extend %with-mask, %swap-horizontal-svg-prop !optional;
+  @extend %with-mask, %swap-horizontal-svg-prop;
   -webkit-mask-image: var(--swap-horizontal-svg);
   mask-image: var(--swap-horizontal-svg);
 }
 
 %with-swap-vertical-16-icon {
-  @extend %with-icon, %swap-vertical-16-svg-prop !optional;
+  @extend %with-icon, %swap-vertical-16-svg-prop;
   background-image: var(--swap-vertical-16-svg);
 }
 %with-swap-vertical-16-mask {
-  @extend %with-mask, %swap-vertical-16-svg-prop !optional;
+  @extend %with-mask, %swap-vertical-16-svg-prop;
   -webkit-mask-image: var(--swap-vertical-16-svg);
   mask-image: var(--swap-vertical-16-svg);
 }
 
 %with-swap-vertical-24-icon {
-  @extend %with-icon, %swap-vertical-24-svg-prop !optional;
+  @extend %with-icon, %swap-vertical-24-svg-prop;
   background-image: var(--swap-vertical-24-svg);
 }
 %with-swap-vertical-24-mask {
-  @extend %with-mask, %swap-vertical-24-svg-prop !optional;
+  @extend %with-mask, %swap-vertical-24-svg-prop;
   -webkit-mask-image: var(--swap-vertical-24-svg);
   mask-image: var(--swap-vertical-24-svg);
 }
 
 %with-swap-vertical-icon {
-  @extend %with-icon, %swap-vertical-svg-prop !optional;
+  @extend %with-icon, %swap-vertical-svg-prop;
   background-image: var(--swap-vertical-svg);
 }
 %with-swap-vertical-mask {
-  @extend %with-mask, %swap-vertical-svg-prop !optional;
+  @extend %with-mask, %swap-vertical-svg-prop;
   -webkit-mask-image: var(--swap-vertical-svg);
   mask-image: var(--swap-vertical-svg);
 }
 
 %with-switcher-16-icon {
-  @extend %with-icon, %switcher-16-svg-prop !optional;
+  @extend %with-icon, %switcher-16-svg-prop;
   background-image: var(--switcher-16-svg);
 }
 %with-switcher-16-mask {
-  @extend %with-mask, %switcher-16-svg-prop !optional;
+  @extend %with-mask, %switcher-16-svg-prop;
   -webkit-mask-image: var(--switcher-16-svg);
   mask-image: var(--switcher-16-svg);
 }
 
 %with-switcher-24-icon {
-  @extend %with-icon, %switcher-24-svg-prop !optional;
+  @extend %with-icon, %switcher-24-svg-prop;
   background-image: var(--switcher-24-svg);
 }
 %with-switcher-24-mask {
-  @extend %with-mask, %switcher-24-svg-prop !optional;
+  @extend %with-mask, %switcher-24-svg-prop;
   -webkit-mask-image: var(--switcher-24-svg);
   mask-image: var(--switcher-24-svg);
 }
 
 %with-sync-16-icon {
-  @extend %with-icon, %sync-16-svg-prop !optional;
+  @extend %with-icon, %sync-16-svg-prop;
   background-image: var(--sync-16-svg);
 }
 %with-sync-16-mask {
-  @extend %with-mask, %sync-16-svg-prop !optional;
+  @extend %with-mask, %sync-16-svg-prop;
   -webkit-mask-image: var(--sync-16-svg);
   mask-image: var(--sync-16-svg);
 }
 
 %with-sync-24-icon {
-  @extend %with-icon, %sync-24-svg-prop !optional;
+  @extend %with-icon, %sync-24-svg-prop;
   background-image: var(--sync-24-svg);
 }
 %with-sync-24-mask {
-  @extend %with-mask, %sync-24-svg-prop !optional;
+  @extend %with-mask, %sync-24-svg-prop;
   -webkit-mask-image: var(--sync-24-svg);
   mask-image: var(--sync-24-svg);
 }
 
 %with-sync-alert-16-icon {
-  @extend %with-icon, %sync-alert-16-svg-prop !optional;
+  @extend %with-icon, %sync-alert-16-svg-prop;
   background-image: var(--sync-alert-16-svg);
 }
 %with-sync-alert-16-mask {
-  @extend %with-mask, %sync-alert-16-svg-prop !optional;
+  @extend %with-mask, %sync-alert-16-svg-prop;
   -webkit-mask-image: var(--sync-alert-16-svg);
   mask-image: var(--sync-alert-16-svg);
 }
 
 %with-sync-alert-24-icon {
-  @extend %with-icon, %sync-alert-24-svg-prop !optional;
+  @extend %with-icon, %sync-alert-24-svg-prop;
   background-image: var(--sync-alert-24-svg);
 }
 %with-sync-alert-24-mask {
-  @extend %with-mask, %sync-alert-24-svg-prop !optional;
+  @extend %with-mask, %sync-alert-24-svg-prop;
   -webkit-mask-image: var(--sync-alert-24-svg);
   mask-image: var(--sync-alert-24-svg);
 }
 
 %with-sync-reverse-16-icon {
-  @extend %with-icon, %sync-reverse-16-svg-prop !optional;
+  @extend %with-icon, %sync-reverse-16-svg-prop;
   background-image: var(--sync-reverse-16-svg);
 }
 %with-sync-reverse-16-mask {
-  @extend %with-mask, %sync-reverse-16-svg-prop !optional;
+  @extend %with-mask, %sync-reverse-16-svg-prop;
   -webkit-mask-image: var(--sync-reverse-16-svg);
   mask-image: var(--sync-reverse-16-svg);
 }
 
 %with-sync-reverse-24-icon {
-  @extend %with-icon, %sync-reverse-24-svg-prop !optional;
+  @extend %with-icon, %sync-reverse-24-svg-prop;
   background-image: var(--sync-reverse-24-svg);
 }
 %with-sync-reverse-24-mask {
-  @extend %with-mask, %sync-reverse-24-svg-prop !optional;
+  @extend %with-mask, %sync-reverse-24-svg-prop;
   -webkit-mask-image: var(--sync-reverse-24-svg);
   mask-image: var(--sync-reverse-24-svg);
 }
 
 %with-tablet-16-icon {
-  @extend %with-icon, %tablet-16-svg-prop !optional;
+  @extend %with-icon, %tablet-16-svg-prop;
   background-image: var(--tablet-16-svg);
 }
 %with-tablet-16-mask {
-  @extend %with-mask, %tablet-16-svg-prop !optional;
+  @extend %with-mask, %tablet-16-svg-prop;
   -webkit-mask-image: var(--tablet-16-svg);
   mask-image: var(--tablet-16-svg);
 }
 
 %with-tablet-24-icon {
-  @extend %with-icon, %tablet-24-svg-prop !optional;
+  @extend %with-icon, %tablet-24-svg-prop;
   background-image: var(--tablet-24-svg);
 }
 %with-tablet-24-mask {
-  @extend %with-mask, %tablet-24-svg-prop !optional;
+  @extend %with-mask, %tablet-24-svg-prop;
   -webkit-mask-image: var(--tablet-24-svg);
   mask-image: var(--tablet-24-svg);
 }
 
 %with-tag-16-icon {
-  @extend %with-icon, %tag-16-svg-prop !optional;
+  @extend %with-icon, %tag-16-svg-prop;
   background-image: var(--tag-16-svg);
 }
 %with-tag-16-mask {
-  @extend %with-mask, %tag-16-svg-prop !optional;
+  @extend %with-mask, %tag-16-svg-prop;
   -webkit-mask-image: var(--tag-16-svg);
   mask-image: var(--tag-16-svg);
 }
 
 %with-tag-24-icon {
-  @extend %with-icon, %tag-24-svg-prop !optional;
+  @extend %with-icon, %tag-24-svg-prop;
   background-image: var(--tag-24-svg);
 }
 %with-tag-24-mask {
-  @extend %with-mask, %tag-24-svg-prop !optional;
+  @extend %with-mask, %tag-24-svg-prop;
   -webkit-mask-image: var(--tag-24-svg);
   mask-image: var(--tag-24-svg);
 }
 
 %with-tag-icon {
-  @extend %with-icon, %tag-svg-prop !optional;
+  @extend %with-icon, %tag-svg-prop;
   background-image: var(--tag-svg);
 }
 %with-tag-mask {
-  @extend %with-mask, %tag-svg-prop !optional;
+  @extend %with-mask, %tag-svg-prop;
   -webkit-mask-image: var(--tag-svg);
   mask-image: var(--tag-svg);
 }
 
 %with-target-16-icon {
-  @extend %with-icon, %target-16-svg-prop !optional;
+  @extend %with-icon, %target-16-svg-prop;
   background-image: var(--target-16-svg);
 }
 %with-target-16-mask {
-  @extend %with-mask, %target-16-svg-prop !optional;
+  @extend %with-mask, %target-16-svg-prop;
   -webkit-mask-image: var(--target-16-svg);
   mask-image: var(--target-16-svg);
 }
 
 %with-target-24-icon {
-  @extend %with-icon, %target-24-svg-prop !optional;
+  @extend %with-icon, %target-24-svg-prop;
   background-image: var(--target-24-svg);
 }
 %with-target-24-mask {
-  @extend %with-mask, %target-24-svg-prop !optional;
+  @extend %with-mask, %target-24-svg-prop;
   -webkit-mask-image: var(--target-24-svg);
   mask-image: var(--target-24-svg);
 }
 
 %with-terminal-16-icon {
-  @extend %with-icon, %terminal-16-svg-prop !optional;
+  @extend %with-icon, %terminal-16-svg-prop;
   background-image: var(--terminal-16-svg);
 }
 %with-terminal-16-mask {
-  @extend %with-mask, %terminal-16-svg-prop !optional;
+  @extend %with-mask, %terminal-16-svg-prop;
   -webkit-mask-image: var(--terminal-16-svg);
   mask-image: var(--terminal-16-svg);
 }
 
 %with-terminal-24-icon {
-  @extend %with-icon, %terminal-24-svg-prop !optional;
+  @extend %with-icon, %terminal-24-svg-prop;
   background-image: var(--terminal-24-svg);
 }
 %with-terminal-24-mask {
-  @extend %with-mask, %terminal-24-svg-prop !optional;
+  @extend %with-mask, %terminal-24-svg-prop;
   -webkit-mask-image: var(--terminal-24-svg);
   mask-image: var(--terminal-24-svg);
 }
 
 %with-terminal-screen-16-icon {
-  @extend %with-icon, %terminal-screen-16-svg-prop !optional;
+  @extend %with-icon, %terminal-screen-16-svg-prop;
   background-image: var(--terminal-screen-16-svg);
 }
 %with-terminal-screen-16-mask {
-  @extend %with-mask, %terminal-screen-16-svg-prop !optional;
+  @extend %with-mask, %terminal-screen-16-svg-prop;
   -webkit-mask-image: var(--terminal-screen-16-svg);
   mask-image: var(--terminal-screen-16-svg);
 }
 
 %with-terminal-screen-24-icon {
-  @extend %with-icon, %terminal-screen-24-svg-prop !optional;
+  @extend %with-icon, %terminal-screen-24-svg-prop;
   background-image: var(--terminal-screen-24-svg);
 }
 %with-terminal-screen-24-mask {
-  @extend %with-mask, %terminal-screen-24-svg-prop !optional;
+  @extend %with-mask, %terminal-screen-24-svg-prop;
   -webkit-mask-image: var(--terminal-screen-24-svg);
   mask-image: var(--terminal-screen-24-svg);
 }
 
 %with-thumbs-down-16-icon {
-  @extend %with-icon, %thumbs-down-16-svg-prop !optional;
+  @extend %with-icon, %thumbs-down-16-svg-prop;
   background-image: var(--thumbs-down-16-svg);
 }
 %with-thumbs-down-16-mask {
-  @extend %with-mask, %thumbs-down-16-svg-prop !optional;
+  @extend %with-mask, %thumbs-down-16-svg-prop;
   -webkit-mask-image: var(--thumbs-down-16-svg);
   mask-image: var(--thumbs-down-16-svg);
 }
 
 %with-thumbs-down-24-icon {
-  @extend %with-icon, %thumbs-down-24-svg-prop !optional;
+  @extend %with-icon, %thumbs-down-24-svg-prop;
   background-image: var(--thumbs-down-24-svg);
 }
 %with-thumbs-down-24-mask {
-  @extend %with-mask, %thumbs-down-24-svg-prop !optional;
+  @extend %with-mask, %thumbs-down-24-svg-prop;
   -webkit-mask-image: var(--thumbs-down-24-svg);
   mask-image: var(--thumbs-down-24-svg);
 }
 
 %with-thumbs-up-16-icon {
-  @extend %with-icon, %thumbs-up-16-svg-prop !optional;
+  @extend %with-icon, %thumbs-up-16-svg-prop;
   background-image: var(--thumbs-up-16-svg);
 }
 %with-thumbs-up-16-mask {
-  @extend %with-mask, %thumbs-up-16-svg-prop !optional;
+  @extend %with-mask, %thumbs-up-16-svg-prop;
   -webkit-mask-image: var(--thumbs-up-16-svg);
   mask-image: var(--thumbs-up-16-svg);
 }
 
 %with-thumbs-up-24-icon {
-  @extend %with-icon, %thumbs-up-24-svg-prop !optional;
+  @extend %with-icon, %thumbs-up-24-svg-prop;
   background-image: var(--thumbs-up-24-svg);
 }
 %with-thumbs-up-24-mask {
-  @extend %with-mask, %thumbs-up-24-svg-prop !optional;
+  @extend %with-mask, %thumbs-up-24-svg-prop;
   -webkit-mask-image: var(--thumbs-up-24-svg);
   mask-image: var(--thumbs-up-24-svg);
 }
 
 %with-toggle-left-16-icon {
-  @extend %with-icon, %toggle-left-16-svg-prop !optional;
+  @extend %with-icon, %toggle-left-16-svg-prop;
   background-image: var(--toggle-left-16-svg);
 }
 %with-toggle-left-16-mask {
-  @extend %with-mask, %toggle-left-16-svg-prop !optional;
+  @extend %with-mask, %toggle-left-16-svg-prop;
   -webkit-mask-image: var(--toggle-left-16-svg);
   mask-image: var(--toggle-left-16-svg);
 }
 
 %with-toggle-left-24-icon {
-  @extend %with-icon, %toggle-left-24-svg-prop !optional;
+  @extend %with-icon, %toggle-left-24-svg-prop;
   background-image: var(--toggle-left-24-svg);
 }
 %with-toggle-left-24-mask {
-  @extend %with-mask, %toggle-left-24-svg-prop !optional;
+  @extend %with-mask, %toggle-left-24-svg-prop;
   -webkit-mask-image: var(--toggle-left-24-svg);
   mask-image: var(--toggle-left-24-svg);
 }
 
 %with-toggle-right-16-icon {
-  @extend %with-icon, %toggle-right-16-svg-prop !optional;
+  @extend %with-icon, %toggle-right-16-svg-prop;
   background-image: var(--toggle-right-16-svg);
 }
 %with-toggle-right-16-mask {
-  @extend %with-mask, %toggle-right-16-svg-prop !optional;
+  @extend %with-mask, %toggle-right-16-svg-prop;
   -webkit-mask-image: var(--toggle-right-16-svg);
   mask-image: var(--toggle-right-16-svg);
 }
 
 %with-toggle-right-24-icon {
-  @extend %with-icon, %toggle-right-24-svg-prop !optional;
+  @extend %with-icon, %toggle-right-24-svg-prop;
   background-image: var(--toggle-right-24-svg);
 }
 %with-toggle-right-24-mask {
-  @extend %with-mask, %toggle-right-24-svg-prop !optional;
+  @extend %with-mask, %toggle-right-24-svg-prop;
   -webkit-mask-image: var(--toggle-right-24-svg);
   mask-image: var(--toggle-right-24-svg);
 }
 
 %with-token-16-icon {
-  @extend %with-icon, %token-16-svg-prop !optional;
+  @extend %with-icon, %token-16-svg-prop;
   background-image: var(--token-16-svg);
 }
 %with-token-16-mask {
-  @extend %with-mask, %token-16-svg-prop !optional;
+  @extend %with-mask, %token-16-svg-prop;
   -webkit-mask-image: var(--token-16-svg);
   mask-image: var(--token-16-svg);
 }
 
 %with-token-24-icon {
-  @extend %with-icon, %token-24-svg-prop !optional;
+  @extend %with-icon, %token-24-svg-prop;
   background-image: var(--token-24-svg);
 }
 %with-token-24-mask {
-  @extend %with-mask, %token-24-svg-prop !optional;
+  @extend %with-mask, %token-24-svg-prop;
   -webkit-mask-image: var(--token-24-svg);
   mask-image: var(--token-24-svg);
 }
 
 %with-tools-16-icon {
-  @extend %with-icon, %tools-16-svg-prop !optional;
+  @extend %with-icon, %tools-16-svg-prop;
   background-image: var(--tools-16-svg);
 }
 %with-tools-16-mask {
-  @extend %with-mask, %tools-16-svg-prop !optional;
+  @extend %with-mask, %tools-16-svg-prop;
   -webkit-mask-image: var(--tools-16-svg);
   mask-image: var(--tools-16-svg);
 }
 
 %with-tools-24-icon {
-  @extend %with-icon, %tools-24-svg-prop !optional;
+  @extend %with-icon, %tools-24-svg-prop;
   background-image: var(--tools-24-svg);
 }
 %with-tools-24-mask {
-  @extend %with-mask, %tools-24-svg-prop !optional;
+  @extend %with-mask, %tools-24-svg-prop;
   -webkit-mask-image: var(--tools-24-svg);
   mask-image: var(--tools-24-svg);
 }
 
 %with-top-16-icon {
-  @extend %with-icon, %top-16-svg-prop !optional;
+  @extend %with-icon, %top-16-svg-prop;
   background-image: var(--top-16-svg);
 }
 %with-top-16-mask {
-  @extend %with-mask, %top-16-svg-prop !optional;
+  @extend %with-mask, %top-16-svg-prop;
   -webkit-mask-image: var(--top-16-svg);
   mask-image: var(--top-16-svg);
 }
 
 %with-top-24-icon {
-  @extend %with-icon, %top-24-svg-prop !optional;
+  @extend %with-icon, %top-24-svg-prop;
   background-image: var(--top-24-svg);
 }
 %with-top-24-mask {
-  @extend %with-mask, %top-24-svg-prop !optional;
+  @extend %with-mask, %top-24-svg-prop;
   -webkit-mask-image: var(--top-24-svg);
   mask-image: var(--top-24-svg);
 }
 
 %with-trash-16-icon {
-  @extend %with-icon, %trash-16-svg-prop !optional;
+  @extend %with-icon, %trash-16-svg-prop;
   background-image: var(--trash-16-svg);
 }
 %with-trash-16-mask {
-  @extend %with-mask, %trash-16-svg-prop !optional;
+  @extend %with-mask, %trash-16-svg-prop;
   -webkit-mask-image: var(--trash-16-svg);
   mask-image: var(--trash-16-svg);
 }
 
 %with-trash-24-icon {
-  @extend %with-icon, %trash-24-svg-prop !optional;
+  @extend %with-icon, %trash-24-svg-prop;
   background-image: var(--trash-24-svg);
 }
 %with-trash-24-mask {
-  @extend %with-mask, %trash-24-svg-prop !optional;
+  @extend %with-mask, %trash-24-svg-prop;
   -webkit-mask-image: var(--trash-24-svg);
   mask-image: var(--trash-24-svg);
 }
 
 %with-trash-icon {
-  @extend %with-icon, %trash-svg-prop !optional;
+  @extend %with-icon, %trash-svg-prop;
   background-image: var(--trash-svg);
 }
 %with-trash-mask {
-  @extend %with-mask, %trash-svg-prop !optional;
+  @extend %with-mask, %trash-svg-prop;
   -webkit-mask-image: var(--trash-svg);
   mask-image: var(--trash-svg);
 }
 
 %with-trend-down-16-icon {
-  @extend %with-icon, %trend-down-16-svg-prop !optional;
+  @extend %with-icon, %trend-down-16-svg-prop;
   background-image: var(--trend-down-16-svg);
 }
 %with-trend-down-16-mask {
-  @extend %with-mask, %trend-down-16-svg-prop !optional;
+  @extend %with-mask, %trend-down-16-svg-prop;
   -webkit-mask-image: var(--trend-down-16-svg);
   mask-image: var(--trend-down-16-svg);
 }
 
 %with-trend-down-24-icon {
-  @extend %with-icon, %trend-down-24-svg-prop !optional;
+  @extend %with-icon, %trend-down-24-svg-prop;
   background-image: var(--trend-down-24-svg);
 }
 %with-trend-down-24-mask {
-  @extend %with-mask, %trend-down-24-svg-prop !optional;
+  @extend %with-mask, %trend-down-24-svg-prop;
   -webkit-mask-image: var(--trend-down-24-svg);
   mask-image: var(--trend-down-24-svg);
 }
 
 %with-trend-up-16-icon {
-  @extend %with-icon, %trend-up-16-svg-prop !optional;
+  @extend %with-icon, %trend-up-16-svg-prop;
   background-image: var(--trend-up-16-svg);
 }
 %with-trend-up-16-mask {
-  @extend %with-mask, %trend-up-16-svg-prop !optional;
+  @extend %with-mask, %trend-up-16-svg-prop;
   -webkit-mask-image: var(--trend-up-16-svg);
   mask-image: var(--trend-up-16-svg);
 }
 
 %with-trend-up-24-icon {
-  @extend %with-icon, %trend-up-24-svg-prop !optional;
+  @extend %with-icon, %trend-up-24-svg-prop;
   background-image: var(--trend-up-24-svg);
 }
 %with-trend-up-24-mask {
-  @extend %with-mask, %trend-up-24-svg-prop !optional;
+  @extend %with-mask, %trend-up-24-svg-prop;
   -webkit-mask-image: var(--trend-up-24-svg);
   mask-image: var(--trend-up-24-svg);
 }
 
 %with-triangle-16-icon {
-  @extend %with-icon, %triangle-16-svg-prop !optional;
+  @extend %with-icon, %triangle-16-svg-prop;
   background-image: var(--triangle-16-svg);
 }
 %with-triangle-16-mask {
-  @extend %with-mask, %triangle-16-svg-prop !optional;
+  @extend %with-mask, %triangle-16-svg-prop;
   -webkit-mask-image: var(--triangle-16-svg);
   mask-image: var(--triangle-16-svg);
 }
 
 %with-triangle-24-icon {
-  @extend %with-icon, %triangle-24-svg-prop !optional;
+  @extend %with-icon, %triangle-24-svg-prop;
   background-image: var(--triangle-24-svg);
 }
 %with-triangle-24-mask {
-  @extend %with-mask, %triangle-24-svg-prop !optional;
+  @extend %with-mask, %triangle-24-svg-prop;
   -webkit-mask-image: var(--triangle-24-svg);
   mask-image: var(--triangle-24-svg);
 }
 
 %with-triangle-fill-16-icon {
-  @extend %with-icon, %triangle-fill-16-svg-prop !optional;
+  @extend %with-icon, %triangle-fill-16-svg-prop;
   background-image: var(--triangle-fill-16-svg);
 }
 %with-triangle-fill-16-mask {
-  @extend %with-mask, %triangle-fill-16-svg-prop !optional;
+  @extend %with-mask, %triangle-fill-16-svg-prop;
   -webkit-mask-image: var(--triangle-fill-16-svg);
   mask-image: var(--triangle-fill-16-svg);
 }
 
 %with-triangle-fill-24-icon {
-  @extend %with-icon, %triangle-fill-24-svg-prop !optional;
+  @extend %with-icon, %triangle-fill-24-svg-prop;
   background-image: var(--triangle-fill-24-svg);
 }
 %with-triangle-fill-24-mask {
-  @extend %with-mask, %triangle-fill-24-svg-prop !optional;
+  @extend %with-mask, %triangle-fill-24-svg-prop;
   -webkit-mask-image: var(--triangle-fill-24-svg);
   mask-image: var(--triangle-fill-24-svg);
 }
 
 %with-truck-16-icon {
-  @extend %with-icon, %truck-16-svg-prop !optional;
+  @extend %with-icon, %truck-16-svg-prop;
   background-image: var(--truck-16-svg);
 }
 %with-truck-16-mask {
-  @extend %with-mask, %truck-16-svg-prop !optional;
+  @extend %with-mask, %truck-16-svg-prop;
   -webkit-mask-image: var(--truck-16-svg);
   mask-image: var(--truck-16-svg);
 }
 
 %with-truck-24-icon {
-  @extend %with-icon, %truck-24-svg-prop !optional;
+  @extend %with-icon, %truck-24-svg-prop;
   background-image: var(--truck-24-svg);
 }
 %with-truck-24-mask {
-  @extend %with-mask, %truck-24-svg-prop !optional;
+  @extend %with-mask, %truck-24-svg-prop;
   -webkit-mask-image: var(--truck-24-svg);
   mask-image: var(--truck-24-svg);
 }
 
 %with-tune-icon {
-  @extend %with-icon, %tune-svg-prop !optional;
+  @extend %with-icon, %tune-svg-prop;
   background-image: var(--tune-svg);
 }
 %with-tune-mask {
-  @extend %with-mask, %tune-svg-prop !optional;
+  @extend %with-mask, %tune-svg-prop;
   -webkit-mask-image: var(--tune-svg);
   mask-image: var(--tune-svg);
 }
 
 %with-tv-16-icon {
-  @extend %with-icon, %tv-16-svg-prop !optional;
+  @extend %with-icon, %tv-16-svg-prop;
   background-image: var(--tv-16-svg);
 }
 %with-tv-16-mask {
-  @extend %with-mask, %tv-16-svg-prop !optional;
+  @extend %with-mask, %tv-16-svg-prop;
   -webkit-mask-image: var(--tv-16-svg);
   mask-image: var(--tv-16-svg);
 }
 
 %with-tv-24-icon {
-  @extend %with-icon, %tv-24-svg-prop !optional;
+  @extend %with-icon, %tv-24-svg-prop;
   background-image: var(--tv-24-svg);
 }
 %with-tv-24-mask {
-  @extend %with-mask, %tv-24-svg-prop !optional;
+  @extend %with-mask, %tv-24-svg-prop;
   -webkit-mask-image: var(--tv-24-svg);
   mask-image: var(--tv-24-svg);
 }
 
 %with-type-16-icon {
-  @extend %with-icon, %type-16-svg-prop !optional;
+  @extend %with-icon, %type-16-svg-prop;
   background-image: var(--type-16-svg);
 }
 %with-type-16-mask {
-  @extend %with-mask, %type-16-svg-prop !optional;
+  @extend %with-mask, %type-16-svg-prop;
   -webkit-mask-image: var(--type-16-svg);
   mask-image: var(--type-16-svg);
 }
 
 %with-type-24-icon {
-  @extend %with-icon, %type-24-svg-prop !optional;
+  @extend %with-icon, %type-24-svg-prop;
   background-image: var(--type-24-svg);
 }
 %with-type-24-mask {
-  @extend %with-mask, %type-24-svg-prop !optional;
+  @extend %with-mask, %type-24-svg-prop;
   -webkit-mask-image: var(--type-24-svg);
   mask-image: var(--type-24-svg);
 }
 
 %with-unfold-close-16-icon {
-  @extend %with-icon, %unfold-close-16-svg-prop !optional;
+  @extend %with-icon, %unfold-close-16-svg-prop;
   background-image: var(--unfold-close-16-svg);
 }
 %with-unfold-close-16-mask {
-  @extend %with-mask, %unfold-close-16-svg-prop !optional;
+  @extend %with-mask, %unfold-close-16-svg-prop;
   -webkit-mask-image: var(--unfold-close-16-svg);
   mask-image: var(--unfold-close-16-svg);
 }
 
 %with-unfold-close-24-icon {
-  @extend %with-icon, %unfold-close-24-svg-prop !optional;
+  @extend %with-icon, %unfold-close-24-svg-prop;
   background-image: var(--unfold-close-24-svg);
 }
 %with-unfold-close-24-mask {
-  @extend %with-mask, %unfold-close-24-svg-prop !optional;
+  @extend %with-mask, %unfold-close-24-svg-prop;
   -webkit-mask-image: var(--unfold-close-24-svg);
   mask-image: var(--unfold-close-24-svg);
 }
 
 %with-unfold-less-icon {
-  @extend %with-icon, %unfold-less-svg-prop !optional;
+  @extend %with-icon, %unfold-less-svg-prop;
   background-image: var(--unfold-less-svg);
 }
 %with-unfold-less-mask {
-  @extend %with-mask, %unfold-less-svg-prop !optional;
+  @extend %with-mask, %unfold-less-svg-prop;
   -webkit-mask-image: var(--unfold-less-svg);
   mask-image: var(--unfold-less-svg);
 }
 
 %with-unfold-more-icon {
-  @extend %with-icon, %unfold-more-svg-prop !optional;
+  @extend %with-icon, %unfold-more-svg-prop;
   background-image: var(--unfold-more-svg);
 }
 %with-unfold-more-mask {
-  @extend %with-mask, %unfold-more-svg-prop !optional;
+  @extend %with-mask, %unfold-more-svg-prop;
   -webkit-mask-image: var(--unfold-more-svg);
   mask-image: var(--unfold-more-svg);
 }
 
 %with-unfold-open-16-icon {
-  @extend %with-icon, %unfold-open-16-svg-prop !optional;
+  @extend %with-icon, %unfold-open-16-svg-prop;
   background-image: var(--unfold-open-16-svg);
 }
 %with-unfold-open-16-mask {
-  @extend %with-mask, %unfold-open-16-svg-prop !optional;
+  @extend %with-mask, %unfold-open-16-svg-prop;
   -webkit-mask-image: var(--unfold-open-16-svg);
   mask-image: var(--unfold-open-16-svg);
 }
 
 %with-unfold-open-24-icon {
-  @extend %with-icon, %unfold-open-24-svg-prop !optional;
+  @extend %with-icon, %unfold-open-24-svg-prop;
   background-image: var(--unfold-open-24-svg);
 }
 %with-unfold-open-24-mask {
-  @extend %with-mask, %unfold-open-24-svg-prop !optional;
+  @extend %with-mask, %unfold-open-24-svg-prop;
   -webkit-mask-image: var(--unfold-open-24-svg);
   mask-image: var(--unfold-open-24-svg);
 }
 
 %with-unlock-16-icon {
-  @extend %with-icon, %unlock-16-svg-prop !optional;
+  @extend %with-icon, %unlock-16-svg-prop;
   background-image: var(--unlock-16-svg);
 }
 %with-unlock-16-mask {
-  @extend %with-mask, %unlock-16-svg-prop !optional;
+  @extend %with-mask, %unlock-16-svg-prop;
   -webkit-mask-image: var(--unlock-16-svg);
   mask-image: var(--unlock-16-svg);
 }
 
 %with-unlock-24-icon {
-  @extend %with-icon, %unlock-24-svg-prop !optional;
+  @extend %with-icon, %unlock-24-svg-prop;
   background-image: var(--unlock-24-svg);
 }
 %with-unlock-24-mask {
-  @extend %with-mask, %unlock-24-svg-prop !optional;
+  @extend %with-mask, %unlock-24-svg-prop;
   -webkit-mask-image: var(--unlock-24-svg);
   mask-image: var(--unlock-24-svg);
 }
 
 %with-upload-16-icon {
-  @extend %with-icon, %upload-16-svg-prop !optional;
+  @extend %with-icon, %upload-16-svg-prop;
   background-image: var(--upload-16-svg);
 }
 %with-upload-16-mask {
-  @extend %with-mask, %upload-16-svg-prop !optional;
+  @extend %with-mask, %upload-16-svg-prop;
   -webkit-mask-image: var(--upload-16-svg);
   mask-image: var(--upload-16-svg);
 }
 
 %with-upload-24-icon {
-  @extend %with-icon, %upload-24-svg-prop !optional;
+  @extend %with-icon, %upload-24-svg-prop;
   background-image: var(--upload-24-svg);
 }
 %with-upload-24-mask {
-  @extend %with-mask, %upload-24-svg-prop !optional;
+  @extend %with-mask, %upload-24-svg-prop;
   -webkit-mask-image: var(--upload-24-svg);
   mask-image: var(--upload-24-svg);
 }
 
 %with-upload-icon {
-  @extend %with-icon, %upload-svg-prop !optional;
+  @extend %with-icon, %upload-svg-prop;
   background-image: var(--upload-svg);
 }
 %with-upload-mask {
-  @extend %with-mask, %upload-svg-prop !optional;
+  @extend %with-mask, %upload-svg-prop;
   -webkit-mask-image: var(--upload-svg);
   mask-image: var(--upload-svg);
 }
 
 %with-user-16-icon {
-  @extend %with-icon, %user-16-svg-prop !optional;
+  @extend %with-icon, %user-16-svg-prop;
   background-image: var(--user-16-svg);
 }
 %with-user-16-mask {
-  @extend %with-mask, %user-16-svg-prop !optional;
+  @extend %with-mask, %user-16-svg-prop;
   -webkit-mask-image: var(--user-16-svg);
   mask-image: var(--user-16-svg);
 }
 
 %with-user-24-icon {
-  @extend %with-icon, %user-24-svg-prop !optional;
+  @extend %with-icon, %user-24-svg-prop;
   background-image: var(--user-24-svg);
 }
 %with-user-24-mask {
-  @extend %with-mask, %user-24-svg-prop !optional;
+  @extend %with-mask, %user-24-svg-prop;
   -webkit-mask-image: var(--user-24-svg);
   mask-image: var(--user-24-svg);
 }
 
 %with-user-add-icon {
-  @extend %with-icon, %user-add-svg-prop !optional;
+  @extend %with-icon, %user-add-svg-prop;
   background-image: var(--user-add-svg);
 }
 %with-user-add-mask {
-  @extend %with-mask, %user-add-svg-prop !optional;
+  @extend %with-mask, %user-add-svg-prop;
   -webkit-mask-image: var(--user-add-svg);
   mask-image: var(--user-add-svg);
 }
 
 %with-user-check-16-icon {
-  @extend %with-icon, %user-check-16-svg-prop !optional;
+  @extend %with-icon, %user-check-16-svg-prop;
   background-image: var(--user-check-16-svg);
 }
 %with-user-check-16-mask {
-  @extend %with-mask, %user-check-16-svg-prop !optional;
+  @extend %with-mask, %user-check-16-svg-prop;
   -webkit-mask-image: var(--user-check-16-svg);
   mask-image: var(--user-check-16-svg);
 }
 
 %with-user-check-24-icon {
-  @extend %with-icon, %user-check-24-svg-prop !optional;
+  @extend %with-icon, %user-check-24-svg-prop;
   background-image: var(--user-check-24-svg);
 }
 %with-user-check-24-mask {
-  @extend %with-mask, %user-check-24-svg-prop !optional;
+  @extend %with-mask, %user-check-24-svg-prop;
   -webkit-mask-image: var(--user-check-24-svg);
   mask-image: var(--user-check-24-svg);
 }
 
 %with-user-circle-16-icon {
-  @extend %with-icon, %user-circle-16-svg-prop !optional;
+  @extend %with-icon, %user-circle-16-svg-prop;
   background-image: var(--user-circle-16-svg);
 }
 %with-user-circle-16-mask {
-  @extend %with-mask, %user-circle-16-svg-prop !optional;
+  @extend %with-mask, %user-circle-16-svg-prop;
   -webkit-mask-image: var(--user-circle-16-svg);
   mask-image: var(--user-circle-16-svg);
 }
 
 %with-user-circle-24-icon {
-  @extend %with-icon, %user-circle-24-svg-prop !optional;
+  @extend %with-icon, %user-circle-24-svg-prop;
   background-image: var(--user-circle-24-svg);
 }
 %with-user-circle-24-mask {
-  @extend %with-mask, %user-circle-24-svg-prop !optional;
+  @extend %with-mask, %user-circle-24-svg-prop;
   -webkit-mask-image: var(--user-circle-24-svg);
   mask-image: var(--user-circle-24-svg);
 }
 
 %with-user-circle-fill-16-icon {
-  @extend %with-icon, %user-circle-fill-16-svg-prop !optional;
+  @extend %with-icon, %user-circle-fill-16-svg-prop;
   background-image: var(--user-circle-fill-16-svg);
 }
 %with-user-circle-fill-16-mask {
-  @extend %with-mask, %user-circle-fill-16-svg-prop !optional;
+  @extend %with-mask, %user-circle-fill-16-svg-prop;
   -webkit-mask-image: var(--user-circle-fill-16-svg);
   mask-image: var(--user-circle-fill-16-svg);
 }
 
 %with-user-circle-fill-24-icon {
-  @extend %with-icon, %user-circle-fill-24-svg-prop !optional;
+  @extend %with-icon, %user-circle-fill-24-svg-prop;
   background-image: var(--user-circle-fill-24-svg);
 }
 %with-user-circle-fill-24-mask {
-  @extend %with-mask, %user-circle-fill-24-svg-prop !optional;
+  @extend %with-mask, %user-circle-fill-24-svg-prop;
   -webkit-mask-image: var(--user-circle-fill-24-svg);
   mask-image: var(--user-circle-fill-24-svg);
 }
 
 %with-user-minus-16-icon {
-  @extend %with-icon, %user-minus-16-svg-prop !optional;
+  @extend %with-icon, %user-minus-16-svg-prop;
   background-image: var(--user-minus-16-svg);
 }
 %with-user-minus-16-mask {
-  @extend %with-mask, %user-minus-16-svg-prop !optional;
+  @extend %with-mask, %user-minus-16-svg-prop;
   -webkit-mask-image: var(--user-minus-16-svg);
   mask-image: var(--user-minus-16-svg);
 }
 
 %with-user-minus-24-icon {
-  @extend %with-icon, %user-minus-24-svg-prop !optional;
+  @extend %with-icon, %user-minus-24-svg-prop;
   background-image: var(--user-minus-24-svg);
 }
 %with-user-minus-24-mask {
-  @extend %with-mask, %user-minus-24-svg-prop !optional;
+  @extend %with-mask, %user-minus-24-svg-prop;
   -webkit-mask-image: var(--user-minus-24-svg);
   mask-image: var(--user-minus-24-svg);
 }
 
 %with-user-organization-icon {
-  @extend %with-icon, %user-organization-svg-prop !optional;
+  @extend %with-icon, %user-organization-svg-prop;
   background-image: var(--user-organization-svg);
 }
 %with-user-organization-mask {
-  @extend %with-mask, %user-organization-svg-prop !optional;
+  @extend %with-mask, %user-organization-svg-prop;
   -webkit-mask-image: var(--user-organization-svg);
   mask-image: var(--user-organization-svg);
 }
 
 %with-user-plain-icon {
-  @extend %with-icon, %user-plain-svg-prop !optional;
+  @extend %with-icon, %user-plain-svg-prop;
   background-image: var(--user-plain-svg);
 }
 %with-user-plain-mask {
-  @extend %with-mask, %user-plain-svg-prop !optional;
+  @extend %with-mask, %user-plain-svg-prop;
   -webkit-mask-image: var(--user-plain-svg);
   mask-image: var(--user-plain-svg);
 }
 
 %with-user-plus-16-icon {
-  @extend %with-icon, %user-plus-16-svg-prop !optional;
+  @extend %with-icon, %user-plus-16-svg-prop;
   background-image: var(--user-plus-16-svg);
 }
 %with-user-plus-16-mask {
-  @extend %with-mask, %user-plus-16-svg-prop !optional;
+  @extend %with-mask, %user-plus-16-svg-prop;
   -webkit-mask-image: var(--user-plus-16-svg);
   mask-image: var(--user-plus-16-svg);
 }
 
 %with-user-plus-24-icon {
-  @extend %with-icon, %user-plus-24-svg-prop !optional;
+  @extend %with-icon, %user-plus-24-svg-prop;
   background-image: var(--user-plus-24-svg);
 }
 %with-user-plus-24-mask {
-  @extend %with-mask, %user-plus-24-svg-prop !optional;
+  @extend %with-mask, %user-plus-24-svg-prop;
   -webkit-mask-image: var(--user-plus-24-svg);
   mask-image: var(--user-plus-24-svg);
 }
 
 %with-user-square-fill-icon {
-  @extend %with-icon, %user-square-fill-svg-prop !optional;
+  @extend %with-icon, %user-square-fill-svg-prop;
   background-image: var(--user-square-fill-svg);
 }
 %with-user-square-fill-mask {
-  @extend %with-mask, %user-square-fill-svg-prop !optional;
+  @extend %with-mask, %user-square-fill-svg-prop;
   -webkit-mask-image: var(--user-square-fill-svg);
   mask-image: var(--user-square-fill-svg);
 }
 
 %with-user-square-outline-icon {
-  @extend %with-icon, %user-square-outline-svg-prop !optional;
+  @extend %with-icon, %user-square-outline-svg-prop;
   background-image: var(--user-square-outline-svg);
 }
 %with-user-square-outline-mask {
-  @extend %with-mask, %user-square-outline-svg-prop !optional;
+  @extend %with-mask, %user-square-outline-svg-prop;
   -webkit-mask-image: var(--user-square-outline-svg);
   mask-image: var(--user-square-outline-svg);
 }
 
 %with-user-team-icon {
-  @extend %with-icon, %user-team-svg-prop !optional;
+  @extend %with-icon, %user-team-svg-prop;
   background-image: var(--user-team-svg);
 }
 %with-user-team-mask {
-  @extend %with-mask, %user-team-svg-prop !optional;
+  @extend %with-mask, %user-team-svg-prop;
   -webkit-mask-image: var(--user-team-svg);
   mask-image: var(--user-team-svg);
 }
 
 %with-user-x-16-icon {
-  @extend %with-icon, %user-x-16-svg-prop !optional;
+  @extend %with-icon, %user-x-16-svg-prop;
   background-image: var(--user-x-16-svg);
 }
 %with-user-x-16-mask {
-  @extend %with-mask, %user-x-16-svg-prop !optional;
+  @extend %with-mask, %user-x-16-svg-prop;
   -webkit-mask-image: var(--user-x-16-svg);
   mask-image: var(--user-x-16-svg);
 }
 
 %with-user-x-24-icon {
-  @extend %with-icon, %user-x-24-svg-prop !optional;
+  @extend %with-icon, %user-x-24-svg-prop;
   background-image: var(--user-x-24-svg);
 }
 %with-user-x-24-mask {
-  @extend %with-mask, %user-x-24-svg-prop !optional;
+  @extend %with-mask, %user-x-24-svg-prop;
   -webkit-mask-image: var(--user-x-24-svg);
   mask-image: var(--user-x-24-svg);
 }
 
 %with-users-16-icon {
-  @extend %with-icon, %users-16-svg-prop !optional;
+  @extend %with-icon, %users-16-svg-prop;
   background-image: var(--users-16-svg);
 }
 %with-users-16-mask {
-  @extend %with-mask, %users-16-svg-prop !optional;
+  @extend %with-mask, %users-16-svg-prop;
   -webkit-mask-image: var(--users-16-svg);
   mask-image: var(--users-16-svg);
 }
 
 %with-users-24-icon {
-  @extend %with-icon, %users-24-svg-prop !optional;
+  @extend %with-icon, %users-24-svg-prop;
   background-image: var(--users-24-svg);
 }
 %with-users-24-mask {
-  @extend %with-mask, %users-24-svg-prop !optional;
+  @extend %with-mask, %users-24-svg-prop;
   -webkit-mask-image: var(--users-24-svg);
   mask-image: var(--users-24-svg);
 }
 
 %with-vault-16-icon {
-  @extend %with-icon, %vault-16-svg-prop !optional;
+  @extend %with-icon, %vault-16-svg-prop;
   background-image: var(--vault-16-svg);
 }
 %with-vault-16-mask {
-  @extend %with-mask, %vault-16-svg-prop !optional;
+  @extend %with-mask, %vault-16-svg-prop;
   -webkit-mask-image: var(--vault-16-svg);
   mask-image: var(--vault-16-svg);
 }
 
 %with-vault-24-icon {
-  @extend %with-icon, %vault-24-svg-prop !optional;
+  @extend %with-icon, %vault-24-svg-prop;
   background-image: var(--vault-24-svg);
 }
 %with-vault-24-mask {
-  @extend %with-mask, %vault-24-svg-prop !optional;
+  @extend %with-mask, %vault-24-svg-prop;
   -webkit-mask-image: var(--vault-24-svg);
   mask-image: var(--vault-24-svg);
 }
 
 %with-verified-16-icon {
-  @extend %with-icon, %verified-16-svg-prop !optional;
+  @extend %with-icon, %verified-16-svg-prop;
   background-image: var(--verified-16-svg);
 }
 %with-verified-16-mask {
-  @extend %with-mask, %verified-16-svg-prop !optional;
+  @extend %with-mask, %verified-16-svg-prop;
   -webkit-mask-image: var(--verified-16-svg);
   mask-image: var(--verified-16-svg);
 }
 
 %with-verified-24-icon {
-  @extend %with-icon, %verified-24-svg-prop !optional;
+  @extend %with-icon, %verified-24-svg-prop;
   background-image: var(--verified-24-svg);
 }
 %with-verified-24-mask {
-  @extend %with-mask, %verified-24-svg-prop !optional;
+  @extend %with-mask, %verified-24-svg-prop;
   -webkit-mask-image: var(--verified-24-svg);
   mask-image: var(--verified-24-svg);
 }
 
 %with-video-16-icon {
-  @extend %with-icon, %video-16-svg-prop !optional;
+  @extend %with-icon, %video-16-svg-prop;
   background-image: var(--video-16-svg);
 }
 %with-video-16-mask {
-  @extend %with-mask, %video-16-svg-prop !optional;
+  @extend %with-mask, %video-16-svg-prop;
   -webkit-mask-image: var(--video-16-svg);
   mask-image: var(--video-16-svg);
 }
 
 %with-video-24-icon {
-  @extend %with-icon, %video-24-svg-prop !optional;
+  @extend %with-icon, %video-24-svg-prop;
   background-image: var(--video-24-svg);
 }
 %with-video-24-mask {
-  @extend %with-mask, %video-24-svg-prop !optional;
+  @extend %with-mask, %video-24-svg-prop;
   -webkit-mask-image: var(--video-24-svg);
   mask-image: var(--video-24-svg);
 }
 
 %with-video-off-16-icon {
-  @extend %with-icon, %video-off-16-svg-prop !optional;
+  @extend %with-icon, %video-off-16-svg-prop;
   background-image: var(--video-off-16-svg);
 }
 %with-video-off-16-mask {
-  @extend %with-mask, %video-off-16-svg-prop !optional;
+  @extend %with-mask, %video-off-16-svg-prop;
   -webkit-mask-image: var(--video-off-16-svg);
   mask-image: var(--video-off-16-svg);
 }
 
 %with-video-off-24-icon {
-  @extend %with-icon, %video-off-24-svg-prop !optional;
+  @extend %with-icon, %video-off-24-svg-prop;
   background-image: var(--video-off-24-svg);
 }
 %with-video-off-24-mask {
-  @extend %with-mask, %video-off-24-svg-prop !optional;
+  @extend %with-mask, %video-off-24-svg-prop;
   -webkit-mask-image: var(--video-off-24-svg);
   mask-image: var(--video-off-24-svg);
 }
 
 %with-visibility-hide-icon {
-  @extend %with-icon, %visibility-hide-svg-prop !optional;
+  @extend %with-icon, %visibility-hide-svg-prop;
   background-image: var(--visibility-hide-svg);
 }
 %with-visibility-hide-mask {
-  @extend %with-mask, %visibility-hide-svg-prop !optional;
+  @extend %with-mask, %visibility-hide-svg-prop;
   -webkit-mask-image: var(--visibility-hide-svg);
   mask-image: var(--visibility-hide-svg);
 }
 
 %with-visibility-show-icon {
-  @extend %with-icon, %visibility-show-svg-prop !optional;
+  @extend %with-icon, %visibility-show-svg-prop;
   background-image: var(--visibility-show-svg);
 }
 %with-visibility-show-mask {
-  @extend %with-mask, %visibility-show-svg-prop !optional;
+  @extend %with-mask, %visibility-show-svg-prop;
   -webkit-mask-image: var(--visibility-show-svg);
   mask-image: var(--visibility-show-svg);
 }
 
 %with-vmware-16-icon {
-  @extend %with-icon, %vmware-16-svg-prop !optional;
+  @extend %with-icon, %vmware-16-svg-prop;
   background-image: var(--vmware-16-svg);
 }
 %with-vmware-16-mask {
-  @extend %with-mask, %vmware-16-svg-prop !optional;
+  @extend %with-mask, %vmware-16-svg-prop;
   -webkit-mask-image: var(--vmware-16-svg);
   mask-image: var(--vmware-16-svg);
 }
 
 %with-vmware-24-icon {
-  @extend %with-icon, %vmware-24-svg-prop !optional;
+  @extend %with-icon, %vmware-24-svg-prop;
   background-image: var(--vmware-24-svg);
 }
 %with-vmware-24-mask {
-  @extend %with-mask, %vmware-24-svg-prop !optional;
+  @extend %with-mask, %vmware-24-svg-prop;
   -webkit-mask-image: var(--vmware-24-svg);
   mask-image: var(--vmware-24-svg);
 }
 
 %with-vmware-color-16-icon {
-  @extend %with-icon, %vmware-color-16-svg-prop !optional;
+  @extend %with-icon, %vmware-color-16-svg-prop;
   background-image: var(--vmware-color-16-svg);
 }
 %with-vmware-color-16-mask {
-  @extend %with-mask, %vmware-color-16-svg-prop !optional;
+  @extend %with-mask, %vmware-color-16-svg-prop;
   -webkit-mask-image: var(--vmware-color-16-svg);
   mask-image: var(--vmware-color-16-svg);
 }
 
 %with-vmware-color-24-icon {
-  @extend %with-icon, %vmware-color-24-svg-prop !optional;
+  @extend %with-icon, %vmware-color-24-svg-prop;
   background-image: var(--vmware-color-24-svg);
 }
 %with-vmware-color-24-mask {
-  @extend %with-mask, %vmware-color-24-svg-prop !optional;
+  @extend %with-mask, %vmware-color-24-svg-prop;
   -webkit-mask-image: var(--vmware-color-24-svg);
   mask-image: var(--vmware-color-24-svg);
 }
 
 %with-volume-16-icon {
-  @extend %with-icon, %volume-16-svg-prop !optional;
+  @extend %with-icon, %volume-16-svg-prop;
   background-image: var(--volume-16-svg);
 }
 %with-volume-16-mask {
-  @extend %with-mask, %volume-16-svg-prop !optional;
+  @extend %with-mask, %volume-16-svg-prop;
   -webkit-mask-image: var(--volume-16-svg);
   mask-image: var(--volume-16-svg);
 }
 
 %with-volume-2-16-icon {
-  @extend %with-icon, %volume-2-16-svg-prop !optional;
+  @extend %with-icon, %volume-2-16-svg-prop;
   background-image: var(--volume-2-16-svg);
 }
 %with-volume-2-16-mask {
-  @extend %with-mask, %volume-2-16-svg-prop !optional;
+  @extend %with-mask, %volume-2-16-svg-prop;
   -webkit-mask-image: var(--volume-2-16-svg);
   mask-image: var(--volume-2-16-svg);
 }
 
 %with-volume-2-24-icon {
-  @extend %with-icon, %volume-2-24-svg-prop !optional;
+  @extend %with-icon, %volume-2-24-svg-prop;
   background-image: var(--volume-2-24-svg);
 }
 %with-volume-2-24-mask {
-  @extend %with-mask, %volume-2-24-svg-prop !optional;
+  @extend %with-mask, %volume-2-24-svg-prop;
   -webkit-mask-image: var(--volume-2-24-svg);
   mask-image: var(--volume-2-24-svg);
 }
 
 %with-volume-24-icon {
-  @extend %with-icon, %volume-24-svg-prop !optional;
+  @extend %with-icon, %volume-24-svg-prop;
   background-image: var(--volume-24-svg);
 }
 %with-volume-24-mask {
-  @extend %with-mask, %volume-24-svg-prop !optional;
+  @extend %with-mask, %volume-24-svg-prop;
   -webkit-mask-image: var(--volume-24-svg);
   mask-image: var(--volume-24-svg);
 }
 
 %with-volume-down-16-icon {
-  @extend %with-icon, %volume-down-16-svg-prop !optional;
+  @extend %with-icon, %volume-down-16-svg-prop;
   background-image: var(--volume-down-16-svg);
 }
 %with-volume-down-16-mask {
-  @extend %with-mask, %volume-down-16-svg-prop !optional;
+  @extend %with-mask, %volume-down-16-svg-prop;
   -webkit-mask-image: var(--volume-down-16-svg);
   mask-image: var(--volume-down-16-svg);
 }
 
 %with-volume-down-24-icon {
-  @extend %with-icon, %volume-down-24-svg-prop !optional;
+  @extend %with-icon, %volume-down-24-svg-prop;
   background-image: var(--volume-down-24-svg);
 }
 %with-volume-down-24-mask {
-  @extend %with-mask, %volume-down-24-svg-prop !optional;
+  @extend %with-mask, %volume-down-24-svg-prop;
   -webkit-mask-image: var(--volume-down-24-svg);
   mask-image: var(--volume-down-24-svg);
 }
 
 %with-volume-x-16-icon {
-  @extend %with-icon, %volume-x-16-svg-prop !optional;
+  @extend %with-icon, %volume-x-16-svg-prop;
   background-image: var(--volume-x-16-svg);
 }
 %with-volume-x-16-mask {
-  @extend %with-mask, %volume-x-16-svg-prop !optional;
+  @extend %with-mask, %volume-x-16-svg-prop;
   -webkit-mask-image: var(--volume-x-16-svg);
   mask-image: var(--volume-x-16-svg);
 }
 
 %with-volume-x-24-icon {
-  @extend %with-icon, %volume-x-24-svg-prop !optional;
+  @extend %with-icon, %volume-x-24-svg-prop;
   background-image: var(--volume-x-24-svg);
 }
 %with-volume-x-24-mask {
-  @extend %with-mask, %volume-x-24-svg-prop !optional;
+  @extend %with-mask, %volume-x-24-svg-prop;
   -webkit-mask-image: var(--volume-x-24-svg);
   mask-image: var(--volume-x-24-svg);
 }
 
 %with-wall-16-icon {
-  @extend %with-icon, %wall-16-svg-prop !optional;
+  @extend %with-icon, %wall-16-svg-prop;
   background-image: var(--wall-16-svg);
 }
 %with-wall-16-mask {
-  @extend %with-mask, %wall-16-svg-prop !optional;
+  @extend %with-mask, %wall-16-svg-prop;
   -webkit-mask-image: var(--wall-16-svg);
   mask-image: var(--wall-16-svg);
 }
 
 %with-wall-24-icon {
-  @extend %with-icon, %wall-24-svg-prop !optional;
+  @extend %with-icon, %wall-24-svg-prop;
   background-image: var(--wall-24-svg);
 }
 %with-wall-24-mask {
-  @extend %with-mask, %wall-24-svg-prop !optional;
+  @extend %with-mask, %wall-24-svg-prop;
   -webkit-mask-image: var(--wall-24-svg);
   mask-image: var(--wall-24-svg);
 }
 
 %with-watch-16-icon {
-  @extend %with-icon, %watch-16-svg-prop !optional;
+  @extend %with-icon, %watch-16-svg-prop;
   background-image: var(--watch-16-svg);
 }
 %with-watch-16-mask {
-  @extend %with-mask, %watch-16-svg-prop !optional;
+  @extend %with-mask, %watch-16-svg-prop;
   -webkit-mask-image: var(--watch-16-svg);
   mask-image: var(--watch-16-svg);
 }
 
 %with-watch-24-icon {
-  @extend %with-icon, %watch-24-svg-prop !optional;
+  @extend %with-icon, %watch-24-svg-prop;
   background-image: var(--watch-24-svg);
 }
 %with-watch-24-mask {
-  @extend %with-mask, %watch-24-svg-prop !optional;
+  @extend %with-mask, %watch-24-svg-prop;
   -webkit-mask-image: var(--watch-24-svg);
   mask-image: var(--watch-24-svg);
 }
 
 %with-webhook-16-icon {
-  @extend %with-icon, %webhook-16-svg-prop !optional;
+  @extend %with-icon, %webhook-16-svg-prop;
   background-image: var(--webhook-16-svg);
 }
 %with-webhook-16-mask {
-  @extend %with-mask, %webhook-16-svg-prop !optional;
+  @extend %with-mask, %webhook-16-svg-prop;
   -webkit-mask-image: var(--webhook-16-svg);
   mask-image: var(--webhook-16-svg);
 }
 
 %with-webhook-24-icon {
-  @extend %with-icon, %webhook-24-svg-prop !optional;
+  @extend %with-icon, %webhook-24-svg-prop;
   background-image: var(--webhook-24-svg);
 }
 %with-webhook-24-mask {
-  @extend %with-mask, %webhook-24-svg-prop !optional;
+  @extend %with-mask, %webhook-24-svg-prop;
   -webkit-mask-image: var(--webhook-24-svg);
   mask-image: var(--webhook-24-svg);
 }
 
 %with-webhook-icon {
-  @extend %with-icon, %webhook-svg-prop !optional;
+  @extend %with-icon, %webhook-svg-prop;
   background-image: var(--webhook-svg);
 }
 %with-webhook-mask {
-  @extend %with-mask, %webhook-svg-prop !optional;
+  @extend %with-mask, %webhook-svg-prop;
   -webkit-mask-image: var(--webhook-svg);
   mask-image: var(--webhook-svg);
 }
 
 %with-wifi-16-icon {
-  @extend %with-icon, %wifi-16-svg-prop !optional;
+  @extend %with-icon, %wifi-16-svg-prop;
   background-image: var(--wifi-16-svg);
 }
 %with-wifi-16-mask {
-  @extend %with-mask, %wifi-16-svg-prop !optional;
+  @extend %with-mask, %wifi-16-svg-prop;
   -webkit-mask-image: var(--wifi-16-svg);
   mask-image: var(--wifi-16-svg);
 }
 
 %with-wifi-24-icon {
-  @extend %with-icon, %wifi-24-svg-prop !optional;
+  @extend %with-icon, %wifi-24-svg-prop;
   background-image: var(--wifi-24-svg);
 }
 %with-wifi-24-mask {
-  @extend %with-mask, %wifi-24-svg-prop !optional;
+  @extend %with-mask, %wifi-24-svg-prop;
   -webkit-mask-image: var(--wifi-24-svg);
   mask-image: var(--wifi-24-svg);
 }
 
 %with-wifi-off-16-icon {
-  @extend %with-icon, %wifi-off-16-svg-prop !optional;
+  @extend %with-icon, %wifi-off-16-svg-prop;
   background-image: var(--wifi-off-16-svg);
 }
 %with-wifi-off-16-mask {
-  @extend %with-mask, %wifi-off-16-svg-prop !optional;
+  @extend %with-mask, %wifi-off-16-svg-prop;
   -webkit-mask-image: var(--wifi-off-16-svg);
   mask-image: var(--wifi-off-16-svg);
 }
 
 %with-wifi-off-24-icon {
-  @extend %with-icon, %wifi-off-24-svg-prop !optional;
+  @extend %with-icon, %wifi-off-24-svg-prop;
   background-image: var(--wifi-off-24-svg);
 }
 %with-wifi-off-24-mask {
-  @extend %with-mask, %wifi-off-24-svg-prop !optional;
+  @extend %with-mask, %wifi-off-24-svg-prop;
   -webkit-mask-image: var(--wifi-off-24-svg);
   mask-image: var(--wifi-off-24-svg);
 }
 
 %with-wrench-16-icon {
-  @extend %with-icon, %wrench-16-svg-prop !optional;
+  @extend %with-icon, %wrench-16-svg-prop;
   background-image: var(--wrench-16-svg);
 }
 %with-wrench-16-mask {
-  @extend %with-mask, %wrench-16-svg-prop !optional;
+  @extend %with-mask, %wrench-16-svg-prop;
   -webkit-mask-image: var(--wrench-16-svg);
   mask-image: var(--wrench-16-svg);
 }
 
 %with-wrench-24-icon {
-  @extend %with-icon, %wrench-24-svg-prop !optional;
+  @extend %with-icon, %wrench-24-svg-prop;
   background-image: var(--wrench-24-svg);
 }
 %with-wrench-24-mask {
-  @extend %with-mask, %wrench-24-svg-prop !optional;
+  @extend %with-mask, %wrench-24-svg-prop;
   -webkit-mask-image: var(--wrench-24-svg);
   mask-image: var(--wrench-24-svg);
 }
 
 %with-x-16-icon {
-  @extend %with-icon, %x-16-svg-prop !optional;
+  @extend %with-icon, %x-16-svg-prop;
   background-image: var(--x-16-svg);
 }
 %with-x-16-mask {
-  @extend %with-mask, %x-16-svg-prop !optional;
+  @extend %with-mask, %x-16-svg-prop;
   -webkit-mask-image: var(--x-16-svg);
   mask-image: var(--x-16-svg);
 }
 
 %with-x-24-icon {
-  @extend %with-icon, %x-24-svg-prop !optional;
+  @extend %with-icon, %x-24-svg-prop;
   background-image: var(--x-24-svg);
 }
 %with-x-24-mask {
-  @extend %with-mask, %x-24-svg-prop !optional;
+  @extend %with-mask, %x-24-svg-prop;
   -webkit-mask-image: var(--x-24-svg);
   mask-image: var(--x-24-svg);
 }
 
 %with-x-circle-16-icon {
-  @extend %with-icon, %x-circle-16-svg-prop !optional;
+  @extend %with-icon, %x-circle-16-svg-prop;
   background-image: var(--x-circle-16-svg);
 }
 %with-x-circle-16-mask {
-  @extend %with-mask, %x-circle-16-svg-prop !optional;
+  @extend %with-mask, %x-circle-16-svg-prop;
   -webkit-mask-image: var(--x-circle-16-svg);
   mask-image: var(--x-circle-16-svg);
 }
 
 %with-x-circle-24-icon {
-  @extend %with-icon, %x-circle-24-svg-prop !optional;
+  @extend %with-icon, %x-circle-24-svg-prop;
   background-image: var(--x-circle-24-svg);
 }
 %with-x-circle-24-mask {
-  @extend %with-mask, %x-circle-24-svg-prop !optional;
+  @extend %with-mask, %x-circle-24-svg-prop;
   -webkit-mask-image: var(--x-circle-24-svg);
   mask-image: var(--x-circle-24-svg);
 }
 
 %with-x-circle-fill-16-icon {
-  @extend %with-icon, %x-circle-fill-16-svg-prop !optional;
+  @extend %with-icon, %x-circle-fill-16-svg-prop;
   background-image: var(--x-circle-fill-16-svg);
 }
 %with-x-circle-fill-16-mask {
-  @extend %with-mask, %x-circle-fill-16-svg-prop !optional;
+  @extend %with-mask, %x-circle-fill-16-svg-prop;
   -webkit-mask-image: var(--x-circle-fill-16-svg);
   mask-image: var(--x-circle-fill-16-svg);
 }
 
 %with-x-circle-fill-24-icon {
-  @extend %with-icon, %x-circle-fill-24-svg-prop !optional;
+  @extend %with-icon, %x-circle-fill-24-svg-prop;
   background-image: var(--x-circle-fill-24-svg);
 }
 %with-x-circle-fill-24-mask {
-  @extend %with-mask, %x-circle-fill-24-svg-prop !optional;
+  @extend %with-mask, %x-circle-fill-24-svg-prop;
   -webkit-mask-image: var(--x-circle-fill-24-svg);
   mask-image: var(--x-circle-fill-24-svg);
 }
 
 %with-x-diamond-16-icon {
-  @extend %with-icon, %x-diamond-16-svg-prop !optional;
+  @extend %with-icon, %x-diamond-16-svg-prop;
   background-image: var(--x-diamond-16-svg);
 }
 %with-x-diamond-16-mask {
-  @extend %with-mask, %x-diamond-16-svg-prop !optional;
+  @extend %with-mask, %x-diamond-16-svg-prop;
   -webkit-mask-image: var(--x-diamond-16-svg);
   mask-image: var(--x-diamond-16-svg);
 }
 
 %with-x-diamond-24-icon {
-  @extend %with-icon, %x-diamond-24-svg-prop !optional;
+  @extend %with-icon, %x-diamond-24-svg-prop;
   background-image: var(--x-diamond-24-svg);
 }
 %with-x-diamond-24-mask {
-  @extend %with-mask, %x-diamond-24-svg-prop !optional;
+  @extend %with-mask, %x-diamond-24-svg-prop;
   -webkit-mask-image: var(--x-diamond-24-svg);
   mask-image: var(--x-diamond-24-svg);
 }
 
 %with-x-diamond-fill-16-icon {
-  @extend %with-icon, %x-diamond-fill-16-svg-prop !optional;
+  @extend %with-icon, %x-diamond-fill-16-svg-prop;
   background-image: var(--x-diamond-fill-16-svg);
 }
 %with-x-diamond-fill-16-mask {
-  @extend %with-mask, %x-diamond-fill-16-svg-prop !optional;
+  @extend %with-mask, %x-diamond-fill-16-svg-prop;
   -webkit-mask-image: var(--x-diamond-fill-16-svg);
   mask-image: var(--x-diamond-fill-16-svg);
 }
 
 %with-x-diamond-fill-24-icon {
-  @extend %with-icon, %x-diamond-fill-24-svg-prop !optional;
+  @extend %with-icon, %x-diamond-fill-24-svg-prop;
   background-image: var(--x-diamond-fill-24-svg);
 }
 %with-x-diamond-fill-24-mask {
-  @extend %with-mask, %x-diamond-fill-24-svg-prop !optional;
+  @extend %with-mask, %x-diamond-fill-24-svg-prop;
   -webkit-mask-image: var(--x-diamond-fill-24-svg);
   mask-image: var(--x-diamond-fill-24-svg);
 }
 
 %with-x-hexagon-16-icon {
-  @extend %with-icon, %x-hexagon-16-svg-prop !optional;
+  @extend %with-icon, %x-hexagon-16-svg-prop;
   background-image: var(--x-hexagon-16-svg);
 }
 %with-x-hexagon-16-mask {
-  @extend %with-mask, %x-hexagon-16-svg-prop !optional;
+  @extend %with-mask, %x-hexagon-16-svg-prop;
   -webkit-mask-image: var(--x-hexagon-16-svg);
   mask-image: var(--x-hexagon-16-svg);
 }
 
 %with-x-hexagon-24-icon {
-  @extend %with-icon, %x-hexagon-24-svg-prop !optional;
+  @extend %with-icon, %x-hexagon-24-svg-prop;
   background-image: var(--x-hexagon-24-svg);
 }
 %with-x-hexagon-24-mask {
-  @extend %with-mask, %x-hexagon-24-svg-prop !optional;
+  @extend %with-mask, %x-hexagon-24-svg-prop;
   -webkit-mask-image: var(--x-hexagon-24-svg);
   mask-image: var(--x-hexagon-24-svg);
 }
 
 %with-x-hexagon-fill-16-icon {
-  @extend %with-icon, %x-hexagon-fill-16-svg-prop !optional;
+  @extend %with-icon, %x-hexagon-fill-16-svg-prop;
   background-image: var(--x-hexagon-fill-16-svg);
 }
 %with-x-hexagon-fill-16-mask {
-  @extend %with-mask, %x-hexagon-fill-16-svg-prop !optional;
+  @extend %with-mask, %x-hexagon-fill-16-svg-prop;
   -webkit-mask-image: var(--x-hexagon-fill-16-svg);
   mask-image: var(--x-hexagon-fill-16-svg);
 }
 
 %with-x-hexagon-fill-24-icon {
-  @extend %with-icon, %x-hexagon-fill-24-svg-prop !optional;
+  @extend %with-icon, %x-hexagon-fill-24-svg-prop;
   background-image: var(--x-hexagon-fill-24-svg);
 }
 %with-x-hexagon-fill-24-mask {
-  @extend %with-mask, %x-hexagon-fill-24-svg-prop !optional;
+  @extend %with-mask, %x-hexagon-fill-24-svg-prop;
   -webkit-mask-image: var(--x-hexagon-fill-24-svg);
   mask-image: var(--x-hexagon-fill-24-svg);
 }
 
 %with-x-square-16-icon {
-  @extend %with-icon, %x-square-16-svg-prop !optional;
+  @extend %with-icon, %x-square-16-svg-prop;
   background-image: var(--x-square-16-svg);
 }
 %with-x-square-16-mask {
-  @extend %with-mask, %x-square-16-svg-prop !optional;
+  @extend %with-mask, %x-square-16-svg-prop;
   -webkit-mask-image: var(--x-square-16-svg);
   mask-image: var(--x-square-16-svg);
 }
 
 %with-x-square-24-icon {
-  @extend %with-icon, %x-square-24-svg-prop !optional;
+  @extend %with-icon, %x-square-24-svg-prop;
   background-image: var(--x-square-24-svg);
 }
 %with-x-square-24-mask {
-  @extend %with-mask, %x-square-24-svg-prop !optional;
+  @extend %with-mask, %x-square-24-svg-prop;
   -webkit-mask-image: var(--x-square-24-svg);
   mask-image: var(--x-square-24-svg);
 }
 
 %with-x-square-fill-16-icon {
-  @extend %with-icon, %x-square-fill-16-svg-prop !optional;
+  @extend %with-icon, %x-square-fill-16-svg-prop;
   background-image: var(--x-square-fill-16-svg);
 }
 %with-x-square-fill-16-mask {
-  @extend %with-mask, %x-square-fill-16-svg-prop !optional;
+  @extend %with-mask, %x-square-fill-16-svg-prop;
   -webkit-mask-image: var(--x-square-fill-16-svg);
   mask-image: var(--x-square-fill-16-svg);
 }
 
 %with-x-square-fill-24-icon {
-  @extend %with-icon, %x-square-fill-24-svg-prop !optional;
+  @extend %with-icon, %x-square-fill-24-svg-prop;
   background-image: var(--x-square-fill-24-svg);
 }
 %with-x-square-fill-24-mask {
-  @extend %with-mask, %x-square-fill-24-svg-prop !optional;
+  @extend %with-mask, %x-square-fill-24-svg-prop;
   -webkit-mask-image: var(--x-square-fill-24-svg);
   mask-image: var(--x-square-fill-24-svg);
 }
 
 %with-zap-16-icon {
-  @extend %with-icon, %zap-16-svg-prop !optional;
+  @extend %with-icon, %zap-16-svg-prop;
   background-image: var(--zap-16-svg);
 }
 %with-zap-16-mask {
-  @extend %with-mask, %zap-16-svg-prop !optional;
+  @extend %with-mask, %zap-16-svg-prop;
   -webkit-mask-image: var(--zap-16-svg);
   mask-image: var(--zap-16-svg);
 }
 
 %with-zap-24-icon {
-  @extend %with-icon, %zap-24-svg-prop !optional;
+  @extend %with-icon, %zap-24-svg-prop;
   background-image: var(--zap-24-svg);
 }
 %with-zap-24-mask {
-  @extend %with-mask, %zap-24-svg-prop !optional;
+  @extend %with-mask, %zap-24-svg-prop;
   -webkit-mask-image: var(--zap-24-svg);
   mask-image: var(--zap-24-svg);
 }
 
 %with-zap-off-16-icon {
-  @extend %with-icon, %zap-off-16-svg-prop !optional;
+  @extend %with-icon, %zap-off-16-svg-prop;
   background-image: var(--zap-off-16-svg);
 }
 %with-zap-off-16-mask {
-  @extend %with-mask, %zap-off-16-svg-prop !optional;
+  @extend %with-mask, %zap-off-16-svg-prop;
   -webkit-mask-image: var(--zap-off-16-svg);
   mask-image: var(--zap-off-16-svg);
 }
 
 %with-zap-off-24-icon {
-  @extend %with-icon, %zap-off-24-svg-prop !optional;
+  @extend %with-icon, %zap-off-24-svg-prop;
   background-image: var(--zap-off-24-svg);
 }
 %with-zap-off-24-mask {
-  @extend %with-mask, %zap-off-24-svg-prop !optional;
+  @extend %with-mask, %zap-off-24-svg-prop;
   -webkit-mask-image: var(--zap-off-24-svg);
   mask-image: var(--zap-off-24-svg);
 }
 
 %with-zoom-in-16-icon {
-  @extend %with-icon, %zoom-in-16-svg-prop !optional;
+  @extend %with-icon, %zoom-in-16-svg-prop;
   background-image: var(--zoom-in-16-svg);
 }
 %with-zoom-in-16-mask {
-  @extend %with-mask, %zoom-in-16-svg-prop !optional;
+  @extend %with-mask, %zoom-in-16-svg-prop;
   -webkit-mask-image: var(--zoom-in-16-svg);
   mask-image: var(--zoom-in-16-svg);
 }
 
 %with-zoom-in-24-icon {
-  @extend %with-icon, %zoom-in-24-svg-prop !optional;
+  @extend %with-icon, %zoom-in-24-svg-prop;
   background-image: var(--zoom-in-24-svg);
 }
 %with-zoom-in-24-mask {
-  @extend %with-mask, %zoom-in-24-svg-prop !optional;
+  @extend %with-mask, %zoom-in-24-svg-prop;
   -webkit-mask-image: var(--zoom-in-24-svg);
   mask-image: var(--zoom-in-24-svg);
 }
 
 %with-zoom-out-16-icon {
-  @extend %with-icon, %zoom-out-16-svg-prop !optional;
+  @extend %with-icon, %zoom-out-16-svg-prop;
   background-image: var(--zoom-out-16-svg);
 }
 %with-zoom-out-16-mask {
-  @extend %with-mask, %zoom-out-16-svg-prop !optional;
+  @extend %with-mask, %zoom-out-16-svg-prop;
   -webkit-mask-image: var(--zoom-out-16-svg);
   mask-image: var(--zoom-out-16-svg);
 }
 
 %with-zoom-out-24-icon {
-  @extend %with-icon, %zoom-out-24-svg-prop !optional;
+  @extend %with-icon, %zoom-out-24-svg-prop;
   background-image: var(--zoom-out-24-svg);
 }
 %with-zoom-out-24-mask {
-  @extend %with-mask, %zoom-out-24-svg-prop !optional;
+  @extend %with-mask, %zoom-out-24-svg-prop;
   -webkit-mask-image: var(--zoom-out-24-svg);
   mask-image: var(--zoom-out-24-svg);
 }


### PR DESCRIPTION
This PR adds @hashicorp/flight-icons to our icon set so we can use them when we want to/need to.

Please note: This PR does not use the new icons at all, it just installs them ready for use. All unused icons are tree-shaken out of the final build so it has absolutely no impact on the current UI as it stands.