### PR TITLE
ui: Allow spaces in template interpolation

### DIFF
--- a/ui/packages/consul-ui/app/helpers/render-template.js
+++ b/ui/packages/consul-ui/app/helpers/render-template.js
@@ -5,11 +5,13 @@ import { inject as service } from '@ember/service';
 // what this regex does
 // (?:\$|\{)            - Match either $ or {
 // \{                   - Match {
+// [\s\n\r]*            - Skip spaces/newlines
 // ([a-z.0-9_-]+)       - Capturing group
+// [\s\n\r]*            - Skip spaces/newlines
 // (?:(?<=\$\{[^{]+)    - Use a positive lookbehind to assert that ${ was matched previously
 //   |\}            )   - or match a }
 // \}                   - Match }
-const templateRe = /(?:\$|\{)\{([a-z.0-9_-]+)(?:(?<=\$\{[^{]+)|\})\}/gi;
+const templateRe = /(?:\$|\{)\{[\s\n\r]*([a-z.0-9_-]+)[\s\n\r]*(?:(?<=\$\{[^{]+)|\})\}/gi;
 let render;
 export default class RenderTemplateHelper extends Helper {
   @service('encoder') encoder;

--- a/ui/packages/consul-ui/tests/integration/helpers/render-template-test.js
+++ b/ui/packages/consul-ui/tests/integration/helpers/render-template-test.js
@@ -16,6 +16,26 @@ module('Integration | Helper | render-template', function(hooks) {
       result: 'http://localhost/?=name/id',
     },
     {
+      href: 'http://localhost/?={{ Name }}/{{  ID  }}',
+      vars: {
+        Name: 'name',
+        ID: 'id',
+      },
+      result: 'http://localhost/?=name/id',
+    },
+    {
+      href: `http://localhost/?={{ 
+        Name 
+      }}/{{  
+        ID  
+      }}`,
+      vars: {
+        Name: 'name',
+        ID: 'id',
+      },
+      result: 'http://localhost/?=name/id',
+    },
+    {
       href: 'http://localhost/?={{Name}}/{{ID}}',
       vars: {
         Name: '{{Name}}',
@@ -42,6 +62,14 @@ module('Integration | Helper | render-template', function(hooks) {
       // If you don't pass actual variables then nothing
       // gets replaced and nothing is URL encoded
       result: 'http://localhost/?={{}}/{{}}',
+    },
+    {
+      href: 'http://localhost/?={{ }}/{{\r\n}}',
+      vars: {
+        Name: 'name',
+        ID: 'id',
+      },
+      result: 'http://localhost/?={{ }}/{{\r\n}}',
     },
     {
       href: 'http://localhost/?={{Service_Name}}/{{Meta-Key}}',
@@ -114,6 +142,26 @@ module('Integration | Helper | render-template', function(hooks) {
       result: 'http://localhost/?=name/id',
     },
     {
+      href: 'http://localhost/?=${ Name }/${  ID  }',
+      vars: {
+        Name: 'name',
+        ID: 'id',
+      },
+      result: 'http://localhost/?=name/id',
+    },
+    {
+      href: `http://localhost/?=\${ 
+        Name 
+      }/\${  
+        ID  
+      }`,
+      vars: {
+        Name: 'name',
+        ID: 'id',
+      },
+      result: 'http://localhost/?=name/id',
+    },
+    {
       href: 'http://localhost/?=${Name}/${ID}',
       vars: {
         Name: '{{Name}}',
@@ -140,6 +188,14 @@ module('Integration | Helper | render-template', function(hooks) {
       // If you don't pass actual variables then nothing
       // gets replaced and nothing is URL encoded
       result: 'http://localhost/?=${}/${}',
+    },
+    {
+      href: 'http://localhost/?=${ }/${\r\n}',
+      vars: {
+        Name: 'name',
+        ID: 'id',
+      },
+      result: 'http://localhost/?=${ }/${\r\n}',
     },
     {
       href: 'http://localhost/?=${Service_Name}/${Meta-Key}',


### PR DESCRIPTION
Allows spaces and newlines in template interpolation, for example `${ Datacenter }`. This is nearer to the js and mustache styles of interpolation that we're trying to replicate.