### PR TITLE
ui: Only allow partition creation with a single datacenter setup

### DIFF
--- a/ui/packages/consul-partitions/app/templates/dc/partitions/index.hbs
+++ b/ui/packages/consul-partitions/app/templates/dc/partitions/index.hbs
@@ -48,7 +48,15 @@ as |route|>
         </h1>
       </BlockSlot>
       <BlockSlot @name="actions">
-          <a data-test-create href="{{href-to 'dc.partitions.create'}}" class="type-create">Create</a>
+{{#if (can 'create partitions')}}
+        <a 
+          data-test-create 
+          class="type-create"
+          href="{{href-to 'dc.partitions.create'}}"
+        >
+          Create
+        </a>
+{{/if}}
       </BlockSlot>
       <BlockSlot @name="toolbar">
       {{#if (gt items.length 0)}}

--- a/ui/packages/consul-ui/app/abilities/partition.js
+++ b/ui/packages/consul-ui/app/abilities/partition.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class PartitionAbility extends BaseAbility {
   @service('env') env;
+  @service('repository/dc') dcs;
 
   resource = 'operator';
   segmented = false;
@@ -12,7 +13,16 @@ export default class PartitionAbility extends BaseAbility {
   }
 
   get canManage() {
-    return this.canCreate;
+    // management currently means "can I write", not necessarily just create
+    return this.canWrite;
+  }
+
+  get canCreate() {
+    // we can only currently create a partition if you have only one datacenter
+    if (this.dcs.peekAll().length > 1) {
+      return false;
+    }
+    return super.canCreate;
   }
 
   get canDelete() {
@@ -20,7 +30,7 @@ export default class PartitionAbility extends BaseAbility {
   }
 
   get canChoose() {
-    if(typeof this.dc === 'undefined') {
+    if (typeof this.dc === 'undefined') {
       return false;
     }
     return this.canUse && this.dc.Primary;


### PR DESCRIPTION
We have disabled partition creation on the backend if a user has more than one datacenter.

This PR reflects that in the UI by only showing the partition [Create] button if there is only one datacenter.

To share some thoughts/rationale here:

- The first API request we make is for a list of datacenters, before we even show you the UI.
- The list of datacenters is very unlikely to change without refreshing the UI, so I decided to use the EmberData cache seeing as we know we always have this list at the start (we have a thin 'repository' layer over Ember Data so we get this using EmberData's `peekAll`)
- There was a choice to pass the data into the ability via `can 'create partitions' dcs=(arrayOfDcs)` but I decided it would be better to inject the Datacenter Repository Service directly and access the count from there. I went this way thinking that this restriction may change in the future and it's better to have the fact that we need to know the amount of datacenters 'hidden' from the "template developer". If it does change in the future, it's just a matter of tweaking the ability class.

Note: No Changelog label here as I believe all our UI partition related changelogs are being squashed together in the next release.