### PR TITLE
Adds consulrs Rust client library to SDK list

### DIFF
--- a/website/content/api-docs/libraries-and-sdks.mdx
+++ b/website/content/api-docs/libraries-and-sdks.mdx
@@ -135,4 +135,8 @@ the community.
     <a href="https://github.com/Roblox/rs-consul">rs-consul</a> -
     Rust client for the Consul HTTP API
   </li>
+  <li>
+    <a href="https://github.com/jmgilman/consulrs">consulrs</a> -
+    Asynchronous Rust client library for the Consul HTTP API
+  </li>
 </ul>


### PR DESCRIPTION
This PR proposes adding [consulrs](https://github.com/jmgilman/consulrs) to the list of SDKs. It's currently the most feature-rich crate in the Rust ecosystem and offers significantly more than the one currently listed. 