### PR TITLE
docs: Redirect mesh-gateway page to new location

### DIFF
--- a/website/redirects.next.js
+++ b/website/redirects.next.js
@@ -114,7 +114,14 @@ module.exports = [
   { source: '/configuration', destination: '/', permanent: true },
   {
     source: '/docs/connect/mesh(_|-)gateway',
-    destination: '/docs/connect/gateways/mesh-gateway',
+    destination:
+      '/docs/connect/gateways/mesh-gateway/service-to-service-traffic-datacenters',
+    permanent: true,
+  },
+  {
+    source: '/docs/connect/gateways/mesh-gateway',
+    destination:
+      '/docs/connect/gateways/mesh-gateway/service-to-service-traffic-datacenters',
     permanent: true,
   },
   {


### PR DESCRIPTION
The mesh gateway docs at /docs/connect/gateways/mesh-gateway were moved in #11859 to a new location in order to accommodate the addition of separate instructions for using gateways with admin partitions.

This commit redirects the old mesh gateway page to its new location at /connect/gateways/mesh-gateway/service-to-service-traffic-datacenters.