### PR TITLE
docs: fix typo in KV store API

### DIFF
--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -69,7 +69,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace to query.
   If not provided, the namespace will be inferred from the request's ACL token,
   or will default to the `default` namespace. This is specified as part of the
-  This is specified as part of the URL as a query parameter.
+  URL as a query parameter.
   For recursive lookups, the namespace may be specified as '\*' and then results
   will be returned for all namespaces. Added in Consul 1.7.0.
 


### PR DESCRIPTION
This PR fixes a typo in the Consul KV Store API documentation.