### PR TITLE
[WIP] Version string normalization

### DIFF
--- a/website/content/docs/upgrading/instructions/upgrade-to-1-6-x.mdx
+++ b/website/content/docs/upgrading/instructions/upgrade-to-1-6-x.mdx
@@ -1,35 +1,35 @@
 ---
 layout: docs
-page_title: Upgrading to 1.6.9
+page_title: Upgrading to Consul 1.6.9
 description: >-
   Specific versions of Consul may have additional information about the upgrade
   process beyond the standard flow.
 ---
 
-# Upgrading to 1.6.9
+# Upgrading to Consul 1.6.9
 
 ## Introduction
-
+ 
 This guide explains how to best upgrade a multi-datacenter Consul deployment that is using
-a version of Consul >= 1.2.4 and < 1.6.9 while maintaining replication. If you are on a version
-older than 1.2.4, please review our [Upgrading to 1.2.4](/docs/upgrading/instructions/upgrade-to-1-2-x)
+versions of Consul 1.2.4 to 1.6.9 while maintaining replication. If you are on a version
+older than Consul 1.2.4, please review our [Upgrading to Consul 1.2.4](/docs/upgrading/instructions/upgrade-to-1-2-x)
 guide. Due to changes to the ACL system, an ACL token migration will need to be performed
-as part of this upgrade. The 1.6.x series is the last series that had support for legacy
-ACL tokens, so this migration _must_ happen before upgrading past the 1.6.x release series.
+as part of this upgrade. The Consul 1.6.x series is the last series that had support for legacy
+ACL tokens, so this migration _must_ happen before upgrading past the Consul 1.6.x release series.
 Here is some documentation that may prove useful for reference during this upgrade process:
 
 - [ACL System in Legacy Mode](https://www.consul.io/docs/acl/acl-legacy) - You can find
   information about legacy configuration options and differences between modes here.
 - [Configuration](https://www.consul.io/docs/agent/options) - You can find more details
   around legacy ACL and new ACL configuration options here. Legacy ACL config options
-  will be listed as deprecates as of 1.4.0.
+  will be listed as deprecates as of Consul 1.4.0.
 
 In this guide, we will be using an example with two datacenters (DCs) and will be
 referring to them as DC1 and DC2. DC1 will be the primary datacenter.
 
 ## Requirements
-
-- All Consul servers should be on a version of Consul >= 1.2.4 and < 1.6.9.
+ 
+- All Consul servers should be installed with versions of Consul 1.2.4 to 1.6.9.
 
 ## Assumptions
 
@@ -40,9 +40,9 @@ This guide makes the following assumptions:
   to replication.
 - You have not already performed the ACL token migration. If you have, please skip all related
   steps.
-
+ 
 ## Considerations
-
+ 
 There are quite a number of changes between releases. Notable changes
 are called out in our [Specific Version Details](/docs/upgrading/upgrade-specific#consul-1-6-3)
 page. You can find more granular details in the full [changelog](https://github.com/hashicorp/consul/blob/main/CHANGELOG.md#124-november-27-2018).
@@ -50,11 +50,11 @@ Looking through these changes prior to upgrading is highly recommended.
 
 Two very notable items are:
 
-- 1.6.2 introduced more strict JSON decoding. Invalid JSON that was previously ignored might result in errors now (e.g., `Connect: null` in service definitions). See [[GH#6680](https://github.com/hashicorp/consul/pull/6680)].
-- 1.6.3 introduced the [http_max_conns_per_client](https://www.consul.io/docs/agent/options.html#http_max_conns_per_client) limit. This defaults to 200. Prior to this, connections per client were unbounded. [[GH#7159](https://github.com/hashicorp/consul/issues/7159)]
+- Consul 1.6.2 introduced more strict JSON decoding. Invalid JSON that was previously ignored might result in errors now (e.g., `Connect: null` in service definitions). See [[GH#6680](https://github.com/hashicorp/consul/pull/6680)].
+- Consul 1.6.3 introduced the [http_max_conns_per_client](https://www.consul.io/docs/agent/options.html#http_max_conns_per_client) limit. This defaults to 200. Prior to this, connections per client were unbounded. [[GH#7159](https://github.com/hashicorp/consul/issues/7159)]
 
 ## Procedure
-
+ 
 **1.** Check the replication status of the primary datacenter (DC1) by issuing the following curl command from a
 consul server in that DC:
 
@@ -98,7 +98,7 @@ You should receive output similar to this:
 }
 ```
 
-**3.** Upgrade DC2 agents to version 1.6.9 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process). _**Leave all DC1 agents at 1.2.4.**_ You should start observing log messages like this after that:
+**3.** Upgrade DC2 agents to Consul 1.6.9 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process). _**Leave all DC1 agents at Consul 1.2.4.**_ You should start observing log messages like this after that:
 
 ```log
 2020/09/08 15:51:29 [DEBUG] acl: Cannot upgrade to new ACLs, servers in acl datacenter have not upgraded - found servers: true, mode: 3
@@ -158,7 +158,7 @@ Failed to retrieve the token list: Unexpected response code: 500 (The ACL system
 
 This is because Consul in legacy mode. ACL CLI commands will not work and you have to hit the old ACL HTTP endpoints (which is why `curl` is being used above rather than the `consul` CLI client).
 
-**5.** Upgrade DC1 agents to version 1.6.9 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process).
+**5.** Upgrade DC1 agents to Consul 1.6.9 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process).
 
 Once this is complete, you should observe a log entry like this from your server agents:
 
@@ -191,12 +191,12 @@ You should receive output similar to this:
 
 **6.** Migrate your legacy ACL tokens to the new ACL system by following the instructions in our [ACL Token Migration guide](https://www.consul.io/docs/acl/acl-migrate-tokens).
 
-~> This step _must_ be completed before upgrading to a version higher than 1.6.x.
+~> This step _must_ be completed before upgrading to a version higher than Consul 1.6.x.
 
 ## Post-Upgrade Configuration Changes
 
-When moving from a pre-1.4.0 version of Consul, you will find that several of the ACL-related
-configuration options were renamed. Backwards compatibility is maintained in the 1.6.x release
+When moving from versions before Consul 1.4.0, you will find that several of the ACL-related
+configuration options were renamed. Backwards compatibility is maintained in the Consul 1.6.x release
 series, so you are old config options will continue working after upgrading, but you will want to
 update those now to avoid issues when moving to newer versions.
 


### PR DESCRIPTION
This task is to search through the documentation and use the following conventions:  
  
1. "Consul x.x.x" and/or "Consul x.x.x+" (whichever is applicable) should be used in listed requirements, i.e., in 'Requirements' sections, tables, etc.  

2. "Consul x.x.x or later" should be used in prose.  

3. "Consul x.x.x to x.x.y" for ranges in listed requirements and prose.


cc @trujillo-adam for 👀 