### PR TITLE
acl: fix default Authorizer for down_policy extend-cache/async-cache

### DIFF
--- a/acl/static_authorizer.go
+++ b/acl/static_authorizer.go
@@ -255,7 +255,11 @@ func ManageAll() Authorizer {
 	return manageAll
 }
 
-// RootAuthorizer returns a possible Authorizer if the ID matches a root policy
+// RootAuthorizer returns a possible Authorizer if the ID matches a root policy.
+//
+// TODO: rename this function. While the returned authorizer is used as a root
+// authorizer in some cases, in others it is not. A more appropriate name might
+// be NewAuthorizerFromPolicyName.
 func RootAuthorizer(id string) Authorizer {
 	switch id {
 	case "allow":

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -355,7 +355,7 @@ func NewACLResolver(config *ACLResolverConfig) (*ACLResolver, error) {
 	case "deny":
 		down = acl.DenyAll()
 	case "async-cache", "extend-cache":
-		// Leave the down policy as nil to signal this.
+		down = acl.RootAuthorizer(config.Config.ACLDefaultPolicy)
 	default:
 		return nil, fmt.Errorf("invalid ACL down policy %q", config.Config.ACLDownPolicy)
 	}

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -780,8 +780,6 @@ func TestACLResolver_ResolveRootACL(t *testing.T) {
 }
 
 func TestACLResolver_DownPolicy(t *testing.T) {
-	t.Parallel()
-
 	requireIdentityCached := func(t *testing.T, r *ACLResolver, id string, present bool, msg string) {
 		t.Helper()
 
@@ -806,7 +804,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	}
 
 	t.Run("Deny", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -831,7 +828,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Allow", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -856,7 +852,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Expired-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -893,7 +888,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Expired-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -925,7 +919,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -956,7 +949,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -988,7 +980,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Expired-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1025,7 +1016,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Expired-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1058,7 +1048,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Async-Cache-Expired-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1106,7 +1095,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Async-Cache-Expired-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1149,7 +1137,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Client-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1185,7 +1172,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Client-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1222,7 +1208,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Async-Cache", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1264,8 +1249,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("PolicyResolve-TokenNotFound", func(t *testing.T) {
-		t.Parallel()
-
 		_, rawToken, _ := testIdentityForToken("found")
 		foundToken := rawToken.(*structs.ACLToken)
 		secretID := foundToken.SecretID
@@ -1331,8 +1314,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("PolicyResolve-PermissionDenied", func(t *testing.T) {
-		t.Parallel()
-
 		_, rawToken, _ := testIdentityForToken("found")
 		foundToken := rawToken.(*structs.ACLToken)
 		secretID := foundToken.SecretID

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -596,8 +596,10 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     token cannot be read from the [`primary_datacenter`](#primary_datacenter) or
     leader node, the down policy is applied. In "allow" mode, all actions are permitted,
     "deny" restricts all operations, and "extend-cache" allows any cached objects
-    to be used, ignoring their TTL values. If a non-cached ACL is used, "extend-cache"
-    acts like "deny". The value "async-cache" acts the same way as "extend-cache"
+    to be used, ignoring the expiry time of the cached entry. If the request uses an
+    ACL that is not in the cache, "extend-cache" falls back to the behaviour of
+    `default_policy`.
+    The value "async-cache" acts the same way as "extend-cache"
     but performs updates asynchronously when ACL is present but its TTL is expired,
     thus, if latency is bad between the primary and secondary datacenters, latency
     of operations is not impacted.


### PR DESCRIPTION
I found this while working on removing legacy ACLs. Now that #10632, #10737, and 10738 have made a `nil` Authorizer invalid, we need to make sure that `ACLResolver` never returns a `nil`. This is one case where we could still return a `nil` if the item was not retrievable and not in the cache.