### PR TITLE
Add QueryRaw method to api

### DIFF
--- a/api/raw.go
+++ b/api/raw.go
@@ -1,5 +1,7 @@
 package api
 
+import "net/http"
+
 // Raw can be used to do raw queries against custom endpoints
 type Raw struct {
 	c *Client
@@ -15,6 +17,13 @@ func (c *Client) Raw() *Raw {
 // standard Consul conventions.
 func (raw *Raw) Query(endpoint string, out interface{}, q *QueryOptions) (*QueryMeta, error) {
 	return raw.c.query(endpoint, out, q)
+}
+
+// QueryRaw is used to do a GET request against an endpoint
+// without deserializing the response. The caller is responsible to close
+// response body.
+func (raw *Raw) QueryRaw(endpoint string, q *QueryOptions) (*http.Response, *QueryMeta, error) {
+	return raw.c.queryRaw(endpoint, q)
 }
 
 // Write is used to do a PUT request against an endpoint


### PR DESCRIPTION
Sometimes there is no need to parse a payload of a request (especially if it's large enough) or other
parsing solutions are preferable (fastjson/easyjson/custom structs/etc). It may be convenient to allow doing such things
on top of a default consul client