### PR TITLE
ui: Don't cache event sources following a 401

### DIFF
--- a/.changelog/11681.txt
+++ b/.changelog/11681.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Fixes an issue where under some circumstances after logging we present the
+data loaded previous to you logging in.
+```

--- a/ui/packages/consul-ui/app/services/data-source/service.js
+++ b/ui/packages/consul-ui/app/services/data-source/service.js
@@ -96,13 +96,15 @@ export default class DataSourceService extends Service {
     if (!(uri instanceof URI) && typeof uri !== 'string') {
       return this.unwrap(uri, ref);
     }
-    runInDebug(
-      _ => {
-        if(!(uri instanceof URI)) {
-          console.error(new Error(`DataSource '${uri}' does not use the uri helper. Please ensure you use the uri helper to ensure correct encoding`))
-        }
+    runInDebug(_ => {
+      if (!(uri instanceof URI)) {
+        console.error(
+          new Error(
+            `DataSource '${uri}' does not use the uri helper. Please ensure you use the uri helper to ensure correct encoding`
+          )
+        );
       }
-    );
+    });
     uri = uri.toString();
     let source;
     // Check the cache for an EventSource that is already being used
@@ -130,7 +132,11 @@ export default class DataSourceService extends Service {
           const event = source.getCurrentEvent();
           const cursor = source.configuration.cursor;
           // only cache data if we have any
-          if (typeof event !== 'undefined' && typeof cursor !== 'undefined') {
+          if (
+            typeof event !== 'undefined' &&
+            typeof cursor !== 'undefined' &&
+            e.errors && e.errors[0].status !== '401'
+          ) {
             cache.set(uri, {
               currentEvent: event,
               cursor: cursor,

--- a/ui/packages/consul-ui/app/utils/dom/event-source/callable.js
+++ b/ui/packages/consul-ui/app/utils/dom/event-source/callable.js
@@ -57,7 +57,7 @@ export default function(
         // close after the dispatch so we can tell if it was an error whilst closed or not
         // but make sure its before the promise tick
         this.readyState = 2; // CLOSE
-        this.dispatchEvent({ type: 'close' });
+        this.dispatchEvent({ type: 'close', error: e });
       })
       .then(() => {
         // This only gets called when the promise chain completely finishes


### PR DESCRIPTION
In Consul we have some endpoints that return an empty array/response when you don't have permissions to view anything. This means that a blocking query will start up for that empty request instead of not doing anything (as is the case with a 403)

Additionally when we 'close' a blocking query we cache/save the last received response plus the 'cursor' of where we were. This means when we need to pick the blocking query back up again, we have the previously received data plus the place where we last stopped listening for changes.

If time has passed when we pick up the blocking query and changes have taken place, the "pick this back up again" blocking query will immediately respond with the new changes. If nothing has changed we just resume waiting for updates from exactly the same place where we were before (and we show the cached data from the previous response)

If you login when listening on a 200 `[]` response, the request is cancelled and we immediately try to pick this back up again with the new auth - but importantly we use the cursor position from the previously un-authed request which means that in all likelihood nothing has changed and you will see the cached response from the un-authed blocking query and we continue to wait from the same cursor position.

This only happens on those endpoints that return a 200/`[]` when unauth'ed.

We currently use a 'fake' 401 response to cancel and open blocking queries when re-auth'ing to the UI. So we know when we are cancelling because of auth rather than for other reasons.

This PR ensures that the cursor and previous response for currently waiting blocking queries are not cached we get these types of 401 cancelations, which in turn means that the blocking query is started afresh with no cursor value.

