### PR TITLE
ui: Filter global intentions list by selected partition

### DIFF
--- a/.changelog/11475.txt
+++ b/.changelog/11475.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Filter the global intentions list by the currently selected parition rather
+than a wildcard
+```

--- a/ui/packages/consul-ui/app/adapters/intention.js
+++ b/ui/packages/consul-ui/app/adapters/intention.js
@@ -6,6 +6,9 @@ import { get } from '@ember/object';
 // Listing of intentions still requires the `ns` query string parameter which
 // will give us all the intentions that have the `ns` as either the SourceNS or
 // the DestinationNS.
+
+// TODO: Investigate the above to see if we should only list intentions with
+// Source/Destination in the currently selected nspace or leave as is.
 export default class IntentionAdapter extends Adapter {
   requestForQuery(request, { dc, ns, partition, filter, index, uri }) {
     return request`
@@ -19,7 +22,7 @@ export default class IntentionAdapter extends Adapter {
 
       ${{
         partition,
-        ns,
+        ns: '*',
         index,
         filter,
       }}

--- a/ui/packages/consul-ui/app/adapters/intention.js
+++ b/ui/packages/consul-ui/app/adapters/intention.js
@@ -6,9 +6,6 @@ import { get } from '@ember/object';
 // Listing of intentions still requires the `ns` query string parameter which
 // will give us all the intentions that have the `ns` as either the SourceNS or
 // the DestinationNS.
-// We currently list intentions by the * wildcard namespace for back compat reasons
-// TODO: Change the above so that we only list intentions with
-// Source/Destination in the currently selected nspace
 export default class IntentionAdapter extends Adapter {
   requestForQuery(request, { dc, ns, partition, filter, index, uri }) {
     return request`
@@ -21,8 +18,8 @@ export default class IntentionAdapter extends Adapter {
     }
 
       ${{
-        partition: '*',
-        ns: '*',
+        partition,
+        ns,
         index,
         filter,
       }}

--- a/ui/packages/consul-ui/tests/integration/adapters/intention-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/intention-test.js
@@ -25,7 +25,7 @@ module('Integration | Adapter | intention', function(hooks) {
         filter: '*',
         index: 1,
         ns: '*',
-        partition: '*',
+        partition: 'partition-1',
       },
       {
         filter: '*',


### PR DESCRIPTION
Filters global intention listing by the current partition rather than trying to use a wildcard.

P.S. @karl-cardenas-coding I think this find came from you so FYI (thankyou!)