### PR TITLE
ca: change the PrivateKey type/bits validation

### DIFF
--- a/.changelog/12267.txt
+++ b/.changelog/12267.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: adjust validation of PrivateKeyType/Bits with the Vault provider, to remove the error when the cert is created manually in Vault.
+```

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -163,11 +163,11 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 func (v *VaultProvider) ValidateConfigUpdate(prevRaw, nextRaw map[string]interface{}) error {
 	prev, err := ParseVaultCAConfig(prevRaw)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse existing CA config: %w", err)
 	}
 	next, err := ParseVaultCAConfig(nextRaw)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse new CA config: %w", err)
 	}
 
 	if prev.RootPKIPath != next.RootPKIPath {


### PR DESCRIPTION
Fixes #12246

This commit makes two changes to the validation.

Previously we would call this validation in GenerateRoot, which happens
both on initialization (when a follower becomes leader), and when a
configuration is updated. We only want to do this validation during
config update so the logic was moved to the `UpdateConfiguration`
method.

Previously we would compare the config values against the actual cert.
This caused problems when the cert was created manually in Vault (not
created by Consul).  Now we compare the new config against the previous
config. Using an already created CA cert should never error now.

Adding the key bit and types to the config should only error when
the previous values were not the defaults.

This does mean that changing these values away from the defaults without
changing the root_pki_path will continue to silently do nothing, but I think
that is a better trade-off than return an error incorrectly at times.

In the future we should look to better structure the CA config to indicate which
values are supposed to rotate the root cert, and which ones are not.

I believe the original change only went into 1.11.x, so I am only backporting to one
release branch.