### PR TITLE
catalog: support `ResultsFilteredByACLs` flag/header

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1508,11 +1508,13 @@ func (f *aclFilter) filterServiceDump(services *structs.ServiceDump) {
 }
 
 // filterNodes is used to filter through all parts of a node list and remove
-// elements the provided ACL token cannot access.
-func (f *aclFilter) filterNodes(nodes *structs.Nodes) {
+// elements the provided ACL token cannot access. Returns true if any elements
+// were removed.
+func (f *aclFilter) filterNodes(nodes *structs.Nodes) bool {
 	n := *nodes
 
 	var authzContext acl.AuthorizerContext
+	var removed bool
 
 	for i := 0; i < len(n); i++ {
 		n[i].FillAuthzContext(&authzContext)
@@ -1521,10 +1523,12 @@ func (f *aclFilter) filterNodes(nodes *structs.Nodes) {
 			continue
 		}
 		f.logger.Debug("dropping node from result due to ACLs", "node", structs.NodeNameString(node, n[i].GetEnterpriseMeta()))
+		removed = true
 		n = append(n[:i], n[i+1:]...)
 		i--
 	}
 	*nodes = n
+	return removed
 }
 
 // redactPreparedQueryTokens will redact any tokens unless the client has a
@@ -1833,7 +1837,7 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 		filt.filterServiceDump(&v.Dump)
 
 	case *structs.IndexedNodes:
-		filt.filterNodes(&v.Nodes)
+		v.QueryMeta.ResultsFilteredByACLs = filt.filterNodes(&v.Nodes)
 
 	case *structs.IndexedNodeServices:
 		filt.filterNodeServices(&v.NodeServices)

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1914,6 +1914,14 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 	case *structs.IndexedGatewayServices:
 		v.QueryMeta.ResultsFilteredByACLs = filt.filterGatewayServices(&v.Services)
 
+	case *structs.IndexedNodesWithGateways:
+		if filt.filterCheckServiceNodes(&v.Nodes) {
+			v.QueryMeta.ResultsFilteredByACLs = true
+		}
+		if filt.filterGatewayServices(&v.Gateways) {
+			v.QueryMeta.ResultsFilteredByACLs = true
+		}
+
 	default:
 		panic(fmt.Errorf("Unhandled type passed to ACL filter: %T %#v", subj, subj))
 	}

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1767,14 +1767,16 @@ func (f *aclFilter) filterAuthMethods(methods *structs.ACLAuthMethods) {
 	*methods = ret
 }
 
-func (f *aclFilter) filterServiceList(services *structs.ServiceList) {
+func (f *aclFilter) filterServiceList(services *structs.ServiceList) bool {
 	ret := make(structs.ServiceList, 0, len(*services))
+	var removed bool
 	for _, svc := range *services {
 		var authzContext acl.AuthorizerContext
 
 		svc.FillAuthzContext(&authzContext)
 
 		if f.authorizer.ServiceRead(svc.Name, &authzContext) != acl.Allow {
+			removed = true
 			sid := structs.NewServiceID(svc.Name, &svc.EnterpriseMeta)
 			f.logger.Debug("dropping service from result due to ACLs", "service", sid.String())
 			continue
@@ -1784,6 +1786,7 @@ func (f *aclFilter) filterServiceList(services *structs.ServiceList) {
 	}
 
 	*services = ret
+	return removed
 }
 
 // filterGatewayServices is used to filter gateway to service mappings based on ACL rules.
@@ -1896,7 +1899,7 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 		filt.filterAuthMethod(v)
 
 	case *structs.IndexedServiceList:
-		filt.filterServiceList(&v.Services)
+		v.QueryMeta.ResultsFilteredByACLs = filt.filterServiceList(&v.Services)
 
 	case *structs.GatewayServices:
 		filt.filterGatewayServices(v)

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -2295,6 +2295,9 @@ service "foo" {
 
 func TestACL_filterServices(t *testing.T) {
 	t.Parallel()
+
+	require := require.New(t)
+
 	// Create some services
 	services := structs.Services{
 		"service1": []string{},
@@ -2304,17 +2307,15 @@ func TestACL_filterServices(t *testing.T) {
 
 	// Try permissive filtering.
 	filt := newACLFilter(acl.AllowAll(), nil)
-	filt.filterServices(services, nil)
-	if len(services) != 3 {
-		t.Fatalf("bad: %#v", services)
-	}
+	removed := filt.filterServices(services, nil)
+	require.False(removed)
+	require.Len(services, 3)
 
 	// Try restrictive filtering.
 	filt = newACLFilter(acl.DenyAll(), nil)
-	filt.filterServices(services, nil)
-	if len(services) != 0 {
-		t.Fatalf("bad: %#v", services)
-	}
+	removed = filt.filterServices(services, nil)
+	require.True(removed)
+	require.Empty(services)
 }
 
 func TestACL_filterServiceNodes(t *testing.T) {

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -2919,6 +2919,9 @@ node "node1" {
 
 func TestACL_filterNodes(t *testing.T) {
 	t.Parallel()
+
+	require := require.New(t)
+
 	// Create a nodes list.
 	nodes := structs.Nodes{
 		&structs.Node{
@@ -2931,17 +2934,15 @@ func TestACL_filterNodes(t *testing.T) {
 
 	// Try permissive filtering.
 	filt := newACLFilter(acl.AllowAll(), nil)
-	filt.filterNodes(&nodes)
-	if len(nodes) != 2 {
-		t.Fatalf("bad: %#v", nodes)
-	}
+	removed := filt.filterNodes(&nodes)
+	require.False(removed)
+	require.Len(nodes, 2)
 
 	// Try restrictive filtering
 	filt = newACLFilter(acl.DenyAll(), nil)
-	filt.filterNodes(&nodes)
-	if len(nodes) != 0 {
-		t.Fatalf("bad: %#v", nodes)
-	}
+	removed = filt.filterNodes(&nodes)
+	require.True(removed)
+	require.Len(nodes, 0)
 }
 
 func TestACL_filterDatacenterCheckServiceNodes(t *testing.T) {

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -2320,83 +2320,72 @@ func TestACL_filterServices(t *testing.T) {
 
 func TestACL_filterServiceNodes(t *testing.T) {
 	t.Parallel()
-	// Create some service nodes.
-	fill := func() structs.ServiceNodes {
-		return structs.ServiceNodes{
-			&structs.ServiceNode{
-				Node:        "node1",
-				ServiceName: "foo",
+
+	logger := hclog.NewNullLogger()
+
+	makeList := func() *structs.IndexedServiceNodes {
+		return &structs.IndexedServiceNodes{
+			ServiceNodes: structs.ServiceNodes{
+				{
+					Node:        "node1",
+					ServiceName: "foo",
+				},
 			},
 		}
 	}
 
-	// Try permissive filtering.
-	{
-		nodes := fill()
-		filt := newACLFilter(acl.AllowAll(), nil)
-		filt.filterServiceNodes(&nodes)
-		if len(nodes) != 1 {
-			t.Fatalf("bad: %#v", nodes)
-		}
-	}
+	t.Run("allowed", func(t *testing.T) {
+		require := require.New(t)
 
-	// Try restrictive filtering.
-	{
-		nodes := fill()
-		filt := newACLFilter(acl.DenyAll(), nil)
-		filt.filterServiceNodes(&nodes)
-		if len(nodes) != 0 {
-			t.Fatalf("bad: %#v", nodes)
-		}
-	}
+		policy, err := acl.NewPolicyFromSource(`
+			service "foo" {
+			  policy = "read"
+			}
+			node "node1" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
 
-	// Allowed to see the service but not the node.
-	policy, err := acl.NewPolicyFromSource(`
-service "foo" {
-  policy = "read"
-}
-`, acl.SyntaxLegacy, nil, nil)
-	if err != nil {
-		t.Fatalf("err %v", err)
-	}
-	perms, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
 
-	// But with version 8 the node will block it.
-	{
-		nodes := fill()
-		filt := newACLFilter(perms, nil)
-		filt.filterServiceNodes(&nodes)
-		if len(nodes) != 0 {
-			t.Fatalf("bad: %#v", nodes)
-		}
-	}
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
 
-	// Chain on access to the node.
-	policy, err = acl.NewPolicyFromSource(`
-node "node1" {
-  policy = "read"
-}
-`, acl.SyntaxLegacy, nil, nil)
-	if err != nil {
-		t.Fatalf("err %v", err)
-	}
-	perms, err = acl.NewPolicyAuthorizerWithDefaults(perms, []*acl.Policy{policy}, nil)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		require.Len(list.ServiceNodes, 1)
+		require.False(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
+	})
 
-	// Now it should go through.
-	{
-		nodes := fill()
-		filt := newACLFilter(perms, nil)
-		filt.filterServiceNodes(&nodes)
-		if len(nodes) != 1 {
-			t.Fatalf("bad: %#v", nodes)
-		}
-	}
+	t.Run("allowed to read the service, but not the node", func(t *testing.T) {
+		require := require.New(t)
+
+		policy, err := acl.NewPolicyFromSource(`
+			service "foo" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
+
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
+
+		require.Empty(list.ServiceNodes)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("denied", func(t *testing.T) {
+		require := require.New(t)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, acl.DenyAll(), list)
+
+		require.Empty(list.ServiceNodes)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
 }
 
 func TestACL_filterNodeServices(t *testing.T) {

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -810,11 +810,8 @@ func (c *Catalog) NodeServiceList(args *structs.NodeSpecificRequest, reply *stru
 				return err
 			}
 
-			if err := c.srv.filterACL(args.Token, &services); err != nil {
-				return err
-			}
-
 			reply.Index = index
+
 			if services != nil {
 				reply.NodeServices = *services
 
@@ -823,6 +820,13 @@ func (c *Catalog) NodeServiceList(args *structs.NodeSpecificRequest, reply *stru
 					return err
 				}
 				reply.NodeServices.Services = raw.([]*structs.NodeService)
+			}
+
+			// Note: we filter the results with ACLs *after* applying the user-supplied
+			// bexpr filter, to ensure QueryMeta.ResultsFilteredByACLs does not include
+			// results that would be filtered out even if the user did have permission.
+			if err := c.srv.filterACL(args.Token, reply); err != nil {
+				return err
 			}
 
 			return nil

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -888,12 +888,11 @@ func (c *Catalog) GatewayServices(args *structs.ServiceSpecificRequest, reply *s
 			if err != nil {
 				return err
 			}
+			reply.Index, reply.Services = index, services
 
-			if err := c.srv.filterACL(args.Token, &services); err != nil {
+			if err := c.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
-
-			reply.Index, reply.Services = index, services
 			return nil
 		})
 }

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -2481,6 +2481,7 @@ node "foo" {
 	require.Len(t, resp.ServiceNodes, 1)
 	v := resp.ServiceNodes[0]
 	require.Equal(t, "foo-proxy", v.ServiceName)
+	require.True(t, resp.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 }
 
 func TestCatalog_ListServiceNodes_ConnectNative(t *testing.T) {
@@ -2836,6 +2837,7 @@ func TestCatalog_ServiceNodes_FilterACL(t *testing.T) {
 			t.Fatalf("bad: %#v", reply.ServiceNodes)
 		}
 	}
+	require.True(t, reply.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 
 	// We've already proven that we call the ACL filtering function so we
 	// test node filtering down in acl.go for node cases. This also proves

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -3395,6 +3395,7 @@ service "gateway" {
 		var resp structs.IndexedGatewayServices
 		assert.Nil(r, msgpackrpc.CallWithCodec(codec, "Catalog.GatewayServices", &req, &resp))
 		assert.Len(r, resp.Services, 0)
+		assert.True(r, resp.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 	})
 
 	rules = `
@@ -3418,6 +3419,7 @@ service "gateway" {
 		var resp structs.IndexedGatewayServices
 		assert.Nil(r, msgpackrpc.CallWithCodec(codec, "Catalog.GatewayServices", &req, &resp))
 		assert.Len(r, resp.Services, 2)
+		assert.True(r, resp.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 
 		expect := structs.GatewayServices{
 			{

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -1313,7 +1313,7 @@ func TestCatalog_ListNodes_ACLFilter(t *testing.T) {
 			s1.config.NodeName,
 			policy,
 		)
-		return createTokenWithPolicyName(t, policy, codec, rules)
+		return createTokenWithPolicyName(t, codec, policy, rules, "root")
 	}
 
 	args := structs.DCSpecificRequest{
@@ -2874,7 +2874,7 @@ func TestCatalog_NodeServices_ACL(t *testing.T) {
 			policy,
 			policy,
 		)
-		return createTokenWithPolicyName(t, policy, codec, rules)
+		return createTokenWithPolicyName(t, codec, policy, rules, "root")
 	}
 
 	args := structs.NodeSpecificRequest{

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -1428,6 +1428,7 @@ func TestCatalog_ListServices(t *testing.T) {
 		t.Fatalf("bad: %v", out)
 	}
 	require.False(t, out.QueryMeta.NotModified)
+	require.False(t, out.QueryMeta.ResultsFilteredByACLs)
 
 	t.Run("with option AllowNotModifiedResponse", func(t *testing.T) {
 		args.QueryOptions = structs.QueryOptions{
@@ -2783,6 +2784,9 @@ func TestCatalog_ListServices_FilterACL(t *testing.T) {
 	}
 	if _, ok := reply.Services["bar"]; ok {
 		t.Fatalf("bad: %#v", reply.Services)
+	}
+	if !reply.QueryMeta.ResultsFilteredByACLs {
+		t.Fatal("ResultsFilteredByACLs should be true")
 	}
 }
 


### PR DESCRIPTION
Adds support for the `ResultsFilteredByACLs` flag, and corresponding `X-Consul-Results-Filtered-By-ACLs` HTTP header (introduced in #11569) to the catalog endpoints.

