### PR TITLE
ui: Adds a set of basic unit tests for abilities

### DIFF
--- a/ui/packages/consul-ui/tests/unit/abilities/-test.js
+++ b/ui/packages/consul-ui/tests/unit/abilities/-test.js
@@ -1,0 +1,65 @@
+/* globals requirejs */
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Ability | *', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const abilities = Object.keys(requirejs.entries)
+      .filter(key => key.indexOf('/abilities/') !== -1)
+      .map(key => key.split('/').pop())
+      .filter(item => item !== '-test');
+    abilities.forEach(item => {
+      const ability = this.owner.factoryFor(`ability:${item}`).create();
+      [true, false].forEach(bool => {
+        const permissions = this.owner.lookup(`service:repository/permission`);
+        ability.permissions = {
+          has: _ => bool,
+          permissions: bool ? ['more-than-zero'] : [],
+          generate: function() {
+            return permissions.generate(...arguments);
+          },
+        };
+        ['Create', 'Read', 'Update', 'Delete', 'Write', 'List'].forEach(perm => {
+          switch (item) {
+            case 'permission':
+              ability.item = {
+                ID: bool ? 'not-anonymous' : 'anonymous',
+              };
+              break;
+            case 'acl':
+              ability.item = {
+                ID: bool ? 'not-anonymous' : 'anonymous',
+              };
+              break;
+            case 'token':
+              ability.item = {
+                AccessorID: 'not-anonymous',
+              };
+              ability.token = {
+                AccessorID: bool ? 'different-to-item' : 'not-anonymous',
+              };
+              break;
+            case 'nspace':
+            case 'partition':
+              ability.item = {
+                ID: bool ? 'not-default' : 'default',
+              };
+              break;
+            case 'kv':
+              // TODO: We currently hardcode KVs to always be true
+              assert.equal(true, ability[`can${perm}`], `Expected ${item}.can${perm} to be true`);
+              return;
+          }
+          assert.equal(
+            bool,
+            ability[`can${perm}`],
+            `Expected ${item}.can${perm} to be ${bool ? 'true' : 'false'}`
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a very small unit test to unit test all of our current and _future_ abilities and stems from an idea here:

https://github.com/hashicorp/consul/pull/10902#issuecomment-905331481

> If we wanted to go lower we could just test the abilities themselves, which would make it easier to just loop through them all and check that read, write, 'create', 'update' permissions report correctly for each model type we have (plus easily test any future models to prevent any typos like we have here). We could almost test the unit itself if it wasn't for the inheritance chain, so we'd be ever so slightly be blurring into integration, but in this case I think doing some sort of unit testing of the abilities themselves (in a future looking way) might be a good idea 🤔 . What do you think?

The PR does exactly that ^, but even when writing it I was very much thinking 'is this actually something that is worthwhile' as the logic we are testing here is extremely simple. I think the benefit here is more likely something that we will notice in the future _if_ it catches any typos etc. Right now I'm still unsure whether long term it will be worthwhile but happy to have it hanging around for a few months to see if its beneficial, we can just delete it later if it's not worthwhile.

I actually would like our adapters to follow a similar testing approach now that they are almost logic-less. Our adapters originally were full of all sorts of sprawly logic, for which the tests we have were super beneficial, especially when we moved to a more logic-less less sprawly approach. They gave us the confidence that everything continued to work correctly during and after the refactor. The thing is now there is not much to test in our adapters, the tests almost get in the way (I've noted this a few times on various admin partition related PRs). So at some point in the not too distant future we should probably decide whether to move all our adapter tests to a much easier to work with approach similar to this one.
