### PR TITLE
ui: Add `is` and `test` helpers in a similar vein to `can`

### DIFF
--- a/ui/packages/consul-ui/app/helpers/is.js
+++ b/ui/packages/consul-ui/app/helpers/is.js
@@ -1,0 +1,24 @@
+import Helper from 'ember-can/helpers/can';
+import { get } from '@ember/object';
+
+import { camelize } from '@ember/string';
+export const is = (helper, [abilityString, model], properties) => {
+  let { abilityName, propertyName } = helper.can.parse(abilityString);
+  let ability = helper.can.abilityFor(abilityName, model, properties);
+
+  if(typeof ability.getCharacteristicProperty === 'function') {
+    propertyName = ability.getCharacteristicProperty(propertyName);
+  } else {
+    propertyName = camelize(`is-${propertyName}`);
+  }
+
+  helper._removeAbilityObserver();
+  helper._addAbilityObserver(ability, propertyName);
+
+  return get(ability, propertyName);
+}
+export default Helper.extend({
+  compute([abilityString, model], properties) {
+    return is(this, [abilityString, model], properties);
+  },
+});

--- a/ui/packages/consul-ui/app/helpers/is.mdx
+++ b/ui/packages/consul-ui/app/helpers/is.mdx
@@ -1,0 +1,20 @@
+# is
+
+`{{is "something model" item=item}}` is used to perform a test on based on a
+type of model, almost the same as `ember-can` but reads better to test for a
+characteristic rather than an ability:
+
+```hbs
+
+{{#if (is "crd intention" item=item)}}
+I'm a CRD intention
+{{/if}}
+
+```
+
+Consider using the `test` helper instead.
+
+## See also
+
+- [`test` helper](./test.mdx)
+

--- a/ui/packages/consul-ui/app/helpers/test.js
+++ b/ui/packages/consul-ui/app/helpers/test.js
@@ -1,0 +1,14 @@
+import Helper from 'ember-can/helpers/can';
+import { is } from 'consul-ui/helpers/is';
+
+export default Helper.extend({
+  compute([abilityString, model], properties) {
+    switch(true) {
+      case abilityString.startsWith('can '):
+        return super.compute([abilityString.substr(4), model], properties);
+      case abilityString.startsWith('is '):
+        return is(this, [abilityString.substr(3), model], properties);
+    }
+    throw new Error(`${abilityString} is not supported by the 'test' helper.`);
+  },
+});

--- a/ui/packages/consul-ui/app/helpers/test.mdx
+++ b/ui/packages/consul-ui/app/helpers/test.mdx
@@ -1,0 +1,16 @@
+# test
+
+`{{and (test "is something model" item=item) (test "can read model")}}` is used
+to perform a test on based on a type of model, almost the same as `ember-can`
+and the `is` helper, but is more generic and extensible whilst reading nicely:
+
+```hbs
+
+{{#if (and (test "is crd intention" item=item) (test "can read intentions"))}}
+I'm a CRD intention
+{{/if}}
+
+```
+
+Consider using this instead of the `can` and `is` helpers, as its more generic.
+


### PR DESCRIPTION
First of a series of iterative PRs for adding CRUD for partitions.

TBD