### PR TITLE
[OSS] Handle discovery chain race

### DIFF
--- a/.changelog/11826.txt
+++ b/.changelog/11826.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: fix race causing xDS generation to lock up when discovery chains are tracked for services that are no longer upstreams.
+```

--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -271,6 +271,7 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEv
 				return fmt.Errorf("failed to watch discovery chain for %s: %v", svc.String(), err)
 			}
 		}
+		snap.ConnectProxy.IntentionUpstreams = seenServices
 
 		// Clean up data from services that were not in the update
 		for sn, targets := range snap.ConnectProxy.WatchedUpstreams {

--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -319,6 +319,17 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEv
 			if _, ok := seenServices[sn]; !ok {
 				cancelFn()
 				delete(snap.ConnectProxy.WatchedDiscoveryChains, sn)
+			}
+		}
+		// These entries are intentionally handled separately from the WatchedDiscoveryChains above.
+		// There have been situations where a discovery watch was cancelled, then fired.
+		// That update event then re-populated the DiscoveryChain map entry, which wouldn't get cleaned up
+		// since there was no known watch for it.
+		for sn := range snap.ConnectProxy.DiscoveryChain {
+			if upstream, ok := snap.ConnectProxy.UpstreamConfig[sn]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
+				continue
+			}
+			if _, ok := seenServices[sn]; !ok {
 				delete(snap.ConnectProxy.DiscoveryChain, sn)
 			}
 		}

--- a/agent/proxycfg/ingress_gateway.go
+++ b/agent/proxycfg/ingress_gateway.go
@@ -128,6 +128,7 @@ func (s *handlerIngressGateway) handleUpdate(ctx context.Context, u cache.Update
 		}
 
 		snap.IngressGateway.Upstreams = upstreamsMap
+		snap.IngressGateway.UpstreamsSet = watchedSvcs
 		snap.IngressGateway.Hosts = hosts
 		snap.IngressGateway.HostsSet = true
 

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -371,6 +371,9 @@ type configSnapshotIngressGateway struct {
 	// the GatewayServices RPC to retrieve them.
 	Upstreams map[IngressListenerKey]structs.Upstreams
 
+	// UpstreamsSet is the unique set of upstream.Identifier() the gateway routes to.
+	UpstreamsSet map[string]struct{}
+
 	// Listeners is the original listener config from the ingress-gateway config
 	// entry to save us trying to pass fields through Upstreams
 	Listeners map[IngressListenerKey]structs.IngressListener
@@ -381,6 +384,7 @@ func (c *configSnapshotIngressGateway) IsEmpty() bool {
 		return true
 	}
 	return len(c.Upstreams) == 0 &&
+		len(c.UpstreamsSet) == 0 &&
 		len(c.DiscoveryChain) == 0 &&
 		len(c.WatchedUpstreams) == 0 &&
 		len(c.WatchedUpstreamEndpoints) == 0

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -17,6 +17,7 @@ import (
 // A shared data structure that contains information about discovered upstreams
 type ConfigSnapshotUpstreams struct {
 	Leaf *structs.IssuedCert
+
 	// DiscoveryChain is a map of upstream.Identifier() ->
 	// CompiledDiscoveryChain's, and is used to determine what services could be
 	// targeted by this upstream. We then instantiate watches for those targets.
@@ -53,6 +54,11 @@ type ConfigSnapshotUpstreams struct {
 
 	// PassthroughEndpoints is a map of: ServiceName -> ServicePassthroughAddrs.
 	PassthroughUpstreams map[string]ServicePassthroughAddrs
+
+	// IntentionUpstreams is a set of upstreams inferred from intentions.
+	// The keys are created with structs.ServiceName.String().
+	// This list only applies to proxies registered in 'transparent' mode.
+	IntentionUpstreams map[string]struct{}
 }
 
 type GatewayKey struct {
@@ -129,6 +135,7 @@ func (c *configSnapshotConnectProxy) IsEmpty() bool {
 		len(c.PreparedQueryEndpoints) == 0 &&
 		len(c.UpstreamConfig) == 0 &&
 		len(c.PassthroughUpstreams) == 0 &&
+		len(c.IntentionUpstreams) == 0 &&
 		!c.MeshConfigSet
 }
 

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -1833,6 +1833,8 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "should still be valid")
 
+						require.Equal(t, map[string]struct{}{db.String(): {}}, snap.ConnectProxy.IntentionUpstreams)
+
 						// Should start watch for db's chain
 						require.Contains(t, snap.ConnectProxy.WatchedDiscoveryChains, db.String())
 
@@ -2062,6 +2064,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.Empty(t, snap.ConnectProxy.WatchedGateways)
 						require.Empty(t, snap.ConnectProxy.WatchedGatewayEndpoints)
 						require.Empty(t, snap.ConnectProxy.DiscoveryChain)
+						require.Empty(t, snap.ConnectProxy.IntentionUpstreams)
 					},
 				},
 			},
@@ -2225,6 +2228,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "should still be valid")
+						require.Empty(t, snap.ConnectProxy.IntentionUpstreams)
 
 						// Explicit upstream discovery chain watches don't get stored in these maps because they don't
 						// get canceled unless the proxy registration is modified.

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -566,7 +566,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					Err:           nil,
 				},
 				{
-					CorrelationID: "discovery-chain:api",
+					CorrelationID: fmt.Sprintf("discovery-chain:%s", api.String()),
 					Result: &structs.DiscoveryChainResponse{
 						Chain: discoverychain.TestCompileConfigEntries(t, "api", "default", "default", "dc1", "trustdomain.consul",
 							func(req *discoverychain.CompileRequest) {
@@ -576,7 +576,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					Err: nil,
 				},
 				{
-					CorrelationID: "discovery-chain:api-failover-remote?dc=dc2",
+					CorrelationID: fmt.Sprintf("discovery-chain:%s-failover-remote?dc=dc2", api.String()),
 					Result: &structs.DiscoveryChainResponse{
 						Chain: discoverychain.TestCompileConfigEntries(t, "api-failover-remote", "default", "default", "dc2", "trustdomain.consul",
 							func(req *discoverychain.CompileRequest) {
@@ -586,7 +586,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					Err: nil,
 				},
 				{
-					CorrelationID: "discovery-chain:api-failover-local?dc=dc2",
+					CorrelationID: fmt.Sprintf("discovery-chain:%s-failover-local?dc=dc2", api.String()),
 					Result: &structs.DiscoveryChainResponse{
 						Chain: discoverychain.TestCompileConfigEntries(t, "api-failover-local", "default", "default", "dc2", "trustdomain.consul",
 							func(req *discoverychain.CompileRequest) {
@@ -596,7 +596,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					Err: nil,
 				},
 				{
-					CorrelationID: "discovery-chain:api-failover-direct?dc=dc2",
+					CorrelationID: fmt.Sprintf("discovery-chain:%s-failover-direct?dc=dc2", api.String()),
 					Result: &structs.DiscoveryChainResponse{
 						Chain: discoverychain.TestCompileConfigEntries(t, "api-failover-direct", "default", "default", "dc2", "trustdomain.consul",
 							func(req *discoverychain.CompileRequest) {
@@ -606,7 +606,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					Err: nil,
 				},
 				{
-					CorrelationID: "discovery-chain:api-dc2",
+					CorrelationID: fmt.Sprintf("discovery-chain:%s-dc2", api.String()),
 					Result: &structs.DiscoveryChainResponse{
 						Chain: discoverychain.TestCompileConfigEntries(t, "api-dc2", "default", "default", "dc1", "trustdomain.consul",
 							func(req *discoverychain.CompileRequest) {
@@ -645,12 +645,12 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 
 		stage1 := verificationStage{
 			requiredWatches: map[string]verifyWatchRequest{
-				"upstream-target:api.default.default.dc1:api":                                        genVerifyServiceWatch("api", "", "dc1", true),
-				"upstream-target:api-failover-remote.default.default.dc2:api-failover-remote?dc=dc2": genVerifyServiceWatch("api-failover-remote", "", "dc2", true),
-				"upstream-target:api-failover-local.default.default.dc2:api-failover-local?dc=dc2":   genVerifyServiceWatch("api-failover-local", "", "dc2", true),
-				"upstream-target:api-failover-direct.default.default.dc2:api-failover-direct?dc=dc2": genVerifyServiceWatch("api-failover-direct", "", "dc2", true),
-				"mesh-gateway:dc2:api-failover-remote?dc=dc2":                                        genVerifyGatewayWatch("dc2"),
-				"mesh-gateway:dc1:api-failover-local?dc=dc2":                                         genVerifyGatewayWatch("dc1"),
+				fmt.Sprintf("upstream-target:api.default.default.dc1:%s", api.String()):                                        genVerifyServiceWatch("api", "", "dc1", true),
+				fmt.Sprintf("upstream-target:api-failover-remote.default.default.dc2:%s-failover-remote?dc=dc2", api.String()): genVerifyServiceWatch("api-failover-remote", "", "dc2", true),
+				fmt.Sprintf("upstream-target:api-failover-local.default.default.dc2:%s-failover-local?dc=dc2", api.String()):   genVerifyServiceWatch("api-failover-local", "", "dc2", true),
+				fmt.Sprintf("upstream-target:api-failover-direct.default.default.dc2:%s-failover-direct?dc=dc2", api.String()): genVerifyServiceWatch("api-failover-direct", "", "dc2", true),
+				fmt.Sprintf("mesh-gateway:dc2:%s-failover-remote?dc=dc2", api.String()):                                        genVerifyGatewayWatch("dc2"),
+				fmt.Sprintf("mesh-gateway:dc1:%s-failover-local?dc=dc2", api.String()):                                         genVerifyGatewayWatch("dc1"),
 			},
 			verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 				require.True(t, snap.Valid())
@@ -673,7 +673,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 		}
 
 		if meshGatewayProxyConfigValue == structs.MeshGatewayModeLocal {
-			stage1.requiredWatches["mesh-gateway:dc1:api-dc2"] = genVerifyGatewayWatch("dc1")
+			stage1.requiredWatches[fmt.Sprintf("mesh-gateway:dc1:%s-dc2", api.String())] = genVerifyGatewayWatch("dc1")
 		}
 
 		return testCase{
@@ -2093,6 +2093,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							DestinationName:      db.Name,
 							DestinationNamespace: db.NamespaceOrDefault(),
 							Datacenter:           "dc2",
+							LocalBindPort:        8080,
 							MeshGateway:          structs.MeshGatewayConfig{Mode: structs.MeshGatewayModeLocal},
 						},
 					},

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -47,8 +47,9 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u cache.Up
 		switch snap.Kind {
 		case structs.ServiceKindIngressGateway:
 			if _, ok := snap.IngressGateway.UpstreamsSet[svc]; !ok {
-				// Discovery chain is not associated with a known explicit or implicit upstream so it is skipped.
+				// Discovery chain is not associated with a known explicit or implicit upstream so it is purged/skipped.
 				// The associated watch was likely cancelled.
+				delete(upstreamsSnapshot.DiscoveryChain, svc)
 				s.logger.Trace("discovery-chain watch fired for unknown upstream", "upstream", svc)
 				return nil
 			}
@@ -56,8 +57,9 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u cache.Up
 		case structs.ServiceKindConnectProxy:
 			explicit := snap.ConnectProxy.UpstreamConfig[svc].HasLocalPortOrSocket()
 			if _, implicit := snap.ConnectProxy.IntentionUpstreams[svc]; !implicit && !explicit {
-				// Discovery chain is not associated with a known explicit or implicit upstream so it is skipped.
+				// Discovery chain is not associated with a known explicit or implicit upstream so it is purged/skipped.
 				// The associated watch was likely cancelled.
+				delete(upstreamsSnapshot.DiscoveryChain, svc)
 				s.logger.Trace("discovery-chain watch fired for unknown upstream", "upstream", svc)
 				return nil
 			}

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -503,15 +503,24 @@ func (u *Upstream) ToKey() UpstreamKey {
 	}
 }
 
-func (u Upstream) HasLocalPortOrSocket() bool {
+func (u *Upstream) HasLocalPortOrSocket() bool {
+	if u == nil {
+		return false
+	}
 	return (u.LocalBindPort != 0 || u.LocalBindSocketPath != "")
 }
 
-func (u Upstream) UpstreamIsUnixSocket() bool {
+func (u *Upstream) UpstreamIsUnixSocket() bool {
+	if u == nil {
+		return false
+	}
 	return (u.LocalBindPort == 0 && u.LocalBindAddress == "" && u.LocalBindSocketPath != "")
 }
 
-func (u Upstream) UpstreamAddressToString() string {
+func (u *Upstream) UpstreamAddressToString() string {
+	if u == nil {
+		return ""
+	}
 	if u.UpstreamIsUnixSocket() {
 		return u.LocalBindSocketPath
 	}

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -665,10 +665,17 @@ func TestClustersFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshot,
 			setup: func(snap *proxycfg.ConfigSnapshot) {
 				snap.Proxy.Mode = structs.ProxyModeTransparent
+				kafka := structs.NewServiceName("kafka", nil)
+				mongo := structs.NewServiceName("mongo", nil)
+
+				snap.ConnectProxy.IntentionUpstreams = map[string]struct{}{
+					kafka.String(): {},
+					mongo.String(): {},
+				}
 
 				// We add a passthrough cluster for each upstream service name
 				snap.ConnectProxy.PassthroughUpstreams = map[string]proxycfg.ServicePassthroughAddrs{
-					"default/kafka": {
+					kafka.String(): {
 						SNI: "kafka.default.dc1.internal.e5b08d03-bfc3-c870-1833-baddb116e648.consul",
 						SpiffeID: connect.SpiffeIDService{
 							Host:       "e5b08d03-bfc3-c870-1833-baddb116e648.consul",
@@ -680,7 +687,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							"9.9.9.9": {},
 						},
 					},
-					"default/mongo": {
+					mongo.String(): {
 						SNI: "mongo.default.dc1.internal.e5b08d03-bfc3-c870-1833-baddb116e648.consul",
 						SpiffeID: connect.SpiffeIDService{
 							Host:       "e5b08d03-bfc3-c870-1833-baddb116e648.consul",
@@ -696,9 +703,9 @@ func TestClustersFromSnapshot(t *testing.T) {
 				}
 
 				// There should still be a cluster for non-passthrough requests
-				snap.ConnectProxy.DiscoveryChain["mongo"] = discoverychain.TestCompileConfigEntries(t, "mongo", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
-				snap.ConnectProxy.WatchedUpstreamEndpoints["mongo"] = map[string]structs.CheckServiceNodes{
-					"mongo.default.dc1": {
+				snap.ConnectProxy.DiscoveryChain[mongo.String()] = discoverychain.TestCompileConfigEntries(t, "mongo", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
+				snap.ConnectProxy.WatchedUpstreamEndpoints[mongo.String()] = map[string]structs.CheckServiceNodes{
+					"mongo.default.default.dc1": {
 						structs.CheckServiceNode{
 							Node: &structs.Node{
 								Datacenter: "dc1",

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -71,6 +71,8 @@ func TestClustersFromSnapshot(t *testing.T) {
 					})
 				snap.ConnectProxy.UpstreamConfig = map[string]*structs.Upstream{
 					"db": {
+						// The local bind port is overridden by the escape hatch, but is required for explicit upstreams.
+						LocalBindPort: 9191,
 						Config: map[string]interface{}{
 							"envoy_cluster_json": customAppClusterJSON(t, customClusterJSONOptions{
 								Name: "myservice",

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -48,11 +48,19 @@ func (s *ResourceGenerator) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		len(cfgSnap.ConnectProxy.PreparedQueryEndpoints)+len(cfgSnap.ConnectProxy.WatchedUpstreamEndpoints))
 
 	for id, chain := range cfgSnap.ConnectProxy.DiscoveryChain {
+		upstreamCfg := cfgSnap.ConnectProxy.UpstreamConfig[id]
+
+		explicit := upstreamCfg.HasLocalPortOrSocket()
+		if _, implicit := cfgSnap.ConnectProxy.IntentionUpstreams[id]; !implicit && !explicit {
+			// Discovery chain is not associated with a known explicit or implicit upstream so it is skipped.
+			continue
+		}
+
 		es := s.endpointsFromDiscoveryChain(
 			id,
 			chain,
 			cfgSnap.Locality,
-			cfgSnap.ConnectProxy.UpstreamConfig[id],
+			upstreamCfg,
 			cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[id],
 			cfgSnap.ConnectProxy.WatchedGatewayEndpoints[id],
 		)

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -327,6 +327,8 @@ func TestEndpointsFromSnapshot(t *testing.T) {
 					})
 				snap.ConnectProxy.UpstreamConfig = map[string]*structs.Upstream{
 					"db": {
+						// The local bind port is overridden by the escape hatch, but is required for explicit upstreams.
+						LocalBindPort: 9191,
 						Config: map[string]interface{}{
 							"envoy_cluster_json": customAppClusterJSON(t, customClusterJSONOptions{
 								Name: "myservice",

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -95,6 +95,13 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 
 	for id, chain := range cfgSnap.ConnectProxy.DiscoveryChain {
 		upstreamCfg := cfgSnap.ConnectProxy.UpstreamConfig[id]
+
+		explicit := upstreamCfg.HasLocalPortOrSocket()
+		if _, implicit := cfgSnap.ConnectProxy.IntentionUpstreams[id]; !implicit && !explicit {
+			// Discovery chain is not associated with a known explicit or implicit upstream so it is skipped.
+			continue
+		}
+
 		cfg := s.getAndModifyUpstreamConfigForListener(id, upstreamCfg, chain)
 
 		// If escape hatch is present, create a listener from it and move on to the next

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -850,8 +850,13 @@ func TestListenersFromSnapshot(t *testing.T) {
 				snap.ConnectProxy.MeshConfigSet = true
 
 				// DiscoveryChain without an UpstreamConfig should yield a filter chain when in transparent proxy mode
-				snap.ConnectProxy.DiscoveryChain["google"] = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
-				snap.ConnectProxy.WatchedUpstreamEndpoints["google"] = map[string]structs.CheckServiceNodes{
+				google := structs.NewServiceName("google", nil)
+				snap.ConnectProxy.IntentionUpstreams = map[string]struct{}{
+					google.String(): {},
+				}
+				snap.ConnectProxy.DiscoveryChain[google.String()] = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
+
+				snap.ConnectProxy.WatchedUpstreamEndpoints[google.String()] = map[string]structs.CheckServiceNodes{
 					"google.default.default.dc1": {
 						structs.CheckServiceNode{
 							Node: &structs.Node{
@@ -905,8 +910,12 @@ func TestListenersFromSnapshot(t *testing.T) {
 				}
 
 				// DiscoveryChain without an UpstreamConfig should yield a filter chain when in transparent proxy mode
-				snap.ConnectProxy.DiscoveryChain["google"] = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
-				snap.ConnectProxy.WatchedUpstreamEndpoints["google"] = map[string]structs.CheckServiceNodes{
+				google := structs.NewServiceName("google", nil)
+				snap.ConnectProxy.IntentionUpstreams = map[string]struct{}{
+					google.String(): {},
+				}
+				snap.ConnectProxy.DiscoveryChain[google.String()] = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
+				snap.ConnectProxy.WatchedUpstreamEndpoints[google.String()] = map[string]structs.CheckServiceNodes{
 					"google.default.default.dc1": {
 						structs.CheckServiceNode{
 							Node: &structs.Node{
@@ -934,13 +943,15 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshot,
 			setup: func(snap *proxycfg.ConfigSnapshot) {
 				snap.Proxy.Mode = structs.ProxyModeTransparent
+				kafka := structs.NewServiceName("kafka", nil)
+				mongo := structs.NewServiceName("mongo", nil)
 
-				snap.ConnectProxy.DiscoveryChain["mongo"] = discoverychain.TestCompileConfigEntries(t, "mongo", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
-
-				snap.ConnectProxy.DiscoveryChain["kafka"] = discoverychain.TestCompileConfigEntries(t, "kafka", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
-
-				kafka := structs.NewServiceName("kafka", structs.DefaultEnterpriseMetaInDefaultPartition())
-				mongo := structs.NewServiceName("mongo", structs.DefaultEnterpriseMetaInDefaultPartition())
+				snap.ConnectProxy.IntentionUpstreams = map[string]struct{}{
+					kafka.String(): {},
+					mongo.String(): {},
+				}
+				snap.ConnectProxy.DiscoveryChain[mongo.String()] = discoverychain.TestCompileConfigEntries(t, "mongo", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
+				snap.ConnectProxy.DiscoveryChain[kafka.String()] = discoverychain.TestCompileConfigEntries(t, "kafka", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
 
 				// We add a filter chains for each passthrough service name.
 				// The filter chain will route to a cluster with the same SNI name.
@@ -961,7 +972,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				}
 
 				// There should still be a filter chain for mongo's virtual address
-				snap.ConnectProxy.WatchedUpstreamEndpoints["mongo"] = map[string]structs.CheckServiceNodes{
+				snap.ConnectProxy.WatchedUpstreamEndpoints[mongo.String()] = map[string]structs.CheckServiceNodes{
 					"mongo.default.default.dc1": {
 						structs.CheckServiceNode{
 							Node: &structs.Node{


### PR DESCRIPTION
In a k8s acceptance test we observed a situation where a discovery watch was cancelled, then a cache update event was received for it. This created a stray entry in the DiscoveryChain map which was no longer associated with an upstream.

This PR adds several layers of mitigation for this:
1. Prevent storing chains when they do not have known upstreams
2. Validate that chains are associated with upstreams when generating xDS resources
3. Clean up the DiscoveryChain map separately from WatchedDIscoveryChains
