### PR TITLE
Start tracking connect service mesh usage metrics

### DIFF
--- a/agent/consul/state/usage_oss.go
+++ b/agent/consul/state/usage_oss.go
@@ -18,6 +18,8 @@ func addEnterpriseServiceInstanceUsage(map[string]int, memdb.Change) {}
 
 func addEnterpriseServiceUsage(map[string]int, map[structs.ServiceName]uniqueServiceState) {}
 
+func addEnterpriseConnectServiceInstanceUsage(map[string]int, *structs.ServiceNode, int) {}
+
 func addEnterpriseKVUsage(map[string]int, memdb.Change) {}
 
 func compileEnterpriseServiceUsage(tx ReadTxn, usage ServiceUsage) (ServiceUsage, error) {

--- a/agent/consul/state/usage_oss.go
+++ b/agent/consul/state/usage_oss.go
@@ -11,6 +11,7 @@ import (
 type EnterpriseServiceUsage struct{}
 type EnterpriseNodeUsage struct{}
 type EnterpriseKVUsage struct{}
+type EnterpriseConfigUsage struct{}
 
 func addEnterpriseNodeUsage(map[string]int, memdb.Change) {}
 
@@ -22,6 +23,8 @@ func addEnterpriseConnectServiceInstanceUsage(map[string]int, *structs.ServiceNo
 
 func addEnterpriseKVUsage(map[string]int, memdb.Change) {}
 
+func addEnterpriseConfigUsage(map[string]int, memdb.Change) {}
+
 func compileEnterpriseServiceUsage(tx ReadTxn, usage ServiceUsage) (ServiceUsage, error) {
 	return usage, nil
 }
@@ -31,5 +34,9 @@ func compileEnterpriseNodeUsage(tx ReadTxn, usage NodeUsage) (NodeUsage, error) 
 }
 
 func compileEnterpriseKVUsage(tx ReadTxn, usage KVUsage) (KVUsage, error) {
+	return usage, nil
+}
+
+func compileEnterpriseConfigUsage(tx ReadTxn, usage ConfigUsage) (ConfigUsage, error) {
 	return usage, nil
 }

--- a/agent/consul/usagemetrics/usagemetrics.go
+++ b/agent/consul/usagemetrics/usagemetrics.go
@@ -176,6 +176,12 @@ func (u *UsageMetricsReporter) runOnce() {
 
 	u.emitKVUsage(kvUsage)
 
+	_, configUsage, err := state.ConfigUsage()
+	if err != nil {
+		u.logger.Warn("failed to retrieve config usage from state store", "error", err)
+	}
+
+	u.emitConfigUsage(configUsage)
 }
 
 func (u *UsageMetricsReporter) memberUsage() []serf.Member {

--- a/agent/consul/usagemetrics/usagemetrics_oss.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss.go
@@ -57,6 +57,14 @@ func (u *UsageMetricsReporter) emitServiceUsage(serviceUsage state.ServiceUsage)
 		float32(serviceUsage.ServiceInstances),
 		u.metricLabels,
 	)
+
+	for k, i := range serviceUsage.ConnectServiceInstances {
+		metrics.SetGaugeWithLabels(
+			[]string{"consul", "state", "connect_instances"},
+			float32(i),
+			append(u.metricLabels, metrics.Label{Name: "kind", Value: k}),
+		)
+	}
 }
 
 func (u *UsageMetricsReporter) emitKVUsage(kvUsage state.KVUsage) {

--- a/agent/consul/usagemetrics/usagemetrics_oss.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss.go
@@ -74,3 +74,13 @@ func (u *UsageMetricsReporter) emitKVUsage(kvUsage state.KVUsage) {
 		u.metricLabels,
 	)
 }
+
+func (u *UsageMetricsReporter) emitConfigUsage(configUsage state.ConfigUsage) {
+	for k, i := range configUsage.ConfigByKind {
+		metrics.SetGaugeWithLabels(
+			[]string{"consul", "state", "config_entries"},
+			float32(i),
+			append(u.metricLabels, metrics.Label{Name: "kind", Value: k}),
+		)
+	}
+}

--- a/agent/consul/usagemetrics/usagemetrics_oss_test.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss_test.go
@@ -90,6 +90,14 @@ func TestUsageReporter_emitNodeUsage_OSS(t *testing.T) {
 						{Name: "kind", Value: "mesh-gateway"},
 					},
 				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-native": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-native"},
+					},
+				},
 				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
@@ -184,6 +192,14 @@ func TestUsageReporter_emitNodeUsage_OSS(t *testing.T) {
 					Labels: []metrics.Label{
 						{Name: "datacenter", Value: "dc1"},
 						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-native": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-native"},
 					},
 				},
 				// --- kv ---
@@ -310,6 +326,14 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 						{Name: "kind", Value: "mesh-gateway"},
 					},
 				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-native": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-native"},
+					},
+				},
 				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
@@ -340,6 +364,7 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 				require.NoError(t, s.EnsureRegistration(10, structs.TestRegisterIngressGateway(t)))
 				require.NoError(t, s.EnsureService(11, "foo", mgw))
 				require.NoError(t, s.EnsureService(12, "foo", tgw))
+				require.NoError(t, s.EnsureService(13, "bar", &structs.NodeService{ID: "db-native", Service: "db", Tags: nil, Address: "", Port: 5000, Connect: structs.ServiceConnect{Native: true}}))
 			},
 			getMembersFunc: func() []serf.Member {
 				return []serf.Member{
@@ -397,7 +422,7 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 				},
 				"consul.usage.test.consul.state.service_instances;datacenter=dc1": {
 					Name:  "consul.usage.test.consul.state.service_instances",
-					Value: 8,
+					Value: 9,
 					Labels: []metrics.Label{
 						{Name: "datacenter", Value: "dc1"},
 					},
@@ -433,6 +458,14 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 					Labels: []metrics.Label{
 						{Name: "datacenter", Value: "dc1"},
 						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-native": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-native"},
 					},
 				},
 				// --- kv ---
@@ -550,6 +583,14 @@ func TestUsageReporter_emitKVUsage_OSS(t *testing.T) {
 						{Name: "kind", Value: "mesh-gateway"},
 					},
 				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-native": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-native"},
+					},
+				},
 				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
@@ -653,6 +694,14 @@ func TestUsageReporter_emitKVUsage_OSS(t *testing.T) {
 					Labels: []metrics.Label{
 						{Name: "datacenter", Value: "dc1"},
 						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-native": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-native"},
 					},
 				},
 				// --- kv ---

--- a/agent/consul/usagemetrics/usagemetrics_oss_test.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss_test.go
@@ -104,6 +104,79 @@ func TestUsageReporter_emitNodeUsage_OSS(t *testing.T) {
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
 				},
+				// --- config entries ---
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-intentions": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-intentions"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-resolver": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-resolver"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-router": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-router"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-splitter": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-splitter"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=mesh": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=proxy-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "proxy-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
 			},
 			getMembersFunc: func() []serf.Member { return []serf.Member{} },
 		},
@@ -207,6 +280,79 @@ func TestUsageReporter_emitNodeUsage_OSS(t *testing.T) {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
+				},
+				// --- config entries ---
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-intentions": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-intentions"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-resolver": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-resolver"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-router": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-router"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-splitter": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-splitter"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=mesh": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=proxy-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "proxy-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
 				},
 			},
 		},
@@ -339,6 +485,79 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
+				},
+				// --- config entries ---
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-intentions": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-intentions"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-resolver": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-resolver"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-router": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-router"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-splitter": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-splitter"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=mesh": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=proxy-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "proxy-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
 				},
 			},
 			getMembersFunc: func() []serf.Member { return []serf.Member{} },
@@ -474,6 +693,79 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
 				},
+				// --- config entries ---
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-intentions": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-intentions"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-resolver": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-resolver"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-router": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-router"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-splitter": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-splitter"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=mesh": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=proxy-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "proxy-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
 			},
 		},
 	}
@@ -597,6 +889,79 @@ func TestUsageReporter_emitKVUsage_OSS(t *testing.T) {
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
 				},
+				// --- config entries ---
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-intentions": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-intentions"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-resolver": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-resolver"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-router": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-router"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-splitter": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-splitter"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=mesh": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=proxy-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "proxy-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
 			},
 			getMembersFunc: func() []serf.Member { return []serf.Member{} },
 		},
@@ -709,6 +1074,79 @@ func TestUsageReporter_emitKVUsage_OSS(t *testing.T) {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  4,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
+				},
+				// --- config entries ---
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-intentions": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-intentions"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-resolver": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-resolver"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-router": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-router"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=service-splitter": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "service-splitter"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=mesh": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=proxy-defaults": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "proxy-defaults"},
+					},
+				},
+				"consul.usage.test.consul.state.config_entries;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.config_entries",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
 				},
 			},
 		},

--- a/agent/consul/usagemetrics/usagemetrics_oss_test.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss_test.go
@@ -57,6 +57,40 @@ func TestUsageReporter_emitNodeUsage_OSS(t *testing.T) {
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
 				},
+				// --- service mesh ---
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-proxy": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-proxy"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=mesh-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  0,
@@ -119,6 +153,40 @@ func TestUsageReporter_emitNodeUsage_OSS(t *testing.T) {
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
 				},
+				// --- service mesh ---
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-proxy": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-proxy"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=mesh-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  0,
@@ -209,6 +277,40 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 						{Name: "datacenter", Value: "dc1"},
 					},
 				},
+				// --- service mesh ---
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-proxy": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-proxy"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=mesh-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  0,
@@ -224,11 +326,20 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 				require.NoError(t, s.EnsureNode(3, &structs.Node{Node: "baz", Address: "127.0.0.2"}))
 				require.NoError(t, s.EnsureNode(4, &structs.Node{Node: "qux", Address: "127.0.0.3"}))
 
+				mgw := structs.TestNodeServiceMeshGateway(t)
+				mgw.ID = "mesh-gateway"
+
+				tgw := structs.TestNodeServiceTerminatingGateway(t, "1.1.1.1")
+				tgw.ID = "terminating-gateway"
 				// Typical services and some consul services spread across two nodes
 				require.NoError(t, s.EnsureService(5, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: nil, Address: "", Port: 5000}))
 				require.NoError(t, s.EnsureService(6, "bar", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}))
 				require.NoError(t, s.EnsureService(7, "foo", &structs.NodeService{ID: "consul", Service: "consul", Tags: nil}))
 				require.NoError(t, s.EnsureService(8, "bar", &structs.NodeService{ID: "consul", Service: "consul", Tags: nil}))
+				require.NoError(t, s.EnsureService(9, "foo", &structs.NodeService{ID: "db-connect-proxy", Service: "db-connect-proxy", Tags: nil, Address: "", Port: 5000, Kind: structs.ServiceKindConnectProxy}))
+				require.NoError(t, s.EnsureRegistration(10, structs.TestRegisterIngressGateway(t)))
+				require.NoError(t, s.EnsureService(11, "foo", mgw))
+				require.NoError(t, s.EnsureService(12, "foo", tgw))
 			},
 			getMembersFunc: func() []serf.Member {
 				return []serf.Member{
@@ -279,18 +390,52 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 				// --- service ---
 				"consul.usage.test.consul.state.services;datacenter=dc1": {
 					Name:  "consul.usage.test.consul.state.services",
-					Value: 3,
+					Value: 7,
 					Labels: []metrics.Label{
 						{Name: "datacenter", Value: "dc1"},
 					},
 				},
 				"consul.usage.test.consul.state.service_instances;datacenter=dc1": {
 					Name:  "consul.usage.test.consul.state.service_instances",
-					Value: 4,
+					Value: 8,
 					Labels: []metrics.Label{
 						{Name: "datacenter", Value: "dc1"},
 					},
 				},
+				// --- service mesh ---
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-proxy": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-proxy"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=mesh-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 1,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  0,
@@ -372,6 +517,40 @@ func TestUsageReporter_emitKVUsage_OSS(t *testing.T) {
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
 				},
+				// --- service mesh ---
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-proxy": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-proxy"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=mesh-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  0,
@@ -443,6 +622,40 @@ func TestUsageReporter_emitKVUsage_OSS(t *testing.T) {
 					Value:  0,
 					Labels: []metrics.Label{{Name: "datacenter", Value: "dc1"}},
 				},
+				// --- service mesh ---
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=connect-proxy": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "connect-proxy"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=terminating-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "terminating-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=ingress-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "ingress-gateway"},
+					},
+				},
+				"consul.usage.test.consul.state.connect_instances;datacenter=dc1;kind=mesh-gateway": {
+					Name:  "consul.usage.test.consul.state.connect_instances",
+					Value: 0,
+					Labels: []metrics.Label{
+						{Name: "datacenter", Value: "dc1"},
+						{Name: "kind", Value: "mesh-gateway"},
+					},
+				},
+				// --- kv ---
 				"consul.usage.test.consul.state.kv_entries;datacenter=dc1": {
 					Name:   "consul.usage.test.consul.state.kv_entries",
 					Value:  4,


### PR DESCRIPTION
This PR will start tracking two kinds of service mesh metrics: 

1. connect instances by kind (count of connect-proxies or connect-native services)
2. config entries also by kind.