### PR TITLE
Update node info sync comment

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1175,6 +1175,9 @@ func (l *State) SyncChanges() error {
 	defer l.Unlock()
 
 	// Sync the node level info if we need to.
+	// At the start to guarantee sync even if services or checks fail,
+	// which is more likely because there are more syncs happening for them.
+
 	if l.nodeInfoInSync {
 		l.logger.Debug("Node info in sync")
 	} else {
@@ -1182,10 +1185,6 @@ func (l *State) SyncChanges() error {
 			return err
 		}
 	}
-
-	// We will do node-level info syncing at the end, since it will get
-	// updated by a service or check sync anyway, given how the register
-	// API works.
 
 	// Sync the services
 	// (logging happens in the helper methods)


### PR DESCRIPTION
Followup to #7189, rewrite outdated comment to reflect current logic in `State.SyncChanges()`.