### PR TITLE
Fix races in anti-entropy tests

### DIFF
--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -373,36 +373,41 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 	// We should have 5 services (consul included)
 	assert.Len(services.NodeServices.Services, 5)
 
-	// All the services should match
+	// Check that virtual IPs have been set
 	vips := make(map[string]struct{})
-	srv1.TaggedAddresses = nil
-	srv2.TaggedAddresses = nil
-	for id, serv := range services.NodeServices.Services {
-		serv.CreateIndex, serv.ModifyIndex = 0, 0
+	for _, serv := range services.NodeServices.Services {
 		if serv.TaggedAddresses != nil {
 			serviceVIP := serv.TaggedAddresses[structs.TaggedAddressVirtualIP].Address
 			assert.NotEmpty(serviceVIP)
 			vips[serviceVIP] = struct{}{}
 		}
-		serv.TaggedAddresses = nil
-		switch id {
-		case "mysql-proxy":
-			assert.Equal(srv1, serv)
-		case "redis-proxy":
-			assert.Equal(srv2, serv)
-		case "web-proxy":
-			assert.Equal(srv3, serv)
-		case "cache-proxy":
-			assert.Equal(srv5, serv)
-		case structs.ConsulServiceID:
-			// ignore
-		default:
-			t.Fatalf("unexpected service: %v", id)
-		}
 	}
-
 	assert.Len(vips, 4)
-	assert.Nil(servicesInSync(a.State, 4, structs.DefaultEnterpriseMetaInDefaultPartition()))
+
+	// All the services should match
+	// Retry to mitigate data races between local and remote state
+	retry.Run(t, func(r *retry.R) {
+		require.NoError(r, a.State.SyncFull())
+		for id, serv := range services.NodeServices.Services {
+			serv.CreateIndex, serv.ModifyIndex = 0, 0
+			switch id {
+			case "mysql-proxy":
+				require.Equal(r, srv1, serv)
+			case "redis-proxy":
+				require.Equal(r, srv2, serv)
+			case "web-proxy":
+				require.Equal(r, srv3, serv)
+			case "cache-proxy":
+				require.Equal(r, srv5, serv)
+			case structs.ConsulServiceID:
+				// ignore
+			default:
+				r.Fatalf("unexpected service: %v", id)
+			}
+		}
+	})
+
+	assert.NoError(servicesInSync(a.State, 4, structs.DefaultEnterpriseMetaInDefaultPartition()))
 
 	// Remove one of the services
 	a.State.RemoveService(structs.NewServiceID("cache-proxy", nil))
@@ -415,12 +420,6 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 	// All the services should match
 	for id, serv := range services.NodeServices.Services {
 		serv.CreateIndex, serv.ModifyIndex = 0, 0
-		if serv.TaggedAddresses != nil {
-			serviceVIP := serv.TaggedAddresses[structs.TaggedAddressVirtualIP].Address
-			assert.NotEmpty(serviceVIP)
-			vips[serviceVIP] = struct{}{}
-		}
-		serv.TaggedAddresses = nil
 		switch id {
 		case "mysql-proxy":
 			assert.Equal(srv1, serv)


### PR DESCRIPTION
Dug into this test and found two races:

### 1. Goroutine data race:
If a state sync is writing to `TaggedAddresses`
https://github.com/hashicorp/consul/blob/1eac39ae9c290431faf71e396559dc896d453436/agent/local/state.go#L1105
there is a chance that we are reading from the same map in a different goroutine:
https://github.com/hashicorp/consul/blob/1eac39ae9c290431faf71e396559dc896d453436/agent/agent_endpoint.go#L262-L264
Failed go-test-race [here](https://app.circleci.com/pipelines/github/hashicorp/consul/25488/workflows/43e31311-9cf6-43d3-9eef-0eaef96be7ad/jobs/540392/tests)

https://github.com/hashicorp/consul/pull/11940 was raised to fix this issue but I am reverting the changes because 1) it doesn't solve the concurrent map read+write; 2) it could potentially give a false sense of security; and 3) it seems to default the EnterpriseMeta which is failing tests in Enterprise

### 2. Local/remote state data race:
`TestAgentAntiEntropy_Services_ConnectProxy` asserts for local/remote state equality. This test started failing often with the addition of Virtual IPs to Connect services - local state services needed their empty `TaggedAddresses` updated with remote values before the assertions (whereas previously, services had no fields that needed updates from remote).

I found the behavior surprising (`svc...svc5` inputs are eventually mutated due to their pointer reference being stored in local state and synced with remote state) but unsure if that's a bug to be fixed in the scope of this PR

### Enterprise testing
I locally merged this PR to enterprise and `TestAgentAntiEntropy_Services_Namespaced` passed