### PR TITLE
docs: Update exported-services page to include required Name field

### DIFF
--- a/website/content/docs/connect/config-entries/exported-services.mdx
+++ b/website/content/docs/connect/config-entries/exported-services.mdx
@@ -42,6 +42,7 @@ Configure the following parameters to define a `exported-services` configuration
 ```hcl
 Kind = "exported-services"
 Partition = "<partition containing services to export>"
+Name = "<partition containing services to export>"
 Services = [
   {
     Name = "<name of service to export>"
@@ -61,6 +62,7 @@ Services = [
 apiVersion: consul.hashicorp.com/v1alpha1
 Kind: ExportedServices
 Partition: <partition containing services to export>
+Name: <partition containing services to export>
 Services:
 - Consumers:
   - Partition: <name of the partition that will dial the exported service>
@@ -73,6 +75,7 @@ Services:
 ```json
 "Kind": "exported-services",
 "Partition": "<partition containing services to export>",
+"Name": "<partition containing services to export>",
 "Services": [
   {
     "Consumers": [
@@ -96,6 +99,7 @@ The following table describes the parameters associated with the `exported-servi
 | ---       | ---         | ---      | ---     |
 | `Kind`    | String value that enables the configuration entry. The value should always be `exported-services` (HCL and JSON) or `ExportedServices` (YAML) | Required | None |
 | `Partition` | String value that specifies the name of the partition that contains the services you want to export. | Required | None |
+| `Name` | String value that specifies the name of the partition that contains the services you want to export. | Required | None |
 | `Services` | List of objects that specify which services to export. See [`Services`](#services) for details. | Required | None| 
 | `Meta` | Object that defines a map of the max 64 key/value pairs. | Optional | None |
 
@@ -117,6 +121,7 @@ The following example configures the agent to export the `billing` service from 
 ```hcl
 Kind = "exported-services" 
 Partition = "finance"
+Name = "finance"
 
 Services = [
   {
@@ -149,6 +154,7 @@ Services = [
 ```yaml
 Kind: exported-services
 Partition: finance
+Name: finance
 Services:
 - Consumers:
   - Partition: frontend
@@ -167,6 +173,7 @@ Services:
 ```json
 "Kind": "exported-services",
   "Partition": "finance",
+  "Name": "finance",
   "Services": [
     {
       "Consumers": [


### PR DESCRIPTION
This adds documentation about the required `Name` field to the exported-services config entry kind (which must match the partition of the config entry).