### PR TITLE
command/redirect_traffic: Redirect DNS requests to Consul if -consul-dns-ip is passed in

### DIFF
--- a/.changelog/11480.txt
+++ b/.changelog/11480.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk: Add support for iptable rules that allow DNS lookup redirection to Consul DNS server.
+```

--- a/.changelog/11480.txt
+++ b/.changelog/11480.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-sdk: Add support for iptable rules that allow DNS lookup redirection to Consul DNS server.
+sdk: Add support for iptable rules that allow DNS lookup redirection to Consul DNS.
 ```

--- a/command/connect/redirecttraffic/redirect_traffic.go
+++ b/command/connect/redirecttraffic/redirect_traffic.go
@@ -36,6 +36,7 @@ type cmd struct {
 	client *api.Client
 
 	// Flags.
+	consulDNSIP          string
 	proxyUID             string
 	proxyID              string
 	proxyInboundPort     int
@@ -45,13 +46,12 @@ type cmd struct {
 	excludeOutboundCIDRs []string
 	excludeUIDs          []string
 	netNS                string
-	// todo dns pass in consul dns ip
-
 }
 
 func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
 
+	c.flags.StringVar(&c.consulDNSIP, "consul-dns-ip", "", "IP used to reach the Consul DNS server. If provided, DNS queries will be redirected to Consul.")
 	c.flags.StringVar(&c.proxyUID, "proxy-uid", "", "The user ID of the proxy to exclude from traffic redirection.")
 	c.flags.StringVar(&c.proxyID, "proxy-id", "", "The service ID of the proxy service registered with Consul.")
 	c.flags.IntVar(&c.proxyInboundPort, "proxy-inbound-port", 0, "The inbound port that the proxy is listening on.")
@@ -132,6 +132,7 @@ type trafficRedirectProxyConfig struct {
 // generateConfigFromFlags generates iptables.Config based on command flags.
 func (c *cmd) generateConfigFromFlags() (iptables.Config, error) {
 	cfg := iptables.Config{
+		ConsulDNSIP:       c.consulDNSIP,
 		ProxyUserID:       c.proxyUID,
 		ProxyInboundPort:  c.proxyInboundPort,
 		ProxyOutboundPort: c.proxyOutboundPort,

--- a/command/connect/redirecttraffic/redirect_traffic.go
+++ b/command/connect/redirecttraffic/redirect_traffic.go
@@ -45,6 +45,8 @@ type cmd struct {
 	excludeOutboundCIDRs []string
 	excludeUIDs          []string
 	netNS                string
+	// todo dns pass in consul dns ip
+
 }
 
 func (c *cmd) init() {

--- a/command/connect/redirecttraffic/redirect_traffic.go
+++ b/command/connect/redirecttraffic/redirect_traffic.go
@@ -51,7 +51,7 @@ type cmd struct {
 func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
 
-	c.flags.StringVar(&c.consulDNSIP, "consul-dns-ip", "", "IP used to reach the Consul DNS server. If provided, DNS queries will be redirected to Consul.")
+	c.flags.StringVar(&c.consulDNSIP, "consul-dns-ip", "", "IP used to reach Consul DNS. If provided, DNS queries will be redirected to Consul.")
 	c.flags.StringVar(&c.proxyUID, "proxy-uid", "", "The user ID of the proxy to exclude from traffic redirection.")
 	c.flags.StringVar(&c.proxyID, "proxy-id", "", "The service ID of the proxy service registered with Consul.")
 	c.flags.IntVar(&c.proxyInboundPort, "proxy-inbound-port", 0, "The inbound port that the proxy is listening on.")

--- a/command/connect/redirecttraffic/redirect_traffic_test.go
+++ b/command/connect/redirecttraffic/redirect_traffic_test.go
@@ -128,6 +128,35 @@ func TestGenerateConfigFromFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "proxyID with Consul DNS IP provided",
+			command: func() cmd {
+				var c cmd
+				c.init()
+				c.proxyUID = "1234"
+				c.proxyID = "test-proxy-id"
+				c.consulDNSIP = "10.0.34.16"
+				return c
+			},
+			consulServices: []api.AgentServiceRegistration{
+				{
+					Kind:    api.ServiceKindConnectProxy,
+					ID:      "test-proxy-id",
+					Name:    "test-proxy",
+					Port:    20000,
+					Address: "1.1.1.1",
+					Proxy: &api.AgentServiceConnectProxyConfig{
+						DestinationServiceName: "foo",
+					},
+				},
+			},
+			expCfg: iptables.Config{
+				ConsulDNSIP:       "10.0.34.16",
+				ProxyUserID:       "1234",
+				ProxyInboundPort:  20000,
+				ProxyOutboundPort: iptables.DefaultTProxyOutboundPort,
+			},
+		},
+		{
 			name: "proxyID with bind_port(string) provided",
 			command: func() cmd {
 				var c cmd

--- a/sdk/iptables/iptables.go
+++ b/sdk/iptables/iptables.go
@@ -106,6 +106,7 @@ func Setup(cfg Config) error {
 		// Redirects outbound TCP traffic hitting PROXY_REDIRECT chain to Envoy's outbound listener port.
 		cfg.IptablesProvider.AddRule("iptables", "-t", "nat", "-A", ProxyOutputRedirectChain, "-p", "tcp", "-j", "REDIRECT", "--to-port", strconv.Itoa(cfg.ProxyOutboundPort))
 
+		// The DNS rules are applied before the rules that directs all TCP traffic, so that the traffic going to port 53 goes through this rule first.
 		if cfg.ConsulDNSIP != "" {
 			// Traffic in the DNSChain is directed to the Consul DNS Service IP.
 			cfg.IptablesProvider.AddRule("iptables", "-t", "nat", "-A", DNSChain, "-p", "udp", "--dport", "53", "-j", "DNAT", "--to-destination", cfg.ConsulDNSIP)


### PR DESCRIPTION
Redirect DNS requests to Consul if `-consul-dns-ip` is passed in.