### PR TITLE
Update version to use 1.11.2 prefix

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -13,7 +13,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.11.0"
+	Version = "1.11.2"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
As @banks mentioned in Slack, when running a server by building from `main`, you'll see warnings like:

```
agent.server.connect: error enabling virtual IPs: error="can't allocate Virtual IPs for terminating gateways until all servers >= 1.11.2"
``` 

More generally, this version on `main` should reflect whatever is the "latest" version of Consul. We should do this as part of our release. I've made a note of it in our docs until we sort out automating it.