### PR TITLE
Make README header look good in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-# Consul
-
-<p>
-  <a href="https://consul.io" title="Consul website">
-    <img src="./website/public/img/logo-hashicorp.svg" alt="HashiCorp Consul logo" width="200px">
-  </a>
-</p>
+<h1>
+  <img src="./website/public/img/logo.svg" align="left" height="46px" alt="Consul logo"/>
+  <span>Consul</span>
+</h1>
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/_/consul.svg)](https://hub.docker.com/_/consul)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hashicorp/consul)](https://goreportcard.com/report/github.com/hashicorp/consul)

--- a/website/public/img/logo.svg
+++ b/website/public/img/logo.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16.649601mm"
+   height="16.806335mm"
+   viewBox="0 0 16.649601 16.806335"
+   version="1.1"
+   id="svg922"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs919" />
+  <g
+     id="layer1"
+     transform="translate(-8.0958706,-110.46823)">
+    <path
+       class="cls-1"
+       d="m 16.503701,127.27456 a 8.4031666,8.4031666 0 1 1 5.688542,-14.58383 v 0 l -1.987021,2.08492 v 0 a 5.5218541,5.5218541 0 1 0 0,8.20208 v 0 l 1.987021,2.07698 v 0 a 8.3767082,8.3767082 0 0 1 -5.688542,2.21985 z"
+       id="path18"
+       style="fill:#e03875;stroke:none;stroke-width:1.32292;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+    <path
+       class="cls-1"
+       d="m 23.266451,123.07033 a 0.68791666,0.68791666 0 1 1 0.687917,-0.68791 0.68791666,0.68791666 0 0 1 -0.687917,0.68791 z"
+       id="path20"
+       style="fill:#e03875;stroke:none;stroke-width:1.32292;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+    <path
+       class="cls-1"
+       d="m 16.450785,120.69173 a 1.8203333,1.8203333 0 1 1 1.820333,-1.82033 1.8203333,1.8203333 0 0 1 -1.820333,1.82033 z"
+       id="path22"
+       style="fill:#e03875;stroke:none;stroke-width:1.32292;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+    <path
+       class="cls-1"
+       d="m 24.057555,120.71819 a 0.68791666,0.68791666 0 1 1 0.687917,-0.68792 0.69056249,0.69056249 0 0 1 -0.687917,0.68792 z"
+       id="path24"
+       style="fill:#e03875;stroke:none;stroke-width:1.32292;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+    <path
+       class="cls-1"
+       d="m 22.009681,120.63881 a 0.68791666,0.68791666 0 1 1 0.687916,-0.68791 0.68791666,0.68791666 0 0 1 -0.687916,0.68791 z"
+       id="path26"
+       style="fill:#e03875;stroke:none;stroke-width:1.32292;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+    <path
+       class="cls-1"
+       d="m 24.057555,118.40308 a 0.68791666,0.68791666 0 1 1 0.687917,-0.68791 0.69056249,0.69056249 0 0 1 -0.687917,0.68791 z"
+       id="path28"
+       style="fill:#e03875;stroke:none;stroke-width:1.32292;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+    <path
+       class="cls-1"
+       d="m 22.009681,118.48246 a 0.68791666,0.68791666 0 1 1 0.687916,-0.68792 0.68791666,0.68791666 0 0 1 -0.687916,0.68792 z"
+       id="path30"
+       style="fill:#e03875;stroke:none;stroke-width:1.32292;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+    <path
+       class="cls-1"
+       d="m 23.306139,116.08798 a 0.68791666,0.68791666 0 1 1 0.687916,-0.68792 0.68791666,0.68791666 0 0 1 -0.687916,0.68792 z"
+       id="path32"
+       style="fill:#e03875;stroke:none;stroke-width:1.32292;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill" />
+  </g>
+</svg>


### PR DESCRIPTION
The README header introduced in #12230 doesn't look good in Github dark mode. The black text in the Consul logo is not readable.

This PR alters the README header to look good in light or dark mode. [README can be viewed here](https://github.com/hashicorp/consul/blob/readme-logo-dark-mode/README.md).

**Light mode rendered in Github**
![image](https://user-images.githubusercontent.com/85913323/152896889-17bd92d7-c54c-487c-abbf-49e96198e036.png)

**Dark mode rendered in Github**
![image](https://user-images.githubusercontent.com/85913323/152896877-e1fd80a7-ccba-4a57-b4df-3bc49afe33b7.png)