### PR TITLE
ui: Remove info panel from the nspace menu when editing nspaces

### DIFF
--- a/.changelog/11130.txt
+++ b/.changelog/11130.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+ui: Removed informational panel from the namespace selector menu when editing
+namespaces
+```

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -115,13 +115,6 @@
                 <BlockSlot @name="trigger">
                   {{@nspace}}
                 </BlockSlot>
-              {{#if (is-href 'dc.nspaces')}}
-                <BlockSlot @name="header">
-                  <p>
-					          Namespaces themselves are not namespaced, so switching will not change the current view.
-                  </p>
-                </BlockSlot>
-              {{/if}}
                 <BlockSlot @name="menu">
                   {{#let components.MenuItem components.MenuSeparator as |MenuItem MenuSeparator|}}
                     <DataSource

--- a/ui/packages/consul-ui/app/styles/themes.scss
+++ b/ui/packages/consul-ui/app/styles/themes.scss
@@ -6,9 +6,6 @@
 %main-nav-horizontal {
   @extend %theme-dark;
 }
-%main-nav-vertical .nspaces .menu-panel > div {
-  @extend %theme-light;
-}
 %main-nav-vertical .menu-panel a:hover,
 %main-nav-vertical .menu-panel a:focus {
   background-color: var(--blue-500);


### PR DESCRIPTION
A while back we decided we would get rid of this informational panel at the top of the Namespace menu when editing namespaces. It kinda felt like a good time to remove of it.

This light-themed panel is the panel that has been removed:

<img width="561" alt="Screenshot 2021-09-23 at 13 53 46" src="https://user-images.githubusercontent.com/554604/134510271-5ee361ed-8bed-40ed-b55b-71f6c5c0e062.png">


