### PR TITLE
ci: Loosen apt source verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,7 +213,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/bin
-      - run: sudo apt-get update && sudo apt-get install -y rsyslog
+      - run: sudo apt-get update --allow-releaseinfo-change-suite --allow-releaseinfo-change-version && sudo apt-get install -y rsyslog
       - run: sudo service rsyslog start
       - run: *install-gotestsum
       - run: go mod download
@@ -406,7 +406,7 @@ jobs:
       GOOS: linux
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
+      - run: sudo apt-get update --allow-releaseinfo-change-suite --allow-releaseinfo-change-version && sudo apt-get install -y gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
       - run:
           environment:
             GOARM: 5


### PR DESCRIPTION
We ran into this again earlier in our builds wherever we were doing `apt-get update`:

```
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '10.9' to '10.11'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.

Exited with code exit status 100
```

Apparently, this can happen whenever apt source channels are updated. This change adds the flags to ignore this check. I thought we had already applied this but I can't find it in history now so here it is. 