### PR TITLE
Use "Open dashboard" everywhere

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -69,9 +69,9 @@
     {{/if}}
     <div class="link">
      {{#if @metricsHref}}
-      <a class="metrics-link" href={{@metricsHref}} target="_blank" rel="noopener noreferrer" data-test-metrics-anchor>Open metrics Dashboard</a>
+      <a class="metrics-link" href={{@metricsHref}} target="_blank" rel="noopener noreferrer" data-test-metrics-anchor>Open dashboard</a>
     {{else}}
-      <a class="config-link" href="{{env 'CONSUL_DOCS_URL'}}/connect/observability/ui-visualization" target="_blank" rel="noopener noreferrer">Configure metrics dashboard</a>
+      <a class="config-link" href="{{env 'CONSUL_DOCS_URL'}}/connect/observability/ui-visualization" target="_blank" rel="noopener noreferrer">Configure dashboard</a>
     {{/if}}
     </div>
   </div>

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -164,7 +164,7 @@ as |items item dc|}}
                 rel="noopener noreferrer"
                 data-test-dashboard-anchor
               >
-                Open Dashboard
+                Open dashboard
               </a>
             {{/if}}
             </DataSource>


### PR DESCRIPTION
Previously we had "Open metrics Dashboard" and "Configure metrics
dashboard" in the topology cards and then we had "Open Dashboard" in the
top nav when the dashboard was configured.

Now we use "Open dashboard" and "Configure dashboard".

This change was made for consistency in wording and casing. In addition,
the dashboard could be used for metrics but also other dashboards so
there's no need to scope it only to metrics. Also the config is:

```hcl
ui_config {
  dashboard_url_templates
}
```

Which does not mention metrics

Before:
![image](https://user-images.githubusercontent.com/1034429/138616641-21850d3f-5598-4284-8fbf-996a17271653.png)
