### PR TITLE
ui: Remove KV pre-flight auth check

### DIFF
--- a/.changelog/11968.txt
+++ b/.changelog/11968.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Temporarily remove KV pre-flight check for KV list permissions
+```

--- a/ui/packages/consul-ui/app/abilities/kv.js
+++ b/ui/packages/consul-ui/app/abilities/kv.js
@@ -10,6 +10,12 @@ export default class KVAbility extends BaseAbility {
     }
     return resources;
   }
+  /**/
+  // Temporarily revert to pre-1.10 UI functionality by overwriting frontend
+  // permissions. These are used to hide certain UI elements, but they are
+  // still enforced on the backend.
+  // This temporary measure should be removed again once https://github.com/hashicorp/consul/issues/11098
+  // has been resolved
   get canRead() {
     return true;
   }
@@ -21,4 +27,5 @@ export default class KVAbility extends BaseAbility {
   get canWrite() {
     return true;
   }
+  /**/
 }

--- a/ui/packages/consul-ui/app/services/repository/kv.js
+++ b/ui/packages/consul-ui/app/services/repository/kv.js
@@ -2,7 +2,7 @@ import RepositoryService from 'consul-ui/services/repository';
 import isFolder from 'consul-ui/utils/isFolder';
 import { get } from '@ember/object';
 import { PRIMARY_KEY } from 'consul-ui/models/kv';
-import { ACCESS_LIST, ACCESS_READ } from 'consul-ui/abilities/base';
+// import { ACCESS_LIST } from 'consul-ui/abilities/base';
 import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'kv';

--- a/ui/packages/consul-ui/app/services/repository/kv.js
+++ b/ui/packages/consul-ui/app/services/repository/kv.js
@@ -2,7 +2,7 @@ import RepositoryService from 'consul-ui/services/repository';
 import isFolder from 'consul-ui/utils/isFolder';
 import { get } from '@ember/object';
 import { PRIMARY_KEY } from 'consul-ui/models/kv';
-import { ACCESS_LIST } from 'consul-ui/abilities/base';
+import { ACCESS_LIST, ACCESS_READ } from 'consul-ui/abilities/base';
 import dataSource from 'consul-ui/decorators/data-source';
 
 const modelName = 'kv';
@@ -54,21 +54,29 @@ export default class KvService extends RepositoryService {
   // this one only gives you keys
   // https://www.consul.io/api/kv.html
   @dataSource('/:partition/:ns/:dc/kvs/:id')
-  findAllBySlug(params, configuration = {}) {
+  async findAllBySlug(params, configuration = {}) {
     params.separator = '/';
     if (params.id === '/') {
       params.id = '';
     }
-    return this.authorizeBySlug(
-      async () => {
-        let items = await this.findAll(...arguments);
-        const meta = items.meta;
-        items = items.filter(item => params.id !== get(item, 'Key'));
-        items.meta = meta;
-        return items;
-      },
-      ACCESS_LIST,
-      params
-    );
+
+    /**/
+    // Temporarily revert to pre-1.10 UI functionality by not pre-checking backend
+    // permissions.
+    // This temporary measure should be removed again once https://github.com/hashicorp/consul/issues/11098
+    // has been resolved
+
+    // return this.authorizeBySlug(
+    //   async () => {
+    let items = await this.findAll(...arguments);
+    const meta = items.meta;
+    items = items.filter(item => params.id !== get(item, 'Key'));
+    items.meta = meta;
+    return items;
+    // },
+    // ACCESS_LIST,
+    // params
+    // );
+    /**/
   }
 }


### PR DESCRIPTION
Related to https://github.com/hashicorp/consul/issues/11098

This PR removes the KV pre-flight check to the internal authorization endpoint and instead relies on the response from the normal KV endpoint, thin client style.