### PR TITLE
ui: Adds a notice for non-primary intention creation

### DIFF
--- a/.changelog/11985.txt
+++ b/.changelog/11985.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added a notice for non-primary intention creation
+```

--- a/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/form/index.hbs
@@ -133,8 +133,26 @@ as |item readonly|}}
         />
     {{/if}}
 
-    {{#if (and api.isCreate this.isManagedByCRDs)}}
+    {{#if api.isCreate}}
+      {{#if (and (can 'use partitions') (not (can 'choose partitions' dc=@dc)))}}
+        <Notice
+          @type="info"
+        as |notice|>
+          <notice.Header>
+            <h3>
+              Cross-partition communication not supported
+            </h3>
+          </notice.Header>
+          <notice.Body>
+            <p>
+              Cross-partition communication is not supported outside of the primary datacenter. You will only be able to select namespaces for source and destination services.
+            </p>
+          </notice.Body>
+        </Notice>
+      {{/if}}
+      {{#if this.isManagedByCRDs}}
         <Consul::Intention::Notice::CustomResource @type="warning" />
+      {{/if}}
     {{/if}}
       <form
         {{on 'submit' (fn this.submit item api.submit)}}


### PR DESCRIPTION
You cannot specify partitions whilst creating intentions if you are not in the primary datacenter.

Here we check to see if we have partitions enabled, then see if we are prohibited from 'choosing' them using our ability for partitions, in which case we show the notice which is just a simple-ish presentational component.

We only do this for the create screen, and as the `isManagedByCRDs` notice was intertwined with this conditional previously, we split that up here.

<img width="1370" alt="Screenshot 2022-01-10 at 17 39 38" src="https://user-images.githubusercontent.com/554604/148812638-9d2506d6-e416-4000-8ecd-ce2cd014c1dd.png">
