### PR TITLE
local: fixes a data race in anti-entropy sync

### DIFF
--- a/.changelog/12324.txt
+++ b/.changelog/12324.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-fix data race in TestAgentConfigWatcherSidecarProxy
+local: fixes a data race in anti-entropy sync that could cause the wrong tags to be applied to a service when EnableTagOverride is used
 ```

--- a/.changelog/12324.txt
+++ b/.changelog/12324.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix data race in TestAgentConfigWatcherSidecarProxy
+```

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1086,12 +1086,14 @@ func (l *State) updateSyncState() error {
 		// Make a shallow copy since we may mutate it below and other readers
 		// may be reading it and we want to avoid a race.
 		nextService := *ls.Service
+		changed := false
 
 		// If our definition is different, we need to update it. Make a
 		// copy so that we don't retain a pointer to any actual state
 		// store info for in-memory RPCs.
 		if nextService.EnableTagOverride {
 			nextService.Tags = structs.CloneStringSlice(rs.Tags)
+			changed = true
 		}
 
 		// Merge any tagged addresses with the consul- prefix (set by the server)
@@ -1109,9 +1111,12 @@ func (l *State) updateSyncState() error {
 				}
 			}
 			nextService.TaggedAddresses = m
+			changed = true
 		}
 
-		ls.Service = &nextService
+		if changed {
+			ls.Service = &nextService
+		}
 		ls.InSync = ls.Service.IsSame(rs)
 	}
 

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1118,7 +1118,6 @@ func (l *State) updateSyncState() error {
 			if !wasCopied {
 				// Make a shallow copy since we're going to mutate it and other
 				// readers may be reading it and we want to avoid a race.
-				wasCopied = true
 				dup := *ls.Service
 				ls.Service = &dup
 			}


### PR DESCRIPTION
The race detector noticed this initially in `TestAgentConfigWatcherSidecarProxy` but it is not restricted to just tests.

The two main changes here were:

- ensure that before we mutate the internal `agent/local` representation of a Service (for tags or VIPs) we clone those fields
- ensure that there's no function argument joint ownership between the caller of a function and the local state when calling `AddService`, `AddCheck`, and related using `copystructure` for now.

```
Failed
=== RUN   TestAgentConfigWatcherSidecarProxy
[INFO] freeport: detected ephemeral port range of [32768, 60999]
[INFO] freeport: reducing max blocks from 30 to 15 to avoid the ephemeral port range
==================
WARNING: DATA RACE
Write at 0x00c000d7e958 by goroutine 130:
  github.com/hashicorp/consul/agent/local.(*State).updateSyncState()
      /home/circleci/project/agent/local/state.go:1109 +0x109e
  github.com/hashicorp/consul/agent/local.(*State).SyncFull()
      /home/circleci/project/agent/local/state.go:1191 +0x30
  github.com/hashicorp/consul/agent/ae.(*StateSyncer).nextFSMState()
      /home/circleci/project/agent/ae/ae.go:178 +0xa2
  github.com/hashicorp/consul/agent/ae.(*StateSyncer).nextFSMState-fm()
      /home/circleci/project/agent/ae/ae.go:171 +0x4d
  github.com/hashicorp/consul/agent/ae.(*StateSyncer).runFSM()
      /home/circleci/project/agent/ae/ae.go:164 +0x89
  github.com/hashicorp/consul/agent/ae.(*StateSyncer).Run()
      /home/circleci/project/agent/ae/ae.go:158 +0x48
  github.com/hashicorp/consul/agent.(*Agent).StartSync·dwrap·28()
      /home/circleci/project/agent/agent.go:1616 +0x39

Previous read at 0x00c000d7e958 by goroutine 167:
  github.com/hashicorp/consul/agent.buildAgentService()
      /home/circleci/project/agent/agent_endpoint.go:260 +0x1a4
  github.com/hashicorp/consul/agent.(*HTTPHandlers).AgentService.func1()
      /home/circleci/project/agent/agent_endpoint.go:448 +0x29d
  github.com/hashicorp/consul/agent.(*Agent).LocalBlockingQuery()
      /home/circleci/project/agent/agent.go:3842 +0x2d0
  github.com/hashicorp/consul/agent.(*HTTPHandlers).AgentService()
      /home/circleci/project/agent/agent_endpoint.go:423 +0x411
  github.com/hashicorp/consul/agent.(*HTTPHandlers).handler.func3()
      /home/circleci/project/agent/http.go:292 +0x65
  github.com/hashicorp/consul/agent.(*HTTPHandlers).wrap.func1()
      /home/circleci/project/agent/http.go:548 +0x1029
  github.com/hashicorp/consul/agent.(*HTTPHandlers).handler.func1.1()
      /home/circleci/project/agent/http.go:226 +0xcb
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2047 +0x4d
  github.com/NYTimes/gziphandler.GzipHandlerWithOpts.func1.1()
      /home/circleci/go/pkg/mod/github.com/!n!y!times/gziphandler@v1.0.1/gzip.go:287 +0x433
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2047 +0x4d
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2425 +0xc5
  github.com/hashicorp/go-cleanhttp.PrintablePathCheckHandler.func1()
      /home/circleci/go/pkg/mod/github.com/hashicorp/go-cleanhttp@v0.5.1/handlers.go:42 +0xc1
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2047 +0x4d
  github.com/hashicorp/consul/agent.(*wrappedMux).ServeHTTP()
      /home/circleci/project/agent/http.go:155 +0x69
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2879 +0x89a
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1930 +0x12e4
  net/http.(*Server).Serve·dwrap·87()
      /usr/local/go/src/net/http/server.go:3034 +0x58

Goroutine 130 (running) created at:
  github.com/hashicorp/consul/agent.(*Agent).StartSync()
      /home/circleci/project/agent/agent.go:1616 +0xb8
  github.com/hashicorp/consul/agent.(*TestAgent).Start()
      /home/circleci/project/agent/testagent.go:230 +0xcaa
  github.com/hashicorp/consul/agent.StartTestAgent.func1()
      /home/circleci/project/agent/testagent.go:106 +0x53
  github.com/hashicorp/consul/sdk/testutil/retry.run.func2()
      /home/circleci/project/sdk/testutil/retry/retry.go:148 +0x58
  github.com/hashicorp/consul/sdk/testutil/retry.run()
      /home/circleci/project/sdk/testutil/retry/retry.go:149 +0xfe
  github.com/hashicorp/consul/sdk/testutil/retry.RunWith()
      /home/circleci/project/sdk/testutil/retry/retry.go:108 +0x72
  github.com/hashicorp/consul/agent.StartTestAgent()
      /home/circleci/project/agent/testagent.go:104 +0x13b
  github.com/hashicorp/consul/connect/proxy.TestAgentConfigWatcherSidecarProxy()
      /home/circleci/project/connect/proxy/config_test.go:90 +0x164
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47

Goroutine 167 (running) created at:
  net/http.(*Server).Serve()
      /usr/local/go/src/net/http/server.go:3034 +0x847
  github.com/hashicorp/consul/agent.newAPIServerHTTP.func1()
      /home/circleci/project/agent/apiserver.go:104 +0x78
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/circleci/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x96
```