### PR TITLE
ui: Fix up missing policy delete warning modal

### DIFF
--- a/.changelog/11868.txt
+++ b/.changelog/11868.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+ui: Fix an issue where attempting to delete a policy from the policy detail page when
+attached to a token would result in the delete button disappearing and no
+deletion being attempted
+```

--- a/ui/packages/consul-ui/app/components/buttons/index.scss
+++ b/ui/packages/consul-ui/app/components/buttons/index.scss
@@ -13,6 +13,7 @@ button.type-cancel {
   @extend %secondary-button;
 }
 .with-confirmation .type-delete,
+.modal-dialog .type-delete,
 %app-view-content form button[type='button'].type-delete {
   @extend %dangerous-button;
 }

--- a/ui/packages/consul-ui/app/components/modal-dialog/README.mdx
+++ b/ui/packages/consul-ui/app/components/modal-dialog/README.mdx
@@ -3,30 +3,8 @@ class: ember
 ---
 # ModalDialog
 
-## Arguments
-
-| Argument | Type | Default | Description |
-| --- | --- | --- | --- |
-| `onopen` | `Function` | `undefined` | A function to call when the modal has opened |
-| `onclose` | `Function` | `undefined` | A function to call when the modal has closed |
-| `aria` | `Object` | `undefined` | A `hash` of aria properties used in the component, currently only label is supported |
-
-## Exports
-
-| Name | Type | Description |
-| --- | --- | --- |
-| `open` | `Function` | Opens the modal dialog |
-| `close` | `Function` | Closes the modal dialog |
-
-Works in tandem with `<ModalLayer />` to render modals. First of all ensure
-you have a modal layer on the page (it doesn't have to be in the same
-template)
-
-```hbs
-<ModalLayer />
-```
-
-Then all modals will be rendered into the `<ModalLayer />` for example:
+Consul UIs modal component is a thin wrapper around the excellent `a11y-dialog`. The
+most common usage will be something like the below:
 
 ```hbs preview-template
 <ModalDialog
@@ -67,3 +45,30 @@ as |modal|>
 </button>
 
 ```
+All modals work in tandem with `<ModalLayer />` to render modals. First of all ensure
+you have a modal layer on the page (it doesn't have to be in the same
+template)
+
+```hbs
+<ModalLayer />
+```
+
+Then all modals will be rendered into the `<ModalLayer />`.
+
+## Arguments
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `onopen` | `Function` | `undefined` | A function to call when the modal has opened |
+| `onclose` | `Function` | `undefined` | A function to call when the modal has closed |
+| `aria` | `Object` | `undefined` | A `hash` of aria properties used in the component, currently only label is supported |
+| `open` | `Boolean` | `false` | Whether the modal should be initialized in its 'open' state. Useful if the modal should be controlled via handlebars conditionals. Please note this argument it not yet reactive, i.e. it is only checked on component insert not attribute update. An improvement here would be to respect this value during the update of the attribute. |
+
+## Exports
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `open` | `Function` | Opens the modal dialog |
+| `close` | `Function` | Closes the modal dialog |
+
+

--- a/ui/packages/consul-ui/app/components/modal-dialog/index.js
+++ b/ui/packages/consul-ui/app/components/modal-dialog/index.js
@@ -11,6 +11,9 @@ export default Component.extend(Slotted, {
       this.dialog = new A11yDialog($el);
       this.dialog.on('hide', () => this.onclose({ target: $el }));
       this.dialog.on('show', () => this.onopen({ target: $el }));
+      if (this.open) {
+        this.dialog.show();
+      }
     },
     disconnect: function($el) {
       this.dialog.destroy();

--- a/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/policies/-form.hbs
@@ -48,6 +48,7 @@
               <ModalDialog
                 data-test-delete-modal
                 @onclose={{action cancel}}
+                @open={{true}}
                 @aria={{hash
                   label="Policy in Use"
                 }}

--- a/ui/packages/consul-ui/tests/pages/dc/acls/policies/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/acls/policies/edit.js
@@ -9,7 +9,7 @@ export default function(visitable, submitable, deletable, cancelable, clickable,
     datacenter: clickable('[name="policy[Datacenters]"]'),
     deleteModal: {
       resetScope: true,
-      scope: '[data-test-delete-modal]',
+      scope: '[data-test-delete-modal]:not([aria-hidden="true"])',
       ...deletable({}),
     },
   };


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/11269

https://github.com/hashicorp/consul/issues/11269#issuecomment-956110990 is pretty good explanation of whats happening here.

In order to see this failing on a preview site/during dev:

1. Enable ACLs for the dev UI using our bookmarklets/cookie values.
2. Click the login button in the top right of the UI and use any value as a token to login.
3. Go to the policy page using the [Policies] link in the left hand main navigation, then click on any policy (apart from Global Management).
4. Depending on randomness you will should see a list of tokens under "Applied to the following tokens" towards the bottom of the form (you must have 'attached tokens' for this to be a problem)
5. Click the delete button and witness the magical "Delete Button Disappearing Act"

Alternatively you can also read the test:

https://github.com/hashicorp/consul/blob/6a7d56951cac9e877fcdc376381f787f824e84c8/ui/packages/consul-ui/tests/acceptance/dc/acls/policies/delete.feature#L35-L42

You should be seeing something like the below instead:

<img width="861" alt="Screenshot 2021-12-16 at 13 46 17" src="https://user-images.githubusercontent.com/554604/146383448-3fb04038-06a3-4733-bc53-e15f6f430085.png">

..which is what this PR does.

The test above wasn't working as the new modal implementation we added in 1.10 works slightly differently in that it is actually on the page, just aria-hidden and css hidden. See the page object change for that test fix which adds a check for aria-hidden-ness which seemed like the most straightforwards approach here.

Please note there is a vague plan in the future to move our modal (yet again) to use a modifier (now that we have those available to us). I both avoided doing that here, but also avoided getting too into the weeds here so that the change is mainly concentrating on fixing the bug with as little churn as possible.

