### PR TITLE
Parse datacenter from request

### DIFF
--- a/.changelog/12370.txt
+++ b/.changelog/12370.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-agent: Parse datacenter from Create/Delete requests for AuthMethods and RoleBindings.
+agent: Parse datacenter from Create/Delete requests for AuthMethods and BindingRules.
 ```

--- a/.changelog/12370.txt
+++ b/.changelog/12370.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Parse datacenter from Create/Delete requests for AuthMethods and RoleBindings.
+```

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -751,9 +751,8 @@ func (s *HTTPHandlers) ACLBindingRuleCreate(resp http.ResponseWriter, req *http.
 }
 
 func (s *HTTPHandlers) ACLBindingRuleWrite(resp http.ResponseWriter, req *http.Request, bindingRuleID string) (interface{}, error) {
-	args := structs.ACLBindingRuleSetRequest{
-		Datacenter: s.agent.config.Datacenter,
-	}
+	args := structs.ACLBindingRuleSetRequest{}
+	s.parseDC(req, &args.Datacenter)
 	s.parseToken(req, &args.Token)
 	if err := s.parseEntMeta(req, &args.BindingRule.EnterpriseMeta); err != nil {
 		return nil, err
@@ -779,9 +778,9 @@ func (s *HTTPHandlers) ACLBindingRuleWrite(resp http.ResponseWriter, req *http.R
 
 func (s *HTTPHandlers) ACLBindingRuleDelete(resp http.ResponseWriter, req *http.Request, bindingRuleID string) (interface{}, error) {
 	args := structs.ACLBindingRuleDeleteRequest{
-		Datacenter:    s.agent.config.Datacenter,
 		BindingRuleID: bindingRuleID,
 	}
+	s.parseDC(req, &args.Datacenter)
 	s.parseToken(req, &args.Token)
 	if err := s.parseEntMeta(req, &args.EnterpriseMeta); err != nil {
 		return nil, err
@@ -898,9 +897,8 @@ func (s *HTTPHandlers) ACLAuthMethodCreate(resp http.ResponseWriter, req *http.R
 }
 
 func (s *HTTPHandlers) ACLAuthMethodWrite(resp http.ResponseWriter, req *http.Request, methodName string) (interface{}, error) {
-	args := structs.ACLAuthMethodSetRequest{
-		Datacenter: s.agent.config.Datacenter,
-	}
+	args := structs.ACLAuthMethodSetRequest{}
+	s.parseDC(req, &args.Datacenter)
 	s.parseToken(req, &args.Token)
 	if err := s.parseEntMeta(req, &args.AuthMethod.EnterpriseMeta); err != nil {
 		return nil, err
@@ -929,9 +927,9 @@ func (s *HTTPHandlers) ACLAuthMethodWrite(resp http.ResponseWriter, req *http.Re
 
 func (s *HTTPHandlers) ACLAuthMethodDelete(resp http.ResponseWriter, req *http.Request, methodName string) (interface{}, error) {
 	args := structs.ACLAuthMethodDeleteRequest{
-		Datacenter:     s.agent.config.Datacenter,
 		AuthMethodName: methodName,
 	}
+	s.parseDC(req, &args.Datacenter)
 	s.parseToken(req, &args.Token)
 	if err := s.parseEntMeta(req, &args.EnterpriseMeta); err != nil {
 		return nil, err

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1174,7 +1174,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root&dc=dc1", jsonBody(methodInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLAuthMethodCreate(resp, req)
 			require.NoError(t, err)
@@ -1222,6 +1222,26 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			methodMap[method.Name] = method
 		})
 
+		t.Run("Create in invalid datacenter", func(t *testing.T) {
+			methodInput := &structs.ACLAuthMethod{
+				Name:        "other",
+				Type:        "testing",
+				Description: "test",
+				Config: map[string]interface{}{
+					"SessionID": testSessionID,
+				},
+				TokenLocality: "global",
+				MaxTokenTTL:   500_000_000_000,
+			}
+
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root&dc=invalid", jsonBody(methodInput))
+			resp := httptest.NewRecorder()
+			_, err := a.srv.ACLAuthMethodCRUD(resp, req)
+			require.Error(t, err)
+			_, ok := err.(BadRequestError)
+			require.True(t, ok)
+		})
+
 		t.Run("Update Name URL Mismatch", func(t *testing.T) {
 			methodInput := &structs.ACLAuthMethod{
 				Name:        "test",
@@ -1232,7 +1252,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/not-test?token=root", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/not-test?token=root&dc=dc1", jsonBody(methodInput))
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.Error(t, err)
@@ -1250,7 +1270,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/test?token=root", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/test?token=root&dc=dc1", jsonBody(methodInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.NoError(t, err)
@@ -1341,7 +1361,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "web",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=dc1", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.NoError(t, err)
@@ -1372,7 +1392,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "fancy-role",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=dc1", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.NoError(t, err)
@@ -1394,8 +1414,23 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			ruleMap[rule.ID] = rule
 		})
 
+		t.Run("Create in invalid datacenter", func(t *testing.T) {
+			ruleInput := &structs.ACLBindingRule{
+				Description: "other",
+				AuthMethod:  "test",
+				Selector:    "serviceaccount.namespace==default",
+				BindType:    structs.BindingRuleBindTypeRole,
+				BindName:    "fancy-role",
+			}
+
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=invalid", jsonBody(ruleInput))
+			resp := httptest.NewRecorder()
+			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
+			require.EqualError(t, err, "No path to datacenter")
+		})
+
 		t.Run("BindingRule CRUD Missing ID in URL", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/?token=root&dc=dc1", nil)
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.Error(t, err)
@@ -1412,7 +1447,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "${serviceaccount.name}",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root&dc=dc1", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)
@@ -1444,7 +1479,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "vault",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=dc1", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.Error(t, err)
@@ -1496,7 +1531,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
-			req, _ := http.NewRequest("DELETE", "/v1/acl/binding-rule/"+idMap["rule-other"]+"?token=root", nil)
+			req, _ := http.NewRequest("DELETE", "/v1/acl/binding-rule/"+idMap["rule-other"]+"?token=root&dc=dc1", nil)
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)
@@ -1505,7 +1540,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("Read", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root&dc=dc1", nil)
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -1174,7 +1174,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root&dc=dc1", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root", jsonBody(methodInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLAuthMethodCreate(resp, req)
 			require.NoError(t, err)
@@ -1222,7 +1222,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			methodMap[method.Name] = method
 		})
 
-		t.Run("Create in invalid datacenter", func(t *testing.T) {
+		t.Run("Create in remote datacenter", func(t *testing.T) {
 			methodInput := &structs.ACLAuthMethod{
 				Name:        "other",
 				Type:        "testing",
@@ -1234,7 +1234,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				MaxTokenTTL:   500_000_000_000,
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root&dc=invalid", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method?token=root&dc=remote", jsonBody(methodInput))
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.Error(t, err)
@@ -1252,7 +1252,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/not-test?token=root&dc=dc1", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/not-test?token=root", jsonBody(methodInput))
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.Error(t, err)
@@ -1270,7 +1270,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				},
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/test?token=root&dc=dc1", jsonBody(methodInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/auth-method/test?token=root", jsonBody(methodInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLAuthMethodCRUD(resp, req)
 			require.NoError(t, err)
@@ -1361,7 +1361,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "web",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=dc1", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.NoError(t, err)
@@ -1392,7 +1392,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "fancy-role",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=dc1", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.NoError(t, err)
@@ -1414,7 +1414,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 			ruleMap[rule.ID] = rule
 		})
 
-		t.Run("Create in invalid datacenter", func(t *testing.T) {
+		t.Run("Create in remote datacenter", func(t *testing.T) {
 			ruleInput := &structs.ACLBindingRule{
 				Description: "other",
 				AuthMethod:  "test",
@@ -1423,14 +1423,14 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "fancy-role",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=invalid", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=remote", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.EqualError(t, err, "No path to datacenter")
 		})
 
 		t.Run("BindingRule CRUD Missing ID in URL", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/?token=root&dc=dc1", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/?token=root", nil)
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.Error(t, err)
@@ -1447,7 +1447,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "${serviceaccount.name}",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root&dc=dc1", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)
@@ -1479,7 +1479,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 				BindName:    "vault",
 			}
 
-			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root&dc=dc1", jsonBody(ruleInput))
+			req, _ := http.NewRequest("PUT", "/v1/acl/binding-rule?token=root", jsonBody(ruleInput))
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCreate(resp, req)
 			require.Error(t, err)
@@ -1531,7 +1531,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
-			req, _ := http.NewRequest("DELETE", "/v1/acl/binding-rule/"+idMap["rule-other"]+"?token=root&dc=dc1", nil)
+			req, _ := http.NewRequest("DELETE", "/v1/acl/binding-rule/"+idMap["rule-other"]+"?token=root", nil)
 			resp := httptest.NewRecorder()
 			_, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)
@@ -1540,7 +1540,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 		})
 
 		t.Run("Read", func(t *testing.T) {
-			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root&dc=dc1", nil)
+			req, _ := http.NewRequest("GET", "/v1/acl/binding-rule/"+idMap["rule-test"]+"?token=root", nil)
 			resp := httptest.NewRecorder()
 			raw, err := a.srv.ACLBindingRuleCRUD(resp, req)
 			require.NoError(t, err)


### PR DESCRIPTION
Parse the value of the datacenter from the create/delete requests for AuthMethods and BindingRules so that they can be created in and deleted from the datacenters specified in the request.