### PR TITLE
docs: mention Consul API gateway in Ingress Controllers page

### DIFF
--- a/website/content/docs/k8s/connect/ingress-controllers.mdx
+++ b/website/content/docs/k8s/connect/ingress-controllers.mdx
@@ -12,7 +12,9 @@ description: Configuring Ingress Controllers With Consul On Kubernetes
 [Transparent Proxy](/docs/connect/transparent-proxy) mode enabled.
 
 This page describes a general approach for integrating Ingress Controllers with Consul on Kubernetes to secure traffic from the Controller
-to the backend services by deploying sidecars along your Ingress Controller. This allows Consul to transparently secure traffic from the ingress point through the entire traffic flow of the service. If you are looking for a fully supported solution for ingress traffic into Consul Service Mesh, please visit [Consul API Gateway](https://www.consul.io/docs/api-gateway) for instruction on how to install Consul API Gateway along with Consul on Kubernetes. 
+to the backend services by deploying sidecars along with your Ingress Controller. This allows Consul to transparently secure traffic from the ingress point through the entire traffic flow of the service. 
+
+If you are looking for a fully supported solution for ingress traffic into Consul Service Mesh, please visit [Consul API Gateway](https://www.consul.io/docs/api-gateway) for instruction on how to install Consul API Gateway along with Consul on Kubernetes. 
 
 A few steps are generally required to enable an Ingress controller to join the mesh and pass traffic through to a service:
 

--- a/website/content/docs/k8s/connect/ingress-controllers.mdx
+++ b/website/content/docs/k8s/connect/ingress-controllers.mdx
@@ -12,7 +12,7 @@ description: Configuring Ingress Controllers With Consul On Kubernetes
 [Transparent Proxy](/docs/connect/transparent-proxy) mode enabled.
 
 This page describes a general approach for integrating Ingress Controllers with Consul on Kubernetes to secure traffic from the Controller
-to the backend services. This allows Consul to transparently secure traffic from the ingress point through the entire traffic flow of the service.
+to the backend services by deploying sidecars along your Ingress Controller. This allows Consul to transparently secure traffic from the ingress point through the entire traffic flow of the service. If you are looking for a fully supported solution for ingress traffic int Consul Service Mesh, please visit [Consul API Gateway](https://www.consul.io/docs/api-gateway). 
 
 A few steps are generally required to enable an Ingress controller to join the mesh and pass traffic through to a service:
 

--- a/website/content/docs/k8s/connect/ingress-controllers.mdx
+++ b/website/content/docs/k8s/connect/ingress-controllers.mdx
@@ -12,7 +12,7 @@ description: Configuring Ingress Controllers With Consul On Kubernetes
 [Transparent Proxy](/docs/connect/transparent-proxy) mode enabled.
 
 This page describes a general approach for integrating Ingress Controllers with Consul on Kubernetes to secure traffic from the Controller
-to the backend services by deploying sidecars along your Ingress Controller. This allows Consul to transparently secure traffic from the ingress point through the entire traffic flow of the service. If you are looking for a fully supported solution for ingress traffic int Consul Service Mesh, please visit [Consul API Gateway](https://www.consul.io/docs/api-gateway). 
+to the backend services by deploying sidecars along your Ingress Controller. This allows Consul to transparently secure traffic from the ingress point through the entire traffic flow of the service. If you are looking for a fully supported solution for ingress traffic into Consul Service Mesh, please visit [Consul API Gateway](https://www.consul.io/docs/api-gateway) for instruction on how to install Consul API Gateway along with Consul on Kubernetes. 
 
 A few steps are generally required to enable an Ingress controller to join the mesh and pass traffic through to a service:
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -508,10 +508,6 @@
             "path": "k8s/connect/connect-ca-provider"
           },
           {
-            "title": "Ambassador Edge Stack Integration",
-            "href": "https://learn.hashicorp.com/tutorials/consul/load-balancing-ambassador"
-          },
-          {
             "title": "Health Checks",
             "path": "k8s/connect/health"
           },


### PR DESCRIPTION
- Mention Consul API Gateway in Ingress Controllers K8s page
- Remove link to Ambassador API GW learn guide from docs