### PR TITLE
docs: revised Helm install to create namespace and install on dedicated namespace 

### DIFF
--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -71,7 +71,7 @@ The Consul Helm only supports Helm 3.2+. Install the latest version of the Helm 
    ```shell-session
    $ helm search repo hashicorp/consul
    NAME            	CHART VERSION	APP VERSION	DESCRIPTION
-   hashicorp/consul	0.32.0       	1.10.0      Official HashiCorp Consul Chart
+   hashicorp/consul	0.35.0       	1.10.3      Official HashiCorp Consul Chart
    ```
 
 1. Prior to installing via Helm, ensure that the `consul` Kubernetes namespace does not exist, as installing on a dedicated namespace


### PR DESCRIPTION
Changing default CLI Docs flow to also recommend installing on a dedicated `consul` namespace. Tested workflow below. The new command creates a namespace if it does not exist

```
❯ helm install consul hashicorp/consul --set global.name=consul --create-namespace -n consul
NAME: consul
LAST DEPLOYED: Thu Oct 28 11:17:21 2021
NAMESPACE: consul
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Consul!

Now that you have deployed Consul, you should look over the docs on using
Consul with Kubernetes available here:

https://www.consul.io/docs/platform/k8s/index.html


Your release is named consul.

To learn more about the release, run:

  $ helm status consul
  $ helm get all consul
```