### PR TITLE
[1.8.x] Backport removal of multi-cluster comment in `consul join`

### DIFF
--- a/website/pages/commands/join.mdx
+++ b/website/pages/commands/join.mdx
@@ -25,9 +25,9 @@ cluster, causing the two clusters to be merged into a single cluster.
 
 Usage: `consul join [options] address ...`
 
-You may call join with multiple addresses if you want to try to join
-multiple clusters. Consul will attempt to join all addresses, and the join
-command will fail only if Consul was unable to join with any.
+You may call `join` with multiple addresses if you want attempt to join the cluster
+through multiple nodes. Consul will attempt to join all addresses. The join
+command will fail only if Consul was unable to join any of the specified addresses.
 
 #### API Options
 


### PR DESCRIPTION
Manual backport of #12199 to 1.8.x.