### PR TITLE
proxycfg: introduce explicit UpstreamID in lieu of bare string

### DIFF
--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -18,16 +18,16 @@ type handlerConnectProxy struct {
 // state.
 func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, error) {
 	snap := newConfigSnapshotFromServiceInstance(s.serviceInstance, s.stateConfig)
-	snap.ConnectProxy.DiscoveryChain = make(map[string]*structs.CompiledDiscoveryChain)
-	snap.ConnectProxy.WatchedDiscoveryChains = make(map[string]context.CancelFunc)
-	snap.ConnectProxy.WatchedUpstreams = make(map[string]map[string]context.CancelFunc)
-	snap.ConnectProxy.WatchedUpstreamEndpoints = make(map[string]map[string]structs.CheckServiceNodes)
-	snap.ConnectProxy.WatchedGateways = make(map[string]map[string]context.CancelFunc)
-	snap.ConnectProxy.WatchedGatewayEndpoints = make(map[string]map[string]structs.CheckServiceNodes)
+	snap.ConnectProxy.DiscoveryChain = make(map[UpstreamID]*structs.CompiledDiscoveryChain)
+	snap.ConnectProxy.WatchedDiscoveryChains = make(map[UpstreamID]context.CancelFunc)
+	snap.ConnectProxy.WatchedUpstreams = make(map[UpstreamID]map[string]context.CancelFunc)
+	snap.ConnectProxy.WatchedUpstreamEndpoints = make(map[UpstreamID]map[string]structs.CheckServiceNodes)
+	snap.ConnectProxy.WatchedGateways = make(map[UpstreamID]map[string]context.CancelFunc)
+	snap.ConnectProxy.WatchedGatewayEndpoints = make(map[UpstreamID]map[string]structs.CheckServiceNodes)
 	snap.ConnectProxy.WatchedServiceChecks = make(map[structs.ServiceID][]structs.CheckType)
-	snap.ConnectProxy.PreparedQueryEndpoints = make(map[string]structs.CheckServiceNodes)
-	snap.ConnectProxy.UpstreamConfig = make(map[string]*structs.Upstream)
-	snap.ConnectProxy.PassthroughUpstreams = make(map[string]ServicePassthroughAddrs)
+	snap.ConnectProxy.PreparedQueryEndpoints = make(map[UpstreamID]structs.CheckServiceNodes)
+	snap.ConnectProxy.UpstreamConfig = make(map[UpstreamID]*structs.Upstream)
+	snap.ConnectProxy.PassthroughUpstreams = make(map[UpstreamID]ServicePassthroughAddrs)
 
 	// Watch for root changes
 	err := s.cache.Notify(ctx, cachetype.ConnectCARootName, &structs.DCSpecificRequest{
@@ -106,9 +106,11 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 	for i := range s.proxyCfg.Upstreams {
 		u := s.proxyCfg.Upstreams[i]
 
+		uid := NewUpstreamID(&u)
+
 		// Store defaults keyed under wildcard so they can be applied to centrally configured upstreams
 		if u.DestinationName == structs.WildcardSpecifier {
-			snap.ConnectProxy.UpstreamConfig[u.DestinationID().String()] = &u
+			snap.ConnectProxy.UpstreamConfig[uid] = &u
 			continue
 		}
 
@@ -117,7 +119,7 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 		if u.CentrallyConfigured {
 			continue
 		}
-		snap.ConnectProxy.UpstreamConfig[u.Identifier()] = &u
+		snap.ConnectProxy.UpstreamConfig[uid] = &u
 
 		dc := s.source.Datacenter
 		if u.Datacenter != "" {
@@ -144,7 +146,7 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 			// the plain discovery chain if there is an error so it's safe to
 			// continue.
 			s.logger.Warn("failed to parse upstream config",
-				"upstream", u.Identifier(),
+				"upstream", uid.String(),
 				"error", err,
 			)
 		}
@@ -157,7 +159,7 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 				QueryIDOrName: u.DestinationName,
 				Connect:       true,
 				Source:        *s.source,
-			}, "upstream:"+u.Identifier(), s.ch)
+			}, "upstream:"+uid.String(), s.ch)
 			if err != nil {
 				return snap, err
 			}
@@ -176,9 +178,9 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 				OverrideMeshGateway:    s.proxyCfg.MeshGateway.OverlayWith(u.MeshGateway),
 				OverrideProtocol:       cfg.Protocol,
 				OverrideConnectTimeout: cfg.ConnectTimeout(),
-			}, "discovery-chain:"+u.Identifier(), s.ch)
+			}, "discovery-chain:"+uid.String(), s.ch)
 			if err != nil {
-				return snap, fmt.Errorf("failed to watch discovery chain for %s: %v", u.Identifier(), err)
+				return snap, fmt.Errorf("failed to watch discovery chain for %s: %v", uid.String(), err)
 			}
 
 		default:
@@ -220,12 +222,14 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEv
 			return fmt.Errorf("invalid type for response %T", u.Result)
 		}
 
-		seenServices := make(map[string]struct{})
+		seenUpstreams := make(map[UpstreamID]struct{})
 		for _, svc := range resp.Services {
-			seenServices[svc.String()] = struct{}{}
+			uid := NewUpstreamIDFromServiceName(svc)
+
+			seenUpstreams[uid] = struct{}{}
 
 			cfgMap := make(map[string]interface{})
-			u, ok := snap.ConnectProxy.UpstreamConfig[svc.String()]
+			u, ok := snap.ConnectProxy.UpstreamConfig[uid]
 			if ok {
 				cfgMap = u.Config
 			} else {
@@ -233,11 +237,12 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEv
 				// This is only relevant to upstreams from intentions because for explicit upstreams the defaulting is handled
 				// by the ResolveServiceConfig endpoint.
 				wildcardSID := structs.NewServiceID(structs.WildcardSpecifier, s.proxyID.WithWildcardNamespace())
-				defaults, ok := snap.ConnectProxy.UpstreamConfig[wildcardSID.String()]
+				wildcardUID := NewUpstreamIDFromServiceID(wildcardSID)
+				defaults, ok := snap.ConnectProxy.UpstreamConfig[wildcardUID]
 				if ok {
 					u = defaults
 					cfgMap = defaults.Config
-					snap.ConnectProxy.UpstreamConfig[svc.String()] = defaults
+					snap.ConnectProxy.UpstreamConfig[uid] = defaults
 				}
 			}
 
@@ -247,7 +252,7 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEv
 				// the plain discovery chain if there is an error so it's safe to
 				// continue.
 				s.logger.Warn("failed to parse upstream config",
-					"upstream", u.Identifier(),
+					"upstream", uid,
 					"error", err,
 				)
 			}
@@ -257,7 +262,7 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEv
 				meshGateway = meshGateway.OverlayWith(u.MeshGateway)
 			}
 			watchOpts := discoveryChainWatchOpts{
-				id:          svc.String(),
+				id:          NewUpstreamIDFromServiceName(svc),
 				name:        svc.Name,
 				namespace:   svc.NamespaceOrDefault(),
 				partition:   svc.PartitionOrDefault(),
@@ -268,69 +273,69 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEv
 			up := &handlerUpstreams{handlerState: s.handlerState}
 			err = up.watchDiscoveryChain(ctx, snap, watchOpts)
 			if err != nil {
-				return fmt.Errorf("failed to watch discovery chain for %s: %v", svc.String(), err)
+				return fmt.Errorf("failed to watch discovery chain for %s: %v", uid, err)
 			}
 		}
-		snap.ConnectProxy.IntentionUpstreams = seenServices
+		snap.ConnectProxy.IntentionUpstreams = seenUpstreams
 
 		// Clean up data from services that were not in the update
-		for sn, targets := range snap.ConnectProxy.WatchedUpstreams {
-			if upstream, ok := snap.ConnectProxy.UpstreamConfig[sn]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
+		for uid, targets := range snap.ConnectProxy.WatchedUpstreams {
+			if upstream, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
 				continue
 			}
-			if _, ok := seenServices[sn]; !ok {
+			if _, ok := seenUpstreams[uid]; !ok {
 				for _, cancelFn := range targets {
 					cancelFn()
 				}
-				delete(snap.ConnectProxy.WatchedUpstreams, sn)
+				delete(snap.ConnectProxy.WatchedUpstreams, uid)
 			}
 		}
-		for sn := range snap.ConnectProxy.WatchedUpstreamEndpoints {
-			if upstream, ok := snap.ConnectProxy.UpstreamConfig[sn]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
+		for uid := range snap.ConnectProxy.WatchedUpstreamEndpoints {
+			if upstream, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
 				continue
 			}
-			if _, ok := seenServices[sn]; !ok {
-				delete(snap.ConnectProxy.WatchedUpstreamEndpoints, sn)
+			if _, ok := seenUpstreams[uid]; !ok {
+				delete(snap.ConnectProxy.WatchedUpstreamEndpoints, uid)
 			}
 		}
-		for sn, cancelMap := range snap.ConnectProxy.WatchedGateways {
-			if upstream, ok := snap.ConnectProxy.UpstreamConfig[sn]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
+		for uid, cancelMap := range snap.ConnectProxy.WatchedGateways {
+			if upstream, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
 				continue
 			}
-			if _, ok := seenServices[sn]; !ok {
+			if _, ok := seenUpstreams[uid]; !ok {
 				for _, cancelFn := range cancelMap {
 					cancelFn()
 				}
-				delete(snap.ConnectProxy.WatchedGateways, sn)
+				delete(snap.ConnectProxy.WatchedGateways, uid)
 			}
 		}
-		for sn := range snap.ConnectProxy.WatchedGatewayEndpoints {
-			if upstream, ok := snap.ConnectProxy.UpstreamConfig[sn]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
+		for uid := range snap.ConnectProxy.WatchedGatewayEndpoints {
+			if upstream, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
 				continue
 			}
-			if _, ok := seenServices[sn]; !ok {
-				delete(snap.ConnectProxy.WatchedGatewayEndpoints, sn)
+			if _, ok := seenUpstreams[uid]; !ok {
+				delete(snap.ConnectProxy.WatchedGatewayEndpoints, uid)
 			}
 		}
-		for sn, cancelFn := range snap.ConnectProxy.WatchedDiscoveryChains {
-			if upstream, ok := snap.ConnectProxy.UpstreamConfig[sn]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
+		for uid, cancelFn := range snap.ConnectProxy.WatchedDiscoveryChains {
+			if upstream, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
 				continue
 			}
-			if _, ok := seenServices[sn]; !ok {
+			if _, ok := seenUpstreams[uid]; !ok {
 				cancelFn()
-				delete(snap.ConnectProxy.WatchedDiscoveryChains, sn)
+				delete(snap.ConnectProxy.WatchedDiscoveryChains, uid)
 			}
 		}
 		// These entries are intentionally handled separately from the WatchedDiscoveryChains above.
 		// There have been situations where a discovery watch was cancelled, then fired.
 		// That update event then re-populated the DiscoveryChain map entry, which wouldn't get cleaned up
 		// since there was no known watch for it.
-		for sn := range snap.ConnectProxy.DiscoveryChain {
-			if upstream, ok := snap.ConnectProxy.UpstreamConfig[sn]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
+		for uid := range snap.ConnectProxy.DiscoveryChain {
+			if upstream, ok := snap.ConnectProxy.UpstreamConfig[uid]; ok && upstream.Datacenter != "" && upstream.Datacenter != s.source.Datacenter {
 				continue
 			}
-			if _, ok := seenServices[sn]; !ok {
-				delete(snap.ConnectProxy.DiscoveryChain, sn)
+			if _, ok := seenUpstreams[uid]; !ok {
+				delete(snap.ConnectProxy.DiscoveryChain, uid)
 			}
 		}
 
@@ -340,7 +345,8 @@ func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEv
 			return fmt.Errorf("invalid type for response: %T", u.Result)
 		}
 		pq := strings.TrimPrefix(u.CorrelationID, "upstream:")
-		snap.ConnectProxy.PreparedQueryEndpoints[pq] = resp.Nodes
+		uid := UpstreamIDFromString(pq)
+		snap.ConnectProxy.PreparedQueryEndpoints[uid] = resp.Nodes
 
 	case strings.HasPrefix(u.CorrelationID, svcChecksWatchIDPrefix):
 		resp, ok := u.Result.([]structs.CheckType)

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -187,6 +187,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 	})
 
 	db := structs.NewServiceName("db", nil)
+	dbUID := NewUpstreamIDFromServiceName(db)
 
 	// Create test cases using some of the common data above.
 	tests := []*testcase_BasicLifecycle{
@@ -214,28 +215,28 @@ func TestManager_BasicLifecycle(t *testing.T) {
 				ConnectProxy: configSnapshotConnectProxy{
 					ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
 						Leaf: leaf,
-						DiscoveryChain: map[string]*structs.CompiledDiscoveryChain{
-							db.String(): dbDefaultChain(),
+						DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{
+							dbUID: dbDefaultChain(),
 						},
-						WatchedDiscoveryChains: map[string]context.CancelFunc{},
+						WatchedDiscoveryChains: map[UpstreamID]context.CancelFunc{},
 						WatchedUpstreams:       nil, // Clone() clears this out
-						WatchedUpstreamEndpoints: map[string]map[string]structs.CheckServiceNodes{
-							db.String(): {
+						WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+							dbUID: {
 								"db.default.default.dc1": TestUpstreamNodes(t, db.Name),
 							},
 						},
 						WatchedGateways: nil, // Clone() clears this out
-						WatchedGatewayEndpoints: map[string]map[string]structs.CheckServiceNodes{
-							db.String(): {},
+						WatchedGatewayEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+							dbUID: {},
 						},
-						UpstreamConfig: map[string]*structs.Upstream{
-							upstreams[0].Identifier(): &upstreams[0],
-							upstreams[1].Identifier(): &upstreams[1],
-							upstreams[2].Identifier(): &upstreams[2],
+						UpstreamConfig: map[UpstreamID]*structs.Upstream{
+							NewUpstreamID(&upstreams[0]): &upstreams[0],
+							NewUpstreamID(&upstreams[1]): &upstreams[1],
+							NewUpstreamID(&upstreams[2]): &upstreams[2],
 						},
-						PassthroughUpstreams: map[string]ServicePassthroughAddrs{},
+						PassthroughUpstreams: map[UpstreamID]ServicePassthroughAddrs{},
 					},
-					PreparedQueryEndpoints: map[string]structs.CheckServiceNodes{},
+					PreparedQueryEndpoints: map[UpstreamID]structs.CheckServiceNodes{},
 					WatchedServiceChecks:   map[structs.ServiceID][]structs.CheckType{},
 					Intentions:             TestIntentions().Matches[0],
 					IntentionsSet:          true,
@@ -271,29 +272,29 @@ func TestManager_BasicLifecycle(t *testing.T) {
 				ConnectProxy: configSnapshotConnectProxy{
 					ConfigSnapshotUpstreams: ConfigSnapshotUpstreams{
 						Leaf: leaf,
-						DiscoveryChain: map[string]*structs.CompiledDiscoveryChain{
-							db.String(): dbSplitChain(),
+						DiscoveryChain: map[UpstreamID]*structs.CompiledDiscoveryChain{
+							dbUID: dbSplitChain(),
 						},
-						WatchedDiscoveryChains: map[string]context.CancelFunc{},
+						WatchedDiscoveryChains: map[UpstreamID]context.CancelFunc{},
 						WatchedUpstreams:       nil, // Clone() clears this out
-						WatchedUpstreamEndpoints: map[string]map[string]structs.CheckServiceNodes{
-							db.String(): {
+						WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+							dbUID: {
 								"v1.db.default.default.dc1": TestUpstreamNodes(t, db.Name),
 								"v2.db.default.default.dc1": TestUpstreamNodesAlternate(t),
 							},
 						},
 						WatchedGateways: nil, // Clone() clears this out
-						WatchedGatewayEndpoints: map[string]map[string]structs.CheckServiceNodes{
-							db.String(): {},
+						WatchedGatewayEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
+							dbUID: {},
 						},
-						UpstreamConfig: map[string]*structs.Upstream{
-							upstreams[0].Identifier(): &upstreams[0],
-							upstreams[1].Identifier(): &upstreams[1],
-							upstreams[2].Identifier(): &upstreams[2],
+						UpstreamConfig: map[UpstreamID]*structs.Upstream{
+							NewUpstreamID(&upstreams[0]): &upstreams[0],
+							NewUpstreamID(&upstreams[1]): &upstreams[1],
+							NewUpstreamID(&upstreams[2]): &upstreams[2],
 						},
-						PassthroughUpstreams: map[string]ServicePassthroughAddrs{},
+						PassthroughUpstreams: map[UpstreamID]ServicePassthroughAddrs{},
 					},
-					PreparedQueryEndpoints: map[string]structs.CheckServiceNodes{},
+					PreparedQueryEndpoints: map[UpstreamID]structs.CheckServiceNodes{},
 					WatchedServiceChecks:   map[structs.ServiceID][]structs.CheckType{},
 					Intentions:             TestIntentions().Matches[0],
 					IntentionsSet:          true,

--- a/agent/proxycfg/naming.go
+++ b/agent/proxycfg/naming.go
@@ -1,0 +1,130 @@
+package proxycfg
+
+import (
+	"strings"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+type UpstreamID struct {
+	Type       string
+	Name       string
+	Datacenter string
+	structs.EnterpriseMeta
+}
+
+func NewUpstreamID(u *structs.Upstream) UpstreamID {
+	id := UpstreamID{
+		Type:       u.DestinationType,
+		Name:       u.DestinationName,
+		Datacenter: u.Datacenter,
+		EnterpriseMeta: structs.NewEnterpriseMetaWithPartition(
+			u.DestinationPartition,
+			u.DestinationNamespace,
+		),
+	}
+	id.normalize()
+	return id
+}
+
+func NewUpstreamIDFromServiceName(sn structs.ServiceName) UpstreamID {
+	id := UpstreamID{
+		Name:           sn.Name,
+		EnterpriseMeta: sn.EnterpriseMeta,
+	}
+	id.normalize()
+	return id
+}
+
+func NewUpstreamIDFromServiceID(sid structs.ServiceID) UpstreamID {
+	id := UpstreamID{
+		Name:           sid.ID,
+		EnterpriseMeta: sid.EnterpriseMeta,
+	}
+	id.normalize()
+	return id
+}
+
+func (u *UpstreamID) normalize() {
+	if u.Type == structs.UpstreamDestTypeService {
+		u.Type = ""
+	}
+
+	u.EnterpriseMeta.Normalize()
+}
+
+// String encodes the UpstreamID into a string for use in agent cache keys.
+// You can decode it back again using UpstreamIDFromString.
+func (u UpstreamID) String() string {
+	return UpstreamIDString(u.Type, u.Datacenter, u.Name, &u.EnterpriseMeta)
+}
+
+func (u UpstreamID) GoString() string {
+	return u.String()
+}
+
+func UpstreamIDFromString(input string) UpstreamID {
+	typ, dc, name, entMeta := ParseUpstreamIDString(input)
+	id := UpstreamID{
+		Type:           typ,
+		Datacenter:     dc,
+		Name:           name,
+		EnterpriseMeta: *entMeta,
+	}
+	id.normalize()
+	return id
+}
+
+const upstreamTypePreparedQueryPrefix = structs.UpstreamDestTypePreparedQuery + ":"
+
+func ParseUpstreamIDString(input string) (typ, dc, name string, meta *structs.EnterpriseMeta) {
+	if strings.HasPrefix(input, upstreamTypePreparedQueryPrefix) {
+		typ = structs.UpstreamDestTypePreparedQuery
+		input = strings.TrimPrefix(input, upstreamTypePreparedQueryPrefix)
+	}
+
+	idx := strings.LastIndex(input, "?dc=")
+	if idx != -1 {
+		dc = input[idx+4:]
+		input = input[0:idx]
+	}
+
+	name, meta = parseInnerUpstreamIDString(input)
+
+	return typ, dc, name, meta
+}
+
+// EnvoyID returns a string representation that uniquely identifies the
+// upstream in a canonical but human readable way.
+//
+// This should be used for any situation where we generate identifiers in Envoy
+// xDS structures for this upstream.
+//
+// This will ensure that generated identifiers for the same thing in OSS and
+// Enterprise render the same and omit default namespaces and partitions.
+func (u UpstreamID) EnvoyID() string {
+	name := u.enterpriseIdentifierPrefix() + u.Name
+	typ := u.Type
+
+	if u.Datacenter != "" {
+		name += "?dc=" + u.Datacenter
+	}
+
+	// Service is default type so never prefix it. This is more readable and long
+	// term it is the only type that matters so we can drop the prefix and have
+	// nicer naming in metrics etc.
+	if typ == "" || typ == structs.UpstreamDestTypeService {
+		return name
+	}
+	return typ + ":" + name
+}
+
+func UpstreamsToMap(us structs.Upstreams) map[UpstreamID]*structs.Upstream {
+	upstreamMap := make(map[UpstreamID]*structs.Upstream)
+
+	for i := range us {
+		u := us[i]
+		upstreamMap[NewUpstreamID(&u)] = &u
+	}
+	return upstreamMap
+}

--- a/agent/proxycfg/naming_oss.go
+++ b/agent/proxycfg/naming_oss.go
@@ -1,0 +1,30 @@
+//go:build !consulent
+// +build !consulent
+
+package proxycfg
+
+import (
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func UpstreamIDString(typ, dc, name string, _ *structs.EnterpriseMeta) string {
+	ret := name
+
+	if dc != "" {
+		ret += "?dc=" + dc
+	}
+
+	if typ == "" || typ == structs.UpstreamDestTypeService {
+		return ret
+	}
+
+	return typ + ":" + ret
+}
+
+func parseInnerUpstreamIDString(input string) (string, *structs.EnterpriseMeta) {
+	return input, structs.DefaultEnterpriseMetaInDefaultPartition()
+}
+
+func (u UpstreamID) enterpriseIdentifierPrefix() string {
+	return ""
+}

--- a/agent/proxycfg/naming_test.go
+++ b/agent/proxycfg/naming_test.go
@@ -1,0 +1,195 @@
+package proxycfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func TestUpstreamIDFromString(t *testing.T) {
+	type testcase struct {
+		id     string
+		expect UpstreamID
+	}
+	run := func(t *testing.T, tc testcase) {
+		tc.expect.EnterpriseMeta.Normalize()
+
+		got := UpstreamIDFromString(tc.id)
+		require.Equal(t, tc.expect, got)
+	}
+
+	prefix := ""
+	if structs.DefaultEnterpriseMetaInDefaultPartition().PartitionOrEmpty() != "" {
+		prefix = "default/default/"
+	}
+
+	cases := map[string]testcase{
+		"prepared query": {
+			"prepared_query:" + prefix + "foo",
+			UpstreamID{
+				Type: structs.UpstreamDestTypePreparedQuery,
+				Name: "foo",
+			},
+		},
+		"prepared query dc": {
+			"prepared_query:" + prefix + "foo?dc=dc2",
+			UpstreamID{
+				Type:       structs.UpstreamDestTypePreparedQuery,
+				Name:       "foo",
+				Datacenter: "dc2",
+			},
+		},
+		"normal": {
+			prefix + "foo",
+			UpstreamID{
+				Name: "foo",
+			},
+		},
+		"normal dc": {
+			prefix + "foo?dc=dc2",
+			UpstreamID{
+				Name:       "foo",
+				Datacenter: "dc2",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestUpstreamID_String(t *testing.T) {
+	type testcase struct {
+		u      UpstreamID
+		expect string
+	}
+	run := func(t *testing.T, tc testcase) {
+		got := tc.u.String()
+		require.Equal(t, tc.expect, got)
+	}
+
+	prefix := ""
+	if structs.DefaultEnterpriseMetaInDefaultPartition().PartitionOrEmpty() != "" {
+		prefix = "default/default/"
+	}
+
+	cases := map[string]testcase{
+		"prepared query": {
+			UpstreamID{
+				Type: structs.UpstreamDestTypePreparedQuery,
+				Name: "foo",
+			},
+			"prepared_query:" + prefix + "foo",
+		},
+		"prepared query dc": {
+			UpstreamID{
+				Type:       structs.UpstreamDestTypePreparedQuery,
+				Name:       "foo",
+				Datacenter: "dc2",
+			},
+			"prepared_query:" + prefix + "foo?dc=dc2",
+		},
+		"normal implicit": {
+			UpstreamID{
+				Name: "foo",
+			},
+			prefix + "foo",
+		},
+		"normal implicit dc": {
+			UpstreamID{
+				Name:       "foo",
+				Datacenter: "dc2",
+			},
+			prefix + "foo?dc=dc2",
+		},
+		"normal explicit": {
+			UpstreamID{
+				Type: structs.UpstreamDestTypeService,
+				Name: "foo",
+			},
+			prefix + "foo",
+		},
+		"normal explicit dc": {
+			UpstreamID{
+				Type:       structs.UpstreamDestTypeService,
+				Name:       "foo",
+				Datacenter: "dc2",
+			},
+			prefix + "foo?dc=dc2",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestUpstreamID_EnvoyID(t *testing.T) {
+	type testcase struct {
+		u      UpstreamID
+		expect string
+	}
+	run := func(t *testing.T, tc testcase) {
+		got := tc.u.EnvoyID()
+		require.Equal(t, tc.expect, got)
+	}
+
+	cases := map[string]testcase{
+		"prepared query": {
+			UpstreamID{
+				Type: structs.UpstreamDestTypePreparedQuery,
+				Name: "foo",
+			},
+			"prepared_query:foo",
+		},
+		"prepared query dc": {
+			UpstreamID{
+				Type:       structs.UpstreamDestTypePreparedQuery,
+				Name:       "foo",
+				Datacenter: "dc2",
+			},
+			"prepared_query:foo?dc=dc2",
+		},
+		"normal implicit": {
+			UpstreamID{
+				Name: "foo",
+			},
+			"foo",
+		},
+		"normal implicit dc": {
+			UpstreamID{
+				Name:       "foo",
+				Datacenter: "dc2",
+			},
+			"foo?dc=dc2",
+		},
+		"normal explicit": {
+			UpstreamID{
+				Type: structs.UpstreamDestTypeService,
+				Name: "foo",
+			},
+			"foo",
+		},
+		"normal explicit dc": {
+			UpstreamID{
+				Type:       structs.UpstreamDestTypeService,
+				Name:       "foo",
+				Datacenter: "dc2",
+			},
+			"foo?dc=dc2",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -18,47 +18,47 @@ import (
 type ConfigSnapshotUpstreams struct {
 	Leaf *structs.IssuedCert
 
-	// DiscoveryChain is a map of upstream.Identifier() ->
-	// CompiledDiscoveryChain's, and is used to determine what services could be
-	// targeted by this upstream. We then instantiate watches for those targets.
-	DiscoveryChain map[string]*structs.CompiledDiscoveryChain
+	// DiscoveryChain is a map of UpstreamID -> CompiledDiscoveryChain's, and
+	// is used to determine what services could be targeted by this upstream.
+	// We then instantiate watches for those targets.
+	DiscoveryChain map[UpstreamID]*structs.CompiledDiscoveryChain
 
-	// WatchedDiscoveryChains is a map of upstream.Identifier() -> CancelFunc's
+	// WatchedDiscoveryChains is a map of UpstreamID -> CancelFunc's
 	// in order to cancel any watches when the proxy's configuration is
 	// changed. Ingress gateways and transparent proxies need this because
 	// discovery chain watches are added and removed through the lifecycle
 	// of a single proxycfg state instance.
-	WatchedDiscoveryChains map[string]context.CancelFunc
+	WatchedDiscoveryChains map[UpstreamID]context.CancelFunc
 
-	// WatchedUpstreams is a map of upstream.Identifier() -> (map of TargetID ->
+	// WatchedUpstreams is a map of UpstreamID -> (map of TargetID ->
 	// CancelFunc's) in order to cancel any watches when the configuration is
 	// changed.
-	WatchedUpstreams map[string]map[string]context.CancelFunc
+	WatchedUpstreams map[UpstreamID]map[string]context.CancelFunc
 
-	// WatchedUpstreamEndpoints is a map of upstream.Identifier() -> (map of
+	// WatchedUpstreamEndpoints is a map of UpstreamID -> (map of
 	// TargetID -> CheckServiceNodes) and is used to determine the backing
 	// endpoints of an upstream.
-	WatchedUpstreamEndpoints map[string]map[string]structs.CheckServiceNodes
+	WatchedUpstreamEndpoints map[UpstreamID]map[string]structs.CheckServiceNodes
 
-	// WatchedGateways is a map of upstream.Identifier() -> (map of
-	// GatewayKey.String() -> CancelFunc) in order to cancel watches for mesh gateways
-	WatchedGateways map[string]map[string]context.CancelFunc
+	// WatchedGateways is a map of UpstreamID -> (map of GatewayKey.String() ->
+	// CancelFunc) in order to cancel watches for mesh gateways
+	WatchedGateways map[UpstreamID]map[string]context.CancelFunc
 
-	// WatchedGatewayEndpoints is a map of upstream.Identifier() -> (map of
-	// GatewayKey.String() -> CheckServiceNodes) and is used to determine the backing
-	// endpoints of a mesh gateway.
-	WatchedGatewayEndpoints map[string]map[string]structs.CheckServiceNodes
+	// WatchedGatewayEndpoints is a map of UpstreamID -> (map of
+	// GatewayKey.String() -> CheckServiceNodes) and is used to determine the
+	// backing endpoints of a mesh gateway.
+	WatchedGatewayEndpoints map[UpstreamID]map[string]structs.CheckServiceNodes
 
 	// UpstreamConfig is a map to an upstream's configuration.
-	UpstreamConfig map[string]*structs.Upstream
+	UpstreamConfig map[UpstreamID]*structs.Upstream
 
-	// PassthroughEndpoints is a map of: ServiceName -> ServicePassthroughAddrs.
-	PassthroughUpstreams map[string]ServicePassthroughAddrs
+	// PassthroughEndpoints is a map of: UpstreamID -> ServicePassthroughAddrs.
+	PassthroughUpstreams map[UpstreamID]ServicePassthroughAddrs
 
 	// IntentionUpstreams is a set of upstreams inferred from intentions.
-	// The keys are created with structs.ServiceName.String().
+	//
 	// This list only applies to proxies registered in 'transparent' mode.
-	IntentionUpstreams map[string]struct{}
+	IntentionUpstreams map[UpstreamID]struct{}
 }
 
 type GatewayKey struct {
@@ -107,7 +107,7 @@ type configSnapshotConnectProxy struct {
 	ConfigSnapshotUpstreams
 
 	WatchedServiceChecks   map[structs.ServiceID][]structs.CheckType // TODO: missing garbage collection
-	PreparedQueryEndpoints map[string]structs.CheckServiceNodes      // DEPRECATED:see:WatchedUpstreamEndpoints
+	PreparedQueryEndpoints map[UpstreamID]structs.CheckServiceNodes  // DEPRECATED:see:WatchedUpstreamEndpoints
 
 	// NOTE: Intentions stores a list of lists as returned by the Intentions
 	// Match RPC. So far we only use the first list as the list of matching
@@ -371,8 +371,8 @@ type configSnapshotIngressGateway struct {
 	// the GatewayServices RPC to retrieve them.
 	Upstreams map[IngressListenerKey]structs.Upstreams
 
-	// UpstreamsSet is the unique set of upstream.Identifier() the gateway routes to.
-	UpstreamsSet map[string]struct{}
+	// UpstreamsSet is the unique set of UpstreamID the gateway routes to.
+	UpstreamsSet map[UpstreamID]struct{}
 
 	// Listeners is the original listener config from the ingress-gateway config
 	// entry to save us trying to pass fields through Upstreams

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -437,7 +437,7 @@ type gatewayWatchOpts struct {
 	source     structs.QuerySource
 	token      string
 	key        GatewayKey
-	upstreamID string
+	upstreamID UpstreamID
 }
 
 func watchMeshGateway(ctx context.Context, opts gatewayWatchOpts) error {
@@ -448,5 +448,5 @@ func watchMeshGateway(ctx context.Context, opts gatewayWatchOpts) error {
 		UseServiceKind: true,
 		Source:         opts.source,
 		EnterpriseMeta: *structs.DefaultEnterpriseMetaInPartition(opts.key.Partition),
-	}, fmt.Sprintf("mesh-gateway:%s:%s", opts.key.String(), opts.upstreamID), opts.notifyCh)
+	}, fmt.Sprintf("mesh-gateway:%s:%s", opts.key.String(), opts.upstreamID.String()), opts.notifyCh)
 }

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -314,15 +314,6 @@ func (us Upstreams) ToAPI() []api.Upstream {
 	return a
 }
 
-func (us Upstreams) ToMap() map[string]*Upstream {
-	upstreamMap := make(map[string]*Upstream)
-
-	for i := range us {
-		upstreamMap[us[i].Identifier()] = &us[i]
-	}
-	return upstreamMap
-}
-
 // UpstreamsFromAPI is a helper for converting api.Upstream to Upstream.
 func UpstreamsFromAPI(us []api.Upstream) Upstreams {
 	a := make([]Upstream, len(us))
@@ -551,24 +542,17 @@ func (k UpstreamKey) String() string {
 	)
 }
 
-// String implements Stringer by returning the Identifier.
-func (u *Upstream) String() string {
-	return u.Identifier()
-}
-
-// Identifier returns a string representation that uniquely identifies the
-// upstream in a canonical but human readable way.
-func (us *Upstream) Identifier() string {
-	name := us.enterpriseIdentifierPrefix() + us.DestinationName
+// String returns a representation of this upstream suitable for debugging
+// purposes but nothing relies upon this format.
+func (us *Upstream) String() string {
+	name := us.enterpriseStringPrefix() + us.DestinationName
 	typ := us.DestinationType
 
 	if us.Datacenter != "" {
 		name += "?dc=" + us.Datacenter
 	}
 
-	// Service is default type so never prefix it. This is more readable and long
-	// term it is the only type that matters so we can drop the prefix and have
-	// nicer naming in metrics etc.
+	// Service is default type so never prefix it.
 	if typ == "" || typ == UpstreamDestTypeService {
 		return name
 	}

--- a/agent/structs/connect_proxy_config_oss.go
+++ b/agent/structs/connect_proxy_config_oss.go
@@ -13,6 +13,6 @@ func (us *Upstream) DestinationID() ServiceID {
 	}
 }
 
-func (us *Upstream) enterpriseIdentifierPrefix() string {
+func (us *Upstream) enterpriseStringPrefix() string {
 	return ""
 }

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -77,22 +77,22 @@ func (s *ResourceGenerator) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.C
 		clusters = append(clusters, passthroughs...)
 	}
 
-	for id, chain := range cfgSnap.ConnectProxy.DiscoveryChain {
-		upstreamCfg := cfgSnap.ConnectProxy.UpstreamConfig[id]
+	for uid, chain := range cfgSnap.ConnectProxy.DiscoveryChain {
+		upstreamCfg := cfgSnap.ConnectProxy.UpstreamConfig[uid]
 
 		explicit := upstreamCfg.HasLocalPortOrSocket()
-		if _, implicit := cfgSnap.ConnectProxy.IntentionUpstreams[id]; !implicit && !explicit {
+		if _, implicit := cfgSnap.ConnectProxy.IntentionUpstreams[uid]; !implicit && !explicit {
 			// Discovery chain is not associated with a known explicit or implicit upstream so it is skipped.
 			continue
 		}
 
-		chainEndpoints, ok := cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[id]
+		chainEndpoints, ok := cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[uid]
 		if !ok {
 			// this should not happen
-			return nil, fmt.Errorf("no endpoint map for upstream %q", id)
+			return nil, fmt.Errorf("no endpoint map for upstream %q", uid)
 		}
 
-		upstreamClusters, err := s.makeUpstreamClustersForDiscoveryChain(id, upstreamCfg, chain, chainEndpoints, cfgSnap)
+		upstreamClusters, err := s.makeUpstreamClustersForDiscoveryChain(uid, upstreamCfg, chain, chainEndpoints, cfgSnap)
 		if err != nil {
 			return nil, err
 		}
@@ -387,30 +387,30 @@ func (s *ResourceGenerator) injectGatewayServiceAddons(cfgSnap *proxycfg.ConfigS
 
 func (s *ResourceGenerator) clustersFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	var clusters []proto.Message
-	createdClusters := make(map[string]bool)
+	createdClusters := make(map[proxycfg.UpstreamID]bool)
 	for _, upstreams := range cfgSnap.IngressGateway.Upstreams {
 		for _, u := range upstreams {
-			id := u.Identifier()
+			uid := proxycfg.NewUpstreamID(&u)
 
 			// If we've already created a cluster for this upstream, skip it. Multiple listeners may
 			// reference the same upstream, so we don't need to create duplicate clusters in that case.
-			if createdClusters[id] {
+			if createdClusters[uid] {
 				continue
 			}
 
-			chain, ok := cfgSnap.IngressGateway.DiscoveryChain[id]
+			chain, ok := cfgSnap.IngressGateway.DiscoveryChain[uid]
 			if !ok {
 				// this should not happen
-				return nil, fmt.Errorf("no discovery chain for upstream %q", id)
+				return nil, fmt.Errorf("no discovery chain for upstream %q", uid)
 			}
 
-			chainEndpoints, ok := cfgSnap.IngressGateway.WatchedUpstreamEndpoints[id]
+			chainEndpoints, ok := cfgSnap.IngressGateway.WatchedUpstreamEndpoints[uid]
 			if !ok {
 				// this should not happen
-				return nil, fmt.Errorf("no endpoint map for upstream %q", id)
+				return nil, fmt.Errorf("no endpoint map for upstream %q", uid)
 			}
 
-			upstreamClusters, err := s.makeUpstreamClustersForDiscoveryChain(id, &u, chain, chainEndpoints, cfgSnap)
+			upstreamClusters, err := s.makeUpstreamClustersForDiscoveryChain(uid, &u, chain, chainEndpoints, cfgSnap)
 			if err != nil {
 				return nil, err
 			}
@@ -418,7 +418,7 @@ func (s *ResourceGenerator) clustersFromSnapshotIngressGateway(cfgSnap *proxycfg
 			for _, c := range upstreamClusters {
 				clusters = append(clusters, c)
 			}
-			createdClusters[id] = true
+			createdClusters[uid] = true
 		}
 	}
 	return clusters, nil
@@ -481,6 +481,8 @@ func (s *ResourceGenerator) makeUpstreamClusterForPreparedQuery(upstream structs
 	var c *envoy_cluster_v3.Cluster
 	var err error
 
+	uid := proxycfg.NewUpstreamID(&upstream)
+
 	dc := upstream.Datacenter
 	if dc == "" {
 		dc = cfgSnap.Datacenter
@@ -491,7 +493,7 @@ func (s *ResourceGenerator) makeUpstreamClusterForPreparedQuery(upstream structs
 	if err != nil {
 		// Don't hard fail on a config typo, just warn. The parse func returns
 		// default config if there is an error so it's safe to continue.
-		s.Logger.Warn("failed to parse", "upstream", upstream.Identifier(), "error", err)
+		s.Logger.Warn("failed to parse", "upstream", uid, "error", err)
 	}
 	if cfg.EnvoyClusterJSON != "" {
 		c, err = makeClusterFromUserConfig(cfg.EnvoyClusterJSON)
@@ -524,7 +526,7 @@ func (s *ResourceGenerator) makeUpstreamClusterForPreparedQuery(upstream structs
 		}
 	}
 
-	endpoints := cfgSnap.ConnectProxy.PreparedQueryEndpoints[upstream.Identifier()]
+	endpoints := cfgSnap.ConnectProxy.PreparedQueryEndpoints[uid]
 	var (
 		spiffeIDs = make([]connect.SpiffeIDService, 0)
 		seen      = make(map[string]struct{})
@@ -571,14 +573,14 @@ func (s *ResourceGenerator) makeUpstreamClusterForPreparedQuery(upstream structs
 }
 
 func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
-	id string,
+	uid proxycfg.UpstreamID,
 	upstream *structs.Upstream,
 	chain *structs.CompiledDiscoveryChain,
 	chainEndpoints map[string]structs.CheckServiceNodes,
 	cfgSnap *proxycfg.ConfigSnapshot,
 ) ([]*envoy_cluster_v3.Cluster, error) {
 	if chain == nil {
-		return nil, fmt.Errorf("cannot create upstream cluster without discovery chain for %s", id)
+		return nil, fmt.Errorf("cannot create upstream cluster without discovery chain for %s", uid)
 	}
 
 	configMap := make(map[string]interface{})
@@ -589,7 +591,7 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 	if err != nil {
 		// Don't hard fail on a config typo, just warn. The parse func returns
 		// default config if there is an error so it's safe to continue.
-		s.Logger.Warn("failed to parse", "upstream", id,
+		s.Logger.Warn("failed to parse", "upstream", uid,
 			"error", err)
 	}
 
@@ -604,7 +606,7 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 			}
 		} else {
 			s.Logger.Warn("ignoring escape hatch setting, because a discovery chain is configured for",
-				"discovery chain", chain.ServiceName, "upstream", id,
+				"discovery chain", chain.ServiceName, "upstream", uid,
 				"envoy_cluster_json", chain.ServiceName)
 		}
 	}

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -69,8 +69,8 @@ func TestClustersFromSnapshot(t *testing.T) {
 					customAppClusterJSON(t, customClusterJSONOptions{
 						Name: "myservice",
 					})
-				snap.ConnectProxy.UpstreamConfig = map[string]*structs.Upstream{
-					"db": {
+				snap.ConnectProxy.UpstreamConfig = map[proxycfg.UpstreamID]*structs.Upstream{
+					UID("db"): {
 						// The local bind port is overridden by the escape hatch, but is required for explicit upstreams.
 						LocalBindPort: 9191,
 						Config: map[string]interface{}{
@@ -669,15 +669,17 @@ func TestClustersFromSnapshot(t *testing.T) {
 				snap.Proxy.Mode = structs.ProxyModeTransparent
 				kafka := structs.NewServiceName("kafka", nil)
 				mongo := structs.NewServiceName("mongo", nil)
+				kafkaUID := proxycfg.NewUpstreamIDFromServiceName(kafka)
+				mongoUID := proxycfg.NewUpstreamIDFromServiceName(mongo)
 
-				snap.ConnectProxy.IntentionUpstreams = map[string]struct{}{
-					kafka.String(): {},
-					mongo.String(): {},
+				snap.ConnectProxy.IntentionUpstreams = map[proxycfg.UpstreamID]struct{}{
+					kafkaUID: {},
+					mongoUID: {},
 				}
 
 				// We add a passthrough cluster for each upstream service name
-				snap.ConnectProxy.PassthroughUpstreams = map[string]proxycfg.ServicePassthroughAddrs{
-					kafka.String(): {
+				snap.ConnectProxy.PassthroughUpstreams = map[proxycfg.UpstreamID]proxycfg.ServicePassthroughAddrs{
+					kafkaUID: {
 						SNI: "kafka.default.dc1.internal.e5b08d03-bfc3-c870-1833-baddb116e648.consul",
 						SpiffeID: connect.SpiffeIDService{
 							Host:       "e5b08d03-bfc3-c870-1833-baddb116e648.consul",
@@ -689,7 +691,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							"9.9.9.9": {},
 						},
 					},
-					mongo.String(): {
+					mongoUID: {
 						SNI: "mongo.default.dc1.internal.e5b08d03-bfc3-c870-1833-baddb116e648.consul",
 						SpiffeID: connect.SpiffeIDService{
 							Host:       "e5b08d03-bfc3-c870-1833-baddb116e648.consul",
@@ -705,8 +707,8 @@ func TestClustersFromSnapshot(t *testing.T) {
 				}
 
 				// There should still be a cluster for non-passthrough requests
-				snap.ConnectProxy.DiscoveryChain[mongo.String()] = discoverychain.TestCompileConfigEntries(t, "mongo", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
-				snap.ConnectProxy.WatchedUpstreamEndpoints[mongo.String()] = map[string]structs.CheckServiceNodes{
+				snap.ConnectProxy.DiscoveryChain[mongoUID] = discoverychain.TestCompileConfigEntries(t, "mongo", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
+				snap.ConnectProxy.WatchedUpstreamEndpoints[mongoUID] = map[string]structs.CheckServiceNodes{
 					"mongo.default.default.dc1": {
 						structs.CheckServiceNode{
 							Node: &structs.Node{
@@ -922,4 +924,9 @@ func TestEnvoyLBConfig_InjectToCluster(t *testing.T) {
 			require.Equal(t, tc.expected, &c)
 		})
 	}
+}
+
+// UID is just a convenience function to aid in writing tests less verbosely.
+func UID(input string) proxycfg.UpstreamID {
+	return proxycfg.UpstreamIDFromString(input)
 }

--- a/agent/xds/delta_test.go
+++ b/agent/xds/delta_test.go
@@ -153,9 +153,9 @@ func TestServer_DeltaAggregatedResources_v3_BasicProtocol_TCP(t *testing.T) {
 		assertDeltaChanBlocked(t, envoy.deltaStream.sendCh)
 	})
 
-	deleteAllButOneEndpoint := func(snap *proxycfg.ConfigSnapshot, svc, targetID string) {
-		snap.ConnectProxy.ConfigSnapshotUpstreams.WatchedUpstreamEndpoints[svc][targetID] =
-			snap.ConnectProxy.ConfigSnapshotUpstreams.WatchedUpstreamEndpoints[svc][targetID][0:1]
+	deleteAllButOneEndpoint := func(snap *proxycfg.ConfigSnapshot, uid proxycfg.UpstreamID, targetID string) {
+		snap.ConnectProxy.ConfigSnapshotUpstreams.WatchedUpstreamEndpoints[uid][targetID] =
+			snap.ConnectProxy.ConfigSnapshotUpstreams.WatchedUpstreamEndpoints[uid][targetID][0:1]
 	}
 
 	runStep(t, "avoid sending config for unsubscribed resource", func(t *testing.T) {
@@ -169,7 +169,7 @@ func TestServer_DeltaAggregatedResources_v3_BasicProtocol_TCP(t *testing.T) {
 
 		// now reconfigure the snapshot and JUST edit the endpoints to strike one of the two current endpoints for DB
 		snap = newTestSnapshot(t, snap, "")
-		deleteAllButOneEndpoint(snap, "db", "db.default.default.dc1")
+		deleteAllButOneEndpoint(snap, UID("db"), "db.default.default.dc1")
 		mgr.DeliverConfig(t, sid, snap)
 
 		// We never send an EDS reply about this change.
@@ -206,7 +206,7 @@ func TestServer_DeltaAggregatedResources_v3_BasicProtocol_TCP(t *testing.T) {
 	runStep(t, "simulate envoy NACKing an endpoint update", func(t *testing.T) {
 		// Trigger only an EDS update.
 		snap = newTestSnapshot(t, snap, "")
-		deleteAllButOneEndpoint(snap, "db", "db.default.default.dc1")
+		deleteAllButOneEndpoint(snap, UID("db"), "db.default.default.dc1")
 		mgr.DeliverConfig(t, sid, snap)
 
 		// Send envoy an EDS update.

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -325,8 +325,8 @@ func TestEndpointsFromSnapshot(t *testing.T) {
 					customAppClusterJSON(t, customClusterJSONOptions{
 						Name: "myservice",
 					})
-				snap.ConnectProxy.UpstreamConfig = map[string]*structs.Upstream{
-					"db": {
+				snap.ConnectProxy.UpstreamConfig = map[proxycfg.UpstreamID]*structs.Upstream{
+					UID("db"): {
 						// The local bind port is overridden by the escape hatch, but is required for explicit upstreams.
 						LocalBindPort: 9191,
 						Config: map[string]interface{}{

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -48,24 +48,24 @@ func (s *ResourceGenerator) routesFromSnapshot(cfgSnap *proxycfg.ConfigSnapshot)
 // "routes" in the snapshot.
 func (s *ResourceGenerator) routesForConnectProxy(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	var resources []proto.Message
-	for id, chain := range cfgSnap.ConnectProxy.DiscoveryChain {
+	for uid, chain := range cfgSnap.ConnectProxy.DiscoveryChain {
 		if chain.IsDefault() {
 			continue
 		}
 
-		explicit := cfgSnap.ConnectProxy.UpstreamConfig[id].HasLocalPortOrSocket()
-		if _, implicit := cfgSnap.ConnectProxy.IntentionUpstreams[id]; !implicit && !explicit {
+		explicit := cfgSnap.ConnectProxy.UpstreamConfig[uid].HasLocalPortOrSocket()
+		if _, implicit := cfgSnap.ConnectProxy.IntentionUpstreams[uid]; !implicit && !explicit {
 			// Discovery chain is not associated with a known explicit or implicit upstream so it is skipped.
 			continue
 		}
 
-		virtualHost, err := makeUpstreamRouteForDiscoveryChain(id, chain, []string{"*"})
+		virtualHost, err := makeUpstreamRouteForDiscoveryChain(uid.EnvoyID(), chain, []string{"*"})
 		if err != nil {
 			return nil, err
 		}
 
 		route := &envoy_route_v3.RouteConfiguration{
-			Name:         id,
+			Name:         uid.EnvoyID(),
 			VirtualHosts: []*envoy_route_v3.VirtualHost{virtualHost},
 			// ValidateClusters defaults to true when defined statically and false
 			// when done via RDS. Re-set the reasonable value of true to prevent
@@ -173,7 +173,7 @@ func makeNamedDefaultRouteWithLB(clusterName string, lb *structs.LoadBalancer, a
 func (s *ResourceGenerator) routesForIngressGateway(
 	listeners map[proxycfg.IngressListenerKey]structs.IngressListener,
 	upstreams map[proxycfg.IngressListenerKey]structs.Upstreams,
-	chains map[string]*structs.CompiledDiscoveryChain,
+	chains map[proxycfg.UpstreamID]*structs.CompiledDiscoveryChain,
 ) ([]proto.Message, error) {
 
 	var result []proto.Message
@@ -195,14 +195,14 @@ func (s *ResourceGenerator) routesForIngressGateway(
 		}
 
 		for _, u := range upstreams {
-			upstreamID := u.Identifier()
-			chain := chains[upstreamID]
+			uid := proxycfg.NewUpstreamID(&u)
+			chain := chains[uid]
 			if chain == nil {
 				continue
 			}
 
 			domains := generateUpstreamIngressDomains(listenerKey, u)
-			virtualHost, err := makeUpstreamRouteForDiscoveryChain(upstreamID, chain, domains)
+			virtualHost, err := makeUpstreamRouteForDiscoveryChain(uid.EnvoyID(), chain, domains)
 			if err != nil {
 				return nil, err
 			}

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -204,11 +204,11 @@ func TestRoutesFromSnapshot(t *testing.T) {
 				bazChain := discoverychain.TestCompileConfigEntries(t, "baz", "default", "default", "dc1", connect.TestClusterID+".consul", nil, entries...)
 				quxChain := discoverychain.TestCompileConfigEntries(t, "qux", "default", "default", "dc1", connect.TestClusterID+".consul", nil, entries...)
 
-				snap.IngressGateway.DiscoveryChain = map[string]*structs.CompiledDiscoveryChain{
-					"foo": fooChain,
-					"bar": barChain,
-					"baz": bazChain,
-					"qux": quxChain,
+				snap.IngressGateway.DiscoveryChain = map[proxycfg.UpstreamID]*structs.CompiledDiscoveryChain{
+					UID("foo"): fooChain,
+					UID("bar"): barChain,
+					UID("baz"): bazChain,
+					UID("qux"): quxChain,
 				}
 			},
 		},
@@ -667,6 +667,9 @@ func setupIngressWithTwoHTTPServices(t *testing.T, o ingressSDSOpts) func(snap *
 			},
 		}
 
+		webUID := proxycfg.NewUpstreamID(&webUpstream)
+		fooUID := proxycfg.NewUpstreamID(&fooUpstream)
+
 		// Setup additional HTTP service on same listener with default router
 		snap.IngressGateway.Upstreams = map[proxycfg.IngressListenerKey]structs.Upstreams{
 			{Protocol: "http", Port: 9191}: {webUpstream, fooUpstream},
@@ -775,7 +778,7 @@ func setupIngressWithTwoHTTPServices(t *testing.T, o ingressSDSOpts) func(snap *
 			o.entMetas["web"].PartitionOrDefault(), "dc1",
 			connect.TestClusterID+".consul", nil, entries...)
 
-		snap.IngressGateway.DiscoveryChain[webUpstream.Identifier()] = webChain
-		snap.IngressGateway.DiscoveryChain[fooUpstream.Identifier()] = fooChain
+		snap.IngressGateway.DiscoveryChain[webUID] = webChain
+		snap.IngressGateway.DiscoveryChain[fooUID] = fooChain
 	}
 }

--- a/agent/xds/testdata/listeners/custom-upstream.envoy-1-20-x.golden
+++ b/agent/xds/testdata/listeners/custom-upstream.envoy-1-20-x.golden
@@ -27,11 +27,11 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
-      "name": "prepared_query:geo-cache:custom-upstream",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
       "address": {
         "socketAddress": {
-          "address": "11.11.11.11",
-          "portValue": 11111
+          "address": "127.10.10.10",
+          "portValue": 8181
         }
       },
       "filterChains": [
@@ -41,13 +41,14 @@
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "foo-stats",
-                "cluster": "random-cluster"
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]
         }
-      ]
+      ],
+      "trafficDirection": "OUTBOUND"
     },
     {
       "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",

--- a/agent/xds/xds_protocol_helpers_test.go
+++ b/agent/xds/xds_protocol_helpers_test.go
@@ -43,8 +43,8 @@ func newTestSnapshot(
 	additionalEntries ...structs.ConfigEntry,
 ) *proxycfg.ConfigSnapshot {
 	snap := proxycfg.TestConfigSnapshotDiscoveryChainDefaultWithEntries(t, additionalEntries...)
-	snap.ConnectProxy.PreparedQueryEndpoints = map[string]structs.CheckServiceNodes{
-		"prepared_query:geo-cache": proxycfg.TestPreparedQueryNodes(t, "geo-cache"),
+	snap.ConnectProxy.PreparedQueryEndpoints = map[proxycfg.UpstreamID]structs.CheckServiceNodes{
+		UID("prepared_query:geo-cache"): proxycfg.TestPreparedQueryNodes(t, "geo-cache"),
 	}
 	if prevSnap != nil {
 		snap.Roots = prevSnap.Roots
@@ -53,7 +53,7 @@ func newTestSnapshot(
 	if dbServiceProtocol != "" {
 		// Simulate ServiceManager injection of protocol
 		snap.Proxy.Upstreams[0].Config["protocol"] = dbServiceProtocol
-		snap.ConnectProxy.ConfigSnapshotUpstreams.UpstreamConfig = snap.Proxy.Upstreams.ToMap()
+		snap.ConnectProxy.ConfigSnapshotUpstreams.UpstreamConfig = proxycfg.UpstreamsToMap(snap.Proxy.Upstreams)
 	}
 	return snap
 }


### PR DESCRIPTION
The gist here is that now we use a value-type struct proxycfg.UpstreamID
as the map key in ConfigSnapshot maps where we used to use "upstream
id-ish" strings. These are internal only and used just for bidirectional
trips through the agent cache keyspace (like the discovery chain target
struct).

For the few places where the upstream id needs to be projected into xDS,
that's what (proxycfg.UpstreamID).EnvoyID() is for. This lets us ALWAYS
inject the partition and namespace into these things without making
stuff like the golden testdata diverge.