### PR TITLE
ui: [Backport 1.9.x] Fixup names of Meta for instance search, also add Node

### DIFF
--- a/.changelog/11774.txt
+++ b/.changelog/11774.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Differentiate between Service Meta and Node Meta when choosing search fields
+in Service Instance listings
+```

--- a/ui/packages/consul-ui/app/routes/dc/services/show/instances.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/instances.js
@@ -7,7 +7,7 @@ export default class InstancesRoute extends Route {
     source: 'source',
     searchproperty: {
       as: 'searchproperty',
-      empty: [['Name', 'Tags', 'ID', 'Address', 'Port', 'Service.Meta', 'Node.Meta']],
+      empty: [['Name', 'Node', 'Tags', 'ID', 'Address', 'Port', 'Service.Meta', 'Node.Meta']],
     },
     search: {
       as: 'filter',

--- a/ui/packages/consul-ui/app/search/predicates/service-instance.js
+++ b/ui/packages/consul-ui/app/search/predicates/service-instance.js
@@ -1,5 +1,6 @@
 export default {
   Name: item => item.Name,
+  Node: item => item.Node.Node,
   Tags: item => item.Service.Tags || [],
   ID: (item, value) => item.Service.ID || '',
   Address: item => item.Address || '',

--- a/ui/packages/consul-ui/translations/en-us.yaml
+++ b/ui/packages/consul-ui/translations/en-us.yaml
@@ -27,6 +27,8 @@ common:
     terminating-gateway: Terminating Gateway
     mesh-gateway: Mesh Gateway
     status: Health Status
+    service.meta: Service Meta
+    node.meta: Node Meta
     service-name: Service Name
     node-name: Node Name
     accessorid: AccessorID


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/consul/pull/11774

In 1.10.x we moved our translations file to use a split up files instead of one big one, hence the need for a manual intervention. This manual backport adds the necessary translation strings to the "one big file" instead of the split up ones.

No changelog label here as the changelog checker doesn't work if the base branch isn't main.