### PR TITLE
URL-encode/decode resource names for HTTP API

### DIFF
--- a/.changelog/11335.txt
+++ b/.changelog/11335.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+api: URL-encode/decode resource names for v1/agent endpoints in API
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -1120,3 +1120,15 @@ func (s *HTTPHandlers) parseFilter(req *http.Request, filter *string) {
 		*filter = other
 	}
 }
+
+func getPathSuffixUnescaped(path string, prefixToTrim string) (string, error) {
+	// The suffix may be URL-encoded, so attempt to decode
+	suffixRaw := strings.TrimPrefix(path, prefixToTrim)
+	suffixUnescaped, err := url.PathUnescape(suffixRaw)
+
+	if err != nil {
+		return suffixRaw, fmt.Errorf("failure in unescaping path param %q: %v", suffixRaw, err)
+	}
+
+	return suffixUnescaped, nil
+}

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -1680,3 +1680,42 @@ func TestRPC_HTTPSMaxConnsPerClient(t *testing.T) {
 		})
 	}
 }
+
+func TestGetPathSuffixUnescaped(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		pathInput    string
+		pathPrefix   string
+		suffixResult string
+		errString    string
+	}{
+		// No decoding required (resource name must be unaffected by the decode)
+		{"Normal Valid", "/foo/bar/resource-1", "/foo/bar/", "resource-1", ""},
+		// This function is not responsible for enforcing a valid URL, just for decoding escaped values.
+		// If there's an invalid URL segment in the path, it will be returned as is.
+		{"Unencoded Invalid", "/foo/bar/resource 1", "/foo/bar/", "resource 1", ""},
+		// Decode the encoded value properly
+		{"Encoded Valid", "/foo/bar/re%2Fsource%201", "/foo/bar/", "re/source 1", ""},
+		// Fail to decode an invalidly encoded input
+		{"Encoded Invalid", "/foo/bar/re%Fsource%201", "/foo/bar/", "re%Fsource%201", "failure in unescaping path param"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			suffixResult, err := getPathSuffixUnescaped(tc.pathInput, tc.pathPrefix)
+
+			require.Equal(t, suffixResult, tc.suffixResult)
+
+			if tc.errString == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.errString)
+			}
+		})
+	}
+}

--- a/api/agent.go
+++ b/api/agent.go
@@ -707,7 +707,7 @@ func (a *Agent) AgentHealthServiceByNameOpts(service string, q *QueryOptions) (s
 // agent-local state. That means there is no persistent raft index so we block
 // based on object hash instead.
 func (a *Agent) Service(serviceID string, q *QueryOptions) (*AgentService, *QueryMeta, error) {
-	r := a.c.newRequest("GET", "/v1/agent/service/"+serviceID)
+	r := a.c.newRequest("GET", "/v1/agent/service/"+url.PathEscape(serviceID))
 	r.setQueryOptions(q)
 	rtt, resp, err := a.c.doRequest(r)
 	if err != nil {
@@ -812,7 +812,7 @@ func (a *Agent) serviceRegister(service *AgentServiceRegistration, opts ServiceR
 // ServiceDeregister is used to deregister a service with
 // the local agent
 func (a *Agent) ServiceDeregister(serviceID string) error {
-	r := a.c.newRequest("PUT", "/v1/agent/service/deregister/"+serviceID)
+	r := a.c.newRequest("PUT", "/v1/agent/service/deregister/"+url.PathEscape(serviceID))
 	_, resp, err := a.c.doRequest(r)
 	if err != nil {
 		return err
@@ -827,7 +827,7 @@ func (a *Agent) ServiceDeregister(serviceID string) error {
 // ServiceDeregisterOpts is used to deregister a service with
 // the local agent with QueryOptions.
 func (a *Agent) ServiceDeregisterOpts(serviceID string, q *QueryOptions) error {
-	r := a.c.newRequest("PUT", "/v1/agent/service/deregister/"+serviceID)
+	r := a.c.newRequest("PUT", "/v1/agent/service/deregister/"+url.PathEscape(serviceID))
 	r.setQueryOptions(q)
 	_, resp, err := a.c.doRequest(r)
 	if err != nil {
@@ -884,7 +884,7 @@ func (a *Agent) updateTTL(checkID, note, status string) error {
 	default:
 		return fmt.Errorf("Invalid status: %s", status)
 	}
-	endpoint := fmt.Sprintf("/v1/agent/check/%s/%s", status, checkID)
+	endpoint := fmt.Sprintf("/v1/agent/check/%s/%s", url.PathEscape(status), url.PathEscape(checkID))
 	r := a.c.newRequest("PUT", endpoint)
 	r.params.Set("note", note)
 	_, resp, err := a.c.doRequest(r)
@@ -932,7 +932,7 @@ func (a *Agent) UpdateTTLOpts(checkID, output, status string, q *QueryOptions) e
 		return fmt.Errorf("Invalid status: %s", status)
 	}
 
-	endpoint := fmt.Sprintf("/v1/agent/check/update/%s", checkID)
+	endpoint := fmt.Sprintf("/v1/agent/check/update/%s", url.PathEscape(checkID))
 	r := a.c.newRequest("PUT", endpoint)
 	r.setQueryOptions(q)
 	r.obj = &checkUpdate{
@@ -976,7 +976,7 @@ func (a *Agent) CheckDeregister(checkID string) error {
 // CheckDeregisterOpts is used to deregister a check with
 // the local agent using query options
 func (a *Agent) CheckDeregisterOpts(checkID string, q *QueryOptions) error {
-	r := a.c.newRequest("PUT", "/v1/agent/check/deregister/"+checkID)
+	r := a.c.newRequest("PUT", "/v1/agent/check/deregister/"+url.PathEscape(checkID))
 	r.setQueryOptions(q)
 	_, resp, err := a.c.doRequest(r)
 	if err != nil {
@@ -992,7 +992,7 @@ func (a *Agent) CheckDeregisterOpts(checkID string, q *QueryOptions) error {
 // Join is used to instruct the agent to attempt a join to
 // another cluster member
 func (a *Agent) Join(addr string, wan bool) error {
-	r := a.c.newRequest("PUT", "/v1/agent/join/"+addr)
+	r := a.c.newRequest("PUT", "/v1/agent/join/"+url.PathEscape(addr))
 	if wan {
 		r.params.Set("wan", "1")
 	}
@@ -1044,7 +1044,7 @@ func (a *Agent) ForceLeavePrune(node string) error {
 // ForceLeaveOpts is used to have the agent eject a failed node or remove it
 // completely from the list of members.
 func (a *Agent) ForceLeaveOpts(node string, opts ForceLeaveOpts) error {
-	r := a.c.newRequest("PUT", "/v1/agent/force-leave/"+node)
+	r := a.c.newRequest("PUT", "/v1/agent/force-leave/"+url.PathEscape(node))
 	if opts.Prune {
 		r.params.Set("prune", "1")
 	}
@@ -1108,7 +1108,7 @@ func (a *Agent) ConnectCARoots(q *QueryOptions) (*CARootList, *QueryMeta, error)
 
 // ConnectCALeaf gets the leaf certificate for the given service ID.
 func (a *Agent) ConnectCALeaf(serviceID string, q *QueryOptions) (*LeafCert, *QueryMeta, error) {
-	r := a.c.newRequest("GET", "/v1/agent/connect/ca/leaf/"+serviceID)
+	r := a.c.newRequest("GET", "/v1/agent/connect/ca/leaf/"+url.PathEscape(serviceID))
 	r.setQueryOptions(q)
 	rtt, resp, err := a.c.doRequest(r)
 	if err != nil {
@@ -1136,7 +1136,7 @@ func (a *Agent) EnableServiceMaintenance(serviceID, reason string) error {
 }
 
 func (a *Agent) EnableServiceMaintenanceOpts(serviceID, reason string, q *QueryOptions) error {
-	r := a.c.newRequest("PUT", "/v1/agent/service/maintenance/"+serviceID)
+	r := a.c.newRequest("PUT", "/v1/agent/service/maintenance/"+url.PathEscape(serviceID))
 	r.setQueryOptions(q)
 	r.params.Set("enable", "true")
 	r.params.Set("reason", reason)
@@ -1158,7 +1158,7 @@ func (a *Agent) DisableServiceMaintenance(serviceID string) error {
 }
 
 func (a *Agent) DisableServiceMaintenanceOpts(serviceID string, q *QueryOptions) error {
-	r := a.c.newRequest("PUT", "/v1/agent/service/maintenance/"+serviceID)
+	r := a.c.newRequest("PUT", "/v1/agent/service/maintenance/"+url.PathEscape(serviceID))
 	r.setQueryOptions(q)
 	r.params.Set("enable", "false")
 	_, resp, err := a.c.doRequest(r)
@@ -1355,7 +1355,7 @@ func (a *Agent) updateTokenFallback(token string, q *WriteOptions, targets ...st
 }
 
 func (a *Agent) updateTokenOnce(target, token string, q *WriteOptions) (*WriteMeta, int, error) {
-	r := a.c.newRequest("PUT", fmt.Sprintf("/v1/agent/token/%s", target))
+	r := a.c.newRequest("PUT", fmt.Sprintf("/v1/agent/token/%s", url.PathEscape(target)))
 	r.setWriteOptions(q)
 	r.obj = &AgentToken{Token: token}
 


### PR DESCRIPTION
### Overview

Relates to: #11258

To encode/decode the path params in HTTP API, we can use golang's `url.PathEscape` and `url.PathUnescape` methods.

url.PathEscape - PathEscape escapes the string so it can be safely placed inside a URL path segment, replacing special characters (including /) with %XX sequences as needed.