### PR TITLE
agent: ensure service maintenance checks for matching partitions ahead of other errors

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1323,6 +1323,10 @@ func (s *HTTPHandlers) AgentServiceMaintenance(resp http.ResponseWriter, req *ht
 
 	sid.Normalize()
 
+	if !s.validateRequestPartition(resp, &sid.EnterpriseMeta) {
+		return nil, nil
+	}
+
 	if err := s.agent.vetServiceUpdateWithAuthorizer(authz, sid); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This matches behavior in most other agent api endpoints.