### PR TITLE
ci: Only install UI dependencies for CI frontend-cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,7 @@ jobs:
 
       - run:
           name: install yarn packages
-          command: cd ui && make
+          command: cd ui && make deps
 
       - save_cache:
           key: *YARN_CACHE_KEY

--- a/ui/GNUmakefile
+++ b/ui/GNUmakefile
@@ -15,10 +15,16 @@ dist-docker: dist
 clean:
 	rm -rf ./dist
 
-# Build a distribution of the UI using the minimal amount of dependencies
+# Build a distribution of the UI
 dist: clean
 	cd packages/consul-ui && \
 		$(MAKE)
+
+# Install deps for the UI only
+deps: clean
+	cd packages/consul-ui && \
+		$(MAKE) deps
+
 
 # Build a distribution of the UI for Vercel previews.
 # The distribution must be copied into the ui/ subfolder


### PR DESCRIPTION
Back in https://github.com/hashicorp/consul/pull/8994 we moved our UIs structure to use a Workspace structure with an eye to splitting up our application into smaller more manageable 'modules'.

During https://github.com/hashicorp/consul/pull/11188 (more specifically https://github.com/hashicorp/consul/pull/11190) we began to make use of this, which meant that we needed to change our CI install script - more in depth info here https://github.com/hashicorp/consul/pull/11267

Our CI performs a separate 'caching' step before then using that dependency cache multiple times for subsequent steps. Not only is this good for caching dependencies, but it also means we need less memory on our CI environment as we run things in multiple steps. Unfortunately I changed this caching step to install _and_ build instead of just installing.

This has resulted in the occasional OOM in CI for ui related CI steps/jobs.

This PR fixes this to only use an install step for caching instead of an install and build. i.e. back to what it was doing previous (but maintaining the fix we needed for being able to use our workspace'd packages/modules). So we should be back to zero OOMs after this 🤞 