### PR TITLE
add a metrics test check GH action

### DIFF
--- a/.github/scripts/metrics_checker.sh
+++ b/.github/scripts/metrics_checker.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+# search for any "new" or modified metric emissions
+metrics_modified=$(git --no-pager diff HEAD origin/main | grep -i "SetGauge\|EmitKey\|IncrCounter\|AddSample\|MeasureSince\|UpdateFilter")
+# search for PR body or title metric references
+metrics_in_pr_body=$(echo "$PR_BODY" | grep "metric")
+metrics_in_pr_title=$(echo "$PR_TITLE" | grep "metric")
+
+# if there have been code changes to any metric or mention of metrics in the pull request body
+if [ "$metrics_modified" ] || [ "$metrics_in_pr_body" ] || [ "$metrics_in_pr_title" ]; then
+  # need to check if there are modifications to metrics_test
+  modified_metrics_test_file=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" | grep -i "metrics_test")
+  if [ "$modified_metrics_test_file" ]; then
+    # 1 happy path: metrics_test has been modified bc we modified metrics behavior
+    echo "PR seems to modify metrics behavior. It seems it has modified agent/metrics_test.go as well."
+    exit 0
+  else
+    echo "PR seems to modify metrics behavior. It seems no tests or test behavior has been modified in agent/metrics_test.go."
+    echo "Please update the PR with any relevant updated testing or add a pr/no-metrics-test label to skip this check."
+    exit 1
+  fi
+
+else
+  # no metrics modified in code, nothing to check
+  echo "No metric behavior seems to be modified."
+  exit 0
+fi

--- a/.github/scripts/metrics_checker.sh
+++ b/.github/scripts/metrics_checker.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 set -o pipefail
 
+### This script checks if any metric behavior has been modified.
+### The checks rely on the git diff against origin/main
+### It is still up to the reviewer to make sure that any tests added are needed and meaningful.
+
 # search for any "new" or modified metric emissions
 metrics_modified=$(git --no-pager diff HEAD origin/main | grep -i "SetGauge\|EmitKey\|IncrCounter\|AddSample\|MeasureSince\|UpdateFilter")
 # search for PR body or title metric references
-metrics_in_pr_body=$(echo "$PR_BODY" | grep "metric")
-metrics_in_pr_title=$(echo "$PR_TITLE" | grep "metric")
+metrics_in_pr_body=$(echo "$PR_BODY" | grep -i "metric")
+metrics_in_pr_title=$(echo "$PR_TITLE" | grep -i "metric")
 
 # if there have been code changes to any metric or mention of metrics in the pull request body
 if [ "$metrics_modified" ] || [ "$metrics_in_pr_body" ] || [ "$metrics_in_pr_title" ]; then
   # need to check if there are modifications to metrics_test
-  modified_metrics_test_file=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" | grep -i "metrics_test")
+  metrics_test_file="agent/metrics_test.go"
+  modified_metrics_test_file=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" | grep -i "$metrics_test_file")
   if [ "$modified_metrics_test_file" ]; then
     # 1 happy path: metrics_test has been modified bc we modified metrics behavior
-    echo "PR seems to modify metrics behavior. It seems it has modified agent/metrics_test.go as well."
+    echo "PR seems to modify metrics behavior. It seems it may have added tests to agent/metrics_test.go as well."
     exit 0
   else
     echo "PR seems to modify metrics behavior. It seems no tests or test behavior has been modified in agent/metrics_test.go."

--- a/.github/scripts/metrics_checker.sh
+++ b/.github/scripts/metrics_checker.sh
@@ -15,7 +15,7 @@ metrics_in_pr_title=$(echo "${PR_TITLE-""}" | grep -i "metric")
 if [ "$metrics_modified" ] || [ "$metrics_in_pr_body" ] || [ "$metrics_in_pr_title" ]; then
   # need to check if there are modifications to metrics_test
   test_files_regex="*_test.go"
-  modified_metrics_test_files=$(git --no-pager diff --name-only HEAD "$(git merge-base HEAD "origin/main")" -- "$test_files_regex" | grep -i "metric")
+  modified_metrics_test_files=$(git --no-pager diff HEAD "$(git merge-base HEAD "origin/main")" -- "$test_files_regex" | grep -i "metric")
   if [ "$modified_metrics_test_files" ]; then
     # 1 happy path: metrics_test has been modified bc we modified metrics behavior
     echo "PR seems to modify metrics behavior. It seems it may have added tests to the metrics as well."

--- a/.github/workflows/pr-metrics-test-checker.yml
+++ b/.github/workflows/pr-metrics-test-checker.yml
@@ -1,0 +1,25 @@
+name: "Check for metrics tests"
+on:
+  pull_request:
+    types: [ opened, synchronize, labeled ]
+    # Runs on PRs to main
+    branches:
+      - main
+
+jobs:
+  metrics_test_check:
+    if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-metrics-test')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: "checkout repo"
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # by default the checkout action doesn't checkout all branches
+      - name: "Check for metrics modifications"
+        run: ./.github/scripts/metrics_checker.sh
+        # as of now, cannot use github vars in "external" scripts; ref: https://github.community/t/using-github-action-environment-variables-in-shell-script/18330
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        shell: bash


### PR DESCRIPTION
#### Overview

This PR wraps a small bash checker in a GH action. The checks are actually done on "diffs" and not necessarily the actual content. That said, I think this get us 80% there!

##### Pros/ Wins:

* quick eye check for reviewers on whether or not this PR has metric behavior changes in it 
* reminder to contributors to add testing for the metric behavior
* helps us build metric behavior testing in the long run

This is not meant to be a replacement for a good old fashioned, through review. It's meant to have the same call to action as a change log PR checker.

#### Testing

* I did a fair amount of testing in the enterprise repo (mostly manual); happy to reproduce some of it here on request.

#### More background

At present, there are some metric behavior checks like [here](https://github.com/hashicorp/consul/pull/11231/files#diff-472e516d540a393b43170efc09098871a521b8b8ed4788089412829311ff81c5). My hope is that we get to a place where we test the behavior of most of our exported metrics if not all.

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>