### PR TITLE
Document API ability to URL-decode resource names

### DIFF
--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -640,7 +640,8 @@ The corresponding CLI command is [`consul join`](/commands/join).
 ### Parameters
 
 - `address` `(string: <required>)` - Specifies the address of the other agent to
-  join. This is specified as part of the URL.
+  join. This is specified as part of the URL as a path segment and
+  [can be URL-encoded](/api-docs#parses-url-encoded-resource-names).
 
 - `wan` `(bool: false)` - Specifies to try and join over the WAN pool. This is
   only optional for agents running in server mode. This is specified as part of
@@ -720,7 +721,9 @@ The corresponding CLI command is [`consul force-leave`](/commands/force-leave).
 
 ### Parameters
 
-- `node` `(string: <required>)` - Specifies the name of the node to be forced into `left` state. This is specified as part of the URL.
+- `node` `(string: <required>)` - Specifies the name of the node to be forced into `left` state.
+  This is specified as part of the URL as a path segment and
+  [can be URL-encoded](/api-docs#parses-url-encoded-resource-names).
 
 - `prune` `(bool: false)` - Specifies whether to forcibly remove the node from the list of members.
   Pruning a node in the `left` or `failed` state removes it from the list altogether. 

--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -75,6 +75,20 @@ $ curl \
     http://127.0.0.1:8500/v1/kv/foo
 ```
 
+## Parses URL-Encoded Resource Names
+
+Some Consul HTTP API endpoints require resource names in the URL. To pass a resource
+name containing characters that are invalid in a URL path segment, such as `/` or ` `,
+the resource name must be URL-encoded into the HTTP API call URL.
+
+Though any resource name *can* be used with the HTTP API if URL-encoded,
+we typically recommend using resource names that don't require URL-encoding anyways.
+Depending on the validation that Consul applies to a resource name, Consul may still
+reject a request if it considers the resource name invalid for that endpoint. And
+even if Consul considers the resource name valid, it may degrade other functionality,
+such as failed [DNS lookups](/docs/discovery/dns)
+for nodes or services with names containing invalid DNS characters.
+
 ## Translated Addresses
 
 Consul 0.7 added the ability to translate addresses in HTTP response based on


### PR DESCRIPTION
To-Do:

- [ ] Add changelog entry
- [ ] Apply pattern shown in Agent HTTP API docs to all other endpoints once reviewers align on approach

This documentation applies to functionality that will be released with Consul 1.12, so it should not have the `type/docs-cherrypick` label.