### PR TITLE
agent: Reject partitions in legacy intention endpoints

### DIFF
--- a/agent/intentions_endpoint.go
+++ b/agent/intentions_endpoint.go
@@ -67,7 +67,13 @@ func (s *HTTPHandlers) IntentionCreate(resp http.ResponseWriter, req *http.Reque
 		return nil, fmt.Errorf("Failed to decode request body: %s", err)
 	}
 
-	// TODO(partitions): reject non-empty/non-default partitions from the decoded body
+	if args.Intention.DestinationPartition != "" && args.Intention.DestinationPartition != "default" {
+		return nil, BadRequestError{Reason: "Cannot specify a destination partition with this endpoint"}
+	}
+	if args.Intention.SourcePartition != "" && args.Intention.SourcePartition != "default" {
+		return nil, BadRequestError{Reason: "Cannot specify a source partition with this endpoint"}
+	}
+
 	args.Intention.FillPartitionAndNamespace(&entMeta, false)
 
 	if err := s.validateEnterpriseIntention(args.Intention); err != nil {
@@ -422,6 +428,13 @@ func (s *HTTPHandlers) IntentionSpecificUpdate(id string, resp http.ResponseWrit
 	s.parseToken(req, &args.Token)
 	if err := decodeBody(req.Body, &args.Intention); err != nil {
 		return nil, BadRequestError{Reason: fmt.Sprintf("Request decode failed: %v", err)}
+	}
+
+	if args.Intention.DestinationPartition != "" && args.Intention.DestinationPartition != "default" {
+		return nil, BadRequestError{Reason: "Cannot specify a destination partition with this endpoint"}
+	}
+	if args.Intention.SourcePartition != "" && args.Intention.SourcePartition != "default" {
+		return nil, BadRequestError{Reason: "Cannot specify a source partition with this endpoint"}
 	}
 
 	args.Intention.FillPartitionAndNamespace(&entMeta, false)

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -437,6 +437,7 @@ func TestIntentionCreate(t *testing.T) {
 			resp := httptest.NewRecorder()
 			_, err := a.srv.IntentionCreate(resp, req)
 			require.Error(t, err)
+			require.Contains(t, err.Error(), "Cannot specify a source partition")
 		}
 		{
 			args := structs.TestIntention(t)
@@ -445,6 +446,7 @@ func TestIntentionCreate(t *testing.T) {
 			resp := httptest.NewRecorder()
 			_, err := a.srv.IntentionCreate(resp, req)
 			require.Error(t, err)
+			require.Contains(t, err.Error(), "Cannot specify a destination partition")
 		}
 	})
 }
@@ -559,6 +561,7 @@ func TestIntentionSpecificUpdate(t *testing.T) {
 			resp := httptest.NewRecorder()
 			_, err := a.srv.IntentionSpecific(resp, req)
 			require.Error(t, err)
+			require.Contains(t, err.Error(), "Cannot specify a destination partition")
 		}
 		{
 			ixn.DestinationPartition = "default"
@@ -567,6 +570,7 @@ func TestIntentionSpecificUpdate(t *testing.T) {
 			resp := httptest.NewRecorder()
 			_, err := a.srv.IntentionSpecific(resp, req)
 			require.Error(t, err)
+			require.Contains(t, err.Error(), "Cannot specify a source partition")
 		}
 	})
 }

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -428,6 +428,25 @@ func TestIntentionCreate(t *testing.T) {
 			require.Equal(t, "foo", actual.SourceName)
 		}
 	})
+
+	t.Run("partition rejected", func(t *testing.T) {
+		{
+			args := structs.TestIntention(t)
+			args.SourcePartition = "part1"
+			req, _ := http.NewRequest("POST", "/v1/connect/intentions", jsonReader(args))
+			resp := httptest.NewRecorder()
+			_, err := a.srv.IntentionCreate(resp, req)
+			require.Error(t, err)
+		}
+		{
+			args := structs.TestIntention(t)
+			args.DestinationPartition = "part2"
+			req, _ := http.NewRequest("POST", "/v1/connect/intentions", jsonReader(args))
+			resp := httptest.NewRecorder()
+			_, err := a.srv.IntentionCreate(resp, req)
+			require.Error(t, err)
+		}
+	})
 }
 
 func TestIntentionSpecificGet(t *testing.T) {
@@ -532,6 +551,24 @@ func TestIntentionSpecificUpdate(t *testing.T) {
 		actual := resp.Intentions[0]
 		require.Equal(t, "bar", actual.SourceName)
 	}
+
+	t.Run("partitions rejected", func(t *testing.T) {
+		{
+			ixn.DestinationPartition = "part1"
+			req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/connect/intentions/%s", reply), jsonReader(ixn))
+			resp := httptest.NewRecorder()
+			_, err := a.srv.IntentionSpecific(resp, req)
+			require.Error(t, err)
+		}
+		{
+			ixn.DestinationPartition = "default"
+			ixn.SourcePartition = "part2"
+			req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/connect/intentions/%s", reply), jsonReader(ixn))
+			resp := httptest.NewRecorder()
+			_, err := a.srv.IntentionSpecific(resp, req)
+			require.Error(t, err)
+		}
+	})
 }
 
 func TestIntentionDeleteExact(t *testing.T) {


### PR DESCRIPTION
Legacy Create and SpecificUpdate endpoints should not handle Source- or Destination- partitions (in either OSS or ENT).