### PR TITLE
build: fix ui make target to use the same frontend stack as the regular release

### DIFF
--- a/build-support/docker/Build-UI.dockerfile
+++ b/build-support/docker/Build-UI.dockerfile
@@ -1,15 +1,7 @@
-ARG ALPINE_VERSION=3.13
-FROM alpine:${ALPINE_VERSION}
+FROM docker.mirror.hashicorp.services/circleci/node:14-browsers
 
-ARG NODEJS_VERSION=14.16.1-r1
-ARG MAKE_VERSION=4.3-r0
-ARG YARN_VERSION=1.22.10
+USER root
 
-RUN apk update && \
-    apk add nodejs=${NODEJS_VERSION} nodejs-npm=${NODEJS_VERSION} make=${MAKE_VERSION} && \
-    npm config set unsafe-perm true && \
-    npm install --global yarn@${YARN_VERSION} && \
-    mkdir /consul-src
-
+RUN mkdir /consul-src
 WORKDIR /consul-src
 CMD make dist-docker


### PR DESCRIPTION
The specific versions of the frontend stack are now just whatever is present in this image `docker.mirror.hashicorp.services/circleci/node:14-browsers`