### PR TITLE
Add GOARM=5 when building on arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,7 @@ jobs:
           GOLDFLAGS: "${{needs.get-product-version.outputs.shared-ldflags}}"
         run: |
           mkdir dist out
+          [ "${{ matrix.goarch }}" == "arm" ] && export GOARM=5
           go build -ldflags="$GOLDFLAGS" -o dist/ .
           zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
 


### PR DESCRIPTION
This corrects  `build.yml` on `main` to include `GOARM=5` when building on `GOARCH=arm`.  This change was added to the 1.10.x and 1.9.x release branches as part of onboarding to CRT but was missed on main and the 1.11.x branch.  

Signed-off-by: Scott Macfarlane <smacfarlane@hashicorp.com>