### PR TITLE
Fix caveat about resolvers operating at L4

### DIFF
--- a/website/content/docs/connect/l7-traffic/index.mdx
+++ b/website/content/docs/connect/l7-traffic/index.mdx
@@ -116,6 +116,6 @@ These config entries may only reference other `service-resolver` entries.
 [Examples](/docs/connect/config-entries/service-resolver#sample-config-entries)
 can be found in the `service-resolver` documentation.
 
--> **Note:** `service-resolver` config entries kinds function at L4 (unlike
+-> **Note:** `service-resolver` config entries kinds can function at L4 (unlike
 `service-router` and `service-splitter` kinds). These can be created for
 services of any protocol such as `tcp`.


### PR DESCRIPTION
Service resolvers can specify L4 rules such as redirects, or L7 rules such as
hash-based load balancing policies.