### PR TITLE
Remove setup-qemu step from Docker build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,10 +242,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Push events on the main branch
       - main
-      - remove-setup-qemu
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Push events on the main branch
       - main
+      - remove-setup-qemu
 
 env:
   PKG_NAME: consul


### PR DESCRIPTION
This has been abstracted into the github action `actions-docker-build`: https://github.com/hashicorp/actions-docker-build/pull/8. 

Link to pipeline that ran for the second commit to this branch: https://github.com/hashicorp/consul/actions/runs/1862910790