### PR TITLE
ui: Add cross partition linking and rollout BucketList

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/bucket/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/bucket/list/index.hbs
@@ -5,7 +5,7 @@
         class="partition"
         {{tooltip}}
       >
-        Partition
+        Admin Partition
       </dt>
       <dd>
         {{@item.Partition}}

--- a/ui/packages/consul-ui/app/components/consul/service/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/list/index.hbs
@@ -25,7 +25,18 @@
       </dd>
     </dl>
 {{#if (gt item.InstanceCount 0)}}
-  <a data-test-service-name href={{href-to "dc.services.show.index" item.Name}}>
+  <a
+    data-test-service-name
+    href={{href-to "dc.services.show.index" item.Name
+      params=(if (not-eq item.Partition @partition)
+        (hash
+          partition=item.Partition
+          nspace=item.Namespace
+        )
+        (hash)
+      )
+    }}
+  >
     {{item.Name}}
   </a>
 {{else}}

--- a/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
@@ -140,11 +140,33 @@ as |key value|}}
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
+{{#let
+  (reject-by 'Partition' @partition @partitions)
+as |nonDefaultPartitions|}}
+{{#if (gt nonDefaultPartitions.length 0)}}
+    <Optgroup
+      @label={{t 'common.brand.consul'}}
+    >
+    {{#each @partitions as |partition|}}
+      <Option class="partition" @value={{partition}} @selected={{contains partition @filter.source.value}}>
+        {{partition}}
+      </Option>
+    {{/each}}
+    </Optgroup>
+{{/if}}
+{{/let}}
+
+{{#if (gt @sources.length 0)}}
+    <Optgroup
+      @label={{t 'common.search.integrations'}}
+    >
     {{#each @sources as |source|}}
           <Option class={{source}} @value={{source}} @selected={{contains source @filter.source.value}}>
             {{t (concat "common.brand." source)}}
           </Option>
     {{/each}}
+    </Optgroup>
+{{/if}}
   {{/let}}
         </BlockSlot>
       </search.Select>

--- a/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream-instance/list/index.hbs
@@ -5,40 +5,26 @@
   <ul>
 {{#each @items as |item|}}
     <li>
+
       <div class="header">
         <p>
           {{item.DestinationName}}
         </p>
       </div>
+
       <div class="detail">
-{{#if (can 'use partitions')}}
-  {{#if (not-eq item.DestinationType 'prepared_query')}}
-        <dl class="partition">
-          <dt
-            {{tooltip}}
-          >
-            Admin Partition
-          </dt>
-          <dd>
-            {{or item.DestinationPartition 'default'}}
-          </dd>
-        </dl>
-  {{/if}}
+
+{{#if (not-eq item.DestinationType 'prepared_query')}}
+        <Consul::Bucket::List
+          @item={{hash
+            Namespace=(or item.DestinationNamespace @nspace)
+            Partition=(or item.DestinationPartition @partition)
+          }}
+          @partition={{@partition}}
+          @nspace={{@nspace}}
+        />
 {{/if}}
-{{#if (can 'use nspaces')}}
-  {{#if (not-eq item.DestinationType 'prepared_query')}}
-        <dl class="nspace">
-          <dt
-            {{tooltip}}
-          >
-            Namespace
-          </dt>
-          <dd>
-            {{or item.DestinationNamespace 'default'}}
-          </dd>
-        </dl>
-  {{/if}}
-{{/if}}
+
 {{#if (and (not-eq item.Datacenter @dc) (not-eq item.Datacenter ""))}}
         <dl class="datacenter">
           <dt
@@ -51,6 +37,7 @@
           </dd>
         </dl>
 {{/if}}
+
 {{#if item.LocalBindSocketPath}}
         <dl class="local-bind-socket-path">
           <dt>
@@ -73,23 +60,26 @@
           </dd>
         </dl>
 {{else}}
+
   {{#if (gt item.LocalBindPort 0)}}
     {{#let (concat (or item.LocalBindAddress '127.0.0.1') ':' item.LocalBindPort) as |combinedAddress|}}
-          <dl class="local-bind-address">
-            <dt>
-              Address
-            </dt>
-            <dd>
-              <CopyButton
-                @value={{combinedAddress}}
-                @name="Address"
-              />
-                {{combinedAddress}}
-            </dd>
-          </dl>
+        <dl class="local-bind-address">
+          <dt>
+            Address
+          </dt>
+          <dd>
+            <CopyButton
+              @value={{combinedAddress}}
+              @name="Address"
+            />
+              {{combinedAddress}}
+          </dd>
+        </dl>
     {{/let}}
   {{/if}}
+
 {{/if}}
+
       </div>
     </li>
 {{/each}}

--- a/ui/packages/consul-ui/app/components/consul/upstream/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/upstream/list/index.hbs
@@ -26,13 +26,19 @@ as |item index|>
     </dl>
     <a
       data-test-service-name
-      href={{if (and (can 'use nspaces') (not-eq item.Namespace @nspace))
-        (href-to 'dc.services.show' @dc item.Name
-          params=(hash
+      href={{href-to "dc.services.show" item.Name
+        params=(if (not-eq item.Partition @partition)
+          (hash
+            partition=item.Partition
             nspace=item.Namespace
           )
+          (if (not-eq item.Namespace @nspace)
+            (hash
+              nspace=item.Namespace
+            )
+            (hash)
+          )
         )
-        (href-to 'dc.services.show' item.Name)
       }}
     >
       {{item.Name}}
@@ -44,30 +50,11 @@ as |item index|>
 {{/if}}
   </BlockSlot>
   <BlockSlot @name="details">
-{{#if (and (can 'use partitions') (not-eq item.Partition @partition))}}
-    <dl class="partition">
-      <dt
-        {{tooltip}}
-      >
-        Admin Partition
-      </dt>
-      <dd>
-        {{item.Partition}}
-      </dd>
-    </dl>
-{{/if}}
-{{#if (and (can 'use nspaces') (not-eq item.Namespace @nspace))}}
-    <dl class="nspace">
-      <dt
-        {{tooltip}}
-      >
-        Namespace
-      </dt>
-      <dd>
-        {{item.Namespace}}
-      </dd>
-    </dl>
-{{/if}}
+    <Consul::Bucket::List
+      @item={{item}}
+      @nspace={{@nspace}}
+      @partition={{@partition}}
+    />
 {{#each item.GatewayConfig.Addresses as |address|}}
     <dl>
       <dt>

--- a/ui/packages/consul-ui/app/components/popover-select/index.scss
+++ b/ui/packages/consul-ui/app/components/popover-select/index.scss
@@ -21,6 +21,8 @@
   margin-right: 10px;
 }
 
+/* TODO: Consider moving these to their specific search bard componets or */
+/* even their own search bar sub menu components */
 %popover-select .value-passing button::before {
   @extend %with-check-circle-fill-mask, %as-pseudo;
   color: rgb(var(--tone-green-500));
@@ -37,11 +39,15 @@
   @extend %with-minus-square-fill-mask, %as-pseudo;
   color: rgb(var(--tone-gray-400));
 }
-%popover-select.type-source li button {
+%popover-select.type-source li:not(.partition) button {
   text-transform: capitalize;
 }
 %popover-select.type-source li.aws button {
   text-transform: uppercase;
+}
+%popover-select.type-source li.partition button::before {
+  @extend %with-user-team-mask, %as-pseudo;
+  color: rgb(var(--tone-gray-500));
 }
 %popover-select .aws button::before {
   @extend %with-logo-aws-color-icon, %as-pseudo;
@@ -68,3 +74,4 @@
 %popover-select .terraform button::before {
   @extend %with-logo-terraform-color-icon, %as-pseudo;
 }
+/**/

--- a/ui/packages/consul-ui/app/filter/predicates/service.js
+++ b/ui/packages/consul-ui/app/filter/predicates/service.js
@@ -20,6 +20,9 @@ export default {
     'not-registered': (item, value) => item.InstanceCount === 0,
   },
   source: (item, values) => {
-    return setHelpers.intersectionSize(values, new Set(item.ExternalSources || [])) !== 0;
+    return (
+      setHelpers.intersectionSize(values, new Set(item.ExternalSources || [])) !== 0 ||
+      values.includes(item.Partition)
+    );
   },
 };

--- a/ui/packages/consul-ui/app/models/service.js
+++ b/ui/packages/consul-ui/app/models/service.js
@@ -15,11 +15,17 @@ export const Collection = class Collection {
   }
 
   get ExternalSources() {
-    const sources = this.items.reduce(function(prev, item) {
+    const items = this.items.reduce(function(prev, item) {
       return prev.concat(item.ExternalSources || []);
     }, []);
     // unique, non-empty values, alpha sort
-    return [...new Set(sources)].filter(Boolean).sort();
+    return [...new Set(items)].filter(Boolean).sort();
+  }
+  // TODO: Think about when this/collections is worthwhile using and explain
+  // when and when not somewhere in the docs
+  get Partitions() {
+    // unique, non-empty values, alpha sort
+    return [...new Set(this.items.map(item => item.Partition))].sort();
   }
 };
 export default class Service extends Model {

--- a/ui/packages/consul-ui/app/templates/dc/services/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/index.hbs
@@ -53,7 +53,10 @@ as |route|>
 
   (reject-by 'Kind' 'connect-proxy' api.data)
 
-as |sort filters items|}}
+  (or route.params.partition route.model.user.token.Partition 'default')
+  (or route.params.nspace route.model.user.token.Namespace 'default')
+
+as |sort filters items partition nspace|}}
 
   <AppView>
     <BlockSlot @name="header">
@@ -88,7 +91,7 @@ as |sort filters items|}}
         <collection.Collection>
           <Consul::Service::List
             @items={{collection.items}}
-            @partition={{route.params.partition}}
+            @partition={{partition}}
           >
           </Consul::Service::List>
         </collection.Collection>
@@ -116,10 +119,20 @@ as |sort filters items|}}
               </BlockSlot>
               <BlockSlot @name="actions">
                 <li class="docs-link">
-                  <a href="{{env 'CONSUL_DOCS_URL'}}/commands/services" rel="noopener noreferrer" target="_blank">Documentation on services</a>
+                  <Action
+                    @href="{{env 'CONSUL_DOCS_URL'}}/commands/services"
+                    @external={{true}}
+                  >
+                    Documentation on services
+                  </Action>
                 </li>
                 <li class="learn-link">
-                  <a href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/getting-started/services" rel="noopener noreferrer" target="_blank">Read the guide</a>
+                  <Action
+                    @href="{{env 'CONSUL_DOCS_LEARN_URL'}}/consul/getting-started/services"
+                    @external={{true}}
+                  >
+                    Read the guide
+                  </Action>
                 </li>
               </BlockSlot>
             </EmptyState>

--- a/ui/packages/consul-ui/app/templates/dc/services/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/index.hbs
@@ -66,9 +66,12 @@ as |sort filters items partition nspace|}}
         <label for="toolbar-toggle"></label>
     </BlockSlot>
     <BlockSlot @name="toolbar">
-      {{#if (gt items.length 0) }}
+{{#if (gt items.length 0) }}
+  {{#let (collection items) as |items|}}
         <Consul::Service::SearchBar
-          @sources={{get (collection items) 'ExternalSources'}}
+          @sources={{get items 'ExternalSources'}}
+          @partitions={{get items 'Partitions'}}
+          @partition={{partition}}
 
           @search={{search}}
           @onsearch={{action (mut search) value="target.value"}}
@@ -78,7 +81,8 @@ as |sort filters items partition nspace|}}
           @filter={{filters}}
 
         />
-      {{/if}}
+  {{/let}}
+{{/if}}
     </BlockSlot>
     <BlockSlot @name="content">
       <DataCollection

--- a/ui/packages/consul-ui/app/templates/dc/services/instance/upstreams.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance/upstreams.hbs
@@ -20,12 +20,14 @@ as |route|>
       )
     )
 
+    (or route.params.partition route.model.user.token.Partition 'default')
+    (or route.params.nspace route.model.user.token.Namespace 'default')
     route.params.dc
-    route.params.nspace
+
     route.model.proxy
     route.model.proxy.Service.Proxy.Upstreams
 
-  as |sort filters dc nspace proxy items|}}
+  as |sort filters partition nspace dc proxy items|}}
       {{#if (gt items.length 0)}}
         <input type="checkbox" id="toolbar-toggle" />
         <Consul::UpstreamInstance::SearchBar

--- a/ui/packages/consul-ui/app/templates/dc/services/show/services.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/services.hbs
@@ -69,8 +69,8 @@ as |route|>
       as |collection|>
         <collection.Collection>
           <Consul::Service::List
-            @nspace={{route.params.nspace}}
-            @partition={{route.params.partition}}
+            @nspace={{or route.params.nspace route.model.user.token.Namespace 'default'}}
+            @partition={{or route.params.partition route.model.user.token.Partition 'default'}}
             @items={{collection.items}}
           >
           </Consul::Service::List>

--- a/ui/packages/consul-ui/app/templates/dc/services/show/upstreams.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/upstreams.hbs
@@ -42,11 +42,12 @@ as |route|>
       )
     )
 
-    route.params.nspace
+    (or route.params.partition route.model.user.token.Partition 'default')
+    (or route.params.nspace route.model.user.token.Namespace 'default')
     route.params.dc
     loader.data
 
-  as |sort filters nspace dc items|}}
+  as |sort filters partition nspace dc items|}}
   {{#if (gt items.length 0)}}
       <input type="checkbox" id="toolbar-toggle" />
       <Consul::Upstream::SearchBar
@@ -74,6 +75,7 @@ as |route|>
               @items={{collection.items}}
               @dc={{dc}}
               @nspace={{nspace}}
+              @partition={{partition}}
             >
             </Consul::Upstream::List>
           </collection.Collection>

--- a/ui/packages/consul-ui/mock-api/v1/health/service/_
+++ b/ui/packages/consul-ui/mock-api/v1/health/service/_
@@ -53,7 +53,7 @@ ${typeof location.search.ns !== 'undefined' ? `
             "Namespace": "${location.search.ns}",
 ` : ``}
 ${typeof location.search.partition !== 'undefined' ? `
-            "Partition": "${location.search.partition}",
+            "Partition": "${fake.helpers.randomize([fake.hacker.noun(), location.search.partition])}",
 ` : ``}
             "Tags":[
                 ${
@@ -132,6 +132,7 @@ ${range(env('CONSUL_UPSTREAM_COUNT', 10)).map((item, j) => `
                     "Datacenter": "${fake.address.countryCode().toLowerCase()} ${ i % 2 ? "west" : "east"}-${j}",
                     "DestinationName": "${fake.hacker.noun()}",
                     "DestinationNamespace": "${fake.hacker.noun()}",
+                    "DestinationPartition": "${fake.hacker.noun()}",
                     "DestinationType": "${fake.helpers.randomize(['service', 'prepared_query'])}",
 ${fake.random.number({min: 1, max: 10}) > 5 ? `
                     "LocalBindAddress": "${fake.internet.ip()}",

--- a/ui/packages/consul-ui/mock-api/v1/health/service/_
+++ b/ui/packages/consul-ui/mock-api/v1/health/service/_
@@ -53,7 +53,7 @@ ${typeof location.search.ns !== 'undefined' ? `
             "Namespace": "${location.search.ns}",
 ` : ``}
 ${typeof location.search.partition !== 'undefined' ? `
-            "Partition": "${fake.helpers.randomize([fake.hacker.noun(), location.search.partition])}",
+            "Partition": "${fake.helpers.randomize([env('CONSUL_PARTITION_EXPORTER', location.search.partition), location.search.partition])}",
 ` : ``}
             "Tags":[
                 ${

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
@@ -18,7 +18,7 @@ ${i === 1 ? `
       "Namespace": "${fake.hacker.noun()}-ns-${i}",
 `}
 ${typeof location.search.partition !== 'undefined' ? `
-            "Partition": "${fake.helpers.randomize([fake.hacker.noun(), location.search.partition])}",
+      "Partition": "${fake.helpers.randomize([env('CONSUL_PARTITION_EXPORTER', location.search.partition), location.search.partition])}",
 ` : ``}
     "Tags": [
       ${

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/services
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/services
@@ -47,7 +47,7 @@ ${typeof location.search.ns !== 'undefined' ? `
             "Namespace": "${location.search.ns}",
 ` : ``}
 ${typeof location.search.partition !== 'undefined' ? `
-            "Partition": "${fake.helpers.randomize([fake.hacker.noun(), location.search.partition])}",
+            "Partition": "${fake.helpers.randomize([env('CONSUL_PARTITION_EXPORTER', location.search.partition), location.search.partition])}",
 ` : ``}
             "Tags": [
                 ${

--- a/ui/packages/consul-ui/translations/common/en-us.yaml
+++ b/ui/packages/consul-ui/translations/common/en-us.yaml
@@ -46,6 +46,7 @@ search:
   critical: Failing
   in-mesh: In service mesh
   not-in-mesh: Not in service mesh
+  integrations: Integrations
 sort:
   alpha:
     asc: A to Z


### PR DESCRIPTION
Follow on from https://github.com/hashicorp/consul/pull/11702 (which is also the base branch here).

This PR adds cross partition linking between the Service list and other places where we use a `partition / namespace` 'bucket list'. Additionally we took the opportunity to roll out of new BucketList component to other areas where we use the same `partition / namespace` form.

Small note: Whilst doing this I had a little internal fight (😆 ) as to where to do the "use the route param, if not use the users token, if not default to `default`" thing. After quibbling about whether to put the "default to `default` if `@partition` wasn't set" in the component, I decided to put everything at the very top level in the route template. If this quibble turns out to be the correct way to go (we probably won't know until we've let it sit for a bit) we should document that this is the preferred way to do the "what partition are we using" thing.
