### PR TITLE
docs: Show `consul intention list` in nav sidebar

### DIFF
--- a/website/data/commands-nav-data.json
+++ b/website/data/commands-nav-data.json
@@ -297,8 +297,7 @@
       },
       {
         "title": "list",
-        "path": "intention/list",
-        "hidden": true
+        "path": "intention/list"
       },
       {
         "title": "match",


### PR DESCRIPTION
Ensure `consul intention list` command is displayed in the navigation sidebar.

Fixes #12036