### PR TITLE
docs/nia: CTS delete task API and CLI

### DIFF
--- a/website/content/docs/nia/api/tasks.mdx
+++ b/website/content/docs/nia/api/tasks.mdx
@@ -88,3 +88,37 @@ Response if changes present:
   }
 }
 ```
+
+## Delete Task
+
+This endpoint allows for deletion of existing tasks. It does not allow deletion of a task that is currently running.
+
+| Method | Path                | Produces           |
+| ------ | ------------------- | ------------------ |
+| `DELETE`  | `/tasks/:task_name` | `application/json` |
+
+#### Response Statuses
+
+| Status | Reason           |
+| ------ | ------------------ |
+| 200  | Successfully deleted the task |
+| 404  | Task with the given name not found |
+| 409  | Task is currently running |
+
+#### Response Fields
+| Name	| Type	 | Description        |
+| --------- | ------ | ------------------ |
+|`request_id` | string | The ID of the request. Used for auditing and debugging purposes.
+
+#### Sample Request
+```shell-session
+$ curl --request DELETE \
+  localhost:8558/v1/tasks/task_a
+```
+
+#### Sample Response
+```json
+{
+  "request_id": "9b23eea7-a435-2797-c71e-10c15766cd73"
+}
+```

--- a/website/content/docs/nia/api/tasks.mdx
+++ b/website/content/docs/nia/api/tasks.mdx
@@ -20,7 +20,7 @@ This endpoint allows patch updates to specifically supported fields for existing
 
 | Name | Type	 | Required | Description  |
 | -----| ----- | -------- | ------------ |
-|`run` | string | false   | Values can be only be `"inspect"` and `"now"`.<br/><ul><li>`"inspect"`: Does not update the task but returns information on if/how resources would be changed for the proposed task update.</li><li> `"now"`: Updates the task accordingly and immediately runs the task, rather than allowing the task to run at the natural daemon cadence</li></ul>
+|`run` | string | false   | Values can only be `"inspect"` and `"now"`.<br/><ul><li>`"inspect"`: Does not update the task but returns information on if/how resources would be changed for the proposed task update.</li><li> `"now"`: Updates the task accordingly and immediately runs the task, rather than allowing the task to run at the natural daemon cadence</li></ul>
 
 #### Request Body
 

--- a/website/content/docs/nia/api/tasks.mdx
+++ b/website/content/docs/nia/api/tasks.mdx
@@ -18,15 +18,30 @@ This endpoint allows patch updates to specifically supported fields for existing
 
 #### Request Parameters
 
-* `run` - (string) Values can be only be "inspect" and "now".
-  * "inspect": Does not update the task but returns information on if/how resources would be changed for the proposed task update.
-  * "now": Updates the task accordingly and immediately runs the task, rather than allowing the task to run at the natural daemon cadence
+| Name | Type	 | Required | Description  |
+| -----| ----- | -------- | ------------ |
+|`run` | string | false   | Values can be only be `"inspect"` and `"now"`.<br/><ul><li>`"inspect"`: Does not update the task but returns information on if/how resources would be changed for the proposed task update.</li><li> `"now"`: Updates the task accordingly and immediately runs the task, rather than allowing the task to run at the natural daemon cadence</li></ul>
+
+#### Request Body
+
+| Name | Type	 | Required | Description  |
+| -----| ----- | -------- | ------------ |
+|`enabled` | boolean | true | Whether the task is enabled to run and manage resources.|
+
+#### Response Statuses
+
+| Status | Reason           |
+| ------ | ------------------ |
+| 200  | Successfully updated the task |
+| 404  | Task with the given name not found |
 
 #### Response Fields
 
-* `inspect` - Information on how resources would be changed given a proposed task update, similar to [inspect-mode](/docs/nia/cli/cli-overview#inspect-mode). This is only returned when passed the `run=inspect` request parameter
-  * `changes_present` - (bool) Whether or not changes were detected for running the proposed task update
-  * `plan` - (string) The Terraform plan generated for the proposed task update . Note: a non-empty string does not necessarily indicate changes were detected.
+| Name	| Type	 | Description        |
+| --------- | ------ | ------------------ |
+|`inspect` | object |  Information on how resources would be changed given a proposed task update, similar to [inspect-mode](/docs/nia/cli/cli-overview#inspect-mode). This is only returned when passed the `run=inspect` request parameter.
+|`inspect.changes_present` | boolean | Whether or not changes were detected for running the proposed task update.
+|`inspect.plan` | string | The Terraform plan generated for the proposed task update. Note: a non-empty string does not necessarily indicate changes were detected.
 
 
 #### Example: Disable a task
@@ -57,15 +72,19 @@ $ curl --header "Content-Type: application/json" \
 Response if no changes present:
 ```json
 {
-  "changes_present": false,
-  "plan": "No changes. Infrastructure is up-to-date. <truncated>"
+  "inspect": {
+    "changes_present": false,
+    "plan": "No changes. Infrastructure is up-to-date. <truncated>"
+  }
 }
 ```
 
 Response if changes present:
 ```json
 {
-  "changes_present": true,
-  "plan": "<terraform plan truncated> Plan: 3 to add, 0 to change, 0 to destroy."
+  "inspect": {
+    "changes_present": true,
+    "plan": "<terraform plan truncated> Plan: 3 to add, 0 to change, 0 to destroy."
+  }
 }
 ```

--- a/website/content/docs/nia/cli/task.mdx
+++ b/website/content/docs/nia/cli/task.mdx
@@ -14,7 +14,10 @@ description: >-
 `consul-terraform-sync task enable [options] <task_name>`
 
 **Arguments:**
-- `task_name` - (string: required) The name of the task to enable
+
+| Name | Type	 | Required | Description  |
+| -----| ----- | -------- | ------------ |
+|`task_name` | string | true | The name of the task to enable.
 
 **Options:** Currently only supporting [general options](/docs/nia/cli/cli-overview#general-options)
 
@@ -60,7 +63,10 @@ Enter a value: yes
 `consul-terraform-sync task disable [options] <task_name>`
 
 **Arguments:**
-- `task_name` - (string: required) The name of the task to disable
+
+| Name | Type	 | Required | Description  |
+| -----| ----- | -------- | ------------ |
+|`task_name` | string | true | The name of the task to disable.
 
 **Options:** Currently only supporting [general options](/docs/nia/cli/cli-overview#general-options)
 

--- a/website/content/docs/nia/cli/task.mdx
+++ b/website/content/docs/nia/cli/task.mdx
@@ -79,3 +79,34 @@ $ consul-terraform-sync task disable task_b
 
 ==> 'task_b' disable complete!
 ```
+
+## task delete
+
+`task delete` command deletes an existing task. The command will ask the user for approval before deleting the task. A task that is currently running cannot be deleted, and the delete must be retried after the task has completed.
+
+### Usage
+`consul-terraform-sync task delete [options] <task_name>`
+
+**Arguments:**
+
+| Name | Type	 | Required | Description  |
+| -----| ----- | -------- | ------------ |
+|`task_name` | string | true | The name of the task to delete.
+
+**Options:** Currently only supporting [general options](/docs/nia/cli/cli-overview#general-options)
+
+
+### Example
+
+```shell-session
+$ consul-terraform-sync task delete task_a
+==> Do you want to delete 'task_a'?
+     - This action cannot be undone.
+    Only 'yes' will be accepted to approve.
+
+Enter a value: yes
+
+==> Deleting task 'task_a'...
+
+==> Deleted task 'task_a'
+```


### PR DESCRIPTION
Adds docs for the delete task API and CLI. Also makes some general changes to the existing docs:

- Updates the API and CLI format of existing task commands to use a table format for the request and response. 
- Adds possible response status codes (other than 5XX status codes)

If we're good with these two format changes, I'll update the status API as well in a follow up PR.

Change Preview:
https://consul-6041d885k-hashicorp.vercel.app/docs/nia/api/tasks
https://consul-6041d885k-hashicorp.vercel.app/docs/nia/cli/task