### PR TITLE
docs: community tools - string2files

### DIFF
--- a/website/content/docs/download-tools.mdx
+++ b/website/content/docs/download-tools.mdx
@@ -61,5 +61,6 @@ These Consul tools are created and managed by the amazing members of the Consul 
 - [IntelliJ IDEA Consul K/V Support](https://plugins.jetbrains.com/plugin/10511-consul-k-v-support) - editor for K/V store
 - [git2consul-go](https://github.com/KohlsTechnology/git2consul-go) - Data feeder for Consul K/V store
 - [kvit](https://github.com/sadedil/kvit) - A command line utility for synchronizing key value pairs between Consul and file system
+- [string2files](https://github.com/heronimus/ct-plugin-string2files) - Standalone plugin to write multiple files from Consul K/V tree or combine them with Vault secret data using only single Consul-Template file.
 
 Are you the author of a tool and you would like to be featured on this page? The Consul website is open source and is embedded inside the [Consul repository](https://github.com/hashicorp/consul) on GitHub. You can submit a Pull Request to add your tool to the list and we will gladly review it.


### PR DESCRIPTION
Changes:
- Add new list to `Community Tools` pages: `string2files` - standalone plugin to writing multiple files from Consul K/V tree or combine them with Vault secret data using only single Consul-Template file.