### PR TITLE
Use correct registry url

### DIFF
--- a/website/content/docs/ecs/get-started/install.mdx
+++ b/website/content/docs/ecs/get-started/install.mdx
@@ -26,7 +26,7 @@ you must use the [`mesh-task` module](https://registry.terraform.io/modules/hash
 
 ```hcl
 module "my_task" {
-  source  = "hashicorp/consul/aws-ecs//modules/mesh-task"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
   version = "<latest version>"
 
   family                = "my_task"


### PR DESCRIPTION
A small typo in the module source leads to an error when performing `terraform init`.