### PR TITLE
[1.9.x] Backport docs change to show `consul intention list` in nav menu

### DIFF
--- a/website/data/commands-nav-data.json
+++ b/website/data/commands-nav-data.json
@@ -292,6 +292,10 @@
         "path": "intention/get"
       },
       {
+        "title": "list",
+        "path": "intention/list"
+      },
+      {
         "title": "match",
         "path": "intention/match"
       }


### PR DESCRIPTION
Manual backport of #12076 to 1.9.x.