### PR TITLE
ca: prepare CAMananger to be moved into a new package

### DIFF
--- a/agent/consul/connect_ca_backend.go
+++ b/agent/consul/connect_ca_backend.go
@@ -1,0 +1,65 @@
+package consul
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/agent/consul/state"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+type caBackend struct {
+	*Server
+}
+
+func (c *caBackend) ServersSupportMultiDCConnectCA() (bool, bool) {
+	return ServersInDCMeetMinimumVersion(c.Server, c.Server.config.PrimaryDatacenter, minMultiDCConnectVersion)
+}
+
+func (c *caBackend) State() *state.Store {
+	return c.Server.fsm.State()
+}
+
+func (c *caBackend) ApplyCARequest(req *structs.CARequest) (interface{}, error) {
+	return c.Server.raftApplyMsgpack(structs.ConnectCARequestType, req)
+}
+
+func (c *caBackend) ApplyCALeafRequest() (uint64, error) {
+	// TODO(banks): when we implement IssuedCerts table we can use the insert to
+	// that as the raft index to return in response.
+	//
+	// UPDATE(mkeeler): The original implementation relied on updating the CAConfig
+	// and using its index as the ModifyIndex for certs. This was buggy. The long
+	// term goal is still to insert some metadata into raft about the certificates
+	// and use that raft index for the ModifyIndex. This is a partial step in that
+	// direction except that we only are setting an index and not storing the
+	// metadata.
+	req := structs.CALeafRequest{
+		Op:         structs.CALeafOpIncrementIndex,
+		Datacenter: c.Server.config.Datacenter,
+	}
+	resp, err := c.Server.raftApplyMsgpack(structs.ConnectCALeafRequestType|structs.IgnoreUnknownTypeFlag, &req)
+	if err != nil {
+		return 0, err
+	}
+
+	modIdx, ok := resp.(uint64)
+	if !ok {
+		return 0, fmt.Errorf("Invalid response from updating the leaf cert index")
+	}
+	return modIdx, err
+}
+
+func (c *caBackend) PrimaryRoots(args structs.DCSpecificRequest, roots *structs.IndexedCARoots) error {
+	return c.Server.forwardDC("ConnectCA.Roots", c.Server.config.PrimaryDatacenter, &args, roots)
+}
+
+func (c *caBackend) SignIntermediate(csr string) (string, error) {
+	req := &structs.CASignRequest{
+		Datacenter:   c.Server.config.PrimaryDatacenter,
+		CSR:          csr,
+		WriteRequest: structs.WriteRequest{Token: c.Server.tokens.ReplicationToken()},
+	}
+	var pem string
+	err := c.Server.forwardDC("ConnectCA.SignIntermediate", c.Server.config.PrimaryDatacenter, req, &pem)
+	return pem, err
+}

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -24,9 +24,7 @@ var (
 	// consul.ErrRateLimited.Error()` which is very sad. Short of replacing our
 	// RPC mechanism it's hard to know how to make that much better though.
 	ErrConnectNotEnabled    = errors.New("Connect must be enabled in order to use this endpoint")
-	ErrRateLimited          = errors.New("Rate limit reached, try again later")
 	ErrNotPrimaryDatacenter = errors.New("not the primary datacenter")
-	ErrStateReadOnly        = errors.New("CA Provider State is read-only")
 )
 
 // ConnectCA manages the Connect CA.

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -28,15 +27,6 @@ var (
 	ErrRateLimited          = errors.New("Rate limit reached, try again later")
 	ErrNotPrimaryDatacenter = errors.New("not the primary datacenter")
 	ErrStateReadOnly        = errors.New("CA Provider State is read-only")
-)
-
-const (
-	// csrLimitWait is the maximum time we'll wait for a slot when CSR concurrency
-	// limiting or rate limiting is occurring. It's intentionally short so small
-	// batches of requests can be accommodated when server has capacity (assuming
-	// signing one cert takes much less than this) but failing requests fast when
-	// a thundering herd comes along.
-	csrLimitWait = 500 * time.Millisecond
 )
 
 // ConnectCA manages the Connect CA.

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -216,22 +216,16 @@ func (s *ConnectCA) SignIntermediate(
 		return acl.ErrPermissionDenied
 	}
 
-	provider, _ := s.srv.caManager.getCAProvider()
-	if provider == nil {
-		return fmt.Errorf("internal error: CA provider is nil")
-	}
-
 	csr, err := connect.ParseCSR(args.CSR)
 	if err != nil {
 		return err
 	}
 
-	cert, err := provider.SignIntermediate(csr)
+	cert, err := s.srv.caManager.SignIntermediate(csr)
 	if err != nil {
 		return err
 	}
 
 	*reply = cert
-
 	return nil
 }

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -117,10 +117,6 @@ func retryLoopBackoff(ctx context.Context, loopFn func() error, errFn func(error
 	retryLoopBackoffHandleSuccess(ctx, loopFn, errFn, false)
 }
 
-func retryLoopBackoffAbortOnSuccess(ctx context.Context, loopFn func() error, errFn func(error)) {
-	retryLoopBackoffHandleSuccess(ctx, loopFn, errFn, true)
-}
-
 func retryLoopBackoffHandleSuccess(ctx context.Context, loopFn func() error, errFn func(error), abortOnSuccess bool) {
 	var failedAttempts uint
 	limiter := rate.NewLimiter(loopRateLimit, retryBucketSize)

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -165,19 +165,3 @@ func nextIndexVal(prevIdx, idx uint64) uint64 {
 	}
 	return idx
 }
-
-// halfTime returns a duration that is half the time between notBefore and
-// notAfter.
-func halfTime(notBefore, notAfter time.Time) time.Duration {
-	interval := notAfter.Sub(notBefore)
-	return interval / 2
-}
-
-// lessThanHalfTimePassed decides if half the time between notBefore and
-// notAfter has passed relative to now.
-// lessThanHalfTimePassed is being called while holding caProviderReconfigurationLock
-// which means it must never take that lock itself or call anything that does.
-func lessThanHalfTimePassed(now, notBefore, notAfter time.Time) bool {
-	t := notBefore.Add(halfTime(notBefore, notAfter))
-	return t.Sub(now) > 0
-}

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1388,7 +1388,7 @@ func (l *connectSignRateLimiter) getCSRRateLimiterWithLimit(limit rate.Limit) *r
 // a thundering herd comes along.
 const csrLimitWait = 500 * time.Millisecond
 
-var ErrRateLimited   = errors.New("Rate limit reached, try again later")
+var ErrRateLimited = errors.New("Rate limit reached, try again later")
 
 func (c *CAManager) SignCertificate(csr *x509.CertificateRequest, spiffeID connect.CertURI) (*structs.IssuedCert, error) {
 	provider, caRoot := c.getCAProvider()
@@ -1551,4 +1551,12 @@ func (c *CAManager) checkExpired(pem string) error {
 		return fmt.Errorf("certificate expired, expiration date: %s ", cert.NotAfter.String())
 	}
 	return nil
+}
+
+func (c *CAManager) SignIntermediate(csr *x509.CertificateRequest) (string, error) {
+	provider, _ := c.getCAProvider()
+	if provider == nil {
+		return "", fmt.Errorf("internal error: CA provider is nil")
+	}
+	return provider.SignIntermediate(csr)
 }

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -749,6 +749,8 @@ func (c *CAManager) persistNewRootAndConfig(provider ca.Provider, newActiveRoot 
 	return nil
 }
 
+var ErrStateReadOnly = errors.New("CA Provider State is read-only")
+
 func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) {
 	// Attempt to update the state first.
 	oldState, err := c.setState(caStateReconfig, true)
@@ -1385,6 +1387,8 @@ func (l *connectSignRateLimiter) getCSRRateLimiterWithLimit(limit rate.Limit) *r
 // signing one cert takes much less than this) but failing requests fast when
 // a thundering herd comes along.
 const csrLimitWait = 500 * time.Millisecond
+
+var ErrRateLimited   = errors.New("Rate limit reached, try again later")
 
 func (c *CAManager) SignCertificate(csr *x509.CertificateRequest, spiffeID connect.CertURI) (*structs.IssuedCert, error) {
 	provider, caRoot := c.getCAProvider()

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -312,11 +312,6 @@ func (c *CAManager) backgroundCAInitialization(ctx context.Context) error {
 // the CA if this is the primary DC or making a remote RPC for intermediate signing
 // if this is a secondary DC.
 func (c *CAManager) InitializeCA() (reterr error) {
-	// Bail if connect isn't enabled.
-	if !c.serverConf.ConnectEnabled {
-		return nil
-	}
-
 	// Update the state before doing anything else.
 	_, err := c.setState(caStateInitializing, true)
 	var errCaState *caStateError

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -68,10 +68,9 @@ type CAManager struct {
 	providerRoot *structs.CARoot
 
 	// stateLock protects the internal state used for administrative CA tasks.
-	stateLock         sync.Mutex
-	state             caState
-	primaryRoots      structs.IndexedCARoots // The most recently seen state of the root CAs from the primary datacenter.
-	actingSecondaryCA bool                   // True if this datacenter has been initialized as a secondary CA.
+	stateLock    sync.Mutex
+	state        caState
+	primaryRoots structs.IndexedCARoots // The most recently seen state of the root CAs from the primary datacenter.
 
 	leaderRoutineManager *routine.Manager
 	// providerShim is used to test CAManager with a fake provider.
@@ -327,7 +326,6 @@ func (c *CAManager) Stop() {
 
 	c.setState(caStateUninitialized, false)
 	c.primaryRoots = structs.IndexedCARoots{}
-	c.actingSecondaryCA = false
 	c.setCAProvider(nil, nil)
 }
 
@@ -1135,7 +1133,7 @@ func (c *CAManager) RenewIntermediate(ctx context.Context, isPrimary bool) error
 		return nil
 	}
 	// If this isn't the primary, make sure the CA has been initialized.
-	if !isPrimary && !c.secondaryIsCAConfigured() {
+	if !isPrimary && !c.secondaryHasProviderRoots() {
 		return fmt.Errorf("secondary CA is not yet configured.")
 	}
 
@@ -1265,7 +1263,7 @@ func (c *CAManager) secondaryUpdateRoots(roots structs.IndexedCARoots) error {
 		// this happens when leadership is being revoked and this go routine will be stopped
 		return nil
 	}
-	if !c.secondaryIsCAConfigured() {
+	if !c.secondaryHasProviderRoots() {
 		versionOk, primaryFound := ServersInDCMeetMinimumVersion(c.delegate, c.serverConf.PrimaryDatacenter, minMultiDCConnectVersion)
 		if !primaryFound {
 			return fmt.Errorf("Primary datacenter is unreachable - deferring secondary CA initialization")
@@ -1275,12 +1273,16 @@ func (c *CAManager) secondaryUpdateRoots(roots structs.IndexedCARoots) error {
 			if err := c.secondaryInitializeProvider(provider, roots); err != nil {
 				return fmt.Errorf("Failed to initialize secondary CA provider: %v", err)
 			}
+			if err := c.secondaryInitializeIntermediateCA(provider, nil); err != nil {
+				return fmt.Errorf("Failed to initialize the secondary CA: %v", err)
+			}
+			return nil
 		}
 	}
 
 	// Run the secondary CA init routine to see if we need to request a new
 	// intermediate.
-	if c.secondaryIsCAConfigured() {
+	if c.secondaryHasProviderRoots() {
 		if err := c.secondaryInitializeIntermediateCA(provider, nil); err != nil {
 			return fmt.Errorf("Failed to initialize the secondary CA: %v", err)
 		}
@@ -1311,29 +1313,16 @@ func (c *CAManager) secondaryInitializeProvider(provider ca.Provider, roots stru
 	if err := provider.Configure(pCfg); err != nil {
 		return fmt.Errorf("error configuring provider: %v", err)
 	}
-
-	return c.secondarySetCAConfigured()
-}
-
-// secondarySetCAConfigured sets the flag for acting as a secondary CA to true.
-func (c *CAManager) secondarySetCAConfigured() error {
-	c.stateLock.Lock()
-	defer c.stateLock.Unlock()
-
-	if c.state == caStateInitializing || c.state == caStateReconfig {
-		c.actingSecondaryCA = true
-	} else {
-		return fmt.Errorf("Cannot update secondary CA flag in state %q", c.state)
-	}
-
 	return nil
 }
 
-// secondaryIsCAConfigured returns true if we have been initialized as a secondary datacenter's CA.
-func (c *CAManager) secondaryIsCAConfigured() bool {
-	c.stateLock.Lock()
-	defer c.stateLock.Unlock()
-	return c.actingSecondaryCA
+// secondaryHasProviderRoots returns true after providerRoot has been set. This
+// method is used to detect when the provider has been fully initialized a
+// ClusterID and roots from the primary.
+func (c *CAManager) secondaryHasProviderRoots() bool {
+	c.providerLock.Lock()
+	defer c.providerLock.Unlock()
+	return c.providerRoot != nil
 }
 
 type connectSignRateLimiter struct {

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1158,6 +1158,15 @@ func (c *CAManager) RenewIntermediate(ctx context.Context, isPrimary bool) error
 	return nil
 }
 
+// lessThanHalfTimePassed decides if half the time between notBefore and
+// notAfter has passed relative to now.
+// lessThanHalfTimePassed is being called while holding caProviderReconfigurationLock
+// which means it must never take that lock itself or call anything that does.
+func lessThanHalfTimePassed(now, notBefore, notAfter time.Time) bool {
+	t := notBefore.Add(notAfter.Sub(notBefore) / 2)
+	return t.Sub(now) > 0
+}
+
 // secondaryCARootWatch maintains a blocking query to the primary datacenter's
 // ConnectCA.Roots endpoint to monitor when it needs to request a new signed
 // intermediate certificate.

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1220,7 +1220,11 @@ func (c *CAManager) secondaryCARootWatch(ctx context.Context) error {
 		if err := c.secondaryUpdateRoots(roots); err != nil {
 			return err
 		}
-		args.QueryOptions.MinQueryIndex = nextIndexVal(args.QueryOptions.MinQueryIndex, roots.QueryMeta.Index)
+		// Reset then index if the latest query index goes backwards.
+		// TODO: how would this happen?
+		if args.QueryOptions.MinQueryIndex > roots.QueryMeta.Index {
+			args.QueryOptions.MinQueryIndex = 0
+		}
 		return nil
 	}
 

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -249,6 +249,10 @@ func (c *CAManager) getCAProvider() (ca.Provider, *structs.CARoot) {
 	}
 }
 
+func (c *CAManager) GetProvider() (ca.Provider, *structs.CARoot) {
+	return c.getCAProvider()
+}
+
 // setCAProvider is being called while holding the stateLock
 // which means it must never take that lock itself or call anything that does.
 func (c *CAManager) setCAProvider(newProvider ca.Provider, root *structs.CARoot) {

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -429,3 +429,13 @@ func generatePem(notBefore time.Time, notAfter time.Time) (error, string) {
 	})
 	return err, caPEM.String()
 }
+
+func TestLessThanHalfTimePassed(t *testing.T) {
+	now := time.Now()
+	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(-5*time.Second)))
+	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now))
+	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(5*time.Second)))
+	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(10*time.Second)))
+
+	require.True(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(20*time.Second)))
+}

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -14,15 +14,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent/connect"
 	ca "github.com/hashicorp/consul/agent/connect/ca"
 	"github.com/hashicorp/consul/agent/consul/state"
-	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
 )
@@ -59,12 +56,8 @@ func (m *mockCAServerDelegate) IsLeader() bool {
 	return true
 }
 
-func (m *mockCAServerDelegate) CheckServers(datacenter string, fn func(*metadata.Server) bool) {
-	ver, _ := version.NewVersion("1.6.0")
-	fn(&metadata.Server{
-		Status: serf.StatusAlive,
-		Build:  *ver,
-	})
+func (m *mockCAServerDelegate) ServersSupportMultiDCConnectCA() (bool, bool) {
+	return true, true
 }
 
 func (m *mockCAServerDelegate) ApplyCALeafRequest() (uint64, error) {

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -10,7 +10,10 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/big"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -438,4 +441,87 @@ func TestLessThanHalfTimePassed(t *testing.T) {
 	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(10*time.Second)))
 
 	require.True(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(20*time.Second)))
+}
+
+func TestLeader_ParseCARoot(t *testing.T) {
+	type test struct {
+		name             string
+		pem              string
+		wantSerial       uint64
+		wantSigningKeyID string
+		wantKeyType      string
+		wantKeyBits      int
+		wantErr          bool
+	}
+	// Test certs generated with
+	//   go run connect/certgen/certgen.go -out-dir /tmp/connect-certs -key-type ec -key-bits 384
+	// for various key types. This does limit the exposure to formats that might
+	// exist in external certificates which can be used as Connect CAs.
+	// Specifically many other certs will have serial numbers that don't fit into
+	// 64 bits but for reasons we truncate down to 64 bits which means our
+	// `SerialNumber` will not match the one reported by openssl. We should
+	// probably fix that at some point as it seems like a big footgun but it would
+	// be a breaking API change to change the type to not be a JSON number and
+	// JSON numbers don't even support the full range of a uint64...
+	tests := []test{
+		{"no cert", "", 0, "", "", 0, true},
+		{
+			name: "default cert",
+			// Watchout for indentations they will break PEM format
+			pem: readTestData(t, "cert-with-ec-256-key.pem"),
+			// Based on `openssl x509 -noout -text` report from the cert
+			wantSerial:       8341954965092507701,
+			wantSigningKeyID: "97:4D:17:81:64:F8:B4:AF:05:E8:6C:79:C5:40:3B:0E:3E:8B:C0:AE:38:51:54:8A:2F:05:DB:E3:E8:E4:24:EC",
+			wantKeyType:      "ec",
+			wantKeyBits:      256,
+			wantErr:          false,
+		},
+		{
+			name: "ec 384 cert",
+			// Watchout for indentations they will break PEM format
+			pem: readTestData(t, "cert-with-ec-384-key.pem"),
+			// Based on `openssl x509 -noout -text` report from the cert
+			wantSerial:       2935109425518279965,
+			wantSigningKeyID: "0B:A0:88:9B:DC:95:31:51:2E:3D:D4:F9:42:D0:6A:A0:62:46:82:D2:7C:22:E7:29:A9:AA:E8:A5:8C:CF:C7:42",
+			wantKeyType:      "ec",
+			wantKeyBits:      384,
+			wantErr:          false,
+		},
+		{
+			name: "rsa 4096 cert",
+			// Watchout for indentations they will break PEM format
+			pem: readTestData(t, "cert-with-rsa-4096-key.pem"),
+			// Based on `openssl x509 -noout -text` report from the cert
+			wantSerial:       5186695743100577491,
+			wantSigningKeyID: "92:FA:CC:97:57:1E:31:84:A2:33:DD:9B:6A:A8:7C:FC:BE:E2:94:CA:AC:B3:33:17:39:3B:B8:67:9B:DC:C1:08",
+			wantKeyType:      "rsa",
+			wantKeyBits:      4096,
+			wantErr:          false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			root, err := parseCARoot(tt.pem, "consul", "cluster")
+			if tt.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+			require.Equal(tt.wantSerial, root.SerialNumber)
+			require.Equal(strings.ToLower(tt.wantSigningKeyID), root.SigningKeyID)
+			require.Equal(tt.wantKeyType, root.PrivateKeyType)
+			require.Equal(tt.wantKeyBits, root.PrivateKeyBits)
+		})
+	}
+}
+
+func readTestData(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	bs, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading fixture file %s: %s", name, err)
+	}
+	return string(bs)
 }

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -1406,16 +1406,6 @@ func readTestData(t *testing.T, name string) string {
 	return string(bs)
 }
 
-func TestLeader_lessThanHalfTimePassed(t *testing.T) {
-	now := time.Now()
-	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(-5*time.Second)))
-	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now))
-	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(5*time.Second)))
-	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(10*time.Second)))
-
-	require.True(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(20*time.Second)))
-}
-
 func TestLeader_retryLoopBackoffHandleSuccess(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -325,7 +325,7 @@ func waitForActiveCARoot(t *testing.T, srv *Server, expect *structs.CARoot) {
 }
 
 func getCAProviderWithLock(s *Server) (ca.Provider, *structs.CARoot) {
-	return s.caManager.getCAProvider()
+	return s.caManager.GetProvider()
 }
 
 func TestLeader_Vault_PrimaryCA_IntermediateRenew(t *testing.T) {

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -1324,7 +1324,7 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 
 	// Wait for ConnectCA initiation to complete.
 	retry.Run(t, func(r *retry.R) {
-		_, root := srv.caManager.getCAProvider()
+		_, root := srv.caManager.GetProvider()
 		if root == nil {
 			r.Fatal("ConnectCA root is still nil")
 		}
@@ -1381,7 +1381,7 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 
 	setupConnectCACert := func(name string) func(t *testing.T) string {
 		return func(t *testing.T) string {
-			_, caRoot := srv.caManager.getCAProvider()
+			_, caRoot := srv.caManager.GetProvider()
 			newCert(t, caRoot.RootCert, connectCApk, "node1", name)
 			return filepath.Join(dir, "node1-"+name)
 		}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -457,7 +457,13 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 		return nil, fmt.Errorf("Failed to start Raft: %v", err)
 	}
 
-	s.caManager = NewCAManager(&caBackend{Server: s}, s.leaderRoutineManager, s.logger.ResetNamed("connect.ca"), s.config)
+	caManagerConfig := CAManagerConfig{
+		PrimaryDatacenter: s.config.PrimaryDatacenter,
+		Datacenter:        s.config.Datacenter,
+		MaxQueryTime:      s.config.MaxQueryTime,
+		CAConfig:          s.config.CAConfig,
+	}
+	s.caManager = NewCAManager(&caBackend{Server: s}, s.leaderRoutineManager, s.logger.ResetNamed("connect.ca"), caManagerConfig)
 	if s.config.ConnectEnabled && (s.config.AutoEncryptAllowTLS || s.config.AutoConfigAuthzEnabled) {
 		go s.connectCARootsMonitor(&lib.StopChannelContext{StopCh: s.shutdownCh})
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -137,9 +137,6 @@ type Server struct {
 	// caManager is used to synchronize CA operations across the leader and RPC functions.
 	caManager *CAManager
 
-	// rate limiter to use when signing leaf certificates
-	caLeafLimiter connectSignRateLimiter
-
 	// Consul configuration
 	config *Config
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -457,7 +457,7 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 		return nil, fmt.Errorf("Failed to start Raft: %v", err)
 	}
 
-	s.caManager = NewCAManager(&caDelegateWithState{Server: s}, s.leaderRoutineManager, s.logger.ResetNamed("connect.ca"), s.config)
+	s.caManager = NewCAManager(&caBackend{Server: s}, s.leaderRoutineManager, s.logger.ResetNamed("connect.ca"), s.config)
 	if s.config.ConnectEnabled && (s.config.AutoEncryptAllowTLS || s.config.AutoConfigAuthzEnabled) {
 		go s.connectCARootsMonitor(&lib.StopChannelContext{StopCh: s.shutdownCh})
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -108,9 +108,6 @@ const (
 	federationStateAntiEntropyRoutineName = "federation state anti-entropy"
 	federationStatePruningRoutineName     = "federation state pruning"
 	intentionMigrationRoutineName         = "intention config entry migration"
-	secondaryCARootWatchRoutineName       = "secondary CA roots watch"
-	intermediateCertRenewWatchRoutineName = "intermediate cert renew watch"
-	backgroundCAInitializationRoutineName = "CA initialization"
 )
 
 var (

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -457,7 +457,7 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 		return nil, fmt.Errorf("Failed to start Raft: %v", err)
 	}
 
-	s.caManager = NewCAManager(&caDelegateWithState{s}, s.leaderRoutineManager, s.logger.ResetNamed("connect.ca"), s.config)
+	s.caManager = NewCAManager(&caDelegateWithState{Server: s}, s.leaderRoutineManager, s.logger.ResetNamed("connect.ca"), s.config)
 	if s.config.ConnectEnabled && (s.config.AutoEncryptAllowTLS || s.config.AutoConfigAuthzEnabled) {
 		go s.connectCARootsMonitor(&lib.StopChannelContext{StopCh: s.shutdownCh})
 	}


### PR DESCRIPTION
Branched from #11339
Related to #11336
Best viewed by individual commit.

This PR makes  bunch of small changes (one per commit) to allow us to "refactor -> move" the `CAMananger` with a minimal diff. By splitting out the changes in this way, `git diff` will be able to show us just the few lines that changed as part of the file move, instead of making it look like a full delete, and full create of separate files. This can be seen in [this commit](https://github.com/hashicorp/consul/compare/dnephin/ca-manager-move-to-new-package...dnephin/ca-manager-move-to-new-package-2), where the file is moved to a new package, but the diff is only +/- 20 lines.

I can split some of these commits into separate PRs if anything is controversial, but I think most of these are valuable clean ups, even if we don't move `CAMananger` to a new package.

TODO: 
* [ ] [some flaky tests](https://app.circleci.com/pipelines/github/hashicorp/consul/22876/workflows/511035db-e7bf-45bc-9e7b-4824600859e6/jobs/476763) to look into. These were flaky before, but I'd like to make sure I haven't made it worse, and maybe look at making it less flaky if possible.
* [ ] re-add rate limiter for retry loop
