### PR TITLE
ui: [Backport/1.9.x] Ensure disconnect error doesn't appear w/auth change on some pages

### DIFF
--- a/.changelog/11905.txt
+++ b/.changelog/11905.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Prevent disconnection notice appearing with auth change on certain pages
+```

--- a/ui/packages/consul-ui/app/components/data-loader/index.hbs
+++ b/ui/packages/consul-ui/app/components/data-loader/index.hbs
@@ -51,6 +51,7 @@
   <State @matches={{array "idle" "disconnected"}}>
 
     <State @matches="disconnected">
+      {{#if (not (eq error.status '401'))}}
         {{#yield-slot name="disconnected" params=(block-params (component 'notification' after=(action dispatch "RESET")))}}
           {{yield api}}
         {{else}}
@@ -61,6 +62,7 @@
             </p>
           </Notification>
         {{/yield-slot}}
+      {{/if}}
     </State>
 
     <YieldSlot @name="loaded">


### PR DESCRIPTION
Backport of https://github.com/hashicorp/consul/pull/11905

@amyrlam I just added you here as you did the original one, unfortunately the 1.9 backport didn't go cleanly due to some sort of template code change, but the changeset is simple enough so should just be a rubber stamp. Ty!