### PR TITLE
Use ClusterID to check for readiness

### DIFF
--- a/agent/consul/server_connect.go
+++ b/agent/consul/server_connect.go
@@ -16,7 +16,7 @@ func (s *Server) getCARoots(ws memdb.WatchSet, state *state.Store) (*structs.Ind
 	if err != nil {
 		return nil, err
 	}
-	if config == nil {
+	if config == nil || config.ClusterID == "" {
 		return nil, fmt.Errorf("CA has not finished initializing")
 	}
 
@@ -28,9 +28,6 @@ func (s *Server) getCARoots(ws memdb.WatchSet, state *state.Store) (*structs.Ind
 		// If CA is bootstrapped at all then this should never happen but be
 		// defensive.
 		return nil, fmt.Errorf("no cluster trust domain setup")
-	}
-	if signingID.ClusterID == "" {
-		return nil, fmt.Errorf("CA has not finished initializing")
 	}
 
 	indexedRoots.TrustDomain = signingID.Host()

--- a/agent/consul/server_connect.go
+++ b/agent/consul/server_connect.go
@@ -29,11 +29,11 @@ func (s *Server) getCARoots(ws memdb.WatchSet, state *state.Store) (*structs.Ind
 		// defensive.
 		return nil, fmt.Errorf("no cluster trust domain setup")
 	}
-
-	indexedRoots.TrustDomain = signingID.Host()
-	if indexedRoots.TrustDomain == "" {
+	if signingID.ClusterID == "" {
 		return nil, fmt.Errorf("CA has not finished initializing")
 	}
+
+	indexedRoots.TrustDomain = signingID.Host()
 
 	indexedRoots.Index, indexedRoots.Roots = index, roots
 	if indexedRoots.Roots == nil {

--- a/test/integration/connect/envoy/case-wanfed-gw/primary/verify.bats
+++ b/test/integration/connect/envoy/case-wanfed-gw/primary/verify.bats
@@ -23,7 +23,7 @@ load helpers
 }
 
 @test "primary should be able to rpc to the secondary" {
-  retry_default curl -sL -f -XPUT localhost:8500/v1/kv/foo?dc=secondary -d'{"Value":"bar"}'
+  retry_long curl -sL -f -XPUT localhost:8500/v1/kv/foo?dc=secondary -d'{"Value":"bar"}'
 }
 
 @test "wan pool should show 2 healthy nodes" {


### PR DESCRIPTION
Surfaced [here](https://github.com/hashicorp/consul/pull/11514/files/d9110136f239b6d89471df028d0ce1093f398ab9..cc5a7ed36c893622f3735977bdc3feb56335d70a#r746828464).

The TrustDomain is populated from the Host() method which includes the
hard-coded "consul" domain. This means that despite having an empty
cluster ID, the TrustDomain won't be empty.