### PR TITLE
Clarify this page is for external CA

### DIFF
--- a/website/content/docs/k8s/connect/connect-ca-provider.mdx
+++ b/website/content/docs/k8s/connect/connect-ca-provider.mdx
@@ -10,11 +10,13 @@ description: Configuring a Connect CA Provider
 To update the Connect CA provider on an existing cluster or to update any properties, such as tokens, of the CA provider,
 please use the [Update CA Configuration Endpoint](/api/connect/ca#update-ca-configuration).
 
-Consul has support for different certificate authority (CA) providers to be used with the Consul Service Mesh.
+Consul has support for different certificate authority (CA) providers to be used with the Consul Service Mesh. 
 Please see [Connect Certificate Management](/docs/connect/ca) for the information on the providers
 we currently support.
 
-To configure a provider via the Consul Helm chart, you need to follow three steps:
+If Connect is enabled, the built-in Consul CA is automatically enabled for the Connect CA.
+
+To configure an external CA provider via the Consul Helm chart, you need to follow three steps:
 
 1. Create a configuration file containing your provider information.
 1. Create a Kubernetes secret containing the configuration file.


### PR DESCRIPTION
It is not clear that this page is to configure an external CA for Connect CA. Added line to clarify that this page is for configuring external CA's for the Connect CA. For the built-in CA, no config is needed.