### PR TITLE
[1.9.x] Fix the build

### DIFF
--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -5711,12 +5711,13 @@ func TestStore_EnsureService_DoesNotPanicOnIngressGateway(t *testing.T) {
 				Services: []structs.IngressService{{Name: "the-service"}},
 			},
 		},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err = store.EnsureRegistration(2, &structs.RegisterRequest{
 		Node: "the-node",
 		Service: &structs.NodeService{
+			ID:      "the-proxy-id",
 			Kind:    structs.ServiceKindConnectProxy,
 			Service: "the-proxy",
 			Proxy: structs.ConnectProxyConfig{


### PR DESCRIPTION
this func has an extra arg in 1.9.x, and for some reason the service needs a ServiceID as well.