### PR TITLE
ci: Fix merge conflicts cleanly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,19 +689,17 @@ jobs:
             if ! git diff --quiet --exit-code HEAD^! ui/; then
               git config --local user.email "github-team-consul-core@hashicorp.com"
               git config --local user.name "hc-github-team-consul-core"
-              
-              # stash newly built bindata_assetfs.go
-              git stash push
-              
-              # checkout the CI branch and merge latest from main
-              git checkout ci/main-assetfs-build
-              git merge --no-edit main
             
-              git stash pop
-            
+              # commit to main in order to checkout ci branch cleanly
               short_sha=$(git rev-parse --short HEAD)
               git add agent/uiserver/bindata_assetfs.go
               git commit -m "auto-updated agent/uiserver/bindata_assetfs.go from commit ${short_sha}"
+              
+              # checkout the CI branch and rebase main
+              # strategy-option=ours keeps changes from main
+              git checkout ci/main-assetfs-build
+              git rebase --strategy-option=ours main                       
+              
               git push origin ci/main-assetfs-build
             else
               echo "no UI changes so no static assets to publish"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,17 +690,14 @@ jobs:
               git config --local user.email "github-team-consul-core@hashicorp.com"
               git config --local user.name "hc-github-team-consul-core"
             
-              # commit to main in order to checkout ci branch cleanly
+              # -B resets the CI branch to main which may diverge history
+              # but we will force push anyways.
+              git checkout -B ci/main-assetfs-build main
+            
               short_sha=$(git rev-parse --short HEAD)
               git add agent/uiserver/bindata_assetfs.go
               git commit -m "auto-updated agent/uiserver/bindata_assetfs.go from commit ${short_sha}"
-              
-              # checkout the CI branch and rebase main
-              # strategy-option=ours keeps changes from main
-              git checkout ci/main-assetfs-build
-              git rebase --strategy-option=ours main                       
-              
-              git push origin ci/main-assetfs-build
+              git push --force origin ci/main-assetfs-build
             else
               echo "no UI changes so no static assets to publish"
             fi
@@ -984,7 +981,7 @@ workflows:
   # verify-ci is a no-op workflow that must run on every PR. It is used in a
   # branch protection rule to detect when CI workflows are not running.
   verify-ci:
-    jobs: [noop]
+    jobs: [ noop ]
 
   go-tests:
     unless: << pipeline.parameters.trigger-load-test >>
@@ -1006,17 +1003,17 @@ workflows:
       - test-connect-ca-providers: *filter-ignore-non-go-branches
       - dev-build: *filter-ignore-non-go-branches
       - go-test:
-          requires: [dev-build]
+          requires: [ dev-build ]
       - go-test-lib:
           name: "go-test-api go1.16"
           path: api
           go-version: "1.16"
-          requires: [dev-build]
+          requires: [ dev-build ]
       - go-test-lib:
           name: "go-test-api go1.17"
           path: api
           go-version: "1.17"
-          requires: [dev-build]
+          requires: [ dev-build ]
       - go-test-lib:
           name: "go-test-sdk go1.16"
           path: sdk


### PR DESCRIPTION
Turns out `stash pop` [attempts a merge](https://app.circleci.com/pipelines/github/hashicorp/consul/26874/workflows/17c33cb9-4e41-43f8-8822-0c590a1c47c9/jobs/573010)!

Instead of:
1. Stash `bindata_assetfs.go`
2. Checkout `ci/main-assetfs-build`
3. Merge `main`
4. Stash pop `bindata_assetfs.go`
5. Conflict!

We instead:
1. Reset `ci/main-assetfs-build` to `main`
2. Commit `bindata_assetfs.go`
3. Force push
