### PR TITLE
[1.8.x] Backport update to supported config kinds in `config write`

### DIFF
--- a/website/pages/commands/config/write.mdx
+++ b/website/pages/commands/config/write.mdx
@@ -43,8 +43,9 @@ From stdin:
 
 ### Config Entry examples
 
-All config entries must have a `Kind` when registered. Currently, the only
-supported types are `service-defaults` and `proxy-defaults`.
+All config entries must have a `Kind` when registered. See
+[Service Mesh - Config Entries](/docs/connect/config-entries) for the list of
+supported config entries.
 
 #### Service defaults
 


### PR DESCRIPTION
Manual backport of #12124 to 1.8.x.