### PR TITLE
ca: improve test coverage for RenewIntermediate

### DIFF
--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -160,7 +161,7 @@ func runTestVault(t testing.T) (*TestVaultServer, error) {
 	}
 	t.Cleanup(func() {
 		if err := testVault.Stop(); err != nil {
-			t.Log("failed to stop vault server: %w", err)
+			t.Logf("failed to stop vault server: %v", err)
 		}
 	})
 
@@ -207,7 +208,7 @@ func (v *TestVaultServer) Stop() error {
 	}
 
 	if v.cmd.Process != nil {
-		if err := v.cmd.Process.Signal(os.Interrupt); err != nil {
+		if err := v.cmd.Process.Signal(os.Interrupt); err != nil && !errors.Is(err, os.ErrProcessDone) {
 			return fmt.Errorf("failed to kill vault server: %v", err)
 		}
 	}

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -697,8 +697,8 @@ func TestConnectCAConfig_UpdateSecondary(t *testing.T) {
 	require.Len(rootList.Roots, 1)
 	rootCert := activeRoot
 
-	waitForActiveCARoot(t, s1, rootCert)
-	waitForActiveCARoot(t, s2, rootCert)
+	testrpc.WaitForActiveCARoot(t, s1.RPC, "primary", rootCert)
+	testrpc.WaitForActiveCARoot(t, s2.RPC, "secondary", rootCert)
 
 	// Capture the current intermediate
 	rootList, activeRoot, err = getTestRoots(s2, "secondary")

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -349,15 +349,7 @@ func TestCAManager_Initialize(t *testing.T) {
 func TestCAManager_UpdateConfigWhileRenewIntermediate(t *testing.T) {
 
 	// No parallel execution because we change globals
-	// Set the interval and drift buffer low for renewing the cert.
-	origInterval := structs.IntermediateCertRenewInterval
-	origDriftBuffer := ca.CertificateTimeDriftBuffer
-	defer func() {
-		structs.IntermediateCertRenewInterval = origInterval
-		ca.CertificateTimeDriftBuffer = origDriftBuffer
-	}()
-	structs.IntermediateCertRenewInterval = time.Millisecond
-	ca.CertificateTimeDriftBuffer = 0
+	patchIntermediateCertRenewInterval(t)
 
 	conf := DefaultConfig()
 	conf.ConnectEnabled = true

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -11,9 +11,11 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"net/rpc"
 	"testing"
 	"time"
 
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -30,6 +32,107 @@ import (
 
 // TODO(kyhavlov): replace with t.Deadline()
 const CATestTimeout = 7 * time.Second
+
+func TestCAManager_Initialize_Vault_Secondary_SharedVault(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+	ca.SkipIfVaultNotPresent(t)
+
+	vault := ca.NewTestVaultServer(t)
+
+	_, serverDC1 := testServerWithConfig(t, func(c *Config) {
+		c.CAConfig = &structs.CAConfiguration{
+			Provider: "vault",
+			Config: map[string]interface{}{
+				"Address":             vault.Addr,
+				"Token":               vault.RootToken,
+				"RootPKIPath":         "pki-root/",
+				"IntermediatePKIPath": "pki-primary/",
+			},
+		}
+	})
+
+	runStep(t, "check primary DC", func(t *testing.T) {
+		testrpc.WaitForTestAgent(t, serverDC1.RPC, "dc1")
+
+		codec := rpcClient(t, serverDC1)
+		defer codec.Close()
+
+		roots := structs.IndexedCARoots{}
+		err := msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", &structs.DCSpecificRequest{}, &roots)
+		require.NoError(t, err)
+		require.Len(t, roots.Roots, 1)
+
+		leafPEM := getLeafCert(t, codec, roots.TrustDomain, "dc1")
+		verifyLeafCert(t, roots.Roots[0], leafPEM)
+	})
+
+	runStep(t, "start secondary DC", func(t *testing.T) {
+		_, serverDC2 := testServerWithConfig(t, func(c *Config) {
+			c.Datacenter = "dc2"
+			c.PrimaryDatacenter = "dc1"
+			c.CAConfig = &structs.CAConfiguration{
+				Provider: "vault",
+				Config: map[string]interface{}{
+					"Address":             vault.Addr,
+					"Token":               vault.RootToken,
+					"RootPKIPath":         "pki-root/",
+					"IntermediatePKIPath": "pki-secondary/",
+				},
+			}
+		})
+		defer serverDC2.Shutdown()
+		joinWAN(t, serverDC2, serverDC1)
+		testrpc.WaitForActiveCARoot(t, serverDC2.RPC, "dc2", nil)
+
+		codec := rpcClient(t, serverDC2)
+		defer codec.Close()
+
+		roots := structs.IndexedCARoots{}
+		err := msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", &structs.DCSpecificRequest{}, &roots)
+		require.NoError(t, err)
+		require.Len(t, roots.Roots, 1)
+
+		leafPEM := getLeafCert(t, codec, roots.TrustDomain, "dc2")
+		verifyLeafCert(t, roots.Roots[0], leafPEM)
+	})
+}
+
+func verifyLeafCert(t *testing.T, root *structs.CARoot, leafCertPEM string) {
+	t.Helper()
+	leaf, intermediates, err := connect.ParseLeafCerts(leafCertPEM)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	ok := pool.AppendCertsFromPEM([]byte(root.RootCert))
+	if !ok {
+		t.Fatalf("Failed to add root CA PEM to cert pool")
+	}
+
+	// verify with intermediates from leaf CertPEM
+	_, err = leaf.Verify(x509.VerifyOptions{
+		Roots:         pool,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	require.NoError(t, err, "failed to verify using intermediates from leaf cert PEM")
+
+	// verify with intermediates from the CARoot
+	intermediates = x509.NewCertPool()
+	for _, intermediate := range root.IntermediateCerts {
+		c, err := connect.ParseCert(intermediate)
+		require.NoError(t, err)
+		intermediates.AddCert(c)
+	}
+
+	_, err = leaf.Verify(x509.VerifyOptions{
+		Roots:         pool,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	require.NoError(t, err, "failed to verify using intermediates from CARoot list")
+}
 
 type mockCAServerDelegate struct {
 	t           *testing.T
@@ -514,4 +617,23 @@ func TestCAManager_UpdateConfiguration_Vault_Primary(t *testing.T) {
 	cert, err = connect.ParseCert(s1.caManager.getLeafSigningCertFromRoot(newRoot))
 	require.NoError(t, err)
 	require.Equal(t, connect.HexString(cert.SubjectKeyId), newRoot.SigningKeyID)
+}
+
+func getLeafCert(t *testing.T, codec rpc.ClientCodec, trustDomain string, dc string) string {
+	pk, _, err := connect.GeneratePrivateKey()
+	require.NoError(t, err)
+	spiffeID := &connect.SpiffeIDService{
+		Host:       trustDomain,
+		Service:    "srv1",
+		Datacenter: dc,
+	}
+	csr, err := connect.CreateCSR(spiffeID, pk, nil, nil)
+	require.NoError(t, err)
+
+	req := structs.CASignRequest{CSR: csr}
+	cert := structs.IssuedCert{}
+	err = msgpackrpc.CallWithCodec(codec, "ConnectCA.Sign", &req, &cert)
+	require.NoError(t, err)
+
+	return cert.CertPEM
 }

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -57,8 +57,6 @@ func TestCAManager_Initialize_Vault_Secondary_SharedVault(t *testing.T) {
 		testrpc.WaitForTestAgent(t, serverDC1.RPC, "dc1")
 
 		codec := rpcClient(t, serverDC1)
-		defer codec.Close()
-
 		roots := structs.IndexedCARoots{}
 		err := msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", &structs.DCSpecificRequest{}, &roots)
 		require.NoError(t, err)
@@ -87,8 +85,6 @@ func TestCAManager_Initialize_Vault_Secondary_SharedVault(t *testing.T) {
 		testrpc.WaitForActiveCARoot(t, serverDC2.RPC, "dc2", nil)
 
 		codec := rpcClient(t, serverDC2)
-		defer codec.Close()
-
 		roots := structs.IndexedCARoots{}
 		err := msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", &structs.DCSpecificRequest{}, &roots)
 		require.NoError(t, err)

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -252,18 +252,8 @@ func caRootsTxn(tx ReadTxn, ws memdb.WatchSet) (uint64, structs.CARoots, error) 
 func (s *Store) CARootActive(ws memdb.WatchSet) (uint64, *structs.CARoot, error) {
 	// Get all the roots since there should never be that many and just
 	// do the filtering in this method.
-	var result *structs.CARoot
 	idx, roots, err := s.CARoots(ws)
-	if err == nil {
-		for _, r := range roots {
-			if r.Active {
-				result = r
-				break
-			}
-		}
-	}
-
-	return idx, result, err
+	return idx, roots.Active(), err
 }
 
 // CARootSetCAS sets the current CA root state using a check-and-set operation.

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -55,6 +55,15 @@ type IndexedCARoots struct {
 	QueryMeta `json:"-"`
 }
 
+func (r IndexedCARoots) Active() *CARoot {
+	for _, root := range r.Roots {
+		if root.ID == r.ActiveRootID {
+			return root
+		}
+	}
+	return nil
+}
+
 // CARoot represents a root CA certificate that is trusted.
 type CARoot struct {
 	// ID is a globally unique ID (UUID) representing this CA root.

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -145,6 +145,20 @@ func (c *CARoot) Clone() *CARoot {
 // CARoots is a list of CARoot structures.
 type CARoots []*CARoot
 
+// Active returns the single CARoot that is marked as active, or nil if there
+// is no active root (ex: when they are no roots).
+func (c CARoots) Active() *CARoot {
+	if c == nil {
+		return nil
+	}
+	for _, r := range c {
+		if r.Active {
+			return r
+		}
+	}
+	return nil
+}
+
 // CASignRequest is the request for signing a service certificate.
 type CASignRequest struct {
 	// Datacenter is the target for this request.

--- a/testrpc/wait.go
+++ b/testrpc/wait.go
@@ -3,9 +3,10 @@ package testrpc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/stretchr/testify/require"
 )
 
 type rpcFn func(string, interface{}, interface{}) error
@@ -152,13 +153,7 @@ func WaitForActiveCARoot(t *testing.T, rpc rpcFn, dc string, expect *structs.CAR
 			r.Fatalf("err: %v", err)
 		}
 
-		var root *structs.CARoot
-		for _, r := range reply.Roots {
-			if r.ID == reply.ActiveRootID {
-				root = r
-				break
-			}
-		}
+		root := reply.Active()
 		if root == nil {
 			r.Fatal("no active root")
 		}


### PR DESCRIPTION
There's a bunch of stuff here, so probably best viewed by individual commit. I'll try to comment on any interesting lines. I've been running the tests with `-count=100` in a loop and the flakes appear to be fixed now.

Primarily this PR:
1. adds a test for using the Vault provider in a secondary PR (previously we mostly only tested with Vault provider in the primary)
2. improves some existing RenewIntermediate tests to be less flaky (hopefully not flaky at all!) and to be less verbose, so easier to read.

Other changes made:
* adds an `Active()` method to both the `IndexedCARoots` (the RPC response) and `CARoots` (the state store result) so that we can stop repeating the "lookup active root" loop in dozens of places.

I'm planning on back porting to reduce conflicts when I back port other fixes.

Fixes #7520 (hopefully for real this time)

You can see [a recent flake of this on main here](https://app.circleci.com/pipelines/github/hashicorp/consul/24678/workflows/b21eb48c-e96e-4a2f-933e-a13dce677ab9/jobs/521497).