### PR TITLE
health: support `ResultsFilteredByACLs` flag/header

### DIFF
--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/mitchellh/copystructure"
@@ -2151,72 +2152,93 @@ func testACLResolver_variousTokens(t *testing.T, delegate *ACLResolverTestDelega
 
 func TestACL_filterHealthChecks(t *testing.T) {
 	t.Parallel()
-	// Create some health checks.
-	fill := func() structs.HealthChecks {
-		return structs.HealthChecks{
-			&structs.HealthCheck{
-				Node:        "node1",
-				CheckID:     "check1",
-				ServiceName: "foo",
+
+	logger := hclog.NewNullLogger()
+
+	makeList := func() *structs.IndexedHealthChecks {
+		return &structs.IndexedHealthChecks{
+			HealthChecks: structs.HealthChecks{
+				{
+					Node:        "node1",
+					CheckID:     "check1",
+					ServiceName: "foo",
+				},
 			},
 		}
 	}
 
-	{
-		hc := fill()
-		filt := newACLFilter(acl.DenyAll(), nil)
-		filt.filterHealthChecks(&hc)
-		if len(hc) != 0 {
-			t.Fatalf("bad: %#v", hc)
-		}
-	}
+	t.Run("allowed", func(t *testing.T) {
+		require := require.New(t)
 
-	// Allowed to see the service but not the node.
-	policy, err := acl.NewPolicyFromSource(`
-service "foo" {
-  policy = "read"
-}
-`, acl.SyntaxLegacy, nil, nil)
-	if err != nil {
-		t.Fatalf("err %v", err)
-	}
-	perms, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		policy, err := acl.NewPolicyFromSource(`
+			service "foo" {
+			  policy = "read"
+			}
+			node "node1" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
 
-	{
-		hc := fill()
-		filt := newACLFilter(perms, nil)
-		filt.filterHealthChecks(&hc)
-		if len(hc) != 0 {
-			t.Fatalf("bad: %#v", hc)
-		}
-	}
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
 
-	// Chain on access to the node.
-	policy, err = acl.NewPolicyFromSource(`
-node "node1" {
-  policy = "read"
-}
-`, acl.SyntaxLegacy, nil, nil)
-	if err != nil {
-		t.Fatalf("err %v", err)
-	}
-	perms, err = acl.NewPolicyAuthorizerWithDefaults(perms, []*acl.Policy{policy}, nil)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
 
-	// Now it should go through.
-	{
-		hc := fill()
-		filt := newACLFilter(perms, nil)
-		filt.filterHealthChecks(&hc)
-		if len(hc) != 1 {
-			t.Fatalf("bad: %#v", hc)
-		}
-	}
+		require.Len(list.HealthChecks, 1)
+		require.False(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
+	})
+
+	t.Run("allowed to read the service, but not the node", func(t *testing.T) {
+		require := require.New(t)
+
+		policy, err := acl.NewPolicyFromSource(`
+			service "foo" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
+
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
+
+		require.Empty(list.HealthChecks)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("allowed to read the node, but not the service", func(t *testing.T) {
+		require := require.New(t)
+
+		policy, err := acl.NewPolicyFromSource(`
+			node "node1" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
+
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
+
+		require.Empty(list.HealthChecks)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("denied", func(t *testing.T) {
+		require := require.New(t)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, acl.DenyAll(), list)
+
+		require.Empty(list.HealthChecks)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
 }
 
 func TestACL_filterIntentions(t *testing.T) {

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -2742,6 +2742,7 @@ node_prefix "" {
 			CheckID:   "service:bar",
 			Name:      "service:bar",
 			ServiceID: "bar",
+			Status:    api.HealthPassing,
 		},
 		WriteRequest: structs.WriteRequest{Token: "root"},
 	}

--- a/agent/consul/health_endpoint.go
+++ b/agent/consul/health_endpoint.go
@@ -55,15 +55,19 @@ func (h *Health) ChecksInState(args *structs.ChecksInStateRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
-			if err := h.srv.filterACL(args.Token, reply); err != nil {
-				return err
-			}
 
 			raw, err := filter.Execute(reply.HealthChecks)
 			if err != nil {
 				return err
 			}
 			reply.HealthChecks = raw.(structs.HealthChecks)
+
+			// Note: we filter the results with ACLs *after* applying the user-supplied
+			// bexpr filter, to ensure QueryMeta.ResultsFilteredByACLs does not include
+			// results that would be filtered out even if the user did have permission.
+			if err := h.srv.filterACL(args.Token, reply); err != nil {
+				return err
+			}
 
 			return h.srv.sortNodesByDistanceFrom(args.Source, reply.HealthChecks)
 		})
@@ -99,15 +103,20 @@ func (h *Health) NodeChecks(args *structs.NodeSpecificRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
-			if err := h.srv.filterACL(args.Token, reply); err != nil {
-				return err
-			}
 
 			raw, err := filter.Execute(reply.HealthChecks)
 			if err != nil {
 				return err
 			}
 			reply.HealthChecks = raw.(structs.HealthChecks)
+
+			// Note: we filter the results with ACLs *after* applying the user-supplied
+			// bexpr filter, to ensure QueryMeta.ResultsFilteredByACLs does not include
+			// results that would be filtered out even if the user did have permission.
+			if err := h.srv.filterACL(args.Token, reply); err != nil {
+				return err
+			}
+
 			return nil
 		})
 }
@@ -156,15 +165,19 @@ func (h *Health) ServiceChecks(args *structs.ServiceSpecificRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
-			if err := h.srv.filterACL(args.Token, reply); err != nil {
-				return err
-			}
 
 			raw, err := filter.Execute(reply.HealthChecks)
 			if err != nil {
 				return err
 			}
 			reply.HealthChecks = raw.(structs.HealthChecks)
+
+			// Note: we filter the results with ACLs *after* applying the user-supplied
+			// bexpr filter, to ensure QueryMeta.ResultsFilteredByACLs does not include
+			// results that would be filtered out even if the user did have permission.
+			if err := h.srv.filterACL(args.Token, reply); err != nil {
+				return err
+			}
 
 			return h.srv.sortNodesByDistanceFrom(args.Source, reply.HealthChecks)
 		})

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -1431,6 +1431,9 @@ func TestHealth_NodeChecks_FilterACL(t *testing.T) {
 	}
 
 	t.Parallel()
+
+	require := require.New(t)
+
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1442,9 +1445,9 @@ func TestHealth_NodeChecks_FilterACL(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Token: token},
 	}
 	reply := structs.IndexedHealthChecks{}
-	if err := msgpackrpc.CallWithCodec(codec, "Health.NodeChecks", &opt, &reply); err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	err := msgpackrpc.CallWithCodec(codec, "Health.NodeChecks", &opt, &reply)
+	require.NoError(err)
+
 	found := false
 	for _, chk := range reply.HealthChecks {
 		switch chk.ServiceName {
@@ -1454,9 +1457,8 @@ func TestHealth_NodeChecks_FilterACL(t *testing.T) {
 			t.Fatalf("bad: %#v", reply.HealthChecks)
 		}
 	}
-	if !found {
-		t.Fatalf("bad: %#v", reply.HealthChecks)
-	}
+	require.True(found, "bad: %#v", reply.HealthChecks)
+	require.True(reply.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 
 	// We've already proven that we call the ACL filtering function so we
 	// test node filtering down in acl.go for node cases. This also proves
@@ -1471,6 +1473,9 @@ func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
 	}
 
 	t.Parallel()
+
+	require := require.New(t)
+
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1482,9 +1487,9 @@ func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Token: token},
 	}
 	reply := structs.IndexedHealthChecks{}
-	if err := msgpackrpc.CallWithCodec(codec, "Health.ServiceChecks", &opt, &reply); err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	err := msgpackrpc.CallWithCodec(codec, "Health.ServiceChecks", &opt, &reply)
+	require.NoError(err)
+
 	found := false
 	for _, chk := range reply.HealthChecks {
 		if chk.ServiceName == "foo" {
@@ -1492,18 +1497,14 @@ func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
 			break
 		}
 	}
-	if !found {
-		t.Fatalf("bad: %#v", reply.HealthChecks)
-	}
+	require.True(found, "bad: %#v", reply.HealthChecks)
 
 	opt.ServiceName = "bar"
 	reply = structs.IndexedHealthChecks{}
-	if err := msgpackrpc.CallWithCodec(codec, "Health.ServiceChecks", &opt, &reply); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if len(reply.HealthChecks) != 0 {
-		t.Fatalf("bad: %#v", reply.HealthChecks)
-	}
+	err = msgpackrpc.CallWithCodec(codec, "Health.ServiceChecks", &opt, &reply)
+	require.NoError(err)
+	require.Empty(reply.HealthChecks)
+	require.True(reply.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 
 	// We've already proven that we call the ACL filtering function so we
 	// test node filtering down in acl.go for node cases. This also proves
@@ -1558,6 +1559,9 @@ func TestHealth_ChecksInState_FilterACL(t *testing.T) {
 	}
 
 	t.Parallel()
+
+	require := require.New(t)
+
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1569,9 +1573,8 @@ func TestHealth_ChecksInState_FilterACL(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Token: token},
 	}
 	reply := structs.IndexedHealthChecks{}
-	if err := msgpackrpc.CallWithCodec(codec, "Health.ChecksInState", &opt, &reply); err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	err := msgpackrpc.CallWithCodec(codec, "Health.ChecksInState", &opt, &reply)
+	require.NoError(err)
 
 	found := false
 	for _, chk := range reply.HealthChecks {
@@ -1582,9 +1585,8 @@ func TestHealth_ChecksInState_FilterACL(t *testing.T) {
 			t.Fatalf("bad service 'bar': %#v", reply.HealthChecks)
 		}
 	}
-	if !found {
-		t.Fatalf("missing service 'foo': %#v", reply.HealthChecks)
-	}
+	require.True(found, "missing service 'foo': %#v", reply.HealthChecks)
+	require.True(reply.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 
 	// We've already proven that we call the ACL filtering function so we
 	// test node filtering down in acl.go for node cases. This also proves


### PR DESCRIPTION
Adds support for the `ResultsFilteredByACLs` flag, and corresponding `X-Consul-Results-Filtered-By-ACLs` HTTP header (introduced in #11569) to the health endpoints.

