### PR TITLE
ui: Change partitions to expect `[]` from the API

### DIFF
--- a/.changelog/11791.txt
+++ b/.changelog/11791.txt
@@ -1,0 +1,3 @@
+```release-note:bugfix
+ui: Change partitions to expect [] from the listing API
+```

--- a/ui/packages/consul-ui/app/serializers/partition.js
+++ b/ui/packages/consul-ui/app/serializers/partition.js
@@ -11,7 +11,7 @@ export default class PartitionSerializer extends Serializer {
         respond((headers, body) => {
           return cb(
             headers,
-            body.Partitions.map(item => {
+            body.map(item => {
               item.Partition = '*';
               item.Namespace = '*';
               return item;

--- a/ui/packages/consul-ui/mock-api/v1/partitions
+++ b/ui/packages/consul-ui/mock-api/v1/partitions
@@ -1,30 +1,28 @@
-{
-  "Partitions": [
-    {
-      "Name": "default",
-      "Description": "Builtin Default Partition"
-    }
+[
+  {
+    "Name": "default",
+    "Description": "Builtin Default Partition"
+  }
 ${range(
-      env(
-        'CONSUL_PARTITION_COUNT',
-        Math.floor(
-          (
-            Math.random() * env('CONSUL_PARTITION_MAX', 10)
-          ) + parseInt(env('CONSUL_PARTITION_MIN', 1))
-        )
-      ) - 1
+    env(
+      'CONSUL_PARTITION_COUNT',
+      Math.floor(
+        (
+          Math.random() * env('CONSUL_PARTITION_MAX', 10)
+        ) + parseInt(env('CONSUL_PARTITION_MIN', 1))
+      )
+    ) - 1
 ).map(i => `
 ${i === 0 ? `
-    ,
+  ,
 ` : ``}
-    {
-      "Name": "${fake.hacker.noun()}-partition-${i}",
-  ${fake.random.boolean() ? `
-      "Description": "${fake.lorem.sentence()}",
-  ` : ``}
-      "CreateIndex": 12,
-      "ModifyIndex": 16
-    }
-  `)}
-  ]
-}
+  {
+    "Name": "${fake.hacker.noun()}-partition-${i}",
+${fake.random.boolean() ? `
+    "Description": "${fake.lorem.sentence()}",
+` : ``}
+    "CreateIndex": 12,
+    "ModifyIndex": 16
+  }
+`)}
+]

--- a/ui/packages/consul-ui/tests/integration/serializers/partition-test.js
+++ b/ui/packages/consul-ui/tests/integration/serializers/partition-test.js
@@ -13,7 +13,7 @@ module('Integration | Serializer | partition', function(hooks) {
       url: `/v1/partitions?dc=${dc}`,
     };
     return get(request.url).then(function(payload) {
-      const expected = payload.Partitions.map(item =>
+      const expected = payload.map(item =>
         Object.assign({}, item, {
           Datacenter: dc,
           Namespace: '*',


### PR DESCRIPTION
Pre-1.11.RC the partition listing API returned a `Partition: []` property. This has now been changed to `[]`.

This PR reflects that change.