### PR TITLE
http: improve 404 Not Found response message

### DIFF
--- a/.changelog/11818.txt
+++ b/.changelog/11818.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+http: when a URL path is not found, include a message with the 404 status code to help the user understand why (e.g., HTTP API endpoint path not prefixed with /v1/)
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -587,6 +587,12 @@ func (s *HTTPHandlers) Index(resp http.ResponseWriter, req *http.Request) {
 	// Check if this is a non-index path
 	if req.URL.Path != "/" {
 		resp.WriteHeader(http.StatusNotFound)
+
+		if strings.Contains(req.URL.Path, "/v1/") {
+			fmt.Fprintln(resp, "Invalid URL path: not a recognized HTTP API endpoint")
+		} else {
+			fmt.Fprintln(resp, "Invalid URL path: if attempting to use the HTTP API, ensure the path starts with '/v1/'")
+		}
 		return
 	}
 


### PR DESCRIPTION
When a URL path is not found, return a non-empty message with the 404 status code to help the user understand what went wrong. If the URL path was not prefixed with '/v1/', suggest that may be the cause of the problem (which is a common mistake).

## Examples

### Path not prefixed with '/v1/`
```
curl --request GET --verbose localhost:8500/agent/services
Note: Unnecessary use of -X or --request, GET is already inferred.
*   Trying 127.0.0.1:8500...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8500 (#0)
> GET /agent/services HTTP/1.1
> Host: localhost:8500
> User-Agent: curl/7.68.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< Date: Mon, 13 Dec 2021 16:32:45 GMT
< Content-Length: 87
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host localhost left intact
Invalid URL path: if attempting to use the HTTP API, ensure the path starts with '/v1/'
```

### Path prefixed with '/v1/`
```
# endpoint is misspelled
$ curl --request GET localhost:8500/v1/agent/srvices
Invalid URL path: not a recognized HTTP API endpoint
```