### PR TITLE
ui: Alter position of dashboard button in the service instance header

### DIFF
--- a/ui/packages/consul-ui/app/components/app-view/layout.scss
+++ b/ui/packages/consul-ui/app/components/app-view/layout.scss
@@ -21,9 +21,6 @@
 %app-view-actions {
   margin-top: 9px;
 }
-%app-view-actions > *:not(:last-child) {
-  margin-right: 12px;
-}
 
 /* content */
 /* TODO: Think about an %app-form or similar */

--- a/ui/packages/consul-ui/app/styles/routes/dc/services/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/services/index.scss
@@ -1,3 +1,11 @@
+/* drop the external dashboard button down if it exists */
+/* so it doesn't sit next to the Intentions create button */
+/* awkwardly */
+html[data-route^='dc.services.show'] .app-view .actions .external-dashboard {
+  position: absolute;
+  top: 50px;
+  right: 0;
+}
 /* instance detail dl text*/
 html[data-route^='dc.services.instance'] .app-view > header dl {
   float: left;

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -186,8 +186,8 @@ as |items item dc|}}
               }}
             as |config|>
             {{#if config.data.dashboard_url_templates.service}}
-              <a
-                href={{render-template config.data.dashboard_url_templates.service
+              <Action
+                @href={{render-template config.data.dashboard_url_templates.service
                   (hash
                     Datacenter=dc.Name
                     Service=(hash
@@ -197,12 +197,12 @@ as |items item dc|}}
                     )
                   )
                 }}
-                target="_blank"
-                rel="noopener noreferrer"
+                @external={{true}}
+                class="external-dashboard"
                 data-test-dashboard-anchor
               >
                 Open dashboard
-              </a>
+              </Action>
             {{/if}}
             </DataSource>
           </BlockSlot>


### PR DESCRIPTION
Before:

<img width="883" alt="Screenshot 2022-01-10 at 18 13 47" src="https://user-images.githubusercontent.com/554604/148817411-da0d2c1d-adf3-4424-99ba-e465d6edb015.png">

After:

<img width="884" alt="Screenshot 2022-01-10 at 18 13 09" src="https://user-images.githubusercontent.com/554604/148817434-480f3030-fed1-4a36-ba43-ed3e8098cafd.png">

Please note: there is a purposeful very exact CSS selector being used here.

Please note, as we have undergone quite a lot of design change over the lifetime of the UI, we are building up to a more general "CSS trace" to bring a lot of things in line. That should be coming pretty soon and there will be updates to this area to go back to the large style buttons here plus some repositioning. That will be part of a larger PR though.

Oh, we also have a long term task to move all our `<a>` and `<button>`s to use `<Action>` which internally uses either `a` or `button` depending on whether you pass it a `@href` or not. So I took the opportunity to do that here also.

Backport-wise I'm guessing this should only go back to 1.10 at the earliest (as that was where we moved to the sidebar menu/re-skin)
