### PR TITLE
docs: Update uninstall to ensure CRDs are deleted

### DIFF
--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -35,6 +35,12 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
     ```
     kubectl config set-context --current --namespace=consul
     ```
+    
+1. Although the Helm chart automates the deletion of CRDs upon uninstall of the Helm chart, sometimes the finalizers tied to those CRDs may not complete executing and leave previous Consul Kubernetes CRDs around. Ensure that the CRDs were previously created for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
+
+   ```shell-session
+   $ kubectl delete crd --selector app=consul
+   ```
 
 1. Run the `helm uninstall <release-name>` command and specify the release name you've installed Consul with, e.g.,:
 
@@ -43,12 +49,6 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
    release "consul" uninstalled
    ```
    
-   
-1. The Helm chart automates the deletion of CRDs. However, on occasion the finalizers tied to those CRDs may not complete executing and leave previous Consul Kubernetes CRDs around. Ensure that the CRDs were previously created for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
-
-   ```shell-session
-   $ kubectl delete crd --selector app=consul
-   ```
 
 1. After deleting the Helm release, you need to delete the `PersistentVolumeClaim`'s
    for the persistent volumes that store Consul's data. A [bug](https://github.com/helm/helm/issues/5156) in Helm prevents PVCs from being deleted. Issue the following commands:

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -44,7 +44,7 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
    ```
    
    
-1. Ensure that the CRDs were previously created for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
+1. The Helm chart automates the deletion of CRDs. However, on occasion the finalizers tied to those CRDs may not complete executing and leave previous Consul Kubernetes CRDs around. Ensure that the CRDs were previously created for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
 
    ```shell-session
    $ kubectl delete crd --selector app=consul

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -36,7 +36,7 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
     kubectl config set-context --current --namespace=consul
     ```
     
-1. Although the Helm chart automates the deletion of CRDs upon uninstall of the Helm chart, sometimes the finalizers tied to those CRDs may not complete executing and leave previous Consul Kubernetes CRDs around. Ensure that the CRDs were previously created for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
+1. Although the Helm chart automates the deletion of CRDs upon the uninstallation of the Helm chart, sometimes the finalizers tied to those CRDs may not complete and leave previous Consul Kubernetes CRDs around. Ensure previously created CRDs for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
 
    ```shell-session
    $ kubectl delete crd --selector app=consul

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -29,6 +29,11 @@ Refer to the [Consul K8s CLI reference](/docs/k8s/k8s-cli#uninstall) topic for d
 
 Run the `helm uninstall` **and** manually remove resources that Helm does not delete.
 
+1. Although the Helm chart automates the deletion of CRDs upon the uninstallation of the Helm chart, sometimes the finalizers tied to those CRDs may not complete because the deletion of the CRDs rely on the Consul K8s controller running. Ensure that previously created CRDs for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
+
+   ```shell-session
+   $ kubectl delete crd --selector app=consul
+   ```
 
 1. (Optional) If Consul is installed in a dedicated namespace, set the kubeConfig context to the `consul` namespace. Otherwise, subsequent commands will need to include `-n consul`. 
 
@@ -36,11 +41,6 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
     kubectl config set-context --current --namespace=consul
     ```
     
-1. Although the Helm chart automates the deletion of CRDs upon the uninstallation of the Helm chart, sometimes the finalizers tied to those CRDs may not complete and leave previous Consul Kubernetes CRDs around. Ensure previously created CRDs for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
-
-   ```shell-session
-   $ kubectl delete crd --selector app=consul
-   ```
 
 1. Run the `helm uninstall <release-name>` command and specify the release name you've installed Consul with, e.g.,:
 

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -42,6 +42,13 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
    $ helm uninstall consul
    release "consul" uninstalled
    ```
+   
+   
+1. Ensure that the CRDs were previously created for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
+
+   ```shell-session
+   $ kubectl get crd | grep consul.hashicorp.com | awk '{print $1}' | xargs kubectl delete crd
+   ```
 
 1. After deleting the Helm release, you need to delete the `PersistentVolumeClaim`'s
    for the persistent volumes that store Consul's data. A [bug](https://github.com/helm/helm/issues/5156) in Helm prevents PVCs from being deleted. Issue the following commands:
@@ -101,4 +108,10 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
    ```shell-session
    $ kubectl delete serviceaccount consul-tls-init
    serviceaccount "consul-tls-init" deleted
+   ```
+   
+1. (Optional) Delete the namespace (i.e. `consul` in the following example) that you have dedicated for installing Consul on Kubernetes. 
+
+   ```shell-session
+   $ kubectl delete ns consul
    ```

--- a/website/content/docs/k8s/operations/uninstall.mdx
+++ b/website/content/docs/k8s/operations/uninstall.mdx
@@ -47,7 +47,7 @@ Run the `helm uninstall` **and** manually remove resources that Helm does not de
 1. Ensure that the CRDs were previously created for Consul on Kubernetes are deleted, so subsequent installs of Consul on Kubernetes on the same Kubernetes cluster do not get blocked. 
 
    ```shell-session
-   $ kubectl get crd | grep consul.hashicorp.com | awk '{print $1}' | xargs kubectl delete crd
+   $ kubectl delete crd --selector app=consul
    ```
 
 1. After deleting the Helm release, you need to delete the `PersistentVolumeClaim`'s


### PR DESCRIPTION
Sometimes CRDs are not deleted since the finalizers don't fully complete execution. The added commands ensure that CRDs are deleted during the uninstall process. 

Sequence of operations

```
❯ export HELM_RELEASE=dyu
helm install ${HELM_RELEASE} hashicorp/consul --version "0.39.0" --create-namespace -n consul -f ./server-config.yaml
NAME: dyu
LAST DEPLOYED: Tue Jan 11 12:12:48 2022
NAMESPACE: consul
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Consul!

Now that you have deployed Consul, you should look over the docs on using
Consul with Kubernetes available here:

https://www.consul.io/docs/platform/k8s/index.html

Your release is named dyu.

To learn more about the release, run:

  $ helm status dyu
  $ helm get all dyu

~/projects/consul1.11 1m 2s
❯ kubectl create ns consul
kubectl create secret -n consul generic license --from-file=key=./consul.hclic

~/projects/consul1.11
❯ k apply -f service-defaults.yaml
servicedefaults.consul.hashicorp.com/foo created
servicedefaults.consul.hashicorp.com/foo2 created

~/projects/consul1.11
❯ kubectl delete crd --selector app=consul
customresourcedefinition.apiextensions.k8s.io "exportedservices.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "ingressgateways.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "meshes.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "proxydefaults.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "servicedefaults.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "serviceintentions.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "serviceresolvers.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "servicerouters.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "servicesplitters.consul.hashicorp.com" deleted
customresourcedefinition.apiextensions.k8s.io "terminatinggateways.consul.hashicorp.com" deleted

❯ k get crd
NAME                                             CREATED AT
backendconfigs.cloud.google.com                  2022-01-11T20:08:24Z
capacityrequests.internal.autoscaling.gke.io     2022-01-11T20:07:59Z
frontendconfigs.networking.gke.io                2022-01-11T20:08:25Z
managedcertificates.networking.gke.io            2022-01-11T20:08:01Z
serviceattachments.networking.gke.io             2022-01-11T20:08:27Z
servicenetworkendpointgroups.networking.gke.io   2022-01-11T20:08:25Z
storagestates.migration.k8s.io                   2022-01-11T20:08:04Z
storageversionmigrations.migration.k8s.io        2022-01-11T20:08:04Z
updateinfos.nodemanagement.gke.io                2022-01-11T20:08:06Z
volumesnapshotclasses.snapshot.storage.k8s.io    2022-01-11T20:08:03Z
volumesnapshotcontents.snapshot.storage.k8s.io   2022-01-11T20:08:03Z
volumesnapshots.snapshot.storage.k8s.io          2022-01-11T20:08:03Z

~/projects/consul1.11
❯ helm uninstall ${HELM_RELEASE} -n consul
release "dyu" uninstalled
```

After uninstall and re-installing Consul K8s via the Helm uninstall steps I get the following: 

```
> export HELM_RELEASE=dyu
helm install ${HELM_RELEASE} hashicorp/consul --version "0.39.0" --create-namespace -n consul -f ./server-config.yaml

~/projects/consul1.11
❯ k get servicedefaults -n consul
No resources found in consul namespace.

~/projects/consul1.11
❯ k get crd
NAME                                             CREATED AT
backendconfigs.cloud.google.com                  2022-01-11T20:08:24Z
capacityrequests.internal.autoscaling.gke.io     2022-01-11T20:07:59Z
exportedservices.consul.hashicorp.com            2022-01-11T20:30:59Z
frontendconfigs.networking.gke.io                2022-01-11T20:08:25Z
ingressgateways.consul.hashicorp.com             2022-01-11T20:31:00Z
managedcertificates.networking.gke.io            2022-01-11T20:08:01Z
meshes.consul.hashicorp.com                      2022-01-11T20:31:00Z
proxydefaults.consul.hashicorp.com               2022-01-11T20:31:00Z
serviceattachments.networking.gke.io             2022-01-11T20:08:27Z
servicedefaults.consul.hashicorp.com             2022-01-11T20:31:00Z
serviceintentions.consul.hashicorp.com           2022-01-11T20:31:00Z
servicenetworkendpointgroups.networking.gke.io   2022-01-11T20:08:25Z
serviceresolvers.consul.hashicorp.com            2022-01-11T20:31:00Z
servicerouters.consul.hashicorp.com              2022-01-11T20:31:00Z
servicesplitters.consul.hashicorp.com            2022-01-11T20:30:59Z
storagestates.migration.k8s.io                   2022-01-11T20:08:04Z
storageversionmigrations.migration.k8s.io        2022-01-11T20:08:04Z
terminatinggateways.consul.hashicorp.com         2022-01-11T20:30:59Z
updateinfos.nodemanagement.gke.io                2022-01-11T20:08:06Z
volumesnapshotclasses.snapshot.storage.k8s.io    2022-01-11T20:08:03Z
volumesnapshotcontents.snapshot.storage.k8s.io   2022-01-11T20:08:03Z
volumesnapshots.snapshot.storage.k8s.io          2022-01-11T20:08:03Z
```
