### PR TITLE
addition of default field to /v1/discovery-chain/:service endpoint

### DIFF
--- a/agent/discovery_chain_endpoint.go
+++ b/agent/discovery_chain_endpoint.go
@@ -85,6 +85,7 @@ func (s *HTTPHandlers) DiscoveryChainRead(resp http.ResponseWriter, req *http.Re
 		}
 	}
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
+	out.Chain.Default = out.Chain.IsDefault()
 
 	return discoveryChainReadResponse{Chain: out.Chain}, nil
 }

--- a/agent/discovery_chain_endpoint_test.go
+++ b/agent/discovery_chain_endpoint_test.go
@@ -79,6 +79,7 @@ func TestDiscoveryChainRead(t *testing.T) {
 				Partition:   "default",
 				Datacenter:  "dc1",
 				Protocol:    "tcp",
+				Default:     true,
 				StartNode:   "resolver:web.default.default.dc1",
 				Nodes: map[string]*structs.DiscoveryGraphNode{
 					"resolver:web.default.default.dc1": {
@@ -123,6 +124,7 @@ func TestDiscoveryChainRead(t *testing.T) {
 				Partition:   "default",
 				Datacenter:  "dc2",
 				Protocol:    "tcp",
+				Default:     true,
 				StartNode:   "resolver:web.default.default.dc2",
 				Nodes: map[string]*structs.DiscoveryGraphNode{
 					"resolver:web.default.default.dc2": {
@@ -176,6 +178,7 @@ func TestDiscoveryChainRead(t *testing.T) {
 				Partition:   "default",
 				Datacenter:  "dc1",
 				Protocol:    "tcp",
+				Default:     true,
 				StartNode:   "resolver:web.default.default.dc1",
 				Nodes: map[string]*structs.DiscoveryGraphNode{
 					"resolver:web.default.default.dc1": {

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -42,6 +42,12 @@ type CompiledDiscoveryChain struct {
 
 	// Targets is a list of all targets used in this chain.
 	Targets map[string]*DiscoveryTarget `json:",omitempty"`
+
+	// Default indicates if the compiled chain represents no routing, no splitting,
+	// and only the default resolution. This is an extra piece of redundant information
+	// calculated through existing information of CompiledDiscoveryChain struct by IsDefault
+	// method.
+	Default bool `json:",omitempty"`
 }
 
 func (c *CompiledDiscoveryChain) WillFailoverThroughMeshGateway(node *DiscoveryGraphNode) bool {


### PR DESCRIPTION
This PR adds a new `Default:bool` field to the  `/v1/discovery-chain/:service` endpoint to indicate if the discovery chain is default or not.

The logic to assert default to a discovery chain is (already been taken care of by `IsDefault` method)
> You can infer that no content went into this by checking:
> 1. is the top node a resolver node?
> 2. is the Resolver.Default field true?
> 3. is the Resolver.Target pointing to a target in the Targets map that points to the same name/namespace as the requested discovery chain (and with no subset), in the same datacenter.

closes #10533 