### PR TITLE
docs:  consul-k8s uninstall with namespace

### DIFF
--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -124,7 +124,7 @@ controller:
 Once you've created your `config.yaml` file, run `helm install` with the `-f` flag:
 
 ```shell-session
-$ helm install consul hashicorp/consul -f config.yaml
+$ helm install consul hashicorp/consul --create-namespace -n consul -f config.yaml
 NAME: consul
 ...
 ```

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -12,7 +12,14 @@ You can uninstall Consul using Helm commands or the Consul K8s CLI.
 
 Run the `helm uninstall` **and** manually remove resources that Helm does not delete.
 
-1. First, run `helm uninstall`:
+
+1. *Optional*: Set your kubeConfig context to the `consul` namespace to avoid having to append `-n consul` to all of the subsequent commands if you've installed Consul in a dedciated namespace.
+
+    ```
+    kubectl config set-context --current --namespace=consul
+    ```
+
+1. Next run `helm uninstall <release-name>` to uninstall Consul using the release name you've installed Consul with:
 
    ```shell-session
    $ helm uninstall hashicorp

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -13,13 +13,13 @@ You can uninstall Consul using Helm commands or the Consul K8s CLI.
 Run the `helm uninstall` **and** manually remove resources that Helm does not delete.
 
 
-1. *Optional* : Set your kubeConfig context to the `consul` namespace to avoid having to append `-n consul` to all of the subsequent commands if you've installed Consul in a dedciated namespace.
+1. (Optional) If Consul is installed in a dedicated namespace, set the kubeConfig context to the `consul` namespace. Otherwise, subsequent commands will need to include `-n consul`. 
 
     ```
     kubectl config set-context --current --namespace=consul
     ```
 
-1. Next run `helm uninstall <release-name>` to uninstall Consul using the release name you've installed Consul with:
+1. Run the `helm uninstall <release-name>` command and specify the release name you've installed Consul with, e.g.,:
 
    ```shell-session
    $ helm uninstall consul

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -13,7 +13,7 @@ You can uninstall Consul using Helm commands or the Consul K8s CLI.
 Run the `helm uninstall` **and** manually remove resources that Helm does not delete.
 
 
-1. *Optional*: Set your kubeConfig context to the `consul` namespace to avoid having to append `-n consul` to all of the subsequent commands if you've installed Consul in a dedciated namespace.
+1. *Optional* : Set your kubeConfig context to the `consul` namespace to avoid having to append `-n consul` to all of the subsequent commands if you've installed Consul in a dedciated namespace.
 
     ```
     kubectl config set-context --current --namespace=consul
@@ -22,8 +22,8 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
 1. Next run `helm uninstall <release-name>` to uninstall Consul using the release name you've installed Consul with:
 
    ```shell-session
-   $ helm uninstall hashicorp
-   release "hashicorp" uninstalled
+   $ helm uninstall consul
+   release "consul" uninstalled
    ```
 
 1. After deleting the Helm release, you need to delete the `PersistentVolumeClaim`'s


### PR DESCRIPTION
Since our docs now point folks to deploy Consul K8s in a dedicated `consul` namespace, this is a follow-on docs PR to allow folks to uninstall with that namespace now accounted for. 