### PR TITLE
ui: Fix dark borders on certain visualizations

### DIFF
--- a/.changelog/11959.txt
+++ b/.changelog/11959.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixes a visual issue with some border colors
+```

--- a/ui/packages/consul-ui/app/components/consul/discovery-chain/skin.scss
+++ b/ui/packages/consul-ui/app/components/consul/discovery-chain/skin.scss
@@ -37,7 +37,10 @@
 }
 %chain-group {
   border-radius: var(--decor-radius-100);
-  border: 1px solid rgb(var(--tone-gray-200));
+  border: 1px solid;
+  /* TODO: If this color is combined with the above */
+  /* border property then the compressor removes the color */
+  border-color: rgb(var(--tone-gray-200));
   background-color: rgb(var(--tone-gray-100));
 
   pointer-events: none;
@@ -102,7 +105,10 @@
   background-color: rgb(var(--tone-gray-000));
 
   border-radius: var(--decor-radius-full);
-  border: 2px solid rgb(var(--tone-gray-400));
+  border: 2px solid;
+  /* TODO: If this color is combined with the above */
+  /* border property then the compressor removes the color */
+  border-color: rgb(var(--tone-gray-400));
 }
 %discovery-chain circle {
   stroke-width: 2;

--- a/ui/packages/consul-ui/app/components/topology-metrics/card/index.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/card/index.scss
@@ -9,7 +9,10 @@
   overflow: hidden;
   background-color: rgb(var(--tone-gray-000));
   border-radius: var(--decor-radius-100);
-  border: 1px solid rgb(var(--tone-gray-200));
+  border: 1px solid;
+  /* TODO: If this color is combined with the above */
+  /* border property then the compressor removes the color */
+  border-color: rgb(var(--tone-gray-200));
   p {
     padding: 12px 12px 0 12px;
     font-size: var(--typo-size-500);

--- a/ui/packages/consul-ui/app/components/topology-metrics/skin.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/skin.scss
@@ -6,8 +6,11 @@
 #downstream-container,
 #metrics-container,
 #upstream-container {
-  border: 1px solid rgb(var(--tone-gray-200));
   border-radius: var(--decor-radius-100);
+  border: 1px solid;
+  /* TODO: If this color is combined with the above */
+  /* border property then the compressor removes the color */
+  border-color: rgb(var(--tone-gray-200));
 }
 #downstream-container,
 #upstream-container {


### PR DESCRIPTION
We recently noticed that our CSS compression seems to remove the odd border color when we compile up the UI for embedding in the binary. This results in some borders being a lot darker than they should be, but only once embedded in the binary/production (so not within our Ember development environment).

**Before:**

<img width="1166" alt="Screenshot 2022-01-07 at 11 10 21" src="https://user-images.githubusercontent.com/554604/148536169-417bf665-8d59-4651-afb8-74bc97155ecc.png">

I noticed that just separating the `border-color` off from the shorthand `border` (which we do a lot anyway) seems to solve the issue without getting into too many ember-cli weeds. So this PR does that in the places I've noticed that are affected (topology and discovery chain visualizations), therefore fixing the issue and giving us time to figure out why this is happening if we want to do that (there's something to be said for just having a lint rule or something to make sure we always split the border-color, off which would make this problem go away).

**After:**

<img width="1170" alt="Screenshot 2022-01-07 at 11 03 26" src="https://user-images.githubusercontent.com/554604/148536232-1c6b401f-a034-4624-9557-470a921645bf.png">

Notes:
- Our unPRed playwright based testing would catch/prevent this sort of thing.
- I know there was an Ember CSS compression dependency which was very out of date, but the later version was not officially supported in Ember the last time I looked. That may have changed now. If that has changed, an upgrade could help.
- Alternatively we could also go with an unsupported upgrade of the dependency and if that solves the issue, then go with that and ignore the unsupported-ness of it. I think my preferred option would be to stick to supported and if it's still an issue stick to the "always split off the border-color from the border" pattern. I like it being separate anyway (i.e. you can't do `font: 12px bold red;`)

