### PR TITLE
docs: added another resolver example for DC and namespace failover

### DIFF
--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -169,7 +169,7 @@ spec:
 </CodeTabs>
 
 <EnterpriseAlert product="consul">
-  Failover to another datacenter and namespace
+  Failover to another datacenter and namespace for all service subsets.
 </EnterpriseAlert>
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
@@ -182,7 +182,7 @@ ConnectTimeout = "0s"
 Failover = {
   "*" = {
     Datacenters = ["dc2"]
-    Namespace = "secodary"
+    Namespace = "secondary"
   }
 }
 ```

--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -169,7 +169,6 @@ spec:
 </CodeTabs>
 
 <EnterpriseAlert product="consul">
-  {' '}
   Failover to another datacenter and namespace
 </EnterpriseAlert>
 

--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -168,6 +168,57 @@ spec:
 
 </CodeTabs>
 
+<EnterpriseAlert product="consul">
+  {' '}
+  Failover to another datacenter and namespace
+</EnterpriseAlert>
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind           = "service-resolver"
+Name           = "product-api"
+Namespace      = "primary"
+ConnectTimeout = "0s"
+Failover = {
+  "*" = {
+    Datacenters = ["dc2"]
+    Namespace = "secodary"
+  }
+}
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: product-api
+  namespace: primary
+spec:
+  connectTimeout: 0
+  failover:
+    namespace: 'secondary'
+    '*':
+      datacenters: ['dc2']
+```
+
+```json
+{
+  "Kind": "service-resolver",
+  "Name": "product-api",
+  "Namespace": "primary"
+  "ConnectTimeout": "0s",
+  "Failover": {
+    "*": {
+      "Datacenters": ["dc2"]
+      "Namespace": "secondary"
+    }
+  }
+}
+```
+
+</CodeTabs>
+
 ### Consistent load balancing
 
 Apply consistent load balancing for requests based on `x-user-id` header:

--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -116,9 +116,9 @@ spec:
 
 </CodeTabs>
 
-### Datacenter failover
+### Failover
 
-Enable failover for subset 'v2' to 'dc2', and all other subsets to dc3 or dc4:
+Enable failover for subset `v2` to `dc2`, and all other subsets to `dc3` or `dc4`:
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
@@ -194,22 +194,70 @@ metadata:
   name: product-api
   namespace: primary
 spec:
-  connectTimeout: 0
+  connectTimeout: 0s
   failover:
     namespace: 'secondary'
-    '*':
-      datacenters: ['dc2']
+    datacenters: ['dc2']
 ```
 
 ```json
 {
   "Kind": "service-resolver",
   "Name": "product-api",
-  "Namespace": "primary"
+  "Namespace": "primary",
   "ConnectTimeout": "0s",
   "Failover": {
     "*": {
-      "Datacenters": ["dc2"]
+      "Datacenters": ["dc2"],
+      "Namespace": "secondary"
+    }
+  }
+}
+```
+
+</CodeTabs>
+
+<EnterpriseAlert product="consul">
+  Failover within a datacenter and a different namespace.
+</EnterpriseAlert>
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+```hcl
+Kind           = "service-resolver"
+Name           = "product-api"
+Namespace      = "primary"
+ConnectTimeout = "0s"
+Failover = {
+  "*" = {
+    Service = "product-api-backup"
+    Namespace = "secondary"
+  }
+}
+```
+
+```yaml
+apiVersion: consul.hashicorp.com/v1alpha1
+kind: ServiceResolver
+metadata:
+  name: product-api
+  namespace: primary
+spec:
+  connectTimeout: 0s
+  failover:
+    service: 'product-api-backup'
+    namespace: 'secondary'
+```
+
+```json
+{
+  "Kind": "service-resolver",
+  "Name": "product-api",
+  "Namespace": "primary",
+  "ConnectTimeout": "0s",
+  "Failover": {
+    "*": {
+      "Service": "product-api-backup",
       "Namespace": "secondary"
     }
   }


### PR DESCRIPTION
This PR adds an example for a datacenter failover while using namespaces