### PR TITLE
Update raft-boltdb and the boltdb telemetry docs

### DIFF
--- a/.changelog/12198.txt
+++ b/.changelog/12198.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+telemetry: Pulling in v2.2.1 of github.com/hashicorp/raft-boltdb so that Consul will emit the consul.raft.boltdb.writeCapacity metric.
+```

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/hashicorp/raft v1.3.3
 	github.com/hashicorp/raft-autopilot v0.1.5
 	github.com/hashicorp/raft-boltdb v0.0.0-20211202195631-7d34b9fb3f42 // indirect
-	github.com/hashicorp/raft-boltdb/v2 v2.2.0
+	github.com/hashicorp/raft-boltdb/v2 v2.2.1
 	github.com/hashicorp/serf v0.9.7
 	github.com/hashicorp/vault/api v1.0.5-0.20200717191844-f687267c8086
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200519221838-e0cfd64bc267

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pN
 github.com/hashicorp/raft-boltdb v0.0.0-20210409134258-03c10cc3d4ea/go.mod h1:qRd6nFJYYS6Iqnc/8HcUmko2/2Gw8qTFEmxDLii6W5I=
 github.com/hashicorp/raft-boltdb v0.0.0-20211202195631-7d34b9fb3f42 h1:Ye8SofeDHJzu9xvvaMmpMkqHELWW7rTcXwdUR0CWW48=
 github.com/hashicorp/raft-boltdb v0.0.0-20211202195631-7d34b9fb3f42/go.mod h1:wcXL8otVu5cpJVLjcmq7pmfdRCdaP+xnvu7WQcKJAhs=
-github.com/hashicorp/raft-boltdb/v2 v2.2.0 h1:/CVN9LSAcH50L3yp2TsPFIpeyHn1m3VF6kiutlDE3Nw=
-github.com/hashicorp/raft-boltdb/v2 v2.2.0/go.mod h1:SgPUD5TP20z/bswEr210SnkUFvQP/YjKV95aaiTbeMQ=
+github.com/hashicorp/raft-boltdb/v2 v2.2.1 h1:QroJPzqRRasquCL74oTrMVw937qjNy3udTsgJQK4uUA=
+github.com/hashicorp/raft-boltdb/v2 v2.2.1/go.mod h1:SgPUD5TP20z/bswEr210SnkUFvQP/YjKV95aaiTbeMQ=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/serf v0.9.7 h1:hkdgbqizGQHuU5IPqYM1JdSMV8nKfpuOnZYXssk9muY=
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -276,45 +276,58 @@ This metric should be monitored to ensure that the license doesn't expire to pre
 | `consul.raft.boltdb.freelistBytes`                  | Represents the number of bytes necessary to encode the freelist metadata. When [`raft_boltdb.NoFreelistSync`](/docs/agent/options#NoFreelistSync) is set to `false` these metadata bytes must also be written to disk for each committed log. | bytes | gauge   |
 | `consul.raft.boltdb.logsPerBatch`                   | Measures the number of logs being written per batch to the db. | logs | sample |
 | `consul.raft.boltdb.storeLogs`                      | Measures the amount of time spent writing logs to the db. | ms | timer |
+| `consul.raft.boltdb.writeCapacity`                  | Represents an estimate of how many Raft log writes per second could be handled given the current disk performance, log batching and log sizes. | logs/second | sample |
 
 
 ** Requirements: **
-* Consul 1.11.0+
+* Consul 1.11.3+ for the `consul.raft.boltdb.writeCapacity` metric.
+* Consul 1.11.0+ for all other Bolt DB metrics.
 
 **Why they're important:**
 
 The `consul.raft.boltdb.storeLogs` metric is a direct indicator of disk write performance of a Consul server. If there are issues with the disk or
-performance degradations related to Bolt DB, these metrics will show the issue and potentially the cause as well.
+performance degradations related to Bolt DB, these metrics will show the issue and potentially the cause as well. The `consul.raft.boltdb.writeCapacity`
+metric is an indicator of how many log writes Bolt DB can process every second. This metric is heavily influenced by disk performance,
+Raft log batching and the size of logs being written to the database.
+
+For Consul versions 1.11.0 - 1.11.2 the `consul.raft.boltdb.writeCapacity` metric can be calculated from the
+other metrics with the following equation: `1000 / consul.raft.boltdb.storeLogs * consul.raft.boltdb.logsPerBatch`.
 
 **What to look for:**
 
 The primary thing to look for are increases in the `consul.raft.boltdb.storeLogs` times. Its value will directly govern an 
 upper limit to the throughput of write operations within Consul.
 
-In Consul each write operation will turn into a single Raft log to be committed. Raft will process these
+In Consul, each write operation will turn into a single Raft log to be committed. Raft will process these
 logs and store them within Bolt DB in batches. Each call to store logs within Bolt DB is measured to record how long
 it took as well as how many logs were contained in the batch. Writing logs is this fashion is serialized so that
-a subsequent log storage operation can only be started after the previous one completed. Therefore the maximum number
-of log storage operations that can be performed each second can be calculated with the following equation: 
-`(1000 ms) / (consul.raft.boltdb.storeLogs ms/op)`. From there we can extrapolate the maximum number of Consul writes
-per second by multiplying that value by the `consul.raft.boltdb.logsPerBatch` metric's value. When log storage 
+a subsequent log storage operation can only be started after the previous one completed. When log storage 
 operations are becoming slower you may not see an immediate decrease in write throughput to Consul due to increased 
 batch sizes of the each operation. However, the max batch size allowed is 64 logs. Therefore if the `logsPerBatch`
 metric is near 64 and the `storeLogs` metric is seeing increased time to write each batch to disk, then it is likely 
 that increased write latencies and other errors may occur.
 
-There can be a number of potential issues that can cause this. Often times it could be performance of the underlying
-disks that is the issue. Other times it may be caused by Bolt DB behavior. Bolt DB keeps track of free space within
-the `raft.db` file. When needing to allocate data it will use existing free space first before further expanding the
-file. By default, Bolt DB will write a data structure containing metadata about free pages within the DB to disk for
-every log storage operation. Therefore if the free space within the database grows excessively large, such as after
-a large spike in writes beyond the normal steady state and a subsequent slow down in the write rate, then Bolt DB
-could end up writing a large amount of extra data to disk for each log storage operation. This has the potential
-to drastically increase disk write throughput, potentially beyond what the underlying disks can keep up with. To
-detect this situation you can look at the `consul.raft.boltdb.freelistBytes` metric. This metric is a count of
-the extra bytes that are being written for each log storage operation beyond the log data itself. While not a clear
-indicator of an actual issue, this metric can be used to diagnose why the `consul.raft.boltdb.storeLogs` metric
-is high. 
+The `consul.raft.boltdb.writeCapacity` metric is emitted as an estimate of how many log writes this Consul server could
+process every second if a few conditions remain steady:
+* disk performance
+* log sizes
+* timing of log writes as this will influence log batch sizes
+
+In a normal cluster its likely that all three of these will fluctuate some so it is likely that the metric will also
+fluctuate a minor amount. However, large fluctuations are not to be expected.
+
+There can be a number of potential issues that can cause these metrics to drastically change. Often times it could 
+be performance of the underlying disks that is the issue. Other times it may be caused by Bolt DB behavior. Bolt DB
+keeps track of free space within the `raft.db` file. When needing to allocate data it will use existing free space
+first before further expanding the file. By default, Bolt DB will write a data structure containing metadata about 
+free pages within the DB to disk for every log storage operation. Therefore if the free space within the database 
+grows excessively large, such as after a large spike in writes beyond the normal steady state and a subsequent slow 
+down in the write rate, then Bolt DB could end up writing a large amount of extra data to disk for each log storage 
+operation. This has the potential to drastically increase disk write throughput, potentially beyond what the underlying 
+disks can keep up with. To detect this situation you can look at the `consul.raft.boltdb.freelistBytes` metric. This 
+metric is a count of the extra bytes that are being written for each log storage operation beyond the log data itself. 
+While not a clear indicator of an actual issue, this metric can be used to diagnose why the 
+`consul.raft.boltdb.storeLogs` metric is high. 
 
 If Bolt DB log storage performance becomes an issue and is caused by free list management then setting
 [`raft_boltdb.NoFreelistSync`](/docs/agent/options#NoFreelistSync) to `true` in the server's configuration
@@ -421,6 +434,7 @@ These metrics are used to monitor the health of the Consul servers.
 | `consul.raft.boltdb.txstats.split`                  | Counts the number of nodes split in the db since Consul was started. | splits | counter |
 | `consul.raft.boltdb.txstats.write`                  | Counts the number of writes to the db since Consul was started. | writes | counter |
 | `consul.raft.boltdb.txstats.writeTime`              | Measures the amount of time spent performing writes to the db. | ms  | timer |
+| `consul.raft.boltdb.writeCapacity`                  | Represents an estimate of how many Raft log writes per second could be handled given the current disk performance, log batching and log sizes. | logs/second | sample |
 | `consul.raft.commitNumLogs`                         | Measures the count of logs processed for application to the FSM in a single batch.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | logs                              | gauge   |
 | `consul.raft.commitTime`                            | Measures the time it takes to commit a new entry to the Raft log on the leader.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | ms                                | timer   |
 | `consul.raft.fsm.lastRestoreDuration`               | Measures the time taken to restore the FSM from a snapshot on an agent restart or from the leader calling installSnapshot. This is a gauge that holds it's value since most servers only restore during restarts which are typically infrequent.                                                                                                                                                                                                                                                                                                                                                                                                              | ms                                | gauge   |


### PR DESCRIPTION
This pulls in a new version of raft-boltdb with the only change to the library being the addition of one more metric. The corresponding telemetry documentation has been updated to account for the metric.