### PR TITLE
ui: Change the URL prefix of partitions from `-` to `_`

### DIFF
--- a/.changelog/11801.txt
+++ b/.changelog/11801.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ui: Change partition URL segment prefix from `-` to `_` 
+```

--- a/ui/packages/consul-ui/app/locations/fsm-with-optional.js
+++ b/ui/packages/consul-ui/app/locations/fsm-with-optional.js
@@ -1,7 +1,7 @@
 import { env } from 'consul-ui/env';
 const OPTIONAL = {};
 if (env('CONSUL_PARTITIONS_ENABLED')) {
-  OPTIONAL.partition = /^-([a-zA-Z0-9]([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?)$/;
+  OPTIONAL.partition = /^_([a-zA-Z0-9]([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?)$/;
 }
 
 if (env('CONSUL_NSPACES_ENABLED')) {
@@ -194,7 +194,7 @@ export default class FSMWithOptionalLocation {
       hash.nspace = `~${hash.nspace}`;
     }
     if (typeof hash.partition !== 'undefined') {
-      hash.partition = `-${hash.partition}`;
+      hash.partition = `_${hash.partition}`;
     }
     if (typeof this.router === 'undefined') {
       this.router = this.container.lookup('router:main');

--- a/ui/packages/consul-ui/app/services/ui-config.js
+++ b/ui/packages/consul-ui/app/services/ui-config.js
@@ -18,7 +18,7 @@ export default class UiConfigService extends Service {
         case item.startsWith('~'):
           prev.nspace = item.substr(1);
           break;
-        case item.startsWith('-'):
+        case item.startsWith('_'):
           prev.partition = item.substr(1);
           break;
         case typeof prev.dc === 'undefined':


### PR DESCRIPTION
We currently use special non-DNS permitted prefixes to detect the URL segments for partitions and namespace in order to keep our URLs as backwards compatible as possible whilst avoiding the use of query parameters `?` for identifying completely different sets of data (as opposed to different views of the same data, which is what we mostly use query params for). For example our URLs can look like any of the following:

- `/ui/datacenter-name/services/service-name`
- `/ui/~namespace-name/datacenter-name/services/service-name`
- `/ui/-partition-name/~namespace-name/datacenter-name/services/service-name`

We decided to change the nicer looking `-` to a `_` for the less common partition segment in order to keep the nicer `-` for other potentially more common purposes.

TLDR; This PR changes the last URL in the above examples to:

- `/ui/_partition-name/~namespace-name/datacenter-name/services/service-name`

There are only a handful of places in the UI where need to change this as its almost all managed in the custom Ember Location we use for our "optional" URL segments, but in order to double check I did a search across the codebase for `~`, which whilst we aren't changing `~` brought up all the areas where we do anything to do with these special prefix characters.
