### PR TITLE
ui: on-outside modifier

### DIFF
--- a/ui/packages/consul-ui/app/modifiers/on-outside.js
+++ b/ui/packages/consul-ui/app/modifiers/on-outside.js
@@ -1,0 +1,43 @@
+import Modifier from 'ember-modifier';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class OnOutsideModifier extends Modifier {
+  @service('dom') dom;
+
+  constructor() {
+    super(...arguments);
+    this.doc = this.dom.document();
+  }
+  async connect(params, options) {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    try {
+      this.doc.addEventListener(params[0], this.listen);
+    } catch (e) {}
+  }
+
+  @action
+  listen(e) {
+    if (this.dom.isOutside(this.element, e.target)) {
+      const dispatch = typeof this.params[1] === 'function' ? this.params[1] : _ => {};
+      dispatch.apply(this.element, [e]);
+    }
+  }
+
+  disconnect() {
+    this.doc.removeEventListener('click', this.listen);
+  }
+
+  didReceiveArguments() {
+    this.params = this.args.positional;
+    this.options = this.args.named;
+  }
+
+  didInstall() {
+    this.connect(this.args.positional, this.args.named);
+  }
+
+  willRemove() {
+    this.disconnect();
+  }
+}

--- a/ui/packages/consul-ui/app/modifiers/on-outside.js
+++ b/ui/packages/consul-ui/app/modifiers/on-outside.js
@@ -13,7 +13,9 @@ export default class OnOutsideModifier extends Modifier {
     await new Promise(resolve => setTimeout(resolve, 0));
     try {
       this.doc.addEventListener(params[0], this.listen);
-    } catch (e) {}
+    } catch (e) {
+      // continue
+    }
   }
 
   @action

--- a/ui/packages/consul-ui/app/modifiers/on-outside.mdx
+++ b/ui/packages/consul-ui/app/modifiers/on-outside.mdx
@@ -1,0 +1,26 @@
+# on-outside
+
+`{{on-outside 'click' (fn @callback}}` works similarly to `{{on }}` but allows
+you to attach handlers that is specifically not the currently modified
+element.
+
+```hbs preview-template
+<button
+  {{on-outside 'click' (set this 'clicked' 'outside clicked')}}
+  {{on 'click' (set this 'clicked' 'inside clicked')}}
+  style={{style-map
+    (array 'background' 'red')
+    (array 'width' '100' 'px')
+    (array 'height' '100' 'px')
+  }}
+>
+  {{or this.clicked "click me or outside of me"}}
+</button>
+```
+
+## Positional Arguments
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `event` | `string` |  | Name of the event to listen for |
+| `handler` | `function` |  | Function to handle the event |

--- a/ui/packages/consul-ui/app/modifiers/on-outside.mdx
+++ b/ui/packages/consul-ui/app/modifiers/on-outside.mdx
@@ -8,11 +8,7 @@ element.
 <button
   {{on-outside 'click' (set this 'clicked' 'outside clicked')}}
   {{on 'click' (set this 'clicked' 'inside clicked')}}
-  style={{style-map
-    (array 'background' 'red')
-    (array 'width' '100' 'px')
-    (array 'height' '100' 'px')
-  }}
+  style="background: red;width: 100px;height: 100px;"
 >
   {{or this.clicked "click me or outside of me"}}
 </button>


### PR DESCRIPTION
`{{on-outside 'click' (fn @callback}}` works similarly to `{{on }}` but allows
you to attach handlers that is specifically not the currently modified
element.

Note: I'm aware there is an `on-click-outside` addon, but it is not in the shape I wanted (the same shape as `on`), plus we already have all the code needed for this already in our `dom` service.

[Rendered Docs](https://consul-ui-staging-m1vvynuio-hashicorp.vercel.app/ui/docs/modifiers/on-outside)

~Just realised the docs page for this one depends on `style-map` so the docs don't render without [that PR](https://github.com/hashicorp/consul/pull/12203) going in first 🤦 , will rebase and post a rendered docs link once that goes down. Or quite happy to merge this as it, the code itself doesn't depend on anything not already in main, the docs will then work again once `style-map` is down. I'm easy either way.~