### PR TITLE
http: error if GET request has non-empty body

### DIFF
--- a/.changelog/11821.txt
+++ b/.changelog/11821.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+http: if a GET request has a non-empty body, log a warning that suggests a possible problem (parameters were meant for the query string, but accidentally placed in the body)
+```

--- a/agent/http.go
+++ b/agent/http.go
@@ -543,6 +543,17 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 		} else {
 			err = s.checkWriteAccess(req)
 
+			// Give the user a hint that they might be doing something wrong if they issue a GET request
+			// with a non-empty body (e.g., parameters placed in body rather than query string).
+			if req.Method == http.MethodGet {
+				if req.ContentLength > 0 {
+					httpLogger.Warn("GET request has a non-empty body that will be ignored; "+
+						"check whether parameters meant for the query string were accidentally placed in the body",
+						"url", logURL,
+						"from", req.RemoteAddr)
+				}
+			}
+
 			if err == nil {
 				// Invoke the handler
 				obj, err = handler(resp, req)


### PR DESCRIPTION
Give the user a hint that they might be doing something wrong if their GET request has a non-empty body, which can easily happen using curl's `--data-urlencode` if specifying request type via `--request GET` rather than `--get`.

Partial solution to #11471. Before closing said issue, we should consider whether a small docs change is warranted, too.

## PR History

For a GET request with a non-empty body, this PR initially returned an error. After internal discussions, we decided that ignoring the body of a GET request was conventional and were hesitant to return an error code other than `200 - OK`. As an alternative, we will log a WARN message instead.

## Questions for reviewers

- Do we have any `GET` requests for which having a non-empty body is valid?
  - Seems unlikely

## Examples

### Invalid GET request (filter is in the body)

#### curl output
```
curl --verbose --request GET localhost:8500/v1/agent/services --data-urlencode 'filter=Service == "counting"'
*   Trying 127.0.0.1:8500...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8500 (#0)
> GET /v1/agent/services HTTP/1.1
> Host: localhost:8500
> User-Agent: curl/7.68.0
> Accept: */*
> Content-Length: 40
> Content-Type: application/x-www-form-urlencoded
>
* upload completely sent off: 40 out of 40 bytes
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Vary: Accept-Encoding
< X-Consul-Default-Acl-Policy: allow
< Date: Tue, 22 Feb 2022 20:25:55 GMT
< Content-Length: 3
<
{}
* Connection #0 to host localhost left intact
```
#### Log messages

```
...
2022-02-22T12:26:32.237-0800 [WARN]  agent.http: GET request has a non-empty body, check whether parameters were accidentally placed in the body rather than in the query string: url=/v1/agent/services from=127.0.0.1:48852
2022-02-22T12:26:32.238-0800 [DEBUG] agent.http: Request finished: method=GET url=/v1/agent/services from=127.0.0.1:48852 latency=68.706µs
...
```

### Valid GET request (filter in query params)

```
$ curl --verbose --get localhost:8500/v1/agent/services --data-urlencode 'filter=Service == "counting"'
...
> GET /v1/agent/services?filter=Service%20%3D%3D%20%22counting%22 HTTP/1.1
...
< HTTP/1.1 200 OK
...
{"counting-id":{"ID":"counting-id","Service":"counting","Tags":[],"Meta":{},"Port":9000,"Address":"","Weights":{"Passing":1,"Warning":1},"EnableTagOverride":false,"Datacenter":"dc1"}}
```