### PR TITLE
testing: Revert assertion for virtual IP flag

### DIFF
--- a/agent/consul/system_metadata_test.go
+++ b/agent/consul/system_metadata_test.go
@@ -33,10 +33,10 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 
 	state := srv.fsm.State()
 
-	// Initially has one entry for virtual-ips feature flag
+	// Initially has no entries
 	_, entries, err := state.SystemMetadataList(nil)
 	require.NoError(t, err)
-	require.Len(t, entries, 1)
+	require.Len(t, entries, 0)
 
 	// Create 3
 	require.NoError(t, srv.setSystemMetadataKey("key1", "val1"))
@@ -53,13 +53,12 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 
 	_, entries, err = state.SystemMetadataList(nil)
 	require.NoError(t, err)
-	require.Len(t, entries, 4)
+	require.Len(t, entries, 3)
 
 	require.Equal(t, map[string]string{
-		structs.SystemMetadataVirtualIPsEnabled: "true",
-		"key1":                                  "val1",
-		"key2":                                  "val2",
-		"key3":                                  "",
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "",
 	}, mapify(entries))
 
 	// Update one and delete one.
@@ -68,11 +67,10 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 
 	_, entries, err = state.SystemMetadataList(nil)
 	require.NoError(t, err)
-	require.Len(t, entries, 3)
+	require.Len(t, entries, 2)
 
 	require.Equal(t, map[string]string{
-		structs.SystemMetadataVirtualIPsEnabled: "true",
-		"key2":                                  "val2",
-		"key3":                                  "val3",
+		"key2": "val2",
+		"key3": "val3",
 	}, mapify(entries))
 }


### PR DESCRIPTION
I think https://github.com/hashicorp/consul/pull/11796 was tested and merged without the changes from https://github.com/hashicorp/consul/pull/11798 as part of its base.

`TestLeader_SystemMetadata_CRUD` is run with with a server configured with `c.ConnectEnabled = false` but https://github.com/hashicorp/consul/pull/11798 moved the Virtual IP check to Leader goroutines which returns early if Connect is not enabled: https://github.com/hashicorp/consul/blob/ecbd3eb2a6c6ef09e4d19026f5e69efec568d7b4/agent/consul/leader_connect.go#L40-L52

This means the routine to check VirtualIPs is never run and we never set the VirtualIP metadata.

Could someone confirm that reverting this assertion makes sense? AFAIK Virtual IPs are only relevant for [Connect-capable services](https://www.consul.io/docs/discovery/dns#service-virtual-ip-lookups).