### PR TITLE
docs: Service Sync clarify requirements when using Service Mesh

### DIFF
--- a/website/content/docs/k8s/service-sync.mdx
+++ b/website/content/docs/k8s/service-sync.mdx
@@ -32,6 +32,8 @@ service discovery, including hosted services like databases.
 
 ## Installation and Configuration
 
+~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Please ensure that Service Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](https://www.consul.io/docs/k8s/service-sync#sync-enable-disable).
+
 The service sync is done using an external long-running process in the
 [consul-k8s project](https://github.com/hashicorp/consul-k8s). This process
 can run either in or out of a Kubernetes cluster. However, running this within

--- a/website/content/docs/k8s/service-sync.mdx
+++ b/website/content/docs/k8s/service-sync.mdx
@@ -32,7 +32,7 @@ service discovery, including hosted services like databases.
 
 ## Installation and Configuration
 
-~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Please ensure that Service Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](https://www.consul.io/docs/k8s/service-sync#sync-enable-disable).
+~> Enabling both Service Mesh and Service Sync on the same Kubernetes services is not supported, as Service Mesh also registers Kubernetes service instances to Consul. Please ensure that Service Sync is only enabled for namespaces and services that are not injected with the Consul sidecar for Service Mesh as described in [Sync Enable/Disable](/docs/k8s/service-sync#sync-enable-disable).
 
 The service sync is done using an external long-running process in the
 [consul-k8s project](https://github.com/hashicorp/consul-k8s). This process


### PR DESCRIPTION
Clarify to only enable service sync on non-mesh Service instances. 