### PR TITLE
Add quick-link for users coming from UI

### DIFF
--- a/website/content/docs/connect/observability/ui-visualization.mdx
+++ b/website/content/docs/connect/observability/ui-visualization.mdx
@@ -8,6 +8,8 @@ description: |-
 
 # UI Visualization
 
+-> Coming here from "Configure metrics dashboard" or "Configure dashboard"? See [Configuring Dashboard URLs](#configuring-dashboard-urls).
+
 Since Consul 1.9.0, Consul's built in UI includes a topology visualization to
 show a service's immediate connectivity at a glance. It is not intended as a
 replacement for dedicated monitoring solutions, but rather as a quick overview


### PR DESCRIPTION
The Consul UI topology view has an icon with the text
"Configure metrics dashboard" that links to this page. Add a notice at
the top of the page that links them directly to the relevant section.