### PR TITLE
ui: Make sure saving intentions from topology includes the partition

### DIFF
--- a/.changelog/12317.txt
+++ b/.changelog/12317.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+ui: Include partition data when saving an intention from the topology
+visualization
+```

--- a/ui/packages/consul-ui/app/routes/dc/services/show/topology.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/topology.js
@@ -20,8 +20,10 @@ export default class TopologyRoute extends Route {
           item.Datacenter === source.Datacenter &&
           item.SourceName === source.Name &&
           item.SourceNS === source.Namespace &&
+          item.SourcePartition === source.Partition &&
           item.DestinationName === destination.Name &&
-          item.DestinationNS === destination.Namespace
+          item.DestinationNS === destination.Namespace &&
+          item.DestinationPartition === destination.Partition
         );
       });
       if (typeof intention === 'undefined') {
@@ -29,8 +31,10 @@ export default class TopologyRoute extends Route {
           Datacenter: source.Datacenter,
           SourceName: source.Name,
           SourceNS: source.Namespace || 'default',
+          SourcePartition: source.Partition || 'default',
           DestinationName: destination.Name,
           DestinationNS: destination.Namespace || 'default',
+          DestinationPartition: destination.Partition || 'default',
         });
       } else {
         // we found an intention in the find higher up, so we are updating


### PR DESCRIPTION
See title.

Manually checking this involves clicking one of the [x] icons in the topology view. You'll see the `exact` HTTP request now includes the partition data. Please note the partition data will be sent whether in a partition supporting version of Consul or not, where partitions aren't supported `default` will be used, this is expected.

The preview site will not show you this information as yet as the preview site uses an in-browser HTTP server so Network traffic isn't 100% visible. When testing locally with `make start` our mock data is automatically served from a little node based HTTP server so you _will_ be able to see the Network requests there (you could also set this up via Consul for realz and just use `make start-consul`).