### PR TITLE
cli: Fix kv import for keys with trailing slash

### DIFF
--- a/command/kv/imp/kv_import.go
+++ b/command/kv/imp/kv_import.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"
@@ -78,8 +79,22 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 
+		var buf strings.Builder
+		if c.prefix != "" {
+			// Append prefix to key
+			buf.WriteString(path.Join(c.prefix, entry.Key))
+
+			// path.Join() removes trailing slashes.
+			// Re-add the trailing slash if it was previously present on the key
+			if strings.HasSuffix(entry.Key, "/") {
+				buf.WriteString("/")
+			}
+		} else {
+			buf.WriteString(entry.Key)
+		}
+
 		pair := &api.KVPair{
-			Key:   path.Join(c.prefix, entry.Key),
+			Key:   buf.String(),
 			Flags: entry.Flags,
 			Value: value,
 		}

--- a/command/kv/imp/kv_import_test.go
+++ b/command/kv/imp/kv_import_test.go
@@ -86,6 +86,11 @@ func TestKVImportPrefixCommand(t *testing.T) {
 			"key": "foo",
 			"flags": 0,
 			"value": "YmFyCg=="
+		},
+		{
+			"key": "foo/b/",
+			"flags": 0,
+			"value": null
 		}
 	]`
 
@@ -120,5 +125,19 @@ func TestKVImportPrefixCommand(t *testing.T) {
 
 	if strings.TrimSpace(string(pair.Value)) != "bar" {
 		t.Fatalf("bad: expected: bar, got %s", pair.Value)
+	}
+
+	// Ensure trailing slash is preserved on import
+	pair, _, err = client.KV().Get("sub/foo/b/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pair == nil {
+		t.Fatalf("bad: expected: %+v, got nil", pair)
+	}
+
+	if len(pair.Value) != 0 {
+		t.Fatalf("bad: expected: null, got %s", string(pair.Value))
 	}
 }


### PR DESCRIPTION
Correctly import keys names that end in a trailing slash.

Fixes #10906