### PR TITLE
ci: combine 'enhancement' entry type with 'improvement'

### DIFF
--- a/.changelog/12376.txt
+++ b/.changelog/12376.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+ci: include 'enhancement' entry type in IMPROVEMENTS section of changelog.
+```

--- a/.changelog/changelog.tmpl
+++ b/.changelog/changelog.tmpl
@@ -22,10 +22,11 @@ FEATURES:
 {{ end -}}
 {{- end -}}
 
-{{- if .NotesByType.improvement }}
+{{- $improvements := combineTypes .NotesByType.improvement .NotesByType.enhancement -}}
+{{- if $improvements }}
 IMPROVEMENTS:
 
-{{range .NotesByType.improvement -}}
+{{range $improvements | sort -}}
 * {{ template "note" . }}
 {{ end -}}
 {{- end -}}


### PR DESCRIPTION
Prior to this change, we excluded entries with the `release-note:enhancement` heading despite it being a valid entry type. This adds it per the suggestion in [the template that ships with go-changelog](https://github.com/hashicorp/go-changelog/blob/main/cmd/changelog-build/changelog.tmpl#L30-L36).

We'll still need to go backport the 12 entries that have been excluded in their associated release. Future releases will do the right thing by including those that are part of the release.