### PR TITLE
cleanup: Clarify deprecated legacy intention endpoints

### DIFF
--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -66,11 +66,11 @@ func init() {
 	registerEndpoint("/v1/config", []string{"PUT"}, (*HTTPHandlers).ConfigApply)
 	registerEndpoint("/v1/connect/ca/configuration", []string{"GET", "PUT"}, (*HTTPHandlers).ConnectCAConfiguration)
 	registerEndpoint("/v1/connect/ca/roots", []string{"GET"}, (*HTTPHandlers).ConnectCARoots)
-	registerEndpoint("/v1/connect/intentions", []string{"GET", "POST"}, (*HTTPHandlers).IntentionEndpoint)
+	registerEndpoint("/v1/connect/intentions", []string{"GET", "POST"}, (*HTTPHandlers).IntentionEndpoint) // POST is deprecated
 	registerEndpoint("/v1/connect/intentions/match", []string{"GET"}, (*HTTPHandlers).IntentionMatch)
 	registerEndpoint("/v1/connect/intentions/check", []string{"GET"}, (*HTTPHandlers).IntentionCheck)
 	registerEndpoint("/v1/connect/intentions/exact", []string{"GET", "PUT", "DELETE"}, (*HTTPHandlers).IntentionExact)
-	registerEndpoint("/v1/connect/intentions/", []string{"GET", "PUT", "DELETE"}, (*HTTPHandlers).IntentionSpecific)
+	registerEndpoint("/v1/connect/intentions/", []string{"GET", "PUT", "DELETE"}, (*HTTPHandlers).IntentionSpecific) // deprecated
 	registerEndpoint("/v1/coordinate/datacenters", []string{"GET"}, (*HTTPHandlers).CoordinateDatacenters)
 	registerEndpoint("/v1/coordinate/nodes", []string{"GET"}, (*HTTPHandlers).CoordinateNodes)
 	registerEndpoint("/v1/coordinate/node/", []string{"GET"}, (*HTTPHandlers).CoordinateNode)

--- a/agent/intentions_endpoint.go
+++ b/agent/intentions_endpoint.go
@@ -46,7 +46,8 @@ func (s *HTTPHandlers) IntentionList(resp http.ResponseWriter, req *http.Request
 	return reply.Intentions, nil
 }
 
-// POST /v1/connect/intentions
+// IntentionCreate is used to create legacy intentions.
+// Deprecated: use IntentionPutExact.
 func (s *HTTPHandlers) IntentionCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Method is tested in IntentionEndpoint
 
@@ -348,7 +349,8 @@ func (s *HTTPHandlers) IntentionExact(resp http.ResponseWriter, req *http.Reques
 	}
 }
 
-// IntentionSpecific handles the endpoint for /v1/connect/intentions/:id
+// IntentionSpecific handles the endpoint for /v1/connect/intentions/:id.
+// Deprecated: use IntentionExact.
 func (s *HTTPHandlers) IntentionSpecific(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	id := strings.TrimPrefix(req.URL.Path, "/v1/connect/intentions/")
 
@@ -367,7 +369,7 @@ func (s *HTTPHandlers) IntentionSpecific(resp http.ResponseWriter, req *http.Req
 	}
 }
 
-// GET /v1/connect/intentions/:id
+// Deprecated: use IntentionGetExact.
 func (s *HTTPHandlers) IntentionSpecificGet(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Method is tested in IntentionEndpoint
 
@@ -408,7 +410,7 @@ func (s *HTTPHandlers) IntentionSpecificGet(id string, resp http.ResponseWriter,
 	return reply.Intentions[0], nil
 }
 
-// PUT /v1/connect/intentions/:id
+// Deprecated: use IntentionPutExact.
 func (s *HTTPHandlers) IntentionSpecificUpdate(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Method is tested in IntentionEndpoint
 
@@ -493,7 +495,7 @@ func (s *HTTPHandlers) IntentionPutExact(resp http.ResponseWriter, req *http.Req
 	return true, nil
 }
 
-// DELETE /v1/connect/intentions/:id
+// Deprecated: use IntentionDeleteExact.
 func (s *HTTPHandlers) IntentionSpecificDelete(id string, resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Method is tested in IntentionEndpoint
 


### PR DESCRIPTION
These endpoints are already marked as deprecated in the [docs](https://www.consul.io/api-docs/connect/intentions). This PR adds deprecation notices and moves the `IntentionSpecific-` set of methods to the bottom of the file.

