### PR TITLE
fix race when starting a service while the agent `serviceManager` is …

### DIFF
--- a/.changelog/12302.txt
+++ b/.changelog/12302.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a data race when a service is added while the agent is shutting down..
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1368,14 +1368,14 @@ func (a *Agent) ShutdownAgent() error {
 	// this should help them to be stopped more quickly
 	a.baseDeps.AutoConfig.Stop()
 
+	a.stateLock.Lock()
+	defer a.stateLock.Unlock()
 	// Stop the service manager (must happen before we take the stateLock to avoid deadlock)
 	if a.serviceManager != nil {
 		a.serviceManager.Stop()
 	}
 
 	// Stop all the checks
-	a.stateLock.Lock()
-	defer a.stateLock.Unlock()
 	for _, chk := range a.checkMonitors {
 		chk.Stop()
 	}


### PR DESCRIPTION
This fix a data race when we add a service while the service manager is stopping. A waitGroup Add is not safe to be called while waiting on the waitGroup.


```
WARNING: DATA RACE
Write at 0x00c000b4dd78 by goroutine 22:
  runtime.racewrite()
      <autogenerated>:1 +0x24
  github.com/hashicorp/consul/agent.(*ServiceManager).Stop()
      /home/circleci/project/agent/service_manager.go:54 +0x50
  github.com/hashicorp/consul/agent.(*Agent).ShutdownAgent()
      /home/circleci/project/agent/agent.go:1373 +0x1b8
  github.com/hashicorp/consul/agent.(*TestAgent).Shutdown()
      /home/circleci/project/agent/testagent.go:307 +0xe7
  github.com/hashicorp/consul/connect/proxy.TestAgentConfigWatcherSidecarProxy·dwrap·13()
      /home/circleci/project/connect/proxy/config_test.go:91 +0x39
  github.com/hashicorp/consul/connect/proxy.TestAgentConfigWatcherSidecarProxy()
      /home/circleci/project/connect/proxy/config_test.go:177 +0xed8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47

Previous read at 0x00c000b4dd78 by goroutine 213:
  runtime.raceread()
      <autogenerated>:1 +0x24
  github.com/hashicorp/consul/agent.(*serviceConfigWatch).start()
      /home/circleci/project/agent/service_manager.go:222 +0x3c4
  github.com/hashicorp/consul/agent.(*ServiceManager).AddService()
      /home/circleci/project/agent/service_manager.go:98 +0x379
  github.com/hashicorp/consul/agent.(*Agent).addServiceLocked()
      /home/circleci/project/agent/agent.go:2010 +0xca4
  github.com/hashicorp/consul/agent.(*Agent).AddService()
      /home/circleci/project/agent/agent.go:1997 +0x2e4
  github.com/hashicorp/consul/agent.(*HTTPHandlers).AgentRegisterService()
      /home/circleci/project/agent/agent_endpoint.go:1244 +0x1404
  github.com/hashicorp/consul/agent.(*HTTPHandlers).handler.func3()
      /home/circleci/project/agent/http.go:292 +0x65
  github.com/hashicorp/consul/agent.(*HTTPHandlers).wrap.func1()
      /home/circleci/project/agent/http.go:548 +0x1029
  github.com/hashicorp/consul/agent.(*HTTPHandlers).handler.func1.1()
      /home/circleci/project/agent/http.go:226 +0xcb
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2047 +0x4d
  github.com/NYTimes/gziphandler.GzipHandlerWithOpts.func1.1()
      /home/circleci/go/pkg/mod/github.com/!n!y!times/gziphandler@v1.0.1/gzip.go:287 +0x433
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2047 +0x4d
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2425 +0xc5
  github.com/hashicorp/go-cleanhttp.PrintablePathCheckHandler.func1()
      /home/circleci/go/pkg/mod/github.com/hashicorp/go-cleanhttp@v0.5.1/handlers.go:42 +0xc1
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2047 +0x4d
  github.com/hashicorp/consul/agent.(*wrappedMux).ServeHTTP()
      /home/circleci/project/agent/http.go:155 +0x69
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2879 +0x89a
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1930 +0x12e4
  net/http.(*Server).Serve·dwrap·87()
      /usr/local/go/src/net/http/server.go:3034 +0x58

Goroutine 22 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1306 +0x726
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1598 +0x99
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1596 +0x7ca
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1504 +0x9d1
  main.main()
      _testmain.go:57 +0x22b

Goroutine 213 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3034 +0x847
  github.com/hashicorp/consul/agent.newAPIServerHTTP.func1()
      /home/circleci/project/agent/apiserver.go:104 +0x78
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/circleci/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x96
==================
```