### PR TITLE
ca: small cleanup of SpiffeIDSigningForCluster args

### DIFF
--- a/agent/connect/ca/provider_aws.go
+++ b/agent/connect/ca/provider_aws.go
@@ -603,7 +603,7 @@ func (a *AWSProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 
 // SignIntermediate implements Provider
 func (a *AWSProvider) SignIntermediate(csr *x509.CertificateRequest) (string, error) {
-	err := validateSignIntermediate(csr, &connect.SpiffeIDSigning{ClusterID: a.clusterID, Domain: "consul"})
+	err := validateSignIntermediate(csr, connect.SpiffeIDSigningForCluster(a.clusterID))
 	if err != nil {
 		return "", err
 	}

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -617,19 +617,13 @@ func (c *ConsulProvider) incrementAndGetNextSerialNumber() (uint64, error) {
 
 // generateCA makes a new root CA using the current private key
 func (c *ConsulProvider) generateCA(privateKey string, sn uint64, rootCertTTL time.Duration) (string, error) {
-	stateStore := c.Delegate.State()
-	_, config, err := stateStore.CAConfig(nil)
-	if err != nil {
-		return "", err
-	}
-
 	privKey, err := connect.ParseSigner(privateKey)
 	if err != nil {
 		return "", fmt.Errorf("error parsing private key %q: %s", privateKey, err)
 	}
 
 	// The URI (SPIFFE compatible) for the cert
-	id := connect.SpiffeIDSigningForCluster(config.ClusterID)
+	id := connect.SpiffeIDSigningForCluster(c.clusterID)
 	keyId, err := connect.KeyId(privKey.Public())
 	if err != nil {
 		return "", err

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -76,7 +76,7 @@ func (c *ConsulProvider) Configure(cfg ProviderConfig) error {
 	c.id = hexStringHash(fmt.Sprintf("%s,%s,%s,%d,%v", config.PrivateKey, config.RootCert, config.PrivateKeyType, config.PrivateKeyBits, cfg.IsPrimary))
 	c.clusterID = cfg.ClusterID
 	c.isPrimary = cfg.IsPrimary
-	c.spiffeID = connect.SpiffeIDSigningForCluster(&structs.CAConfiguration{ClusterID: c.clusterID})
+	c.spiffeID = connect.SpiffeIDSigningForCluster(c.clusterID)
 
 	// Passthrough test state for state handling tests. See testState doc.
 	c.parseTestState(cfg.RawConfig, cfg.State)
@@ -629,7 +629,7 @@ func (c *ConsulProvider) generateCA(privateKey string, sn uint64, rootCertTTL ti
 	}
 
 	// The URI (SPIFFE compatible) for the cert
-	id := connect.SpiffeIDSigningForCluster(config)
+	id := connect.SpiffeIDSigningForCluster(config.ClusterID)
 	keyId, err := connect.KeyId(privKey.Public())
 	if err != nil {
 		return "", err

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -87,7 +87,7 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	v.client = client
 	v.isPrimary = cfg.IsPrimary
 	v.clusterID = cfg.ClusterID
-	v.spiffeID = connect.SpiffeIDSigningForCluster(&structs.CAConfiguration{ClusterID: v.clusterID})
+	v.spiffeID = connect.SpiffeIDSigningForCluster(v.clusterID)
 
 	// Look up the token to see if we can auto-renew its lease.
 	secret, err := client.Auth().Token().LookupSelf()

--- a/agent/connect/uri_signing.go
+++ b/agent/connect/uri_signing.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-
-	"github.com/hashicorp/consul/agent/structs"
 )
 
 // SpiffeIDSigning is the structure to represent the SPIFFE ID for a
@@ -64,6 +62,6 @@ func (id SpiffeIDSigning) CanSign(cu CertURI) bool {
 // break all certificate validation. That does mean that DNS prefix might not
 // match the identity URIs and so the trust domain might not actually resolve
 // which we would like but don't actually need.
-func SpiffeIDSigningForCluster(config *structs.CAConfiguration) *SpiffeIDSigning {
-	return &SpiffeIDSigning{ClusterID: config.ClusterID, Domain: "consul"}
+func SpiffeIDSigningForCluster(clusterID string) *SpiffeIDSigning {
+	return &SpiffeIDSigning{ClusterID: clusterID, Domain: "consul"}
 }

--- a/agent/connect/uri_signing_test.go
+++ b/agent/connect/uri_signing_test.go
@@ -5,17 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/agent/structs"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSpiffeIDSigningForCluster(t *testing.T) {
 	// For now it should just append .consul to the ID.
-	config := &structs.CAConfiguration{
-		ClusterID: TestClusterID,
-	}
-	id := SpiffeIDSigningForCluster(config)
+	id := SpiffeIDSigningForCluster(TestClusterID)
 	assert.Equal(t, id.URI().String(), "spiffe://"+TestClusterID+".consul")
 }
 

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1401,7 +1401,7 @@ func (c *CAManager) SignCertificate(csr *x509.CertificateRequest, spiffeID conne
 	if err != nil {
 		return nil, err
 	}
-	signingID := connect.SpiffeIDSigningForCluster(config)
+	signingID := connect.SpiffeIDSigningForCluster(config.ClusterID)
 	serviceID, isService := spiffeID.(*connect.SpiffeIDService)
 	agentID, isAgent := spiffeID.(*connect.SpiffeIDAgent)
 	if !isService && !isAgent {

--- a/agent/consul/server_connect.go
+++ b/agent/consul/server_connect.go
@@ -23,7 +23,7 @@ func (s *Server) getCARoots(ws memdb.WatchSet, state *state.Store) (*structs.Ind
 	indexedRoots := &structs.IndexedCARoots{}
 
 	// Build TrustDomain based on the ClusterID stored.
-	signingID := connect.SpiffeIDSigningForCluster(config)
+	signingID := connect.SpiffeIDSigningForCluster(config.ClusterID)
 	if signingID == nil {
 		// If CA is bootstrapped at all then this should never happen but be
 		// defensive.

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -800,7 +800,7 @@ func (s *Store) serviceDiscoveryChainTxn(
 	}
 
 	// Build TrustDomain based on the ClusterID stored.
-	signingID := connect.SpiffeIDSigningForCluster(config)
+	signingID := connect.SpiffeIDSigningForCluster(config.ClusterID)
 	if signingID == nil {
 		// If CA is bootstrapped at all then this should never happen but be
 		// defensive.


### PR DESCRIPTION
Slightly related to #11347

This was some cleanup I found sitting on a branch. I did this while working on #11514, and I'm opening a PR now so I don't lose the changes.

The idea here is that we only use one field from this struct, and it seems very likely that we'll want to store this ClusterID somewhere else (not on this struct), so by changing this functional signature now it'll be easier to make the larger change later.

This also helps simplify the `ConsulProvider`, because the provider no longer needs to get all `State`, it only needs the provider specific state. I had another commit which changed the interface to make that explicit, but I dropped it for now as it wasn't necessary.