### PR TITLE
Add darwin arm64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,11 @@ name: build
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches: [ main ]
+    branches: [ 
+      "main", 
+      # Remove before merging
+      "support-darwin-arm64" 
+    ]
 
 env:
   PKG_NAME: consul
@@ -169,7 +173,7 @@ jobs:
     strategy:
       matrix:
         goos: [ darwin ]
-        goarch: [ "amd64" ]
+        goarch: [ "amd64", "arm64" ]
         go: [ "1.17.5" ]
       fail-fast: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,7 @@ on:
   push:
     # Sequence of patterns matched against refs/heads
     branches: [ 
-      "main", 
-      # Remove before merging
-      "support-darwin-arm64" 
+      "main"
     ]
 
 env:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,7 +14,8 @@ project "consul" {
       "release/1.8.x",
       "release/1.9.x",
       "release/1.10.x",
-      "release/1.11.x"
+      "release/1.11.x",
+      "support-darwin-arm64"
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -14,8 +14,7 @@ project "consul" {
       "release/1.8.x",
       "release/1.9.x",
       "release/1.10.x",
-      "release/1.11.x",
-      "support-darwin-arm64"
+      "release/1.11.x"
     ]
   }
 }


### PR DESCRIPTION
Following up on a request from Jared Kirschner, this PR builds a new darwin arm64 binary. When this PR is merged to main or a release branch, the binary will be signed and notarized just like the other darwin binary.

An example binary built from this branch can be downloaded from github artifacts and smoke tested here: https://github.com/hashicorp/consul/actions/runs/1580741218

A note can be added to the changelog when the next release goes out saying that we will support darwin arm64 binaries from this release onwards.  