### PR TITLE
docs: add Exported Services to overview

### DIFF
--- a/website/content/docs/connect/config-entries/exported-services.mdx
+++ b/website/content/docs/connect/config-entries/exported-services.mdx
@@ -6,11 +6,11 @@ description: >-
   Settings in this configuration entry can apply to services in any namespace of the specified partition. Write access to the mesh resource is required.
 ---
 
-# Exported Services
+# Exported Services <EnterpriseAlert inline />
 
 This topic describes the `exported-services` configuration entry type. The `exported-services` configuration entry enables Consul to export service instances to other admin partitions from a single file. This enables your services to be networked across admin partitions. See [Admin Partitions](/docs/enterprise/admin-partitions) for additional information.     
 
--> **v1.11.0+:** This config entry is supported in Consul versions 1.11.0+.
+-> **v1.11.0+:** This config entry is supported in Consul Enterprise versions 1.11.0+.
 
 ## Introduction
 

--- a/website/content/docs/connect/config-entries/index.mdx
+++ b/website/content/docs/connect/config-entries/index.mdx
@@ -17,6 +17,9 @@ The following configuration entries are supported:
 
 - [Mesh](/docs/connect/config-entries/mesh) - controls
   mesh-wide configuration that applies across namespaces and federated datacenters.
+  
+- [Exported Services](/docs/connect/config-entries/exported-services) <EnterpriseAlert inline /> - enables 
+  Consul to export service instances to other admin partitions. 
 
 - [Proxy Defaults](/docs/connect/config-entries/proxy-defaults) - controls
   proxy configuration


### PR DESCRIPTION
Adds Enterprise tag to Exported Services Config entry and adds to Overview