### PR TITLE
ci: test against go1.17

### DIFF
--- a/.changelog/11364.txt
+++ b/.changelog/11364.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+tls: With the upgrade to Go 1.17, the ordering of `tls_cipher_suites` will no longer be honored, and `tls_prefer_server_cipher_suites` is now ignored.
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ references:
   images:
     # When updating the Go version, remember to also update the versions in the
     # workflows section for go-test-lib jobs.
-    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.16.7
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.17.2
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:14-browsers
 
   paths:
@@ -1017,9 +1017,9 @@ workflows:
           go-version: "1.16"
           requires: [dev-build]
       - go-test-lib:
-          name: "go-test-api go1.15"
+          name: "go-test-api go1.17"
           path: api
-          go-version: "1.15"
+          go-version: "1.17"
           requires: [dev-build]
       - go-test-lib:
           name: "go-test-sdk go1.16"
@@ -1027,9 +1027,9 @@ workflows:
           go-version: "1.16"
           <<: *filter-ignore-non-go-branches
       - go-test-lib:
-          name: "go-test-sdk go1.15"
+          name: "go-test-sdk go1.17"
           path: sdk
-          go-version: "1.15"
+          go-version: "1.17"
           <<: *filter-ignore-non-go-branches
       - go-test-race: *filter-ignore-non-go-branches
       - go-test-32bit: *filter-ignore-non-go-branches

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.16.7
+ARG GOLANG_VERSION=1.17.2
 FROM golang:${GOLANG_VERSION}
 
 ARG GOTOOLS="github.com/elazarl/go-bindata-assetfs/... \

--- a/build-support/docker/Test-Flake.dockerfile
+++ b/build-support/docker/Test-Flake.dockerfile
@@ -1,6 +1,6 @@
 FROM travisci/ci-garnet:packer-1512502276-986baf0
 
-ENV GOLANG_VERSION 1.16.7
+ENV GOLANG_VERSION 1.17.2
 
 RUN mkdir -p /home/travis/go && chown -R travis /home/travis/go
 


### PR DESCRIPTION
Release notes: https://golang.org/doc/go1.17


TODO:
* [x] Coordinate with #11070 to mention the change impacts Consul 1.11
* [ ] update CRT pipeline
* [x] update consul-releases (for beta releases)