### PR TITLE
ui: [Backport/1.10.x] Add `Service.Namespace` variable to dashboard URL templates (#11640)

### DIFF
--- a/.changelog/11640.txt
+++ b/.changelog/11640.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Include `Service.Namespace` into available variables for `dashboard_url_templates`
+```

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -101,8 +101,11 @@ as |route|>
             {{#if urls.service}}
               <a href={{render-template urls.service (hash
                 Datacenter=dc.Name
-                Service=(hash Name=item.Service.Service)
-              )}}
+                Service=(hash
+                  Name=item.Service.Service
+                  Namespace=(or item.Service.Namespace '')
+                  )
+                )}}
                 target="_blank"
                 rel="noopener noreferrer"
                 data-test-dashboard-anchor>

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -106,11 +106,15 @@ as |route|>
         @dc={{dc.Name}}
         @service={{items.firstObject}}
         @topology={{topology}}
-
-        @metricsHref={{render-template urls.service (hash
-          Datacenter=dc.Name
-          Service=items.firstObject
-        )}}
+        @metricsHref={{render-template urls.service
+          (hash
+            Datacenter=dc.Name
+            Service=(hash
+              Name=items.firstObject.Name
+              Namespace=(or items.firstObject.Namespace '')
+            )
+          )
+        }}
         @isRemoteDC={{not dc.Local}}
         @hasMetricsProvider={{hasMetricsProvider}}
         @oncreate={{route-action 'createIntention'}}


### PR DESCRIPTION
See #11640

We currently allow only Datacenter, Service.Name, this PR adds Service.Namespace.
