### PR TITLE
Partitions: Include ACL Info and API cross-ref for CLI Commands

### DIFF
--- a/website/content/api-docs/admin-partitions.mdx
+++ b/website/content/api-docs/admin-partitions.mdx
@@ -19,14 +19,14 @@ This endpoint creates a new partition and has the following characteristics:
 
 | Characteristic | Value |
 | -------------- | ----- |
-| [HTTP Method] | `PUT` |
-| [URL Path] | `/partition` |
-| [Response Type] | `application/json` |
+| HTTP method | `PUT` |
+| URL path | `/v1/partition` |
+| Response type | `application/json` |
 | [Required ACLs] | `operator:write` |
-| Corresponding CLI Command | [`consul partition create`](/commands/partition#create) |
-| [Consistency Modes] | N/A |
-| [Blocking Queries] | N/A |
-| [Agent Caching] | N/A |
+| Corresponding CLI command | [`consul partition create`](/commands/partition#create) |
+| [Consistency modes] | N/A |
+| [Blocking queries] | N/A |
+| [Agent caching] | N/A |
 
 ### JSON Request Body Schema
 
@@ -70,14 +70,14 @@ This endpoint reads a partition with the given name and has the following charac
 
 | Characteristic | Value |
 | -------------- | ----- |
-| [HTTP Method] | `GET` |
-| [URL Path] | `/partition/:name` |
-| [Response Type] | `application/json` |
+| HTTP method | `GET` |
+| URL path | `/v1/partition/:name` |
+| Response type | `application/json` |
 | [Required ACLs] | `operator:read`; however, a non-anonymous token can always read its own partition |
-| Corresponding CLI Command | [`consul partition read`](/commands/partition#read) |
-| [Consistency Modes] | `default`, `consistent` |
-| [Blocking Queries] | no |
-| [Agent Caching] | no |
+| Corresponding CLI command | [`consul partition read`](/commands/partition#read) |
+| [Consistency modes] | `default`, `consistent` |
+| [Blocking queries] | No |
+| [Agent caching] | No |
 
 ### Path Parameters
 
@@ -107,14 +107,14 @@ This endpoint updates a partition description and has the following characterist
 
 | Characteristic | Value |
 | -------------- | ----- |
-| [HTTP Method] | `PUT` |
-| [URL Path] | `/partition/:name` |
-| [Response Type] | `application/json` |
+| HTTP method | `PUT` |
+| URL path | `/v1/partition/:name` |
+| Response type | `application/json` |
 | [Required ACLs] | `operator:write` |
-| Corresponding CLI Command | [`consul partition write`](/commands/partition#write) |
-| [Consistency Modes] | N/A |
-| [Blocking Queries] | N/A |
-| [Agent Caching] | N/A |
+| Corresponding CLI command | [`consul partition write`](/commands/partition#write) |
+| [Consistency modes] | N/A |
+| [Blocking queries] | N/A |
+| [Agent caching] | N/A |
 
 ### Path Parameters
 
@@ -169,14 +169,14 @@ This endpoint has the following characteristics:
 
 | Characteristic | Value |
 | -------------- | ----- |
-| [HTTP Method] | `DELETE` |
-| [URL Path] | `/partition/:name` |
-| [Response Type] | none; success or failure is indicated by the HTTP response status code |
+| HTTP method | `DELETE` |
+| URL path | `/v1/partition/:name` |
+| Response type | none; success or failure is indicated by the HTTP response status code |
 | [Required ACLs] | `operator:write` |
-| Corresponding CLI Command | [`consul partition delete`](/commands/partition#delete) |
-| [Consistency Modes] | N/A |
-| [Blocking Queries] | N/A |
-| [Agent Caching] | N/A |
+| Corresponding CLI command | [`consul partition delete`](/commands/partition#delete) |
+| [Consistency modes] | N/A |
+| [Blocking queries] | N/A |
+| [Agent caching] | N/A |
 
 ### Path Parameters
 
@@ -208,14 +208,14 @@ This endpoint lists all the partitions and has the following characteristics:
 
 | Characteristic | Value |
 | -------------- | ----- |
-| [HTTP Method] | `GET` |
-| [URL Path] | `/partitions` |
-| [Response Type] | `application/json` |
+| HTTP method | `GET` |
+| URL path | `/v1/partitions` |
+| Response type | `application/json` |
 | [Required ACLs] | `operator:read` |
-| Corresponding CLI Command | [`consul partition list`](/commands/partition#list) |
-| [Consistency Modes] | `default`, `consistent` |
-| [Blocking Queries] | no |
-| [Agent Caching] | no |
+| Corresponding CLI command | [`consul partition list`](/commands/partition#list) |
+| [Consistency modes] | `default`, `consistent` |
+| [Blocking queries] | No |
+| [Agent caching] | No |
 
 ### Sample Request
 

--- a/website/content/api-docs/admin-partitions.mdx
+++ b/website/content/api-docs/admin-partitions.mdx
@@ -4,6 +4,8 @@ page_title: Admin Partition - HTTP API
 description: The /partition endpoints allow for managing Consul Enterprise Admin Partitions.
 ---
 
+@include 'http_api_and_cli_characteristics_links.mdx'
+
 # Admin Partition - HTTP API
 
 <EnterpriseAlert />
@@ -13,23 +15,18 @@ The functionality described here is available only in
 
 ## Create a Partition
 
-This endpoint creates a new Partition.
+This endpoint creates a new partition and has the following characteristics:
 
-| Method | Path         | Produces           |
-| ------ | ------------ | ------------------ |
-| `PUT`  | `/partition` | `application/json` |
-
-The table below shows this endpoint's support for
-[blocking queries](/api-docs/features/blocking),
-[consistency modes](/api-docs/features/consistency),
-[agent caching](/api-docs/features/caching), and
-[required ACLs](/api#authentication).
-
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
-| ---------------- | ----------------- | ------------- | ---------------- |
-| `NO`             | `none`            | `none`        | `operator:write` |
-
-The corresponding CLI command is [`consul partition create`](/commands/partition#create).
+| Characteristic | Value |
+| -------------- | ----- |
+| [HTTP Method] | `PUT` |
+| [URL Path] | `/partition` |
+| [Response Type] | `application/json` |
+| [Required ACLs] | `operator:write` |
+| Corresponding CLI Command | [`consul partition create`](/commands/partition#create) |
+| [Consistency Modes] | N/A |
+| [Blocking Queries] | N/A |
+| [Agent Caching] | N/A |
 
 ### JSON Request Body Schema
 
@@ -69,25 +66,18 @@ $ curl ---request PUT \
 
 ## Read a Partition
 
-This endpoint reads a Partition with the given name.
+This endpoint reads a partition with the given name and has the following characteristics:
 
-| Method | Path               | Produces           |
-| ------ | ------------------ | ------------------ |
-| `GET`  | `/partition/:name` | `application/json` |
-
-The table below shows this endpoint's support for
-[blocking queries](/api-docs/features/blocking),
-[consistency modes](/api-docs/features/consistency),
-[agent caching](/api-docs/features/caching), and
-[required ACLs](/api#authentication).
-
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required                          |
-| ---------------- | ----------------- | ------------- | ------------------------------------- |
-| `NO`             | `consistent`      | `none`        | `operator:read` or `none`<sup>1</sup> |
-
-<sup>1</sup> A non-anonymous token can read its own partition.
-
-The corresponding CLI command is [`consul partition read`](/commands/partition#read).
+| Characteristic | Value |
+| -------------- | ----- |
+| [HTTP Method] | `GET` |
+| [URL Path] | `/partition/:name` |
+| [Response Type] | `application/json` |
+| [Required ACLs] | `operator:read`; however, a non-anonymous token can always read its own partition |
+| Corresponding CLI Command | [`consul partition read`](/commands/partition#read) |
+| [Consistency Modes] | `default`, `consistent` |
+| [Blocking Queries] | no |
+| [Agent Caching] | no |
 
 ### Path Parameters
 
@@ -100,7 +90,7 @@ $ curl --header "X-Consul-Token: b23b3cad-5ea1-4413-919e-c76884b9ad60" \
    http://127.0.0.1:8500/v1/partition/na-west
 ```
 
-### SampleResponse
+### Sample Response
 
 ```json
 {
@@ -113,23 +103,18 @@ $ curl --header "X-Consul-Token: b23b3cad-5ea1-4413-919e-c76884b9ad60" \
 
 ## Update a Partition
 
-This endpoint updates a Partition description.
+This endpoint updates a partition description and has the following characteristics:
 
-| Method | Path               | Produces           |
-| ------ | ------------------ | ------------------ |
-| `PUT`  | `/partition/:name` | `application/json` |
-
-The table below shows this endpoint's support for
-[blocking queries](/api-docs/features/blocking),
-[consistency modes](/api-docs/features/consistency),
-[agent caching](/api-docs/features/caching), and
-[required ACLs](/api#authentication).
-
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
-| ---------------- | ----------------- | ------------- | ---------------- |
-| `NO`             | `none`            | `none`        | `operator:write` |
-
-The corresponding CLI command is [`consul partition write`](/commands/partition#write).
+| Characteristic | Value |
+| -------------- | ----- |
+| [HTTP Method] | `PUT` |
+| [URL Path] | `/partition/:name` |
+| [Response Type] | `application/json` |
+| [Required ACLs] | `operator:write` |
+| Corresponding CLI Command | [`consul partition write`](/commands/partition#write) |
+| [Consistency Modes] | N/A |
+| [Blocking Queries] | N/A |
+| [Agent Caching] | N/A |
 
 ### Path Parameters
 
@@ -173,31 +158,25 @@ $ curl --request PUT \
 
 ## Delete a Partition
 
-This endpoint marks a Partition for deletion. Once marked Consul will
+This endpoint marks a partition for deletion. Once marked Consul will
 deleted all the associated partitioned data in the background. Only once
-all associated data has been deleted will the Partition actually disappear.
+all associated data has been deleted will the partition actually disappear.
 Until then, further reads can be performed on the partition and a `DeletedAt`
-field will now be populated with the timestamp of when the Partition was
+field will now be populated with the timestamp of when the partition was
 marked for deletion.
 
-| Method   | Path               | Produces |
-| -------- | ------------------ | -------- |
-| `DELETE` | `/partition/:name` | N/A      |
+This endpoint has the following characteristics:
 
-This endpoint will return no data. Success or failure is indicated by the status
-code returned.
-
-The table below shows this endpoint's support for
-[blocking queries](/api-docs/features/blocking),
-[consistency modes](/api-docs/features/consistency),
-[agent caching](/api-docs/features/caching), and
-[required ACLs](/api#authentication).
-
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
-| ---------------- | ----------------- | ------------- | ---------------- |
-| `NO`             | `none`            | `none`        | `operator:write` |
-
-The corresponding CLI command is [`consul partition delete`](/commands/partition#delete).
+| Characteristic | Value |
+| -------------- | ----- |
+| [HTTP Method] | `DELETE` |
+| [URL Path] | `/partition/:name` |
+| [Response Type] | none; success or failure is indicated by the HTTP response status code |
+| [Required ACLs] | `operator:write` |
+| Corresponding CLI Command | [`consul partition delete`](/commands/partition#delete) |
+| [Consistency Modes] | N/A |
+| [Blocking Queries] | N/A |
+| [Agent Caching] | N/A |
 
 ### Path Parameters
 
@@ -225,23 +204,18 @@ $ curl --request DELETE \
 
 ## List all Partitions
 
-This endpoint lists all the Partitions.
+This endpoint lists all the partitions and has the following characteristics:
 
-| Method | Path          | Produces           |
-| ------ | ------------- | ------------------ |
-| `GET`  | `/partitions` | `application/json` |
-
-The table below shows this endpoint's support for
-[blocking queries](/api-docs/features/blocking),
-[consistency modes](/api-docs/features/consistency),
-[agent caching](/api-docs/features/caching), and
-[required ACLs](/api#authentication).
-
-| Blocking Queries | Consistency Modes | Agent Caching | ACL Required    |
-| ---------------- | ----------------- | ------------- | --------------- |
-| `NO`             | `consistent`      | `none`        | `operator:read` |
-
-The corresponding CLI command is [`consul partition list`](/commands/partition#list).
+| Characteristic | Value |
+| -------------- | ----- |
+| [HTTP Method] | `GET` |
+| [URL Path] | `/partitions` |
+| [Response Type] | `application/json` |
+| [Required ACLs] | `operator:read` |
+| Corresponding CLI Command | [`consul partition list`](/commands/partition#list) |
+| [Consistency Modes] | `default`, `consistent` |
+| [Blocking Queries] | no |
+| [Agent Caching] | no |
 
 ### Sample Request
 

--- a/website/content/commands/partition.mdx
+++ b/website/content/commands/partition.mdx
@@ -73,9 +73,9 @@ This subcommand has the following characteristics:
 | Characteristic | Value |
 | -------------- | ----- |
 | [Required ACLs] | `operator:write` |
-| Corresponding HTTP API Endpoint | [\[PUT\] /partition](/api-docs/admin-partitions#create-a-partition) |
-| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| Corresponding HTTP API endpoint | [\[PUT\] /v1/partition](/api-docs/admin-partitions#create-a-partition) |
+| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
@@ -107,9 +107,9 @@ This subcommand has the following characteristics:
 | Characteristic | Value |
 | -------------- | ----- |
 | [Required ACLs] | `operator:write` |
-| Corresponding HTTP API Endpoint | [\[PUT\] /partition/:name](/api-docs/admin-partitions#update-a-partition) |
-| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| Corresponding HTTP API endpoint | [\[PUT\] /v1/partition/:name](/api-docs/admin-partitions#update-a-partition) |
+| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 Use the following syntax to write from file:
 
@@ -153,9 +153,9 @@ This subcommand has the following characteristics:
 | Characteristic | Value |
 | -------------- | ----- |
 | [Required ACLs] | `operator:read`; however, a non-anonymous token can always read its own partition |
-| Corresponding HTTP API Endpoint | [\[GET\] /partition/:name](/api-docs/admin-partitions#read-a-partition) |
-| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| Corresponding HTTP API endpoint | [\[GET\] /v1/partition/:name](/api-docs/admin-partitions#read-a-partition) |
+| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
@@ -184,9 +184,9 @@ This subcommand has the following characteristics:
 | Characteristic | Value |
 | -------------- | ----- |
 | [Required ACLs] | `operator:read` |
-| Corresponding HTTP API Endpoint | [\[GET\] /partitions](/api-docs/admin-partitions#list-all-partitions) |
-| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| Corresponding HTTP API endpoint | [\[GET\] /v1/partitions](/api-docs/admin-partitions#list-all-partitions) |
+| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
@@ -229,9 +229,9 @@ This subcommand has the following characteristics:
 | Characteristic | Value |
 | -------------- | ----- |
 | [Required ACLs] | `operator:write` |
-| Corresponding HTTP API Endpoint | [\[DELETE\] /partitions](/api-docs/admin-partitions#delete-a-partition) |
-| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| Corresponding HTTP API endpoint | [\[DELETE\] /v1/partitions](/api-docs/admin-partitions#delete-a-partition) |
+| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 In the following example, the `webdev-bu` partition is deleted:
 

--- a/website/content/commands/partition.mdx
+++ b/website/content/commands/partition.mdx
@@ -77,12 +77,6 @@ This subcommand has the following characteristics:
 | [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 | [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
-#### Usage
-
-```shell-session
-consul partition create <OPTIONS>
-```
-
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
 | Option                                     | Description                                                                                                                                                             | Default  | Required |
@@ -107,7 +101,7 @@ $ consul partition create -name "webdev" -description "Partition for admin of we
 
 ### `write`
 
-The `write` subcommand sends a request to the server to create a new admin partition or update an existing partition from its full definition.
+The `write` subcommand sends a request to the server to create a new admin partition or update an existing partition from its full definition. You can specify an admin partition definition file or use values from `stdin`.
 This subcommand has the following characteristics:
 
 | Characteristic | Value |
@@ -116,11 +110,6 @@ This subcommand has the following characteristics:
 | Corresponding HTTP API Endpoint | [\[PUT\] /partition/:name](/api-docs/admin-partitions#update-a-partition) |
 | [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 | [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-
-#### Usage
-
-You can specify an admin partition definition file or use values from `stdin`
-in either JSON or HCL format.
 
 Use the following syntax to write from file:
 
@@ -134,7 +123,7 @@ Use the following syntax to write from `stdin`:
 consul partition write <OPTIONS> -
 ```
 
-Refer to the [Admin Partition Definition](#partition-definition) section for details about the supported parameters.
+The definition file or `stdin` values can be provided in JSON or HCL format. Refer to the [Admin Partition Definition](#admin-partition-definition) section for details about the supported parameters.
 
 You can specify the following options:
 
@@ -168,12 +157,6 @@ This subcommand has the following characteristics:
 | [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 | [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
-#### Usage
-
-```shell-session
-consul partition read <OPTIONS> <PARTITION_NAME>
-```
-
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
 | Option                  | Description                                                                                                                                                             | Default  | Required |
@@ -204,12 +187,6 @@ This subcommand has the following characteristics:
 | Corresponding HTTP API Endpoint | [\[GET\] /partitions](/api-docs/admin-partitions#list-all-partitions) |
 | [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 | [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-
-#### Usage
-
-```shell-session
-consul partition list <OPTIONS>
-```
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
@@ -255,12 +232,6 @@ This subcommand has the following characteristics:
 | Corresponding HTTP API Endpoint | [\[DELETE\] /partitions](/api-docs/admin-partitions#delete-a-partition) |
 | [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 | [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-
-#### Usage
-
-```shell-session
-$ consul partition delete <PARTITION_NAME>
-```
 
 In the following example, the `webdev-bu` partition is deleted:
 

--- a/website/content/commands/partition.mdx
+++ b/website/content/commands/partition.mdx
@@ -5,6 +5,8 @@ description: |
   The partition command enables you create and manage Consul Enterprise admin partitions.
 ---
 
+@include 'http_api_and_cli_characteristics_links.mdx'
+
 # Consul Admin Partition
 
 Command: `consul partition`
@@ -66,6 +68,16 @@ You can issue the following subcommands with the `consul partition` command.
 ### `create`
 
 The `create` subcommand sends a request to the server to create a new admin partition.
+This subcommand has the following characteristics:
+
+| Characteristic | Value |
+| -------------- | ----- |
+| [Required ACLs] | `operator:write` |
+| Corresponding HTTP API Endpoint | [\[PUT\] /partition](/api-docs/admin-partitions#create-a-partition) |
+| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+
+#### Usage
 
 ```shell-session
 consul partition create <OPTIONS>
@@ -95,7 +107,20 @@ $ consul partition create -name "webdev" -description "Partition for admin of we
 
 ### `write`
 
-The `write` subcommand sends a request to the server to create a new admin partition or update an existing partition from its full definition. You can specify an admin partition definition file or use values from `stdin`.
+The `write` subcommand sends a request to the server to create a new admin partition or update an existing partition from its full definition.
+This subcommand has the following characteristics:
+
+| Characteristic | Value |
+| -------------- | ----- |
+| [Required ACLs] | `operator:write` |
+| Corresponding HTTP API Endpoint | [\[PUT\] /partition/:name](/api-docs/admin-partitions#update-a-partition) |
+| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+
+#### Usage
+
+You can specify an admin partition definition file or use values from `stdin`
+in either JSON or HCL format.
 
 Use the following syntax to write from file:
 
@@ -109,7 +134,7 @@ Use the following syntax to write from `stdin`:
 consul partition write <OPTIONS> -
 ```
 
-The definition file or `stdin` values can be provided in JSON or HCL format. Refer to the [Admin Partition Definition](#partition-definition) section for details about the supported parameters.
+Refer to the [Admin Partition Definition](#partition-definition) section for details about the supported parameters.
 
 You can specify the following options:
 
@@ -134,6 +159,16 @@ $ consul partition write -format json -show-meta - <<< 'name = "webdev-bu" descr
 ### `read`
 
 The `read` subcommand sends a request to the server to read the configuration for the specified partition and print it to the console.
+This subcommand has the following characteristics:
+
+| Characteristic | Value |
+| -------------- | ----- |
+| [Required ACLs] | `operator:read`; however, a non-anonymous token can always read its own partition |
+| Corresponding HTTP API Endpoint | [\[GET\] /partition/:name](/api-docs/admin-partitions#read-a-partition) |
+| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+
+#### Usage
 
 ```shell-session
 consul partition read <OPTIONS> <PARTITION_NAME>
@@ -161,6 +196,16 @@ consul partition read -format json -meta webdev
 ### `list`
 
 The `list` subcommand prints existing admin partitions to the console.
+This subcommand has the following characteristics:
+
+| Characteristic | Value |
+| -------------- | ----- |
+| [Required ACLs] | `operator:read` |
+| Corresponding HTTP API Endpoint | [\[GET\] /partitions](/api-docs/admin-partitions#list-all-partitions) |
+| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+
+#### Usage
 
 ```shell-session
 consul partition list <OPTIONS>
@@ -202,6 +247,16 @@ $ consul partition list -format json -show-meta
 ### `delete`
 
 The `delete` subcommand sends a request to the server to remove the specified partition.
+This subcommand has the following characteristics:
+
+| Characteristic | Value |
+| -------------- | ----- |
+| [Required ACLs] | `operator:write` |
+| Corresponding HTTP API Endpoint | [\[DELETE\] /partitions](/api-docs/admin-partitions#delete-a-partition) |
+| [Blocking Queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+| [Agent Caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
+
+#### Usage
 
 ```shell-session
 $ consul partition delete <PARTITION_NAME>

--- a/website/content/commands/partition.mdx
+++ b/website/content/commands/partition.mdx
@@ -74,8 +74,6 @@ This subcommand has the following characteristics:
 | -------------- | ----- |
 | [Required ACLs] | `operator:write` |
 | Corresponding HTTP API endpoint | [\[PUT\] /v1/partition](/api-docs/admin-partitions#create-a-partition) |
-| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
@@ -108,8 +106,6 @@ This subcommand has the following characteristics:
 | -------------- | ----- |
 | [Required ACLs] | `operator:write` |
 | Corresponding HTTP API endpoint | [\[PUT\] /v1/partition/:name](/api-docs/admin-partitions#update-a-partition) |
-| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 Use the following syntax to write from file:
 
@@ -154,8 +150,6 @@ This subcommand has the following characteristics:
 | -------------- | ----- |
 | [Required ACLs] | `operator:read`; however, a non-anonymous token can always read its own partition |
 | Corresponding HTTP API endpoint | [\[GET\] /v1/partition/:name](/api-docs/admin-partitions#read-a-partition) |
-| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
@@ -185,8 +179,6 @@ This subcommand has the following characteristics:
 | -------------- | ----- |
 | [Required ACLs] | `operator:read` |
 | Corresponding HTTP API endpoint | [\[GET\] /v1/partitions](/api-docs/admin-partitions#list-all-partitions) |
-| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 The admin partition is created according to the values specified in the options. You can specify the following options:
 
@@ -230,8 +222,6 @@ This subcommand has the following characteristics:
 | -------------- | ----- |
 | [Required ACLs] | `operator:write` |
 | Corresponding HTTP API endpoint | [\[DELETE\] /v1/partitions](/api-docs/admin-partitions#delete-a-partition) |
-| [Blocking queries] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
-| [Agent caching] | Not supported from commands, but may be from the corresponding HTTP API endpoint |
 
 In the following example, the `webdev-bu` partition is deleted:
 

--- a/website/content/partials/http_api_and_cli_characteristics_links.mdx
+++ b/website/content/partials/http_api_and_cli_characteristics_links.mdx
@@ -1,9 +1,6 @@
 <!-- list of reference-style links (must have have an empty line beneath) -->
 
-[HTTP Method]: /api-docs#http-methods
-[URL Path]: /api-docs#version-prefix
-[Response Type]: /api-docs#formatted-json-output
-[Required ACLs]: /docs/security/acl/acl-system
-[Blocking Queries]: /api-docs/features/blocking
-[Consistency Modes]: /api-docs/features/consistency
-[Agent Caching]: /api-docs/features/caching
+[Required ACLs]: /docs/security/acl
+[Blocking queries]: /api-docs/features/blocking
+[Consistency modes]: /api-docs/features/consistency
+[Agent caching]: /api-docs/features/caching

--- a/website/content/partials/http_api_and_cli_characteristics_links.mdx
+++ b/website/content/partials/http_api_and_cli_characteristics_links.mdx
@@ -1,0 +1,9 @@
+<!-- list of reference-style links (must have have an empty line beneath) -->
+
+[HTTP Method]: /api-docs#http-methods
+[URL Path]: /api-docs#version-prefix
+[Response Type]: /api-docs#formatted-json-output
+[Required ACLs]: /docs/security/acl/acl-system
+[Blocking Queries]: /api-docs/features/blocking
+[Consistency Modes]: /api-docs/features/consistency
+[Agent Caching]: /api-docs/features/caching


### PR DESCRIPTION
## Description

This draft PR serves two purposes:
- Close #12035
- Improve the structure of info introduced by #11984
  - Align on a new structure for this information within the admin partition command section that can be applied to all other commands
  - This is a follow-up to the long conversation @karl-cardenas-coding and @trujillo-adam started on a previous draft PR: https://github.com/hashicorp/consul/pull/11031#issuecomment-938952197
  
## Previews

[Partition command page](https://consul-mikdi9uno-hashicorp.vercel.app/commands/partition)

![image](https://user-images.githubusercontent.com/85913323/157716721-65d3e909-5ad8-4492-9a4d-3e9dbf59bc29.png)

[Partition HTTP API page](https://consul-mikdi9uno-hashicorp.vercel.app/api-docs/admin-partitions)

![image](https://user-images.githubusercontent.com/85913323/157716645-ea81ca43-1e7f-4322-97f3-9a1c789ce8b0.png)
