### PR TITLE
kv: support `ResultsFilteredByACLs` flag/header

### DIFF
--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -204,7 +204,10 @@ func (k *KVS) List(args *structs.KeyRequest, reply *structs.IndexedDirEntries) e
 			if err != nil {
 				return err
 			}
+
+			total := len(ent)
 			ent = FilterDirEnt(authz, ent)
+			reply.QueryMeta.ResultsFilteredByACLs = total != len(ent)
 
 			if len(ent) == 0 {
 				// Must provide non-zero index to prevent blocking
@@ -263,7 +266,9 @@ func (k *KVS) ListKeys(args *structs.KeyListRequest, reply *structs.IndexedKeyLi
 				reply.Index = index
 			}
 
+			total := len(entries)
 			entries = FilterDirEnt(authz, entries)
+			reply.QueryMeta.ResultsFilteredByACLs = total != len(entries)
 
 			// Collect the keys from the filtered entries
 			prefixLen := len(args.Prefix)

--- a/agent/consul/kvs_endpoint_test.go
+++ b/agent/consul/kvs_endpoint_test.go
@@ -287,6 +287,9 @@ func TestKVSEndpoint_List(t *testing.T) {
 			t.Fatalf("bad: %v", d)
 		}
 	}
+	if dirent.QueryMeta.ResultsFilteredByACLs {
+		t.Fatal("ResultsFilteredByACLs should not be true")
+	}
 
 	// Try listing a nonexistent prefix
 	getR.Key = "/nope"
@@ -475,6 +478,9 @@ func TestKVSEndpoint_List_ACLDeny(t *testing.T) {
 			}
 		}
 	}
+	if !dirent.QueryMeta.ResultsFilteredByACLs {
+		t.Fatal("ResultsFilteredByACLs should be true")
+	}
 }
 
 func TestKVSEndpoint_List_ACLEnableKeyListPolicy(t *testing.T) {
@@ -652,6 +658,9 @@ func TestKVSEndpoint_ListKeys(t *testing.T) {
 	if dirent.Keys[2] != "/test/sub/" {
 		t.Fatalf("Bad: %v", dirent.Keys)
 	}
+	if dirent.QueryMeta.ResultsFilteredByACLs {
+		t.Fatal("ResultsFilteredByACLs should not be true")
+	}
 
 	// Try listing a nonexistent prefix
 	getR.Prefix = "/nope"
@@ -733,6 +742,9 @@ func TestKVSEndpoint_ListKeys_ACLDeny(t *testing.T) {
 	}
 	if dirent.Keys[1] != "test" {
 		t.Fatalf("Bad: %v", dirent.Keys)
+	}
+	if !dirent.QueryMeta.ResultsFilteredByACLs {
+		t.Fatal("ResultsFilteredByACLs should be true")
 	}
 }
 


### PR DESCRIPTION
Adds support for the `ResultsFilteredByACLs` flag, and corresponding `X-Consul-Results-Filtered-By-ACLs` HTTP header (introduced in #11569) to the KV `List` and `ListKeys` endpoints.