### PR TITLE
Fix Windows logging to files

### DIFF
--- a/.changelog/11960.txt
+++ b/.changelog/11960.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+windows: Fixes a bug with empty log files when Consul is run as a Windows Service
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -162,7 +162,10 @@ func (c *cmd) run(args []string) int {
 
 	// FIXME: logs should always go to stderr, but previously they were sent to
 	// stdout, so continue to use Stdout for now, and fix this in a future release.
-	logGate := &logging.GatedWriter{Writer: c.ui.Stdout()}
+	// UiWriter is being used here so that writes to Stdout do not error (e.g.
+	// Windows Services are non-interactive and do not have Stdout) and inadvertently
+	// stop writes to other logging outputs like syslogs or log files.
+	logGate := &logging.GatedWriter{Writer: &mcli.UiWriter{Ui: c.ui}}
 	loader := func(source config.Source) (config.LoadResult, error) {
 		c.configLoadOpts.DefaultConfig = source
 		return config.Load(c.configLoadOpts)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -162,10 +162,7 @@ func (c *cmd) run(args []string) int {
 
 	// FIXME: logs should always go to stderr, but previously they were sent to
 	// stdout, so continue to use Stdout for now, and fix this in a future release.
-	// UiWriter is being used here so that writes to Stdout do not error (e.g.
-	// Windows Services are non-interactive and do not have Stdout) and inadvertently
-	// stop writes to other logging outputs like syslogs or log files.
-	logGate := &logging.GatedWriter{Writer: &mcli.UiWriter{Ui: c.ui}}
+	logGate := &logging.GatedWriter{Writer: c.ui.Stdout()}
 	loader := func(source config.Source) (config.LoadResult, error) {
 		c.configLoadOpts.DefaultConfig = source
 		return config.Load(c.configLoadOpts)

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -51,8 +51,9 @@ type noErrorWriter struct {
 }
 
 func (w noErrorWriter) Write(p []byte) (n int, err error) {
-	n, _ = w.w.Write(p)
-	return n, nil
+	_, _ = w.w.Write(p)
+	// We purposely return n == len(p) as if write was successful
+	return len(p), nil
 }
 
 // Setup logging from Config, and return an hclog Logger.

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -27,16 +27,16 @@ type Config struct {
 	// SyslogFacility is the destination for syslog forwarding.
 	SyslogFacility string
 
-	//LogFilePath is the path to write the logs to the user specified file.
+	// LogFilePath is the path to write the logs to the user specified file.
 	LogFilePath string
 
-	//LogRotateDuration is the user specified time to rotate logs
+	// LogRotateDuration is the user specified time to rotate logs
 	LogRotateDuration time.Duration
 
-	//LogRotateBytes is the user specified byte limit to rotate logs
+	// LogRotateBytes is the user specified byte limit to rotate logs
 	LogRotateBytes int
 
-	//LogRotateMaxFiles is the maximum number of past archived log files to keep
+	// LogRotateMaxFiles is the maximum number of past archived log files to keep
 	LogRotateMaxFiles int
 }
 


### PR DESCRIPTION
closes https://github.com/hashicorp/consul/issues/11773

Our logger uses [`io.MultiWriter`](https://pkg.go.dev/io#MultiWriter) which at minimum writes to `os.Stdout` and optionally to syslog or log file targets.

When Consul is run as a Windows Service, `os.Stdout` is not available and any writes by the logger fails silently, which inadvertently stopped writes to other targets because of `io.MultiWriter`'s behaviour:
```
If a listed writer returns an error, that overall write operation stops 
and returns the error; it does not continue down the list.
```

This PR uses a `noErrorWriter` wrapper which never returns an error so that even if writes to Stdout fail, writes to syslog and log file are unaffected.