### PR TITLE
docs: Decode K8s secrets with base64decode function

### DIFF
--- a/website/content/docs/k8s/connect/terminating-gateways.mdx
+++ b/website/content/docs/k8s/connect/terminating-gateways.mdx
@@ -73,7 +73,7 @@ $ export CONSUL_HTTP_SSL_VERIFY=false
 If ACLs are enabled also set:
 
 ```shell-session
-$ export CONSUL_HTTP_TOKEN=$(kubectl get secret consul-bootstrap-acl-token -o jsonpath={.data.token} | base64 --decode)
+$ export CONSUL_HTTP_TOKEN=$(kubectl get secret consul-bootstrap-acl-token --template='{{.data.token | base64decode }}')
 ```
 
 ## Register external services with Consul

--- a/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
@@ -113,7 +113,7 @@ Then you have likely enabled ACLs. You need to specify your ACL token when
 running the `license get` command. First, assign the ACL token to the `CONSUL_HTTP_TOKEN` environment variable:
 
 ```shell-session
-$ export CONSUL_HTTP_TOKEN=$(kubectl get secrets/hashicorp-consul-bootstrap-acl-token --template={{.data.token}} | base64 --decode)
+$ export CONSUL_HTTP_TOKEN=$(kubectl get secrets/hashicorp-consul-bootstrap-acl-token --template='{{.data.token | base64decode }}')
 ```
 
 Now the token will be used when running Consul commands:

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -197,7 +197,7 @@ to see all resources and make modifications.
 To retrieve the bootstrap token that has full permissions, run:
 
 ```shell-session
-$ kubectl get secrets/consul-bootstrap-acl-token --template={{.data.token}} | base64 --decode
+$ kubectl get secrets/consul-bootstrap-acl-token --template='{{.data.token | base64decode }}'
 e7924dd1-dc3f-f644-da54-81a73ba0a178%
 ```
 

--- a/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
+++ b/website/content/docs/k8s/installation/multi-cluster/vms-and-kubernetes.mdx
@@ -35,15 +35,13 @@ The following sections detail how to export this data.
 1. Retrieve the certificate authority cert:
 
    ```sh
-   kubectl get secrets/consul-ca-cert --template='{{index .data "tls.crt" }}' |
-     base64 --decode > consul-agent-ca.pem
+   kubectl get secrets/consul-ca-cert --template='{{index .data "tls.crt" | base64decode }}' > consul-agent-ca.pem
    ```
 
 1. And the certificate authority signing key:
 
    ```sh
-   kubectl get secrets/consul-ca-key --template='{{index .data "tls.key" }}' |
-      base64 --decode > consul-agent-ca-key.pem
+   kubectl get secrets/consul-ca-key --template='{{index .data "tls.key" | base64decode }}' > consul-agent-ca-key.pem
    ```
 
 1. With the `consul-agent-ca.pem` and `consul-agent-ca-key.pem` files you can


### PR DESCRIPTION
Use kubectl's base64decode template function ([added in K8s 1.11](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.11.md#sig-cli-1)) to decode values in Secrets. Removes external call to `base64` utility on the host system.