### PR TITLE
ui: Store the default partition when logging in

### DIFF
--- a/.changelog/11591.txt
+++ b/.changelog/11591.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Ensure the UI stores the default partition for the users token
+```

--- a/ui/packages/consul-ui/app/components/token-source/index.js
+++ b/ui/packages/consul-ui/app/components/token-source/index.js
@@ -21,6 +21,7 @@ export default Component.extend({
           // in the response
           SecretID: this.SecretID,
           Namespace: this.Namespace,
+          Partition: this.Partition,
           ...{
             AuthMethod: typeof this.AuthMethod !== 'undefined' ? this.AuthMethod : undefined,
             // TODO: We should be able to only set namespaces if they are enabled


### PR DESCRIPTION
Make sure we store the default `Partition` for a users token.