### PR TITLE
[1.10.x] Backport docs for RingHashConfig typo

### DIFF
--- a/website/content/docs/connect/config-entries/service-resolver.mdx
+++ b/website/content/docs/connect/config-entries/service-resolver.mdx
@@ -426,13 +426,13 @@ spec:
           description: 'Configuration for the `ring_hash` policy type.',
           children: [
             {
-              name: 'MinimumRingRize',
+              name: 'MinimumRingSize',
               type: 'int: 1024',
               description:
                 'Determines the minimum number of entries in the hash ring.',
             },
             {
-              name: 'MaximumRingRize',
+              name: 'MaximumRingSize',
               type: 'int: 8192',
               description:
                 'Determines the maximum number of entries in the hash ring.',


### PR DESCRIPTION
Manual backport of #12122 to 1.10.x.