### PR TITLE
ui: Some ACL component documentation

### DIFF
--- a/ui/packages/consul-acls/app/components/consul/acl/selector/README.mdx
+++ b/ui/packages/consul-acls/app/components/consul/acl/selector/README.mdx
@@ -1,0 +1,35 @@
+# Consul::Acl::Selector
+
+A component to allow the user to 'select' the ACL area they wish to view.
+Whilst the 'Selector' naming here is a bit of a reach, it fits well with other
+similar 'Selector' components that we use within the main navigation area.
+
+The component itself is a simple wrapper around a bunch of `li a`'s.
+
+Please note: 
+
+- Currently at least, you must add this inside of a `<ul>` element.
+
+```hbs preview-template
+<ul>
+  <Consul::Acl::Selector
+    @dc={{hash
+      Name='dc-1'
+    }}
+  />
+</ul>
+```
+
+
+## Arguments
+
+| Argument/Attribute | Type | Default | Description |
+| --- | --- | --- | --- |
+| `dc` | `object` |  | The current datacenter |
+
+## See
+
+- [Template Source Code](./index.hbs)
+- [Component Source Code](./index.js)
+
+---

--- a/ui/packages/consul-acls/app/components/consul/token/selector/README.mdx
+++ b/ui/packages/consul-acls/app/components/consul/token/selector/README.mdx
@@ -1,0 +1,49 @@
+# Consul::Token::Selector
+
+A self-contained component to allow the user to 'select' their token a.k.a.
+log in. The component is mostly a wrapper around a composition of `<AuthDialog
+/>`, `<AuthForm />`, `<AuthProfile />` and `<ModalDialog />`. The majority of
+the functionality is contained in those other components. This composition
+mostly orchestrates the interactions between them i.e. wires them together.
+
+As it uses `<AuthDialog />` (a componentized state machine), retrieving and saving
+the token is all managed via that component (via `<DataSource />` and
+`<DataSink />`, but this component provides the Consul specific DataSource
+uri's to tell `AuthDialog` to save user tokens to a Consul namespaced user
+settings area (Consul uses localStorage for saving user settings)
+
+Please note: 
+
+- Currently at least, you must add this inside of a `<ul>` element.
+- For the moment, make sure you have enabled ACLs using developer debug
+  cookies.
+
+```hbs preview-template
+<ul>
+  <Consul::Token::Selector
+    @dc={{hash
+      Name='dc-1'
+    }}
+    @nspace='default'
+    @partition='default'
+    @onchange={{noop}}
+  />
+</ul>
+```
+
+
+## Arguments
+
+| Argument/Attribute | Type | Default | Description |
+| --- | --- | --- | --- |
+| `dc` | `object` |  | The current datacenter |
+| `nspace` | `string` |  | The name of the current namespace |
+| `partition` | `string` |  | The name of the current partition |
+| `onchange` | `function` |  | An event handler, for when the user token change, either via logging in, logging out or re-logging in.
+
+## See
+
+- [Template Source Code](./index.hbs)
+- [Component Source Code](./index.js)
+
+---

--- a/ui/packages/consul-acls/app/components/consul/token/selector/index.hbs
+++ b/ui/packages/consul-acls/app/components/consul/token/selector/index.hbs
@@ -126,10 +126,10 @@
           <BlockSlot @name="menu">
             {{#let components.MenuItem components.MenuSeparator as |MenuItem MenuSeparator|}}
 {{!TODO: It might be nice to use one of our recursive components here}}
-{{#if @token.AccessorID}}
+{{#if authDialog.token.AccessorID}}
                 <li role="none">
                   <AuthProfile
-                    @item={{@token}}
+                    @item={{authDialog.token}}
                   />
                 </li>
                 <MenuSeparator />

--- a/ui/packages/consul-ui/.docfy-config.js
+++ b/ui/packages/consul-ui/.docfy-config.js
@@ -87,6 +87,12 @@ module.exports = {
       urlPrefix: 'docs/consul',
     },
     {
+      root: `${path.dirname(require.resolve('consul-acls/package.json'))}/app/components`,
+      pattern: '**/README.mdx',
+      urlSchema: 'auto',
+      urlPrefix: 'docs/consul-acls',
+    },
+    {
       root: `${path.dirname(require.resolve('consul-partitions/package.json'))}/app/components`,
       pattern: '**/README.mdx',
       urlSchema: 'auto',

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -236,7 +236,6 @@
             </a>
         </li>
         <Consul::Token::Selector
-          @token={{@user.token}}
           @dc={{@dc}}
           @partition={{@partition}}
           @nspace={{@nspace}}


### PR DESCRIPTION
Whilst working on https://github.com/hashicorp/consul/pull/11981 I added docs for the new TokenSelector and ACLSelector (which are mainly just wrapper components), I wasn't sure whether folks would prefer a separate PR so I decided to do this one separate.

There is one meaningful change here (which came to light due to writing the docs) in that previous we expected the user of the component to pass through a `@token` argument to AuthDialog (which then gets passed through to AuthProfile to show a truncated token.AccessorID.

As the AuthDialog component orchestrates the entire authorization dance (both for non-sso and sso flows) it reads and saves any user token changes and therefore knows about the token and 'exports'/yields it. Therefore I switched to use that reference to the `token` instead of the one we were passing in, which means one less `@argument` for the user of the TokenSelector component to worry about.

Actually now thinking about it I suppose the 'TokenSelector' component could export the token into `application.hbs`also 🤔 - will save that for a future PR so I can get this finished up, its not in the least bit important as of right now.

Lastly, as per the base branch of this PR, there is no backporting here as its only for a future yet to be released version of Consul (1.12)