### PR TITLE
docs: update the wan mesh gateway page

### DIFF
--- a/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/wan-federation-via-mesh-gateways.mdx
@@ -126,7 +126,7 @@ connect {
 }
 ```
 
-Any references to [`start_join_wan`](/docs/agent/options#start_join_wan) or [`retry_join_wan`](/docs/agent/options#retry_join_wan) should be omitted.
+The [`start_join_wan`](/docs/agent/options#start_join_wan) or [`retry_join_wan`](/docs/agent/options#retry_join_wan) are only used for the legacy federation process. They must be omitted when federating Consul servers via gateways.
 
 -> The `primary_gateways` configuration can also use `go-discover` syntax just
 like `retry_join_wan`.


### PR DESCRIPTION
This PR updates the language in the WAN mesh gateway page. The change clarifies why `start_join_wan` or `retry_join_wan `should be omitted when federating Consul servers through mesh gateways.