### PR TITLE
[1.9.x] Fixing the build after auto-backport

### DIFF
--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -12,9 +12,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func startRPCTLSServer(config *Config) (net.Conn, chan error) {


### PR DESCRIPTION
Backport of #11210 was "successful" , but the imports were wrong.