### PR TITLE
fixing a confusing sentence in network segments page

### DIFF
--- a/website/content/docs/enterprise/network-segments.mdx
+++ b/website/content/docs/enterprise/network-segments.mdx
@@ -52,8 +52,7 @@ in their local cluster through the gossip mechanism and make RPC requests to
 them. LAN Gossip (OSS) is an open intra-cluster networking model, and Network
 Segments (Enterprise) creates multiple segments within one cluster.
 
-**Federated Cluster:** A cluster of clusters with a Consul server group per
-cluster each set per "datacenter". These Consul servers are federated together
+**Federated Cluster:** A set of connected clusters, each representing a unique Consul “datacenter”. These Consul servers are federated together
 over the WAN. Consul clients make use of resources in federated clusters by
 forwarding RPCs through the Consul servers in their local cluster, but they
 never interact with remote Consul servers directly. There are currently two


### PR DESCRIPTION
This PR fixes a confusing to read sentence in the Enterprise network segments page.

🧵 [Slack thread](https://hashicorp.slack.com/archives/C011HP57U0Y/p1643320798042500)

![image](https://user-images.githubusercontent.com/29551334/151479166-1c1171c5-0637-4d3c-95a8-e175ab1e9dcf.png)
