### PR TITLE
Document Consul enterprise 1.10.0-1.10.4 forwards incompatibility with 1.11

### DIFF
--- a/website/content/docs/upgrading/instructions/upgrade-to-1-10-x.mdx
+++ b/website/content/docs/upgrading/instructions/upgrade-to-1-10-x.mdx
@@ -14,7 +14,7 @@ description: >-
 
 This guide explains how to best upgrade a single Consul Enterprise datacenter to v1.10.0
 from a version of Consul that is forward compatible with v1.10. If you are on a major
-version of Consul prior to 1.8, you will need to complete and [upgrade to 1.8.13](/docs/upgrading/instructions)
+version of Consul prior to 1.8, you will need to complete and [upgrade to 1.8.13](/docs/upgrading/instructions/upgrade-to-1-8-x)
 or higher before continuing with this guide. If you are already on a major version of 1.8 or 1.9, then
 this guide will go over the procedures required for upgrading to v1.10. This process
 will require intermediate version upgrades to a forward-compatible release of v1.8 or v1.9,

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -21,7 +21,7 @@ Consul Enterprise versions 1.10.0 through 1.10.4 contain a latent bug that
 causes those client or server agents to deregister their own services or health
 checks when some of the servers have been upgraded to 1.11. Prior
 to upgrading Consul Enterprise servers to 1.11, all Consul agents should first 
-be upgraded to 1.10.6 or higher to ensure forwards compatibility and preventing
+be upgraded to 1.10.6 or higher to ensure forwards compatibility and to prevent
 flapping of catalog registrations.
 
 ### Deprecated Agent Config Options

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -18,11 +18,11 @@ upgrade flow.
 
 ### 1.10 Compatibility <EnterpriseAlert inline />
 Consul Enterprise versions 1.10.0 through 1.10.4 contain a latent bug that
-causes those agents to deregister the Serf health check of the node when they 
-are syncing their services and health checks with a server running 1.11. Prior
+causes those client or server agents to deregister their own services or health
+checks when some of the servers have been upgraded to 1.11. Prior
 to upgrading Consul Enterprise servers to 1.11, all Consul agents should first 
 be upgraded to 1.10.6 or higher to ensure forwards compatibility and preventing
-flapping of health checks.
+flapping of catalog registrations.
 
 ### Deprecated Agent Config Options
 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -19,9 +19,8 @@ upgrade flow.
 ### 1.10 Compatibility <EnterpriseAlert inline />
 Consul Enterprise versions 1.10.0 through 1.10.4 contain a latent bug that
 causes those client or server agents to deregister their own services or health
-checks when some of the servers have been upgraded to 1.11. Prior
-to upgrading Consul Enterprise servers to 1.11, all Consul agents should first 
-be upgraded to 1.10.6 or higher to ensure forwards compatibility and to prevent
+checks when some of the servers have been upgraded to 1.11. Before upgrading Consul Enterprise servers to 1.11, all Consul agents should first 
+be upgraded to 1.10.6 or higher to ensure forward compatibility and prevent
 flapping of catalog registrations.
 
 ### Deprecated Agent Config Options

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -16,6 +16,14 @@ upgrade flow.
 
 ## Consul 1.11.0
 
+### 1.10 Compatibility <EnterpriseAlert inline />
+Consul Enterprise versions 1.10.0 through 1.10.4 contain a latent bug that
+causes those agents to deregister the Serf health check of the node when they 
+are syncing their services and health checks with a server running 1.11. Prior
+to upgrading Consul Enterprise servers to 1.11, all Consul agents should first 
+be upgraded to 1.10.6 or higher to ensure forwards compatibility and preventing
+flapping of health checks.
+
 ### Deprecated Agent Config Options
 
 Consul 1.11.0 is compiled with Go 1.17 and now the ordering of


### PR DESCRIPTION
Also fixed a broken link in the 1.10.x upgrade instructions.

Live Docs Link to the new section: https://consul-oqyiiecv4-hashicorp.vercel.app/docs/upgrading/upgrade-specific#1-10-compatibility