### PR TITLE
Docs: Updating HTTP API endpoints with CLI equivalent links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.11.1 (December 15, 2021)
+
+SECURITY:
+
+* ci: Upgrade golang.org/x/net to address [CVE-2021-44716](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44716) [[GH-11854](https://github.com/hashicorp/consul/issues/11854)]
+
+FEATURES:
+
+* Admin Partitions (Consul Enterprise only) This version adds admin partitions, a new entity defining administrative and networking boundaries within a Consul deployment. For more information refer to the
+ [Admin Partition](https://www.consul.io/docs/enterprise/admin-partitions) documentation. [[GH-11855](https://github.com/hashicorp/consul/issues/11855)]
+* networking: **(Enterprise Only)** Make `segment_limit` configurable, cap at 256.
+
 ## 1.11.0 (December 14, 2021)
 
 BREAKING CHANGES:
@@ -120,6 +132,22 @@ permissions errors rather than using UI capabilities 'pre-user-action' [[GH-1152
 NOTES:
 
 * Renamed the `agent_master` field to `agent_recovery` in the `acl-tokens.json` file in which tokens are persisted on-disk (when `acl.enable_token_persistence` is enabled) [[GH-11744](https://github.com/hashicorp/consul/issues/11744)]
+
+## 1.10.6 (December 15, 2021)
+
+SECURITY:
+
+* ci: Upgrade golang.org/x/net to address [CVE-2021-44716](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44716) [[GH-11856](https://github.com/hashicorp/consul/issues/11856)]
+
+## 1.10.5 (December 13, 2021)
+
+SECURITY:
+
+* ci: Upgrade to Go 1.16.12 to address [CVE-2021-44716](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44716) [[GH-11808](https://github.com/hashicorp/consul/issues/11808)]
+
+BUG FIXES:
+
+* agent: **(Enterprise only)** fix bug where 1.10.x agents would deregister serf checks from 1.11.x servers [[GH-11700](https://github.com/hashicorp/consul/issues/11700)]
 
 ## 1.10.4 (November 11, 2021)
 
@@ -388,6 +416,18 @@ being expired. [[GH-10161](https://github.com/hashicorp/consul/issues/10161)]
 NOTES:
 
 * legal: **(Enterprise only)** Enterprise binary downloads will now include a copy of the EULA and Terms of Evaluation in the zip archive
+
+## 1.9.13 (December 15, 2021)
+
+SECURITY:
+
+* ci: Upgrade golang.org/x/net to address [CVE-2021-44716](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44716) [[GH-11858](https://github.com/hashicorp/consul/issues/11858)]
+
+## 1.9.12 (December 13, 2021)
+
+SECURITY:
+
+* ci: Upgrade to Go 1.16.12 to address [CVE-2021-44716](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44716) [[GH-11807](https://github.com/hashicorp/consul/issues/11807)]
 
 ## 1.9.11 (November 11, 2021)
 
@@ -768,6 +808,26 @@ BUG FIXES:
 * server: skip deleted and deleting namespaces when migrating intentions to config entries [[GH-9186](https://github.com/hashicorp/consul/issues/9186)]
 * telemetry: fixed a bug that caused logs to be flooded with `[WARN] agent.router: Non-server in server-only area` [[GH-8685](https://github.com/hashicorp/consul/issues/8685)]
 * ui: show correct datacenter for gateways [[GH-8704](https://github.com/hashicorp/consul/issues/8704)]
+
+## 1.8.19 (December 15, 2021)
+
+SECURITY:
+
+* ci: Upgrade golang.org/x/net to address [CVE-2021-44716](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44716) [[GH-11857](https://github.com/hashicorp/consul/issues/11857)]
+
+## 1.8.18 (December 13, 2021)
+
+SECURITY:
+
+* ci: Upgrade to Go 1.16.12 to address [CVE-2021-44716](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44716) [[GH-11806](https://github.com/hashicorp/consul/issues/11806)]
+* namespaces: **(Enterprise only)** Creating or editing namespaces that include default ACL policies or ACL roles now requires `acl:write` permission in the default namespace. This change fixes CVE-2021-41805.
+
+BUG FIXES:
+
+* snapshot: **(Enterprise only)** fixed a bug where the snapshot agent would ignore the `license_path` setting in config files
+* ui: Fixes an issue where under some circumstances after logging we present the
+data loaded previous to you logging in. [[GH-11681](https://github.com/hashicorp/consul/issues/11681)]
+* ui: Include `Service.Namespace` into available variables for `dashboard_url_templates` [[GH-11640](https://github.com/hashicorp/consul/issues/11640)]
 
 ## 1.8.17 (November 11, 2021)
 

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -34,7 +34,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl auth-method create`](https://www.consul.io/commands/acl/auth-method/create)
+-> The corresponding CLI command is [`consul acl auth-method create`](https://www.consul.io/commands/acl/auth-method/create).
 
 ### Parameters
 
@@ -162,7 +162,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl auth-method read`](https://www.consul.io/commands/acl/auth-method/read)
+-> The corresponding CLI command is [`consul acl auth-method read`](https://www.consul.io/commands/acl/auth-method/read).
 
 ### Parameters
 
@@ -216,7 +216,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl auth-method update`](https://www.consul.io/commands/acl/auth-method/update)
+-> The corresponding CLI command is [`consul acl auth-method update`](https://www.consul.io/commands/acl/auth-method/update).
 
 ### Parameters
 
@@ -349,7 +349,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl auth-method delete`](https://www.consul.io/commands/acl/auth-method/delete)
+-> The corresponding CLI command is [`consul acl auth-method delete`](/commands/acl/auth-method/delete).
 
 ### Parameters
 
@@ -393,7 +393,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl auth-method list`](https://www.consul.io/commands/acl/auth-method/list)
+-> The corresponding CLI command is [`consul acl auth-method list`](https://www.consul.io/commands/acl/auth-method/list).
 
 ### Parameters
 

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -34,11 +34,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
--> The corresponding CLI command is [`consul acl auth-method create`](https://www.consul.io/commands/acl/auth-method/create).
-=======
--> The corresponding CLI command is [`consul acl auth-method create`](https://www.consul.io/commands/acl/auth-method/create)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
+-> The corresponding CLI command is [`consul acl auth-method create`](/commands/acl/auth-method/create).
 
 ### Parameters
 
@@ -166,11 +162,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
--> The corresponding CLI command is [`consul acl auth-method read`](https://www.consul.io/commands/acl/auth-method/read).
-=======
--> The corresponding CLI command is [`consul acl auth-method read`](https://www.consul.io/commands/acl/auth-method/read)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
+-> The corresponding CLI command is [`consul acl auth-method read`](/commands/acl/auth-method/read).
 
 ### Parameters
 
@@ -224,11 +216,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
--> The corresponding CLI command is [`consul acl auth-method update`](https://www.consul.io/commands/acl/auth-method/update).
-=======
--> The corresponding CLI command is [`consul acl auth-method update`](https://www.consul.io/commands/acl/auth-method/update)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
+-> The corresponding CLI command is [`consul acl auth-method update`](/commands/acl/auth-method/update).
 
 ### Parameters
 
@@ -361,11 +349,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl auth-method delete`](/commands/acl/auth-method/delete).
-=======
--> The corresponding CLI command is [`consul acl auth-method delete`](https://www.consul.io/commands/acl/auth-method/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -409,11 +393,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
--> The corresponding CLI command is [`consul acl auth-method list`](https://www.consul.io/commands/acl/auth-method/list).
-=======
--> The corresponding CLI command is [`consul acl auth-method list`](https://www.consul.io/commands/acl/auth-method/list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
+-> The corresponding CLI command is [`consul acl auth-method list`](/commands/acl/auth-method/list).
 
 ### Parameters
 

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -34,7 +34,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl auth-method create`](/commands/acl/auth-method/create).
+The corresponding CLI command is [`consul acl auth-method create`](/commands/acl/auth-method/create).
 
 ### Parameters
 
@@ -162,7 +162,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl auth-method read`](/commands/acl/auth-method/read).
+The corresponding CLI command is [`consul acl auth-method read`](/commands/acl/auth-method/read).
 
 ### Parameters
 
@@ -216,7 +216,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl auth-method update`](/commands/acl/auth-method/update).
+The corresponding CLI command is [`consul acl auth-method update`](/commands/acl/auth-method/update).
 
 ### Parameters
 
@@ -349,7 +349,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl auth-method delete`](/commands/acl/auth-method/delete).
+The corresponding CLI command is [`consul acl auth-method delete`](/commands/acl/auth-method/delete).
 
 ### Parameters
 
@@ -393,7 +393,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl auth-method list`](/commands/acl/auth-method/list).
+The corresponding CLI command is [`consul acl auth-method list`](/commands/acl/auth-method/list).
 
 ### Parameters
 

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -34,7 +34,9 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-### Payload Fields
+-> The corresponding CLI command is [`consul acl auth-method create`](https://www.consul.io/commands/acl/auth-method/create)
+
+### Parameters
 
 - `Name` `(string: <required>)` - Specifies a name for the ACL auth method. The
   name can contain alphanumeric characters, dashes `-`, and underscores `_`.
@@ -160,6 +162,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl auth-method read`](https://www.consul.io/commands/acl/auth-method/read)
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the name of the ACL auth method to
@@ -211,6 +215,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
+
+-> The corresponding CLI command is [`consul acl auth-method update`](https://www.consul.io/commands/acl/auth-method/update)
 
 ### Parameters
 
@@ -343,6 +349,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl auth-method delete`](https://www.consul.io/commands/acl/auth-method/delete)
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the name of the ACL auth method to
@@ -384,6 +392,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
+
+-> The corresponding CLI command is [`consul acl auth-method list`](https://www.consul.io/commands/acl/auth-method/list)
 
 ### Parameters
 

--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -34,6 +34,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl binding-rule create`](https://www.consul.io/commands/acl/binding-rule/create)
+
 ### Parameters
 
 - `Description` `(string: "")` - Free form human readable description of the binding rule.
@@ -158,6 +160,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl binding-rule read`](https://www.consul.io/commands/acl/binding-rule/read)
+
 ### Parameters
 
 - `id` `(string: <required>)` - Specifies the UUID of the ACL binding rule
@@ -207,6 +211,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
+
+-> The corresponding CLI command is [`consul acl binding-rule update`](https://www.consul.io/commands/acl/binding-rule/update)
 
 ### Parameters
 
@@ -338,6 +344,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl binding-rule delete`](https://www.consul.io/commands/acl/binding-rule/delete)
+
 ### Parameters
 
 - `id` `(string: <required>)` - Specifies the UUID of the ACL binding rule to
@@ -379,6 +387,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
+
+-> The corresponding CLI command is [`consul acl binding-rule list`](https://www.consul.io/commands/acl/binding-rule/list)
 
 ## Parameters
 

--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -34,7 +34,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl binding-rule create`](/commands/acl/binding-rule/create).
+The corresponding CLI command is [`consul acl binding-rule create`](/commands/acl/binding-rule/create).
 
 ### Parameters
 
@@ -160,7 +160,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl binding-rule read`](/commands/acl/binding-rule/read).
+The corresponding CLI command is [`consul acl binding-rule read`](/commands/acl/binding-rule/read).
 
 ### Parameters
 
@@ -212,7 +212,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl binding-rule update`](/commands/acl/binding-rule/update).
+The corresponding CLI command is [`consul acl binding-rule update`](/commands/acl/binding-rule/update).
 
 ### Parameters
 
@@ -344,7 +344,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl binding-rule delete`](/commands/acl/binding-rule/delete).
+The corresponding CLI command is [`consul acl binding-rule delete`](/commands/acl/binding-rule/delete).
 
 ### Parameters
 
@@ -388,7 +388,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl binding-rule list`](/commands/acl/binding-rule/list).
+The corresponding CLI command is [`consul acl binding-rule list`](/commands/acl/binding-rule/list).
 
 ## Parameters
 

--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -34,7 +34,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl binding-rule create`](https://www.consul.io/commands/acl/binding-rule/create)
+-> The corresponding CLI command is [`consul acl binding-rule create`](/commands/acl/binding-rule/create).
 
 ### Parameters
 
@@ -160,7 +160,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl binding-rule read`](https://www.consul.io/commands/acl/binding-rule/read)
+-> The corresponding CLI command is [`consul acl binding-rule read`](/commands/acl/binding-rule/read).
 
 ### Parameters
 
@@ -212,7 +212,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl binding-rule update`](https://www.consul.io/commands/acl/binding-rule/update)
+-> The corresponding CLI command is [`consul acl binding-rule update`](/commands/acl/binding-rule/update).
 
 ### Parameters
 
@@ -344,7 +344,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl binding-rule delete`](https://www.consul.io/commands/acl/binding-rule/delete)
+-> The corresponding CLI command is [`consul acl binding-rule delete`](/commands/acl/binding-rule/delete).
 
 ### Parameters
 
@@ -388,7 +388,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl binding-rule list`](https://www.consul.io/commands/acl/binding-rule/list)
+-> The corresponding CLI command is [`consul acl binding-rule list`](/commands/acl/binding-rule/list).
 
 ## Parameters
 

--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -34,11 +34,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl binding-rule create`](/commands/acl/binding-rule/create).
-=======
--> The corresponding CLI command is [`consul acl binding-rule create`](https://www.consul.io/commands/acl/binding-rule/create)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -164,11 +160,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl binding-rule read`](/commands/acl/binding-rule/read).
-=======
--> The corresponding CLI command is [`consul acl binding-rule read`](https://www.consul.io/commands/acl/binding-rule/read)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -220,11 +212,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl binding-rule update`](/commands/acl/binding-rule/update).
-=======
--> The corresponding CLI command is [`consul acl binding-rule update`](https://www.consul.io/commands/acl/binding-rule/update)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -356,11 +344,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl binding-rule delete`](/commands/acl/binding-rule/delete).
-=======
--> The corresponding CLI command is [`consul acl binding-rule delete`](https://www.consul.io/commands/acl/binding-rule/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -404,11 +388,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl binding-rule list`](/commands/acl/binding-rule/list).
-=======
--> The corresponding CLI command is [`consul acl binding-rule list`](https://www.consul.io/commands/acl/binding-rule/list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ## Parameters
 

--- a/website/content/api-docs/acl/index.mdx
+++ b/website/content/api-docs/acl/index.mdx
@@ -38,6 +38,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
+-> The corresponding CLI command is [`consul acl bootstrap`](https://www.consul.io/commands/acl/bootstrap)
+
 ### Sample Request
 
 ```shell-session
@@ -202,6 +204,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl translate-rules`](https://www.consul.io/commands/acl/translate-rules)
+
 ### Sample Payload
 
 ```hcl
@@ -249,6 +253,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl translate-rules`](https://www.consul.io/commands/acl/translate-rules)
+
 ### Sample Request
 
 ```shell-session
@@ -289,6 +295,8 @@ replication](/docs/agent/options#acl_enable_token_replication) must be
 enabled. Login requires the ability to create local tokens which is restricted
 to the primary datacenter and any secondary datacenters with ACL token
 replication enabled.
+
+-> The corresponding CLI command is [`consul login`](https://www.consul.io/commands/login)
 
 ### Parameters
 
@@ -375,6 +383,8 @@ The table below shows this endpoint's support for
 
 -> **Note** - This endpoint requires no specific privileges as it is just
 deleting a token for which you already must possess its secret.
+
+-> The corresponding CLI command is [`consul logout`](https://www.consul.io/commands/logout)
 
 ### Sample Request
 

--- a/website/content/api-docs/acl/index.mdx
+++ b/website/content/api-docs/acl/index.mdx
@@ -38,7 +38,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul acl bootstrap`](/commands/acl/bootstrap).
+The corresponding CLI command is [`consul acl bootstrap`](/commands/acl/bootstrap).
 
 ### Sample Request
 
@@ -204,7 +204,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl translate-rules`](/commands/acl/translate-rules).
+The corresponding CLI command is [`consul acl translate-rules`](/commands/acl/translate-rules).
 
 ### Sample Payload
 
@@ -253,7 +253,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl translate-rules`](/commands/acl/translate-rules).
+The corresponding CLI command is [`consul acl translate-rules`](/commands/acl/translate-rules).
 
 ### Sample Request
 
@@ -296,7 +296,7 @@ enabled. Login requires the ability to create local tokens which is restricted
 to the primary datacenter and any secondary datacenters with ACL token
 replication enabled.
 
--> The corresponding CLI command is [`consul login`](/commands/login).
+The corresponding CLI command is [`consul login`](/commands/login).
 
 ### Parameters
 
@@ -384,7 +384,7 @@ The table below shows this endpoint's support for
 -> **Note** - This endpoint requires no specific privileges as it is just
 deleting a token for which you already must possess its secret.
 
--> The corresponding CLI command is [`consul logout`](/commands/logout).
+The corresponding CLI command is [`consul logout`](/commands/logout).
 
 ### Sample Request
 

--- a/website/content/api-docs/acl/index.mdx
+++ b/website/content/api-docs/acl/index.mdx
@@ -38,11 +38,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl bootstrap`](/commands/acl/bootstrap).
-=======
--> The corresponding CLI command is [`consul acl bootstrap`](https://www.consul.io/commands/acl/bootstrap)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 
@@ -208,11 +204,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl translate-rules`](/commands/acl/translate-rules).
-=======
--> The corresponding CLI command is [`consul acl translate-rules`](https://www.consul.io/commands/acl/translate-rules)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Payload
 
@@ -261,11 +253,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl translate-rules`](/commands/acl/translate-rules).
-=======
--> The corresponding CLI command is [`consul acl translate-rules`](https://www.consul.io/commands/acl/translate-rules)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 
@@ -308,11 +296,7 @@ enabled. Login requires the ability to create local tokens which is restricted
 to the primary datacenter and any secondary datacenters with ACL token
 replication enabled.
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul login`](/commands/login).
-=======
--> The corresponding CLI command is [`consul login`](https://www.consul.io/commands/login)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -400,11 +384,7 @@ The table below shows this endpoint's support for
 -> **Note** - This endpoint requires no specific privileges as it is just
 deleting a token for which you already must possess its secret.
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul logout`](/commands/logout).
-=======
--> The corresponding CLI command is [`consul logout`](https://www.consul.io/commands/logout)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 

--- a/website/content/api-docs/acl/index.mdx
+++ b/website/content/api-docs/acl/index.mdx
@@ -38,7 +38,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul acl bootstrap`](https://www.consul.io/commands/acl/bootstrap)
+-> The corresponding CLI command is [`consul acl bootstrap`](/commands/acl/bootstrap).
 
 ### Sample Request
 
@@ -204,7 +204,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl translate-rules`](https://www.consul.io/commands/acl/translate-rules)
+-> The corresponding CLI command is [`consul acl translate-rules`](/commands/acl/translate-rules).
 
 ### Sample Payload
 
@@ -253,7 +253,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl translate-rules`](https://www.consul.io/commands/acl/translate-rules)
+-> The corresponding CLI command is [`consul acl translate-rules`](/commands/acl/translate-rules).
 
 ### Sample Request
 
@@ -296,7 +296,7 @@ enabled. Login requires the ability to create local tokens which is restricted
 to the primary datacenter and any secondary datacenters with ACL token
 replication enabled.
 
--> The corresponding CLI command is [`consul login`](https://www.consul.io/commands/login)
+-> The corresponding CLI command is [`consul login`](/commands/login).
 
 ### Parameters
 
@@ -384,7 +384,7 @@ The table below shows this endpoint's support for
 -> **Note** - This endpoint requires no specific privileges as it is just
 deleting a token for which you already must possess its secret.
 
--> The corresponding CLI command is [`consul logout`](https://www.consul.io/commands/logout)
+-> The corresponding CLI command is [`consul logout`](/commands/logout).
 
 ### Sample Request
 

--- a/website/content/api-docs/acl/policies.mdx
+++ b/website/content/api-docs/acl/policies.mdx
@@ -33,11 +33,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl policy create`](/commands/acl/policy/create).
-=======
--> The corresponding CLI command is [`consul acl policy create`](https://www.consul.io/commands/acl/policy/create)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -112,11 +108,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl policy read`](/commands/acl/policy/read).
-=======
--> The corresponding CLI command is [`consul acl policy read`](https://www.consul.io/commands/acl/policy/read)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -168,11 +160,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl policy read -name=<string>`](/commands/acl/policy/read#name).
-=======
--> The corresponding CLI command is [`consul acl policy read -name=<string>`](https://www.consul.io/commands/acl/policy/read#name)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -224,11 +212,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl policy update`](/commands/acl/policy/update).
-=======
--> The corresponding CLI command is [`consul acl policy update`](https://www.consul.io/commands/acl/policy/update)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -309,11 +293,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl policy delete`](/commands/acl/policy/delete).
-=======
--> The corresponding CLI command is [`consul acl policy delete`](https://www.consul.io/commands/acl/policy/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -357,11 +337,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl policy list`](/commands/acl/policy/list).
-=======
--> The corresponding CLI command is [`consul acl policy list`](https://www.consul.io/commands/acl/policy/list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/acl/policies.mdx
+++ b/website/content/api-docs/acl/policies.mdx
@@ -33,7 +33,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl policy create`](/commands/acl/policy/create).
+The corresponding CLI command is [`consul acl policy create`](/commands/acl/policy/create).
 
 ### Parameters
 
@@ -108,7 +108,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl policy read`](/commands/acl/policy/read).
+The corresponding CLI command is [`consul acl policy read`](/commands/acl/policy/read).
 
 ### Parameters
 
@@ -160,7 +160,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl policy read -name=<string>`](/commands/acl/policy/read#name).
+The corresponding CLI command is [`consul acl policy read -name=<string>`](/commands/acl/policy/read#name).
 
 ### Parameters
 
@@ -212,7 +212,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl policy update`](/commands/acl/policy/update).
+The corresponding CLI command is [`consul acl policy update`](/commands/acl/policy/update).
 
 ### Parameters
 
@@ -293,7 +293,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl policy delete`](/commands/acl/policy/delete).
+The corresponding CLI command is [`consul acl policy delete`](/commands/acl/policy/delete).
 
 ### Parameters
 
@@ -337,7 +337,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl policy list`](/commands/acl/policy/list).
+The corresponding CLI command is [`consul acl policy list`](/commands/acl/policy/list).
 
 ### Parameters
 

--- a/website/content/api-docs/acl/policies.mdx
+++ b/website/content/api-docs/acl/policies.mdx
@@ -33,6 +33,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl policy create`](https://www.consul.io/commands/acl/policy/create)
+
 ### Parameters
 
 - `Name` `(string: <required>)` - Specifies a name for the ACL policy. The name
@@ -106,6 +108,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl policy read`](https://www.consul.io/commands/acl/policy/read)
+
 ### Parameters
 
 - `id` `(string: <required>)` - Specifies the UUID of the ACL policy to
@@ -156,6 +160,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl policy read -name=<string>`](https://www.consul.io/commands/acl/policy/read#name)
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the name of the ACL policy to
@@ -205,6 +211,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
+
+-> The corresponding CLI command is [`consul acl policy update`](https://www.consul.io/commands/acl/policy/update)
 
 ### Parameters
 
@@ -285,6 +293,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl policy delete`](https://www.consul.io/commands/acl/policy/delete)
+
 ### Parameters
 
 - `id` `(string: <required>)` - Specifies the UUID of the ACL policy to
@@ -326,6 +336,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
+
+-> The corresponding CLI command is [`consul acl policy list`](https://www.consul.io/commands/acl/policy/list)
 
 ### Parameters
 

--- a/website/content/api-docs/acl/policies.mdx
+++ b/website/content/api-docs/acl/policies.mdx
@@ -33,7 +33,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl policy create`](https://www.consul.io/commands/acl/policy/create)
+-> The corresponding CLI command is [`consul acl policy create`](/commands/acl/policy/create).
 
 ### Parameters
 
@@ -108,7 +108,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl policy read`](https://www.consul.io/commands/acl/policy/read)
+-> The corresponding CLI command is [`consul acl policy read`](/commands/acl/policy/read).
 
 ### Parameters
 
@@ -160,7 +160,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl policy read -name=<string>`](https://www.consul.io/commands/acl/policy/read#name)
+-> The corresponding CLI command is [`consul acl policy read -name=<string>`](/commands/acl/policy/read#name).
 
 ### Parameters
 
@@ -212,7 +212,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl policy update`](https://www.consul.io/commands/acl/policy/update)
+-> The corresponding CLI command is [`consul acl policy update`](/commands/acl/policy/update).
 
 ### Parameters
 
@@ -293,7 +293,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl policy delete`](https://www.consul.io/commands/acl/policy/delete)
+-> The corresponding CLI command is [`consul acl policy delete`](/commands/acl/policy/delete).
 
 ### Parameters
 
@@ -337,7 +337,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl policy list`](https://www.consul.io/commands/acl/policy/list)
+-> The corresponding CLI command is [`consul acl policy list`](/commands/acl/policy/list).
 
 ### Parameters
 

--- a/website/content/api-docs/acl/roles.mdx
+++ b/website/content/api-docs/acl/roles.mdx
@@ -32,7 +32,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl role create`](https://www.consul.io/commands/acl/role/create)
+-> The corresponding CLI command is [`consul acl role create`](/commands/acl/role/create).
 
 ### Parameters
 
@@ -174,7 +174,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl role read`](https://www.consul.io/commands/acl/role/read)
+-> The corresponding CLI command is [`consul acl role read`](/commands/acl/role/read).
 
 ### Parameters
 
@@ -246,7 +246,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl role read -name=<string>`](https://www.consul.io/commands/acl/role/read#name)
+-> The corresponding CLI command is [`consul acl role read -name=<string>`](/commands/acl/role/read#name).
 
 ### Parameters
 
@@ -317,7 +317,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl role update`](https://www.consul.io/commands/acl/role/update)
+-> The corresponding CLI command is [`consul acl role update`](/commands/acl/role/update).
 
 ### Parameters
 
@@ -435,7 +435,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl role delete`](https://www.consul.io/commands/acl/role/delete)
+-> The corresponding CLI command is [`consul acl role delete`](/commands/acl/role/delete).
 
 ### Parameters
 
@@ -479,7 +479,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl role list`](https://www.consul.io/commands/acl/role/list)
+-> The corresponding CLI command is [`consul acl role list`](/commands/acl/role/list).
 
 ## Parameters
 

--- a/website/content/api-docs/acl/roles.mdx
+++ b/website/content/api-docs/acl/roles.mdx
@@ -32,11 +32,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl role create`](/commands/acl/role/create).
-=======
--> The corresponding CLI command is [`consul acl role create`](https://www.consul.io/commands/acl/role/create)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -178,11 +174,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl role read`](/commands/acl/role/read).
-=======
--> The corresponding CLI command is [`consul acl role read`](https://www.consul.io/commands/acl/role/read)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -254,11 +246,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl role read -name=<string>`](/commands/acl/role/read#name).
-=======
--> The corresponding CLI command is [`consul acl role read -name=<string>`](https://www.consul.io/commands/acl/role/read#name)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -329,11 +317,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl role update`](/commands/acl/role/update).
-=======
--> The corresponding CLI command is [`consul acl role update`](https://www.consul.io/commands/acl/role/update)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -451,11 +435,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl role delete`](/commands/acl/role/delete).
-=======
--> The corresponding CLI command is [`consul acl role delete`](https://www.consul.io/commands/acl/role/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -499,11 +479,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl role list`](/commands/acl/role/list).
-=======
--> The corresponding CLI command is [`consul acl role list`](https://www.consul.io/commands/acl/role/list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ## Parameters
 

--- a/website/content/api-docs/acl/roles.mdx
+++ b/website/content/api-docs/acl/roles.mdx
@@ -32,6 +32,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl role create`](https://www.consul.io/commands/acl/role/create)
+
 ### Parameters
 
 - `Name` `(string: <required>)` - Specifies a name for the ACL role. The name
@@ -172,6 +174,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl role read`](https://www.consul.io/commands/acl/role/read)
+
 ### Parameters
 
 - `id` `(string: <required>)` - Specifies the UUID of the ACL role to
@@ -242,6 +246,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl role read -name=<string>`](https://www.consul.io/commands/acl/role/read#name)
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the Name of the ACL role to
@@ -310,6 +316,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
+
+-> The corresponding CLI command is [`consul acl role update`](https://www.consul.io/commands/acl/role/update)
 
 ### Parameters
 
@@ -427,6 +435,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl role delete`](https://www.consul.io/commands/acl/role/delete)
+
 ### Parameters
 
 - `id` `(string: <required>)` - Specifies the UUID of the ACL role to
@@ -468,6 +478,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
+
+-> The corresponding CLI command is [`consul acl role list`](https://www.consul.io/commands/acl/role/list)
 
 ## Parameters
 

--- a/website/content/api-docs/acl/roles.mdx
+++ b/website/content/api-docs/acl/roles.mdx
@@ -32,7 +32,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl role create`](/commands/acl/role/create).
+The corresponding CLI command is [`consul acl role create`](/commands/acl/role/create).
 
 ### Parameters
 
@@ -174,7 +174,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl role read`](/commands/acl/role/read).
+The corresponding CLI command is [`consul acl role read`](/commands/acl/role/read).
 
 ### Parameters
 
@@ -246,7 +246,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl role read -name=<string>`](/commands/acl/role/read#name).
+The corresponding CLI command is [`consul acl role read -name=<string>`](/commands/acl/role/read#name).
 
 ### Parameters
 
@@ -317,7 +317,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl role update`](/commands/acl/role/update).
+The corresponding CLI command is [`consul acl role update`](/commands/acl/role/update).
 
 ### Parameters
 
@@ -435,7 +435,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl role delete`](/commands/acl/role/delete).
+The corresponding CLI command is [`consul acl role delete`](/commands/acl/role/delete).
 
 ### Parameters
 
@@ -479,7 +479,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl role list`](/commands/acl/role/list).
+The corresponding CLI command is [`consul acl role list`](/commands/acl/role/list).
 
 ## Parameters
 

--- a/website/content/api-docs/acl/tokens.mdx
+++ b/website/content/api-docs/acl/tokens.mdx
@@ -32,7 +32,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl token create`](/commands/acl/token/create).
+The corresponding CLI command is [`consul acl token create`](/commands/acl/token/create).
 
 ### Parameters
 
@@ -175,7 +175,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl token read`](/commands/acl/token/read).
+The corresponding CLI command is [`consul acl token read`](/commands/acl/token/read).
 
 ### Parameters
 
@@ -247,7 +247,7 @@ The table below shows this endpoint's support for
 -> **Note** - This endpoint requires no specific privileges as it is just
 retrieving the data for a token that you must already possess its secret.
 
--> The corresponding CLI command is [`consul acl token read -self`](/commands/acl/token/read#self).
+The corresponding CLI command is [`consul acl token read -self`](/commands/acl/token/read#self).
 
 ### Sample Request
 
@@ -299,7 +299,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl token update`](/commands/acl/token/update).
+The corresponding CLI command is [`consul acl token update`](/commands/acl/token/update).
 
 ### Parameters
 
@@ -449,7 +449,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl token clone`](/commands/acl/token/clone).
+The corresponding CLI command is [`consul acl token clone`](/commands/acl/token/clone).
 
 ### Parameters
 
@@ -530,7 +530,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl token delete`](/commands/acl/token/delete).
+The corresponding CLI command is [`consul acl token delete`](/commands/acl/token/delete).
 
 ### Parameters
 
@@ -574,7 +574,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl token list`](/commands/acl/token/list).
+The corresponding CLI command is [`consul acl token list`](/commands/acl/token/list).
 
 ## Parameters
 

--- a/website/content/api-docs/acl/tokens.mdx
+++ b/website/content/api-docs/acl/tokens.mdx
@@ -32,7 +32,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl token create`](https://www.consul.io/commands/acl/token/create)
+-> The corresponding CLI command is [`consul acl token create`](/commands/acl/token/create).
 
 ### Parameters
 
@@ -175,7 +175,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl token read`](https://www.consul.io/commands/acl/token/read)
+-> The corresponding CLI command is [`consul acl token read`](/commands/acl/token/read).
 
 ### Parameters
 
@@ -247,7 +247,7 @@ The table below shows this endpoint's support for
 -> **Note** - This endpoint requires no specific privileges as it is just
 retrieving the data for a token that you must already possess its secret.
 
--> The corresponding CLI command is [`consul acl token read -self`](https://www.consul.io/commands/acl/token/read#self)
+-> The corresponding CLI command is [`consul acl token read -self`](/commands/acl/token/read#self).
 
 ### Sample Request
 
@@ -299,7 +299,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl token update`](https://www.consul.io/commands/acl/token/update)
+-> The corresponding CLI command is [`consul acl token update`](/commands/acl/token/update).
 
 ### Parameters
 
@@ -449,7 +449,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl token clone`](https://www.consul.io/commands/acl/token/clone)
+-> The corresponding CLI command is [`consul acl token clone`](/commands/acl/token/clone).
 
 ### Parameters
 
@@ -530,7 +530,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
--> The corresponding CLI command is [`consul acl token delete`](https://www.consul.io/commands/acl/token/delete)
+-> The corresponding CLI command is [`consul acl token delete`](/commands/acl/token/delete).
 
 ### Parameters
 
@@ -574,7 +574,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
--> The corresponding CLI command is [`consul acl token list`](https://www.consul.io/commands/acl/token/list)
+-> The corresponding CLI command is [`consul acl token list`](/commands/acl/token/list).
 
 ## Parameters
 

--- a/website/content/api-docs/acl/tokens.mdx
+++ b/website/content/api-docs/acl/tokens.mdx
@@ -32,6 +32,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl token create`](https://www.consul.io/commands/acl/token/create)
+
 ### Parameters
 
 - `AccessorID` `(string: "")` - Specifies a UUID to use as the token's Accessor ID.
@@ -173,6 +175,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
+-> The corresponding CLI command is [`consul acl token read`](https://www.consul.io/commands/acl/token/read)
+
 ### Parameters
 
 - `AccessorID` `(string: <required>)` - Specifies the accessor ID of the ACL token to
@@ -243,6 +247,8 @@ The table below shows this endpoint's support for
 -> **Note** - This endpoint requires no specific privileges as it is just
 retrieving the data for a token that you must already possess its secret.
 
+-> The corresponding CLI command is [`consul acl token read -self`](https://www.consul.io/commands/acl/token/read#self)
+
 ### Sample Request
 
 ```shell-session
@@ -292,6 +298,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
+
+-> The corresponding CLI command is [`consul acl token update`](https://www.consul.io/commands/acl/token/update)
 
 ### Parameters
 
@@ -441,6 +449,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl token clone`](https://www.consul.io/commands/acl/token/clone)
+
 ### Parameters
 
 - `AccessorID` `(string: <required>)` - The accessor ID of the token to clone. This is required
@@ -520,6 +530,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
+-> The corresponding CLI command is [`consul acl token delete`](https://www.consul.io/commands/acl/token/delete)
+
 ### Parameters
 
 - `AccessorID` `(string: <required>)` - Specifies the accessor ID of the ACL token to
@@ -561,6 +573,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
+
+-> The corresponding CLI command is [`consul acl token list`](https://www.consul.io/commands/acl/token/list)
 
 ## Parameters
 

--- a/website/content/api-docs/acl/tokens.mdx
+++ b/website/content/api-docs/acl/tokens.mdx
@@ -32,11 +32,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl token create`](/commands/acl/token/create).
-=======
--> The corresponding CLI command is [`consul acl token create`](https://www.consul.io/commands/acl/token/create)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -179,11 +175,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl token read`](/commands/acl/token/read).
-=======
--> The corresponding CLI command is [`consul acl token read`](https://www.consul.io/commands/acl/token/read)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -255,11 +247,7 @@ The table below shows this endpoint's support for
 -> **Note** - This endpoint requires no specific privileges as it is just
 retrieving the data for a token that you must already possess its secret.
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl token read -self`](/commands/acl/token/read#self).
-=======
--> The corresponding CLI command is [`consul acl token read -self`](https://www.consul.io/commands/acl/token/read#self)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 
@@ -311,11 +299,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl token update`](/commands/acl/token/update).
-=======
--> The corresponding CLI command is [`consul acl token update`](https://www.consul.io/commands/acl/token/update)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -465,11 +449,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl token clone`](/commands/acl/token/clone).
-=======
--> The corresponding CLI command is [`consul acl token clone`](https://www.consul.io/commands/acl/token/clone)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -550,11 +530,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `acl:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl token delete`](/commands/acl/token/delete).
-=======
--> The corresponding CLI command is [`consul acl token delete`](https://www.consul.io/commands/acl/token/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -598,11 +574,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `acl:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl token list`](/commands/acl/token/list).
-=======
--> The corresponding CLI command is [`consul acl token list`](https://www.consul.io/commands/acl/token/list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ## Parameters
 

--- a/website/content/api-docs/admin-partitions.mdx
+++ b/website/content/api-docs/admin-partitions.mdx
@@ -29,6 +29,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
+-> The corresponding CLI command is [`consul partition create`](/commands/partition#create).
+
 ### Parameters
 
 - `Name` `(string: <required>)` - The partition name. This must be a valid
@@ -85,6 +87,8 @@ The table below shows this endpoint's support for
 
 <sup>1</sup> A non-anonymous token can read its own partition.
 
+-> The corresponding CLI command is [`consul partition read`](/commands/partition#read).
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the partition to read. This
@@ -125,6 +129,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul partition write`](/commands/partition#write).
 
 ### Parameters
 
@@ -188,6 +194,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
+-> The corresponding CLI command is [`consul partition delete`](/commands/partition#delete).
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the partition to delete. This
@@ -230,6 +238,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required    |
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `consistent`      | `none`        | `operator:read` |
+
+-> The corresponding CLI command is [`consul partition list`](/commands/partition#list).
 
 ### Sample Request
 

--- a/website/content/api-docs/admin-partitions.mdx
+++ b/website/content/api-docs/admin-partitions.mdx
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul partition create`](/commands/partition#create).
+The corresponding CLI command is [`consul partition create`](/commands/partition#create).
 
 ### Parameters
 
@@ -87,7 +87,7 @@ The table below shows this endpoint's support for
 
 <sup>1</sup> A non-anonymous token can read its own partition.
 
--> The corresponding CLI command is [`consul partition read`](/commands/partition#read).
+The corresponding CLI command is [`consul partition read`](/commands/partition#read).
 
 ### Parameters
 
@@ -130,7 +130,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul partition write`](/commands/partition#write).
+The corresponding CLI command is [`consul partition write`](/commands/partition#write).
 
 ### Parameters
 
@@ -194,7 +194,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul partition delete`](/commands/partition#delete).
+The corresponding CLI command is [`consul partition delete`](/commands/partition#delete).
 
 ### Parameters
 
@@ -239,7 +239,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `consistent`      | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul partition list`](/commands/partition#list).
+The corresponding CLI command is [`consul partition list`](/commands/partition#list).
 
 ### Sample Request
 

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -227,7 +227,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `node:read`  |
 
--> The corresponding CLI command is [`consul members`](/commands/members).
+The corresponding CLI command is [`consul members`](/commands/members).
 
 ### Parameters
 
@@ -375,7 +375,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
--> The corresponding CLI command is [`consul reload`](/commands/reload).
+The corresponding CLI command is [`consul reload`](/commands/reload).
 
 ### Sample Request
 
@@ -408,7 +408,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `node:write` |
 
--> The corresponding CLI command is [`consul maint`](/commands/maint).
+The corresponding CLI command is [`consul maint`](/commands/maint).
 
 ### Parameters
 
@@ -635,7 +635,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
--> The corresponding CLI command is [`consul join`](/commands/join).
+The corresponding CLI command is [`consul join`](/commands/join).
 
 ### Parameters
 
@@ -677,7 +677,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
--> The corresponding CLI command is [`consul leave`](/commands/leave).
+The corresponding CLI command is [`consul leave`](/commands/leave).
 
 ### Sample Request
 
@@ -716,7 +716,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul force-leave`](/commands/force-leave).
+The corresponding CLI command is [`consul force-leave`](/commands/force-leave).
 
 ### Parameters
 
@@ -792,7 +792,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
--> The corresponding CLI command is [`consul acl set-agent-token`](/commands/acl/set-agent-token).
+The corresponding CLI command is [`consul acl set-agent-token`](/commands/acl/set-agent-token).
 
 ### Parameters
 

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -227,11 +227,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `node:read`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul members`](/commands/members).
-=======
--> The corresponding CLI command is [`consul members`](https://www.consul.io/commands/members)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -379,11 +375,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul reload`](/commands/reload).
-=======
--> The corresponding CLI command is [`consul reload`](https://www.consul.io/commands/reload)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 
@@ -416,11 +408,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `node:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul maint`](/commands/maint).
-=======
--> The corresponding CLI command is [`consul maint`](https://www.consul.io/commands/maint)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -647,11 +635,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul join`](/commands/join).
-=======
--> The corresponding CLI command is [`consul join`](https://www.consul.io/commands/join)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -693,11 +677,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul leave`](/commands/leave).
-=======
--> The corresponding CLI command is [`consul leave`](https://www.consul.io/commands/leave)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 
@@ -736,11 +716,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul force-leave`](/commands/force-leave).
-=======
--> The corresponding CLI command is [`consul force-leave`](https://www.consul.io/commands/force-leave)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -816,11 +792,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul acl set-agent-token`](/commands/acl/set-agent-token).
-=======
--> The corresponding CLI command is [`consul acl set-agent-token`](https://www.consul.io/commands/acl/set-agent-token)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -227,6 +227,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `node:read`  |
 
+-> The corresponding CLI command is [`consul members`](https://www.consul.io/commands/members)
+
 ### Parameters
 
 - `wan` `(bool: false)` - Specifies to list WAN members instead of the LAN
@@ -373,6 +375,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
+-> The corresponding CLI command is [`consul reload`](https://www.consul.io/commands/reload)
+
 ### Sample Request
 
 ```shell-session
@@ -403,6 +407,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `node:write` |
+
+-> The corresponding CLI command is [`consul maint`](https://www.consul.io/commands/maint)
 
 ### Parameters
 
@@ -629,6 +635,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
+-> The corresponding CLI command is [`consul join`](https://www.consul.io/commands/join)
+
 ### Parameters
 
 - `address` `(string: <required>)` - Specifies the address of the other agent to
@@ -669,6 +677,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
+-> The corresponding CLI command is [`consul leave`](https://www.consul.io/commands/leave)
+
 ### Sample Request
 
 ```shell-session
@@ -705,6 +715,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul force-leave`](https://www.consul.io/commands/force-leave)
 
 ### Parameters
 
@@ -779,6 +791,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required  |
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
+
+-> The corresponding CLI command is [`consul acl set-agent-token`](https://www.consul.io/commands/acl/set-agent-token)
 
 ### Parameters
 

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -227,7 +227,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `node:read`  |
 
--> The corresponding CLI command is [`consul members`](https://www.consul.io/commands/members)
+-> The corresponding CLI command is [`consul members`](/commands/members).
 
 ### Parameters
 
@@ -375,7 +375,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
--> The corresponding CLI command is [`consul reload`](https://www.consul.io/commands/reload)
+-> The corresponding CLI command is [`consul reload`](/commands/reload).
 
 ### Sample Request
 
@@ -408,7 +408,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `node:write` |
 
--> The corresponding CLI command is [`consul maint`](https://www.consul.io/commands/maint)
+-> The corresponding CLI command is [`consul maint`](/commands/maint).
 
 ### Parameters
 
@@ -635,7 +635,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
--> The corresponding CLI command is [`consul join`](https://www.consul.io/commands/join)
+-> The corresponding CLI command is [`consul join`](/commands/join).
 
 ### Parameters
 
@@ -677,7 +677,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
--> The corresponding CLI command is [`consul leave`](https://www.consul.io/commands/leave)
+-> The corresponding CLI command is [`consul leave`](/commands/leave).
 
 ### Sample Request
 
@@ -716,7 +716,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul force-leave`](https://www.consul.io/commands/force-leave)
+-> The corresponding CLI command is [`consul force-leave`](/commands/force-leave).
 
 ### Parameters
 
@@ -792,7 +792,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `agent:write` |
 
--> The corresponding CLI command is [`consul acl set-agent-token`](https://www.consul.io/commands/acl/set-agent-token)
+-> The corresponding CLI command is [`consul acl set-agent-token`](/commands/acl/set-agent-token).
 
 ### Parameters
 

--- a/website/content/api-docs/agent/service.mdx
+++ b/website/content/api-docs/agent/service.mdx
@@ -593,6 +593,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `service:write` |
 
+-> The corresponding CLI command is [`consul services register`](https://www.consul.io/commands/services/register)
+
 ### Query string parameters
 
 - `replace-existing-checks` - Missing health checks from the request will be deleted from the agent. Using this parameter allows to idempotently register a service and its checks without having to manually deregister checks.
@@ -765,6 +767,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required    |
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `service:write` |
+
+-> The corresponding CLI command is [`consul services deregister`](https://www.consul.io/commands/services/deregister)
 
 ### Parameters
 

--- a/website/content/api-docs/agent/service.mdx
+++ b/website/content/api-docs/agent/service.mdx
@@ -593,11 +593,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `service:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul services register`](/commands/services/register).
-=======
--> The corresponding CLI command is [`consul services register`](https://www.consul.io/commands/services/register)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Query string parameters
 
@@ -772,11 +768,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `service:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul services deregister`](/commands/services/deregister).
-=======
--> The corresponding CLI command is [`consul services deregister`](https://www.consul.io/commands/services/deregister)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/agent/service.mdx
+++ b/website/content/api-docs/agent/service.mdx
@@ -593,7 +593,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `service:write` |
 
--> The corresponding CLI command is [`consul services register`](https://www.consul.io/commands/services/register)
+-> The corresponding CLI command is [`consul services register`](/commands/services/register).
 
 ### Query string parameters
 
@@ -768,7 +768,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `service:write` |
 
--> The corresponding CLI command is [`consul services deregister`](https://www.consul.io/commands/services/deregister)
+-> The corresponding CLI command is [`consul services deregister`](/commands/services/deregister).
 
 ### Parameters
 

--- a/website/content/api-docs/agent/service.mdx
+++ b/website/content/api-docs/agent/service.mdx
@@ -593,7 +593,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `service:write` |
 
--> The corresponding CLI command is [`consul services register`](/commands/services/register).
+The corresponding CLI command is [`consul services register`](/commands/services/register).
 
 ### Query string parameters
 
@@ -768,7 +768,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `service:write` |
 
--> The corresponding CLI command is [`consul services deregister`](/commands/services/deregister).
+The corresponding CLI command is [`consul services deregister`](/commands/services/deregister).
 
 ### Parameters
 

--- a/website/content/api-docs/catalog.mdx
+++ b/website/content/api-docs/catalog.mdx
@@ -266,7 +266,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul catalog datacenters`](/commands/catalog/datacenters).
+The corresponding CLI command is [`consul catalog datacenters`](/commands/catalog/datacenters).
 
 ### Sample Request
 
@@ -299,7 +299,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
 
--> The corresponding CLI command is [`consul catalog nodes`](/commands/catalog/nodes).
+The corresponding CLI command is [`consul catalog nodes`](/commands/catalog/nodes).
 
 ### Parameters
 
@@ -396,7 +396,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | -------------- |
 | `YES`            | `all`             | `none`        | `service:read` |
 
--> The corresponding CLI command is [`consul catalog services`](/commands/catalog/services).
+The corresponding CLI command is [`consul catalog services`](/commands/catalog/services).
 
 ### Parameters
 

--- a/website/content/api-docs/catalog.mdx
+++ b/website/content/api-docs/catalog.mdx
@@ -266,6 +266,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
+-> The corresponding CLI command is [`consul catalog datacenters`](https://www.consul.io/commands/catalog/datacenters)
+
 ### Sample Request
 
 ```shell-session
@@ -296,6 +298,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
+
+-> The corresponding CLI command is [`consul catalog nodes`](https://www.consul.io/commands/catalog/nodes)
 
 ### Parameters
 
@@ -391,6 +395,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required   |
 | ---------------- | ----------------- | ------------- | -------------- |
 | `YES`            | `all`             | `none`        | `service:read` |
+
+-> The corresponding CLI command is [`consul catalog services`](https://www.consul.io/commands/catalog/services)
 
 ### Parameters
 

--- a/website/content/api-docs/catalog.mdx
+++ b/website/content/api-docs/catalog.mdx
@@ -266,11 +266,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul catalog datacenters`](/commands/catalog/datacenters).
-=======
--> The corresponding CLI command is [`consul catalog datacenters`](https://www.consul.io/commands/catalog/datacenters)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 
@@ -303,11 +299,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul catalog nodes`](/commands/catalog/nodes).
-=======
--> The corresponding CLI command is [`consul catalog nodes`](https://www.consul.io/commands/catalog/nodes)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -404,11 +396,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | -------------- |
 | `YES`            | `all`             | `none`        | `service:read` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul catalog services`](/commands/catalog/services).
-=======
--> The corresponding CLI command is [`consul catalog services`](https://www.consul.io/commands/catalog/services)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/catalog.mdx
+++ b/website/content/api-docs/catalog.mdx
@@ -266,7 +266,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul catalog datacenters`](https://www.consul.io/commands/catalog/datacenters)
+-> The corresponding CLI command is [`consul catalog datacenters`](/commands/catalog/datacenters).
 
 ### Sample Request
 
@@ -299,7 +299,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
 
--> The corresponding CLI command is [`consul catalog nodes`](https://www.consul.io/commands/catalog/nodes)
+-> The corresponding CLI command is [`consul catalog nodes`](/commands/catalog/nodes).
 
 ### Parameters
 
@@ -396,7 +396,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | -------------- |
 | `YES`            | `all`             | `none`        | `service:read` |
 
--> The corresponding CLI command is [`consul catalog services`](https://www.consul.io/commands/catalog/services)
+-> The corresponding CLI command is [`consul catalog services`](/commands/catalog/services).
 
 ### Parameters
 

--- a/website/content/api-docs/config.mdx
+++ b/website/content/api-docs/config.mdx
@@ -48,11 +48,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:write`    |
 | terminating-gateway | `operator:write`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul config write`](/commands/config/write).
-=======
--> The corresponding CLI command is [`consul config write`](https://www.consul.io/commands/config/write)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -121,11 +117,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:read`    |
 | terminating-gateway | `service:read`    |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul config read`](/commands/config/read).
-=======
--> The corresponding CLI command is [`consul config read`](https://www.consul.io/commands/config/read)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -196,11 +188,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:read`    |
 | terminating-gateway | `service:read`    |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul config list`](/commands/config/list).
-=======
--> The corresponding CLI command is [`consul config list`](https://www.consul.io/commands/config/list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -276,11 +264,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:write`    |
 | terminating-gateway | `operator:write `  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul config delete`](/commands/config/delete).
-=======
--> The corresponding CLI command is [`consul config delete`](https://www.consul.io/commands/config/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/config.mdx
+++ b/website/content/api-docs/config.mdx
@@ -48,6 +48,8 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:write`    |
 | terminating-gateway | `operator:write`   |
 
+-> The corresponding CLI command is [`consul config write`](https://www.consul.io/commands/config/write)
+
 ### Parameters
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
@@ -114,6 +116,8 @@ The table below shows this endpoint's support for
 | service-router      | `service:read`    |
 | service-splitter    | `service:read`    |
 | terminating-gateway | `service:read`    |
+
+-> The corresponding CLI command is [`consul config read`](https://www.consul.io/commands/config/read)
 
 ### Parameters
 
@@ -183,6 +187,8 @@ The table below shows this endpoint's support for
 | service-router      | `service:read`    |
 | service-splitter    | `service:read`    |
 | terminating-gateway | `service:read`    |
+
+-> The corresponding CLI command is [`consul config list`](https://www.consul.io/commands/config/list)
 
 ### Parameters
 
@@ -257,6 +263,8 @@ The table below shows this endpoint's support for
 | service-router      | `service:write`    |
 | service-splitter    | `service:write`    |
 | terminating-gateway | `operator:write `  |
+
+-> The corresponding CLI command is [`consul config delete`](https://www.consul.io/commands/config/delete)
 
 ### Parameters
 

--- a/website/content/api-docs/config.mdx
+++ b/website/content/api-docs/config.mdx
@@ -48,7 +48,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:write`    |
 | terminating-gateway | `operator:write`   |
 
--> The corresponding CLI command is [`consul config write`](/commands/config/write).
+The corresponding CLI command is [`consul config write`](/commands/config/write).
 
 ### Parameters
 
@@ -117,7 +117,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:read`    |
 | terminating-gateway | `service:read`    |
 
--> The corresponding CLI command is [`consul config read`](/commands/config/read).
+The corresponding CLI command is [`consul config read`](/commands/config/read).
 
 ### Parameters
 
@@ -188,7 +188,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:read`    |
 | terminating-gateway | `service:read`    |
 
--> The corresponding CLI command is [`consul config list`](/commands/config/list).
+The corresponding CLI command is [`consul config list`](/commands/config/list).
 
 ### Parameters
 
@@ -264,7 +264,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:write`    |
 | terminating-gateway | `operator:write `  |
 
--> The corresponding CLI command is [`consul config delete`](/commands/config/delete).
+The corresponding CLI command is [`consul config delete`](/commands/config/delete).
 
 ### Parameters
 

--- a/website/content/api-docs/config.mdx
+++ b/website/content/api-docs/config.mdx
@@ -48,7 +48,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:write`    |
 | terminating-gateway | `operator:write`   |
 
--> The corresponding CLI command is [`consul config write`](https://www.consul.io/commands/config/write)
+-> The corresponding CLI command is [`consul config write`](/commands/config/write).
 
 ### Parameters
 
@@ -117,7 +117,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:read`    |
 | terminating-gateway | `service:read`    |
 
--> The corresponding CLI command is [`consul config read`](https://www.consul.io/commands/config/read)
+-> The corresponding CLI command is [`consul config read`](/commands/config/read).
 
 ### Parameters
 
@@ -188,7 +188,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:read`    |
 | terminating-gateway | `service:read`    |
 
--> The corresponding CLI command is [`consul config list`](https://www.consul.io/commands/config/list)
+-> The corresponding CLI command is [`consul config list`](/commands/config/list).
 
 ### Parameters
 
@@ -264,7 +264,7 @@ The table below shows this endpoint's support for
 | service-splitter    | `service:write`    |
 | terminating-gateway | `operator:write `  |
 
--> The corresponding CLI command is [`consul config delete`](https://www.consul.io/commands/config/delete)
+-> The corresponding CLI command is [`consul config delete`](/commands/config/delete).
 
 ### Parameters
 

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -125,11 +125,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> ACL required was <code>operator:read</code> prior to versions 1.8.6,
 1.7.10, and 1.6.10.
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul connect ca get-config`](/commands/connect/ca#get-config).
-=======
--> The corresponding CLI command is [`consul connect ca get-config`](https://www.consul.io/commands/connect/ca#get-config)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 
@@ -171,11 +167,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul connect ca set-config`](/commands/connect/ca#set-config).
-=======
--> The corresponding CLI command is [`consul connect ca set-config`](https://www.consul.io/commands/connect/ca#set-config)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -125,7 +125,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> ACL required was <code>operator:read</code> prior to versions 1.8.6,
 1.7.10, and 1.6.10.
 
--> The corresponding CLI command is [`consul connect ca get-config`](https://www.consul.io/commands/connect/ca#get-config)
+-> The corresponding CLI command is [`consul connect ca get-config`](/commands/connect/ca#get-config).
 
 ### Sample Request
 
@@ -167,7 +167,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul connect ca set-config`](https://www.consul.io/commands/connect/ca#set-config)
+-> The corresponding CLI command is [`consul connect ca set-config`](/commands/connect/ca#set-config).
 
 ### Parameters
 

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -125,6 +125,8 @@ The table below shows this endpoint's support for
 <sup>1</sup> ACL required was <code>operator:read</code> prior to versions 1.8.6,
 1.7.10, and 1.6.10.
 
+-> The corresponding CLI command is [`consul connect ca get-config`](https://www.consul.io/commands/connect/ca#get-config)
+
 ### Sample Request
 
 ```shell-session
@@ -164,6 +166,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul connect ca set-config`](https://www.consul.io/commands/connect/ca#set-config)
 
 ### Parameters
 

--- a/website/content/api-docs/connect/ca.mdx
+++ b/website/content/api-docs/connect/ca.mdx
@@ -125,7 +125,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> ACL required was <code>operator:read</code> prior to versions 1.8.6,
 1.7.10, and 1.6.10.
 
--> The corresponding CLI command is [`consul connect ca get-config`](/commands/connect/ca#get-config).
+The corresponding CLI command is [`consul connect ca get-config`](/commands/connect/ca#get-config).
 
 ### Sample Request
 
@@ -167,7 +167,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul connect ca set-config`](/commands/connect/ca#set-config).
+The corresponding CLI command is [`consul connect ca set-config`](/commands/connect/ca#set-config).
 
 ### Parameters
 

--- a/website/content/api-docs/connect/intentions.mdx
+++ b/website/content/api-docs/connect/intentions.mdx
@@ -319,7 +319,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create`](/commands/intention/get).
+-> The corresponding CLI command is [`consul intention get`](/commands/intention/get).
 
 ### Parameters
 
@@ -396,7 +396,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create`](/commands/intention/get).
+-> The corresponding CLI command is [`consul intention get`](/commands/intention/get).
 
 ### Parameters
 

--- a/website/content/api-docs/connect/intentions.mdx
+++ b/website/content/api-docs/connect/intentions.mdx
@@ -54,11 +54,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul intention create -replace`](/commands/intention/create#replace).
-=======
--> The corresponding CLI command is [`consul intention create -replace`](https://www.consul.io/commands/intention/create#replace)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### URL Parameters
 
@@ -169,11 +165,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul intention create`](/commands/intention/create).
-=======
--> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/create)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### URL Parameters
 
@@ -327,11 +319,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul intention create`](/commands/intention/get).
-=======
--> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -408,11 +396,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul intention create`](/commands/intention/get).
-=======
--> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -474,11 +458,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
--> The corresponding CLI command is [`consul intention create`](/commands/intention/get).
-=======
--> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
+-> The corresponding CLI command is `consul intention list`.
 
 ### Parameters
 
@@ -569,11 +549,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul intention delete`](/commands/intention/delete).
-=======
--> The corresponding CLI command is [`consul intention delete`](https://www.consul.io/commands/intention/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -633,11 +609,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul intention delete`](/commands/intention/delete).
-=======
--> The corresponding CLI command is [`consul intention delete`](https://www.consul.io/commands/intention/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -694,11 +666,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul intention check`](/commands/intention/check).
-=======
--> The corresponding CLI command is [`consul intention check`](https://www.consul.io/commands/intention/check)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -763,11 +731,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul intention match`](/commands/intention/match).
-=======
--> The corresponding CLI command is [`consul intention match`](https://www.consul.io/commands/intention/match)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/connect/intentions.mdx
+++ b/website/content/api-docs/connect/intentions.mdx
@@ -458,7 +458,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
-The corresponding CLI command is `consul intention list`.
+The corresponding CLI command is [`consul intention list`](/commands/intention/list).
 
 ### Parameters
 

--- a/website/content/api-docs/connect/intentions.mdx
+++ b/website/content/api-docs/connect/intentions.mdx
@@ -54,7 +54,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create -replace`](/commands/intention/create#replace).
+The corresponding CLI command is [`consul intention create -replace`](/commands/intention/create#replace).
 
 ### URL Parameters
 
@@ -165,7 +165,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create`](/commands/intention/create).
+The corresponding CLI command is [`consul intention create`](/commands/intention/create).
 
 ### URL Parameters
 
@@ -319,7 +319,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention get`](/commands/intention/get).
+The corresponding CLI command is [`consul intention get`](/commands/intention/get).
 
 ### Parameters
 
@@ -396,7 +396,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention get`](/commands/intention/get).
+The corresponding CLI command is [`consul intention get`](/commands/intention/get).
 
 ### Parameters
 
@@ -458,7 +458,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is `consul intention list`.
+The corresponding CLI command is `consul intention list`.
 
 ### Parameters
 
@@ -549,7 +549,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention delete`](/commands/intention/delete).
+The corresponding CLI command is [`consul intention delete`](/commands/intention/delete).
 
 ### Parameters
 
@@ -609,7 +609,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention delete`](/commands/intention/delete).
+The corresponding CLI command is [`consul intention delete`](/commands/intention/delete).
 
 ### Parameters
 
@@ -666,7 +666,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention check`](/commands/intention/check).
+The corresponding CLI command is [`consul intention check`](/commands/intention/check).
 
 ### Parameters
 
@@ -731,7 +731,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention match`](/commands/intention/match).
+The corresponding CLI command is [`consul intention match`](/commands/intention/match).
 
 ### Parameters
 

--- a/website/content/api-docs/connect/intentions.mdx
+++ b/website/content/api-docs/connect/intentions.mdx
@@ -54,7 +54,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create -replace`](https://www.consul.io/commands/intention/create#replace)
+-> The corresponding CLI command is [`consul intention create -replace`](/commands/intention/create#replace).
 
 ### URL Parameters
 
@@ -165,7 +165,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/create)
+-> The corresponding CLI command is [`consul intention create`](/commands/intention/create).
 
 ### URL Parameters
 
@@ -319,7 +319,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
+-> The corresponding CLI command is [`consul intention create`](/commands/intention/get).
 
 ### Parameters
 
@@ -396,7 +396,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
+-> The corresponding CLI command is [`consul intention create`](/commands/intention/get).
 
 ### Parameters
 
@@ -458,7 +458,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
+-> The corresponding CLI command is [`consul intention create`](/commands/intention/get).
 
 ### Parameters
 
@@ -549,7 +549,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention delete`](https://www.consul.io/commands/intention/delete)
+-> The corresponding CLI command is [`consul intention delete`](/commands/intention/delete).
 
 ### Parameters
 
@@ -609,7 +609,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention delete`](https://www.consul.io/commands/intention/delete)
+-> The corresponding CLI command is [`consul intention delete`](/commands/intention/delete).
 
 ### Parameters
 
@@ -666,7 +666,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention check`](https://www.consul.io/commands/intention/check)
+-> The corresponding CLI command is [`consul intention check`](/commands/intention/check).
 
 ### Parameters
 
@@ -731,7 +731,7 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
--> The corresponding CLI command is [`consul intention match`](https://www.consul.io/commands/intention/match)
+-> The corresponding CLI command is [`consul intention match`](/commands/intention/match).
 
 ### Parameters
 

--- a/website/content/api-docs/connect/intentions.mdx
+++ b/website/content/api-docs/connect/intentions.mdx
@@ -54,6 +54,8 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
+-> The corresponding CLI command is [`consul intention create -replace`](https://www.consul.io/commands/intention/create#replace)
+
 ### URL Parameters
 
 - `source` `(string: <required>)` - Specifies the source service. This
@@ -162,6 +164,8 @@ The table below shows this endpoint's support for
   </a>{' '}
   for more details.
 </p>
+
+-> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/create)
 
 ### URL Parameters
 
@@ -315,6 +319,8 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
+-> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
+
 ### Parameters
 
 - `source` `(string: <required>)` - Specifies the source service. This
@@ -390,6 +396,8 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
+-> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
+
 ### Parameters
 
 - `uuid` `(string: <required>)` - Specifies the UUID of the intention to read. This
@@ -449,6 +457,8 @@ The table below shows this endpoint's support for
   </a>{' '}
   for more details.
 </p>
+
+-> The corresponding CLI command is [`consul intention create`](https://www.consul.io/commands/intention/get)
 
 ### Parameters
 
@@ -539,6 +549,8 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
+-> The corresponding CLI command is [`consul intention delete`](https://www.consul.io/commands/intention/delete)
+
 ### Parameters
 
 - `source` `(string: <required>)` - Specifies the source service. This
@@ -597,6 +609,8 @@ The table below shows this endpoint's support for
   for more details.
 </p>
 
+-> The corresponding CLI command is [`consul intention delete`](https://www.consul.io/commands/intention/delete)
+
 ### Parameters
 
 - `uuid` `(string: <required>)` - Specifies the UUID of the intention to delete. This
@@ -651,6 +665,8 @@ The table below shows this endpoint's support for
   </a>{' '}
   for more details.
 </p>
+
+-> The corresponding CLI command is [`consul intention check`](https://www.consul.io/commands/intention/check)
 
 ### Parameters
 
@@ -714,6 +730,8 @@ The table below shows this endpoint's support for
   </a>{' '}
   for more details.
 </p>
+
+-> The corresponding CLI command is [`consul intention match`](https://www.consul.io/commands/intention/match)
 
 ### Parameters
 

--- a/website/content/api-docs/coordinate.mdx
+++ b/website/content/api-docs/coordinate.mdx
@@ -38,6 +38,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
+-> The corresponding CLI command is [`consul rtt -wan #`](https://www.consul.io/commands/rtt#wan)
+
 ### Sample Request
 
 ```shell-session
@@ -89,6 +91,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
+
+-> The corresponding CLI command is [`consul rtt #`](https://www.consul.io/commands/rtt)
 
 ### Parameters
 

--- a/website/content/api-docs/coordinate.mdx
+++ b/website/content/api-docs/coordinate.mdx
@@ -38,7 +38,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul rtt -wan #`](/commands/rtt#wan).
+-> The corresponding CLI command is [`consul rtt -wan`](/commands/rtt#wan).
 
 ### Sample Request
 
@@ -92,7 +92,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
 
--> The corresponding CLI command is [`consul rtt #`](/commands/rtt).
+-> The corresponding CLI command is [`consul rtt`](/commands/rtt).
 
 ### Parameters
 

--- a/website/content/api-docs/coordinate.mdx
+++ b/website/content/api-docs/coordinate.mdx
@@ -38,7 +38,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul rtt -wan`](/commands/rtt#wan).
+The corresponding CLI command is [`consul rtt -wan`](/commands/rtt#wan).
 
 ### Sample Request
 
@@ -92,7 +92,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
 
--> The corresponding CLI command is [`consul rtt`](/commands/rtt).
+The corresponding CLI command is [`consul rtt`](/commands/rtt).
 
 ### Parameters
 

--- a/website/content/api-docs/coordinate.mdx
+++ b/website/content/api-docs/coordinate.mdx
@@ -38,7 +38,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul rtt -wan #`](https://www.consul.io/commands/rtt#wan)
+-> The corresponding CLI command is [`consul rtt -wan #`](/commands/rtt#wan).
 
 ### Sample Request
 
@@ -92,7 +92,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
 
--> The corresponding CLI command is [`consul rtt #`](https://www.consul.io/commands/rtt)
+-> The corresponding CLI command is [`consul rtt #`](/commands/rtt).
 
 ### Parameters
 

--- a/website/content/api-docs/coordinate.mdx
+++ b/website/content/api-docs/coordinate.mdx
@@ -38,11 +38,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul rtt -wan #`](/commands/rtt#wan).
-=======
--> The corresponding CLI command is [`consul rtt -wan #`](https://www.consul.io/commands/rtt#wan)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 
@@ -96,11 +92,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `node:read`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul rtt #`](/commands/rtt).
-=======
--> The corresponding CLI command is [`consul rtt #`](https://www.consul.io/commands/rtt)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/event.mdx
+++ b/website/content/api-docs/event.mdx
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `event:write` |
 
--> The corresponding CLI command is [`consul event`](https://www.consul.io/commands/event)
+-> The corresponding CLI command is [`consul event`](/commands/event).
 
 ### Parameters
 

--- a/website/content/api-docs/event.mdx
+++ b/website/content/api-docs/event.mdx
@@ -29,6 +29,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `event:write` |
 
+-> The corresponding CLI command is [`consul event`](https://www.consul.io/commands/event)
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the name of the event to fire. This

--- a/website/content/api-docs/event.mdx
+++ b/website/content/api-docs/event.mdx
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `event:write` |
 
--> The corresponding CLI command is [`consul event`](/commands/event).
+The corresponding CLI command is [`consul event`](/commands/event).
 
 ### Parameters
 

--- a/website/content/api-docs/event.mdx
+++ b/website/content/api-docs/event.mdx
@@ -29,11 +29,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------- |
 | `NO`             | `none`            | `none`        | `event:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul event`](/commands/event).
-=======
--> The corresponding CLI command is [`consul event`](https://www.consul.io/commands/event)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -41,7 +41,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `key:read`   |
 
--> The corresponding CLI command is [`consul kv get`](/commands/kv/get).
+The corresponding CLI command is [`consul kv get`](/commands/kv/get).
 
 ### Parameters
 
@@ -173,7 +173,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `key:write`  |
 
--> The corresponding CLI command is [`consul kv put`](/commands/kv/put).
+The corresponding CLI command is [`consul kv put`](/commands/kv/put).
 
 ### Parameters
 
@@ -261,7 +261,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `key:write`  |
 
--> The corresponding CLI command is [`consul kv delete`](/commands/kv/delete).
+The corresponding CLI command is [`consul kv delete`](/commands/kv/delete).
 
 ### Parameters
 

--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -41,11 +41,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `key:read`   |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul kv get`](/commands/kv/get).
-=======
--> The corresponding CLI command is [`consul kv get`](https://www.consul.io/commands/kv/get)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -177,11 +173,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `key:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul kv put`](/commands/kv/put).
-=======
--> The corresponding CLI command is [`consul kv put`](https://www.consul.io/commands/kv/put)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -269,11 +261,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `key:write`  |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul kv delete`](/commands/kv/delete).
-=======
--> The corresponding CLI command is [`consul kv delete`](https://www.consul.io/commands/kv/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -41,6 +41,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `key:read`   |
 
+-> The corresponding CLI command is [`consul kv get`](https://www.consul.io/commands/kv/get)
+
 ### Parameters
 
 - `key` `(string: "")` - Specifies the path of the key to read.
@@ -171,6 +173,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `key:write`  |
 
+-> The corresponding CLI command is [`consul kv put`](https://www.consul.io/commands/kv/put)
+
 ### Parameters
 
 - `key` `(string: "")` - Specifies the path of the key.
@@ -256,6 +260,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `key:write`  |
+
+-> The corresponding CLI command is [`consul kv delete`](https://www.consul.io/commands/kv/delete)
 
 ### Parameters
 

--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -41,7 +41,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `YES`            | `all`             | `none`        | `key:read`   |
 
--> The corresponding CLI command is [`consul kv get`](https://www.consul.io/commands/kv/get)
+-> The corresponding CLI command is [`consul kv get`](/commands/kv/get).
 
 ### Parameters
 
@@ -173,7 +173,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `key:write`  |
 
--> The corresponding CLI command is [`consul kv put`](https://www.consul.io/commands/kv/put)
+-> The corresponding CLI command is [`consul kv put`](/commands/kv/put).
 
 ### Parameters
 
@@ -261,7 +261,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `key:write`  |
 
--> The corresponding CLI command is [`consul kv delete`](https://www.consul.io/commands/kv/delete)
+-> The corresponding CLI command is [`consul kv delete`](/commands/kv/delete).
 
 ### Parameters
 

--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -29,6 +29,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
+-> The corresponding CLI command is [`consul namespace create`](https://www.consul.io/commands/namespace/create)
+
 ### Parameters
 
 - `Name` `(string: <required>)` - The namespaces name. This must be a valid
@@ -161,6 +163,8 @@ The table below shows this endpoint's support for
 <sup>1</sup> Access can be granted to list the Namespace if the token used when making
 the request has been granted any access in the namespace (read, list or write).
 
+-> The corresponding CLI command is [`consul namespace read`](https://www.consul.io/commands/namespace/read)
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the namespace to read. This
@@ -226,6 +230,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul namespace update`](https://www.consul.io/commands/namespace/update) or [`consul namespace write`](https://www.consul.io/commands/namespace/write)
 
 ### Parameters
 
@@ -364,6 +370,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
+-> The corresponding CLI command is [`consul namespace delete`](https://www.consul.io/commands/namespace/delete)
+
 ### Parameters
 
 - `name` `(string: <required>)` - Specifies the namespace to delete. This
@@ -435,6 +443,8 @@ The table below shows this endpoint's support for
 
 <sup>1</sup> Access can be granted to list the Namespace if the token used when making
 the request has been granted any access in the namespace (read, list or write).
+
+-> The corresponding CLI command is [`consul namespace list`](https://www.consul.io/commands/namespace/list)
 
 ### Sample Request
 

--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul namespace create`](https://www.consul.io/commands/namespace/create)
+-> The corresponding CLI command is [`consul namespace create`](/commands/namespace/create).
 
 ### Parameters
 
@@ -163,7 +163,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> Access can be granted to list the Namespace if the token used when making
 the request has been granted any access in the namespace (read, list or write).
 
--> The corresponding CLI command is [`consul namespace read`](https://www.consul.io/commands/namespace/read)
+-> The corresponding CLI command is [`consul namespace read`](/commands/namespace/read).
 
 ### Parameters
 
@@ -231,7 +231,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul namespace update`](https://www.consul.io/commands/namespace/update) or [`consul namespace write`](https://www.consul.io/commands/namespace/write)
+-> The corresponding CLI command is [`consul namespace update`](/commands/namespace/update) or [`consul namespace write`](/commands/namespace/write).
 
 ### Parameters
 
@@ -370,7 +370,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul namespace delete`](https://www.consul.io/commands/namespace/delete)
+-> The corresponding CLI command is [`consul namespace delete`](/commands/namespace/delete).
 
 ### Parameters
 
@@ -444,7 +444,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> Access can be granted to list the Namespace if the token used when making
 the request has been granted any access in the namespace (read, list or write).
 
--> The corresponding CLI command is [`consul namespace list`](https://www.consul.io/commands/namespace/list)
+-> The corresponding CLI command is [`consul namespace list`](/commands/namespace/list).
 
 ### Sample Request
 

--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -29,11 +29,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul namespace create`](/commands/namespace/create).
-=======
--> The corresponding CLI command is [`consul namespace create`](https://www.consul.io/commands/namespace/create)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -167,11 +163,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> Access can be granted to list the Namespace if the token used when making
 the request has been granted any access in the namespace (read, list or write).
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul namespace read`](/commands/namespace/read).
-=======
--> The corresponding CLI command is [`consul namespace read`](https://www.consul.io/commands/namespace/read)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -239,11 +231,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul namespace update`](/commands/namespace/update) or [`consul namespace write`](/commands/namespace/write).
-=======
--> The corresponding CLI command is [`consul namespace update`](https://www.consul.io/commands/namespace/update) or [`consul namespace write`](https://www.consul.io/commands/namespace/write)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -382,11 +370,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul namespace delete`](/commands/namespace/delete).
-=======
--> The corresponding CLI command is [`consul namespace delete`](https://www.consul.io/commands/namespace/delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -460,11 +444,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> Access can be granted to list the Namespace if the token used when making
 the request has been granted any access in the namespace (read, list or write).
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul namespace list`](/commands/namespace/list).
-=======
--> The corresponding CLI command is [`consul namespace list`](https://www.consul.io/commands/namespace/list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Sample Request
 

--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul namespace create`](/commands/namespace/create).
+The corresponding CLI command is [`consul namespace create`](/commands/namespace/create).
 
 ### Parameters
 
@@ -163,7 +163,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> Access can be granted to list the Namespace if the token used when making
 the request has been granted any access in the namespace (read, list or write).
 
--> The corresponding CLI command is [`consul namespace read`](/commands/namespace/read).
+The corresponding CLI command is [`consul namespace read`](/commands/namespace/read).
 
 ### Parameters
 
@@ -231,7 +231,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul namespace update`](/commands/namespace/update) or [`consul namespace write`](/commands/namespace/write).
+The corresponding CLI command is [`consul namespace update`](/commands/namespace/update) or [`consul namespace write`](/commands/namespace/write).
 
 ### Parameters
 
@@ -370,7 +370,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul namespace delete`](/commands/namespace/delete).
+The corresponding CLI command is [`consul namespace delete`](/commands/namespace/delete).
 
 ### Parameters
 
@@ -444,7 +444,7 @@ The table below shows this endpoint's support for
 <sup>1</sup> Access can be granted to list the Namespace if the token used when making
 the request has been granted any access in the namespace (read, list or write).
 
--> The corresponding CLI command is [`consul namespace list`](/commands/namespace/list).
+The corresponding CLI command is [`consul namespace list`](/commands/namespace/list).
 
 ### Sample Request
 

--- a/website/content/api-docs/operator/area.mdx
+++ b/website/content/api-docs/operator/area.mdx
@@ -45,11 +45,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator area create`](/commands/operator/area#create).
-=======
--> The corresponding CLI command is [`consul operator area create`](https://www.consul.io/commands/operator/area#create)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -117,11 +113,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `YES`            | `all`             | `none`        | `operator:read` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator area list`](/commands/operator/area#list).
-=======
--> The corresponding CLI command is [`consul operator area list`](https://www.consul.io/commands/operator/area#list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -166,11 +158,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator area update`](/commands/operator/area#update).
-=======
--> The corresponding CLI command is [`consul operator area update`](https://www.consul.io/commands/operator/area#update)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -262,11 +250,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator area delete`](/commands/operator/area#delete).
-=======
--> The corresponding CLI command is [`consul operator area delete`](https://www.consul.io/commands/operator/area#delete)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -304,11 +288,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator area join`](/commands/operator/area#join).
-=======
--> The corresponding CLI command is [`consul operator area join`](https://www.consul.io/commands/operator/area#join)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -383,11 +363,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator area members`](/commands/operator/area#members).
-=======
--> The corresponding CLI command is [`consul operator area members`](https://www.consul.io/commands/operator/area#members)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/operator/area.mdx
+++ b/website/content/api-docs/operator/area.mdx
@@ -45,6 +45,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
+-> The corresponding CLI command is [`consul operator area create`](https://www.consul.io/commands/operator/area#create)
+
 ### Parameters
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
@@ -111,6 +113,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `YES`            | `all`             | `none`        | `operator:read` |
 
+-> The corresponding CLI command is [`consul operator area list`](https://www.consul.io/commands/operator/area#list)
+
 ### Parameters
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
@@ -153,6 +157,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul operator area update`](https://www.consul.io/commands/operator/area#update)
 
 ### Parameters
 
@@ -244,6 +250,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
+-> The corresponding CLI command is [`consul operator area delete`](https://www.consul.io/commands/operator/area#delete)
+
 ### Parameters
 
 - `uuid` `(string: <required>)` - Specifies the UUID of the area to delete. This
@@ -279,6 +287,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul operator area join`](https://www.consul.io/commands/operator/area#join)
 
 ### Parameters
 
@@ -352,6 +362,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required    |
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
+
+-> The corresponding CLI command is [`consul operator area members`](https://www.consul.io/commands/operator/area#members)
 
 ### Parameters
 

--- a/website/content/api-docs/operator/area.mdx
+++ b/website/content/api-docs/operator/area.mdx
@@ -45,7 +45,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator area create`](/commands/operator/area#create).
+The corresponding CLI command is [`consul operator area create`](/commands/operator/area#create).
 
 ### Parameters
 
@@ -113,7 +113,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `YES`            | `all`             | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul operator area list`](/commands/operator/area#list).
+The corresponding CLI command is [`consul operator area list`](/commands/operator/area#list).
 
 ### Parameters
 
@@ -158,7 +158,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator area update`](/commands/operator/area#update).
+The corresponding CLI command is [`consul operator area update`](/commands/operator/area#update).
 
 ### Parameters
 
@@ -250,7 +250,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator area delete`](/commands/operator/area#delete).
+The corresponding CLI command is [`consul operator area delete`](/commands/operator/area#delete).
 
 ### Parameters
 
@@ -288,7 +288,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator area join`](/commands/operator/area#join).
+The corresponding CLI command is [`consul operator area join`](/commands/operator/area#join).
 
 ### Parameters
 
@@ -363,7 +363,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul operator area members`](/commands/operator/area#members).
+The corresponding CLI command is [`consul operator area members`](/commands/operator/area#members).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/area.mdx
+++ b/website/content/api-docs/operator/area.mdx
@@ -45,7 +45,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator area create`](https://www.consul.io/commands/operator/area#create)
+-> The corresponding CLI command is [`consul operator area create`](/commands/operator/area#create).
 
 ### Parameters
 
@@ -113,7 +113,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `YES`            | `all`             | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul operator area list`](https://www.consul.io/commands/operator/area#list)
+-> The corresponding CLI command is [`consul operator area list`](/commands/operator/area#list).
 
 ### Parameters
 
@@ -158,7 +158,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator area update`](https://www.consul.io/commands/operator/area#update)
+-> The corresponding CLI command is [`consul operator area update`](/commands/operator/area#update).
 
 ### Parameters
 
@@ -250,7 +250,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator area delete`](https://www.consul.io/commands/operator/area#delete)
+-> The corresponding CLI command is [`consul operator area delete`](/commands/operator/area#delete).
 
 ### Parameters
 
@@ -288,7 +288,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator area join`](https://www.consul.io/commands/operator/area#join)
+-> The corresponding CLI command is [`consul operator area join`](/commands/operator/area#join).
 
 ### Parameters
 
@@ -363,7 +363,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul operator area members`](https://www.consul.io/commands/operator/area#members)
+-> The corresponding CLI command is [`consul operator area members`](/commands/operator/area#members).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/autopilot.mdx
+++ b/website/content/api-docs/operator/autopilot.mdx
@@ -33,11 +33,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator autopilot get-config`](/commands/operator/autopilot#get-config).
-=======
--> The corresponding CLI command is [`consul operator autopilot get-config`](https://www.consul.io/commands/operator/autopilot#get-config)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -93,11 +89,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator autopilot set-config`](/commands/operator/autopilot#set-config).
-=======
--> The corresponding CLI command is [`consul operator autopilot set-config`](https://www.consul.io/commands/operator/autopilot#set-config)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -281,11 +273,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator autopilot state`](/commands/operator/autopilot#state).
-=======
--> The corresponding CLI command is [`consul operator autopilot state`](https://www.consul.io/commands/operator/autopilot#state)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/operator/autopilot.mdx
+++ b/website/content/api-docs/operator/autopilot.mdx
@@ -33,6 +33,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
+-> The corresponding CLI command is [`consul operator autopilot get-config`](https://www.consul.io/commands/operator/autopilot#get-config)
+
 ### Parameters
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
@@ -86,6 +88,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul operator autopilot set-config`](https://www.consul.io/commands/operator/autopilot#set-config)
 
 ### Parameters
 
@@ -268,6 +272,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required    |
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
+
+-> The corresponding CLI command is [`consul operator autopilot state`](https://www.consul.io/commands/operator/autopilot#state)
 
 ### Parameters
 

--- a/website/content/api-docs/operator/autopilot.mdx
+++ b/website/content/api-docs/operator/autopilot.mdx
@@ -33,7 +33,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul operator autopilot get-config`](https://www.consul.io/commands/operator/autopilot#get-config)
+-> The corresponding CLI command is [`consul operator autopilot get-config`](/commands/operator/autopilot#get-config).
 
 ### Parameters
 
@@ -89,7 +89,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator autopilot set-config`](https://www.consul.io/commands/operator/autopilot#set-config)
+-> The corresponding CLI command is [`consul operator autopilot set-config`](/commands/operator/autopilot#set-config).
 
 ### Parameters
 
@@ -273,7 +273,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul operator autopilot state`](https://www.consul.io/commands/operator/autopilot#state)
+-> The corresponding CLI command is [`consul operator autopilot state`](/commands/operator/autopilot#state).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/autopilot.mdx
+++ b/website/content/api-docs/operator/autopilot.mdx
@@ -33,7 +33,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul operator autopilot get-config`](/commands/operator/autopilot#get-config).
+The corresponding CLI command is [`consul operator autopilot get-config`](/commands/operator/autopilot#get-config).
 
 ### Parameters
 
@@ -89,7 +89,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator autopilot set-config`](/commands/operator/autopilot#set-config).
+The corresponding CLI command is [`consul operator autopilot set-config`](/commands/operator/autopilot#set-config).
 
 ### Parameters
 
@@ -273,7 +273,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `operator:read` |
 
--> The corresponding CLI command is [`consul operator autopilot state`](/commands/operator/autopilot#state).
+The corresponding CLI command is [`consul operator autopilot state`](/commands/operator/autopilot#state).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/keyring.mdx
+++ b/website/content/api-docs/operator/keyring.mdx
@@ -35,7 +35,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | -------------- |
 | `NO`             | `none`            | `none`        | `keyring:read` |
 
--> The corresponding CLI command is [`consul keyring -list`](/commands/keyring#list).
+The corresponding CLI command is [`consul keyring -list`](/commands/keyring#list).
 
 ### Parameters
 
@@ -122,7 +122,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
--> The corresponding CLI command is [`consul keyring -intstall`](/commands/keyring#install).
+The corresponding CLI command is [`consul keyring -intstall`](/commands/keyring#install).
 
 ### Parameters
 
@@ -170,7 +170,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
--> The corresponding CLI command is [`consul keyring -use`](/commands/keyring#use).
+The corresponding CLI command is [`consul keyring -use`](/commands/keyring#use).
 
 ### Parameters
 
@@ -218,7 +218,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
--> The corresponding CLI command is [`consul keyring -remove`](/commands/keyring#remove).
+The corresponding CLI command is [`consul keyring -remove`](/commands/keyring#remove).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/keyring.mdx
+++ b/website/content/api-docs/operator/keyring.mdx
@@ -35,7 +35,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | -------------- |
 | `NO`             | `none`            | `none`        | `keyring:read` |
 
--> The corresponding CLI command is [`consul keyring -list`](https://www.consul.io/commands/keyring#list)
+-> The corresponding CLI command is [`consul keyring -list`](/commands/keyring#list).
 
 ### Parameters
 
@@ -122,7 +122,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
--> The corresponding CLI command is [`consul keyring -intstall`](https://www.consul.io/commands/keyring#install)
+-> The corresponding CLI command is [`consul keyring -intstall`](/commands/keyring#install).
 
 ### Parameters
 
@@ -170,7 +170,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
--> The corresponding CLI command is [`consul keyring -use`](https://www.consul.io/commands/keyring#use)
+-> The corresponding CLI command is [`consul keyring -use`](/commands/keyring#use).
 
 ### Parameters
 
@@ -218,7 +218,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
--> The corresponding CLI command is [`consul keyring -remove`](https://www.consul.io/commands/keyring#remove)
+-> The corresponding CLI command is [`consul keyring -remove`](/commands/keyring#remove).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/keyring.mdx
+++ b/website/content/api-docs/operator/keyring.mdx
@@ -35,11 +35,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | -------------- |
 | `NO`             | `none`            | `none`        | `keyring:read` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul keyring -list`](/commands/keyring#list).
-=======
--> The corresponding CLI command is [`consul keyring -list`](https://www.consul.io/commands/keyring#list)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -126,11 +122,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul keyring -intstall`](/commands/keyring#install).
-=======
--> The corresponding CLI command is [`consul keyring -intstall`](https://www.consul.io/commands/keyring#install)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -178,11 +170,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul keyring -use`](/commands/keyring#use).
-=======
--> The corresponding CLI command is [`consul keyring -use`](https://www.consul.io/commands/keyring#use)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -230,11 +218,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul keyring -remove`](/commands/keyring#remove).
-=======
--> The corresponding CLI command is [`consul keyring -remove`](https://www.consul.io/commands/keyring#remove)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/operator/keyring.mdx
+++ b/website/content/api-docs/operator/keyring.mdx
@@ -35,6 +35,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | -------------- |
 | `NO`             | `none`            | `none`        | `keyring:read` |
 
+-> The corresponding CLI command is [`consul keyring -list`](https://www.consul.io/commands/keyring#list)
+
 ### Parameters
 
 - `relay-factor` `(int: 0)` - Specifies the relay factor. Setting this to a
@@ -120,6 +122,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
+-> The corresponding CLI command is [`consul keyring -intstall`](https://www.consul.io/commands/keyring#install)
+
 ### Parameters
 
 - `relay-factor` `(int: 0)` - Specifies the relay factor. Setting this to a
@@ -166,6 +170,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
 
+-> The corresponding CLI command is [`consul keyring -use`](https://www.consul.io/commands/keyring#use)
+
 ### Parameters
 
 - `relay-factor` `(int: 0)` - Specifies the relay factor. Setting this to a
@@ -211,6 +217,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required    |
 | ---------------- | ----------------- | ------------- | --------------- |
 | `NO`             | `none`            | `none`        | `keyring:write` |
+
+-> The corresponding CLI command is [`consul keyring -remove`](https://www.consul.io/commands/keyring#remove)
 
 ### Parameters
 

--- a/website/content/api-docs/operator/license.mdx
+++ b/website/content/api-docs/operator/license.mdx
@@ -31,7 +31,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `all`             | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul license get`](https://www.consul.io/commands/license#get)
+-> The corresponding CLI command is [`consul license get`](/commands/license#get).
 
 ### Parameters
 
@@ -98,7 +98,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul license put`](https://www.consul.io/commands/license#put)
+-> The corresponding CLI command is [`consul license put`](/commands/license#put).
 
 ### Parameters
 
@@ -170,7 +170,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul license reset`](https://www.consul.io/commands/license#reset)
+-> The corresponding CLI command is [`consul license reset`](/commands/license#reset).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/license.mdx
+++ b/website/content/api-docs/operator/license.mdx
@@ -31,6 +31,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `all`             | `none`        | `none`       |
 
+-> The corresponding CLI command is [`consul license get`](https://www.consul.io/commands/license#get)
+
 ### Parameters
 
 - `dc` `(string: "")` - Specifies the datacenter whose license should be retrieved.
@@ -95,6 +97,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul license put`](https://www.consul.io/commands/license#put)
 
 ### Parameters
 
@@ -165,6 +169,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
+
+-> The corresponding CLI command is [`consul license reset`](https://www.consul.io/commands/license#reset)
 
 ### Parameters
 

--- a/website/content/api-docs/operator/license.mdx
+++ b/website/content/api-docs/operator/license.mdx
@@ -31,11 +31,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `all`             | `none`        | `none`       |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul license get`](/commands/license#get).
-=======
--> The corresponding CLI command is [`consul license get`](https://www.consul.io/commands/license#get)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -102,11 +98,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul license put`](/commands/license#put).
-=======
--> The corresponding CLI command is [`consul license put`](https://www.consul.io/commands/license#put)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -178,11 +170,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul license reset`](/commands/license#reset).
-=======
--> The corresponding CLI command is [`consul license reset`](https://www.consul.io/commands/license#reset)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/operator/license.mdx
+++ b/website/content/api-docs/operator/license.mdx
@@ -31,7 +31,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `all`             | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul license get`](/commands/license#get).
+The corresponding CLI command is [`consul license get`](/commands/license#get).
 
 ### Parameters
 
@@ -98,7 +98,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul license put`](/commands/license#put).
+The corresponding CLI command is [`consul license put`](/commands/license#put).
 
 ### Parameters
 
@@ -170,7 +170,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul license reset`](/commands/license#reset).
+The corresponding CLI command is [`consul license reset`](/commands/license#reset).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/raft.mdx
+++ b/website/content/api-docs/operator/raft.mdx
@@ -130,6 +130,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
+-> The corresponding CLI command is [`consul operator raft remove-peer`](https://www.consul.io/commands/operator/raft#remove-peer)
+
 ### Parameters
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to

--- a/website/content/api-docs/operator/raft.mdx
+++ b/website/content/api-docs/operator/raft.mdx
@@ -130,7 +130,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator raft remove-peer`](https://www.consul.io/commands/operator/raft#remove-peer)
+-> The corresponding CLI command is [`consul operator raft remove-peer`](/commands/operator/raft#remove-peer).
 
 ### Parameters
 

--- a/website/content/api-docs/operator/raft.mdx
+++ b/website/content/api-docs/operator/raft.mdx
@@ -130,11 +130,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator raft remove-peer`](/commands/operator/raft#remove-peer).
-=======
--> The corresponding CLI command is [`consul operator raft remove-peer`](https://www.consul.io/commands/operator/raft#remove-peer)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/operator/raft.mdx
+++ b/website/content/api-docs/operator/raft.mdx
@@ -130,7 +130,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ---------------- |
 | `NO`             | `none`            | `none`        | `operator:write` |
 
--> The corresponding CLI command is [`consul operator raft remove-peer`](/commands/operator/raft#remove-peer).
+The corresponding CLI command is [`consul operator raft remove-peer`](/commands/operator/raft#remove-peer).
 
 ### Parameters
 

--- a/website/content/api-docs/snapshot.mdx
+++ b/website/content/api-docs/snapshot.mdx
@@ -39,6 +39,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `default,stale`   | `none`        | `management` |
 
+-> The corresponding CLI command is [`consul snapshot save`](https://www.consul.io/commands/snapshot/save)
+
 ### Parameters
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default
@@ -93,6 +95,8 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `management` |
+
+-> The corresponding CLI command is [`consul snapshot restore`](https://www.consul.io/commands/snapshot/restore)
 
 ### Parameters
 

--- a/website/content/api-docs/snapshot.mdx
+++ b/website/content/api-docs/snapshot.mdx
@@ -39,7 +39,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `default,stale`   | `none`        | `management` |
 
--> The corresponding CLI command is [`consul snapshot save`](https://www.consul.io/commands/snapshot/save)
+-> The corresponding CLI command is [`consul snapshot save`](/commands/snapshot/save).
 
 ### Parameters
 
@@ -96,7 +96,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `management` |
 
--> The corresponding CLI command is [`consul snapshot restore`](https://www.consul.io/commands/snapshot/restore)
+-> The corresponding CLI command is [`consul snapshot restore`](/commands/snapshot/restore).
 
 ### Parameters
 

--- a/website/content/api-docs/snapshot.mdx
+++ b/website/content/api-docs/snapshot.mdx
@@ -39,11 +39,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `default,stale`   | `none`        | `management` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul snapshot save`](/commands/snapshot/save).
-=======
--> The corresponding CLI command is [`consul snapshot save`](https://www.consul.io/commands/snapshot/save)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 
@@ -100,11 +96,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `management` |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul snapshot restore`](/commands/snapshot/restore).
-=======
--> The corresponding CLI command is [`consul snapshot restore`](https://www.consul.io/commands/snapshot/restore)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/snapshot.mdx
+++ b/website/content/api-docs/snapshot.mdx
@@ -39,7 +39,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `default,stale`   | `none`        | `management` |
 
--> The corresponding CLI command is [`consul snapshot save`](/commands/snapshot/save).
+The corresponding CLI command is [`consul snapshot save`](/commands/snapshot/save).
 
 ### Parameters
 
@@ -96,7 +96,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `management` |
 
--> The corresponding CLI command is [`consul snapshot restore`](/commands/snapshot/restore).
+The corresponding CLI command is [`consul snapshot restore`](/commands/snapshot/restore).
 
 ### Parameters
 

--- a/website/content/api-docs/status.mdx
+++ b/website/content/api-docs/status.mdx
@@ -70,7 +70,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul operator raft list-peers`](https://www.consul.io/commands/operator/raft#list-peers)
+-> The corresponding CLI command is [`consul operator raft list-peers`](/commands/operator/raft#list-peers).
 
 ### Parameters
 

--- a/website/content/api-docs/status.mdx
+++ b/website/content/api-docs/status.mdx
@@ -70,11 +70,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
-<<<<<<< HEAD
 -> The corresponding CLI command is [`consul operator raft list-peers`](/commands/operator/raft#list-peers).
-=======
--> The corresponding CLI command is [`consul operator raft list-peers`](https://www.consul.io/commands/operator/raft#list-peers)
->>>>>>> f3587417d0a80537b28263338c32bfd840714733
 
 ### Parameters
 

--- a/website/content/api-docs/status.mdx
+++ b/website/content/api-docs/status.mdx
@@ -70,7 +70,7 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
--> The corresponding CLI command is [`consul operator raft list-peers`](/commands/operator/raft#list-peers).
+The corresponding CLI command is [`consul operator raft list-peers`](/commands/operator/raft#list-peers).
 
 ### Parameters
 

--- a/website/content/api-docs/status.mdx
+++ b/website/content/api-docs/status.mdx
@@ -70,6 +70,8 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
+-> The corresponding CLI command is [`consul operator raft list-peers`](https://www.consul.io/commands/operator/raft#list-peers)
+
 ### Parameters
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to


### PR DESCRIPTION
As the title suggests, this docs changes is to include a link to the CLI command from the equivalent HTTP API page