### PR TITLE
ca: remove Provider.ActiveRoot, return the root from Provider.GenerateRoot

### DIFF
--- a/agent/connect/ca/mock_Provider.go
+++ b/agent/connect/ca/mock_Provider.go
@@ -34,34 +34,13 @@ func (_m *MockProvider) ActiveIntermediate() (string, error) {
 	return r0, r1
 }
 
-// ActiveRoot provides a mock function with given fields:
-func (_m *MockProvider) ActiveRoot() (string, error) {
-	ret := _m.Called()
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// Cleanup provides a mock function with given fields: providerTypeChange, config
-func (_m *MockProvider) Cleanup(providerTypeChange bool, config map[string]interface{}) error {
-	ret := _m.Called(providerTypeChange, config)
+// Cleanup provides a mock function with given fields: providerTypeChange, otherConfig
+func (_m *MockProvider) Cleanup(providerTypeChange bool, otherConfig map[string]interface{}) error {
+	ret := _m.Called(providerTypeChange, otherConfig)
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(bool, map[string]interface{}) error); ok {
-		r0 = rf(providerTypeChange, config)
+		r0 = rf(providerTypeChange, otherConfig)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -147,17 +126,24 @@ func (_m *MockProvider) GenerateIntermediateCSR() (string, error) {
 }
 
 // GenerateRoot provides a mock function with given fields:
-func (_m *MockProvider) GenerateRoot() error {
+func (_m *MockProvider) GenerateRoot() (RootResult, error) {
 	ret := _m.Called()
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
+	var r0 RootResult
+	if rf, ok := ret.Get(0).(func() RootResult); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(RootResult)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // SetIntermediate provides a mock function with given fields: intermediatePEM, rootPEM

--- a/agent/connect/ca/provider.go
+++ b/agent/connect/ca/provider.go
@@ -129,14 +129,7 @@ type PrimaryProvider interface {
 	//
 	// The provider should return an existing root certificate if one exists,
 	// otherwise it should generate a new root certificate and return it.
-	GenerateRoot() error
-
-	// ActiveRoot returns the currently active root CA for this
-	// provider. This should be a parent of the certificate returned by
-	// ActiveIntermediate()
-	//
-	// TODO: currently called from secondaries, but shouldn't be so is on PrimaryProvider
-	ActiveRoot() (string, error)
+	GenerateRoot() (RootResult, error)
 
 	// GenerateIntermediate returns a new intermediate signing cert and sets it to
 	// the active intermediate. If multiple intermediates are needed to complete
@@ -187,6 +180,14 @@ type SecondaryProvider interface {
 	// as well as the root it was signed by. This completes the initialization for
 	// a provider where IsPrimary was set to false in Configure().
 	SetIntermediate(intermediatePEM, rootPEM string) error
+}
+
+// RootResult is the result returned by PrimaryProvider.GenerateRoot.
+//
+// TODO: rename this struct
+type RootResult struct {
+	// PEM encoded certificate that will be used as the primary CA.
+	PEM string
 }
 
 // NeedsStop is an optional interface that allows a CA to define a function

--- a/agent/connect/ca/provider.go
+++ b/agent/connect/ca/provider.go
@@ -118,9 +118,17 @@ type Provider interface {
 }
 
 type PrimaryProvider interface {
-	// GenerateRoot causes the creation of a new root certificate for this provider.
-	// This can also be a no-op if a root certificate already exists for the given
-	// config. If IsPrimary is false, calling this method is an error.
+	// GenerateRoot is called:
+	//   * to initialize the CA system when a server is elected as a raft leader
+	//   * when the CA configuration is updated in a way that might require
+	//     generating a new root certificate.
+	//
+	// In both cases GenerateRoot is always called on a newly created provider
+	// after calling Provider.Configure, and before any other calls to the
+	// provider.
+	//
+	// The provider should return an existing root certificate if one exists,
+	// otherwise it should generate a new root certificate and return it.
 	GenerateRoot() error
 
 	// ActiveRoot returns the currently active root CA for this

--- a/agent/connect/ca/provider_aws_test.go
+++ b/agent/connect/ca/provider_aws_test.go
@@ -46,12 +46,9 @@ func TestAWSBootstrapAndSignPrimary(t *testing.T) {
 			provider := testAWSProvider(t, testProviderConfigPrimary(t, cfg))
 			defer provider.Cleanup(true, nil)
 
-			// Generate the root
-			require.NoError(t, provider.GenerateRoot())
-
-			// Fetch Active Root
-			rootPEM, err := provider.ActiveRoot()
+			root, err := provider.GenerateRoot()
 			require.NoError(t, err)
+			rootPEM := root.PEM
 
 			// Generate Intermediate (not actually needed for this provider for now
 			// but this simulates the calls in Server.initializeRoot).
@@ -81,16 +78,12 @@ func TestAWSBootstrapAndSignPrimary(t *testing.T) {
 	}
 
 	t.Run("Test default root ttl for aws ca provider", func(t *testing.T) {
-
 		provider := testAWSProvider(t, testProviderConfigPrimary(t, nil))
 		defer provider.Cleanup(true, nil)
 
-		// Generate the root
-		require.NoError(t, provider.GenerateRoot())
-
-		// Fetch Active Root
-		rootPEM, err := provider.ActiveRoot()
+		root, err := provider.GenerateRoot()
 		require.NoError(t, err)
+		rootPEM := root.PEM
 
 		// Ensure they use the right key type
 		rootCert, err := connect.ParseCert(rootPEM)
@@ -123,8 +116,9 @@ func TestAWSBootstrapAndSignSecondary(t *testing.T) {
 
 	p1 := testAWSProvider(t, testProviderConfigPrimary(t, nil))
 	defer p1.Cleanup(true, nil)
-	rootPEM, err := p1.ActiveRoot()
+	root, err := p1.GenerateRoot()
 	require.NoError(t, err)
+	rootPEM := root.PEM
 
 	p2 := testAWSProvider(t, testProviderConfigSecondary(t, nil))
 	defer p2.Cleanup(true, nil)
@@ -151,8 +145,9 @@ func TestAWSBootstrapAndSignSecondary(t *testing.T) {
 		cfg1 := testProviderConfigPrimary(t, nil)
 		cfg1.State = p1State
 		p1 = testAWSProvider(t, cfg1)
-		newRootPEM, err := p1.ActiveRoot()
+		root, err := p1.GenerateRoot()
 		require.NoError(t, err)
+		newRootPEM := root.PEM
 
 		cfg2 := testProviderConfigPrimary(t, nil)
 		cfg2.State = p2State
@@ -184,8 +179,9 @@ func TestAWSBootstrapAndSignSecondary(t *testing.T) {
 			"ExistingARN": p1State[AWSStateCAARNKey],
 		})
 		p1 = testAWSProvider(t, cfg1)
-		newRootPEM, err := p1.ActiveRoot()
+		root, err := p1.GenerateRoot()
 		require.NoError(t, err)
+		newRootPEM := root.PEM
 
 		cfg2 := testProviderConfigPrimary(t, map[string]interface{}{
 			"ExistingARN": p2State[AWSStateCAARNKey],
@@ -222,8 +218,9 @@ func TestAWSBootstrapAndSignSecondary(t *testing.T) {
 		p2 = testAWSProvider(t, cfg2)
 		require.NoError(t, p2.SetIntermediate(newIntPEM, newRootPEM))
 
-		newRootPEM, err = p1.ActiveRoot()
+		root, err = p1.GenerateRoot()
 		require.NoError(t, err)
+		newRootPEM = root.PEM
 		newIntPEM, err = p2.ActiveIntermediate()
 		require.NoError(t, err)
 
@@ -243,7 +240,8 @@ func TestAWSBootstrapAndSignSecondaryConsul(t *testing.T) {
 		p1 := TestConsulProvider(t, delegate)
 		cfg := testProviderConfig(conf)
 		require.NoError(t, p1.Configure(cfg))
-		require.NoError(t, p1.GenerateRoot())
+		_, err := p1.GenerateRoot()
+		require.NoError(t, err)
 
 		p2 := testAWSProvider(t, testProviderConfigSecondary(t, nil))
 		defer p2.Cleanup(true, nil)
@@ -254,7 +252,9 @@ func TestAWSBootstrapAndSignSecondaryConsul(t *testing.T) {
 	t.Run("pri=aws,sec=consul", func(t *testing.T) {
 		p1 := testAWSProvider(t, testProviderConfigPrimary(t, nil))
 		defer p1.Cleanup(true, nil)
-		require.NoError(t, p1.GenerateRoot())
+
+		_, err := p1.GenerateRoot()
+		require.NoError(t, err)
 
 		conf := testConsulCAConfig()
 		delegate := newMockDelegate(t, conf)
@@ -315,11 +315,13 @@ func TestAWSProvider_Cleanup(t *testing.T) {
 	}
 
 	requirePCADeleted := func(t *testing.T, provider *AWSProvider) {
+		t.Helper()
 		deleted, err := describeCA(t, provider)
 		require.True(t, err != nil || deleted, "The AWS PCA instance has not been deleted")
 	}
 
 	requirePCANotDeleted := func(t *testing.T, provider *AWSProvider) {
+		t.Helper()
 		deleted, err := describeCA(t, provider)
 		require.NoError(t, err)
 		require.False(t, deleted, "The AWS PCA instance should not have been deleted")

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -149,28 +149,18 @@ func (c *ConsulProvider) State() (map[string]string, error) {
 	return c.testState, nil
 }
 
-// ActiveRoot returns the active root CA certificate.
-func (c *ConsulProvider) ActiveRoot() (string, error) {
-	providerState, err := c.getState()
-	if err != nil {
-		return "", err
-	}
-
-	return providerState.RootCert, nil
-}
-
 // GenerateRoot initializes a new root certificate and private key if needed.
-func (c *ConsulProvider) GenerateRoot() error {
+func (c *ConsulProvider) GenerateRoot() (RootResult, error) {
 	providerState, err := c.getState()
 	if err != nil {
-		return err
+		return RootResult{}, err
 	}
 
 	if !c.isPrimary {
-		return fmt.Errorf("provider is not the root certificate authority")
+		return RootResult{}, fmt.Errorf("provider is not the root certificate authority")
 	}
 	if providerState.RootCert != "" {
-		return nil
+		return RootResult{PEM: providerState.RootCert}, nil
 	}
 
 	// Generate a private key if needed
@@ -178,7 +168,7 @@ func (c *ConsulProvider) GenerateRoot() error {
 	if c.config.PrivateKey == "" {
 		_, pk, err := connect.GeneratePrivateKeyWithConfig(c.config.PrivateKeyType, c.config.PrivateKeyBits)
 		if err != nil {
-			return err
+			return RootResult{}, err
 		}
 		newState.PrivateKey = pk
 	} else {
@@ -189,12 +179,12 @@ func (c *ConsulProvider) GenerateRoot() error {
 	if c.config.RootCert == "" {
 		nextSerial, err := c.incrementAndGetNextSerialNumber()
 		if err != nil {
-			return fmt.Errorf("error computing next serial number: %v", err)
+			return RootResult{}, fmt.Errorf("error computing next serial number: %v", err)
 		}
 
 		ca, err := c.generateCA(newState.PrivateKey, nextSerial, c.config.RootCertTTL)
 		if err != nil {
-			return fmt.Errorf("error generating CA: %v", err)
+			return RootResult{}, fmt.Errorf("error generating CA: %v", err)
 		}
 		newState.RootCert = ca
 	} else {
@@ -207,10 +197,10 @@ func (c *ConsulProvider) GenerateRoot() error {
 		ProviderState: &newState,
 	}
 	if _, err := c.Delegate.ApplyCARequest(args); err != nil {
-		return err
+		return RootResult{}, err
 	}
 
-	return nil
+	return RootResult{PEM: newState.RootCert}, nil
 }
 
 // GenerateIntermediateCSR creates a private key and generates a CSR
@@ -287,18 +277,15 @@ func (c *ConsulProvider) SetIntermediate(intermediatePEM, rootPEM string) error 
 	return nil
 }
 
-// We aren't maintaining separate root/intermediate CAs for the builtin
-// provider, so just return the root.
 func (c *ConsulProvider) ActiveIntermediate() (string, error) {
-	if c.isPrimary {
-		return c.ActiveRoot()
-	}
-
 	providerState, err := c.getState()
 	if err != nil {
 		return "", err
 	}
 
+	if c.isPrimary {
+		return providerState.RootCert, nil
+	}
 	return providerState.IntermediateCert, nil
 }
 

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -159,8 +159,7 @@ func (c *ConsulProvider) ActiveRoot() (string, error) {
 	return providerState.RootCert, nil
 }
 
-// GenerateRoot initializes a new root certificate and private key
-// if needed.
+// GenerateRoot initializes a new root certificate and private key if needed.
 func (c *ConsulProvider) GenerateRoot() error {
 	providerState, err := c.getState()
 	if err != nil {

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -83,18 +83,17 @@ func TestConsulCAProvider_Bootstrap(t *testing.T) {
 
 	provider := TestConsulProvider(t, delegate)
 	require.NoError(t, provider.Configure(testProviderConfig(conf)))
-	require.NoError(t, provider.GenerateRoot())
 
-	root, err := provider.ActiveRoot()
+	root, err := provider.GenerateRoot()
 	require.NoError(t, err)
 
 	// Intermediate should be the same cert.
 	inter, err := provider.ActiveIntermediate()
 	require.NoError(t, err)
-	require.Equal(t, root, inter)
+	require.Equal(t, root.PEM, inter)
 
 	// Should be a valid cert
-	parsed, err := connect.ParseCert(root)
+	parsed, err := connect.ParseCert(root.PEM)
 	require.NoError(t, err)
 	require.Equal(t, parsed.URIs[0].String(), fmt.Sprintf("spiffe://%s.consul", conf.ClusterID))
 	requireNotEncoded(t, parsed.SubjectKeyId)
@@ -123,14 +122,13 @@ func TestConsulCAProvider_Bootstrap_WithCert(t *testing.T) {
 
 	provider := TestConsulProvider(t, delegate)
 	require.NoError(t, provider.Configure(testProviderConfig(conf)))
-	require.NoError(t, provider.GenerateRoot())
 
-	root, err := provider.ActiveRoot()
+	root, err := provider.GenerateRoot()
 	require.NoError(t, err)
-	require.Equal(t, root, rootCA.RootCert)
+	require.Equal(t, root.PEM, rootCA.RootCert)
 
 	// Should be a valid cert
-	parsed, err := connect.ParseCert(root)
+	parsed, err := connect.ParseCert(root.PEM)
 	require.NoError(t, err)
 
 	// test that the default root cert ttl was not applied to the provided cert
@@ -160,7 +158,8 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 
 			provider := TestConsulProvider(t, delegate)
 			require.NoError(t, provider.Configure(testProviderConfig(conf)))
-			require.NoError(t, provider.GenerateRoot())
+			_, err := provider.GenerateRoot()
+			require.NoError(t, err)
 
 			spiffeService := &connect.SpiffeIDService{
 				Host:       connect.TestClusterID + ".consul",
@@ -272,7 +271,8 @@ func TestConsulCAProvider_CrossSignCA(t *testing.T) {
 			conf1.Config["PrivateKeyType"] = tc.SigningKeyType
 			conf1.Config["PrivateKeyBits"] = tc.SigningKeyBits
 			require.NoError(t, provider1.Configure(testProviderConfig(conf1)))
-			require.NoError(t, provider1.GenerateRoot())
+			_, err := provider1.GenerateRoot()
+			require.NoError(t, err)
 
 			conf2 := testConsulCAConfig()
 			conf2.CreateIndex = 10
@@ -281,7 +281,8 @@ func TestConsulCAProvider_CrossSignCA(t *testing.T) {
 			conf2.Config["PrivateKeyType"] = tc.CSRKeyType
 			conf2.Config["PrivateKeyBits"] = tc.CSRKeyBits
 			require.NoError(t, provider2.Configure(testProviderConfig(conf2)))
-			require.NoError(t, provider2.GenerateRoot())
+			_, err = provider2.GenerateRoot()
+			require.NoError(t, err)
 
 			testCrossSignProviders(t, provider1, provider2)
 		})
@@ -291,9 +292,10 @@ func TestConsulCAProvider_CrossSignCA(t *testing.T) {
 func testCrossSignProviders(t *testing.T, provider1, provider2 Provider) {
 
 	// Get the root from the new provider to be cross-signed.
-	newRootPEM, err := provider2.ActiveRoot()
+	root, err := provider2.GenerateRoot()
 	require.NoError(t, err)
-	newRoot, err := connect.ParseCert(newRootPEM)
+
+	newRoot, err := connect.ParseCert(root.PEM)
 	require.NoError(t, err)
 	oldSubject := newRoot.Subject.CommonName
 	requireNotEncoded(t, newRoot.SubjectKeyId)
@@ -314,9 +316,9 @@ func testCrossSignProviders(t *testing.T, provider1, provider2 Provider) {
 	requireNotEncoded(t, xc.SubjectKeyId)
 	requireNotEncoded(t, xc.AuthorityKeyId)
 
-	oldRootPEM, err := provider1.ActiveRoot()
+	p1Root, err := provider1.GenerateRoot()
 	require.NoError(t, err)
-	oldRoot, err := connect.ParseCert(oldRootPEM)
+	oldRoot, err := connect.ParseCert(p1Root.PEM)
 	require.NoError(t, err)
 	requireNotEncoded(t, oldRoot.SubjectKeyId)
 	requireNotEncoded(t, oldRoot.AuthorityKeyId)
@@ -392,7 +394,8 @@ func TestConsulProvider_SignIntermediate(t *testing.T) {
 			conf1.Config["PrivateKeyType"] = tc.SigningKeyType
 			conf1.Config["PrivateKeyBits"] = tc.SigningKeyBits
 			require.NoError(t, provider1.Configure(testProviderConfig(conf1)))
-			require.NoError(t, provider1.GenerateRoot())
+			_, err := provider1.GenerateRoot()
+			require.NoError(t, err)
 
 			conf2 := testConsulCAConfig()
 			conf2.CreateIndex = 10
@@ -422,8 +425,9 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	// Sign the CSR with provider1.
 	intermediatePEM, err := provider1.SignIntermediate(csr)
 	require.NoError(t, err)
-	rootPEM, err := provider1.ActiveRoot()
+	root, err := provider1.GenerateRoot()
 	require.NoError(t, err)
+	rootPEM := root.PEM
 
 	// Give the new intermediate to provider2 to use.
 	require.NoError(t, provider2.SetIntermediate(intermediatePEM, rootPEM))
@@ -496,7 +500,8 @@ func TestConsulCAProvider_MigrateOldID(t *testing.T) {
 
 			provider := TestConsulProvider(t, delegate)
 			require.NoError(t, provider.Configure(testProviderConfig(conf)))
-			require.NoError(t, provider.GenerateRoot())
+			_, err = provider.GenerateRoot()
+			require.NoError(t, err)
 
 			// After running Configure, the old ID entry should be gone.
 			_, providerState, err = delegate.state.CAProviderState(tc.oldID)

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -227,9 +227,8 @@ type mockCAProvider struct {
 
 func (m *mockCAProvider) Configure(cfg ca.ProviderConfig) error { return nil }
 func (m *mockCAProvider) State() (map[string]string, error)     { return nil, nil }
-func (m *mockCAProvider) GenerateRoot() error                   { return nil }
-func (m *mockCAProvider) ActiveRoot() (string, error) {
-	return m.rootPEM, nil
+func (m *mockCAProvider) GenerateRoot() (ca.RootResult, error) {
+	return ca.RootResult{PEM: m.rootPEM}, nil
 }
 func (m *mockCAProvider) GenerateIntermediateCSR() (string, error) {
 	m.callbackCh <- "provider/GenerateIntermediateCSR"


### PR DESCRIPTION
Branched from #11663

This is the next step to support #11598.  We will need to return a full chain from `GenerateRoot`, so this PR starts adding support by changing the interface to return a struct, and removing `ActiveRoot`, which is no only ever called immediately after `GenerateRoot`.

I tested the AWS provider locally because those tests to do run in CI.