### PR TITLE
test: remove some envoy integ test warnings

### DIFF
--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -212,7 +212,10 @@ function verify {
 
   echo "Running ${DC} verification step for ${CASE_DIR}..."
 
+  # need to tell the PID 1 inside of the container that it won't be actual PID
+  # 1 because we're using --pid=host so we use TINI_SUBREAPER
   if docker run --name envoy_verify-${DC}_1 -t \
+    -e TINI_SUBREAPER=1 \
     -e ENVOY_VERSION \
     $WORKDIR_SNIPPET \
     --pid=host \


### PR DESCRIPTION
We launch one container as part of the test with --pid=host but
apparently within that container it launches a copy of "tini" as a
process supervisor that prefers to be PID 1.

Because it's not PID 1 it logs a warning message about this to the envoy
integration test logs that can lead to thinking somehow that a test
failure is related when in fact it's completely unrelated.

Adding this environment variable avoids the warning.