### PR TITLE
agent: use TLS types for config

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1987,8 +1987,10 @@ func (b *builder) cidrsVal(name string, v []string) (nets []*net.IPNet) {
 }
 
 func (b *builder) tlsVersion(name string, v *string) types.TLSVersion {
+	// TODO: should the nil check be moved into ParseTLSVersion and the arguments
+	// switched to take a pointer?
 	if v == nil {
-		return nil
+		return types.TLSVersionAuto
 	}
 
 	a, err := tlsutil.ParseTLSVersion(*v)

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1350,14 +1350,16 @@ type RuntimeConfig struct {
 	// todo(fs): since they are standardized by IANA.
 	//
 	// hcl: tls_cipher_suites = []string
-	TLSCipherSuites []uint16
+	// TODO: is using types possible here or does this need to be a []string?
+	TLSCipherSuites []types.TLSCipherSuite
 
 	// TLSMinVersion is used to set the minimum TLS version used for TLS
-	// connections. Should be either "tls10", "tls11", "tls12" or "tls13".
-	// Defaults to tls12.
+	// connections. Should be either "TLSv1_0", "TLSv1_1", "TLSv1_2" or "TLSv1_3".
+	// Defaults to TLSv1_2.
 	//
 	// hcl: tls_min_version = string
-	TLSMinVersion string
+	// TODO: is using types possible here or does this need to be a string?
+	TLSMinVersion types.TLSVersion
 
 	// TLSPreferServerCipherSuites specifies whether to prefer the server's
 	// cipher suite over the client cipher suites.
@@ -1707,6 +1709,9 @@ func (c *RuntimeConfig) Sanitized() map[string]interface{} {
 	return sanitize("rt", reflect.ValueOf(c)).Interface().(map[string]interface{})
 }
 
+// TODO: Convert TLSMinVersion and CipherSuites from raw string input to types
+// here or somewhere earlier? Call ParseTLSVersion and ParseCipherSuites
+// somewhere around here?
 func (c *RuntimeConfig) ToTLSUtilConfig() tlsutil.Config {
 	return tlsutil.Config{
 		VerifyIncoming:           c.VerifyIncoming,

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -5962,8 +5961,8 @@ func TestLoad_FullConfig(t *testing.T) {
 				Name:       "ftO6DySn", // notice this is the same as the metrics prefix
 			},
 		},
-		TLSCipherSuites:             []uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256},
-		TLSMinVersion:               "pAOWafkR",
+		TLSCipherSuites:             []types.TLSCipherSuite{types.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, types.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256},
+		TLSMinVersion:               types.TLSv1_1, // FIXME: add a separate test for config parsing error
 		TLSPreferServerCipherSuites: true,
 		TaggedAddresses: map[string]string{
 			"7MYgHrYH": "dALJAhLD",
@@ -6522,8 +6521,8 @@ func TestRuntime_ToTLSUtilConfig(t *testing.T) {
 		NodeName:                    "e",
 		ServerName:                  "f",
 		DNSDomain:                   "g",
-		TLSMinVersion:               "tls12",
-		TLSCipherSuites:             []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
+		TLSMinVersion:               types.TLSv1_2,
+		TLSCipherSuites:             []types.TLSCipherSuite{types.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 		TLSPreferServerCipherSuites: true,
 		EnableAgentTLSForChecks:     true,
 		AutoEncryptTLS:              true,
@@ -6544,8 +6543,8 @@ func TestRuntime_ToTLSUtilConfig(t *testing.T) {
 	require.Equal(t, "e", r.NodeName)
 	require.Equal(t, "f", r.ServerName)
 	require.Equal(t, "g", r.Domain)
-	require.Equal(t, "tls12", r.TLSMinVersion)
-	require.Equal(t, []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA}, r.CipherSuites)
+	require.Equal(t, types.TLSv1_2, r.TLSMinVersion)
+	require.Equal(t, []types.TLSCipherSuite{types.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA}, r.CipherSuites)
 }
 
 func TestRuntime_ToTLSUtilConfig_AutoConfig(t *testing.T) {
@@ -6562,8 +6561,8 @@ func TestRuntime_ToTLSUtilConfig_AutoConfig(t *testing.T) {
 		NodeName:                    "e",
 		ServerName:                  "f",
 		DNSDomain:                   "g",
-		TLSMinVersion:               "tls12",
-		TLSCipherSuites:             []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
+		TLSMinVersion:               types.TLSv1_2,
+		TLSCipherSuites:             []types.TLSCipherSuite{types.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 		TLSPreferServerCipherSuites: true,
 		EnableAgentTLSForChecks:     true,
 		AutoConfig:                  AutoConfig{Enabled: true},
@@ -6584,8 +6583,8 @@ func TestRuntime_ToTLSUtilConfig_AutoConfig(t *testing.T) {
 	require.Equal(t, "e", r.NodeName)
 	require.Equal(t, "f", r.ServerName)
 	require.Equal(t, "g", r.Domain)
-	require.Equal(t, "tls12", r.TLSMinVersion)
-	require.Equal(t, []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA}, r.CipherSuites)
+	require.Equal(t, types.TLSv1_2, r.TLSMinVersion)
+	require.Equal(t, []types.TLSCipherSuite{types.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA}, r.CipherSuites)
 }
 
 func Test_UIPathBuilder(t *testing.T) {

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -351,7 +351,7 @@
     "SyncCoordinateIntervalMin": "0s",
     "SyncCoordinateRateTarget": 0,
     "TLSCipherSuites": [],
-    "TLSMinVersion": "",
+    "TLSMinVersion": 0,
     "TLSPreferServerCipherSuites": false,
     "TaggedAddresses": {},
     "Telemetry": {

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -641,7 +641,7 @@ telemetry {
     disable_compat_1.9 = true
 }
 tls_cipher_suites = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
-tls_min_version = "pAOWafkR"
+tls_min_version = "TLSv1_1"
 tls_prefer_server_cipher_suites = true
 translate_wan_addrs = true
 ui_config {

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -638,7 +638,7 @@
     "disable_compat_1.9": true
   },
   "tls_cipher_suites": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-  "tls_min_version": "pAOWafkR",
+  "tls_min_version": "TLSv1_1",
   "tls_prefer_server_cipher_suites": true,
   "translate_wan_addrs": true,
   "ui_config": {

--- a/agent/consul/auto_config_endpoint.go
+++ b/agent/consul/auto_config_endpoint.go
@@ -281,16 +281,13 @@ func (ac *AutoConfig) updateTLSSettingsInConfig(_ AutoConfigOptions, resp *pbaut
 	resp.Config.TLS.VerifyServerHostname = ac.tlsConfigurator.VerifyServerHostname()
 	base := ac.tlsConfigurator.Base()
 	resp.Config.TLS.VerifyOutgoing = base.VerifyOutgoing
-	resp.Config.TLS.MinVersion = base.TLSMinVersion
+	// FIXME: is the response from this not actually validated in
+	// auto_config_endpoint_test.go?
+	resp.Config.TLS.MinVersion = types.ConsulAutoConfigTLSVersionStrings[base.TLSMinVersion]
 	resp.Config.TLS.PreferServerCipherSuites = base.PreferServerCipherSuites
 
 	var err error
-	// FIXME: is the base.CipherSuites uint16 value exported or stored in
-	// memory remotely anywhere, or is this always passed as a string?
-	// This _might_ be okay regardless, as the underlying values are both
-	// IANA uint16 constant values.
 	resp.Config.TLS.CipherSuites, err = tlsutil.CipherString(base.CipherSuites)
-
 	return err
 }
 

--- a/agent/consul/auto_config_endpoint.go
+++ b/agent/consul/auto_config_endpoint.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/consul/proto/pbconfig"
 	"github.com/hashicorp/consul/proto/pbconnect"
 	"github.com/hashicorp/consul/tlsutil"
+	"github.com/hashicorp/consul/types"
 )
 
 type AutoConfigOptions struct {
@@ -284,7 +285,12 @@ func (ac *AutoConfig) updateTLSSettingsInConfig(_ AutoConfigOptions, resp *pbaut
 	resp.Config.TLS.PreferServerCipherSuites = base.PreferServerCipherSuites
 
 	var err error
+	// FIXME: is the base.CipherSuites uint16 value exported or stored in
+	// memory remotely anywhere, or is this always passed as a string?
+	// This _might_ be okay regardless, as the underlying values are both
+	// IANA uint16 constant values.
 	resp.Config.TLS.CipherSuites, err = tlsutil.CipherString(base.CipherSuites)
+
 	return err
 }
 

--- a/agent/consul/auto_config_endpoint_test.go
+++ b/agent/consul/auto_config_endpoint_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/consul/proto/pbconfig"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/tlsutil"
+	"github.com/hashicorp/consul/types"
 
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -171,7 +172,7 @@ func TestAutoConfigInitialConfiguration(t *testing.T) {
 		c.TLSConfig.VerifyOutgoing = true
 		c.TLSConfig.VerifyIncoming = true
 		c.TLSConfig.VerifyServerHostname = true
-		c.TLSConfig.TLSMinVersion = "tls12"
+		c.TLSConfig.TLSMinVersion = types.TLSv1_2
 		c.TLSConfig.PreferServerCipherSuites = true
 
 		c.ConnectEnabled = true
@@ -386,7 +387,7 @@ func TestAutoConfig_baseConfig(t *testing.T) {
 	}
 }
 
-func parseCiphers(t *testing.T, cipherStr string) []uint16 {
+func parseCiphers(t *testing.T, cipherStr string) []types.TLSCipherSuite {
 	t.Helper()
 	ciphers, err := tlsutil.ParseCiphers(cipherStr)
 	require.NoError(t, err)
@@ -412,7 +413,7 @@ func TestAutoConfig_updateTLSSettingsInConfig(t *testing.T) {
 			tlsConfig: tlsutil.Config{
 				VerifyOutgoing:           true,
 				VerifyServerHostname:     true,
-				TLSMinVersion:            "tls12",
+				TLSMinVersion:            types.TLSv1_2,
 				PreferServerCipherSuites: true,
 				CAFile:                   cafile,
 				CipherSuites:             parseCiphers(t, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),
@@ -433,7 +434,7 @@ func TestAutoConfig_updateTLSSettingsInConfig(t *testing.T) {
 			tlsConfig: tlsutil.Config{
 				VerifyOutgoing:           true,
 				VerifyServerHostname:     false,
-				TLSMinVersion:            "tls10",
+				TLSMinVersion:            types.TLSv1_0,
 				PreferServerCipherSuites: false,
 				CAFile:                   cafile,
 				CipherSuites:             parseCiphers(t, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),
@@ -629,7 +630,7 @@ func TestAutoConfig_updateTLSCertificatesInConfig(t *testing.T) {
 			tlsConfig: tlsutil.Config{
 				VerifyOutgoing:           true,
 				VerifyServerHostname:     true,
-				TLSMinVersion:            "tls12",
+				TLSMinVersion:            types.TLSv1_2,
 				PreferServerCipherSuites: true,
 				CAFile:                   cafile,
 				CipherSuites:             parseCiphers(t, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),
@@ -647,7 +648,7 @@ func TestAutoConfig_updateTLSCertificatesInConfig(t *testing.T) {
 			tlsConfig: tlsutil.Config{
 				VerifyOutgoing:           true,
 				VerifyServerHostname:     true,
-				TLSMinVersion:            "tls12",
+				TLSMinVersion:            types.TLSv1_2,
 				PreferServerCipherSuites: true,
 				CAFile:                   cafile,
 				CipherSuites:             parseCiphers(t, "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"),

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -548,10 +548,6 @@ func (c *Configurator) commonTLSConfig(verifyIncoming bool) *tls.Config {
 	// default (TLS 1.0) and because the initial check in validateConfig makes
 	// sure the version is not invalid.
 
-	// FIXME: move ParseTLSVersion to be called externally, maybe in
-	// agent/config/runtime parsing before the tlsutil.Config struct is created?
-	// tlsVersion, _ := ParseTLSVersion(c.base.TLSMinVersion)
-
 	tlsConfig.MinVersion = goTLSVersions[c.base.TLSMinVersion]
 
 	// Set ClientAuth if necessary

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -720,14 +720,14 @@ func TestConfigurator_CommonTLSConfigCAs(t *testing.T) {
 func TestConfigurator_CommonTLSConfigTLSMinVersion(t *testing.T) {
 	c, err := NewConfigurator(Config{TLSMinVersion: ""}, nil)
 	require.NoError(t, err)
-	tlsVersion, _ := tlsLookup("TLSv1_0")
-	require.Equal(t, c.commonTLSConfig(false).MinVersion, GoTLSVersions[tlsVersion])
+	tlsVersion, _ := ParseTLSVersion("TLSv1_0")
+	require.Equal(t, c.commonTLSConfig(false).MinVersion, goTLSVersions[tlsVersion])
 
 	for _, version := range tlsVersions() {
 		require.NoError(t, c.Update(Config{TLSMinVersion: version}))
-		tlsVersion, _ := tlsLookup(version)
+		tlsVersion, _ := ParseTLSVersion(version)
 		require.Equal(t, c.commonTLSConfig(false).MinVersion,
-			GoTLSVersions[tlsVersion])
+			goTLSVersions[tlsVersion])
 	}
 
 	// NOTE: checks for deprecated TLS version string warnings,
@@ -735,9 +735,9 @@ func TestConfigurator_CommonTLSConfigTLSMinVersion(t *testing.T) {
 	for version := range types.DeprecatedAgentTLSVersions {
 		// TODO: check for warning log message? how?
 		require.NoError(t, c.Update(Config{TLSMinVersion: version}))
-		tlsVersion, _ := tlsLookup(version)
+		tlsVersion, _ := ParseTLSVersion(version)
 		require.Equal(t, c.commonTLSConfig(false).MinVersion,
-			GoTLSVersions[tlsVersion])
+			goTLSVersions[tlsVersion])
 	}
 
 	require.Error(t, c.Update(Config{TLSMinVersion: "tlsBOGUS"}))

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -395,17 +395,17 @@ func TestConfig_ParseCiphers(t *testing.T) {
 		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
 		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
 	}, ",")
-	ciphers := []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	ciphers := []types.TLSCipherSuite{
+		types.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		types.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		types.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		types.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		types.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		types.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		types.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		types.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		types.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		types.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 	}
 	v, err := ParseCiphers(testOk)
 	require.NoError(t, err)
@@ -418,7 +418,7 @@ func TestConfig_ParseCiphers(t *testing.T) {
 
 	v, err = ParseCiphers("")
 	require.NoError(t, err)
-	require.Equal(t, []uint16{}, v)
+	require.Equal(t, []types.TLSCipherSuite{}, v)
 }
 
 func TestLoadKeyPair(t *testing.T) {
@@ -651,13 +651,20 @@ func TestConfigurator_CommonTLSConfigCipherSuites(t *testing.T) {
 	tlsConf := c.commonTLSConfig(false)
 	require.Empty(t, tlsConf.CipherSuites)
 
-	// TODO: this test previously was expected to pass with an unexpected, but
-	// valid, value??
 	conf := Config{CipherSuites: []types.TLSCipherSuite{
 		types.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256}}
 	require.NoError(t, c.Update(conf))
 	tlsConf = c.commonTLSConfig(false)
-	require.Equal(t, conf.CipherSuites, tlsConf.CipherSuites)
+
+	// TODO: this test previously was expected to pass with an unexpected, but
+	// valid, value??
+	require.Equal(t, []uint16{}, tlsConf.CipherSuites)
+
+	conf = Config{CipherSuites: []types.TLSCipherSuite{
+		types.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA}}
+	require.NoError(t, c.Update(conf))
+	tlsConf = c.commonTLSConfig(false)
+	require.Equal(t, []uint16{0xc009}, tlsConf.CipherSuites)
 }
 
 func TestConfigurator_CommonTLSConfigGetClientCertificate(t *testing.T) {

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -718,29 +718,29 @@ func TestConfigurator_CommonTLSConfigCAs(t *testing.T) {
 }
 
 func TestConfigurator_CommonTLSConfigTLSMinVersion(t *testing.T) {
-	c, err := NewConfigurator(Config{TLSMinVersion: ""}, nil)
+	c, err := NewConfigurator(Config{TLSMinVersion: types.TLSVersionAuto}, nil)
 	require.NoError(t, err)
-	tlsVersion, _ := ParseTLSVersion("TLSv1_0")
-	require.Equal(t, c.commonTLSConfig(false).MinVersion, goTLSVersions[tlsVersion])
+	require.Equal(t, c.commonTLSConfig(false).MinVersion, goTLSVersions[types.TLSv1_0])
 
-	for _, version := range tlsVersions() {
+	for version, _ := range goTLSVersions {
 		require.NoError(t, c.Update(Config{TLSMinVersion: version}))
-		tlsVersion, _ := ParseTLSVersion(version)
 		require.Equal(t, c.commonTLSConfig(false).MinVersion,
-			goTLSVersions[tlsVersion])
+			goTLSVersions[version])
 	}
 
+	// FIXME: this and a version of the prior test to check string parsing are
+	// necessary, but need to move out to agent/config/builder
 	// NOTE: checks for deprecated TLS version string warnings,
 	// should be removed when removing support for these config values
-	for version := range types.DeprecatedAgentTLSVersions {
-		// TODO: check for warning log message? how?
-		require.NoError(t, c.Update(Config{TLSMinVersion: version}))
-		tlsVersion, _ := ParseTLSVersion(version)
-		require.Equal(t, c.commonTLSConfig(false).MinVersion,
-			goTLSVersions[tlsVersion])
-	}
+	// for version := range types.DeprecatedAgentTLSVersions {
+	// 	// TODO: check for warning log message? how?
+	// 	require.NoError(t, c.Update(Config{TLSMinVersion: version}))
+	// 	tlsVersion, _ := ParseTLSVersion(version)
+	// 	require.Equal(t, c.commonTLSConfig(false).MinVersion,
+	// 		goTLSVersions[tlsVersion])
+	// }
 
-	require.Error(t, c.Update(Config{TLSMinVersion: "tlsBOGUS"}))
+	// require.Error(t, c.Update(Config{TLSMinVersion: "tlsBOGUS"}))
 }
 
 func TestConfigurator_CommonTLSConfigVerifyIncoming(t *testing.T) {
@@ -998,7 +998,7 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 			name: "default tls, skip verify, no server name",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{
-					TLSMinVersion:           "tls12",
+					TLSMinVersion:           types.TLSv1_2,
 					EnableAgentTLSForChecks: false,
 				}, nil)
 			},
@@ -1009,7 +1009,7 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 			name: "default tls, skip verify, default server name",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{
-					TLSMinVersion:           "tls12",
+					TLSMinVersion:           types.TLSv1_2,
 					EnableAgentTLSForChecks: false,
 					ServerName:              "servername",
 					NodeName:                "nodename",
@@ -1022,7 +1022,7 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 			name: "default tls, skip verify, check server name",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{
-					TLSMinVersion:           "tls12",
+					TLSMinVersion:           types.TLSv1_2,
 					EnableAgentTLSForChecks: false,
 					ServerName:              "servername",
 				}, nil)
@@ -1038,7 +1038,7 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 			name: "agent tls, default server name",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{
-					TLSMinVersion:           "tls12",
+					TLSMinVersion:           types.TLSv1_2,
 					EnableAgentTLSForChecks: true,
 					NodeName:                "nodename",
 					ServerName:              "servername",
@@ -1053,7 +1053,7 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 			name: "agent tls, skip verify, node name for server name",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{
-					TLSMinVersion:           "tls12",
+					TLSMinVersion:           types.TLSv1_2,
 					EnableAgentTLSForChecks: true,
 					NodeName:                "nodename",
 				}, nil)
@@ -1069,7 +1069,7 @@ func TestConfigurator_OutgoingTLSConfigForCheck(t *testing.T) {
 			name: "agent tls, skip verify, with server name override",
 			conf: func() (*Configurator, error) {
 				return NewConfigurator(Config{
-					TLSMinVersion:           "tls12",
+					TLSMinVersion:           types.TLSv1_2,
 					EnableAgentTLSForChecks: true,
 					ServerName:              "servername",
 				}, nil)

--- a/types/tls.go
+++ b/types/tls.go
@@ -1,0 +1,93 @@
+package types
+
+// TLSVersion is a strongly-typed int used for relative comparison
+// (minimum, maximum, greater than, less than) of TLS versions
+type TLSVersion int
+
+const (
+	// Error value, excluded from lookup maps
+	TLSVersionInvalid TLSVersion = iota - 1
+
+	// Explictly allow implementation to select TLS version
+	// May be useful to supercede defaults specified at a higher layer
+	TLSVersionAuto
+
+	_ // Placeholder for SSLv3, hopefully we won't have to add this
+
+	// TLS versions
+	TLSv1_0
+	TLSv1_1
+	TLSv1_2
+	TLSv1_3
+)
+
+var (
+	TLSVersions = map[string]TLSVersion{
+		"TLS_AUTO": TLSVersionAuto,
+		"TLSv1_0":  TLSv1_0,
+		"TLSv1_1":  TLSv1_1,
+		"TLSv1_2":  TLSv1_2,
+		"TLSv1_3":  TLSv1_3,
+	}
+	// NOTE: This interface is deprecated in favor of TLSVersions
+	// and should be eventually removed in a future release.
+	DeprecatedAgentTLSVersions = map[string]TLSVersion{
+		"":      TLSVersionAuto,
+		"tls10": TLSv1_0,
+		"tls11": TLSv1_1,
+		"tls12": TLSv1_2,
+		"tls13": TLSv1_3,
+	}
+	HumanTLSVersionStrings = map[TLSVersion]string{
+		TLSVersionAuto: "Allow implementation to select TLS version",
+		TLSv1_0:        "TLS 1.0",
+		TLSv1_1:        "TLS 1.1",
+		TLSv1_2:        "TLS 1.2",
+		TLSv1_3:        "TLS 1.3",
+	}
+	EnvoyTLSVersionStrings = map[TLSVersion]string{
+		TLSVersionAuto: "TLS_AUTO",
+		TLSv1_0:        "TLSv1_0",
+		TLSv1_1:        "TLSv1_1",
+		TLSv1_2:        "TLSv1_2",
+		TLSv1_3:        "TLSv1_3",
+	}
+)
+
+func (v TLSVersion) String() string {
+	return HumanTLSVersionStrings[v]
+}
+
+func (v TLSVersion) EnvoyString() string {
+	return EnvoyTLSVersionStrings[v]
+}
+
+// The naming convention for cipher suites changed in TLS 1.3
+// but constant values should still be globally unqiue
+// Handling validation on a subset of TLSCipherSuite constants
+// would be a future exercise if cipher suites for TLS 1.3 ever
+// become configurable in BoringSSL, Envoy, or other implementation
+type TLSCipherSuite string
+
+// IANA cipher suite constants
+// NOTE: This is the total list of TLS 1.2-style cipher suites
+// which are currently supported by Envoy 1.21 and may change
+// as some older suites are removed in future Envoy releases
+// and Consul drops support for older Envoy versions
+// TODO: Is there any better/less verbose way to handle this mapping?
+const (
+	ECDHE_ECDSA_AES128_GCM_SHA256 TLSCipherSuite = "ECDHE-ECDSA-AES128-GCM-SHA256"
+	ECDHE_ECDSA_CHACHA20_POLY1305                = "ECDHE-ECDSA-CHACHA20-POLY1305"
+	ECDHE_RSA_AES128_GCM_SHA256                  = "ECDHE-RSA-AES128-GCM-SHA256"
+	ECDHE_RSA_CHACHA20_POLY1305                  = "ECDHE-RSA-CHACHA20-POLY1305"
+	ECDHE_ECDSA_AES128_SHA                       = "ECDHE-ECDSA-AES128-SHA"
+	ECDHE_RSA_AES128_SHA                         = "ECDHE-RSA-AES128-SHA"
+	AES128_GCM_SHA256                            = "AES128-GCM-SHA256"
+	AES128_SHA                                   = "AES128-SHA"
+	ECDHE_ECDSA_AES256_GCM_SHA384                = "ECDHE-ECDSA-AES256-GCM-SHA384"
+	ECDHE_RSA_AES256_GCM_SHA384                  = "ECDHE-RSA-AES256-GCM-SHA384"
+	ECDHE_ECDSA_AES256_SHA                       = "ECDHE-ECDSA-AES256-SHA"
+	ECDHE_RSA_AES256_SHA                         = "ECDHE-RSA-AES256-SHA"
+	AES256_GCM_SHA384                            = "AES256-GCM-SHA384"
+	AES256_SHA                                   = "AES256-SHA"
+)

--- a/types/tls.go
+++ b/types/tls.go
@@ -45,6 +45,16 @@ var (
 		TLSv1_2:        "TLS 1.2",
 		TLSv1_3:        "TLS 1.3",
 	}
+	// NOTE: these currently map to the deprecated config strings to support the
+	// deployment pattern of upgrading servers first. These should be updated to
+	// the newer config strings in a future release.
+	ConsulAutoConfigTLSVersionStrings = map[TLSVersion]string{
+		TLSVersionAuto: "",
+		TLSv1_0:        "tls10",
+		TLSv1_1:        "tls11",
+		TLSv1_2:        "tls12",
+		TLSv1_3:        "tls13",
+	}
 	EnvoyTLSVersionStrings = map[TLSVersion]string{
 		TLSVersionAuto: "TLS_AUTO",
 		TLSv1_0:        "TLSv1_0",

--- a/types/tls_test.go
+++ b/types/tls_test.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTLSVersion_PartialEq(t *testing.T) {
+	require.Greater(t, TLSv1_3, TLSv1_2)
+	require.Greater(t, TLSv1_2, TLSv1_1)
+	require.Greater(t, TLSv1_1, TLSv1_0)
+
+	require.Less(t, TLSv1_2, TLSv1_3)
+	require.Less(t, TLSv1_1, TLSv1_2)
+	require.Less(t, TLSv1_0, TLSv1_1)
+}
+
+func TestTLSVersion_Invalid(t *testing.T) {
+	require.NotEqual(t, TLSVersionAuto, TLSVersionInvalid)
+
+	// Error values should be negative
+	require.Less(t, TLSVersionInvalid, 0)
+}

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -231,7 +231,7 @@ The options below are all specified on the command-line.
   Like [`enable_script_checks`](#_enable_script_checks), but only enable them when
   they are defined in the local configuration files. Script checks defined in HTTP
   API registrations will still not be allowed.
-  
+
 
 - `-encrypt` ((#\_encrypt)) - Specifies the secret key to use for encryption
   of Consul network traffic. This key must be 32-bytes that are Base64-encoded. The
@@ -2261,9 +2261,11 @@ signed by the CA can be used to gain full access to Consul.
   the hostname we declare.
 
 - `tls_min_version` Added in Consul 0.7.4, this specifies
-  the minimum supported version of TLS. Accepted values are "tls10", "tls11", "tls12",
-  or "tls13". This defaults to "tls12". WARNING: TLS 1.1 and lower are generally
-  considered less secure; avoid using these if possible.
+  the minimum supported version of TLS. Accepted values as of Consul 1.11.0 are "TLSv1_0",
+  "TLSv1_1", "TLSv1_2", or "TLSv1_3". This defaults to "TLSv1_2". WARNING: TLS 1.1 and
+  lower are generally considered less secure; avoid using these if possible.
+  Deprecated values of "tls10", "tls11", "tls12" and "tls13" are currently still accepted
+  but will emit a warning during configuration and will be removed in a future release.
 
 - `tls_cipher_suites` Added in Consul 0.8.2, this specifies the list of
   supported ciphersuites as a comma-separated-list. Applicable to TLS 1.2 and below only.


### PR DESCRIPTION
Although this deprecates the current config values for agent config `tls_min_version`, it _should_ be backwards compatible because those values will still be supported (with a warning) and the auto-config implementation will continue to use the _old, deprecated_ values for at least a full major release cycle, to support the pattern of upgrading servers before client agents. All internal implementation has been moved to use typed constants instead of passing the raw strings around.

The config values for `tls_cipher_suites` are unchanged, but internal implementation now uses typed constants instead of `uint16`.

_Aside_: changelog checker seemed to not enforce an entry on PR, I think because it touched `website`? That should probably be modified to check if _all_ files in the diff are in that directory rather than _any_.

TODO:
- [ ] Check if any duplication of structs can be avoided following the pattern in https://github.com/hashicorp/consul/issues/9983