### PR TITLE
rpc: set response to nil when not found

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -205,12 +205,10 @@ func (c *ConfigEntry) Get(args *structs.ConfigEntryQuery, reply *structs.ConfigE
 				return err
 			}
 
-			reply.Index = index
+			reply.Index, reply.Entry = index, entry
 			if entry == nil {
 				return errNotFound
 			}
-
-			reply.Entry = entry
 			return nil
 		})
 }

--- a/agent/consul/federation_state_endpoint.go
+++ b/agent/consul/federation_state_endpoint.go
@@ -122,12 +122,10 @@ func (c *FederationState) Get(args *structs.FederationStateQuery, reply *structs
 				return err
 			}
 
-			reply.Index = index
+			reply.Index, reply.State = index, fedState
 			if fedState == nil {
 				return errNotFound
 			}
-
-			reply.State = fedState
 			return nil
 		})
 }

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -945,7 +945,17 @@ type blockingQueryResponseMeta interface {
 //
 // The query function is expected to be a closure that has access to responseMeta
 // so that it can set the Index. The actual result of the query is opaque to blockingQuery.
-// If query function returns an error, the error is returned to the caller immediately.
+//
+// The query function can return errNotFound, which is a sentinel error. Returning
+// errNotFound indicates that the query found no results, which allows
+// blockingQuery to keep blocking until the query returns a non-nil error.
+// The query function must take care to set the actual result of the query to
+// nil in these cases, otherwise when blockingQuery times out it may return
+// a previous result. errNotFound will never be returned to the caller, it is
+// converted to nil before returning.
+//
+// If query function returns any other error, the error is returned to the caller
+// immediately.
 //
 // The query function must follow these rules:
 //


### PR DESCRIPTION
Otherwise when the query times out we might incorrectly send a value for the reply, when we should send an empty reply.

I went through all the changes in #12110. These were the only two places that seemed to be a problem. The rest appear to correctly set the reply value before returning `errNotFound`.

Thanks to @rboyer and @kisunji for finding this.