### PR TITLE
ui: Don't show the CRD menu for read-only intentions

### DIFF
--- a/.changelog/11149.txt
+++ b/.changelog/11149.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Don't show a CRD warning for read-only intentions
+```

--- a/ui/packages/consul-ui/app/abilities/intention.js
+++ b/ui/packages/consul-ui/app/abilities/intention.js
@@ -4,6 +4,9 @@ export default class IntentionAbility extends BaseAbility {
   resource = 'intention';
 
   get canWrite() {
-    return super.canWrite && (typeof this.item === 'undefined' || this.item.IsEditable);
+    return super.canWrite && (typeof this.item === 'undefined' || !this.canViewCRD);
+  }
+  get canViewCRD() {
+    return (typeof this.item !== 'undefined' && this.item.IsManagedByCRD);
   }
 }

--- a/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
@@ -53,6 +53,7 @@ as |item index|>
         {{/if}}
         </td>
     </BlockSlot>
+{{#if (or (can "write intention" item=item) (can "view CRD intention" item=item))}}
     <BlockSlot @name="actions" as |index change checked|>
       <PopoverMenu
         @expanded={{if (eq checked index) true false}}
@@ -101,7 +102,7 @@ as |item index|>
                 </InformedAction>
               </div>
             </li>
-          {{else}}
+          {{else if (can "view CRD intention" item=item)}}
             <li role="none">
               <div role="menu">
                 <InformedAction
@@ -140,4 +141,5 @@ as |item index|>
         </BlockSlot>
       </PopoverMenu>
     </BlockSlot>
+{{/if}}
 </TabularCollection>

--- a/ui/packages/consul-ui/app/models/intention.js
+++ b/ui/packages/consul-ui/app/models/intention.js
@@ -38,9 +38,4 @@ export default class Intention extends Model {
     );
     return typeof meta !== 'undefined';
   }
-
-  @computed('IsManagedByCRD')
-  get IsEditable() {
-    return !this.IsManagedByCRD;
-  }
 }

--- a/ui/packages/consul-ui/app/templates/dc/intentions/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/edit.hbs
@@ -31,7 +31,7 @@ as |item|}}
       </BlockSlot>
       <BlockSlot @name="header">
           <h1>
-  {{#if item.IsEditable}}
+  {{#if (can "write intention" item=item)}}
     {{#if item.ID}}
             <route.Title @title="Edit Intention" />
     {{else}}


### PR DESCRIPTION
Thanks to the amazing folks in https://github.com/hashicorp/consul/issues/11012 I realised that we had a small UI bug here that was further complicated by a problem with our `/v1/internal/acl/authorize` endpoint which was recently fixed here https://github.com/hashicorp/consul/pull/11061 . I initially thought this authorize endpoint error was in a 1.10.x release but looking a little harder, it seems like it isn't, it's only in our recent 1.11 alpha.

The UI bug here manifests itself only when a user/token is configured to have read-only access to intentions. Instead of only letting folks click to see a read only page of the intention, we would show an additional message saying that the intention was read-only due to it being 'Managed by [a kubernetes] CRD'. Whilst the intention was still read only, this extra message was still confusing for users.

This PR fixes up the conditional logic and further moves the logic to use `ember-can` - looking at the history of the files in question, this bug snuck itself in partly due to it being 'permission-y type stuff' previous to using `ember-can` and when something being editable or not was nothing to do with ACLs. Then we moved to start using `ember-can` without completely realising what `IsEditable` previously meant. So overall the code here is a tiny bit clearer/cleaner by adding a proper `can view CRD intention` instead of overloading the idea of 'editability'.

Backports-wise the bug only manifests itself in 1.10.x onwards as we only started using the authorize endpoint + ACLs permissions from 1.10.x onwards.

fixes https://github.com/hashicorp/consul/issues/11012