### PR TITLE
ui: Fix up if/let nesting in partition menu

### DIFF
--- a/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
+++ b/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
@@ -1,8 +1,8 @@
 {{#if (can "use partitions")}}
-  {{#if (can "choose partitions" dc=@dc)}}
 {{#let
   (or @partition 'default')
 as |partition|}}
+  {{#if (can "choose partitions" dc=@dc)}}
       <li
         class="partitions"
         data-test-partition-menu
@@ -58,9 +58,9 @@ as |partition|}}
       class="partition"
       aria-label="Admin Partition"
     >
-      {{partition}}
+      {{'default'}}
     </li>
-{{/let}}
   {{/if}}
+{{/let}}
 {{/if}}
 


### PR DESCRIPTION
I spotted a little bug which meant that when switching to a non-primary datacenter it would not display the 'default' word showing you the partition you are always in in a non-primary.

The fix essentially moves the `let` up by one indentation/conditional.

Whilst doing this I thought I may aswell just hardcode the 'default' word in. I left it in curlies as just as it feels like something that is hardcoded for reasons but is kind of not in a funny kind of way.