### PR TITLE
docs: Clarify docs for providing multiple join addresses

### DIFF
--- a/website/content/commands/join.mdx
+++ b/website/content/commands/join.mdx
@@ -34,9 +34,9 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul join [options] address ...`
 
-You may call join with multiple addresses if you want to try to join
-multiple clusters. Consul will attempt to join all addresses, and the join
-command will fail only if Consul was unable to join with any.
+You may call `join` with multiple addresses if you want attempt to join the cluster
+through multiple nodes. Consul will attempt to join all addresses. The join
+command will fail only if Consul was unable to join any of the specified addresses.
 
 #### API Options
 


### PR DESCRIPTION
Rephrase the comment about specifying multiple join addresses to clarify that it pertains to joining a single cluster by attempting to contact one or more nodes.