### PR TITLE
Updating the docs to point out that 1.10.7 should be used instead of 1.10.6

### DIFF
--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -20,7 +20,7 @@ upgrade flow.
 Consul Enterprise versions 1.10.0 through 1.10.4 contain a latent bug that
 causes those client or server agents to deregister their own services or health
 checks when some of the servers have been upgraded to 1.11. Before upgrading Consul Enterprise servers to 1.11, all Consul agents should first 
-be upgraded to 1.10.6 or higher to ensure forward compatibility and prevent
+be upgraded to 1.10.7 or higher to ensure forward compatibility and prevent
 flapping of catalog registrations.
 
 ### Deprecated Agent Config Options


### PR DESCRIPTION
This just ensures we note that the right compatible 1.10 version for upgrades is 1.10.7 and not 1.10.6 as we found another issue in 1.10.6.