### PR TITLE
ci: Don't --focus install JS deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,7 @@ jobs:
 
       - run:
           name: install yarn packages
-          command: cd ui && yarn install && cd packages/consul-ui && yarn install
+          command: cd ui && make
 
       - save_cache:
           key: *YARN_CACHE_KEY

--- a/ui/GNUmakefile
+++ b/ui/GNUmakefile
@@ -18,7 +18,6 @@ clean:
 # Build a distribution of the UI using the minimal amount of dependencies
 dist: clean
 	cd packages/consul-ui && \
-		CONSUL_UI_INSTALL_FLAGS=--focus \
 		$(MAKE)
 
 # Build a distribution of the UI for Vercel previews.


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/9049 we tried out storybook for cataloging and documenting our component files. One of the problems with that was that storybook has oodles of dependencies that we didn't really want to have folks have to download/install if they only wanted to build the production application.

The JS community/ecosystem gets around this problem by having separate dependencies for developer tooling in the `devDependencies` property of the `package.json` file. Conversely, conventional ember development dictates you should also use this `devDependency` property for your shipped project `dependencies` also. Back in https://github.com/hashicorp/consul/pull/5992 we tried a different more JS traditional convention to work around this, but that was never approved.

When started depending on storybook we tried using `yarn install` with the `--focus` flag to as another attempt to prevent folks from having to install the 'kitchen sink' when all they wanted was a production UI. Unfortunately this didn't quite work out either, but the `--focus` flag in our build script has stuck around for one reason or another.

Since then, we've uninstalled storybook and used the marvellous docfy to catalog and document our components, plus other things. An additional benefit of this has been far less dependencies for our documentation, so the 'please don't download so much _stuff_' problem has pretty much just gone away.

Unfortunately, the left over yarn `--focus` flag has caused a few issues in CI, as CI generally installs from the root of the workspace whereas engineers generally install from the `consul-ui` root.

This PR brings everything together and reverts everything to just using `make` (with no `--focus`), which will do the right thing where-ever you are ( 🤞 ).



