### PR TITLE
ui: Bump our browser support

### DIFF
--- a/.changelog/11505.txt
+++ b/.changelog/11505.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Update UI browser support to 'roughly ~2 years back'
+```

--- a/ui/packages/consul-ui/config/targets.js
+++ b/ui/packages/consul-ui/config/targets.js
@@ -9,5 +9,5 @@
 // came in Safari 9.1. Safari's async/await support came in Safari 10, so thats
 // the earliest Safari we cover in reality here.
 module.exports = {
-  browsers: ['Chrome 55', 'Firefox 53', 'Safari 13', 'Edge 15'],
+  browsers: ['Chrome 79', 'Firefox 72', 'Safari 13', 'Edge 79'],
 };

--- a/ui/packages/consul-ui/config/targets.js
+++ b/ui/packages/consul-ui/config/targets.js
@@ -1,13 +1,29 @@
 'use strict';
-// async/await support came with the below specified versions for Chrome,
+
+// Technically this file configures babel transpilation support but we also
+// use this file as a reference for our current browser support matrix and is
+// therefore used by humans also. Therefore please feel free to be liberal
+// with comments.
+
+// We are moving to a rough ~2 years back support rather than a 2 versions
+// back support. This strikes a balance between folks who need to get a job
+// done in the Consul UI and keeping the codebase modern and being able to use
+// modern Web Platform features. This is not set in stone but please consult
+// with the rest of the team before bumping forwards (or backwards)
+// We pin specific versions rather than use a relative value so we can choose
+// to bump and it's clear what is supported.
+
+///
+
+// async/await support came before the below specified versions for Chrome,
 // Firefox and Edge. Async/await is is the newest ES6 feature we are not
 // transpiling. Safari's template literal support is a little problematic during
 // v12 in that it has a GC bug for tagged template literals. We don't currently
 // rely on this functionality so the bug wouldn't effect us, but in order to use
 // browser versions as a measure for ES6 features we need to specify Safari 13
 // for native, non-transpiled template literals. In reality template literals
-// came in Safari 9.1. Safari's async/await support came in Safari 10, so thats
-// the earliest Safari we cover in reality here.
+// came in Safari 9.1. Safari's async/await support came in Safari 10.
+
 module.exports = {
   browsers: ['Chrome 79', 'Firefox 72', 'Safari 13', 'Edge 79'],
 };

--- a/ui/packages/consul-ui/docs/testing.mdx
+++ b/ui/packages/consul-ui/docs/testing.mdx
@@ -24,6 +24,20 @@ filter field in QUnit's HTML test runner to run a subset of tests (see below).
 If you have started the tests with a filter, you don't have to quit everything
 and start again in order to filter by something different.
 
+## Browser support
+
+Please check our current browser support when adding features or fixing bugs.
+
+At the time of writing we use a rough ~2 years back support matrix for our
+browser support. As most of our targetted browsers are 'evergreen' and
+auto-update this feels like it strikes a balance between the folks that are
+likely to be using the Consul UI and the desire to maintain a modern
+codebase/feature set. This is a balance that should always be revisited and is
+not set in stone. i.e. if you need to use something check-in with the team
+first, it might be the time to bump again.
+
+Please see [../config/targets.js](../config/targets.js) for our current support.
+
 ### Running a single or a range of tests
 
 Please use the same `make test-oss-view` command to get the tests up and


### PR DESCRIPTION
Bumps our browser support to a "rough ~2 years back" approach.

Best way to understand this PR is to read the copy included in the PR.

Suggestions welcome!

cc @david-yu as I know you were interested in this last time we did it.

P.S. Whilst this doesn't touch any code we should probably changelog this, thoughts? edit: changelog added