### PR TITLE
rename helper method to reflect the non-deprecated terminology

### DIFF
--- a/.changelog/_1284.txt
+++ b/.changelog/_1284.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+state: **(Enterprise Only)** ensure partition delete triggers namespace deletes
+```

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -82,13 +82,13 @@ func (s *Server) checkBindingRuleUUID(id string) (bool, error) {
 	return !structs.ACLIDReserved(id), nil
 }
 
-func (s *Server) InACLDatacenter() bool {
+func (s *Server) InPrimaryDatacenter() bool {
 	return s.config.PrimaryDatacenter == "" || s.config.Datacenter == s.config.PrimaryDatacenter
 }
 
 func (s *Server) LocalTokensEnabled() bool {
 	// in ACL datacenter so local tokens are always enabled
-	if s.InACLDatacenter() {
+	if s.InPrimaryDatacenter() {
 		return true
 	}
 
@@ -117,7 +117,7 @@ func (s *Server) ACLDatacenter() string {
 func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
 	// only allow remote RPC resolution when token replication is off and
 	// when not in the ACL datacenter
-	if !s.InACLDatacenter() && !s.config.ACLTokenReplication {
+	if !s.InPrimaryDatacenter() && !s.config.ACLTokenReplication {
 		return false, nil, nil
 	}
 
@@ -128,7 +128,7 @@ func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdenti
 		return true, aclToken, nil
 	}
 
-	return s.InACLDatacenter() || index > 0, nil, acl.ErrNotFound
+	return s.InPrimaryDatacenter() || index > 0, nil, acl.ErrNotFound
 }
 
 func (s *Server) ResolvePolicyFromID(policyID string) (bool, *structs.ACLPolicy, error) {
@@ -142,7 +142,7 @@ func (s *Server) ResolvePolicyFromID(policyID string) (bool, *structs.ACLPolicy,
 	// If the max index of the policies table is non-zero then we have acls, until then
 	// we may need to allow remote resolution. This is particularly useful to allow updating
 	// the replication token via the API in a non-primary dc.
-	return s.InACLDatacenter() || index > 0, policy, acl.ErrNotFound
+	return s.InPrimaryDatacenter() || index > 0, policy, acl.ErrNotFound
 }
 
 func (s *Server) ResolveRoleFromID(roleID string) (bool, *structs.ACLRole, error) {
@@ -156,7 +156,7 @@ func (s *Server) ResolveRoleFromID(roleID string) (bool, *structs.ACLRole, error
 	// If the max index of the roles table is non-zero then we have acls, until then
 	// we may need to allow remote resolution. This is particularly useful to allow updating
 	// the replication token via the API in a non-primary dc.
-	return s.InACLDatacenter() || index > 0, role, acl.ErrNotFound
+	return s.InPrimaryDatacenter() || index > 0, role, acl.ErrNotFound
 }
 
 func (s *Server) ResolveToken(token string) (acl.Authorizer, error) {

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -22,7 +22,7 @@ func (s *Server) reapExpiredTokens(ctx context.Context) error {
 				s.logger.Error("error reaping expired local ACL tokens", "error", err)
 			}
 		}
-		if s.InACLDatacenter() {
+		if s.InPrimaryDatacenter() {
 			if _, err := s.reapExpiredGlobalACLTokens(); err != nil {
 				s.logger.Error("error reaping expired global ACL tokens", "error", err)
 			}
@@ -37,7 +37,7 @@ func (s *Server) startACLTokenReaping(ctx context.Context) {
 	// We can only check the config settings here that cannot change without a
 	// restart, so we omit the check for a non-empty replication token as that
 	// can be changed at runtime.
-	if !s.InACLDatacenter() && !s.config.ACLTokenReplication {
+	if !s.InPrimaryDatacenter() && !s.config.ACLTokenReplication {
 		return
 	}
 

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -375,7 +375,7 @@ func (s *Server) initializeACLs(ctx context.Context) error {
 	s.aclAuthMethodValidators.Purge()
 
 	// Remove any token affected by CVE-2019-8336
-	if !s.InACLDatacenter() {
+	if !s.InPrimaryDatacenter() {
 		_, token, err := s.fsm.State().ACLTokenGetBySecret(nil, redactedToken, nil)
 		if err == nil && token != nil {
 			req := structs.ACLTokenBatchDeleteRequest{
@@ -389,7 +389,7 @@ func (s *Server) initializeACLs(ctx context.Context) error {
 		}
 	}
 
-	if s.InACLDatacenter() {
+	if s.InPrimaryDatacenter() {
 		s.logger.Info("initializing acls")
 
 		// TODO(partitions): initialize acls in all of the partitions?
@@ -623,7 +623,7 @@ func (s *Server) stopACLUpgrade() {
 }
 
 func (s *Server) startACLReplication(ctx context.Context) {
-	if s.InACLDatacenter() {
+	if s.InPrimaryDatacenter() {
 		return
 	}
 

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -203,6 +203,28 @@ func (s *Store) Snapshot() *Snapshot {
 	return &Snapshot{s, tx, idx}
 }
 
+// WalkAllTables basically lets you dump memdb generically and exists primarily
+// for very specific types of unit tests and should not be executed in
+// production code.
+func (s *Store) WalkAllTables(fn func(table string, item interface{}) bool) error {
+	snap := s.Snapshot()
+	defer snap.Close()
+
+	for name := range s.schema.Tables {
+		iter, err := snap.tx.Get(name, indexID)
+		if err != nil {
+			return fmt.Errorf("error walking table %q: %w", name, err)
+		}
+		for item := iter.Next(); item != nil; item = iter.Next() {
+			if keepGoing := fn(name, item); !keepGoing {
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
 // LastIndex returns that last index that affects the snapshotted data.
 func (s *Snapshot) LastIndex() uint64 {
 	return s.lastIndex


### PR DESCRIPTION
also add a state store helper function for unit tests