### PR TITLE
ui: Add exported service partition to the source filter menu

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
@@ -140,11 +140,33 @@ as |key value|}}
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
+{{#let
+  (reject-by 'Partition' @partition @partitions)
+as |nonDefaultPartitions|}}
+{{#if (gt nonDefaultPartitions.length 0)}}
+    <Optgroup
+      @label={{t 'common.brand.consul'}}
+    >
+    {{#each @partitions as |partition|}}
+      <Option class="partition" @value={{partition}} @selected={{contains partition @filter.source.value}}>
+        {{partition}}
+      </Option>
+    {{/each}}
+    </Optgroup>
+{{/if}}
+{{/let}}
+
+{{#if (gt @sources.length 0)}}
+    <Optgroup
+      @label={{t 'common.search.integrations'}}
+    >
     {{#each @sources as |source|}}
           <Option class={{source}} @value={{source}} @selected={{contains source @filter.source.value}}>
             {{t (concat "common.brand." source)}}
           </Option>
     {{/each}}
+    </Optgroup>
+{{/if}}
   {{/let}}
         </BlockSlot>
       </search.Select>

--- a/ui/packages/consul-ui/app/components/popover-select/index.scss
+++ b/ui/packages/consul-ui/app/components/popover-select/index.scss
@@ -21,6 +21,8 @@
   margin-right: 10px;
 }
 
+/* TODO: Consider moving these to their specific search bard componets or */
+/* even their own search bar sub menu components */
 %popover-select .value-passing button::before {
   @extend %with-check-circle-fill-mask, %as-pseudo;
   color: rgb(var(--tone-green-500));
@@ -37,11 +39,15 @@
   @extend %with-minus-square-fill-mask, %as-pseudo;
   color: rgb(var(--tone-gray-400));
 }
-%popover-select.type-source li button {
+%popover-select.type-source li:not(.partition) button {
   text-transform: capitalize;
 }
 %popover-select.type-source li.aws button {
   text-transform: uppercase;
+}
+%popover-select.type-source li.partition button::before {
+  @extend %with-user-team-mask, %as-pseudo;
+  color: rgb(var(--tone-gray-500));
 }
 %popover-select .aws button::before {
   @extend %with-logo-aws-color-icon, %as-pseudo;
@@ -68,3 +74,4 @@
 %popover-select .terraform button::before {
   @extend %with-logo-terraform-color-icon, %as-pseudo;
 }
+/**/

--- a/ui/packages/consul-ui/app/filter/predicates/service.js
+++ b/ui/packages/consul-ui/app/filter/predicates/service.js
@@ -20,6 +20,9 @@ export default {
     'not-registered': (item, value) => item.InstanceCount === 0,
   },
   source: (item, values) => {
-    return setHelpers.intersectionSize(values, new Set(item.ExternalSources || [])) !== 0;
+    return (
+      setHelpers.intersectionSize(values, new Set(item.ExternalSources || [])) !== 0 ||
+      values.includes(item.Partition)
+    );
   },
 };

--- a/ui/packages/consul-ui/app/models/service.js
+++ b/ui/packages/consul-ui/app/models/service.js
@@ -15,11 +15,17 @@ export const Collection = class Collection {
   }
 
   get ExternalSources() {
-    const sources = this.items.reduce(function(prev, item) {
+    const items = this.items.reduce(function(prev, item) {
       return prev.concat(item.ExternalSources || []);
     }, []);
     // unique, non-empty values, alpha sort
-    return [...new Set(sources)].filter(Boolean).sort();
+    return [...new Set(items)].filter(Boolean).sort();
+  }
+  // TODO: Think about when this/collections is worthwhile using and explain
+  // when and when not somewhere in the docs
+  get Partitions() {
+    // unique, non-empty values, alpha sort
+    return [...new Set(this.items.map(item => item.Partition))].sort();
   }
 };
 export default class Service extends Model {

--- a/ui/packages/consul-ui/app/templates/dc/services/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/index.hbs
@@ -66,9 +66,12 @@ as |sort filters items partition nspace|}}
         <label for="toolbar-toggle"></label>
     </BlockSlot>
     <BlockSlot @name="toolbar">
-      {{#if (gt items.length 0) }}
+{{#if (gt items.length 0) }}
+  {{#let (collection items) as |items|}}
         <Consul::Service::SearchBar
-          @sources={{get (collection items) 'ExternalSources'}}
+          @sources={{get items 'ExternalSources'}}
+          @partitions={{get items 'Partitions'}}
+          @partition={{partition}}
 
           @search={{search}}
           @onsearch={{action (mut search) value="target.value"}}
@@ -78,7 +81,8 @@ as |sort filters items partition nspace|}}
           @filter={{filters}}
 
         />
-      {{/if}}
+  {{/let}}
+{{/if}}
     </BlockSlot>
     <BlockSlot @name="content">
       <DataCollection

--- a/ui/packages/consul-ui/translations/common/en-us.yaml
+++ b/ui/packages/consul-ui/translations/common/en-us.yaml
@@ -46,6 +46,7 @@ search:
   critical: Failing
   in-mesh: In service mesh
   not-in-mesh: Not in service mesh
+  integrations: Integrations
 sort:
   alpha:
     asc: A to Z


### PR DESCRIPTION
Adds an extra source filter if you have an Services exported from a different partition:

<img width="1088" alt="Screenshot 2021-12-03 at 14 35 31" src="https://user-images.githubusercontent.com/554604/144621698-94ab5005-2700-45ea-be11-645d38176248.png">

Note the base branch here is previous related work, not main.
