### PR TITLE
ui: Use last-child for selecting the desired nspace instead of nth-child

### DIFF
--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/create.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/create.feature
@@ -37,11 +37,11 @@ Feature: dc / intentions / create: Intention Create
     Then I see the text "db" in "[data-test-destination-element] .ember-power-select-selected-item"
     # Set source nspace
     And I click "[data-test-source-nspace] .ember-power-select-trigger"
-    And I click ".ember-power-select-option:nth-child(2)"
+    And I click ".ember-power-select-option:last-child"
     Then I see the text "nspace-0" in "[data-test-source-nspace] .ember-power-select-selected-item"
     # Set destination nspace
     And I click "[data-test-destination-nspace] .ember-power-select-trigger"
-    And I click ".ember-power-select-option:nth-child(2)"
+    And I click ".ember-power-select-option:last-child"
     Then I see the text "nspace-0" in "[data-test-destination-nspace] .ember-power-select-selected-item"
     # Specifically set deny
     And I click ".value-deny"


### PR DESCRIPTION
This one has a long and complicated story, so I'll keep it as brief as I can.

- https://github.com/hashicorp/consul/pull/10706 fixed a visual bug reported in https://github.com/hashicorp/consul/issues/10686 but in doing so created a blocking bug that was only backported to 1.10 and 1.9 (I'm not entirely sure why, there seems to be some backporting confusion on that PR judging by the GH history)
- The blocking bug was fixed in https://github.com/hashicorp/consul/pull/11095 by reverting to the previous functionality and fixing the original visual bug with some ~copypasta so that our namespace menus consistently worked the same as the service menus. This fixed the blocking bug across 1.9 and 1.10 but the blocking bug was never backported to 1.8 so only the visual bug needed to be fixed there.
- I fixed the original visual bug in 1.8 by manually backporting the final fix to 1.18 in https://github.com/hashicorp/consul/pull/11102
- The final fix from https://github.com/hashicorp/consul/pull/11095 included tests for both the visual bug and the blocking bug. Which again were backported to 1.10 and 1.9, and manually to 1.8, but as we don't fix bugs on the version where they were introduced and bring the fix forwards testing as we go (we fix on the latest version and bot/backport), it's easy to get the older branches in a state where tests don't pass without anyone noticing due to the botporting.
- The tests for the final fix in https://github.com/hashicorp/consul/pull/11095 relied on tiny details that are different throughout 1.8, 1.9, 1.10 and main (soon to be 1.11). I manually backported 1.8 so I knew the tests there worked, but a while after by chance I noticed that our tests were failing on 1.9 and 1.10 🎉 

This PR is the first part of bringing all of this back into line:

1. The test selector previously used (`nth-child(2)`) has been changed to a less brittle selector (`last-child`). This change is not needed for main/1.11, but it is needed for 1.10 and I'd rather have 1.10 as close as possible to 1.11. This PR contains this change, which will be backported to 1.10 and 1.9 and maybe 1.8 now I come to think of it 🤔 .
2. Even with this change 1.9 is still broken as 1.9 doesn't have `dont` available which is what the testing relies on here https://github.com/hashicorp/consul/pull/11102/files#diff-9942694b32bb45cceda71fd48237cc5876378c7063fdddd5a89899d2405ca16aR17, so there will be a further PR just for 1.9 to add that line in (https://github.com/hashicorp/consul/blob/05e5bc0248ccadcfbee73d5896fbd3a846290398/ui-v2/tests/steps/assertions/dom.js#L1), so until that PR is up and merged 1.9 tests will still be broken even with this 'selector' change backported. (I'll be PRing a 1.9 only fix to add `dont` shortly)

I'll try to link things together with GH links as much as I can, I'm pretty sure that everything will be good to go once all of this is sorted out 🤞 We'll see what happens when its all done.

Just to be clear, all of this is just hoop jumping to ensure tests pass on older release branches. Both user facing 'bugs' were fixed in https://github.com/hashicorp/consul/pull/11095 and nothing here is required for that fix.

(it might be best longer term to add a 1.8 backport here also, just triple checking/thinking about that now before I do that)


