### PR TITLE
docs: update docs about namespace default policy/role

### DIFF
--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -50,13 +50,17 @@ The table below shows this endpoint's support for
     that should be applied to all tokens created in this namespace. The ACLLink
     struct is an object with an "ID" and/or "Name" field to identify a policy.
     When a name is used instead of an ID, Consul will resolve the name to an ID
-    and store that internally.
+    and store that internally. The ACL token used in the API request
+    must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules)
+    to the linked policy.
 
   - `RoleDefaults` `(array<ACLLink>)` - This is the list of default roles
     that should be applied to all tokens created in this namespace. The ACLLink
     struct is an object with an "ID" and/or "Name" field to identify a policy.
     When a name is used instead of an ID, Consul will resolve the name to an ID
-    and store that internally.
+    and store that internally. The ACL token used in the API request
+    must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules)
+    access to the linked role.
 
 - `Meta` `(map<string|string>: <optional>)` - Specifies arbitrary KV metadata
   to associate with the namespace.
@@ -245,13 +249,17 @@ The table below shows this endpoint's support for
     that should be applied to all tokens created in this namespace. The ACLLink
     struct is an object with an "ID" and/or "Name" field to identify a policy.
     When a name is used instead of an ID, Consul will resolve the name to an ID
-    and store that internally.
+    and store that internally. The ACL token used in the API request
+    must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules)
+    to the linked policy.
 
   - `RoleDefaults` `(array<ACLLink>)` - This is the list of default roles
     that should be applied to all tokens created in this namespace. The ACLLink
     struct is an object with an "ID" and/or "Name" field to identify a policy.
     When a name is used instead of an ID, Consul will resolve the name to an ID
-    and store that internally.
+    and store that internally. The ACL token used in the API request
+    must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules)
+    to the linked role.
 
 - `Meta` `(map<string|string>: <optional>)` - Specifies arbitrary KV metadata
   to associate with the namespace.

--- a/website/content/commands/namespace/create.mdx
+++ b/website/content/commands/namespace/create.mdx
@@ -31,10 +31,12 @@ from the CLI arguments.
   in this namespace. May be specified multiple times.
 
 - `-default-policy-name=<value>` - Name of a policy from the default namespace to inject for all
-  tokens in this namespace. May be specified multiple times.
+  tokens in this namespace. May be specified multiple times. The ACL token used with
+  this command must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules) to the linked policy.
 
 - `-default-role-id=<value>` - ID of a role from the default namespace to inject for all tokens in
-  this namespace. May be specified multiple times.
+  this namespace. May be specified multiple times. The ACL token used with
+  this command must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules) to the linked role.
 
 - `-default-role-name=<value>` - Name of a role from the default namespace to inject for all tokens
   in this namespace. May be specified multiple times.

--- a/website/content/commands/namespace/update.mdx
+++ b/website/content/commands/namespace/update.mdx
@@ -29,16 +29,20 @@ with the existing namespace definition.
 #### Command Options
 
 - `-default-policy-id=<value>` - ID of a policy from the default namespace to inject for all tokens
-  in this namespace. May be specified multiple times.
+  in this namespace. May be specified multiple times. The ACL token used with
+  this command must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules) to the linked policy.
 
 - `-default-policy-name=<value>` - Name of a policy from the default namespace to inject for all
-  tokens in this namespace. May be specified multiple times.
+  tokens in this namespace. May be specified multiple times. The ACL token used with
+  this command must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules) to the linked policy.
 
 - `-default-role-id=<value>` - ID of a role from the default namespace to inject for all tokens in
-  this namespace. May be specified multiple times.
+  this namespace. May be specified multiple times. The ACL token used with
+  this command must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules) to the linked role.
 
 - `-default-role-name=<value>` - Name of a role from the default namespace to inject for all tokens
-  in this namespace. May be specified multiple times.
+  in this namespace. May be specified multiple times. The ACL token used with
+  this command must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules) to the linked role.
 
 - `-description=<string>` - A description of the namespace.
 

--- a/website/content/docs/enterprise/namespaces.mdx
+++ b/website/content/docs/enterprise/namespaces.mdx
@@ -101,13 +101,15 @@ Meta {
     created in this namespace. The ACLLink object can contain an `ID` and/or `Name` field. When the
     policies ID is omitted Consul will resolve the name to an ID before writing the namespace
     definition internally. Note that all policies linked in a namespace definition must be defined
-    within the `default namespace.
+    within the `default` namespace, and the ACL token used to create or edit the
+    namespace must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules) to the linked policy.
 
   - `RoleDefaults` `(array<ACLLink>)` - A list of default roles to be applied to all tokens
     created in this namespace. The ACLLink object can contain an `ID` and/or `Name` field. When the
     roles' ID is omitted Consul will resolve the name to an ID before writing the namespace
     definition internally. Note that all roles linked in a namespace definition must be defined
-    within the `default namespace.
+    within the `default` namespace, and the ACL token used to create or edit the
+    namespace must have [`acl:write` access](/docs/security/acl/acl-rules#acl-resource-rules) to the linked role.
 
 - `Meta` `(map<string|string>: <optional>)` - Specifies arbitrary KV metadata to associate with
   this namespace.


### PR DESCRIPTION
I updated all the (many) places I found that mention these fields to include details about the permissions the ACL token must have to perform the request.

I think probably having these fields on `website/content/docs/enterprise/namespaces.mdx` is a bit redundant, since we document it well in both the API and CLI reference. We should probably link to those instead of duplicating the docs, but I left that clean up for some other time.

Preview the docs here: https://consul-bpyodmi9x-hashicorp.vercel.app/api-docs/namespaces