### PR TITLE
docs: added deprecation message to CLI command intentions overview page

### DIFF
--- a/website/content/commands/intention/index.mdx
+++ b/website/content/commands/intention/index.mdx
@@ -17,6 +17,12 @@ Intentions are managed primarily via
 entries after Consul 1.9. Intentions may also be managed via the [HTTP
 API](/api/connect/intentions).
 
+~> **Deprecated** - This command is deprecated in Consul 1.9.0 in favor of
+using the [config entry CLI command](/commands/config/write). To create an
+intention, create or modify a
+[`service-intentions`](/docs/connect/config-entries/service-intentions) config
+entry for the destination.
+
 ## Usage
 
 Usage: `consul intention <subcommand>`


### PR DESCRIPTION
This PR adds a deprecation message to the CLI command, intention, documentation overview page.

![image](https://user-images.githubusercontent.com/29551334/138328148-fd6cd1d8-3624-4ec8-a21f-4af6121b8146.png)
