### PR TITLE
Backport 1.11.x: tproxy http upstream fix

### DIFF
--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -1142,6 +1142,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				snap.ConnectProxy.IntentionUpstreams = map[string]struct{}{
 					google.String(): {},
 				}
+
 				snap.ConnectProxy.DiscoveryChain[google.String()] = discoverychain.TestCompileConfigEntries(t, "google", "default", "default", "dc1", connect.TestClusterID+".consul", nil,
 					// Set default service protocol to HTTP
 					&structs.ProxyConfigEntry{
@@ -1164,8 +1165,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 								Address: "9.9.9.9",
 								Port:    9090,
 								TaggedAddresses: map[string]structs.ServiceAddress{
-									"virtual":                      {Address: "10.0.0.1"},
-									structs.TaggedAddressVirtualIP: {Address: "240.0.0.1"},
+									"virtual": {Address: "10.0.0.1"},
 								},
 							},
 						},
@@ -1189,7 +1189,9 @@ func TestListenersFromSnapshot(t *testing.T) {
 				}
 
 				// DiscoveryChains without endpoints do not get a filter chain because there are no addresses to match on.
-				snap.ConnectProxy.DiscoveryChain["no-endpoints"] = discoverychain.TestCompileConfigEntries(t, "no-endpoints", "default", "default", "dc1", connect.TestClusterID+".consul", nil)
+				snap.ConnectProxy.DiscoveryChain["no-endpoints"] = discoverychain.TestCompileConfigEntries(
+					t, "no-endpoints", "default", "dc1",
+					connect.TestClusterID+".consul", "dc1", nil)
 			},
 		},
 		{

--- a/agent/xds/testdata/listeners/transparent-proxy-http-upstream.envoy-1-20-x.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-http-upstream.envoy-1-20-x.golden
@@ -42,10 +42,6 @@
               {
                 "addressPrefix": "10.0.0.1",
                 "prefixLen": 32
-              },
-              {
-                "addressPrefix": "240.0.0.1",
-                "prefixLen": 32
               }
             ]
           },


### PR DESCRIPTION
Backporting some test changes to fix the 1.11.x branch