### PR TITLE
refactor: replace `(*bytes.Buffer).WriteString` with `(*bytes.Buffer).Write`

### DIFF
--- a/command/acl/authmethod/formatter.go
+++ b/command/acl/authmethod/formatter.go
@@ -80,7 +80,7 @@ func (f *prettyFormatter) FormatAuthMethod(method *api.ACLAuthMethod) (string, e
 	if err != nil {
 		return "", fmt.Errorf("Error formatting auth method configuration: %s", err)
 	}
-	buffer.WriteString(string(output))
+	buffer.Write(output)
 
 	return buffer.String(), nil
 }


### PR DESCRIPTION
This PR change one method of `bytes.Buffer` struct package with a similar one, as result - code produces fewer allocations on the heap.