### PR TITLE
ui: Remove any route level auth checks

### DIFF
--- a/.changelog/11891.txt
+++ b/.changelog/11891.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Fixes an issue where once a 403 page is displayed in some circumstances its
+diffcult to click back to where you where before receiving a 403
+```

--- a/ui/packages/consul-ui/app/routing/route.js
+++ b/ui/packages/consul-ui/app/routing/route.js
@@ -51,27 +51,6 @@ export default class BaseRoute extends Route {
   }
 
   /**
-   * Inspects a custom `abilities` array on the router for this route. Every
-   * abililty needs to 'pass' for the route not to throw a 403 error. Anything
-   * more complex then this (say ORs) should use a single ability and perform
-   * the OR logic in the test for the ability. Note, this ability check happens
-   * before any calls to the backend for this model/route.
-   */
-  async beforeModel() {
-    // remove any references to index as it is the same as the root routeName
-    const routeName = this.routeName
-      .split('.')
-      .filter(item => item !== 'index')
-      .join('.');
-    const abilities = get(routes, `${routeName}._options.abilities`) || [];
-    if (abilities.length > 0) {
-      if (!abilities.every(ability => this.permissions.can(ability))) {
-        throw new HTTPError('403');
-      }
-    }
-  }
-
-  /**
    * By default any empty string query parameters should remove the query
    * parameter from the URL. This is the most common behavior if you don't
    * require this behavior overwrite this method in the specific Route for the

--- a/ui/packages/consul-ui/app/routing/route.js
+++ b/ui/packages/consul-ui/app/routing/route.js
@@ -1,7 +1,6 @@
 import Route from '@ember/routing/route';
 import { get, setProperties, action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import HTTPError from 'consul-ui/utils/http/error';
 
 // paramsFor
 import { routes } from 'consul-ui/router';


### PR DESCRIPTION
Semi-related to https://github.com/hashicorp/consul/issues/11098 but not entirely, there is also an extra bit of gymnastics involved here for backporting/version complications, so the description is that extra bit complicated.

As of Consul UI 1.10 we started inspecting permissions ahead of time in order to decide which links/page/capabilities to show the user. The purpose was to prevent unnecessary HTTP requests from being performed and/or wasted time for users (for example filling out forms that are impossible to save on the backend dues to ACL permissions).

We added a `beforeModel` hook to all of our Routes (via our custom `route:basic` that all app Routes also inherit from). This hook would use the ahead of time permissions to make a decision on whether to proceed to the `model` hook, therefore avoiding unnecessary HTTP requests to the backend if we knew that the user did not have the necessary permissions required to get a successful response from any requests performed in the `model` hook.

The `beforeModel` hook is the recommended place to do such work (from Ember Docs):

> For example, if they're not logged in, you might want to prevent them from editing their profile, accessing private information, or checking out items in their shopping cart.

> Since a route's beforeModel() executes before the model() hook, it's a good place to do a redirect if you don't need any information that is contained in the model.

Note: We don't want to 'redirect' as such but just use our 'default/global' error page which has an additional [Log in] button we also want to keep the user on the URL they initially navigated to, meaning a redirect is out of the question.

Unfortunately Ember has a UX of not changing the URL to the link you have clicked on if an error is thrown during the beforeModel/model hooks. This can make it look like the 403 error has occurred at URLs where it hasn't, the URL stays as it was before you clicked the link. This fact has different negative effects depending on which version of the Consul UI you are running:

**1.10.x:** (`release/1.10.x`)

If you click from say KV (`/ui/dc/kv`) to Tokens with no permissions. The URL will not change but you will see a 403 error produced by the Tokens `beforeModel` hook. As the URL hasn't changed (it's still `/ui/dc/kv` even though you are on Tokens) you cannot then return to the KV page without first clicking another area of the UI first, Ember thinks you are already on KV due the the URL not having changed. Previous to us adding this beforeModel hook in 1.10 we would go through quite a few hoops to make the model hook return successfully but tell the UI that it was really a 401/403. This avoided any model hook error UX issues, but this is something we only did in the ACLs area (with a `repo.status` decorator). Moving forwards we needed a way to make these errors "Just Work" everywhere without having to think about it. Unfortunately, using Ember Route patterns are not the way that we are going to be able to solve this that additionally works from a UX perspective.

**1.11.x/main:**

This is similar to 1.10.x but worse for currently unknown reasons as you cannot click off the tokens 403 page at all unless you login (if you own a valid token) or you refresh the page (not great for a JS app). 1.11.x moved almost entirely away from using Ember Routes for anything and everything, and this is another Ember Route thing that we will be moving away from in another 1.11 follow up PR to come at some point relatively soon (with an approach that is more straightforwards/less surprising 🤞 )

Applicable to both version branches: Seeing as we are returning to the 'Consul UI is a thin client' idea until we have a way to inspect all the permissions we need (see https://github.com/hashicorp/consul/issues/11098), it felt like it was ok to just remove this to revert to the 'thin client' idea that we've stuck to up until 1.10 - the only downside is the UI makes a request than gets 403'ed from the backend, which then produces the same error in the UI, but importantly lets you move away from it. Right now we've disabled the ahead of time inspection idea for the majority of the UI anyway.

Applicable to 1.11 only: With no more changes here, we don't have this strange behaviour of getting 'stuck' on a URL. As of 1.11 we have zero model hooks in the UI and data is not fetched until Ember has changed the URL of the application. This means we can deal with any errors thrown once the URL has changed which is much better both from a UX and DX standpoint. There'll be a follow up PR coming soon to improve this in 1.11 only (which is where a solution to https://github.com/hashicorp/consul/issues/11098 will be landing). I'll refer back to this PR once thats up.

To view/play with this without running Consul itself (and proxying to it via our `make start-consul` target), the best thing to do would be to play set a dev time cookie using your Web Inspector (there is no bookmarklet for this specific one):

```
CONSUL_RESOURCE_ACL_READ=false
```

(details for that at at the bottom of [[Eng Docs] > Debug/EngineeringUtilities](https://consul-ui-staging-hashicorp.vercel.app/ui/docs/bookmarklets))


<img width="976" alt="Screenshot 2021-12-20 at 12 05 31" src="https://user-images.githubusercontent.com/554604/146764744-224ca687-4ad9-4e9c-ac0b-363183216c9a.png">

Decision on how we changelog this is coming and even more complex and shouldn't block review/potential approval.

