### PR TITLE
re-run gofmt on 1.17

### DIFF
--- a/acl/acl_oss.go
+++ b/acl/acl_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package acl

--- a/acl/authorizer_oss.go
+++ b/acl/authorizer_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package acl

--- a/acl/policy_authorizer_oss.go
+++ b/acl/policy_authorizer_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package acl

--- a/acl/policy_merger_oss.go
+++ b/acl/policy_merger_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package acl

--- a/acl/policy_oss.go
+++ b/acl/policy_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package acl

--- a/agent/acl_oss.go
+++ b/agent/acl_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/agent_endpoint_oss.go
+++ b/agent/agent_endpoint_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/agent_oss.go
+++ b/agent/agent_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/auto-config/auto_config_oss.go
+++ b/agent/auto-config/auto_config_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package autoconf

--- a/agent/auto-config/auto_config_oss_test.go
+++ b/agent/auto-config/auto_config_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package autoconf

--- a/agent/auto-config/config_oss.go
+++ b/agent/auto-config/config_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package autoconf

--- a/agent/auto-config/mock_oss_test.go
+++ b/agent/auto-config/mock_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package autoconf

--- a/agent/cache-types/connect_ca_leaf_oss.go
+++ b/agent/cache-types/connect_ca_leaf_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package cachetype

--- a/agent/cache-types/norace_test.go
+++ b/agent/cache-types/norace_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package cachetype

--- a/agent/cache-types/race_test.go
+++ b/agent/cache-types/race_test.go
@@ -1,3 +1,4 @@
+//go:build race
 // +build race
 
 package cachetype

--- a/agent/catalog_endpoint_oss.go
+++ b/agent/catalog_endpoint_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/checks/docker_unix.go
+++ b/agent/checks/docker_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package checks

--- a/agent/config/builder_oss.go
+++ b/agent/config/builder_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package config

--- a/agent/config/builder_oss_test.go
+++ b/agent/config/builder_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package config

--- a/agent/config/config_oss.go
+++ b/agent/config/config_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package config

--- a/agent/config/default_oss.go
+++ b/agent/config/default_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package config

--- a/agent/config/limits.go
+++ b/agent/config/limits.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package config

--- a/agent/config/limits_windows.go
+++ b/agent/config/limits_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package config

--- a/agent/config/runtime_oss.go
+++ b/agent/config/runtime_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package config

--- a/agent/config/runtime_oss_test.go
+++ b/agent/config/runtime_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package config

--- a/agent/config/segment_oss.go
+++ b/agent/config/segment_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package config

--- a/agent/config/segment_oss_test.go
+++ b/agent/config/segment_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package config

--- a/agent/connect/uri_agent_oss.go
+++ b/agent/connect/uri_agent_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package connect

--- a/agent/connect/uri_agent_oss_test.go
+++ b/agent/connect/uri_agent_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package connect

--- a/agent/connect/uri_service_oss.go
+++ b/agent/connect/uri_service_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package connect

--- a/agent/connect/uri_service_oss_test.go
+++ b/agent/connect/uri_service_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package connect

--- a/agent/consul/acl_authmethod_oss.go
+++ b/agent/consul/acl_authmethod_oss.go
@@ -1,4 +1,5 @@
-//+build !consulent
+//go:build !consulent
+// +build !consulent
 
 package consul
 

--- a/agent/consul/acl_endpoint_oss.go
+++ b/agent/consul/acl_endpoint_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/acl_oss.go
+++ b/agent/consul/acl_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/acl_oss_test.go
+++ b/agent/consul/acl_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/acl_server_oss.go
+++ b/agent/consul/acl_server_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/authmethod/authmethods_oss.go
+++ b/agent/consul/authmethod/authmethods_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package authmethod

--- a/agent/consul/authmethod/kubeauth/k8s_oss.go
+++ b/agent/consul/authmethod/kubeauth/k8s_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package kubeauth

--- a/agent/consul/authmethod/ssoauth/sso_oss.go
+++ b/agent/consul/authmethod/ssoauth/sso_oss.go
@@ -1,4 +1,5 @@
-//+build !consulent
+//go:build !consulent
+// +build !consulent
 
 package ssoauth
 

--- a/agent/consul/authmethod/testauth/testing_oss.go
+++ b/agent/consul/authmethod/testauth/testing_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package testauth

--- a/agent/consul/autopilot_oss.go
+++ b/agent/consul/autopilot_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/config_oss.go
+++ b/agent/consul/config_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/discoverychain/compile_oss.go
+++ b/agent/consul/discoverychain/compile_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package discoverychain

--- a/agent/consul/enterprise_config_oss.go
+++ b/agent/consul/enterprise_config_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/enterprise_server_oss_test.go
+++ b/agent/consul/enterprise_server_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/leader_intentions_oss.go
+++ b/agent/consul/leader_intentions_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/leader_intentions_oss_test.go
+++ b/agent/consul/leader_intentions_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/options_oss.go
+++ b/agent/consul/options_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package consul

--- a/agent/consul/prepared_query/walk_oss_test.go
+++ b/agent/consul/prepared_query/walk_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package prepared_query

--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/acl_oss_test.go
+++ b/agent/consul/state/acl_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/catalog_events_oss.go
+++ b/agent/consul/state/catalog_events_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/config_entry_intention_oss.go
+++ b/agent/consul/state/config_entry_intention_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/config_entry_oss.go
+++ b/agent/consul/state/config_entry_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/config_entry_oss_test.go
+++ b/agent/consul/state/config_entry_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/coordinate_oss.go
+++ b/agent/consul/state/coordinate_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/coordinate_oss_test.go
+++ b/agent/consul/state/coordinate_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/delay_oss.go
+++ b/agent/consul/state/delay_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/intention_oss.go
+++ b/agent/consul/state/intention_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/kvs_oss_test.go
+++ b/agent/consul/state/kvs_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/schema_oss_test.go
+++ b/agent/consul/state/schema_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/state_store_oss_test.go
+++ b/agent/consul/state/state_store_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/state/usage_oss.go
+++ b/agent/consul/state/usage_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package state

--- a/agent/consul/usagemetrics/usagemetrics_oss.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package usagemetrics

--- a/agent/consul/usagemetrics/usagemetrics_oss_test.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package usagemetrics

--- a/agent/dns_oss.go
+++ b/agent/dns_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/enterprise_delegate_oss.go
+++ b/agent/enterprise_delegate_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/exec/exec_unix.go
+++ b/agent/exec/exec_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package exec

--- a/agent/exec/exec_windows.go
+++ b/agent/exec/exec_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package exec

--- a/agent/http_oss.go
+++ b/agent/http_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/intentions_endpoint_oss_test.go
+++ b/agent/intentions_endpoint_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/operator_endpoint_oss.go
+++ b/agent/operator_endpoint_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/proxycfg/mesh_gateway_oss.go
+++ b/agent/proxycfg/mesh_gateway_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package proxycfg

--- a/agent/setup_oss.go
+++ b/agent/setup_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/signal_unix.go
+++ b/agent/signal_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package agent

--- a/agent/signal_windows.go
+++ b/agent/signal_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package agent

--- a/agent/structs/acl_oss.go
+++ b/agent/structs/acl_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/autopilot_oss.go
+++ b/agent/structs/autopilot_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/catalog_oss.go
+++ b/agent/structs/catalog_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/config_entry_discoverychain_oss.go
+++ b/agent/structs/config_entry_discoverychain_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/config_entry_intentions_oss.go
+++ b/agent/structs/config_entry_intentions_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/config_entry_mesh_oss.go
+++ b/agent/structs/config_entry_mesh_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/config_entry_oss.go
+++ b/agent/structs/config_entry_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/config_entry_oss_test.go
+++ b/agent/structs/config_entry_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/connect_oss.go
+++ b/agent/structs/connect_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/connect_proxy_config_oss.go
+++ b/agent/structs/connect_proxy_config_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/discovery_chain_oss.go
+++ b/agent/structs/discovery_chain_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/intention_oss.go
+++ b/agent/structs/intention_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/sanitize_oss.go
+++ b/agent/structs/sanitize_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/structs/structs_oss_test.go
+++ b/agent/structs/structs_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package structs

--- a/agent/token/store_oss.go
+++ b/agent/token/store_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package token

--- a/agent/ui_endpoint_oss_test.go
+++ b/agent/ui_endpoint_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package agent

--- a/agent/xds/net_fallback.go
+++ b/agent/xds/net_fallback.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package xds

--- a/agent/xds/net_linux.go
+++ b/agent/xds/net_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package xds

--- a/agent/xds/server_oss.go
+++ b/agent/xds/server_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package xds

--- a/api/namespace_test.go
+++ b/api/namespace_test.go
@@ -1,3 +1,4 @@
+//go:build consulent
 // +build consulent
 
 package api

--- a/api/oss_test.go
+++ b/api/oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package api

--- a/command/acl/authmethod/create/authmethod_create_oss.go
+++ b/command/acl/authmethod/create/authmethod_create_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package authmethodcreate

--- a/command/acl/authmethod/update/authmethod_update_oss.go
+++ b/command/acl/authmethod/update/authmethod_update_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package authmethodupdate

--- a/command/catalog/helpers_oss.go
+++ b/command/catalog/helpers_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package catalog

--- a/command/connect/envoy/envoy_oss_test.go
+++ b/command/connect/envoy/envoy_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package envoy

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package envoy

--- a/command/connect/envoy/exec_unix.go
+++ b/command/connect/envoy/exec_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package envoy

--- a/command/connect/envoy/exec_unsupported.go
+++ b/command/connect/envoy/exec_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 package envoy

--- a/command/lock/util_unix.go
+++ b/command/lock/util_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package lock

--- a/command/lock/util_windows.go
+++ b/command/lock/util_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package lock

--- a/command/login/login_oss.go
+++ b/command/login/login_oss.go
@@ -1,4 +1,5 @@
-//+build !consulent
+//go:build !consulent
+// +build !consulent
 
 package login
 

--- a/proto/pbcommon/common_oss.go
+++ b/proto/pbcommon/common_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package pbcommon

--- a/proto/pbservice/convert_oss.go
+++ b/proto/pbservice/convert_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package pbservice

--- a/proto/pbservice/convert_oss_test.go
+++ b/proto/pbservice/convert_oss_test.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package pbservice

--- a/sdk/freeport/ephemeral_darwin.go
+++ b/sdk/freeport/ephemeral_darwin.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 package freeport
 

--- a/sdk/freeport/ephemeral_darwin_test.go
+++ b/sdk/freeport/ephemeral_darwin_test.go
@@ -1,4 +1,5 @@
-//+build darwin
+//go:build darwin
+// +build darwin
 
 package freeport
 

--- a/sdk/freeport/ephemeral_fallback.go
+++ b/sdk/freeport/ephemeral_fallback.go
@@ -1,4 +1,5 @@
-//+build !linux,!darwin
+//go:build !linux && !darwin
+// +build !linux,!darwin
 
 package freeport
 

--- a/sdk/freeport/ephemeral_linux.go
+++ b/sdk/freeport/ephemeral_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package freeport
 

--- a/sdk/freeport/ephemeral_linux_test.go
+++ b/sdk/freeport/ephemeral_linux_test.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package freeport
 

--- a/sdk/freeport/systemlimit.go
+++ b/sdk/freeport/systemlimit.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package freeport

--- a/sdk/freeport/systemlimit_windows.go
+++ b/sdk/freeport/systemlimit_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package freeport

--- a/sdk/iptables/iptables_executor_linux.go
+++ b/sdk/iptables/iptables_executor_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package iptables

--- a/sdk/iptables/iptables_executor_unsupported.go
+++ b/sdk/iptables/iptables_executor_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package iptables

--- a/sentinel/sentinel_oss.go
+++ b/sentinel/sentinel_oss.go
@@ -1,3 +1,4 @@
+//go:build !consulent
 // +build !consulent
 
 package sentinel

--- a/service_os/service_windows.go
+++ b/service_os/service_windows.go
@@ -1,4 +1,5 @@
-//+build windows
+//go:build windows
+// +build windows
 
 package service_os
 

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package envoy


### PR DESCRIPTION
This should let freshly recompiled golangci-lint binaries using Go 1.17
pass 'make lint'

Fixed mostly by `for f in $(find . -name '*.go' ); do gofmt -s -w $f; done`