### PR TITLE
ca: fix storing the leaf signing cert with Vault provider

### DIFF
--- a/.changelog/11671.txt
+++ b/.changelog/11671.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: fixes a bug that caused the intermediate cert used to sign leaf certs to be missing from the /connect/ca/roots API response when the Vault provider was used.
+```

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -403,7 +403,7 @@ func TestLeader_Vault_PrimaryCA_IntermediateRenew(t *testing.T) {
 	store := s1.caManager.delegate.State()
 	_, activeRoot, err := store.CARootActive(nil)
 	require.NoError(err)
-	require.Equal(intermediatePEM, activeRoot.LeafSigningCert())
+	require.Equal(intermediatePEM, s1.caManager.getLeafSigningCertFromRoot(activeRoot))
 	require.Equal(connect.HexString(intermediateCert.SubjectKeyId), activeRoot.SigningKeyID)
 
 	// Wait for dc1's intermediate to be refreshed.
@@ -422,7 +422,7 @@ func TestLeader_Vault_PrimaryCA_IntermediateRenew(t *testing.T) {
 
 	_, activeRoot, err = store.CARootActive(nil)
 	require.NoError(err)
-	require.Equal(intermediatePEM, activeRoot.LeafSigningCert())
+	require.Equal(intermediatePEM, s1.caManager.getLeafSigningCertFromRoot(activeRoot))
 	require.Equal(connect.HexString(intermediateCert.SubjectKeyId), activeRoot.SigningKeyID)
 
 	// Get the root from dc1 and validate a chain of:
@@ -548,7 +548,7 @@ func TestLeader_SecondaryCA_IntermediateRenew(t *testing.T) {
 	store := s2.fsm.State()
 	_, activeRoot, err := store.CARootActive(nil)
 	require.NoError(err)
-	require.Equal(intermediatePEM, activeRoot.LeafSigningCert())
+	require.Equal(intermediatePEM, s2.caManager.getLeafSigningCertFromRoot(activeRoot))
 	require.Equal(connect.HexString(intermediateCert.SubjectKeyId), activeRoot.SigningKeyID)
 
 	// Wait for dc2's intermediate to be refreshed.
@@ -572,7 +572,7 @@ func TestLeader_SecondaryCA_IntermediateRenew(t *testing.T) {
 
 	_, activeRoot, err = store.CARootActive(nil)
 	require.NoError(err)
-	require.Equal(intermediatePEM, activeRoot.LeafSigningCert())
+	require.Equal(intermediatePEM, s2.caManager.getLeafSigningCertFromRoot(activeRoot))
 	require.Equal(connect.HexString(intermediateCert.SubjectKeyId), activeRoot.SigningKeyID)
 
 	// Get the root from dc1 and validate a chain of:

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -142,23 +142,6 @@ func (c *CARoot) Clone() *CARoot {
 	return &newCopy
 }
 
-// LeafSigningCert returns the PEM encoded certificate that should be used to
-// sign leaf certificates in the local datacenter. The SubjectKeyId of the
-// returned cert should always match the SigningKeyID of the CARoot.
-//
-// This method has no knowledge of the provider, so it makes assumptions about
-// which cert is used based on established convention. Generally you should
-// check CAManager.isIntermediateUsedToSignLeaf first.
-//
-// If there are no IntermediateCerts the RootCert is returned. If there are
-// IntermediateCerts the last one in the list is returned.
-func (c *CARoot) LeafSigningCert() string {
-	if len(c.IntermediateCerts) == 0 {
-		return c.RootCert
-	}
-	return c.IntermediateCerts[len(c.IntermediateCerts)-1]
-}
-
 // CARoots is a list of CARoot structures.
 type CARoots []*CARoot
 

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -86,11 +86,20 @@ type CARoot struct {
 	NotBefore time.Time
 	NotAfter  time.Time
 
-	// RootCert is the PEM-encoded public certificate.
+	// RootCert is the PEM-encoded public certificate for the root CA. The
+	// certificate is the same for all federated clusters.
 	RootCert string
 
 	// IntermediateCerts is a list of PEM-encoded intermediate certs to
-	// attach to any leaf certs signed by this CA.
+	// attach to any leaf certs signed by this CA. The list may include a
+	// certificate cross-signed by an old root CA, any subordinate CAs below the
+	// root CA, and the intermediate CA used to sign leaf certificates in the
+	// local Datacenter.
+	//
+	// If the provider which created this root uses an intermediate to sign
+	// leaf certificates (Vault provider), or this is a secondary Datacenter then
+	// the intermediate used to sign leaf certificates will be the last in the
+	// list.
 	IntermediateCerts []string
 
 	// SigningCert is the PEM-encoded signing certificate and SigningKey

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -142,6 +142,23 @@ func (c *CARoot) Clone() *CARoot {
 	return &newCopy
 }
 
+// LeafSigningCert returns the PEM encoded certificate that should be used to
+// sign leaf certificates in the local datacenter. The SubjectKeyId of the
+// returned cert should always match the SigningKeyID of the CARoot.
+//
+// This method has no knowledge of the provider, so it makes assumptions about
+// which cert is used based on established convention. Generally you should
+// check CAManager.isIntermediateUsedToSignLeaf first.
+//
+// If there are no IntermediateCerts the RootCert is returned. If there are
+// IntermediateCerts the last one in the list is returned.
+func (c *CARoot) LeafSigningCert() string {
+	if len(c.IntermediateCerts) == 0 {
+		return c.RootCert
+	}
+	return c.IntermediateCerts[len(c.IntermediateCerts)-1]
+}
+
 // CARoots is a list of CARoot structures.
 type CARoots []*CARoot
 


### PR DESCRIPTION
Fixes #10826 
Fixes #10532

We were not saving the leaf signing cert on the `CARoot` when the Vault provider was initialized. This was only a problem for API users (not envoy and xDS) because [this extra code](https://github.com/hashicorp/consul/pull/11661#discussion_r757059682) was masking the bug.

In #11661 I'd like to remove that masking code (because it is unnecessary, and because we need to change the Provider interface, so fewer callers makes that easier).

This PR updates an existing test to catch the bug, then fixes the bug. I added a few more assertions to both the primary and secondary test cases to make sure we did not have a similar bug in other places.