### PR TITLE
build: switch to 'go install' over 'go get'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - image: *GOLANG_IMAGE
     steps:
       - checkout
-      - run: go get -u github.com/hashicorp/lint-consul-retry && lint-consul-retry
+      - run: go install github.com/hashicorp/lint-consul-retry@master && lint-consul-retry
       - run: *notify-slack-failure
 
   lint:
@@ -184,9 +184,8 @@ jobs:
           name: Install gogo/protobuf
           command: |
             gogo_version=$(go list -m github.com/gogo/protobuf | awk '{print $2}')
-            mkdir -p .gotools; cd .gotools; go mod init consul-tools
-            go get -v github.com/hashicorp/protoc-gen-go-binary
-            go get -v github.com/gogo/protobuf/protoc-gen-gofast@${gogo_version}
+            go install -v github.com/hashicorp/protoc-gen-go-binary@master
+            go install -v github.com/gogo/protobuf/protoc-gen-gofast@${gogo_version}
 
       - run:
           command: make --always-make proto

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,12 +3,13 @@ GOGOVERSION?=$(shell grep github.com/gogo/protobuf go.mod | awk '{print $$2}')
 GOTOOLS = \
 	github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@master \
 	github.com/hashicorp/go-bindata/go-bindata@master \
-	golang.org/x/tools/cmd/cover \
-	golang.org/x/tools/cmd/stringer \
+	golang.org/x/tools/cmd/cover@master \
+	golang.org/x/tools/cmd/stringer@master \
 	github.com/gogo/protobuf/protoc-gen-gofast@$(GOGOVERSION) \
-	github.com/hashicorp/protoc-gen-go-binary \
-	github.com/vektra/mockery/cmd/mockery \
-	github.com/golangci/golangci-lint/cmd/golangci-lint@v1.40.1
+	github.com/hashicorp/protoc-gen-go-binary@master \
+	github.com/vektra/mockery/cmd/mockery@master \
+	github.com/golangci/golangci-lint/cmd/golangci-lint@v1.40.1 \
+	github.com/hashicorp/lint-consul-retry@master
 
 GOTAGS ?=
 GOOS?=$(shell go env GOOS)
@@ -283,12 +284,10 @@ static-assets:
 ui: ui-docker static-assets-docker
 
 tools:
-	@mkdir -p .gotools
-	@cd .gotools && for TOOL in $(GOTOOLS); do \
+	@if [[ -d .gotools ]]; then rm -rf .gotools ; fi
+	@for TOOL in $(GOTOOLS); do \
 		echo "=== TOOL: $$TOOL" ; \
-		rm -f go.mod go.sum ; \
-		go mod init consul-tools ; \
-		go get -v $$TOOL ; \
+		go install -v $$TOOL ; \
 	done
 
 version:


### PR DESCRIPTION
Also add lint-consul-retry to the 'make tools' set.

`go get` to install binaries is deprecated. Also `go install` is faster and doesn't require the weird interim directory and go.mod file.