### PR TITLE
Cross port of ent #1383

### DIFF
--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -700,9 +700,8 @@ func (a *ACL) tokenSetInternal(args *structs.ACLTokenSetRequest, reply *structs.
 
 	token.SetHash(true)
 
-	// validate the enterprise meta
-	err = state.ACLTokenUpsertValidateEnterprise(token, accessorMatch)
-	if err != nil {
+	// validate the enterprise specific fields
+	if err = a.tokenUpsertValidateEnterprise(token, accessorMatch); err != nil {
 		return err
 	}
 
@@ -1181,9 +1180,8 @@ func (a *ACL) PolicySet(args *structs.ACLPolicySetRequest, reply *structs.ACLPol
 		return err
 	}
 
-	// validate the enterprise meta
-	err = state.ACLPolicyUpsertValidateEnterprise(policy, idMatch)
-	if err != nil {
+	// validate the enterprise specific fields
+	if err = a.policyUpsertValidateEnterprise(policy, idMatch); err != nil {
 		return err
 	}
 
@@ -1543,8 +1541,8 @@ func (a *ACL) RoleSet(args *structs.ACLRoleSetRequest, reply *structs.ACLRole) e
 		}
 	}
 
-	// validate the enterprise meta
-	if err := state.ACLRoleUpsertValidateEnterprise(role, existing); err != nil {
+	// validate the enterprise specific fields
+	if err := a.roleUpsertValidateEnterprise(role, existing); err != nil {
 		return err
 	}
 

--- a/agent/consul/acl_endpoint_oss.go
+++ b/agent/consul/acl_endpoint_oss.go
@@ -8,6 +8,21 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
+func (a *ACL) tokenUpsertValidateEnterprise(token *structs.ACLToken, existing *structs.ACLToken) error {
+	state := a.srv.fsm.State()
+	return state.ACLTokenUpsertValidateEnterprise(token, existing)
+}
+
+func (a *ACL) policyUpsertValidateEnterprise(policy *structs.ACLPolicy, existing *structs.ACLPolicy) error {
+	state := a.srv.fsm.State()
+	return state.ACLPolicyUpsertValidateEnterprise(policy, existing)
+}
+
+func (a *ACL) roleUpsertValidateEnterprise(role *structs.ACLRole, existing *structs.ACLRole) error {
+	state := a.srv.fsm.State()
+	return state.ACLRoleUpsertValidateEnterprise(role, existing)
+}
+
 func (a *ACL) enterpriseAuthMethodTypeValidation(authMethodType string) error {
 	return nil
 }

--- a/agent/structs/acl_oss.go
+++ b/agent/structs/acl_oss.go
@@ -94,3 +94,7 @@ func (r *ACLRole) NodeIdentityList() []*ACLNodeIdentity {
 	}
 	return out
 }
+
+func IsValidPartitionAndDatacenter(meta EnterpriseMeta, datacenters []string, primaryDatacenter string) bool {
+	return true
+}


### PR DESCRIPTION
Cross port of ent #1383 "Reject non-default datacenter when making partitioned ACLs"

On the OSS side this is a minor refactor to add some more checks that are no-ops on oss, but add function to the enterprise code.

Signed-off-by: Mark Anderson <manderson@hashicorp.com>