### PR TITLE
cli: Show node identities in acl token list output

### DIFF
--- a/.changelog/11926.txt
+++ b/.changelog/11926.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
+```release-note:bug
 cli: Display assigned node identities in output of `consul acl token list`.
 ```

--- a/.changelog/11926.txt
+++ b/.changelog/11926.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Display assigned node identities in output of `consul acl token list`.
+```

--- a/command/acl/token/formatter.go
+++ b/command/acl/token/formatter.go
@@ -173,13 +173,9 @@ func (f *prettyFormatter) formatTokenListEntry(token *api.ACLTokenListEntry) str
 		}
 	}
 	if len(token.NodeIdentities) > 0 {
-		buffer.WriteString(fmt.Sprintln("Service Identities:"))
-		for _, svcid := range token.ServiceIdentities {
-			if len(svcid.Datacenters) > 0 {
-				buffer.WriteString(fmt.Sprintf("   %s (Datacenters: %s)\n", svcid.ServiceName, strings.Join(svcid.Datacenters, ", ")))
-			} else {
-				buffer.WriteString(fmt.Sprintf("   %s (Datacenters: all)\n", svcid.ServiceName))
-			}
+		buffer.WriteString(fmt.Sprintln("Node Identities:"))
+		for _, nodeid := range token.NodeIdentities {
+			buffer.WriteString(fmt.Sprintf("   %s (Datacenter: %s)\n", nodeid.NodeName, nodeid.Datacenter))
 		}
 	}
 	return buffer.String()

--- a/command/acl/token/testdata/FormatTokenList/complex.pretty-meta.golden
+++ b/command/acl/token/testdata/FormatTokenList/complex.pretty-meta.golden
@@ -18,5 +18,5 @@ Roles:
    6c9d1e1d-34bc-4d55-80f3-add0890ad791 - west-farthing
 Service Identities:
    gardener (Datacenters: middleearth-northwest)
-Service Identities:
-   gardener (Datacenters: middleearth-northwest)
+Node Identities:
+   bagend (Datacenter: middleearth-northwest)

--- a/command/acl/token/testdata/FormatTokenList/complex.pretty.golden
+++ b/command/acl/token/testdata/FormatTokenList/complex.pretty.golden
@@ -15,5 +15,5 @@ Roles:
    6c9d1e1d-34bc-4d55-80f3-add0890ad791 - west-farthing
 Service Identities:
    gardener (Datacenters: middleearth-northwest)
-Service Identities:
-   gardener (Datacenters: middleearth-northwest)
+Node Identities:
+   bagend (Datacenter: middleearth-northwest)

--- a/website/content/commands/acl/token/list.mdx
+++ b/website/content/commands/acl/token/list.mdx
@@ -46,14 +46,6 @@ Legacy:       false
 Policies:
    00000000-0000-0000-0000-000000000001 - global-management
 
-AccessorID:   59f86a9b-d3b6-166c-32a0-be4ab3f94caa
-Description:  Super User
-Local:        false
-Create Time:  2018-10-22 15:35:28.787003 -0400 EDT
-Legacy:       false
-Policies:
-   00000000-0000-0000-0000-000000000001 - global-management
-
 AccessorID:   00000000-0000-0000-0000-000000000002
 Description:  Anonymous Token
 Local:        false
@@ -69,4 +61,14 @@ Create Time:  2018-10-22 15:33:39.01789 -0400 EDT
 Legacy:       false
 Policies:
    06acc965-df4b-5a99-58cb-3250930c6324 - node-services-read
+Service Identities:
+   wonderservice (Datacenters: all)
+
+AccessorID:       def4895d-eeb9-f78a-fbb9-2a15a568af31
+Description:      Node 1 agent token
+Local:            false
+Create Time:      2020-12-22 04:19:30.552528733 +0000 UTC
+Legacy:           false
+Node Identities:
+   node1 (Datacenter: dc1)
 ```


### PR DESCRIPTION
Fix pretty CLI output of `consul acl token list` so that it properly displays node identities that are associated with a token.