### PR TITLE
consul pls cert create usage example provided in CLI help shows outdated arguments

### DIFF
--- a/command/tls/cert/tls_cert.go
+++ b/command/tls/cert/tls_cert.go
@@ -40,7 +40,7 @@ Usage: consul tls cert <subcommand> [options] [filename-prefix]
 
   Create a certificate with your own CA:
 
-    $ consul tls cert create -server -ca-file my-ca.pem -ca-key-file my-ca-key.pem
+    $ consul tls cert create -server -ca my-ca.pem -key my-ca-key.pem
     ==> saved dc1-server-consul.pem
     ==> saved dc1-server-consul-key.pem
 


### PR DESCRIPTION
the usage example shows incorrect arguments for ca cert and key. the correct arguments are now -ca and -key