### PR TITLE
ui: Disable setting wildcard partitions for intentions

### DIFF
--- a/.changelog/11804.txt
+++ b/.changelog/11804.txt
@@ -1,0 +1,4 @@
+```release-note:bugfix
+ui: Don't offer to save an intention with a source/destinatiojn wildcard
+partition
+```

--- a/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/fieldsets/index.hbs
@@ -63,11 +63,7 @@
               @showCreateWhen={{action "isUnique" partitions}}
               @onCreate={{action onchange "SourcePartition"}}
               @onChange={{action onchange "SourcePartition"}} as |partition|>
-                {{#if (eq partition.Name '*') }}
-                  * (All Partitions)
-                {{else}}
-                  {{partition.Name}}
-                {{/if}}
+                {{partition.Name}}
           </PowerSelectWithCreate>
         {{#if create}}
           <em>Search for an existing partition, or enter any Partition name.</em>
@@ -136,11 +132,7 @@
               @showCreateWhen={{action "isUnique" partitions}}
               @onCreate={{action onchange "DestinationPartition"}}
               @onChange={{action onchange "DestinationPartition"}} as |partition|>
-                  {{#if (eq partition.Name '*') }}
-                    * (All Partitions)
-                  {{else}}
-                    {{partition.Name}}
-                  {{/if}}
+                {{partition.Name}}
           </PowerSelectWithCreate>
         {{#if create}}
           <em>For the destination, you may choose any partition for which you have access.</em>

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.js
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.js
@@ -122,10 +122,9 @@ export default class ConsulIntentionForm extends Component {
   @action
   createPartitions(item, e) {
     // Partitions in the menus should:
-    // 1. Include an 'All Partitions' option
+    // 1. NOT include an 'All Partitions' option
     // 2. Include the current SourcePartition and DestinationPartition incase they don't exist yet
     let items = e.data.toArray().sort((a, b) => a.Name.localeCompare(b.Name));
-    items = [{ Name: '*' }].concat(items);
     let source = items.findBy('Name', item.SourcePartition);
     if (!source) {
       source = { Name: item.SourcePartition };

--- a/ui/packages/consul-ui/app/services/repository/intention.js
+++ b/ui/packages/consul-ui/app/services/repository/intention.js
@@ -69,7 +69,7 @@ export default class IntentionRepository extends RepositoryService {
     let item;
     if (params.id === '') {
       const defaultNspace = this.env.var('CONSUL_NSPACES_ENABLED') ? '*' : 'default';
-      const defaultPartition = this.env.var('CONSUL_PARTITIONS_ENABLED') ? '*' : 'default';
+      const defaultPartition = 'default';
       item = await this.create({
         SourceNS: params.nspace || defaultNspace,
         DestinationNS: params.nspace || defaultNspace,


### PR DESCRIPTION
Previously it was possible to select a wildcard partition when trying to make an intention, but as this is not possible, when doing so you would see one of our UI backend errors, which is a little confusing.

[Preview link for this PR](https://consul-ui-staging-2yg4bxp50-hashicorp.vercel.app/ui/dc1/intentions/create) notice the 2 partition menus have 'default' in them, not `* (All Partitions)`.

[Borken Preview Link](https://consul-ui-staging-gihql7391-hashicorp.vercel.app/ui/dc1/intentions/create) is very borken as it lets you specify `* (All Partitions)` which leads to the response when you try to save an intention into a non-mock Consul being very borked 😅 

This PR removes being able to select a wildcard partition from the intention menus.