### PR TITLE
OSS: Add virtual IP generation for terminating gateway backed services

### DIFF
--- a/.changelog/12049.txt
+++ b/.changelog/12049.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Add support for connecting to services behind a terminating gateway when using a transparent proxy.
+```

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -2134,7 +2134,7 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 		c.Bootstrap = false
 		c.BootstrapExpect = 3
 		c.Datacenter = "dc1"
-		c.Build = "1.11.0"
+		c.Build = "1.11.2"
 	}
 	dir1, s1 := testServerWithConfig(t, conf)
 	defer os.RemoveAll(dir1)
@@ -2163,6 +2163,10 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 	_, entry, err := state.SystemMetadataGet(nil, structs.SystemMetadataVirtualIPsEnabled)
 	require.NoError(t, err)
 	require.Nil(t, entry)
+	state = s1.fsm.State()
+	_, entry, err = state.SystemMetadataGet(nil, structs.SystemMetadataTermGatewayVirtualIPsEnabled)
+	require.NoError(t, err)
+	require.Nil(t, entry)
 
 	// Register a connect-native service and make sure we don't have a virtual IP yet.
 	err = state.EnsureRegistration(10, &structs.RegisterRequest{
@@ -2181,10 +2185,43 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", vip)
 
+	// Register a terminating gateway.
+	err = state.EnsureRegistration(11, &structs.RegisterRequest{
+		Node:    "bar",
+		Address: "127.0.0.2",
+		Service: &structs.NodeService{
+			Service: "tgate1",
+			ID:      "tgate1",
+			Kind:    structs.ServiceKindTerminatingGateway,
+		},
+	})
+	require.NoError(t, err)
+
+	err = state.EnsureConfigEntry(12, &structs.TerminatingGatewayConfigEntry{
+		Kind: structs.TerminatingGateway,
+		Name: "tgate1",
+		Services: []structs.LinkedService{
+			{
+				Name: "bar",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Make sure the service referenced in the terminating gateway config doesn't have
+	// a virtual IP yet.
+	vip, err = state.VirtualIPForService(structs.NewServiceName("bar", nil))
+	require.NoError(t, err)
+	require.Equal(t, "", vip)
+
 	// Leave s3 and wait for the version to get updated.
 	require.NoError(t, s3.Leave())
 	retry.Run(t, func(r *retry.R) {
 		_, entry, err := state.SystemMetadataGet(nil, structs.SystemMetadataVirtualIPsEnabled)
+		require.NoError(r, err)
+		require.NotNil(r, entry)
+		require.Equal(r, "true", entry.Value)
+		_, entry, err = state.SystemMetadataGet(nil, structs.SystemMetadataTermGatewayVirtualIPsEnabled)
 		require.NoError(r, err)
 		require.NotNil(r, entry)
 		require.Equal(r, "true", entry.Value)
@@ -2206,6 +2243,34 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 	vip, err = state.VirtualIPForService(structs.NewServiceName("api", nil))
 	require.NoError(t, err)
 	require.Equal(t, "240.0.0.1", vip)
+
+	// Update the terminating gateway config entry - now there should be a virtual IP assigned.
+	err = state.EnsureConfigEntry(21, &structs.TerminatingGatewayConfigEntry{
+		Kind: structs.TerminatingGateway,
+		Name: "tgate1",
+		Services: []structs.LinkedService{
+			{
+				Name: "api",
+			},
+			{
+				Name: "baz",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, node, err := state.NodeService("bar", "tgate1", nil)
+	require.NoError(t, err)
+	sn := structs.ServiceName{Name: "api"}
+	key := structs.ServiceGatewayVirtualIPTag(sn)
+	require.Contains(t, node.TaggedAddresses, key)
+	require.Equal(t, node.TaggedAddresses[key].Address, "240.0.0.1")
+
+	// Make sure the baz service (only referenced in the config entry so far)
+	// has a virtual IP.
+	vip, err = state.VirtualIPForService(structs.NewServiceName("baz", nil))
+	require.NoError(t, err)
+	require.Equal(t, "240.0.0.2", vip)
 }
 
 func TestLeader_ACL_Initialization_AnonymousToken(t *testing.T) {

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -787,6 +787,32 @@ func ensureServiceTxn(tx WriteTxn, idx uint64, node string, preserveIndexes bool
 		}
 	}
 
+	// If there's a terminating gateway config entry for this service, populate the tagged addresses
+	// with virtual IP mappings.
+	termGatewayVIPsSupported, err := terminatingGatewayVirtualIPsSupported(tx, nil)
+	if err != nil {
+		return err
+	}
+	if termGatewayVIPsSupported && svc.Kind == structs.ServiceKindTerminatingGateway {
+		_, conf, err := configEntryTxn(tx, nil, structs.TerminatingGateway, svc.Service, &svc.EnterpriseMeta)
+		if err != nil {
+			return fmt.Errorf("failed to retrieve terminating gateway config: %s", err)
+		}
+		if conf != nil {
+			termGatewayConf := conf.(*structs.TerminatingGatewayConfigEntry)
+			addrs, err := getTermGatewayVirtualIPs(tx, termGatewayConf.Services, &svc.EnterpriseMeta)
+			if err != nil {
+				return err
+			}
+			if svc.TaggedAddresses == nil {
+				svc.TaggedAddresses = make(map[string]structs.ServiceAddress)
+			}
+			for key, addr := range addrs {
+				svc.TaggedAddresses[key] = addr
+			}
+		}
+	}
+
 	// Create the service node entry and populate the indexes. Note that
 	// conversion doesn't populate any of the node-specific information.
 	// That's always populated when we read from the state store.
@@ -929,6 +955,18 @@ func addIPOffset(a, b net.IP) (net.IP, error) {
 
 func virtualIPsSupported(tx ReadTxn, ws memdb.WatchSet) (bool, error) {
 	_, entry, err := systemMetadataGetTxn(tx, ws, structs.SystemMetadataVirtualIPsEnabled)
+	if err != nil {
+		return false, fmt.Errorf("failed system metadata lookup: %s", err)
+	}
+	if entry == nil {
+		return false, nil
+	}
+
+	return entry.Value != "", nil
+}
+
+func terminatingGatewayVirtualIPsSupported(tx ReadTxn, ws memdb.WatchSet) (bool, error) {
+	_, entry, err := systemMetadataGetTxn(tx, ws, structs.SystemMetadataTermGatewayVirtualIPsEnabled)
 	if err != nil {
 		return false, fmt.Errorf("failed system metadata lookup: %s", err)
 	}
@@ -1697,7 +1735,7 @@ func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID st
 			if err := cleanupGatewayWildcards(tx, idx, svc); err != nil {
 				return fmt.Errorf("failed to clean up gateway-service associations for %q: %v", name.String(), err)
 			}
-			if err := freeServiceVirtualIP(tx, svc.ServiceName, entMeta); err != nil {
+			if err := freeServiceVirtualIP(tx, svc.ServiceName, nil, entMeta); err != nil {
 				return fmt.Errorf("failed to clean up virtual IP for %q: %v", name.String(), err)
 			}
 			if err := cleanupKindServiceName(tx, idx, svc.CompoundServiceName(), svc.ServiceKind); err != nil {
@@ -1713,7 +1751,7 @@ func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID st
 
 // freeServiceVirtualIP is used to free a virtual IP for a service after the last instance
 // is removed.
-func freeServiceVirtualIP(tx WriteTxn, svc string, entMeta *structs.EnterpriseMeta) error {
+func freeServiceVirtualIP(tx WriteTxn, svc string, excludeGateway *structs.ServiceName, entMeta *structs.EnterpriseMeta) error {
 	supported, err := virtualIPsSupported(tx, nil)
 	if err != nil {
 		return err
@@ -1722,7 +1760,28 @@ func freeServiceVirtualIP(tx WriteTxn, svc string, entMeta *structs.EnterpriseMe
 		return nil
 	}
 
+	// Don't deregister the virtual IP if at least one terminating gateway still references this service.
 	sn := structs.NewServiceName(svc, entMeta)
+	termGatewaySupported, err := terminatingGatewayVirtualIPsSupported(tx, nil)
+	if err != nil {
+		return err
+	}
+	if termGatewaySupported {
+		svcGateways, err := tx.Get(tableGatewayServices, indexService, sn)
+		if err != nil {
+			return fmt.Errorf("failed gateway lookup for %q: %s", sn.Name, err)
+		}
+
+		for service := svcGateways.Next(); service != nil; service = svcGateways.Next() {
+			if svc, ok := service.(*structs.GatewayService); ok && svc != nil {
+				ignoreGateway := excludeGateway == nil || !svc.Gateway.Matches(*excludeGateway)
+				if ignoreGateway && svc.GatewayKind == structs.ServiceKindTerminatingGateway {
+					return nil
+				}
+			}
+		}
+	}
+
 	serviceVIP, err := tx.First(tableServiceVirtualIPs, indexID, sn)
 	if err != nil {
 		return fmt.Errorf("failed service virtual IP lookup: %s", err)
@@ -2862,6 +2921,18 @@ func updateGatewayServices(tx WriteTxn, idx uint64, conf structs.ConfigEntry, en
 		return err
 	}
 
+	// Update terminating gateway service virtual IPs
+	vipsSupported, err := terminatingGatewayVirtualIPsSupported(tx, nil)
+	if err != nil {
+		return err
+	}
+	if vipsSupported && conf.GetKind() == structs.TerminatingGateway {
+		gatewayConf := conf.(*structs.TerminatingGatewayConfigEntry)
+		if err := updateTerminatingGatewayVirtualIPs(tx, idx, gatewayConf, entMeta); err != nil {
+			return err
+		}
+	}
+
 	// Delete all associated with gateway first, to avoid keeping mappings that were removed
 	sn := structs.NewServiceName(conf.GetName(), entMeta)
 
@@ -2896,6 +2967,96 @@ func updateGatewayServices(tx WriteTxn, idx uint64, conf structs.ConfigEntry, en
 	if err := indexUpdateMaxTxn(tx, idx, tableGatewayServices); err != nil {
 		return fmt.Errorf("failed updating gateway-services index: %v", err)
 	}
+	return nil
+}
+
+func getTermGatewayVirtualIPs(tx WriteTxn, services []structs.LinkedService, entMeta *structs.EnterpriseMeta) (map[string]structs.ServiceAddress, error) {
+	addrs := make(map[string]structs.ServiceAddress, len(services))
+	for _, s := range services {
+		sn := structs.ServiceName{Name: s.Name, EnterpriseMeta: *entMeta}
+		vip, err := assignServiceVirtualIP(tx, sn)
+		if err != nil {
+			return nil, err
+		}
+		key := structs.ServiceGatewayVirtualIPTag(sn)
+		addrs[key] = structs.ServiceAddress{Address: vip}
+	}
+
+	return addrs, nil
+}
+
+func updateTerminatingGatewayVirtualIPs(tx WriteTxn, idx uint64, conf *structs.TerminatingGatewayConfigEntry, entMeta *structs.EnterpriseMeta) error {
+	// Build the current map of services with virtual IPs for this gateway
+	services := conf.Services
+	addrs, err := getTermGatewayVirtualIPs(tx, services, entMeta)
+	if err != nil {
+		return err
+	}
+
+	// Find any deleted service entries by comparing the new config entry to the existing one.
+	_, existing, err := configEntryTxn(tx, nil, conf.GetKind(), conf.GetName(), entMeta)
+	if err != nil {
+		return fmt.Errorf("failed to get config entry: %v", err)
+	}
+	var deletes []structs.ServiceName
+	cfg, ok := existing.(*structs.TerminatingGatewayConfigEntry)
+	if ok {
+		for _, s := range cfg.Services {
+			sn := structs.ServiceName{Name: s.Name, EnterpriseMeta: *entMeta}
+			key := structs.ServiceGatewayVirtualIPTag(sn)
+			if _, ok := addrs[key]; !ok {
+				deletes = append(deletes, sn)
+			}
+		}
+	}
+
+	q := Query{Value: conf.GetName(), EnterpriseMeta: *entMeta}
+	_, svcNodes, err := serviceNodesTxn(tx, nil, indexService, q)
+	if err != nil {
+		return err
+	}
+
+	// Update the tagged addrs for any existing instances of this terminating gateway.
+	for _, s := range svcNodes {
+		newAddrs := make(map[string]structs.ServiceAddress)
+		for key, addr := range s.ServiceTaggedAddresses {
+			if !strings.HasPrefix(key, structs.TaggedAddressVirtualIP+":") {
+				newAddrs[key] = addr
+			}
+		}
+		for key, addr := range addrs {
+			newAddrs[key] = addr
+		}
+
+		// Don't need to update the service record if it's a no-op.
+		if reflect.DeepEqual(newAddrs, s.ServiceTaggedAddresses) {
+			continue
+		}
+
+		newSN := s.PartialClone()
+		newSN.ServiceTaggedAddresses = newAddrs
+		newSN.ModifyIndex = idx
+		if err := catalogInsertService(tx, newSN); err != nil {
+			return err
+		}
+	}
+
+	// Check if we can delete any virtual IPs for the removed services.
+	gatewayName := structs.NewServiceName(conf.GetName(), entMeta)
+	for _, sn := range deletes {
+		// If there's no existing service nodes, attempt to free the virtual IP.
+		q := Query{Value: sn.Name, EnterpriseMeta: sn.EnterpriseMeta}
+		_, nodes, err := serviceNodesTxn(tx, nil, indexConnect, q)
+		if err != nil {
+			return err
+		}
+		if len(nodes) == 0 {
+			if err := freeServiceVirtualIP(tx, sn.Name, &gatewayName, &sn.EnterpriseMeta); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -315,8 +315,8 @@ func ServiceHealthEventsFromChanges(tx ReadTxn, changes Changes) ([]stream.Event
 		events = append(events, e)
 	}
 
-	for gatewayName, serviceChanges := range termGatewayChanges {
-		for serviceName, gsChange := range serviceChanges {
+	for gatewayName, svcChanges := range termGatewayChanges {
+		for serviceName, gsChange := range svcChanges {
 			gs := changeObject(gsChange.change).(*structs.GatewayService)
 
 			q := Query{
@@ -355,6 +355,12 @@ func ServiceHealthEventsFromChanges(tx ReadTxn, changes Changes) ([]stream.Event
 			// Build service events and append them
 			for _, sn := range nodes {
 				tuple := newNodeServiceTupleFromServiceNode(sn)
+
+				// If we're already sending an event for the service, don't send another.
+				if _, ok := serviceChanges[tuple]; ok {
+					continue
+				}
+
 				e, err := newServiceHealthEventForService(tx, changes.Index, tuple)
 				if err != nil {
 					return nil, err

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1551,10 +1551,7 @@ func TestStateStore_EnsureService_connectProxy(t *testing.T) {
 func TestStateStore_EnsureService_VirtualIPAssign(t *testing.T) {
 	assert := assert.New(t)
 	s := testStateStore(t)
-	require.NoError(t, s.SystemMetadataSet(0, &structs.SystemMetadataEntry{
-		Key:   structs.SystemMetadataVirtualIPsEnabled,
-		Value: "true",
-	}))
+	setVirtualIPFlags(t, s)
 
 	// Create the service registration.
 	entMeta := structs.DefaultEnterpriseMetaInDefaultPartition()
@@ -1687,10 +1684,7 @@ func TestStateStore_EnsureService_VirtualIPAssign(t *testing.T) {
 func TestStateStore_EnsureService_ReassignFreedVIPs(t *testing.T) {
 	assert := assert.New(t)
 	s := testStateStore(t)
-	require.NoError(t, s.SystemMetadataSet(0, &structs.SystemMetadataEntry{
-		Key:   structs.SystemMetadataVirtualIPsEnabled,
-		Value: "true",
-	}))
+	setVirtualIPFlags(t, s)
 
 	// Create the service registration.
 	entMeta := structs.DefaultEnterpriseMetaInDefaultPartition()
@@ -7985,4 +7979,15 @@ func generateUUID() ([]byte, string) {
 		buf[8:10],
 		buf[10:16])
 	return buf, uuid
+}
+
+func setVirtualIPFlags(t *testing.T, s *Store) {
+	require.NoError(t, s.SystemMetadataSet(0, &structs.SystemMetadataEntry{
+		Key:   structs.SystemMetadataVirtualIPsEnabled,
+		Value: "true",
+	}))
+	require.NoError(t, s.SystemMetadataSet(0, &structs.SystemMetadataEntry{
+		Key:   structs.SystemMetadataTermGatewayVirtualIPsEnabled,
+		Value: "true",
+	}))
 }

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1999,6 +1999,10 @@ func (n ServiceName) ToServiceID() ServiceID {
 	return ServiceID{ID: n.Name, EnterpriseMeta: n.EnterpriseMeta}
 }
 
+func ServiceGatewayVirtualIPTag(sn ServiceName) string {
+	return fmt.Sprintf("%s:%s", TaggedAddressVirtualIP, sn.String())
+}
+
 type ServiceList []ServiceName
 
 type IndexedServiceList struct {

--- a/agent/structs/system_metadata.go
+++ b/agent/structs/system_metadata.go
@@ -25,10 +25,11 @@ type SystemMetadataRequest struct {
 }
 
 const (
-	SystemMetadataIntentionFormatKey         = "intention-format"
-	SystemMetadataIntentionFormatConfigValue = "config-entry"
-	SystemMetadataIntentionFormatLegacyValue = "legacy"
-	SystemMetadataVirtualIPsEnabled          = "virtual-ips"
+	SystemMetadataIntentionFormatKey           = "intention-format"
+	SystemMetadataIntentionFormatConfigValue   = "config-entry"
+	SystemMetadataIntentionFormatLegacyValue   = "legacy"
+	SystemMetadataVirtualIPsEnabled            = "virtual-ips"
+	SystemMetadataTermGatewayVirtualIPsEnabled = "virtual-ips-term-gateway"
 )
 
 type SystemMetadataEntry struct {

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -175,6 +175,15 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		// We do not match on all endpoints here since it would lead to load balancing across
 		// all instances when any instance address is dialed.
 		for _, e := range endpoints {
+			if e.Service.Kind == structs.ServiceKind(structs.TerminatingGateway) {
+				key := structs.ServiceGatewayVirtualIPTag(chain.CompoundServiceName())
+
+				if vip := e.Service.TaggedAddresses[key]; vip.Address != "" {
+					uniqueAddrs[vip.Address] = struct{}{}
+				}
+
+				continue
+			}
 			if vip := e.Service.TaggedAddresses[structs.TaggedAddressVirtualIP]; vip.Address != "" {
 				uniqueAddrs[vip.Address] = struct{}{}
 			}

--- a/agent/xds/testdata/listeners/transparent-proxy-terminating-gateway.envoy-1-20-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-terminating-gateway.envoy-1-20-x.golden
@@ -1,0 +1,177 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "outbound_listener:127.0.0.1:15001",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 15001
+        }
+      },
+      "filterChains": [
+        {
+          "filterChainMatch": {
+            "prefixRanges": [
+              {
+                "addressPrefix": "10.0.0.1",
+                "prefixLen": 32
+              }
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.google.default.default.dc1",
+                "cluster": "google.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        },
+        {
+          "filterChainMatch": {
+            "prefixRanges": [
+              {
+                "addressPrefix": "10.0.0.2",
+                "prefixLen": 32
+              }
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.kafka.default.default.dc1",
+                "cluster": "kafka.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.original_dst"
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "public_listener",
+                "cluster": "local_app"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
This PR adds support for connecting to services behind a terminating gateway when using a transparent proxy.