### PR TITLE
ui: Ensure disconnect error doesn't appear w/auth change on some pages

### DIFF
--- a/.changelog/11905.txt
+++ b/.changelog/11905.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Prevent disconnection notice appearing with auth change on certain pages
+```

--- a/ui/packages/consul-ui/app/components/data-loader/index.hbs
+++ b/ui/packages/consul-ui/app/components/data-loader/index.hbs
@@ -50,10 +50,10 @@
   <State @matches={{array "idle" "disconnected" "invalidating"}}>
 
     <State @matches="disconnected">
+      {{#if (not (eq error.status '401'))}}
         {{#yield-slot name="disconnected" params=(block-params (action dispatch "RESET"))}}
-          {{yield api}}
+            {{yield api}}
         {{else}}
-        {{#if (not eq error.status '401')}}
           <Notice
             {{notification
               sticky=true
@@ -70,8 +70,8 @@
               </p>
             </notice.Body>
           </Notice>
-        {{/if}}
         {{/yield-slot}}
+      {{/if}}
     </State>
     {{#if (eq error.status "403")}}
       {{#yield-slot name="error"}}


### PR DESCRIPTION
We recently updated a bug were in certain configurations you could log in but the view of data would not be refreshed/re-requested using the new token that you logged in with. Details in https://github.com/hashicorp/consul/pull/11681.

The approach in the mentioned PR was to use a client generated 401 error to cancel out all running blocking queries and immediately start them up again using the new token.

Unfortunately, on some pages where things can disappear whilst blocking on them (for instance a service might be deregistered whilst viewing the service detail page), we catch any errors and show a message saying the connection was lost for some reason. In some circumstances we get an error that we can safely ignore, and these are usually our client generated errors (such as our 429 errors which are produced when we force cancel a blocking query due to reaching our connection limit).

As we added a new client generated error code in the above PR (401) we should have also made sure to ignore that error code also, which is what this PR adds in a place that is somewhat 'global'.

