### PR TITLE
clone the service under lock to avoid a data race

### DIFF
--- a/.changelog/11940.txt
+++ b/.changelog/11940.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ clone `NodeService` under lock so it can safely be accessed from 2 separate routines.
+```

--- a/.changelog/11940.txt
+++ b/.changelog/11940.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
- clone `NodeService` under lock so it can safely be accessed from 2 separate routines.
+ Mutate `NodeService` struct properly to avoid a data race.
 ```

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -429,9 +429,7 @@ func (s *HTTPHandlers) AgentService(resp http.ResponseWriter, req *http.Request)
 					sid.String())
 				return "", nil, nil
 			}
-			s.agent.State.Lock()
-			svc := *svcState.Service
-			s.agent.State.Unlock()
+			svc := svcState.Service
 
 			// Setup watch on the service
 			ws.Add(svcState.WatchCh)
@@ -448,7 +446,7 @@ func (s *HTTPHandlers) AgentService(resp http.ResponseWriter, req *http.Request)
 			}
 
 			// Calculate the content hash over the response, minus the hash field
-			aSvc := buildAgentService(&svc, dc)
+			aSvc := buildAgentService(svc, dc)
 
 			reply := &aSvc
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -429,8 +429,9 @@ func (s *HTTPHandlers) AgentService(resp http.ResponseWriter, req *http.Request)
 					sid.String())
 				return "", nil, nil
 			}
-
-			svc := svcState.Service
+			s.agent.State.Lock()
+			svc := *svcState.Service
+			s.agent.State.Unlock()
 
 			// Setup watch on the service
 			ws.Add(svcState.WatchCh)
@@ -447,7 +448,8 @@ func (s *HTTPHandlers) AgentService(resp http.ResponseWriter, req *http.Request)
 			}
 
 			// Calculate the content hash over the response, minus the hash field
-			aSvc := buildAgentService(svc, dc)
+			aSvc := buildAgentService(&svc, dc)
+
 			reply := &aSvc
 
 			// TODO(partitions): do we need to do anything here?

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -429,6 +429,7 @@ func (s *HTTPHandlers) AgentService(resp http.ResponseWriter, req *http.Request)
 					sid.String())
 				return "", nil, nil
 			}
+
 			svc := svcState.Service
 
 			// Setup watch on the service
@@ -447,7 +448,6 @@ func (s *HTTPHandlers) AgentService(resp http.ResponseWriter, req *http.Request)
 
 			// Calculate the content hash over the response, minus the hash field
 			aSvc := buildAgentService(svc, dc)
-
 			reply := &aSvc
 
 			// TODO(partitions): do we need to do anything here?

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1082,27 +1082,29 @@ func (l *State) updateSyncState() error {
 			continue
 		}
 
+		svc := *ls.Service
 		// If our definition is different, we need to update it. Make a
 		// copy so that we don't retain a pointer to any actual state
 		// store info for in-memory RPCs.
-		if ls.Service.EnableTagOverride {
-			ls.Service.Tags = make([]string, len(rs.Tags))
-			copy(ls.Service.Tags, rs.Tags)
+		if svc.EnableTagOverride {
+			svc.Tags = make([]string, len(rs.Tags))
+			copy(svc.Tags, rs.Tags)
 		}
 
 		// Merge any tagged addresses with the consul- prefix (set by the server)
 		// back into the local state.
-		if !reflect.DeepEqual(ls.Service.TaggedAddresses, rs.TaggedAddresses) {
-			if ls.Service.TaggedAddresses == nil {
-				ls.Service.TaggedAddresses = make(map[string]structs.ServiceAddress)
+		if !reflect.DeepEqual(svc.TaggedAddresses, rs.TaggedAddresses) {
+			if svc.TaggedAddresses == nil {
+				svc.TaggedAddresses = make(map[string]structs.ServiceAddress)
 			}
 			for k, v := range rs.TaggedAddresses {
 				if strings.HasPrefix(k, structs.MetaKeyReservedPrefix) {
-					ls.Service.TaggedAddresses[k] = v
+					svc.TaggedAddresses[k] = v
 				}
 			}
 		}
-		ls.InSync = ls.Service.IsSame(rs)
+		ls.InSync = svc.IsSame(rs)
+		ls.Service = &svc
 	}
 
 	// Check which checks need syncing

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1082,7 +1082,10 @@ func (l *State) updateSyncState() error {
 			continue
 		}
 
+		// to avoid a data race with the service struct,
+		// We copy the Service struct, mutate it and replace the pointer
 		svc := *ls.Service
+
 		// If our definition is different, we need to update it. Make a
 		// copy so that we don't retain a pointer to any actual state
 		// store info for in-memory RPCs.
@@ -1104,6 +1107,8 @@ func (l *State) updateSyncState() error {
 			}
 		}
 		ls.InSync = svc.IsSame(rs)
+
+		// replace the service pointer to the new mutated struct
 		ls.Service = &svc
 	}
 

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -415,6 +415,12 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 	// All the services should match
 	for id, serv := range services.NodeServices.Services {
 		serv.CreateIndex, serv.ModifyIndex = 0, 0
+		if serv.TaggedAddresses != nil {
+			serviceVIP := serv.TaggedAddresses[structs.TaggedAddressVirtualIP].Address
+			assert.NotEmpty(serviceVIP)
+			vips[serviceVIP] = struct{}{}
+		}
+		serv.TaggedAddresses = nil
 		switch id {
 		case "mysql-proxy":
 			assert.Equal(srv1, serv)


### PR DESCRIPTION
This is a fix to the data race discovered in [here](https://app.circleci.com/pipelines/github/hashicorp/consul/25488/workflows/43e31311-9cf6-43d3-9eef-0eaef96be7ad/jobs/540392/tests)