### PR TITLE
Add protocol example for TFC driver address

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -14,16 +14,18 @@ The Consul-Terraform-Sync daemon is configured using configuration files and sup
 Top level options are reserved for configuring Consul-Terraform-Sync.
 
 ```hcl
-log_level = "INFO"
+log_level   = "INFO"
 working_dir = "sync-tasks"
-port = 8558
+port        = 8558
+
 syslog {
   facility = "local2"
 }
+
 buffer_period {
   enabled = true
-  min = "5s"
-  max = "20s"
+  min     = "5s"
+  max     = "20s"
 }
 ```
 
@@ -89,8 +91,8 @@ A `service` block is an optional block to explicitly define configuration of ser
 
 ```hcl
 service {
-  name = "web"
-  datacenter = "dc1"
+  name        = "web"
+  datacenter  = "dc1"
   description = "all instances of the service web in datacenter dc1"
 }
 ```
@@ -110,13 +112,13 @@ A `task` block configures which task to execute in automation. When the task sho
 
 ```hcl
 task {
-  name = "taskA"
-  description = ""
-  enabled = true,
-  providers = []
-  services = ["web", "api"]
-  source = "org/example/module"
-  version = "1.0.0"
+  name           = "taskA"
+  description    = ""
+  enabled        = true,
+  providers      = []
+  services       = ["web", "api"]
+  source         = "org/example/module"
+  version        = "1.0.0"
   variable_files = []
   condition "catalog-services" {
     regexp = ".*"
@@ -182,10 +184,10 @@ See [Task Execution: Services Condition](/docs/nia/tasks#services-condition) for
 
 ```hcl
 task {
-  name = "services_condition_task"
+  name        = "services_condition_task"
   description = "execute on changes to services with names starting with web"
-  providers = ["my-provider"]
-  source = "path/to/services-condition-module"
+  providers   = ["my-provider"]
+  source      = "path/to/services-condition-module"
 
   condition "services" {
     regexp = "^web.*"
@@ -203,10 +205,10 @@ See [Task Execution: Catalog Services Condition](/docs/nia/tasks#catalog-service
 
 ```hcl
 task {
-  name = "catalog_service_condition_task"
+  name        = "catalog_service_condition_task"
   description = "execute on service de/registrations with name matching 'web.*'"
-  source = "path/to/catalog-services-module"
-  providers = ["my-provider"]
+  source      = "path/to/catalog-services-module"
+  providers   = ["my-provider"]
 
   // configure depending on module. provides detailed information for these
   // services but does not execute task. refer to module docs on how to configure.
@@ -238,11 +240,11 @@ See [Task Execution: Consul KV Condition](/docs/nia/tasks#consul-kv-condition) f
 
 ```hcl
 task {
-  name = "consul_kv_condition_task"
+  name        = "consul_kv_condition_task"
   description = "execute on changes to Consul KV entry"
-  source = "path/to/consul-kv-module"
-  providers = ["my-provider"]
-  services = ["web-api"]
+  source      = "path/to/consul-kv-module"
+  providers   = ["my-provider"]
+  services    = ["web-api"]
 
   condition "consul-kv" {
     path                = "my-key"
@@ -272,10 +274,10 @@ See [Terraform Module: Source Input](/docs/nia/terraform-modules#source-input) f
 
 ```hcl
 task {
-  name = "scheduled_task"
+  name        = "scheduled_task"
   description = "execute every Monday using service information from web and db"
-  services = ["web", "db"]
-  source = "path/to/module"
+  services    = ["web", "db"]
+  source      = "path/to/module"
   condition "schedule" {
     cron = "* * * * Mon"
   }
@@ -360,9 +362,9 @@ The Terraform driver block is used to configure Consul-Terraform-Sync for instal
 
 ```hcl
 driver "terraform" {
-  log = false
+  log         = false
   persist_log = false
-  path = ""
+  path        = ""
 
   backend "consul" {
     gzip = true
@@ -370,7 +372,7 @@ driver "terraform" {
 
   required_providers {
     myprovider = {
-      source = "namespace/myprovider"
+      source  = "namespace/myprovider"
       version = "1.3.0"
     }
   }
@@ -415,7 +417,7 @@ driver "terraform-cloud" {
 
   required_providers {
     myprovider = {
-      source = "namespace/myprovider"
+      source  = "namespace/myprovider"
       version = "1.3.0"
     }
   }
@@ -457,7 +459,7 @@ The below configuration captures the general design of defining a provider using
 driver "terraform" {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "3.33.0"
     }
   }
@@ -469,9 +471,9 @@ terraform_provider "aws" {
 }
 
 task {
-  source = "some/source"
+  source    = "some/source"
   providers = ["aws"]
-  services = ["web", "api"]
+  services  = ["web", "api"]
 }
 ```
 
@@ -577,7 +579,7 @@ The example Consul-Terraform-Sync configuration below defines two similar tasks 
 
 ```hcl
 terraform_provider "aws" {
-  alias = "a"
+  alias   = "a"
   profile = "team-a"
   task_env {
     "AWS_ACCESS_KEY_ID" = "{{ env \"CTS_AWS_ACCESS_KEY_ID_A\" }}"
@@ -585,7 +587,7 @@ terraform_provider "aws" {
 }
 
 terraform_provider "aws" {
-  alias = "b"
+  alias   = "b"
   profile = "team-b"
   task_env {
     "AWS_ACCESS_KEY_ID" = "{{ env \"CTS_AWS_ACCESS_KEY_ID_B\" }}"
@@ -597,15 +599,15 @@ terraform_provider "dns" {
 }
 
 task {
-  name = "task-a"
-  source = "org/module"
+  name      = "task-a"
+  source    = "org/module"
   providers = ["aws.a", "dns"]
   // ...
 }
 
 task {
-  name = "task-b"
-  source = "org/module"
+  name      = "task-b"
+  source    = "org/module"
   providers = ["aws.b", "dns"]
   // ...
 }

--- a/website/content/docs/nia/installation/configure.mdx
+++ b/website/content/docs/nia/installation/configure.mdx
@@ -19,12 +19,12 @@ Review the Terraform module to be used for network automation and identify the T
 
 ```hcl
 task {
-  name = "website-x"
+  name        = "website-x"
   description = "automate services for website-x"
-  source = "namespace/example/module"
-  version = "1.0.0"
-  providers = ["myprovider"]
-  services = ["web", "api"]
+  source      = "namespace/example/module"
+  version     = "1.0.0"
+  providers   = ["myprovider"]
+  services    = ["web", "api"]
 }
 ```
 
@@ -36,7 +36,7 @@ Configuring Terraform providers within Consul-Terraform-Sync requires 2 config c
 driver "terraform" {
   required_providers {
     myprovider = {
-      source = "namespace/myprovider"
+      source  = "namespace/myprovider"
       version = "1.3.0"
     }
   }
@@ -59,6 +59,8 @@ Piecing it all together, the configuration file for Consul-Terraform-Sync will h
 
 An example HCL configuration file is shown below to automate one task to execute a Terraform module on the condition when there are changes to two services.
 
+<CodeBlockConfig filename="cts-example-config.hcl">
+
 ```hcl
 log_level = "info"
 
@@ -71,12 +73,12 @@ consul {
 }
 
 task {
-  name = "website-x"
+  name        = "website-x"
   description = "automate services for website-x"
-  source = "namespace/example/module"
-  version = "1.0.0"
-  providers = ["myprovider"]
-  services = ["web", "api"]
+  source      = "namespace/example/module"
+  version     = "1.0.0"
+  providers   = ["myprovider"]
+  services    = ["web", "api"]
   buffer_period {
     min = "10s"
   }
@@ -87,7 +89,7 @@ driver "terraform" {
 
   required_providers {
     myprovider = {
-      source = "namespace/myprovider"
+      source  = "namespace/myprovider"
       version = "1.3.0"
     }
   }
@@ -97,3 +99,5 @@ terraform_provider "myprovider" {
   address = "myprovider.example.com"
 }
 ```
+
+</CodeBlockConfig>

--- a/website/content/docs/nia/installation/install.mdx
+++ b/website/content/docs/nia/installation/install.mdx
@@ -46,7 +46,7 @@ Consul-Terraform-Sync connects with your Consul cluster in order to monitor the 
 ```hcl
 consul {
   address = "localhost:8500"
-  token = "my-consul-acl-token"
+  token   = "my-consul-acl-token"
 }
 ```
 
@@ -58,7 +58,7 @@ Once you have identified a Terraform provider for all of your network devices, y
 
 ```hcl
 terraform_provider "fake-firewall" {
-  address = "10.10.10.10"
+  address  = "10.10.10.10"
   username = "admin"
   password = "password123"
 }

--- a/website/content/docs/nia/tasks.mdx
+++ b/website/content/docs/nia/tasks.mdx
@@ -13,12 +13,12 @@ Below is an example task configuration:
 
 ```hcl
 task {
-  name = "frontend-firewall-policies"
+  name        = "frontend-firewall-policies"
   description = "Add firewall policy rules for frontend services"
-  providers = ["fake-firewall", "null"]
-  services = ["web", "image"]
-  source = "example/firewall-policy/module"
-  version = "1.0.0"
+  providers   = ["fake-firewall", "null"]
+  services    = ["web", "image"]
+  source      = "example/firewall-policy/module"
+  version     = "1.0.0"
 }
 ```
 
@@ -69,19 +69,19 @@ The services condition is the default behavior if no `condition` block is config
 
 ```hcl
 task {
-  name = "services_condition_task_1"
+  name        = "services_condition_task_1"
   description = "execute on changes to api, db, and web services"
-  providers = ["my-provider"]
-  source = "path/to/services-condition-module"
-  services = ["api", "db", "web"]
+  providers   = ["my-provider"]
+  source      = "path/to/services-condition-module"
+  services    = ["api", "db", "web"]
 }
 
 task {
-  name = "services_condition_task_2"
+  name        = "services_condition_task_2"
   description = "execute on changes to api, db, and web services"
-  providers = ["my-provider"]
-  source = "path/to/services-condition-module"
-  services = ["api", "db", "web"]
+  providers   = ["my-provider"]
+  source      = "path/to/services-condition-module"
+  services    = ["api", "db", "web"]
 
   condition "services" {}
 }
@@ -91,10 +91,10 @@ Below is an example configuration for a task that will execute when a service wi
 
 ```hcl
 task {
-  name = "services_condition_task"
+  name        = "services_condition_task"
   description = "execute on changes to services whose name starts with web"
-  providers = ["my-provider"]
-  source = "path/to/services-condition-module"
+  providers   = ["my-provider"]
+  source      = "path/to/services-condition-module"
 
   condition "services" {
     regexp = "^web.*"
@@ -112,10 +112,10 @@ Below is an example configuration for a task that will execute when a service wi
 
 ```hcl
 task {
-  name = "catalog_service_condition_task"
-  source = "path/to/catalog-services-module"
+  name      = "catalog_service_condition_task"
+  source    = "path/to/catalog-services-module"
   providers = ["my-provider"]
-  services = ["web-api"]
+  services  = ["web-api"]
 
   condition "catalog-services" {
     datacenter          = "dc1"
@@ -125,7 +125,7 @@ task {
 }
 
 service {
-  name = "web-api"
+  name       = "web-api"
   datacenter = "dc2"
 }
 ```
@@ -144,11 +144,11 @@ Based on the `recurse` option, the condition either monitors a single Consul KV 
 
 ```hcl
 task {
-  name = "consul_kv_condition_task"
+  name        = "consul_kv_condition_task"
   description = "execute on changes to Consul KV entry"
-  source = "path/to/consul-kv-module"
-  providers = ["my-provider"]
-  services = ["web-api"]
+  source      = "path/to/consul-kv-module"
+  providers   = ["my-provider"]
+  services    = ["web-api"]
 
   condition "consul-kv" {
     path                = "my-key"
@@ -170,10 +170,10 @@ Below is an example configuration for a task that will execute every Monday, whi
 
 ```hcl
 task {
-  name = "scheduled_task"
+  name        = "scheduled_task"
   description = "execute every Monday using service information from web and db"
-  services = ["web", "db"]
-  source = "path/to/module"
+  services    = ["web", "db"]
+  source      = "path/to/module"
 
   condition "schedule" {
     cron = "* * * * Mon"

--- a/website/content/docs/nia/terraform-modules.mdx
+++ b/website/content/docs/nia/terraform-modules.mdx
@@ -118,10 +118,10 @@ Below is an example configuration for a task that will execute on a schedule and
 
 ```hcl
 task {
-  name = "services_condition_task"
+  name        = "services_condition_task"
   description = "execute on changes to services whose name starts with web"
-  providers = ["my-provider"]
-  source = "path/to/services-condition-module"
+  providers   = ["my-provider"]
+  source      = "path/to/services-condition-module"
   condition "schedule" {
     cron = "* * * * Mon"
   }
@@ -156,19 +156,21 @@ Below is a similar example to the one provided in the [Consul KV Condition](/doc
 
 ```hcl
 task {
-  name = "consul_kv_schedule_task"
+  name        = "consul_kv_schedule_task"
   description = "executes on Monday monitoring Consul KV"
-  providers = ["my-provider"]
-  services = ["web-api"]
-  source = "path/to/consul-kv-module"
-  source_input "consul-kv" {
-    path                = "my-key"
-    recurse             = true
-    datacenter          = "dc1"
-    namespace           = "default"
-  }
+  providers   = ["my-provider"]
+  services    = ["web-api"]
+  source      = "path/to/consul-kv-module"
+
   condition "schedule" {
     cron = "* * * * Mon"
+  }
+
+  source_input "consul-kv" {
+    path       = "my-key"
+    recurse    = true
+    datacenter = "dc1"
+    namespace  = "default"
   }
 }
 ```
@@ -201,11 +203,11 @@ Example of a catalog-services condition which supports source input through `sou
 
 ```hcl
 task {
-  name = "catalog_services_condition_task"
+  name        = "catalog_services_condition_task"
   description = "execute on registration/deregistration of services"
-  providers = ["my-provider"]
-  services = ["web-api"]
-  source = "path/to/catalog-services-module"
+  providers   = ["my-provider"]
+  services    = ["web-api"]
+  source      = "path/to/catalog-services-module"
   condition "catalog-services" {
     datacenter          = "dc1"
     namespace           = "default"
@@ -312,7 +314,7 @@ If you are creating a module for a [catalog-services condition](/docs/nia/tasks#
 ```hcl
 variable "catalog_services" {
   description = "Consul catalog service names and tags monitored by Consul-Terraform-Sync"
-  type = map(list(string))
+  type        = map(list(string))
 }
 ```
 
@@ -333,7 +335,7 @@ If you are creating a module for a [consul-kv condition](/docs/nia/tasks#consul-
 ```hcl
 variable "consul_kv" {
 	description = "Keys and values of the Consul KV pairs monitored by Consul-Terraform-Sync"
-	type = map(string)
+	type        = map(string)
 }
 ```
 


### PR DESCRIPTION
* Updates TFC driver address example to `https://app.terraform.io`
* Formats code blocks for all NIA docs (HCL and TF)

Configuring the TFC driver without protocol results in an obscure error

```hcl
driver "terraform-cloud" {
  address = "app.terraform.io" // errors
  address = "https://app.terraform.io" // correct
}
```

```
2021-10-14T09:10:39.322+0900 [ERROR] driver.tfc: error creating Terraform Cloud client for verification: error="Get "/api/v2/ping": unsupported protocol scheme """
2021-10-14T09:10:39.322+0900 [ERROR] cli: error initializing controller: error="Get "/api/v2/ping": unsupported protocol scheme """
2021-10-14T09:10:39.322+0900 [ERROR] cli: unexpected shutdown: error="Get "/api/v2/ping": unsupported protocol scheme """
```

Code block example changes
![image](https://user-images.githubusercontent.com/6362111/137377816-8a6173c6-c643-422a-813d-907618a2a09c.png)
![image](https://user-images.githubusercontent.com/6362111/137377838-76e0e146-f343-47a3-abb0-a3110869a326.png)
