### PR TITLE
Add GRPC to HealthCheckDefinition

### DIFF
--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -277,6 +277,8 @@ func (s *HTTPHandlers) convertOps(resp http.ResponseWriter, req *http.Request) (
 							Method:                         check.Definition.Method,
 							Body:                           check.Definition.Body,
 							TCP:                            check.Definition.TCP,
+							GRPC:                           check.Definition.GRPC,
+							GRPCUseTLS:                     check.Definition.GRPCUseTLS,
 							Interval:                       interval,
 							Timeout:                        timeout,
 							DeregisterCriticalServiceAfter: deregisterCriticalServiceAfter,

--- a/api/health.go
+++ b/api/health.go
@@ -63,6 +63,7 @@ type HealthCheckDefinition struct {
 	TLSSkipVerify                          bool
 	TCP                                    string
 	GRPC                                   string
+	GRPCUseTLS                             bool
 	IntervalDuration                       time.Duration `json:"-"`
 	TimeoutDuration                        time.Duration `json:"-"`
 	DeregisterCriticalServiceAfterDuration time.Duration `json:"-"`

--- a/api/health.go
+++ b/api/health.go
@@ -62,6 +62,7 @@ type HealthCheckDefinition struct {
 	TLSServerName                          string
 	TLSSkipVerify                          bool
 	TCP                                    string
+	GRPC                                   string
 	IntervalDuration                       time.Duration `json:"-"`
 	TimeoutDuration                        time.Duration `json:"-"`
 	DeregisterCriticalServiceAfterDuration time.Duration `json:"-"`


### PR DESCRIPTION
Hi guys,

Add GRPC to HealthCheckDefinition because it missing, and it is required for consul-esm to handle GRPC health-checks.

I have no idea if there is anything else to add to this PR. If there is please tell me.
