### PR TITLE
ui: Fixup partiton > partition typo

### DIFF
--- a/ui/packages/consul-ui/app/services/repository.js
+++ b/ui/packages/consul-ui/app/services/repository.js
@@ -104,7 +104,7 @@ export default class RepositoryService extends Service {
     }
     if (this.env.var('CONSUL_PARTITIONS_ENABLED')) {
       const partition = get(item, 'Partition');
-      if (typeof partiton !== 'undefined' && partition !== params.partition) {
+      if (typeof partition !== 'undefined' && partition !== params.partition) {
         return false;
       }
     }


### PR DESCRIPTION
This PR fixes up a tiny typo with `partition` which was causing reconciliation clean up to be performed when it shouldn't be.