### PR TITLE
docs: removed broken link to Ambassador

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -463,6 +463,10 @@
             "path": "k8s/connect/connect-ca-provider"
           },
           {
+            "title": "Ambassador Edge Stack Integration",
+            "href": "https://learn.hashicorp.com/tutorials/consul/load-balancing-ambassador"
+          },
+          {
             "title": "Health Checks",
             "path": "k8s/connect/health"
           },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -459,10 +459,6 @@
             "path": "k8s/connect/ingress-controllers"
           },
           {
-            "title": "Ambassador Edge Stack Integration",
-            "href": "https://learn.hashicorp.com/tutorials/consul/load-balancing-ambassador"
-          },
-          {
             "title": "Configuring a Connect CA Provider",
             "path": "k8s/connect/connect-ca-provider"
           },
@@ -952,10 +948,6 @@
       {
         "title": "Vault Integration",
         "href": "/docs/connect/ca/vault"
-      },
-      {
-        "title": "Ambassador Integration",
-        "href": "/docs/k8s/connect/ambassador"
       },
       {
         "title": "Proxy Integration",


### PR DESCRIPTION
This PR removes a broken link to previous Ambassador content that was hosted. 