### PR TITLE
ui: [Backport/1.8.x] Add `Service.Namespace` variable to dashboard URL templates (#11640)

### DIFF
--- a/.changelog/11640.txt
+++ b/.changelog/11640.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Include `Service.Namespace` into available variables for `dashboard_url_templates`
+```

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -47,7 +47,13 @@
   </BlockSlot>
   <BlockSlot @name="actions">
     {{#if urls.service}}
-      {{#templated-anchor data-test-dashboard-anchor href=urls.service vars=(hash Datacenter=dc Service=(hash Name=item.Service.Service)) rel="external"}}Open Dashboard{{/templated-anchor}}
+      {{#templated-anchor data-test-dashboard-anchor href=urls.service vars=(hash
+        Datacenter=dc
+        Service=(hash
+          Name=item.Service.Service
+          Namespace=(or item.Service.Namespace '')
+        )
+      ) rel="external"}}Open Dashboard{{/templated-anchor}}
     {{/if}}
   </BlockSlot>
   <BlockSlot @name="content">


### PR DESCRIPTION
See #11640 Note: 1.8.x doesn't have a topology view, therefore we only need to do this in once place.

We currently allow only Datacenter, Service.Name, this PR adds Service.Namespace.