### PR TITLE
internal: support `ResultsFilteredByACLs` flag/header

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1821,8 +1821,8 @@ func (f *aclFilter) filterServiceList(services *structs.ServiceList) bool {
 // filterGatewayServices is used to filter gateway to service mappings based on ACL rules.
 // Returns true if any elements were removed.
 func (f *aclFilter) filterGatewayServices(mappings *structs.GatewayServices) bool {
-	var removed bool
 	ret := make(structs.GatewayServices, 0, len(*mappings))
+	var removed bool
 	for _, s := range *mappings {
 		// This filter only checks ServiceRead on the linked service.
 		// ServiceRead on the gateway is checked in the GatewayServices endpoint before filtering.
@@ -1936,6 +1936,14 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 
 	case *structs.IndexedGatewayServices:
 		v.QueryMeta.ResultsFilteredByACLs = filt.filterGatewayServices(&v.Services)
+
+	case *structs.IndexedNodesWithGateways:
+		if filt.filterCheckServiceNodes(&v.Nodes) {
+			v.QueryMeta.ResultsFilteredByACLs = true
+		}
+		if filt.filterGatewayServices(&v.Gateways) {
+			v.QueryMeta.ResultsFilteredByACLs = true
+		}
 
 	case *structs.IndexedNodesWithGateways:
 		if filt.filterCheckServiceNodes(&v.Nodes) {

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1515,10 +1515,12 @@ func (f *aclFilter) filterNodeDump(dump *structs.NodeDump) bool {
 	return removed
 }
 
-// filterServiceDump is used to filter nodes based on ACL rules.
-func (f *aclFilter) filterServiceDump(services *structs.ServiceDump) {
+// filterServiceDump is used to filter nodes based on ACL rules. Returns true
+// if any elements were removed.
+func (f *aclFilter) filterServiceDump(services *structs.ServiceDump) bool {
 	svcs := *services
 	var authzContext acl.AuthorizerContext
+	var removed bool
 
 	for i := 0; i < len(svcs); i++ {
 		service := svcs[i]
@@ -1536,10 +1538,12 @@ func (f *aclFilter) filterServiceDump(services *structs.ServiceDump) {
 		}
 
 		f.logger.Debug("dropping service from result due to ACLs", "service", service.GatewayService.Service)
+		removed = true
 		svcs = append(svcs[:i], svcs[i+1:]...)
 		i--
 	}
 	*services = svcs
+	return removed
 }
 
 // filterNodes is used to filter through all parts of a node list and remove
@@ -1876,7 +1880,7 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 		v.QueryMeta.ResultsFilteredByACLs = filt.filterNodeDump(&v.Dump)
 
 	case *structs.IndexedServiceDump:
-		filt.filterServiceDump(&v.Dump)
+		v.QueryMeta.ResultsFilteredByACLs = filt.filterServiceDump(&v.Dump)
 
 	case *structs.IndexedNodes:
 		v.QueryMeta.ResultsFilteredByACLs = filt.filterNodes(&v.Nodes)

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1949,14 +1949,6 @@ func filterACLWithAuthorizer(logger hclog.Logger, authorizer acl.Authorizer, sub
 			v.QueryMeta.ResultsFilteredByACLs = true
 		}
 
-	case *structs.IndexedNodesWithGateways:
-		if filt.filterCheckServiceNodes(&v.Nodes) {
-			v.QueryMeta.ResultsFilteredByACLs = true
-		}
-		if filt.filterGatewayServices(&v.Gateways) {
-			v.QueryMeta.ResultsFilteredByACLs = true
-		}
-
 	default:
 		panic(fmt.Errorf("Unhandled type passed to ACL filter: %T %#v", subj, subj))
 	}

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -3024,107 +3024,105 @@ func TestACL_filterSessions(t *testing.T) {
 
 func TestACL_filterNodeDump(t *testing.T) {
 	t.Parallel()
-	// Create a node dump.
-	fill := func() structs.NodeDump {
-		return structs.NodeDump{
-			&structs.NodeInfo{
-				Node: "node1",
-				Services: []*structs.NodeService{
-					{
-						ID:      "foo",
-						Service: "foo",
+
+	logger := hclog.NewNullLogger()
+
+	makeList := func() *structs.IndexedNodeDump {
+		return &structs.IndexedNodeDump{
+			Dump: structs.NodeDump{
+				{
+					Node: "node1",
+					Services: []*structs.NodeService{
+						{
+							ID:      "foo",
+							Service: "foo",
+						},
 					},
-				},
-				Checks: []*structs.HealthCheck{
-					{
-						Node:        "node1",
-						CheckID:     "check1",
-						ServiceName: "foo",
+					Checks: []*structs.HealthCheck{
+						{
+							Node:        "node1",
+							CheckID:     "check1",
+							ServiceName: "foo",
+						},
 					},
 				},
 			},
 		}
 	}
 
-	// Try permissive filtering.
-	{
-		dump := fill()
-		filt := newACLFilter(acl.AllowAll(), nil)
-		filt.filterNodeDump(&dump)
-		if len(dump) != 1 {
-			t.Fatalf("bad: %#v", dump)
-		}
-		if len(dump[0].Services) != 1 {
-			t.Fatalf("bad: %#v", dump[0].Services)
-		}
-		if len(dump[0].Checks) != 1 {
-			t.Fatalf("bad: %#v", dump[0].Checks)
-		}
-	}
+	t.Run("allowed", func(t *testing.T) {
+		require := require.New(t)
 
-	// Try restrictive filtering.
-	{
-		dump := fill()
-		filt := newACLFilter(acl.DenyAll(), nil)
-		filt.filterNodeDump(&dump)
-		if len(dump) != 0 {
-			t.Fatalf("bad: %#v", dump)
-		}
-	}
+		policy, err := acl.NewPolicyFromSource(`
+			service "foo" {
+			  policy = "read"
+			}
+			node "node1" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
 
-	// Allowed to see the service but not the node.
-	policy, err := acl.NewPolicyFromSource(`
-service "foo" {
-  policy = "read"
-}
-`, acl.SyntaxLegacy, nil, nil)
-	if err != nil {
-		t.Fatalf("err %v", err)
-	}
-	perms, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
 
-	// But the node will block it.
-	{
-		dump := fill()
-		filt := newACLFilter(perms, nil)
-		filt.filterNodeDump(&dump)
-		if len(dump) != 0 {
-			t.Fatalf("bad: %#v", dump)
-		}
-	}
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
 
-	// Chain on access to the node.
-	policy, err = acl.NewPolicyFromSource(`
-node "node1" {
-  policy = "read"
-}
-`, acl.SyntaxLegacy, nil, nil)
-	if err != nil {
-		t.Fatalf("err %v", err)
-	}
-	perms, err = acl.NewPolicyAuthorizerWithDefaults(perms, []*acl.Policy{policy}, nil)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+		require.Len(list.Dump, 1)
+		require.False(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
+	})
 
-	// Now it should go through.
-	{
-		dump := fill()
-		filt := newACLFilter(perms, nil)
-		filt.filterNodeDump(&dump)
-		if len(dump) != 1 {
-			t.Fatalf("bad: %#v", dump)
-		}
-		if len(dump[0].Services) != 1 {
-			t.Fatalf("bad: %#v", dump[0].Services)
-		}
-		if len(dump[0].Checks) != 1 {
-			t.Fatalf("bad: %#v", dump[0].Checks)
-		}
-	}
+	t.Run("allowed to read the service, but not the node", func(t *testing.T) {
+		require := require.New(t)
+
+		policy, err := acl.NewPolicyFromSource(`
+			service "foo" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
+
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
+
+		require.Empty(list.Dump)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("allowed to read the node, but not the service", func(t *testing.T) {
+		require := require.New(t)
+
+		policy, err := acl.NewPolicyFromSource(`
+			node "node1" {
+			  policy = "read"
+			}
+		`, acl.SyntaxLegacy, nil, nil)
+		require.NoError(err)
+
+		authz, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
+		require.NoError(err)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, authz, list)
+
+		require.Len(list.Dump, 1)
+		require.Empty(list.Dump[0].Services)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("denied", func(t *testing.T) {
+		require := require.New(t)
+
+		list := makeList()
+		filterACLWithAuthorizer(logger, acl.DenyAll(), list)
+
+		require.Empty(list.Dump)
+		require.True(list.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
 }
 
 func TestACL_filterNodes(t *testing.T) {

--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -117,10 +117,6 @@ func (m *Internal) ServiceDump(args *structs.ServiceDumpRequest, reply *structs.
 			}
 			reply.Nodes = nodes
 
-			if err := m.srv.filterACL(args.Token, &reply.Nodes); err != nil {
-				return err
-			}
-
 			// Get, store, and filter gateway services
 			idx, gatewayServices, err := state.DumpGatewayServices(ws)
 			if err != nil {

--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -72,18 +72,21 @@ func (m *Internal) NodeDump(args *structs.DCSpecificRequest,
 			if err != nil {
 				return err
 			}
-
 			reply.Index, reply.Dump = index, dump
-			if err := m.srv.filterACL(args.Token, reply); err != nil {
-				return err
-			}
 
 			raw, err := filter.Execute(reply.Dump)
 			if err != nil {
 				return err
 			}
-
 			reply.Dump = raw.(structs.NodeDump)
+
+			// Note: we filter the results with ACLs *after* applying the user-supplied
+			// bexpr filter, to ensure QueryMeta.ResultsFilteredByACLs does not include
+			// results that would be filtered out even if the user did have permission.
+			if err := m.srv.filterACL(args.Token, reply); err != nil {
+				return err
+			}
+
 			return nil
 		})
 }

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -1301,6 +1301,7 @@ func TestInternal_GatewayServiceDump_Terminating_ACL(t *testing.T) {
 	require.Equal(t, nodes[0].Node.Node, "bar")
 	require.Equal(t, nodes[0].Service.Service, "db")
 	require.Equal(t, nodes[0].Checks[0].Status, api.HealthWarning)
+	require.True(t, out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
 }
 
 func TestInternal_GatewayServiceDump_Ingress(t *testing.T) {

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -758,6 +758,217 @@ func TestInternal_ServiceDump_Kind(t *testing.T) {
 	})
 }
 
+func TestInternal_ServiceDump_ACL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir, s := testServerWithConfig(t, func(c *Config) {
+		c.PrimaryDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLMasterToken = "root"
+		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir)
+	defer s.Shutdown()
+	codec := rpcClient(t, s)
+	defer codec.Close()
+
+	testrpc.WaitForLeader(t, s.RPC, "dc1")
+
+	registrations := []*structs.RegisterRequest{
+		// Service `redis` on `node1`
+		{
+			Datacenter: "dc1",
+			Node:       "node1",
+			ID:         types.NodeID("e0155642-135d-4739-9853-a1ee6c9f945b"),
+			Address:    "192.18.1.1",
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindTypical,
+				ID:      "redis",
+				Service: "redis",
+				Port:    5678,
+			},
+			Check: &structs.HealthCheck{
+				Name:      "redis check",
+				Status:    api.HealthPassing,
+				ServiceID: "redis",
+			},
+		},
+		// Ingress gateway `igw` on `node2`
+		{
+			Datacenter: "dc1",
+			Node:       "node2",
+			ID:         types.NodeID("3a9d7530-20d4-443a-98d3-c10fe78f09f4"),
+			Address:    "192.18.1.2",
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindIngressGateway,
+				ID:      "igw",
+				Service: "igw",
+			},
+			Check: &structs.HealthCheck{
+				Name:      "igw check",
+				Status:    api.HealthPassing,
+				ServiceID: "igw",
+			},
+		},
+	}
+	for _, reg := range registrations {
+		reg.Token = "root"
+		err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", reg, nil)
+		require.NoError(t, err)
+	}
+
+	{
+		req := structs.ConfigEntryRequest{
+			Datacenter: "dc1",
+			Entry: &structs.IngressGatewayConfigEntry{
+				Kind: structs.IngressGateway,
+				Name: "igw",
+				Listeners: []structs.IngressListener{
+					{
+						Port:     8765,
+						Protocol: "tcp",
+						Services: []structs.IngressService{
+							{Name: "redis"},
+						},
+					},
+				},
+			},
+		}
+		req.Token = "root"
+
+		var out bool
+		err := msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out)
+		require.NoError(t, err)
+	}
+
+	tokenWithRules := func(t *testing.T, rules string) string {
+		t.Helper()
+		tok, err := upsertTestTokenWithPolicyRules(codec, "root", "dc1", rules)
+		require.NoError(t, err)
+		return tok.SecretID
+	}
+
+	t.Run("can read all", func(t *testing.T) {
+		require := require.New(t)
+
+		token := tokenWithRules(t, `
+			node_prefix "" {
+				policy = "read"
+			}
+			service_prefix "" {
+				policy = "read"
+			}
+		`)
+
+		args := structs.DCSpecificRequest{
+			Datacenter:   "dc1",
+			QueryOptions: structs.QueryOptions{Token: token},
+		}
+		var out structs.IndexedNodesWithGateways
+		err := msgpackrpc.CallWithCodec(codec, "Internal.ServiceDump", &args, &out)
+		require.NoError(err)
+		require.NotEmpty(out.Nodes)
+		require.NotEmpty(out.Gateways)
+		require.False(out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be false")
+	})
+
+	t.Run("cannot read service node", func(t *testing.T) {
+		require := require.New(t)
+
+		token := tokenWithRules(t, `
+			node "node1" {
+				policy = "deny"
+			}
+			service "redis" {
+				policy = "read"
+			}
+		`)
+
+		args := structs.DCSpecificRequest{
+			Datacenter:   "dc1",
+			QueryOptions: structs.QueryOptions{Token: token},
+		}
+		var out structs.IndexedNodesWithGateways
+		err := msgpackrpc.CallWithCodec(codec, "Internal.ServiceDump", &args, &out)
+		require.NoError(err)
+		require.Empty(out.Nodes)
+		require.True(out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("cannot read service", func(t *testing.T) {
+		require := require.New(t)
+
+		token := tokenWithRules(t, `
+			node "node1" {
+				policy = "read"
+			}
+			service "redis" {
+				policy = "deny"
+			}
+		`)
+
+		args := structs.DCSpecificRequest{
+			Datacenter:   "dc1",
+			QueryOptions: structs.QueryOptions{Token: token},
+		}
+		var out structs.IndexedNodesWithGateways
+		err := msgpackrpc.CallWithCodec(codec, "Internal.ServiceDump", &args, &out)
+		require.NoError(err)
+		require.Empty(out.Nodes)
+		require.True(out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("cannot read gateway node", func(t *testing.T) {
+		require := require.New(t)
+
+		token := tokenWithRules(t, `
+			node "node2" {
+				policy = "deny"
+			}
+			service "mgw" {
+				policy = "read"
+			}
+		`)
+
+		args := structs.DCSpecificRequest{
+			Datacenter:   "dc1",
+			QueryOptions: structs.QueryOptions{Token: token},
+		}
+		var out structs.IndexedNodesWithGateways
+		err := msgpackrpc.CallWithCodec(codec, "Internal.ServiceDump", &args, &out)
+		require.NoError(err)
+		require.Empty(out.Gateways)
+		require.True(out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+
+	t.Run("cannot read gateway", func(t *testing.T) {
+		require := require.New(t)
+
+		token := tokenWithRules(t, `
+			node "node2" {
+				policy = "read"
+			}
+			service "mgw" {
+				policy = "deny"
+			}
+		`)
+
+		args := structs.DCSpecificRequest{
+			Datacenter:   "dc1",
+			QueryOptions: structs.QueryOptions{Token: token},
+		}
+		var out structs.IndexedNodesWithGateways
+		err := msgpackrpc.CallWithCodec(codec, "Internal.ServiceDump", &args, &out)
+		require.NoError(err)
+		require.Empty(out.Gateways)
+		require.True(out.QueryMeta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be true")
+	})
+}
+
 func TestInternal_GatewayServiceDump_Terminating(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -461,7 +461,7 @@ func TestInternal_NodeInfo_FilterACL(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Token: token},
 	}
 	reply := structs.IndexedNodeDump{}
-	if err := msgpackrpc.CallWithCodec(codec, "Health.NodeChecks", &opt, &reply); err != nil {
+	if err := msgpackrpc.CallWithCodec(codec, "Internal.NodeInfo", &opt, &reply); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	for _, info := range reply.Dump {
@@ -490,6 +490,10 @@ func TestInternal_NodeInfo_FilterACL(t *testing.T) {
 		if !found {
 			t.Fatalf("bad: %#v", info.Services)
 		}
+	}
+
+	if !reply.QueryMeta.ResultsFilteredByACLs {
+		t.Fatal("ResultsFilteredByACLs should be true")
 	}
 
 	// We've already proven that we call the ACL filtering function so we
@@ -515,7 +519,7 @@ func TestInternal_NodeDump_FilterACL(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Token: token},
 	}
 	reply := structs.IndexedNodeDump{}
-	if err := msgpackrpc.CallWithCodec(codec, "Health.NodeChecks", &opt, &reply); err != nil {
+	if err := msgpackrpc.CallWithCodec(codec, "Internal.NodeDump", &opt, &reply); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	for _, info := range reply.Dump {
@@ -544,6 +548,10 @@ func TestInternal_NodeDump_FilterACL(t *testing.T) {
 		if !found {
 			t.Fatalf("bad: %#v", info.Services)
 		}
+	}
+
+	if !reply.QueryMeta.ResultsFilteredByACLs {
+		t.Fatal("ResultsFilteredByACLs should be true")
 	}
 
 	// We've already proven that we call the ACL filtering function so we


### PR DESCRIPTION
Adds support for the `ResultsFilteredByACLs` flag, and corresponding `X-Consul-Results-Filtered-By-ACLs` HTTP header (introduced in #11569) to the internal endpoints.

Note: I didn't update `GatewayIntentions` in this PR as this is handled by https://github.com/hashicorp/consul/pull/11612.