### PR TITLE
xds: prefer fed state gateway definitions if they're fresher

### DIFF
--- a/.changelog/11522.txt
+++ b/.changelog/11522.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+xds: fixes a bug where replacing a mesh gateway node used for WAN federation (with another that has a different IP) could leave gateways in the other DC unable to re-establish the connection
+```

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -1532,6 +1532,31 @@ func TestConfigSnapshotMeshGatewayNewerInformationInFederationStates(t testing.T
 	return snap
 }
 
+func TestConfigSnapshotMeshGatewayOlderInformationInFederationStates(t testing.T) *ConfigSnapshot {
+	snap := TestConfigSnapshotMeshGateway(t)
+
+	// Create a duplicate entry in FedStateGateways, with a low ModifyIndex, to
+	// verify that stale data in the federation state is ignored in favor of the
+	// fresher data in GatewayGroups.
+	svc := structs.TestNodeServiceMeshGatewayWithAddrs(t,
+		"10.0.1.3", 8443,
+		structs.ServiceAddress{Address: "10.0.1.3", Port: 8443},
+		structs.ServiceAddress{Address: "198.18.1.3", Port: 443},
+	)
+	svc.RaftIndex.ModifyIndex = 0
+
+	snap.MeshGateway.FedStateGateways = map[string]structs.CheckServiceNodes{
+		"dc2": {
+			{
+				Node:    snap.MeshGateway.GatewayGroups["dc2"][0].Node,
+				Service: svc,
+			},
+		},
+	}
+
+	return snap
+}
+
 func TestConfigSnapshotMeshGatewayNoServices(t testing.T) *ConfigSnapshot {
 	return testConfigSnapshotMeshGateway(t, false, false)
 }

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"path"
 	"path/filepath"
 	"sync"
@@ -1509,37 +1510,21 @@ func TestConfigSnapshotMeshGatewayUsingFederationStates(t testing.T) *ConfigSnap
 func TestConfigSnapshotMeshGatewayNewerInformationInFederationStates(t testing.T) *ConfigSnapshot {
 	snap := TestConfigSnapshotMeshGateway(t)
 
-	csn1 := snap.MeshGateway.GatewayGroups["dc2"][0]
-	csn2 := snap.MeshGateway.GatewayGroups["dc2"][1]
-
-	// Create a duplicate entry in FedStateGateways, with a higher ModifyIndex, to
-	// verify that its IP is chosen over the one in GatewayGroups (198.18.1.1).
-	svc1 := structs.TestNodeServiceMeshGatewayWithAddrs(t,
+	// Create a duplicate entry in FedStateGateways, with a high ModifyIndex, to
+	// verify that fresh data in the federation state is preferred over stale data
+	// in GatewayGroups.
+	svc := structs.TestNodeServiceMeshGatewayWithAddrs(t,
 		"10.0.1.3", 8443,
 		structs.ServiceAddress{Address: "10.0.1.3", Port: 8443},
 		structs.ServiceAddress{Address: "198.18.1.3", Port: 443},
 	)
-	svc1.RaftIndex.ModifyIndex = csn1.Service.ModifyIndex + 1
-
-	// Create another duplicate entry, this time without increasing its ModifyIndex,
-	// to verify that the IP in GatewayGroups (198.18.1.2) is chosen.
-	svc2 := structs.TestNodeServiceMeshGatewayWithAddrs(t,
-		"10.0.1.4", 8443,
-		structs.ServiceAddress{Address: "10.0.1.4", Port: 8443},
-		structs.ServiceAddress{Address: "198.18.1.4", Port: 443},
-	)
+	svc.RaftIndex.ModifyIndex = math.MaxUint64
 
 	snap.MeshGateway.FedStateGateways = map[string]structs.CheckServiceNodes{
 		"dc2": {
 			{
-				Node:    csn1.Node,
-				Service: svc1,
-				Checks:  csn1.Checks,
-			},
-			{
-				Node:    csn2.Node,
-				Service: svc2,
-				Checks:  csn2.Checks,
+				Node:    snap.MeshGateway.GatewayGroups["dc2"][0].Node,
+				Service: svc,
 			},
 		},
 	}

--- a/agent/structs/testing_catalog.go
+++ b/agent/structs/testing_catalog.go
@@ -130,6 +130,9 @@ func TestNodeServiceMeshGatewayWithAddrs(t testing.T, address string, port int, 
 			TaggedAddressLAN: lanAddr,
 			TaggedAddressWAN: wanAddr,
 		},
+		RaftIndex: RaftIndex{
+			ModifyIndex: 1,
+		},
 	}
 }
 

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -166,12 +166,13 @@ func (s *ResourceGenerator) endpointsFromSnapshotMeshGateway(cfgSnap *proxycfg.C
 				}
 			}
 
-			if idx == -1 {
+			switch {
+			case idx == -1:
+				// Definition is only present in the federation state, add it wholesale.
 				endpoints = append(endpoints, fse)
-			} else {
-				if endpoints[idx].Service.RaftIndex.ModifyIndex < fse.Service.RaftIndex.ModifyIndex {
-					endpoints[idx] = fse
-				}
+			case endpoints[idx].Service.RaftIndex.ModifyIndex < fse.Service.RaftIndex.ModifyIndex:
+				// Definition in the federation state is fresher, prefer it over the other.
+				endpoints[idx] = fse
 			}
 		}
 

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -246,6 +246,10 @@ func TestEndpointsFromSnapshot(t *testing.T) {
 			setup:  nil,
 		},
 		{
+			name:   "mesh-gateway-newer-information-in-federation-states",
+			create: proxycfg.TestConfigSnapshotMeshGatewayNewerInformationInFederationStates,
+		},
+		{
 			name:   "mesh-gateway-no-services",
 			create: proxycfg.TestConfigSnapshotMeshGatewayNoServices,
 		},

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -250,6 +250,10 @@ func TestEndpointsFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshotMeshGatewayNewerInformationInFederationStates,
 		},
 		{
+			name:   "mesh-gateway-older-information-in-federation-states",
+			create: proxycfg.TestConfigSnapshotMeshGatewayOlderInformationInFederationStates,
+		},
+		{
 			name:   "mesh-gateway-no-services",
 			create: proxycfg.TestConfigSnapshotMeshGatewayNoServices,
 		},

--- a/agent/xds/testdata/endpoints/mesh-gateway-newer-information-in-federation-states.envoy-1-20-x.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-newer-information-in-federation-states.envoy-1-20-x.golden
@@ -1,0 +1,145 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.6",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.7",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.8",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "198.18.1.3",
+                    "portValue": 443
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "198.18.1.2",
+                    "portValue": 443
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.3",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.4",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.5",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.9",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/endpoints/mesh-gateway-newer-information-in-federation-states.envoy-1-20-x.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-newer-information-in-federation-states.envoy-1-20-x.golden
@@ -64,18 +64,6 @@
               },
               "healthStatus": "HEALTHY",
               "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "198.18.1.2",
-                    "portValue": 443
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
             }
           ]
         }

--- a/agent/xds/testdata/endpoints/mesh-gateway-older-information-in-federation-states.envoy-1-20-x.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-older-information-in-federation-states.envoy-1-20-x.golden
@@ -1,0 +1,145 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.6",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.7",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.8",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "198.18.1.1",
+                    "portValue": 443
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "198.18.1.2",
+                    "portValue": 443
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+      "clusterName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.3",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.4",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.5",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.9",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
Fixes an issue (described in #10132) where if two DCs are WAN federated over mesh gateways, and the gateway in the non-primary DC is terminated and receives a new IP address (as is commonly the case when running them
on ephemeral compute instances) the primary DC is unable to re-establish its connection until the agent running on its own gateway is restarted.

This was happening because we always preferred gateways discovered by the `Internal.ServiceDump` RPC (which would fail because there's no way to dial the remote DC) over those discovered in the federation state, which is replicated as long as the primary DC's gateway is reachable - see the comment in `endpointsFromSnapshotMeshGateway`.