### PR TITLE
ui: [Backport 1.9.x] Don't cache event sources following a 401

### DIFF
--- a/.changelog/11681.txt
+++ b/.changelog/11681.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Fixes an issue where under some circumstances after logging we present the
+data loaded previous to you logging in.
+```

--- a/ui/packages/consul-ui/app/services/data-source/service.js
+++ b/ui/packages/consul-ui/app/services/data-source/service.js
@@ -116,7 +116,12 @@ export default class DataSourceService extends Service {
           const event = source.getCurrentEvent();
           const cursor = source.configuration.cursor;
           // only cache data if we have any
-          if (typeof event !== 'undefined' && typeof cursor !== 'undefined') {
+          if (
+            typeof event !== 'undefined' &&
+            typeof cursor !== 'undefined' &&
+            e.errors &&
+            e.errors[0].status !== '401'
+          ) {
             cache.set(uri, {
               currentEvent: event,
               cursor: cursor,

--- a/ui/packages/consul-ui/app/utils/dom/event-source/callable.js
+++ b/ui/packages/consul-ui/app/utils/dom/event-source/callable.js
@@ -57,7 +57,7 @@ export default function(
         // close after the dispatch so we can tell if it was an error whilst closed or not
         // but make sure its before the promise tick
         this.readyState = 2; // CLOSE
-        this.dispatchEvent({ type: 'close' });
+        this.dispatchEvent({ type: 'close', error: e });
       })
       .then(() => {
         // This only gets called when the promise chain completely finishes


### PR DESCRIPTION
See #11681