### PR TITLE
Fix broken link on Downloads page on wedsite

### DIFF
--- a/website/components/downloads-props/index.jsx
+++ b/website/components/downloads-props/index.jsx
@@ -22,7 +22,7 @@ export default function DownloadsProps(preMerchandisingSlot) {
       {
         label: 'Kubernetes Quickstart',
         href:
-          'https: //learn.hashicorp.com/collections/consul/gs-consul-service-mesh',
+          'https://learn.hashicorp.com/collections/consul/gs-consul-service-mesh',
       },
       {
         label: 'View all Consul tutorials',


### PR DESCRIPTION
The link to the Kubernetes Quickstart guide had a typo (space character) in the URL.