### PR TITLE
Add support for 'Partition' and 'RetryJoin' to sdk/TestServerConfig

### DIFF
--- a/.changelog/12126.txt
+++ b/.changelog/12126.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+sdk: Add support for `Partition` and `RetryJoin` to the TestServerConfig struct.
+```

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -77,6 +77,8 @@ type TestServerConfig struct {
 	Performance         *TestPerformanceConfig `json:"performance,omitempty"`
 	Bootstrap           bool                   `json:"bootstrap,omitempty"`
 	Server              bool                   `json:"server,omitempty"`
+	Partition           string                 `json:"partition,omitempty"`
+	RetryJoin           []string               `json:"retry_join,omitempty"`
 	DataDir             string                 `json:"data_dir,omitempty"`
 	Datacenter          string                 `json:"datacenter,omitempty"`
 	Segments            []TestNetworkSegment   `json:"segments"`


### PR DESCRIPTION
- Adding a 'Partition' and 'RetryJoin' command allows test cases where one would like to spin up a Consul Agent in a non-default partition to test use-cases that are common when enabling Admin Partition on Kubernetes.

Question: Is the ability for a client to run as a non-server Agent intentionally unsupported? If so, the `retry_join` flag does enable one to do so.

Closes #12118 