### PR TITLE
Adding documentation to store Enterprise License in Vault

### DIFF
--- a/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
@@ -10,7 +10,7 @@ You can use this Helm chart to deploy Consul Enterprise by following a few extra
 
 Find the license file that you received in your welcome email. It should have a `.hclic` extension. You will use the contents of this file to create a Kubernetes secret before installing the Helm chart.
 
--> **Note:** This guide assumes you are storing your license as a Kubernetes Secret. If you would like to store the enterprise license, please reference [Storing the Enterprise License in Vault](/docs/k8s/installation/vault/enterprise-license).
+-> **Note:** This guide assumes you are storing your license as a Kubernetes Secret. If you would like to store the enterprise license in Vault, please reference [Storing the Enterprise License in Vault](/docs/k8s/installation/vault/enterprise-license).
 
 You can use the following commands to create the secret with name `consul-ent-license` and key `key`:
 

--- a/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
@@ -47,7 +47,8 @@ server:
 
 </CodeBlockConfig>
 
-If the version of Consul is < 1.10, use the following config with the name and key of the secret you just created.
+If the version of Consul is < 1.10, use the following config with the name and key of the secret you just created. 
+(These values arerequired on top ofyour normal configuration.)
 
 -> **Note:** The value of `server.enterpriseLicense.enableLicenseAutoload` must be set to `false`.
 

--- a/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/consul-enterprise.mdx
@@ -10,6 +10,8 @@ You can use this Helm chart to deploy Consul Enterprise by following a few extra
 
 Find the license file that you received in your welcome email. It should have a `.hclic` extension. You will use the contents of this file to create a Kubernetes secret before installing the Helm chart.
 
+-> **Note:** This guide assumes you are storing your license as a Kubernetes Secret. If you would like to store the enterprise license, please reference [Storing the Enterprise License in Vault](/docs/k8s/installation/vault/enterprise-license).
+
 You can use the following commands to create the secret with name `consul-ent-license` and key `key`:
 
 ```bash

--- a/website/content/docs/k8s/installation/vault/enterprise-license.mdx
+++ b/website/content/docs/k8s/installation/vault/enterprise-license.mdx
@@ -1,0 +1,98 @@
+---
+layout: docs
+page_title: Storing Enterprise License in Vault
+description: >-
+  Configuring the Consul Helm chart to use enterprise license stored in Vault.
+---
+
+# Storing the Enterprise License in Vault
+
+To use an enterprise license stored in Vault, the steps will be similar to [Storing Gossip Encryption Key in Vault](/docs/k8s/installation/vault/gossip). We need to do the following:
+
+1. Store an enterprise license key in Vault.
+1. Create policies that will allow Consul client and server to access that key.
+1. Create a Kubernetes auth roles that link policies from step 2 to Kubernetes service accounts of the Consul servers and clients.
+
+## Configuring Vault
+
+First, store the license key in Vault:
+
+```shell-session
+$ vault kv put secret/consul/enterpriselicense key="<enterprise license>"
+```
+
+Next, we will need to create a policy that allows read access to this secret:
+
+
+<CodeBlockConfig filename="enterpriselicense-policy.hcl">
+
+```HCL
+path "secret/data/consul/enterpriselicense" {
+  capabilities = ["read"]
+}
+```
+
+</CodeBlockConfig>
+
+```shell-session
+$ vault policy write enterpriselicense-policy enterpriselicense-policy.hcl
+```
+
+Prior to creating Vault auth roles for the Consul servers and clients, ensure that the Vault Kubernetes auth method is enabled as described in [Vault Kubernetes Auth Method](/docs/k8s/installation/vault#vault-kubernetes-auth-method).
+
+Next, we will create Kubernetes auth roles for the Consul server and client:
+
+```shell-session
+$ vault write auth/kubernetes/role/consul-server \
+    bound_service_account_names=<Consul server service account> \
+    bound_service_account_namespaces=<Consul installation namespace> \
+    policies=enterpriselicense-policy \
+    ttl=1h
+```
+
+```shell-session
+$ vault write auth/kubernetes/role/consul-client \
+    bound_service_account_names=<Consul client service account> \
+    bound_service_account_namespaces=<Consul installation namespace> \
+    policies=enterpriselicense-policy \
+    ttl=1h
+```
+
+To find out the service account names of the Consul server and client,
+you can run the following `helm template` commands with your Consul on Kubernetes values file:
+
+- Generate Consul server service account name
+  ```shell-session
+  $ helm template --release-name ${RELEASE_NAME} -s templates/server-serviceaccount.yaml hashicorp/consul
+  ```
+
+- Generate Consul client service account name
+  ```shell-session
+  $ helm template --release-name ${RELEASE_NAME} -s templates/client-serviceaccount.yaml hashicorp/consul
+  ```
+
+## Deploying the Consul Helm chart
+
+Now that we've configured Vault, you can configure the Consul Helm chart to
+use the enterprise license key in Vault:
+
+<CodeBlockConfig filename="values.yaml">
+
+```yaml
+global:
+  secretsBackend:
+    vault:
+      enabled: true
+      consulServerRole: consul-server
+      consulClientRole: consul-client
+  enterpriseLicense:
+    secretName: secret/data/consul/enterpriselicense
+    secretKey: key
+```
+
+</CodeBlockConfig>
+
+Note that `global.enterpriseLicense.secretName` is the path of the secret in Vault.
+This should be the same path as the one you'd include in your Vault policy.
+`global.enterpriseLicense.secretKey` is the key inside the secret data. This should be the same
+as the key we passed when we created the enterprise license secret in Vault.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -479,6 +479,10 @@
                 "path": "k8s/installation/vault/gossip"
               },
               {
+                "title": "Enterprise License",
+                "path": "k8s/installation/vault/enterprise-license"
+              },
+              {
                 "title": "Server TLS",
                 "path": "k8s/installation/vault/server-tls"
               },


### PR DESCRIPTION
Documentation for configuring Enterprise License in Vault.  Related to https://github.com/hashicorp/consul-k8s/pull/1032

The process is effectively the same as configuring the gossip encryption.  I created a similar page and added it to the nav. At some point if these steps start to look the same for each page, we could think about how we combine them...but at the moment, I'm not sure the best way forward.