### PR TITLE
Fix broken backport of #11107 1.9.x

### DIFF
--- a/agent/delegate_mock_test.go
+++ b/agent/delegate_mock_test.go
@@ -15,6 +15,10 @@ type delegateMock struct {
 	mock.Mock
 }
 
+var (
+	_ delegate = &delegateMock{}
+)
+
 func (m *delegateMock) GetLANCoordinate() (lib.CoordinateSet, error) {
 	ret := m.Called()
 	return ret.Get(0).(lib.CoordinateSet), ret.Error(1)
@@ -81,6 +85,6 @@ func (m *delegateMock) Stats() map[string]map[string]string {
 	return m.Called().Get(0).(map[string]map[string]string)
 }
 
-func (m *delegateMock) ReloadConfig(config consul.ReloadableConfig) error {
+func (m *delegateMock) ReloadConfig(config *consul.Config) error {
 	return m.Called(config).Error(0)
 }


### PR DESCRIPTION
Fixes backport of #11107

Not sure why the backporting process didn't catch that the type didn't exist in the old version. Regardless its fixed