### PR TITLE
config: default verify_incoming_rpc=true and deprecate verify_incoming

### DIFF
--- a/.changelog/11257.txt
+++ b/.changelog/11257.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+config: `verify_incoming_rpc` now defaults to true if either `ca_file` or `ca_path` are set. Previously it defaulted to false in all cases.
+```
+
+```release-note:deprecation
+config: `verify_incoming` is deprecated and may be removed in a future version. Use `verify_incoming_https` and `verify_incoming_rpc` instead.
+```

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3915,7 +3915,7 @@ func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 	require.Error(t, a.reloadConfigInternal(c))
 	tlsConf, err := tlsConf.GetConfigForClient(nil)
 	require.NoError(t, err)
-	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
+	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 1)
 	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
 }

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1080,13 +1080,14 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		UnixSocketGroup:             stringVal(c.UnixSocket.Group),
 		UnixSocketMode:              stringVal(c.UnixSocket.Mode),
 		UnixSocketUser:              stringVal(c.UnixSocket.User),
-		VerifyIncoming:              boolVal(c.VerifyIncoming),
 		VerifyIncomingHTTPS:         boolVal(c.VerifyIncomingHTTPS),
-		VerifyIncomingRPC:           boolVal(c.VerifyIncomingRPC),
 		VerifyOutgoing:              verifyOutgoing,
 		VerifyServerHostname:        verifyServerName,
 		Watches:                     c.Watches,
 	}
+
+	tlsCA := c.CAFile != nil || c.CAPath != nil
+	rt.VerifyIncomingRPC = boolValWithDefault(c.VerifyIncomingRPC, tlsCA)
 
 	rt.UseStreamingBackend = boolValWithDefault(c.UseStreamingBackend, true)
 
@@ -1468,8 +1469,8 @@ func (b *builder) validate(rt RuntimeConfig) error {
 	}
 
 	if rt.AutoEncryptAllowTLS {
-		if !rt.VerifyIncoming && !rt.VerifyIncomingRPC {
-			b.warn("if auto_encrypt.allow_tls is turned on, either verify_incoming or verify_incoming_rpc should be enabled. It is necessary to turn it off during a migration to TLS, but it should definitely be turned on afterwards.")
+		if !rt.VerifyIncomingRPC {
+			b.warn("if auto_encrypt.allow_tls is turned on, verify_incoming_rpc should be enabled. It is necessary to turn it off during a migration to TLS, but we strongly recommend setting the value to true once the migration is complete.")
 		}
 	}
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -247,7 +247,6 @@ type Config struct {
 	UIConfig RawUIConfig `mapstructure:"ui_config"`
 
 	UnixSocket           UnixSocket               `mapstructure:"unix_sockets"`
-	VerifyIncoming       *bool                    `mapstructure:"verify_incoming"`
 	VerifyIncomingHTTPS  *bool                    `mapstructure:"verify_incoming_https"`
 	VerifyIncomingRPC    *bool                    `mapstructure:"verify_incoming_rpc"`
 	VerifyOutgoing       *bool                    `mapstructure:"verify_outgoing"`

--- a/agent/config/deprecated.go
+++ b/agent/config/deprecated.go
@@ -28,6 +28,10 @@ type DeprecatedConfig struct {
 	ACLDownPolicy *string `mapstructure:"acl_down_policy"`
 	// DEPRECATED (ACL-Legacy-Compat) - moved to "acl.token_ttl"
 	ACLTTL *string `mapstructure:"acl_ttl"`
+
+	// Deprecated because it impacted two very different systems (http and rpc)
+	// which would lead to insecure setups. Use verify_incoming_https instead.
+	VerifyIncoming *bool `mapstructure:"verify_incoming"`
 }
 
 func applyDeprecatedConfig(d *decodeTarget) (Config, []string) {
@@ -113,6 +117,13 @@ func applyDeprecatedConfig(d *decodeTarget) (Config, []string) {
 			d.Config.ACL.EnableKeyListPolicy = dep.ACLEnableKeyListPolicy
 		}
 		warns = append(warns, deprecationWarning("acl_enable_key_list_policy", "acl.enable_key_list_policy"))
+	}
+
+	if dep.VerifyIncoming != nil {
+		if d.Config.VerifyIncomingHTTPS == nil {
+			d.Config.VerifyIncomingHTTPS = dep.VerifyIncoming
+		}
+		warns = append(warns, deprecationWarning("verify_incoming", "verify_incoming_https"))
 	}
 
 	return d.Config, warns

--- a/agent/config/deprecated_test.go
+++ b/agent/config/deprecated_test.go
@@ -28,6 +28,7 @@ acl_down_policy = "async-cache"
 acl_ttl = "3h"
 acl_enable_key_list_policy = true
 
+verify_incoming = false
 `},
 	}
 	patchLoadOptsShims(&opts)
@@ -45,6 +46,7 @@ acl_enable_key_list_policy = true
 		deprecationWarning("acl_replication_token", "acl.tokens.replication"),
 		deprecationWarning("acl_token", "acl.tokens.default"),
 		deprecationWarning("acl_ttl", "acl.token_ttl"),
+		deprecationWarning("verify_incoming", "verify_incoming_https"),
 	}
 	sort.Strings(result.Warnings)
 	require.Equal(t, expectWarns, result.Warnings)

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -378,13 +378,13 @@ type RuntimeConfig struct {
 	Cache cache.Options
 
 	// CAFile is a path to a certificate authority file. This is used with
-	// VerifyIncoming or VerifyOutgoing to verify the TLS connection.
+	// VerifyIncoming{RPC,HTTPS} or VerifyOutgoing to verify the TLS connection.
 	//
 	// hcl: ca_file = string
 	CAFile string
 
 	// CAPath is a path to a directory of certificate authority files. This is
-	// used with VerifyIncoming or VerifyOutgoing to verify the TLS connection.
+	// used with VerifyIncoming{RPC,HTTPS} or VerifyOutgoing to verify the TLS connection.
 	//
 	// hcl: ca_path = string
 	CAPath string
@@ -1419,14 +1419,6 @@ type RuntimeConfig struct {
 	// hcl: unix_sockets { user = string }
 	UnixSocketUser string
 
-	// VerifyIncoming is used to verify the authenticity of incoming
-	// connections. This means that TCP requests are forbidden, only allowing
-	// for TLS. TLS connections must match a provided certificate authority.
-	// This can be used to force client auth.
-	//
-	// hcl: verify_incoming = (true|false)
-	VerifyIncoming bool
-
 	// VerifyIncomingHTTPS is used to verify the authenticity of incoming HTTPS
 	// connections. This means that TCP requests are forbidden, only allowing
 	// for TLS. TLS connections must match a provided certificate authority.
@@ -1708,7 +1700,6 @@ func (c *RuntimeConfig) Sanitized() map[string]interface{} {
 
 func (c *RuntimeConfig) ToTLSUtilConfig() tlsutil.Config {
 	return tlsutil.Config{
-		VerifyIncoming:           c.VerifyIncoming,
 		VerifyIncomingRPC:        c.VerifyIncomingRPC,
 		VerifyIncomingHTTPS:      c.VerifyIncomingHTTPS,
 		VerifyOutgoing:           c.VerifyOutgoing,

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -411,7 +411,6 @@
     "UnixSocketMode": "",
     "UnixSocketUser": "",
     "UseStreamingBackend": false,
-    "VerifyIncoming": false,
     "VerifyIncomingHTTPS": false,
     "VerifyIncomingRPC": false,
     "VerifyOutgoing": false,

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -660,7 +660,6 @@ unix_sockets = {
     mode = "E8sAwOv4"
     user = "E0nB1DwA"
 }
-verify_incoming = true
 verify_incoming_https = true
 verify_incoming_rpc = true
 verify_outgoing = true

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -657,7 +657,6 @@
     "mode": "E8sAwOv4",
     "user": "E0nB1DwA"
   },
-  "verify_incoming": true,
   "verify_incoming_https": true,
   "verify_incoming_rpc": true,
   "verify_outgoing": true,

--- a/agent/consul/auto_config_endpoint_test.go
+++ b/agent/consul/auto_config_endpoint_test.go
@@ -169,7 +169,7 @@ func TestAutoConfigInitialConfiguration(t *testing.T) {
 		c.TLSConfig.CertFile = certfile
 		c.TLSConfig.KeyFile = keyfile
 		c.TLSConfig.VerifyOutgoing = true
-		c.TLSConfig.VerifyIncoming = true
+		c.TLSConfig.VerifyIncomingRPC = true
 		c.TLSConfig.VerifyServerHostname = true
 		c.TLSConfig.TLSMinVersion = "tls12"
 		c.TLSConfig.PreferServerCipherSuites = true

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -451,7 +451,7 @@ func TestClient_RPC_ConsulServerPing(t *testing.T) {
 func TestClient_RPC_TLS(t *testing.T) {
 	t.Parallel()
 	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
+	conf1.TLSConfig.VerifyIncomingRPC = true
 	conf1.TLSConfig.VerifyOutgoing = true
 	configureTLS(conf1)
 	s1, err := newServer(t, conf1)
@@ -664,7 +664,7 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 
 	t.Parallel()
 	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
+	conf1.TLSConfig.VerifyIncomingRPC = true
 	conf1.TLSConfig.VerifyOutgoing = true
 	configureTLS(conf1)
 	s1, err := newServer(t, conf1)

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -461,7 +461,7 @@ func TestRPC_TLSHandshakeTimeout(t *testing.T) {
 		c.TLSConfig.KeyFile = "../../test/hostname/Alice.key"
 		c.TLSConfig.VerifyServerHostname = true
 		c.TLSConfig.VerifyOutgoing = true
-		c.TLSConfig.VerifyIncoming = true
+		c.TLSConfig.VerifyIncomingRPC = true
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -557,7 +557,7 @@ func TestRPC_PreventsTLSNesting(t *testing.T) {
 				c.TLSConfig.KeyFile = "../../test/hostname/Alice.key"
 				c.TLSConfig.VerifyServerHostname = true
 				c.TLSConfig.VerifyOutgoing = true
-				c.TLSConfig.VerifyIncoming = false // saves us getting client cert setup
+				c.TLSConfig.VerifyIncomingRPC = false // saves us getting client cert setup
 				c.TLSConfig.Domain = "consul"
 			})
 			defer os.RemoveAll(dir1)
@@ -712,7 +712,7 @@ func TestRPC_RPCMaxConnsPerClient(t *testing.T) {
 					c.TLSConfig.KeyFile = "../../test/hostname/Alice.key"
 					c.TLSConfig.VerifyServerHostname = true
 					c.TLSConfig.VerifyOutgoing = true
-					c.TLSConfig.VerifyIncoming = false // saves us getting client cert setup
+					c.TLSConfig.VerifyIncomingRPC = false // saves us getting client cert setup
 					c.TLSConfig.Domain = "consul"
 				}
 			})
@@ -1308,7 +1308,7 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 		c.TLSConfig.CAFile = filepath.Join(dir, "ca.pem")
 		c.TLSConfig.CertFile = filepath.Join(dir, "srv1-server.dc1.consul.pem")
 		c.TLSConfig.KeyFile = filepath.Join(dir, "srv1-server.dc1.consul.key")
-		c.TLSConfig.VerifyIncoming = true
+		c.TLSConfig.VerifyIncomingRPC = true
 		c.TLSConfig.VerifyServerHostname = true
 		// Enable Auto-Encrypt so that Connect CA roots are added to the
 		// tlsutil.Configurator.

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -661,7 +661,7 @@ func TestServer_JoinWAN_viaMeshGateway(t *testing.T) {
 		c.TLSConfig.CAFile = "../../test/hostname/CertAuth.crt"
 		c.TLSConfig.CertFile = "../../test/hostname/Bob.crt"
 		c.TLSConfig.KeyFile = "../../test/hostname/Bob.key"
-		c.TLSConfig.VerifyIncoming = true
+		c.TLSConfig.VerifyIncomingRPC = true
 		c.TLSConfig.VerifyOutgoing = true
 		c.TLSConfig.VerifyServerHostname = true
 		// wanfed
@@ -680,7 +680,7 @@ func TestServer_JoinWAN_viaMeshGateway(t *testing.T) {
 		c.TLSConfig.CAFile = "../../test/hostname/CertAuth.crt"
 		c.TLSConfig.CertFile = "../../test/hostname/Betty.crt"
 		c.TLSConfig.KeyFile = "../../test/hostname/Betty.key"
-		c.TLSConfig.VerifyIncoming = true
+		c.TLSConfig.VerifyIncomingRPC = true
 		c.TLSConfig.VerifyOutgoing = true
 		c.TLSConfig.VerifyServerHostname = true
 		// wanfed
@@ -699,7 +699,7 @@ func TestServer_JoinWAN_viaMeshGateway(t *testing.T) {
 		c.TLSConfig.CAFile = "../../test/hostname/CertAuth.crt"
 		c.TLSConfig.CertFile = "../../test/hostname/Bonnie.crt"
 		c.TLSConfig.KeyFile = "../../test/hostname/Bonnie.key"
-		c.TLSConfig.VerifyIncoming = true
+		c.TLSConfig.VerifyIncomingRPC = true
 		c.TLSConfig.VerifyOutgoing = true
 		c.TLSConfig.VerifyServerHostname = true
 		// wanfed
@@ -1085,7 +1085,7 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 
 	t.Parallel()
 	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
+	conf1.TLSConfig.VerifyIncomingRPC = true
 	conf1.TLSConfig.VerifyOutgoing = true
 	configureTLS(conf1)
 	s1, err := newServer(t, conf1)
@@ -1097,7 +1097,7 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 
 	_, conf2 := testServerConfig(t)
 	conf2.Bootstrap = false
-	conf2.TLSConfig.VerifyIncoming = true
+	conf2.TLSConfig.VerifyIncomingRPC = true
 	conf2.TLSConfig.VerifyOutgoing = true
 	configureTLS(conf2)
 	s2, err := newServer(t, conf2)

--- a/agent/consul/subscribe_backend_test.go
+++ b/agent/consul/subscribe_backend_test.go
@@ -28,7 +28,7 @@ func TestSubscribeBackend_IntegrationWithServer_TLSEnabled(t *testing.T) {
 	// TODO(rb): add tests for the wanfed/alpn variations
 
 	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
+	conf1.TLSConfig.VerifyIncomingRPC = true
 	conf1.TLSConfig.VerifyOutgoing = true
 	conf1.RPCConfig.EnableStreaming = true
 	configureTLS(conf1)
@@ -160,7 +160,7 @@ func TestSubscribeBackend_IntegrationWithServer_TLSReload(t *testing.T) {
 
 	// Set up a server with initially bad certificates.
 	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
+	conf1.TLSConfig.VerifyIncomingRPC = true
 	conf1.TLSConfig.VerifyOutgoing = true
 	conf1.TLSConfig.CAFile = "../../test/ca/root.cer"
 	conf1.TLSConfig.CertFile = "../../test/key/ssl-cert-snakeoil.pem"

--- a/agent/grpc/client_test.go
+++ b/agent/grpc/client_test.go
@@ -152,11 +152,11 @@ func TestNewDialer_IntegrationWithTLSEnabledHandler(t *testing.T) {
 	registerWithGRPC(t, res)
 
 	tlsConf, err := tlsutil.NewConfigurator(tlsutil.Config{
-		VerifyIncoming: true,
-		VerifyOutgoing: true,
-		CAFile:         "../../test/hostname/CertAuth.crt",
-		CertFile:       "../../test/hostname/Alice.crt",
-		KeyFile:        "../../test/hostname/Alice.key",
+		VerifyIncomingRPC: true,
+		VerifyOutgoing:    true,
+		CAFile:            "../../test/hostname/CertAuth.crt",
+		CertFile:          "../../test/hostname/Alice.crt",
+		KeyFile:           "../../test/hostname/Alice.key",
 	}, hclog.New(nil))
 	require.NoError(t, err)
 
@@ -198,7 +198,7 @@ func TestNewDialer_IntegrationWithTLSEnabledHandler_viaMeshGateway(t *testing.T)
 	registerWithGRPC(t, res)
 
 	tlsConf, err := tlsutil.NewConfigurator(tlsutil.Config{
-		VerifyIncoming:       true,
+		VerifyIncomingRPC:    true,
 		VerifyOutgoing:       true,
 		VerifyServerHostname: true,
 		CAFile:               "../../test/hostname/CertAuth.crt",
@@ -226,7 +226,7 @@ func TestNewDialer_IntegrationWithTLSEnabledHandler_viaMeshGateway(t *testing.T)
 	t.Cleanup(srv.shutdown)
 
 	clientTLSConf, err := tlsutil.NewConfigurator(tlsutil.Config{
-		VerifyIncoming:       true,
+		VerifyIncomingRPC:    true,
 		VerifyOutgoing:       true,
 		VerifyServerHostname: true,
 		CAFile:               "../../test/hostname/CertAuth.crt",

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -207,7 +207,7 @@ func (c *cmd) run(args []string) int {
 	ui.Info(fmt.Sprintf("  Cluster Addr: %v (LAN: %d, WAN: %d)", config.AdvertiseAddrLAN,
 		config.SerfPortLAN, config.SerfPortWAN))
 	ui.Info(fmt.Sprintf("       Encrypt: Gossip: %v, TLS-Outgoing: %v, TLS-Incoming: %v, Auto-Encrypt-TLS: %t",
-		config.EncryptKey != "", config.VerifyOutgoing, config.VerifyIncoming, config.AutoEncryptTLS || config.AutoEncryptAllowTLS))
+		config.EncryptKey != "", config.VerifyOutgoing, config.VerifyIncomingRPC, config.AutoEncryptTLS || config.AutoEncryptAllowTLS))
 	// Enable log streaming
 	ui.Output("")
 	ui.Output("Log data will now stream in as it occurs:\n")

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -491,19 +491,17 @@ func TestConfigurator_ErrorPropagation(t *testing.T) {
 			false, false}, // 12
 		{Config{VerifyOutgoing: true, CAFile: cafile, CAPath: capath},
 			false, false}, // 13
-		{Config{VerifyIncoming: true, CAFile: "", CAPath: ""}, true, false}, // 14
-		{Config{VerifyIncomingRPC: true, CAFile: "", CAPath: ""},
-			true, false}, // 15
+		{Config{VerifyIncomingRPC: true, CAFile: "", CAPath: ""}, true, false}, // 14
 		{Config{VerifyIncomingHTTPS: true, CAFile: "", CAPath: ""},
 			true, false}, // 16
-		{Config{VerifyIncoming: true, CAFile: cafile, CAPath: ""}, true, false}, // 17
-		{Config{VerifyIncoming: true, CAFile: "", CAPath: capath}, true, false}, // 18
-		{Config{VerifyIncoming: true, CAFile: "", CAPath: capath,
+		{Config{VerifyIncomingRPC: true, CAFile: cafile, CAPath: ""}, true, false}, // 17
+		{Config{VerifyIncomingRPC: true, CAFile: "", CAPath: capath}, true, false}, // 18
+		{Config{VerifyIncomingRPC: true, CAFile: "", CAPath: capath,
 			CertFile: certfile, KeyFile: keyfile}, false, false}, // 19
-		{Config{CertFile: "bogus", KeyFile: "bogus"}, true, true},                   // 20
-		{Config{CAFile: "bogus"}, true, true},                                       // 21
-		{Config{CAPath: "bogus"}, true, true},                                       // 22
-		{Config{VerifyIncoming: true, CAFile: cafile, AutoTLS: true}, false, false}, // 22
+		{Config{CertFile: "bogus", KeyFile: "bogus"}, true, true},                      // 20
+		{Config{CAFile: "bogus"}, true, true},                                          // 21
+		{Config{CAPath: "bogus"}, true, true},                                          // 22
+		{Config{VerifyIncomingRPC: true, CAFile: cafile, AutoTLS: true}, false, false}, // 22
 	}
 	for _, v := range tlsVersions() {
 		variants = append(variants, variant{Config{TLSMinVersion: v}, false, false})
@@ -895,7 +893,6 @@ func TestConfigurator_IncomingALPNRPCConfig(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
-
 	// compare tls.Config.GetConfigForClient by nil/not-nil, since Go can not compare
 	// functions any other way.
 	cmpClientFunc := cmp.Comparer(func(x, y func(*tls.ClientHelloInfo) (*tls.Config, error)) bool {
@@ -920,7 +917,7 @@ func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
 	})
 
 	t.Run("verify incoming", func(t *testing.T) {
-		c := Configurator{base: &Config{VerifyIncoming: true}}
+		c := Configurator{base: &Config{VerifyIncomingHTTPS: true}}
 
 		cfg := c.IncomingHTTPSConfig()
 
@@ -1158,8 +1155,8 @@ func TestConfigurator_UpdateChecks(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.Update(Config{}))
 	require.Error(t, c.Update(Config{VerifyOutgoing: true}))
-	require.Error(t, c.Update(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer"}))
-	require.False(t, c.base.VerifyIncoming)
+	require.Error(t, c.Update(Config{VerifyIncomingRPC: true, CAFile: "../test/ca/root.cer"}))
+	require.False(t, c.base.VerifyIncomingRPC)
 	require.False(t, c.base.VerifyOutgoing)
 	require.Equal(t, uint64(2), c.version)
 }

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -2265,7 +2265,8 @@ signed by the CA can be used to gain full access to Consul.
   ~> **Note:** This config will be deprecated in Consul 1.11. See this
   [post](https://go.dev/blog/tls-cipher-suites) for details.
 
-- `verify_incoming` - If set to true, Consul
+- `verify_incoming` - **Deprecated in Consul v1.11.0. Use `verify_incoming_https` and
+  `verify_incomfing_rpc` instead.** If set to true, Consul
   requires that all incoming connections make use of TLS and that the client
   provides a certificate signed by a Certificate Authority from the
   [`ca_file`](#ca_file) or [`ca_path`](#ca_path). This applies to both server
@@ -2279,7 +2280,8 @@ signed by the CA can be used to gain full access to Consul.
 - `verify_incoming_rpc` - When set to true, Consul
   requires that all incoming RPC connections use TLS and that the client
   provides a certificate signed by a Certificate Authority from the [`ca_file`](#ca_file)
-  or [`ca_path`](#ca_path). By default, this is false, and Consul will not enforce
+  or [`ca_path`](#ca_path). Defaults to true if either `ca_file` or `ca_path` are set,
+  otherwise defaults to false. When set to false Consul will not enforce
   the use of TLS or verify a client's authenticity.
 
   ~> **Security Note:** `verify_incoming_rpc` _must_ be set to true to prevent anyone


### PR DESCRIPTION
Related to #11207
Branched from #11255

The `verify_incoming` config setting has been a problem because it groups together two very different settings. `verify_incoming_https` can be false and it doesn't present any serious security risk to the cluster. `verify_incoming_rpc` however effectively disables any protection provided by enabling tls.  Grouping these two things together makes it too easy to introduce an insecure setup.

This PR makes two changes to address this problem:
1. Deprecate `verify_incoming`. For now it continues to exist as an alias for `verify_incoming_https` and prints a warning when it is used. We may remove it in the future.
2. When either `ca_file` or `ca_path` are set, `verify_incoming_rpc` now defaults to `true`. This is a breaking change that is called out in the release notes. This changes makes it easier for users to get a secure setup by removing the need to set another configuration field to true.

TODO:
* [ ] what to do about verify_outgoing=false (See comments below)
* [ ] audit our learn guides to make sure we no longer reference `verify_incoming`
* [ ] audit our consul.io docs to make sure we never reference `verify_incoming`