### PR TITLE
ui: Fix URL params decoding

### DIFF
--- a/.changelog/11931.txt
+++ b/.changelog/11931.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes a bug with URL decoding within KV area
+```

--- a/ui/packages/consul-ui/app/services/routlet.js
+++ b/ui/packages/consul-ui/app/services/routlet.js
@@ -1,6 +1,11 @@
 import Service, { inject as service } from '@ember/service';
 import { schedule } from '@ember/runloop';
 
+import wildcard from 'consul-ui/utils/routing/wildcard';
+import { routes } from 'consul-ui/router';
+
+const isWildcard = wildcard(routes);
+
 class Outlets {
   constructor() {
     this.map = new Map();
@@ -87,6 +92,24 @@ export default class RoutletService extends Service {
     return {};
   }
 
+  /**
+   * Adds urldecoding to any wildcard route `params`
+   */
+  normalizeParamsFor(name, params = {}) {
+    if (isWildcard(name)) {
+      return Object.keys(params).reduce(function(prev, item) {
+        if (typeof params[item] !== 'undefined') {
+          prev[item] = decodeURIComponent(params[item]);
+        } else {
+          prev[item] = params[item];
+        }
+        return prev;
+      }, {});
+    } else {
+      return params;
+    }
+  }
+
   paramsFor(name) {
     let outletParams = {};
     const outlet = outlets.get(name);
@@ -102,16 +125,14 @@ export default class RoutletService extends Service {
     // of the specified params with the values specified
     let current = route;
     let parent;
-    let routeParams = {
-      ...current.params,
-    };
+    let routeParams = this.normalizeParamsFor(name, current.params);
     // TODO: Not entirely sure whether we are ok exposing queryParams here
     // seeing as accessing them from here means you can get them but not set
     // them as yet
     // let queryParams = {};
     while ((parent = current.parent)) {
       routeParams = {
-        ...parent.params,
+        ...this.normalizeParamsFor(parent.name, parent.params),
         ...routeParams,
       };
       // queryParams = {

--- a/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
@@ -83,7 +83,7 @@ as |parts|}}
     </BlockSlot>
 
     <BlockSlot @name="header">
-        <h1>
+        <h1 data-test-kv-key={{item.Key}}>
 {{#if (and item.Key (not-eq item.Key parentKey))}}
           <route.Title @title="Edit Key / Value" @render={{false}} />
           {{left-trim item.Key parentKey}}

--- a/ui/packages/consul-ui/tests/acceptance/dc/kvs/edit.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/kvs/edit.feature
@@ -1,6 +1,19 @@
 @setupApplicationTest
 Feature: dc / kvs / edit: KV Viewing
-  Scenario:
+  Scenario: Viewing a KV with a URL unsafe character
+    Given 1 datacenter model with the value "datacenter"
+    And 1 kv model from yaml
+    ---
+      Key: "@key"
+    ---
+    When I visit the kv page for yaml
+    ---
+      dc: datacenter
+      kv: "@key"
+    ---
+    Then the url should be /datacenter/kv/%40key/edit
+    And I see Key on the kv like "@key"
+  Scenario: Viewing a Session attached to a KV
     Given 1 datacenter model with the value "datacenter"
     And 1 kv model from yaml
     ---
@@ -14,7 +27,9 @@ Feature: dc / kvs / edit: KV Viewing
     ---
     Then the url should be /datacenter/kv/key/edit
     And I see ID on the session like "session-id"
-    Given 1 kv model from yaml
+  Scenario: Viewing a Session attached to a KV
+    Given 1 datacenter model with the value "datacenter"
+    And 1 kv model from yaml
     ---
       Key: another-key
       Session: ~

--- a/ui/packages/consul-ui/tests/pages/dc/kv/edit.js
+++ b/ui/packages/consul-ui/tests/pages/dc/kv/edit.js
@@ -11,6 +11,9 @@ export default function(visitable, attribute, present, submitable, deletable, ca
     ...submitable({}, 'main'),
     ...cancelable(),
     ...deletable(),
+    kv: {
+      Key: attribute('data-test-kv-key', '[data-test-kv-key]')
+    },
     session: {
       warning: present('[data-test-session-warning]'),
       ID: attribute('data-test-session', '[data-test-session]'),


### PR DESCRIPTION
In 1.11.0/1 we moved our routing to use our Routlets almost entirely, but we missed moving the extra URL decoding for Ember Wildcard routes over to our routlet code that deals with URL params 😿 (Ember does not urlencode/urldecode wildcard routes by default)

This PR moves the code from our base Route (which all of our routes inherit from) over to our Routlet Service via a `normalizeParamsFor` method, which we then call from both our base Route and the Routlet Service. Whilst we barely use Ember Routes anymore, I left the required decoding in our base Route just incase it's required in future.

I'm a little surprised we had no acceptance test for this, so this fixes an unfortunate regression in 1.11.0/1 plus adds an acceptance test which would have caught this (and will catch it if it ever happens again)

Fixes https://github.com/hashicorp/consul/issues/11925

Small note here: If we ever want this to be non-project specific we'll have to decide on how to inject the project specific routes into the routlet service, for the moment we simply `import`

