### PR TITLE
Update proxy-defaults.mdx

### DIFF
--- a/website/content/docs/connect/config-entries/proxy-defaults.mdx
+++ b/website/content/docs/connect/config-entries/proxy-defaults.mdx
@@ -14,7 +14,7 @@ description: >-
 
 The `proxy-defaults` config entry kind (`ProxyDefaults` on Kubernetes) allows for configuring global config
 defaults across all services for Connect proxy configuration. Currently, only
-one global entry is supported.
+one global entry is supported. This is a requirement for service to service communication between datacenters over mesh gateways.
 
 ## Sample Config Entries
 


### PR DESCRIPTION
Adding a note to clarify that without proxy-defaults configured, service to service comms between DCs is not possible over MGW.
event/consul-docs-day