### PR TITLE
docs/nia: Update task delete with async behavior

### DIFF
--- a/website/content/docs/nia/api/tasks.mdx
+++ b/website/content/docs/nia/api/tasks.mdx
@@ -269,7 +269,7 @@ Response if changes present:
 
 ## Delete Task
 
-This endpoint allows for deletion of existing tasks. It does not allow deletion of a task that is currently running.
+This endpoint allows for deletion of existing tasks. It marks a task for deletion based on the name provided. If the task is not running, it will be deleted immediately. Otherwise, it will be deleted once the task is completed.
 
 | Method   | Path                | Produces           |
 | -------- | ------------------- | ------------------ |
@@ -283,11 +283,10 @@ This endpoint allows for deletion of existing tasks. It does not allow deletion 
 
 #### Response Statuses
 
-| Status | Reason                             |
-| ------ | ---------------------------------- |
-| 200    | Successfully deleted the task      |
-| 404    | Task with the given name not found |
-| 409    | Task is currently running          |
+| Status | Reason                                    |
+| ------ | ----------------------------------------- |
+| 202    | Successfully marked the task for deletion |
+| 404    | Task with the given name not found        |
 
 #### Response Fields
 

--- a/website/content/docs/nia/cli/task.mdx
+++ b/website/content/docs/nia/cli/task.mdx
@@ -163,7 +163,8 @@ $ consul-terraform-sync task disable task_b
 
 ## task delete
 
-`task delete` command deletes an existing task. The command will ask the user for approval before deleting the task. A task that is currently running cannot be deleted, and the delete must be retried after the task has completed.
+`task delete` command deletes an existing task. The command will ask the user for approval before deleting the task. The task will be marked for deletion and will be deleted immediately if it is not running. Otherwise, the task will be deleted once it has completed.
+
 
 ### Usage
 
@@ -183,11 +184,13 @@ $ consul-terraform-sync task disable task_b
 $ consul-terraform-sync task delete task_a
 ==> Do you want to delete 'task_a'?
      - This action cannot be undone.
-    Only 'yes' will be accepted to approve.
+     - If the task is not running, it will be deleted immediately.
+     - If the task is running, it will be deleted once it has completed.
+    Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.
 
 Enter a value: yes
 
-==> Deleting task 'task_a'...
+==> Marking task 'task_a' for deletion...
 
-==> Deleted task 'task_a'
+==> Task 'task_a' has been marked for deletion and will be deleted when not running.
 ```


### PR DESCRIPTION
CTS delete task command is now asynchronous, so updating docs to reflect
this new behavior.

https://consul-i5h6x6w1g-hashicorp.vercel.app/docs/nia/api/tasks#delete-task
https://consul-i5h6x6w1g-hashicorp.vercel.app/docs/nia/cli/task#task-delete
