### PR TITLE
Transparent proxy support for cross-partition

### DIFF
--- a/.changelog/11738.txt
+++ b/.changelog/11738.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: **(Enterprise only)** add support for cross-partition transparent proxying.
+```

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -570,7 +570,7 @@ func (c *Catalog) ServiceList(args *structs.DCSpecificRequest, reply *structs.In
 		&args.QueryOptions,
 		&reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
-			index, services, err := state.ServiceList(ws, nil, &args.EnterpriseMeta)
+			index, services, err := state.ServiceList(ws, &args.EnterpriseMeta)
 			if err != nil {
 				return err
 			}

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -464,6 +464,14 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, vip, "240.0.0.2")
 
+	_, serviceNames, err := fsm.state.ServiceNamesOfKind(nil, structs.ServiceKindTypical)
+	require.NoError(t, err)
+
+	expect := []string{"backend", "db", "frontend", "web"}
+	for i, sn := range serviceNames {
+		require.Equal(t, expect[i], sn.Service.Name)
+	}
+
 	// Snapshot
 	snap, err := fsm.Snapshot()
 	require.NoError(t, err)
@@ -690,10 +698,10 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	require.Len(t, roots, 2)
 
 	// Verify provider state is restored.
-	_, state, err := fsm2.state.CAProviderState("asdf")
+	_, provider, err := fsm2.state.CAProviderState("asdf")
 	require.NoError(t, err)
-	require.Equal(t, "foo", state.PrivateKey)
-	require.Equal(t, "bar", state.RootCert)
+	require.Equal(t, "foo", provider.PrivateKey)
+	require.Equal(t, "bar", provider.RootCert)
 
 	// Verify CA configuration is restored.
 	_, caConf, err := fsm2.state.CAConfig(nil)
@@ -750,6 +758,14 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	_, meshConfigEntry, err := fsm2.state.ConfigEntry(nil, structs.MeshConfig, structs.MeshConfigMesh, structs.DefaultEnterpriseMetaInDefaultPartition())
 	require.NoError(t, err)
 	require.Equal(t, meshConfig, meshConfigEntry)
+
+	_, restoredServiceNames, err := fsm2.state.ServiceNamesOfKind(nil, structs.ServiceKindTypical)
+	require.NoError(t, err)
+
+	expect = []string{"backend", "db", "frontend", "web"}
+	for i, sn := range restoredServiceNames {
+		require.Equal(t, expect[i], sn.Service.Name)
+	}
 
 	// Snapshot
 	snap, err = fsm2.Snapshot()

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"strings"
 
 	memdb "github.com/hashicorp/go-memdb"
 
@@ -18,13 +19,7 @@ func serviceIndexName(name string, _ *structs.EnterpriseMeta) string {
 }
 
 func serviceKindIndexName(kind structs.ServiceKind, _ *structs.EnterpriseMeta) string {
-	switch kind {
-	case structs.ServiceKindTypical:
-		// needs a special case here
-		return "service_kind.typical"
-	default:
-		return "service_kind." + string(kind)
-	}
+	return "service_kind." + kind.Normalized()
 }
 
 func catalogUpdateNodesIndexes(tx WriteTxn, idx uint64, entMeta *structs.EnterpriseMeta) error {
@@ -191,4 +186,23 @@ func validateRegisterRequestTxn(_ ReadTxn, _ *structs.RegisterRequest, _ bool) (
 
 func (s *Store) ValidateRegisterRequest(_ *structs.RegisterRequest) (*structs.EnterpriseMeta, error) {
 	return nil, nil
+}
+
+func indexFromKindServiceName(arg interface{}) ([]byte, error) {
+	var b indexBuilder
+
+	switch n := arg.(type) {
+	case KindServiceNameQuery:
+		b.String(strings.ToLower(string(n.Kind)))
+		b.String(strings.ToLower(n.Name))
+		return b.Bytes(), nil
+
+	case *KindServiceName:
+		b.String(strings.ToLower(string(n.Kind)))
+		b.String(strings.ToLower(n.Service.Name))
+		return b.Bytes(), nil
+
+	default:
+		return nil, fmt.Errorf("type must be KindServiceNameQuery or *KindServiceName: %T", arg)
+	}
 }

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -412,3 +412,40 @@ func testIndexerTableServiceVirtualIPs() map[string]indexerTestCase {
 		},
 	}
 }
+
+func testIndexerTableKindServiceNames() map[string]indexerTestCase {
+	obj := &KindServiceName{
+		Service: structs.ServiceName{
+			Name: "web-sidecar-proxy",
+		},
+		Kind: structs.ServiceKindConnectProxy,
+	}
+
+	return map[string]indexerTestCase{
+		indexID: {
+			read: indexValue{
+				source: &KindServiceName{
+					Service: structs.ServiceName{
+						Name: "web-sidecar-proxy",
+					},
+					Kind: structs.ServiceKindConnectProxy,
+				},
+				expected: []byte("connect-proxy\x00web-sidecar-proxy\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("connect-proxy\x00web-sidecar-proxy\x00"),
+			},
+		},
+		indexKind: {
+			read: indexValue{
+				source:   structs.ServiceKindConnectProxy,
+				expected: []byte("connect-proxy\x00"),
+			},
+			write: indexValue{
+				source:   obj,
+				expected: []byte("connect-proxy\x00"),
+			},
+		},
+	}
+}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -7656,6 +7656,143 @@ func TestProtocolForIngressGateway(t *testing.T) {
 	}
 }
 
+func TestStateStore_EnsureService_ServiceNames(t *testing.T) {
+	s := testStateStore(t)
+
+	// Create the service registration.
+	entMeta := structs.DefaultEnterpriseMetaInDefaultPartition()
+
+	services := []structs.NodeService{
+		{
+			Kind:           structs.ServiceKindIngressGateway,
+			ID:             "ingress-gateway",
+			Service:        "ingress-gateway",
+			Address:        "2.2.2.2",
+			Port:           2222,
+			EnterpriseMeta: *entMeta,
+		},
+		{
+			Kind:           structs.ServiceKindMeshGateway,
+			ID:             "mesh-gateway",
+			Service:        "mesh-gateway",
+			Address:        "4.4.4.4",
+			Port:           4444,
+			EnterpriseMeta: *entMeta,
+		},
+		{
+			Kind:           structs.ServiceKindConnectProxy,
+			ID:             "connect-proxy",
+			Service:        "connect-proxy",
+			Address:        "1.1.1.1",
+			Port:           1111,
+			Proxy:          structs.ConnectProxyConfig{DestinationServiceName: "foo"},
+			EnterpriseMeta: *entMeta,
+		},
+		{
+			Kind:           structs.ServiceKindTerminatingGateway,
+			ID:             "terminating-gateway",
+			Service:        "terminating-gateway",
+			Address:        "3.3.3.3",
+			Port:           3333,
+			EnterpriseMeta: *entMeta,
+		},
+		{
+			Kind:           structs.ServiceKindTypical,
+			ID:             "web",
+			Service:        "web",
+			Address:        "5.5.5.5",
+			Port:           5555,
+			EnterpriseMeta: *entMeta,
+		},
+	}
+
+	var idx uint64
+	testRegisterNode(t, s, idx, "node1")
+
+	for _, svc := range services {
+		idx++
+		require.NoError(t, s.EnsureService(idx, "node1", &svc))
+
+		// Ensure the service name was stored for all of them under the appropriate kind
+		gotIdx, gotNames, err := s.KindServiceNamesOfKind(nil, svc.Kind)
+		require.NoError(t, err)
+		require.Equal(t, idx, gotIdx)
+		require.Len(t, gotNames, 1)
+		require.Equal(t, svc.CompoundServiceName(), gotNames[0].Service)
+		require.Equal(t, svc.Kind, gotNames[0].Kind)
+	}
+
+	// Register another ingress gateway and there should be two names under the kind index
+	newIngress := structs.NodeService{
+		Kind:           structs.ServiceKindIngressGateway,
+		ID:             "new-ingress-gateway",
+		Service:        "new-ingress-gateway",
+		Address:        "6.6.6.6",
+		Port:           6666,
+		EnterpriseMeta: *entMeta,
+	}
+	idx++
+	require.NoError(t, s.EnsureService(idx, "node1", &newIngress))
+
+	gotIdx, got, err := s.KindServiceNamesOfKind(nil, structs.ServiceKindIngressGateway)
+	require.NoError(t, err)
+	require.Equal(t, idx, gotIdx)
+
+	expect := []*KindServiceName{
+		{
+			Kind:    structs.ServiceKindIngressGateway,
+			Service: structs.NewServiceName("ingress-gateway", nil),
+			RaftIndex: structs.RaftIndex{
+				CreateIndex: 1,
+				ModifyIndex: 1,
+			},
+		},
+		{
+			Kind:    structs.ServiceKindIngressGateway,
+			Service: structs.NewServiceName("new-ingress-gateway", nil),
+			RaftIndex: structs.RaftIndex{
+				CreateIndex: idx,
+				ModifyIndex: idx,
+			},
+		},
+	}
+	require.Equal(t, expect, got)
+
+	// Deregister an ingress gateway and the index should not slide back
+	idx++
+	require.NoError(t, s.DeleteService(idx, "node1", "new-ingress-gateway", entMeta))
+
+	gotIdx, got, err = s.ServiceNamesOfKind(nil, structs.ServiceKindIngressGateway)
+	require.NoError(t, err)
+	require.Equal(t, idx, gotIdx)
+	require.Equal(t, expect[:1], got)
+
+	// Registering another instance of a known service should not bump the kind index
+	newMGW := structs.NodeService{
+		Kind:           structs.ServiceKindMeshGateway,
+		ID:             "mesh-gateway-1",
+		Service:        "mesh-gateway",
+		Address:        "7.7.7.7",
+		Port:           7777,
+		EnterpriseMeta: *entMeta,
+	}
+	idx++
+	require.NoError(t, s.EnsureService(idx, "node1", &newMGW))
+
+	gotIdx, _, err = s.KindServiceNamesOfKind(nil, structs.ServiceKindMeshGateway)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), gotIdx)
+
+	// Deregister the single typical service and the service name should also be dropped
+	idx++
+	require.NoError(t, s.DeleteService(idx, "node1", "web", entMeta))
+
+	gotIdx, got, err = s.KindServiceNamesOfKind(nil, structs.ServiceKindTypical)
+	require.NoError(t, err)
+	require.Equal(t, idx, gotIdx)
+	require.Empty(t, got)
+}
+
 func runStep(t *testing.T, name string, fn func(t *testing.T)) {
 	t.Helper()
 	if !t.Run(name, fn) {

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -7714,7 +7714,7 @@ func TestStateStore_EnsureService_ServiceNames(t *testing.T) {
 		require.NoError(t, s.EnsureService(idx, "node1", &svc))
 
 		// Ensure the service name was stored for all of them under the appropriate kind
-		gotIdx, gotNames, err := s.KindServiceNamesOfKind(nil, svc.Kind)
+		gotIdx, gotNames, err := s.ServiceNamesOfKind(nil, svc.Kind)
 		require.NoError(t, err)
 		require.Equal(t, idx, gotIdx)
 		require.Len(t, gotNames, 1)
@@ -7734,7 +7734,7 @@ func TestStateStore_EnsureService_ServiceNames(t *testing.T) {
 	idx++
 	require.NoError(t, s.EnsureService(idx, "node1", &newIngress))
 
-	gotIdx, got, err := s.KindServiceNamesOfKind(nil, structs.ServiceKindIngressGateway)
+	gotIdx, got, err := s.ServiceNamesOfKind(nil, structs.ServiceKindIngressGateway)
 	require.NoError(t, err)
 	require.Equal(t, idx, gotIdx)
 
@@ -7779,7 +7779,7 @@ func TestStateStore_EnsureService_ServiceNames(t *testing.T) {
 	idx++
 	require.NoError(t, s.EnsureService(idx, "node1", &newMGW))
 
-	gotIdx, _, err = s.KindServiceNamesOfKind(nil, structs.ServiceKindMeshGateway)
+	gotIdx, _, err = s.ServiceNamesOfKind(nil, structs.ServiceKindMeshGateway)
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), gotIdx)
 
@@ -7787,7 +7787,7 @@ func TestStateStore_EnsureService_ServiceNames(t *testing.T) {
 	idx++
 	require.NoError(t, s.DeleteService(idx, "node1", "web", entMeta))
 
-	gotIdx, got, err = s.KindServiceNamesOfKind(nil, structs.ServiceKindTypical)
+	gotIdx, got, err = s.ServiceNamesOfKind(nil, structs.ServiceKindTypical)
 	require.NoError(t, err)
 	require.Equal(t, idx, gotIdx)
 	require.Empty(t, got)

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -995,19 +995,6 @@ func (s *Store) intentionTopologyTxn(tx ReadTxn, ws memdb.WatchSet,
 		maxIdx = index
 	}
 
-	// Check for a wildcard intention (* -> *) since it overrides the default decision from ACLs
-	if len(intentions) > 0 {
-		// Intentions with wildcard source and destination have the lowest precedence, so they are last in the list
-		ixn := intentions[len(intentions)-1]
-
-		if ixn.HasWildcardSource() && ixn.HasWildcardDestination() {
-			defaultDecision = acl.Allow
-			if ixn.Action == structs.IntentionActionDeny {
-				defaultDecision = acl.Deny
-			}
-		}
-	}
-
 	index, allServices, err := serviceListTxn(tx, ws, func(svc *structs.ServiceNode) bool {
 		// Only include ingress gateways as downstreams, since they cannot receive service mesh traffic
 		// TODO(freddy): One remaining issue is that this includes non-Connect services (typical services without a proxy)

--- a/agent/consul/state/schema.go
+++ b/agent/consul/state/schema.go
@@ -40,6 +40,7 @@ func newDBSchema() *memdb.DBSchema {
 		tombstonesTableSchema,
 		usageTableSchema,
 		freeVirtualIPTableSchema,
+		kindServiceNameTableSchema,
 	)
 	withEnterpriseSchema(db)
 	return db

--- a/agent/consul/state/schema_test.go
+++ b/agent/consul/state/schema_test.go
@@ -50,6 +50,7 @@ func TestNewDBSchema_Indexers(t *testing.T) {
 		tableMeshTopology:      testIndexerTableMeshTopology,
 		tableGatewayServices:   testIndexerTableGatewayServices,
 		tableServiceVirtualIPs: testIndexerTableServiceVirtualIPs,
+		tableKindServiceNames:  testIndexerTableKindServiceNames,
 		// KV
 		tableKVs:        testIndexerTableKVs,
 		tableTombstones: testIndexerTableTombstones,

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -72,6 +72,7 @@ const (
 	SystemMetadataRequestType                   = 31
 	ServiceVirtualIPRequestType                 = 32
 	FreeVirtualIPRequestType                    = 33
+	KindServiceNamesType                        = 34
 )
 
 // if a new request type is added above it must be
@@ -114,6 +115,7 @@ var requestTypeStrings = map[MessageType]string{
 	SystemMetadataRequestType:       "SystemMetadata",
 	ServiceVirtualIPRequestType:     "ServiceVirtualIP",
 	FreeVirtualIPRequestType:        "FreeVirtualIP",
+	KindServiceNamesType:            "KindServiceName",
 }
 
 const (
@@ -1028,6 +1030,13 @@ type ServiceNodes []*ServiceNode
 
 // ServiceKind is the kind of service being registered.
 type ServiceKind string
+
+func (k ServiceKind) Normalized() string {
+	if k == ServiceKindTypical {
+		return "typical"
+	}
+	return string(k)
+}
 
 const (
 	// ServiceKindTypical is a typical, classic Consul service. This is

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -863,7 +863,8 @@ func TestListenersFromSnapshot(t *testing.T) {
 								Address: "9.9.9.9",
 								Port:    9090,
 								TaggedAddresses: map[string]structs.ServiceAddress{
-									"virtual": {Address: "10.0.0.1"},
+									"virtual":                      {Address: "10.0.0.1"},
+									structs.TaggedAddressVirtualIP: {Address: "240.0.0.1"},
 								},
 							},
 						},

--- a/agent/xds/testdata/listeners/transparent-proxy.envoy-1-20-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy.envoy-1-20-x.golden
@@ -42,6 +42,10 @@
               {
                 "addressPrefix": "10.0.0.1",
                 "prefixLen": 32
+              },
+              {
+                "addressPrefix": "240.0.0.1",
+                "prefixLen": 32
               }
             ]
           },


### PR DESCRIPTION
There are a few changes here:
- Transparent proxy listener configuration needs to account for the new tagged address with virtual IPs generated by Consul. These should be considered both for cross-partition and partition-local traffic. The plain "virtual" tagged address should only be used for partition-local traffic, since the address is not guaranteed to be unique across partitions.
- The existing way of computing upstreams/downstreams from intentions was based on watching the "services" table and then evaluating a service's intentions against the unique service names. This won't work in 1.11 because the services table does not have a wildcard partition index, and cross-partition upstreams from intentions are supported. This watch was replaced with a watch of a table that stores service names by kind across all partitions. 