### PR TITLE
ui: Change metrics view outbound bytes color to blue

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/series/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/series/index.js
@@ -101,6 +101,7 @@ export default Component.extend({
     // Use the grey/red we prefer by default but have more colors available in
     // case user adds extra series with a custom provider.
     let colorScheme = ['#DCE0E6', '#C73445'].concat(schemeTableau10);
+
     if (keys.includes('Outbound')) {
       colorScheme = ['#DCE0E6', '#0E40A3'].concat(schemeTableau10);
     }


### PR DESCRIPTION
<img width="1432" alt="Screen Shot 2021-10-16 at 10 47 31 PM" src="https://user-images.githubusercontent.com/9301491/137609213-1c131943-5094-428f-87f4-f556787f1104.png">

<img width="1432" alt="Screen Shot 2021-10-16 at 10 47 12 PM" src="https://user-images.githubusercontent.com/9301491/137609169-27b986b5-68c0-4fbb-a166-1f355192017d.png">

Changed the color scheme when there is outbound 