### PR TITLE
ui: Stop tables overlapping with their headers when scrolling

### DIFF
--- a/.changelog/11670.txt
+++ b/.changelog/11670.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix visual issue with slight table header overflow
+```

--- a/ui/packages/consul-ui/app/components/consul/intention/list/README.mdx
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/README.mdx
@@ -1,0 +1,36 @@
+# Consul::Intention::List
+
+A component for rendering Intentions.
+
+
+There are some extra conextual components to use here due to how we detect
+intention CRDs and make that easy to work with/add necessary notices. The
+notice will only show if applicable, but the contextual component is used to
+define where that is when it does display.
+
+```hbs preview-template
+
+<DataSource @src="/partition/default/dc-1/intentions" as |source|>
+  <Consul::Intention::List
+    @items={{source.data}}
+    @delete={{noop}}
+  as |list|>
+      <list.CustomResourceNotice />
+      <list.Table />
+  </Consul::Intention::List>
+</DataSource>
+
+```
+
+## Arguments
+
+| Argument/Attribute | Type | Default | Description |
+| --- | --- | --- | --- |
+| `items` | `array` |  | An array of Intentions |
+| `ondelete` | `function` |  | An action to execute when the `Delete` action is clicked |
+
+## See
+
+- [Template Source Code](./index.hbs)
+
+---

--- a/ui/packages/consul-ui/app/components/tabular-collection/index.scss
+++ b/ui/packages/consul-ui/app/components/tabular-collection/index.scss
@@ -5,7 +5,7 @@ table.dom-recycling {
 %dom-recycling-table tbody {
   /* tbodys are all absolute so,*/
   /* make room for the header */
-  top: 29px !important;
+  top: 33px !important;
   /* Make room for the header, plus 20px for a margin on the bottom */
   width: 100%;
 }


### PR DESCRIPTION
I also added a very basic Consul::Intention::List documentation page here, mostly for isolation whilst I was looking at this, but at some point in the future (probably when working on it next instead of just tweaking a value) we should probably fill that out in more detail.

On to the fix:

Before:

<img width="674" alt="Screenshot 2021-11-26 at 16 34 08" src="https://user-images.githubusercontent.com/554604/143610221-afaf6f3a-2ca7-4342-90ef-05904c8a7b6a.png">

After:

<img width="753" alt="Screenshot 2021-11-26 at 16 33 28" src="https://user-images.githubusercontent.com/554604/143610237-e0d1fcf1-5e75-4525-b23c-33428d8a192e.png">

Actually, need to take a look at how far back we can/need to backport this 👀 , at least 1.10.x, but need to check 1.9 and 1.8.


