### PR TITLE
Prevent running build workflows on all PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: build
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches:
-      # Provide the release branch
+    branches: [ crt-release-migration-1.11.x ]
 
 env:
   PKG_NAME: consul


### PR DESCRIPTION
At the moment release builds are created for every PR. This change temporarily sets the target branch to an arbitrary name. 

It will be updated later to release branches. Currently there is no long-lived release branch for 1.11. 