### PR TITLE
[1.10.x] grpc: strip local ACL tokens from RPCs during forwarding if crossing datacenters

### DIFF
--- a/.changelog/11099.txt
+++ b/.changelog/11099.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+grpc: strip local ACL tokens from RPCs during forwarding if crossing datacenters
+```
+```release-note:feature
+partitions: allow for partition queries to be forwarded
+```

--- a/.changelog/11099.txt
+++ b/.changelog/11099.txt
@@ -1,6 +1,3 @@
 ```release-note:bug
 grpc: strip local ACL tokens from RPCs during forwarding if crossing datacenters
 ```
-```release-note:feature
-partitions: allow for partition queries to be forwarded
-```

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/binary"
 	"errors"
@@ -25,15 +26,17 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/hashicorp/consul/agent/connect"
+	"google.golang.org/grpc"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/state"
+	agent_grpc "github.com/hashicorp/consul/agent/grpc"
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/structs"
 	tokenStore "github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/proto/pbsubscribe"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
@@ -967,6 +970,201 @@ func TestRPC_LocalTokenStrippedOnForward(t *testing.T) {
 	require.Equal(t, localToken2.SecretID, arg.WriteRequest.Token, "token should not be stripped")
 }
 
+func TestRPC_LocalTokenStrippedOnForward_GRPC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLDefaultPolicy = "deny"
+		c.ACLMasterToken = "root"
+		c.RPCConfig.EnableStreaming = true
+	})
+	s1.tokens.UpdateAgentToken("root", tokenStore.TokenSourceConfig)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc2"
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLDefaultPolicy = "deny"
+		c.ACLTokenReplication = true
+		c.ACLReplicationRate = 100
+		c.ACLReplicationBurst = 100
+		c.ACLReplicationApplyLimit = 1000000
+		c.RPCConfig.EnableStreaming = true
+	})
+	s2.tokens.UpdateReplicationToken("root", tokenStore.TokenSourceConfig)
+	s2.tokens.UpdateAgentToken("root", tokenStore.TokenSourceConfig)
+	testrpc.WaitForLeader(t, s2.RPC, "dc2")
+	defer os.RemoveAll(dir2)
+	defer s2.Shutdown()
+	codec2 := rpcClient(t, s2)
+	defer codec2.Close()
+
+	// Try to join.
+	joinWAN(t, s2, s1)
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	testrpc.WaitForLeader(t, s1.RPC, "dc2")
+
+	// Wait for legacy acls to be disabled so we are clear that
+	// legacy replication isn't meddling.
+	waitForNewACLs(t, s1)
+	waitForNewACLs(t, s2)
+	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
+
+	// create simple service policy
+	policy, err := upsertTestPolicyWithRules(codec, "root", "dc1", `
+	node_prefix "" { policy = "read" }
+	service_prefix "" { policy = "read" }
+	`)
+	require.NoError(t, err)
+
+	// Wait for it to replicate
+	retry.Run(t, func(r *retry.R) {
+		_, p, err := s2.fsm.State().ACLPolicyGetByID(nil, policy.ID, &structs.EnterpriseMeta{})
+		require.Nil(r, err)
+		require.NotNil(r, p)
+	})
+
+	// create local token that only works in DC2
+	localToken2, err := upsertTestToken(codec, "root", "dc2", func(token *structs.ACLToken) {
+		token.Local = true
+		token.Policies = []structs.ACLTokenPolicyLink{
+			{ID: policy.ID},
+		}
+	})
+	require.NoError(t, err)
+
+	runStep(t, "Register a dummy node with a service", func(t *testing.T) {
+		req := &structs.RegisterRequest{
+			Node:       "node1",
+			Address:    "3.4.5.6",
+			Datacenter: "dc1",
+			Service: &structs.NodeService{
+				ID:      "redis1",
+				Service: "redis",
+				Address: "3.4.5.6",
+				Port:    8080,
+			},
+			WriteRequest: structs.WriteRequest{Token: "root"},
+		}
+		var out struct{}
+		require.NoError(t, s1.RPC("Catalog.Register", &req, &out))
+	})
+
+	var conn *grpc.ClientConn
+	{
+		client, builder := newClientWithGRPCResolver(t, func(c *Config) {
+			c.Datacenter = "dc2"
+			c.PrimaryDatacenter = "dc1"
+			c.RPCConfig.EnableStreaming = true
+		})
+		joinLAN(t, client, s2)
+		testrpc.WaitForTestAgent(t, client.RPC, "dc2", testrpc.WithToken("root"))
+
+		pool := agent_grpc.NewClientConnPool(agent_grpc.ClientConnPoolConfig{
+			Servers:               builder,
+			DialingFromServer:     false,
+			DialingFromDatacenter: "dc2",
+		})
+
+		conn, err = pool.ClientConn("dc2")
+		require.NoError(t, err)
+	}
+
+	// Try to use it locally (it should work)
+	runStep(t, "token used locally should work", func(t *testing.T) {
+		arg := &pbsubscribe.SubscribeRequest{
+			Topic:      pbsubscribe.Topic_ServiceHealth,
+			Key:        "redis",
+			Token:      localToken2.SecretID,
+			Datacenter: "dc2",
+		}
+		event, err := getFirstSubscribeEventOrError(conn, arg)
+		require.NoError(t, err)
+		require.NotNil(t, event)
+
+		// make sure that token restore defer works
+		require.Equal(t, localToken2.SecretID, arg.Token, "token should not be stripped")
+	})
+
+	runStep(t, "token used remotely should not work", func(t *testing.T) {
+		arg := &pbsubscribe.SubscribeRequest{
+			Topic:      pbsubscribe.Topic_ServiceHealth,
+			Key:        "redis",
+			Token:      localToken2.SecretID,
+			Datacenter: "dc1",
+		}
+
+		event, err := getFirstSubscribeEventOrError(conn, arg)
+
+		// NOTE: the subscription endpoint is a filtering style instead of a
+		// hard-fail style so when the token isn't present 100% of the data is
+		// filtered out leading to a stream with an empty snapshot.
+		require.NoError(t, err)
+		require.IsType(t, &pbsubscribe.Event_EndOfSnapshot{}, event.Payload)
+		require.True(t, event.Payload.(*pbsubscribe.Event_EndOfSnapshot).EndOfSnapshot)
+	})
+
+	runStep(t, "update anonymous token to read services", func(t *testing.T) {
+		tokenUpsertReq := structs.ACLTokenSetRequest{
+			Datacenter: "dc1",
+			ACLToken: structs.ACLToken{
+				AccessorID: structs.ACLTokenAnonymousID,
+				Policies: []structs.ACLTokenPolicyLink{
+					{ID: policy.ID},
+				},
+			},
+			WriteRequest: structs.WriteRequest{Token: "root"},
+		}
+		token := structs.ACLToken{}
+		err = msgpackrpc.CallWithCodec(codec, "ACL.TokenSet", &tokenUpsertReq, &token)
+		require.NoError(t, err)
+		require.NotEmpty(t, token.SecretID)
+	})
+
+	runStep(t, "token used remotely should fallback on anonymous token now", func(t *testing.T) {
+		arg := &pbsubscribe.SubscribeRequest{
+			Topic:      pbsubscribe.Topic_ServiceHealth,
+			Key:        "redis",
+			Token:      localToken2.SecretID,
+			Datacenter: "dc1",
+		}
+
+		event, err := getFirstSubscribeEventOrError(conn, arg)
+		require.NoError(t, err)
+		require.NotNil(t, event)
+
+		// So now that we can read data, we should get a snapshot with just instances of the "consul" service.
+		require.NoError(t, err)
+
+		require.IsType(t, &pbsubscribe.Event_ServiceHealth{}, event.Payload)
+		esh := event.Payload.(*pbsubscribe.Event_ServiceHealth)
+
+		require.Equal(t, pbsubscribe.CatalogOp_Register, esh.ServiceHealth.Op)
+		csn := esh.ServiceHealth.CheckServiceNode
+
+		require.NotNil(t, csn)
+		require.NotNil(t, csn.Node)
+		require.Equal(t, "node1", csn.Node.Node)
+		require.Equal(t, "3.4.5.6", csn.Node.Address)
+		require.NotNil(t, csn.Service)
+		require.Equal(t, "redis1", csn.Service.ID)
+		require.Equal(t, "redis", csn.Service.Service)
+
+		// make sure that token restore defer works
+		require.Equal(t, localToken2.SecretID, arg.Token, "token should not be stripped")
+	})
+}
+
 func TestCanRetry(t *testing.T) {
 	type testCase struct {
 		name     string
@@ -1312,4 +1510,24 @@ func isConnectionClosedError(err error) bool {
 	default:
 		return false
 	}
+}
+
+func getFirstSubscribeEventOrError(conn *grpc.ClientConn, req *pbsubscribe.SubscribeRequest) (*pbsubscribe.Event, error) {
+	streamClient := pbsubscribe.NewStateChangeSubscriptionClient(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handle, err := streamClient.Subscribe(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	event, err := handle.Recv()
+	if err == io.EOF {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return event, nil
 }

--- a/agent/consul/subscribe_backend.go
+++ b/agent/consul/subscribe_backend.go
@@ -26,20 +26,8 @@ func (s subscribeBackend) ResolveTokenAndDefaultMeta(
 
 var _ subscribe.Backend = (*subscribeBackend)(nil)
 
-// Forward requests to a remote datacenter by calling f if the target dc does not
-// match the config. Does nothing but return handled=false if dc is not specified,
-// or if it matches the Datacenter in config.
-//
-// TODO: extract this so that it can be used with other grpc services.
-func (s subscribeBackend) Forward(dc string, f func(*grpc.ClientConn) error) (handled bool, err error) {
-	if dc == "" || dc == s.srv.config.Datacenter {
-		return false, nil
-	}
-	conn, err := s.connPool.ClientConn(dc)
-	if err != nil {
-		return false, err
-	}
-	return true, f(conn)
+func (s subscribeBackend) Forward(info structs.RPCInfo, f func(*grpc.ClientConn) error) (handled bool, err error) {
+	return s.srv.ForwardGRPC(s.connPool, info, f)
 }
 
 func (s subscribeBackend) Subscribe(req *stream.SubscribeRequest) (*stream.Subscription, error) {

--- a/agent/consul/subscribe_backend_test.go
+++ b/agent/consul/subscribe_backend_test.go
@@ -363,16 +363,18 @@ func TestSubscribeBackend_IntegrationWithServer_DeliversAllMessages(t *testing.T
 }
 
 func newClientWithGRPCResolver(t *testing.T, ops ...func(*Config)) (*Client, *resolver.ServerResolverBuilder) {
-	builder := resolver.NewServerResolverBuilder(newTestResolverConfig(t, "client"))
-	resolver.Register(builder)
-	t.Cleanup(func() {
-		resolver.Deregister(builder.Authority())
-	})
-
 	_, config := testClientConfig(t)
 	for _, op := range ops {
 		op(config)
 	}
+
+	builder := resolver.NewServerResolverBuilder(newTestResolverConfig(t,
+		"client."+config.Datacenter+"."+string(config.NodeID)))
+
+	resolver.Register(builder)
+	t.Cleanup(func() {
+		resolver.Deregister(builder.Authority())
+	})
 
 	deps := newDefaultDeps(t, config)
 	deps.Router = router.NewRouter(

--- a/agent/rpc/subscribe/subscribe.go
+++ b/agent/rpc/subscribe/subscribe.go
@@ -37,13 +37,13 @@ var _ pbsubscribe.StateChangeSubscriptionServer = (*Server)(nil)
 
 type Backend interface {
 	ResolveTokenAndDefaultMeta(token string, entMeta *structs.EnterpriseMeta, authzContext *acl.AuthorizerContext) (acl.Authorizer, error)
-	Forward(dc string, f func(*grpc.ClientConn) error) (handled bool, err error)
+	Forward(info structs.RPCInfo, f func(*grpc.ClientConn) error) (handled bool, err error)
 	Subscribe(req *stream.SubscribeRequest) (*stream.Subscription, error)
 }
 
 func (h *Server) Subscribe(req *pbsubscribe.SubscribeRequest, serverStream pbsubscribe.StateChangeSubscription_SubscribeServer) error {
 	logger := newLoggerForRequest(h.Logger, req)
-	handled, err := h.Backend.Forward(req.Datacenter, forwardToDC(req, serverStream, logger))
+	handled, err := h.Backend.Forward(req, forwardToDC(req, serverStream, logger))
 	if handled || err != nil {
 		return err
 	}

--- a/agent/rpc/subscribe/subscribe_test.go
+++ b/agent/rpc/subscribe/subscribe_test.go
@@ -289,7 +289,7 @@ func (b testBackend) ResolveTokenAndDefaultMeta(
 	return b.authorizer(token), nil
 }
 
-func (b testBackend) Forward(_ string, fn func(*gogrpc.ClientConn) error) (handled bool, err error) {
+func (b testBackend) Forward(_ structs.RPCInfo, fn func(*gogrpc.ClientConn) error) (handled bool, err error) {
 	if b.forwardConn != nil {
 		return true, fn(b.forwardConn)
 	}

--- a/agent/submatview/store_integration_test.go
+++ b/agent/submatview/store_integration_test.go
@@ -146,7 +146,7 @@ func (b backend) ResolveTokenAndDefaultMeta(string, *structs.EnterpriseMeta, *ac
 	return acl.AllowAll(), nil
 }
 
-func (b backend) Forward(string, func(*grpc.ClientConn) error) (handled bool, err error) {
+func (b backend) Forward(structs.RPCInfo, func(*grpc.ClientConn) error) (handled bool, err error) {
 	return false, nil
 }
 

--- a/proto/pbcommon/common.go
+++ b/proto/pbcommon/common.go
@@ -104,23 +104,30 @@ func (q *QueryMeta) GetBackend() structs.QueryBackend {
 }
 
 // WriteRequest only applies to writes, always false
+//
+// IsRead implements structs.RPCInfo
 func (w WriteRequest) IsRead() bool {
 	return false
 }
 
+// SetTokenSecret implements structs.RPCInfo
 func (w WriteRequest) TokenSecret() string {
 	return w.Token
 }
 
+// SetTokenSecret implements structs.RPCInfo
 func (w *WriteRequest) SetTokenSecret(s string) {
 	w.Token = s
 }
 
 // AllowStaleRead returns whether a stale read should be allowed
+//
+// AllowStaleRead implements structs.RPCInfo
 func (w WriteRequest) AllowStaleRead() bool {
 	return false
 }
 
+// RequestDatacenter implements structs.RPCInfo
 func (td TargetDatacenter) RequestDatacenter() string {
 	return td.Datacenter
 }

--- a/proto/pbsubscribe/subscribe.go
+++ b/proto/pbsubscribe/subscribe.go
@@ -1,0 +1,26 @@
+package pbsubscribe
+
+// RequestDatacenter implements structs.RPCInfo
+func (req *SubscribeRequest) RequestDatacenter() string {
+	return req.Datacenter
+}
+
+// IsRead implements structs.RPCInfo
+func (req *SubscribeRequest) IsRead() bool {
+	return true
+}
+
+// AllowStaleRead implements structs.RPCInfo
+func (req *SubscribeRequest) AllowStaleRead() bool {
+	return true
+}
+
+// TokenSecret implements structs.RPCInfo
+func (req *SubscribeRequest) TokenSecret() string {
+	return req.Token
+}
+
+// SetTokenSecret implements structs.RPCInfo
+func (req *SubscribeRequest) SetTokenSecret(token string) {
+	req.Token = token
+}


### PR DESCRIPTION
backport of #11099 to `release/1.10.x`

Conflicts:
- `agent/consul/rpc.go`: this needed a lot of work just because there is no concept of leader forwarding for gRPC in 1.10.x
- `agent/consul/subscribe_backend.go`
- `proto/pbcommon/common.go`