### PR TITLE
ca: remove one call to Provider.ActiveRoot

### DIFF
--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1463,28 +1463,22 @@ func (c *CAManager) SignCertificate(csr *x509.CertificateRequest, spiffeID conne
 
 	connect.HackSANExtensionForCSR(csr)
 
-	root, err := provider.ActiveRoot()
-	if err != nil {
-		return nil, err
-	}
 	// Check if the root expired before using it to sign.
-	err = c.checkExpired(root)
+	// TODO: we store NotBefore and NotAfter on this struct, so we could avoid
+	// parsing the cert here.
+	err = c.checkExpired(caRoot.RootCert)
 	if err != nil {
 		return nil, fmt.Errorf("root expired: %w", err)
 	}
 
-	inter, err := provider.ActiveIntermediate()
-	if err != nil {
-		return nil, err
-	}
-	// Check if the intermediate expired before using it to sign.
-	err = c.checkExpired(inter)
-	if err != nil {
-		return nil, fmt.Errorf("intermediate expired: %w", err)
+	if c.isIntermediateUsedToSignLeaf() && len(caRoot.IntermediateCerts) > 0 {
+		inter := caRoot.IntermediateCerts[len(caRoot.IntermediateCerts)-1]
+		if err := c.checkExpired(inter); err != nil {
+			return nil, fmt.Errorf("intermediate expired: %w", err)
+		}
 	}
 
 	// All seems to be in order, actually sign it.
-
 	pem, err := provider.Sign(csr)
 	if err == ca.ErrRateLimited {
 		return nil, ErrRateLimited

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1498,11 +1498,6 @@ func (c *CAManager) SignCertificate(csr *x509.CertificateRequest, spiffeID conne
 		pem = pem + ca.EnsureTrailingNewline(p)
 	}
 
-	// Append our local CA's intermediate if there is one.
-	if inter != root {
-		pem = pem + ca.EnsureTrailingNewline(inter)
-	}
-
 	modIdx, err := c.delegate.ApplyCALeafRequest()
 	if err != nil {
 		return nil, err

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -422,6 +422,9 @@ func TestCAManager_SignCertificate_WithExpiredCert(t *testing.T) {
 		{"root in the future", time.Now().AddDate(0, 0, 1), time.Now().AddDate(0, 0, 2), time.Now().AddDate(0, 0, -1), time.Now().AddDate(0, 0, 2), false, ""},
 	}
 
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err, "failed to generate key")
+
 	for _, arg := range args {
 		t.Run(arg.testName, func(t *testing.T) {
 			// No parallel execution because we change globals
@@ -439,11 +442,13 @@ func TestCAManager_SignCertificate_WithExpiredCert(t *testing.T) {
 			conf.ConnectEnabled = true
 			conf.PrimaryDatacenter = "dc1"
 			conf.Datacenter = "dc2"
+
+			rootPEM := generateCertPEM(t, caPrivKey, arg.notBeforeRoot, arg.notAfterRoot)
+			intermediatePEM := generateCertPEM(t, caPrivKey, arg.notBeforeIntermediate, arg.notAfterIntermediate)
+
 			delegate := NewMockCAServerDelegate(t, conf)
 			manager := NewCAManager(delegate, nil, testutil.Logger(t), conf)
 
-			rootPEM := generateCertPEM(t, arg.notBeforeRoot, arg.notAfterRoot)
-			intermediatePEM := generateCertPEM(t, arg.notBeforeIntermediate, arg.notAfterIntermediate)
 			manager.providerShim = &mockCAProvider{
 				callbackCh:      delegate.callbackCh,
 				rootPEM:         rootPEM,
@@ -471,7 +476,7 @@ func TestCAManager_SignCertificate_WithExpiredCert(t *testing.T) {
 	}
 }
 
-func generateCertPEM(t *testing.T, notBefore time.Time, notAfter time.Time) string {
+func generateCertPEM(t *testing.T, caPrivKey *rsa.PrivateKey, notBefore time.Time, notAfter time.Time) string {
 	t.Helper()
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),
@@ -490,8 +495,6 @@ func generateCertPEM(t *testing.T, notBefore time.Time, notAfter time.Time) stri
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
-	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	require.NoError(t, err, "failed to generate key")
 
 	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
 	require.NoError(t, err, "failed to create cert")

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -400,7 +400,7 @@ func TestCAManager_UpdateConfigWhileRenewIntermediate(t *testing.T) {
 	require.EqualValues(t, caStateInitialized, manager.state)
 }
 
-func TestCAManager_SignLeafWithExpiredCert(t *testing.T) {
+func TestCAManager_SignCertificate_WithExpiredCert(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -423,7 +423,6 @@ func TestCAManager_SignLeafWithExpiredCert(t *testing.T) {
 	}
 
 	for _, arg := range args {
-
 		t.Run(arg.testName, func(t *testing.T) {
 			// No parallel execution because we change globals
 			// Set the interval and drift buffer low for renewing the cert.
@@ -443,10 +442,8 @@ func TestCAManager_SignLeafWithExpiredCert(t *testing.T) {
 			delegate := NewMockCAServerDelegate(t, conf)
 			manager := NewCAManager(delegate, nil, testutil.Logger(t), conf)
 
-			err, rootPEM := generatePem(arg.notBeforeRoot, arg.notAfterRoot)
-			require.NoError(t, err)
-			err, intermediatePEM := generatePem(arg.notBeforeIntermediate, arg.notAfterIntermediate)
-			require.NoError(t, err)
+			rootPEM := generateCertPEM(t, arg.notBeforeRoot, arg.notAfterRoot)
+			intermediatePEM := generateCertPEM(t, arg.notBeforeIntermediate, arg.notAfterIntermediate)
 			manager.providerShim = &mockCAProvider{
 				callbackCh:      delegate.callbackCh,
 				rootPEM:         rootPEM,
@@ -462,7 +459,7 @@ func TestCAManager_SignLeafWithExpiredCert(t *testing.T) {
 			// Call RenewIntermediate and then confirm the RPCs and provider calls
 			// happen in the expected order.
 
-			_, err = manager.SignCertificate(&x509.CertificateRequest{}, &connect.SpiffeIDAgent{})
+			_, err := manager.SignCertificate(&x509.CertificateRequest{}, &connect.SpiffeIDAgent{})
 
 			if arg.isError {
 				require.Error(t, err)
@@ -474,7 +471,8 @@ func TestCAManager_SignLeafWithExpiredCert(t *testing.T) {
 	}
 }
 
-func generatePem(notBefore time.Time, notAfter time.Time) (error, string) {
+func generateCertPEM(t *testing.T, notBefore time.Time, notAfter time.Time) string {
+	t.Helper()
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),
 		Subject: pkix.Name{
@@ -493,25 +491,18 @@ func generatePem(notBefore time.Time, notAfter time.Time) (error, string) {
 		BasicConstraintsValid: true,
 	}
 	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		return err, ""
-	}
+	require.NoError(t, err, "failed to generate key")
+
 	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
-	if err != nil {
-		return err, ""
-	}
+	require.NoError(t, err, "failed to create cert")
+
 	caPEM := new(bytes.Buffer)
-	pem.Encode(caPEM, &pem.Block{
+	err = pem.Encode(caPEM, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: caBytes,
 	})
-
-	caPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(caPrivKeyPEM, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
-	})
-	return err, caPEM.String()
+	require.NoError(t, err, "failed to encode")
+	return caPEM.String()
 }
 
 func TestCADelegateWithState_GenerateCASignRequest(t *testing.T) {


### PR DESCRIPTION
This change is related to #11598, and #11159.  More detail in the commit messages, and I'll call out a few things below with inline comments.

The PR is not large, but it is still best viewed by individual commit, as there are a few independent changes, and the commit message has more context.

ActiveRoot should not be called from the secondary DC, because there should not be a requirement to run the same Vault instance in a secondary DC (#11159). `SignCertificate` is called in a secondary DC, so it should not call `Provider.ActiveRoot`. This PR removes that call.

We would also like to change the interface of `Provider.ActiveRoot` so that we can support using an intermediate cert as the primary CA in Consul (#11598). In preparation for making that change I am reducing the number of calls to `Provider.ActiveRoot`, so that there are fewer code paths to modify when the interface changes.

In order to make this change I had to modify the existing test a bit, and fix a couple problems with the mock. I also reduced the runtime of the test so that I wasted less time waiting for it to run.