### PR TITLE
query: support `ResultsFilteredByACLs` in query list endpoint

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1824,6 +1824,9 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 	case *structs.IndexedCheckServiceNodes:
 		v.QueryMeta.ResultsFilteredByACLs = filt.filterCheckServiceNodes(&v.Nodes)
 
+	case *structs.PreparedQueryExecuteResponse:
+		v.QueryMeta.ResultsFilteredByACLs = filt.filterCheckServiceNodes(&v.Nodes)
+
 	case *structs.IndexedServiceTopology:
 		filtered := filt.filterServiceTopology(v.ServiceTopology)
 		if filtered {

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1568,8 +1568,10 @@ func (f *aclFilter) redactPreparedQueryTokens(query **structs.PreparedQuery) {
 
 // filterPreparedQueries is used to filter prepared queries based on ACL rules.
 // We prune entries the user doesn't have access to, and we redact any tokens
-// if the user doesn't have a management token.
-func (f *aclFilter) filterPreparedQueries(queries *structs.PreparedQueries) {
+// if the user doesn't have a management token. Returns true if any (named)
+// queries were removed - un-named queries are meant to be ephemeral and can
+// only be enumerated by a management token
+func (f *aclFilter) filterPreparedQueries(queries *structs.PreparedQueries) bool {
 	var authzContext acl.AuthorizerContext
 	structs.DefaultEnterpriseMetaInDefaultPartition().FillAuthzContext(&authzContext)
 	// Management tokens can see everything with no filtering.
@@ -1577,17 +1579,22 @@ func (f *aclFilter) filterPreparedQueries(queries *structs.PreparedQueries) {
 	// the 1.4 ACL rewrite. The global-management token will provide unrestricted query privileges
 	// so asking for ACLWrite should be unnecessary.
 	if f.authorizer.ACLWrite(&authzContext) == acl.Allow {
-		return
+		return false
 	}
 
 	// Otherwise, we need to see what the token has access to.
+	var namedQueriesRemoved bool
 	ret := make(structs.PreparedQueries, 0, len(*queries))
 	for _, query := range *queries {
 		// If no prefix ACL applies to this query then filter it, since
 		// we know at this point the user doesn't have a management
 		// token, otherwise see what the policy says.
-		prefix, ok := query.GetACLPrefix()
-		if !ok || f.authorizer.PreparedQueryRead(prefix, &authzContext) != acl.Allow {
+		prefix, hasName := query.GetACLPrefix()
+		switch {
+		case hasName && f.authorizer.PreparedQueryRead(prefix, &authzContext) != acl.Allow:
+			namedQueriesRemoved = true
+			fallthrough
+		case !hasName:
 			f.logger.Debug("dropping prepared query from result due to ACLs", "query", query.ID)
 			continue
 		}
@@ -1599,6 +1606,7 @@ func (f *aclFilter) filterPreparedQueries(queries *structs.PreparedQueries) {
 		ret = append(ret, final)
 	}
 	*queries = ret
+	return namedQueriesRemoved
 }
 
 func (f *aclFilter) filterToken(token **structs.ACLToken) {
@@ -1860,7 +1868,7 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 		v.QueryMeta.ResultsFilteredByACLs = filt.filterSessions(&v.Sessions)
 
 	case *structs.IndexedPreparedQueries:
-		filt.filterPreparedQueries(&v.Queries)
+		v.QueryMeta.ResultsFilteredByACLs = filt.filterPreparedQueries(&v.Queries)
 
 	case **structs.PreparedQuery:
 		filt.redactPreparedQueryTokens(v)

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -3176,70 +3176,97 @@ func TestFilterACL_redactTokenSecrets(t *testing.T) {
 
 func TestACL_filterPreparedQueries(t *testing.T) {
 	t.Parallel()
-	queries := structs.PreparedQueries{
-		&structs.PreparedQuery{
-			ID: "f004177f-2c28-83b7-4229-eacc25fe55d1",
-		},
-		&structs.PreparedQuery{
-			ID:   "f004177f-2c28-83b7-4229-eacc25fe55d2",
-			Name: "query-with-no-token",
-		},
-		&structs.PreparedQuery{
-			ID:    "f004177f-2c28-83b7-4229-eacc25fe55d3",
-			Name:  "query-with-a-token",
-			Token: "root",
-		},
+
+	logger := hclog.NewNullLogger()
+
+	makeList := func() *structs.IndexedPreparedQueries {
+		return &structs.IndexedPreparedQueries{
+			Queries: structs.PreparedQueries{
+				{ID: "f004177f-2c28-83b7-4229-eacc25fe55d1"},
+				{
+					ID:   "f004177f-2c28-83b7-4229-eacc25fe55d2",
+					Name: "query-with-no-token",
+				},
+				{
+					ID:    "f004177f-2c28-83b7-4229-eacc25fe55d3",
+					Name:  "query-with-a-token",
+					Token: "root",
+				},
+			},
+		}
 	}
 
-	expected := structs.PreparedQueries{
-		&structs.PreparedQuery{
-			ID: "f004177f-2c28-83b7-4229-eacc25fe55d1",
-		},
-		&structs.PreparedQuery{
-			ID:   "f004177f-2c28-83b7-4229-eacc25fe55d2",
-			Name: "query-with-no-token",
-		},
-		&structs.PreparedQuery{
-			ID:    "f004177f-2c28-83b7-4229-eacc25fe55d3",
-			Name:  "query-with-a-token",
-			Token: "root",
-		},
-	}
+	t.Run("management token", func(t *testing.T) {
+		require := require.New(t)
 
-	// Try permissive filtering with a management token. This will allow the
-	// embedded token to be seen.
-	filt := newACLFilter(acl.ManageAll(), nil)
-	filt.filterPreparedQueries(&queries)
-	if !reflect.DeepEqual(queries, expected) {
-		t.Fatalf("bad: %#v", queries)
-	}
+		list := makeList()
+		filterACLWithAuthorizer(logger, acl.ManageAll(), list)
 
-	// Hang on to the entry with a token, which needs to survive the next
-	// operation.
-	original := queries[2]
+		// Check we get the un-named query.
+		require.Len(list.Queries, 3)
 
-	// Now try permissive filtering with a client token, which should cause
-	// the embedded token to get redacted, and the query with no name to get
-	// filtered out.
-	filt = newACLFilter(acl.AllowAll(), nil)
-	filt.filterPreparedQueries(&queries)
-	expected[2].Token = redactedToken
-	expected = append(structs.PreparedQueries{}, expected[1], expected[2])
-	if !reflect.DeepEqual(queries, expected) {
-		t.Fatalf("bad: %#v", queries)
-	}
+		// Check we get the un-redacted token.
+		require.Equal("root", list.Queries[2].Token)
 
-	// Make sure that the original object didn't lose its token.
-	if original.Token != "root" {
-		t.Fatalf("bad token: %s", original.Token)
-	}
+		require.False(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
+	})
 
-	// Now try restrictive filtering.
-	filt = newACLFilter(acl.DenyAll(), nil)
-	filt.filterPreparedQueries(&queries)
-	if len(queries) != 0 {
-		t.Fatalf("bad: %#v", queries)
-	}
+	t.Run("permissive filtering", func(t *testing.T) {
+		require := require.New(t)
+
+		list := makeList()
+		queryWithToken := list.Queries[2]
+
+		filterACLWithAuthorizer(logger, acl.AllowAll(), list)
+
+		// Check the un-named query is filtered out.
+		require.Len(list.Queries, 2)
+
+		// Check the token is redacted.
+		require.Equal(redactedToken, list.Queries[1].Token)
+
+		// Check the original object is unmodified.
+		require.Equal("root", queryWithToken.Token)
+
+		// ResultsFilteredByACLs should not include un-named queries, which are only
+		// readable by a management token.
+		require.False(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
+	})
+
+	t.Run("limited access", func(t *testing.T) {
+		require := require.New(t)
+
+		policy, err := acl.NewPolicyFromSource(`
+			query "query-with-a-token" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
+
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
+
+		// Check we only get the query we have access to.
+		require.Len(list.Queries, 1)
+
+		// Check the token is redacted.
+		require.Equal(redactedToken, list.Queries[0].Token)
+
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("restrictive filtering", func(t *testing.T) {
+		require := require.New(t)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, acl.DenyAll(), list)
+
+		require.Empty(list.Queries)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
 }
 
 func TestACL_unhandledFilterType(t *testing.T) {

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -373,7 +373,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	if query.Token != "" {
 		token = query.Token
 	}
-	if err := p.srv.filterACL(token, &reply.Nodes); err != nil {
+	if err := p.srv.filterACL(token, reply); err != nil {
 		return err
 	}
 
@@ -500,7 +500,7 @@ func (p *PreparedQuery) ExecuteRemote(args *structs.PreparedQueryExecuteRemoteRe
 	if args.Query.Token != "" {
 		token = args.Query.Token
 	}
-	if err := p.srv.filterACL(token, &reply.Nodes); err != nil {
+	if err := p.srv.filterACL(token, reply); err != nil {
 		return err
 	}
 

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -1169,11 +1169,11 @@ func TestPreparedQuery_List(t *testing.T) {
 
 	// Same for a token without access to the query.
 	{
-		token := createTokenWithPolicyName(t, "deny-queries", codec, `
+		token := createTokenWithPolicyName(t, codec, "deny-queries", `
 			query_prefix "" {
 				policy = "deny"
 			}
-		`)
+		`, "root")
 
 		req := &structs.DCSpecificRequest{
 			Datacenter:   "dc1",


### PR DESCRIPTION
Adds support for the `ResultsFilteredByACLs` flag, and corresponding `X-Consul-Results-Filtered-By-ACLs` HTTP header (introduced in #11569) to the prepared queries list and execute endpoints.

Note: we only set the `ResultsFilteredByACLs` flag if **named** queries were removed from the result set. This is because un-named queries are treated as ephemeral and can only be listed by a management token.