### PR TITLE
connect: Allow upstream listener escape hatch for prepared queries

### DIFF
--- a/.changelog/11109.txt
+++ b/.changelog/11109.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fix upstream listener escape hatch for prepared queries
+```

--- a/agent/structs/testing_connect_proxy_config.go
+++ b/agent/structs/testing_connect_proxy_config.go
@@ -31,13 +31,11 @@ func TestUpstreams(t testing.T) Upstreams {
 			DestinationName:  "geo-cache",
 			LocalBindPort:    8181,
 			LocalBindAddress: "127.10.10.10",
-			Config:           map[string]interface{}{},
 		},
 		{
 			DestinationName:     "upstream_socket",
 			LocalBindSocketPath: "/tmp/upstream.sock",
 			LocalBindSocketMode: "0700",
-			Config:              map[string]interface{}{},
 		},
 	}
 }

--- a/agent/structs/testing_connect_proxy_config.go
+++ b/agent/structs/testing_connect_proxy_config.go
@@ -31,11 +31,13 @@ func TestUpstreams(t testing.T) Upstreams {
 			DestinationName:  "geo-cache",
 			LocalBindPort:    8181,
 			LocalBindAddress: "127.10.10.10",
+			Config:           map[string]interface{}{},
 		},
 		{
 			DestinationName:     "upstream_socket",
 			LocalBindSocketPath: "/tmp/upstream.sock",
 			LocalBindSocketMode: "0700",
+			Config:              map[string]interface{}{},
 		},
 	}
 }

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -257,7 +257,7 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		if cfg.EnvoyListenerJSON != "" {
 			upstreamListener, err := makeListenerFromUserConfig(cfg.EnvoyListenerJSON)
 			if err != nil {
-				s.Logger.Warn("failed to parse envoy_listener_json",
+				s.Logger.Error("failed to parse envoy_listener_json",
 					"upstream", u.Identifier(),
 					"error", err)
 				continue

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -257,7 +257,10 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		if cfg.EnvoyListenerJSON != "" {
 			upstreamListener, err := makeListenerFromUserConfig(cfg.EnvoyListenerJSON)
 			if err != nil {
-				return nil, err
+				s.Logger.Warn("failed to parse envoy_listener_json",
+					"upstream", u.Identifier(),
+					"error", err)
+				continue
 			}
 			resources = append(resources, upstreamListener)
 			continue

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -252,6 +252,17 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			// default config if there is an error so it's safe to continue.
 			s.Logger.Warn("failed to parse", "upstream", u.Identifier(), "error", err)
 		}
+
+		// If escape hatch is present, create a listener from it and move on to the next
+		if cfg.EnvoyListenerJSON != "" {
+			upstreamListener, err := makeListenerFromUserConfig(cfg.EnvoyListenerJSON)
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, upstreamListener)
+			continue
+		}
+
 		upstreamListener := makeListener(id, u, envoy_core_v3.TrafficDirection_OUTBOUND)
 
 		filterChain, err := s.makeUpstreamFilterChainForDiscoveryChain(

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -159,20 +159,24 @@ func TestListenersFromSnapshot(t *testing.T) {
 			name:   "custom-upstream",
 			create: proxycfg.TestConfigSnapshot,
 			setup: func(snap *proxycfg.ConfigSnapshot) {
-				snap.Proxy.Upstreams[0].Config["envoy_listener_json"] =
-					customListenerJSON(t, customListenerJSONOptions{
-						Name: "custom-upstream",
-					})
+				for i := range snap.Proxy.Upstreams {
+					snap.Proxy.Upstreams[i].Config["envoy_listener_json"] =
+						customListenerJSON(t, customListenerJSONOptions{
+							Name: snap.Proxy.Upstreams[i].DestinationName + ":custom-upstream",
+						})
+				}
 			},
 		},
 		{
 			name:   "custom-upstream-ignored-with-disco-chain",
 			create: proxycfg.TestConfigSnapshotDiscoveryChainWithFailover,
 			setup: func(snap *proxycfg.ConfigSnapshot) {
-				snap.Proxy.Upstreams[0].Config["envoy_listener_json"] =
-					customListenerJSON(t, customListenerJSONOptions{
-						Name: "custom-upstream",
-					})
+				for i := range snap.Proxy.Upstreams {
+					snap.Proxy.Upstreams[i].Config["envoy_listener_json"] =
+						customListenerJSON(t, customListenerJSONOptions{
+							Name: snap.Proxy.Upstreams[i].DestinationName + ":custom-upstream",
+						})
+				}
 			},
 		},
 		{

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -165,7 +165,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 					}
 					snap.Proxy.Upstreams[i].Config["envoy_listener_json"] =
 						customListenerJSON(t, customListenerJSONOptions{
-							Name: snap.Proxy.Upstreams[i].DestinationName + ":custom-upstream",
+							Name: snap.Proxy.Upstreams[i].Identifier() + ":custom-upstream",
 						})
 				}
 			},
@@ -180,7 +180,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 					}
 					snap.Proxy.Upstreams[i].Config["envoy_listener_json"] =
 						customListenerJSON(t, customListenerJSONOptions{
-							Name: snap.Proxy.Upstreams[i].DestinationName + ":custom-upstream",
+							Name: snap.Proxy.Upstreams[i].Identifier() + ":custom-upstream",
 						})
 				}
 			},

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -160,6 +160,9 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshot,
 			setup: func(snap *proxycfg.ConfigSnapshot) {
 				for i := range snap.Proxy.Upstreams {
+					if snap.Proxy.Upstreams[i].Config == nil {
+						snap.Proxy.Upstreams[i].Config = map[string]interface{}{}
+					}
 					snap.Proxy.Upstreams[i].Config["envoy_listener_json"] =
 						customListenerJSON(t, customListenerJSONOptions{
 							Name: snap.Proxy.Upstreams[i].DestinationName + ":custom-upstream",
@@ -172,6 +175,9 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshotDiscoveryChainWithFailover,
 			setup: func(snap *proxycfg.ConfigSnapshot) {
 				for i := range snap.Proxy.Upstreams {
+					if snap.Proxy.Upstreams[i].Config == nil {
+						snap.Proxy.Upstreams[i].Config = map[string]interface{}{}
+					}
 					snap.Proxy.Upstreams[i].Config["envoy_listener_json"] =
 						customListenerJSON(t, customListenerJSONOptions{
 							Name: snap.Proxy.Upstreams[i].DestinationName + ":custom-upstream",

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-18-x.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name": "custom-upstream",
+      "name": "db:custom-upstream",
       "address": {
         "socketAddress": {
           "address": "11.11.11.11",
@@ -27,11 +27,11 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "name": "geo-cache:custom-upstream",
       "address": {
         "socketAddress": {
-          "address": "127.10.10.10",
-          "portValue": 8181
+          "address": "11.11.11.11",
+          "portValue": 11111
         }
       },
       "filterChains": [
@@ -41,14 +41,13 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "upstream.prepared_query_geo-cache",
-                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+                "statPrefix": "foo-stats",
+                "cluster": "random-cluster"
               }
             }
           ]
         }
-      ],
-      "trafficDirection": "OUTBOUND"
+      ]
     },
     {
       "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-18-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-18-x.golden
@@ -27,7 +27,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name": "geo-cache:custom-upstream",
+      "name": "prepared_query:geo-cache:custom-upstream",
       "address": {
         "socketAddress": {
           "address": "11.11.11.11",

--- a/agent/xds/testdata/listeners/custom-upstream.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.v2compat.envoy-1-16-x.golden
@@ -27,7 +27,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Listener",
-      "name": "geo-cache:custom-upstream",
+      "name": "prepared_query:geo-cache:custom-upstream",
       "address": {
         "socketAddress": {
           "address": "11.11.11.11",

--- a/agent/xds/testdata/listeners/custom-upstream.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.v2compat.envoy-1-16-x.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Listener",
-      "name": "custom-upstream",
+      "name": "db:custom-upstream",
       "address": {
         "socketAddress": {
           "address": "11.11.11.11",
@@ -27,11 +27,11 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Listener",
-      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "name": "geo-cache:custom-upstream",
       "address": {
         "socketAddress": {
-          "address": "127.10.10.10",
-          "portValue": 8181
+          "address": "11.11.11.11",
+          "portValue": 11111
         }
       },
       "filterChains": [
@@ -41,14 +41,13 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy",
-                "statPrefix": "upstream.prepared_query_geo-cache",
-                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+                "statPrefix": "foo-stats",
+                "cluster": "random-cluster"
               }
             }
           ]
         }
-      ],
-      "trafficDirection": "OUTBOUND"
+      ]
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Listener",


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/10897

We were missing a codepath for envoy listener escape hatches defined on Prepared Query upstream configs. The envoy tests were updated to cover this case.