### PR TITLE
test: pin the version of bats to one that works on CircleCI

### DIFF
--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,6 +1,8 @@
 FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
 
-FROM docker.mirror.hashicorp.services/bats/bats:latest
+# Both :1.5.0 and :latest tags are broken on CircleCI as of 2021-10-22 with an
+# inability to locate the bats binary.
+FROM docker.mirror.hashicorp.services/bats/bats:v1.4.1
 
 RUN apk add curl
 RUN apk add openssl


### PR DESCRIPTION
Example error during the envoy integration tests prior to this fix:

```
Running primary verification step for case-terminating-gateway-without-services...
bash: bats: No such file or directory
```