### PR TITLE
ui: Ignore erroneous ember/jquery eslint warnings

### DIFF
--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -1,3 +1,4 @@
+/*eslint ember/no-jquery: "off", ember/no-global-jquery: "off"*/
 'use strict';
 const Funnel = require('broccoli-funnel');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');

--- a/ui/packages/consul-ui/tests/steps/assertions/page.js
+++ b/ui/packages/consul-ui/tests/steps/assertions/page.js
@@ -1,4 +1,4 @@
-/* eslint no-console: "off" */
+/*eslint no-console: "off", ember/no-jquery: "off", ember/no-global-jquery: "off"*/
 
 const elementNotFound = 'Element not found';
 // this error comes from our pageObject `find `function


### PR DESCRIPTION
We are currently on a non-LTS version of Ember and Ember 4 is soon to be released (I believe the upcoming Ember 4.4 will be the first Ember 4 LTS). We've been slowly knocking off Ember deprecation warnings for a little while now with an eye to making it easier for us to upgrade to either the latest 3.x LTS or the next 4.x LTS.

Previous to https://github.com/hashicorp/consul/pull/11017 we were on about 30 warnings:

<img width="272" alt="Screenshot 2021-10-06 at 14 56 30" src="https://user-images.githubusercontent.com/554604/136231258-2a106bbd-7609-4b1e-8692-251ea650c566.png">

The changes in https://github.com/hashicorp/consul/pull/11017 got us down to half that - 15:

<img width="269" alt="Screenshot 2021-10-06 at 14 57 01" src="https://user-images.githubusercontent.com/554604/136231319-c67071c0-52b9-4d49-bdaa-070022d6fe26.png">

Now a lot of the noise has gone I noticed a `jQuery` warning which made me go 🤔 , and a realized that it was the ember/jquery rules catching the character `$` and thinking it was jQuery. We use the character `$` to always signify either an environment (or pseudo environment) variable (ie `$CONSUL_SERVICE_COUNT`), or a reference to a DOM node (ie. `$button`)

This was a quick fix and get us down to just 9 warnings left 🎉 :

<img width="263" alt="Screenshot 2021-10-06 at 14 55 46" src="https://user-images.githubusercontent.com/554604/136231751-5b5e1c87-6f80-41d1-83df-a6887a7fd6d5.png">

All of which have alternatives already in the codebase, its just a matter of getting around to doing the upgrades where those warnings occur.

Once those are done we should be a lot closer to the current Ember LTS and/or Ember 4 🎉 .


