### PR TITLE
ui: Improve error messaging for when we can't make a slug

### DIFF
--- a/ui/packages/consul-ui/app/utils/create-fingerprinter.js
+++ b/ui/packages/consul-ui/app/utils/create-fingerprinter.js
@@ -5,14 +5,19 @@ export default function(foreignKey, nspaceKey, partitionKey, hash = JSON.stringi
     return function(item) {
       foreignKeyValue = foreignKeyValue == null ? item[foreignKey] : foreignKeyValue;
       if (foreignKeyValue == null) {
-        throw new Error('Unable to create fingerprint, missing foreignKey value');
+        throw new Error(
+          `Unable to create fingerprint, missing foreignKey value. Looking for value in \`${foreignKey}\` got \`${foreignKeyValue}\``
+        );
       }
       const slugKeys = slugKey.split(',');
       const slugValues = slugKeys.map(function(slugKey) {
-        if (get(item, slugKey) == null || get(item, slugKey).length < 1) {
-          throw new Error('Unable to create fingerprint, missing slug');
+        const slug = get(item, slugKey);
+        if (slug == null || slug.length < 1) {
+          throw new Error(
+            `Unable to create fingerprint, missing slug. Looking for value in \`${slugKey}\` got \`${slug}\``
+          );
         }
-        return get(item, slugKey);
+        return slug;
       });
       // This ensures that all data objects have a Namespace and a Partition
       // value set, even in OSS.


### PR DESCRIPTION
Ember Data requires the usage of unique ID to identify its records in the frontend, and we use a centralized function to do that for all records. There are occasions where it can't make an ID, usually this is a bug our side, but there are occasions where Consul might not be giving us the data needed to make an ID, for example if a Service comes down to us with a blank Name. Whilst this isn't a problem to be fixed in the UI, I thought we could make an improvement here by giving a little more info as to why the UI cannot make a unique ID.

This is currently semi-hidden away in the javascript console, but we could potentially surface this in the UI itself as a larger task. I figured this smaller task could help folks in the meantime if they hit upon this as they might open up the javascript console themselves to see whats up and they'd at least get this extra clue.