### PR TITLE
agent: Backport partitioned IDs for updateSyncState 

### DIFF
--- a/.changelog/11700.txt
+++ b/.changelog/11700.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: **(Enterprise only)** fix bug where 1.10.x agents would deregister serf checks from 1.11.x servers
+```

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -958,7 +958,7 @@ func (l *State) updateSyncState() error {
 		if ls == nil {
 			// The consul service is managed automatically and does
 			// not need to be deregistered
-			if id == structs.ConsulCompoundServiceID {
+			if structs.IsConsulServiceID(id) {
 				continue
 			}
 
@@ -1002,7 +1002,7 @@ func (l *State) updateSyncState() error {
 		if lc == nil {
 			// The Serf check is created automatically and does not
 			// need to be deregistered.
-			if id == structs.SerfCompoundCheckID {
+			if structs.IsSerfCheckID(id) {
 				l.logger.Debug("Skipping remote check since it is managed automatically", "check", structs.SerfCheckID)
 				continue
 			}

--- a/agent/structs/catalog.go
+++ b/agent/structs/catalog.go
@@ -19,8 +19,3 @@ const (
 	ConsulServiceID   = "consul"
 	ConsulServiceName = "consul"
 )
-
-var (
-	ConsulCompoundServiceID = NewServiceID(ConsulServiceID, nil)
-	SerfCompoundCheckID     = NewCheckID(SerfCheckID, nil)
-)

--- a/agent/structs/catalog_oss.go
+++ b/agent/structs/catalog_oss.go
@@ -1,0 +1,12 @@
+//go:build !consulent
+// +build !consulent
+
+package structs
+
+func IsConsulServiceID(id ServiceID) bool {
+	return id.ID == ConsulServiceID
+}
+
+func IsSerfCheckID(id CheckID) bool {
+	return id.ID == SerfCheckID
+}


### PR DESCRIPTION
Sync from enterprise

(Enterprise only) For 1.10.x client compatibility with 1.11.x servers