### PR TITLE
connect: Remove envoy_version from bootstrap template

### DIFF
--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -145,8 +145,7 @@ const bootstrapTemplate = `{
     "id": "{{ .ProxyID }}",
     "metadata": {
       "namespace": "{{if ne .Namespace ""}}{{ .Namespace }}{{else}}default{{end}}",
-      "partition": "{{if ne .Partition ""}}{{ .Partition }}{{else}}default{{end}}",
-      "envoy_version": "{{ .EnvoyVersion }}"
+      "partition": "{{if ne .Partition ""}}{{ .Partition }}{{else}}default{{end}}"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -13,8 +13,7 @@
     "id": "ingress-gateway",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -13,8 +13,7 @@
     "id": "ingress-gateway",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -13,8 +13,7 @@
     "id": "my-gateway-123",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -13,8 +13,7 @@
     "id": "my-gateway",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -13,8 +13,7 @@
     "id": "ingress-gateway-1",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/prometheus-metrics.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/xds-addr-config.golden
+++ b/command/connect/envoy/testdata/xds-addr-config.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -13,8 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "partition": "default",
-      "envoy_version": "1.19.1"
+      "partition": "default"
     }
   },
   "static_resources": {


### PR DESCRIPTION
Fixes #11134. This just removes the `envoy_version` property from the bootstrap template. See the issue for more details on the background. In effect, this reduces the PR noise when adding and removing support for versions of Envoy. 