### PR TITLE
ui: Don't check global session permissions for a single session

### DIFF
--- a/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
@@ -108,8 +108,10 @@ as |parts|}}
         @parent={{parentKey}}
       />
 
-    {{! session is slightly different to item.Session as we only have session if you have session:read perms}}
-{{#if (and item.Session (can "read sessions"))}}
+{{! `session` is slightly different to `item.Session` as we only have `session` }}
+{{! if you have `session:read perms` whereas you can get the sessions ID from }}
+{{! `item.Session` without any session perms }}
+{{#if (and item.Session)}}
       <DataSource
         @src={{uri '/${partition}/${nspace}/${dc}/sessions/for-key/${id}'
             (hash


### PR DESCRIPTION
I noticed during https://github.com/hashicorp/consul/pull/11559 that we shouldn't check for global session permissions when checking for read of a session for KV.

This removes that for 1.11 onwards.