### PR TITLE
agent: Clean up unused built-in proxy config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2864,44 +2864,6 @@ func (a *Agent) AdvertiseAddrLAN() string {
 	return a.config.AdvertiseAddrLAN.String()
 }
 
-// resolveProxyCheckAddress returns the best address to use for a TCP check of
-// the proxy's public listener. It expects the input to already have default
-// values populated by applyProxyConfigDefaults. It may return an empty string
-// indicating that the TCP check should not be created at all.
-//
-// By default this uses the proxy's bind address which in turn defaults to the
-// agent's bind address. If the proxy bind address ends up being 0.0.0.0 we have
-// to assume the agent can dial it over loopback which is usually true.
-//
-// In some topologies such as proxy being in a different container, the IP the
-// agent used to dial proxy over a local bridge might not be the same as the
-// container's public routable IP address so we allow a manual override of the
-// check address in config "tcp_check_address" too.
-//
-// Finally the TCP check can be disabled by another manual override
-// "disable_tcp_check" in cases where the agent will never be able to dial the
-// proxy directly for some reason.
-func (a *Agent) resolveProxyCheckAddress(proxyCfg map[string]interface{}) string {
-	// If user disabled the check return empty string
-	if disable, ok := proxyCfg["disable_tcp_check"].(bool); ok && disable {
-		return ""
-	}
-
-	// If user specified a custom one, use that
-	if chkAddr, ok := proxyCfg["tcp_check_address"].(string); ok && chkAddr != "" {
-		return chkAddr
-	}
-
-	// If we have a bind address and its diallable, use that
-	if bindAddr, ok := proxyCfg["bind_address"].(string); ok &&
-		bindAddr != "" && bindAddr != "0.0.0.0" && bindAddr != "[::]" {
-		return bindAddr
-	}
-
-	// Default to localhost
-	return "127.0.0.1"
-}
-
 func (a *Agent) cancelCheckMonitors(checkID structs.CheckID) {
 	// Stop any monitors
 	delete(a.checkReapAfter, checkID)

--- a/website/content/docs/connect/proxies/built-in.mdx
+++ b/website/content/docs/connect/proxies/built-in.mdx
@@ -32,8 +32,6 @@ for the built-in proxy.
         "config": {
           "bind_address": "0.0.0.0",
           "bind_port": 20000,
-          "tcp_check_address": "192.168.0.1",
-          "disable_tcp_check": false,
           "local_service_address": "127.0.0.1:1234",
           "local_connect_timeout_ms": 1000,
           "handshake_timeout_ms": 10000,
@@ -63,19 +61,6 @@ All fields are optional with a reasonable default.
   [configured proxy port range](/docs/agent/options#sidecar_min_port) if available.
   By default the range is [20000, 20255] and the port is selected at random from
   that range.
-
-- `tcp_check_address` - The address the agent will
-  run a [TCP health check](/docs/agent/checks) against. By default this is the same
-  as the proxy's [bind address](#bind_address) except if the bind address is `0.0.0.0`
-  or `[::]` in which case this defaults to `127.0.0.1` and assumes the agent can
-  dial the proxy over loopback. For more complex configurations where agent and proxy
-  communicate over a bridge for example, this configuration can be used to specify
-  a different _address_ (but not port) for the agent to use for health checks if
-  it can't talk to the proxy over localhost or its publicly advertised port. The
-  check always uses the same port that the proxy is bound to.
-
-- `disable_tcp_check` - If true, this disables a
-  TCP check being setup for the proxy. Default is false.
 
 - `local_service_address`- The `[address]:port`
   that the proxy should use to connect to the local application instance. By default


### PR DESCRIPTION
References to these members were previously removed in https://github.com/hashicorp/consul/pull/6220. 