### PR TITLE
ui: Use --tones instead of --black/--white

### DIFF
--- a/ui/packages/consul-ui/app/components/auth-form/skin.scss
+++ b/ui/packages/consul-ui/app/components/auth-form/skin.scss
@@ -8,5 +8,5 @@
 /* in the center so if the background color of what the */
 /* line is on is different, then this should be different */
 %auth-form-hr span {
-  background-color: rgb(var(--white));
+  background-color: rgb(var(--tone-gray-000));
 }

--- a/ui/packages/consul-ui/app/components/card/skin.scss
+++ b/ui/packages/consul-ui/app/components/card/skin.scss
@@ -5,7 +5,7 @@
 %card {
   border: var(--decor-border-100);
   border-radius: var(--decor-radius-100);
-  background-color: rgb(var(--white) / 90%);
+  background-color: rgb(var(--tone-gray-000) / 90%);
 }
 %card > section,
 %card > ul > li {

--- a/ui/packages/consul-ui/app/components/certificate/index.scss
+++ b/ui/packages/consul-ui/app/components/certificate/index.scss
@@ -20,7 +20,7 @@
   }
   hr {
     border: 3px dashed rgb(var(--tone-gray-300));
-    background-color: rgb(var(--white));
+    background-color: rgb(var(--tone-gray-000));
     width: 150px;
     margin: auto;
     margin-top: 9px;

--- a/ui/packages/consul-ui/app/components/code-editor/layout.scss
+++ b/ui/packages/consul-ui/app/components/code-editor/layout.scss
@@ -11,7 +11,7 @@
   bottom: 0px;
   width: 100%;
   height: 25px;
-  background-color: var(--black);
+  background-color: rgb(var(--tone-gray-999));
   content: '';
   display: block;
 }

--- a/ui/packages/consul-ui/app/components/code-editor/skin.scss
+++ b/ui/packages/consul-ui/app/components/code-editor/skin.scss
@@ -46,7 +46,7 @@ $syntax-dark-gray: #535f73;
 .cm-s-hashi {
   &.CodeMirror {
     width: 100%;
-    background-color: rgb(var(--black)) !important;
+    background-color: rgb(var(--tone-gray-999)) !important;
     color: #cfd2d1 !important;
     border: none;
     font-family: var(--typo-family-mono);
@@ -81,7 +81,7 @@ $syntax-dark-gray: #535f73;
   .CodeMirror-line::-moz-selection,
   .CodeMirror-line > span::-moz-selection,
   .CodeMirror-line > span > span::-moz-selection {
-    background: rgb(var(--white) / 10%);
+    background: rgb(var(--tone-gray-000) / 10%);
   }
 
   span.cm-comment {
@@ -154,7 +154,7 @@ $syntax-dark-gray: #535f73;
 
   .CodeMirror-matchingbracket {
     text-decoration: underline;
-    color: rgb(var(--white)) !important;
+    color: rgb(var(--tone-gray-000)) !important;
   }
 }
 
@@ -178,7 +178,7 @@ $syntax-dark-gray: #535f73;
     }
 
     span.cm-property {
-      color: rgb(var(--white));
+      color: rgb(var(--tone-gray-000));
     }
 
     span.cm-variable-2 {

--- a/ui/packages/consul-ui/app/components/confirmation-dialog/skin.scss
+++ b/ui/packages/consul-ui/app/components/confirmation-dialog/skin.scss
@@ -1,5 +1,5 @@
 table div.with-confirmation.confirming {
-  background-color: rgb(var(--white));
+  background-color: rgb(var(--tone-gray-000));
 }
 %confirmation-dialog-inline p {
   color: rgb(var(--tone-gray-400));

--- a/ui/packages/consul-ui/app/components/consul/auth-method/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/auth-method/index.scss
@@ -27,7 +27,7 @@
       tbody {
         td {
           font-size: var(--typo-size-600);
-          color: var(--black);
+          color: rgb(var(--tone-gray-999));
         }
         tr {
           cursor: default;
@@ -74,7 +74,7 @@
   tbody {
     td {
       font-size: var(--typo-size-600);
-      color: var(--black);
+      color: rgb(var(--tone-gray-999));
     }
     tr {
       cursor: default;

--- a/ui/packages/consul-ui/app/components/consul/discovery-chain/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/discovery-chain/index.hbs
@@ -3,7 +3,7 @@
     {{selected.nodes}} {
       opacity: 1 !important;
 
-      background-color: var(--white);
+      background-color: var(--tone-gray-000);
       border: var(--decor-border-100);
       border-radius: var(--decor-radius-200);
       border-color: rgb(var(--tone-gray-500));

--- a/ui/packages/consul-ui/app/components/consul/discovery-chain/skin.scss
+++ b/ui/packages/consul-ui/app/components/consul/discovery-chain/skin.scss
@@ -63,7 +63,7 @@
 }
 %chain-node-active {
   opacity: 1;
-  background-color: rgb(var(--white));
+  background-color: rgb(var(--tone-gray-000));
   border-color: rgb(var(--tone-gray-500));
 }
 /* TODO: More text truncation, centralize */
@@ -99,7 +99,7 @@
 /**/
 %with-chain-outlet::before {
   @extend %as-pseudo;
-  background-color: rgb(var(--white));
+  background-color: rgb(var(--tone-gray-000));
 
   border-radius: var(--decor-radius-full);
   border: 2px solid rgb(var(--tone-gray-400));
@@ -107,5 +107,5 @@
 %discovery-chain circle {
   stroke-width: 2;
   stroke: rgb(var(--tone-gray-400));
-  fill: rgb(var(--white));
+  fill: rgb(var(--tone-gray-000));
 }

--- a/ui/packages/consul-ui/app/components/expanded-single-select/skin.scss
+++ b/ui/packages/consul-ui/app/components/expanded-single-select/skin.scss
@@ -14,5 +14,5 @@
 %expanded-single-select input[type='radio']:checked + *,
 %expanded-single-select input[type='radio']:hover + *,
 %expanded-single-select input[type='radio']:focus + * {
-  background-color: rgb(var(--white));
+  background-color: rgb(var(--tone-gray-000));
 }

--- a/ui/packages/consul-ui/app/components/freetext-filter/skin.scss
+++ b/ui/packages/consul-ui/app/components/freetext-filter/skin.scss
@@ -3,7 +3,7 @@
     border: var(--decor-border-100);
     border-radius: var(--decor-radius-100);
 
-    background-color: rgb(var(--white));
+    background-color: rgb(var(--tone-gray-000));
     border-color: rgb(var(--tone-gray-200));
     color: rgb(var(--tone-gray-400));
   }

--- a/ui/packages/consul-ui/app/components/informed-action/skin.scss
+++ b/ui/packages/consul-ui/app/components/informed-action/skin.scss
@@ -3,7 +3,7 @@
     border-radius: var(--decor-radius-200);
     border: var(--decor-border-100);
     border-color: rgb(var(--tone-gray-300));
-    background-color: rgb(var(--white));
+    background-color: rgb(var(--tone-gray-000));
   }
   > div {
     border-top-left-radius: var(--decor-radius-200);
@@ -18,7 +18,7 @@
   }
   p {
     @extend %p2;
-    color: var(--black);
+    color: rgb(var(--tone-gray-999));
   }
   > ul {
     list-style: none;

--- a/ui/packages/consul-ui/app/components/list-row/skin.scss
+++ b/ui/packages/consul-ui/app/components/list-row/skin.scss
@@ -13,7 +13,7 @@
   cursor: pointer;
 }
 %list-row-header {
-  color: var(--black);
+  color: rgb(var(--tone-gray-999));
 }
 %list-row-header * {
   color: inherit;

--- a/ui/packages/consul-ui/app/components/modal-dialog/skin.scss
+++ b/ui/packages/consul-ui/app/components/modal-dialog/skin.scss
@@ -15,7 +15,7 @@
   margin-right: 3px;
 }
 %modal-dialog-overlay {
-  background-color: rgb(var(--white) / 90%);
+  background-color: rgb(var(--tone-gray-000) / 90%);
 }
 %modal-window {
   box-shadow: var(--decor-elevation-800);

--- a/ui/packages/consul-ui/app/components/notice/skin.scss
+++ b/ui/packages/consul-ui/app/components/notice/skin.scss
@@ -1,7 +1,7 @@
 %notice {
   border-radius: var(--decor-radius-100);
   border: var(--decor-border-100);
-  color: var(--black);
+  color: rgb(var(--tone-gray-999));
 }
 %notice::before {
   @extend %as-pseudo;

--- a/ui/packages/consul-ui/app/components/overlay/none.scss
+++ b/ui/packages/consul-ui/app/components/overlay/none.scss
@@ -26,7 +26,7 @@
     transition-timing-function: cubic-bezier(0.54, 1.5, 0.38, 1.11);
   }
   & {
-    background-color: rgb(var(--white));
+    background-color: rgb(var(--tone-gray-000));
     border-radius: var(--decor-radius-100);
     box-shadow: var(--decor-elevation-400);
   }

--- a/ui/packages/consul-ui/app/components/overlay/square-tail.scss
+++ b/ui/packages/consul-ui/app/components/overlay/square-tail.scss
@@ -4,7 +4,7 @@
     left: calc(0px - (var(--size) / 2)) !important;
   }
   .tippy-arrow::before {
-    background-color: rgb(var(--white));
+    background-color: rgb(var(--tone-gray-000));
     width: calc(1px + var(--size));
     height: calc(1px + var(--size));
     border: var(--decor-border-100);

--- a/ui/packages/consul-ui/app/components/radio-card/skin.scss
+++ b/ui/packages/consul-ui/app/components/radio-card/skin.scss
@@ -19,7 +19,7 @@
   margin-bottom: 0.5em;
 }
 %radio-card header {
-  color: var(--black);
+  color: rgb(var(--tone-gray-999));
 }
 %radio-card-with-icon > :last-child {
   padding-left: 47px;

--- a/ui/packages/consul-ui/app/components/skip-links/skin.scss
+++ b/ui/packages/consul-ui/app/components/skip-links/skin.scss
@@ -1,6 +1,6 @@
 %skip-links {
-  outline: 1px solid rgb(var(--white));
-  color: rgb(var(--white));
+  outline: 1px solid rgb(var(--tone-gray-000));
+  color: rgb(var(--tone-gray-000));
   background-color: rgb(var(--tone-blue-500));
 }
 %skip-links button,

--- a/ui/packages/consul-ui/app/components/sliding-toggle/skin.scss
+++ b/ui/packages/consul-ui/app/components/sliding-toggle/skin.scss
@@ -18,7 +18,7 @@
   color: rgb(var(--tone-gray-900));
 }
 %sliding-toggle label span::after {
-  background-color: rgb(var(--white));
+  background-color: rgb(var(--tone-gray-000));
 }
 %sliding-toggle label input:checked + span::before,
 %sliding-toggle-negative label input + span::before {

--- a/ui/packages/consul-ui/app/components/tabular-details/skin.scss
+++ b/ui/packages/consul-ui/app/components/tabular-details/skin.scss
@@ -14,7 +14,7 @@
 %tabular-detail::before,
 %tabular-detail > div,
 %tabular-detail > label {
-  background-color: rgb(var(--white));
+  background-color: rgb(var(--tone-gray-000));
 }
 %tabular-detail > label::before {
   transform: rotate(180deg);

--- a/ui/packages/consul-ui/app/components/tabular-dl/skin.scss
+++ b/ui/packages/consul-ui/app/components/tabular-dl/skin.scss
@@ -6,13 +6,13 @@
   dt,
   dd {
     border-color: rgb(var(--tone-gray-300)) !important;
-    color: var(--black) !important;
+    color: rgb(var(--tone-gray-999)) !important;
   }
   dt {
     font-weight: var(--typo-weight-bold);
   }
   dd .copy-button button::before {
-    background-color: var(--black);
+    background-color: rgb(var(--tone-gray-999));
   }
   dt.type + dd span::before {
     @extend %with-info-circle-outline-mask, %as-pseudo;

--- a/ui/packages/consul-ui/app/components/tooltip/index.scss
+++ b/ui/packages/consul-ui/app/components/tooltip/index.scss
@@ -32,7 +32,7 @@
 %tooltip-bubble {
   & {
     background-color: rgb(var(--tone-gray-700));
-    color: rgb(var(--white));
+    color: rgb(var(--tone-gray-000));
   }
 }
 %tooltip-tail {

--- a/ui/packages/consul-ui/app/components/topology-metrics/card/index.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/card/index.scss
@@ -7,7 +7,7 @@
   display: block;
   color: rgb(var(--tone-gray-700));
   overflow: hidden;
-  background-color: rgb(var(--white));
+  background-color: rgb(var(--tone-gray-000));
   border-radius: var(--decor-radius-100);
   border: 1px solid rgb(var(--tone-gray-200));
   p {

--- a/ui/packages/consul-ui/app/components/topology-metrics/popover/index.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/popover/index.scss
@@ -2,7 +2,7 @@
   > button {
     position: absolute;
     transform: translate(-50%, -50%);
-    background-color: rgb(var(--white));
+    background-color: rgb(var(--tone-gray-000));
     padding: 1px 1px;
     &:hover {
       cursor: pointer;

--- a/ui/packages/consul-ui/app/components/topology-metrics/skin.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/skin.scss
@@ -24,7 +24,7 @@
 // Metrics Container
 #metrics-container {
   div:first-child {
-    background-color: rgb(var(--white));
+    background-color: rgb(var(--tone-gray-000));
   }
   .link {
     background-color: rgb(var(--tone-gray-100));
@@ -53,7 +53,7 @@
     fill: var(--transparent);
   }
   circle {
-    fill: rgb(var(--white));
+    fill: rgb(var(--tone-gray-000));
   }
   .allow-arrow {
     fill: rgb(var(--tone-gray-300));

--- a/ui/packages/consul-ui/app/styles/base/color/ui/themes/dark-high-contrast.scss
+++ b/ui/packages/consul-ui/app/styles/base/color/ui/themes/dark-high-contrast.scss
@@ -95,22 +95,5 @@
   --tone-yellow-950: var(--yellow-950);
   --tone-yellow-999: var(--black);
 
-  --tone-yellow-000: var(--white);
-  --tone-yellow-050: var(--yellow-050);
-  --tone-yellow-100: var(--yellow-100);
-  --tone-yellow-150: var(--yellow-150);
-  --tone-yellow-200: var(--yellow-200);
-  --tone-yellow-300: var(--yellow-300);
-  --tone-yellow-400: var(--yellow-400);
-  --tone-yellow-500: var(--yellow-500);
-  --tone-yellow-600: var(--yellow-600);
-  --tone-yellow-700: var(--yellow-700);
-  --tone-yellow-800: var(--yellow-800);
-  --tone-yellow-850: var(--yellow-850);
-  --tone-yellow-900: var(--yellow-900);
-  --tone-yellow-950: var(--yellow-950);
-  --tone-yellow-999: var(--black);
-
   --tone-transparent: var(--transparent);
 }
-

--- a/ui/packages/consul-ui/app/styles/base/color/ui/themes/dark.scss
+++ b/ui/packages/consul-ui/app/styles/base/color/ui/themes/dark.scss
@@ -79,38 +79,21 @@
   --tone-orange-950: var(--orange-950);
   --tone-orange-999: var(--black);
 
-  --tone-yellow-000: var(--white);
-  --tone-yellow-050: var(--yellow-050);
-  --tone-yellow-100: var(--yellow-100);
-  --tone-yellow-150: var(--yellow-150);
-  --tone-yellow-200: var(--yellow-200);
-  --tone-yellow-300: var(--yellow-300);
-  --tone-yellow-400: var(--yellow-400);
+  --tone-yellow-000: var(--black);
+  --tone-yellow-050: var(--blue-950);
+  --tone-yellow-100: var(--yellow-900);
+  --tone-yellow-150: var(--yellow-850);
+  --tone-yellow-200: var(--yellow-800);
+  --tone-yellow-300: var(--yellow-700);
+  --tone-yellow-400: var(--yellow-600);
   --tone-yellow-500: var(--yellow-500);
-  --tone-yellow-600: var(--yellow-600);
-  --tone-yellow-700: var(--yellow-700);
-  --tone-yellow-800: var(--yellow-800);
-  --tone-yellow-850: var(--yellow-850);
-  --tone-yellow-900: var(--yellow-900);
-  --tone-yellow-950: var(--yellow-950);
-  --tone-yellow-999: var(--black);
-
-  --tone-yellow-000: var(--white);
-  --tone-yellow-050: var(--yellow-050);
-  --tone-yellow-100: var(--yellow-100);
-  --tone-yellow-150: var(--yellow-150);
-  --tone-yellow-200: var(--yellow-200);
-  --tone-yellow-300: var(--yellow-300);
-  --tone-yellow-400: var(--yellow-400);
-  --tone-yellow-500: var(--yellow-500);
-  --tone-yellow-600: var(--yellow-600);
-  --tone-yellow-700: var(--yellow-700);
-  --tone-yellow-800: var(--yellow-800);
-  --tone-yellow-850: var(--yellow-850);
-  --tone-yellow-900: var(--yellow-900);
-  --tone-yellow-950: var(--yellow-950);
-  --tone-yellow-999: var(--black);
+  --tone-yellow-600: var(--yellow-400);
+  --tone-yellow-700: var(--yellow-300);
+  --tone-yellow-800: var(--yellow-200);
+  --tone-yellow-850: var(--yellow-250);
+  --tone-yellow-900: var(--yellow-100);
+  --tone-yellow-950: var(--yellow-050);
+  --tone-yellow-999: var(--white);
 
   --tone-transparent: var(--transparent);
 }
-

--- a/ui/packages/consul-ui/app/styles/base/color/ui/themes/light-high-contrast.scss
+++ b/ui/packages/consul-ui/app/styles/base/color/ui/themes/light-high-contrast.scss
@@ -95,21 +95,5 @@
   --tone-yellow-950: var(--yellow-950);
   --tone-yellow-999: var(--black);
 
-  --tone-yellow-000: var(--white);
-  --tone-yellow-050: var(--yellow-050);
-  --tone-yellow-100: var(--yellow-100);
-  --tone-yellow-150: var(--yellow-150);
-  --tone-yellow-200: var(--yellow-200);
-  --tone-yellow-300: var(--yellow-300);
-  --tone-yellow-400: var(--yellow-400);
-  --tone-yellow-500: var(--yellow-500);
-  --tone-yellow-600: var(--yellow-600);
-  --tone-yellow-700: var(--yellow-700);
-  --tone-yellow-800: var(--yellow-800);
-  --tone-yellow-850: var(--yellow-850);
-  --tone-yellow-900: var(--yellow-900);
-  --tone-yellow-950: var(--yellow-950);
-  --tone-yellow-999: var(--black);
-
   --tone-transparent: var(--transparent);
 }

--- a/ui/packages/consul-ui/app/styles/base/color/ui/themes/light.scss
+++ b/ui/packages/consul-ui/app/styles/base/color/ui/themes/light.scss
@@ -95,21 +95,5 @@
   --tone-yellow-950: var(--yellow-950);
   --tone-yellow-999: var(--black);
 
-  --tone-yellow-000: var(--white);
-  --tone-yellow-050: var(--yellow-050);
-  --tone-yellow-100: var(--yellow-100);
-  --tone-yellow-150: var(--yellow-150);
-  --tone-yellow-200: var(--yellow-200);
-  --tone-yellow-300: var(--yellow-300);
-  --tone-yellow-400: var(--yellow-400);
-  --tone-yellow-500: var(--yellow-500);
-  --tone-yellow-600: var(--yellow-600);
-  --tone-yellow-700: var(--yellow-700);
-  --tone-yellow-800: var(--yellow-800);
-  --tone-yellow-850: var(--yellow-850);
-  --tone-yellow-900: var(--yellow-900);
-  --tone-yellow-950: var(--yellow-950);
-  --tone-yellow-999: var(--black);
-
   --tone-transparent: var(--transparent);
 }

--- a/ui/packages/consul-ui/app/styles/variables/skin.scss
+++ b/ui/packages/consul-ui/app/styles/variables/skin.scss
@@ -20,7 +20,7 @@
   /* themeable ui colors */
   --typo-action-500: rgb(var(--tone-blue-500));
   --decor-error-500: rgb(var(--tone-red-500));
-  --typo-contrast-999: rgb(var(--black));
+  --typo-contrast-999: rgb(var(--tone-gray-999));
 
   /* themeable brand colors */
   --typo-brand-050: rgb(var(--tone-brand-050));


### PR DESCRIPTION
Moves almost all instances of `--white`/`--black` to use `--tone`. Also spotted that I'd doubled up on yellows by accident so I've undone that typo here.

_Mostly_ nothing user facing here, just general cleanliness/consistency/clarity for present and future engs, but I think that previous to this there where some instances that weren't using `rgb(var())` when they should have been, so I guess this is kinda of a bugfix, but I think these maybe were being defaulted to black so not totally sure if that bug was actually visible.