### PR TITLE
Remove S3 deployment reference for our ent binaries

### DIFF
--- a/website/content/docs/enterprise/license/overview.mdx
+++ b/website/content/docs/enterprise/license/overview.mdx
@@ -21,17 +21,18 @@ when they are started.
 
 -> Visit the [Enterprise License Tutorial](https://learn.hashicorp.com/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise) for detailed steps on how to install the license key.
 
-### Binaries with Built In Licenses
+-> Amazon S3 deployment of binaries with built-in licenses has been discontinued as a deployment mechansim. Please follow the instructions for ### Binaries Without Built In Licenses 
+->### Binaries with Built In Licenses
 
-If you are downloading Consul from Amazon S3, then the license is included
+-> If you are downloading Consul from Amazon S3, then the license is included
 in the binary and you do not need to take further action. This is the
 most common use case.
 
-In the S3 bucket you will find three Enterprise zip packages. The packages with `+pro` and
+-> In the S3 bucket you will find three Enterprise zip packages. The packages with `+pro` and
 `+prem` in the name, are the binaries that include the license. The package
 with `+ent` in the name does not include the license.
 
-When using these binaries no further action is necessary to configure the license.
+-> When using these binaries no further action is necessary to configure the license.
 
 ### Binaries Without Built In Licenses
 


### PR DESCRIPTION
My understanding is that we no longer support the S3 deployment mechanism and it has been turned off. 
Ideally we should remove the whole block referring to this mechanism? It will confuse customers that have previously used this approach.