### PR TITLE
Confirmation dropdown on delete action

### DIFF
--- a/.changelog/11252.txt
+++ b/.changelog/11252.txt
@@ -1,0 +1,3 @@
+```release-note: improvement
+ui: Confirmation dropdown for delete actions in draft mode for kv, intention, token, role, policies
+```

--- a/ui/packages/consul-ui/app/components/confirmation-dialog/index.hbs
+++ b/ui/packages/consul-ui/app/components/confirmation-dialog/index.hbs
@@ -1,12 +1,13 @@
-<div class={{concat "with-confirmation" (if confirming " confirming" "") (if permanent " permanent" "")}} ...attributes>
+<div class={{concat "with-confirmation" (if confirming " confirming" "")}} ...attributes>
 {{yield}}
-<YieldSlot @name="action" @params={{block-params (action "confirm") (action "cancel")}}>
-{{#if (or permanent (not confirming))}}
+<YieldSlot @name="dialog" @params={{block-params (action "execute") (action "cancel") message actionName}}>
+{{#if confirming }}
     {{yield}}
 {{/if}}
 </YieldSlot>
-<YieldSlot @name="dialog" @params={{block-params (action "execute") (action "cancel") message actionName}}>
-{{#if confirming }}
+
+<YieldSlot @name="action" @params={{block-params (action "confirm") (action "cancel")}}>
+{{#if (or permanent (not confirming))}}
     {{yield}}
 {{/if}}
 </YieldSlot>

--- a/ui/packages/consul-ui/app/components/confirmation-dialog/index.hbs
+++ b/ui/packages/consul-ui/app/components/confirmation-dialog/index.hbs
@@ -1,4 +1,4 @@
-<div class={{concat "with-confirmation" (if confirming " confirming" "")}} ...attributes>
+<div class={{concat "with-confirmation" (if confirming " confirming" "") (if permanent " permanent" "")}} ...attributes>
 {{yield}}
 <YieldSlot @name="action" @params={{block-params (action "confirm") (action "cancel")}}>
 {{#if (or permanent (not confirming))}}

--- a/ui/packages/consul-ui/app/components/confirmation-dialog/index.js
+++ b/ui/packages/consul-ui/app/components/confirmation-dialog/index.js
@@ -18,10 +18,16 @@ export default Component.extend(Slotted, {
       this.sendAction(...['actionName', ...this['arguments']]);
     },
     confirm: function() {
-      const [action, ...args] = arguments;
-      set(this, 'actionName', action);
-      set(this, 'arguments', args);
-      set(this, 'confirming', true);
+      var isConfirming = this.get('confirming');
+      if (isConfirming == true) {
+        set(this, 'confirming', false);
+      }
+      if (!isConfirming) {
+        const [action, ...args] = arguments;
+        set(this, 'actionName', action);
+        set(this, 'arguments', args);
+        set(this, 'confirming', true);
+      }
     },
   },
 });

--- a/ui/packages/consul-ui/app/components/confirmation-dialog/index.scss
+++ b/ui/packages/consul-ui/app/components/confirmation-dialog/index.scss
@@ -8,10 +8,6 @@ table td > div.with-confirmation.confirming {
   right: 0;
 }
 
-div.with-confirmation.permanent {
-  display: block;
-  text-align: right;
-}
 @media #{$--lt-wide-form} {
   %confirmation-dialog {
     float: none;

--- a/ui/packages/consul-ui/app/components/confirmation-dialog/index.scss
+++ b/ui/packages/consul-ui/app/components/confirmation-dialog/index.scss
@@ -7,6 +7,11 @@ table td > div.with-confirmation.confirming {
   position: absolute;
   right: 0;
 }
+
+div.with-confirmation.permanent {
+  display: block;
+  text-align: right;
+}
 @media #{$--lt-wide-form} {
   %confirmation-dialog {
     float: none;

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -143,7 +143,7 @@ as |api|>
           </button>
 {{#if (not api.isCreate)}}
   {{#if (not-eq item.ID 'anonymous') }}
-          <ConfirmationDialog @message="Are you sure you want to delete this Intention?">
+          <ConfirmationDialog @message="Are you sure you want to delete this Intention?" @permanent="true">
             <BlockSlot @name="action" as |confirm|>
               <button
                 data-test-delete

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -143,7 +143,7 @@ as |api|>
           </button>
 {{#if (not api.isCreate)}}
   {{#if (not-eq item.ID 'anonymous') }}
-          <ConfirmationDialog @message="Are you sure you want to delete this intention?">
+          <ConfirmationDialog @message="Are you sure you want to delete this Intention?">
             <BlockSlot @name="action" as |confirm|>
               <button
                 data-test-delete

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -143,7 +143,7 @@ as |api|>
           </button>
 {{#if (not api.isCreate)}}
   {{#if (not-eq item.ID 'anonymous') }}
-          <ConfirmationDialog @message="Are you sure you want to delete this Intention?">
+          <ConfirmationDialog @message="Are you sure you want to delete this intention?">
             <BlockSlot @name="action" as |confirm|>
               <button
                 data-test-delete

--- a/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
@@ -90,7 +90,7 @@ as |item index|>
                   </:header>
                   <:body>
                     <p>
-                      Are you sure you want to delete this intention?
+                      Are you sure you want to delete this Intention?
                     </p>
                   </:body>
                   <:actions as |Actions|>

--- a/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
@@ -96,7 +96,7 @@ as |item index|>
                   <:actions as |Actions|>
                     <Actions.Action class="dangerous">
                       <Action
-                        class="type-delete"
+                        data-test-confirm-delete
                         tabindex="-1"
                         {{on 'click' (queue (action change) (action @delete item))}}
                       >

--- a/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
@@ -69,7 +69,7 @@
 {{/if}}
         <button type="reset" onclick={{action oncancel api.data}} disabled={{api.disabled}}>Cancel</button>
 {{#if (not disabld)}}
-        <ConfirmationDialog @message="Are you sure you want to delete this Key/Value entry?">
+        <ConfirmationDialog @message="Are you sure you want to delete this Key/Value entry?" @permanent="true">
           <BlockSlot @name="action" as |confirm|>
             <button data-test-delete type="button" class="type-delete" {{action confirm api.delete}} disabled={{api.disabled}}>Delete</button>
           </BlockSlot>

--- a/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
@@ -69,7 +69,7 @@
 {{/if}}
         <button type="reset" onclick={{action oncancel api.data}} disabled={{api.disabled}}>Cancel</button>
 {{#if (not disabld)}}
-        <ConfirmationDialog @message="Are you sure you want to delete this key?">
+        <ConfirmationDialog @message="Are you sure you want to delete this key/value entry?">
           <BlockSlot @name="action" as |confirm|>
             <button data-test-delete type="button" class="type-delete" {{action confirm api.delete}} disabled={{api.disabled}}>Delete</button>
           </BlockSlot>

--- a/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/form/index.hbs
@@ -69,7 +69,7 @@
 {{/if}}
         <button type="reset" onclick={{action oncancel api.data}} disabled={{api.disabled}}>Cancel</button>
 {{#if (not disabld)}}
-        <ConfirmationDialog @message="Are you sure you want to delete this key/value entry?">
+        <ConfirmationDialog @message="Are you sure you want to delete this Key/Value entry?">
           <BlockSlot @name="action" as |confirm|>
             <button data-test-delete type="button" class="type-delete" {{action confirm api.delete}} disabled={{api.disabled}}>Delete</button>
           </BlockSlot>

--- a/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
@@ -32,7 +32,7 @@ as |item index|>
                 </:header>
                 <:body>
                   <p>
-                    Are you sure you want to delete this KV entry?
+                    Are you sure you want to delete this key/value entry?
                   </p>
                 </:body>
                 <:actions as |Actions|>

--- a/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
@@ -32,7 +32,7 @@ as |item index|>
                 </:header>
                 <:body>
                   <p>
-                    Are you sure you want to delete this key/value entry?
+                    Are you sure you want to delete this Key/Value entry?
                   </p>
                 </:body>
                 <:actions as |Actions|>

--- a/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/kv/list/index.hbs
@@ -38,7 +38,7 @@ as |item index|>
                 <:actions as |Actions|>
                   <Actions.Action class="dangerous">
                     <Action
-                      class="type-delete"
+                      data-test-confirm-delete
                       tabindex="-1"
                       {{on 'click' (queue (action change) (action @delete item))}}
                     >

--- a/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
@@ -53,7 +53,7 @@
             <p>
               {{message}}
             </p>
-            <button data-test-confirm-delete type="button" class="type-delete" {{action execute}}>Confirm Invalidation</button>
+            <button data-test-confirm-delete type="button" class="type-delete" {{action execute}}>Confirm Invalidate</button>
             <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
           </BlockSlot>
         </ConfirmationDialog>

--- a/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/form/index.hbs
@@ -53,7 +53,7 @@
             <p>
               {{message}}
             </p>
-            <button type="button" class="type-delete" {{action execute}}>Confirm Invalidation</button>
+            <button data-test-confirm-delete type="button" class="type-delete" {{action execute}}>Confirm Invalidation</button>
             <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
           </BlockSlot>
         </ConfirmationDialog>

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
@@ -83,7 +83,7 @@
           <p>
               {{message}}
           </p>
-          <button type="button" class="type-delete" onclick={{action execute}}>Confirm Invalidate</button>
+          <button data-test-confirm-delete type="button" onclick={{action execute}}>Confirm Invalidate</button>
           <button type="button" class="type-cancel" onclick={{action cancel}}>Cancel</button>
       </BlockSlot>
     </ConfirmationDialog>

--- a/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/lock-session/list/index.hbs
@@ -83,7 +83,7 @@
           <p>
               {{message}}
           </p>
-          <button data-test-confirm-delete type="button" onclick={{action execute}}>Confirm Invalidate</button>
+          <button data-test-confirm-delete type="button" class="type-delete" onclick={{action execute}}>Confirm Invalidate</button>
           <button type="button" class="type-cancel" onclick={{action cancel}}>Cancel</button>
       </BlockSlot>
     </ConfirmationDialog>

--- a/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/policy/list/index.hbs
@@ -54,7 +54,7 @@ as |item|>
               </BlockSlot>
               <BlockSlot @name="body">
                 <p>
-                  Are you sure you want to delete this policy?
+                  Are you sure you want to delete this Policy?
                 </p>
               </BlockSlot>
               <BlockSlot @name="confirm" as |Confirm|>

--- a/ui/packages/consul-ui/app/components/consul/role/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/role/list/index.hbs
@@ -38,7 +38,7 @@ as |item|>
               </BlockSlot>
               <BlockSlot @name="body">
                 <p>
-                  Are you sure you want to delete this role?
+                  Are you sure you want to delete this Role?
                 </p>
               </BlockSlot>
               <BlockSlot @name="confirm" as |Confirm|>

--- a/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/token/list/index.hbs
@@ -113,7 +113,7 @@ as |item|>
               </BlockSlot>
               <BlockSlot @name="body">
                 <p>
-                  Are you sure you want to delete this token?
+                  Are you sure you want to delete this Token?
                 </p>
               </BlockSlot>
               <BlockSlot @name="confirm" as |Confirm|>

--- a/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
+++ b/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
@@ -12,7 +12,7 @@
                 <Actions.Action class="dangerous">
                 <Action
                     tabindex="-1"
-                    class="type-delete"
+                    data-test-confirm-delete
                     {{on 'click' (action execute)}}
                 >
                     Delete

--- a/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
+++ b/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
@@ -1,7 +1,28 @@
-<p>
-  {{message}}
-</p>
-<button type="button" class="type-delete" onclick={{action execute}}>
-  Confirm Delete
-</button>
-<button type="button" class="type-cancel" onclick={{action cancel}}>Cancel</button>
+<div role="menu">
+    <InformedAction class="warning">
+            <:header>
+                Confirm Delete
+            </:header>
+            <:body>
+                <p>
+                {{message}}
+                </p>
+            </:body>
+            <:actions as |Actions|>
+                <Actions.Action class="dangerous">
+                <Action
+                    tabindex="-1"
+                    class="type-delete"
+                    {{on 'click' (action execute)}}
+                >
+                    Delete
+                </Action>
+                </Actions.Action>
+                <Actions.Action>
+                <Action {{on 'click' (action cancel)}}>
+                    Cancel
+                </Action>
+                </Actions.Action>
+            </:actions>
+    </InformedAction>
+</div>

--- a/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
+++ b/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
@@ -1,4 +1,4 @@
-<div role="menu" class="above">
+<div class="delete-confirmation">
     <InformedAction class="warning">
             <:header>
                 Confirm Delete

--- a/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
+++ b/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
@@ -1,4 +1,4 @@
-<div class="delete-confirmation">
+<div role="menu" class="delete-confirmation">
     <InformedAction class="warning">
             <:header>
                 Confirm Delete

--- a/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
+++ b/ui/packages/consul-ui/app/components/delete-confirmation/index.hbs
@@ -1,4 +1,4 @@
-<div role="menu">
+<div role="menu" class="above">
     <InformedAction class="warning">
             <:header>
                 Confirm Delete
@@ -10,11 +10,7 @@
             </:body>
             <:actions as |Actions|>
                 <Actions.Action class="dangerous">
-                <Action
-                    tabindex="-1"
-                    data-test-confirm-delete
-                    {{on 'click' (action execute)}}
-                >
+                <Action data-test-confirm-delete {{on 'click' (action execute)}}>
                     Delete
                 </Action>
                 </Actions.Action>

--- a/ui/packages/consul-ui/app/components/delete-confirmation/index.scss
+++ b/ui/packages/consul-ui/app/components/delete-confirmation/index.scss
@@ -1,0 +1,5 @@
+@import './layout';
+
+.delete-confirmation {
+  @extend %delete-confirmation;
+}

--- a/ui/packages/consul-ui/app/components/delete-confirmation/layout.scss
+++ b/ui/packages/consul-ui/app/components/delete-confirmation/layout.scss
@@ -1,6 +1,8 @@
 %delete-confirmation {
   & {
     max-width: 250px;
-    text-align: left;
+    position: absolute;
+    right: 150px;
+    z-index: 1;
   }
 }

--- a/ui/packages/consul-ui/app/components/delete-confirmation/layout.scss
+++ b/ui/packages/consul-ui/app/components/delete-confirmation/layout.scss
@@ -1,0 +1,6 @@
+%delete-confirmation {
+  & {
+    max-width: 250px;
+    text-align: left;
+  }
+}

--- a/ui/packages/consul-ui/app/components/policy-selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/policy-selector/index.hbs
@@ -149,7 +149,7 @@
                   {{message}}
                 </p>
 
-                <button type="button" class="type-delete" {{action execute}}>Confirm remove</button>
+                <button data-test-confirm-delete type="button" class="type-delete" {{action execute}}>Confirm remove</button>
                 <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
               </BlockSlot>
             </ConfirmationDialog>

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -96,3 +96,4 @@
 @import 'consul-ui/components/topology-metrics/series';
 @import 'consul-ui/components/topology-metrics/stats';
 @import 'consul-ui/components/topology-metrics/status';
+@import 'consul-ui/components/delete-confirmation';

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
@@ -39,7 +39,7 @@
 {{/if}}
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete policy" item=item) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this policy?">
+        <ConfirmationDialog @message="Are you sure you want to delete this Policy?">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
@@ -39,7 +39,7 @@
 {{/if}}
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete policy" item=item) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this Policy?">
+        <ConfirmationDialog @message="Are you sure you want to delete this Policy?" @permanent="true">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
@@ -39,7 +39,7 @@
 {{/if}}
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete policy" item=item) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this Policy?">
+        <ConfirmationDialog @message="Are you sure you want to delete this policy?">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
@@ -65,7 +65,7 @@
                     </p>
                   </BlockSlot>
                   <BlockSlot @name="actions" as |close|>
-                    <button type="button" class="type-delete" {{action execute}}>Yes, Delete</button>
+                    <button data-test-confirm-delete type="button" class="type-delete" {{action execute}}>Yes, Delete</button>
                     <button type="button" class="type-cancel" {{action close}}>Cancel</button>
                   </BlockSlot>
               </ModalDialog>

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/-form.hbs
@@ -62,8 +62,8 @@
                     </p>
                   </BlockSlot>
                   <BlockSlot @name="actions" as |close|>
-                    <button type="button" class="type-delete" {{action execute}}>Yes, Delete</button>
-                    <button type="button" class="type-cancel" {{action close}}>Cancel</button>
+                    <button data-test-confirm-delete type="button" class="type-delete" {{action execute}}>Yes, Delete</button>
+                    <button type="button" class="type-cancel data-test-confirm-delete" {{action close}}>Cancel</button>
                   </BlockSlot>
                 </ModalDialog>
     {{else}}

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/-form.hbs
@@ -37,7 +37,7 @@
 {{/if}}
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete role" item=item) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this role?">
+        <ConfirmationDialog @message="Are you sure you want to delete this Role?">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/-form.hbs
@@ -37,7 +37,7 @@
 {{/if}}
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete role" item=item) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this Role?">
+        <ConfirmationDialog @message="Are you sure you want to delete this Role?" @permanent="true">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/roles/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/roles/-form.hbs
@@ -37,7 +37,7 @@
 {{/if}}
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete role" item=item) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this Role?">
+        <ConfirmationDialog @message="Are you sure you want to delete this role?">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/-form.hbs
@@ -17,7 +17,7 @@
 
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete token" item=item token=token) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this Token?">
+        <ConfirmationDialog @message="Are you sure you want to delete this token?">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/-form.hbs
@@ -17,7 +17,7 @@
 
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete token" item=item token=token) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this Token?">
+        <ConfirmationDialog @message="Are you sure you want to delete this Token?" @permanent="true">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/-form.hbs
@@ -17,7 +17,7 @@
 
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (can "delete token" item=item token=token) ) }}
-        <ConfirmationDialog @message="Are you sure you want to delete this token?">
+        <ConfirmationDialog @message="Are you sure you want to delete this Token?">
             <BlockSlot @name="action" as |confirm|>
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/acls/tokens/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/tokens/edit.hbs
@@ -69,7 +69,7 @@ as |dc partition nspace item create|}}
             <p>
                 {{message}}
             </p>
-            <button type="button" class="type-delete" {{action execute}}>Confirm Use</button>
+            <button data-test-confirm-use type="button" class="type-delete" {{action execute}}>Confirm Use</button>
             <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
           </BlockSlot>
         </ConfirmationDialog>

--- a/ui/packages/consul-ui/tests/integration/components/delete-confirmation-test.js
+++ b/ui/packages/consul-ui/tests/integration/components/delete-confirmation-test.js
@@ -12,13 +12,13 @@ module('Integration | Component | delete confirmation', function(hooks) {
 
     await render(hbs`{{delete-confirmation}}`);
 
-    assert.dom('.type-delete').exists({ count: 1 });
+    assert.dom('[data-test-confirm-delete]').exists({ count: 1 });
 
     // Template block usage:
     await render(hbs`
       {{#delete-confirmation}}{{/delete-confirmation}}
     `);
 
-    assert.dom('.type-delete').exists({ count: 1 });
+    assert.dom('[data-test-confirm-delete]').exists({ count: 1 });
   });
 });

--- a/ui/packages/consul-ui/tests/lib/page-object/createDeletable.js
+++ b/ui/packages/consul-ui/tests/lib/page-object/createDeletable.js
@@ -7,7 +7,7 @@ export default function(clickable) {
       ...obj,
       ...{
         delete: clickable(scope + '[data-test-delete]'),
-        confirmDelete: clickable(scope + 'button.type-delete'),
+        confirmDelete: clickable(scope + '[data-test-confirm-delete]'),
       },
     };
   };

--- a/ui/packages/consul-ui/tests/pages/dc/acls/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/acls/edit.js
@@ -4,7 +4,7 @@ export default function(visitable, submitable, deletable, cancelable, clickable)
       deletable({
         visit: visitable(['/:dc/acls/:acl', '/:dc/acls/create']),
         use: clickable('[data-test-use]'),
-        confirmUse: clickable('button.type-delete'),
+        confirmUse: clickable('[data-test-confirm-use]'),
       })
     ),
     'main'

--- a/ui/packages/consul-ui/tests/pages/dc/acls/tokens/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/acls/tokens/edit.js
@@ -13,7 +13,7 @@ export default function(
     ...cancelable({}, 'main form > div'),
     ...deletable({}, 'main form > div'),
     use: clickable('[data-test-use]'),
-    confirmUse: clickable('button.type-delete'),
+    confirmUse: clickable('[data-test-confirm-use]'),
     clone: clickable('[data-test-clone]'),
     policies: policySelector(),
     roles: roleSelector(),


### PR DESCRIPTION
Continuing from https://github.com/hashicorp/consul/pull/11252 since I had to change the branch.

Adds the confirmation dropdown for delete action
Updates the messages as per Confirmation dropdown for delete actions #11228

Closes #11228


Earlier we were using the `type-delete` class for css as well test actions, Incase you didn't want css effect however the test would break since both use the same thing. To separate the concerns I have introduced the data-test-id `data-test-confirm-delete` for reference in test.

Key/value delete
![image](https://user-images.githubusercontent.com/6999221/136602720-e8dacec6-aa16-4ed6-a6dd-6a315750922a.png)

Intention delete
![image](https://user-images.githubusercontent.com/6999221/136602812-e5a8f94c-38a5-4fd4-8fd8-fb2d031caadf.png)

Token delete
![image](https://user-images.githubusercontent.com/6999221/136602901-512623e8-38f3-428c-8dd0-89f8205a1093.png)

Role delete
![image](https://user-images.githubusercontent.com/6999221/136602964-34f82dfc-21e5-4f9f-b047-5d5b3dfcf2ae.png)

When I am deleting a policy, on clicking delete button just disappears. I see this issue on the main branch as well.
