### PR TITLE
Show URL decoding of query params is not needed

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -1156,3 +1156,21 @@ func getPathSuffixUnescaped(path string, prefixToTrim string) (string, error) {
 
 	return suffixUnescaped, nil
 }
+
+func getQueryParamUnescaped(queryParamRaw string) (string) {
+	// If unescaping causes an error, the original input will be returned.
+	// This function does not return an error for convenience of use:
+	// not needing to define error handling everywhere a query parameter is
+	// read. The caller does not need to adapt its behavior based on whether
+	// or not an error is generated here. And it's likely that a malformed
+	// query parameter would generate an error in the higher level http handler
+	// anyways, so the unescape in this function should never fail in actual use.
+
+	queryParamUnescaped, err := url.QueryUnescape(queryParamRaw)
+
+	if err != nil {
+		return queryParamRaw
+	}
+
+	return queryParamUnescaped
+}


### PR DESCRIPTION
On #11258, we stated:
> We intend to open a separate issue for applying the same encode/decode approach to URL query parameters (e.g., "/v1/example/endpoint?id=" + "12345"), which a community member can work on after the URL path parameters fix (this issue) is merged/closed!

However, it looks like that change isn't necessary.

The URL library's accessor function for query parameters (`req.URL.Query().Get("param")`) seems to already do that URL decoding for us. This is demonstrated in the added unit test.

This PR is not meant to be merged, only to get confirmation from others that no change is necessary to URL decode query parameters.