### PR TITLE
systemd unit: validate config on reload

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/consul.service
+++ b/.release/linux/package/usr/lib/systemd/system/consul.service
@@ -10,6 +10,7 @@ EnvironmentFile=-/etc/consul.d/consul.env
 User=consul
 Group=consul
 ExecStart=/usr/bin/consul agent -config-dir=/etc/consul.d/
+ExecReload=/usr/bin/consul validate /etc/consul.d/
 ExecReload=/bin/kill --signal HUP $MAINPID
 KillMode=process
 KillSignal=SIGTERM


### PR DESCRIPTION
Hey,
After creating a new service file under /etc/consul.d/ we perform `systemctl reload consul` either by hands or by a configuration management system.
Unfortunately, if we did a mistake or typo, we can't know it immediately because `systemctl reload consul` just sends a signal to Consul and this command always return success.
On the one hand, we can run `consul validate` each time we want to add a new config file from the other hand, we'd like not to do it.
Instead of it would be great to get feedback from `systemctl` right after `systemctl reload ...`.
Fortunately,  systemd provides a straightforward way to do it: we're able to add multiple reload commands and in case of failure of one of them, users/configuration management system will get an error.
I'm sure that this improvement will make it easier to interact with Consul.
At least for us 🙂 