### PR TITLE
acl: remove upgrade from legacy, start in non-legacy mode

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -54,14 +54,6 @@ const (
 	// are not allowed to be displayed.
 	redactedToken = "<hidden>"
 
-	// aclUpgradeBatchSize controls how many tokens we look at during each round of upgrading. Individual raft logs
-	// will be further capped using the aclBatchUpsertSize. This limit just prevents us from creating a single slice
-	// with all tokens in it.
-	aclUpgradeBatchSize = 128
-
-	// aclUpgradeRateLimit is the number of batch upgrade requests per second allowed.
-	aclUpgradeRateLimit rate.Limit = 1.0
-
 	// aclTokenReapingRateLimit is the number of batch token reaping requests per second allowed.
 	aclTokenReapingRateLimit rate.Limit = 1.0
 

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -77,20 +77,6 @@ const (
 	// due to the data being more variable in its size.
 	aclBatchUpsertSize = 256 * 1024
 
-	// DEPRECATED (ACL-Legacy-Compat) aclModeCheck* are all only for legacy usage
-	// aclModeCheckMinInterval is the minimum amount of time between checking if the
-	// agent should be using the new or legacy ACL system. All the places it is
-	// currently used will backoff as it detects that it is remaining in legacy mode.
-	// However the initial min value is kept small so that new cluster creation
-	// can enter into new ACL mode quickly.
-	// TODO(ACL-Legacy-Compat): remove
-	aclModeCheckMinInterval = 50 * time.Millisecond
-
-	// aclModeCheckMaxInterval controls the maximum interval for how often the agent
-	// checks if it should be using the new or legacy ACL system.
-	// TODO(ACL-Legacy-Compat): remove
-	aclModeCheckMaxInterval = 30 * time.Second
-
 	// Maximum number of re-resolution requests to be made if the token is modified between
 	// resolving the token and resolving its policies that would remove one of its policies.
 	tokenPolicyResolutionMaxRetries = 5

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -170,11 +170,6 @@ func (a *ACL) aclPreCheck() error {
 	if !a.srv.config.ACLsEnabled {
 		return acl.ErrDisabled
 	}
-
-	if a.srv.UseLegacyACLs() {
-		return fmt.Errorf("The ACL system is currently in legacy mode.")
-	}
-
 	return nil
 }
 

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -1393,9 +1393,6 @@ func TestACLEndpoint_TokenDelete(t *testing.T) {
 	// Try to join
 	joinWAN(t, s2, s1)
 
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
-
 	// Ensure s2 is authoritative.
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
 
@@ -3632,9 +3629,6 @@ func TestACLEndpoint_SecureIntroEndpoints_LocalTokensDisabled(t *testing.T) {
 	// Try to join
 	joinWAN(t, s2, s1)
 
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
-
 	acl2 := ACL{srv: s2}
 	var ignored bool
 
@@ -3735,9 +3729,6 @@ func TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData(t *testing.T) {
 
 	// Try to join
 	joinWAN(t, s2, s1)
-
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
 
 	// Ensure s2 is authoritative.
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
@@ -4622,9 +4613,6 @@ func TestACLEndpoint_Login_with_TokenLocality(t *testing.T) {
 	waitForLeaderEstablishment(t, s2)
 
 	joinWAN(t, s2, s1)
-
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
 
 	// Ensure s2 is authoritative.
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -327,11 +327,6 @@ func TestACLReplication_Tokens(t *testing.T) {
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	testrpc.WaitForLeader(t, s1.RPC, "dc2")
-
-	// Wait for legacy acls to be disabled so we are clear that
-	// legacy replication isn't meddling.
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
 
 	// Create a bunch of new tokens and policies
@@ -544,11 +539,6 @@ func TestACLReplication_Policies(t *testing.T) {
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	testrpc.WaitForLeader(t, s1.RPC, "dc2")
-
-	// Wait for legacy acls to be disabled so we are clear that
-	// legacy replication isn't meddling.
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
 	waitForNewACLReplication(t, s2, structs.ACLReplicatePolicies, 1, 0, 0)
 
 	// Create a bunch of new policies
@@ -700,7 +690,6 @@ func TestACLReplication_TokensRedacted(t *testing.T) {
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s2.RPC, "dc2")
 	testrpc.WaitForLeader(t, s2.RPC, "dc1")
-	waitForNewACLs(t, s2)
 
 	// ensures replication is working ok
 	retry.Run(t, func(r *retry.R) {
@@ -820,11 +809,6 @@ func TestACLReplication_AllTypes(t *testing.T) {
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	testrpc.WaitForLeader(t, s1.RPC, "dc2")
-
-	// Wait for legacy acls to be disabled so we are clear that
-	// legacy replication isn't meddling.
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
 
 	const (

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -538,7 +538,7 @@ func TestACLReplication_Policies(t *testing.T) {
 	// Try to join.
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-	testrpc.WaitForLeader(t, s1.RPC, "dc2")
+	testrpc.WaitForLeader(t, s1.RPC, "dc2", testrpc.WithToken("root"))
 	waitForNewACLReplication(t, s2, structs.ACLReplicatePolicies, 1, 0, 0)
 
 	// Create a bunch of new policies

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -1,12 +1,10 @@
 package consul
 
 import (
-	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/lib/serf"
 )
 
 var serverACLCacheConfig *structs.ACLCachesConfig = &structs.ACLCachesConfig{
@@ -84,71 +82,8 @@ func (s *Server) checkBindingRuleUUID(id string) (bool, error) {
 	return !structs.ACLIDReserved(id), nil
 }
 
-func (s *Server) updateSerfTags(key, value string) {
-	// Update the LAN serf
-	serf.UpdateTag(s.serfLAN, key, value)
-
-	if s.serfWAN != nil {
-		serf.UpdateTag(s.serfWAN, key, value)
-	}
-
-	s.updateEnterpriseSerfTags(key, value)
-}
-
-// TODO:
-func (s *Server) updateACLAdvertisement() {
-	// One thing to note is that once in new ACL mode the server will
-	// never transition to legacy ACL mode. This is not currently a
-	// supported use case.
-	s.updateSerfTags("acls", string(structs.ACLModeEnabled))
-}
-
-func (s *Server) canUpgradeToNewACLs(isLeader bool) bool {
-	if atomic.LoadInt32(&s.useNewACLs) != 0 {
-		// can't upgrade because we are already upgraded
-		return false
-	}
-
-	// Check to see if we already upgraded the last time we ran by seeing if we
-	// have a copy of any global management policy stored locally. This should
-	// always be true because policies always replicate.
-	_, mgmtPolicy, err := s.fsm.State().ACLPolicyGetByID(nil, structs.ACLPolicyGlobalManagementID, structs.DefaultEnterpriseMetaInDefaultPartition())
-	if err != nil {
-		s.logger.Warn("Failed to get the builtin global-management policy to check for a completed ACL upgrade; skipping this optimization", "error", err)
-	} else if mgmtPolicy != nil {
-		return true
-	}
-
-	if !s.InACLDatacenter() {
-		foundServers, mode, _ := ServersGetACLMode(s, "", s.config.PrimaryDatacenter)
-		if mode != structs.ACLModeEnabled || !foundServers {
-			s.logger.Debug("Cannot upgrade to new ACLs, servers in acl datacenter are not yet upgraded", "PrimaryDatacenter", s.config.PrimaryDatacenter, "mode", mode, "found", foundServers)
-			return false
-		}
-	}
-
-	leaderAddr := string(s.raft.Leader())
-	foundServers, mode, leaderMode := ServersGetACLMode(s, leaderAddr, s.config.Datacenter)
-	if isLeader {
-		if mode == structs.ACLModeLegacy {
-			return true
-		}
-	} else {
-		if leaderMode == structs.ACLModeEnabled {
-			return true
-		}
-	}
-
-	s.logger.Debug("Cannot upgrade to new ACLs", "leaderMode", leaderMode, "mode", mode, "found", foundServers, "leader", leaderAddr)
-	return false
-}
-
 func (s *Server) InACLDatacenter() bool {
 	return s.config.PrimaryDatacenter == "" || s.config.Datacenter == s.config.PrimaryDatacenter
-}
-
-func (s *Server) UseLegacyACLs() bool {
-	return atomic.LoadInt32(&s.useNewACLs) == 0
 }
 
 func (s *Server) LocalTokensEnabled() bool {

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -58,9 +58,6 @@ func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
 	if !s.config.ACLsEnabled {
 		return 0, nil
 	}
-	if s.UseLegacyACLs() {
-		return 0, nil
-	}
 	if local == global {
 		return 0, fmt.Errorf("cannot reap both local and global tokens in the same request")
 	}

--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul
@@ -84,11 +85,5 @@ func (s *Server) validateEnterpriseIntentionNamespace(ns string, _ bool) error {
 }
 
 func addEnterpriseSerfTags(_ map[string]string, _ *structs.EnterpriseMeta) {
-	// do nothing
-}
-
-// updateEnterpriseSerfTags in enterprise will update any instances of Serf with the tag that
-// are not the normal LAN or WAN serf instances (network segments and network areas)
-func (_ *Server) updateEnterpriseSerfTags(_, _ string) {
 	// do nothing
 }

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -165,16 +165,6 @@ func joinWAN(t *testing.T, member, leader *Server) {
 	}
 }
 
-func waitForNewACLs(t *testing.T, server *Server) {
-	t.Helper()
-
-	retry.Run(t, func(r *retry.R) {
-		require.False(r, server.UseLegacyACLs(), "Server cannot use new ACLs")
-	})
-
-	require.False(t, server.UseLegacyACLs(), "Server cannot use new ACLs")
-}
-
 func waitForNewACLReplication(t *testing.T, server *Server, expectedReplicationType structs.ACLReplicationType, minPolicyIndex, minTokenIndex, minRoleIndex uint64) {
 	t.Helper()
 	retry.Run(t, func(r *retry.R) {

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -1606,7 +1606,6 @@ func TestIntentionList_acl(t *testing.T) {
 	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
-	waitForNewACLs(t, s1)
 
 	token, err := upsertTestTokenWithPolicyRules(codec, TestDefaultMasterToken, "dc1", `service_prefix "foo" { policy = "write" }`)
 	require.NoError(t, err)

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -569,6 +569,7 @@ func (s *Server) legacyACLTokenUpgrade(ctx context.Context) error {
 
 		if len(tokens) == 0 {
 			// No new legacy tokens can be created, so we can exit
+			s.stopACLUpgrade() // required to prevent goroutine leak, according to TestAgentLeaks_Server
 			return nil
 		}
 

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -240,9 +240,6 @@ func TestLeader_SecondaryCA_Initialize(t *testing.T) {
 
 			testrpc.WaitForLeader(t, s2.RPC, "secondary")
 
-			waitForNewACLs(t, s1)
-			waitForNewACLs(t, s2)
-
 			// Ensure s2 is authoritative.
 			waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
 

--- a/agent/consul/leader_federation_state_ae_test.go
+++ b/agent/consul/leader_federation_state_ae_test.go
@@ -383,7 +383,7 @@ func TestLeader_FederationStateAntiEntropyPruning_ACLDeny(t *testing.T) {
 	// Try to join.
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-	testrpc.WaitForLeader(t, s1.RPC, "dc2")
+	testrpc.WaitForLeader(t, s1.RPC, "dc2", testrpc.WithToken("root"))
 
 	// Create the ACL token.
 	opWriteToken, err := upsertTestTokenWithPolicyRules(client, "root", "dc1", `operator = "write"`)

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1771,14 +1771,11 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 }
 
 func updateSerfTags(s *Server, key, value string) {
-	// Update the LAN serf
 	libserf.UpdateTag(s.serfLAN, key, value)
 
 	if s.serfWAN != nil {
 		libserf.UpdateTag(s.serfWAN, key, value)
 	}
-
-	s.updateEnterpriseSerfTags(key, value)
 }
 
 func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	tokenStore "github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
+	libserf "github.com/hashicorp/consul/lib/serf"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
@@ -1257,9 +1258,6 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 	joinWAN(t, s2, s1)
 	waitForLeaderEstablishment(t, s1)
 	waitForLeaderEstablishment(t, s2)
-
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
 	waitForNewACLReplication(t, s2, structs.ACLReplicatePolicies, 1, 0, 0)
 
 	// Everybody has the management policy.
@@ -1296,9 +1294,6 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 	defer s2new.Shutdown()
 
 	waitForLeaderEstablishment(t, s2new)
-
-	// It should be able to transition without connectivity to the primary.
-	waitForNewACLs(t, s2new)
 }
 
 func TestLeader_ConfigEntryBootstrap(t *testing.T) {
@@ -1507,7 +1502,7 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 		defer os.RemoveAll(dir1)
 		defer s1.Shutdown()
 
-		s1.updateSerfTags("ft_fs", "0")
+		updateSerfTags(s1, "ft_fs", "0")
 
 		waitForLeaderEstablishment(t, s1)
 
@@ -1562,7 +1557,7 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 		defer os.RemoveAll(dir1)
 		defer s1.Shutdown()
 
-		s1.updateSerfTags("ft_fs", "0")
+		updateSerfTags(s1, "ft_fs", "0")
 
 		waitForLeaderEstablishment(t, s1)
 
@@ -1737,7 +1732,7 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 		defer os.RemoveAll(dir1)
 		defer s1.Shutdown()
 
-		s1.updateSerfTags("ft_fs", "0")
+		updateSerfTags(s1, "ft_fs", "0")
 
 		waitForLeaderEstablishment(t, s1)
 
@@ -1773,6 +1768,17 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 			}
 		})
 	})
+}
+
+func updateSerfTags(s *Server, key, value string) {
+	// Update the LAN serf
+	libserf.UpdateTag(s.serfLAN, key, value)
+
+	if s.serfWAN != nil {
+		libserf.UpdateTag(s.serfWAN, key, value)
+	}
+
+	s.updateEnterpriseSerfTags(key, value)
 }
 
 func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -873,11 +873,6 @@ func TestRPC_LocalTokenStrippedOnForward(t *testing.T) {
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	testrpc.WaitForLeader(t, s1.RPC, "dc2")
-
-	// Wait for legacy acls to be disabled so we are clear that
-	// legacy replication isn't meddling.
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
 
 	// create simple kv policy
@@ -1010,11 +1005,6 @@ func TestRPC_LocalTokenStrippedOnForward_GRPC(t *testing.T) {
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	testrpc.WaitForLeader(t, s1.RPC, "dc2")
-
-	// Wait for legacy acls to be disabled so we are clear that
-	// legacy replication isn't meddling.
-	waitForNewACLs(t, s1)
-	waitForNewACLs(t, s2)
 	waitForNewACLReplication(t, s2, structs.ACLReplicateTokens, 1, 1, 0)
 
 	// create simple service policy

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -134,10 +134,6 @@ type Server struct {
 
 	aclAuthMethodValidators authmethod.Cache
 
-	// DEPRECATED (ACL-Legacy-Compat) - only needed while we support both
-	// useNewACLs is used to determine whether we can use new ACLs or not
-	useNewACLs int32
-
 	// autopilot is the Autopilot instance for this server.
 	autopilot *autopilot.Autopilot
 
@@ -428,7 +424,6 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 	s.statsFetcher = NewStatsFetcher(logger, s.connPool, s.config.Datacenter)
 
 	s.aclConfig = newACLConfig(logger)
-	s.useNewACLs = 0
 	aclConfig := ACLResolverConfig{
 		Config:      config.ACLResolverSettings,
 		Delegate:    s,
@@ -1346,11 +1341,7 @@ func (s *Server) Stats() map[string]map[string]string {
 	}
 
 	if s.config.ACLsEnabled {
-		if s.UseLegacyACLs() {
-			stats["consul"]["acl"] = "legacy"
-		} else {
-			stats["consul"]["acl"] = "enabled"
-		}
+		stats["consul"]["acl"] = "enabled"
 	} else {
 		stats["consul"]["acl"] = "disabled"
 	}

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -72,6 +72,8 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 		conf.Tags["use_tls"] = "1"
 	}
 
+	// TODO(ACL-Legacy-Compat): remove in phase 2. These are kept for now to
+	// allow for upgrades.
 	if s.acls.ACLsEnabled() {
 		conf.Tags[metadata.TagACLs] = string(structs.ACLModeEnabled)
 	} else {

--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -728,6 +728,7 @@ func (s *Store) ACLTokenList(ws memdb.WatchSet, local, global bool, policy, role
 	return idx, result, nil
 }
 
+// TODO(ACL-Legacy-Compat): remove in phase 2
 func (s *Store) ACLTokenListUpgradeable(max int) (structs.ACLTokens, <-chan struct{}, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()

--- a/agent/consul/state/acl_schema.go
+++ b/agent/consul/state/acl_schema.go
@@ -107,6 +107,7 @@ func tokensTableSchema() *memdb.TableSchema {
 
 			//DEPRECATED (ACL-Legacy-Compat) - This index is only needed while we support upgrading v1 to v2 acls
 			// This table indexes all the ACL tokens that do not have an AccessorID
+			// TODO(ACL-Legacy-Compat): remove in phase 2
 			"needs-upgrade": {
 				Name:         "needs-upgrade",
 				AllowMissing: false,

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -4,10 +4,11 @@ import (
 	"runtime"
 	"strconv"
 
-	"github.com/hashicorp/consul/agent/metadata"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/serf/serf"
+
+	"github.com/hashicorp/consul/agent/metadata"
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 // CanServersUnderstandProtocol checks to see if all the servers in the given
@@ -212,18 +213,4 @@ func (s *serversACLMode) update(srv *metadata.Server) bool {
 	}
 
 	return true
-}
-
-// ServersGetACLMode checks all the servers in a particular datacenter and determines
-// what the minimum ACL mode amongst them is and what the leaders ACL mode is.
-// The "found" return value indicates whether there were any servers considered in
-// this datacenter. If that is false then the other mode return values are meaningless
-// as they will be ACLModeEnabled and ACLModeUnkown respectively.
-func ServersGetACLMode(provider checkServersProvider, leaderAddr string, datacenter string) (found bool, mode structs.ACLMode, leaderMode structs.ACLMode) {
-	var state serversACLMode
-	state.init(leaderAddr)
-
-	provider.CheckServers(datacenter, state.update)
-
-	return state.found, state.mode, state.leaderMode
 }

--- a/agent/metadata/server.go
+++ b/agent/metadata/server.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/serf/serf"
-
-	"github.com/hashicorp/consul/agent/structs"
 )
 
 // Key is used in maps and for equality tests.  A key is based on endpoints.
@@ -42,7 +40,6 @@ type Server struct {
 	Addr         net.Addr
 	Status       serf.MemberStatus
 	ReadReplica  bool
-	ACLs         structs.ACLMode
 	FeatureFlags map[string]int
 
 	// If true, use TLS when connecting to this server
@@ -95,13 +92,6 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		return false, nil
-	}
-
-	var acls structs.ACLMode
-	if aclMode, ok := m.Tags[TagACLs]; ok {
-		acls = structs.ACLMode(aclMode)
-	} else {
-		acls = structs.ACLModeUnknown
 	}
 
 	segmentAddrs := make(map[string]string)
@@ -188,12 +178,12 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 		UseTLS:       useTLS,
 		// DEPRECATED - remove nonVoter check once support for that tag is removed
 		ReadReplica:  nonVoter || readReplica,
-		ACLs:         acls,
 		FeatureFlags: featureFlags,
 	}
 	return true, parts
 }
 
+// TODO(ACL-Legacy-Compat): remove in phase 2
 const TagACLs = "acls"
 
 const featureFlagPrefix = "ft_"

--- a/agent/routine-leak-checker/leak_test.go
+++ b/agent/routine-leak-checker/leak_test.go
@@ -6,12 +6,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/tlsutil"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
 func testTLSCertificates(serverName string) (cert string, key string, cacert string, err error) {

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -20,16 +20,10 @@ import (
 type ACLMode string
 
 const (
-	// ACLs are disabled by configuration
+	// ACLModeDisabled indicates the ACL system is disabled
 	ACLModeDisabled ACLMode = "0"
-	// ACLs are enabled
+	// ACLModeEnabled indicates the ACL system is enabled
 	ACLModeEnabled ACLMode = "1"
-	// DEPRECATED (ACL-Legacy-Compat) - only needed while legacy ACLs are supported
-	// ACLs are enabled and using legacy ACLs
-	ACLModeLegacy ACLMode = "2"
-	// DEPRECATED (ACL-Legacy-Compat) - only needed while legacy ACLs are supported
-	// ACLs are assumed enabled but not being advertised
-	ACLModeUnknown ACLMode = "3"
 )
 
 type ACLTokenIDType string


### PR DESCRIPTION
Branched from #11126

This PR removes the rest of the "start in legacy" logic from `Server`. The upgrade token goroutine is kept around for cases where a user may restore from a snapshot with legacy tokens, or when a legacy token is created immediately before the server is shutdown for an upgrade.