### PR TITLE
URL-encode/decode resource names for HTTP API part 4

### DIFF
--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/consul/acl"
@@ -19,15 +20,12 @@ func (s *HTTPHandlers) EventFire(resp http.ResponseWriter, req *http.Request) (i
 	var dc string
 	s.parseDC(req, &dc)
 
-	var err error
 	event := &UserEvent{}
-
-	event.Name, err = getPathSuffixUnescaped(req.URL.Path, "/v1/event/fire/")
-	if err != nil {
-		return nil, err
-	}
+	event.Name = strings.TrimPrefix(req.URL.Path, "/v1/event/fire/")
 	if event.Name == "" {
-		return nil, BadRequestError{Reason: "Missing name"}
+		resp.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(resp, "Missing name")
+		return nil, nil
 	}
 
 	// Get the ACL token

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -133,7 +133,11 @@ func (s *HTTPHandlers) UINodeInfo(resp http.ResponseWriter, req *http.Request) (
 	}
 
 	// Verify we have some DC, or use the default
-	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/internal/ui/node/")
+	var err error
+	args.Node, err = getPathSuffixUnescaped(req.URL.Path, "/v1/internal/ui/node/")
+	if err != nil {
+		return nil, err
+	}
 	if args.Node == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing node name")

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -249,7 +249,11 @@ func (s *HTTPHandlers) UIGatewayServicesNodes(resp http.ResponseWriter, req *htt
 	}
 
 	// Pull out the service name
-	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/internal/ui/gateway-services-nodes/")
+	var err error
+	args.ServiceName, err = getPathSuffixUnescaped(req.URL.Path, "/v1/internal/ui/gateway-services-nodes/")
+	if err != nil {
+		return nil, err
+	}
 	if args.ServiceName == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing gateway name")
@@ -291,7 +295,11 @@ func (s *HTTPHandlers) UIServiceTopology(resp http.ResponseWriter, req *http.Req
 		return nil, err
 	}
 
-	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/internal/ui/service-topology/")
+	var err error
+	args.ServiceName, err = getPathSuffixUnescaped(req.URL.Path, "/v1/internal/ui/service-topology/")
+	if err != nil {
+		return nil, err
+	}
 	if args.ServiceName == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing service name")
@@ -570,7 +578,11 @@ func (s *HTTPHandlers) UIGatewayIntentions(resp http.ResponseWriter, req *http.R
 	}
 
 	// Pull out the service name
-	name := strings.TrimPrefix(req.URL.Path, "/v1/internal/ui/gateway-intentions/")
+	var err error
+	name, err := getPathSuffixUnescaped(req.URL.Path, "/v1/internal/ui/gateway-intentions/")
+	if err != nil {
+		return nil, err
+	}
 	if name == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing gateway name")
@@ -651,7 +663,10 @@ func (s *HTTPHandlers) UIMetricsProxy(resp http.ResponseWriter, req *http.Reques
 	// here.
 
 	// Replace prefix in the path
-	subPath := strings.TrimPrefix(req.URL.Path, "/v1/internal/ui/metrics-proxy")
+	subPath, err := getPathSuffixUnescaped(req.URL.Path, "/v1/internal/ui/metrics-proxy")
+	if err != nil {
+		return nil, err
+	}
 
 	// Append that to the BaseURL (which might contain a path prefix component)
 	newURL := cfg.BaseURL + subPath


### PR DESCRIPTION
Hi, I noticed that #12103 and #11957 did not contain changes to consul/ui_endpoint.go, I changed that endpoint. 