### PR TITLE
docs: Add ingress TLS cipher and version documentation

### DIFF
--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -1000,7 +1000,7 @@ You can specify the following parameters to configure ingress gateway configurat
           description: `A list of TLS cipher suites to support when negotiating
                         connections using TLS 1.2 or earlier. If unspecified,
                         Envoy will use a
-                        [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites"). The list of supported cipher suites can seen in [`types/tls.go`](https://github.com/hashicorp/consul/blob/main/types/tls.go#L154-L169) and is dependent on underlying support in Envoy - future releases of Envoy may remove currently-supported but insecure cipher suites, and future releases of Consul may add new supported cipher suites if any are added to Envoy."
+                        [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites). The list of supported cipher suites can seen in [\`types/tls.go\`](https://github.com/hashicorp/consul/blob/main/types/tls.go#L154-L169) and is dependent on underlying support in Envoy - future releases of Envoy may remove currently-supported but insecure cipher suites, and future releases of Consul may add new supported cipher suites if any are added to Envoy.`
         },
         {
           name: 'SDS',
@@ -1182,7 +1182,7 @@ You can specify the following parameters to configure ingress gateway configurat
               description: `A list of TLS cipher suites to support when negotiating
                             connections using TLS 1.2 or earlier. If unspecified,
                             Envoy will use a
-                            [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites").
+                            [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites).
                             <br><br>
                             Supported values:<br>
                             \`\`\`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 <br>

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -980,6 +980,29 @@ You can specify the following parameters to configure ingress gateway configurat
           },
         },
         {
+          name: 'TLSMinVersion',
+          type: 'string: ""',
+          description: "Set the minimum TLS version supported for this listener. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`. If unspecified, Envoy v1.22.0 and newer [will default to TLS 1.2 as a min version](https://github.com/envoyproxy/envoy/pull/19330), while older releases of Envoy default to TLS 1.0.",
+        },
+        {
+          name: 'TLSMaxVersion',
+          type: 'string: ""',
+          description: {
+            hcl:
+              "Set the maximum TLS version supported for this listener. Must be greater than or equal to `TLSMinVersion`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
+            yaml:
+              "Set the maximum TLS version supported for this listener. Must be greater than or equal to `tls_min_version`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
+          },
+        },
+        {
+          name: 'CipherSuites',
+          type: 'array<string>: <optional>',
+          description: `A list of TLS cipher suites to support when negotiating
+                        connections using TLS 1.2 or earlier. If unspecified,
+                        Envoy will use a
+                        [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites"). The list of supported cipher suites can seen in [`types/tls.go`](https://github.com/hashicorp/consul/blob/main/types/tls.go#L154-L169) and is dependent on underlying support in Envoy - future releases of Envoy may remove currently-supported but insecure cipher suites, and future releases of Consul may add new supported cipher suites if any are added to Envoy."
+        },
+        {
           name: 'SDS',
           yaml: false,
           type: 'SDSConfig: <optional>',
@@ -1133,9 +1156,9 @@ You can specify the following parameters to configure ingress gateway configurat
               type: 'bool: false',
               description: {
                 hcl:
-                  "Set this configuration to `true` to enable built-in TLS for this listener.<br><br>If TLS is enabled, then each host defined in each service's `Hosts` field will be added as a DNSSAN to the gateway's x509 certificate. Note that even hosts from other listeners with TLS disabled will be added.",
+                  "Set this configuration to `true` to enable built-in TLS for this listener.<br><br>If TLS is enabled, then each host defined in each service's `Hosts` field will be added as a DNSSAN to the gateway's x509 certificate. Note that even hosts from other listeners with TLS disabled will be added. TLS can not be disabled for individual listeners if it is enabled on the gateway.",
                 yaml:
-                  "Set this configuration to `true` to enable built-in TLS for this listener.<br><br>If TLS is enabled, then each host defined in the `hosts` field will be added as a DNSSAN to the gateway's x509 certificate. Note that even hosts from other listeners with TLS disabled will be added.",
+                  "Set this configuration to `true` to enable built-in TLS for this listener.<br><br>If TLS is enabled, then each host defined in the `hosts` field will be added as a DNSSAN to the gateway's x509 certificate. Note that even hosts from other listeners with TLS disabled will be added. TLS can not be disabled for individual listeners if it is enabled on the gateway.",
               },
             },
             {

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -982,24 +982,24 @@ You can specify the following parameters to configure ingress gateway configurat
         {
           name: 'TLSMinVersion',
           type: 'string: ""',
-          description: "Set the minimum TLS version supported for the gateway's listeners. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`. If unspecified, Envoy v1.22.0 and newer [will default to TLS 1.2 as a min version](https://github.com/envoyproxy/envoy/pull/19330), while older releases of Envoy default to TLS 1.0.",
+          description: "Set the default minimum TLS version supported for the gateway's listeners. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`. If unspecified, Envoy v1.22.0 and newer [will default to TLS 1.2 as a min version](https://github.com/envoyproxy/envoy/pull/19330), while older releases of Envoy default to TLS 1.0.",
         },
         {
           name: 'TLSMaxVersion',
           type: 'string: ""',
           description: {
             hcl:
-              "Set the maximum TLS version supported for the gateway's listeners. Must be greater than or equal to `TLSMinVersion`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
+              "Set the default maximum TLS version supported for the gateway's listeners. Must be greater than or equal to `TLSMinVersion`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
             yaml:
-              "Set the maximum TLS version supported for the gateway's listeners. Must be greater than or equal to `tls_min_version`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
+              "Set the default maximum TLS version supported for the gateway's listeners. Must be greater than or equal to `tls_min_version`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
           },
         },
         {
           name: 'CipherSuites',
           type: 'array<string>: <optional>',
-          description: `A list of TLS cipher suites to support when negotiating
-                        connections using TLS 1.2 or earlier. If unspecified,
-                        Envoy will use a
+          description: `Set the default list of TLS cipher suites for the gateway's
+                        listeners to support when negotiating connections using
+                        TLS 1.2 or earlier. If unspecified, Envoy will use a
                         [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites).
                         The list of supported cipher suites can seen in
                         [\`consul/types/tls.go\`](https://github.com/hashicorp/consul/blob/v1.11.2/types/tls.go#L154-L169)
@@ -1171,7 +1171,7 @@ You can specify the following parameters to configure ingress gateway configurat
             {
               name: 'TLSMinVersion',
               type: 'string: ""',
-              description: "Set the minimum TLS version supported for this listener. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`.",
+              description: "Set the minimum TLS version supported for this listener. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`. If unspecified, Envoy v1.22.0 and newer [will default to TLS 1.2 as a min version](https://github.com/envoyproxy/envoy/pull/19330), while older releases of Envoy default to TLS 1.0.",
             },
             {
               name: 'TLSMaxVersion',
@@ -1186,7 +1186,7 @@ You can specify the following parameters to configure ingress gateway configurat
             {
               name: 'CipherSuites',
               type: 'array<string>: <optional>',
-              description: `A list of TLS cipher suites to support when negotiating
+              description: `Set the list of TLS cipher suites to support when negotiating
                             connections using TLS 1.2 or earlier. If unspecified,
                             Envoy will use a
                             [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites).

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -1139,6 +1139,45 @@ You can specify the following parameters to configure ingress gateway configurat
               },
             },
             {
+              name: 'TLSMinVersion',
+              type: 'string: ""',
+              description: "Set the minimum TLS version supported for this listener. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`.",
+            },
+            {
+              name: 'TLSMaxVersion',
+              type: 'string: ""',
+              description: {
+                hcl:
+                  "Set the maximum TLS version supported for this listener. Must be greater than or equal to `TLSMinVersion`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
+                yaml:
+                  "Set the maximum TLS version supported for this listener. Must be greater than or equal to `tls_min_version`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
+              },
+            },
+            {
+              name: 'CipherSuites',
+              type: 'array<string>: <optional>',
+              description: `A list of TLS cipher suites to support when negotiating
+                            connections using TLS 1.2 or earlier. If unspecified,
+                            Envoy will use a
+                            [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites").
+                            <br><br>
+                            Supported values:<br>
+                            \`\`\`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 <br>
+                            TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256<br>
+                            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256<br>
+                            TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256<br>
+                            TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA<br>
+                            TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA<br>
+                            TLS_RSA_WITH_AES_128_GCM_SHA256<br>
+                            TLS_RSA_WITH_AES_128_CBC_SHA<br>
+                            TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384<br>
+                            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384<br>
+                            TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA<br>
+                            TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA<br>
+                            TLS_RSA_WITH_AES_256_GCM_SHA384<br>
+                            TLS_RSA_WITH_AES_256_CBC_SHA\`\`\``
+            },
+            {
               name: 'SDS',
               type: 'SDSConfig: <optional>',
               description:

--- a/website/content/docs/connect/config-entries/ingress-gateway.mdx
+++ b/website/content/docs/connect/config-entries/ingress-gateway.mdx
@@ -982,16 +982,16 @@ You can specify the following parameters to configure ingress gateway configurat
         {
           name: 'TLSMinVersion',
           type: 'string: ""',
-          description: "Set the minimum TLS version supported for this listener. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`. If unspecified, Envoy v1.22.0 and newer [will default to TLS 1.2 as a min version](https://github.com/envoyproxy/envoy/pull/19330), while older releases of Envoy default to TLS 1.0.",
+          description: "Set the minimum TLS version supported for the gateway's listeners. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`. If unspecified, Envoy v1.22.0 and newer [will default to TLS 1.2 as a min version](https://github.com/envoyproxy/envoy/pull/19330), while older releases of Envoy default to TLS 1.0.",
         },
         {
           name: 'TLSMaxVersion',
           type: 'string: ""',
           description: {
             hcl:
-              "Set the maximum TLS version supported for this listener. Must be greater than or equal to `TLSMinVersion`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
+              "Set the maximum TLS version supported for the gateway's listeners. Must be greater than or equal to `TLSMinVersion`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
             yaml:
-              "Set the maximum TLS version supported for this listener. Must be greater than or equal to `tls_min_version`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
+              "Set the maximum TLS version supported for the gateway's listeners. Must be greater than or equal to `tls_min_version`. One of `TLS_AUTO`, `TLSv1_0`, `TLSv1_1`, `TLSv1_2`, or `TLSv1_3`." ,
           },
         },
         {
@@ -1000,7 +1000,14 @@ You can specify the following parameters to configure ingress gateway configurat
           description: `A list of TLS cipher suites to support when negotiating
                         connections using TLS 1.2 or earlier. If unspecified,
                         Envoy will use a
-                        [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites). The list of supported cipher suites can seen in [\`types/tls.go\`](https://github.com/hashicorp/consul/blob/main/types/tls.go#L154-L169) and is dependent on underlying support in Envoy - future releases of Envoy may remove currently-supported but insecure cipher suites, and future releases of Consul may add new supported cipher suites if any are added to Envoy.`
+                        [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites).
+                        The list of supported cipher suites can seen in
+                        [\`consul/types/tls.go\`](https://github.com/hashicorp/consul/blob/v1.11.2/types/tls.go#L154-L169)
+                        and is dependent on underlying support in Envoy. Future
+                        releases of Envoy may remove currently-supported but
+                        insecure cipher suites, and future releases of Consul
+                        may add new supported cipher suites if any are added to
+                        Envoy.`
         },
         {
           name: 'SDS',
@@ -1183,22 +1190,12 @@ You can specify the following parameters to configure ingress gateway configurat
                             connections using TLS 1.2 or earlier. If unspecified,
                             Envoy will use a
                             [default server cipher list](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-tlsparameters-cipher-suites).
-                            <br><br>
-                            Supported values:<br>
-                            \`\`\`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 <br>
-                            TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256<br>
-                            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256<br>
-                            TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256<br>
-                            TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA<br>
-                            TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA<br>
-                            TLS_RSA_WITH_AES_128_GCM_SHA256<br>
-                            TLS_RSA_WITH_AES_128_CBC_SHA<br>
-                            TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384<br>
-                            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384<br>
-                            TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA<br>
-                            TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA<br>
-                            TLS_RSA_WITH_AES_256_GCM_SHA384<br>
-                            TLS_RSA_WITH_AES_256_CBC_SHA\`\`\``
+                            The list of supported cipher suites can seen in
+                            [\`consul/types/tls.go\`](https://github.com/hashicorp/consul/blob/v1.11.2/types/tls.go#L154-L169)
+                            and is dependent on underlying support in Envoy. Future
+                            releases of Envoy may remove currently-supported but
+                            insecure cipher suites, and future releases of Consul
+                            may add new supported cipher suites if any are added to Envoy.`
             },
             {
               name: 'SDS',


### PR DESCRIPTION
Document the new TLS cipher and version parameters that were added to ingress gateways in #11576.