### PR TITLE
Make LockRetryTime configurable in api locks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.extensionOutputFolder": "./.vscode"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "makefile.extensionOutputFolder": "./.vscode"
-}

--- a/api/lock.go
+++ b/api/lock.go
@@ -81,7 +81,7 @@ type LockOptions struct {
 	LockTryOnce      bool          // Optional, defaults to false which means try forever
 	LockDelay        time.Duration // Optional, defaults to 15s
 	Namespace        string        `json:",omitempty"` // Optional, defaults to API client config, namespace of ACL token, or "default" namespace
-	LockRetryTime    time.Duration //Optional, defaults to DefaultLockRetryTime
+	LockRetryTime    time.Duration // Optional, defaults to DefaultLockRetryTime
 }
 
 // LockKey returns a handle to a lock struct which can be used


### PR DESCRIPTION
The lock time is not configurable and by default, it is set to 5 seconds which may not be suitable to consumers.

This preserves the default and allows the user to set it with a new config field called `LockRetryTime` which is similar to the existing `LockWaitTime` option.