### PR TITLE
testing: stop using an old version in testServer

### DIFF
--- a/agent/consul/autopilot_test.go
+++ b/agent/consul/autopilot_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/testrpc"
 )
 
 func TestAutopilot_IdempotentShutdown(t *testing.T) {
@@ -19,7 +20,7 @@ func TestAutopilot_IdempotentShutdown(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	dir1, s1 := testServerWithConfig(t, nil)
+	dir1, s1 := testServerWithConfig(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 	retry.Run(t, func(r *retry.R) { r.Check(waitForLeader(s1)) })

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -1599,7 +1599,7 @@ func TestIntentionList_acl(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, testServerACLConfig(nil))
+	dir1, s1 := testServerWithConfig(t, testServerACLConfig)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -1784,7 +1784,7 @@ func TestInternal_GatewayIntentions_aclDeny(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	dir1, s1 := testServerWithConfig(t, testServerACLConfig(nil))
+	dir1, s1 := testServerWithConfig(t, testServerACLConfig)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 	codec := rpcClient(t, s1)

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -164,8 +164,6 @@ func testServerConfig(t *testing.T) (string, *Config) {
 	config.ServerHealthInterval = 50 * time.Millisecond
 	config.AutopilotInterval = 100 * time.Millisecond
 
-	config.Build = "1.7.2"
-
 	config.CoordinateUpdatePeriod = 100 * time.Millisecond
 	config.LeaveDrainTime = 1 * time.Millisecond
 

--- a/agent/consul/system_metadata_test.go
+++ b/agent/consul/system_metadata_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLeader_SystemMetadata_CRUD(t *testing.T) {
@@ -32,10 +33,10 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 
 	state := srv.fsm.State()
 
-	// Initially has no entries
+	// Initially has one entry for virtual-ips feature flag
 	_, entries, err := state.SystemMetadataList(nil)
 	require.NoError(t, err)
-	require.Len(t, entries, 0)
+	require.Len(t, entries, 1)
 
 	// Create 3
 	require.NoError(t, srv.setSystemMetadataKey("key1", "val1"))
@@ -52,12 +53,13 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 
 	_, entries, err = state.SystemMetadataList(nil)
 	require.NoError(t, err)
-	require.Len(t, entries, 3)
+	require.Len(t, entries, 4)
 
 	require.Equal(t, map[string]string{
-		"key1": "val1",
-		"key2": "val2",
-		"key3": "",
+		structs.SystemMetadataVirtualIPsEnabled: "true",
+		"key1":                                  "val1",
+		"key2":                                  "val2",
+		"key3":                                  "",
 	}, mapify(entries))
 
 	// Update one and delete one.
@@ -66,10 +68,11 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 
 	_, entries, err = state.SystemMetadataList(nil)
 	require.NoError(t, err)
-	require.Len(t, entries, 2)
+	require.Len(t, entries, 3)
 
 	require.Equal(t, map[string]string{
-		"key2": "val2",
-		"key3": "val3",
+		structs.SystemMetadataVirtualIPsEnabled: "true",
+		"key2":                                  "val2",
+		"key3":                                  "val3",
 	}, mapify(entries))
 }


### PR DESCRIPTION
Our tests should run with the current version by default.

Also deprecate some functions, see commit message for the rationale. 