### PR TITLE
docs: remove acl config section from acl docs

### DIFF
--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -545,7 +545,7 @@ They are documented separately under [check configuration](/docs/agent/checks) a
 [service configuration](/docs/agent/services) respectively. The service and check
 definitions support being updated during a reload.
 
-#### Example Configuration File
+### Example Configuration File
 
 ```json
 {
@@ -566,7 +566,7 @@ definitions support being updated during a reload.
 }
 ```
 
-#### Configuration Key Reference
+## Configuration Reference
 
 -> **Note:** All the TTL values described below are parsed by Go's `time` package, and have the following
 [formatting specification](https://golang.org/pkg/time/#ParseDuration): "A
@@ -574,13 +574,11 @@ duration string is a possibly signed sequence of decimal numbers, each with
 optional fraction and a unit suffix, such as '300ms', '-1.5h' or '2h45m'.
 Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 
-- `acl` ((#acl)) - This object allows a number of sub-keys to be set which
-  controls the ACL system. Configuring the ACL system within the ACL stanza was added
-  in Consul 1.4.0
+- `acl` ((#acl)) - the `acl` stanza contains all of the configuration for the ACL system.
 
-  The following sub-keys are available:
-
-  - `enabled` ((#acl_enabled)) - Enables ACLs.
+  - `enabled` ((#acl_enabled)) - Enable the ACL system. When enabled all requests made to
+    Consul must be authorized by an ACL token. To fully secure Consul this setting must be
+    enabled on both client agents and server agents.
 
   - `policy_ttl` ((#acl_policy_ttl)) - Used to control Time-To-Live caching
     of ACL policies. By default, this is 30 seconds. This setting has a major performance

--- a/website/content/docs/security/acl/acl-system.mdx
+++ b/website/content/docs/security/acl/acl-system.mdx
@@ -20,8 +20,10 @@ step-to-step guide see [Bootstrap and Explore ACLs] for getting started with ACL
 [Bootstrap and Explore ACLs]: https://learn.hashicorp.com/tutorials/consul/access-control-setup?utm_source=consul.io&utm_medium=docs
 [Secure Consul with ACLs]: https://learn.hashicorp.com/tutorials/consul/access-control-setup-production?utm_source=consul.io&utm_medium=docs
 
-See allso the [ACL API reference](/api-docs/acl), [ACL CLI reference](/commands/acl), and
+See also the [ACL API reference](/api-docs/acl), [ACL CLI reference](/commands/acl), and
 [Troubleshoot the ACL System](https://learn.hashicorp.com/tutorials/consul/access-control-troubleshoot).
+The ACL system can be enabled and configured using the [acl stanza](/docs/agent/options#acl)
+in the agent configuration file.
 
 
 ## Overview
@@ -243,20 +245,6 @@ Constructing rules from these policies is covered in detail on the
 -> **Consul Enterprise Namespacing** - In addition to directly linked policies, roles and service identities, Consul Enterprise
 will include the ACL policies and roles defined in the [Namespaces definition](/docs/enterprise/namespaces#namespace-definition). (Added in Consul Enterprise 1.7.0)
 
-## Configuring ACLs
-
-ACLs are configured using several different configuration options. These are marked
-as to whether they are set on servers, clients, or both.
-
-| Configuration Option                                           | Servers    | Clients    | Purpose                                                                |
-| -------------------------------------------------------------- | ---------- | ---------- | ---------------------------------------------------------------------- |
-| [`acl.enabled`](/docs/agent/options#acl_enabled)               | `REQUIRED` | `REQUIRED` | Controls whether ACLs are enabled                                      |
-| [`acl.default_policy`](/docs/agent/options#acl_default_policy) | `OPTIONAL` | `N/A`      | Determines allowlist or denylist mode                                  |
-| [`acl.down_policy`](/docs/agent/options#acl_down_policy)       | `OPTIONAL` | `OPTIONAL` | Determines what to do when the remote token or policy resolution fails |
-| [`acl.role_ttl`](/docs/agent/options#acl_role_ttl)             | `OPTIONAL` | `OPTIONAL` | Determines time-to-live for cached ACL Roles                           |
-| [`acl.policy_ttl`](/docs/agent/options#acl_policy_ttl)         | `OPTIONAL` | `OPTIONAL` | Determines time-to-live for cached ACL Policies                        |
-| [`acl.token_ttl`](/docs/agent/options#acl_token_ttl)           | `OPTIONAL` | `OPTIONAL` | Determines time-to-live for cached ACL Tokens                          |
-
 ## Special and builtin Tokens
 
 A number of special tokens can also be configured which allow for bootstrapping the ACL
@@ -269,7 +257,7 @@ system, or accessing Consul in special situations:
 | [`acl.tokens.initial_management`](/docs/agent/options#acl_tokens_initial_management) | `OPTIONAL` | `N/A`      | Special token used to bootstrap the ACL system, check the [Bootstrapping ACLs](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production) tutorial for more details                                                                                    |
 | [`acl.tokens.default`](/docs/agent/options#acl_tokens_default)                       | `OPTIONAL` | `OPTIONAL` | Default token to use for client requests where no token is supplied; this is often configured with read-only access to services to enable DNS service discovery on agents                                                                                                 |
 
-All of these tokens except the `initial_management` token can all be introduced or updated via the [/v1/agent/token API](/api/agent#update-acl-tokens).
+All of these tokens except the `initial_management` token can all be introduced or updated via the [/v1/agent/token API](/api-docs/agent#update-acl-tokens).
 
 In Consul 1.4 - 1.10, the following special tokens were known by different names:
 


### PR DESCRIPTION
Branched from #11993, so I'll be looking to merge that PR first.

These config settings are already documented in the config reference. Instead of duplicating them, we can link to the from the ACL docs. The table removed in this PR included columns for server vs client, but the one case that claimed it wasn't necessarily on clients was wrong. `default_policy` is also used the ACLResolver on clients. So I've left those details out of the config reference.

Also adds a bit more detail to the acl.enabled docs, and fixes the headers so that the configuration reference appears in the table of contents dropdown, and so that sub-headers  are always 1 below their parent (not H2 to H4).