### PR TITLE
Ensure consistency with error-handling across all handlers.

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -16,6 +16,8 @@ type aclBootstrapResponse struct {
 	structs.ACLToken
 }
 
+var aclDisabled = UnauthorizedError{Reason: "ACL support disabled"}
+
 // checkACLDisabled will return a standard response if ACLs are disabled. This
 // returns true if they are disabled and we should not continue.
 func (s *HTTPHandlers) checkACLDisabled(resp http.ResponseWriter, _req *http.Request) bool {
@@ -23,8 +25,6 @@ func (s *HTTPHandlers) checkACLDisabled(resp http.ResponseWriter, _req *http.Req
 		return false
 	}
 
-	resp.WriteHeader(http.StatusUnauthorized)
-	fmt.Fprint(resp, "ACL support disabled")
 	return true
 }
 
@@ -32,7 +32,7 @@ func (s *HTTPHandlers) checkACLDisabled(resp http.ResponseWriter, _req *http.Req
 // a cluster to get the first management token.
 func (s *HTTPHandlers) ACLBootstrap(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	args := structs.DCSpecificRequest{
@@ -54,7 +54,7 @@ func (s *HTTPHandlers) ACLBootstrap(resp http.ResponseWriter, req *http.Request)
 
 func (s *HTTPHandlers) ACLReplicationStatus(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	// Note that we do not forward to the ACL DC here. This is a query for
@@ -75,7 +75,7 @@ func (s *HTTPHandlers) ACLReplicationStatus(resp http.ResponseWriter, req *http.
 
 func (s *HTTPHandlers) ACLPolicyList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var args structs.ACLPolicyListRequest
@@ -106,7 +106,7 @@ func (s *HTTPHandlers) ACLPolicyList(resp http.ResponseWriter, req *http.Request
 
 func (s *HTTPHandlers) ACLPolicyCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var fn func(resp http.ResponseWriter, req *http.Request, policyID string) (interface{}, error)
@@ -167,7 +167,7 @@ func (s *HTTPHandlers) ACLPolicyRead(resp http.ResponseWriter, req *http.Request
 
 func (s *HTTPHandlers) ACLPolicyReadByName(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	policyName := strings.TrimPrefix(req.URL.Path, "/v1/acl/policy/name/")
@@ -184,7 +184,7 @@ func (s *HTTPHandlers) ACLPolicyReadByID(resp http.ResponseWriter, req *http.Req
 
 func (s *HTTPHandlers) ACLPolicyCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	return s.aclPolicyWriteInternal(resp, req, "", true)
@@ -249,7 +249,7 @@ func (s *HTTPHandlers) ACLPolicyDelete(resp http.ResponseWriter, req *http.Reque
 
 func (s *HTTPHandlers) ACLTokenList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	args := &structs.ACLTokenListRequest{
@@ -286,7 +286,7 @@ func (s *HTTPHandlers) ACLTokenList(resp http.ResponseWriter, req *http.Request)
 
 func (s *HTTPHandlers) ACLTokenCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var fn func(resp http.ResponseWriter, req *http.Request, tokenID string) (interface{}, error)
@@ -319,7 +319,7 @@ func (s *HTTPHandlers) ACLTokenCRUD(resp http.ResponseWriter, req *http.Request)
 
 func (s *HTTPHandlers) ACLTokenSelf(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	args := structs.ACLTokenGetRequest{
@@ -352,7 +352,7 @@ func (s *HTTPHandlers) ACLTokenSelf(resp http.ResponseWriter, req *http.Request)
 
 func (s *HTTPHandlers) ACLTokenCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	return s.aclTokenSetInternal(req, "", true)
@@ -443,7 +443,7 @@ func (s *HTTPHandlers) ACLTokenDelete(resp http.ResponseWriter, req *http.Reques
 
 func (s *HTTPHandlers) ACLTokenClone(resp http.ResponseWriter, req *http.Request, tokenID string) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	args := structs.ACLTokenSetRequest{
@@ -472,7 +472,7 @@ func (s *HTTPHandlers) ACLTokenClone(resp http.ResponseWriter, req *http.Request
 
 func (s *HTTPHandlers) ACLRoleList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var args structs.ACLRoleListRequest
@@ -505,7 +505,7 @@ func (s *HTTPHandlers) ACLRoleList(resp http.ResponseWriter, req *http.Request) 
 
 func (s *HTTPHandlers) ACLRoleCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var fn func(resp http.ResponseWriter, req *http.Request, roleID string) (interface{}, error)
@@ -534,7 +534,7 @@ func (s *HTTPHandlers) ACLRoleCRUD(resp http.ResponseWriter, req *http.Request) 
 
 func (s *HTTPHandlers) ACLRoleReadByName(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	roleName := strings.TrimPrefix(req.URL.Path, "/v1/acl/role/name/")
@@ -582,7 +582,7 @@ func (s *HTTPHandlers) ACLRoleRead(resp http.ResponseWriter, req *http.Request, 
 
 func (s *HTTPHandlers) ACLRoleCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	return s.ACLRoleWrite(resp, req, "")
@@ -635,7 +635,7 @@ func (s *HTTPHandlers) ACLRoleDelete(resp http.ResponseWriter, req *http.Request
 
 func (s *HTTPHandlers) ACLBindingRuleList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var args structs.ACLBindingRuleListRequest
@@ -669,7 +669,7 @@ func (s *HTTPHandlers) ACLBindingRuleList(resp http.ResponseWriter, req *http.Re
 
 func (s *HTTPHandlers) ACLBindingRuleCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var fn func(resp http.ResponseWriter, req *http.Request, bindingRuleID string) (interface{}, error)
@@ -729,7 +729,7 @@ func (s *HTTPHandlers) ACLBindingRuleRead(resp http.ResponseWriter, req *http.Re
 
 func (s *HTTPHandlers) ACLBindingRuleCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	return s.ACLBindingRuleWrite(resp, req, "")
@@ -782,7 +782,7 @@ func (s *HTTPHandlers) ACLBindingRuleDelete(resp http.ResponseWriter, req *http.
 
 func (s *HTTPHandlers) ACLAuthMethodList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var args structs.ACLAuthMethodListRequest
@@ -813,7 +813,7 @@ func (s *HTTPHandlers) ACLAuthMethodList(resp http.ResponseWriter, req *http.Req
 
 func (s *HTTPHandlers) ACLAuthMethodCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	var fn func(resp http.ResponseWriter, req *http.Request, methodName string) (interface{}, error)
@@ -873,7 +873,7 @@ func (s *HTTPHandlers) ACLAuthMethodRead(resp http.ResponseWriter, req *http.Req
 
 func (s *HTTPHandlers) ACLAuthMethodCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	return s.ACLAuthMethodWrite(resp, req, "")
@@ -929,7 +929,7 @@ func (s *HTTPHandlers) ACLAuthMethodDelete(resp http.ResponseWriter, req *http.R
 
 func (s *HTTPHandlers) ACLLogin(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	args := &structs.ACLLoginRequest{
@@ -955,7 +955,7 @@ func (s *HTTPHandlers) ACLLogin(resp http.ResponseWriter, req *http.Request) (in
 
 func (s *HTTPHandlers) ACLLogout(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	args := structs.ACLLogoutRequest{
@@ -1015,7 +1015,7 @@ func (s *HTTPHandlers) ACLAuthorize(resp http.ResponseWriter, req *http.Request)
 	const maxRequests = 64
 
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, aclDisabled
 	}
 
 	request := structs.RemoteACLAuthorizationRequest{

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -20,18 +20,17 @@ var aclDisabled = UnauthorizedError{Reason: "ACL support disabled"}
 
 // checkACLDisabled will return a standard response if ACLs are disabled. This
 // returns true if they are disabled and we should not continue.
-func (s *HTTPHandlers) checkACLDisabled(resp http.ResponseWriter, _req *http.Request) bool {
+func (s *HTTPHandlers) checkACLDisabled() bool {
 	if s.agent.config.ACLsEnabled {
 		return false
 	}
-
 	return true
 }
 
 // ACLBootstrap is used to perform a one-time ACL bootstrap operation on
 // a cluster to get the first management token.
 func (s *HTTPHandlers) ACLBootstrap(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -53,7 +52,7 @@ func (s *HTTPHandlers) ACLBootstrap(resp http.ResponseWriter, req *http.Request)
 }
 
 func (s *HTTPHandlers) ACLReplicationStatus(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -74,7 +73,7 @@ func (s *HTTPHandlers) ACLReplicationStatus(resp http.ResponseWriter, req *http.
 }
 
 func (s *HTTPHandlers) ACLPolicyList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -105,7 +104,7 @@ func (s *HTTPHandlers) ACLPolicyList(resp http.ResponseWriter, req *http.Request
 }
 
 func (s *HTTPHandlers) ACLPolicyCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -166,7 +165,7 @@ func (s *HTTPHandlers) ACLPolicyRead(resp http.ResponseWriter, req *http.Request
 }
 
 func (s *HTTPHandlers) ACLPolicyReadByName(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -183,7 +182,7 @@ func (s *HTTPHandlers) ACLPolicyReadByID(resp http.ResponseWriter, req *http.Req
 }
 
 func (s *HTTPHandlers) ACLPolicyCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -248,7 +247,7 @@ func (s *HTTPHandlers) ACLPolicyDelete(resp http.ResponseWriter, req *http.Reque
 }
 
 func (s *HTTPHandlers) ACLTokenList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -285,7 +284,7 @@ func (s *HTTPHandlers) ACLTokenList(resp http.ResponseWriter, req *http.Request)
 }
 
 func (s *HTTPHandlers) ACLTokenCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -318,7 +317,7 @@ func (s *HTTPHandlers) ACLTokenCRUD(resp http.ResponseWriter, req *http.Request)
 }
 
 func (s *HTTPHandlers) ACLTokenSelf(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -351,7 +350,7 @@ func (s *HTTPHandlers) ACLTokenSelf(resp http.ResponseWriter, req *http.Request)
 }
 
 func (s *HTTPHandlers) ACLTokenCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -442,7 +441,7 @@ func (s *HTTPHandlers) ACLTokenDelete(resp http.ResponseWriter, req *http.Reques
 }
 
 func (s *HTTPHandlers) ACLTokenClone(resp http.ResponseWriter, req *http.Request, tokenID string) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -471,7 +470,7 @@ func (s *HTTPHandlers) ACLTokenClone(resp http.ResponseWriter, req *http.Request
 }
 
 func (s *HTTPHandlers) ACLRoleList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -504,7 +503,7 @@ func (s *HTTPHandlers) ACLRoleList(resp http.ResponseWriter, req *http.Request) 
 }
 
 func (s *HTTPHandlers) ACLRoleCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -533,7 +532,7 @@ func (s *HTTPHandlers) ACLRoleCRUD(resp http.ResponseWriter, req *http.Request) 
 }
 
 func (s *HTTPHandlers) ACLRoleReadByName(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -581,7 +580,7 @@ func (s *HTTPHandlers) ACLRoleRead(resp http.ResponseWriter, req *http.Request, 
 }
 
 func (s *HTTPHandlers) ACLRoleCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -634,7 +633,7 @@ func (s *HTTPHandlers) ACLRoleDelete(resp http.ResponseWriter, req *http.Request
 }
 
 func (s *HTTPHandlers) ACLBindingRuleList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -668,7 +667,7 @@ func (s *HTTPHandlers) ACLBindingRuleList(resp http.ResponseWriter, req *http.Re
 }
 
 func (s *HTTPHandlers) ACLBindingRuleCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -728,7 +727,7 @@ func (s *HTTPHandlers) ACLBindingRuleRead(resp http.ResponseWriter, req *http.Re
 }
 
 func (s *HTTPHandlers) ACLBindingRuleCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -781,7 +780,7 @@ func (s *HTTPHandlers) ACLBindingRuleDelete(resp http.ResponseWriter, req *http.
 }
 
 func (s *HTTPHandlers) ACLAuthMethodList(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -812,7 +811,7 @@ func (s *HTTPHandlers) ACLAuthMethodList(resp http.ResponseWriter, req *http.Req
 }
 
 func (s *HTTPHandlers) ACLAuthMethodCRUD(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -872,7 +871,7 @@ func (s *HTTPHandlers) ACLAuthMethodRead(resp http.ResponseWriter, req *http.Req
 }
 
 func (s *HTTPHandlers) ACLAuthMethodCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -928,7 +927,7 @@ func (s *HTTPHandlers) ACLAuthMethodDelete(resp http.ResponseWriter, req *http.R
 }
 
 func (s *HTTPHandlers) ACLLogin(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -954,7 +953,7 @@ func (s *HTTPHandlers) ACLLogin(resp http.ResponseWriter, req *http.Request) (in
 }
 
 func (s *HTTPHandlers) ACLLogout(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 
@@ -1014,7 +1013,7 @@ func (s *HTTPHandlers) ACLAuthorize(resp http.ResponseWriter, req *http.Request)
 	//    policy.
 	const maxRequests = 64
 
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, aclDisabled
 	}
 

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -41,9 +41,7 @@ func (s *HTTPHandlers) ACLBootstrap(resp http.ResponseWriter, req *http.Request)
 	err := s.agent.RPC("ACL.BootstrapTokens", &args, &out)
 	if err != nil {
 		if strings.Contains(err.Error(), structs.ACLBootstrapNotAllowedErr.Error()) {
-			resp.WriteHeader(http.StatusForbidden)
-			fmt.Fprint(resp, acl.PermissionDeniedError{Cause: err.Error()}.Error())
-			return nil, nil
+			return nil, acl.PermissionDeniedError{Cause: err.Error()}
 		} else {
 			return nil, err
 		}

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -117,9 +117,6 @@ func TestACL_Bootstrap(t *testing.T) {
 			if tt.token && err != nil {
 				t.Fatalf("err: %v", err)
 			}
-			if got, want := resp.Code, tt.code; got != want {
-				t.Fatalf("got %d want %d", got, want)
-			}
 			if tt.token {
 				wrap, ok := out.(*aclBootstrapResponse)
 				if !ok {

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -70,10 +70,8 @@ func TestACL_Disabled_Response(t *testing.T) {
 			req, _ := http.NewRequest("PUT", "/should/not/care", nil)
 			resp := httptest.NewRecorder()
 			obj, err := tt.fn(resp, req)
-			require.NoError(t, err)
 			require.Nil(t, obj)
-			require.Equal(t, http.StatusUnauthorized, resp.Code)
-			require.Contains(t, resp.Body.String(), "ACL support disabled")
+			require.ErrorIs(t, err, UnauthorizedError{Reason: "ACL support disabled"})
 		})
 	}
 }

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1465,7 +1465,7 @@ func (s *HTTPHandlers) AgentMonitor(resp http.ResponseWriter, req *http.Request)
 
 func (s *HTTPHandlers) AgentToken(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
-		return nil, nil
+		return nil, UnauthorizedError{Reason: "ACL support disabled"}
 	}
 
 	// Fetch the ACL token, if any, and enforce agent policy.

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -811,12 +811,12 @@ func (s *HTTPHandlers) AgentDeregisterCheck(resp http.ResponseWriter, req *http.
 
 	checkID.Normalize()
 
-	if err := s.agent.vetCheckUpdateWithAuthorizer(authz, checkID); err != nil {
-		return nil, err
-	}
-
 	if !s.validateRequestPartition(resp, &checkID.EnterpriseMeta) {
 		return nil, nil
+	}
+
+	if err := s.agent.vetCheckUpdateWithAuthorizer(authz, checkID); err != nil {
+		return nil, err
 	}
 
 	if err := s.agent.RemoveCheck(checkID, true); err != nil {

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -156,8 +156,8 @@ func (s *HTTPHandlers) AgentMetrics(resp http.ResponseWriter, req *http.Request)
 	if enablePrometheusOutput(req) {
 		if s.agent.config.Telemetry.PrometheusOpts.Expiration < 1 {
 			return nil, CodeWithPayloadError{
-				StatusCode: http.StatusUnsupportedMediaType,
-				Reason: "Prometheus is not enabled since its retention time is not positive",
+				StatusCode:  http.StatusUnsupportedMediaType,
+				Reason:      "Prometheus is not enabled since its retention time is not positive",
 				ContentType: "text/plain",
 			}
 		}
@@ -1464,7 +1464,7 @@ func (s *HTTPHandlers) AgentMonitor(resp http.ResponseWriter, req *http.Request)
 }
 
 func (s *HTTPHandlers) AgentToken(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
+	if s.checkACLDisabled() {
 		return nil, UnauthorizedError{Reason: "ACL support disabled"}
 	}
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -660,8 +660,8 @@ func TestAgent_Service(t *testing.T) {
 			wantResp: &updatedResponse,
 		},
 		{
-			name:     "err: non-existent proxy",
-			url:      "/v1/agent/service/nope",
+			name:    "err: non-existent proxy",
+			url:     "/v1/agent/service/nope",
 			wantErr: "unknown service ID: nope",
 		},
 		{

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -662,7 +662,7 @@ func TestAgent_Service(t *testing.T) {
 		{
 			name:     "err: non-existent proxy",
 			url:      "/v1/agent/service/nope",
-			wantCode: 404,
+			wantErr: "unknown service ID: nope",
 		},
 		{
 			name: "err: bad ACL for service",
@@ -3783,9 +3783,6 @@ func testAgent_RegisterService_InvalidAddress(t *testing.T, extraHCL string) {
 			a.srv.h.ServeHTTP(resp, req)
 			if got, want := resp.Code, 400; got != want {
 				t.Fatalf("got code %d want %d", got, want)
-			}
-			if got, want := resp.Body.String(), "Invalid service address"; got != want {
-				t.Fatalf("got body %q want %q", got, want)
 			}
 		})
 	}

--- a/agent/http.go
+++ b/agent/http.go
@@ -251,6 +251,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 			// If enableDebug is not set, and ACLs are disabled, write
 			// an unauthorized response
 			if !enableDebug && s.checkACLDisabled() {
+				resp.WriteHeader(http.StatusUnauthorized)
 				return
 			}
 

--- a/agent/http.go
+++ b/agent/http.go
@@ -69,7 +69,7 @@ func (e NotFoundError) Error() string {
 	return e.Reason
 }
 
-// UnauthorizedError should be returned by a handler when the request lacks valid authentication.
+// UnauthorizedError should be returned by a handler when the request lacks valid authorization.
 type UnauthorizedError struct {
 	Reason string
 }

--- a/agent/http.go
+++ b/agent/http.go
@@ -250,7 +250,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 
 			// If enableDebug is not set, and ACLs are disabled, write
 			// an unauthorized response
-			if !enableDebug && s.checkACLDisabled(resp, req) {
+			if !enableDebug && s.checkACLDisabled() {
 				return
 			}
 


### PR DESCRIPTION
issue #11393 

**Problem:**
There are several instances where handlers will write directly to ``resp`` instead of returning the appropriate error and letting the handler’s wrapper write the status code and body. As discussed, this is not optimal since there isn’t consistency which also affects how each function can be tested.

**Solution:** 
As discussed, I have begun changing some of these cases to use the created custom errors instead of writing directly to ``resp``. 

I was made aware that several unit tests check the response code, however we are transitioning to returning an error so the response code or body is never written. From my understanding there will be 2 approaches to testing with this new system.
1) Check the returned error type directly and ignore the response body or code.
2) Transition the tests to go through ``ServeHTTP`` which allows for the handler’s wrapper to write the code and body to the response. This is actually directly related to #11396 which I was recently working on and currently have an open [PR](https://github.com/hashicorp/consul/pull/11499#pullrequestreview-807767260) for.

@dnephin recommended that I open a PR and discuss potential approaches before committing to a specific approach.