### PR TITLE
ca: remove unused SigningKey field

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -5956,7 +5956,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 
 	// CA already setup by default by NewTestAgent but force a new one so we can
 	// verify it was signed easily.
-	ca1 := connect.TestCAConfigSet(t, a)
+	ca1 := connect.TestCAConfigSet(t, a).ToCARoot()
 
 	{
 		// Register a local service
@@ -6010,7 +6010,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 	}
 
 	// Set a new CA
-	ca2 := connect.TestCAConfigSet(t, a)
+	ca2 := connect.TestCAConfigSet(t, a).ToCARoot()
 
 	// Issue a blocking query to ensure that the cert gets updated appropriately
 	{
@@ -6046,7 +6046,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 		// Issue a non blocking query to ensure that the cert gets updated appropriately
 		{
 			// Set a new CA
-			ca3 := connect.TestCAConfigSet(t, a)
+			ca3 := connect.TestCAConfigSet(t, a).ToCARoot()
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test", nil)
@@ -6099,7 +6099,7 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 
 	// CA already setup by default by NewTestAgent but force a new one so we can
 	// verify it was signed easily.
-	ca1 := connect.TestCAConfigSet(t, a)
+	ca1 := connect.TestCAConfigSet(t, a).ToCARoot()
 
 	{
 		// Register a non-local service (central catalog)
@@ -6172,7 +6172,7 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 	// Test that caching is updated in the background
 	{
 		// Set a new CA
-		ca := connect.TestCAConfigSet(t, a)
+		ca := connect.TestCAConfigSet(t, a).ToCARoot()
 
 		retry.Run(t, func(r *retry.R) {
 			resp := httptest.NewRecorder()
@@ -6371,7 +6371,7 @@ func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
 
 	// CA already setup by default by NewTestAgent but force a new one so we can
 	// verify it was signed easily.
-	dc1_ca1 := connect.TestCAConfigSet(t, a1)
+	dc1_ca1 := connect.TestCAConfigSet(t, a1).ToCARoot()
 
 	// Wait until root is updated in both dcs.
 	waitForActiveCARoot(t, a1.srv, dc1_ca1)
@@ -6468,7 +6468,7 @@ func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
 	}
 
 	// Set a new CA
-	dc1_ca2 := connect.TestCAConfigSet(t, a2)
+	dc1_ca2 := connect.TestCAConfigSet(t, a2).ToCARoot()
 
 	// Wait until root is updated in both dcs.
 	waitForActiveCARoot(t, a1.srv, dc1_ca2)

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -5720,7 +5720,7 @@ func TestAgentConnectCARoots_list(t *testing.T) {
 
 	// Set some CAs. Note that NewTestAgent already bootstraps one CA so this just
 	// adds a second and makes it active.
-	ca2 := connect.TestCAConfigSet(t, a, nil)
+	ca2 := connect.TestCAConfigSet(t, a)
 
 	// List
 	req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/roots", nil)
@@ -5763,7 +5763,7 @@ func TestAgentConnectCARoots_list(t *testing.T) {
 	// Test that caching is updated in the background
 	{
 		// Set a new CA
-		ca := connect.TestCAConfigSet(t, a, nil)
+		ca := connect.TestCAConfigSet(t, a)
 
 		retry.Run(t, func(r *retry.R) {
 			// List it again
@@ -5956,7 +5956,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 
 	// CA already setup by default by NewTestAgent but force a new one so we can
 	// verify it was signed easily.
-	ca1 := connect.TestCAConfigSet(t, a, nil)
+	ca1 := connect.TestCAConfigSet(t, a)
 
 	{
 		// Register a local service
@@ -6010,7 +6010,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 	}
 
 	// Set a new CA
-	ca2 := connect.TestCAConfigSet(t, a, nil)
+	ca2 := connect.TestCAConfigSet(t, a)
 
 	// Issue a blocking query to ensure that the cert gets updated appropriately
 	{
@@ -6046,7 +6046,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 		// Issue a non blocking query to ensure that the cert gets updated appropriately
 		{
 			// Set a new CA
-			ca3 := connect.TestCAConfigSet(t, a, nil)
+			ca3 := connect.TestCAConfigSet(t, a)
 
 			resp := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "/v1/agent/connect/ca/leaf/test", nil)
@@ -6099,7 +6099,7 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 
 	// CA already setup by default by NewTestAgent but force a new one so we can
 	// verify it was signed easily.
-	ca1 := connect.TestCAConfigSet(t, a, nil)
+	ca1 := connect.TestCAConfigSet(t, a)
 
 	{
 		// Register a non-local service (central catalog)
@@ -6172,7 +6172,7 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 	// Test that caching is updated in the background
 	{
 		// Set a new CA
-		ca := connect.TestCAConfigSet(t, a, nil)
+		ca := connect.TestCAConfigSet(t, a)
 
 		retry.Run(t, func(r *retry.R) {
 			resp := httptest.NewRecorder()
@@ -6371,7 +6371,7 @@ func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
 
 	// CA already setup by default by NewTestAgent but force a new one so we can
 	// verify it was signed easily.
-	dc1_ca1 := connect.TestCAConfigSet(t, a1, nil)
+	dc1_ca1 := connect.TestCAConfigSet(t, a1)
 
 	// Wait until root is updated in both dcs.
 	waitForActiveCARoot(t, a1.srv, dc1_ca1)
@@ -6468,7 +6468,7 @@ func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
 	}
 
 	// Set a new CA
-	dc1_ca2 := connect.TestCAConfigSet(t, a2, nil)
+	dc1_ca2 := connect.TestCAConfigSet(t, a2)
 
 	// Wait until root is updated in both dcs.
 	waitForActiveCARoot(t, a1.srv, dc1_ca2)

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -5741,7 +5741,6 @@ func TestAgentConnectCARoots_list(t *testing.T) {
 	// We should never have the secret information
 	for _, r := range value.Roots {
 		assert.Equal(t, "", r.SigningCert)
-		assert.Equal(t, "", r.SigningKey)
 	}
 
 	assert.Equal(t, "MISS", resp.Header().Get("X-Cache"))

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -113,7 +113,7 @@ func TestConsulCAProvider_Bootstrap_WithCert(t *testing.T) {
 	t.Parallel()
 
 	// Make sure setting a custom private key/root cert works.
-	rootCA := connect.TestCAWithTTL(t, nil, 5*time.Hour)
+	rootCA := connect.NewTestCA(t, connect.TestCAOptions{TTL: 5 * time.Hour})
 	conf := testConsulCAConfig()
 	conf.Config = map[string]interface{}{
 		"PrivateKey": rootCA.SigningKey,

--- a/agent/connect/generate_test.go
+++ b/agent/connect/generate_test.go
@@ -136,10 +136,8 @@ func TestSignatureMismatches(t *testing.T) {
 				continue
 			}
 			t.Run(fmt.Sprintf("TestMismatches-%s%d-%s%d", p1.keyType, p1.keyBits, p2.keyType, p2.keyBits), func(t *testing.T) {
-				ca := TestCAWithKeyType(t, nil, p1.keyType, p1.keyBits)
-				require.Equal(t, p1.keyType, ca.PrivateKeyType)
-				require.Equal(t, p1.keyBits, ca.PrivateKeyBits)
-				certPEM, keyPEM, err := testLeaf(t, "foobar.service.consul", "default", ca, p2.keyType, p2.keyBits)
+				ca := NewTestCA(t, TestCAOptions{KeyType: p1.keyType, KeyBits: p1.keyBits})
+				certPEM, keyPEM, err := testLeaf(t, "foobar.service.consul", "default", ca.KeyPair(), p2.keyType, p2.keyBits)
 				require.NoError(t, err)
 				_, err = ParseCert(certPEM)
 				require.NoError(t, err)

--- a/agent/connect/testing_ca_test.go
+++ b/agent/connect/testing_ca_test.go
@@ -30,7 +30,7 @@ func testCAAndLeaf(t *testing.T, keyType string, keyBits int) {
 	skipIfMissingOpenSSL(t)
 
 	// Create the certs
-	ca := TestCAWithKeyType(t, nil, keyType, keyBits)
+	ca := NewTestCA(t, TestCAOptions{KeyType: keyType, KeyBits: keyBits})
 	leaf, _ := TestLeaf(t, "web", ca)
 
 	// Create a temporary directory for storing the certs
@@ -60,8 +60,8 @@ func testCAAndLeaf_xc(t *testing.T, keyType string, keyBits int) {
 	skipIfMissingOpenSSL(t)
 
 	// Create the certs
-	ca1 := TestCAWithKeyType(t, nil, keyType, keyBits)
-	ca2 := TestCAWithKeyType(t, ca1, keyType, keyBits)
+	ca1 := NewTestCA(t, TestCAOptions{KeyType: keyType, KeyBits: keyBits})
+	ca2 := NewTestCA(t, TestCAOptions{PreviousCARoot: ca1.KeyPair(), KeyType: keyType, KeyBits: keyBits})
 	leaf1, _ := TestLeaf(t, "web", ca1)
 	leaf2, _ := TestLeaf(t, "web", ca2)
 
@@ -73,7 +73,7 @@ func testCAAndLeaf_xc(t *testing.T, keyType string, keyBits int) {
 	// Write the cert
 	xcbundle := []byte(ca1.RootCert)
 	xcbundle = append(xcbundle, '\n')
-	xcbundle = append(xcbundle, []byte(ca2.SigningCert)...)
+	xcbundle = append(xcbundle, []byte(ca2.CrossSigningCert)...)
 	assert.Nil(t, ioutil.WriteFile(filepath.Join(td, "ca.pem"), xcbundle, 0644))
 	assert.Nil(t, ioutil.WriteFile(filepath.Join(td, "leaf1.pem"), []byte(leaf1), 0644))
 	assert.Nil(t, ioutil.WriteFile(filepath.Join(td, "leaf2.pem"), []byte(leaf2), 0644))

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -49,7 +49,7 @@ func TestConnectCARoots_list(t *testing.T) {
 
 	// Set some CAs. Note that NewTestAgent already bootstraps one CA so this just
 	// adds a second and makes it active.
-	ca2 := connect.TestCAConfigSet(t, a, nil)
+	ca2 := connect.TestCAConfigSet(t, a)
 
 	// List
 	req, _ := http.NewRequest("GET", "/v1/connect/ca/roots", nil)

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -64,7 +64,6 @@ func TestConnectCARoots_list(t *testing.T) {
 	// We should never have the secret information
 	for _, r := range value.Roots {
 		assert.Equal(t, "", r.SigningCert)
-		assert.Equal(t, "", r.SigningKey)
 	}
 }
 

--- a/agent/consul/auto_config_endpoint_test.go
+++ b/agent/consul/auto_config_endpoint_test.go
@@ -557,15 +557,13 @@ func TestAutoConfig_updateTLSCertificatesInConfig(t *testing.T) {
 	later := now.Add(time.Hour)
 
 	// Generate a Test CA
-	ca := connect.TestCA(t, nil)
+	ca := connect.TestCA(t, nil).ToCARoot()
 
 	// roots will be returned by the mock backend
 	roots := structs.IndexedCARoots{
 		ActiveRootID: ca.ID,
 		TrustDomain:  connect.TestClusterID + ".consul",
-		Roots: []*structs.CARoot{
-			ca,
-		},
+		Roots:        []*structs.CARoot{ca},
 	}
 
 	// this CSR is what gets put into the opts for the

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -72,7 +72,6 @@ func TestConnectCARoots(t *testing.T) {
 	for _, r := range reply.Roots {
 		// These must never be set, for security
 		assert.Equal(t, "", r.SigningCert)
-		assert.Equal(t, "", r.SigningKey)
 	}
 	assert.Equal(t, fmt.Sprintf("%s.consul", caCfg.ClusterID), reply.TrustDomain)
 }

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -48,8 +48,8 @@ func TestConnectCARoots(t *testing.T) {
 
 	// Insert some CAs
 	state := s1.fsm.State()
-	ca1 := connect.TestCA(t, nil)
-	ca2 := connect.TestCA(t, nil)
+	ca1 := connect.TestCA(t, nil).ToCARoot()
+	ca2 := connect.TestCA(t, nil).ToCARoot()
 	ca2.Active = false
 	idx, _, err := state.CARoots(nil)
 	require.NoError(t, err)

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -1243,8 +1243,8 @@ func TestFSM_CARoots(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Roots
-	ca1 := connect.TestCA(t, nil)
-	ca2 := connect.TestCA(t, nil)
+	ca1 := connect.TestCA(t, nil).ToCARoot()
+	ca2 := connect.TestCA(t, nil).ToCARoot()
 	ca2.Active = false
 
 	// Create a new request.
@@ -1253,11 +1253,14 @@ func TestFSM_CARoots(t *testing.T) {
 		Roots: []*structs.CARoot{ca1, ca2},
 	}
 
-	{
-		buf, err := structs.Encode(structs.ConnectCARequestType, req)
-		assert.Nil(t, err)
-		assert.True(t, fsm.Apply(makeLog(buf)).(bool))
+	buf, err := structs.Encode(structs.ConnectCARequestType, req)
+	assert.NoError(t, err)
+	result := fsm.Apply(makeLog(buf))
+	success, ok := result.(bool)
+	if !ok {
+		t.Fatalf("expected bool, got %T (%v)", result, result)
 	}
+	require.True(t, success)
 
 	// Verify it's in the state store.
 	{

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -195,8 +195,8 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 
 	// CA Roots
 	roots := []*structs.CARoot{
-		connect.TestCA(t, nil),
-		connect.TestCA(t, nil),
+		connect.TestCA(t, nil).ToCARoot(),
+		connect.TestCA(t, nil).ToCARoot(),
 	}
 	for _, r := range roots[1:] {
 		r.Active = false

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -145,7 +145,7 @@ func NewMockCAServerDelegate(t *testing.T, config *Config) *mockCAServerDelegate
 		t:           t,
 		config:      config,
 		store:       state.NewStateStore(nil),
-		primaryRoot: connect.TestCAWithTTL(t, nil, 1*time.Second),
+		primaryRoot: connect.NewTestCA(t, connect.TestCAOptions{TTL: 1 * time.Second}),
 		callbackCh:  make(chan string, 0),
 	}
 	delegate.store.CASetConfig(1, testCAConfig())

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -145,7 +145,7 @@ func NewMockCAServerDelegate(t *testing.T, config *Config) *mockCAServerDelegate
 		t:           t,
 		config:      config,
 		store:       state.NewStateStore(nil),
-		primaryRoot: connect.NewTestCA(t, connect.TestCAOptions{TTL: 1 * time.Second}),
+		primaryRoot: connect.NewTestCA(t, connect.TestCAOptions{TTL: 1 * time.Second}).ToCARoot(),
 		callbackCh:  make(chan string, 0),
 	}
 	delegate.store.CASetConfig(1, testCAConfig())

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -192,7 +192,7 @@ func TestStore_CARootSetList(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Build a valid value
-	ca1 := connect.TestCA(t, nil)
+	ca1 := connect.TestCA(t, nil).ToCARoot()
 	expected := *ca1
 	// Set
 	ok, err := s.CARootSetCAS(1, 0, []*structs.CARoot{ca1})
@@ -226,7 +226,7 @@ func TestStore_CARootSet_emptyID(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Build a valid value
-	ca1 := connect.TestCA(t, nil)
+	ca1 := connect.TestCA(t, nil).ToCARoot()
 	ca1.ID = ""
 
 	// Set
@@ -255,9 +255,9 @@ func TestStore_CARootSet_noActive(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Build a valid value
-	ca1 := connect.TestCA(t, nil)
+	ca1 := connect.TestCA(t, nil).ToCARoot()
 	ca1.Active = false
-	ca2 := connect.TestCA(t, nil)
+	ca2 := connect.TestCA(t, nil).ToCARoot()
 	ca2.Active = false
 
 	// Set
@@ -276,8 +276,8 @@ func TestStore_CARootSet_multipleActive(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Build a valid value
-	ca1 := connect.TestCA(t, nil)
-	ca2 := connect.TestCA(t, nil)
+	ca1 := connect.TestCA(t, nil).ToCARoot()
+	ca2 := connect.TestCA(t, nil).ToCARoot()
 
 	// Set
 	ok, err := s.CARootSetCAS(1, 0, []*structs.CARoot{ca1, ca2})
@@ -290,10 +290,10 @@ func TestStore_CARootActive_valid(t *testing.T) {
 	s := testStateStore(t)
 
 	// Build a valid value
-	ca1 := connect.TestCA(t, nil)
+	ca1 := connect.TestCA(t, nil).ToCARoot()
 	ca1.Active = false
-	ca2 := connect.TestCA(t, nil)
-	ca3 := connect.TestCA(t, nil)
+	ca2 := connect.TestCA(t, nil).ToCARoot()
+	ca3 := connect.TestCA(t, nil).ToCARoot()
 	ca3.Active = false
 
 	// Set
@@ -327,9 +327,9 @@ func TestStore_CARoot_Snapshot_Restore(t *testing.T) {
 
 	// Create some intentions.
 	roots := structs.CARoots{
-		connect.TestCA(t, nil),
-		connect.TestCA(t, nil),
-		connect.TestCA(t, nil),
+		connect.TestCA(t, nil).ToCARoot(),
+		connect.TestCA(t, nil).ToCARoot(),
+		connect.TestCA(t, nil).ToCARoot(),
 	}
 	for _, r := range roots[1:] {
 		r.Active = false

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -57,7 +57,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 	}
 
 	// Create a bunch of common data for the various test cases.
-	roots, leaf := TestCerts(t)
+	roots, leaf := newTestCerts(t)
 
 	dbDefaultChain := func() *structs.CompiledDiscoveryChain {
 		return discoverychain.TestCompileConfigEntries(t, "db", "default", "default", "dc1", connect.TestClusterID+".consul", func(req *discoverychain.CompileRequest) {
@@ -418,7 +418,7 @@ func testManager_BasicLifecycle(
 	// mock type will have been blocked on those for a while.
 	assertLastReqArgs(t, types, "other-token", source)
 	// Update roots
-	newRoots, newLeaf := TestCerts(t)
+	newRoots, newLeaf := newTestCerts(t)
 	newRoots.Roots = append(newRoots.Roots, roots.Roots...)
 	types.roots.Set(rootsCacheKey, newRoots)
 
@@ -659,7 +659,7 @@ func TestManager_SyncState_No_Notify(t *testing.T) {
 	notifyCH := m.proxies[srv.CompoundServiceID()].ch
 
 	// update the leaf certs
-	roots, issuedCert := TestCerts(t)
+	roots, issuedCert := newTestCerts(t)
 	notifyCH <- cache.UpdateEvent{
 		CorrelationID: leafWatchID,
 		Result:        issuedCert,

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -403,7 +403,7 @@ func upstreamIDForDC2(uid UpstreamID) UpstreamID {
 func TestState_WatchesAndUpdates(t *testing.T) {
 	t.Parallel()
 
-	indexedRoots, issuedCert := TestCerts(t)
+	indexedRoots, issuedCert := newTestCerts(t)
 
 	// Used to account for differences in OSS/ent implementations of ServiceID.String()
 	var (

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -111,11 +111,12 @@ type CARoot struct {
 	// list.
 	IntermediateCerts []string
 
-	// SigningCert is the PEM-encoded signing certificate and SigningKey
-	// is the PEM-encoded private key for the signing certificate. These
-	// may actually be empty if the CA plugin in use manages these for us.
+	// SigningCert is the PEM-encoded CA certificate that is used to sign
+	// leaf certificates in the local datacenter.
+	//
+	// It is only used for internal storage, not part of the RPC or API response.
+	// TODO: actually set this value
 	SigningCert string `json:",omitempty"`
-	SigningKey  string `json:",omitempty"`
 
 	// Active is true if this is the current active CA. This must only
 	// be true for exactly one CA. For any method that modifies roots in the

--- a/connect/service_test.go
+++ b/connect/service_test.go
@@ -184,7 +184,7 @@ func TestService_ServerTLSConfig(t *testing.T) {
 	// Now test that rotating the root updates
 	{
 		// Setup a new generated CA
-		connect.TestCAConfigSet(t, a, nil)
+		connect.TestCAConfigSet(t, a)
 	}
 
 	// After some time, both root and leaves should be different but both should

--- a/connect/tls_test.go
+++ b/connect/tls_test.go
@@ -81,13 +81,14 @@ func testCertPEMBlock(t *testing.T, pemValue string) []byte {
 
 func TestClientSideVerifier(t *testing.T) {
 	ca1 := connect.TestCA(t, nil)
-	ca2 := connect.TestCA(t, ca1)
+	pair := ca1.KeyPair()
+	ca2 := connect.TestCA(t, &pair)
 
 	webCA1PEM, _ := connect.TestLeaf(t, "web", ca1)
 	webCA2PEM, _ := connect.TestLeaf(t, "web", ca2)
 
 	webCA1 := testCertPEMBlock(t, webCA1PEM)
-	xcCA2 := testCertPEMBlock(t, ca2.SigningCert)
+	xcCA2 := testCertPEMBlock(t, ca2.CrossSigningCert)
 	webCA2 := testCertPEMBlock(t, webCA2PEM)
 
 	tests := []struct {
@@ -140,7 +141,7 @@ func TestServerSideVerifier(t *testing.T) {
 	}
 
 	ca1 := connect.TestCA(t, nil)
-	ca2 := connect.TestCA(t, ca1)
+	ca2 := connect.NewTestCA(t, connect.TestCAOptions{PreviousCARoot: ca1.KeyPair()})
 
 	webCA1PEM, _ := connect.TestLeaf(t, "web", ca1)
 	webCA2PEM, _ := connect.TestLeaf(t, "web", ca2)
@@ -149,7 +150,7 @@ func TestServerSideVerifier(t *testing.T) {
 	apiCA2PEM, _ := connect.TestLeaf(t, "api", ca2)
 
 	webCA1 := testCertPEMBlock(t, webCA1PEM)
-	xcCA2 := testCertPEMBlock(t, ca2.SigningCert)
+	xcCA2 := testCertPEMBlock(t, ca2.CrossSigningCert)
 	webCA2 := testCertPEMBlock(t, webCA2PEM)
 
 	apiCA1 := testCertPEMBlock(t, apiCA1PEM)


### PR DESCRIPTION
Related to #11347

Best viewed by individual commit.

This PR removes the `CARoot.SigningKey` field, which was only ever used by tests. It also removes the use of `CARoot.SigningCert` in tests, so that we can re-purpose that field in production to store the leaf signing cert.

The change required updates to a few test helpers, and many tests. Comments inline.