### PR TITLE
Ma/ipv6 robustness fixes

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4032,6 +4032,9 @@ func grpcInjectAddr(existing string, ip string, port int) string {
 	portRepl := fmt.Sprintf("${1}:%d${3}", port)
 	out := grpcAddrRE.ReplaceAllString(existing, portRepl)
 
+	// TODO Is this necessary?
+	// Ensure that ipv6 addr is enclosed in brackets (RFC 3986)
+	ip = fixIPv6(ip)
 	addrRepl := fmt.Sprintf("%s${2}${3}", ip)
 	out = grpcAddrRE.ReplaceAllString(out, addrRepl)
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -4167,21 +4167,21 @@ func TestAgent_grpcInjectAddr(t *testing.T) {
 			grpc: "2001:db8:1f70::999:de8:7648:6e8:5000",
 			ip:   "::FFFF:C0A8:1",
 			port: 9090,
-			want: "::FFFF:C0A8:1:9090",
+			want: "[::FFFF:C0A8:1]:9090",
 		},
 		{
 			name: "ipv6 injected into ipv6 url with svc",
 			grpc: "2001:db8:1f70::999:de8:7648:6e8:5000/web",
 			ip:   "::FFFF:C0A8:1",
 			port: 9090,
-			want: "::FFFF:C0A8:1:9090/web",
+			want: "[::FFFF:C0A8:1]:9090/web",
 		},
 		{
 			name: "ipv6 injected into ipv6 url with special",
 			grpc: "2001:db8:1f70::999:de8:7648:6e8:5000/service-$name:with@special:Chars",
 			ip:   "::FFFF:C0A8:1",
 			port: 9090,
-			want: "::FFFF:C0A8:1:9090/service-$name:with@special:Chars",
+			want: "[::FFFF:C0A8:1]:9090/service-$name:with@special:Chars",
 		},
 	}
 	for _, tt := range tt {

--- a/agent/auto-config/auto_encrypt_test.go
+++ b/agent/auto-config/auto_encrypt_test.go
@@ -136,7 +136,7 @@ func TestAutoEncrypt_hosts(t *testing.T) {
 			hosts: []string{
 				"192.168.1.1",
 				"start.local",
-				"[::ffff:172.16.5.4]",
+				"::ffff:172.16.5.4",
 				"main.dev",
 				"198.18.0.1",
 				"foo.com",

--- a/agent/auto-config/server_addr_test.go
+++ b/agent/auto-config/server_addr_test.go
@@ -1,0 +1,92 @@
+package autoconf
+
+import (
+	"github.com/hashicorp/consul/agent/config"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+	"net"
+	"testing"
+)
+
+type testAddr struct {
+	Host string
+	Port int
+}
+
+func makeIPHelper(address string, port int) net.TCPAddr {
+	return net.TCPAddr{IP: net.ParseIP(address), Port: port}
+}
+func makeIPArrayHelper(addr []testAddr) []net.TCPAddr {
+	if addr == nil {
+		return nil
+	}
+	tcp := make([]net.TCPAddr, len(addr))
+	for i, v := range addr {
+		tcp[i] = makeIPHelper(v.Host, v.Port)
+	}
+	return tcp
+}
+
+func TestResolv(t *testing.T) {
+
+	tests := []struct {
+		address string
+		hosts   []testAddr
+	}{
+		//	{"example.org", "example.org", -1, false},
+		//	{"example.org:10", "example.org", 10, false},
+		{"example.org:10:10", nil},
+
+		// IPv4 addresses
+		{"10.0.0.1", []testAddr{{Host: "10.0.0.1", Port: 1234}}},
+		{"10.0.0.1:10", []testAddr{{Host: "10.0.0.1", Port: 10}}},
+		{"10.0.0.1:10:4", nil},
+
+		// IPv6 addresses w/o port
+		{"::1", []testAddr{{"::1", 1234}}},
+		{"fe80::1", []testAddr{{"fe80::1", 1234}}},
+		{"2001:db8::1", []testAddr{{"2001:db8::1", 1234}}},
+		{"2a05:d014:d9e:c303:e4d3:d281:a61d:8ebd", []testAddr{{"2a05:d014:d9e:c303:e4d3:d281:a61d:8ebd", 1234}}},
+
+		//
+		//// well formed IPv6 addresses with port
+		{"[::1]:10", []testAddr{{"::1", 10}}},
+		{"[fe80::1]:10", []testAddr{{"fe80::1", 10}}},
+		{"[2001:db8::1]:10", []testAddr{{"2001:db8::1", 10}}},
+
+		// Various wierd IPv6 shaped things should do the right thing
+		{"2001:db8:1:2:3:4:5:6:7:8", nil},
+		{"[::ffff:172.16.5.4]", []testAddr{{"::ffff:172.16.5.4", 1234}}},
+		{"[::ffff:172.16.5.4]:10", []testAddr{{"::ffff:172.16.5.4", 10}}},
+		{"2001:db8:1:2:3:4:5:6:7", []testAddr{{"2001:db8:1:2:3:4:5:6", 7}}},
+	}
+
+	datacenter := "foo"
+	nodeName := "bar"
+
+	mcfg := newMockedConfig(t)
+
+	ac := AutoConfig{
+		config: &config.RuntimeConfig{
+			Datacenter: datacenter,
+			NodeName:   nodeName,
+			RetryJoinLAN: []string{
+				"198.18.0.1:1234", "198.18.0.2:3456",
+			},
+			ServerPort: 1234,
+		},
+		acConfig: mcfg.Config,
+		logger:   testutil.Logger(t),
+	}
+
+	require.Equal(t, ac.config.ServerPort, 1234)
+
+	for _, tt := range tests {
+		t.Run(tt.address, func(t *testing.T) {
+			host := ac.resolveHost(tt.address)
+
+			hostTCP := makeIPArrayHelper(tt.hosts)
+			require.Equal(t, hostTCP, host)
+		})
+	}
+}

--- a/ipaddr/ipaddr.go
+++ b/ipaddr/ipaddr.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 // FormatAddressPort Helper for net.JoinHostPort that takes int for port
@@ -56,4 +57,83 @@ func iptos(ip interface{}) string {
 	default:
 		panic(fmt.Sprintf("invalid type: %T", ip))
 	}
+}
+
+// In many cases we receive a network address with an optional port field.
+// Well formed examples of this include:
+// Description             Example
+// <Hostname>              example.org
+// <Hostname>:<Port>       example.org:1234
+// <IPv4>                  120.0.0.1
+// <IPv4>:<port>           127.0.0.1:1234
+// <IPv6>                  ::1
+// [<IPv6>]:<port>         [::1]:1234
+// Mildly unusual but legal examples include:
+// [<IPv4>]:<port>         [127.0.0.1]:1234
+// Ill formed examples include:
+// <IPv6>:port             ::1:1234
+
+// Extend net.SplitHostPort to split address into host/ip and optional port fields. Returns -1 if no port. Attempts to deal with
+// bare IPv6 address optimistically.
+func SplitHostPort(address string) (host string, port int, err error) {
+	var portString string
+	host, portString, err = net.SplitHostPort(address)
+
+	if err != nil {
+		// IPv6 addresses have at least two colons. A single colon is treated as host:port or ip:port
+		// We're assuming we either have a bare address w/o port
+		byColon := strings.Split(address, ":")
+		segments := len(byColon)
+		switch segments {
+		case 1:
+			// Maybe we have a bare IPv4 or host name without a port
+			if strings.Contains(err.Error(), "missing port in address") {
+				host = byColon[0] // TODO validate this as IPv4 or hostname
+				portString = ""
+				err = nil
+			}
+			// no case for 2, because that should be picked up by the net.SplitHostPort above.
+		case 3, 4, 5, 6, 7, 8:
+			// Maybe we have a bare IPv6 address without a port (maybe check err for assistance?)
+			if strings.HasPrefix(address, "[") && strings.HasSuffix(address, "]") {
+				address = strings.TrimSuffix(strings.TrimPrefix(address, "["), "]")
+			}
+
+			if net.ParseIP(address) != nil {
+				host = address
+				portString = ""
+				err = nil
+			} else {
+
+			}
+		case 9: // special case for ill formed, but unambigous full ipv6+port
+			host = strings.Join(byColon[:segments-1], ":")
+			if net.ParseIP(host) != nil {
+				portString = byColon[segments-1]
+				err = nil
+			} else {
+				host = ""
+				err = fmt.Errorf("Ill formed address %s. IPv6 addresses with port should be [IPv6]:port", address) // error?
+			}
+		default: // Note this includes the case were we have 2 segments
+		}
+	}
+
+	if err != nil {
+		host = ""
+		port = -1
+		return
+	}
+	if portString == "" {
+		port = -1
+		return
+	}
+	port, err = strconv.Atoi(portString)
+	return
+}
+
+// Handle potentially malformed addresses with optional port fields.
+func StripOptionalPort(address string) (host string, err error) {
+	host, _, err = SplitHostPort(address)
+	return
 }

--- a/ipaddr/ipaddr.go
+++ b/ipaddr/ipaddr.go
@@ -104,7 +104,8 @@ func SplitHostPort(address string) (host string, port int, err error) {
 				portString = ""
 				err = nil
 			} else {
-
+				host = ""
+				portString = ""
 			}
 		case 9: // special case for ill formed, but unambigous full ipv6+port
 			host = strings.Join(byColon[:segments-1], ":")
@@ -136,4 +137,29 @@ func SplitHostPort(address string) (host string, port int, err error) {
 func StripOptionalPort(address string) (host string, err error) {
 	host, _, err = SplitHostPort(address)
 	return
+}
+
+func Canonicalize(address string) string {
+	host, port, err := SplitHostPort(address)
+	if err != nil {
+		return ""
+	}
+	if port > 0 {
+		return net.JoinHostPort(host, strconv.Itoa(port))
+	} else {
+		// We may want to put IPv6 in [] even without ports, because not all users
+		// handle IPv6 addresses correctly when looking for optional ports
+		return host
+	}
+}
+
+func CanonicalizeAddresslist(addresses []string) []string {
+	out := make([]string, 0, len(addresses))
+	for _, addr := range addresses {
+		canon := Canonicalize(addr)
+		if canon != "" {
+			out = append(out, canon)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
This is an effort towards being more robust in the face of ill formed address/port combinations, such as seen in https://github.com/hashicorp/consul/issues/11847
