### PR TITLE
ui: Remove class-map reference from 1.11

### DIFF
--- a/.changelog/12358.txt
+++ b/.changelog/12358.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix missing helper javascript error
+```

--- a/ui/packages/consul-ui/app/components/consul/instance-checks/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/instance-checks/index.hbs
@@ -16,11 +16,7 @@ as |grouped|}}
       checks.firstObject.Status
     as |status|}}
     <dl
-      class={{class-map
-        'consul-instance-checks'
-        (array 'empty' (eq checks.length 0))
-        (array status (not-eq checks.length 0))
-      }}
+      class={{concat 'consul-instance-checks' (if (eq checks.length 0) ' empty') (if (not-eq checks.length 0) (concat ' ' status))}}
       ...attributes
     >
       <dt>


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/12351

A new helper added for 1.12 work unfortunately ended up in our 1.11 branch. This removes the helper and replaces it with equivalent code.