### PR TITLE
ui: Add documentation link for partitions

### DIFF
--- a/.changelog/11668.txt
+++ b/.changelog/11668.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Add documentation link to Partition empty state
+```

--- a/ui/packages/consul-partitions/app/templates/dc/partitions/index.hbs
+++ b/ui/packages/consul-partitions/app/templates/dc/partitions/index.hbs
@@ -119,10 +119,12 @@ as |route|>
               </BlockSlot>
               <BlockSlot @name="actions">
                 <li class="docs-link">
-                  <a href="{{env 'CONSUL_DOCS_URL'}}/commands/FIXME" rel="noopener noreferrer" target="_blank">Documentation on partitions</a>
-                </li>
-                <li class="learn-link">
-                  <a href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/FIXME" rel="noopener noreferrer" target="_blank">Read the guide</a>
+                  <Action
+                    @href="{{env 'CONSUL_DOCS_URL'}}/enterprise/admin-partitions"
+                    @external={{true}}
+                  >
+                    Documentation on Admin Partitions
+                  </Action>
                 </li>
               </BlockSlot>
             </EmptyState>


### PR DESCRIPTION
This is definitely the last application facing FIXME for admin partitions.

This PR adds the correct link to the Admin Partition empty state.

I also took the opportunity to upgrade to use `<Action />`