### PR TITLE
Get service identities from role by accessor

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -636,7 +636,7 @@ func (r *ACLResolver) resolvePoliciesForIdentity(identity structs.ACLIdentity) (
 		for _, link := range role.Policies {
 			policyIDs = append(policyIDs, link.ID)
 		}
-		serviceIdentities = append(serviceIdentities, role.ServiceIdentities...)
+		serviceIdentities = append(serviceIdentities, role.ServiceIdentityList()...)
 		nodeIdentities = append(nodeIdentities, role.NodeIdentityList()...)
 	}
 

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -953,6 +953,18 @@ func (r *ACLRole) SetHash(force bool) []byte {
 	return r.Hash
 }
 
+func (r *ACLRole) ServiceIdentityList() []*ACLServiceIdentity {
+	if len(r.ServiceIdentities) == 0 {
+		return nil
+	}
+
+	out := make([]*ACLServiceIdentity, 0, len(r.ServiceIdentities))
+	for _, s := range r.ServiceIdentities {
+		out = append(out, s.Clone())
+	}
+	return out
+}
+
 func (r *ACLRole) EstimateSize() int {
 	// This is just an estimate. There is other data structure overhead
 	// pointers etc that this does not account for.


### PR DESCRIPTION
Make consistent with how node identities are accessed from an `ACLRole`.

I noticed an inconsistency between how service identities and node identities are accessed from a role when merging into the service and node identity lists for an identity:
https://github.com/hashicorp/consul/blob/a5c292c000ace8b9bd6a0231f86039ba629753cd/agent/consul/acl.go#L639-L640

Node identities come from an accessor:
https://github.com/hashicorp/consul/blob/a5c292c000ace8b9bd6a0231f86039ba629753cd/agent/structs/acl_oss.go#L85-L95

Whereas service identities are accessed directly, despite previously in the same function by an accessor from `ACLIdentity`:
https://github.com/hashicorp/consul/blob/a5c292c000ace8b9bd6a0231f86039ba629753cd/agent/consul/acl.go#L614

This PR copies `ACLIdentity:ServiceIdentityList` to create `ACLRole:ServiceIdentityList`, then uses that new function to access that information from the role (rather than directly).

**Question for reviewer:**
- Is there some reason for this existing inconsistency? (I don't _know_ whether this change is needed, I only know that it's a seeming inconsistency in the code which isn't explained with a comment.)

**TODO:**
- Add changelog if reviewer(s) agree this change is needed