### PR TITLE
URL-encode/decode resource names for HTTP API part 2

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -122,7 +122,10 @@ func (s *HTTPHandlers) ACLPolicyCRUD(resp http.ResponseWriter, req *http.Request
 		return nil, MethodNotAllowedError{req.Method, []string{"GET", "PUT", "DELETE"}}
 	}
 
-	policyID := strings.TrimPrefix(req.URL.Path, "/v1/acl/policy/")
+	policyID, err := getPathSuffixUnescaped(req.URL.Path, "/v1/acl/policy/")
+	if err != nil {
+		return nil, err
+	}
 	if policyID == "" && req.Method != "PUT" {
 		return nil, BadRequestError{Reason: "Missing policy ID"}
 	}
@@ -167,7 +170,10 @@ func (s *HTTPHandlers) ACLPolicyReadByName(resp http.ResponseWriter, req *http.R
 		return nil, aclDisabled
 	}
 
-	policyName := strings.TrimPrefix(req.URL.Path, "/v1/acl/policy/name/")
+	policyName, err := getPathSuffixUnescaped(req.URL.Path, "/v1/acl/policy/name/")
+	if err != nil {
+		return nil, err
+	}
 	if policyName == "" {
 		return nil, BadRequestError{Reason: "Missing policy Name"}
 	}
@@ -302,7 +308,10 @@ func (s *HTTPHandlers) ACLTokenCRUD(resp http.ResponseWriter, req *http.Request)
 		return nil, MethodNotAllowedError{req.Method, []string{"GET", "PUT", "DELETE"}}
 	}
 
-	tokenID := strings.TrimPrefix(req.URL.Path, "/v1/acl/token/")
+	tokenID, err := getPathSuffixUnescaped(req.URL.Path, "/v1/acl/token/")
+	if err != nil {
+		return nil, err
+	}
 	if strings.HasSuffix(tokenID, "/clone") && req.Method == "PUT" {
 		tokenID = tokenID[:len(tokenID)-6]
 		fn = s.ACLTokenClone
@@ -521,7 +530,10 @@ func (s *HTTPHandlers) ACLRoleCRUD(resp http.ResponseWriter, req *http.Request) 
 		return nil, MethodNotAllowedError{req.Method, []string{"GET", "PUT", "DELETE"}}
 	}
 
-	roleID := strings.TrimPrefix(req.URL.Path, "/v1/acl/role/")
+	roleID, err := getPathSuffixUnescaped(req.URL.Path, "/v1/acl/role/")
+	if err != nil {
+		return nil, err
+	}
 	if roleID == "" && req.Method != "PUT" {
 		return nil, BadRequestError{Reason: "Missing role ID"}
 	}
@@ -534,7 +546,10 @@ func (s *HTTPHandlers) ACLRoleReadByName(resp http.ResponseWriter, req *http.Req
 		return nil, aclDisabled
 	}
 
-	roleName := strings.TrimPrefix(req.URL.Path, "/v1/acl/role/name/")
+	roleName, err := getPathSuffixUnescaped(req.URL.Path, "/v1/acl/role/name/")
+	if err != nil {
+		return nil, err
+	}
 	if roleName == "" {
 		return nil, BadRequestError{Reason: "Missing role Name"}
 	}
@@ -685,7 +700,10 @@ func (s *HTTPHandlers) ACLBindingRuleCRUD(resp http.ResponseWriter, req *http.Re
 		return nil, MethodNotAllowedError{req.Method, []string{"GET", "PUT", "DELETE"}}
 	}
 
-	bindingRuleID := strings.TrimPrefix(req.URL.Path, "/v1/acl/binding-rule/")
+	bindingRuleID, err := getPathSuffixUnescaped(req.URL.Path, "/v1/acl/binding-rule/")
+	if err != nil {
+		return nil, err
+	}
 	if bindingRuleID == "" && req.Method != "PUT" {
 		return nil, BadRequestError{Reason: "Missing binding rule ID"}
 	}
@@ -829,7 +847,10 @@ func (s *HTTPHandlers) ACLAuthMethodCRUD(resp http.ResponseWriter, req *http.Req
 		return nil, MethodNotAllowedError{req.Method, []string{"GET", "PUT", "DELETE"}}
 	}
 
-	methodName := strings.TrimPrefix(req.URL.Path, "/v1/acl/auth-method/")
+	methodName, err := getPathSuffixUnescaped(req.URL.Path, "/v1/acl/auth-method/")
+	if err != nil {
+		return nil, err
+	}
 	if methodName == "" && req.Method != "PUT" {
 		return nil, BadRequestError{Reason: "Missing auth method name"}
 	}

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -2,9 +2,10 @@ package agent
 
 import (
 	"fmt"
+	"net/http"
+
 	metrics "github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
-	"net/http"
 
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -2,11 +2,9 @@ package agent
 
 import (
 	"fmt"
-	"net/http"
-	"strings"
-
 	metrics "github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
+	"net/http"
 
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"
@@ -362,7 +360,11 @@ func (s *HTTPHandlers) catalogServiceNodes(resp http.ResponseWriter, req *http.R
 	}
 
 	// Pull out the service name
-	args.ServiceName = strings.TrimPrefix(req.URL.Path, pathPrefix)
+	var err error
+	args.ServiceName, err = getPathSuffixUnescaped(req.URL.Path, pathPrefix)
+	if err != nil {
+		return nil, err
+	}
 	if args.ServiceName == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing service name")
@@ -435,7 +437,11 @@ func (s *HTTPHandlers) CatalogNodeServices(resp http.ResponseWriter, req *http.R
 	}
 
 	// Pull out the node name
-	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/catalog/node/")
+	var err error
+	args.Node, err = getPathSuffixUnescaped(req.URL.Path, "/v1/catalog/node/")
+	if err != nil {
+		return nil, err
+	}
 	if args.Node == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing node name")
@@ -498,7 +504,11 @@ func (s *HTTPHandlers) CatalogNodeServiceList(resp http.ResponseWriter, req *htt
 	}
 
 	// Pull out the node name
-	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/catalog/node-services/")
+	var err error
+	args.Node, err = getPathSuffixUnescaped(req.URL.Path, "/v1/catalog/node-services/")
+	if err != nil {
+		return nil, err
+	}
 	if args.Node == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing node name")
@@ -547,7 +557,11 @@ func (s *HTTPHandlers) CatalogGatewayServices(resp http.ResponseWriter, req *htt
 	}
 
 	// Pull out the gateway's service name
-	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/catalog/gateway-services/")
+	var err error
+	args.ServiceName, err = getPathSuffixUnescaped(req.URL.Path, "/v1/catalog/gateway-services/")
+	if err != nil {
+		return nil, err
+	}
 	if args.ServiceName == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing gateway name")

--- a/agent/config_endpoint.go
+++ b/agent/config_endpoint.go
@@ -32,7 +32,11 @@ func (s *HTTPHandlers) configGet(resp http.ResponseWriter, req *http.Request) (i
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
-	pathArgs := strings.SplitN(strings.TrimPrefix(req.URL.Path, "/v1/config/"), "/", 2)
+	kindAndName, err := getPathSuffixUnescaped(req.URL.Path, "/v1/config/")
+	if err != nil {
+		return nil, err
+	}
+	pathArgs := strings.SplitN(kindAndName, "/", 2)
 
 	switch len(pathArgs) {
 	case 2:
@@ -79,7 +83,11 @@ func (s *HTTPHandlers) configDelete(resp http.ResponseWriter, req *http.Request)
 	var args structs.ConfigEntryRequest
 	s.parseDC(req, &args.Datacenter)
 	s.parseToken(req, &args.Token)
-	pathArgs := strings.SplitN(strings.TrimPrefix(req.URL.Path, "/v1/config/"), "/", 2)
+	kindAndName, err := getPathSuffixUnescaped(req.URL.Path, "/v1/config/")
+	if err != nil {
+		return nil, err
+	}
+	pathArgs := strings.SplitN(kindAndName, "/", 2)
 
 	if len(pathArgs) != 2 {
 		resp.WriteHeader(http.StatusNotFound)

--- a/agent/coordinate_endpoint.go
+++ b/agent/coordinate_endpoint.go
@@ -2,9 +2,10 @@ package agent
 
 import (
 	"fmt"
-	"github.com/hashicorp/consul/agent/structs"
 	"net/http"
 	"sort"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 // checkCoordinateDisabled will return a standard response if coordinates are

--- a/agent/coordinate_endpoint.go
+++ b/agent/coordinate_endpoint.go
@@ -2,11 +2,9 @@ package agent
 
 import (
 	"fmt"
+	"github.com/hashicorp/consul/agent/structs"
 	"net/http"
 	"sort"
-	"strings"
-
-	"github.com/hashicorp/consul/agent/structs"
 )
 
 // checkCoordinateDisabled will return a standard response if coordinates are
@@ -103,7 +101,10 @@ func (s *HTTPHandlers) CoordinateNode(resp http.ResponseWriter, req *http.Reques
 		return nil, nil
 	}
 
-	node := strings.TrimPrefix(req.URL.Path, "/v1/coordinate/node/")
+	node, err := getPathSuffixUnescaped(req.URL.Path, "/v1/coordinate/node/")
+	if err != nil {
+		return nil, err
+	}
 	args := structs.NodeSpecificRequest{Node: node}
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil

--- a/agent/discovery_chain_endpoint.go
+++ b/agent/discovery_chain_endpoint.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -19,7 +18,11 @@ func (s *HTTPHandlers) DiscoveryChainRead(resp http.ResponseWriter, req *http.Re
 		return nil, nil
 	}
 
-	args.Name = strings.TrimPrefix(req.URL.Path, "/v1/discovery-chain/")
+	var err error
+	args.Name, err = getPathSuffixUnescaped(req.URL.Path, "/v1/discovery-chain/")
+	if err != nil {
+		return nil, err
+	}
 	if args.Name == "" {
 		return nil, BadRequestError{Reason: "Missing chain name"}
 	}


### PR DESCRIPTION
### Overview
This MR solves some parts of the issues in #11258. I intend to break it down into several smaller MRs to review those easily

Thanks @littlestar642 for his work . With #11335, we have with a generic function `getPathSuffixUnescaped` so I just apply it where necessary