### PR TITLE
Support Vault Namespaces explicitly in CA config

### DIFF
--- a/.changelog/11477.txt
+++ b/.changelog/11477.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-connect: add Namespace configuration entry for Vault provider
+connect: add Namespace configuration setting for Vault CA provider
 ```

--- a/.changelog/11477.txt
+++ b/.changelog/11477.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: add Namespace configuration entry for Vault provider
+```

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -75,6 +76,12 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	}
 
 	client.SetToken(config.Token)
+
+	// We don't want to set the namespace if it's empty to prevent potential
+	// unknown behavior. It's also what the Vault client does.
+	if config.Namespace != "" {
+		client.SetNamespace(config.Namespace)
+	}
 	v.config = config
 	v.client = client
 	v.isPrimary = cfg.IsPrimary
@@ -582,6 +589,7 @@ func (v *VaultProvider) Stop() {
 func (v *VaultProvider) PrimaryUsesIntermediate() {}
 
 func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderConfig, error) {
+	fmt.Fprintf(os.Stderr, "%+v\n", raw)
 	config := structs.VaultCAProviderConfig{
 		CommonCAProviderConfig: defaultCommonConfig(),
 	}
@@ -600,6 +608,7 @@ func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderCon
 	if err := decoder.Decode(raw); err != nil {
 		return nil, fmt.Errorf("error decoding config: %s", err)
 	}
+	fmt.Fprintf(os.Stderr, "%+v\n", config)
 
 	if config.Token == "" {
 		return nil, fmt.Errorf("must provide a Vault token")

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -77,7 +77,9 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	client.SetToken(config.Token)
 
 	// We don't want to set the namespace if it's empty to prevent potential
-	// unknown behavior. It's also what the Vault client does.
+	// unknown behavior (what does Vault do with an empty namespace). The Vault
+	// client also makes sure the inputs are not empty strings so let's do the
+	// same.
 	if config.Namespace != "" {
 		client.SetNamespace(config.Namespace)
 	}

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -589,7 +588,6 @@ func (v *VaultProvider) Stop() {
 func (v *VaultProvider) PrimaryUsesIntermediate() {}
 
 func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderConfig, error) {
-	fmt.Fprintf(os.Stderr, "%+v\n", raw)
 	config := structs.VaultCAProviderConfig{
 		CommonCAProviderConfig: defaultCommonConfig(),
 	}
@@ -608,7 +606,6 @@ func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderCon
 	if err := decoder.Decode(raw); err != nil {
 		return nil, fmt.Errorf("error decoding config: %s", err)
 	}
-	fmt.Fprintf(os.Stderr, "%+v\n", config)
 
 	if config.Token == "" {
 		return nil, fmt.Errorf("must provide a Vault token")

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -38,6 +38,8 @@ func TestVaultCAProvider_VaultTLSConfig(t *testing.T) {
 }
 
 func TestVaultCAProvider_Configure(t *testing.T) {
+	SkipIfVaultNotPresent(t)
+
 	testcases := []struct {
 		name          string
 		rawConfig     map[string]interface{}

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -44,6 +44,16 @@ func TestVaultCAProvider_Configure(t *testing.T) {
 		expectedValue func(t *testing.T, v *VaultProvider)
 	}{
 		{
+			name:      "DefaultConfig",
+			rawConfig: map[string]interface{}{},
+			expectedValue: func(t *testing.T, v *VaultProvider) {
+				headers := v.client.Headers()
+				require.Equal(t, "", headers.Get(vaultconst.NamespaceHeaderName))
+				require.Equal(t, "pki-root/", v.config.RootPKIPath)
+				require.Equal(t, "pki-intermediate/", v.config.IntermediatePKIPath)
+			},
+		},
+		{
 			name:      "TestConfigWithNamespace",
 			rawConfig: map[string]interface{}{"namespace": "ns1"},
 			expectedValue: func(t *testing.T, v *VaultProvider) {

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -50,7 +49,6 @@ func TestVaultCAProvider_Configure(t *testing.T) {
 			expectedValue: func(t *testing.T, v *VaultProvider) {
 
 				h := v.client.Headers()
-				fmt.Fprintf(os.Stderr, "%+v\n", h)
 				require.Equal(t, "ns1", h.Get(vaultconst.NamespaceHeaderName))
 			},
 		},

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -465,6 +465,7 @@ type VaultCAProviderConfig struct {
 	Token               string
 	RootPKIPath         string
 	IntermediatePKIPath string
+	Namespace           string
 
 	CAFile        string
 	CAPath        string

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea
 	github.com/hashicorp/serf v0.9.6-0.20210609195804-2b5dd0cd2de9
 	github.com/hashicorp/vault/api v1.0.5-0.20200717191844-f687267c8086
+	github.com/hashicorp/vault/sdk v0.1.14-0.20200519221838-e0cfd64bc267
 	github.com/hashicorp/yamux v0.0.0-20210826001029-26ff87cf9493
 	github.com/imdario/mergo v0.3.6
 	github.com/joyent/triton-go v1.7.1-0.20200416154420-6801d15b779f // indirect

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -131,7 +131,7 @@ The configuration options are listed below.
 
 - `Namespace` / `namespace` (`string: <optional>`) - The Vault Namespace that
   the `Token` and PKI Certificates are a part of. Vault Namespaces are a Vault
-  Enterprise feature.
+  Enterprise feature. Added in Consul 1.11.0
 
 @include 'http_api_connect_ca_common_options.mdx'
 

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -129,6 +129,10 @@ The configuration options are listed below.
 - `TLSSkipVerify` / `tls_skip_verify` (`bool: false`) - Specifies if SSL peer
   validation should be enforced.
 
+- `Namespace` / `namespace` (`string: <optional>`) - The Vault Namespace that
+  the `Token` and PKI Certificates are a part of. Vault Namespaces are a Vault
+  Enterprise feature.
+
 @include 'http_api_connect_ca_common_options.mdx'
 
 ## Root and Intermediate PKI Paths


### PR DESCRIPTION
If there is a Namespace entry included in the Vault CA configuration,
set it as the Vault Namespace on the Vault client

Currently the only way to support Vault namespaces in the Consul CA
config is by doing one of the following:
1) Set the VAULT_NAMESPACE environment variable which will be picked up
by the Vault API client
2) Prefix all Vault paths with the namespace

Neither of these are super pleasant. The first requires direct access
and modification to the Consul runtime environment. It's possible and
expected that the consul owner has that access but it's not super pleasant.

The second requires more indepth knowledge of Vault and how it uses
Namespaces and could be confusing for anyone without that context. It
also infers that it is not supported