### PR TITLE
config: support `ResultsFilteredByACLs` in list/list all endpoints

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -186,6 +186,7 @@ func (c *ConfigEntry) List(args *structs.ConfigEntryQuery, reply *structs.Indexe
 			filteredEntries := make([]structs.ConfigEntry, 0, len(entries))
 			for _, entry := range entries {
 				if !entry.CanRead(authz) {
+					reply.QueryMeta.ResultsFilteredByACLs = true
 					continue
 				}
 				filteredEntries = append(filteredEntries, entry)
@@ -246,6 +247,7 @@ func (c *ConfigEntry) ListAll(args *structs.ConfigEntryListAllRequest, reply *st
 			filteredEntries := make([]structs.ConfigEntry, 0, len(entries))
 			for _, entry := range entries {
 				if !entry.CanRead(authz) {
+					reply.QueryMeta.ResultsFilteredByACLs = true
 					continue
 				}
 				// Doing this filter outside of memdb isn't terribly

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -518,6 +518,7 @@ operator = "read"
 	require.True(ok)
 	require.Equal("foo", serviceConf.Name)
 	require.Equal(structs.ServiceDefaults, serviceConf.Kind)
+	require.True(out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 
 	// Get the global proxy config.
 	args.Kind = structs.ProxyDefaults
@@ -529,6 +530,7 @@ operator = "read"
 	require.True(ok)
 	require.Equal(structs.ProxyConfigGlobal, proxyConf.Name)
 	require.Equal(structs.ProxyDefaults, proxyConf.Kind)
+	require.False(out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
 }
 
 func TestConfigEntry_ListAll_ACLDeny(t *testing.T) {
@@ -601,6 +603,7 @@ operator = "read"
 	require.Equal(structs.ServiceDefaults, svcConf.Kind)
 	require.Equal(structs.ProxyConfigGlobal, proxyConf.Name)
 	require.Equal(structs.ProxyDefaults, proxyConf.Kind)
+	require.True(out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 }
 
 func TestConfigEntry_Delete(t *testing.T) {


### PR DESCRIPTION
Adds support for the `ResultsFilteredByACLs` flag, and corresponding `X-Consul-Results-Filtered-By-ACLs` HTTP header (introduced in #11569) to the config list endpoints.