### PR TITLE
ca: reduce consul provider backend interface a bit

### DIFF
--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -17,8 +17,9 @@ type consulCAMockDelegate struct {
 	state *state.Store
 }
 
-func (c *consulCAMockDelegate) State() *state.Store {
-	return c.state
+func (c *consulCAMockDelegate) ProviderState(id string) (*structs.CAConsulProviderState, error) {
+	_, s, err := c.state.CAProviderState(id)
+	return s, err
 }
 
 func (c *consulCAMockDelegate) ApplyCARequest(req *structs.CARequest) (interface{}, error) {

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -246,7 +246,6 @@ func (v *VaultProvider) GenerateRoot() error {
 				DefaultLeaseTTL: v.config.RootCertTTL.String(),
 			},
 		})
-
 		if err != nil {
 			return err
 		}

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -168,8 +168,11 @@ func runTestVault(t testing.T) (*TestVaultServer, error) {
 		returnPortsFn: returnPortsFn,
 	}
 	t.Cleanup(func() {
-		testVault.Stop()
+		if err := testVault.Stop(); err != nil {
+			t.Log("failed to stop vault server: %w", err)
+		}
 	})
+
 	return testVault, nil
 }
 

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -38,6 +38,8 @@ const (
 // easier testing.
 type caServerDelegate interface {
 	ca.ConsulProviderStateDelegate
+
+	State() *state.Store
 	IsLeader() bool
 	ApplyCALeafRequest() (uint64, error)
 
@@ -136,6 +138,11 @@ func (c *caDelegateWithState) ServersSupportMultiDCConnectCA() error {
 		return fmt.Errorf("all servers in the primary datacenter are not at the minimum version %v", minMultiDCConnectVersion)
 	}
 	return nil
+}
+
+func (c *caDelegateWithState) ProviderState(id string) (*structs.CAConsulProviderState, error) {
+	_, s, err := c.fsm.State().CAProviderState(id)
+	return s, err
 }
 
 func NewCAManager(delegate caServerDelegate, leaderRoutineManager *routine.Manager, logger hclog.Logger, config *Config) *CAManager {

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -53,6 +53,11 @@ func (m *mockCAServerDelegate) State() *state.Store {
 	return m.store
 }
 
+func (m *mockCAServerDelegate) ProviderState(id string) (*structs.CAConsulProviderState, error) {
+	_, s, err := m.store.CAProviderState(id)
+	return s, err
+}
+
 func (m *mockCAServerDelegate) IsLeader() bool {
 	return true
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -472,7 +472,7 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 		return nil, fmt.Errorf("Failed to start Raft: %v", err)
 	}
 
-	s.caManager = NewCAManager(&caDelegateWithState{s}, s.leaderRoutineManager, s.logger.ResetNamed("connect.ca"), s.config)
+	s.caManager = NewCAManager(&caDelegateWithState{Server: s}, s.leaderRoutineManager, s.logger.ResetNamed("connect.ca"), s.config)
 	if s.config.ConnectEnabled && (s.config.AutoEncryptAllowTLS || s.config.AutoConfigAuthzEnabled) {
 		go s.connectCARootsMonitor(&lib.StopChannelContext{StopCh: s.shutdownCh})
 	}


### PR DESCRIPTION
This is a small change I made while working on other bug fixes. I did this as a way of using the ConsulProvider as an "external PKI", but I decided to take a different approach. While the original reason for this change no longer exists, I thought this was still a nice cleanup because it limits the access the Consul Provider has to the state store. This should prevent accidentally using something from the state store that other providers would not have access to.