### PR TITLE
ui: [Backport 1.8.x] Remove refresh-route action for session invalidation (#11105)

### DIFF
--- a/ui-v2/app/templates/dc/nodes/show/sessions.hbs
+++ b/ui-v2/app/templates/dc/nodes/show/sessions.hbs
@@ -39,7 +39,7 @@
                 <td>
                     <ConfirmationDialog @message="Are you sure you want to invalidate this session?">
                         <BlockSlot @name="action" as |confirm|>
-                            <button data-test-delete type="button" class="type-delete" onclick={{queue (action confirm 'invalidateSession' item) (refresh-route)}}>Invalidate</button>
+                            <button data-test-delete type="button" class="type-delete" onclick={{action confirm 'invalidateSession' item}}>Invalidate</button>
                         </BlockSlot>
                         <BlockSlot @name="dialog" as |execute cancel message|>
                             <p>


### PR DESCRIPTION
* ui: Move action to the correct button for session invalidation

* Remove refresh-route completely, its not needed

(Also see #11105)