### PR TITLE
Refactor to make ACL errors more structured.

### DIFF
--- a/.changelog/12308.txt
+++ b/.changelog/12308.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+Refactor ACL denied error code and start improving error details
+```

--- a/acl/errors.go
+++ b/acl/errors.go
@@ -82,16 +82,17 @@ type PermissionDeniedError struct {
 // 1) Named entities without a context
 // 2) Unnamed entities with a context
 // 3) Completely context free checks (global permissions)
-// 4) Errors that only have a cause and bad
+// 4) Errors that only have a cause (for example bad token)
 func (e PermissionDeniedError) Error() string {
 	var message strings.Builder
 	message.WriteString(errPermissionDenied)
 
-	// This is used where we
+	// Type 4)
 	if e.Cause != "" {
 		fmt.Fprintf(&message, ": %s", e.Cause)
 		return message.String()
 	}
+	// Should only be empty when default struct is used.
 	if e.Resource == "" {
 		return message.String()
 	}

--- a/acl/errors.go
+++ b/acl/errors.go
@@ -69,13 +69,12 @@ type PermissionDeniedError struct {
 
 	// Accessor contains information on the accessor used e.g. "token <GUID>"
 	Accessor string
-	// Resource
+	// Resource (e.g. Service)
 	Resource string
-	// Permission is the resource and type of access. e.g. "service:read". Perhaps split into two fields resource (e.g. service)
-	// access type (read)
-	Permission string
+	// Access leve (e.g. Read)
+	AccessLevel string
 	// e.g. "sidecar-proxy-1"
-	Object ResourceDescriptor
+	ResourceID ResourceDescriptor
 }
 
 // Initially we may not have attribution information; that will become more complete as we work this change through
@@ -103,10 +102,10 @@ func (e PermissionDeniedError) Error() string {
 		fmt.Fprintf(&message, ": accessor '%s'", e.Accessor)
 	}
 
-	fmt.Fprintf(&message, " lacks permission '%s:%s'", e.Resource, e.Permission)
+	fmt.Fprintf(&message, " lacks permission '%s:%s'", e.Resource, e.AccessLevel)
 
-	if e.Object.Name != "" {
-		fmt.Fprintf(&message, " %s", e.Object.ToString())
+	if e.ResourceID.Name != "" {
+		fmt.Fprintf(&message, " %s", e.ResourceID.ToString())
 	}
 	return message.String()
 }
@@ -117,12 +116,12 @@ func PermissionDenied(msg string, args ...interface{}) PermissionDeniedError {
 }
 
 // TODO Extract information from Authorizer
-func PermissionDeniedByACL(_ Authorizer, context *AuthorizerContext, resource string, permission string, object string) PermissionDeniedError {
-	desc := NewResourceDescriptor(object, context)
-	return PermissionDeniedError{Accessor: "", Resource: resource, Permission: permission, Object: desc}
+func PermissionDeniedByACL(_ Authorizer, context *AuthorizerContext, resource string, accessLevel string, resourceID string) PermissionDeniedError {
+	desc := NewResourceDescriptor(resourceID, context)
+	return PermissionDeniedError{Accessor: "", Resource: resource, AccessLevel: accessLevel, ResourceID: desc}
 }
 
-func PermissionDeniedByACLUnnamed(_ Authorizer, context *AuthorizerContext, resource string, permission string) PermissionDeniedError {
+func PermissionDeniedByACLUnnamed(_ Authorizer, context *AuthorizerContext, accessLevel string, permission string) PermissionDeniedError {
 	desc := NewResourceDescriptor("", context)
-	return PermissionDeniedError{Accessor: "", Resource: resource, Permission: permission, Object: desc}
+	return PermissionDeniedError{Accessor: "", Resource: accessLevel, AccessLevel: permission, ResourceID: desc}
 }

--- a/acl/errors.go
+++ b/acl/errors.go
@@ -61,15 +61,53 @@ func IsErrPermissionDenied(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errPermissionDenied)
 }
 
+// Arguably this should be some sort of union type.
+// The usage of Cause and the rest of the fields is entirely disjoint.
+//
 type PermissionDeniedError struct {
 	Cause string
+
+	// Accessor contains information on the accessor used e.g. "token <GUID>"
+	Accessor string
+	// Resource
+	Resource string
+	// Permission is the resource and type of access. e.g. "service:read". Perhaps split into two fields resource (e.g. service)
+	// access type (read)
+	Permission string
+	// e.g. "sidecar-proxy-1"
+	Object ResourceDescriptor
 }
 
+// Initially we may not have attribution information; that will become more complete as we work this change through
+// There are generally three classes of errors
+// 1) Named entities without a context
+// 2) Unnamed entities with a context
+// 3) Completely context free checks (global permissions)
+// 4) Errors that only have a cause and bad
 func (e PermissionDeniedError) Error() string {
+	var message strings.Builder
+	message.WriteString(errPermissionDenied)
+
+	// This is used where we
 	if e.Cause != "" {
-		return errPermissionDenied + ": " + e.Cause
+		message.WriteString(e.Cause)
 	}
-	return errPermissionDenied
+	if e.Resource == "" {
+		return message.String()
+	}
+
+	if e.Accessor == "" {
+		message.WriteString(": accessor ")
+	} else {
+		fmt.Fprintf(&message, ": accessor '%s'", e.Accessor)
+	}
+
+	fmt.Fprintf(&message, " lacks permission '%s:%s'", e.Resource, e.Permission)
+
+	if e.Object.Name != "" {
+		fmt.Fprintf(&message, " %s", e.Object.ToString())
+	}
+	return message.String()
 }
 
 func PermissionDenied(msg string, args ...interface{}) PermissionDeniedError {
@@ -77,37 +115,13 @@ func PermissionDenied(msg string, args ...interface{}) PermissionDeniedError {
 	return PermissionDeniedError{Cause: cause}
 }
 
-type PermissionDeniedByACLError struct {
-	Accessor   string                     // "token guid"
-	Permission string                     // e.g. "service:read" Perhaps split into resource and level
-	ObjectType string                     // e.g. service
-	Object     EnterpriseObjectDescriptor // e.g. "sidecar-proxy-1"
+// TODO Extract information from Authorizer
+func PermissionDeniedByACL(_ Authorizer, context *AuthorizerContext, resource string, permission string, object string) PermissionDeniedError {
+	desc := NewResourceDescriptor(object, context)
+	return PermissionDeniedError{Accessor: "", Resource: resource, Permission: permission, Object: desc}
 }
 
-func (e PermissionDeniedByACLError) Error() string {
-	message := errPermissionDenied
-
-	if e.Accessor == "" {
-		message += ": accessor "
-	} else {
-		message += fmt.Sprintf(": accessor '%s'", e.Accessor)
-	}
-
-	message += fmt.Sprintf(" lacks permission '%s' on %s", e.Permission, e.ObjectType)
-
-	if e.Object.Name != "" {
-		message += " " + e.Object.ToString()
-	}
-	return message
-}
-
-// TODO Extract informoration from Authorizer
-func PermissionDeniedByACL(_ Authorizer, context AuthorizerContext, permission string, objectType string, object string) PermissionDeniedByACLError {
-	desc := MakeEnterpriseObjectDescriptor(object, context)
-	return PermissionDeniedByACLError{Accessor: "", Permission: permission, ObjectType: objectType, Object: desc}
-}
-
-func PermissionDeniedByACLUnnamed(_ Authorizer, permission string, objectType string) PermissionDeniedByACLError {
-	desc := EnterpriseObjectDescriptor{Name: ""}
-	return PermissionDeniedByACLError{Accessor: "", Permission: permission, ObjectType: objectType, Object: desc}
+func PermissionDeniedByACLUnnamed(_ Authorizer, context *AuthorizerContext, resource string, permission string) PermissionDeniedError {
+	desc := NewResourceDescriptor("", context)
+	return PermissionDeniedError{Accessor: "", Resource: resource, Permission: permission, Object: desc}
 }

--- a/acl/errors.go
+++ b/acl/errors.go
@@ -98,7 +98,7 @@ func (e PermissionDeniedError) Error() string {
 	}
 
 	if e.Accessor == "" {
-		message.WriteString(": accessor ")
+		message.WriteString(": provided accessor")
 	} else {
 		fmt.Fprintf(&message, ": accessor '%s'", e.Accessor)
 	}

--- a/acl/errors.go
+++ b/acl/errors.go
@@ -70,9 +70,9 @@ type PermissionDeniedError struct {
 	// Accessor contains information on the accessor used e.g. "token <GUID>"
 	Accessor string
 	// Resource (e.g. Service)
-	Resource string
+	Resource Resource
 	// Access leve (e.g. Read)
-	AccessLevel string
+	AccessLevel AccessLevel
 	// e.g. "sidecar-proxy-1"
 	ResourceID ResourceDescriptor
 }
@@ -102,7 +102,7 @@ func (e PermissionDeniedError) Error() string {
 		fmt.Fprintf(&message, ": accessor '%s'", e.Accessor)
 	}
 
-	fmt.Fprintf(&message, " lacks permission '%s:%s'", e.Resource, e.AccessLevel)
+	fmt.Fprintf(&message, " lacks permission '%s:%s'", e.Resource, e.AccessLevel.String())
 
 	if e.ResourceID.Name != "" {
 		fmt.Fprintf(&message, " %s", e.ResourceID.ToString())
@@ -116,12 +116,12 @@ func PermissionDenied(msg string, args ...interface{}) PermissionDeniedError {
 }
 
 // TODO Extract information from Authorizer
-func PermissionDeniedByACL(_ Authorizer, context *AuthorizerContext, resource string, accessLevel string, resourceID string) PermissionDeniedError {
+func PermissionDeniedByACL(_ Authorizer, context *AuthorizerContext, resource Resource, accessLevel AccessLevel, resourceID string) PermissionDeniedError {
 	desc := NewResourceDescriptor(resourceID, context)
 	return PermissionDeniedError{Accessor: "", Resource: resource, AccessLevel: accessLevel, ResourceID: desc}
 }
 
-func PermissionDeniedByACLUnnamed(_ Authorizer, context *AuthorizerContext, accessLevel string, permission string) PermissionDeniedError {
+func PermissionDeniedByACLUnnamed(_ Authorizer, context *AuthorizerContext, resource Resource, accessLevel AccessLevel) PermissionDeniedError {
 	desc := NewResourceDescriptor("", context)
-	return PermissionDeniedError{Accessor: "", Resource: accessLevel, AccessLevel: permission, ResourceID: desc}
+	return PermissionDeniedError{Accessor: "", Resource: resource, AccessLevel: accessLevel, ResourceID: desc}
 }

--- a/acl/errors.go
+++ b/acl/errors.go
@@ -90,7 +90,8 @@ func (e PermissionDeniedError) Error() string {
 
 	// This is used where we
 	if e.Cause != "" {
-		message.WriteString(e.Cause)
+		fmt.Fprintf(&message, ": %s", e.Cause)
+		return message.String()
 	}
 	if e.Resource == "" {
 		return message.String()

--- a/acl/errors_oss.go
+++ b/acl/errors_oss.go
@@ -1,0 +1,18 @@
+//go:build !consulent
+// +build !consulent
+
+package acl
+
+// In some sense we really want this to contain an EnterpriseMeta, but
+// this turns out to be a convenient place to hang helper functions off of.
+type EnterpriseObjectDescriptor struct {
+	Name string
+}
+
+func MakeEnterpriseObjectDescriptor(name string, _ AuthorizerContext) EnterpriseObjectDescriptor {
+	return EnterpriseObjectDescriptor{Name: name}
+}
+
+func (od *EnterpriseObjectDescriptor) ToString() string {
+	return od.Name
+}

--- a/acl/errors_oss.go
+++ b/acl/errors_oss.go
@@ -5,14 +5,14 @@ package acl
 
 // In some sense we really want this to contain an EnterpriseMeta, but
 // this turns out to be a convenient place to hang helper functions off of.
-type EnterpriseObjectDescriptor struct {
+type ResourceDescriptor struct {
 	Name string
 }
 
-func MakeEnterpriseObjectDescriptor(name string, _ AuthorizerContext) EnterpriseObjectDescriptor {
-	return EnterpriseObjectDescriptor{Name: name}
+func NewResourceDescriptor(name string, _ *AuthorizerContext) ResourceDescriptor {
+	return ResourceDescriptor{Name: name}
 }
 
-func (od *EnterpriseObjectDescriptor) ToString() string {
+func (od *ResourceDescriptor) ToString() string {
 	return od.Name
 }

--- a/acl/errors_test.go
+++ b/acl/errors_test.go
@@ -1,0 +1,46 @@
+package acl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermissionDeniedError(t *testing.T) {
+	type testCase struct {
+		err      PermissionDeniedError
+		expected string
+	}
+
+	testName := func(t testCase) string {
+		return t.expected
+	}
+
+	auth1 := mockAuthorizer{}
+
+	cases := []testCase{
+		{
+			err:      PermissionDeniedError{},
+			expected: "Permission denied",
+		},
+		{
+			err:      PermissionDeniedError{Cause: "simon says"},
+			expected: "Permission denied: simon says",
+		},
+		{
+			err:      PermissionDeniedByACL(&auth1, nil, "Service", "Read", "foobar"),
+			expected: "Permission denied: provided accessor lacks permission 'Service:Read' foobar",
+		},
+		{
+			err:      PermissionDeniedByACLUnnamed(&auth1, nil, "Service", "Read"),
+			expected: "Permission denied: provided accessor lacks permission 'Service:Read'",
+		},
+	}
+
+	for _, tcase := range cases {
+		t.Run(testName(tcase), func(t *testing.T) {
+			require.Error(t, tcase.err)
+			require.Equal(t, tcase.expected, tcase.err.Error())
+		})
+	}
+}

--- a/acl/errors_test.go
+++ b/acl/errors_test.go
@@ -28,12 +28,12 @@ func TestPermissionDeniedError(t *testing.T) {
 			expected: "Permission denied: simon says",
 		},
 		{
-			err:      PermissionDeniedByACL(&auth1, nil, "Service", "Read", "foobar"),
-			expected: "Permission denied: provided accessor lacks permission 'Service:Read' foobar",
+			err:      PermissionDeniedByACL(&auth1, nil, ResourceService, AccessRead, "foobar"),
+			expected: "Permission denied: provided accessor lacks permission 'service:read' foobar",
 		},
 		{
-			err:      PermissionDeniedByACLUnnamed(&auth1, nil, "Service", "Read"),
-			expected: "Permission denied: provided accessor lacks permission 'Service:Read'",
+			err:      PermissionDeniedByACLUnnamed(&auth1, nil, ResourceService, AccessRead),
+			expected: "Permission denied: provided accessor lacks permission 'service:read'",
 		},
 	}
 

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -44,14 +44,14 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 	// Vet the service itself.
 	service.FillAuthzContext(&authzContext)
 	if authz.ServiceWrite(service.Service, &authzContext) != acl.Allow {
-		return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", service.Service)
+		return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", service.Service)
 	}
 
 	// Vet any service that might be getting overwritten.
 	if existing := a.State.Service(service.CompoundServiceID()); existing != nil {
 		existing.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(existing.Service, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", existing.Service)
+			return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", existing.Service)
 		}
 	}
 
@@ -60,7 +60,7 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 	if service.Kind == structs.ServiceKindConnectProxy {
 		service.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(service.Proxy.DestinationServiceName, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", service.Proxy.DestinationServiceName)
+			return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", service.Proxy.DestinationServiceName)
 		}
 	}
 
@@ -74,7 +74,7 @@ func (a *Agent) vetServiceUpdateWithAuthorizer(authz acl.Authorizer, serviceID s
 	if existing := a.State.Service(serviceID); existing != nil {
 		existing.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(existing.Service, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", existing.Service)
+			return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", existing.Service)
 		}
 	} else {
 		// Take care if modifying this error message.
@@ -96,12 +96,12 @@ func (a *Agent) vetCheckRegisterWithAuthorizer(authz acl.Authorizer, check *stru
 	// Vet the check itself.
 	if len(check.ServiceName) > 0 {
 		if authz.ServiceWrite(check.ServiceName, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", check.ServiceName)
+			return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", check.ServiceName)
 		}
 	} else {
 		// N.B. Should this authzContext be derived from a.AgentEnterpriseMeta()
 		if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, authzContext, "node:write", "node", a.config.NodeName)
+			return acl.PermissionDeniedByACL(authz, &authzContext, "node", "write", a.config.NodeName)
 		}
 	}
 
@@ -110,12 +110,12 @@ func (a *Agent) vetCheckRegisterWithAuthorizer(authz acl.Authorizer, check *stru
 		if len(existing.ServiceName) > 0 {
 			// N.B. Should this authzContext be derived from existing.EnterpriseMeta?
 			if authz.ServiceWrite(existing.ServiceName, &authzContext) != acl.Allow {
-				return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", existing.ServiceName)
+				return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", existing.ServiceName)
 			}
 		} else {
 			// N.B. Should this authzContext be derived from a.AgentEnterpriseMeta()
 			if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-				return acl.PermissionDeniedByACL(authz, authzContext, "node:write", "node", a.config.NodeName)
+				return acl.PermissionDeniedByACL(authz, &authzContext, "node", "write", a.config.NodeName)
 			}
 		}
 	}
@@ -131,11 +131,11 @@ func (a *Agent) vetCheckUpdateWithAuthorizer(authz acl.Authorizer, checkID struc
 	if existing := a.State.Check(checkID); existing != nil {
 		if len(existing.ServiceName) > 0 {
 			if authz.ServiceWrite(existing.ServiceName, &authzContext) != acl.Allow {
-				return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", existing.ServiceName)
+				return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", existing.ServiceName)
 			}
 		} else {
 			if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-				return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "node", a.config.NodeName)
+				return acl.PermissionDeniedByACL(authz, &authzContext, "node", "write", a.config.NodeName)
 			}
 		}
 	} else {

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -44,14 +44,14 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 	// Vet the service itself.
 	service.FillAuthzContext(&authzContext)
 	if authz.ServiceWrite(service.Service, &authzContext) != acl.Allow {
-		return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", service.Service)
+		return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessWrite, service.Service)
 	}
 
 	// Vet any service that might be getting overwritten.
 	if existing := a.State.Service(service.CompoundServiceID()); existing != nil {
 		existing.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(existing.Service, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", existing.Service)
+			return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessWrite, existing.Service)
 		}
 	}
 
@@ -60,7 +60,7 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 	if service.Kind == structs.ServiceKindConnectProxy {
 		service.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(service.Proxy.DestinationServiceName, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", service.Proxy.DestinationServiceName)
+			return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessWrite, service.Proxy.DestinationServiceName)
 		}
 	}
 
@@ -74,7 +74,7 @@ func (a *Agent) vetServiceUpdateWithAuthorizer(authz acl.Authorizer, serviceID s
 	if existing := a.State.Service(serviceID); existing != nil {
 		existing.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(existing.Service, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", existing.Service)
+			return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessWrite, existing.Service)
 		}
 	} else {
 		// Take care if modifying this error message.
@@ -96,12 +96,12 @@ func (a *Agent) vetCheckRegisterWithAuthorizer(authz acl.Authorizer, check *stru
 	// Vet the check itself.
 	if len(check.ServiceName) > 0 {
 		if authz.ServiceWrite(check.ServiceName, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", check.ServiceName)
+			return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessWrite, check.ServiceName)
 		}
 	} else {
 		// N.B. Should this authzContext be derived from a.AgentEnterpriseMeta()
 		if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-			return acl.PermissionDeniedByACL(authz, &authzContext, "node", "write", a.config.NodeName)
+			return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceNode, acl.AccessWrite, a.config.NodeName)
 		}
 	}
 
@@ -110,12 +110,12 @@ func (a *Agent) vetCheckRegisterWithAuthorizer(authz acl.Authorizer, check *stru
 		if len(existing.ServiceName) > 0 {
 			// N.B. Should this authzContext be derived from existing.EnterpriseMeta?
 			if authz.ServiceWrite(existing.ServiceName, &authzContext) != acl.Allow {
-				return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", existing.ServiceName)
+				return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessWrite, existing.ServiceName)
 			}
 		} else {
 			// N.B. Should this authzContext be derived from a.AgentEnterpriseMeta()
 			if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-				return acl.PermissionDeniedByACL(authz, &authzContext, "node", "write", a.config.NodeName)
+				return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceNode, acl.AccessWrite, a.config.NodeName)
 			}
 		}
 	}
@@ -131,11 +131,11 @@ func (a *Agent) vetCheckUpdateWithAuthorizer(authz acl.Authorizer, checkID struc
 	if existing := a.State.Check(checkID); existing != nil {
 		if len(existing.ServiceName) > 0 {
 			if authz.ServiceWrite(existing.ServiceName, &authzContext) != acl.Allow {
-				return acl.PermissionDeniedByACL(authz, &authzContext, "service", "write", existing.ServiceName)
+				return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessWrite, existing.ServiceName)
 			}
 		} else {
 			if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-				return acl.PermissionDeniedByACL(authz, &authzContext, "node", "write", a.config.NodeName)
+				return acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceNode, acl.AccessWrite, a.config.NodeName)
 			}
 		}
 	} else {

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -44,16 +44,14 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 	// Vet the service itself.
 	service.FillAuthzContext(&authzContext)
 	if authz.ServiceWrite(service.Service, &authzContext) != acl.Allow {
-		return acl.PermissionDenied("Missing service:write on %s",
-			structs.ServiceIDString(service.Service, &service.EnterpriseMeta))
+		return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", service.Service)
 	}
 
 	// Vet any service that might be getting overwritten.
 	if existing := a.State.Service(service.CompoundServiceID()); existing != nil {
 		existing.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(existing.Service, &authzContext) != acl.Allow {
-			return acl.PermissionDenied("Missing service:write on %s",
-				structs.ServiceIDString(service.Service, &service.EnterpriseMeta))
+			return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", existing.Service)
 		}
 	}
 
@@ -62,8 +60,7 @@ func (a *Agent) vetServiceRegisterWithAuthorizer(authz acl.Authorizer, service *
 	if service.Kind == structs.ServiceKindConnectProxy {
 		service.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(service.Proxy.DestinationServiceName, &authzContext) != acl.Allow {
-			return acl.PermissionDenied("Missing service:write on %s",
-				structs.ServiceIDString(service.Proxy.DestinationServiceName, &service.EnterpriseMeta))
+			return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", service.Proxy.DestinationServiceName)
 		}
 	}
 
@@ -77,8 +74,7 @@ func (a *Agent) vetServiceUpdateWithAuthorizer(authz acl.Authorizer, serviceID s
 	if existing := a.State.Service(serviceID); existing != nil {
 		existing.FillAuthzContext(&authzContext)
 		if authz.ServiceWrite(existing.Service, &authzContext) != acl.Allow {
-			return acl.PermissionDenied("Missing service:write on %s",
-				structs.ServiceIDString(existing.Service, &existing.EnterpriseMeta))
+			return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", existing.Service)
 		}
 	} else {
 		// Take care if modifying this error message.
@@ -100,27 +96,26 @@ func (a *Agent) vetCheckRegisterWithAuthorizer(authz acl.Authorizer, check *stru
 	// Vet the check itself.
 	if len(check.ServiceName) > 0 {
 		if authz.ServiceWrite(check.ServiceName, &authzContext) != acl.Allow {
-			return acl.PermissionDenied("Missing service:write on %s",
-				structs.ServiceIDString(check.ServiceName, &check.EnterpriseMeta))
+			return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", check.ServiceName)
 		}
 	} else {
+		// N.B. Should this authzContext be derived from a.AgentEnterpriseMeta()
 		if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-			return acl.PermissionDenied("Missing node:write on %s",
-				structs.NodeNameString(a.config.NodeName, a.AgentEnterpriseMeta()))
+			return acl.PermissionDeniedByACL(authz, authzContext, "node:write", "node", a.config.NodeName)
 		}
 	}
 
 	// Vet any check that might be getting overwritten.
 	if existing := a.State.Check(check.CompoundCheckID()); existing != nil {
 		if len(existing.ServiceName) > 0 {
+			// N.B. Should this authzContext be derived from existing.EnterpriseMeta?
 			if authz.ServiceWrite(existing.ServiceName, &authzContext) != acl.Allow {
-				return acl.PermissionDenied("Missing service:write on %s",
-					structs.ServiceIDString(existing.ServiceName, &existing.EnterpriseMeta))
+				return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", existing.ServiceName)
 			}
 		} else {
+			// N.B. Should this authzContext be derived from a.AgentEnterpriseMeta()
 			if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-				return acl.PermissionDenied("Missing node:write on %s",
-					structs.NodeNameString(a.config.NodeName, a.AgentEnterpriseMeta()))
+				return acl.PermissionDeniedByACL(authz, authzContext, "node:write", "node", a.config.NodeName)
 			}
 		}
 	}
@@ -136,13 +131,11 @@ func (a *Agent) vetCheckUpdateWithAuthorizer(authz acl.Authorizer, checkID struc
 	if existing := a.State.Check(checkID); existing != nil {
 		if len(existing.ServiceName) > 0 {
 			if authz.ServiceWrite(existing.ServiceName, &authzContext) != acl.Allow {
-				return acl.PermissionDenied("Missing service:write on %s",
-					structs.ServiceIDString(existing.ServiceName, &existing.EnterpriseMeta))
+				return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "service", existing.ServiceName)
 			}
 		} else {
 			if authz.NodeWrite(a.config.NodeName, &authzContext) != acl.Allow {
-				return acl.PermissionDenied("Missing node:write on %s",
-					structs.NodeNameString(a.config.NodeName, a.AgentEnterpriseMeta()))
+				return acl.PermissionDeniedByACL(authz, authzContext, "service:write", "node", a.config.NodeName)
 			}
 		}
 	} else {

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -622,7 +622,7 @@ func (s *HTTPHandlers) AgentJoin(resp http.ResponseWriter, req *http.Request) (i
 	var authzContext acl.AuthorizerContext
 	s.agent.AgentEnterpriseMeta().FillAuthzContext(&authzContext)
 	if authz.AgentWrite(s.agent.config.NodeName, &authzContext) != acl.Allow {
-		return nil, acl.ErrPermissionDenied
+		return nil, acl.PermissionDeniedByACL(authz, &authzContext, "Agent", "Write", s.agent.config.NodeName)
 	}
 
 	// Get the request partition and default to that of the agent.
@@ -686,7 +686,7 @@ func (s *HTTPHandlers) AgentForceLeave(resp http.ResponseWriter, req *http.Reque
 	}
 	// TODO(partitions): should this be possible in a partition?
 	if authz.OperatorWrite(nil) != acl.Allow {
-		return nil, acl.ErrPermissionDenied
+		return nil, acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Write")
 	}
 
 	// Get the request partition and default to that of the agent.
@@ -1008,7 +1008,7 @@ func (s *HTTPHandlers) AgentHealthServiceByID(resp http.ResponseWriter, req *htt
 
 	if service := s.agent.State.Service(sid); service != nil {
 		if authz.ServiceRead(service.Service, &authzContext) != acl.Allow {
-			return nil, acl.ErrPermissionDenied
+			return nil, acl.PermissionDeniedByACL(authz, &authzContext, "Service", "Read", service.Service)
 		}
 		code, status, healthChecks := agentHealthService(sid, s)
 		if returnTextPlain(req) {
@@ -1061,7 +1061,7 @@ func (s *HTTPHandlers) AgentHealthServiceByName(resp http.ResponseWriter, req *h
 	}
 
 	if authz.ServiceRead(serviceName, &authzContext) != acl.Allow {
-		return nil, acl.ErrPermissionDenied
+		return nil, acl.PermissionDeniedByACL(authz, &authzContext, "Service", "Read", serviceName)
 	}
 
 	if !s.validateRequestPartition(resp, &entMeta) {
@@ -1684,7 +1684,7 @@ func (s *HTTPHandlers) AgentHost(resp http.ResponseWriter, req *http.Request) (i
 
 	// TODO(partitions): should this be possible in a partition?
 	if authz.OperatorRead(nil) != acl.Allow {
-		return nil, acl.ErrPermissionDenied
+		return nil, acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Read")
 	}
 
 	return debug.CollectHostInfo(), nil

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -622,7 +622,7 @@ func (s *HTTPHandlers) AgentJoin(resp http.ResponseWriter, req *http.Request) (i
 	var authzContext acl.AuthorizerContext
 	s.agent.AgentEnterpriseMeta().FillAuthzContext(&authzContext)
 	if authz.AgentWrite(s.agent.config.NodeName, &authzContext) != acl.Allow {
-		return nil, acl.PermissionDeniedByACL(authz, &authzContext, "Agent", "Write", s.agent.config.NodeName)
+		return nil, acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceAgent, acl.AccessWrite, s.agent.config.NodeName)
 	}
 
 	// Get the request partition and default to that of the agent.
@@ -686,7 +686,7 @@ func (s *HTTPHandlers) AgentForceLeave(resp http.ResponseWriter, req *http.Reque
 	}
 	// TODO(partitions): should this be possible in a partition?
 	if authz.OperatorWrite(nil) != acl.Allow {
-		return nil, acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Write")
+		return nil, acl.PermissionDeniedByACLUnnamed(authz, nil, acl.ResourceOperator, acl.AccessWrite)
 	}
 
 	// Get the request partition and default to that of the agent.
@@ -1008,7 +1008,7 @@ func (s *HTTPHandlers) AgentHealthServiceByID(resp http.ResponseWriter, req *htt
 
 	if service := s.agent.State.Service(sid); service != nil {
 		if authz.ServiceRead(service.Service, &authzContext) != acl.Allow {
-			return nil, acl.PermissionDeniedByACL(authz, &authzContext, "Service", "Read", service.Service)
+			return nil, acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessRead, service.Service)
 		}
 		code, status, healthChecks := agentHealthService(sid, s)
 		if returnTextPlain(req) {
@@ -1061,7 +1061,7 @@ func (s *HTTPHandlers) AgentHealthServiceByName(resp http.ResponseWriter, req *h
 	}
 
 	if authz.ServiceRead(serviceName, &authzContext) != acl.Allow {
-		return nil, acl.PermissionDeniedByACL(authz, &authzContext, "Service", "Read", serviceName)
+		return nil, acl.PermissionDeniedByACL(authz, &authzContext, acl.ResourceService, acl.AccessRead, serviceName)
 	}
 
 	if !s.validateRequestPartition(resp, &entMeta) {
@@ -1684,7 +1684,7 @@ func (s *HTTPHandlers) AgentHost(resp http.ResponseWriter, req *http.Request) (i
 
 	// TODO(partitions): should this be possible in a partition?
 	if authz.OperatorRead(nil) != acl.Allow {
-		return nil, acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Read")
+		return nil, acl.PermissionDeniedByACLUnnamed(authz, nil, acl.ResourceOperator, acl.AccessRead)
 	}
 
 	return debug.CollectHostInfo(), nil

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -25,7 +25,7 @@ func (op *Operator) AutopilotGetConfiguration(args *structs.DCSpecificRequest, r
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDenied("Missing operator:read permissions")
+		return acl.PermissionDeniedByACLUnnamed(authz, "Operator:Read", "")
 	}
 
 	state := op.srv.fsm.State()
@@ -57,7 +57,7 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 		return err
 	}
 	if authz.OperatorWrite(nil) != acl.Allow {
-		return acl.PermissionDenied("Missing operator:write permissions")
+		return acl.PermissionDeniedByACLUnnamed(authz, "Operator:Write", "")
 	}
 
 	// Apply the update
@@ -92,7 +92,7 @@ func (op *Operator) ServerHealth(args *structs.DCSpecificRequest, reply *structs
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDenied("Missing operator:read permissions")
+		return acl.PermissionDeniedByACLUnnamed(authz, "Operator:Read", "")
 	}
 
 	state := op.srv.autopilot.GetState()
@@ -159,7 +159,7 @@ func (op *Operator) AutopilotState(args *structs.DCSpecificRequest, reply *autop
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDenied("Missing operator:read permissions")
+		return acl.PermissionDeniedByACLUnnamed(authz, "Operator:Read", "")
 	}
 
 	state := op.srv.autopilot.GetState()

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -25,7 +25,7 @@ func (op *Operator) AutopilotGetConfiguration(args *structs.DCSpecificRequest, r
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDeniedByACLUnnamed(authz, "Operator:Read", "")
+		return acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Read")
 	}
 
 	state := op.srv.fsm.State()
@@ -57,7 +57,7 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 		return err
 	}
 	if authz.OperatorWrite(nil) != acl.Allow {
-		return acl.PermissionDeniedByACLUnnamed(authz, "Operator:Write", "")
+		return acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Write")
 	}
 
 	// Apply the update
@@ -92,7 +92,7 @@ func (op *Operator) ServerHealth(args *structs.DCSpecificRequest, reply *structs
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDeniedByACLUnnamed(authz, "Operator:Read", "")
+		return acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Read")
 	}
 
 	state := op.srv.autopilot.GetState()
@@ -159,7 +159,7 @@ func (op *Operator) AutopilotState(args *structs.DCSpecificRequest, reply *autop
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDeniedByACLUnnamed(authz, "Operator:Read", "")
+		return acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Read")
 	}
 
 	state := op.srv.autopilot.GetState()

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -25,7 +25,7 @@ func (op *Operator) AutopilotGetConfiguration(args *structs.DCSpecificRequest, r
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Read")
+		return acl.PermissionDeniedByACLUnnamed(authz, nil, acl.ResourceOperator, acl.AccessRead)
 	}
 
 	state := op.srv.fsm.State()
@@ -57,7 +57,7 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 		return err
 	}
 	if authz.OperatorWrite(nil) != acl.Allow {
-		return acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Write")
+		return acl.PermissionDeniedByACLUnnamed(authz, nil, acl.ResourceOperator, acl.AccessWrite)
 	}
 
 	// Apply the update
@@ -92,7 +92,7 @@ func (op *Operator) ServerHealth(args *structs.DCSpecificRequest, reply *structs
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Read")
+		return acl.PermissionDeniedByACLUnnamed(authz, nil, acl.ResourceOperator, acl.AccessRead)
 	}
 
 	state := op.srv.autopilot.GetState()
@@ -159,7 +159,7 @@ func (op *Operator) AutopilotState(args *structs.DCSpecificRequest, reply *autop
 		return err
 	}
 	if authz.OperatorRead(nil) != acl.Allow {
-		return acl.PermissionDeniedByACLUnnamed(authz, nil, "Operator", "Read")
+		return acl.PermissionDeniedByACLUnnamed(authz, nil, acl.ResourceOperator, acl.AccessRead)
 	}
 
 	state := op.srv.autopilot.GetState()

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -172,6 +172,10 @@ func NodeNameString(node string, _ *EnterpriseMeta) string {
 	return node
 }
 
+func IDToEnterpriseObjectDescriptor(id string, entMeta *EnterpriseMeta) acl.EnterpriseObjectDescriptor {
+	return acl.EnterpriseObjectDescriptor{Name: id}
+}
+
 func ServiceIDString(id string, _ *EnterpriseMeta) string {
 	return id
 }

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -172,10 +172,6 @@ func NodeNameString(node string, _ *EnterpriseMeta) string {
 	return node
 }
 
-func IDToEnterpriseObjectDescriptor(id string, entMeta *EnterpriseMeta) acl.EnterpriseObjectDescriptor {
-	return acl.EnterpriseObjectDescriptor{Name: id}
-}
-
 func ServiceIDString(id string, _ *EnterpriseMeta) string {
 	return id
 }


### PR DESCRIPTION
Port of the structured error work in consul-enterprise.

This is the OSS side of #12239 