### PR TITLE
ca: set the correct SigningKeyID after config update with Vault provider

### DIFF
--- a/.changelog/11672.txt
+++ b/.changelog/11672.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: fixes a bug that caused the SigningKeyID to be wrong in the primary DC, when the Vault provider is used, after a CA config creates a new root.
+```


### PR DESCRIPTION
Fixes #11662
Branched from #11671 

Two other instance of this same bug were fixed a year+ ago in #6513 and  #7012, but this last one remained.

The test failed before the fix, and I extracted a new function for this since the logic is the same in all places, and the method name helps indicate the significance of this intermediate certificate.

We already have logic to fix the `SigningKeyID` on stored `CARoot` when the `CAMananger` is initialized, so we don't need to add more logic for it.