### PR TITLE
Remove references to "master" ACL tokens in tests

### DIFF
--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1689,7 +1689,7 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			method, err := upsertTestCustomizedAuthMethod(a.RPC, TestDefaultMasterToken, "dc1", func(method *structs.ACLAuthMethod) {
+			method, err := upsertTestCustomizedAuthMethod(a.RPC, TestDefaultInitialManagementToken, "dc1", func(method *structs.ACLAuthMethod) {
 				method.Type = "jwt"
 				method.Config = map[string]interface{}{
 					"JWTSupportedAlgs": []string{"ES256"},
@@ -1758,7 +1758,7 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 				testutil.RequireErrorContains(t, err, "Permission denied")
 			})
 
-			_, err = upsertTestCustomizedBindingRule(a.RPC, TestDefaultMasterToken, "dc1", func(rule *structs.ACLBindingRule) {
+			_, err = upsertTestCustomizedBindingRule(a.RPC, TestDefaultInitialManagementToken, "dc1", func(rule *structs.ACLBindingRule) {
 				rule.AuthMethod = method.Name
 				rule.BindType = structs.BindingRuleBindTypeService
 				rule.BindName = "test--${value.name}--${value.primary_org}"
@@ -1798,7 +1798,7 @@ func TestACLEndpoint_LoginLogout_jwt(t *testing.T) {
 
 				// verify the token was deleted
 				req, _ = http.NewRequest("GET", "/v1/acl/token/"+token.AccessorID, nil)
-				req.Header.Add("X-Consul-Token", TestDefaultMasterToken)
+				req.Header.Add("X-Consul-Token", TestDefaultInitialManagementToken)
 				resp = httptest.NewRecorder()
 
 				// make the request
@@ -1819,7 +1819,7 @@ func TestACL_Authorize(t *testing.T) {
 	a1 := NewTestAgent(t, TestACLConfigWithParams(nil))
 	defer a1.Shutdown()
 
-	testrpc.WaitForTestAgent(t, a1.RPC, "dc1", testrpc.WithToken(TestDefaultMasterToken))
+	testrpc.WaitForTestAgent(t, a1.RPC, "dc1", testrpc.WithToken(TestDefaultInitialManagementToken))
 
 	policyReq := structs.ACLPolicySetRequest{
 		Policy: structs.ACLPolicy{
@@ -1827,7 +1827,7 @@ func TestACL_Authorize(t *testing.T) {
 			Rules: `acl = "read" operator = "write" service_prefix "" { policy = "read"} node_prefix "" { policy= "write" } key_prefix "/foo" { policy = "write" } `,
 		},
 		Datacenter:   "dc1",
-		WriteRequest: structs.WriteRequest{Token: TestDefaultMasterToken},
+		WriteRequest: structs.WriteRequest{Token: TestDefaultInitialManagementToken},
 	}
 	var policy structs.ACLPolicy
 	require.NoError(t, a1.RPC("ACL.PolicySet", &policyReq, &policy))
@@ -1841,7 +1841,7 @@ func TestACL_Authorize(t *testing.T) {
 			},
 		},
 		Datacenter:   "dc1",
-		WriteRequest: structs.WriteRequest{Token: TestDefaultMasterToken},
+		WriteRequest: structs.WriteRequest{Token: TestDefaultInitialManagementToken},
 	}
 
 	var token structs.ACLToken
@@ -1849,7 +1849,7 @@ func TestACL_Authorize(t *testing.T) {
 
 	// secondary also needs to setup a replication token to pull tokens and policies
 	secondaryParams := DefaulTestACLConfigParams()
-	secondaryParams.ReplicationToken = secondaryParams.MasterToken
+	secondaryParams.ReplicationToken = secondaryParams.InitialManagementToken
 	secondaryParams.EnableTokenReplication = true
 
 	a2 := NewTestAgent(t, `datacenter = "dc2" `+TestACLConfigWithParams(secondaryParams))
@@ -1859,7 +1859,7 @@ func TestACL_Authorize(t *testing.T) {
 	_, err := a2.JoinWAN([]string{addr})
 	require.NoError(t, err)
 
-	testrpc.WaitForTestAgent(t, a2.RPC, "dc2", testrpc.WithToken(TestDefaultMasterToken))
+	testrpc.WaitForTestAgent(t, a2.RPC, "dc2", testrpc.WithToken(TestDefaultInitialManagementToken))
 	// this actually ensures a few things. First the dcs got connect okay, secondly that the policy we
 	// are about ready to use in our local token creation exists in the secondary DC
 	testrpc.WaitForACLReplication(t, a2.RPC, "dc2", structs.ACLReplicateTokens, policy.CreateIndex, 1, 0)
@@ -1874,7 +1874,7 @@ func TestACL_Authorize(t *testing.T) {
 			Local: true,
 		},
 		Datacenter:   "dc2",
-		WriteRequest: structs.WriteRequest{Token: TestDefaultMasterToken},
+		WriteRequest: structs.WriteRequest{Token: TestDefaultInitialManagementToken},
 	}
 
 	var localToken structs.ACLToken
@@ -2004,7 +2004,7 @@ func TestACL_Authorize(t *testing.T) {
 		for _, dc := range []string{"dc1", "dc2"} {
 			t.Run(dc, func(t *testing.T) {
 				req, _ := http.NewRequest("POST", "/v1/internal/acl/authorize?dc="+dc, jsonBody(request))
-				req.Header.Add("X-Consul-Token", TestDefaultMasterToken)
+				req.Header.Add("X-Consul-Token", TestDefaultInitialManagementToken)
 				recorder := httptest.NewRecorder()
 				raw, err := a1.srv.ACLAuthorize(recorder, req)
 				require.NoError(t, err)

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -91,9 +91,14 @@ func TestACL_Bootstrap(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, TestACLConfig()+`
-      acl_master_token = ""
-   `)
+	a := NewTestAgent(t, `
+		primary_datacenter = "dc1"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+		}
+	`)
 	defer a.Shutdown()
 
 	tests := []struct {

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1848,7 +1848,7 @@ func TestACL_Authorize(t *testing.T) {
 	require.NoError(t, a1.RPC("ACL.TokenSet", &tokenReq, &token))
 
 	// secondary also needs to setup a replication token to pull tokens and policies
-	secondaryParams := DefaulTestACLConfigParams()
+	secondaryParams := DefaultTestACLConfigParams()
 	secondaryParams.ReplicationToken = secondaryParams.InitialManagementToken
 	secondaryParams.EnableTokenReplication = true
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1295,7 +1295,7 @@ func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
 	t.Run("root-token-health-by-id", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/v1/agent/health/service/id/foo1", nil)
 		require.NoError(t, err)
-		req.Header.Add("X-Consul-Token", TestDefaultMasterToken)
+		req.Header.Add("X-Consul-Token", TestDefaultInitialManagementToken)
 		resp := httptest.NewRecorder()
 		_, err = a.srv.AgentHealthServiceByID(resp, req)
 		require.NotEqual(t, acl.ErrPermissionDenied, err)
@@ -1304,7 +1304,7 @@ func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
 	t.Run("root-token-health-by-name", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/v1/agent/health/service/name/foo", nil)
 		require.NoError(t, err)
-		req.Header.Add("X-Consul-Token", TestDefaultMasterToken)
+		req.Header.Add("X-Consul-Token", TestDefaultInitialManagementToken)
 		resp := httptest.NewRecorder()
 		_, err = a.srv.AgentHealthServiceByName(resp, req)
 		require.NotEqual(t, acl.ErrPermissionDenied, err)

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -5327,9 +5327,15 @@ func TestAgent_TokenTriggersFullSync(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			url := fmt.Sprintf("/v1/agent/token/%s?token=root", tt.path)
 
-			a := NewTestAgent(t, TestACLConfig()+`
+			a := NewTestAgent(t, `
+				primary_datacenter = "dc1"
+
 				acl {
+					enabled = true
+					default_policy = "deny"
+
 					tokens {
+						initial_management = "root"
 						default = ""
 						agent = ""
 						agent_master = ""
@@ -5369,9 +5375,15 @@ func TestAgent_Token(t *testing.T) {
 	// The behavior of this handler when ACLs are disabled is vetted over
 	// in TestACL_Disabled_Response since there's already good infra set
 	// up over there to test this, and it calls the common function.
-	a := NewTestAgent(t, TestACLConfig()+`
+	a := NewTestAgent(t, `
+		primary_datacenter = "dc1"
+
 		acl {
+			enabled = true
+			default_policy = "deny"
+
 			tokens {
+				initial_management = "root"
 				default = ""
 				agent = ""
 				agent_master = ""

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -214,10 +214,14 @@ func TestAgent_TokenStore(t *testing.T) {
 	t.Parallel()
 
 	a := NewTestAgent(t, `
-		acl_token = "user"
-		acl_agent_token = "agent"
-		acl_agent_master_token = "master"`,
-	)
+		acl {
+			tokens {
+				default = "user"
+				agent = "agent"
+				agent_recovery = "recovery"
+			}
+		}
+	`)
 	defer a.Shutdown()
 
 	if got, want := a.tokens.UserToken(), "user"; got != want {
@@ -226,7 +230,7 @@ func TestAgent_TokenStore(t *testing.T) {
 	if got, want := a.tokens.AgentToken(), "agent"; got != want {
 		t.Fatalf("got %q want %q", got, want)
 	}
-	if got, want := a.tokens.IsAgentRecoveryToken("master"), true; got != want {
+	if got, want := a.tokens.IsAgentRecoveryToken("recovery"), true; got != want {
 		t.Fatalf("got %v want %v", got, want)
 	}
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -5037,7 +5037,7 @@ func TestAutoConfig_Integration(t *testing.T) {
 	srv := StartTestAgent(t, TestAgent{Name: "TestAgent-Server", HCL: hclConfig})
 	defer srv.Shutdown()
 
-	testrpc.WaitForTestAgent(t, srv.RPC, "dc1", testrpc.WithToken(TestDefaultMasterToken))
+	testrpc.WaitForTestAgent(t, srv.RPC, "dc1", testrpc.WithToken(TestDefaultInitialManagementToken))
 
 	// sign a JWT token
 	now := time.Now()
@@ -5084,7 +5084,7 @@ func TestAutoConfig_Integration(t *testing.T) {
 	// when this is successful we managed to get the gossip key and serf addresses to bind to
 	// and then connect. Additionally we would have to have certificates or else the
 	// verify_incoming config on the server would not let it work.
-	testrpc.WaitForTestAgent(t, client.RPC, "dc1", testrpc.WithToken(TestDefaultMasterToken))
+	testrpc.WaitForTestAgent(t, client.RPC, "dc1", testrpc.WithToken(TestDefaultInitialManagementToken))
 
 	// spot check that we now have an ACL token
 	require.NotEmpty(t, client.tokens.AgentToken())
@@ -5098,7 +5098,7 @@ func TestAutoConfig_Integration(t *testing.T) {
 	ca := connect.TestCA(t, nil)
 	req := &structs.CARequest{
 		Datacenter:   "dc1",
-		WriteRequest: structs.WriteRequest{Token: TestDefaultMasterToken},
+		WriteRequest: structs.WriteRequest{Token: TestDefaultInitialManagementToken},
 		Config: &structs.CAConfiguration{
 			Provider: "consul",
 			Config: map[string]interface{}{
@@ -5170,7 +5170,7 @@ func TestAgent_AutoEncrypt(t *testing.T) {
 	srv := StartTestAgent(t, TestAgent{Name: "test-server", HCL: hclConfig})
 	defer srv.Shutdown()
 
-	testrpc.WaitForTestAgent(t, srv.RPC, "dc1", testrpc.WithToken(TestDefaultMasterToken))
+	testrpc.WaitForTestAgent(t, srv.RPC, "dc1", testrpc.WithToken(TestDefaultInitialManagementToken))
 
 	client := StartTestAgent(t, TestAgent{Name: "test-client", HCL: TestACLConfigWithParams(nil) + `
 	   bootstrap = false
@@ -5193,7 +5193,7 @@ func TestAgent_AutoEncrypt(t *testing.T) {
 
 	// when this is successful we managed to get a TLS certificate and are using it for
 	// encrypted RPC connections.
-	testrpc.WaitForTestAgent(t, client.RPC, "dc1", testrpc.WithToken(TestDefaultMasterToken))
+	testrpc.WaitForTestAgent(t, client.RPC, "dc1", testrpc.WithToken(TestDefaultInitialManagementToken))
 
 	// now we need to validate that our certificate has the correct CN
 	aeCert := client.tlsConfigurator.Cert()

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6224,11 +6224,18 @@ func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run("ACLToken == "+tt.token, func(t *testing.T) {
 			a := NewTestAgent(t, `
-				acl_token = "`+tt.token+`"
-				acl_master_token = "root"
-				acl_datacenter = "dc1"
-				acl_down_policy = "deny"
-				acl_default_policy = "deny"
+				primary_datacenter = "dc1"
+
+				acl {
+					enabled = true
+					default_policy = "deny"
+					down_policy = "deny"
+
+					tokens {
+						initial_management = "root"
+						default = "`+tt.token+`"
+					}
+				}
 			`)
 			defer a.Shutdown()
 			testrpc.WaitForLeader(t, a.RPC, "dc1")

--- a/agent/http_oss_test.go
+++ b/agent/http_oss_test.go
@@ -72,13 +72,13 @@ func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
 		enabled        = true
 		default_policy = "deny"
 		tokens {
-			master  = "sekrit"
-			agent   = "sekrit"
+			initial_management = "sekrit"
+			agent              = "sekrit"
 		}
 	}
 	`)
 	defer a.Shutdown()
-	// Use the master token here so the wait actually works.
+	// Use the initial management token here so the wait actually works.
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1", testrpc.WithToken("sekrit"))
 
 	all := []string{"GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS"}

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -994,13 +994,21 @@ func TestHTTPServer_PProfHandlers_ACLs(t *testing.T) {
 	dc1 := "dc1"
 
 	a := NewTestAgent(t, `
-	acl_datacenter = "`+dc1+`"
-	acl_default_policy = "deny"
-	acl_master_token = "master"
-	acl_agent_token = "agent"
-	acl_agent_master_token = "towel"
-	enable_debug = false
-`)
+		primary_datacenter = "`+dc1+`"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+				agent = "agent"
+				agent_recovery = "towel"
+			}
+		}
+
+		enable_debug = false
+	`)
 
 	cases := []struct {
 		code        int
@@ -1010,7 +1018,7 @@ func TestHTTPServer_PProfHandlers_ACLs(t *testing.T) {
 	}{
 		{
 			code:        http.StatusOK,
-			token:       "master",
+			token:       "root",
 			endpoint:    "/debug/pprof/heap",
 			nilResponse: false,
 		},
@@ -1034,7 +1042,7 @@ func TestHTTPServer_PProfHandlers_ACLs(t *testing.T) {
 		},
 		{
 			code:        http.StatusOK,
-			token:       "master",
+			token:       "root",
 			endpoint:    "/debug/pprof/heap",
 			nilResponse: false,
 		},

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -302,10 +302,17 @@ func TestAgentKeyring_ACL(t *testing.T) {
 	dataDir := testutil.TempDir(t, "keyfile")
 	writeKeyRings(t, key1, dataDir)
 
-	a := StartTestAgent(t, TestAgent{HCL: TestACLConfig() + `
-		acl_datacenter = "dc1"
-		acl_master_token = "root"
-		acl_default_policy = "deny"
+	a := StartTestAgent(t, TestAgent{HCL: `
+		primary_datacenter = "dc1"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+			}
+		}
 	`, DataDir: dataDir})
 	defer a.Shutdown()
 

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -796,9 +796,17 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 	a := agent.NewTestAgent(t, `
-		acl_datacenter = "dc1"
-		acl_master_token = "root"
-		acl_default_policy = "deny" `)
+		primary_datacenter = "dc1"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+			}
+		}
+	`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1241,9 +1249,17 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 	t.Parallel()
 	dc := "dc1"
 	a := &agent.TestAgent{HCL: `
-		acl_datacenter = "` + dc + `"
-		acl_master_token = "root"
-		acl_default_policy = "deny" `}
+		primary_datacenter = "` + dc + `"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+			}
+		}
+	`}
 	if err := a.Start(t); err != nil {
 		t.Fatal(err)
 	}

--- a/agent/remote_exec_test.go
+++ b/agent/remote_exec_test.go
@@ -117,10 +117,17 @@ func TestRemoteExecGetSpec_ACLToken(t *testing.T) {
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecGetSpec(t, `
-		acl_datacenter = "`+dc+`"
-		acl_master_token = "root"
-		acl_token = "root"
-		acl_default_policy = "deny"
+		primary_datacenter = "`+dc+`"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+				default = "root"
+			}
+		}
 	`, "root", true, dc)
 }
 
@@ -132,10 +139,17 @@ func TestRemoteExecGetSpec_ACLAgentToken(t *testing.T) {
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecGetSpec(t, `
-		acl_datacenter = "`+dc+`"
-		acl_master_token = "root"
-		acl_agent_token = "root"
-		acl_default_policy = "deny"
+		primary_datacenter = "`+dc+`"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+				agent = "root"
+			}
+		}
 	`, "root", true, dc)
 }
 
@@ -147,9 +161,16 @@ func TestRemoteExecGetSpec_ACLDeny(t *testing.T) {
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecGetSpec(t, `
-		acl_datacenter = "`+dc+`"
-		acl_master_token = "root"
-		acl_default_policy = "deny"
+		primary_datacenter = "`+dc+`"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+			}
+		}
 	`, "root", false, dc)
 }
 
@@ -207,10 +228,17 @@ func TestRemoteExecWrites_ACLToken(t *testing.T) {
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecWrites(t, `
-		acl_datacenter = "`+dc+`"
-		acl_master_token = "root"
-		acl_token = "root"
-		acl_default_policy = "deny"
+		primary_datacenter = "`+dc+`"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+				default = "root"
+			}
+		}
 	`, "root", true, dc)
 }
 
@@ -222,10 +250,17 @@ func TestRemoteExecWrites_ACLAgentToken(t *testing.T) {
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecWrites(t, `
-		acl_datacenter = "`+dc+`"
-		acl_master_token = "root"
-		acl_agent_token = "root"
-		acl_default_policy = "deny"
+		primary_datacenter = "`+dc+`"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+				agent = "root"
+			}
+		}
 	`, "root", true, dc)
 }
 
@@ -237,9 +272,16 @@ func TestRemoteExecWrites_ACLDeny(t *testing.T) {
 	t.Parallel()
 	dc := "dc1"
 	testRemoteExecWrites(t, `
-		acl_datacenter = "`+dc+`"
-		acl_master_token = "root"
-		acl_default_policy = "deny"
+		primary_datacenter = "`+dc+`"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+			}
+		}
 	`, "root", false, dc)
 }
 

--- a/agent/routine-leak-checker/leak_test.go
+++ b/agent/routine-leak-checker/leak_test.go
@@ -76,7 +76,7 @@ func setupPrimaryServer(t *testing.T) *agent.TestAgent {
 	a := agent.NewTestAgent(t, config)
 	t.Cleanup(func() { a.Shutdown() })
 
-	testrpc.WaitForTestAgent(t, a.RPC, "primary", testrpc.WithToken(agent.TestDefaultMasterToken))
+	testrpc.WaitForTestAgent(t, a.RPC, "primary", testrpc.WithToken(agent.TestDefaultInitialManagementToken))
 
 	return a
 }

--- a/agent/routine-leak-checker/leak_test.go
+++ b/agent/routine-leak-checker/leak_test.go
@@ -55,7 +55,7 @@ func setupPrimaryServer(t *testing.T) *agent.TestAgent {
 	require.NoError(t, ioutil.WriteFile(keyPath, []byte(keyPEM), 0600))
 	require.NoError(t, ioutil.WriteFile(caPath, []byte(caPEM), 0600))
 
-	aclParams := agent.DefaulTestACLConfigParams()
+	aclParams := agent.DefaultTestACLConfigParams()
 	aclParams.PrimaryDatacenter = "primary"
 	aclParams.EnableTokenReplication = true
 

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -470,46 +470,46 @@ func TestACLConfig() string {
 }
 
 const (
-	TestDefaultMasterToken      = "d9f05e83-a7ae-47ce-839e-c0d53a68c00a"
-	TestDefaultAgentMasterToken = "bca580d4-db07-4074-b766-48acc9676955'"
+	TestDefaultInitialManagementToken = "d9f05e83-a7ae-47ce-839e-c0d53a68c00a"
+	TestDefaultAgentRecoveryToken     = "bca580d4-db07-4074-b766-48acc9676955'"
 )
 
 type TestACLConfigParams struct {
 	PrimaryDatacenter      string
 	DefaultPolicy          string
-	MasterToken            string
+	InitialManagementToken string
 	AgentToken             string
 	DefaultToken           string
-	AgentMasterToken       string
+	AgentRecoveryToken     string
 	ReplicationToken       string
 	EnableTokenReplication bool
 }
 
 func DefaulTestACLConfigParams() *TestACLConfigParams {
 	return &TestACLConfigParams{
-		PrimaryDatacenter: "dc1",
-		DefaultPolicy:     "deny",
-		MasterToken:       TestDefaultMasterToken,
-		AgentToken:        TestDefaultMasterToken,
-		AgentMasterToken:  TestDefaultAgentMasterToken,
+		PrimaryDatacenter:      "dc1",
+		DefaultPolicy:          "deny",
+		InitialManagementToken: TestDefaultInitialManagementToken,
+		AgentToken:             TestDefaultInitialManagementToken,
+		AgentRecoveryToken:     TestDefaultAgentRecoveryToken,
 	}
 }
 
 func (p *TestACLConfigParams) HasConfiguredTokens() bool {
-	return p.MasterToken != "" ||
+	return p.InitialManagementToken != "" ||
 		p.AgentToken != "" ||
 		p.DefaultToken != "" ||
-		p.AgentMasterToken != "" ||
+		p.AgentRecoveryToken != "" ||
 		p.ReplicationToken != ""
 }
 
 func TestACLConfigNew() string {
 	return TestACLConfigWithParams(&TestACLConfigParams{
-		PrimaryDatacenter: "dc1",
-		DefaultPolicy:     "deny",
-		MasterToken:       "root",
-		AgentToken:        "root",
-		AgentMasterToken:  "towel",
+		PrimaryDatacenter:      "dc1",
+		DefaultPolicy:          "deny",
+		InitialManagementToken: "root",
+		AgentToken:             "root",
+		AgentRecoveryToken:     "towel",
 	})
 }
 
@@ -525,14 +525,14 @@ var aclConfigTpl = template.Must(template.New("ACL Config").Parse(`
 		enable_token_replication = {{printf "%t" .EnableTokenReplication }}
 		{{- if .HasConfiguredTokens}}
 		tokens {
-			{{- if ne .MasterToken ""}}
-			master = "{{ .MasterToken }}"
+			{{- if ne .InitialManagementToken ""}}
+			initial_management = "{{ .InitialManagementToken }}"
 			{{- end}}
 			{{- if ne .AgentToken ""}}
 			agent = "{{ .AgentToken }}"
 			{{- end}}
-			{{- if ne .AgentMasterToken "" }}
-			agent_master = "{{ .AgentMasterToken }}"
+			{{- if ne .AgentRecoveryToken "" }}
+			agent_recovery = "{{ .AgentRecoveryToken }}"
 			{{- end}}
 			{{- if ne .DefaultToken "" }}
 			default = "{{ .DefaultToken }}"

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -485,7 +485,7 @@ type TestACLConfigParams struct {
 	EnableTokenReplication bool
 }
 
-func DefaulTestACLConfigParams() *TestACLConfigParams {
+func DefaultTestACLConfigParams() *TestACLConfigParams {
 	return &TestACLConfigParams{
 		PrimaryDatacenter:      "dc1",
 		DefaultPolicy:          "deny",
@@ -550,7 +550,7 @@ func TestACLConfigWithParams(params *TestACLConfigParams) string {
 
 	cfg := params
 	if params == nil {
-		cfg = DefaulTestACLConfigParams()
+		cfg = DefaultTestACLConfigParams()
 	}
 
 	err := aclConfigTpl.Execute(&buf, &cfg)

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -461,11 +461,18 @@ func TestConfig(logger hclog.Logger, sources ...config.Source) *config.RuntimeCo
 // with ACLs.
 func TestACLConfig() string {
 	return `
-		acl_datacenter = "dc1"
-		acl_default_policy = "deny"
-		acl_master_token = "root"
-		acl_agent_token = "root"
-		acl_agent_master_token = "towel"
+		primary_datacenter = "dc1"
+
+		acl {
+			enabled = true
+			default_policy = "deny"
+
+			tokens {
+				initial_management = "root"
+				agent = "root"
+				agent_recovery = "towel"
+			}
+		}
 	`
 }
 

--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -43,7 +43,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -197,7 +197,7 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -368,7 +368,7 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -514,7 +514,7 @@ func TestAuthMethodCreateCommand_config(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/authmethod/delete/authmethod_delete_test.go
+++ b/command/acl/authmethod/delete/authmethod_delete_test.go
@@ -36,7 +36,7 @@ func TestAuthMethodDeleteCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/authmethod/list/authmethod_list_test.go
+++ b/command/acl/authmethod/list/authmethod_list_test.go
@@ -37,7 +37,7 @@ func TestAuthMethodListCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -118,7 +118,7 @@ func TestAuthMethodListCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/authmethod/read/authmethod_read_test.go
+++ b/command/acl/authmethod/read/authmethod_read_test.go
@@ -37,7 +37,7 @@ func TestAuthMethodReadCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -127,7 +127,7 @@ func TestAuthMethodReadCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/authmethod/update/authmethod_update_test.go
+++ b/command/acl/authmethod/update/authmethod_update_test.go
@@ -42,7 +42,7 @@ func TestAuthMethodUpdateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -179,7 +179,7 @@ func TestAuthMethodUpdateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -270,7 +270,7 @@ func TestAuthMethodUpdateCommand_noMerge(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -374,7 +374,7 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -612,7 +612,7 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -802,7 +802,7 @@ func TestAuthMethodUpdateCommand_config(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/bindingrule/create/bindingrule_create_test.go
+++ b/command/acl/bindingrule/create/bindingrule_create_test.go
@@ -36,7 +36,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -187,7 +187,7 @@ func TestBindingRuleCreateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/bindingrule/delete/bindingrule_delete_test.go
+++ b/command/acl/bindingrule/delete/bindingrule_delete_test.go
@@ -35,7 +35,7 @@ func TestBindingRuleDeleteCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/bindingrule/list/bindingrule_list_test.go
+++ b/command/acl/bindingrule/list/bindingrule_list_test.go
@@ -37,7 +37,7 @@ func TestBindingRuleListCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/bindingrule/read/bindingrule_read_test.go
+++ b/command/acl/bindingrule/read/bindingrule_read_test.go
@@ -36,7 +36,7 @@ func TestBindingRuleReadCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/bindingrule/update/bindingrule_update_test.go
+++ b/command/acl/bindingrule/update/bindingrule_update_test.go
@@ -37,7 +37,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -478,7 +478,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/policy/create/policy_create_test.go
+++ b/command/acl/policy/create/policy_create_test.go
@@ -37,7 +37,7 @@ func TestPolicyCreateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -78,7 +78,7 @@ func TestPolicyCreateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/policy/delete/policy_delete_test.go
+++ b/command/acl/policy/delete/policy_delete_test.go
@@ -33,7 +33,7 @@ func TestPolicyDeleteCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/policy/list/policy_list_test.go
+++ b/command/acl/policy/list/policy_list_test.go
@@ -34,7 +34,7 @@ func TestPolicyListCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -89,7 +89,7 @@ func TestPolicyListCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/policy/read/policy_read_test.go
+++ b/command/acl/policy/read/policy_read_test.go
@@ -34,7 +34,7 @@ func TestPolicyReadCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -98,7 +98,7 @@ func TestPolicyReadCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/policy/update/policy_update_test.go
+++ b/command/acl/policy/update/policy_update_test.go
@@ -37,7 +37,7 @@ func TestPolicyUpdateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -88,7 +88,7 @@ func TestPolicyUpdateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/role/create/role_create_test.go
+++ b/command/acl/role/create/role_create_test.go
@@ -33,7 +33,7 @@ func TestRoleCreateCommand_Pretty(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -126,7 +126,7 @@ func TestRoleCreateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/role/delete/role_delete_test.go
+++ b/command/acl/role/delete/role_delete_test.go
@@ -32,7 +32,7 @@ func TestRoleDeleteCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/role/list/role_list_test.go
+++ b/command/acl/role/list/role_list_test.go
@@ -35,7 +35,7 @@ func TestRoleListCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -93,7 +93,7 @@ func TestRoleListCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/role/read/role_read_test.go
+++ b/command/acl/role/read/role_read_test.go
@@ -35,7 +35,7 @@ func TestRoleReadCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -203,7 +203,7 @@ func TestRoleReadCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/role/update/role_update_test.go
+++ b/command/acl/role/update/role_update_test.go
@@ -35,7 +35,7 @@ func TestRoleUpdateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -209,7 +209,7 @@ func TestRoleUpdateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -292,7 +292,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/rules/translate_test.go
+++ b/command/acl/rules/translate_test.go
@@ -35,7 +35,7 @@ func TestRulesTranslateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/token/clone/token_clone_test.go
+++ b/command/acl/token/clone/token_clone_test.go
@@ -70,7 +70,7 @@ func TestTokenCloneCommand_Pretty(t *testing.T) {
    acl {
       enabled = true
       tokens {
-         master = "root"
+         initial_management = "root"
       }
    }`)
 
@@ -178,7 +178,7 @@ func TestTokenCloneCommand_JSON(t *testing.T) {
    acl {
       enabled = true
       tokens {
-         master = "root"
+         initial_management = "root"
       }
    }`)
 

--- a/command/acl/token/create/token_create_test.go
+++ b/command/acl/token/create/token_create_test.go
@@ -33,7 +33,7 @@ func TestTokenCreateCommand_Pretty(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -131,7 +131,7 @@ func TestTokenCreateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/token/delete/token_delete_test.go
+++ b/command/acl/token/delete/token_delete_test.go
@@ -33,7 +33,7 @@ func TestTokenDeleteCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/token/list/token_list_test.go
+++ b/command/acl/token/list/token_list_test.go
@@ -35,7 +35,7 @@ func TestTokenListCommand_Pretty(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -90,7 +90,7 @@ func TestTokenListCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/token/read/token_read_test.go
+++ b/command/acl/token/read/token_read_test.go
@@ -35,7 +35,7 @@ func TestTokenReadCommand_Pretty(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -83,7 +83,7 @@ func TestTokenReadCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -34,7 +34,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -166,7 +166,7 @@ func TestTokenUpdateCommand_JSON(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/login/login_test.go
+++ b/command/login/login_test.go
@@ -44,7 +44,7 @@ func TestLoginCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -241,7 +241,7 @@ func TestLoginCommand_k8s(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -339,7 +339,7 @@ func TestLoginCommand_jwt(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 

--- a/command/logout/logout_test.go
+++ b/command/logout/logout_test.go
@@ -35,7 +35,7 @@ func TestLogoutCommand(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 
@@ -165,7 +165,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 	acl {
 		enabled = true
 		tokens {
-			master = "root"
+			initial_management = "root"
 		}
 	}`)
 


### PR DESCRIPTION
Following #11665 and #11669, this PR removes references to the old (pre-1.11) name for `agent_recovery` and `initial_management` tokens in tests.