### PR TITLE
grpc: strip local ACL tokens from RPCs during forwarding if crossing datacenters

### DIFF
--- a/.changelog/11099.txt
+++ b/.changelog/11099.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+grpc: strip local ACL tokens from RPCs during forwarding if crossing datacenters
+```
+```release-note:feature
+partitions: allow for partition queries to be forwarded
+```

--- a/agent/consul/subscribe_backend.go
+++ b/agent/consul/subscribe_backend.go
@@ -26,21 +26,8 @@ func (s subscribeBackend) ResolveTokenAndDefaultMeta(
 
 var _ subscribe.Backend = (*subscribeBackend)(nil)
 
-// Forward requests to a remote datacenter by calling f if the target dc does not
-// match the config. Does nothing but return handled=false if dc is not specified,
-// or if it matches the Datacenter in config.
-//
-// TODO: extract this so that it can be used with other grpc services.
-// TODO: rename to ForwardToDC
-func (s subscribeBackend) Forward(dc string, f func(*grpc.ClientConn) error) (handled bool, err error) {
-	if dc == "" || dc == s.srv.config.Datacenter {
-		return false, nil
-	}
-	conn, err := s.connPool.ClientConn(dc)
-	if err != nil {
-		return false, err
-	}
-	return true, f(conn)
+func (s subscribeBackend) Forward(info structs.RPCInfo, f func(*grpc.ClientConn) error) (handled bool, err error) {
+	return s.srv.ForwardGRPC(s.connPool, info, f)
 }
 
 func (s subscribeBackend) Subscribe(req *stream.SubscribeRequest) (*stream.Subscription, error) {

--- a/agent/consul/subscribe_backend_test.go
+++ b/agent/consul/subscribe_backend_test.go
@@ -362,16 +362,18 @@ func TestSubscribeBackend_IntegrationWithServer_DeliversAllMessages(t *testing.T
 }
 
 func newClientWithGRPCResolver(t *testing.T, ops ...func(*Config)) (*Client, *resolver.ServerResolverBuilder) {
-	builder := resolver.NewServerResolverBuilder(newTestResolverConfig(t, "client"))
-	resolver.Register(builder)
-	t.Cleanup(func() {
-		resolver.Deregister(builder.Authority())
-	})
-
 	_, config := testClientConfig(t)
 	for _, op := range ops {
 		op(config)
 	}
+
+	builder := resolver.NewServerResolverBuilder(newTestResolverConfig(t,
+		"client."+config.Datacenter+"."+string(config.NodeID)))
+
+	resolver.Register(builder)
+	t.Cleanup(func() {
+		resolver.Deregister(builder.Authority())
+	})
 
 	deps := newDefaultDeps(t, config)
 	deps.Router = router.NewRouter(

--- a/agent/rpc/subscribe/subscribe.go
+++ b/agent/rpc/subscribe/subscribe.go
@@ -37,13 +37,13 @@ var _ pbsubscribe.StateChangeSubscriptionServer = (*Server)(nil)
 
 type Backend interface {
 	ResolveTokenAndDefaultMeta(token string, entMeta *structs.EnterpriseMeta, authzContext *acl.AuthorizerContext) (acl.Authorizer, error)
-	Forward(dc string, f func(*grpc.ClientConn) error) (handled bool, err error)
+	Forward(info structs.RPCInfo, f func(*grpc.ClientConn) error) (handled bool, err error)
 	Subscribe(req *stream.SubscribeRequest) (*stream.Subscription, error)
 }
 
 func (h *Server) Subscribe(req *pbsubscribe.SubscribeRequest, serverStream pbsubscribe.StateChangeSubscription_SubscribeServer) error {
 	logger := newLoggerForRequest(h.Logger, req)
-	handled, err := h.Backend.Forward(req.Datacenter, forwardToDC(req, serverStream, logger))
+	handled, err := h.Backend.Forward(req, forwardToDC(req, serverStream, logger))
 	if handled || err != nil {
 		return err
 	}

--- a/agent/rpc/subscribe/subscribe_test.go
+++ b/agent/rpc/subscribe/subscribe_test.go
@@ -292,7 +292,7 @@ func (b testBackend) ResolveTokenAndDefaultMeta(
 	return b.authorizer(token, entMeta), nil
 }
 
-func (b testBackend) Forward(_ string, fn func(*gogrpc.ClientConn) error) (handled bool, err error) {
+func (b testBackend) Forward(_ structs.RPCInfo, fn func(*gogrpc.ClientConn) error) (handled bool, err error) {
 	if b.forwardConn != nil {
 		return true, fn(b.forwardConn)
 	}

--- a/agent/submatview/store_integration_test.go
+++ b/agent/submatview/store_integration_test.go
@@ -146,7 +146,7 @@ func (b backend) ResolveTokenAndDefaultMeta(string, *structs.EnterpriseMeta, *ac
 	return acl.AllowAll(), nil
 }
 
-func (b backend) Forward(string, func(*grpc.ClientConn) error) (handled bool, err error) {
+func (b backend) Forward(structs.RPCInfo, func(*grpc.ClientConn) error) (handled bool, err error) {
 	return false, nil
 }
 

--- a/proto/pbcommon/common.go
+++ b/proto/pbcommon/common.go
@@ -112,27 +112,61 @@ func (q *QueryMeta) GetBackend() structs.QueryBackend {
 }
 
 // WriteRequest only applies to writes, always false
+//
+// IsRead implements structs.RPCInfo
 func (w WriteRequest) IsRead() bool {
 	return false
 }
 
+// SetTokenSecret implements structs.RPCInfo
 func (w WriteRequest) TokenSecret() string {
 	return w.Token
 }
 
+// SetTokenSecret implements structs.RPCInfo
 func (w *WriteRequest) SetTokenSecret(s string) {
 	w.Token = s
 }
 
 // AllowStaleRead returns whether a stale read should be allowed
+//
+// AllowStaleRead implements structs.RPCInfo
 func (w WriteRequest) AllowStaleRead() bool {
 	return false
 }
 
+// HasTimedOut implements structs.RPCInfo
 func (w WriteRequest) HasTimedOut(start time.Time, rpcHoldTimeout, _, _ time.Duration) bool {
 	return time.Since(start) > rpcHoldTimeout
 }
 
+// IsRead implements structs.RPCInfo
+func (r *ReadRequest) IsRead() bool {
+	return true
+}
+
+// AllowStaleRead implements structs.RPCInfo
+func (r *ReadRequest) AllowStaleRead() bool {
+	// TODO(partitions): plumb this?
+	return false
+}
+
+// TokenSecret implements structs.RPCInfo
+func (r *ReadRequest) TokenSecret() string {
+	return r.Token
+}
+
+// SetTokenSecret implements structs.RPCInfo
+func (r *ReadRequest) SetTokenSecret(token string) {
+	r.Token = token
+}
+
+// HasTimedOut implements structs.RPCInfo
+func (r *ReadRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
+	return time.Since(start) > rpcHoldTimeout
+}
+
+// RequestDatacenter implements structs.RPCInfo
 func (td TargetDatacenter) RequestDatacenter() string {
 	return td.Datacenter
 }

--- a/proto/pbsubscribe/subscribe.go
+++ b/proto/pbsubscribe/subscribe.go
@@ -1,0 +1,33 @@
+package pbsubscribe
+
+import "time"
+
+// RequestDatacenter implements structs.RPCInfo
+func (req *SubscribeRequest) RequestDatacenter() string {
+	return req.Datacenter
+}
+
+// IsRead implements structs.RPCInfo
+func (req *SubscribeRequest) IsRead() bool {
+	return true
+}
+
+// AllowStaleRead implements structs.RPCInfo
+func (req *SubscribeRequest) AllowStaleRead() bool {
+	return true
+}
+
+// TokenSecret implements structs.RPCInfo
+func (req *SubscribeRequest) TokenSecret() string {
+	return req.Token
+}
+
+// SetTokenSecret implements structs.RPCInfo
+func (req *SubscribeRequest) SetTokenSecret(token string) {
+	req.Token = token
+}
+
+// HasTimedOut implements structs.RPCInfo
+func (req *SubscribeRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
+	return time.Since(start) > rpcHoldTimeout
+}


### PR DESCRIPTION
Fixes #11086