### PR TITLE
docs/nia: new config field names for services condition/source_input

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -195,7 +195,7 @@ A `task` block can be optionally configured with a `condition` block to set the 
 
 #### Services Condition
 
-This is the default type of condition when no `condition` block is configured for a task. This condition will trigger the task on either changes in services configured in [`task.services`](#services) or changes in services that match the regular expression configured in `regexp`. The default behavior is to trigger on changes to [`task.services`](#services). The [`task.services`](#services) option is required if `regexp` is not configured.
+This condition will trigger the task on services that match the regular expression configured in `regexp` or services listed by name in `names`. Either `regexp` or `names` must be configured, but not both.
 
 See [Task Execution: Services Condition](/docs/nia/tasks#services-condition) for more details on how tasks are triggered with a services condition.
 

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -201,7 +201,7 @@ See [Task Execution: Services Condition](/docs/nia/tasks#services-condition) for
 
 ```hcl
 task {
-  name        = "services_condition_task"
+  name        = "services_condition_regexp_task"
   description = "execute on changes to services with names starting with web"
   providers   = ["my-provider"]
   source      = "path/to/services-condition-module"
@@ -217,10 +217,29 @@ task {
   }
 }
 ```
+```hcl
+task {
+  name        = "services_condition_names_task"
+  description = "execute on changes to services with names api or web"
+  source      = "path/to/services-condition-module"
+
+  condition "services" {
+    names = ["api", "web"]
+    datacenter = "dc1"
+    namespace  = "default"
+    filter     = "Service.Tags not contains \"prod\""
+    cts_user_defined_meta {
+      key = "value"
+    }
+  }
+}
+
+```
 
 | Parameter |  Required |Description | Default |
 | --------- | --------- | ---------- | ------- |
-| `regexp` |  Optional | String value matching the names of Consul services to monitor. Only services that have a name matching the regular expression are used by the task. <br/><br/> If `regexp` is configured, then [`task.services`](#services) list must be omitted or empty. <br/><br/> If both a list and a regex are needed, consider including the list as part of the regex or creating separate tasks. | none |
+| `regexp` |  Required if `names` is not configured | String value matching the names of Consul services to monitor. Only services that have a name matching the regular expression are used by the task. <br/><br/> If `regexp` is configured, then [`task.services`](#services) list must be omitted or empty. <br/><br/> If both a list and a regex are needed, consider including the list as part of the regex or creating separate tasks. | none |
+| `names` |  Required if `regexp` is not configured | List of string values specifying the names of Consul services to monitor. Only services that have their name listed in `names` are used by the task. | none |
 | `datacenter` |  Optional | String value specifying the name of a datacenter to query for the task. | Datacenter of the agent that Consul-Terraform-Sync queries. |
 | `namespace`  | Optional | <EnterpriseAlert inline /> <br/> String value indicating the namespace of the services to query for the task. | In order of precedence: <br/> 1. Inferred from the Consul-Terraform-Sync ACL token <br/> 2. The `default` namespace. |
 | `filter` |  Optional | String value specifying an expression used to additionally filter the services to monitor. <br/><br/> Refer to the [services filtering documentation](/api-docs/health#filtering-2) and section about [how to write filter expressions](/api-docs/features/filtering#creating-expressions) for additional information. | none |
@@ -327,7 +346,8 @@ This `services` source input object defines services registered to Consul whose 
 
 | Parameter |  Required |Description | Default |
 | --------- | --------- | ---------- | ------- |
-| `regexp` |  Optional | String value matching the names of Consul services to monitor. Only services that have a name matching the regular expression are used by the task. <br/><br/> If `regexp` is configured, then [`task.services`](#services) list must be omitted or empty. <br/><br/> If both a list and a regex are needed, consider including the list as part of the regex or creating separate tasks. | none |
+| `regexp` |  Required if `names` is not configured | String value matching the names of Consul services to monitor. Only services that have a name matching the regular expression are used by the task. <br/><br/> If `regexp` is configured, then [`task.services`](#services) list must be omitted or empty. <br/><br/> If both a list and a regex are needed, consider including the list as part of the regex or creating separate tasks. | none |
+| `names` |  Required if `regexp` is not configured | List of string values specifying the names of Consul services to monitor. Only services that have their name listed in `names` are used by the task. | none |
 | `datacenter` |  Optional | String value specifying the name of a datacenter to query for the task. | Datacenter of the agent that Consul-Terraform-Sync queries. |
 | `namespace`  | Optional | <EnterpriseAlert inline /> <br/> String value indicating the namespace of the services to query for the task. | In order of precedence: <br/> 1. Inferred from the Consul-Terraform-Sync ACL token <br/> 2. The `default` namespace. |
 | `filter` |  Optional | String value specifying an expression used to additionally filter the services to monitor. <br/><br/> Refer to the [services filtering documentation](/api-docs/health#filtering-2) and section about [how to write filter expressions](/api-docs/features/filtering#creating-expressions) for additional information. | none |

--- a/website/content/docs/nia/tasks.mdx
+++ b/website/content/docs/nia/tasks.mdx
@@ -42,7 +42,7 @@ Below are details on the types of execution conditions that Consul-Terraform-Syn
 
 ### Services Condition
 
-The services condition is the default condition to execute a task. Tasks with the services condition monitor and execute on either changes to a list of configured services or changes to any services that match a given regex.
+Tasks with the services condition monitor and execute on either changes to a list of configured services or changes to any services that match a given regex.
 
 There are two ways to configure a task with a services condition. Only one of the two options below can be configured for a single task:
 1. Configure a task's [`services`](/docs/nia/configuration#services) field to specify the list of services to trigger the task
@@ -67,29 +67,7 @@ The services condition operates by monitoring the [Health List Nodes For Service
 | `node_tagged_addresses` | List of explicit LAN and WAN IP addresses for the agent                                           |
 | `node_meta`             | List of user-defined metadata key/value pairs for the node                                        |
 
-The services condition is the default behavior if no `condition` block is configured for a task. The two tasks below have equivalent behavior, which is to execute when any of the listed services have changes to the previously stated attributes.
-
-```hcl
-task {
-  name        = "services_condition_task_1"
-  description = "execute on changes to api, db, and web services"
-  providers   = ["my-provider"]
-  source      = "path/to/services-condition-module"
-  services    = ["api", "db", "web"]
-}
-
-task {
-  name        = "services_condition_task_2"
-  description = "execute on changes to api, db, and web services"
-  providers   = ["my-provider"]
-  source      = "path/to/services-condition-module"
-  services    = ["api", "db", "web"]
-
-  condition "services" {}
-}
-```
-
-Below is an example configuration for a task that will execute when a service with a name that matches the regular expression has a change. Note that because `regexp` is set, `task.services` is omitted.
+Below is an example configuration for a task that will execute when a service with a name that matches the regular expression has a change.
 
 ```hcl
 task {

--- a/website/content/docs/nia/tasks.mdx
+++ b/website/content/docs/nia/tasks.mdx
@@ -44,7 +44,9 @@ Below are details on the types of execution conditions that Consul-Terraform-Syn
 
 The services condition is the default condition to execute a task. Tasks with the services condition monitor and execute on either changes to a list of configured services or changes to any services that match a given regex.
 
-In order to configure a task with the services condition, the list of services to trigger the task must be configured in the task's [`services`](/docs/nia/configuration#services) or a regex must be configured in the task's `condition` block. Only one of these two options can be configured for a single task. See the [Services Condition](/docs/nia/configuration#services-condition) configuration section for more details.
+There are two ways to configure a task with a services condition. Only one of the two options below can be configured for a single task:
+1. Configure a task's [`services`](/docs/nia/configuration#services) field to specify the list of services to trigger the task
+1. Configure a task's `condition` block with the [services condition](/docs/nia/configuration#services-condition) type to specify services to trigger the task.
 
 The services condition operates by monitoring the [Health List Nodes For Service API](/api-docs/health#list-nodes-for-service) and executing the task on any change of information for services configured. These changes include one or more changes to service values, like IP address, added or removed service instance, or tags. A complete list of values that would cause a task to run are expanded below:
 

--- a/website/content/docs/nia/terraform-modules.mdx
+++ b/website/content/docs/nia/terraform-modules.mdx
@@ -114,7 +114,7 @@ The services source input operates by monitoring the [Health List Nodes For Serv
 | `node_tagged_addresses` | List of explicit LAN and WAN IP addresses for the agent                                           |
 | `node_meta`             | List of user-defined metadata key/value pairs for the node                                        |
 
-Below is an example configuration for a task that will execute on a schedule and provide information about the services matching the `regexp` parameter to the task’s module. Note that because `regexp` is set, `task.services` is omitted, and since a schedule is being used to trigger task execution, a `condition "services"` block cannot be used.
+Below is an example configuration for a task that will execute on a schedule and provide information about the services matching the `regexp` parameter to the task’s module.
 
 ```hcl
 task {

--- a/website/content/docs/nia/terraform-modules.mdx
+++ b/website/content/docs/nia/terraform-modules.mdx
@@ -92,8 +92,8 @@ services = {
 In order to configure a task with the services source input, the list of services that will be used for the input must be configured in one of the following ways:
 
 - the task's [`services`](/docs/nia/configuration#services)
-- a [`condition "services"` block](/docs/nia/configuration#services-condition) configured with `regexp` and `source_includes_var` set to true
-- a [`source_input "services"` block](/docs/nia/configuration#services-source-input) configured with `regexp`
+- a [`condition "services"` block](/docs/nia/configuration#services-condition) configured with `source_includes_var` set to true
+- a [`source_input "services"` block](/docs/nia/configuration#services-source-input)
 
 The services source input operates by monitoring the [Health List Nodes For Service API](/api-docs/health#list-nodes-for-service) and provides the latest service information to the input variables. A complete list of service information that would be provided to the module is expanded below:
 


### PR DESCRIPTION
Changes:
 - Add `names` to `condition "services"` and `source_input "services"`
 - Update any language that suggests `condition "services"` and `source_input "services"` only supports `regexp`
 - Remove language around "default condition" and relationship to default relationship with `task.services` (see commit for details)

Links to previews:
 - [configs](https://consul-8ducgp3y4-hashicorp.vercel.app/docs/nia/configuration#services-condition)
 - [task page](https://consul-8ducgp3y4-hashicorp.vercel.app/docs/nia/tasks#services-condition)
 - [tf module page](https://consul-8ducgp3y4-hashicorp.vercel.app/docs/nia/terraform-modules#services-source-input)