### PR TITLE
ui: Exclude all debug-like files from the build

### DIFF
--- a/ui/packages/consul-acls/vendor/consul-acls/routes.js
+++ b/ui/packages/consul-acls/vendor/consul-acls/routes.js
@@ -1,16 +1,18 @@
-(function(data) {
-  const appNameJS = data.appName.split('-')
-    .map((item, i) => i ? `${item.substr(0, 1).toUpperCase()}${item.substr(1)}` : item)
-    .join('');
-  data[`${appNameJS}Routes`] = JSON.stringify({
-    dc: {
-      acls: {
-        tokens: {
-          _options: {
-            abilities: ['read tokens'],
-          },
+(routes => routes({
+  dc: {
+    acls: {
+      tokens: {
+        _options: {
+          abilities: ['read tokens'],
         },
       },
     },
-  });
-})(document.currentScript.dataset);
+  },
+}))(
+  (json, data = document.currentScript.dataset) => {
+    const appNameJS = data.appName.split('-')
+      .map((item, i) => i ? `${item.substr(0, 1).toUpperCase()}${item.substr(1)}` : item)
+      .join('');
+    data[`${appNameJS}Routes`] = JSON.stringify(json);
+  }
+);

--- a/ui/packages/consul-partitions/vendor/consul-partitions/routes.js
+++ b/ui/packages/consul-partitions/vendor/consul-partitions/routes.js
@@ -1,36 +1,38 @@
-(function(data) {
-  const appNameJS = data.appName.split('-')
-    .map((item, i) => i ? `${item.substr(0, 1).toUpperCase()}${item.substr(1)}` : item)
-    .join('');
-  data[`${appNameJS}Routes`] = JSON.stringify({
-    dc: {
-      partitions: {
+(routes => routes({
+  dc: {
+    partitions: {
+      _options: {
+        path: '/partitions',
+        queryParams: {
+          sortBy: 'sort',
+          searchproperty: {
+            as: 'searchproperty',
+            empty: [['Name', 'Description']],
+          },
+          search: {
+            as: 'filter',
+            replace: true,
+          },
+        },
+        abilities: ['read partitions'],
+      },
+      edit: {
+        _options: { path: '/:name' },
+      },
+      create: {
         _options: {
-          path: '/partitions',
-          queryParams: {
-            sortBy: 'sort',
-            searchproperty: {
-              as: 'searchproperty',
-              empty: [['Name', 'Description']],
-            },
-            search: {
-              as: 'filter',
-              replace: true,
-            },
-          },
-          abilities: ['read partitions'],
-        },
-        edit: {
-          _options: { path: '/:name' },
-        },
-        create: {
-          _options: {
-            template: 'dc/partitions/edit',
-            path: '/create',
-            abilities: ['create partitions'],
-          },
+          template: 'dc/partitions/edit',
+          path: '/create',
+          abilities: ['create partitions'],
         },
       },
     },
-  });
-})(document.currentScript.dataset);
+  },
+}))(
+  (json, data = document.currentScript.dataset) => {
+    const appNameJS = data.appName.split('-')
+      .map((item, i) => i ? `${item.substr(0, 1).toUpperCase()}${item.substr(1)}` : item)
+      .join('');
+    data[`${appNameJS}Routes`] = JSON.stringify(json);
+  }
+);

--- a/ui/packages/consul-ui/app/instance-initializers/container.js
+++ b/ui/packages/consul-ui/app/instance-initializers/container.js
@@ -1,8 +1,21 @@
 import { runInDebug } from '@ember/debug';
 import require from 'require';
+import merge from 'deepmerge';
 
-import services from 'consul-ui/services';
-import servicesDebug from 'consul-ui/services-debug';
+const doc = document;
+const appName = 'consul-ui';
+const appNameJS = appName
+  .split('-')
+  .map((item, i) => (i ? `${item.substr(0, 1).toUpperCase()}${item.substr(1)}` : item))
+  .join('');
+
+export const services = merge.all(
+  [].concat(
+    ...[...doc.querySelectorAll(`script[data-${appName}-services]`)].map($item =>
+      JSON.parse($item.dataset[`${appNameJS}Services`])
+    )
+  )
+);
 
 const inject = function(container, obj) {
   // inject all the things
@@ -23,7 +36,6 @@ export default {
   initialize(application) {
 
     inject(application, services);
-    runInDebug(_ => inject(application, servicesDebug));
 
     const container = application.lookup('service:container');
     // find all the services and add their classes to the container so we can

--- a/ui/packages/consul-ui/app/services-debug.js
+++ b/ui/packages/consul-ui/app/services-debug.js
@@ -1,8 +1,0 @@
-export default {
-  "route:application": {
-    "class": "consul-ui/routing/application-debug"
-  },
-  "service:intl": {
-    "class": "consul-ui/services/i18n-debug"
-  }
-}

--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -17,6 +17,7 @@ module.exports = function(defaults, $ = process.env) {
   $ = utils.env($);
   const env = EmberApp.env();
   const prodlike = ['production', 'staging'];
+  const devlike = ['development', 'staging'];
   const sourcemaps = !['production'].includes(env) && !$('BABEL_DISABLE_SOURCEMAPS', false);
 
   const trees = {};
@@ -46,6 +47,7 @@ module.exports = function(defaults, $ = process.env) {
     // exclude any component/pageobject.js files from anything but test
     excludeFiles = excludeFiles.concat([
       'components/**/pageobject.js',
+      'components/**/test-support.js',
       'components/**/*.test-support.js',
       'components/**/*.test.js',
     ])
@@ -55,6 +57,8 @@ module.exports = function(defaults, $ = process.env) {
     // exclude our debug initializer, route and template
     excludeFiles = excludeFiles.concat([
       'instance-initializers/debug.js',
+      'routing/**/*-debug.js',
+      'services/**/*-debug.js',
       'templates/debug.hbs',
       'components/debug/**/*.*'
     ])
@@ -83,7 +87,7 @@ module.exports = function(defaults, $ = process.env) {
   trees.app = mergeTrees([
     new Funnel('app', { exclude: excludeFiles })
   ].concat(
-    apps.filter(item => exists(`${item.path}/app`)).map(item => new Funnel(`${item.path}/app`))
+    apps.filter(item => exists(`${item.path}/app`)).map(item => new Funnel(`${item.path}/app`, {exclude: excludeFiles}))
   ), {
     overwrite: true
   });
@@ -142,6 +146,11 @@ module.exports = function(defaults, $ = process.env) {
   apps.forEach(item => {
     app.import(`vendor/${item.name}/routes.js`, {
       outputFile: `assets/${item.name}/routes.js`,
+    });
+  });
+  ['consul-ui/services'].concat(devlike ? ['consul-ui/services-debug'] : []).forEach(item => {
+    app.import(`vendor/${item}.js`, {
+      outputFile: `assets/${item}.js`,
     });
   });
   // Use `app.import` to add additional libraries to the generated

--- a/ui/packages/consul-ui/lib/startup/templates/body.html.js
+++ b/ui/packages/consul-ui/lib/startup/templates/body.html.js
@@ -41,6 +41,12 @@ ${environment === 'production' ? `{{jsonEncode .}}` : JSON.stringify(config.oper
     "codemirror/mode/yaml/yaml.js": "${rootURL}assets/codemirror/mode/yaml/yaml.js"
   }
   </script>
+  <script data-app-name="${appName}" data-${appName}-services src="${rootURL}assets/consul-ui/services.js"></script>
+${
+  environment === 'development' || environment === 'staging'
+    ? `
+  <script data-app-name="${appName}" data-${appName}-services src="${rootURL}assets/consul-ui/services-debug.js"></script>
+` : ``}
 ${
   environment === 'production'
     ? `

--- a/ui/packages/consul-ui/vendor/consul-ui/services-debug.js
+++ b/ui/packages/consul-ui/vendor/consul-ui/services-debug.js
@@ -1,0 +1,15 @@
+(services => services({
+  "route:application": {
+    "class": "consul-ui/routing/application-debug"
+  },
+  "service:intl": {
+    "class": "consul-ui/services/i18n-debug"
+  }
+}))(
+  (json, data = document.currentScript.dataset) => {
+    const appNameJS = data.appName.split('-')
+      .map((item, i) => i ? `${item.substr(0, 1).toUpperCase()}${item.substr(1)}` : item)
+      .join('');
+    data[`${appNameJS}Services`] = JSON.stringify(json);
+  }
+);

--- a/ui/packages/consul-ui/vendor/consul-ui/services.js
+++ b/ui/packages/consul-ui/vendor/consul-ui/services.js
@@ -1,4 +1,4 @@
-export default {
+(services => services({
   "route:basic": {
     "class": "consul-ui/routing/route"
   },
@@ -11,4 +11,11 @@ export default {
   "auth-provider:oidc-with-url": {
     "class": "consul-ui/services/auth-providers/oauth2-code-with-url-provider"
   }
-}
+}))(
+  (json, data = document.currentScript.dataset) => {
+    const appNameJS = data.appName.split('-')
+      .map((item, i) => i ? `${item.substr(0, 1).toUpperCase()}${item.substr(1)}` : item)
+      .join('');
+    data[`${appNameJS}Services`] = JSON.stringify(json);
+  }
+);


### PR DESCRIPTION
Luckily I have a thing I was playing with that made me realise we had ballooned our vendor javascript file from about 430kb gzipped to about 1MB gzipped / 3.3MB un-gzipped (around double our normal size). Pretty sure I'd managed to import the whole of `faker.js` 😬 .

This PR adds `**/*-debug.*` to our test/prod excluded files (realised I needed to add `test-support.js` also so added that here as its more or less the same thing). Conditionally juggling ES6 static imports (specifically debug ones) for this was also getting a little hairy, so I moved it all to use the same approach as our conditional routes. All in all it brings the vendor build back down to ~430kb gzipped.

I wasn't sure whether to pop this on the end of https://github.com/hashicorp/consul/pull/11188 but since thats already an umbrella issue, I decided to go with a separate PR (will add a new TODO over in 11188). Lastly, theres a little evolution here, and there's probably a tiny bit more cleanup and DRYing out to come, but it's fine to kick that can down the road for a little bit longer if that's preferable and put that in a separate PR.