### PR TITLE
[1.8.x]  acl: fix default Authorizer for down_policy extend-cache/async-cache

### DIFF
--- a/.changelog/11136.txt
+++ b/.changelog/11136.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: fixes the fallback behaviour of down_policy with setting extend-cache/async-cache when the token is not cached.
+```

--- a/acl/static_authorizer.go
+++ b/acl/static_authorizer.go
@@ -227,7 +227,11 @@ func ManageAll() Authorizer {
 	return manageAll
 }
 
-// RootAuthorizer returns a possible Authorizer if the ID matches a root policy
+// RootAuthorizer returns a possible Authorizer if the ID matches a root policy.
+//
+// TODO: rename this function. While the returned authorizer is used as a root
+// authorizer in some cases, in others it is not. A more appropriate name might
+// be NewAuthorizerFromPolicyName.
 func RootAuthorizer(id string) Authorizer {
 	switch id {
 	case "allow":

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -287,7 +287,7 @@ func NewACLResolver(config *ACLResolverConfig) (*ACLResolver, error) {
 	case "deny":
 		down = acl.DenyAll()
 	case "async-cache", "extend-cache":
-		// Leave the down policy as nil to signal this.
+		down = acl.RootAuthorizer(config.Config.ACLDefaultPolicy)
 	default:
 		return nil, fmt.Errorf("invalid ACL down policy %q", config.Config.ACLDownPolicy)
 	}

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -767,8 +767,6 @@ func TestACLResolver_ResolveRootACL(t *testing.T) {
 }
 
 func TestACLResolver_DownPolicy(t *testing.T) {
-	t.Parallel()
-
 	requireIdentityCached := func(t *testing.T, r *ACLResolver, id string, present bool, msg string) {
 		t.Helper()
 
@@ -793,7 +791,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	}
 
 	t.Run("Deny", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -818,7 +815,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Allow", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -843,7 +839,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Expired-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -880,7 +875,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Expired-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -912,7 +906,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -942,8 +935,28 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 		require.Equal(t, acl.Allow, authz2.NodeWrite("foo", nil))
 	})
 
+	t.Run("Extend-Cache with no cache entry defaults to default_policy", func(t *testing.T) {
+		delegate := &ACLResolverTestDelegate{
+			enabled:       true,
+			datacenter:    "dc1",
+			localPolicies: true,
+			localRoles:    true,
+		}
+		delegate.tokenReadFn = func(*structs.ACLTokenGetRequest, *structs.ACLTokenResponse) error {
+			return ACLRemoteError{Err: fmt.Errorf("connection problem")}
+		}
+
+		r := newTestACLResolver(t, delegate, func(config *ACLResolverConfig) {
+			config.Config.ACLDownPolicy = "extend-cache"
+		})
+
+		_, authz, err := r.ResolveTokenToIdentityAndAuthorizer("not-found")
+		require.NoError(t, err)
+		require.NotNil(t, authz)
+		require.Equal(t, acl.Deny, authz.NodeWrite("foo", nil))
+	})
+
 	t.Run("Extend-Cache-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -975,7 +988,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Expired-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1012,7 +1024,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Expired-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1045,7 +1056,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Async-Cache-Expired-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1093,7 +1103,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Async-Cache-Expired-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1136,7 +1145,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Client-Policy", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1172,7 +1180,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Extend-Cache-Client-Role", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1209,7 +1216,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("Async-Cache", func(t *testing.T) {
-		t.Parallel()
 		delegate := &ACLResolverTestDelegate{
 			enabled:       true,
 			datacenter:    "dc1",
@@ -1251,8 +1257,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("PolicyResolve-TokenNotFound", func(t *testing.T) {
-		t.Parallel()
-
 		_, rawToken, _ := testIdentityForToken("found")
 		foundToken := rawToken.(*structs.ACLToken)
 		secretID := foundToken.SecretID
@@ -1318,8 +1322,6 @@ func TestACLResolver_DownPolicy(t *testing.T) {
 	})
 
 	t.Run("PolicyResolve-PermissionDenied", func(t *testing.T) {
-		t.Parallel()
-
 		_, rawToken, _ := testIdentityForToken("found")
 		foundToken := rawToken.(*structs.ACLToken)
 		secretID := foundToken.SecretID

--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -615,8 +615,10 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     token cannot be read from the [`primary_datacenter`](#primary_datacenter) or
     leader node, the down policy is applied. In "allow" mode, all actions are permitted,
     "deny" restricts all operations, and "extend-cache" allows any cached objects
-    to be used, ignoring their TTL values. If a non-cached ACL is used, "extend-cache"
-    acts like "deny". The value "async-cache" acts the same way as "extend-cache"
+    to be used, ignoring the expiry time of the cached entry. If the request uses an
+    ACL that is not in the cache, "extend-cache" falls back to the behaviour of
+    `default_policy`.
+    The value "async-cache" acts the same way as "extend-cache"
     but performs updates asynchronously when ACL is present but its TTL is expired,
     thus, if latency is bad between the primary and secondary datacenters, latency
     of operations is not impacted.


### PR DESCRIPTION
Backport of https://github.com/hashicorp/consul/pull/11136

Surprisingly, when I ran `git cherry-pick -m 1 19040586ce9102b083c82ea9bb3c5efd141b4712` localy it did not fail to merge. I'm guessing the automation failed ([link](https://app.circleci.com/pipelines/github/hashicorp/consul/22222/workflows/4c8c9b02-16f1-4024-89f0-42365b3b6448/jobs/460799)) because of this warning:

```
warning: inexact rename detection was skipped due to too many files.
warning: you may want to set your merge.renamelimit variable to at least 5920 and retry the command.
```

In the release/1.8.x branch the website content is at a different path, so I guess it has to check too many files for renames. Maybe that's non-deterministic, which results in this problem?
