### PR TITLE
docs: Fix indentation for gossipEncryption when using Vault secrets backend 

### DIFF
--- a/website/content/docs/k8s/installation/vault/gossip.mdx
+++ b/website/content/docs/k8s/installation/vault/gossip.mdx
@@ -76,9 +76,9 @@ global:
       enabled: true
       consulServerRole: consul-server
       consulClientRole: consul-client
-    gossipEncryption:
-      secretName: secret/data/consul/gossip
-      secretKey: key
+  gossipEncryption:
+    secretName: secret/data/consul/gossip
+    secretKey: key
 ```
 
 Note that `global.gossipEncryption.secretName` is the path of the secret in Vault.


### PR DESCRIPTION
The example Helm values file had the incorrect indent which was not properly setting the gossipEncyprtion key when using Vault as a secrets backend for Consul K8s. 