### PR TITLE
ui: [Port] Ensure the tokens default nspace (and partition) is passed thru to the auth endpoint

### DIFF
--- a/.changelog/11472.txt
+++ b/.changelog/11472.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: **(Enterprise only)** When no namespace is selected, make sure to default to the tokens default namespace when requesting permissions
+```

--- a/ui/packages/consul-ui/app/adapters/permission.js
+++ b/ui/packages/consul-ui/app/adapters/permission.js
@@ -37,11 +37,20 @@ export default class PermissionAdapter extends Adapter {
         // instead. Decided this is the best place for it as its almost hidden
         // from the rest of the app so from an app eng point of view it almost
         // feels like it does happen on the backend.
+        // Same goes ^ for partitions
         const nspacesEnabled = this.env.var('CONSUL_NSPACES_ENABLED');
-        if(nspacesEnabled) {
+        const partitionsEnabled = this.env.var('CONSUL_PARTITIONS_ENABLED');
+        if(nspacesEnabled || partitionsEnabled) {
           const token = await this.settings.findBySlug('token');
-          if(typeof serialized.ns === 'undefined' || serialized.ns.length === 0) {
-            serialized.ns = token.Namespace;
+          if(nspacesEnabled) {
+            if(typeof serialized.ns === 'undefined' || serialized.ns.length === 0) {
+              serialized.ns = token.Namespace;
+            }
+          }
+          if(partitionsEnabled) {
+            if(typeof serialized.partition === 'undefined' || serialized.partition.length === 0) {
+              serialized.partition = token.Partition;
+            }
           }
         }
         return adapter.requestForAuthorize(request, serialized);

--- a/ui/packages/consul-ui/app/adapters/permission.js
+++ b/ui/packages/consul-ui/app/adapters/permission.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class PermissionAdapter extends Adapter {
   @service('env') env;
+  @service('settings') settings;
 
   requestForAuthorize(request, { dc, ns, partition, resources = [], index }) {
     // the authorize endpoint is slightly different to all others in that it
@@ -29,8 +30,21 @@ export default class PermissionAdapter extends Adapter {
 
   authorize(store, type, id, snapshot) {
     return this.rpc(
-      function(adapter, request, serialized, unserialized) {
-        return adapter.requestForAuthorize(request, serialized, unserialized);
+      async (adapter, request, serialized, unserialized) => {
+        // the authorize endpoint does not automatically take into account the
+        // default namespace of the token on the backend. This means that we
+        // need to add the default namespace of the token on the frontend
+        // instead. Decided this is the best place for it as its almost hidden
+        // from the rest of the app so from an app eng point of view it almost
+        // feels like it does happen on the backend.
+        const nspacesEnabled = this.env.var('CONSUL_NSPACES_ENABLED');
+        if(nspacesEnabled) {
+          const token = await this.settings.findBySlug('token');
+          if(typeof serialized.ns === 'undefined' || serialized.ns.length === 0) {
+            serialized.ns = token.Namespace;
+          }
+        }
+        return adapter.requestForAuthorize(request, serialized);
       },
       function(serializer, respond, serialized, unserialized) {
         // Completely skip the serializer here

--- a/ui/packages/consul-ui/tests/unit/adapters/permission-test.js
+++ b/ui/packages/consul-ui/tests/unit/adapters/permission-test.js
@@ -1,12 +1,97 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
+const assertAuthorize = function(assertion, params = {}, token, $, adapter) {
+  const rpc = adapter.rpc;
+  const env = adapter.env;
+  const settings = adapter.settings;
+  adapter.env = {
+    var: str => $[str]
+  };
+  adapter.settings = {
+    findBySlug: _ => token
+  };
+
+  adapter.rpc = function(request, respond) {
+    request(
+      {
+        requestForAuthorize: (request, params) => {
+          assertion(request, params);
+        }
+      },
+      () => {},
+      params,
+      params
+    )
+  };
+  adapter.authorize({}, {modelName: 'permission'}, 1, {});
+  adapter.rpc = rpc;
+  adapter.env = env;
+  adapter.settings = settings;
+}
 module('Unit | Adapter | permission', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
   test('it exists', function(assert) {
     let adapter = this.owner.lookup('adapter:permission');
     assert.ok(adapter);
+  });
+
+  test(`authorize adds the tokens default namespace if one isn't specified`, function(assert) {
+    const adapter = this.owner.lookup('adapter:permission');
+    const expected = 'test';
+    const token = {
+      Namespace: expected
+    };
+    const env = {
+      CONSUL_NSPACES_ENABLED: true
+    };
+    const cases = [
+      undefined,
+      {
+        ns: undefined
+      },
+      {
+        ns: ''
+      }
+    ];
+    assert.expect(cases.length);
+    cases.forEach(
+      (params) => {
+        assertAuthorize(
+          (request, params) => {
+            assert.equal(params.ns, expected)
+          },
+          params,
+          token,
+          env,
+          adapter
+        )
+      }
+    );
+  });
+
+  test(`authorize doesn't add the tokens default namespace if one is specified`, function(assert) {
+    assert.expect(1);
+    const adapter = this.owner.lookup('adapter:permission');
+    const notExpected = 'test';
+    const expected = 'default';
+    const token = {
+      Namespace: notExpected
+    };
+    const env = {
+      CONSUL_NSPACES_ENABLED: true
+    };
+    assertAuthorize(
+      (request, params) => {
+        assert.equal(params.ns, expected)
+      },
+      {
+        ns: expected
+      },
+      token,
+      env,
+      adapter
+    )
   });
 });

--- a/ui/packages/consul-ui/tests/unit/adapters/permission-test.js
+++ b/ui/packages/consul-ui/tests/unit/adapters/permission-test.js
@@ -94,4 +94,61 @@ module('Unit | Adapter | permission', function(hooks) {
       adapter
     )
   });
+  test(`authorize adds the tokens default partition if one isn't specified`, function(assert) {
+    const adapter = this.owner.lookup('adapter:permission');
+    const expected = 'test';
+    const token = {
+      Partition: expected
+    };
+    const env = {
+      CONSUL_PARTITIONS_ENABLED: true
+    };
+    const cases = [
+      undefined,
+      {
+        partition: undefined
+      },
+      {
+        partition: ''
+      }
+    ];
+    assert.expect(cases.length);
+    cases.forEach(
+      (params) => {
+        assertAuthorize(
+          (request, params) => {
+            assert.equal(params.partition, expected)
+          },
+          params,
+          token,
+          env,
+          adapter
+        )
+      }
+    );
+  });
+
+  test(`authorize doesn't add the tokens default partition if one is specified`, function(assert) {
+    assert.expect(1);
+    const adapter = this.owner.lookup('adapter:permission');
+    const notExpected = 'test';
+    const expected = 'default';
+    const token = {
+      Partition: notExpected
+    };
+    const env = {
+      CONSUL_PARTITIONS_ENABLED: true
+    };
+    assertAuthorize(
+      (request, params) => {
+        assert.equal(params.partition, expected)
+      },
+      {
+        partition: expected
+      },
+      token,
+      env,
+      adapter
+    )
+  });
 });


### PR DESCRIPTION
See https://github.com/hashicorp/consul/pull/11472

This port additionally adds support for the tokens default partition.

Note: Similar to https://github.com/hashicorp/consul/pull/11472 we are probably going to change this internal endpoint to also inspect the tokens default namespace on the backend. At which point we can revert this commit/PR. Revert will need to happen on 1.10 and 1.11