### PR TITLE
Support auth methods for the vault connect CA provider

### DIFF
--- a/.changelog/11573.txt
+++ b/.changelog/11573.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Support Vault auth methods for the Connect CA Vault provider.
+```

--- a/.changelog/11573.txt
+++ b/.changelog/11573.txt
@@ -1,3 +1,5 @@
 ```release-note:improvement
-connect: Support Vault auth methods for the Connect CA Vault provider.
+connect: Support Vault auth methods for the Connect CA Vault provider. Currently, we support any non-deprecated auth methods
+the latest version of Vault supports (v1.8.5), which include AppRole, AliCloud, AWS, Azure, Cloud Foundry, GitHub, Google Cloud,
+JWT/OIDC, Kerberos, Kubernetes, LDAP, Oracle Cloud Infrastructure, Okta, Radius, TLS Certificates, and Username & Password.
 ```

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/consul/lib/decode"
 	"github.com/hashicorp/go-hclog"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
@@ -19,7 +21,23 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-const VaultCALeafCertRole = "leaf-cert"
+const (
+	VaultCALeafCertRole = "leaf-cert"
+
+	defaultK8SServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+)
+
+const (
+	VaultAuthMethodTypeKubernetes = "kubernetes"
+
+	VaultAuthMethodTypeLDAP     = "ldap"
+	VaultAuthMethodTypeUserpass = "userpass"
+	VaultAuthMethodTypeOkta     = "okta"
+	VaultAuthMethodTypeRadius   = "radius"
+	VaultAuthMethodTypeOCI      = "oci"
+
+	VaultAuthMethodTypeToken = "token"
+)
 
 var ErrBackendNotMounted = fmt.Errorf("backend not mounted")
 var ErrBackendNotInitialized = fmt.Errorf("backend not initialized")
@@ -74,6 +92,13 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 		return err
 	}
 
+	if config.AuthMethod != nil {
+		loginResp, err := vaultLogin(client, config.AuthMethod)
+		if err != nil {
+			return err
+		}
+		config.Token = loginResp.Auth.ClientToken
+	}
 	client.SetToken(config.Token)
 
 	// We don't want to set the namespace if it's empty to prevent potential
@@ -94,7 +119,7 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	if err != nil {
 		return err
 	} else if secret == nil {
-		return fmt.Errorf("Could not look up Vault provider token: not found")
+		return fmt.Errorf("could not look up Vault provider token: not found")
 	}
 	var token struct {
 		Renewable bool
@@ -105,7 +130,7 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	}
 
 	// Set up a renewer to renew the token automatically, if supported.
-	if token.Renewable {
+	if token.Renewable || config.AuthMethod != nil {
 		lifetimeWatcher, err := client.NewLifetimeWatcher(&vaultapi.LifetimeWatcherInput{
 			Secret: &vaultapi.Secret{
 				Auth: &vaultapi.SecretAuth{
@@ -118,10 +143,10 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 			RenewBehavior: vaultapi.RenewBehaviorIgnoreErrors,
 		})
 		if err != nil {
-			return fmt.Errorf("Error beginning Vault provider token renewal: %v", err)
+			return fmt.Errorf("error beginning Vault provider token renewal: %v", err)
 		}
 
-		ctx, cancel := context.WithCancel(context.TODO())
+		ctx, cancel := context.WithCancel(context.Background())
 		v.shutdown = cancel
 		go v.renewToken(ctx, lifetimeWatcher)
 	}
@@ -129,7 +154,9 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	return nil
 }
 
-// renewToken uses a vaultapi.Renewer to repeatedly renew our token's lease.
+// renewToken uses a vaultapi.LifetimeWatcher to repeatedly renew our token's lease.
+// If the token can no longer be renewed and auth method is set,
+// it will re-authenticate to Vault using the auth method and restart the renewer with the new token.
 func (v *VaultProvider) renewToken(ctx context.Context, watcher *vaultapi.LifetimeWatcher) {
 	go watcher.Start()
 	defer watcher.Stop()
@@ -144,7 +171,35 @@ func (v *VaultProvider) renewToken(ctx context.Context, watcher *vaultapi.Lifeti
 				v.logger.Error("Error renewing token for Vault provider", "error", err)
 			}
 
-			// Watcher routine has finished, so start it again.
+			// If the watcher has exited and auth method is enabled,
+			// re-authenticate using the auth method and set up a new watcher.
+			if v.config.AuthMethod != nil {
+				// Login to Vault using the auth method.
+				loginResp, err := vaultLogin(v.client, v.config.AuthMethod)
+				if err != nil {
+					v.logger.Error("Error login in to Vault with %q auth method", v.config.AuthMethod.Type)
+					// Restart the watcher.
+					go watcher.Start()
+					continue
+				}
+
+				// Set the new token for the vault client.
+				v.client.SetToken(loginResp.Auth.ClientToken)
+				v.logger.Info("Successfully re-authenticated with Vault using auth method")
+
+				// Start the new watcher for the new token.
+				watcher, err = v.client.NewLifetimeWatcher(&vaultapi.LifetimeWatcherInput{
+					Secret:        loginResp,
+					RenewBehavior: vaultapi.RenewBehaviorIgnoreErrors,
+				})
+				if err != nil {
+					v.logger.Error("Error starting token renewal process")
+					go watcher.Start()
+					continue
+				}
+			}
+
+			// Restart the watcher.
 			go watcher.Start()
 
 		case <-watcher.RenewCh():
@@ -599,7 +654,10 @@ func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderCon
 	}
 
 	decodeConf := &mapstructure.DecoderConfig{
-		DecodeHook:       structs.ParseDurationFunc(),
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			structs.ParseDurationFunc(),
+			decode.HookTranslateKeys,
+		),
 		Result:           &config,
 		WeaklyTypedInput: true,
 	}
@@ -613,8 +671,12 @@ func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderCon
 		return nil, fmt.Errorf("error decoding config: %s", err)
 	}
 
-	if config.Token == "" {
-		return nil, fmt.Errorf("must provide a Vault token")
+	if config.Token == "" && config.AuthMethod == nil {
+		return nil, fmt.Errorf("must provide a Vault token or configure a Vault auth method")
+	}
+
+	if config.Token != "" && config.AuthMethod != nil {
+		return nil, fmt.Errorf("only one of Vault token or auth method can be provided, but not both")
 	}
 
 	if config.RootPKIPath == "" {
@@ -636,4 +698,65 @@ func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderCon
 	}
 
 	return &config, nil
+}
+
+func vaultLogin(client *vaultapi.Client, authMethod *structs.VaultAuthMethod) (*vaultapi.Secret, error) {
+	loginPath, err := configureVaultAuthMethod(authMethod)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Logical().Write(loginPath, authMethod.Params)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || resp.Auth == nil || resp.Auth.ClientToken == "" {
+		return nil, fmt.Errorf("login response did not return client token")
+	}
+
+	return resp, nil
+}
+
+func configureVaultAuthMethod(authMethod *structs.VaultAuthMethod) (loginPath string, err error) {
+	if authMethod.MountPath == "" {
+		authMethod.MountPath = authMethod.Type
+	}
+
+	switch authMethod.Type {
+	case VaultAuthMethodTypeKubernetes:
+		// For the Kubernetes Auth method, we will try to read the JWT token
+		// from the default service account file location if jwt was not provided.
+		if jwt, ok := authMethod.Params["jwt"]; !ok || jwt == "" {
+			serviceAccountToken, err := os.ReadFile(defaultK8SServiceAccountTokenPath)
+			if err != nil {
+				return "", err
+			}
+
+			authMethod.Params["jwt"] = string(serviceAccountToken)
+		}
+		loginPath = fmt.Sprintf("auth/%s/login", authMethod.MountPath)
+	// These auth methods require a username for the login API path.
+	case VaultAuthMethodTypeLDAP, VaultAuthMethodTypeUserpass, VaultAuthMethodTypeOkta, VaultAuthMethodTypeRadius:
+		// Get username from the params.
+		if username, ok := authMethod.Params["username"]; ok {
+			loginPath = fmt.Sprintf("auth/%s/login/%s", authMethod.MountPath, username)
+		} else {
+			return "", fmt.Errorf("failed to get 'username' from auth method params")
+		}
+	// This auth method requires a role for the login API path.
+	case VaultAuthMethodTypeOCI:
+		if role, ok := authMethod.Params["role"]; ok {
+			loginPath = fmt.Sprintf("auth/%s/login/%s", authMethod.MountPath, role)
+		} else {
+			return "", fmt.Errorf("failed to get 'role' from auth method params")
+		}
+	case VaultAuthMethodTypeToken:
+		return "", fmt.Errorf("'token' auth method is not supported via auth method configuration; " +
+			"please provide the token with the 'token' parameter in the CA configuration")
+	// The rest of the auth methods use auth/<auth method path> login API path.
+	default:
+		loginPath = fmt.Sprintf("auth/%s/login", authMethod.MountPath)
+	}
+
+	return
 }

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -24,13 +24,23 @@ import (
 const (
 	VaultCALeafCertRole = "leaf-cert"
 
-	VaultAuthMethodTypeKubernetes = "kubernetes"
-	VaultAuthMethodTypeLDAP       = "ldap"
-	VaultAuthMethodTypeUserpass   = "userpass"
-	VaultAuthMethodTypeOkta       = "okta"
-	VaultAuthMethodTypeRadius     = "radius"
-	VaultAuthMethodTypeOCI        = "oci"
-	VaultAuthMethodTypeToken      = "token"
+	VaultAuthMethodTypeAliCloud     = "alicloud"
+	VaultAuthMethodTypeAppRole      = "approle"
+	VaultAuthMethodTypeAWS          = "aws"
+	VaultAuthMethodTypeAzure        = "azure"
+	VaultAuthMethodTypeCloudFoundry = "cf"
+	VaultAuthMethodTypeGitHub       = "github"
+	VaultAuthMethodTypeGCP          = "gcp"
+	VaultAuthMethodTypeJWT          = "jwt"
+	VaultAuthMethodTypeKerberos     = "kerberos"
+	VaultAuthMethodTypeKubernetes   = "kubernetes"
+	VaultAuthMethodTypeLDAP         = "ldap"
+	VaultAuthMethodTypeOCI          = "oci"
+	VaultAuthMethodTypeOkta         = "okta"
+	VaultAuthMethodTypeRadius       = "radius"
+	VaultAuthMethodTypeTLS          = "cert"
+	VaultAuthMethodTypeToken        = "token"
+	VaultAuthMethodTypeUserpass     = "userpass"
 
 	defaultK8SServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
@@ -751,8 +761,19 @@ func configureVaultAuthMethod(authMethod *structs.VaultAuthMethod) (loginPath st
 		return "", fmt.Errorf("'token' auth method is not supported via auth method configuration; " +
 			"please provide the token with the 'token' parameter in the CA configuration")
 	// The rest of the auth methods use auth/<auth method path> login API path.
-	default:
+	case VaultAuthMethodTypeAliCloud,
+		VaultAuthMethodTypeAppRole,
+		VaultAuthMethodTypeAWS,
+		VaultAuthMethodTypeAzure,
+		VaultAuthMethodTypeCloudFoundry,
+		VaultAuthMethodTypeGitHub,
+		VaultAuthMethodTypeGCP,
+		VaultAuthMethodTypeJWT,
+		VaultAuthMethodTypeKerberos,
+		VaultAuthMethodTypeTLS:
 		loginPath = fmt.Sprintf("auth/%s/login", authMethod.MountPath)
+	default:
+		return "", fmt.Errorf("auth method %q is not supported", authMethod.Type)
 	}
 
 	return

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -24,19 +24,15 @@ import (
 const (
 	VaultCALeafCertRole = "leaf-cert"
 
-	defaultK8SServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-)
-
-const (
 	VaultAuthMethodTypeKubernetes = "kubernetes"
+	VaultAuthMethodTypeLDAP       = "ldap"
+	VaultAuthMethodTypeUserpass   = "userpass"
+	VaultAuthMethodTypeOkta       = "okta"
+	VaultAuthMethodTypeRadius     = "radius"
+	VaultAuthMethodTypeOCI        = "oci"
+	VaultAuthMethodTypeToken      = "token"
 
-	VaultAuthMethodTypeLDAP     = "ldap"
-	VaultAuthMethodTypeUserpass = "userpass"
-	VaultAuthMethodTypeOkta     = "okta"
-	VaultAuthMethodTypeRadius   = "radius"
-	VaultAuthMethodTypeOCI      = "oci"
-
-	VaultAuthMethodTypeToken = "token"
+	defaultK8SServiceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 var ErrBackendNotMounted = fmt.Errorf("backend not mounted")

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -672,7 +672,7 @@ func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderCon
 	}
 
 	if config.Token != "" && config.AuthMethod != nil {
-		return nil, fmt.Errorf("only one of Vault token or auth method can be provided, but not both")
+		return nil, fmt.Errorf("only one of Vault token or Vault auth method can be provided, but not both")
 	}
 
 	if config.RootPKIPath == "" {
@@ -697,6 +697,7 @@ func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderCon
 }
 
 func vaultLogin(client *vaultapi.Client, authMethod *structs.VaultAuthMethod) (*vaultapi.Secret, error) {
+	// Adapted from https://www.vaultproject.io/docs/auth/kubernetes#code-example
 	loginPath, err := configureVaultAuthMethod(authMethod)
 	if err != nil {
 		return nil, err

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -147,7 +147,7 @@ func TestVaultCAProvider_RenewToken(t *testing.T) {
 	// Create a token with a short TTL to be renewed by the provider.
 	ttl := 1 * time.Second
 	tcr := &vaultapi.TokenCreateRequest{
-		TTL:       ttl.String(),
+		TTL: ttl.String(),
 	}
 	secret, err := testVault.client.Auth().Token().Create(tcr)
 	require.NoError(t, err)

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -30,7 +30,7 @@ func TestVaultCAProvider_ParseVaultCAConfig(t *testing.T) {
 		},
 		"both token and auth method provided": {
 			rawConfig: map[string]interface{}{"Token": "test", "AuthMethod": map[string]interface{}{"Type": "test"}},
-			expError:  "only one of Vault token or auth method can be provided, but not both",
+			expError:  "only one of Vault token or Vault auth method can be provided, but not both",
 		},
 		"no root PKI path": {
 			rawConfig: map[string]interface{}{"Token": "test"},

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -156,17 +156,14 @@ func TestVaultCAProvider_RenewToken(t *testing.T) {
 	_, err = createVaultProvider(t, true, testVault.Addr, providerToken, nil)
 	require.NoError(t, err)
 
+	// Check the last renewal time.
+	secret, err = testVault.client.Auth().Token().Lookup(providerToken)
+	require.NoError(t, err)
+	firstRenewal, err := secret.Data["last_renewal_time"].(json.Number).Int64()
+	require.NoError(t, err)
+
 	// Wait past the TTL and make sure the token has been renewed.
 	retry.Run(t, func(r *retry.R) {
-		// Check the last renewal time. We need to wait for the first renewal to happen
-		// for this value to be populated.
-		secret, err = testVault.client.Auth().Token().Lookup(providerToken)
-		require.NoError(r, err)
-		lastRenewalData, ok := secret.Data["last_renewal_time"]
-		require.True(r, ok)
-		firstRenewal, err := lastRenewalData.(json.Number).Int64()
-		require.NoError(r, err)
-
 		secret, err = testVault.client.Auth().Token().Lookup(providerToken)
 		require.NoError(r, err)
 		lastRenewal, err := secret.Data["last_renewal_time"].(json.Number).Int64()

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -554,6 +554,9 @@ func TestVaultProvider_Cleanup(t *testing.T) {
 }
 
 func TestVaultProvider_ConfigureWithAuthMethod(t *testing.T) {
+
+	SkipIfVaultNotPresent(t)
+
 	cases := []struct {
 		authMethodType          string
 		configureAuthMethodFunc func(t *testing.T, vaultClient *vaultapi.Client) map[string]interface{}
@@ -630,6 +633,9 @@ func TestVaultProvider_ConfigureWithAuthMethod(t *testing.T) {
 }
 
 func TestVaultProvider_RotateAuthMethodToken(t *testing.T) {
+
+	SkipIfVaultNotPresent(t)
+
 	testVault := NewTestVaultServer(t)
 
 	err := testVault.Client().Sys().EnableAuthWithOptions("approle", &vaultapi.EnableAuthOptions{Type: "approle"})

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -481,6 +481,14 @@ type VaultCAProviderConfig struct {
 	KeyFile       string
 	TLSServerName string
 	TLSSkipVerify bool
+
+	AuthMethod *VaultAuthMethod `alias:"auth_method"`
+}
+
+type VaultAuthMethod struct {
+	Type      string
+	MountPath string `alias:"mount_path"`
+	Params    map[string]interface{}
 }
 
 type AWSCAProviderConfig struct {

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -88,12 +88,31 @@ The configuration options are listed below.
 - `Address` / `address` (`string: <required>`) - The address of the Vault
   server.
 
-- `Token` / `token` (`string: <required>`) - A token for accessing Vault.
+- `Token` / `token` (`string: ""`) - A token for accessing Vault.
   This is write-only and will not be exposed when reading the CA configuration.
   This token must have [proper privileges](#vault-acl-policies) for the PKI
   paths configured. In Consul 1.8.5 and later, if the token has the [renewable](https://www.vaultproject.io/api-docs/auth/token#renewable)
   flag set, Consul will attempt to renew its lease periodically after half the
-  duration has expired.
+  duration has expired. You must either provide a token or configure an auth method below.
+
+- `AuthMethod` / `auth_method` (`map: nil`) - Vault auth method to use for logging in to Vault.
+   Please see [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for more information
+   on how to configure individual auth methods. If auth method is provided, Consul will obtain a
+   a new token from Vault when the token can no longer be renewed.
+   You must either configure the auth method or provide a token above.
+
+   - `Type`/ `type` (`string: ""`) - The type of Vault auth method, e.g. `kubernetes` or `approle`.
+
+   - `MountPath`/ `mount_path` (`string: <AuthMethod.Type>`) - The mount path of the auth method.
+      If not provided the auth method type will be used as the mount path.
+
+   - `Params`/`params` (`map: nil`) - The parameters to configure the auth method. Please see
+    [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for information on how to configure the
+    auth method you wish to use. If using the Kuberentes auth method,
+    Consul will try to read the service account token from the
+    default mount path `/var/run/secrets/kubernetes.io/serviceaccount/token` if the `jwt` parameter
+    is not provided.
+
 
 - `RootPKIPath` / `root_pki_path` (`string: <required>`) - The path to
   a PKI secrets engine for the root certificate. If the path does not

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -93,23 +93,26 @@ The configuration options are listed below.
   This token must have [proper privileges](#vault-acl-policies) for the PKI
   paths configured. In Consul 1.8.5 and later, if the token has the [renewable](https://www.vaultproject.io/api-docs/auth/token#renewable)
   flag set, Consul will attempt to renew its lease periodically after half the
-  duration has expired. You must either provide a token or configure an auth method below.
+  duration has expired.
+
+  !> **Warning:** You must either provide a token or configure an auth method below.
 
 - `AuthMethod` / `auth_method` (`map: nil`) - Vault auth method to use for logging in to Vault.
    Please see [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for more information
    on how to configure individual auth methods. If auth method is provided, Consul will obtain a
    a new token from Vault when the token can no longer be renewed.
-   You must either configure the auth method or provide a token above.
 
-   - `Type`/ `type` (`string: ""`) - The type of Vault auth method, e.g. `kubernetes` or `approle`.
+   !> **Warning:** You must either configure the auth method or provide a token above.
+
+   - `Type`/ `type` (`string: ""`) - The type of Vault auth method.
 
    - `MountPath`/ `mount_path` (`string: <AuthMethod.Type>`) - The mount path of the auth method.
       If not provided the auth method type will be used as the mount path.
 
    - `Params`/`params` (`map: nil`) - The parameters to configure the auth method. Please see
     [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for information on how to configure the
-    auth method you wish to use. If using the Kuberentes auth method,
-    Consul will try to read the service account token from the
+    auth method you wish to use. If using the Kubernetes auth method,
+    Consul will read the service account token from the
     default mount path `/var/run/secrets/kubernetes.io/serviceaccount/token` if the `jwt` parameter
     is not provided.
 

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -98,11 +98,11 @@ The configuration options are listed below.
   !> **Warning:** You must either provide a token or configure an auth method below.
 
 - `AuthMethod` / `auth_method` (`map: nil`) - Vault auth method to use for logging in to Vault.
-   Please see [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for more information
-   on how to configure individual auth methods. If auth method is provided, Consul will obtain a
-   a new token from Vault when the token can no longer be renewed.
+  Please see [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for more information
+  on how to configure individual auth methods. If auth method is provided, Consul will obtain a
+  a new token from Vault when the token can no longer be renewed.
 
-   !> **Warning:** You must either configure the auth method or provide a token above.
+  !> **Warning:** You must either configure the auth method or provide a token above.
 
    - `Type`/ `type` (`string: ""`) - The type of Vault auth method.
 

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -102,8 +102,6 @@ The configuration options are listed below.
   on how to configure individual auth methods. If auth method is provided, Consul will obtain a
   a new token from Vault when the token can no longer be renewed.
 
-  !> **Warning:** You must either configure the auth method or provide a token above.
-
    - `Type`/ `type` (`string: ""`) - The type of Vault auth method.
 
    - `MountPath`/ `mount_path` (`string: <AuthMethod.Type>`) - The mount path of the auth method.


### PR DESCRIPTION
## Changes proposed
- Support vault auth methods for the Vault connect CA provider
- Rotate the token (re-authenticate to vault using auth method) when the token can no longer be renewed

## Notes
- The unit tests only test auth methods that don't require an external system (like aws or kubernetes)
- I've tested it manually on Kubernetes using the helm chart