### PR TITLE
docs/nia: deprecate `source`

### DIFF
--- a/website/content/docs/nia/api/status.mdx
+++ b/website/content/docs/nia/api/status.mdx
@@ -123,7 +123,8 @@ Event represents the process of updating network infrastructure of a task. The d
 |`error.message` | string | Error message that is returned on failure.
 |`config`           | object | Configuration values for the task when it was run.
 |`config.services`  | list[string] | List of the services configured for the task.
-|`config.source`    | string | Source configured for the task.
+|`config.source`    | string | **Deprecated in CTS 0.5.0 and will be removed in a future major release. See the `config.module` field instead.**
+|`config.module`    | string | Module configured for the task.
 |`config.providers` | list[string] | List of the providers configured for the task.
 
 #### Example: All Task Statuses
@@ -201,7 +202,7 @@ Response:
           "services": [
             "web",
           ],
-          "source": "../modules/test_task"
+          "module": "../modules/test_task"
         }
       },
       {
@@ -218,7 +219,7 @@ Response:
           "services": [
             "web",
           ],
-          "source": "../modules/test_task"
+          "module": "../modules/test_task"
         }
       }
     ]

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -137,7 +137,7 @@ task {
   description    = ""
   enabled        = true,
   providers      = []
-  source         = "org/example/module"
+  module         = "org/example/module"
   version        = "1.0.0"
   variable_files = []
   condition "services" {
@@ -163,13 +163,13 @@ task {
 
     ```hcl
     // local module example: "./terraform-cts-hello"
-    source = "<PATH>"
+    module = "<PATH>"
 
     // public module example: "mkam/hello/cts"
-    source = "<NAMESPACE>/<MODULE NAME>/<PROVIDER>"
+    module = "<NAMESPACE>/<MODULE NAME>/<PROVIDER>"
 
     // private module example: "my.tfe.hostname.io/my-org/hello/cts"
-    source = "<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>"
+    module = "<HOSTNAME>/<ORGANIZATION>/<MODULE NAME>/<PROVIDER>"
     ```
 
 - `variable_files` - (list[string]) Specifies list of paths to [Terraform variable definition files (`.tfvars`)](https://www.terraform.io/docs/configuration/variables.html#variable-definitions-tfvars-files). The content of these files should consist of only variable name assignments. The variable assignments must match the corresponding variable declarations made available by the Terraform module for the task.
@@ -219,7 +219,7 @@ task {
   name        = "services_condition_regexp_task"
   description = "execute on changes to services with names starting with web"
   providers   = ["my-provider"]
-  source      = "path/to/services-condition-module"
+  module      = "path/to/services-condition-module"
 
   condition "services" {
     regexp     = "^web.*"
@@ -236,7 +236,7 @@ task {
 task {
   name        = "services_condition_names_task"
   description = "execute on changes to services with names api or web"
-  source      = "path/to/services-condition-module"
+  module      = "path/to/services-condition-module"
 
   condition "services" {
     names = ["api", "web"]
@@ -273,7 +273,7 @@ See [Task Execution: Catalog Services Condition](/docs/nia/tasks#catalog-service
 task {
   name        = "catalog_service_condition_task"
   description = "execute on service de/registrations with name matching 'web.*'"
-  source      = "path/to/catalog-services-module"
+  module      = "path/to/catalog-services-module"
   providers   = ["my-provider"]
 
   condition "catalog-services" {
@@ -310,7 +310,7 @@ See [Task Execution: Consul KV Condition](/docs/nia/tasks#consul-kv-condition) f
 task {
   name        = "consul_kv_condition_task"
   description = "execute on changes to Consul KV entry"
-  source      = "path/to/consul-kv-module"
+  module      = "path/to/consul-kv-module"
   providers   = ["my-provider"]
 
   condition "consul-kv" {
@@ -347,7 +347,7 @@ See [Terraform Module: Module Input](/docs/nia/terraform-modules#module-input) f
 task {
   name        = "scheduled_task"
   description = "execute every Monday using service information from web and db"
-  source      = "path/to/module"
+  module      = "path/to/module"
 
   condition "schedule" {
     cron = "* * * * Mon"
@@ -374,7 +374,7 @@ The example below shows an outline of `module_input` within a task configuration
 ```hcl
 task {
   name     = "task_a"
-  source   = "path/to/module"
+  module   = "path/to/module"
   services = ["api"] // (deprecated)
 
   condition "<condition-type>" {
@@ -410,7 +410,7 @@ In the following example, the scheduled task queries all Consul services with `w
 task {
   name        = "schedule_condition_task"
   description = "execute every Monday using information from service names starting with web"
-  source      = "path/to/module"
+  module      = "path/to/module"
 
   condition "schedule" {
     cron = "* * * * Mon"
@@ -445,7 +445,7 @@ In the following example, the scheduled task queries datacenter `dc1` in the `de
 task {
   name        = "schedule_condition_task_kv"
   description = "execute every Monday using information from Consul KV entry my-key"
-  source      =  "path/to/module"
+  module      =  "path/to/module"
 
   condition "schedule" {
     cron = "* * * * Mon"
@@ -604,7 +604,7 @@ terraform_provider "aws" {
 }
 
 task {
-  source    = "some/source"
+  module    = "path/to/module"
   providers = ["aws"]
   condition "services" {
     names = ["web", "api"]
@@ -735,14 +735,14 @@ terraform_provider "dns" {
 
 task {
   name      = "task-a"
-  source    = "org/module"
+  module    = "org/module"
   providers = ["aws.a", "dns"]
   // ...
 }
 
 task {
   name      = "task-b"
-  source    = "org/module"
+  module    = "org/module"
   providers = ["aws.b", "dns"]
   // ...
 }

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -156,7 +156,8 @@ task {
   - the `condition` block configured for all other types: `services` will act only to provide services module input.
 
   Service values that are not explicitly defined by a `service` block that have a matching ID are assumed to be logical service names in the `default` namespace.
-- `source` - (string: required) Source is the location the driver uses to discover the Terraform module used for automation. The source is the module path which can be local or remote on the [Terraform Registry](https://registry.terraform.io/) or private module registry. Read more on [Terraform module source and other supported types here](https://www.terraform.io/docs/modules/sources.html).
+- `source` - (string: required) **Deprecated in CTS 0.5.0 and will be removed in a future major release. See the `module` field instead.**
+- `module` - (string: required) Module is the location the driver uses to discover the Terraform module used for automation. The module's source can be local or remote on the [Terraform Registry](https://registry.terraform.io/) or private module registry. Read more on [Terraform module source and other supported types here](https://www.terraform.io/docs/modules/sources.html).
 
   - To use a private module with the [`terraform` driver](#terraform-driver), run the command [`terraform login [hostname]`](https://learn.hashicorp.com/tutorials/terraform/cloud-login) to authenticate the local Terraform CLI prior to starting CTS.
   - To use a private module with the [`terraform_cloud` driver](#terraform-cloud-driver), no extra steps are needed.
@@ -187,7 +188,7 @@ task {
 
     </CodeBlockConfig>
 
-- `version` - (string) The version of the provided source the task will use. For the [Terraform driver](#terraform-driver), this is the module version. The latest version will be used as the default if omitted.
+- `version` - (string) The version of the provided module the task will use. The latest version will be used as the default if omitted.
 - `working_dir` - (string) The working directory to manage generated artifacts by CTS for this task, including Terraform configuration files. By default, a working directory is created for each task as a subdirectory in the base [`working_dir`](#working_dir), e.g. `sync-tasks/task-name`.
 - `buffer_period` - Configures the buffer period for a dynamic task to dampen the effects of flapping services to downstream network devices. It defines the minimum and maximum amount of time to wait for the cluster to reach a consistent state and accumulate changes before triggering task execution. The default is inherited from the top level [`buffer_period` block](#global-config-options). If configured, these values will take precedence over the global buffer period. This is useful to enable for a task that is dependent on services that have a lot of flapping. Buffer periods do not apply to scheduled tasks.
   - `enabled` - (bool) Enable or disable buffer periods for this task. Specifying `min` will also enable it.

--- a/website/content/docs/nia/installation/configure.mdx
+++ b/website/content/docs/nia/installation/configure.mdx
@@ -13,7 +13,7 @@ The page will cover the main components for configuring your Network Infrastruct
 
 A task captures a network automation process by defining which network resources to update on a given condition. Configure CTS with one or more tasks that contain a list of Consul services, a Terraform module, and various Terraform providers.
 
-Within the [`task` block](/docs/nia/configuration#task), the list of services for a task represents the service layer that drives network automation. The `source` is the discovery location of the Terraform module that defines the network automation process for the task. The `condition`, not shown below, defaults to the services condition when unconfigured such that network resources are updated on changes to the list of services over time.
+Within the [`task` block](/docs/nia/configuration#task), the list of services for a task represents the service layer that drives network automation. The `module` is the discovery location of the Terraform module that defines the network automation process for the task. The `condition`, not shown below, defaults to the services condition when unconfigured such that network resources are updated on changes to the list of services over time.
 
 Review the Terraform module to be used for network automation and identify the Terraform providers required by the module. If the module depends on a set of providers, include the list of provider names in the `providers` field to associate the corresponding provider configuration with the task. These providers will need to be configured later in a separate block.
 

--- a/website/content/docs/nia/installation/configure.mdx
+++ b/website/content/docs/nia/installation/configure.mdx
@@ -21,7 +21,7 @@ Review the Terraform module to be used for network automation and identify the T
 task {
   name        = "website-x"
   description = "automate services for website-x"
-  source      = "namespace/example/module"
+  module      = "namespace/example/module"
   version     = "1.0.0"
   providers   = ["myprovider"]
   condition "services" {
@@ -77,7 +77,7 @@ consul {
 task {
   name        = "website-x"
   description = "automate services for website-x"
-  source      = "namespace/example/module"
+  module      = "namespace/example/module"
   version     = "1.0.0"
   providers   = ["myprovider"]
   condition "services" {

--- a/website/content/docs/nia/tasks.mdx
+++ b/website/content/docs/nia/tasks.mdx
@@ -24,7 +24,7 @@ task {
 }
 ```
 
-In the example task above, the "fake-firewall" and "null" providers, listed in the `providers` field, are used. These providers themselves should be configured in their own separate [`terraform_provider` blocks](/docs/nia/configuration#terraform-provider). These providers are used in the Terraform module "example/firewall-policy/module", configured in the `source` field, to create, update, and destroy resources. This module may do something like use the providers to create and destroy firewall policy objects based on IP addresses. The IP addresses come from the "web" and "image" service instances configured in the `condition "services"` block. This service-level information is retrieved by CTS which watches Consul catalog for changes.
+In the example task above, the "fake-firewall" and "null" providers, listed in the `providers` field, are used. These providers themselves should be configured in their own separate [`terraform_provider` blocks](/docs/nia/configuration#terraform-provider). These providers are used in the Terraform module "example/firewall-policy/module", configured in the `module` field, to create, update, and destroy resources. This module may do something like use the providers to create and destroy firewall policy objects based on IP addresses. The IP addresses come from the "web" and "image" service instances configured in the `condition "services"` block. This service-level information is retrieved by CTS which watches Consul catalog for changes.
 
 See [task configuration](/docs/nia/configuration#task) for more details on how to configure a task.
 

--- a/website/content/docs/nia/tasks.mdx
+++ b/website/content/docs/nia/tasks.mdx
@@ -16,7 +16,7 @@ task {
   name        = "frontend-firewall-policies"
   description = "Add firewall policy rules for frontend services"
   providers   = ["fake-firewall", "null"]
-  source      = "example/firewall-policy/module"
+  module      = "example/firewall-policy/module"
   version     = "1.0.0"
   condition "services" {
     names = ["web", "image"]
@@ -72,7 +72,7 @@ task {
   name        = "services_condition_task"
   description = "execute on changes to services whose name starts with web"
   providers   = ["my-provider"]
-  source      = "path/to/services-condition-module"
+  module      = "path/to/services-condition-module"
 
   condition "services" {
     regexp              = "^web.*"
@@ -97,7 +97,7 @@ Below is an example configuration for a task that will execute when a service wi
 ```hcl
 task {
   name      = "catalog_service_condition_task"
-  source    = "path/to/catalog-services-module"
+  module    = "path/to/catalog-services-module"
   providers = ["my-provider"]
 
   condition "catalog-services" {
@@ -127,7 +127,7 @@ Based on the `recurse` option, the condition either monitors a single Consul KV 
 task {
   name        = "consul_kv_condition_task"
   description = "execute on changes to Consul KV entry"
-  source      = "path/to/consul-kv-module"
+  module      = "path/to/consul-kv-module"
   providers   = ["my-provider"]
 
   condition "consul-kv" {
@@ -154,7 +154,7 @@ Below is an example configuration for a task that will execute every Monday, whi
 task {
   name        = "scheduled_task"
   description = "execute every Monday using service information from web and db"
-  source      = "path/to/module"
+  module      = "path/to/module"
 
   condition "schedule" {
     cron = "* * * * Mon"

--- a/website/content/docs/nia/terraform-modules.mdx
+++ b/website/content/docs/nia/terraform-modules.mdx
@@ -127,7 +127,7 @@ task {
   name        = "services_condition_task"
   description = "execute on changes to services whose name starts with web"
   providers   = ["my-provider"]
-  source      = "path/to/services-condition-module"
+  module      = "path/to/services-condition-module"
   condition "schedule" {
     cron = "* * * * Mon"
   }
@@ -166,7 +166,7 @@ Below is a similar example to the one provided in the [Consul KV Condition](/doc
 task {
   name        = "consul_kv_schedule_task"
   description = "executes on Monday monitoring Consul KV"
-  source      = "path/to/consul-kv-module"
+  module      = "path/to/consul-kv-module"
 
   condition "schedule" {
     cron = "* * * * Mon"
@@ -213,7 +213,7 @@ task {
   name        = "catalog_services_condition_task"
   description = "execute on registration/deregistration of services"
   providers   = ["my-provider"]
-  source      = "path/to/catalog-services-module"
+  module      = "path/to/catalog-services-module"
   condition "catalog-services" {
     datacenter          = "dc1"
     namespace           = "default"


### PR DESCRIPTION
Deprecate `source` and associate language. Update to `module`

Previous PR: Deprecate `source_includes_var` and `source_input`

link to [config preview](https://consul-b17c87e58-hashicorp.vercel.app/docs/nia/configuration#source) and [status api preview](https://consul-b17c87e58-hashicorp.vercel.app/docs/nia/api/status#event)