### PR TITLE
ui: Fixup notifications for token using and topology intention saving

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/intention/notifications/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/notifications/index.hbs
@@ -1,0 +1,24 @@
+{{#if (eq @type 'create')}}
+  {{#if (eq @status 'success') }}
+    Your intention has been added.
+  {{else}}
+    There was an error adding your intention.
+  {{/if}}
+{{else if (eq @type 'update') }}
+  {{#if (eq @status 'success') }}
+    Your intention has been saved.
+  {{else}}
+    There was an error saving your intention.
+  {{/if}}
+{{ else if (eq @type 'delete')}}
+  {{#if (eq @status 'success') }}
+    Your intention was deleted.
+  {{else}}
+    There was an error deleting your intention.
+  {{/if}}
+{{/if}}
+{{#let @error.errors.firstObject as |error|}}
+  {{#if error.detail }}
+    <br />{{concat '(' (if error.status (concat error.status ': ')) error.detail ')'}}
+  {{/if}}
+{{/let}}

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -39,8 +39,15 @@
               There was an error, please check your SecretID/Token
             {{/if}}
           {{else}}
-            {{#if (eq flash.model 'token')}}
+            {{#if (or (eq type 'use') (eq flash.model 'token'))}}
               <Consul::Token::Notifications
+                @type={{type}}
+                @status={{status}}
+                @item={{flash.item}}
+                @error={{flash.error}}
+              />
+            {{else if (eq flash.model 'intention')}}
+              <Consul::Intention::Notifications
                 @type={{type}}
                 @status={{status}}
                 @item={{flash.item}}

--- a/ui/packages/consul-ui/app/routes/dc/services/show/topology.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/topology.js
@@ -11,7 +11,7 @@ export default class TopologyRoute extends Route {
   async createIntention(source, destination) {
     // begin with a create action as it makes more sense if the we can't even
     // get a list of intentions
-    let notification = this.feedback.notification('create');
+    let notification = this.feedback.notification('create', 'intention');
     try {
       // intentions will be a proxy object
       let intentions = await this.intentions;
@@ -34,7 +34,7 @@ export default class TopologyRoute extends Route {
         });
       } else {
         // we found an intention in the find higher up, so we are updating
-        notification = this.feedback.notification('update');
+        notification = this.feedback.notification('update', 'intention');
       }
       set(intention, 'Action', 'allow');
       await this.repo.persist(intention);

--- a/ui/packages/consul-ui/app/services/feedback.js
+++ b/ui/packages/consul-ui/app/services/feedback.js
@@ -10,17 +10,17 @@ const notificationDefaults = function() {
   return {
     timeout: 6000,
     extendedTimeout: 300,
-    destroyOnClick: true
+    destroyOnClick: true,
   };
 };
 export default class FeedbackService extends Service {
   @service('flashMessages') notify;
   @service('logger') logger;
 
-  notification(action) {
+  notification(action, modelName) {
     return {
-      success: item => this.success(item, action),
-      error: e => this.error(e, action),
+      success: item => this.success(item, action, undefined, modelName),
+      error: e => this.error(e, action, undefined, modelName),
     };
   }
 
@@ -39,7 +39,7 @@ export default class FeedbackService extends Service {
         // here..
         action: getAction(),
         item: item,
-        model:  model
+        model: model,
       });
     }
   }
@@ -55,7 +55,7 @@ export default class FeedbackService extends Service {
         type: getStatus(TYPE_SUCCESS),
         // and here
         action: getAction(),
-        model:  model
+        model: model,
       });
     } else {
       this.notify.add({
@@ -63,7 +63,7 @@ export default class FeedbackService extends Service {
         type: getStatus(TYPE_ERROR, e),
         action: getAction(),
         error: e,
-        model:  model
+        model: model,
       });
     }
   }


### PR DESCRIPTION
I noticed that some of our notifications had lost their text content following our reshuffle of notifications in https://github.com/hashicorp/consul/pull/11577 (towards getting rid of the old style notifications). The changes here all kind of make sense:

- The intention notifications here are for the topology view which still have a small bit of old code that we are yet to move over - all other intention areas use the new approach still.
- "Using" a token is part of our completely untouched for ages (but soon to be) ACLs area and is still therefore using the old style

Please note when I say 'style' above I mean 'style of code' not 'visual style'

If we were keeping this code longer term, there would be questions about making this less copypasta i.e. there are better ways to do it - but as this is a means to an end, its a case of move what we already have to a place where its easy to slowly remove as we go.

(No changelog as https://github.com/hashicorp/consul/pull/11577 isn't in a release as yet)

