### PR TITLE
catalog: initialize the refs map to prevent a nil panic

### DIFF
--- a/.changelog/12277.txt
+++ b/.changelog/12277.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+config-entry: fix a panic when creating an ingress gateway config-entry and a proxy service instance, where both provided the same upstream and downstream mapping.
+```

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -4016,6 +4016,7 @@ func insertGatewayServiceTopologyMapping(tx WriteTxn, idx uint64, gs *structs.Ga
 	mapping := upstreamDownstream{
 		Upstream:   gs.Service,
 		Downstream: gs.Gateway,
+		Refs:       make(map[string]struct{}),
 		RaftIndex:  gs.RaftIndex,
 	}
 	if err := tx.Insert(tableMeshTopology, &mapping); err != nil {


### PR DESCRIPTION
Fixes #12258

The test was able to reproduce the panic, and the second commit fixes the test. There are other ways we could fix this, but this one seemed like the most obvious. Open to other suggestions.

TODO:
* [x] changelog