### PR TITLE
ui: [Backport] Temporarily force all UI capabilities (#11520)

### DIFF
--- a/.changelog/11520.txt
+++ b/.changelog/11520.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Revert to depending on the backend, 'post-user-action', to report
+permissions errors rather than using UI capabilities 'pre-user-action'
+```

--- a/ui/packages/consul-ui/app/routes/dc/kv/edit.js
+++ b/ui/packages/consul-ui/app/routes/dc/kv/edit.js
@@ -49,7 +49,7 @@ export default class EditRoute extends Route {
       // TODO: Consider loading this after initial page load
       if (typeof model.item !== 'undefined') {
         const session = get(model.item, 'Session');
-        if (session && this.permissions.can('read sessions')) {
+        if (session) {
           return hash({
             ...model,
             ...{
@@ -57,7 +57,7 @@ export default class EditRoute extends Route {
                 ns: nspace,
                 dc: dc,
                 id: session,
-              }),
+              }).catch((e) => null),
             },
           });
         }

--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -146,6 +146,18 @@ export default class PermissionService extends RepositoryService {
   async findAll(params) {
     params.resources = REQUIRED_PERMISSIONS;
     this.permissions = await this.findByPermissions(params);
+    /**/
+    // Temporarily revert to pre-1.10 UI functionality by overwriting frontend
+    // permissions. These are used to hide certain UI elements, but they are
+    // still enforced on the backend.
+    // This temporary measure should be removed again once https://github.com/hashicorp/consul/issues/11098
+    // has been resolved
+    this.permissions.forEach(item => {
+      if(['key', 'node', 'service', 'intentions', 'session'].includes(item.Resource)) {
+        item.Allow = true;
+      }
+    })
+    /**/
     return this.permissions;
   }
 }


### PR DESCRIPTION
Temporarily revert to pre-1.10 UI functionality by overwriting frontend
permissions. These are used to hide certain UI elements, but they are
still enforced on the backend.

This temporary measure should be removed again once https://github.com/hashicorp/consul/issues/11098
has been resolved

p.s. no-changelog label due to base branch not being main