### PR TITLE
ui: Ensure we show a special readonly page for intentions

### DIFF
--- a/.changelog/11767.txt
+++ b/.changelog/11767.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Ensure we show a readonly designed page for readonly intentions
+```

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -222,6 +222,7 @@ as |item readonly|}}
 
     <Consul::Intention::View
       @item={{item}}
+      data-test-readonly
     />
   {{/if}}
 {{/let}}

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -56,7 +56,10 @@ as |api|>
     </BlockSlot>
 
     <BlockSlot @name="form">
-{{#let api.data as |item|}}
+{{#let
+  api.data
+  (not (can 'write intention' item=api.data))
+as |item readonly|}}
 {{#if (not readonly)}}
 
   {{#let (changeset-get item 'Action') as |newAction|}}
@@ -193,6 +196,7 @@ as |api|>
         </div>
       </form>
   {{else}}
+
     {{#if item.IsManagedByCRD}}
       <Notice
         class="crd"
@@ -215,6 +219,7 @@ as |api|>
         </notice.Footer>
       </Notice>
     {{/if}}
+
     <Consul::Intention::View
       @item={{item}}
     />

--- a/ui/packages/consul-ui/app/components/consul/intention/view/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/view/index.hbs
@@ -1,4 +1,7 @@
-<div class="consul-intention-view">
+<div
+  class="consul-intention-view"
+  ...attributes
+>
 
   <div class="definition-table">
       <dl>

--- a/ui/packages/consul-ui/mock-api/v1/connect/intentions/exact
+++ b/ui/packages/consul-ui/mock-api/v1/connect/intentions/exact
@@ -81,7 +81,7 @@ ${fake.helpers.randomize([
     ],
 `:``}
     "Precedence": ${fake.random.number({min: 1, max: 100})},
-${ !legacy && fake.random.number({min: 1, max: 10}) > 2 ? `
+${ (!legacy || source[1] === "external-source") && fake.random.number({min: 1, max: 10}) > 2 ? `
     "Meta": {
       "external-source": "${fake.helpers.randomize(['kubernetes', 'consul-api-gateway'])}"
     },

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/read-only.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/read-only.feature
@@ -1,0 +1,15 @@
+@setupApplicationTest
+Feature: dc / intentions / read-only
+  Scenario: Viewing a readonly intention
+    Given 1 datacenter model with the value "dc1"
+    And 1 intention model from yaml:
+    ---
+      Meta:
+        external-source: kubernetes
+    ---
+    When I visit the intention page for yaml
+    ---
+      dc: dc1
+      intention: default:external-source:web:default:external-source:db
+    ---
+    Then I see the "[data-test-readonly]" element

--- a/ui/packages/consul-ui/tests/acceptance/steps/dc/intentions/read-only-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/dc/intentions/read-only-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}


### PR DESCRIPTION
I noticed we were no longer showing our specially designed read only page for intentions due to an undefined handlebars variable, so I fixed that up and added an acceptance test to prevent this happening here again.

It seems like this bug is only/specifically in 1.10.4 (and currently unreleased 1.11 branch)