### PR TITLE
ui: Add selective no-console eslint rule

### DIFF
--- a/ui/packages/consul-ui/.dev.eslintrc.js
+++ b/ui/packages/consul-ui/.dev.eslintrc.js
@@ -1,8 +1,0 @@
-module.exports = {
-  extends: ['./.eslintrc.js'],
-  rules: {
-    'no-console': 'warn',
-    'no-unused-vars': ['error', { args: 'none' }],
-    'ember/routes-segments-snake-case': 'warn',
-  },
-};

--- a/ui/packages/consul-ui/.eslintrc.js
+++ b/ui/packages/consul-ui/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     browser: true,
   },
   rules: {
+    'no-console': ['error', {allow: ['error', 'info']}],
     'no-unused-vars': ['error', { args: 'none' }],
     'ember/no-new-mixins': ['warn'],
     'ember/no-jquery': 'warn',

--- a/ui/packages/consul-ui/app/locations/fsm-with-optional.js
+++ b/ui/packages/consul-ui/app/locations/fsm-with-optional.js
@@ -240,7 +240,7 @@ export default class FSMWithOptionalLocation {
    */
   transitionTo(url) {
     if (this.router.currentRouteName.startsWith('docs') && url.startsWith('console://')) {
-      console.log(`location.transitionTo: ${url.substr(10)}`);
+      console.info(`location.transitionTo: ${url.substr(10)}`);
       return true;
     }
     const previousOptional = Object.entries(this.optionalParams());

--- a/ui/packages/consul-ui/app/services/auth-providers/oauth2-code-with-url-provider.js
+++ b/ui/packages/consul-ui/app/services/auth-providers/oauth2-code-with-url-provider.js
@@ -2,7 +2,6 @@ import OAuth2CodeProvider from 'torii/providers/oauth2-code';
 import { runInDebug } from '@ember/debug';
 
 export default class OAuth2CodeWithURLProvider extends OAuth2CodeProvider {
-
   name = 'oidc-with-url';
 
   buildUrl() {
@@ -23,7 +22,9 @@ export default class OAuth2CodeWithURLProvider extends OAuth2CodeProvider {
           authorizationCode: decodeURIComponent(authData[responseType]),
           provider: name,
         };
-        runInDebug(_ => console.log('Retrieved the following creds from the OAuth Provider', creds))
+        runInDebug(_ =>
+          console.info('Retrieved the following creds from the OAuth Provider', creds)
+        );
         return creds;
       });
   }
@@ -34,6 +35,4 @@ export default class OAuth2CodeWithURLProvider extends OAuth2CodeProvider {
       return popup.close();
     }
   }
-
 }
-

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -16,7 +16,6 @@
     "lint": "FORCE_COLOR=1 npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
-    "_lint:dev:js": "eslint -c .dev.eslintrc.js --fix ./*.js ./.*.js app config lib server tests",
     "format": "npm-run-all format:*",
     "format:js": "prettier --write \"{app,config,lib,server,vendor,tests}/**/*.js\" ./*.js ./.*.js",
     "format:sass": "prettier --write \"app/**/*.scss\"",


### PR DESCRIPTION
Thankfully @amyrlam spotted this in a recent PR https://github.com/hashicorp/consul/pull/11900#discussion_r774261990 and this PR is off the back of that.

Back when we started in Ember 2.18 eslint tests would be run in the QUnit test runner along with the rest of our tests, initially this proved to be a little frustrating when trying to debug, create and fixup tests, as everytime you'd use a `console.log` statement somewhere a bunch more tests would fail confusing matters. Due to this we didn't add a no console rule to our eslint config, but instead kept a 'dev' eslint config that we could run separately containing a no-console rule. Nowadays we barely run this at all (and infact we commented it out quite a while back), but by chance we've been fairly good at keeping `console.log`s out of PRs and Draft PRs

During upgrades to Ember 3.something eslint tests stopped running in the QUnit test runner and we changed to use a specific make target which runs `eslint` directly using node. Therefore eslint no longer runs whilst you are debugging, creating or writing tests, only when you initially start up the tests. All in all this means there is no longer a need for a separate 'dev' eslint config and we can bring in these extra nice to have rules to our eslint setup.

Changes:

1. Deleted the old dev eslint setup things.
2. Moved over the no-console rule to our eslint config
3. Didn't bother with the snake case thing as it doesn't affect us anymore (it was originally setting that to a warn so it must have affected us at some point)
4. We had a few console.logs but these where for DX purposes and were therefore all wrapped in `runInDebug`. I changed all these to `console.info` which makes more sense for what their purpose is.
5. Used eslint config to allow console.error and console.info only as we use these for good reason (I'd rather do this using config rather than using eslint comments everywhere)
