### PR TITLE
acl: extract a backend type for the ACLResolverBackend

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -301,7 +301,7 @@ func NewACLResolver(config *ACLResolverConfig) (*ACLResolver, error) {
 		return nil, fmt.Errorf("ACL Resolver must be initialized with a config")
 	}
 	if config.Backend == nil {
-		return nil, fmt.Errorf("ACL Resolver must be initialized with a valid delegate")
+		return nil, fmt.Errorf("ACL Resolver must be initialized with a valid backend")
 	}
 
 	if config.Logger == nil {

--- a/agent/consul/acl_client.go
+++ b/agent/consul/acl_client.go
@@ -5,7 +5,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-var clientACLCacheConfig *structs.ACLCachesConfig = &structs.ACLCachesConfig{
+var clientACLCacheConfig = &structs.ACLCachesConfig{
 	// The ACL cache configuration on client agents is more conservative than
 	// on the servers. It is assumed that individual client agents will have
 	// fewer distinct identities accessing the client than a server would
@@ -23,23 +23,28 @@ var clientACLCacheConfig *structs.ACLCachesConfig = &structs.ACLCachesConfig{
 	Roles: 128,
 }
 
-func (c *Client) ACLDatacenter() string {
-	// For resolution running on clients, servers within the current datacenter
+type clientACLResolverBackend struct {
+	// TODO: un-embed
+	*Client
+}
+
+func (c *clientACLResolverBackend) ACLDatacenter() string {
+	// For resolution running on clients servers within the current datacenter
 	// must be queried first to pick up local tokens.
 	return c.config.Datacenter
 }
 
-func (c *Client) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
+func (c *clientACLResolverBackend) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
 	// clients do no local identity resolution at the moment
 	return false, nil, nil
 }
 
-func (c *Client) ResolvePolicyFromID(policyID string) (bool, *structs.ACLPolicy, error) {
+func (c *clientACLResolverBackend) ResolvePolicyFromID(policyID string) (bool, *structs.ACLPolicy, error) {
 	// clients do no local policy resolution at the moment
 	return false, nil, nil
 }
 
-func (c *Client) ResolveRoleFromID(roleID string) (bool, *structs.ACLRole, error) {
+func (c *clientACLResolverBackend) ResolveRoleFromID(roleID string) (bool, *structs.ACLRole, error) {
 	// clients do no local role resolution at the moment
 	return false, nil, nil
 }

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -100,9 +100,14 @@ func (s *Server) LocalTokensEnabled() bool {
 	return true
 }
 
-func (s *Server) ACLDatacenter() string {
-	// For resolution running on servers the only option
-	// is to contact the configured ACL Datacenter
+type serverACLResolverBackend struct {
+	// TODO: un-embed
+	*Server
+}
+
+func (s *serverACLResolverBackend) ACLDatacenter() string {
+	// For resolution running on servers the only option is to contact the
+	// configured ACL Datacenter
 	if s.config.PrimaryDatacenter != "" {
 		return s.config.PrimaryDatacenter
 	}
@@ -114,6 +119,7 @@ func (s *Server) ACLDatacenter() string {
 }
 
 // ResolveIdentityFromToken retrieves a token's full identity given its secretID.
+// TODO: why does some code call this directly instead of using ACLResolver.ResolveTokenToIdentity ?
 func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
 	// only allow remote RPC resolution when token replication is off and
 	// when not in the ACL datacenter
@@ -131,7 +137,7 @@ func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdenti
 	return s.InPrimaryDatacenter() || index > 0, nil, acl.ErrNotFound
 }
 
-func (s *Server) ResolvePolicyFromID(policyID string) (bool, *structs.ACLPolicy, error) {
+func (s *serverACLResolverBackend) ResolvePolicyFromID(policyID string) (bool, *structs.ACLPolicy, error) {
 	index, policy, err := s.fsm.State().ACLPolicyGetByID(nil, policyID, nil)
 	if err != nil {
 		return true, nil, err
@@ -145,7 +151,7 @@ func (s *Server) ResolvePolicyFromID(policyID string) (bool, *structs.ACLPolicy,
 	return s.InPrimaryDatacenter() || index > 0, policy, acl.ErrNotFound
 }
 
-func (s *Server) ResolveRoleFromID(roleID string) (bool, *structs.ACLRole, error) {
+func (s *serverACLResolverBackend) ResolveRoleFromID(roleID string) (bool, *structs.ACLRole, error) {
 	index, role, err := s.fsm.State().ACLRoleGetByID(nil, roleID, nil)
 	if err != nil {
 		return true, nil, err

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -715,7 +715,7 @@ func newTestACLResolver(t *testing.T, delegate *ACLResolverTestDelegate, cb func
 			Roles:          4,
 		},
 		DisableDuration: aclClientDisabledTTL,
-		Delegate:        delegate,
+		Backend:         delegate,
 	}
 
 	if cb != nil {

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -119,7 +119,7 @@ func NewClient(config *Config, deps Deps) (*Client, error) {
 
 	aclConfig := ACLResolverConfig{
 		Config:          config.ACLResolverSettings,
-		Delegate:        c,
+		Backend:         &clientACLResolverBackend{Client: c},
 		Logger:          c.logger,
 		DisableDuration: aclClientDisabledTTL,
 		CacheConfig:     clientACLCacheConfig,

--- a/agent/consul/replication.go
+++ b/agent/consul/replication.go
@@ -110,7 +110,7 @@ func NewReplicator(config *ReplicatorConfig) (*Replicator, error) {
 		return nil, fmt.Errorf("Cannot create the Replicator without a config")
 	}
 	if config.Delegate == nil {
-		return nil, fmt.Errorf("Cannot create the Replicator without a Delegate set in the config")
+		return nil, fmt.Errorf("Cannot create the Replicator without a Backend set in the config")
 	}
 	if config.Logger == nil {
 		logger := hclog.New(&hclog.LoggerOptions{})

--- a/agent/consul/replication.go
+++ b/agent/consul/replication.go
@@ -110,7 +110,7 @@ func NewReplicator(config *ReplicatorConfig) (*Replicator, error) {
 		return nil, fmt.Errorf("Cannot create the Replicator without a config")
 	}
 	if config.Delegate == nil {
-		return nil, fmt.Errorf("Cannot create the Replicator without a Backend set in the config")
+		return nil, fmt.Errorf("Cannot create the Replicator without a Delegate set in the config")
 	}
 	if config.Logger == nil {
 		logger := hclog.New(&hclog.LoggerOptions{})

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -450,7 +450,7 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 	s.aclConfig = newACLConfig(partitionInfo, logger)
 	aclConfig := ACLResolverConfig{
 		Config:      config.ACLResolverSettings,
-		Delegate:    s,
+		Backend:     &serverACLResolverBackend{Server: s},
 		CacheConfig: serverACLCacheConfig,
 		Logger:      logger,
 		ACLConfig:   s.aclConfig,


### PR DESCRIPTION
Related to #11337 

This is a small step to isolate the functionality that is used for the `ACLResolver` from the large Client and Server structs. This follows the pattern and naming we use for all new RPC endpoints.