### PR TITLE
ci: fix stalebot config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,4 @@ jobs:
             mistake or you wish to re-open at any time in the future, please
             leave a comment and it will be re-surfaced for the maintainers to review.
           stale-pr-label: meta/stale
-          exempt-pr-labels:
-            - meta/staleproof
+          exempt-pr-labels: meta/staleproof


### PR DESCRIPTION
I noticed that our stale action is broken. Apparently, the `exempt-pr-labels` key for the stale action needs to be a string and not an array type. 