### PR TITLE
docs/nia: deprecate "services" field and "service" block

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -103,6 +103,8 @@ consul {
 
 ## Service
 
+~> Deprecated in CTS 0.5.0 and will be removed in a future major release. `service` blocks are used to define the `task` block's `services` fields, which were also deprecated and replaced with [Services Condition](/docs/nia/configuration#services-condition) and [Services Source Input](/docs/nia/configuration#services-source-input). `service` block configuration can be replaced by configuring the equivalent fields of the corresponding Services Condition and Services Source Input. See [0.5.0 release notes](/docs/nia/release-notes/0-5-0#deprecate-service-block) for examples.
+
 A `service` block is an optional block to explicitly define the services configured in the `task` block's `services` field (deprecated). `service` blocks do not define services configured in the `task` block's `condition "services"` or `source_input "services` blocks.
 
 A `service` block is only necessary for services that have non-default values e.g. custom datacenter. Services that do not have a `service` block configured will assume default values. To configure multiple services, specify multiple `service` blocks. If a `service` block is configured, the service can be referred in `task.services` by service name or ID. If a `service` block is not configured, it can only be referred to by service name.
@@ -127,7 +129,7 @@ service {
 
 ## Task
 
-A `task` block configures which task to execute in automation. When the task should execute can be determined by the `service` block and `condition` block. The `task` block may be specified multiple times to configure multiple tasks.
+A `task` block configures which task to execute in automation. When the task should execute can be determined by the `service` block (deprecated) and `condition` block. The `task` block may be specified multiple times to configure multiple tasks.
 
 ```hcl
 task {

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -103,7 +103,9 @@ consul {
 
 ## Service
 
-A `service` block is an optional block to explicitly define configuration of services that CTS monitors. A `service` block is only necessary for services that have non-default values e.g. custom datacenter. Services that do not have a `service` block configured will assume default values. To configure multiple services, specify multiple `service` blocks. For services to be included in task automation, the service must be included in the `task.services` field of a [`task` block](#task). If a `service` block is configured, the service can be referred in `task.services` by service name or ID. If a `service` block is not configured, it can only be referred to by service name.
+A `service` block is an optional block to explicitly define the services configured in the `task` block's `services` field (deprecated). `service` blocks do not define services configured in the `task` block's `condition "services"` or `source_input "services` blocks.
+
+A `service` block is only necessary for services that have non-default values e.g. custom datacenter. Services that do not have a `service` block configured will assume default values. To configure multiple services, specify multiple `service` blocks. If a `service` block is configured, the service can be referred in `task.services` by service name or ID. If a `service` block is not configured, it can only be referred to by service name.
 
 ```hcl
 service {
@@ -133,12 +135,11 @@ task {
   description    = ""
   enabled        = true,
   providers      = []
-  services       = ["web", "api"]
   source         = "org/example/module"
   version        = "1.0.0"
   variable_files = []
-  condition "catalog-services" {
-    regexp = ".*"
+  condition "services" {
+    names = ["web", "api"]
   }
 }
 ```
@@ -147,7 +148,7 @@ task {
 - `name` - (string: required) Name is the unique name of the task (required). A task name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.
 - `enabled` - (bool: true) Enable or disable a task from running and managing resources.
 - `providers` - (list[string]) Providers is the list of provider names the task is dependent on. This is used to map [Terraform provider configuration](#terraform-provider) to the task.
-- `services` - (list[string]) Specifies an optional list of logical service names or service IDs that the task monitors for changes in the Consul catalog. The `services` can act in different ways depending on the configuration of the task's `condition` block:
+- `services` - (list[string]) **Deprecated in CTS 0.5.0 and will be removed in a future major release. Use [Services Condition](/docs/nia/configuration#services-condition) or [Services Source Input](/docs/nia/configuration#services-source-input) instead. See [0.5.0 release notes](/docs/nia/release-notes/0-5-0#deprecate-services-field) for examples** Specifies an optional list of logical service names or service IDs that the task monitors for changes in the Consul catalog. The `services` can act in different ways depending on the configuration of the task's `condition` block:
   - no `condition` block configured: `services` will act as the task's condition and provide the services information as source input
   - the `condition` block configured for type `services`: `services` is incompatible with this type of `condition` because both configure the services source input. CTS will return an error.
   - the `condition` block configured for all other types: `services` will act only to provide services source input.
@@ -190,8 +191,8 @@ task {
   - `enabled` - (bool) Enable or disable buffer periods for this task. Specifying `min` will also enable it.
   - `min` - (string: "5s") The minimum period of time to wait after changes are detected before triggering related tasks.
   - `max` - (string: "20s") The maximum period of time to wait after changes are detected before triggering related tasks. If `min` is set, the default period for `max` is 4 times the value of `min`.
-- `condition` - (obj) The requirement that, when met, triggers CTS to execute the task. When unconfigured, the default condition is to trigger the task on changes in the services configured in [`services`](#services). Only one `condition` may be configured per task. CTS supports different types of conditions, which each have their own configuration options. See [Task Condition](#task-condition) configuration for full details on configuration options for each condition type.
-- `source_input` - (obj) Specifies a Consul object containing values or metadata to be provided to the Terraform Module. The `source_input` block defines any extra source inputs needed for task execution.  This is in addition to any source input provided by the `condition` block or `services` list. Multiple `source_input` blocks can be configured per task. [Task Source Input](#task-source-input) configuration for full details on usage and restrictions.
+- `condition` - (obj: required) The requirement that, when met, triggers CTS to execute the task. Only one `condition` may be configured per task. CTS supports different types of conditions, which each have their own configuration options. See [Task Condition](#task-condition) configuration for full details on configuration options for each condition type.
+- `source_input` - (obj) Specifies a Consul object containing values or metadata to be provided to the Terraform Module. The `source_input` block defines any extra source inputs needed for task execution.  This is in addition to any source input provided by the `condition` block or `services` field (deprecated). Multiple `source_input` blocks can be configured per task. [Task Source Input](#task-source-input) configuration for full details on usage and restrictions.
 - `terraform_version` - (string) <EnterpriseAlert inline /> The version of Terraform to use for the Terraform Cloud workspace associated with the task. Defaults to the latest compatible version supported by the organization. This option is only available when used with the [Terraform Cloud driver](#terraform-cloud-driver); otherwise, set the version within the [Terraform driver](#terraform-driver).
 
 ### Task Condition
@@ -203,7 +204,7 @@ A `task` block can be optionally configured with a `condition` block to set the 
 This condition will trigger the task on services that match the regular expression configured in `regexp` or services listed by name in `names`. Either `regexp` or `names` must be configured, but not both.
 
 When a `condition "services"` block is configured for a task, then the following restrictions become applicable:
-- the task cannot be configured with the `services` list field
+- the task cannot be configured with the `services` field (deprecated)
 - the task cannot be configure with a `source_input "services"` block
 
 These restrictions are due to the fact that the monitored services information for a task can only be set through one configuration option. Any services source input that the task needs should be configured solely through the `condition` block.
@@ -249,7 +250,7 @@ task {
 
 | Parameter | Required | Type | Description | Default |
 | --------- | -------- | ---- | ----------- | ------- |
-| `regexp` |  Required if `names` is not configured | string | Regular expression used to match the names of Consul services to monitor. Only services that have a name matching the regular expression are used by the task. <br/><br/> If `regexp` is configured, then [`task.services`](#services) list must be omitted or empty. <br/><br/> If both a list and a regex are needed, consider including the list as part of the regex or creating separate tasks. | none |
+| `regexp` |  Required if `names` is not configured | string | Regular expression used to match the names of Consul services to monitor. Only services that have a name matching the regular expression are used by the task. <br/><br/> If both a list and a regex are needed, consider including the list as part of the regex or creating separate tasks. | none |
 | `names` |  Required if `regexp` is not configured | list[string] | Names of Consul services to monitor. Only services that have their name listed in `names` are used by the task. | none |
 | `datacenter` |  Optional | string | Name of a datacenter to query for the task. | Datacenter of the agent that CTS queries. |
 | `namespace`  | Optional | string | <EnterpriseAlert inline /> <br/> Namespace of the services to query for the task. | In order of precedence: <br/> 1. Inferred from the CTS ACL token <br/> 2. The `default` namespace. |
@@ -269,10 +270,6 @@ task {
   description = "execute on service de/registrations with name matching 'web.*'"
   source      = "path/to/catalog-services-module"
   providers   = ["my-provider"]
-
-  // configure depending on module. provides detailed information for these
-  // services but does not execute task. refer to module docs on how to configure.
-  services = ["web-api"]
 
   condition "catalog-services" {
     datacenter          = "dc1"
@@ -309,7 +306,6 @@ task {
   description = "execute on changes to Consul KV entry"
   source      = "path/to/consul-kv-module"
   providers   = ["my-provider"]
-  services    = ["web-api"]
 
   condition "consul-kv" {
     path                = "my-key"
@@ -333,7 +329,7 @@ task {
 
 A scheduled task has a schedule condition block, which defines the schedule for executing the task. Unlike a dynamic task, a scheduled task does not dynamically trigger on changes in Consul.
 
-Schedule tasks also rely on additional task configuration, separate from the condition block to determine the source input information to provide to the task module. See [`task.services`](#services) or [`source_input`](#source_input) block configuration for details on how to configure source input.
+Schedule tasks also rely on additional task configuration, separate from the condition block to determine the source input information to provide to the task module. See [`source_input`](#source_input) block configuration for details on how to configure source input.
 
 See [Task Execution: Schedule Condition](/docs/nia/tasks#schedule-condition) for more information on how tasks are triggered with schedule conditions.
 
@@ -343,10 +339,14 @@ See [Terraform Module: Source Input](/docs/nia/terraform-modules#source-input) f
 task {
   name        = "scheduled_task"
   description = "execute every Monday using service information from web and db"
-  services    = ["web", "db"]
   source      = "path/to/module"
+
   condition "schedule" {
     cron = "* * * * Mon"
+  }
+
+  source_input "services" {
+    names = ["web", "db"]
   }
 }
 ```
@@ -365,7 +365,7 @@ The example below shows an outline of `source_input` within a task configuration
 task {
   name     = "task_a"
   source   = "path/to/module"
-  services = ["api"]
+  services = ["api"] // (deprecated)
 
   condition "<condition-type>" {
     // ...
@@ -377,7 +377,7 @@ task {
 }
 ```
 
-~> The type of the `source_input` block that can be configured depends on the `condition` block type and `services` field. See [Task Source Input Restrictions](/docs/nia/configuration#task-source-input-restrictions) for more details.
+~> The type of the `source_input` block that can be configured depends on the `condition` block type and the `services` field (deprecated). See [Task Source Input Restrictions](/docs/nia/configuration#task-source-input-restrictions) for more details.
 
 The following sections describe the source input types that CTS supports.
 
@@ -387,7 +387,7 @@ This `services` source input object defines services registered to Consul whose 
 
 | Parameter | Required | Type | Description | Default |
 | --------- | -------- | ---- | ----------- | ------- |
-| `regexp` |  Required if `names` is not configured | string | Regular expression used to match the names of Consul services to monitor. Only services that have a name matching the regular expression are used by the task. <br/><br/> If `regexp` is configured, then [`task.services`](#services) list must be omitted or empty. <br/><br/> If both a list and a regex are needed, consider including the list as part of the regex or creating separate tasks. | none |
+| `regexp` |  Required if `names` is not configured | string | Regular expression used to match the names of Consul services to monitor. Only services that have a name matching the regular expression are used by the task. <br/><br/> If both a list and a regex are needed, consider including the list as part of the regex or creating separate tasks. | none |
 | `names` |  Required if `regexp` is not configured | list[string] | Names of Consul services to monitor. Only services that have their name listed in `names` are used by the task. | none |
 | `datacenter` |  Optional | string | Name of a datacenter to query for the task. | Datacenter of the agent that CTS queries. |
 | `namespace` | Optional | string |<EnterpriseAlert inline /> <br/> String value indicating the namespace of the services to query for the task. | In order of precedence: <br/> 1. Inferred from the CTS ACL token <br/> 2. The `default` namespace. |
@@ -452,13 +452,13 @@ task {
 
 #### Task Source Input Restrictions
 
-There are some limitations to the type of `source_input` blocks that can be configured for a task given the task's `condition` block and `services` field. This is because a task cannot have multiple configurations defining the same type of monitored variable:
+There are some limitations to the type of `source_input` blocks that can be configured for a task given the task's `condition` block and `services` field (deprecated). This is because a task cannot have multiple configurations defining the same type of monitored variable:
 - A task cannot be configured with a `condition` and `source_input` block of the same type. For example, configuring `condition "consul-kv"` and `source_input "consul-kv"` will error because both configure the `consul_kv` variable.
 - A task cannot be configured with two or more `source_input` blocks of the same type. For example, configuring two `source_input "catalog-services"` within a task will return an error because they define multiple configurations for the `catalog_services` variable.
 - A task that monitors services can only contain one of the following configurations:
   - `condition "services"` block
   - `source_input "services"` block
-  - `services` list
+  - `services` field (deprecated)
 
   All of the listed configurations define the `services` variable and including more than one configuration will return an error.
 
@@ -595,7 +595,9 @@ terraform_provider "aws" {
 task {
   source    = "some/source"
   providers = ["aws"]
-  services  = ["web", "api"]
+  condition "services" {
+    names = ["web", "api"]
+  }
 }
 ```
 

--- a/website/content/docs/nia/installation/configure.mdx
+++ b/website/content/docs/nia/installation/configure.mdx
@@ -24,7 +24,9 @@ task {
   source      = "namespace/example/module"
   version     = "1.0.0"
   providers   = ["myprovider"]
-  services    = ["web", "api"]
+  condition "services" {
+    names = ["web", "api"]
+  }
 }
 ```
 
@@ -78,7 +80,9 @@ task {
   source      = "namespace/example/module"
   version     = "1.0.0"
   providers   = ["myprovider"]
-  services    = ["web", "api"]
+  condition "services" {
+    names = ["web", "api"]
+  }
   buffer_period {
     min = "10s"
   }

--- a/website/content/docs/nia/installation/requirements.mdx
+++ b/website/content/docs/nia/installation/requirements.mdx
@@ -54,7 +54,7 @@ $ echo '{
 $ curl --request PUT --data @payload.json http://localhost:8500/v1/agent/service/register
 ```
 
-The above example registers a service named "web" with your Consul agent. This represents a non-existent web service running at 10.10.10.10:8000. Your web service is now available for CTS to consume. In CTS, you can optionally configure the web service with a [service block](/docs/nia/configuration#service) if it has any non-default values. You can also have CTS monitor the web service to execute a task and update network device(s) by configuring "web" in [`condition "services"`](/docs/nia/configuration#services-condition) of a task block.
+The above example registers a service named "web" with your Consul agent. This represents a non-existent web service running at 10.10.10.10:8000. Your web service is now available for CTS to consume. You can have CTS monitor the web service to execute a task and update network device(s) by configuring "web" in [`condition "services"`](/docs/nia/configuration#services-condition) of a task block. If the web service has any non-default values, it can also be configured in `condition "services"`.
 
 For more details on registering a service by HTTP API request, refer to the [register service API docs](https://www.consul.io/api-docs/agent/service#register-service).
 

--- a/website/content/docs/nia/installation/requirements.mdx
+++ b/website/content/docs/nia/installation/requirements.mdx
@@ -54,7 +54,7 @@ $ echo '{
 $ curl --request PUT --data @payload.json http://localhost:8500/v1/agent/service/register
 ```
 
-The above example registers a service named "web" with your Consul agent. This represents a non-existent web service running at 10.10.10.10:8000. Your web service is now available for CTS to consume. In CTS, you can optionally configure the web service with a [service block](/docs/nia/configuration#service) if it has any non-default values. You can also have CTS monitor the web service to execute a task and update network device(s) by configuring "web" in [`task.services`](/docs/nia/configuration#services) of a task block.
+The above example registers a service named "web" with your Consul agent. This represents a non-existent web service running at 10.10.10.10:8000. Your web service is now available for CTS to consume. In CTS, you can optionally configure the web service with a [service block](/docs/nia/configuration#service) if it has any non-default values. You can also have CTS monitor the web service to execute a task and update network device(s) by configuring "web" in [`condition "services"`](/docs/nia/configuration#services-condition) of a task block.
 
 For more details on registering a service by HTTP API request, refer to the [register service API docs](https://www.consul.io/api-docs/agent/service#register-service).
 

--- a/website/content/docs/nia/release-notes/0-5-0.mdx
+++ b/website/content/docs/nia/release-notes/0-5-0.mdx
@@ -278,7 +278,7 @@ task {
   }
 }
 
-services {
+service {
  name       = "api"
  datacenter = "dc2"
  namespace  = "ns"
@@ -320,12 +320,12 @@ task {
   services = ["api", "web"]
 }
 
-services {
+service {
   name       = "api"
   datacenter = "api_dc"
 }
 
-services {
+service {
   name       = "web"
   datacenter = "web_dc"
 }

--- a/website/content/docs/nia/tasks.mdx
+++ b/website/content/docs/nia/tasks.mdx
@@ -16,13 +16,15 @@ task {
   name        = "frontend-firewall-policies"
   description = "Add firewall policy rules for frontend services"
   providers   = ["fake-firewall", "null"]
-  services    = ["web", "image"]
   source      = "example/firewall-policy/module"
   version     = "1.0.0"
+  condition "services" {
+    names = ["web", "image"]
+  }
 }
 ```
 
-In the example task above, the "fake-firewall" and "null" providers, listed in the `providers` field, are used. These providers themselves should be configured in their own separate [`terraform_provider` blocks](/docs/nia/configuration#terraform-provider). These providers are used in the Terraform module "example/firewall-policy/module", configured in the `source` field, to create, update, and destroy resources. This module may do something like use the providers to create and destroy firewall policy objects based on IP addresses. The IP addresses come from the "web" and "image" service instances configured in the `services` field. This service-level information is retrieved by CTS which watches Consul catalog for changes.
+In the example task above, the "fake-firewall" and "null" providers, listed in the `providers` field, are used. These providers themselves should be configured in their own separate [`terraform_provider` blocks](/docs/nia/configuration#terraform-provider). These providers are used in the Terraform module "example/firewall-policy/module", configured in the `source` field, to create, update, and destroy resources. This module may do something like use the providers to create and destroy firewall policy objects based on IP addresses. The IP addresses come from the "web" and "image" service instances configured in the `condition "services"` block. This service-level information is retrieved by CTS which watches Consul catalog for changes.
 
 See [task configuration](/docs/nia/configuration#task) for more details on how to configure a task.
 
@@ -41,7 +43,7 @@ All configured monitored information, regardless if it's used for execution or n
 Tasks with the services condition monitor and execute on either changes to a list of configured services or changes to any services that match a given regex.
 
 There are two ways to configure a task with a services condition. Only one of the two options below can be configured for a single task:
-1. Configure a task's [`services`](/docs/nia/configuration#services) field to specify the list of services to trigger the task
+1. Configure a task's [`services`](/docs/nia/configuration#services) field (deprecated) to specify the list of services to trigger the task
 1. Configure a task's `condition` block with the [services condition](/docs/nia/configuration#services-condition) type to specify services to trigger the task.
 
 The services condition operates by monitoring the [Health List Nodes For Service API](/api-docs/health#list-nodes-for-service) and executing the task on any change of information for services configured. These changes include one or more changes to service values, like IP address, added or removed service instance, or tags. A complete list of values that would cause a task to run are expanded below:
@@ -80,7 +82,7 @@ task {
 ```
 
 The services condition can provide input for the [`services` input variable](/docs/nia/terraform-modules#services-variable) that is required for each CTS module. This can be provided depending on how the services condition is configured:
-1. task's `services` field: services object is automatically passed as module input
+1. task's `services` field (deprecated): services object is automatically passed as module input
 1. task's `condition "services"` block: users can configure the `source_includes_var` field to optionally use the condition's services object as module input
 
 ### Catalog-Services Condition
@@ -96,18 +98,17 @@ task {
   name      = "catalog_service_condition_task"
   source    = "path/to/catalog-services-module"
   providers = ["my-provider"]
-  services  = ["web-api"]
 
   condition "catalog-services" {
     datacenter          = "dc1"
     regexp              = "web.*"
     source_includes_var = false
   }
-}
 
-service {
-  name       = "web-api"
-  datacenter = "dc2"
+  source_input "services" {
+    names = ["web-api"]
+    datacenter = "dc2"
+  }
 }
 ```
 
@@ -127,7 +128,6 @@ task {
   description = "execute on changes to Consul KV entry"
   source      = "path/to/consul-kv-module"
   providers   = ["my-provider"]
-  services    = ["web-api"]
 
   condition "consul-kv" {
     path                = "my-key"
@@ -145,26 +145,28 @@ See the [Consul-KV Condition](/docs/nia/configuration#consul-kv-condition) confi
 
 ### Schedule Condition
 
-All scheduled tasks must be configured with a schedule condition. The schedule condition sets the cadence to trigger a task with a [`cron`](/docs/nia/configuration#cron) configuration. The schedule condition block does not support parameters to configure source input. As a result, inputs must be configured separately. You can configure [`task.services`](/docs/nia/configuration#services) or a [`source_input` block](/docs/nia/configuration#source_input) to set the source input.
+All scheduled tasks must be configured with a schedule condition. The schedule condition sets the cadence to trigger a task with a [`cron`](/docs/nia/configuration#cron) configuration. The schedule condition block does not support parameters to configure source input. As a result, inputs must be configured separately. You can configure a [`source_input` block](/docs/nia/configuration#source_input) to set the source input.
 
-Below is an example configuration for a task that will execute every Monday, which is set by the schedule condition’s [`cron`](/docs/nia/configuration#cron) configuration. The source input is defined by the `task.services` configuration. When the task is triggered on Monday, it will retrieve the latest information on "web" and "db" from Consul and provide this to the module’s input variables.
+Below is an example configuration for a task that will execute every Monday, which is set by the schedule condition's [`cron`](/docs/nia/configuration#cron) configuration. The source input is defined by the `source_input` block. When the task is triggered on Monday, it will retrieve the latest information on "web" and "db" from Consul and provide this to the module's input variables.
 
 ```hcl
 task {
   name        = "scheduled_task"
   description = "execute every Monday using service information from web and db"
-  services    = ["web", "db"]
   source      = "path/to/module"
 
   condition "schedule" {
     cron = "* * * * Mon"
+  }
+  source_input "services" {
+    names = ["web", "db"]
   }
 }
 ```
 
 Below are the available options for source input types and how to configure them:
 
-- [Services source input](/docs/nia/terraform-modules/#services-source-input): configure through [`task.services`](/docs/nia/configuration#services) or [`source_input "services"`](/docs/nia/configuration#services-source-input)
+- [Services source input](/docs/nia/terraform-modules/#services-source-input): configure through [`task.services`](/docs/nia/configuration#services) (deprecated) or [`source_input "services"`](/docs/nia/configuration#services-source-input)
 - [Consul KV source input](/docs/nia/terraform-modules/#consul-kv-source-input): configure through [`source_input "consul-kv"`](/docs/nia/configuration#consul-kv-source-input)
 
 #### Running Behavior

--- a/website/content/docs/nia/terraform-modules.mdx
+++ b/website/content/docs/nia/terraform-modules.mdx
@@ -41,7 +41,7 @@ Each type of object that CTS monitors can only be defined through one configurat
 
 There are a few ways that a source input can be defined:
 
-- [**`services` list**](/docs/nia/configuration#services) - The list of services to use as source input.
+- [**`services` list**](/docs/nia/configuration#services) (deprecated) - The list of services to use as source input.
 - **`condition` block's `source_includes_var` field** - When set to true, the condition's objects are used as source input.
 - [**`source_input` blocks**](/docs/nia/configuration#source-input) - This block can be configured multiple times to define objects to use as source input.
 
@@ -93,7 +93,7 @@ services = {
 
 In order to configure a task with the services source input, the list of services that will be used for the input must be configured in one of the following ways:
 
-- the task's [`services`](/docs/nia/configuration#services)
+- the task's [`services`](/docs/nia/configuration#services) (deprecated)
 - a [`condition "services"` block](/docs/nia/configuration#services-condition) configured with `source_includes_var` set to true
 - a [`source_input "services"` block](/docs/nia/configuration#services-source-input)
 
@@ -154,14 +154,12 @@ To configure a task with the Consul KV source input, the KVs which will be used 
 - a [`condition "consul-kv"` block](/docs/nia/configuration#consul-kv-condition) configured with the `source_includes_var` set to true.
 - a [`source_input "consul-kv"` block](/docs/nia/configuration#consul-kv-source-input).
 
-Below is a similar example to the one provided in the [Consul KV Condition](/docs/nia/tasks#consul-kv-condition) section. However, the difference in this example is that instead of triggering based on a change to Consul KV, this task will instead execute on a schedule. Once execution is triggered, Consul KV information is then provided to the task’s module.
+Below is a similar example to the one provided in the [Consul KV Condition](/docs/nia/tasks#consul-kv-condition) section. However, the difference in this example is that instead of triggering based on a change to Consul KV, this task will instead execute on a schedule. Once execution is triggered, Consul KV information is then provided to the task's module.
 
 ```hcl
 task {
   name        = "consul_kv_schedule_task"
   description = "executes on Monday monitoring Consul KV"
-  providers   = ["my-provider"]
-  services    = ["web-api"]
   source      = "path/to/consul-kv-module"
 
   condition "schedule" {
@@ -199,7 +197,7 @@ To configure a task with the Catalog Services source input, the catalog services
 
 - a [`condition "catalog-services"` block](/docs/nia/configuration#consul-kv-condition) configured with `source_includes_var` set to true.
 
--> **Note:** Currently there is no support for a `source_input “catalog-services”` block.
+-> **Note:** Currently there is no support for a `source_input "catalog-services"` block.
 
 Example of a catalog-services condition which supports source input through `source_includes_var`:
 
@@ -208,7 +206,6 @@ task {
   name        = "catalog_services_condition_task"
   description = "execute on registration/deregistration of services"
   providers   = ["my-provider"]
-  services    = ["web-api"]
   source      = "path/to/catalog-services-module"
   condition "catalog-services" {
     datacenter          = "dc1"


### PR DESCRIPTION
In 0.5 CTS deprecated:
 - `task` block's `services` field configuration
 - `service` block configuration

Doc changes for deprecated configs
 - Add "deprecation" warning messages
 - Remove / replace unnecessary references to deprecated configs

Other changes
 - Aligned `services` field vs. list to field
 - Fix typos where `service` block was pluralized

[link to config preview](https://consul-6ayxu6fry-hashicorp.vercel.app/docs/nia/configuration#service) (updated with latest)