### PR TITLE
ui: Add `Service.Namespace` variable to dashboard URL templates

### DIFF
--- a/.changelog/11640.txt
+++ b/.changelog/11640.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Include `Service.Namespace` into available variables for `dashboard_url_templates`
+```

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -156,10 +156,16 @@ as |items item dc|}}
               }}
             as |config|>
             {{#if config.data.dashboard_url_templates.service}}
-              <a href={{render-template config.data.dashboard_url_templates.service (hash
-                Datacenter=dc.Name
-                Service=(hash Name=item.Service.Service)
-              )}}
+              <a
+                href={{render-template config.data.dashboard_url_templates.service
+                  (hash
+                    Datacenter=dc.Name
+                    Service=(hash
+                      Name=item.Service.Service
+                      Namespace=(or item.Service.Namespace '')
+                    )
+                  )
+                }}
                 target="_blank"
                 rel="noopener noreferrer"
                 data-test-dashboard-anchor

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -103,10 +103,15 @@ as |nspace dc items topology|}}
         @service={{items.firstObject}}
         @topology={{topology}}
 
-        @metricsHref={{render-template config.data.dashboard_url_templates.service (hash
-          Datacenter=dc.Name
-          Service=items.firstObject
-        )}}
+        @metricsHref={{render-template config.data.dashboard_url_templates.service
+          (hash
+            Datacenter=dc.Name
+            Service=(hash
+              Name=items.firstObject.Name
+              Namespace=(or items.firstObject.Namespace '')
+            )
+          )
+        }}
         @isRemoteDC={{not dc.Local}}
         @hasMetricsProvider={{gt config.data.metrics_provider.length 0}}
         @oncreate={{route-action 'createIntention'}}


### PR DESCRIPTION
See https://www.consul.io/docs/connect/observability/ui-visualization#configuring-dashboard-urls

Allows only `Datacenter`, `Service.Name` (as before) this PR adds `Service.Namespace`.

I've added backport labels here but pretty sure 1.9 and 1.8 will have to be manual.

P.S. There needs to be a follow up after the backports are done to add `Partition` here for 1.11 also.
