### PR TITLE
ui: remove old head.hbs file we don't need

### DIFF
--- a/ui/packages/consul-ui/app/templates/head.hbs
+++ b/ui/packages/consul-ui/app/templates/head.hbs
@@ -1,1 +1,0 @@
-<title>{{model.title}}</title>


### PR DESCRIPTION
This file was used quite a way back for `ember-page-title`. All in all we no longer use this file anywhere.