### PR TITLE
draft: use the CARoots as the source of truth for ClusterID

### DIFF
--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -534,6 +534,13 @@ func (c *CAManager) primaryInitialize(provider ca.Provider, conf *structs.CAConf
 	if err != nil {
 		return err
 	}
+
+	// Ensure that any stored CARoot has their ClusterID set
+	if activeRoot != nil && activeRoot.ExternalTrustDomain == "" {
+		activeRoot.ExternalTrustDomain = rootCA.ExternalTrustDomain
+		needsSigningKeyUpdate = true
+	}
+
 	if activeRoot != nil && needsSigningKeyUpdate {
 		c.logger.Info("Correcting stored SigningKeyID value", "previous", rootCA.SigningKeyID, "updated", expectedSigningKeyID)
 

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -404,7 +404,7 @@ func (c *CAManager) InitializeCA() (reterr error) {
 	if err != nil {
 		return err
 	}
-	provider, err := c.newProvider(conf)
+	provider, err := c.newProvider(conf.Provider)
 	if err != nil {
 		return err
 	}
@@ -445,9 +445,9 @@ func (c *CAManager) secondaryInitialize(provider ca.Provider, conf *structs.CACo
 }
 
 // createProvider returns a connect CA provider from the given config.
-func (c *CAManager) newProvider(conf *structs.CAConfiguration) (ca.Provider, error) {
-	logger := c.logger.Named(conf.Provider)
-	switch conf.Provider {
+func (c *CAManager) newProvider(provider string) (ca.Provider, error) {
+	logger := c.logger.Named(provider)
+	switch provider {
 	case structs.ConsulCAProvider:
 		return ca.NewConsulProvider(c.delegate, logger), nil
 	case structs.VaultCAProvider:
@@ -458,7 +458,7 @@ func (c *CAManager) newProvider(conf *structs.CAConfiguration) (ca.Provider, err
 		if c.providerShim != nil {
 			return c.providerShim, nil
 		}
-		return nil, fmt.Errorf("unknown CA provider %q", conf.Provider)
+		return nil, fmt.Errorf("unknown CA provider %q", provider)
 	}
 }
 
@@ -842,7 +842,7 @@ func (c *CAManager) UpdateConfiguration(args *structs.CARequest) (reterr error) 
 	// and get the current active root CA. This acts as a good validation
 	// of the config and makes sure the provider is functioning correctly
 	// before we commit any changes to Raft.
-	newProvider, err := c.newProvider(args.Config)
+	newProvider, err := c.newProvider(args.Config.Provider)
 	if err != nil {
 		return fmt.Errorf("could not initialize provider: %v", err)
 	}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -7188,10 +7188,10 @@ func TestCatalog_DownstreamsForService(t *testing.T) {
 				i++
 			}
 
-			ca := &structs.CAConfiguration{
-				Provider: "consul",
+			roots := []*structs.CARoot{
+				{ID: "123", Active: true, ExternalTrustDomain: "12345"},
 			}
-			err := s.CASetConfig(0, ca)
+			_, err := s.CARootSetCAS(0, 0, roots)
 			require.NoError(t, err)
 
 			for _, entry := range tc.entries {
@@ -7221,10 +7221,10 @@ func TestCatalog_DownstreamsForService_Updates(t *testing.T) {
 	)
 
 	s := testStateStore(t)
-	ca := &structs.CAConfiguration{
-		Provider: "consul",
+	roots := []*structs.CARoot{
+		{ID: "123", Active: true, ExternalTrustDomain: "12345"},
 	}
-	err := s.CASetConfig(1, ca)
+	_, err := s.CARootSetCAS(0, 0, roots)
 	require.NoError(t, err)
 
 	require.NoError(t, s.EnsureNode(2, &structs.Node{

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -1854,10 +1854,10 @@ func TestSourcesForTarget(t *testing.T) {
 			s := testStateStore(t)
 			ws := memdb.NewWatchSet()
 
-			ca := &structs.CAConfiguration{
-				Provider: "consul",
+			roots := []*structs.CARoot{
+				{ID: "123", Active: true, ExternalTrustDomain: "12345"},
 			}
-			err := s.CASetConfig(0, ca)
+			_, err := s.CARootSetCAS(0, 0, roots)
 			require.NoError(t, err)
 
 			var i uint64 = 1
@@ -2056,10 +2056,10 @@ func TestTargetsForSource(t *testing.T) {
 			s := testStateStore(t)
 			ws := memdb.NewWatchSet()
 
-			ca := &structs.CAConfiguration{
-				Provider: "consul",
+			roots := []*structs.CARoot{
+				{ID: "123", Active: true, ExternalTrustDomain: "12345"},
 			}
-			err := s.CASetConfig(0, ca)
+			_, err := s.CARootSetCAS(0, 0, roots)
 			require.NoError(t, err)
 
 			var i uint64 = 1

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -252,18 +252,8 @@ func caRootsTxn(tx ReadTxn, ws memdb.WatchSet) (uint64, structs.CARoots, error) 
 func (s *Store) CARootActive(ws memdb.WatchSet) (uint64, *structs.CARoot, error) {
 	// Get all the roots since there should never be that many and just
 	// do the filtering in this method.
-	var result *structs.CARoot
 	idx, roots, err := s.CARoots(ws)
-	if err == nil {
-		for _, r := range roots {
-			if r.Active {
-				result = r
-				break
-			}
-		}
-	}
-
-	return idx, result, err
+	return idx, roots.Active(), err
 }
 
 // CARootSetCAS sets the current CA root state using a check-and-set operation.

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -176,13 +176,10 @@ func (s *Store) caSetConfigTxn(idx uint64, tx WriteTxn, config *structs.CAConfig
 	if err != nil {
 		return fmt.Errorf("failed CA config lookup: %s", err)
 	}
-	// Set the indexes, prevent the cluster ID from changing.
+	// Set the indexes
 	if prev != nil {
 		existing := prev.(*structs.CAConfiguration)
 		config.CreateIndex = existing.CreateIndex
-		if config.ClusterID == "" {
-			config.ClusterID = existing.ClusterID
-		}
 	} else {
 		config.CreateIndex = idx
 	}

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -130,6 +130,20 @@ func (c *CARoot) Clone() *CARoot {
 // CARoots is a list of CARoot structures.
 type CARoots []*CARoot
 
+// Active returns the single CARoot that is marked as active, or nil if there
+// is no active root (ex: when they are no roots).
+func (c CARoots) Active() *CARoot {
+	if c == nil {
+		return nil
+	}
+	for _, r := range c {
+		if r.Active {
+			return r
+		}
+	}
+	return nil
+}
+
 // CASignRequest is the request for signing a service certificate.
 type CASignRequest struct {
 	// Datacenter is the target for this request.

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -31,12 +31,6 @@ type IndexedCARoots struct {
 	// implement other protocols in future with equivalent semantics. It should be
 	// compared against the "authority" section of a URI (i.e. host:port).
 	//
-	// We need to support migrating a cluster between trust domains to support
-	// Multi-DC migration in Enterprise. In this case the current trust domain is
-	// here but entries in Roots may also have ExternalTrustDomain set to a
-	// non-empty value implying they were previous roots that are still trusted
-	// but under a different trust domain.
-	//
 	// Note that we DON'T validate trust domain during AuthZ since it causes
 	// issues of loss of connectivity during migration between trust domains. The
 	// only time the additional validation adds value is where the cluster shares
@@ -72,14 +66,14 @@ type CARoot struct {
 	// raw AuthorityKeyID bytes.
 	SigningKeyID string
 
-	// ExternalTrustDomain is the trust domain this root was generated under. It
-	// is usually empty implying "the current cluster trust-domain". It is set
-	// only in the case that a cluster changes trust domain and then all old roots
-	// that are still trusted have the old trust domain set here.
+	// ExternalTrustDomain is the ClusterID of the trust domain this root was
+	// generated under.
 	//
-	// We currently DON'T validate these trust domains explicitly anywhere, see
-	// IndexedRoots.TrustDomain doc. We retain this information for debugging and
-	// future flexibility.
+	// Note this value is different from IndexedCARoots.TrustDomain. This value
+	// does not have a .consul suffix. It is only the ClusterID portion of the
+	// TrustDomain.
+	//
+	// TODO: rename to make it clear this is the canonical data source for the cluster ID.
 	ExternalTrustDomain string
 
 	// Time validity bounds.


### PR DESCRIPTION
Relates to points 2 and 3 in #11347

Previously we used the `CAConfiguration` to pass around the "ClusterID". This resulted in:
1. a lot of code having to refer to the config when it already had access to the `CARoot`
2. having to update the stored config when a secondary received a new `CARoot` from the primary

I believe this shows that the "ClusterID" does not really belong as part of the `CAConfiguration`. Even if we wanted to make it settable for boostrapping, it should be clearly marked as a one-time setting , and likely set in a different config field.

Additionally "ClusterID" is quite misleading. It's actually a global ID for all federated clusters.

We were already storing this value as `ExternalTrustDomain` (which is also confusing because the `TrustDomain` field has a value of `<ClusterID>.consul`, but that is cleanup we'll have to leave for later).

This PR uses the existing `ExternalTrustDomain` field to communicate this value. Storing this value on the `CARoot` seems like a better fit. The life cycle of a `CARoot` is a bit closer to the life cycle of this value.

I'm sure there are still test to add, and failures to debug, but opening this PR now for visibility , and to see which tests fail.

