### PR TITLE
Make systemd EnvironmentFile optional

### DIFF
--- a/.changelog/12176.txt
+++ b/.changelog/12176.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+systemd: Support starting/stopping the systemd service for linux packages when the optional EnvironmentFile does not exist.
+```

--- a/.release/linux/package/usr/lib/systemd/system/consul.service
+++ b/.release/linux/package/usr/lib/systemd/system/consul.service
@@ -6,7 +6,7 @@ After=network-online.target
 ConditionFileNotEmpty=/etc/consul.d/consul.hcl
 
 [Service]
-EnvironmentFile=/etc/consul.d/consul.env
+EnvironmentFile=-/etc/consul.d/consul.env
 User=consul
 Group=consul
 ExecStart=/usr/bin/consul agent -config-dir=/etc/consul.d/


### PR DESCRIPTION
Folks should be able to start/stop the service for linux packages even when the [optional] EnvironmentFile does not exist. This PR makes that possible- big thanks to @blake for this one! 

[Relevant snippet](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=) from the docs:

> The argument passed should be an absolute filename or wildcard expression, optionally prefixed with "-", which indicates that if the file does not exist, it will not be read and no error or warning message is logged. This option may be specified more than once in which case all specified files are read. If the empty string is assigned to this option, the list of file to read is reset, all prior assignments have no effect.

Relates to https://github.com/hashicorp/consul/issues/11943 