### PR TITLE
agent: support `X-Consul-Results-Filtered-By-ACLs` header in agent-local endpoints

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/types"
 )
 
 // aclAccessorID is used to convert an ACLToken's secretID to its accessorID for non-
@@ -182,10 +183,10 @@ func (a *Agent) filterServicesWithAuthorizer(authz acl.Authorizer, services map[
 	return nil
 }
 
-func (a *Agent) filterChecksWithAuthorizer(authz acl.Authorizer, checks *map[structs.CheckID]*structs.HealthCheck) error {
+func (a *Agent) filterChecksWithAuthorizer(authz acl.Authorizer, checks map[types.CheckID]*structs.HealthCheck) error {
 	var authzContext acl.AuthorizerContext
 	// Filter out checks based on the node or service policy.
-	for id, check := range *checks {
+	for id, check := range checks {
 		check.FillAuthzContext(&authzContext)
 		if len(check.ServiceName) > 0 {
 			if authz.ServiceRead(check.ServiceName, &authzContext) == acl.Allow {
@@ -196,8 +197,8 @@ func (a *Agent) filterChecksWithAuthorizer(authz acl.Authorizer, checks *map[str
 				continue
 			}
 		}
-		a.logger.Debug("dropping check from result due to ACLs", "check", id.String())
-		delete(*checks, id)
+		a.logger.Debug("dropping check from result due to ACLs", "check", id)
+		delete(checks, id)
 	}
 	return nil
 }

--- a/agent/acl_oss.go
+++ b/agent/acl_oss.go
@@ -7,8 +7,13 @@ import (
 	"github.com/hashicorp/serf/serf"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/api"
 )
 
 func serfMemberFillAuthzContext(m *serf.Member, ctx *acl.AuthorizerContext) {
+	// no-op
+}
+
+func agentServiceFillAuthzContext(s *api.AgentService, ctx *acl.AuthorizerContext) {
 	// no-op
 }

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -489,7 +489,7 @@ func TestACL_filterChecksWithAuthorizer(t *testing.T) {
 	t.Parallel()
 	a := NewTestACLAgent(t, t.Name(), TestACLConfig(), catalogPolicy, catalogIdent)
 
-	filterChecks := func(token string, checks *map[structs.CheckID]*structs.HealthCheck) error {
+	filterChecks := func(token string, checks map[types.CheckID]*structs.HealthCheck) error {
 		authz, err := a.delegate.ResolveTokenAndDefaultMeta(token, nil, nil)
 		if err != nil {
 			return err
@@ -498,29 +498,29 @@ func TestACL_filterChecksWithAuthorizer(t *testing.T) {
 		return a.filterChecksWithAuthorizer(authz, checks)
 	}
 
-	checks := make(map[structs.CheckID]*structs.HealthCheck)
-	require.NoError(t, filterChecks(nodeROSecret, &checks))
+	checks := make(map[types.CheckID]*structs.HealthCheck)
+	require.NoError(t, filterChecks(nodeROSecret, checks))
 
-	checks[structs.NewCheckID("my-node", nil)] = &structs.HealthCheck{}
-	checks[structs.NewCheckID("my-service", nil)] = &structs.HealthCheck{ServiceName: "service"}
-	checks[structs.NewCheckID("my-other", nil)] = &structs.HealthCheck{ServiceName: "other"}
-	require.NoError(t, filterChecks(serviceROSecret, &checks))
-	_, ok := checks[structs.NewCheckID("my-node", nil)]
+	checks["my-node"] = &structs.HealthCheck{}
+	checks["my-service"] = &structs.HealthCheck{ServiceName: "service"}
+	checks["my-other"] = &structs.HealthCheck{ServiceName: "other"}
+	require.NoError(t, filterChecks(serviceROSecret, checks))
+	_, ok := checks["my-node"]
 	require.False(t, ok)
-	_, ok = checks[structs.NewCheckID("my-service", nil)]
+	_, ok = checks["my-service"]
 	require.True(t, ok)
-	_, ok = checks[structs.NewCheckID("my-other", nil)]
+	_, ok = checks["my-other"]
 	require.False(t, ok)
 
-	checks[structs.NewCheckID("my-node", nil)] = &structs.HealthCheck{}
-	checks[structs.NewCheckID("my-service", nil)] = &structs.HealthCheck{ServiceName: "service"}
-	checks[structs.NewCheckID("my-other", nil)] = &structs.HealthCheck{ServiceName: "other"}
-	require.NoError(t, filterChecks(nodeROSecret, &checks))
-	_, ok = checks[structs.NewCheckID("my-node", nil)]
+	checks["my-node"] = &structs.HealthCheck{}
+	checks["my-service"] = &structs.HealthCheck{ServiceName: "service"}
+	checks["my-other"] = &structs.HealthCheck{ServiceName: "other"}
+	require.NoError(t, filterChecks(nodeROSecret, checks))
+	_, ok = checks["my-node"]
 	require.True(t, ok)
-	_, ok = checks[structs.NewCheckID("my-service", nil)]
+	_, ok = checks["my-service"]
 	require.False(t, ok)
-	_, ok = checks[structs.NewCheckID("my-other", nil)]
+	_, ok = checks["my-other"]
 	require.False(t, ok)
 }
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -366,7 +366,7 @@ func (s *HTTPHandlers) AgentServices(resp http.ResponseWriter, req *http.Request
 	// that sets QueryMeta.ResultsFilteredByACLs, but must be done manually for
 	// agent-local endpoints.
 	//
-	// For more information see the comment in: Server.blockingQuery.
+	// For more information see the comment on: Server.maskResultsFilteredByACLs.
 	if token != "" {
 		setResultsFilteredByACLs(resp, total != len(agentSvcs))
 	}
@@ -528,7 +528,7 @@ func (s *HTTPHandlers) AgentChecks(resp http.ResponseWriter, req *http.Request) 
 	// that sets QueryMeta.ResultsFilteredByACLs, but must be done manually for
 	// agent-local endpoints.
 	//
-	// For more information see the comment in: Server.blockingQuery.
+	// For more information see the comment on: Server.maskResultsFilteredByACLs.
 	if token != "" {
 		setResultsFilteredByACLs(resp, total != len(agentChecks))
 	}
@@ -603,7 +603,7 @@ func (s *HTTPHandlers) AgentMembers(resp http.ResponseWriter, req *http.Request)
 	// that sets QueryMeta.ResultsFilteredByACLs, but must be done manually for
 	// agent-local endpoints.
 	//
-	// For more information see the comment in: Server.blockingQuery.
+	// For more information see the comment on: Server.maskResultsFilteredByACLs.
 	if token != "" {
 		setResultsFilteredByACLs(resp, total != len(members))
 	}

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -327,9 +327,6 @@ func (s *HTTPHandlers) AgentServices(resp http.ResponseWriter, req *http.Request
 	// NOTE: we're explicitly fetching things in the requested partition and
 	// namespace here.
 	services := s.agent.State.Services(&entMeta)
-	if err := s.agent.filterServicesWithAuthorizer(authz, &services); err != nil {
-		return nil, err
-	}
 
 	// Convert into api.AgentService since that includes Connect config but so far
 	// NodeService doesn't need to internally. They are otherwise identical since
@@ -337,11 +334,8 @@ func (s *HTTPHandlers) AgentServices(resp http.ResponseWriter, req *http.Request
 	// anyway.
 	agentSvcs := make(map[string]*api.AgentService)
 
-	dc := s.agent.config.Datacenter
-
-	// Use empty list instead of nil
-	for id, s := range services {
-		agentService := buildAgentService(s, dc)
+	for id, svc := range services {
+		agentService := buildAgentService(svc, s.agent.config.Datacenter)
 		agentSvcs[id.ID] = &agentService
 	}
 
@@ -350,7 +344,34 @@ func (s *HTTPHandlers) AgentServices(resp http.ResponseWriter, req *http.Request
 		return nil, err
 	}
 
-	return filter.Execute(agentSvcs)
+	raw, err := filter.Execute(agentSvcs)
+	if err != nil {
+		return nil, err
+	}
+	agentSvcs = raw.(map[string]*api.AgentService)
+
+	// Note: we filter the results with ACLs *after* applying the user-supplied
+	// bexpr filter, to ensure total (and the filter-by-acls header we set below)
+	// do not include results that would be filtered out even if the user did have
+	// permission.
+	total := len(agentSvcs)
+	if err := s.agent.filterServicesWithAuthorizer(authz, agentSvcs); err != nil {
+		return nil, err
+	}
+
+	// Set the X-Consul-Results-Filtered-By-ACLs header, but only if the user is
+	// authenticated (to prevent information leaking).
+	//
+	// This is done automatically for HTTP endpoints that proxy to an RPC endpoint
+	// that sets QueryMeta.ResultsFilteredByACLs, but must be done manually for
+	// agent-local endpoints.
+	//
+	// For more information see the comment in: Server.blockingQuery.
+	if token != "" {
+		setResultsFilteredByACLs(resp, total != len(agentSvcs))
+	}
+
+	return agentSvcs, nil
 }
 
 // GET /v1/agent/service/:service_id

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -283,7 +283,7 @@ func TestAgent_Services_MeshGateway(t *testing.T) {
 	a.State.AddService(srv1, "")
 
 	req, _ := http.NewRequest("GET", "/v1/agent/services", nil)
-	obj, err := a.srv.AgentServices(nil, req)
+	obj, err := a.srv.AgentServices(httptest.NewRecorder(), req)
 	require.NoError(t, err)
 	val := obj.(map[string]*api.AgentService)
 	require.Len(t, val, 1)
@@ -319,7 +319,7 @@ func TestAgent_Services_TerminatingGateway(t *testing.T) {
 	require.NoError(t, a.State.AddService(srv1, ""))
 
 	req, _ := http.NewRequest("GET", "/v1/agent/services", nil)
-	obj, err := a.srv.AgentServices(nil, req)
+	obj, err := a.srv.AgentServices(httptest.NewRecorder(), req)
 	require.NoError(t, err)
 	val := obj.(map[string]*api.AgentService)
 	require.Len(t, val, 1)
@@ -339,36 +339,69 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
-	srv1 := &structs.NodeService{
-		ID:      "mysql",
-		Service: "mysql",
-		Tags:    []string{"master"},
-		Port:    5000,
+
+	services := []*structs.NodeService{
+		{
+			ID:      "web",
+			Service: "web",
+			Port:    5000,
+		},
+		{
+			ID:      "api",
+			Service: "api",
+			Port:    6000,
+		},
 	}
-	a.State.AddService(srv1, "")
+	for _, s := range services {
+		a.State.AddService(s, "")
+	}
 
 	t.Run("no token", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/v1/agent/services", nil)
-		obj, err := a.srv.AgentServices(nil, req)
-		if err != nil {
-			t.Fatalf("Err: %v", err)
-		}
+		require := require.New(t)
+
+		req := httptest.NewRequest("GET", "/v1/agent/services", nil)
+		rsp := httptest.NewRecorder()
+
+		obj, err := a.srv.AgentServices(rsp, req)
+		require.NoError(err)
+
 		val := obj.(map[string]*api.AgentService)
-		if len(val) != 0 {
-			t.Fatalf("bad: %v", obj)
-		}
+		require.Empty(val)
+		require.Empty(rsp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
+	})
+
+	t.Run("limited token", func(t *testing.T) {
+		require := require.New(t)
+
+		token := testCreateToken(t, a, `
+			service "web" {
+				policy = "read"
+			}
+		`)
+
+		req := httptest.NewRequest("GET", fmt.Sprintf("/v1/agent/services?token=%s", token), nil)
+		rsp := httptest.NewRecorder()
+
+		obj, err := a.srv.AgentServices(rsp, req)
+		require.NoError(err)
+
+		val := obj.(map[string]*api.AgentService)
+		require.Len(val, 1)
+		require.NotEmpty(rsp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 
 	t.Run("root token", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/v1/agent/services?token=root", nil)
-		obj, err := a.srv.AgentServices(nil, req)
-		if err != nil {
-			t.Fatalf("Err: %v", err)
-		}
+		require := require.New(t)
+
+		req := httptest.NewRequest("GET", "/v1/agent/services?token=root", nil)
+		rsp := httptest.NewRecorder()
+
+		obj, err := a.srv.AgentServices(rsp, req)
+		require.NoError(err)
+
 		val := obj.(map[string]*api.AgentService)
-		if len(val) != 1 {
-			t.Fatalf("bad: %v", obj)
-		}
+		require.Len(val, 2)
+		require.Empty(rsp.Header().Get("X-Consul-Results-Filtered-By-ACLs"))
 	})
 }
 
@@ -6970,7 +7003,7 @@ func TestAgent_Services_ExposeConfig(t *testing.T) {
 	a.State.AddService(srv1, "")
 
 	req, _ := http.NewRequest("GET", "/v1/agent/services", nil)
-	obj, err := a.srv.AgentServices(nil, req)
+	obj, err := a.srv.AgentServices(httptest.NewRecorder(), req)
 	require.NoError(t, err)
 	val := obj.(map[string]*api.AgentService)
 	require.Len(t, val, 1)


### PR DESCRIPTION
Adds support for the `X-Consul-Results-Filtered-By-ACLs` HTTP header (introduced in #11569) to the agent-local endpoints.