### PR TITLE
rpc: Unset partition before forwarding to remote datacenter

### DIFF
--- a/.changelog/11758.txt
+++ b/.changelog/11758.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+rpc: unset partition before forwarding to remote datacenter
+```

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -47,6 +47,10 @@ func (m *EnterpriseMeta) WithWildcardNamespace() *EnterpriseMeta {
 	return &emptyEnterpriseMeta
 }
 
+func (m *EnterpriseMeta) UnsetPartition() {
+	// do nothing
+}
+
 // TODO(partition): stop using this
 func NewEnterpriseMetaInDefaultPartition(_ string) EnterpriseMeta {
 	return emptyEnterpriseMeta


### PR DESCRIPTION
There are cases where we cannot safely forward along a `Partition` value to remote servers. Specifically in the case where the server is "partition-aware" but not "partition-capable" -- these are typically servers on 1.10.x that can parse/handle EnterpriseMeta with a `Partition` value. Having a value, but not applying it correctly can lead to inadvertent filtering of `memdb` requests since these values are blindly forwarded through to the `memdb` query.

This adds the plumbing to unset the value specifically in the case of RPC prior to forwarding requests to a remote DC which is effectively a no-op for Consul OSS. 