### PR TITLE
ui: css-prop modifier

### DIFF
--- a/ui/packages/consul-ui/app/modifiers/css-prop.js
+++ b/ui/packages/consul-ui/app/modifiers/css-prop.js
@@ -1,0 +1,12 @@
+import Modifier from 'ember-modifier';
+import { inject as service } from '@ember/service';
+
+export default class CSSPropModifier extends Modifier {
+  @service('-document') doc;
+  didReceiveArguments() {
+    const params = this.args.positional;
+    const options = this.args.named;
+    const returns = params[1] || options.returns;
+    returns(this.doc.defaultView.getComputedStyle(this.element).getPropertyValue(params[0]));
+  }
+}

--- a/ui/packages/consul-ui/app/modifiers/css-prop.mdx
+++ b/ui/packages/consul-ui/app/modifiers/css-prop.mdx
@@ -1,0 +1,25 @@
+# css-prop
+
+Get the value for a single specific CSS Property from the modified element.
+`returns` can be specified either as a second parameter or an option.
+
+```hbs preview-template
+<div
+  {{css-prop '--red-500' returns=(set this 'red')}}
+>
+  <code>--red-500: {{this.red}}</code>
+</div>
+```
+
+## Positional Arguments
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `property` | `string` |  | The name of the CSS property to fetch from the element |
+| `returns` | `function` |  | Usually `set` or `mut` or similar |
+
+## Named Arguments
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `returns` | `function` |  | See the `returns` positional argument |


### PR DESCRIPTION
Get the value for a single specific CSS Property from the modified element.
`returns` can be specified either as a second parameter or an option.

[Rendered Docs](https://consul-ui-staging-2nldyoc5c-hashicorp.vercel.app/ui/docs/modifiers/css-prop)