### PR TITLE
Fix back compat issues with UDS config

### DIFF
--- a/.changelog/11318.txt
+++ b/.changelog/11318.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: fixed backwards compatibility issue with AgentService SocketPath field.
+```

--- a/api/agent.go
+++ b/api/agent.go
@@ -84,7 +84,7 @@ type AgentService struct {
 	Meta              map[string]string
 	Port              int
 	Address           string
-	SocketPath        string
+	SocketPath        string                    `json:",omitempty"`
 	TaggedAddresses   map[string]ServiceAddress `json:",omitempty"`
 	Weights           AgentWeights
 	EnableTagOverride bool


### PR DESCRIPTION
SocketPath needs to be omitted when empty to avoid confusing older versions of Consul

Signed-off-by: Mark Anderson <manderson@hashicorp.com>