### PR TITLE
api: Return 404 when deregistering a non-existent check

### DIFF
--- a/.changelog/11950.txt
+++ b/.changelog/11950.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Return 404 when de-registering a non-existent check
+```

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -149,7 +149,9 @@ func (a *Agent) vetCheckUpdateWithAuthorizer(authz acl.Authorizer, checkID struc
 			}
 		}
 	} else {
-		return fmt.Errorf("Unknown check ID %q. Ensure that the check ID is passed, not the check name.", checkID.String())
+		return NotFoundError{Reason: fmt.Sprintf(
+			"Unknown check ID %q. Ensure that the check ID is passed, not the check name.",
+			checkID.String())}
 	}
 
 	return nil


### PR DESCRIPTION
Update the `/agent/check/deregister/` API endpoint to return a 404 HTTP response code when an attempt is made to de-register a check ID that does not exist on the agent.

This brings the behavior of /agent/check/deregister/ inline with the behavior of /agent/service/deregister/ which was changed in #10632 to similarly return a 404 when de-registering non-existent services.

Fixes #5821