### PR TITLE
ui: Fixup names of Meta for instance search, also add Node

### DIFF
--- a/.changelog/11774.txt
+++ b/.changelog/11774.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Differentiate between Service Meta and Node Meta when choosing search fields
+in Service Instance listings
+```

--- a/ui/packages/consul-ui/app/routes/dc/services/show/instances.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/instances.js
@@ -7,7 +7,7 @@ export default class InstancesRoute extends Route {
     source: 'source',
     searchproperty: {
       as: 'searchproperty',
-      empty: [['Name', 'Tags', 'ID', 'Address', 'Port', 'Service.Meta', 'Node.Meta']],
+      empty: [['Name', 'Node', 'Tags', 'ID', 'Address', 'Port', 'Service.Meta', 'Node.Meta']],
     },
     search: {
       as: 'filter',

--- a/ui/packages/consul-ui/app/search/predicates/service-instance.js
+++ b/ui/packages/consul-ui/app/search/predicates/service-instance.js
@@ -1,5 +1,6 @@
 export default {
   Name: item => item.Name,
+  Node: item => item.Node.Node,
   Tags: item => item.Service.Tags || [],
   ID: item => item.Service.ID || '',
   Address: item => item.Address || '',

--- a/ui/packages/consul-ui/translations/common/en-us.yaml
+++ b/ui/packages/consul-ui/translations/common/en-us.yaml
@@ -30,6 +30,8 @@ consul:
   terminating-gateway: Terminating Gateway
   mesh-gateway: Mesh Gateway
   status: Health Status
+  service.meta: Service Meta
+  node.meta: Node Meta
   service-name: Service Name
   node-name: Node Name
   accessorid: AccessorID


### PR DESCRIPTION
When searching through our Service Instance list, you can choose to limit the search to Meta data, but in Service Instance listing we have Service Meta _and_ Node Meta available to us. Previous to this PR both these options would read 'Meta'.

This PR changes these texts to read Service Meta and Node Meta.

We also took the opportunity to add Node Name here to the list of options you can limit the search to.