### PR TITLE
ui: Only show partition / partition selector if partitions enabled

### DIFF
--- a/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
+++ b/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
@@ -1,60 +1,62 @@
-{{#if (can "choose partitions" dc=@dc)}}
-    <li
-      class="partitions"
-      data-test-partition-menu
+{{#if (can "use partitions")}}
+  {{#if (can "choose partitions" dc=@dc)}}
+      <li
+        class="partitions"
+        data-test-partition-menu
+      >
+          <PopoverMenu
+            aria-label="Admin Partition"
+            @position="left"
+          as |components api|>
+            <BlockSlot @name="trigger">
+              {{@partition}}
+            </BlockSlot>
+            <BlockSlot @name="menu">
+              {{#let components.MenuItem components.MenuSeparator as |MenuItem MenuSeparator|}}
+                <DataSource
+                  @src={{uri
+                    '/*/*/${dc}/partitions'
+                    (hash
+                      dc=@dc.Name
+                    )
+                  }}
+                  @onchange={{fn (optional @onchange)}}
+                />
+              {{#each (reject-by 'DeletedAt' @partitions) as |item|}}
+                <MenuItem
+                  class={{if (eq @partition item.Name) 'is-active'}}
+                  @href={{href-to '.' params=(hash
+                    partition=item.Name
+                    nspace=(if (gt @nspace.length 0) @nspace undefined)
+                  )}}
+                >
+                  <BlockSlot @name="label">
+                    {{item.Name}}
+                  </BlockSlot>
+                </MenuItem>
+              {{/each}}
+      {{#if (can 'manage partitions')}}
+                <MenuSeparator />
+                <MenuItem
+                  data-test-main-nav-partitions
+                  @href={{href-to 'dc.partitions.index' @dc.Name}}
+                >
+                  <BlockSlot @name="label">
+                    Manage Admin Partitions
+                  </BlockSlot>
+                </MenuItem>
+      {{/if}}
+              {{/let}}
+            </BlockSlot>
+          </PopoverMenu>
+      </li>
+  {{else}}
+    <li 
+      class="partition"
+      aria-label="Admin Partition"
     >
-        <PopoverMenu
-          aria-label="Admin Partition"
-          @position="left"
-        as |components api|>
-          <BlockSlot @name="trigger">
-            {{@partition}}
-          </BlockSlot>
-          <BlockSlot @name="menu">
-            {{#let components.MenuItem components.MenuSeparator as |MenuItem MenuSeparator|}}
-              <DataSource
-                @src={{uri
-                  '/*/*/${dc}/partitions'
-                  (hash
-                    dc=@dc.Name
-                  )
-                }}
-                @onchange={{fn (optional @onchange)}}
-              />
-            {{#each (reject-by 'DeletedAt' @partitions) as |item|}}
-              <MenuItem
-                class={{if (eq @partition item.Name) 'is-active'}}
-                @href={{href-to '.' params=(hash
-                  partition=item.Name
-                  nspace=(if (gt @nspace.length 0) @nspace undefined)
-                )}}
-              >
-                <BlockSlot @name="label">
-                  {{item.Name}}
-                </BlockSlot>
-              </MenuItem>
-            {{/each}}
-    {{#if (can 'manage partitions')}}
-              <MenuSeparator />
-              <MenuItem
-                data-test-main-nav-partitions
-                @href={{href-to 'dc.partitions.index' @dc.Name}}
-              >
-                <BlockSlot @name="label">
-                  Manage Admin Partitions
-                </BlockSlot>
-              </MenuItem>
-    {{/if}}
-            {{/let}}
-          </BlockSlot>
-        </PopoverMenu>
+      {{@partition}}
     </li>
-{{else}}
-  <li 
-    class="partition"
-    aria-label="Admin Partition"
-  >
-    {{@partition}}
-  </li>
+  {{/if}}
 {{/if}}
 


### PR DESCRIPTION
I missed that partitions should never display if you can't use them, not just if you can't choose them.

This PR just adds a wrapping conditional for that, hoping the `Hide whitespace` thing in GH helps with review (yup it does, make sure you enable that for review)