### PR TITLE
chore: add stable website preview workflow

### DIFF
--- a/.github/workflows/stable-website-preview.yaml
+++ b/.github/workflows/stable-website-preview.yaml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - stable-website
+
+jobs:
+  stable_website_preview_cherry_pick:
+    runs-on: ubuntu-latest
+    name: Cherry pick stable-website to stable-website-preview branch
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: stable-website-preview
+      - run: |
+          git fetch --no-tags --prune origin stable-website
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git cherry-pick ${{ github.sha }}
+          git push origin stable-website-preview

--- a/website/components/io-home-intro/index.tsx
+++ b/website/components/io-home-intro/index.tsx
@@ -16,13 +16,13 @@ interface IoHomeIntroProps {
   description: string
   features?: Array<IoHomeFeatureProps>
   offerings?: {
-    image: {
+    image?: {
       src: string
       width: number
       height: number
       alt: string
     }
-    list: Array<{
+    list?: Array<{
       heading: string
       description: string
     }>
@@ -135,18 +135,14 @@ export default function IoHomeIntro({
         </div>
       ) : null}
 
-      {video ? (
+      {video.youtubeId && video.thumbnail ? (
         <div className={s.video}>
           <IoVideoCallout
             youtubeId={video.youtubeId}
             thumbnail={video.thumbnail}
             heading={video.heading}
             description={video.description}
-            person={{
-              name: video.person.name,
-              description: video.person.description,
-              avatar: video.person.avatar,
-            }}
+            person={video.person}
           />
         </div>
       ) : null}

--- a/website/components/io-home-pre-footer/style.module.css
+++ b/website/components/io-home-pre-footer/style.module.css
@@ -82,6 +82,18 @@
     @nest .vault & {
       color: var(--black);
     }
+
+    @nest .nomad & {
+      color: var(--black);
+    }
+
+    @nest .packer & {
+      color: var(--black);
+    }
+
+    @nest .waypoint & {
+      color: var(--black);
+    }
   }
 
   &:nth-of-type(2) {

--- a/website/components/io-video-callout/index.tsx
+++ b/website/components/io-video-callout/index.tsx
@@ -11,7 +11,7 @@ export interface IoHomeVideoCalloutProps {
   thumbnail: string
   heading: string
   description: string
-  person: {
+  person?: {
     avatar: string
     name: string
     description: string
@@ -52,8 +52,12 @@ export default function IoVideoCallout({
                 </div>
               ) : null}
               <div>
-                <p className={s.personName}>{person.name}</p>
-                <p className={s.personDescription}>{person.description}</p>
+                {person.name ? (
+                  <p className={s.personName}>{person.name}</p>
+                ) : null}
+                {person.description ? (
+                  <p className={s.personDescription}>{person.description}</p>
+                ) : null}
               </div>
             </div>
           )}

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,23 +1,6 @@
 const withHashicorp = require('@hashicorp/platform-nextjs-plugin')
 const redirects = require('./redirects.next')
 
-// add a X-Robots-Tag noindex HTTP header
-// prevent indexing for preview.consul.io
-let customHeaders = []
-const robotsHeader = { key: 'X-Robots-Tag', value: 'noindex' }
-if (process.env.VERCEL_GIT_COMMIT_REF == 'stable-website-preview') {
-  customHeaders.push(
-    {
-      source: '/',
-      headers: [robotsHeader],
-    },
-    {
-      source: '/:all*',
-      headers: [robotsHeader],
-    }
-  )
-}
-
 module.exports = withHashicorp({
   dato: {
     // This token is safe to be in this public repository, it only has access to content that is publicly viewable on the website

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,6 +1,23 @@
 const withHashicorp = require('@hashicorp/platform-nextjs-plugin')
 const redirects = require('./redirects.next')
 
+// add a X-Robots-Tag noindex HTTP header
+// prevent indexing for preview.consul.io
+let customHeaders = []
+const robotsHeader = { key: 'X-Robots-Tag', value: 'noindex' }
+if (process.env.VERCEL_GIT_COMMIT_REF == 'stable-website-preview') {
+  customHeaders.push(
+    {
+      source: '/',
+      headers: [robotsHeader],
+    },
+    {
+      source: '/:all*',
+      headers: [robotsHeader],
+    }
+  )
+}
+
 module.exports = withHashicorp({
   dato: {
     // This token is safe to be in this public repository, it only has access to content that is publicly viewable on the website

--- a/website/pages/home/index.tsx
+++ b/website/pages/home/index.tsx
@@ -86,14 +86,14 @@ export default function Homepage({ data }): React.ReactElement {
           cta: _introOfferingsCta,
         }}
         video={{
-          youtubeId: _introVideo.youtubeId,
-          thumbnail: _introVideo.thumbnail.url,
-          heading: _introVideo.heading,
-          description: _introVideo.description,
+          youtubeId: _introVideo?.youtubeId,
+          thumbnail: _introVideo?.thumbnail?.url,
+          heading: _introVideo?.heading,
+          description: _introVideo?.description,
           person: {
-            name: _introVideo.personName,
-            description: _introVideo.personDescription,
-            avatar: _introVideo.personAvatar?.url,
+            name: _introVideo?.personName,
+            description: _introVideo?.personDescription,
+            avatar: _introVideo?.personAvatar?.url,
           },
         }}
       />


### PR DESCRIPTION
This PR adds a new workflow to get `stable-website-preview` up to date with `stable-website`. Allowing authors to preview content in progress from our CMS.