### PR TITLE
ui: Check for `intention` ACL resources, not `intentions` ACL resources

### DIFF
--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -155,10 +155,10 @@ export default class PermissionService extends RepositoryService {
     // This temporary measure should be removed again once https://github.com/hashicorp/consul/issues/11098
     // has been resolved
     this.permissions.forEach(item => {
-      if(['key', 'node', 'service', 'intentions', 'session'].includes(item.Resource)) {
+      if (['key', 'node', 'service', 'intention', 'session'].includes(item.Resource)) {
         item.Allow = true;
       }
-    })
+    });
     /**/
     return this.permissions;
   }

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/index.feature
@@ -23,7 +23,12 @@ Feature: dc / intentions / index
       dc: dc-1
     ---
     Then the url should be /dc-1/intentions
-    And I don't see create
+    And I see create
+# We currently hardcode intention write to true until the API does what we need
+# Once we can use this as we need we'll be able to un-hardcode And this test
+# will fail again, at which point we can remove the above assertion and
+# uncomment the below one
+    # And I don't see create
   Scenario: Viewing intentions in the listing live updates
     Given 1 datacenter model with the value "dc-1"
     Given 3 intention models


### PR DESCRIPTION
TLDR Remove an additional `s`.

---

ACL intention rules are called `intention` not `intentions`. 

The code involved here temporarily ignores the result of our HTTP API result as it does not function exactly how we need (more info in this issue but _not_ essential reading for PR purposes: https://github.com/hashicorp/consul/pull/11520), the original PR to do this ignore is https://github.com/hashicorp/consul/pull/11520.

The ignore essentially loops through the response of the HTTP request we make to the auth HTTP API and overwrites the ones which could be wrong (only a subset hence the `includes`) with a hardcoded `Allow: true`, which means we still show UI links for places that, once navigated or submitted to, may result in a 403 response from the backend.

The original desired UX improvement was to not even show the links if you weren't able to perform actions or visit those pages in the first place.

As we had an additional `s` on `intention` here, it wasn't overwriting any potentially erroneous intention ACL rules, and therefore, when they were erroneous the link in the left hand side navigation for intentions would not be visible.

Here's the reference in the code to the list of rules we request, note `intention`:

https://github.com/hashicorp/consul/blob/dd1179177fc8303c8ca3ee84c4cd28182803d4ad/ui/packages/consul-ui/app/services/repository/permission.js#L44-L50

Finally this fix (so the one from the PR before this is temporary https://github.com/hashicorp/consul/pull/11520) and will be removed as soon as the HTTP API functions as desired. The previous PR has not yet landed in a release, hence no changelog here, but autobackports are required for 1.10 and 1.11 and the necessary labels have been added here.

There is currently a CI test fail here, which reading the title of it is actually expected with this change, will look and fix up now.
 