### PR TITLE
Update docs: Mention grafana dashboard

### DIFF
--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -61,7 +61,7 @@ Below is sample output of a telemetry dump:
 
 # Key Metrics
 
-These are some metrics emitted that can help you understand the health of your cluster at a glance. A [Grafana](https://grafana.com/grafana/) [dashboard](https://grafana.com/grafana/dashboards/13396) is also available, which is maintained by the Consul team and displays these metrics for easy visualization. For a full list of metrics emitted by Consul, see [Metrics Reference](#metrics-reference)
+These are some metrics emitted that can help you understand the health of your cluster at a glance. A [Grafana dashboard](https://grafana.com/grafana/dashboards/13396) is also available, which is maintained by the Consul team and displays these metrics for easy visualization. For a full list of metrics emitted by Consul, see [Metrics Reference](#metrics-reference)
 
 ### Transaction timing
 


### PR DESCRIPTION
The Grafana dashboard is now linked in the telemetry section of the documentation. Since many of the details about the dashboard itself are mentioned in the linked sites, it has been omitted in the documentation.

Fixes #10327