### PR TITLE
docs: Fix discrepancy with sidecar min/max port range

### DIFF
--- a/website/content/docs/connect/proxies/built-in.mdx
+++ b/website/content/docs/connect/proxies/built-in.mdx
@@ -13,7 +13,6 @@ The [Envoy proxy](/docs/connect/proxies/envoy) should be used for production dep
 Consul comes with a built-in L4 proxy for testing and development with Consul
 Connect service mesh.
 
-
 ## Getting Started
 
 To get started with the built-in proxy and see a working example you can follow the [Getting Started](https://learn.hashicorp.com/tutorials/consul/get-started-service-networking) tutorial.
@@ -57,10 +56,9 @@ All fields are optional with a reasonable default.
   _public_ mTLS listener to. It defaults to the same address the agent binds to.
 
 - `bind_port` - The port the proxy will bind its _public_
-  mTLS listener to. If not provided, the agent will attempt to assign one from its
-  [configured proxy port range](/docs/agent/options#sidecar_min_port) if available.
-  By default the range is [20000, 20255] and the port is selected at random from
-  that range.
+  mTLS listener to. If not provided, the agent will assign a random port from its
+  configured proxy port range specified by [`sidecar_min_port`](/docs/agent/options#sidecar_min_port)
+  and [`sidecar_max_port`](/docs/agent/options#sidecar_max_port).
 
 - `local_service_address`- The `[address]:port`
   that the proxy should use to connect to the local application instance. By default

--- a/website/content/docs/connect/registration/sidecar-service.mdx
+++ b/website/content/docs/connect/registration/sidecar-service.mdx
@@ -130,9 +130,9 @@ proxy.
 - `name` - Defaults to being `<parent-service-name>-sidecar-proxy`.
 - `tags` - Defaults to the tags of the parent service.
 - `meta` - Defaults to the service metadata of the parent service.
-- `port` - Defaults to being auto-assigned from a [configurable
-  range](/docs/agent/options#sidecar_min_port) that is
-  by default `[21000, 21255]`.
+- `port` - Defaults to being auto-assigned from a configurable
+  range specified by [`sidecar_min_port`](/docs/agent/options#sidecar_min_port)
+  and [`sidecar_max_port`](/docs/agent/options#sidecar_max_port).
 - `kind` - Defaults to `connect-proxy`. This can't be overridden currently.
 - `check`, `checks` - By default we add a TCP check on the local address and
   port for the proxy, and a [service alias


### PR DESCRIPTION
Remove incorrect sidecar port range on docs for built-in proxy.

Updates the bind_port/port fields on the built-in proxy and sidecar service registration pages to link to the `sidecar_min_port` and `sidecar_max_port` configuration options for the defined port range.

Fixes #12253