### PR TITLE
ui: Exclude Service Health from Node listing page

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
@@ -3,7 +3,7 @@
   @items={{@items}}
 as |item index|>
   <BlockSlot @name="header">
-    <dl class={{item.Status}}>
+    <dl data-test-status={{item.Status}} class={{item.Status}}>
       <dt>
         Health
       </dt>

--- a/ui/packages/consul-ui/app/models/node.js
+++ b/ui/packages/consul-ui/app/models/node.js
@@ -29,7 +29,9 @@ export default class Node extends Model {
   // currently includes gateways as these need to show up in listings
   @filter('Services', item => item.Service.Kind !== 'connect-proxy') MeshServiceInstances;
 
-  @computed('Checks.[]', 'ChecksCritical', 'ChecksPassing', 'ChecksWarning')
+  @filter('Checks', item => item.ServiceID === '') NodeChecks;
+
+  @computed('ChecksCritical', 'ChecksPassing', 'ChecksWarning')
   get Status() {
     switch (true) {
       case this.ChecksCritical !== 0:
@@ -45,16 +47,16 @@ export default class Node extends Model {
 
   @computed('Checks.[]')
   get ChecksCritical() {
-    return this.Checks.filter(item => item.Status === 'critical').length;
+    return this.NodeChecks.filter(item => item.Status === 'critical').length;
   }
 
   @computed('Checks.[]')
   get ChecksPassing() {
-    return this.Checks.filter(item => item.Status === 'passing').length;
+    return this.NodeChecks.filter(item => item.Status === 'passing').length;
   }
 
   @computed('Checks.[]')
   get ChecksWarning() {
-    return this.Checks.filter(item => item.Status === 'warning').length;
+    return this.NodeChecks.filter(item => item.Status === 'warning').length;
   }
 }

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/index.feature
@@ -7,6 +7,36 @@ Feature: dc / nodes / index
     body: |
       "211.245.86.75:8500"
     ---
+  Scenario: Viewing an a node with an unhealthy NodeCheck
+    Given 1 node model from yaml
+    ---
+    - Checks:
+        - Status: critical
+          ServiceID: ""
+    ---
+    When I visit the nodes page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/nodes
+    Then I see 1 node models
+    And I see status on the nodes.0 like "critical"
+  Scenario: Viewing an a node with an unhealthy ServiceCheck
+    Given 1 node model from yaml
+    ---
+    - Checks:
+        - Status: passing
+          ServiceID: ""
+        - Status: critical
+          ServiceID: web
+    ---
+    When I visit the nodes page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/nodes
+    Then I see 1 node models
+    And I see status on the nodes.0 like "passing"
   Scenario: Viewing nodes in the listing
     Given 3 node models
     When I visit the nodes page for yaml

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/sorting.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/sorting.feature
@@ -7,21 +7,27 @@ Feature: dc / nodes / sorting
       - Node: Node-A
         Checks:
           - Status: critical
+            ServiceID: ""
       - Node: Node-B
         Checks:
           - Status: passing
+            ServiceID: ""
       - Node: Node-C
         Checks:
           - Status: warning
+            ServiceID: ""
       - Node: Node-D
         Checks:
           - Status: critical
+            ServiceID: ""
       - Node: Node-E
         Checks:
           - Status: critical
+            ServiceID: ""
       - Node: Node-F
         Checks:
           - Status: warning
+            ServiceID: ""
     ---
     When I visit the nodes page for yaml
     ---

--- a/ui/packages/consul-ui/tests/pages/dc/nodes/index.js
+++ b/ui/packages/consul-ui/tests/pages/dc/nodes/index.js
@@ -3,6 +3,7 @@ export default function(visitable, text, clickable, attribute, collection, popov
     name: text('[data-test-node]'),
     leader: attribute('data-test-leader', '[data-test-leader]'),
     node: clickable('a'),
+    status: attribute('data-test-status', '[data-test-status]'),
   };
   return {
     visit: visitable('/:dc/nodes'),


### PR DESCRIPTION
This PR excludes the health of any service instances from the Node Listing page. This means that if you are viewing the Node listing page you will only see failing nodes if there are any Node Checks failing, Service Instance Health checks are no longer taken into account.