### PR TITLE
ui: Cope with case where we have 403'ed or zero'ed partitions

### DIFF
--- a/ui/packages/consul-nspaces/app/components/consul/nspace/selector/index.hbs
+++ b/ui/packages/consul-nspaces/app/components/consul/nspace/selector/index.hbs
@@ -1,8 +1,19 @@
 {{#if (can "use nspaces")}}
-    {{#if (can "choose nspaces")}}
-{{#let
-  (or @nspace 'default')
-as |nspace|}}
+  {{#let
+    (or @nspace 'default')
+  as |nspace|}}
+    <DataSource
+      @src={{uri
+        '/${partition}/*/${dc}/namespaces/once'
+        (hash
+          partition=@partition
+          dc=@dc.Name
+        )
+      }}
+      @onchange={{fn (optional @onchange)}}
+    />
+    {{#if (can 'see nspaces' items=@nspaces)}}
+{{#if (can "choose nspaces")}}
           <li
             class="nspaces"
             data-test-nspace-menu
@@ -16,10 +27,9 @@ as |nspace|}}
                 </BlockSlot>
                 <BlockSlot @name="menu">
                   {{#let components.MenuItem components.MenuSeparator as |MenuItem MenuSeparator|}}
-                  {{#if (gt @nspaces.length 0)}}
                     <DataSource
                       @src={{uri
-                      '/${partition}/*/${dc}/namespaces'
+                      '/${partition}/*/${dc}/namespaces/once'
                         (hash
                           partition=@partition
                           dc=@dc.Name
@@ -28,18 +38,6 @@ as |nspace|}}
                       @onchange={{fn (optional @onchange)}}
                       @loading="lazy"
                     />
-                  {{else}}
-                    <DataSource
-                      @src={{uri
-                      '/${partition}/*/${dc}/namespaces'
-                        (hash
-                          partition=@partition
-                          dc=@dc.Name
-                        )
-                      }}
-                      @onchange={{fn (optional @onchange)}}
-                    />
-                  {{/if}}
                   {{#each (reject-by 'DeletedAt' @nspaces) as |item|}}
                     <MenuItem
                       class={{if (eq nspace item.Name) 'is-active'}}
@@ -68,7 +66,8 @@ as |nspace|}}
                 </BlockSlot>
               </PopoverMenu>
           </li>
-{{/let}}
+{{/if}}
     {{/if}}
-  {{/if}}
+  {{/let}}
+{{/if}}
 

--- a/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
+++ b/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
@@ -2,6 +2,16 @@
 {{#let
   (or @partition 'default')
 as |partition|}}
+  <DataSource
+    @src={{uri
+      '/*/*/${dc}/partitions'
+      (hash
+        dc=@dc.Name
+      )
+    }}
+    @onchange={{fn (optional @onchange)}}
+  />
+{{#if (can 'see partitions' items=@partitions)}}
   {{#if (can "choose partitions" dc=@dc)}}
       <li
         class="partitions"
@@ -16,15 +26,6 @@ as |partition|}}
             </BlockSlot>
             <BlockSlot @name="menu">
               {{#let components.MenuItem components.MenuSeparator as |MenuItem MenuSeparator|}}
-                <DataSource
-                  @src={{uri
-                    '/*/*/${dc}/partitions'
-                    (hash
-                      dc=@dc.Name
-                    )
-                  }}
-                  @onchange={{fn (optional @onchange)}}
-                />
               {{#each (reject-by 'DeletedAt' @partitions) as |item|}}
                 <MenuItem
                   class={{if (eq partition item.Name) 'is-active'}}
@@ -60,7 +61,9 @@ as |partition|}}
     >
       {{'default'}}
     </li>
-  {{/if}}
-{{/let}}
+{{/if}}
+
+    {{/if}}
+  {{/let}}
 {{/if}}
 

--- a/ui/packages/consul-ui/app/abilities/nspace.js
+++ b/ui/packages/consul-ui/app/abilities/nspace.js
@@ -23,6 +23,13 @@ export default class NspaceAbility extends BaseAbility {
     return this.canUse;
   }
 
+  get canSee() {
+    if (typeof this.items !== 'undefined' && this.items.length > 0) {
+      return true;
+    }
+    return false;
+  }
+
   get canUse() {
     return this.env.var('CONSUL_NSPACES_ENABLED');
   }

--- a/ui/packages/consul-ui/app/abilities/partition.js
+++ b/ui/packages/consul-ui/app/abilities/partition.js
@@ -20,10 +20,17 @@ export default class PartitionAbility extends BaseAbility {
   }
 
   get canChoose() {
-    if(typeof this.dc === 'undefined') {
+    if (typeof this.dc === 'undefined') {
       return false;
     }
     return this.canUse && this.dc.Primary;
+  }
+
+  get canSee() {
+    if (typeof this.items !== 'undefined' && this.items.length > 0) {
+      return true;
+    }
+    return false;
   }
 
   get canUse() {

--- a/ui/packages/consul-ui/app/adapters/nspace.js
+++ b/ui/packages/consul-ui/app/adapters/nspace.js
@@ -3,8 +3,8 @@ import { SLUG_KEY } from 'consul-ui/models/nspace';
 
 // namespaces aren't categorized by datacenter, therefore no dc
 export default class NspaceAdapter extends Adapter {
-  requestForQuery(request, { dc, partition, index, uri }) {
-    return request`
+  async requestForQuery(request, { dc, partition, index, uri, once }) {
+    const respond = await request`
       GET /v1/namespaces?${{ dc }}
       X-Request-ID: ${uri}
 
@@ -13,6 +13,10 @@ export default class NspaceAdapter extends Adapter {
         index,
       }}
     `;
+    if (once === 'once') {
+      await respond((headers, body) => delete headers['x-consul-index']);
+    }
+    return respond;
   }
 
   requestForQueryRecord(request, { dc, partition, index, id }) {

--- a/ui/packages/consul-ui/app/services/repository/nspace.js
+++ b/ui/packages/consul-ui/app/services/repository/nspace.js
@@ -48,6 +48,7 @@ export default class NspaceService extends RepositoryService {
   }
 
   @dataSource('/:partition/:ns/:dc/namespaces')
+  @dataSource('/:partition/:ns/:dc/namespaces/:once')
   async findAll() {
     if (!this.permissions.can('use nspaces')) {
       return [];

--- a/ui/packages/consul-ui/tests/integration/adapters/nspace-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/nspace-test.js
@@ -6,14 +6,17 @@ module('Integration | Adapter | nspace', function(hooks) {
   setupTest(hooks);
   const id = 'slug';
   const dc = 'dc-1';
-  test('requestForQuery returns the correct url/method', function(assert) {
+  test('requestForQuery returns the correct url/method', async function(assert) {
     const adapter = this.owner.lookup('adapter:nspace');
     const client = this.owner.lookup('service:client/http');
-    const request = client.requestParams.bind(client);
+    const request = function() {
+      return () => client.requestParams.bind(client)(...arguments);
+    };
     const expected = `GET /v1/namespaces?dc=${dc}`;
-    const actual = adapter.requestForQuery(request, {
+    let actual = await adapter.requestForQuery(request, {
       dc: dc,
     });
+    actual = actual();
     assert.equal(`${actual.method} ${actual.url}`, expected);
   });
   test('requestForQueryRecord returns the correct url/method', function(assert) {


### PR DESCRIPTION
In certain Consul configurations our partitions and namespaces listing endpoints can return either a 403 or an `[]` when you don't have access to one or the other.

This can result in the side nav menus appearing with 'default' in them (which is arguably correct and arguably not correct depending on your opinion), but when you click on them they open but are empty and look like this until you login:

<img width="1346" alt="Screenshot 2021-12-15 at 13 48 56" src="https://user-images.githubusercontent.com/554604/146198482-bf5fc1d9-66fa-40f2-9aeb-25e33362bea6.png">

This fix hides the entire menu (both of them) until you have actually logged in and get a non-403 or non-empty result back from the API.

P.S. There is a weird "only in test mode" flake here, and there's a chance I'll close this and try a different approach. I have an alternative idea forming. I'll let folks know once I'm clear myself, sorry for the noise!
