### PR TITLE
[1.11.x] Backport CRT-related fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:
       - release/1.11.x
-      - eculver/1.11/dockerfile-fixes
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     # Sequence of patterns matched against refs/heads
     branches: 
       - release/1.11.x
+      - eculver/1.11/dockerfile-fixes
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
           config_dir: ".release/linux/package"
           preinstall: ".release/linux/preinstall"
           postinstall: ".release/linux/postinstall"
+          preremove: ".release/linux/preremove"
           postremove: ".release/linux/postremove"
 
       - name: Set Package Names

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,6 +240,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,7 @@ jobs:
           GOLDFLAGS: "${{needs.get-product-version.outputs.shared-ldflags}}"
         run: |
           mkdir dist out
+          [ "${{ matrix.goarch }}" == "arm" ] && export GOARM=5
           go build -ldflags="$GOLDFLAGS" -o dist/ .
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches: 
+    branches:
       - release/1.11.x
       - eculver/1.11/dockerfile-fixes
 
@@ -242,10 +242,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
+
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -11,10 +11,7 @@ project "consul" {
     repository = "consul"
     release_branches = [
       "main",
-      "release/1.8.x",
-      "release/1.9.x",
-      "release/1.10.x",
-      "release/1.11.x",
+      "release/1.11.x"
     ]
   }
 }
@@ -42,8 +39,36 @@ event "upload-dev" {
   }
 }
 
-event "notarize-darwin-amd64" {
+event "security-scan-binaries" {
   depends = ["upload-dev"]
+  action "security-scan-binaries" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-binaries"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "security-scan-containers" {
+  depends = ["security-scan-binaries"]
+  action "security-scan-containers" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-containers"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "notarize-darwin-amd64" {
+  depends = ["security-scan-containers"]
   action "notarize-darwin-amd64" {
     organization = "hashicorp"
     repository = "crt-workflows-common"

--- a/.release/linux/preremove
+++ b/.release/linux/preremove
@@ -1,0 +1,11 @@
+#!/bin/bash
+case "$1" in
+    remove | 0)
+        if [ -d "/run/systemd/system" ]; then
+            systemctl --no-reload disable consul.service > /dev/null || :
+            systemctl stop consul.service > /dev/null || :
+        fi
+        ;;
+esac
+
+exit 0

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,13 @@
+container {
+	dependencies = true
+	alpine_secdb = false
+	secrets      = false
+}
+
+binary {
+	secrets      = true
+	go_modules   = false
+	osv          = true
+	oss_index    = true
+	nvd          = true
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,126 @@
-# This Dockerfile creates a production release image for the project using crt release flow.
-FROM alpine:3.13 as  default
+# This Dockerfile contains multiple targets.
+# Use 'docker build --target=<name> .' to build one.
+# e.g. `docker build --target=official .`
+#
+# All non-dev targets have a VERSION argument that must be provided 
+# via --build-arg=VERSION=<version> when building. 
+# e.g. --build-arg VERSION=1.11.2
+#
+# `default` is the production docker image which cannot be built locally. 
+# For local dev and testing purposes, please build and use the `dev` docker image.
+
+
+# Official docker image that includes binaries from releases.hashicorp.com. This
+# downloads the release from releases.hashicorp.com and therefore requires that
+# the release is published before building the Docker image.
+FROM docker.mirror.hashicorp.services/alpine:3.15 as official
+
+# This is the release of Consul to pull in.
+ARG VERSION
+
+LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
+      org.opencontainers.image.url="https://www.consul.io/" \
+      org.opencontainers.image.documentation="https://www.consul.io/docs" \
+      org.opencontainers.image.source="https://github.com/hashicorp/consul" \
+      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.vendor="HashiCorp" \
+      org.opencontainers.image.title="consul" \
+      org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
+
+# This is the location of the releases.
+ENV HASHICORP_RELEASES=https://releases.hashicorp.com
+
+# Create a consul user and group first so the IDs get set the same way, even as
+# the rest of this may change over time.
+RUN addgroup consul && \
+    adduser -S -G consul consul
+
+# Set up certificates, base tools, and Consul.
+# libc6-compat is needed to symlink the shared libraries for ARM builds
+RUN set -eux && \
+    apk add --no-cache ca-certificates curl dumb-init gnupg libcap openssl su-exec iputils jq libc6-compat iptables tzdata && \
+    gpg --keyserver keyserver.ubuntu.com --recv-keys C874011F0AB405110D02105534365D9472D7468F && \
+    mkdir -p /tmp/build && \
+    cd /tmp/build && \
+    apkArch="$(apk --print-arch)" && \
+    case "${apkArch}" in \
+        aarch64) consulArch='arm64' ;; \
+        armhf) consulArch='arm' ;; \
+        x86) consulArch='386' ;; \
+        x86_64) consulArch='amd64' ;; \
+        *) echo >&2 "error: unsupported architecture: ${apkArch} (see ${HASHICORP_RELEASES}/consul/${VERSION}/)" && exit 1 ;; \
+    esac && \
+    wget ${HASHICORP_RELEASES}/consul/${VERSION}/consul_${VERSION}_linux_${consulArch}.zip && \
+    wget ${HASHICORP_RELEASES}/consul/${VERSION}/consul_${VERSION}_SHA256SUMS && \
+    wget ${HASHICORP_RELEASES}/consul/${VERSION}/consul_${VERSION}_SHA256SUMS.sig && \
+    gpg --batch --verify consul_${VERSION}_SHA256SUMS.sig consul_${VERSION}_SHA256SUMS && \
+    grep consul_${VERSION}_linux_${consulArch}.zip consul_${VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip -d /tmp/build consul_${VERSION}_linux_${consulArch}.zip && \
+    cp /tmp/build/consul /bin/consul && \
+    if [ -f /tmp/build/EULA.txt ]; then mkdir -p /usr/share/doc/consul; mv /tmp/build/EULA.txt /usr/share/doc/consul/EULA.txt; fi && \
+    if [ -f /tmp/build/TermsOfEvaluation.txt ]; then mkdir -p /usr/share/doc/consul; mv /tmp/build/TermsOfEvaluation.txt /usr/share/doc/consul/TermsOfEvaluation.txt; fi && \
+    cd /tmp && \
+    rm -rf /tmp/build && \
+    gpgconf --kill all && \
+    apk del gnupg openssl && \
+    rm -rf /root/.gnupg && \
+# tiny smoke test to ensure the binary we downloaded runs
+    consul version
+
+# The /consul/data dir is used by Consul to store state. The agent will be started
+# with /consul/config as the configuration directory so you can add additional
+# config files in that location.
+RUN mkdir -p /consul/data && \
+    mkdir -p /consul/config && \
+    chown -R consul:consul /consul
+
+# set up nsswitch.conf for Go's "netgo" implementation which is used by Consul,
+# otherwise DNS supercedes the container's hosts file, which we don't want.
+RUN test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
+
+# Expose the consul data directory as a volume since there's mutable state in there.
+VOLUME /consul/data
+
+# Server RPC is used for communication between Consul clients and servers for internal
+# request forwarding.
+EXPOSE 8300
+
+# Serf LAN and WAN (WAN is used only by Consul servers) are used for gossip between
+# Consul agents. LAN is within the datacenter and WAN is between just the Consul
+# servers in all datacenters.
+EXPOSE 8301 8301/udp 8302 8302/udp
+
+# HTTP and DNS (both TCP and UDP) are the primary interfaces that applications
+# use to interact with Consul.
+EXPOSE 8500 8600 8600/udp
+
+# Consul doesn't need root privileges so we run it as the consul user from the
+# entry point script. The entry point script also uses dumb-init as the top-level
+# process to reap any zombie processes created by Consul sub-processes.
+COPY .release/docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+# By default you'll get an insecure single-node development server that stores
+# everything in RAM, exposes a web UI and HTTP endpoints, and bootstraps itself.
+# Don't use this configuration for production.
+CMD ["agent", "-dev", "-client", "0.0.0.0"]
+
+
+# Production docker image that uses CI built binaries.
+# Remember, this image cannot be built locally.
+FROM docker.mirror.hashicorp.services/alpine:3.15 as default
 
 ARG VERSION
 ARG BIN_NAME
 
-# PRODUCT_NAME and PRODUCT_VERSION are the name of the software in releases.hashicorp.com
+# PRODUCT_NAME and PRODUCT_VERSION are the name of the software on releases.hashicorp.com
 # and the version to download. Example: PRODUCT_NAME=consul PRODUCT_VERSION=1.2.3.
 ENV BIN_NAME=$BIN_NAME
 ENV VERSION=$VERSION
-#ARG CONSUL_VERSION=$VERSION
-#ARG PRODUCT_VERSION
+
 ARG PRODUCT_REVISION
 ARG PRODUCT_NAME=$BIN_NAME
+
 # TARGETOS and TARGETARCH are set automatically when --platform is provided.
 ARG TARGETOS TARGETARCH
 
@@ -24,7 +133,22 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
       org.opencontainers.image.title="consul" \
       org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
 
-RUN apk add --no-cache dumb-init
+# Set up certificates and base tools.
+# libc6-compat is needed to symlink the shared libraries for ARM builds
+RUN apk add -v --no-cache \
+		dumb-init \
+		libc6-compat \
+		iptables \
+		tzdata \
+		curl \
+		ca-certificates \
+		gnupg \
+		iputils \ 
+		libcap \
+		openssl \
+		su-exec \
+		jq 
+
 # Create a consul user and group first so the IDs get set the same way, even as
 # the rest of this may change over time.
 RUN addgroup $BIN_NAME && \
@@ -35,6 +159,10 @@ COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
 RUN mkdir -p /consul/data && \
     mkdir -p /consul/config && \
     chown -R consul:consul /consul
+
+# Set up nsswitch.conf for Go's "netgo" implementation which is used by Consul,
+# otherwise DNS supercedes the container's hosts file, which we don't want.
+RUN test -e /etc/nsswitch.conf || echo 'hosts: files dns' > /etc/nsswitch.conf
 
 # Expose the consul data directory as a volume since there's mutable state in there.
 VOLUME /consul/data


### PR DESCRIPTION
This is a backport of a number of either failed or unapplied changes relating to CRT and Docker. In particular, these are the PRs that contain the original changes that have already been merged to `main`:

- #12097 - The bulk of changes to fix the production Dockerfile and become compatible with CRT
- #12276 - Update Dockerfile to use `alpine:3.15`
- #11956 - Enable security scanner for Consul binaries and containers
- #12275 - Update security scanner config to work with not-yet-deprecated keys
- #12281 - Temporarily turn off `alpine_secdb` container scanning and secret scanning
- #12147 -  Fix issues in Linux `preremove`/`postremove` package scripts

See example runs of the build workflow [here](https://github.com/hashicorp/consul/actions/workflows/build.yml?query=branch%3Aeculver%2F1.11%2Fdockerfile-fixes)