### PR TITLE
ui: Make 'dangerous' buttons have white text even in dark theme

### DIFF
--- a/ui/packages/consul-ui/app/styles/themes.scss
+++ b/ui/packages/consul-ui/app/styles/themes.scss
@@ -9,6 +9,11 @@
 %main-nav-horizontal {
   @extend %theme-dark;
 }
+%main-nav-horizontal .dangerous button:hover,
+%main-nav-horizontal .dangerous button:focus {
+  color: rgb(var(--white)) !important;
+}
+
 %main-nav-vertical .menu-panel a:hover,
 %main-nav-vertical .menu-panel a:focus {
   background-color: rgb(var(--tone-blue-500));


### PR DESCRIPTION
We recently added our 'auto theming' `--tone` colors, which are just reversed when using a dark theme. We also built in an escape hatch to be able to use colors that we didn't want ever to be themed i.e. we can then inject from The Outside using specific CSS selecting using a non `--tone`ed, non-reversing color just for those cases.

The TLDR:

Before:

<img width="239" alt="Screenshot 2021-12-06 at 19 02 52" src="https://user-images.githubusercontent.com/554604/144906455-3e3a8f83-6593-482e-a2db-7d8ae51a2ea3.png">

After:

<img width="221" alt="Screenshot 2021-12-06 at 19 00 34" src="https://user-images.githubusercontent.com/554604/144906477-779c27ba-d9ab-4f17-bbce-9f1cfca25740.png">

This one specifically was a good one to "go wrong" as it gave me a chance to have a little bit of a think how this approach would work with our ['composite color set' `%frame` idea from a while back](https://github.com/hashicorp/consul/pull/4623), as our 'dangerous button' styling here uses a `%frame`. First impressions of that are that we probably need a similar set of `%frame-tones` here as well as similar escape hatches. Another note here is that it _may not_ be worth doing that if these frames aren't shared across design. Whilst they are super useful to define combinations of colors to use from a DX perspective, if we can't reference them back to designs then they become less useful (half the reason why we don't use them as much as we could)

Small note: I've not added a 1.11 Milestone here as yet
