### PR TITLE
docs: Link to supported config kinds in `config write`

### DIFF
--- a/website/content/commands/config/write.mdx
+++ b/website/content/commands/config/write.mdx
@@ -70,8 +70,9 @@ From stdin:
 
 ### Config Entry examples
 
-All config entries must have a `Kind` when registered. Currently, the only
-supported types are `service-defaults` and `proxy-defaults`.
+All config entries must have a `Kind` when registered. See
+[Service Mesh - Config Entries](/docs/connect/config-entries) for the list of
+supported config entries.
 
 #### Service defaults
 


### PR DESCRIPTION
Remove statement about service-defaults and proxy-defaults being the
only supported configuration entry types. Update the sentence to point to the configuration entry documentation for a list of supported types.