### PR TITLE
nia/docs: Remove references to v0.4.0-beta

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -223,8 +223,6 @@ task {
 
 #### Consul KV Condition
 
--> **Beta:** This feature is currently only available in Consul-Terraform-Sync v0.4.0-beta.
-
 A consul-kv condition block configures a task to only execute on changes to a Consul KV entry. The condition can be configured for a single Consul KV entry or for any Consul KV entries that are prefixed with a given path.
 
 See [Task Execution: Consul KV Condition](/docs/nia/tasks#consul-kv-condition) for more information on how tasks are triggered with a consul-kv condition.
@@ -301,8 +299,6 @@ driver "terraform" {
   </a>{' '}
   which is available with <strong>Consul Enterprise</strong>.
 </EnterpriseAlert>
-
--> **Beta:** The integration with the HashiCorp managed service version of Terraform Cloud is currently only available in Consul-Terraform-Sync v0.4.0-beta. Integration with the self-hosted version of Terraform Cloud is available as of v0.3.0.
 
 The Terraform Cloud driver enables Consul-Terraform-Sync Enterprise to integrate with **Terraform Cloud**, including both the [self-hosted distribution](https://www.hashicorp.com/products/terraform/editions/enterprise) and the [managed service](https://www.hashicorp.com/products/terraform/editions/cloud). With this driver, Consul-Terraform-Sync automates Terraform runs and remote operations for workspaces.
 

--- a/website/content/docs/nia/network-drivers/index.mdx
+++ b/website/content/docs/nia/network-drivers/index.mdx
@@ -13,8 +13,6 @@ Consul-Terraform-Sync is a HashiCorp solution to Network Infrastructure Automati
 
 The following table highlights some of the additional features Terraform and Terraform Cloud offer when used as a network driver for Consul-Terraform-Sync. Visit the [Terraform product page](https://www.hashicorp.com/products/terraform) or [contact our sales team](https://www.hashicorp.com/contact-sales) for a comprehensive list of features.
 
--> **Beta:** The integration with the HashiCorp managed service version of Terraform Cloud is currently only available in Consul-Terraform-Sync v0.4.0-beta. Integration with the self-hosted version of Terraform Cloud is available as of v0.3.0.
-
 | Network Driver | Description | Features |
 | -------------- | ----------- | -------- |
 | [Terraform driver](/docs/nia/network-drivers/terraform) | Consul-Terraform-Sync automates a local installation of the [Terraform CLI](https://www.terraform.io/) | - Local Terraform execution <br/> - Local workspace directories <br/> - [Backend options](/docs/nia/configuration#backend) available for state storage <br/> |

--- a/website/content/docs/nia/network-drivers/terraform-cloud.mdx
+++ b/website/content/docs/nia/network-drivers/terraform-cloud.mdx
@@ -12,8 +12,6 @@ description: >-
   which is available with <strong>Consul Enterprise</strong>.
 </EnterpriseAlert>
 
--> **Beta:** The integration with the HashiCorp managed service version of Terraform Cloud is currently only available in Consul-Terraform-Sync v0.4.0-beta. Integration with the self-hosted version of Terraform Cloud is available as of v0.3.0.
-
 Consul-Terraform-Sync is more powerful when you integrate it with [Terraform Cloud](https://www.terraform.io/cloud). Integrating with Terraform Cloud provides features, such as enhanced workspaces and insight into Terraform operations as Consul-Terraform-Sync dynamically updates your network infrastructure. Consul-Terraform-Sync is compatible with both the [self-hosted](https://www.hashicorp.com/products/terraform/editions/enterprise) and [managed service](https://www.hashicorp.com/products/terraform/editions/cloud) versions of Terraform Cloud.
 
 

--- a/website/content/docs/nia/tasks.mdx
+++ b/website/content/docs/nia/tasks.mdx
@@ -134,8 +134,6 @@ One particular condition configuration, [`regexp`](/docs/nia/configuration#regex
 
 ### Consul KV Condition
 
--> **Beta:** This feature is currently only available in Consul-Terraform-Sync v0.4.0-beta.
-
 Tasks with a consul-kv condition monitor and execute on Consul KV changes for KV pairs that satisfy the condition configuration. The consul-kv condition operates by monitoring the [Consul KV API](/api-docs/kv#read-key) and executing the task when a configured KV entry is created, deleted, or updated.
 
 Based on the `recurse` option, the condition either monitors a single Consul KV pair for a given path or monitors all pairs that are prefixed by that path. In the example below, because `recurse` is set to true, the `path` option is treated as a prefix. Changes to an entry with the key `my-key` and an entry with the key `my-key/another-key` would both trigger the task. If `recurse` were set to false, then only changes to `my-key` would trigger the task.

--- a/website/content/docs/nia/terraform-modules.mdx
+++ b/website/content/docs/nia/terraform-modules.mdx
@@ -126,8 +126,6 @@ Similarly, if you include the `catalog_services` variable in your module, we rec
 
 ### Consul KV Variable
 
--> **Beta:** This feature is currently only available in Consul-Terraform-Sync v0.4.0-beta.
-
 If you are creating a module for a [consul-kv condition](/docs/nia/tasks#consul-kv-condition), then you have the option to add the `consul_kv` variable, which contains a map of the keys and values for the Consul KV pairs. If your module would benefit from consuming this information, you can copy the `consul_kv` variable declaration to your `variables.tf` file in addition to the other variables.
 
 ```hcl


### PR DESCRIPTION
Removes beta callouts in preparation for GA release. Essentially reverts https://github.com/hashicorp/consul/pull/11151