### PR TITLE
docs/nia - Get Task API docs & Task Status API deprecations

### DIFF
--- a/website/content/docs/nia/api/status.mdx
+++ b/website/content/docs/nia/api/status.mdx
@@ -199,7 +199,7 @@ Response:
             "null"
           ],
           "services": [
-            "web",
+            "web"
           ],
           "module": "../modules/test_task"
         }

--- a/website/content/docs/nia/api/status.mdx
+++ b/website/content/docs/nia/api/status.mdx
@@ -77,13 +77,13 @@ Task health status value is determined by the success or failure of all stored [
 
 | Method | Path                | Produces           |
 | ------ | ------------------- | ------------------ |
-| `GET`  | `/status/tasks/:task` | `application/json` |
+| `GET`  | `/status/tasks/:task_name` | `application/json` |
 
 #### Request Parameters
 
 | Name	   | Required | Type	 | Description        | Default |
 | -------- | -------- | ------ | ------------------ | ------- |
-|`task`    | Optional | string | Option to specify the name of the task to return in the response. If not specified, all tasks are returned in the response.| none
+|`:task_name` | Optional | string | Option to specify the name of the task to return in the response. If not specified, all tasks are returned in the response.| none
 |`include` | Optional | string | Only accepts the value `"events"`. Use to include stored event information in response. | none
 |`status`  | Optional | string | Only accepts health status values `"successful"`, `"errored"`, `"critical"`, or `"unknown"`. Use to filter response by tasks that have the specified health status value. Recommend setting this parameter when requesting all tasks i.e. no `task` parameter is set. | none
 

--- a/website/content/docs/nia/api/status.mdx
+++ b/website/content/docs/nia/api/status.mdx
@@ -103,8 +103,8 @@ The response is a JSON map of task name to a status information structure with t
 |`task_name`  | string | Name of the task as configured in CTS.
 |`status`     | string | Values are `"successful"`, `"errored"`, `"critical"`, or `"unknown"`. This is determined by the success or failure of all stored events on the network infrastructure update process for the task, as described earlier.
 |`enabled`    | boolean | Whether the task is enabled or not.
-|`services`   | list[string] | List of the services configured for the task.
-|`providers`  | list[string] | List of the providers configured for the task.
+|`services`   | list[string] | **Deprecated in CTS 0.5.0 and will be removed in a future major release.** List of the services configured for the task.
+|`providers`  | list[string] | **Deprecated in CTS 0.5.0 and will be removed in v0.8.0.** List of the providers configured for the task.
 |`events_url` | string | Relative URL to retrieve the event data stored for the task.
 |`events`     | list[[Event](/docs/nia/api/status#event)] | List of stored events that inform the task's status. See [section below](/docs/nia/api/status#event) for information on event data. This field is only included in the response upon request by setting the `?include=events` parameter. The relative URL for the request to include events can be retrieved from the `events_url` field.
 
@@ -121,11 +121,10 @@ Event represents the process of updating network infrastructure of a task. The d
 |`task_name`  | string | Name that task is configured with in CTS.
 |`error`         | object | Information when the event fails. Null when successful.
 |`error.message` | string | Error message that is returned on failure.
-|`config`           | object | Configuration values for the task when it was run.
-|`config.services`  | list[string] | List of the services configured for the task.
-|`config.source`    | string | **Deprecated in CTS 0.5.0 and will be removed in a future major release. See the `config.module` field instead.**
-|`config.module`    | string | Module configured for the task.
-|`config.providers` | list[string] | List of the providers configured for the task.
+|`config`           | object | **Deprecated in CTS 0.5.0 and will be removed in v0.8.0.** Configuration values for the task when it was run.
+|`config.services`  | list[string] | **Deprecated in CTS 0.5.0 and will be removed in v0.8.0.** List of the services configured for the task.
+|`config.source`    | string | **Deprecated in CTS 0.5.0 and will be removed in v0.8.0.** Module configured for the task.
+|`config.providers` | list[string] | **Deprecated in CTS 0.5.0 and will be removed in v0.8.0.** List of the providers configured for the task.
 
 #### Example: All Task Statuses
 

--- a/website/content/docs/nia/api/tasks.mdx
+++ b/website/content/docs/nia/api/tasks.mdx
@@ -211,19 +211,19 @@ $ curl --request DELETE \
 
 The task object is used by the Task APIs as part of a request or response. It represents the task's [configuration information](/docs/nia/configuration#task).
 
-| Name	| Type | Description |
-| ----- | ---- | ----------- |
-| `buffer_period` | object |  The buffer period for triggering task execution. |
-| `buffer_period.enabled` | bool | Whether the buffer period is enabled or disabled. |
-| `buffer_period.min` | string | The minimum period of time to wait after changes are detected before triggering the task. |
-| `buffer_period.max` | string | The maximum period of time to wait after changes are detected before triggering the task. |
-| `condition` | object | The [condition](/docs/nia/configuration#task-condition) on which to trigger the task to execute. <br/><br/> If the task has the deprecated `services` field configured as a module input, it is represented here as `condition.services`. |
-| `description` | string | The human readable text to describe the task. |
-| `enabled` | bool | Whether the task is enabled or disabled from executing. |
-| `module` | string | The location of the Terraform module. |
-| `module_input` | object | The additional [module input(s)](/docs/nia/configuration#task-source-input) that the tasks provides to the Terraform module on execution. <br/><br/> If the task has the deprecated `services` field configured as a module input, it is represented here as `module_input.services`. |
-| `name` | string | The unique name of the task. |
-| `providers` | list[string] | The list of provider names that the task's module uses. |
-| `variables` | map[string] | The map of variables that are provided to the task's module. |
-| `version` | string | The version of the configured module that the task uses. If empty, the latest version is used.
-| `terraform_version` | string | <EnterpriseAlert inline /> The version of Terraform to use for the Terraform Cloud workspace associated with the task. This is only available when used with the [Terraform Cloud driver](/docs/nia/configuration#terraform-driver). |
+| Name	| Required | Type | Description | Default |
+| ----- | -------- | ---- | ----------- | ------- |
+| `buffer_period` | object | Optional | The buffer period for triggering task execution. | The global buffer period configured for CTS. |
+| `buffer_period.enabled` | bool | Optional | Whether the buffer period is enabled or disabled. | The global buffer period's enabled value configured for CTS. |
+| `buffer_period.min` | string | Optional | The minimum period of time to wait after changes are detected before triggering the task. | The global buffer period's min value configured for CTS. |
+| `buffer_period.max` | string | Optional | The maximum period of time to wait after changes are detected before triggering the task. | The global buffer period's max value configured for CTS. |
+| `condition` | object | Required | The [condition](/docs/nia/configuration#task-condition) on which to trigger the task to execute. <br/><br/> If the task has the deprecated `services` field configured as a module input, it is represented here as `condition.services`. | none |
+| `description` | string | Optional | The human readable text to describe the task. | none |
+| `enabled` | bool | Optional | Whether the task is enabled or disabled from executing. | `true` |
+| `module` | string | Required | The location of the Terraform module. | none |
+| `module_input` | object | Optional | The additional [module input(s)](/docs/nia/configuration#task-source-input) that the tasks provides to the Terraform module on execution. <br/><br/> If the task has the deprecated `services` field configured as a module input, it is represented here as `module_input.services`. | none |
+| `name` | string | Required | The unique name of the task. | none |
+| `providers` | list[string] | Optional | The list of provider names that the task's module uses. | none |
+| `variables` | map[string] | Optional | The map of variables that are provided to the task's module. | none |
+| `version` | string | Optional | The version of the configured module that the task uses.| The latest version. |
+| `terraform_version` | string | Optional | <EnterpriseAlert inline /> The version of Terraform to use for the Terraform Cloud workspace associated with the task. This is only available when used with the [Terraform Cloud driver](/docs/nia/configuration#terraform-driver). | The latest compatible version supported by the organization. |

--- a/website/content/docs/nia/api/tasks.mdx
+++ b/website/content/docs/nia/api/tasks.mdx
@@ -6,7 +6,84 @@ description: >-
 ---
 # Tasks
 
-The `/tasks` endpoints modify the tasks that Consul-Terraform-Sync (CTS) is responsible for running.
+The `/tasks` endpoints interact with the tasks that Consul-Terraform-Sync (CTS) is responsible for running.
+
+## Get Task
+
+This endpoint returns information about an existing task.
+
+| Method | Path                | Produces           |
+| ------ | ------------------- | ------------------ |
+| `GET`  | `/tasks/:task_name` | `application/json` |
+
+#### Request Parameters
+
+| Name | Required | Type | Description  | Default |
+| -----| -------- | ---- | ------------ | ------- |
+|`:task_name` | Required | string | Specifies the name of the task to retrieve | none |
+
+#### Response Statuses
+
+| Status | Reason |
+| ------ | ------ |
+| 200  | Successfully retrieved and returned task information |
+| 404  | Task with the given name not found |
+
+#### Response Fields
+
+| Name	| Type | Description |
+| ----- | ---- | ----------- |
+| `request_id` | string | The ID of the request. Used for auditing and debugging purposes. |
+| `task` | object | The task's configuration information. See [task object](#task-object) for details. |
+
+#### Example: Retrieve a task
+
+Request:
+```shell-session
+$ curl --request GET \
+  localhost:8558/v1/tasks/task_a
+```
+
+Response:
+```json
+{
+  "request_id": "b7559ab0-5111-381b-367a-0dfb7e216d41",
+  "task": {
+    "buffer_period": {
+      "enabled": true,
+      "max": "20s",
+      "min": "5s"
+    },
+    "condition": {
+      "consul_kv": {
+        "datacenter": "",
+        "namespace": "",
+        "path": "my_key",
+        "recurse": false,
+        "use_as_module_input": true
+      }
+    },
+    "description": "task triggering on consul-kv",
+    "enabled": true,
+    "module": "path/to/module",
+    "module_input": {
+      "services": {
+        "cts_user_defined_meta": {},
+        "datacenter": "",
+        "filter": "",
+        "names": [
+          "api"
+        ],
+        "namespace": ""
+      }
+    },
+    "name": "task_a",
+    "providers": [],
+    "variables": {},
+    "version": ""
+  }
+}
+```
 
 ## Update Task
 
@@ -122,3 +199,24 @@ $ curl --request DELETE \
   "request_id": "9b23eea7-a435-2797-c71e-10c15766cd73"
 }
 ```
+
+## Task Object
+
+The task object is used by the Task APIs as part of a request or response. It represents the task's [configuration information](/docs/nia/configuration#task).
+
+| Name	| Type | Description |
+| ----- | ---- | ----------- |
+| `buffer_period` | object |  The buffer period for triggering task execution. |
+| `buffer_period.enabled` | bool | Whether the buffer period is enabled or disabled. |
+| `buffer_period.min` | string | The minimum period of time to wait after changes are detected before triggering the task. |
+| `buffer_period.max` | string | The maximum period of time to wait after changes are detected before triggering the task. |
+| `condition` | object | The [condition](/docs/nia/configuration#task-condition) on which to trigger the task to execute. <br/><br/> If the task has the deprecated `services` field configured as a module input, it is represented here as `condition.services`. |
+| `description` | string | The human readable text to describe the task. |
+| `enabled` | bool | Whether the task is enabled or disabled from executing. |
+| `module` | string | The location of the Terraform module. |
+| `module_input` | object | The additional [module input(s)](/docs/nia/configuration#task-source-input) that the tasks provides to the Terraform module on execution. <br/><br/> If the task has the deprecated `services` field configured as a module input, it is represented here as `module_input.services`. |
+| `name` | string | The unique name of the task. |
+| `providers` | list[string] | The list of provider names that the task's module uses. |
+| `variables` | map[string] | The map of variables that are provided to the task's module. |
+| `version` | string | The version of the configured module that the task uses. If empty, the latest version is used.
+| `terraform_version` | string | <EnterpriseAlert inline /> The version of Terraform to use for the Terraform Cloud workspace associated with the task. This is only available when used with the [Terraform Cloud driver](/docs/nia/configuration#terraform-driver). |

--- a/website/content/docs/nia/api/tasks.mdx
+++ b/website/content/docs/nia/api/tasks.mdx
@@ -97,6 +97,7 @@ This endpoint allows patch updates to specifically supported fields for existing
 
 | Name | Required | Type | Description  | Default |
 | -----| -------- | ---- | ------------ | ------- |
+|`:task_name` | Required | string | Specifies the name of the task to update | none |
 |`run` | Optional | string | Values can only be `"inspect"` and `"now"`.<br/><ul><li>`"inspect"`: Does not update the task but returns information on if/how resources would be changed for the proposed task update.</li><li> `"now"`: Updates the task accordingly and immediately runs the task, rather than allowing the task to run at the natural daemon cadence</li></ul> | none |
 
 #### Request Body
@@ -173,6 +174,12 @@ This endpoint allows for deletion of existing tasks. It does not allow deletion 
 | Method | Path                | Produces           |
 | ------ | ------------------- | ------------------ |
 | `DELETE`  | `/tasks/:task_name` | `application/json` |
+
+#### Request Parameters
+
+| Name | Required | Type | Description  | Default |
+| -----| -------- | ---- | ------------ | ------- |
+|`:task_name` | Required | string | Specifies the name of the task to retrieve | none |
 
 #### Response Statuses
 

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -55,7 +55,7 @@ tls {
   - `verify_incoming` - (bool: false) Enable mutual TLS. Requires all incoming connections to the CTS API to use a TLS connection and provide a certificate signed by a Certificate Authority specified by the `ca_cert` or `ca_path`.
   - `ca_cert` - (string) The path to a PEM-encoded certificate authority file used to verify the authenticity of the incoming client connections to the CTS API when `verify_incoming` is set to true. Takes precedence over `ca_path` if both are configured.
   - `ca_path` - (string) The path to a directory of PEM-encoded certificate authority files used to verify the authenticity of the incoming client connections to the CTS API when `verify_incoming` is set to true.
-- `license_path` <EnterpriseAlert inline /> - (string: "") Configures the path to the file containing the license. A license must be set to use enterprise features. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details.
+- `license_path` <EnterpriseAlert inline /> - (string) Configures the path to the file containing the license. A license must be set to use enterprise features. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details.
 
 ## Consul
 
@@ -146,7 +146,7 @@ task {
 }
 ```
 
-- `description` - (string) The human readable text to describe the service.
+- `description` - (string) The human readable text to describe the task.
 - `name` - (string: required) Name is the unique name of the task (required). A task name must start with a letter or underscore and may contain only letters, digits, underscores, and dashes.
 - `enabled` - (bool: true) Enable or disable a task from running and managing resources.
 - `providers` - (list[string]) Providers is the list of provider names the task is dependent on. This is used to map [Terraform provider configuration](#terraform-provider) to the task.
@@ -201,7 +201,7 @@ task {
 
 ### Task Condition
 
-A `task` block can be optionally configured with a `condition` block to set the conditions that should be met in order to execute that particular task. Below are the different types of conditions that CTS supports.
+A `task` block is configured with a `condition` block to set the conditions that should be met in order to execute that particular task. Below are the different types of conditions that CTS supports.
 
 #### Services Condition
 


### PR DESCRIPTION
We are deprecating some fields in Task Status API and replacing them with a new Get Task API

Changes (details in commit msg):
 - new docs for Get Task API (also prepares for Create Task API)
 - deprecate fields in Task Status API
 - update APIs to align on `:task_name` in request parameter (open to feedback)
 - misc fixes

[get status api preview link](https://consul-7qhowv9sm-hashicorp.vercel.app/docs/nia/api/tasks#get-task)