### PR TITLE
Improved performance of the version.GetHumanVersion function by 50% on memory allocation.

### DIFF
--- a/.changelog/11507.txt
+++ b/.changelog/11507.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+version: Improved performance of the version.GetHumanVersion function by 50% on memory allocation.
+```

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -29,9 +28,10 @@ func GetHumanVersion() string {
 	release := VersionPrerelease
 
 	if release != "" {
-		if !strings.HasSuffix(version, "-"+release) {
+		suffix := "-" + release
+		if !strings.HasSuffix(version, suffix) {
 			// if we tagged a prerelease version then the release is in the version already
-			version += fmt.Sprintf("-%s", release)
+			version += suffix
 		}
 	}
 

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,11 @@
+package version
+
+import (
+	"testing"
+)
+
+func BenchmarkGetHumanVersion(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		GetHumanVersion()
+	}
+}


### PR DESCRIPTION
Improved performance and added benchmark for func version.GetHumanVersion.

Instructions:
```
$ go install golang.org/x/perf/cmd/benchstat@latest

$ go test -bench=GetHumanVersion -count 5 -benchmem ./version > old.txt
$ go test -bench=GetHumanVersion -count 5 -benchmem ./version > new.txt

$ benchstat old.txt new.txt
```

Results
```
name               old time/op    new time/op    delta
GetHumanVersion-8     177ns ± 2%      80ns ± 3%  -54.53%  (p=0.008 n=5+5)

name               old alloc/op   new alloc/op   delta
GetHumanVersion-8     32.0B ± 0%     16.0B ± 0%  -50.00%  (p=0.008 n=5+5)

name               old allocs/op  new allocs/op  delta
GetHumanVersion-8      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
```