### PR TITLE
acl: demonstrate new authz interface

### DIFF
--- a/acl/errors.go
+++ b/acl/errors.go
@@ -62,12 +62,22 @@ func IsErrPermissionDenied(err error) bool {
 }
 
 type PermissionDeniedError struct {
+	Resource    Resource
+	AccessLevel AccessLevel
+	AccessorID  string
+	ResourceID  string
+
+	// TODO: remove Cause, use other fields
 	Cause string
 }
 
 func (e PermissionDeniedError) Error() string {
 	if e.Cause != "" {
 		return errPermissionDenied + ": " + e.Cause
+	}
+	if e.Resource != "" {
+		return fmt.Sprintf("%s: token %s is missing %s:%s for %s",
+			errPermissionDenied, e.AccessorID, e.Resource, e.AccessLevel, e.ResourceID)
 	}
 	return errPermissionDenied
 }

--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -32,7 +32,7 @@ type KVS struct {
 // preApply does all the verification of a KVS update that is performed BEFORE
 // we submit as a Raft log entry. This includes enforcing the lock delay which
 // must only be done on the leader.
-func kvsPreApply(logger hclog.Logger, srv *Server, authz acl.Authorizer, op api.KVOp, dirEnt *structs.DirEntry) (bool, error) {
+func kvsPreApply(logger hclog.Logger, srv *Server, authz ACLResolveResult, op api.KVOp, dirEnt *structs.DirEntry) (bool, error) {
 	// Verify the entry.
 	if dirEnt.Key == "" && op != api.KVDeleteTree {
 		return false, fmt.Errorf("Must provide key")
@@ -66,8 +66,8 @@ func kvsPreApply(logger hclog.Logger, srv *Server, authz acl.Authorizer, op api.
 		var authzContext acl.AuthorizerContext
 		dirEnt.FillAuthzContext(&authzContext)
 
-		if authz.KeyWrite(dirEnt.Key, &authzContext) != acl.Allow {
-			return false, acl.ErrPermissionDenied
+		if err := authz.HasKeyWrite(dirEnt); err != nil {
+			return false, err
 		}
 	}
 

--- a/agent/consul/txn_endpoint.go
+++ b/agent/consul/txn_endpoint.go
@@ -32,7 +32,7 @@ type Txn struct {
 
 // preCheck is used to verify the incoming operations before any further
 // processing takes place. This checks things like ACLs.
-func (t *Txn) preCheck(authorizer acl.Authorizer, ops structs.TxnOps) structs.TxnErrors {
+func (t *Txn) preCheck(authorizer ACLResolveResult, ops structs.TxnOps) structs.TxnErrors {
 	var errors structs.TxnErrors
 
 	// Perform the pre-apply checks for any KV operations.

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2279,6 +2279,10 @@ func (d *DirEntry) IDValue() string {
 	return d.Key
 }
 
+func (d *DirEntry) KVResourceID() string {
+	return d.Key
+}
+
 type DirEntries []*DirEntry
 
 // KVSRequest is used to operate on the Key-Value store


### PR DESCRIPTION
Branched from #12167, demonstrates the authorization interface proposed in #11690.

This PR also demonstrates how we can used a typed error, built in a centralized place, to provide better error messages when permission is denied.

TODO:
* remove `Cause` field from `PermissionDeniedError`
* move `ACLResolveResult` and the types used in its method signatures to a new package under `acl/` maybe `acl/aclauthz` or something like that.