### PR TITLE
Support Check-And-Set deletion of config entries

### DIFF
--- a/.changelog/11419.txt
+++ b/.changelog/11419.txt
@@ -1,0 +1,6 @@
+```release-note:improvement
+config: Support Check-And-Set (CAS) deletion of config entries
+```
+```release-note:improvement
+cli: Add `-cas` and `-modify-index` flags to the `consul config delete` command to support Check-And-Set (CAS) deletion of config entries
+```

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -196,6 +196,90 @@ func TestConfig_Delete(t *testing.T) {
 	}
 }
 
+func TestConfig_Delete_CAS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+	t.Parallel()
+
+	require := require.New(t)
+
+	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	// Create a config entry.
+	entry := &structs.ServiceConfigEntry{
+		Kind: structs.ServiceDefaults,
+		Name: "foo",
+	}
+	var created bool
+	require.NoError(a.RPC("ConfigEntry.Apply", &structs.ConfigEntryRequest{
+		Datacenter: "dc1",
+		Entry:      entry,
+	}, &created))
+	require.True(created)
+
+	// Read it back to get its ModifyIndex.
+	var out structs.ConfigEntryResponse
+	require.NoError(a.RPC("ConfigEntry.Get", &structs.ConfigEntryQuery{
+		Datacenter: "dc1",
+		Kind:       entry.Kind,
+		Name:       entry.Name,
+	}, &out))
+	require.NotNil(out.Entry)
+
+	modifyIndex := out.Entry.GetRaftIndex().ModifyIndex
+
+	{
+		// Attempt to delete it with an invalid index.
+		req := httptest.NewRequest(
+			"DELETE",
+			fmt.Sprintf("/v1/config/%s/%s?cas=%d", entry.Kind, entry.Name, modifyIndex-1),
+			nil,
+		)
+		rawRsp, err := a.srv.Config(httptest.NewRecorder(), req)
+		require.NoError(err)
+
+		deleted, isBool := rawRsp.(bool)
+		require.True(isBool, "response should be a boolean")
+		require.False(deleted, "entry should not have been deleted")
+
+		// Verify it was not deleted.
+		var out structs.ConfigEntryResponse
+		require.NoError(a.RPC("ConfigEntry.Get", &structs.ConfigEntryQuery{
+			Datacenter: "dc1",
+			Kind:       entry.Kind,
+			Name:       entry.Name,
+		}, &out))
+		require.NotNil(out.Entry)
+	}
+
+	{
+		// Attempt to delete it with a valid index.
+		req := httptest.NewRequest(
+			"DELETE",
+			fmt.Sprintf("/v1/config/%s/%s?cas=%d", entry.Kind, entry.Name, modifyIndex),
+			nil,
+		)
+		rawRsp, err := a.srv.Config(httptest.NewRecorder(), req)
+		require.NoError(err)
+
+		deleted, isBool := rawRsp.(bool)
+		require.True(isBool, "response should be a boolean")
+		require.True(deleted, "entry should have been deleted")
+
+		// Verify it was deleted.
+		var out structs.ConfigEntryResponse
+		require.NoError(a.RPC("ConfigEntry.Get", &structs.ConfigEntryQuery{
+			Datacenter: "dc1",
+			Kind:       entry.Kind,
+			Name:       entry.Name,
+		}, &out))
+		require.Nil(out.Entry)
+	}
+}
+
 func TestConfig_Apply(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -231,8 +231,7 @@ func TestConfig_Delete_CAS(t *testing.T) {
 
 	modifyIndex := out.Entry.GetRaftIndex().ModifyIndex
 
-	{
-		// Attempt to delete it with an invalid index.
+	t.Run("attempt to delete with an invalid index", func(t *testing.T) {
 		req := httptest.NewRequest(
 			"DELETE",
 			fmt.Sprintf("/v1/config/%s/%s?cas=%d", entry.Kind, entry.Name, modifyIndex-1),
@@ -253,10 +252,9 @@ func TestConfig_Delete_CAS(t *testing.T) {
 			Name:       entry.Name,
 		}, &out))
 		require.NotNil(out.Entry)
-	}
+	})
 
-	{
-		// Attempt to delete it with a valid index.
+	t.Run("attempt to delete with a valid index", func(t *testing.T) {
 		req := httptest.NewRequest(
 			"DELETE",
 			fmt.Sprintf("/v1/config/%s/%s?cas=%d", entry.Kind, entry.Name, modifyIndex),
@@ -277,7 +275,7 @@ func TestConfig_Delete_CAS(t *testing.T) {
 			Name:       entry.Name,
 		}, &out))
 		require.Nil(out.Entry)
-	}
+	})
 }
 
 func TestConfig_Apply(t *testing.T) {

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -262,7 +262,7 @@ func (c *ConfigEntry) ListAll(args *structs.ConfigEntryListAllRequest, reply *st
 }
 
 // Delete deletes a config entry.
-func (c *ConfigEntry) Delete(args *structs.ConfigEntryRequest, reply *struct{}) error {
+func (c *ConfigEntry) Delete(args *structs.ConfigEntryRequest, reply *structs.ConfigEntryDeleteResponse) error {
 	if err := c.srv.validateEnterpriseRequest(args.Entry.GetEnterpriseMeta(), true); err != nil {
 		return err
 	}
@@ -294,9 +294,29 @@ func (c *ConfigEntry) Delete(args *structs.ConfigEntryRequest, reply *struct{}) 
 		return acl.ErrPermissionDenied
 	}
 
-	args.Op = structs.ConfigEntryDelete
-	_, err = c.srv.raftApply(structs.ConfigEntryRequestType, args)
-	return err
+	// Ignore non-delete Ops.
+	switch args.Op {
+	case structs.ConfigEntryDelete, structs.ConfigEntryDeleteCAS:
+	default:
+		args.Op = structs.ConfigEntryDelete
+	}
+
+	rsp, err := c.srv.raftApply(structs.ConfigEntryRequestType, args)
+	if err != nil {
+		return err
+	}
+
+	if args.Op == structs.ConfigEntryDeleteCAS {
+		// In CAS deletions the FSM will return a boolean value indicating whether the
+		// operation was successful.
+		deleted, _ := rsp.(bool)
+		reply.Deleted = deleted
+	} else {
+		// For non-CAS deletions any non-error result indicates a successful deletion.
+		reply.Deleted = true
+	}
+
+	return nil
 }
 
 // ResolveServiceConfig

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -294,7 +294,8 @@ func (c *ConfigEntry) Delete(args *structs.ConfigEntryRequest, reply *structs.Co
 		return acl.ErrPermissionDenied
 	}
 
-	// Ignore non-delete Ops.
+	// Only delete and delete-cas ops are supported. If the caller erroneously
+	// sent something else, we assume they meant delete.
 	switch args.Op {
 	case structs.ConfigEntryDelete, structs.ConfigEntryDeleteCAS:
 	default:

--- a/agent/consul/config_replication_test.go
+++ b/agent/consul/config_replication_test.go
@@ -237,7 +237,7 @@ func TestReplication_ConfigEntries(t *testing.T) {
 			Entry:      entry,
 		}
 
-		var out struct{}
+		var out structs.ConfigEntryDeleteResponse
 		require.NoError(t, s1.RPC("ConfigEntry.Delete", &arg, &out))
 	}
 

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -543,6 +543,14 @@ func (c *FSM) applyConfigEntryOperation(buf []byte, index uint64) interface{} {
 			return err
 		}
 		return true
+	case structs.ConfigEntryDeleteCAS:
+		defer metrics.MeasureSinceWithLabels([]string{"fsm", "config_entry", req.Entry.GetKind()}, time.Now(),
+			[]metrics.Label{{Name: "op", Value: "delete"}})
+		deleted, err := c.state.DeleteConfigEntryCAS(index, req.Entry.GetRaftIndex().ModifyIndex, req.Entry)
+		if err != nil {
+			return err
+		}
+		return deleted
 	case structs.ConfigEntryDelete:
 		defer metrics.MeasureSinceWithLabels([]string{"fsm", "config_entry", req.Entry.GetKind()}, time.Now(),
 			[]metrics.Label{{Name: "op", Value: "delete"}})

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -445,6 +445,7 @@ const (
 	ConfigEntryUpsert    ConfigEntryOp = "upsert"
 	ConfigEntryUpsertCAS ConfigEntryOp = "upsert-cas"
 	ConfigEntryDelete    ConfigEntryOp = "delete"
+	ConfigEntryDeleteCAS ConfigEntryOp = "delete-cas"
 )
 
 // ConfigEntryRequest is used when creating/updating/deleting a ConfigEntry.

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -1122,3 +1122,7 @@ func validateConfigEntryMeta(meta map[string]string) error {
 	}
 	return err
 }
+
+type ConfigEntryDeleteResponse struct {
+	Deleted bool
+}

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -249,6 +249,37 @@ func TestAPI_ConfigEntries(t *testing.T) {
 		})
 	})
 
+	t.Run("CAS deletion", func(t *testing.T) {
+		require := require.New(t)
+
+		entry := &ProxyConfigEntry{
+			Kind: ProxyDefaults,
+			Name: ProxyConfigGlobal,
+			Config: map[string]interface{}{
+				"foo": "bar",
+			},
+		}
+
+		// Create a config entry.
+		created, _, err := config_entries.Set(entry, nil)
+		require.NoError(err)
+		require.True(created, "entry should have been created")
+
+		// Read it back to get the ModifyIndex.
+		result, _, err := config_entries.Get(entry.Kind, entry.Name, nil)
+		require.NoError(err)
+		require.NotNil(entry)
+
+		// Attempt a deletion with an invalid index.
+		deleted, _, err := config_entries.DeleteCAS(entry.Kind, entry.Name, result.GetModifyIndex()-1, nil)
+		require.NoError(err)
+		require.False(deleted, "entry should not have been deleted")
+
+		// Attempt a deletion with a valid index.
+		deleted, _, err = config_entries.DeleteCAS(entry.Kind, entry.Name, result.GetModifyIndex(), nil)
+		require.NoError(err)
+		require.True(deleted, "entry should have been deleted")
+	})
 }
 
 func runStep(t *testing.T, name string, fn func(t *testing.T)) {

--- a/command/config/delete/config_delete.go
+++ b/command/config/delete/config_delete.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 
@@ -49,13 +50,8 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	if c.kind == "" {
-		c.UI.Error("Must specify the -kind parameter")
-		return 1
-	}
-
-	if c.name == "" {
-		c.UI.Error("Must specify the -name parameter")
+	if err := c.validateArgs(); err != nil {
+		c.UI.Error(err.Error())
 		return 1
 	}
 
@@ -86,6 +82,26 @@ func (c *cmd) Run(args []string) int {
 
 	c.UI.Info(fmt.Sprintf("Config entry deleted: %s/%s", c.kind, c.name))
 	return 0
+}
+
+func (c *cmd) validateArgs() error {
+	if c.kind == "" {
+		return errors.New("Must specify the -kind parameter")
+	}
+
+	if c.name == "" {
+		return errors.New("Must specify the -name parameter")
+	}
+
+	if c.cas && c.modifyIndex == 0 {
+		return errors.New("Must specify a -modify-index greater than 0 with -cas")
+	}
+
+	if c.modifyIndex != 0 && !c.cas {
+		return errors.New("Cannot specify -modify-index without -cas")
+	}
+
+	return nil
 }
 
 func (c *cmd) Synopsis() string {

--- a/command/config/delete/config_delete_test.go
+++ b/command/config/delete/config_delete_test.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
@@ -51,6 +52,70 @@ func TestConfigDelete(t *testing.T) {
 	entry, _, err := client.ConfigEntries().Get(api.ServiceDefaults, "web", nil)
 	require.Error(t, err)
 	require.Nil(t, entry)
+}
+
+func TestConfigDelete_CAS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	_, _, err := client.ConfigEntries().Set(&api.ServiceConfigEntry{
+		Kind:     api.ServiceDefaults,
+		Name:     "web",
+		Protocol: "tcp",
+	}, nil)
+	require.NoError(t, err)
+
+	entry, _, err := client.ConfigEntries().Get(api.ServiceDefaults, "web", nil)
+	require.NoError(t, err)
+
+	t.Run("with an invalid modify index", func(t *testing.T) {
+		ui := cli.NewMockUi()
+		c := New(ui)
+
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-kind=" + api.ServiceDefaults,
+			"-name=web",
+			"-cas",
+			"-modify-index=" + strconv.FormatUint(entry.GetModifyIndex()-1, 10),
+		}
+
+		code := c.Run(args)
+		require.Equal(t, 1, code)
+		require.Contains(t, ui.ErrorWriter.String(),
+			"Config entry not deleted: service-defaults/web")
+		require.Empty(t, ui.OutputWriter.String())
+	})
+
+	t.Run("with a valid modify index", func(t *testing.T) {
+		ui := cli.NewMockUi()
+		c := New(ui)
+
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-kind=" + api.ServiceDefaults,
+			"-name=web",
+			"-cas",
+			"-modify-index=" + strconv.FormatUint(entry.GetModifyIndex(), 10),
+		}
+
+		code := c.Run(args)
+		require.Equal(t, 0, code)
+		require.Contains(t, ui.OutputWriter.String(),
+			"Config entry deleted: service-defaults/web")
+		require.Empty(t, ui.ErrorWriter.String())
+
+		entry, _, err := client.ConfigEntries().Get(api.ServiceDefaults, "web", nil)
+		require.Error(t, err)
+		require.Nil(t, entry)
+	})
 }
 
 func TestConfigDelete_InvalidArgs(t *testing.T) {

--- a/testrpc/wait.go
+++ b/testrpc/wait.go
@@ -182,7 +182,7 @@ func WaitForServiceIntentions(t *testing.T, rpc rpcFn, dc string) {
 				Name: fakeConfigName,
 			},
 		}
-		var ignored struct{}
+		var ignored structs.ConfigEntryDeleteResponse
 		if err := rpc("ConfigEntry.Delete", args, &ignored); err != nil {
 			r.Fatalf("err: %v", err)
 		}

--- a/website/content/api-docs/config.mdx
+++ b/website/content/api-docs/config.mdx
@@ -276,6 +276,12 @@ The table below shows this endpoint's support for
   `X-Consul-Namespace` header. If not provided, the namespace will be inherited
   from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
+- `cas` `(int: 0)` - Specifies to use a Check-And-Set operation. Unlike `PUT`,
+  the index must be greater than 0 for Consul to take any action: a 0 index will
+  not delete the config entry. If the index is non-zero, the config entry is only
+  deleted if the index matches the `ModifyIndex` of that config entry. This is
+  specified as part of the URL as a query parameter.
+
 ### Sample Request
 
 ```shell-session

--- a/website/content/commands/config/delete.mdx
+++ b/website/content/commands/config/delete.mdx
@@ -31,6 +31,14 @@ Usage: `consul config delete [options]`
   `proxy-defaults` config entry must be `global`, and the name of the `mesh`
   config entry must be `mesh`.
 
+- `-cas` - Perform a Check-And-Set operation. Specifying this value also
+  requires the -modify-index flag to be set. The default value is false.
+
+- `-modify-index=<int>` - Unsigned integer representing the ModifyIndex of the
+  config entry. This is used in combination with the -cas flag.
+
 ## Examples
 
     $ consul config delete -kind service-defaults -name web
+
+    $ consul config delete -kind service-defaults -name web -cas -modify-index 26


### PR DESCRIPTION
Adds support for Check-And-Set (CAS) deletion of config entries, similar to that [of KVs](https://www.consul.io/api-docs/kv#cas-1).

This is useful for cases where it is desirable to delete a config entry, but only if it has not been modified by another process since reading it (such as the scenario described in #11372).

Sidenote: this is my first PR to Consul 🎉 so any meta/style feedback is greatly appreciated!
