### PR TITLE
ui: [Backport 1.10.x] Add version information back into the footer (#11803)

### DIFF
--- a/.changelog/11803.txt
+++ b/.changelog/11803.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+ui: Adds visible Consul version information
+```

--- a/ui/packages/consul-ui/app/components/app/index.scss
+++ b/ui/packages/consul-ui/app/components/app/index.scss
@@ -1,6 +1,9 @@
 .app .skip-links {
   @extend %skip-links;
 }
+.app footer {
+  @extend %footer;
+}
 [role='banner'] {
   @extend %main-header-horizontal;
 }
@@ -31,13 +34,35 @@
 %main-nav-vertical-hoisted.is-active > label > * {
   @extend %main-nav-horizontal-action-active;
 }
+%footer,
 %main-nav-sidebar,
 main {
   @extend %transition-pushover;
 }
+%footer {
+  position: absolute;
+  z-index: 50;
+
+  color: var(--gray-400);
+  font-size: $typo-size-800;
+
+  width: 250px;
+  padding-left: 25px;
+}
+.app footer {
+  top: calc(100vh - 42px);
+  top: calc(max(100vh, 460px) - 42px);
+}
+html.has-nspaces .app footer {
+  top: calc(100vh - 42px);
+  top: calc(max(100vh, 550px) - 42px);
+}
+%main-nav-sidebar {
+  z-index: 10;
+}
+%footer,
 %main-nav-sidebar {
   transition-property: left;
-  z-index: 10;
 }
 main {
   margin-top: var(--chrome-height, 64px);
@@ -45,30 +70,31 @@ main {
 }
 
 @media #{$--sidebar-open} {
+  %main-nav-horizontal-toggle ~ footer,
   %main-nav-horizontal-toggle + header > div > nav:first-of-type {
     left: 0;
   }
+  %main-nav-horizontal-toggle:checked ~ footer,
   %main-nav-horizontal-toggle:checked + header > div > nav:first-of-type {
     left: calc(var(--chrome-width, 300px) * -1);
   }
-  %main-nav-horizontal-toggle ~ main,
-  %main-nav-horizontal-toggle ~ footer {
+  %main-nav-horizontal-toggle ~ main {
     margin-left: var(--chrome-width, 300px);
   }
-  %main-nav-horizontal-toggle:checked ~ main,
-  %main-nav-horizontal-toggle:checked ~ footer {
+  %main-nav-horizontal-toggle:checked ~ main {
     margin-left: 0;
   }
 }
 @media #{$--lt-sidebar-open} {
+  %main-nav-horizontal-toggle:checked ~ footer,
   %main-nav-horizontal-toggle:checked + header > div > nav:first-of-type {
     left: 0;
   }
+  %main-nav-horizontal-toggle ~ footer,
   %main-nav-horizontal-toggle + header > div > nav:first-of-type {
     left: calc(var(--chrome-width, 300px) * -1);
   }
-  %main-nav-horizontal-toggle ~ main,
-  %main-nav-horizontal-toggle ~ footer {
+  %main-nav-horizontal-toggle ~ main {
     margin-left: 0;
   }
 }

--- a/ui/packages/consul-ui/app/components/app/index.scss
+++ b/ui/packages/consul-ui/app/components/app/index.scss
@@ -1,7 +1,7 @@
 .app .skip-links {
   @extend %skip-links;
 }
-.app footer {
+[role='contentinfo'] {
   @extend %footer;
 }
 [role='banner'] {
@@ -40,7 +40,7 @@ main {
   @extend %transition-pushover;
 }
 %footer {
-  position: absolute;
+  position: fixed;
   z-index: 50;
 
   color: var(--gray-400);
@@ -49,11 +49,11 @@ main {
   width: 250px;
   padding-left: 25px;
 }
-.app footer {
+%footer {
   top: calc(100vh - 42px);
   top: calc(max(100vh, 460px) - 42px);
 }
-html.has-nspaces .app footer {
+html.has-nspaces .app [role='contentinfo'] {
   top: calc(100vh - 42px);
   top: calc(max(100vh, 550px) - 42px);
 }

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -329,6 +329,9 @@
     </:main>
 
     <:content-info>
+      <p>
+        Consul v{{env 'CONSUL_VERSION'}}
+      </p>
       {{{concat '<!-- ' (env 'CONSUL_GIT_SHA') '-->'}}}
     </:content-info>
   </App>


### PR DESCRIPTION
See https://github.com/hashicorp/consul/pull/11803 and #11850 (which was also added post initial PR)