### PR TITLE
docs: Document datacenter limitations for admin partitions

### DIFF
--- a/website/content/commands/admin-partition.mdx
+++ b/website/content/commands/admin-partition.mdx
@@ -13,14 +13,14 @@ Command: `consul admin-partition`
 
 The `admin-partition` command enables you to create and manage Consul Enterprise administrative or admin partitions. Admin partitions are boundaries that allow multiple namespaces with the same name to exist independently of each other. This features is currently in beta.
 
-If ACLs are enabled then a token with operator privileges may be required in order to use this command. 
+If ACLs are enabled then a token with operator privileges may be required in order to use this command.
 
 You should only run the `admin-partition` command in the primary datacenter.
 
 ## Usage
 
 ```shell-session
-consul admin-partition <SUBCOMMAND> <OPTIONS> 
+consul admin-partition <SUBCOMMAND> <OPTIONS>
 ```
 
 Issue the `consul admin-partition -h` command to view the subcommands.
@@ -61,14 +61,14 @@ Usage: consul admin-partition <subcommand> [options] [args]
 
 ## Subcommands
 
-You can issue the folloing subcommands with the `consul admin-partition` command.
+You can issue the following subcommands with the `consul admin-partition` command.
 
 ### `create`
 
-The `create` subcommand sends a request to the server to create a new admin partition. 
+The `create` subcommand sends a request to the server to create a new admin partition.
 
 ```shell-session
-consul admin-partition create <OPTIONS> 
+consul admin-partition create <OPTIONS>
 ```
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
@@ -78,7 +78,7 @@ The admin partition is created according to the values specified in the options.
 | `-name` | String value that specifies the name for the new partition. | none | Required |
 | `-description` &nbsp; &nbsp; &nbsp; &nbsp; | String value that specifies a description of the new partition. | none | Optional |
 | `-format` | Specifies how to format the output of the operation in the console. | none | Optional |
-| `-show-meta` | Prints the description and raft indices to the console in the response. <br/> This option does not take a value. Include the option when issuing the command to enable. | Disabled | Optional | 
+| `-show-meta` | Prints the description and raft indices to the console in the response. <br/> This option does not take a value. Include the option when issuing the command to enable. | Disabled | Optional |
 
 In the following example, a partition named `webdev` is created:
 
@@ -116,12 +116,12 @@ You can specify the following options:
 | Option | Description | Default | Required |
 | ---    | ---         | ---     | ---      |
 | `-format` | Specifies how to format the output of the operation in the console. | none | Optional |
-| `-show-meta` &nbsp; &nbsp; | Prints the description and raft indices to the console in the response. <br/> This option does not take a value. Include the option when issuing the command to enable. | Disabled | Optional | 
+| `-show-meta` &nbsp; &nbsp; | Prints the description and raft indices to the console in the response. <br/> This option does not take a value. Include the option when issuing the command to enable. | Disabled | Optional |
 
 In the following example, the `webdev-bu` partition is written using `stdin` values:
 
 ```shell-session
-consul admin-partition write -format  json -show-meta - <<< 'name = "webdev-bu" description = "backup webdev partition"' 
+consul admin-partition write -format  json -show-meta - <<< 'name = "webdev-bu" description = "backup webdev partition"'
 
 {
    "Name": "webdev-bu",
@@ -133,7 +133,7 @@ consul admin-partition write -format  json -show-meta - <<< 'name = "webdev-bu" 
 
 ### `read`
 
-The `read` subcommand sends a request to the server to read the configuration for the specified partition and print it to the console. 
+The `read` subcommand sends a request to the server to read the configuration for the specified partition and print it to the console.
 
 ```shell-session
 consul admin-partition read <OPTIONS> <PARTITION_NAME>
@@ -144,7 +144,7 @@ The admin partition is created according to the values specified in the options.
 | Option | Description | Default | Required |
 | ---    | ---         | ---     | ---      |
 | `-format` &nbsp; &nbsp; | Specifies how to format the output of the operation in the console. | none | Optional |
-| `-meta` | Prints the description and raft indices to the console in the response. <br/> This option does not take a value. Include the option when issuing the command to enable. | Disabled | Optional | 
+| `-meta` | Prints the description and raft indices to the console in the response. <br/> This option does not take a value. Include the option when issuing the command to enable. | Disabled | Optional |
 
 In the following example, the configuration for the `webdev` partition is read:
 
@@ -160,10 +160,10 @@ consul admin-partition read -format json -meta webdev
 
 ### `list`
 
-The `list` subcommand prints existing admin partitions to the console. 
+The `list` subcommand prints existing admin partitions to the console.
 
 ```shell-session
-consul admin-partition list <OPTIONS> 
+consul admin-partition list <OPTIONS>
 ```
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
@@ -171,7 +171,7 @@ The admin partition is created according to the values specified in the options.
 | Option | Description | Default | Required |
 | ---    | ---         | ---     | ---      |
 | `-format` | Specifies how to format the output of the operation in the console. | none | Optional |
-| `-show-meta` | Prints the description and raft indices to the console in the response. <br/> This option does not take a value. Include the option when issuing the command to enable. | Disabled | Optional | 
+| `-show-meta` | Prints the description and raft indices to the console in the response. <br/> This option does not take a value. Include the option when issuing the command to enable. | Disabled | Optional |
 
 The following example lists the admin partitions and their meta data in JSON format:
 
@@ -201,7 +201,7 @@ consul admin-partition list -format  json -show-meta
 
 ### `delete`
 
-The `delete` subcommand sends a request to the server to remove the specified partition. 
+The `delete` subcommand sends a request to the server to remove the specified partition.
 
 ```shell-session
 consul admin-partition delete PARTITION_NAME>
@@ -216,11 +216,11 @@ consul admin-partition delete webdev
 
 Admin partitions are managed exclusively through the HTTP API and the Consul CLI. The HTTP API accepts only JSON formatted definitions while the CLI will parse either JSON or HCL.
 
-The following parameters are supported in admin partition defintion files:
+The following parameters are supported in admin partition definition files:
 
 | Option | Description | Default | Required |
 | ---    | ---         | ---     | ---      |
-| `Name` | String value that specifies the name of partiion you are creating or writing. <br/> The value must be valid DNS hostname value. | none | Required |
+| `Name` | String value that specifies the name of partition you are creating or writing. <br/> The value must be valid DNS hostname value. | none | Required |
 | `Description` | String value that specifies a description for the partition you are creating or writing. <br/> The value should provide human-readable information to help other users understand the purpose of the partition. | none | Optional |
 
 ### Example Definition File
@@ -234,7 +234,7 @@ Description = "Partition for dev team"
 
 ## HTTP API Options
 
-You can include the following options to interact with the HTTP API when using the `admin-partition` command. 
+You can include the following options to interact with the HTTP API when using the `admin-partition` command.
 
 | Option | Description | Default | Required |
 | ---    | ---         | ---     | ---      |
@@ -242,6 +242,6 @@ You can include the following options to interact with the HTTP API when using t
 | `-ca-path` | Specifies the path to a client certificate file when TLS is enabled. <br/> You can also specify `CONSUL_CAPATH` as the value if the environment variable is configured. | none | Required if TLS is enabled |
 | `-client-cert` | Specifies the path to a client certificate file when TLS and the `verify_incoming` option are enabled. <br/> You can also specify `CONSUL_CLIENT_CERT` as the value if the environment variable is configured. | none | Required if TLS and `verify_incoming` are enabled |
 | `-client-key` | Specifies the path to a client key file when TLS and the `verify_incoming` option are enabled. <br/> You can also specify `CONSUL_CLIENT_KEY` as the value if the environment variable is configured. | none | Required if TLS and `verify_incoming` are enabled |
-| `-datacenter` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Specifies the name of the datacenter to query. | Datacenter of the queried agent | Optional |
+| `-datacenter` | Specifies the name of the datacenter to query. <br/> Non-default admin partitions are only supported in the primary datacenter. | Datacenter of the queried agent | Required if the agent is in a non-primary datacenter. |
 | `-http-addr` | Specifies the address and port number of the Consul HTTP agent. <br/>IP and DNS addresses are supported. The address must also include the port. <br/>You can also specify `CONSUL_HTTP_ADDR` if the environment variable is configured. <br/>To use an HTTPS address, set the `CONSUL_HTTP_SSL` environment variable to `true`. | `http://127.0.0.1:8500` | Optional |
 | `-stale` | Boolean value that enables any Consul server (non-leader) to respond to the request. <br/>This switch can lower latency and increase throughput, but may result in stale data. This option has no effect on non-read operations. | `false` | Optional |

--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -12,17 +12,17 @@ description: Consul Enterprise enables you to create paritions that can be admin
   with the Governance and Policy module.
 </EnterpriseAlert>
 
-This topic provides and overview of admin partitions, which are entities that define one or more administrative boundaries for single Consul deployments. 
+This topic provides and overview of admin partitions, which are entities that define one or more administrative boundaries for single Consul deployments.
 
 ## Introduction
 
-Admin partitions exist a level above namespaces in the identity hierarchy. They contain one or more namespaces and allow multiple independent tenants to share a Consul server cluster. As a result, admin partitions enable you to define administrative and communication boundaries between services managed by separate teams or belonging to separate stakeholders. They can also segment production and non-production services within the Consul deployment. 
+Admin partitions exist a level above namespaces in the identity hierarchy. They contain one or more namespaces and allow multiple independent tenants to share a Consul server cluster. As a result, admin partitions enable you to define administrative and communication boundaries between services managed by separate teams or belonging to separate stakeholders. They can also segment production and non-production services within the Consul deployment.
 
 -> **Preexisting resource nodes and namespaces**: Admin partitions were introduced in Consul 1.11. Resource nodes were not namespaced prior to 1.11. After upgrading to Consul 1.11 or later, all resource nodes will be namespaced.
 
 ### Default Admin Partition
 
-Each Consul cluster will have at least one default admin partition (named `default`). Any resource created without specifying an admin partition will inherit the partition of the ACL token.  
+Each Consul cluster will have at least one default admin partition (named `default`). Any resource created without specifying an admin partition will inherit the partition of the ACL token.
 
 The `default` admin partition is special in that it may contain namespaces and other entities that are replicated between datacenters.
 
@@ -35,20 +35,19 @@ Names must also start with a letter.
 
 ### Namespaces
 
-When an admin partition is created, it will include a `default` namespace. You can create additional namespaces within the partition. 
+When an admin partition is created, it will include a `default` namespace. You can create additional namespaces within the partition.
 
-All namespaces must exist within an admin partition. By extension, the partition will also contain all namespaced resources. 
+All namespaces must exist within an admin partition. By extension, the partition will also contain all namespaced resources.
 
-Within a single datacenter, a namespace in one admin partition is logically separate from any other namespace with the same name in other admin partitions. 
+Within a single datacenter, a namespace in one admin partition is logically separate from any other namespace with the same name in other admin partitions.
 
 ### Cross-datacenter Replication
 
-Only resources in the default admin partition will be replicated to secondary datacenters.
-
+Only resources in the default admin partition will be replicated to secondary datacenters. Non-default partitions are currently not supported in secondary datacenters.
 
 ### DNS Queries
 
-Client agents will be configured to operate within a specific admin partition. The DNS interface will only return results for the admin partition within the scope of the client.  
+Client agents will be configured to operate within a specific admin partition. The DNS interface will only return results for the admin partition within the scope of the client.
 
 ### Service Mesh Configurations
 
@@ -58,16 +57,16 @@ Values specified for [`proxy-defaults`](docs/connect/config-entries/proxy-defaul
 
 Your Consul configuration must meet the following requirements to use admin partitions.
 
-### Versions  
+### Versions
 
 * Consul 1.11.0 and newer
 
 ### Security Configurations
 
-* The agent token used by the client agent will need to allow `node:write` in the admin partition. 
+* The agent token used by the client agent will need to allow `node:write` in the admin partition.
 * The `write` permission for `proxy-defaults` requires `mesh:write`. See [Admin Partition Rules](/docs/security/acl/acl-rules#admin-partition-rules) for additional information.
 * The `write` permissions for ingress and terminating gateways require `mesh:write` privileges.
-* Wildcards (`*`) are not supported when creating intentions for admin partitions, but you can use a wildcard to specify services within a partition. 
+* Wildcards (`*`) are not supported when creating intentions for admin partitions, but you can use a wildcard to specify services within a partition.
 
 ### Agent Configurations
 
@@ -76,17 +75,17 @@ Your Consul configuration must meet the following requirements to use admin part
   ```hcl
   partition = "<NAME>"
   ```
-* The anti-entropy sync will use the configured admin partition name when registering the node. 
+* The anti-entropy sync will use the configured admin partition name when registering the node.
 
 ### Kubernetes Requirements
 
 One of the primary use cases for admin partitions is for enabling a service mesh on Kubernetes clusters. The following requirements must be met to create admin partitions on Kubernetes:
 
-* Two or more Kubernetes clusters with Consul servers installed on one of them. The other clusters should run Consul clients. 
-* A Consul Enterprise license must be installed on each instance of Consul. 
+* Two or more Kubernetes clusters with Consul servers installed on one of them. The other clusters should run Consul clients.
+* A Consul Enterprise license must be installed on each instance of Consul.
 * The helm chart consul-k8s v0.34.1 or greater.
 * Consul 1.11.0-ent-alpha or greater.
-* All instances in the VPC must be able to communicate with each other. 
+* All instances in the VPC must be able to communicate with each other.
 * Pods must be able to communicate with each other (flat pod and node network). See [step 3](#firewall-rules) in the Deploying Consul with Admin Partitions on Kubernetes section for additional information
 
 ## Usage
@@ -97,24 +96,24 @@ This section describes how to deploy Consul admin partitions to Kubernetes clust
 
 The expected use case to create admin partitions on Kubernetes clusters. This is because many organizations prefer to use cloud-managed Kubernetes offerings to provision separate Kubernetes clusters for individual teams, business units, or environments. This is opposed to deploying a single, large Kubernetes cluster. When these organizations attempt to use a service mesh to enable cross-cluster activities, such as administration tasks and communication between nodes, they encounter problems.
 
-The following procedure will result in different admin partitions in each Kubernetes cluster. The Consul clients running in the cluster with servers will be in the `default` partition. Another partition called `clients` will also be created. 
+The following procedure will result in different admin partitions in each Kubernetes cluster. The Consul clients running in the cluster with servers will be in the `default` partition. Another partition called `clients` will also be created.
 
 Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernetes-requirements) before proceeding.
 
 1. <a id="firewall-rules"/> Update the firewall rules to ensure the pod network is flat. The following example for Google Kubernetes Engine (GKE) describes how to create a firewall rule that allows all pod and node network traffic to talk to the server and workload nodegroups:
-  
+
     1. Open the **VPC Network > Firewall** section and identify the rules associated with your clusters. The cluster name is a part of the rule.
 
      ![IP address ranges for GKE clusters](/img/admin-partitions/consul-admin-partitions-gke-cluster-1.png)
-  
-     ![IP address ranges for GKE clusters](/img/admin-partitions/consul-admin-partitions-gke-cluster-2.png)    
-  
-     The `gke-cluster-1-7b43116f-node` and `gke-cluster-2-48d3bee6-node` labels are the node names for the GKE clusters. 
-    
-     The `10.128.0.0/9` IP range represents the node IP network. The IP range of the node VMs in the clusters are within this range. 
-       
+
+     ![IP address ranges for GKE clusters](/img/admin-partitions/consul-admin-partitions-gke-cluster-2.png)
+
+     The `gke-cluster-1-7b43116f-node` and `gke-cluster-2-48d3bee6-node` labels are the node names for the GKE clusters.
+
+     The `10.128.0.0/9` IP range represents the node IP network. The IP range of the node VMs in the clusters are within this range.
+
      The `10.44.0.0/14` and `10.4.0.0/14` IP ranges are the pod IP ranges for the GKE clusters.
-    
+
     1. Enter the `gke-cluster-1-7b43116f-node` and `gke-cluster-2-48d3bee6-node` node names in the target fields of the firewall rule.
     1. Enter the `10.128.0.0/9`, `10.44.0.0/14`, and `10.4.0.0/14` IP into the source fields. This will ensure that traffic from the nodes and the pods in each cluster can access the nodes and pods in the other.
 
@@ -125,10 +124,10 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
   ```shell-session
 kubectl create secret generic license --from-file=key=[license file path i.e. ./license.hclic]
   ```
-  This step must also be completed for each workload cluster. 
+  This step must also be completed for each workload cluster.
 
 1. Create a server configuration file to override the default Consul Helm chart settings:
-  
+
   ```yaml
   global:
   enableConsulNamespaces: true
@@ -157,7 +156,7 @@ kubectl create secret generic license --from-file=key=[license file path i.e. ./
   ```shell-session
     helm install server hashicorp/consul -f server.yaml
   ```
-1. After the server starts, get the external IP address for partition service so that it can be added to the client configuration. The partition service is a `LoadBalancer` type. The IP address is where clients that across your partitions will communicate with servers in this cluster.  
+1. After the server starts, get the external IP address for partition service so that it can be added to the client configuration. The partition service is a `LoadBalancer` type. The IP address is where clients that across your partitions will communicate with servers in this cluster.
 
   ```shell-session
   kubectl get service
@@ -194,7 +193,7 @@ kubectl create secret generic license --from-file=key=[license file path i.e. ./
       secretKey: key
   externalServers:
     enabled: true
-    hosts: "35.192.119.38" # Insert External IP of LoadBalancer here 
+    hosts: "35.192.119.38" # Insert External IP of LoadBalancer here
     tlsServerName: server.dc1.consul
   client:
     enabled: true
@@ -216,8 +215,8 @@ kubectl create secret generic license --from-file=key=[license file path i.e. ./
   ```
 
 1. Copy the server key to the workload cluster.
-  
-  ```shell-session  
+
+  ```shell-session
   kubectl get secret consul-consul-ca-key --context server -o yaml | kubectl apply --context client -f -
   ```
 1. Start the workload client clusters:
@@ -225,12 +224,13 @@ kubectl create secret generic license --from-file=key=[license file path i.e. ./
   ```shell-session
     helm install client hashicorp/consul -f client.yaml
   ```
- 
+
 ### CLI Usage
 
-You can use create and manage admin partitions through the CLI. Refer to the [admin partition CLI documentation](/commands/admin-partition) for details. 
+You can use create and manage admin partitions through the CLI. Refer to the [admin partition CLI documentation](/commands/admin-partition) for details.
 
 ## Known Limitations
 
 * Gossip between nodes in different admin partitions must be constrained. You can accomplish this with through the use of [network segments](network-segments).
-* Cross-partition communication is not currently supported. 
+* Cross-partition communication is not currently supported.
+* Partitions can only be created in the primary datacenter.


### PR DESCRIPTION
Looks like my Goland stripped a lot of white spaces, making a larger diff!

Best viewed when hiding whitespace changes:
![image](https://user-images.githubusercontent.com/30640057/138948287-2a083c04-f3e8-4def-b265-c794ad10a59b.png)
