### PR TITLE
Document requirements to use network areas

### DIFF
--- a/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
@@ -19,8 +19,6 @@ When setting up a
 Consul cluster, operators must ensure that each Consul server can directly reach
 every Consul server in every datacenter over its WAN-advertised network address.
 
-[![WAN federation without mesh gateways](/img/wan-federation-connectivity-traditional.png)](/img/wan-federation-connectivity-traditional.png)
-
 This requires that operators setting up the virtual machines or containers
 hosting the servers take additional steps to ensure the necessary routing and
 firewall rules are in place to allow the servers to speak to each other over
@@ -39,7 +37,18 @@ Operators looking to simplify their WAN deployment and minimize the exposed
 security surface area can elect to join these datacenters together using [mesh
 gateways](/docs/connect/gateways/mesh-gateway/service-to-service-traffic-datacenters) to do so.
 
+<Tabs>
+<Tab heading="Traditional WAN Federation">
+
+[![WAN federation without mesh gateways](/img/wan-federation-connectivity-traditional.png)](/img/wan-federation-connectivity-traditional.png)
+
+</Tab>
+<Tab heading="WAN Federation via Mesh Gateways">
+
 [![WAN federation with mesh gateways](/img/wan-federation-connectivity-mesh-gateways.png)](/img/wan-federation-connectivity-mesh-gateways.png)
+
+</Tab>
+</Tabs>
 
 ## Requirements
 

--- a/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
@@ -7,18 +7,17 @@ description: |-
 
 # WAN Federation via Mesh Gateways
 
--> **1.8.0+:** This feature is available in Consul versions 1.8.0 and higher
-
 ~> This topic requires familiarity with [mesh gateways](/docs/connect/gateways/mesh-gateway/service-to-service-traffic-datacenters).
 
-WAN federation via mesh gateways allows for Consul servers in different datacenters
-to be federated exclusively through mesh gateways.
+This topic describes how to configure Consul servers in federated datacenters to
+communicate exclusively through mesh gateways.
+
+## Background
 
 When setting up a
-[multi-datacenter](https://learn.hashicorp.com/tutorials/consul/federation-gossip-wan)
-Consul cluster, operators must ensure that all Consul servers in every
-datacenter must be directly connectable over their WAN-advertised network
-address from each other.
+[multi-datacenter](https://learn.hashicorp.com/tutorials/consul/federarion-gossip-wan)
+Consul cluster, operators must ensure that each Consul server can directly reach
+every Consul server in every datacenter over its WAN-advertised network address.
 
 [![WAN federation without mesh gateways](/img/wan-federation-connectivity-traditional.png)](/img/wan-federation-connectivity-traditional.png)
 
@@ -41,6 +40,16 @@ security surface area can elect to join these datacenters together using [mesh
 gateways](/docs/connect/gateways/mesh-gateway/service-to-service-traffic-datacenters) to do so.
 
 [![WAN federation with mesh gateways](/img/wan-federation-connectivity-mesh-gateways.png)](/img/wan-federation-connectivity-mesh-gateways.png)
+
+## Requirements
+
+- Consul 1.8.0+
+- **Fully connected topology:**
+  All Consul datacenters must be connected to all other datacenters.
+  Other topologies, such as _hub-and-spoke_, are not supported with WAN gossip federation.
+  To support more complex topologies, review
+  [cluster peering](/docs/connect/cluster-peering) or
+  [Consul Enterprise network areas](/docs/enterprise/federation).
 
 ## Architecture
 

--- a/website/content/docs/enterprise/federation.mdx
+++ b/website/content/docs/enterprise/federation.mdx
@@ -17,8 +17,8 @@ description: >-
   {' '}for additional information.
 </EnterpriseAlert>
 
-Consul's core federation capability uses the same gossip mechanism that is used
-for a single datacenter. This requires that every server from every datacenter
+Consul's _WAN gossip_ federation capability uses the same gossip mechanism that is used for a single datacenter.
+WAN gossip federation requires that every server from every datacenter
 be in a fully connected mesh with an open gossip port (8302/tcp and 8302/udp)
 and an open server RPC port (8300/tcp). For organizations with large numbers of
 datacenters, it becomes difficult to support a fully connected mesh. It is often
@@ -33,3 +33,20 @@ can make queries to the remote datacenter in service of both API and DNS
 requests for remote resources (in spite of the partially-connected nature of the
 topology as a whole). Consul datacenters can simultaneously participate in both
 network areas and the existing WAN pool, which eases migration.
+
+## Requirements
+
+- Consul Enterprise 0.8+
+- **Direct server connectivity:**
+  All Consul servers in the 2 Consul datacenters
+  you want to connect with a network area must have direct network connection. 
+  To ensure connectivity is direct, not funneled through mesh gateways,
+  verify that the
+  [`connect.enable_mesh_gateway_wan_federation`](/docs/agent/config/config-files#connect_enable_mesh_gateway_wan_federation)
+  option is set to `false` (default).
+- **Primary datacenter connectivity:**
+  All Consul datacenters must be connected
+  to the [primary_datacenter](/docs/agent/config/config-files#primary_datacenter)
+  through WAN gossip or a network area.
+  Network areas cannot be if two datacenters are connected only through a
+  [cluster peering](/docs/connect/cluster-peering) relationship.


### PR DESCRIPTION
(Enterprise) network areas cannot be used if cross-datacenter control plane traffic is going through mesh gateways. This requirement wasn't clear in our documentation. This requirement has been added to both affected pages:
- [network areas (preview)](https://consul-5xptuor6m-hashicorp.vercel.app/docs/enterprise/federation#requirements)
- [WAN federation via mesh gateways (preview)](https://consul-5xptuor6m-hashicorp.vercel.app/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways#requirements)