### PR TITLE
improve location of DNS alt domain docs section

### DIFF
--- a/website/content/docs/discovery/dns.mdx
+++ b/website/content/docs/discovery/dns.mdx
@@ -96,47 +96,6 @@ pairs according to [RFC1464](https://www.ietf.org/rfc/rfc1464.txt).
 Alternatively, the TXT record will only include the node's metadata value when the
 node's metadata key starts with `rfc1035-`.
 
-## Alternative Domain
-
-By default, Consul responds to DNS queries in the `consul` domain,
-but you can set a specific domain for responding to DNS queries by configuring the [`domain`](/docs/agent/options#domain) parameter.
-
-In some instances, Consul may need to respond to queries in more than one domain,
-such as during a DNS migration or to distinguish between internal and external queries.
-
-Consul versions 1.5.2+ can be configured to respond to DNS queries on an alternative domain
-through the [`alt_domain`](/docs/agent/options#alt_domain) agent configuration
-option. As of Consul versions 1.11.0+, Consul's DNS response will use the same domain as was used in the query;
-in prior versions, the response may use the primary [`domain`](/docs/agent/options#domain) no matter which
-domain was used in the query.
-
-In the following example, the `alt_domain` parameter is set to `test-domain`:
-
-```hcl
- alt_domain = "test-domain"
-```
-
-```shell-session
-$ dig @127.0.0.1 -p 8600  consul.service.test-domain SRV
-```
-The following responses are returned:
-
-```
-;; QUESTION SECTION:
-;consul.service.test-domain.	IN	SRV
-
-;; ANSWER SECTION:
-consul.service.test-domain. 0	IN	SRV	1 1 8300 machine.node.dc1.test-domain.
-
-;; ADDITIONAL SECTION:
-machine.node.dc1.test-domain. 0	IN	A	127.0.0.1
-machine.node.dc1.test-domain. 0	IN	TXT	"consul-network-segment="
-```
-
--> **PTR queries:**  Responses to PTR queries (`<ip>.in-addr.arpa.`) will always use the
-[primary domain](/docs/agent/options#domain) (not the alternative domain),
-as there is no way for the query to specify a domain.
-
 ## Service Lookups
 
 A service lookup is used to query for service providers. Service queries support
@@ -318,6 +277,47 @@ When the DNS query is performed using UDP, Consul will truncate the results
 without setting the truncate bit. This is to prevent a redundant lookup over
 TCP that generates additional load. If the lookup is done over TCP, the results
 are not truncated.
+
+## Alternative Domain
+
+By default, Consul responds to DNS queries in the `consul` domain,
+but you can set a specific domain for responding to DNS queries by configuring the [`domain`](/docs/agent/options#domain) parameter.
+
+In some instances, Consul may need to respond to queries in more than one domain,
+such as during a DNS migration or to distinguish between internal and external queries.
+
+Consul versions 1.5.2+ can be configured to respond to DNS queries on an alternative domain
+through the [`alt_domain`](/docs/agent/options#alt_domain) agent configuration
+option. As of Consul versions 1.11.0+, Consul's DNS response will use the same domain as was used in the query;
+in prior versions, the response may use the primary [`domain`](/docs/agent/options#domain) no matter which
+domain was used in the query.
+
+In the following example, the `alt_domain` parameter is set to `test-domain`:
+
+```hcl
+ alt_domain = "test-domain"
+```
+
+```shell-session
+$ dig @127.0.0.1 -p 8600  consul.service.test-domain SRV
+```
+The following responses are returned:
+
+```
+;; QUESTION SECTION:
+;consul.service.test-domain.	IN	SRV
+
+;; ANSWER SECTION:
+consul.service.test-domain. 0	IN	SRV	1 1 8300 machine.node.dc1.test-domain.
+
+;; ADDITIONAL SECTION:
+machine.node.dc1.test-domain. 0	IN	A	127.0.0.1
+machine.node.dc1.test-domain. 0	IN	TXT	"consul-network-segment="
+```
+
+-> **PTR queries:**  Responses to PTR queries (`<ip>.in-addr.arpa.`) will always use the
+[primary domain](/docs/agent/options#domain) (not the alternative domain),
+as there is no way for the query to specify a domain.
 
 ## Caching
 


### PR DESCRIPTION
We overlooked the location of the placement of the alt domain docs in #11458, as discussed [here](https://github.com/hashicorp/consul/pull/11458#issuecomment-985908493). This PR improves (fixes) the location.