### PR TITLE
Update CTS compatibility matrix to include TFC and flexible

### DIFF
--- a/website/content/docs/nia/compatibility.mdx
+++ b/website/content/docs/nia/compatibility.mdx
@@ -13,9 +13,7 @@ Below are the supported Consul versions with compatible Consul-Terraform-Sync ve
 
 | Consul Version               | Compatible Consul-Terraform-Sync Version |
 | ---------------------------- | ---------------------------------------- |
-| Latest patch version of 1.10 | 0.1 - 0.2                                |
-| Latest patch version of 1.9  | 0.1 - 0.2                                |
-| Latest patch version of 1.8  | 0.1 - 0.2                                |
+| 1.8+                         | 0.1+                                     |
 
 ## Terraform
 
@@ -23,5 +21,14 @@ Consul-Terraform-Sync is compatible with the following Terraform OSS versions:
 
 | Consul-Terraform-Sync | Compatible Terraform Version |
 | --------------------- | ---------------------------- |
-| 0.2                   | 0.13 - 1.0                   |
+| 0.2+                  | 0.13 - 1.0                   |
 | 0.1                   | 0.13 - 0.14                  |
+
+## Terraform Cloud
+
+Consul-Terraform-Sync integration with Terraform Cloud is supported for the following:
+
+| Consul-Terraform-Sync Enterprise | Terraform Cloud            | Version            |
+| -------------------------------- | -------------------------- | ------------------ |
+| 0.4+                             | Terraform Cloud            | Latest             |
+| 0.3+                             | Terraform Enterprise       | v202010-2 - Latest |


### PR DESCRIPTION
The current matrix is explicit for each version, but we've clearly been behind at updating it with our recent releases. This gives us a bit more flexibility and only need to update the matrix when we have compatibility changes.

![image](https://user-images.githubusercontent.com/6362111/138930095-88fa95be-4da2-41ad-bd93-718c3806c41e.png)
