### PR TITLE
packaging: fix issues in pre/postremove scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches: [ 
+    branches: [
       "main"
     ]
 
@@ -145,6 +145,7 @@ jobs:
           config_dir: ".release/linux/package"
           preinstall: ".release/linux/preinstall"
           postinstall: ".release/linux/postinstall"
+          preremove: ".release/linux/preremove"
           postremove: ".release/linux/postremove"
 
       - name: Set Package Names

--- a/.release/linux/postremove
+++ b/.release/linux/postremove
@@ -1,14 +1,19 @@
 #!/bin/bash
 
-if [ "$1" = "purge" ]
-then
-  userdel consul
+if [ -d "/run/systemd/system" ]; then
+    systemctl --system daemon-reload >/dev/null || :
 fi
 
-if [ "$1" == "upgrade" ] && [ -d /run/systemd/system ]; then
-  systemctl --system daemon-reload >/dev/null || true
-  systemctl restart consul >/dev/null || true
-fi
+case "$1" in
+    purge | 0)
+        userdel consul
+        ;;
+
+    upgrade | [1-9]*)
+        if [ -d "/run/systemd/system" ]; then
+            systemctl try-restart consul.service >/dev/null || :
+        fi
+        ;;
+esac
 
 exit 0
-

--- a/.release/linux/preremove
+++ b/.release/linux/preremove
@@ -1,0 +1,11 @@
+#!/bin/bash
+case "$1" in
+    remove | 0)
+        if [ -d "/run/systemd/system" ]; then
+            systemctl --no-reload disable consul.service > /dev/null || :
+            systemctl stop consul.service > /dev/null || :
+        fi
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
Fixes several issues with the pre/postremove scripts for both rpm and deb packages. Specifically:

For postremove:

- the postremove script now functions correctly (i.e. restarts consul after a package upgrade) on rpm-based systems (where `$1` is numeric rather than `purge` or `upgrade`)
- `systemctl daemon-reload` is called on package removal (rather than only on upgrade)
- calls `systemctl try-restart` instead of `systemctl restart`, which will only (re)start consul if it was already running when the upgrade happened.

For preremove:
- if the package is being completely uninstalled (rather than upgraded), stop consul before removing the package

Tested on CentOS 7.9 and Ubuntu 20.04, but should be applicable to all rpm and deb based distributions.