### PR TITLE
Transition all endpoint tests in agent_endpoint_test.go to go through ServeHTTP

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1005,7 +1005,7 @@ func (s *HTTPHandlers) AgentHealthServiceByID(resp http.ResponseWriter, req *htt
 	}
 	notFoundReason := fmt.Sprintf("ServiceId %s not found", sid.String())
 	if returnTextPlain(req) {
-		return notFoundReason, CodeWithPayloadError{StatusCode: http.StatusNotFound, Reason: notFoundReason, ContentType: "application/json"}
+		return notFoundReason, CodeWithPayloadError{StatusCode: http.StatusNotFound, Reason: notFoundReason, ContentType: "text/plain"}
 	}
 	return &api.AgentServiceChecksInfo{
 		AggregatedStatus: api.HealthCritical,

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -5856,7 +5856,7 @@ func TestAgentConnectCALeafCert_aclServiceWrite(t *testing.T) {
 
 	// Get the issued cert
 	dec := json.NewDecoder(resp.Body)
-	value := &structs.IndexedCARoots{}
+	value := &structs.IssuedCert{}
 	require.NoError(dec.Decode(value))
 	require.NotNil(value)
 }
@@ -6303,6 +6303,11 @@ func TestAgentConnectCALeafCert_Vault_doesNotChurnLeafCertsAtIdle(t *testing.T) 
 			req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test?index="+strconv.Itoa(int(issued.ModifyIndex)), nil)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
+			if resp.Code != http.StatusOK {
+				ch <- fmt.Errorf(resp.Body.String())
+				return
+			}
+
 			dec := json.NewDecoder(resp.Body)
 			issued2 := &structs.IssuedCert{}
 			if err := dec.Decode(issued2); err != nil {
@@ -6317,7 +6322,6 @@ func TestAgentConnectCALeafCert_Vault_doesNotChurnLeafCertsAtIdle(t *testing.T) 
 		}()
 
 		start := time.Now()
-
 		select {
 		case <-time.After(5 * time.Second):
 		case err := <-ch:
@@ -6441,6 +6445,11 @@ func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
 			req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test?index="+strconv.Itoa(int(issued.ModifyIndex)), nil)
 			resp := httptest.NewRecorder()
 			a2.srv.h.ServeHTTP(resp, req)
+			if resp.Code != http.StatusOK {
+				ch <- fmt.Errorf(resp.Body.String())
+				return
+			}
+
 			dec := json.NewDecoder(resp.Body)
 			issued2 := &structs.IssuedCert{}
 			if err := dec.Decode(issued2); err != nil {

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -2950,12 +2950,11 @@ func TestAgent_PassCheck(t *testing.T) {
 	}
 
 	req, _ := http.NewRequest("PUT", "/v1/agent/check/pass/test", nil)
-	obj, err := a.srv.AgentCheckPass(nil, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if obj != nil {
-		t.Fatalf("bad: %v", obj)
+	resp := httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+
+	if http.StatusOK != resp.Code {
+		t.Fatalf("expected 200 by got %v", resp.Code)
 	}
 
 	// Ensure we have a check mapping
@@ -2983,16 +2982,16 @@ func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/pass/test", nil)
-		if _, err := a.srv.AgentCheckPass(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	t.Run("root token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/pass/test?token=root", nil)
-		if _, err := a.srv.AgentCheckPass(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 }
 
@@ -3013,12 +3012,11 @@ func TestAgent_WarnCheck(t *testing.T) {
 	}
 
 	req, _ := http.NewRequest("PUT", "/v1/agent/check/warn/test", nil)
-	obj, err := a.srv.AgentCheckWarn(nil, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if obj != nil {
-		t.Fatalf("bad: %v", obj)
+	resp := httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+
+	if http.StatusOK != resp.Code {
+		t.Fatalf("expected 200 by got %v", resp.Code)
 	}
 
 	// Ensure we have a check mapping
@@ -3046,16 +3044,16 @@ func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/warn/test", nil)
-		if _, err := a.srv.AgentCheckWarn(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	t.Run("root token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/warn/test?token=root", nil)
-		if _, err := a.srv.AgentCheckWarn(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 }
 
@@ -3076,12 +3074,11 @@ func TestAgent_FailCheck(t *testing.T) {
 	}
 
 	req, _ := http.NewRequest("PUT", "/v1/agent/check/fail/test", nil)
-	obj, err := a.srv.AgentCheckFail(nil, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if obj != nil {
-		t.Fatalf("bad: %v", obj)
+	resp := httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+
+	if http.StatusOK != resp.Code {
+		t.Fatalf("expected 200 by got %v", resp.Code)
 	}
 
 	// Ensure we have a check mapping
@@ -3109,16 +3106,16 @@ func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/fail/test", nil)
-		if _, err := a.srv.AgentCheckFail(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	t.Run("root token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/fail/test?token=root", nil)
-		if _, err := a.srv.AgentCheckFail(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 }
 
@@ -3149,14 +3146,8 @@ func TestAgent_UpdateCheck(t *testing.T) {
 		t.Run(c.Status, func(t *testing.T) {
 			req, _ := http.NewRequest("PUT", "/v1/agent/check/update/test", jsonReader(c))
 			resp := httptest.NewRecorder()
-			obj, err := a.srv.AgentCheckUpdate(resp, req)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
-			if obj != nil {
-				t.Fatalf("bad: %v", obj)
-			}
-			if resp.Code != 200 {
+			a.srv.h.ServeHTTP(resp, req)
+			if resp.Code != http.StatusOK {
 				t.Fatalf("expected 200, got %d", resp.Code)
 			}
 
@@ -3174,14 +3165,8 @@ func TestAgent_UpdateCheck(t *testing.T) {
 		}
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/update/test", jsonReader(args))
 		resp := httptest.NewRecorder()
-		obj, err := a.srv.AgentCheckUpdate(resp, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if obj != nil {
-			t.Fatalf("bad: %v", obj)
-		}
-		if resp.Code != 200 {
+		a.srv.h.ServeHTTP(resp, req)
+		if resp.Code != http.StatusOK {
 			t.Fatalf("expected 200, got %d", resp.Code)
 		}
 
@@ -3198,14 +3183,8 @@ func TestAgent_UpdateCheck(t *testing.T) {
 		args := checkUpdate{Status: "itscomplicated"}
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/update/test", jsonReader(args))
 		resp := httptest.NewRecorder()
-		obj, err := a.srv.AgentCheckUpdate(resp, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		if obj != nil {
-			t.Fatalf("bad: %v", obj)
-		}
-		if resp.Code != 400 {
+		a.srv.h.ServeHTTP(resp, req)
+		if resp.Code != http.StatusBadRequest {
 			t.Fatalf("expected 400, got %d", resp.Code)
 		}
 	})
@@ -3230,17 +3209,17 @@ func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 	t.Run("no token", func(t *testing.T) {
 		args := checkUpdate{api.HealthPassing, "hello-passing"}
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/update/test", jsonReader(args))
-		if _, err := a.srv.AgentCheckUpdate(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	t.Run("root token", func(t *testing.T) {
 		args := checkUpdate{api.HealthPassing, "hello-passing"}
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/update/test?token=root", jsonReader(args))
-		if _, err := a.srv.AgentCheckUpdate(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 }
 
@@ -3288,13 +3267,10 @@ func testAgent_RegisterService(t *testing.T, extraHCL string) {
 		},
 	}
 	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
-
-	obj, err := a.srv.AgentRegisterService(nil, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if obj != nil {
-		t.Fatalf("bad: %v", obj)
+	resp := httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+	if http.StatusOK != resp.Code {
+		t.Fatalf("expected 200 but got %v", resp.Code)
 	}
 
 	// Ensure the service
@@ -3377,8 +3353,9 @@ func testAgent_RegisterService_ReRegister(t *testing.T, extraHCL string) {
 		},
 	}
 	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
-	_, err := a.srv.AgentRegisterService(nil, req)
-	require.NoError(t, err)
+	resp := httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
 
 	args = &structs.ServiceDefinition{
 		Name: "test",
@@ -3401,8 +3378,9 @@ func testAgent_RegisterService_ReRegister(t *testing.T, extraHCL string) {
 		},
 	}
 	req, _ = http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
-	_, err = a.srv.AgentRegisterService(nil, req)
-	require.NoError(t, err)
+	resp = httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
 
 	checks := a.State.Checks(structs.DefaultEnterpriseMetaInDefaultPartition())
 	require.Equal(t, 3, len(checks))
@@ -3457,8 +3435,9 @@ func testAgent_RegisterService_ReRegister_ReplaceExistingChecks(t *testing.T, ex
 		},
 	}
 	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?replace-existing-checks", jsonReader(args))
-	_, err := a.srv.AgentRegisterService(nil, req)
-	require.NoError(t, err)
+	resp := httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
 
 	args = &structs.ServiceDefinition{
 		Name: "test",
@@ -3480,8 +3459,9 @@ func testAgent_RegisterService_ReRegister_ReplaceExistingChecks(t *testing.T, ex
 		},
 	}
 	req, _ = http.NewRequest("PUT", "/v1/agent/service/register?replace-existing-checks", jsonReader(args))
-	_, err = a.srv.AgentRegisterService(nil, req)
-	require.NoError(t, err)
+	resp = httptest.NewRecorder()
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
 
 	checks := a.State.Checks(structs.DefaultEnterpriseMetaInDefaultPartition())
 	require.Len(t, checks, 2)
@@ -3609,9 +3589,7 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 			req, _ := http.NewRequest("PUT", "/v1/agent/service/register", strings.NewReader(json))
 
 			rr := httptest.NewRecorder()
-			obj, err := a.srv.AgentRegisterService(rr, req)
-			require.NoError(t, err)
-			require.Nil(t, obj)
+			a.srv.h.ServeHTTP(rr, req)
 			require.Equal(t, 200, rr.Code, "body: %s", rr.Body)
 
 			svc := &structs.NodeService{
@@ -3761,16 +3739,16 @@ func testAgent_RegisterService_ACLDeny(t *testing.T, extraHCL string) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
-		if _, err := a.srv.AgentRegisterService(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	t.Run("root token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(args))
-		if _, err := a.srv.AgentRegisterService(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 }
 
@@ -3805,10 +3783,7 @@ func testAgent_RegisterService_InvalidAddress(t *testing.T, extraHCL string) {
 			}
 			req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
 			resp := httptest.NewRecorder()
-			_, err := a.srv.AgentRegisterService(resp, req)
-			if err != nil {
-				t.Fatalf("got error %v want nil", err)
-			}
+			a.srv.h.ServeHTTP(resp, req)
 			if got, want := resp.Code, 400; got != want {
 				t.Fatalf("got code %d want %d", got, want)
 			}
@@ -3873,9 +3848,8 @@ func testAgent_RegisterService_UnmanagedConnectProxy(t *testing.T, extraHCL stri
 
 	req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=abc123", jsonReader(args))
 	resp := httptest.NewRecorder()
-	obj, err := a.srv.AgentRegisterService(resp, req)
-	require.NoError(t, err)
-	require.Nil(t, obj)
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
 
 	// Ensure the service
 	sid := structs.NewServiceID("connect-proxy", nil)
@@ -3952,10 +3926,14 @@ func testCreateToken(t *testing.T, a *TestAgent, rules string) string {
 	}
 	req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonReader(args))
 	resp := httptest.NewRecorder()
-	obj, err := a.srv.ACLTokenCreate(resp, req)
-	require.NoError(t, err)
-	require.NotNil(t, obj)
-	aclResp := obj.(*structs.ACLToken)
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	dec := json.NewDecoder(resp.Body)
+	aclResp := &structs.ACLToken{}
+	if err := dec.Decode(aclResp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 	return aclResp.SecretID
 }
 
@@ -3966,10 +3944,14 @@ func testCreatePolicy(t *testing.T, a *TestAgent, name, rules string) string {
 	}
 	req, _ := http.NewRequest("PUT", "/v1/acl/policy?token=root", jsonReader(args))
 	resp := httptest.NewRecorder()
-	obj, err := a.srv.ACLPolicyCreate(resp, req)
-	require.NoError(t, err)
-	require.NotNil(t, obj)
-	aclResp := obj.(*structs.ACLPolicy)
+	a.srv.h.ServeHTTP(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	dec := json.NewDecoder(resp.Body)
+	aclResp := &structs.ACLPolicy{}
+	if err := dec.Decode(aclResp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 	return aclResp.ID
 }
 
@@ -4401,15 +4383,11 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 
 			req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token="+token, br)
 			resp := httptest.NewRecorder()
-			obj, err := a.srv.AgentRegisterService(resp, req)
+			a.srv.h.ServeHTTP(resp, req)
 			if tt.wantErr != "" {
-				require.Error(err, "response code=%d, body:\n%s",
-					resp.Code, resp.Body.String())
-				require.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.wantErr))
+				require.Contains(strings.ToLower(resp.Body.String()), strings.ToLower(tt.wantErr))
 				return
 			}
-			require.NoError(err)
-			assert.Nil(obj)
 			require.Equal(200, resp.Code, "request failed with body: %s",
 				resp.Body.String())
 
@@ -4418,7 +4396,7 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 
 			// Parse the expected definition into a ServiceDefinition
 			var sd structs.ServiceDefinition
-			err = json.Unmarshal([]byte(tt.json), &sd)
+			err := json.Unmarshal([]byte(tt.json), &sd)
 			require.NoError(err)
 			require.NotEmpty(sd.Name)
 
@@ -4459,9 +4437,8 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 				req := httptest.NewRequest("PUT",
 					"/v1/agent/service/deregister/"+svcID+"?token="+token, nil)
 				resp := httptest.NewRecorder()
-				obj, err := a.srv.AgentDeregisterService(resp, req)
-				require.NoError(err)
-				require.Nil(obj)
+				a.srv.h.ServeHTTP(resp, req)
+				require.Equal(http.StatusOK, resp.Code)
 
 				svcs := a.State.AllServices()
 				_, ok = svcs[structs.NewServiceID(tt.wantNS.ID, nil)]

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -965,7 +965,6 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 			req, _ := http.NewRequest("GET", url, nil)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
-			//dataRaw, err := a.srv.AgentHealthServiceByID(resp, req)
 			if got, want := resp.Code, expectedCode; got != want {
 				t.Fatalf("returned bad status: expected %d, but had: %d", expectedCode, resp.Code)
 			}
@@ -991,7 +990,6 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 	t.Run("critical checks", func(t *testing.T) {
 		eval(t, "/v1/agent/health/service/id/mysql3", http.StatusServiceUnavailable, "critical")
 	})
-	// TODO: Look into why the http response body is formatted with quotes while previous do not have quotes.
 	t.Run("unknown serviceid", func(t *testing.T) {
 		eval(t, "/v1/agent/health/service/id/mysql1", http.StatusNotFound, fmt.Sprintf("ServiceId %s not found", structs.ServiceIDString("mysql1", nil)))
 	})

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -850,11 +850,11 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 	}
 
 	serviceReq := AddServiceRequest{
-		Service: service,
+		Service:  service,
 		chkTypes: nil,
-		persist: false,
-		token: "",
-		Source: ConfigSourceLocal,
+		persist:  false,
+		token:    "",
+		Source:   ConfigSourceLocal,
 	}
 	if err := a.AddService(serviceReq); err != nil {
 		t.Fatalf("err: %v", err)
@@ -866,7 +866,7 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 	if err := a.AddService(serviceReq); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	serviceReq.Service= &structs.NodeService{
+	serviceReq.Service = &structs.NodeService{
 		ID:      "mysql3",
 		Service: "mysql3",
 	}
@@ -1042,11 +1042,11 @@ func TestAgent_HealthServiceByName(t *testing.T) {
 		Service: "mysql-pool-r",
 	}
 	serviceReq := AddServiceRequest{
-		Service: service,
+		Service:  service,
 		chkTypes: nil,
-		persist: false,
-		token: "",
-		Source: ConfigSourceLocal,
+		persist:  false,
+		token:    "",
+		Source:   ConfigSourceLocal,
 	}
 	if err := a.AddService(serviceReq); err != nil {
 		t.Fatalf("err: %v", err)
@@ -1197,7 +1197,7 @@ func TestAgent_HealthServiceByName(t *testing.T) {
 			t.Helper()
 			req, _ := http.NewRequest("GET", url+"?format=text", nil)
 			resp := httptest.NewRecorder()
-			a.srv.h.ServeHTTP(resp ,req)
+			a.srv.h.ServeHTTP(resp, req)
 			if got, want := resp.Code, expectedCode; got != want {
 				t.Fatalf("returned bad status: %d. Body: %q", resp.Code, resp.Body.String())
 			}
@@ -1209,7 +1209,7 @@ func TestAgent_HealthServiceByName(t *testing.T) {
 			t.Helper()
 			req, _ := http.NewRequest("GET", url, nil)
 			resp := httptest.NewRecorder()
-			a.srv.h.ServeHTTP(resp ,req)
+			a.srv.h.ServeHTTP(resp, req)
 			dec := json.NewDecoder(resp.Body)
 			data := make([]*api.AgentServiceChecksInfo, 0)
 			if err := dec.Decode(&data); err != nil {
@@ -1294,11 +1294,11 @@ func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
 		Service: "mysql",
 	}
 	serviceReq := AddServiceRequest{
-		Service: service,
+		Service:  service,
 		chkTypes: nil,
-		persist: false,
-		token: "",
-		Source: ConfigSourceLocal,
+		persist:  false,
+		token:    "",
+		Source:   ConfigSourceLocal,
 	}
 	require.NoError(t, a.AddService(serviceReq))
 
@@ -4664,9 +4664,9 @@ func TestAgent_DeregisterService(t *testing.T) {
 			Service: "test",
 		},
 		chkTypes: nil,
-		persist: false,
-		token: "",
-		Source: ConfigSourceLocal,
+		persist:  false,
+		token:    "",
+		Source:   ConfigSourceLocal,
 	}
 	require.NoError(t, a.AddService(serviceReq))
 
@@ -4698,9 +4698,9 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 			Service: "test",
 		},
 		chkTypes: nil,
-		persist: false,
-		token: "",
-		Source: ConfigSourceLocal,
+		persist:  false,
+		token:    "",
+		Source:   ConfigSourceLocal,
 	}
 	require.NoError(t, a.AddService(serviceReq))
 
@@ -4773,9 +4773,9 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 			Service: "test",
 		},
 		chkTypes: nil,
-		persist: false,
-		token: "",
-		Source: ConfigSourceLocal,
+		persist:  false,
+		token:    "",
+		Source:   ConfigSourceLocal,
 	}
 	require.NoError(t, a.AddService(serviceReq))
 
@@ -4822,9 +4822,9 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 			Service: "test",
 		},
 		chkTypes: nil,
-		persist: false,
-		token: "",
-		Source: ConfigSourceLocal,
+		persist:  false,
+		token:    "",
+		Source:   ConfigSourceLocal,
 	}
 	require.NoError(t, a.AddService(serviceReq))
 
@@ -4865,9 +4865,9 @@ func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 			Service: "test",
 		},
 		chkTypes: nil,
-		persist: false,
-		token: "",
-		Source: ConfigSourceLocal,
+		persist:  false,
+		token:    "",
+		Source:   ConfigSourceLocal,
 	}
 	require.NoError(t, a.AddService(serviceReq))
 
@@ -5111,7 +5111,7 @@ func TestAgent_Monitor(t *testing.T) {
 			}, 3*time.Second, 100*time.Millisecond)
 
 			cancelFunc()
-			code := <- codeCh
+			code := <-codeCh
 			require.Equal(t, http.StatusOK, code)
 			got := resp.Body.String()
 
@@ -5198,7 +5198,7 @@ func TestAgent_Monitor(t *testing.T) {
 			}, 3*time.Second, 100*time.Millisecond)
 
 			cancelFunc()
-			code := <- codeCh
+			code := <-codeCh
 			require.Equal(t, http.StatusOK, code)
 
 			// Each line is output as a separate JSON object, we grab the first and
@@ -5235,7 +5235,7 @@ func TestAgent_Monitor(t *testing.T) {
 		}, 3*time.Second, 100*time.Millisecond)
 
 		cancelFunc()
-		code := <- codeCh
+		code := <-codeCh
 		require.Equal(t, http.StatusOK, code)
 
 		got := resp.Body.String()

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -425,7 +425,7 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 			t.Fatalf("Err: %v", err)
 		}
 		require.Len(t, val, 2)
-		require.NotEmpty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
+		require.Empty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 }
 
@@ -1425,7 +1425,7 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 			t.Fatalf("Err: %v", err)
 		}
 		require.Len(t, val, 2)
-		require.NotEmpty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
+		require.Empty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 }
 
@@ -2040,7 +2040,7 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 			t.Fatalf("Err: %v", err)
 		}
 		require.Len(t, val, 2)
-		require.NotEmpty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
+		require.Empty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 }
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -388,6 +388,7 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 		if len(val) != 0 {
 			t.Fatalf("bad: %v", val)
 		}
+		require.Len(t, val, 0)
 		require.Empty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 
@@ -423,10 +424,7 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Err: %v", err)
 		}
-
-		if len(val) != 1 {
-			t.Fatalf("bad: %v", val)
-		}
+		require.Len(t, val, 2)
 	})
 }
 
@@ -1425,7 +1423,7 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 		if err := dec.Decode(&val); err != nil {
 			t.Fatalf("Err: %v", err)
 		}
-		require.Len(t, val, 1)
+		require.Len(t, val, 2)
 	})
 }
 
@@ -2039,7 +2037,7 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 		if err := dec.Decode(&val); err != nil {
 			t.Fatalf("Err: %v", err)
 		}
-		require.Len(t, val, 1)
+		require.Len(t, val, 2)
 	})
 }
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -425,6 +425,7 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 			t.Fatalf("Err: %v", err)
 		}
 		require.Len(t, val, 2)
+		require.NotEmpty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 }
 
@@ -1424,6 +1425,7 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 			t.Fatalf("Err: %v", err)
 		}
 		require.Len(t, val, 2)
+		require.NotEmpty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 }
 
@@ -2038,6 +2040,7 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 			t.Fatalf("Err: %v", err)
 		}
 		require.Len(t, val, 2)
+		require.NotEmpty(t, resp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 }
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1514,24 +1514,24 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
-		if _, err := a.srv.AgentSelf(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	t.Run("agent master token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/self?token=towel", nil)
-		if _, err := a.srv.AgentSelf(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a.srv)
 		req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/agent/self?token=%s", ro), nil)
-		if _, err := a.srv.AgentSelf(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 }
 
@@ -1547,24 +1547,24 @@ func TestAgent_Metrics_ACLDeny(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/metrics", nil)
-		if _, err := a.srv.AgentMetrics(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	t.Run("agent master token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/metrics?token=towel", nil)
-		if _, err := a.srv.AgentMetrics(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a.srv)
 		req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/agent/metrics?token=%s", ro), nil)
-		if _, err := a.srv.AgentMetrics(nil, req); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
 	})
 }
 
@@ -1896,17 +1896,17 @@ func TestAgent_Reload_ACLDeny(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/reload", nil)
-		if _, err := a.srv.AgentReload(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	t.Run("read-only token", func(t *testing.T) {
 		ro := createACLTokenWithAgentReadPolicy(t, a.srv)
 		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/reload?token=%s", ro), nil)
-		if _, err := a.srv.AgentReload(nil, req); !acl.IsErrPermissionDenied(err) {
-			t.Fatalf("err: %v", err)
-		}
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusForbidden, resp.Code)
 	})
 
 	// This proves we call the ACL function, and we've got the other reload


### PR DESCRIPTION
Continues issue #11396 

**Overview:**
The goal of this PR is to transition the rest of the endpoint tests in ``agent_endpoint_test.go`` to use ServeHTTP. This is going to be a large change so I’m hoping to get some progressive feedback.
