### PR TITLE
update maintenance check to passing before removing

### DIFF
--- a/.changelog/11332.txt
+++ b/.changelog/11332.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-agent: update maintenance check to passing instead of removing the check
+agent: update maintenance check to passing before removing
 ```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4068,7 +4068,7 @@ func (a *Agent) EnableServiceMaintenance(serviceID structs.ServiceID, reason, to
 
 	// Check if maintenance mode is not already enabled
 	checkID := serviceMaintCheckID(serviceID)
-	if a.State.Check(checkID) != nil && a.State.Check(checkID).Status != api.HealthPassing {
+	if a.State.Check(checkID) != nil {
 		return nil
 	}
 
@@ -4077,7 +4077,7 @@ func (a *Agent) EnableServiceMaintenance(serviceID structs.ServiceID, reason, to
 		reason = defaultServiceMaintReason
 	}
 
-	// New Critical Health Check
+	// Create and register the critical health check
 	check := &structs.HealthCheck{
 		Node:           a.config.NodeName,
 		CheckID:        checkID.ID,
@@ -4089,17 +4089,7 @@ func (a *Agent) EnableServiceMaintenance(serviceID structs.ServiceID, reason, to
 		Type:           "maintenance",
 		EnterpriseMeta: checkID.EnterpriseMeta,
 	}
-
-	// If check exists, update status, else create a new check
-	if a.State.Check(checkID) != nil {
-		a.State.UpdateCheck(checkID, api.HealthCritical, "")
-	} else {
-		err := a.AddCheck(check, nil, true, token, ConfigSourceLocal)
-		if err != nil {
-			return nil
-		}
-	}
-
+	a.AddCheck(check, nil, true, token, ConfigSourceLocal)
 	a.logger.Info("Service entered maintenance mode", "service", serviceID.String())
 
 	return nil
@@ -4122,11 +4112,9 @@ func (a *Agent) DisableServiceMaintenance(serviceID structs.ServiceID) error {
 	// Update check to trigger an event for watchers
 	a.State.UpdateCheck(checkID, api.HealthPassing, "")
 	// Make sure state change is propagated
-	err := a.State.SyncFull()
-	if err != nil {
-		return err
-	}
-
+	a.State.SyncChanges()
+	// Deregister the maintenance check
+	a.RemoveCheck(checkID, true)
 	a.logger.Info("Service left maintenance mode", "service", serviceID.String())
 
 	return nil

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3377,8 +3377,9 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Ensure the check has updated status
-	if found := a.State.Check(checkID); found != nil && found.Status != api.HealthPassing {
+	// Ensure the check was deregistered
+
+	if found := a.State.Check(checkID); found != nil {
 		t.Fatalf("should have deregistered maintenance check")
 	}
 
@@ -3392,10 +3393,7 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 	if check == nil {
 		t.Fatalf("should have registered critical check")
 	}
-	if check.Notes != "broken" {
-		t.Fatalf("bad: %#v", check)
-	}
-	if check.Status != api.HealthCritical {
+	if check.Notes != defaultServiceMaintReason {
 		t.Fatalf("bad: %#v", check)
 	}
 }
@@ -3622,10 +3620,8 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 	// Leave maintenance mode
 	a.DisableNodeMaintenance()
 
-	// Ensure the check indicates passing status
-	if check.Status == api.HealthPassing {
-		t.Fatalf("bad: %#v", check)
-	}
+	// Ensure the check was deregistered
+	requireCheckMissing(t, a, structs.NodeMaint)
 
 	// Enter maintenance mode without passing a reason
 	a.EnableNodeMaintenance("", "")
@@ -3634,9 +3630,6 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 	check = requireCheckExists(t, a, structs.NodeMaint)
 	if check.Notes != defaultNodeMaintReason {
 		t.Fatalf("bad: %#v", check)
-	}
-	if check.Status != api.HealthCritical {
-		t.Fatalf("check status must be passing")
 	}
 }
 


### PR DESCRIPTION
Without this update service using `consul watch` to monitor check changes will never see maintenance mode being disabled.

Resolves: https://github.com/hashicorp/consul/issues/11330

Question for reviewer:
- Open to suggestions on how I can check for status change in a check that was removed (so that tests can be updated)
- Should `SyncChanges` or `SyncFull` be used to force the health check update event to fire before the health check is removed? (And are there any negative repercussions of that?)