### PR TITLE
rpc: improve docs for blockingQuery

### DIFF
--- a/agent/consul/gateway_locator.go
+++ b/agent/consul/gateway_locator.go
@@ -8,14 +8,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+	memdb "github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/lib/stringslice"
 	"github.com/hashicorp/consul/logging"
-	"github.com/hashicorp/go-hclog"
-	memdb "github.com/hashicorp/go-memdb"
 )
 
 // GatewayLocator assists in selecting an appropriate mesh gateway when wan
@@ -269,7 +270,7 @@ func getRandomItem(items []string) string {
 }
 
 type serverDelegate interface {
-	blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta structs.QueryMetaCompat, fn queryFn) error
+	blockingQuery(queryOpts blockingQueryOptions, queryMeta blockingQueryResponseMeta, fn queryFn) error
 	IsLeader() bool
 	LeaderLastContact() time.Time
 	setDatacenterSupportsFederationStates()

--- a/agent/consul/gateway_locator_test.go
+++ b/agent/consul/gateway_locator_test.go
@@ -493,8 +493,8 @@ func (d *testServerDelegate) datacenterSupportsFederationStates() bool {
 
 // This is just enough to exercise the logic.
 func (d *testServerDelegate) blockingQuery(
-	queryOpts structs.QueryOptionsCompat,
-	queryMeta structs.QueryMetaCompat,
+	queryOpts blockingQueryOptions,
+	queryMeta blockingQueryResponseMeta,
 	fn queryFn,
 ) error {
 	minQueryIndex := queryOpts.GetMinQueryIndex()


### PR DESCRIPTION
Clarify the rules for implementing a query function passed to `Server.blockingQuery`. Related to #12109 and #12110

The new interfaces here are to follow the Go convention of accepting a small interface that documents the methods used by the function.  They help document the function by being explicit about which methods are used.

In the future we can probably removes `structs.QueryOptionsCompat` and `structs.QueryMetaCompat` since those are now only used by a few parse functions in `http.go`. By following the pattern used here we could replace that usage as well.