### PR TITLE
ui: Use of header default ACL policy

### DIFF
--- a/ui/packages/consul-ui/app/models/dc.js
+++ b/ui/packages/consul-ui/app/models/dc.js
@@ -8,6 +8,7 @@ export default class Datacenter extends Model {
   @attr('string') uid;
   @attr('string') Name;
   @attr('boolean') Local;
+  @attr('string') DefaultACLPolicy;
 
   @attr('boolean', { defaultValue: () => true }) MeshEnabled;
 }

--- a/ui/packages/consul-ui/app/serializers/dc.js
+++ b/ui/packages/consul-ui/app/serializers/dc.js
@@ -8,17 +8,21 @@ export default class DcSerializer extends Serializer {
 
   respondForQuery(respond, query) {
     return respond(function(headers, body) {
-      return body;
+      return {
+        body,
+        headers,
+      };
     });
   }
 
   normalizePayload(payload, id, requestType) {
     switch (requestType) {
       case 'query':
-        return payload.map(item => {
+        return payload.body.map(item => {
           return {
             Local: this.env.var('CONSUL_DATACENTER_LOCAL') === item,
             [this.primaryKey]: item,
+            DefaultACLPolicy: payload.headers['x-consul-default-acl-policy'],
           };
         });
     }

--- a/ui/packages/consul-ui/mock-api/v1/catalog/.config
+++ b/ui/packages/consul-ui/mock-api/v1/catalog/.config
@@ -1,0 +1,7 @@
+---
+"*":
+  GET:
+    "*":
+      headers:
+        response:
+          X-Consul-Default-Acl-Policy: ${fake.helpers.randomize(['allow', 'deny'])}

--- a/ui/packages/consul-ui/tests/integration/serializers/dc-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/dc-test.js
@@ -9,7 +9,10 @@ module('Integration | Serializer | dc', function(hooks) {
       url: `/v1/catalog/datacenters`,
     };
     return get(request.url).then(function(payload) {
-      const expected = payload;
+      const expected = {
+        body: payload,
+        headers: {},
+      };
       const actual = serializer.respondForQuery(function(cb) {
         const headers = {};
         const body = payload;


### PR DESCRIPTION
### ✨ Description:
Adding [Default ACL Policy](https://www.consul.io/api-docs#default-acl-policy) header to the UI.

### 📸 Screenshots:
No screenshots.

### ⚡ Backend Changes:
No BE Changes.

### 🤡 Updates to mock-api:
Updating the headers for `X-Consul-Default-Acl-Policy` to return from the dc endpoint.

### 🧪 Testing:
Update DC serializer test.
Adding integration tests with future implementation.
