### PR TITLE
ui: Fix sticky namespace selector

### DIFF
--- a/.changelog/11830.txt
+++ b/.changelog/11830.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Fixes an issue where under some circumstances the namespace selector could
+become 'stuck' on the default namespace
+```

--- a/ui/packages/consul-ui/app/routes/dc.js
+++ b/ui/packages/consul-ui/app/routes/dc.js
@@ -26,20 +26,19 @@ export default class DcRoute extends Route {
   @service('repository/dc') repo;
   @service('repository/nspace/disabled') nspacesRepo;
   @service('settings') settingsRepo;
+  @service('store') store;
 
   async model(params) {
-    const app = this.modelFor('application');
-
     let [token, nspace, dc] = await Promise.all([
       this.settingsRepo.findBySlug('token'),
       this.nspacesRepo.getActive(),
-      this.repo.findBySlug(params.dc, app.dcs),
+      this.repo.findBySlug(params.dc, this.store.peekAll('dc')),
     ]);
     // if there is only 1 namespace then use that
     // otherwise find the namespace object that corresponds
     // to the active one
-    nspace =
-      app.nspaces.length > 1 ? findActiveNspace(app.nspaces, nspace) : app.nspaces.firstObject;
+    const nspaces = this.store.peekAll('nspace');
+    nspace = findActiveNspace(nspaces, nspace);
 
     let permissions;
     if (get(token, 'SecretID')) {


### PR DESCRIPTION
When the application initially loads we request a list of namespaces from the backend within the application model hook in order to immediately populate the namespace menu in the top left of the UI.

We also use this application model namespace list to find 'valid' namespaces to mark as 'selected' in order to show the currently selected menu item. If we can't find the specified namespace (taken from the URL segment) then we default to just show the 'default' namespace instead.

The namespace menu is refreshed everytime it is opened (we fire off a request to get a refreshed response) - importantly this request doesn't refresh the model on the application model hook, which is the one we sometimes use to check for a 'valid' selection 😬 .

The application model hook is also not refreshed when you save a new namespace via the UI. Meaning that we end up defaulting to 'default' if you save a new namespace and then immediately try to select it with the same 'javascript execution session' (i.e. without manually hitting refresh)

All in all this can mean that once you have saved a namespace, whilst it possible to select it and navigate to it, it sometimes seems like the top menu doesn't want to mark it as selected.

The fix here is to just make sure to use the central data store instead of using the result of the application model hook which in Ember's case is the Ember Data store.

Lastly, 1.10 forwards uses a completely different approach for the entire UI so this is a 1.9 only fix (note the base branch) that will never be ported forwards and we will soonish drop support for this version. Oh I also changed to retrieve the list of dcs here also, which meant I could get rid of the `app` variable, and whilst there isn't a similar related bug there, I felt it was best to just access this directly from the store also.

Changelog coming shortly.

Fixes https://github.com/hashicorp/consul/issues/11553