### PR TITLE
use *telemetry.MetricsPrefix as prometheus.PrometheusOpts Name

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -940,6 +940,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 			StatsiteAddr:                       stringVal(c.Telemetry.StatsiteAddr),
 			PrometheusOpts: prometheus.PrometheusOpts{
 				Expiration: b.durationVal("prometheus_retention_time", c.Telemetry.PrometheusRetentionTime),
+				Name:       stringVal(c.Telemetry.MetricsPrefix),
 			},
 		},
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5855,6 +5855,7 @@ func TestLoad_FullConfig(t *testing.T) {
 			StatsiteAddr:                       "HpFwKB8R",
 			PrometheusOpts: prometheus.PrometheusOpts{
 				Expiration: 15 * time.Second,
+				Name:       "ftO6DySn", // notice this is the same as the metrics prefix
 			},
 		},
 		TLSCipherSuites:             []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256},

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -379,6 +379,7 @@
             "CounterDefinitions": [],
             "Expiration": "0s",
             "GaugeDefinitions": [],
+            "Name": "",
             "Registerer": null,
             "SummaryDefinitions": []
         },

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.3 // indirect
 	github.com/NYTimes/gziphandler v1.0.1
 	github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e
-	github.com/armon/go-metrics v0.3.9
+	github.com/armon/go-metrics v0.3.10
 	github.com/armon/go-radix v1.0.0
 	github.com/aws/aws-sdk-go v1.25.41
 	github.com/coredns/coredns v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
-github.com/armon/go-metrics v0.3.9 h1:O2sNqxBdvq8Eq5xmzljcYzAORli6RWCvEym4cJf9m18=
-github.com/armon/go-metrics v0.3.9/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
+github.com/armon/go-metrics v0.3.10 h1:FR+drcQStOe+32sYyJYyZ7FIdgoGGBnwLl+flodp8Uo=
+github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=


### PR DESCRIPTION
#### Overview

Now that https://github.com/armon/go-metrics/pull/129/files was merged the changes are reflected in go-metrics v.0.3.10, which this PR upgrades to.

I think a minimal change would be to use the existing metrics prefix as the sink name but I am open to more ideas.

#### Testing

* testing is done thru existing `telemetry_test.go` but I can "set/get" the field if anyone thinks it would be valuable

#### Issues/ PRs related
- https://github.com/hashicorp/consul/issues/11273
- https://github.com/hashicorp/consul/pull/11295 <-- needs 11290 to go in
- https://github.com/hashicorp/consul/issues/11378

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>