### PR TITLE
wrap doRequest calls for error handling

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"bufio"
-	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -602,6 +602,8 @@ func (a *Agent) AgentHealthServiceByIDOpts(serviceID string, q *QueryOptions) (s
 	r.setQueryOptions(q)
 	r.params.Add("format", "json")
 	r.header.Set("Accept", "application/json")
+	// not a lot of value in wrapping the doRequest call in a requireHttpCodes call
+	// we manipulate the resp body  and the require calls "swallow" the content on err
 	_, resp, err := a.c.doRequest(r)
 	if err != nil {
 		return "", nil, err
@@ -641,6 +643,8 @@ func (a *Agent) AgentHealthServiceByNameOpts(service string, q *QueryOptions) (s
 	r.setQueryOptions(q)
 	r.params.Add("format", "json")
 	r.header.Set("Accept", "application/json")
+	// not a lot of value in wrapping the doRequest call in a requireHttpCodes call
+	// we manipulate the resp body  and the require calls "swallow" the content on err
 	_, resp, err := a.c.doRequest(r)
 	if err != nil {
 		return "", nil, err
@@ -1233,19 +1237,20 @@ func (a *Agent) updateTokenOnce(target, token string, q *WriteOptions) (*WriteMe
 	r.setWriteOptions(q)
 	r.obj = &AgentToken{Token: token}
 
-	rtt, resp, err := a.c.doRequest(r)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer closeResponseBody(resp)
-
+	rtt, resp, err := requireOK(a.c.doRequest(r))
 	wm := &WriteMeta{RequestTime: rtt}
 
-	if resp.StatusCode != 200 {
-		var buf bytes.Buffer
-		io.Copy(&buf, resp.Body)
-		return wm, resp.StatusCode, fmt.Errorf("Unexpected response code: %d (%s)", resp.StatusCode, buf.Bytes())
+	if err != nil {
+		// if the error was bc of a non 200 response
+		// from requireOK
+		var statusE StatusError
+		if errors.As(err, &statusE) {
+			return wm, statusE.Code, statusE
+		}
+		// otherwise, the error came via doRequest
+		return nil, 500, err
 	}
+	defer closeResponseBody(resp)
 
 	return wm, resp.StatusCode, nil
 }

--- a/api/debug.go
+++ b/api/debug.go
@@ -25,15 +25,11 @@ func (c *Client) Debug() *Debug {
 // Heap returns a pprof heap dump
 func (d *Debug) Heap() ([]byte, error) {
 	r := d.c.newRequest("GET", "/debug/pprof/heap")
-	_, resp, err := d.c.doRequest(r)
+	_, resp, err := requireOK(d.c.doRequest(r))
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 	defer closeResponseBody(resp)
-
-	if resp.StatusCode != 200 {
-		return nil, generateUnexpectedResponseCodeError(resp)
-	}
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
@@ -52,15 +48,11 @@ func (d *Debug) Profile(seconds int) ([]byte, error) {
 	// Capture a profile for the specified number of seconds
 	r.params.Set("seconds", strconv.Itoa(seconds))
 
-	_, resp, err := d.c.doRequest(r)
+	_, resp, err := requireOK(d.c.doRequest(r))
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 	defer closeResponseBody(resp)
-
-	if resp.StatusCode != 200 {
-		return nil, generateUnexpectedResponseCodeError(resp)
-	}
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
@@ -81,14 +73,11 @@ func (d *Debug) PProf(ctx context.Context, name string, seconds int) (io.ReadClo
 	// Capture a profile for the specified number of seconds
 	r.params.Set("seconds", strconv.Itoa(seconds))
 
-	_, resp, err := d.c.doRequest(r)
+	_, resp, err := requireOK(d.c.doRequest(r))
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 
-	if resp.StatusCode != 200 {
-		return nil, generateUnexpectedResponseCodeError(resp)
-	}
 	return resp.Body, nil
 }
 
@@ -99,15 +88,11 @@ func (d *Debug) Trace(seconds int) ([]byte, error) {
 	// Capture a trace for the specified number of seconds
 	r.params.Set("seconds", strconv.Itoa(seconds))
 
-	_, resp, err := d.c.doRequest(r)
+	_, resp, err := requireOK(d.c.doRequest(r))
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 	defer closeResponseBody(resp)
-
-	if resp.StatusCode != 200 {
-		return nil, generateUnexpectedResponseCodeError(resp)
-	}
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
@@ -123,15 +108,11 @@ func (d *Debug) Trace(seconds int) ([]byte, error) {
 func (d *Debug) Goroutine() ([]byte, error) {
 	r := d.c.newRequest("GET", "/debug/pprof/goroutine")
 
-	_, resp, err := d.c.doRequest(r)
+	_, resp, err := requireOK(d.c.doRequest(r))
 	if err != nil {
 		return nil, fmt.Errorf("error making request: %s", err)
 	}
 	defer closeResponseBody(resp)
-
-	if resp.StatusCode != 200 {
-		return nil, generateUnexpectedResponseCodeError(resp)
-	}
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers

--- a/api/kv.go
+++ b/api/kv.go
@@ -129,6 +129,8 @@ func (k *KV) getInternal(key string, params map[string]string, q *QueryOptions) 
 		r.params.Set(param, val)
 	}
 	rtt, resp, err := k.c.doRequest(r)
+	rtt, resp, err = requireHttpCodes(rtt, resp, err, 200, 404)
+
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/kv.go
+++ b/api/kv.go
@@ -142,10 +142,8 @@ func (k *KV) getInternal(key string, params map[string]string, q *QueryOptions) 
 	if resp.StatusCode == 404 {
 		closeResponseBody(resp)
 		return nil, qm, nil
-	} else if resp.StatusCode != 200 {
-		closeResponseBody(resp)
-		return nil, nil, fmt.Errorf("Unexpected response code: %d", resp.StatusCode)
 	}
+
 	return resp, qm, nil
 }
 


### PR DESCRIPTION
### Overview

This PR builds on https://github.com/hashicorp/consul/pull/11054 to wrap all remaining `doRequest()` calls around a `require*()` call.

### Issue Related
https://github.com/hashicorp/consul/issues/10865

### Notes:
* mostly refactoring, no logic changes

### PR Checklist
* [x] `go fmt`
* [x] `go mod`
* [x] n/a pr/changelog -- no "public" api changes
