### PR TITLE
Ensure calls to BestAddress consider partition

### DIFF
--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -239,6 +239,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 					IntentionsSet:          true,
 				},
 				Datacenter: "dc1",
+				Locality:   GatewayKey{Datacenter: "dc1", Partition: structs.PartitionOrDefault("")},
 			},
 		},
 		{
@@ -296,6 +297,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 					IntentionsSet:          true,
 				},
 				Datacenter: "dc1",
+				Locality:   GatewayKey{Datacenter: "dc1", Partition: structs.PartitionOrDefault("")},
 			},
 		},
 	}

--- a/agent/proxycfg/mesh_gateway.go
+++ b/agent/proxycfg/mesh_gateway.go
@@ -143,7 +143,10 @@ func (s *handlerMeshGateway) handleUpdate(ctx context.Context, u cache.UpdateEve
 
 		for dc, nodes := range dcIndexedNodes.DatacenterNodes {
 			snap.MeshGateway.HostnameDatacenters[dc] = hostnameEndpoints(
-				s.logger.Named(logging.MeshGateway), snap.Datacenter, nodes)
+				s.logger.Named(logging.MeshGateway),
+				GatewayKey{Partition: snap.ProxyID.PartitionOrDefault(), Datacenter: snap.Datacenter},
+				nodes,
+			)
 		}
 
 		for dc := range snap.MeshGateway.HostnameDatacenters {
@@ -323,7 +326,10 @@ func (s *handlerMeshGateway) handleUpdate(ctx context.Context, u cache.UpdateEve
 			if len(resp.Nodes) > 0 {
 				snap.MeshGateway.GatewayGroups[key] = resp.Nodes
 				snap.MeshGateway.HostnameDatacenters[key] = hostnameEndpoints(
-					s.logger.Named(logging.MeshGateway), snap.Datacenter, resp.Nodes)
+					s.logger.Named(logging.MeshGateway),
+					GatewayKey{Partition: snap.ProxyID.PartitionOrDefault(), Datacenter: snap.Datacenter},
+					resp.Nodes,
+				)
 			}
 
 		default:

--- a/agent/proxycfg/mesh_gateway.go
+++ b/agent/proxycfg/mesh_gateway.go
@@ -144,7 +144,7 @@ func (s *handlerMeshGateway) handleUpdate(ctx context.Context, u cache.UpdateEve
 		for dc, nodes := range dcIndexedNodes.DatacenterNodes {
 			snap.MeshGateway.HostnameDatacenters[dc] = hostnameEndpoints(
 				s.logger.Named(logging.MeshGateway),
-				GatewayKey{Partition: snap.ProxyID.PartitionOrDefault(), Datacenter: snap.Datacenter},
+				snap.Locality,
 				nodes,
 			)
 		}
@@ -327,7 +327,7 @@ func (s *handlerMeshGateway) handleUpdate(ctx context.Context, u cache.UpdateEve
 				snap.MeshGateway.GatewayGroups[key] = resp.Nodes
 				snap.MeshGateway.HostnameDatacenters[key] = hostnameEndpoints(
 					s.logger.Named(logging.MeshGateway),
-					GatewayKey{Partition: snap.ProxyID.PartitionOrDefault(), Datacenter: snap.Datacenter},
+					snap.Locality,
 					resp.Nodes,
 				)
 			}

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -408,6 +408,7 @@ type ConfigSnapshot struct {
 	Proxy                 structs.ConnectProxyConfig
 	Datacenter            string
 	IntentionDefaultAllow bool
+	Locality              GatewayKey
 
 	ServerSNIFn ServerSNIFunc
 	Roots       *structs.IndexedCARoots

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -303,12 +303,13 @@ func (c *configSnapshotMeshGateway) GatewayKeys() []GatewayKey {
 	}
 
 	keys := make([]GatewayKey, 0, sz)
-	for key := range c.GatewayGroups {
+	for key := range c.FedStateGateways {
 		keys = append(keys, gatewayKeyFromString(key))
 	}
-	for key := range c.FedStateGateways {
-		if _, ok := c.GatewayGroups[key]; !ok {
-			keys = append(keys, gatewayKeyFromString(key))
+	for key := range c.GatewayGroups {
+		gk := gatewayKeyFromString(key)
+		if _, ok := c.FedStateGateways[gk.Datacenter]; !ok {
+			keys = append(keys, gk)
 		}
 	}
 

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mitchellh/copystructure"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
 )
@@ -61,7 +62,7 @@ type GatewayKey struct {
 
 func (k GatewayKey) String() string {
 	resp := k.Datacenter
-	if k.Partition != "" {
+	if !structs.IsDefaultPartition(k.Partition) {
 		resp = k.Partition + "." + resp
 	}
 	return resp
@@ -79,7 +80,7 @@ func gatewayKeyFromString(s string) GatewayKey {
 	split := strings.SplitN(s, ".", 2)
 
 	if len(split) == 1 {
-		return GatewayKey{Datacenter: split[0]}
+		return GatewayKey{Datacenter: split[0], Partition: acl.DefaultPartitionName}
 	}
 	return GatewayKey{Partition: split[0], Datacenter: split[1]}
 }

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -401,7 +401,7 @@ func (s *state) Changed(ns *structs.NodeService, token string) bool {
 // Envoy cannot resolve hostnames provided through EDS, so we exclusively use CDS for these clusters.
 // If there is a mix of hostnames and addresses we exclusively use the hostnames, since clusters cannot discover
 // services with both EDS and DNS.
-func hostnameEndpoints(logger hclog.Logger, localDC string, nodes structs.CheckServiceNodes) structs.CheckServiceNodes {
+func hostnameEndpoints(logger hclog.Logger, localKey GatewayKey, nodes structs.CheckServiceNodes) structs.CheckServiceNodes {
 	var (
 		hasIP       bool
 		hasHostname bool
@@ -409,7 +409,7 @@ func hostnameEndpoints(logger hclog.Logger, localDC string, nodes structs.CheckS
 	)
 
 	for _, n := range nodes {
-		addr, _ := n.BestAddress(localDC != n.Node.Datacenter)
+		addr, _ := n.BestAddress(!localKey.Matches(n.Node.Datacenter, n.Node.PartitionOrDefault()))
 		if net.ParseIP(addr) != nil {
 			hasIP = true
 			continue

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -254,6 +254,7 @@ func newConfigSnapshotFromServiceInstance(s serviceInstance, config stateConfig)
 		TaggedAddresses:       s.taggedAddresses,
 		Proxy:                 s.proxyCfg,
 		Datacenter:            config.source.Datacenter,
+		Locality:              GatewayKey{Datacenter: config.source.Datacenter, Partition: s.proxyID.PartitionOrDefault()},
 		ServerSNIFn:           config.serverSNIFn,
 		IntentionDefaultAllow: config.intentionDefaultAllow,
 	}

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -649,8 +649,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				"upstream-target:api-failover-remote.default.default.dc2:api-failover-remote?dc=dc2": genVerifyServiceWatch("api-failover-remote", "", "dc2", true),
 				"upstream-target:api-failover-local.default.default.dc2:api-failover-local?dc=dc2":   genVerifyServiceWatch("api-failover-local", "", "dc2", true),
 				"upstream-target:api-failover-direct.default.default.dc2:api-failover-direct?dc=dc2": genVerifyServiceWatch("api-failover-direct", "", "dc2", true),
-				"mesh-gateway:default.dc2:api-failover-remote?dc=dc2":                                genVerifyGatewayWatch("dc2"),
-				"mesh-gateway:default.dc1:api-failover-local?dc=dc2":                                 genVerifyGatewayWatch("dc1"),
+				"mesh-gateway:dc2:api-failover-remote?dc=dc2":                                        genVerifyGatewayWatch("dc2"),
+				"mesh-gateway:dc1:api-failover-local?dc=dc2":                                         genVerifyGatewayWatch("dc1"),
 			},
 			verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 				require.True(t, snap.Valid())
@@ -673,7 +673,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 		}
 
 		if meshGatewayProxyConfigValue == structs.MeshGatewayModeLocal {
-			stage1.requiredWatches["mesh-gateway:default.dc1:api-dc2"] = genVerifyGatewayWatch("dc1")
+			stage1.requiredWatches["mesh-gateway:dc1:api-dc2"] = genVerifyGatewayWatch("dc1")
 		}
 
 		return testCase{

--- a/agent/proxycfg/terminating_gateway.go
+++ b/agent/proxycfg/terminating_gateway.go
@@ -286,7 +286,7 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u cache.Up
 			snap.TerminatingGateway.ServiceGroups[sn] = resp.Nodes
 			snap.TerminatingGateway.HostnameServices[sn] = hostnameEndpoints(
 				s.logger,
-				GatewayKey{Partition: snap.ProxyID.PartitionOrDefault(), Datacenter: snap.Datacenter},
+				snap.Locality,
 				resp.Nodes,
 			)
 		}

--- a/agent/proxycfg/terminating_gateway.go
+++ b/agent/proxycfg/terminating_gateway.go
@@ -285,7 +285,10 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u cache.Up
 		if len(resp.Nodes) > 0 {
 			snap.TerminatingGateway.ServiceGroups[sn] = resp.Nodes
 			snap.TerminatingGateway.HostnameServices[sn] = hostnameEndpoints(
-				s.logger, snap.Datacenter, resp.Nodes)
+				s.logger,
+				GatewayKey{Partition: snap.ProxyID.PartitionOrDefault(), Datacenter: snap.Datacenter},
+				resp.Nodes,
+			)
 		}
 
 	// Store leaf cert for watched service

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/connect"
@@ -674,11 +675,12 @@ func TestConfigSnapshot(t testing.T) *ConfigSnapshot {
 	upstreams := structs.TestUpstreams(t)
 
 	return &ConfigSnapshot{
-		Kind:    structs.ServiceKindConnectProxy,
-		Service: "web-sidecar-proxy",
-		ProxyID: structs.NewServiceID("web-sidecar-proxy", nil),
-		Address: "0.0.0.0",
-		Port:    9999,
+		Locality: GatewayKey{Datacenter: "dc1", Partition: acl.DefaultPartitionName},
+		Kind:     structs.ServiceKindConnectProxy,
+		Service:  "web-sidecar-proxy",
+		ProxyID:  structs.NewServiceID("web-sidecar-proxy", nil),
+		Address:  "0.0.0.0",
+		Port:     9999,
 		Proxy: structs.ConnectProxyConfig{
 			DestinationServiceID:   "web",
 			DestinationServiceName: "web",
@@ -798,11 +800,12 @@ func testConfigSnapshotDiscoveryChain(t testing.T, variation string, additionalE
 	roots, leaf := TestCerts(t)
 
 	snap := &ConfigSnapshot{
-		Kind:    structs.ServiceKindConnectProxy,
-		Service: "web-sidecar-proxy",
-		ProxyID: structs.NewServiceID("web-sidecar-proxy", nil),
-		Address: "0.0.0.0",
-		Port:    9999,
+		Locality: GatewayKey{Datacenter: "dc1", Partition: acl.DefaultPartitionName},
+		Kind:     structs.ServiceKindConnectProxy,
+		Service:  "web-sidecar-proxy",
+		ProxyID:  structs.NewServiceID("web-sidecar-proxy", nil),
+		Address:  "0.0.0.0",
+		Port:     9999,
 		Proxy: structs.ConnectProxyConfig{
 			DestinationServiceID:   "web",
 			DestinationServiceName: "web",
@@ -1510,11 +1513,12 @@ func TestConfigSnapshotMeshGatewayNoServices(t testing.T) *ConfigSnapshot {
 func testConfigSnapshotMeshGateway(t testing.T, populateServices bool, useFederationStates bool) *ConfigSnapshot {
 	roots, _ := TestCerts(t)
 	snap := &ConfigSnapshot{
-		Kind:    structs.ServiceKindMeshGateway,
-		Service: "mesh-gateway",
-		ProxyID: structs.NewServiceID("mesh-gateway", nil),
-		Address: "1.2.3.4",
-		Port:    8443,
+		Locality: GatewayKey{Datacenter: "dc1", Partition: acl.DefaultPartitionName},
+		Kind:     structs.ServiceKindMeshGateway,
+		Service:  "mesh-gateway",
+		ProxyID:  structs.NewServiceID("mesh-gateway", nil),
+		Address:  "1.2.3.4",
+		Port:     8443,
 		Proxy: structs.ConnectProxyConfig{
 			Config: map[string]interface{}{},
 		},
@@ -1721,6 +1725,7 @@ func testConfigSnapshotIngressGateway(
 	roots, leaf := TestCerts(t)
 
 	snap := &ConfigSnapshot{
+		Locality:   GatewayKey{Datacenter: "dc1", Partition: acl.DefaultPartitionName},
 		Kind:       structs.ServiceKindIngressGateway,
 		Service:    "ingress-gateway",
 		ProxyID:    structs.NewServiceID("ingress-gateway", nil),
@@ -1760,11 +1765,12 @@ func testConfigSnapshotIngressGateway(
 
 func TestConfigSnapshotExposeConfig(t testing.T) *ConfigSnapshot {
 	return &ConfigSnapshot{
-		Kind:    structs.ServiceKindConnectProxy,
-		Service: "web-proxy",
-		ProxyID: structs.NewServiceID("web-proxy", nil),
-		Address: "1.2.3.4",
-		Port:    8080,
+		Locality: GatewayKey{Datacenter: "dc1", Partition: acl.DefaultPartitionName},
+		Kind:     structs.ServiceKindConnectProxy,
+		Service:  "web-proxy",
+		ProxyID:  structs.NewServiceID("web-proxy", nil),
+		Address:  "1.2.3.4",
+		Port:     8080,
 		Proxy: structs.ConnectProxyConfig{
 			DestinationServiceName: "web",
 			DestinationServiceID:   "web",
@@ -1801,10 +1807,11 @@ func testConfigSnapshotTerminatingGateway(t testing.T, populateServices bool) *C
 	roots, _ := TestCerts(t)
 
 	snap := &ConfigSnapshot{
-		Kind:    structs.ServiceKindTerminatingGateway,
-		Service: "terminating-gateway",
-		ProxyID: structs.NewServiceID("terminating-gateway", nil),
-		Address: "1.2.3.4",
+		Locality: GatewayKey{Datacenter: "dc1", Partition: acl.DefaultPartitionName},
+		Kind:     structs.ServiceKindTerminatingGateway,
+		Service:  "terminating-gateway",
+		ProxyID:  structs.NewServiceID("terminating-gateway", nil),
+		Address:  "1.2.3.4",
 		TaggedAddresses: map[string]structs.ServiceAddress{
 			structs.TaggedAddressWAN: {
 				Address: "198.18.0.1",
@@ -2035,11 +2042,12 @@ func testConfigSnapshotTerminatingGateway(t testing.T, populateServices bool) *C
 
 func TestConfigSnapshotGRPCExposeHTTP1(t testing.T) *ConfigSnapshot {
 	return &ConfigSnapshot{
-		Kind:    structs.ServiceKindConnectProxy,
-		Service: "grpc-proxy",
-		ProxyID: structs.NewServiceID("grpc-proxy", nil),
-		Address: "1.2.3.4",
-		Port:    8080,
+		Locality: GatewayKey{Datacenter: "dc1", Partition: acl.DefaultPartitionName},
+		Kind:     structs.ServiceKindConnectProxy,
+		Service:  "grpc-proxy",
+		ProxyID:  structs.NewServiceID("grpc-proxy", nil),
+		Address:  "1.2.3.4",
+		Port:     8080,
 		Proxy: structs.ConnectProxyConfig{
 			DestinationServiceName: "grpc",
 			DestinationServiceID:   "grpc",

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -1432,7 +1432,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 			TestUpstreamNodesDC2(t)
 		snap.WatchedGatewayEndpoints = map[string]map[string]structs.CheckServiceNodes{
 			"db": {
-				"default.dc2": TestGatewayNodesDC2(t),
+				"dc2": TestGatewayNodesDC2(t),
 			},
 		}
 	case "failover-through-double-remote-gateway-triggered":
@@ -1445,8 +1445,8 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		snap.WatchedUpstreamEndpoints["db"]["db.default.default.dc3"] = TestUpstreamNodesDC2(t)
 		snap.WatchedGatewayEndpoints = map[string]map[string]structs.CheckServiceNodes{
 			"db": {
-				"default.dc2": TestGatewayNodesDC2(t),
-				"default.dc3": TestGatewayNodesDC3(t),
+				"dc2": TestGatewayNodesDC2(t),
+				"dc3": TestGatewayNodesDC3(t),
 			},
 		}
 	case "failover-through-local-gateway-triggered":
@@ -1458,7 +1458,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 			TestUpstreamNodesDC2(t)
 		snap.WatchedGatewayEndpoints = map[string]map[string]structs.CheckServiceNodes{
 			"db": {
-				"default.dc1": TestGatewayNodesDC1(t),
+				"dc1": TestGatewayNodesDC1(t),
 			},
 		}
 	case "failover-through-double-local-gateway-triggered":
@@ -1471,7 +1471,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		snap.WatchedUpstreamEndpoints["db"]["db.default.default.dc3"] = TestUpstreamNodesDC2(t)
 		snap.WatchedGatewayEndpoints = map[string]map[string]structs.CheckServiceNodes{
 			"db": {
-				"default.dc1": TestGatewayNodesDC1(t),
+				"dc1": TestGatewayNodesDC1(t),
 			},
 		}
 	case "splitter-with-resolver-redirect-multidc":
@@ -1547,7 +1547,7 @@ func testConfigSnapshotMeshGateway(t testing.T, populateServices bool, useFedera
 			},
 			WatchedServicesSet: true,
 			WatchedGateways: map[string]context.CancelFunc{
-				"default.dc2": nil,
+				"dc2": nil,
 			},
 			ServiceGroups: map[structs.ServiceName]structs.CheckServiceNodes{
 				structs.NewServiceName("foo", nil): TestGatewayServiceGroupFooDC1(t),

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -107,6 +107,8 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u cache.Up
 						Addrs: make(map[string]struct{}),
 					}
 				}
+
+				// TODO(partitions) Update to account for upstream in remote partition once tproxy supports it
 				addr, _ := node.BestAddress(false)
 				upstreamsSnapshot.PassthroughUpstreams[svc.String()].Addrs[addr] = struct{}{}
 			}

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -299,10 +299,9 @@ func (s *ResourceGenerator) makeGatewayServiceClusters(
 			hostnameEndpoints = cfgSnap.TerminatingGateway.HostnameServices[svc]
 		}
 
-		localKey := proxycfg.GatewayKey{Partition: cfgSnap.ProxyID.PartitionOrDefault(), Datacenter: cfgSnap.Datacenter}
 		var isRemote bool
 		if len(services[svc]) > 0 {
-			isRemote = !localKey.Matches(services[svc][0].Node.Datacenter, services[svc][0].Node.PartitionOrDefault())
+			isRemote = !cfgSnap.Locality.Matches(services[svc][0].Node.Datacenter, services[svc][0].Node.PartitionOrDefault())
 		}
 
 		opts := gatewayClusterOpts{

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -51,7 +51,7 @@ func (s *ResourceGenerator) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		es := s.endpointsFromDiscoveryChain(
 			id,
 			chain,
-			proxycfg.GatewayKey{Datacenter: cfgSnap.Datacenter, Partition: cfgSnap.ProxyID.PartitionOrDefault()},
+			cfgSnap.Locality,
 			cfgSnap.ConnectProxy.UpstreamConfig[id],
 			cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[id],
 			cfgSnap.ConnectProxy.WatchedGatewayEndpoints[id],
@@ -79,7 +79,7 @@ func (s *ResourceGenerator) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.
 				[]loadAssignmentEndpointGroup{
 					{Endpoints: endpoints},
 				},
-				proxycfg.GatewayKey{Datacenter: cfgSnap.Datacenter, Partition: cfgSnap.ProxyID.PartitionOrDefault()},
+				cfgSnap.Locality,
 			)
 			resources = append(resources, la)
 		}
@@ -140,7 +140,7 @@ func (s *ResourceGenerator) endpointsFromSnapshotMeshGateway(cfgSnap *proxycfg.C
 				[]loadAssignmentEndpointGroup{
 					{Endpoints: endpoints},
 				},
-				proxycfg.GatewayKey{Datacenter: cfgSnap.Datacenter, Partition: cfgSnap.ProxyID.PartitionOrDefault()},
+				cfgSnap.Locality,
 			)
 			resources = append(resources, la)
 		}
@@ -155,7 +155,7 @@ func (s *ResourceGenerator) endpointsFromSnapshotMeshGateway(cfgSnap *proxycfg.C
 				[]loadAssignmentEndpointGroup{
 					{Endpoints: endpoints},
 				},
-				proxycfg.GatewayKey{Datacenter: cfgSnap.Datacenter, Partition: cfgSnap.ProxyID.PartitionOrDefault()},
+				cfgSnap.Locality,
 			)
 			resources = append(resources, la)
 		}
@@ -256,7 +256,7 @@ func (s *ResourceGenerator) endpointsFromServicesAndResolvers(
 			la := makeLoadAssignment(
 				clusterName,
 				groups,
-				proxycfg.GatewayKey{Datacenter: cfgSnap.Datacenter, Partition: cfgSnap.ProxyID.PartitionOrDefault()},
+				cfgSnap.Locality,
 			)
 			resources = append(resources, la)
 		}

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -209,7 +209,7 @@ func Test_makeLoadAssignment(t *testing.T) {
 			got := makeLoadAssignment(
 				tt.clusterName,
 				tt.endpoints,
-				"dc1",
+				proxycfg.GatewayKey{Datacenter: "dc1"},
 			)
 			require.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
When checking which endpoint to use for an upstream we call BestAddress on the service instance. This function will optionally look for the tagged WAN address if it's a WAN request.

Originally we would only check whether the datacenters match, but now are also checking whether partitions match.

The last commit also fixes an issue with how the `GatewayKeys()` method wasn't deduplicating data.