### PR TITLE
fix aws pca certs

### DIFF
--- a/agent/connect/ca/provider_aws.go
+++ b/agent/connect/ca/provider_aws.go
@@ -359,15 +359,15 @@ func (a *AWSProvider) loadCACerts() error {
 
 	if a.isPrimary {
 		// Just use the cert as a root
-		a.rootPEM = *output.Certificate
+		a.rootPEM = EnsureTrailingNewline(*output.Certificate)
 	} else {
-		a.intermediatePEM = *output.Certificate
+		a.intermediatePEM = EnsureTrailingNewline(*output.Certificate)
 		// TODO(banks) support user-supplied CA being a Subordinate even in the
 		// primary DC. For now this assumes there is only one cert in the chain
 		if output.CertificateChain == nil {
 			return fmt.Errorf("Subordinate CA %s returned no chain", a.arn)
 		}
-		a.rootPEM = *output.CertificateChain
+		a.rootPEM = EnsureTrailingNewline(*output.CertificateChain)
 	}
 	return nil
 }
@@ -485,7 +485,7 @@ func (a *AWSProvider) signCSR(csrPEM string, templateARN string, ttl time.Durati
 			}
 
 			if certOutput.Certificate != nil {
-				return true, *certOutput.Certificate, nil
+				return true, EnsureTrailingNewline(*certOutput.Certificate), nil
 			}
 
 			return false, "", nil
@@ -540,9 +540,9 @@ func (a *AWSProvider) SetIntermediate(intermediatePEM string, rootPEM string) er
 		return err
 	}
 
-	// We succsefully initialized, keep track of the root and intermediate certs.
-	a.rootPEM = rootPEM
-	a.intermediatePEM = intermediatePEM
+	// We successfully initialized, keep track of the root and intermediate certs.
+	a.rootPEM = EnsureTrailingNewline(rootPEM)
+	a.intermediatePEM = EnsureTrailingNewline(intermediatePEM)
 
 	return nil
 }


### PR DESCRIPTION
#### Overview

These changes just build on https://github.com/hashicorp/consul/commit/9b45107c1e907a8209ad4d38af230f2fa863fd22. ( https://github.com/hashicorp/consul/pull/10411 )

#### Notes:
* testing is done thru existing units; this PR essentially "fixes" the tests too.
* this PR is blocking https://github.com/hashicorp/consul/pull/11449

```shell
$ export ENABLE_AWS_PCA_TESTS=true
$ go test -run TestAWS ./agent/connect/ca -v
...
ok      github.com/hashicorp/consul/agent/connect/ca    35.387s
```

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>