### PR TITLE
add root_cert_ttl option for consul connect, vault ca providers

### DIFF
--- a/.changelog/11428.txt
+++ b/.changelog/11428.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ca: Add a configurable ttl for root certs for connect, vault ca providers.
+```

--- a/.changelog/11428.txt
+++ b/.changelog/11428.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-ca: Add a configurable ttl for root certs for connect, vault ca providers.
+ca: Add a configurable TTL for Connect CA root certificates. The configuration is supported by the Vault and Consul providers.
 ```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -724,6 +724,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 			"csr_max_concurrent": "CSRMaxConcurrent",
 			"private_key_type":   "PrivateKeyType",
 			"private_key_bits":   "PrivateKeyBits",
+			"root_cert_ttl":      "RootCertTTL",
 		})
 	}
 

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1623,6 +1623,7 @@ func (c *RuntimeConfig) ConnectCAConfiguration() (*structs.CAConfiguration, erro
 		Config: map[string]interface{}{
 			"LeafCertTTL":         structs.DefaultLeafCertTTL,
 			"IntermediateCertTTL": structs.DefaultIntermediateCertTTL,
+			"RootCertTTL":         structs.DefaultRootCertTTL,
 		},
 	}
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3144,7 +3144,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 						"tls_skip_verify": true,
 						"token": "abc",
 						"root_pki_path": "consul-vault",
-						"root_cert_ttl": "87600h",
+						"root_cert_ttl": "96360h",
 						"intermediate_pki_path": "connect-intermediate"
 					}
 				}
@@ -3163,7 +3163,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 						root_pki_path = "consul-vault"
 						token = "abc"
 						intermediate_pki_path = "connect-intermediate"
-						root_cert_ttl = "87600h"
+						root_cert_ttl = "96360h"
 					}
 				}
 			`},
@@ -3180,7 +3180,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 				"TLSSkipVerify":       true,
 				"Token":               "abc",
 				"RootPKIPath":         "consul-vault",
-				"RootCertTTL":         "87600h",
+				"RootCertTTL":         "96360h",
 				"IntermediatePKIPath": "connect-intermediate",
 			}
 		},
@@ -5492,7 +5492,7 @@ func TestLoad_FullConfig(t *testing.T) {
 		ConnectCAConfig: map[string]interface{}{
 			"IntermediateCertTTL": "8760h",
 			"LeafCertTTL":         "1h",
-			"RootCertTTL":         "87600h",
+			"RootCertTTL":         "96360h",
 			"CSRMaxPerSecond":     float64(100),
 			"CSRMaxConcurrent":    float64(2),
 		},
@@ -6718,7 +6718,7 @@ func TestConnectCAConfiguration(t *testing.T) {
 				ConnectEnabled: true,
 				ConnectCAConfig: map[string]interface{}{
 					"foo":         "bar",
-					"RootCertTTL": "8761h", // 365 * 10 * 24h
+					"RootCertTTL": "8761h", // 365 * 24h + 1
 				},
 			},
 			expected: &structs.CAConfiguration{
@@ -6726,7 +6726,7 @@ func TestConnectCAConfiguration(t *testing.T) {
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
 					"IntermediateCertTTL": "8760h", // 365 * 24h
-					"RootCertTTL":         "8761h", // 365 * 10 * 24h
+					"RootCertTTL":         "8761h", // 365 * 24h + 1
 					"foo":                 "bar",
 				},
 			},

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3127,6 +3127,65 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 	})
 	run(t, testCase{
+		desc: "test connect vault provider configuration with root cert ttl",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json: []string{`{
+				"connect": {
+					"enabled": true,
+					"ca_provider": "vault",
+					"ca_config": {
+						"ca_file": "/capath/ca.pem",
+						"ca_path": "/capath/",
+						"cert_file": "/certpath/cert.pem",
+						"key_file": "/certpath/key.pem",
+						"tls_server_name": "server.name",
+						"tls_skip_verify": true,
+						"token": "abc",
+						"root_pki_path": "consul-vault",
+						"root_cert_ttl": "87600h",
+						"intermediate_pki_path": "connect-intermediate"
+					}
+				}
+			}`},
+		hcl: []string{`
+			  connect {
+					enabled = true
+					ca_provider = "vault"
+					ca_config {
+						ca_file = "/capath/ca.pem"
+						ca_path = "/capath/"
+						cert_file = "/certpath/cert.pem"
+						key_file = "/certpath/key.pem"
+						tls_server_name = "server.name"
+						tls_skip_verify = true
+						root_pki_path = "consul-vault"
+						token = "abc"
+						intermediate_pki_path = "connect-intermediate"
+						root_cert_ttl = "87600h"
+					}
+				}
+			`},
+		expected: func(rt *RuntimeConfig) {
+			rt.DataDir = dataDir
+			rt.ConnectEnabled = true
+			rt.ConnectCAProvider = "vault"
+			rt.ConnectCAConfig = map[string]interface{}{
+				"CAFile":              "/capath/ca.pem",
+				"CAPath":              "/capath/",
+				"CertFile":            "/certpath/cert.pem",
+				"KeyFile":             "/certpath/key.pem",
+				"TLSServerName":       "server.name",
+				"TLSSkipVerify":       true,
+				"Token":               "abc",
+				"RootPKIPath":         "consul-vault",
+				"RootCertTTL":         "87600h",
+				"IntermediatePKIPath": "connect-intermediate",
+			}
+		},
+	})
+	run(t, testCase{
 		desc: "Connect AWS CA provider configuration",
 		args: []string{
 			`-data-dir=` + dataDir,
@@ -5433,6 +5492,7 @@ func TestLoad_FullConfig(t *testing.T) {
 		ConnectCAConfig: map[string]interface{}{
 			"IntermediateCertTTL": "8760h",
 			"LeafCertTTL":         "1h",
+			"RootCertTTL":         "87600h",
 			"CSRMaxPerSecond":     float64(100),
 			"CSRMaxConcurrent":    float64(2),
 		},
@@ -6607,7 +6667,8 @@ func TestConnectCAConfiguration(t *testing.T) {
 				Provider: "consul",
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
-					"IntermediateCertTTL": "8760h", // 365 * 24h
+					"IntermediateCertTTL": "8760h",  // 365 * 24h
+					"RootCertTTL":         "87600h", // 365 * 10 * 24h
 				},
 			},
 		},
@@ -6623,7 +6684,8 @@ func TestConnectCAConfiguration(t *testing.T) {
 				ClusterID: "adfe7697-09b4-413a-ac0a-fa81ed3a3001",
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
-					"IntermediateCertTTL": "8760h", // 365 * 24h
+					"IntermediateCertTTL": "8760h",  // 365 * 24h
+					"RootCertTTL":         "87600h", // 365 * 10 * 24h
 					"cluster_id":          "adfe7697-09b4-413a-ac0a-fa81ed3a3001",
 				},
 			},
@@ -6646,7 +6708,8 @@ func TestConnectCAConfiguration(t *testing.T) {
 				Provider: "vault",
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
-					"IntermediateCertTTL": "8760h", // 365 * 24h
+					"IntermediateCertTTL": "8760h",  // 365 * 24h
+					"RootCertTTL":         "87600h", // 365 * 10 * 24h
 				},
 			},
 		},
@@ -6654,7 +6717,8 @@ func TestConnectCAConfiguration(t *testing.T) {
 			config: RuntimeConfig{
 				ConnectEnabled: true,
 				ConnectCAConfig: map[string]interface{}{
-					"foo": "bar",
+					"foo":         "bar",
+					"RootCertTTL": "8761h", // 365 * 10 * 24h
 				},
 			},
 			expected: &structs.CAConfiguration{
@@ -6662,6 +6726,7 @@ func TestConnectCAConfiguration(t *testing.T) {
 				Config: map[string]interface{}{
 					"LeafCertTTL":         "72h",
 					"IntermediateCertTTL": "8760h", // 365 * 24h
+					"RootCertTTL":         "8761h", // 365 * 10 * 24h
 					"foo":                 "bar",
 				},
 			},

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -197,7 +197,7 @@ connect {
     ca_config {
         intermediate_cert_ttl = "8760h"
         leaf_cert_ttl = "1h"
-        root_cert_ttl = "87600h"
+        root_cert_ttl = "96360h"
         # hack float since json parses numbers as float and we have to
         # assert against the same thing
         csr_max_per_second = 100.0

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -197,6 +197,7 @@ connect {
     ca_config {
         intermediate_cert_ttl = "8760h"
         leaf_cert_ttl = "1h"
+        root_cert_ttl = "87600h"
         # hack float since json parses numbers as float and we have to
         # assert against the same thing
         csr_max_per_second = 100.0

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -199,6 +199,7 @@
     "ca_config": {
       "intermediate_cert_ttl": "8760h",
       "leaf_cert_ttl": "1h",
+      "root_cert_ttl": "87600h",
       "csr_max_per_second": 100,
       "csr_max_concurrent": 2
     },

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -197,7 +197,7 @@
   "connect": {
     "ca_provider": "consul",
     "ca_config": {
-      "root_cert_ttl": "87600h",
+      "root_cert_ttl": "96360h",
       "intermediate_cert_ttl": "8760h",
       "leaf_cert_ttl": "1h",
       "csr_max_per_second": 100,

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -197,9 +197,9 @@
   "connect": {
     "ca_provider": "consul",
     "ca_config": {
+      "root_cert_ttl": "87600h",
       "intermediate_cert_ttl": "8760h",
       "leaf_cert_ttl": "1h",
-      "root_cert_ttl": "87600h",
       "csr_max_per_second": 100,
       "csr_max_concurrent": 2
     },

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -96,7 +96,7 @@ func (c *ConsulProvider) Configure(cfg ProviderConfig) error {
 		fmt.Sprintf("%s,%s", config.PrivateKey, config.RootCert),
 	}
 
-	// Check if there any entries with old ID schemes.
+	// Check if there are any entries with old ID schemes.
 	for _, oldID := range oldIDs {
 		_, providerState, err = c.Delegate.State().CAProviderState(oldID)
 		if err != nil {
@@ -194,7 +194,7 @@ func (c *ConsulProvider) GenerateRoot() error {
 			return fmt.Errorf("error computing next serial number: %v", err)
 		}
 
-		ca, err := c.generateCA(newState.PrivateKey, nextSerial)
+		ca, err := c.generateCA(newState.PrivateKey, nextSerial, c.config.RootCertTTL)
 		if err != nil {
 			return fmt.Errorf("error generating CA: %v", err)
 		}
@@ -616,7 +616,7 @@ func (c *ConsulProvider) incrementAndGetNextSerialNumber() (uint64, error) {
 }
 
 // generateCA makes a new root CA using the current private key
-func (c *ConsulProvider) generateCA(privateKey string, sn uint64) (string, error) {
+func (c *ConsulProvider) generateCA(privateKey string, sn uint64, rootCertTTL time.Duration) (string, error) {
 	stateStore := c.Delegate.State()
 	_, config, err := stateStore.CAConfig(nil)
 	if err != nil {
@@ -652,7 +652,7 @@ func (c *ConsulProvider) generateCA(privateKey string, sn uint64) (string, error
 			x509.KeyUsageCRLSign |
 			x509.KeyUsageDigitalSignature,
 		IsCA:           true,
-		NotAfter:       time.Now().AddDate(10, 0, 0),
+		NotAfter:       time.Now().Add(rootCertTTL),
 		NotBefore:      time.Now(),
 		AuthorityKeyId: keyId,
 		SubjectKeyId:   keyId,

--- a/agent/connect/ca/provider_consul_config.go
+++ b/agent/connect/ca/provider_consul_config.go
@@ -52,5 +52,6 @@ func defaultCommonConfig() structs.CommonCAProviderConfig {
 		IntermediateCertTTL: 24 * 365 * time.Hour,
 		PrivateKeyType:      connect.DefaultPrivateKeyType,
 		PrivateKeyBits:      connect.DefaultPrivateKeyBits,
+		RootCertTTL:         10 * 24 * 365 * time.Hour,
 	}
 }

--- a/agent/connect/ca/provider_test.go
+++ b/agent/connect/ca/provider_test.go
@@ -34,6 +34,7 @@ func TestStructs_CAConfiguration_MsgpackEncodeDecode(t *testing.T) {
 		CSRMaxConcurrent:    55,
 		PrivateKeyType:      "rsa",
 		PrivateKeyBits:      4096,
+		RootCertTTL:         10 * 24 * 365 * time.Hour,
 	}
 
 	cases := map[string]testcase{

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -170,7 +170,11 @@ func (v *VaultProvider) GenerateRoot() error {
 			Type:        "pki",
 			Description: "root CA backend for Consul Connect",
 			Config: vaultapi.MountConfigInput{
-				MaxLeaseTTL: "8760h",
+				// the max lease ttl denotes the maximum ttl that secrets are created from the engine
+				// the default lease ttl is the kind of ttl that will *reliably* set the ttl to v.config.RootCertTTL
+				// https://www.vaultproject.io/docs/secrets/pki#configure-a-ca-certificate
+				MaxLeaseTTL:     v.config.RootCertTTL.String(),
+				DefaultLeaseTTL: v.config.RootCertTTL.String(),
 			},
 		})
 

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -89,28 +89,51 @@ func TestVaultCAProvider_Bootstrap(t *testing.T) {
 
 	SkipIfVaultNotPresent(t)
 
-	provider, testVault := testVaultProvider(t)
-	defer testVault.Stop()
-	client := testVault.client
+	providerWDefaultRootCertTtl, testvault1 := testVaultProviderWithConfig(t, true, map[string]interface{}{
+		"LeafCertTTL": "1h",
+	})
+	defer testvault1.Stop()
+	client1 := testvault1.client
+
+	providerCustomRootCertTtl, testvault2 := testVaultProviderWithConfig(t, true, map[string]interface{}{
+		"LeafCertTTL": "1h",
+		"RootCertTTL": "8761h",
+	})
+	defer testvault2.Stop()
+	client2 := testvault2.client
 
 	require := require.New(t)
 
 	cases := []struct {
-		certFunc    func() (string, error)
-		backendPath string
+		certFunc            func() (string, error)
+		backendPath         string
+		rootCaCreation      bool
+		provider            *VaultProvider
+		client              *vaultapi.Client
+		expectedRootCertTTL string
 	}{
 		{
-			certFunc:    provider.ActiveRoot,
-			backendPath: "pki-root/",
+			certFunc:            providerWDefaultRootCertTtl.ActiveRoot,
+			backendPath:         "pki-root/",
+			rootCaCreation:      true,
+			client:              client1,
+			provider:            providerWDefaultRootCertTtl,
+			expectedRootCertTTL: structs.DefaultRootCertTTL,
 		},
 		{
-			certFunc:    provider.ActiveIntermediate,
-			backendPath: "pki-intermediate/",
+			certFunc:            providerCustomRootCertTtl.ActiveIntermediate,
+			backendPath:         "pki-intermediate/",
+			rootCaCreation:      false,
+			provider:            providerCustomRootCertTtl,
+			client:              client2,
+			expectedRootCertTTL: "8761h",
 		},
 	}
 
 	// Verify the root and intermediate certs match the ones in the vault backends
 	for _, tc := range cases {
+		provider := tc.provider
+		client := tc.client
 		cert, err := tc.certFunc()
 		require.NoError(err)
 		req := client.NewRequest("GET", "/v1/"+tc.backendPath+"ca/pem")
@@ -126,6 +149,15 @@ func TestVaultCAProvider_Bootstrap(t *testing.T) {
 		require.True(parsed.IsCA)
 		require.Len(parsed.URIs, 1)
 		require.Equal(fmt.Sprintf("spiffe://%s.consul", provider.clusterID), parsed.URIs[0].String())
+
+		// test that the root cert ttl as applied
+		if tc.rootCaCreation {
+			rootCertTTL, err := time.ParseDuration(tc.expectedRootCertTTL)
+			require.NoError(err)
+			expectedNotAfter := time.Now().Add(rootCertTTL).UTC()
+
+			require.True(expectedNotAfter.Sub(parsed.NotAfter) < 10*time.Minute, "expected parsed cert ttl to be the same as the value configured")
+		}
 	}
 }
 

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -156,7 +156,7 @@ func TestVaultCAProvider_Bootstrap(t *testing.T) {
 			require.NoError(err)
 			expectedNotAfter := time.Now().Add(rootCertTTL).UTC()
 
-			require.True(expectedNotAfter.Sub(parsed.NotAfter) < 10*time.Minute, "expected parsed cert ttl to be the same as the value configured")
+			require.WithinDuration(expectedNotAfter, parsed.NotAfter, 10*time.Minute, "expected parsed cert ttl to be the same as the value configured")
 		}
 	}
 }

--- a/agent/connect/generate_test.go
+++ b/agent/connect/generate_test.go
@@ -40,6 +40,7 @@ func makeConfig(kc KeyConfig) structs.CommonCAProviderConfig {
 	return structs.CommonCAProviderConfig{
 		LeafCertTTL:         3 * 24 * time.Hour,
 		IntermediateCertTTL: 365 * 24 * time.Hour,
+		RootCertTTL:         10 * 365 * 24 * time.Hour,
 		PrivateKeyType:      kc.keyType,
 		PrivateKeyBits:      kc.keyBits,
 	}

--- a/agent/connect_ca_endpoint.go
+++ b/agent/connect_ca_endpoint.go
@@ -65,7 +65,7 @@ func (s *HTTPHandlers) ConnectCAConfiguration(resp http.ResponseWriter, req *htt
 	}
 }
 
-// GEt /v1/connect/ca/configuration
+// GET /v1/connect/ca/configuration
 func (s *HTTPHandlers) ConnectCAConfigurationGet(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Method is tested in ConnectCAConfiguration
 	var args structs.DCSpecificRequest

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -494,6 +494,7 @@ func DefaultConfig() *Config {
 			Config: map[string]interface{}{
 				"LeafCertTTL":         structs.DefaultLeafCertTTL,
 				"IntermediateCertTTL": structs.DefaultIntermediateCertTTL,
+				"RootCertTTL":         structs.DefaultRootCertTTL,
 			},
 		},
 

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -382,11 +382,6 @@ func (c CommonCAProviderConfig) Validate() error {
 		return nil
 	}
 
-	// if the root cert ttl is not set, set it to the default
-	if c.RootCertTTL == 0 {
-		c.RootCertTTL = 10 * 365 * 24 * time.Hour
-	}
-
 	// it's sufficient to check that the root cert ttl >= intermediate cert ttl
 	// since intermediate cert ttl >= 3* leaf cert ttl; so root cert ttl >= 3 * leaf cert ttl > leaf cert ttl
 	if c.RootCertTTL < c.IntermediateCertTTL {

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -12,7 +12,8 @@ import (
 
 const (
 	DefaultLeafCertTTL         = "72h"
-	DefaultIntermediateCertTTL = "8760h" // 365 * 24h
+	DefaultIntermediateCertTTL = "8760h"  // ~ 1 year = 365 * 24h
+	DefaultRootCertTTL         = "87600h" // ~ 10 years = 365 * 24h * 10
 )
 
 // IndexedCARoots is the list of currently trusted CA Roots.
@@ -326,6 +327,7 @@ func (c *CAConfiguration) GetCommonConfig() (*CommonCAProviderConfig, error) {
 type CommonCAProviderConfig struct {
 	LeafCertTTL         time.Duration
 	IntermediateCertTTL time.Duration
+	RootCertTTL         time.Duration
 
 	SkipValidate bool
 
@@ -378,6 +380,18 @@ var IntermediateCertRenewInterval = time.Hour
 func (c CommonCAProviderConfig) Validate() error {
 	if c.SkipValidate {
 		return nil
+	}
+
+	// if the root cert ttl is not set, set it to the default
+	if c.RootCertTTL.Nanoseconds() == 0 {
+		c.RootCertTTL = 10 * 365 * 24 * time.Hour
+	}
+
+	fmt.Println("in here with ", c.RootCertTTL)
+	// it's sufficient to check that the root cert ttl >= intermediate cert ttl
+	// since intermediate cert ttl >= 3* leaf cert ttl; so root cert ttl >= 3 * leaf cert ttl > leaf cert ttl
+	if c.RootCertTTL < c.IntermediateCertTTL {
+		return fmt.Errorf("root Cert TTL is set and is not greater than intermediate cert ttl. root cert ttl: %s, intermediate cert ttl %s", c.RootCertTTL.String(), c.IntermediateCertTTL.String())
 	}
 
 	if c.LeafCertTTL < MinLeafCertTTL {

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -383,15 +383,14 @@ func (c CommonCAProviderConfig) Validate() error {
 	}
 
 	// if the root cert ttl is not set, set it to the default
-	if c.RootCertTTL.Nanoseconds() == 0 {
+	if c.RootCertTTL == 0 {
 		c.RootCertTTL = 10 * 365 * 24 * time.Hour
 	}
 
-	fmt.Println("in here with ", c.RootCertTTL)
 	// it's sufficient to check that the root cert ttl >= intermediate cert ttl
 	// since intermediate cert ttl >= 3* leaf cert ttl; so root cert ttl >= 3 * leaf cert ttl > leaf cert ttl
 	if c.RootCertTTL < c.IntermediateCertTTL {
-		return fmt.Errorf("root Cert TTL is set and is not greater than intermediate cert ttl. root cert ttl: %s, intermediate cert ttl %s", c.RootCertTTL.String(), c.IntermediateCertTTL.String())
+		return fmt.Errorf("root cert TTL is set and is not greater than intermediate cert ttl. root cert ttl: %s, intermediate cert ttl: %s", c.RootCertTTL, c.IntermediateCertTTL)
 	}
 
 	if c.LeafCertTTL < MinLeafCertTTL {

--- a/agent/structs/connect_ca_test.go
+++ b/agent/structs/connect_ca_test.go
@@ -144,7 +144,7 @@ func TestCAProviderConfig_Validate(t *testing.T) {
 				PrivateKeyBits:      256,
 			},
 			wantErr: true,
-			wantMsg: "root Cert TTL is set and is not greater than intermediate cert ttl. root cert ttl: 3h0m0s, intermediate cert ttl 4h0m0s",
+			wantMsg: "root cert TTL is set and is not greater than intermediate cert ttl. root cert ttl: 3h0m0s, intermediate cert ttl: 4h0m0s",
 		},
 	}
 	for _, tt := range tests {

--- a/agent/structs/connect_ca_test.go
+++ b/agent/structs/connect_ca_test.go
@@ -122,6 +122,30 @@ func TestCAProviderConfig_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "good root cert/ intermediate TTLs",
+			cfg: &CommonCAProviderConfig{
+				LeafCertTTL:         1 * time.Hour,
+				IntermediateCertTTL: 4 * time.Hour,
+				RootCertTTL:         5 * time.Hour,
+				PrivateKeyType:      "ec",
+				PrivateKeyBits:      256,
+			},
+			wantErr: false,
+			wantMsg: "",
+		},
+		{
+			name: "bad root cert/ intermediate TTLs",
+			cfg: &CommonCAProviderConfig{
+				LeafCertTTL:         1 * time.Hour,
+				IntermediateCertTTL: 4 * time.Hour,
+				RootCertTTL:         3 * time.Hour,
+				PrivateKeyType:      "ec",
+				PrivateKeyBits:      256,
+			},
+			wantErr: true,
+			wantMsg: "root Cert TTL is set and is not greater than intermediate cert ttl. root cert ttl: 3h0m0s, intermediate cert ttl 4h0m0s",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/agent/structs/connect_ca_test.go
+++ b/agent/structs/connect_ca_test.go
@@ -80,6 +80,7 @@ func TestCAProviderConfig_Validate(t *testing.T) {
 			cfg: &CommonCAProviderConfig{
 				LeafCertTTL:         2 * time.Hour,
 				IntermediateCertTTL: 4 * time.Hour,
+				RootCertTTL:         5 * time.Hour,
 			},
 			wantErr: true,
 			wantMsg: "Intermediate Cert TTL must be greater or equal than 3 * LeafCertTTL (>=6h0m0s).",
@@ -89,6 +90,7 @@ func TestCAProviderConfig_Validate(t *testing.T) {
 			cfg: &CommonCAProviderConfig{
 				LeafCertTTL:         5 * time.Hour,
 				IntermediateCertTTL: 15*time.Hour - 1,
+				RootCertTTL:         15 * time.Hour,
 			},
 			wantErr: true,
 			wantMsg: "Intermediate Cert TTL must be greater or equal than 3 * LeafCertTTL (>=15h0m0s).",
@@ -98,6 +100,7 @@ func TestCAProviderConfig_Validate(t *testing.T) {
 			cfg: &CommonCAProviderConfig{
 				LeafCertTTL:         1 * time.Hour,
 				IntermediateCertTTL: 4 * time.Hour,
+				RootCertTTL:         5 * time.Hour,
 			},
 			wantErr: true,
 			wantMsg: "private key type must be either 'ec' or 'rsa'",
@@ -107,6 +110,7 @@ func TestCAProviderConfig_Validate(t *testing.T) {
 			cfg: &CommonCAProviderConfig{
 				LeafCertTTL:         1 * time.Hour,
 				IntermediateCertTTL: 4 * time.Hour,
+				RootCertTTL:         5 * time.Hour,
 				PrivateKeyType:      "ec",
 			},
 			wantErr: true,
@@ -117,6 +121,7 @@ func TestCAProviderConfig_Validate(t *testing.T) {
 			cfg: &CommonCAProviderConfig{
 				LeafCertTTL:         1 * time.Hour,
 				IntermediateCertTTL: 4 * time.Hour,
+				RootCertTTL:         5 * time.Hour,
 				PrivateKeyType:      "ec",
 				PrivateKeyBits:      256,
 			},

--- a/api/connect_ca.go
+++ b/api/connect_ca.go
@@ -38,6 +38,7 @@ type CAConfig struct {
 // CommonCAProviderConfig is the common options available to all CA providers.
 type CommonCAProviderConfig struct {
 	LeafCertTTL      time.Duration
+	RootCertTTL      time.Duration
 	SkipValidate     bool
 	CSRMaxPerSecond  float32
 	CSRMaxConcurrent int

--- a/api/connect_ca_test.go
+++ b/api/connect_ca_test.go
@@ -66,6 +66,7 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 		IntermediateCertTTL: 365 * 24 * time.Hour,
 	}
 	expected.LeafCertTTL = 72 * time.Hour
+	expected.RootCertTTL = 10 * 365 * 24 * time.Hour
 
 	// This fails occasionally if server doesn't have time to bootstrap CA so
 	// retry
@@ -84,6 +85,7 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 		// Change a config value and update
 		conf.Config["PrivateKey"] = ""
 		conf.Config["IntermediateCertTTL"] = 300 * 24 * time.Hour
+		conf.Config["RootCertTTL"] = 11 * 365 * 24 * time.Hour
 
 		// Pass through some state as if the provider stored it so we can make sure
 		// we can read it again.
@@ -95,6 +97,7 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 		updated, _, err := connect.CAGetConfig(nil)
 		r.Check(err)
 		expected.IntermediateCertTTL = 300 * 24 * time.Hour
+		expected.RootCertTTL = 11 * 365 * 24 * time.Hour
 		parsed, err = ParseConsulCAConfig(updated.Config)
 		r.Check(err)
 		require.Equal(r, expected, parsed)

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -224,6 +224,7 @@ type TestServer struct {
 // callback function to modify the configuration. If there is an error
 // configuring or starting the server, the server will NOT be running when the
 // function returns (thus you do not need to stop it).
+// A TestServer does not run in the same process as, say, a debugger.
 func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, error) {
 	path, err := exec.LookPath("consul")
 	if err != nil || path == "" {

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -224,7 +224,7 @@ type TestServer struct {
 // callback function to modify the configuration. If there is an error
 // configuring or starting the server, the server will NOT be running when the
 // function returns (thus you do not need to stop it).
-// A TestServer does not run in the same process as, say, a debugger.
+// This function will call the `consul` binary in GOPATH.
 func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, error) {
 	path, err := exec.LookPath("consul")
 	if err != nil || path == "" {

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1277,7 +1277,7 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
 
       For the Vault provider, this value is only used if the backend is not initialized at first.
 
-      This value is also applied on ca set-config command.
+      This value is also applied on the `ca set-config` command.
 
     - `private_key_type` ((#ca_private_key_type)) The type of key to generate
       for this CA. This is only used when the provider is generating a new key. If

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1267,10 +1267,17 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
       for more than twice the _current_ `leaf_cert_ttl`, it will be removed
       from the trusted list.
 
-    - `root_cert_ttl` ((#todo)) todo. Defaults to 10 years as `87600h`.
-      todo restrictions.
+    - `root_cert_ttl` ((#ca_root_cert_ttl)) The time to live (TTL) for a root certificate.
+      Defaults to 10 years as `87600h`. This value, if provided, needs to be higher than the
+      intermediate certificate TTL.
 
-      todo
+      This setting currently applies only to the consul connect and Vault CA providers. It is
+      ignored for the AWS acm pca provider. The value for root certificates issued by the AWS
+      CA provider is 5 years and not configurable at this time.
+
+      For the Vault provider, this value is only used if the backend is not initialized at first.
+
+      This value is also applied on ca set-config command.
 
     - `private_key_type` ((#ca_private_key_type)) The type of key to generate
       for this CA. This is only used when the provider is generating a new key. If

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1267,6 +1267,11 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
       for more than twice the _current_ `leaf_cert_ttl`, it will be removed
       from the trusted list.
 
+    - `root_cert_ttl` ((#todo)) todo. Defaults to 10 years as `87600h`.
+      todo restrictions.
+
+      todo
+
     - `private_key_type` ((#ca_private_key_type)) The type of key to generate
       for this CA. This is only used when the provider is generating a new key. If
       `private_key` is set for the Consul provider, or existing root or intermediate

--- a/website/content/partials/http_api_connect_ca_common_options.mdx
+++ b/website/content/partials/http_api_connect_ca_common_options.mdx
@@ -35,6 +35,16 @@ The following configuration options are supported by all CA providers:
   for more than twice the _current_ `leaf_cert_ttl`, it will be removed
   from the trusted list.
 
+- `RootCertTTL` / `root_cert_ttl` (`duration: "87600h"`) The time to live (TTL) for a root certificate.
+  Defaults to 10 years as `87600h`. This value, if provided, needs to be higher than the
+  intermediate certificate TTL.
+
+  This setting currently applies only to the consul connect and Vault CA providers. It is
+  ignored for the AWS acm pca provider. The value for root certificates issued by the AWS
+  CA provider is 5 years and not configurable at this time.
+
+  For the Vault provider, this value is only used if the backend is not initialized at first.
+
 - `PrivateKeyType` / `private_key_type` (`string: "ec"`) - The type of key to generate
   for this CA. This is only used when the provider is generating a new key. If
   `private_key` is set for the Consul provider, or existing root or intermediate


### PR DESCRIPTION
#### Overview

This change adds an option to the `CommonCA` config to allow a `root_cert_ttl` value which will control the TTL (time to live) for root certs issued by supported CA providers. It's mostly plumbing.

#### PR Notes/ Callouts
* At present the only providers supported are `consul connect `and `vault`. 
* Let's focus on the functionality (going QSF -- quality, security, feature), before delving into all the refactoring opportunities
* No corresponding "cli flag" option added as it's not a pattern for our current ca config

#### Config checklist
I used the config file checklist [here](https://github.com/hashicorp/consul/blob/main/docs/config/checklist-adding-config-fields.md). Click below to expand on a "filled in" version of it.

<details>
  <summary>Click to expand!</summary>
  
  #### Legend
  * `n/a` -- not applicable
  * `?` -- I believe I may have fully completed it
  
  #### Adding a Simple Config Field for Client Agents

- [x] Add the field to the Config struct (or an appropriate sub-struct) in
  `agent/config/config.go`.
- [x] Add the field to the actual RuntimeConfig struct in
  `agent/config/runtime.go`.
- [x] Add an appropriate parser/setter in `agent/config/builder.go` to
  translate.
- [x] Add the new field with a random value to both the JSON and HCL files in
  `agent/config/testdata/full-config.*`, which should cause the test to fail.
  Then update the expected value in `TestLoad_FullConfig` in
  `agent/config/runtime_test.go` to make the test pass again.
- [x] Run `go test -run TestRuntimeConfig_Sanitize ./agent/config -update` to update
  the expected value for `TestRuntimeConfig_Sanitize`. Look at `git diff` to
  make sure the value changed as you expect.
- [?] **If** your new config field needed some validation as it's only valid in
  some cases or with some values (often true).
    - [?] Add validation to Validate in `agent/config/builder.go`.
    - [?] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
      `agent/config/runtime_test.go`.
- [x] **If** your new config field needs a non-zero-value default.
    - [x] Add that to `DefaultSource` in `agent/config/defaults.go`.
    - [x] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
      `agent/config/runtime_test.go`.
- [?] **If** your config should take effect on a reload/HUP.
    - [x] Add necessary code to trigger a safe (locked or atomic) update to
      any state the feature needs changing. This needs to be added to one or
      more of the following places:
        - `ReloadConfig` in `agent/agent.go` if it needs to affect the local
          client state or another client agent component.
        - `ReloadConfig` in `agent/consul/client.go` if it needs to affect
          state for client agent's RPC client.
    - [x] Add a test to `agent/agent_test.go` similar to others with prefix
      `TestAgent_reloadConfig*`.
- [?] Add documentation to `website/content/docs/agent/options.mdx`.

#### Adding a Simple Config Field for Servers

- [?] Do all of the steps in [Adding a Simple Config
  Field For Client Agents](#adding-a-simple-config-field-for-client-agents).
- [x] Add the new field to Config struct in `agent/consul/config.go`
- [?] Add code to set the values from the `RuntimeConfig` in the confusingly
  named `consulConfig` method in `agent/agent.go`
- [n/a] **If needed**, add a test to `agent_test.go` if there is some non-trivial
  behavior in the code you added in the previous step. We tend not to test
  simple assignments from one to the other since these are typically caught by
  higher-level tests of the actual functionality that matters but some examples
  can be found prefixed with `TestAgent_consulConfig*`
- [n/a] **If** your config should take effect on a reload/HUP
    - [n/a] Add necessary code to `ReloadConfig` in `agent/consul/server.go` this
      needs to be adequately synchronized with any readers of the state being
      updated.
      - [n/a] Add a new test or a new assertion to `TestServer_ReloadConfig`

</details>

#### Issues related
* https://github.com/hashicorp/consul/issues/10762

#### TODO:
* [x] one off testing with https://github.com/dhiaayachi/consul-local-cluster

<details>
  <summary>Steps to expand!</summary>
  
  1. `make linux`
  2.  Use the binary with https://github.com/dhiaayachi/consul-local-cluster 
  3.  Add a `RootCertTTL` value to  the `vault-provider.json.template` file locally to something like:
  ```
  {
    "Provider": "vault",
    "Config": {
        "LeafCertTTL": "72h",
        "Address": "http://myvault:8200",
        "Token": {{VAULT_TOKEN}},
        "RootPKIPath": "connect-root",
        "IntermediatePKIPath": "connect-intermediate",
        "RootCertTTL": "8761h"
    },
    "ForceWithoutCrossSigning": false
}
  ```
  4. Assert root cert properties are as expected -- `consul connect ca get-config -token=<TOKEN>`
</details>

* [x] awspca --> https://github.com/hashicorp/consul/pull/11449
* [x] gofmt
* [x] go mod
* [x] docs
* [x] changelog
 

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>