### PR TITLE
ci: Add explanation in forbidigo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,8 +61,8 @@ linters-settings:
   forbidigo:
     # Forbid the following identifiers (list of regexp).
     forbid:
-      - '\brequire\.New\b'
-      - '\bassert\.New\b'
+      - '\brequire\.New\b(# Use package-level functions with explicit TestingT)?'
+      - '\bassert\.New\b(# Use package-level functions with explicit TestingT)?'
     # Exclude godoc examples from forbidigo checks.
     # Default: true
     exclude_godoc_examples: false


### PR DESCRIPTION
This is a neat hack forbigido provides: https://github.com/ashanbrown/forbidigo#usage https://github.com/ashanbrown/forbidigo/pull/11

Better UX to provide a short explanation why we forbid these