### PR TITLE
rpc: make blockingQuery easier to read

### DIFF
--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -821,6 +821,7 @@ func TestTxn_Read(t *testing.T) {
 		},
 		QueryMeta: structs.QueryMeta{
 			KnownLeader: true,
+			Index:       1,
 		},
 	}
 	require.Equal(expected, out)

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -370,7 +370,9 @@ func (q QueryBackend) String() string {
 // QueryMeta allows a query response to include potentially
 // useful metadata about a query
 type QueryMeta struct {
-	// Index in the raft log of the latest item returned by the query.
+	// Index in the raft log of the latest item returned by the query. If the
+	// query did not return any results the Index will be a value that will
+	// change when a new item is added.
 	Index uint64
 
 	// If AllowStale is used, this is time elapsed since

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/hashicorp/raft"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTxnEndpoint_Bad_JSON(t *testing.T) {
@@ -385,6 +386,7 @@ func TestTxnEndpoint_KV_Actions(t *testing.T) {
 				},
 				QueryMeta: structs.QueryMeta{
 					KnownLeader: true,
+					Index:       1,
 				},
 			}
 			assert.Equal(t, expected, txnResp)


### PR DESCRIPTION
This is being done to make space for fixing #9449.  Best viewed by individual commit. There is more detail in the commit messages.

The current implementation of `blockingQueries` is difficult to read, and difficult to modify, for a few reasons.

1. the `goto`. While it is safe to use `goto` in Go, most readers will not be used to following logic that uses goto. A for loop is not only much easier to reason about, it removes the need to pre-define a bunch of variables at the top of the function. Sometimes a `goto` is the right solution for complicated logic, but I believe this refactor shows it is not necessary here, and that a for loop reads better.
2. there were many long inline block comments. These comments are almost always better as godoc comments on functions (even if that function is unexported). A large block comment like this breaks the flow of someone trying to read the code. If the flow is going to be broken anyway, the code that the comment is documented may as well be in a separate function. That allows the main function to read much better without losing the flow. I left a couple of the shorter multi-line comments, but I do think we would benefit from reducing or removing those as well.
3. the block and exit logic was difficult to reason about because it was not using guard clauses for early returns. It relied on falling through to the end of the function. By inverting these conditions we can see the flow much better.

The getter methods on `QueryOptionsCompat` and `QueryMetaCompat` also make the code a little harder to read. It'd be great to use a struct field directly, or rename the interface methods to have them read a bit more naturally. Those renames are left for a future commit.