### PR TITLE
plumb thru root cert tll to the aws ca provider

### DIFF
--- a/.changelog/11449.txt
+++ b/.changelog/11449.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-ca: Add a configurable TTL the AWS ACM Private CA provider.
+ca: Add a configurable TTL to the AWS ACM Private CA provider root certificate.
 ```

--- a/.changelog/11449.txt
+++ b/.changelog/11449.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ca: Add a configurable TTL the AWS ACM Private CA provider.
+```

--- a/agent/connect/ca/provider_aws.go
+++ b/agent/connect/ca/provider_aws.go
@@ -33,9 +33,6 @@ const (
 	// leaf cert.
 	LeafTemplateARN = "arn:aws:acm-pca:::template/EndEntityCertificate/V1"
 
-	// RootTTL is the validity duration for root certs we create.
-	AWSRootTTL = 5 * 365 * 24 * time.Hour
-
 	// IntermediateTTL is the validity duration for the intermediate certs we
 	// create.
 	AWSIntermediateTTL = 1 * 365 * 24 * time.Hour
@@ -211,7 +208,7 @@ func (a *AWSProvider) ensureCA() error {
 	}
 
 	// Self-sign it as a root
-	certPEM, err := a.signCSR(csrPEM, RootTemplateARN, AWSRootTTL)
+	certPEM, err := a.signCSR(csrPEM, RootTemplateARN, a.config.RootCertTTL)
 	if err != nil {
 		return err
 	}

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1271,9 +1271,7 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
       Defaults to 10 years as `87600h`. This value, if provided, needs to be higher than the
       intermediate certificate TTL.
 
-      This setting currently applies only to the consul connect and Vault CA providers. It is
-      ignored for the AWS acm pca provider. The value for root certificates issued by the AWS
-      CA provider is 5 years and not configurable at this time.
+      This setting applies to all Consul CA providers.
 
       For the Vault provider, this value is only used if the backend is not initialized at first.
 

--- a/website/content/partials/http_api_connect_ca_common_options.mdx
+++ b/website/content/partials/http_api_connect_ca_common_options.mdx
@@ -39,9 +39,7 @@ The following configuration options are supported by all CA providers:
   Defaults to 10 years as `87600h`. This value, if provided, needs to be higher than the
   intermediate certificate TTL.
 
-  This setting currently applies only to the consul connect and Vault CA providers. It is
-  ignored for the AWS acm pca provider. The value for root certificates issued by the AWS
-  CA provider is 5 years and not configurable at this time.
+  This setting applies to all Consul CA providers.
 
   For the Vault provider, this value is only used if the backend is not initialized at first.
 


### PR DESCRIPTION
Branching off from https://github.com/hashicorp/consul/pull/11428

PR adds root cert ttl config to AWS CA provider.

#### Testing

* added new units around root cert ttl testing, also:

```
go test -run TestAWS ./agent/connect/ca
ok      github.com/hashicorp/consul/agent/connect/ca    53.035s
```

#### PR Checklist

* [x] gofmt
* [x] go mod -- n/a
* [x] docs
* [x] changelog

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>