### PR TITLE
acl: un-embed ACLIdentity

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -39,6 +39,12 @@ type TestACLAgent struct {
 func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzResolver, resolveIdent identResolver) *TestACLAgent {
 	t.Helper()
 
+	if resolveIdent == nil {
+		resolveIdent = func(s string) (structs.ACLIdentity, error) {
+			return nil, nil
+		}
+	}
+
 	a := &TestACLAgent{resolveAuthzFn: resolveAuthz, resolveIdentFn: resolveIdent}
 
 	dataDir := testutil.TempDir(t, "acl-agent")

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1120,7 +1120,7 @@ func (r *ACLResolver) ResolveToken(token string) (ACLResolveResult, error) {
 type ACLResolveResult struct {
 	acl.Authorizer
 	// TODO: likely we can reduce this interface
-	structs.ACLIdentity
+	ACLIdentity structs.ACLIdentity
 }
 
 func (a ACLResolveResult) AccessorID() string {
@@ -1128,6 +1128,10 @@ func (a ACLResolveResult) AccessorID() string {
 		return ""
 	}
 	return a.ACLIdentity.ID()
+}
+
+func (a ACLResolveResult) Identity() structs.ACLIdentity {
+	return a.ACLIdentity
 }
 
 func (r *ACLResolver) ACLsEnabled() bool {

--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -437,7 +437,7 @@ func (m *Internal) KeyringOperation(
 	if err != nil {
 		return err
 	}
-	if err := m.srv.validateEnterpriseToken(authz.ACLIdentity); err != nil {
+	if err := m.srv.validateEnterpriseToken(authz.Identity()); err != nil {
 		return err
 	}
 	switch args.Operation {

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -21,7 +21,7 @@ func (op *Operator) AutopilotGetConfiguration(args *structs.DCSpecificRequest, r
 	if err != nil {
 		return err
 	}
-	if err := op.srv.validateEnterpriseToken(authz.ACLIdentity); err != nil {
+	if err := op.srv.validateEnterpriseToken(authz.Identity()); err != nil {
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
@@ -53,7 +53,7 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 	if err != nil {
 		return err
 	}
-	if err := op.srv.validateEnterpriseToken(authz.ACLIdentity); err != nil {
+	if err := op.srv.validateEnterpriseToken(authz.Identity()); err != nil {
 		return err
 	}
 	if authz.OperatorWrite(nil) != acl.Allow {
@@ -88,7 +88,7 @@ func (op *Operator) ServerHealth(args *structs.DCSpecificRequest, reply *structs
 	if err != nil {
 		return err
 	}
-	if err := op.srv.validateEnterpriseToken(authz.ACLIdentity); err != nil {
+	if err := op.srv.validateEnterpriseToken(authz.Identity()); err != nil {
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
@@ -155,7 +155,7 @@ func (op *Operator) AutopilotState(args *structs.DCSpecificRequest, reply *autop
 	if err != nil {
 		return err
 	}
-	if err := op.srv.validateEnterpriseToken(authz.ACLIdentity); err != nil {
+	if err := op.srv.validateEnterpriseToken(authz.Identity()); err != nil {
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {

--- a/agent/consul/operator_raft_endpoint.go
+++ b/agent/consul/operator_raft_endpoint.go
@@ -85,7 +85,7 @@ func (op *Operator) RaftRemovePeerByAddress(args *structs.RaftRemovePeerRequest,
 	if err != nil {
 		return err
 	}
-	if err := op.srv.validateEnterpriseToken(authz.ACLIdentity); err != nil {
+	if err := op.srv.validateEnterpriseToken(authz.Identity()); err != nil {
 		return err
 	}
 	if authz.OperatorWrite(nil) != acl.Allow {
@@ -138,7 +138,7 @@ func (op *Operator) RaftRemovePeerByID(args *structs.RaftRemovePeerRequest, repl
 	if err != nil {
 		return err
 	}
-	if err := op.srv.validateEnterpriseToken(authz.ACLIdentity); err != nil {
+	if err := op.srv.validateEnterpriseToken(authz.Identity()); err != nil {
 		return err
 	}
 	if authz.OperatorWrite(nil) != acl.Allow {


### PR DESCRIPTION
This is safer than embedding two interface because there are a number of places where we check the concrete type. If we check the concrete type on the top-level interface it will fail. So instead expose the ACLIdentity from a method.

The top-level type (`ACLResultResult`) is a struct, but in other packages we may consume it as an interface, which introduces the problem.