### PR TITLE
Fix fine-grained blocking queries for Catalog.NodeServices

### DIFF
--- a/.changelog/12399.txt
+++ b/.changelog/12399.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+catalog: Add per-node indexes to reduce watchset firing for unrelated nodes and services.
+```

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -17,11 +17,15 @@ import (
 	"github.com/hashicorp/consul/types"
 )
 
-// indexServiceExtinction keeps track of the last raft index when the last instance
-// of any service was unregistered. This is used by blocking queries on missing services.
-const indexServiceExtinction = "service_last_extinction"
+const (
+	// indexServiceExtinction keeps track of the last raft index when the last instance
+	// of any service was unregistered. This is used by blocking queries on missing services.
+	indexServiceExtinction = "service_last_extinction"
 
-const indexNodeExtinction = "node_last_extinction"
+	// indexNodeExtinction keeps track of the last raft index when the last instance
+	// of any node was unregistered. This is used by blocking queries on missing nodes.
+	indexNodeExtinction = "node_last_extinction"
+)
 
 const (
 	// minUUIDLookupLen is used as a minimum length of a node name required before
@@ -36,6 +40,8 @@ var (
 	startingVirtualIP = net.IP{240, 0, 0, 0}
 
 	virtualIPMaxOffset = net.IP{15, 255, 255, 254}
+
+	ErrNodeNotFound = errors.New("node not found")
 )
 
 func resizeNodeLookupKey(s string) string {
@@ -59,7 +65,7 @@ func (s *Snapshot) Nodes() (memdb.ResultIterator, error) {
 
 // Services is used to pull the full list of services for a given node for use
 // during snapshots.
-func (s *Snapshot) Services(node string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Snapshot) Services(node string, entMeta *acl.EnterpriseMeta, peerName string) (memdb.ResultIterator, error) {
 	// TODO: accept non-pointer value
 	if entMeta == nil {
 		entMeta = structs.NodeEnterpriseMetaInDefaultPartition()
@@ -67,12 +73,13 @@ func (s *Snapshot) Services(node string, entMeta *structs.EnterpriseMeta) (memdb
 	return s.tx.Get(tableServices, indexNode, Query{
 		Value:          node,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 }
 
 // Checks is used to pull the full list of checks for a given node for use
 // during snapshots.
-func (s *Snapshot) Checks(node string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Snapshot) Checks(node string, entMeta *acl.EnterpriseMeta, peerName string) (memdb.ResultIterator, error) {
 	// TODO: accept non-pointer value
 	if entMeta == nil {
 		entMeta = structs.NodeEnterpriseMetaInDefaultPartition()
@@ -80,6 +87,7 @@ func (s *Snapshot) Checks(node string, entMeta *structs.EnterpriseMeta) (memdb.R
 	return s.tx.Get(tableChecks, indexNode, Query{
 		Value:          node,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 }
 
@@ -136,9 +144,13 @@ func (s *Store) ensureCheckIfNodeMatches(
 	preserveIndexes bool,
 	node string,
 	nodePartition string,
+	nodePeerName string,
 	check *structs.HealthCheck,
 ) error {
-	if check.Node != node || !structs.EqualPartitions(nodePartition, check.PartitionOrDefault()) {
+	if !strings.EqualFold(check.PeerName, nodePeerName) {
+		return fmt.Errorf("check peer name %q does not match node peer name %q", check.PeerName, nodePeerName)
+	}
+	if !strings.EqualFold(check.Node, node) || !acl.EqualPartitions(nodePartition, check.PartitionOrDefault()) {
 		return fmt.Errorf("check node %q does not match node %q",
 			printNodeName(check.Node, check.PartitionOrDefault()),
 			printNodeName(node, nodePartition),
@@ -151,7 +163,7 @@ func (s *Store) ensureCheckIfNodeMatches(
 }
 
 func printNodeName(nodeName, partition string) string {
-	if structs.IsDefaultPartition(partition) {
+	if acl.IsDefaultPartition(partition) {
 		return nodeName
 	}
 	return partition + "/" + nodeName
@@ -161,6 +173,9 @@ func printNodeName(nodeName, partition string) string {
 // registration is performed within a single transaction to avoid race
 // conditions on state updates.
 func (s *Store) ensureRegistrationTxn(tx WriteTxn, idx uint64, preserveIndexes bool, req *structs.RegisterRequest, restore bool) error {
+	if err := validateRegisterRequestPeerNamesTxn(tx, req, restore); err != nil {
+		return err
+	}
 	if _, err := validateRegisterRequestTxn(tx, req, restore); err != nil {
 		return err
 	}
@@ -174,6 +189,7 @@ func (s *Store) ensureRegistrationTxn(tx WriteTxn, idx uint64, preserveIndexes b
 		Partition:       req.PartitionOrDefault(),
 		TaggedAddresses: req.TaggedAddresses,
 		Meta:            req.NodeMeta,
+		PeerName:        req.PeerName,
 	}
 	if preserveIndexes {
 		node.CreateIndex = req.CreateIndex
@@ -189,6 +205,7 @@ func (s *Store) ensureRegistrationTxn(tx WriteTxn, idx uint64, preserveIndexes b
 		existing, err := tx.First(tableNodes, indexID, Query{
 			Value:          node.Node,
 			EnterpriseMeta: *node.GetEnterpriseMeta(),
+			PeerName:       node.PeerName,
 		})
 		if err != nil {
 			return fmt.Errorf("node lookup failed: %s", err)
@@ -208,6 +225,7 @@ func (s *Store) ensureRegistrationTxn(tx WriteTxn, idx uint64, preserveIndexes b
 			EnterpriseMeta: req.Service.EnterpriseMeta,
 			Node:           req.Node,
 			Service:        req.Service.ID,
+			PeerName:       req.PeerName,
 		})
 		if err != nil {
 			return fmt.Errorf("failed service lookup: %s", err)
@@ -222,17 +240,74 @@ func (s *Store) ensureRegistrationTxn(tx WriteTxn, idx uint64, preserveIndexes b
 
 	// Add the checks, if any.
 	if req.Check != nil {
-		if err := s.ensureCheckIfNodeMatches(tx, idx, preserveIndexes, req.Node, req.PartitionOrDefault(), req.Check); err != nil {
+		err := s.ensureCheckIfNodeMatches(tx, idx, preserveIndexes, req.Node, req.PartitionOrDefault(), req.PeerName, req.Check)
+		if err != nil {
 			return err
 		}
 	}
 	for _, check := range req.Checks {
-		if err := s.ensureCheckIfNodeMatches(tx, idx, preserveIndexes, req.Node, req.PartitionOrDefault(), check); err != nil {
+		err := s.ensureCheckIfNodeMatches(tx, idx, preserveIndexes, req.Node, req.PartitionOrDefault(), req.PeerName, check)
+		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func validateRegisterRequestPeerNamesTxn(_ ReadTxn, args *structs.RegisterRequest, _ bool) error {
+	var (
+		peerNames = make(map[string]struct{})
+	)
+	if args.Service != nil {
+		if args.Service.PeerName == "" {
+			args.Service.PeerName = args.PeerName
+		}
+
+		peerName := args.Service.PeerName
+		// TODO(peering): validate the peering exists (skip check on restore)
+
+		peerNames[peerName] = struct{}{}
+	}
+
+	validateCheck := func(chk *structs.HealthCheck) error {
+		if chk.PeerName == "" {
+			chk.PeerName = args.PeerName
+		}
+
+		peerName := chk.PeerName
+		// TODO(peering): validate the peering exists (skip check on restore)
+
+		peerNames[peerName] = struct{}{}
+
+		return nil
+	}
+
+	if args.Check != nil {
+		if err := validateCheck(args.Check); err != nil {
+			return err
+		}
+	}
+	for _, chk := range args.Checks {
+		if err := validateCheck(chk); err != nil {
+			return err
+		}
+	}
+
+	{
+		// TODO(peering): validate the node's peering exists (skip check on restore)
+		peerName := args.PeerName
+		peerNames[peerName] = struct{}{}
+	}
+
+	if len(peerNames) > 1 {
+		return fmt.Errorf("Cannot register services and checks for multiple peer names in one registration request")
+	} else if len(peerNames) == 0 {
+		return fmt.Errorf("No peer names are present on the registration request; this makes no sense")
+	}
+
+	return nil
+
 }
 
 // EnsureNode is used to upsert node registration or modification.
@@ -252,8 +327,11 @@ func (s *Store) EnsureNode(idx uint64, node *structs.Node) error {
 // If allowClashWithoutID then, getting a conflict on another node without ID will be allowed
 func ensureNoNodeWithSimilarNameTxn(tx ReadTxn, node *structs.Node, allowClashWithoutID bool) error {
 	// Retrieve all of the nodes
-
-	enodes, err := tx.Get(tableNodes, indexID+"_prefix", node.GetEnterpriseMeta())
+	q := Query{
+		PeerName:       node.PeerName,
+		EnterpriseMeta: *node.GetEnterpriseMeta(),
+	}
+	enodes, err := tx.Get(tableNodes, indexID+"_prefix", q)
 	if err != nil {
 		return fmt.Errorf("Cannot lookup all nodes: %s", err)
 	}
@@ -266,6 +344,7 @@ func ensureNoNodeWithSimilarNameTxn(tx ReadTxn, node *structs.Node, allowClashWi
 				EnterpriseMeta: *node.GetEnterpriseMeta(),
 				Node:           enode.Node,
 				CheckID:        string(structs.SerfCheckID),
+				PeerName:       enode.PeerName,
 			})
 			if err != nil {
 				return fmt.Errorf("Cannot get status of node %s: %s", enode.Node, err)
@@ -293,7 +372,7 @@ func ensureNoNodeWithSimilarNameTxn(tx ReadTxn, node *structs.Node, allowClashWi
 // Returns a bool indicating if a write happened and any error.
 func (s *Store) ensureNodeCASTxn(tx WriteTxn, idx uint64, node *structs.Node) (bool, error) {
 	// Retrieve the existing entry.
-	existing, err := getNodeTxn(tx, node.Node, node.GetEnterpriseMeta())
+	existing, err := getNodeTxn(tx, node.Node, node.GetEnterpriseMeta(), node.PeerName)
 	if err != nil {
 		return false, err
 	}
@@ -326,23 +405,23 @@ func (s *Store) ensureNodeTxn(tx WriteTxn, idx uint64, preserveIndexes bool, nod
 	// name is the same.
 	var n *structs.Node
 	if node.ID != "" {
-		existing, err := getNodeIDTxn(tx, node.ID, node.GetEnterpriseMeta())
+		existing, err := getNodeIDTxn(tx, node.ID, node.GetEnterpriseMeta(), node.PeerName)
 		if err != nil {
 			return fmt.Errorf("node lookup failed: %s", err)
 		}
 		if existing != nil {
 			n = existing
-			if n.Node != node.Node {
+			if !strings.EqualFold(n.Node, node.Node) {
 				// Lets first get all nodes and check whether name do match, we do not allow clash on nodes without ID
 				dupNameError := ensureNoNodeWithSimilarNameTxn(tx, node, false)
 				if dupNameError != nil {
 					return fmt.Errorf("Error while renaming Node ID: %q (%s): %s", node.ID, node.Address, dupNameError)
 				}
 				// We are actually renaming a node, remove its reference first
-				err := s.deleteNodeTxn(tx, idx, n.Node, n.GetEnterpriseMeta())
+				err := s.deleteNodeTxn(tx, idx, n.Node, n.GetEnterpriseMeta(), n.PeerName)
 				if err != nil {
-					return fmt.Errorf("Error while renaming Node ID: %q (%s) from %s to %s",
-						node.ID, node.Address, n.Node, node.Node)
+					return fmt.Errorf("Error while renaming Node ID: %q (%s) from %s to %s: %w",
+						node.ID, node.Address, n.Node, node.Node, err)
 				}
 			}
 		} else {
@@ -362,6 +441,7 @@ func (s *Store) ensureNodeTxn(tx WriteTxn, idx uint64, preserveIndexes bool, nod
 		existing, err := tx.First(tableNodes, indexID, Query{
 			Value:          node.Node,
 			EnterpriseMeta: *node.GetEnterpriseMeta(),
+			PeerName:       node.PeerName,
 		})
 		if err != nil {
 			return fmt.Errorf("node name lookup failed: %s", err)
@@ -398,7 +478,7 @@ func (s *Store) ensureNodeTxn(tx WriteTxn, idx uint64, preserveIndexes bool, nod
 }
 
 // GetNode is used to retrieve a node registration by node name ID.
-func (s *Store) GetNode(nodeNameOrID string, entMeta *structs.EnterpriseMeta) (uint64, *structs.Node, error) {
+func (s *Store) GetNode(nodeNameOrID string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.Node, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -408,20 +488,21 @@ func (s *Store) GetNode(nodeNameOrID string, entMeta *structs.EnterpriseMeta) (u
 	}
 
 	// Get the table index.
-	idx := catalogNodesMaxIndex(tx, entMeta)
+	idx := catalogNodesMaxIndex(tx, entMeta, peerName)
 
 	// Retrieve the node from the state store
-	node, err := getNodeTxn(tx, nodeNameOrID, entMeta)
+	node, err := getNodeTxn(tx, nodeNameOrID, entMeta, peerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("node lookup failed: %s", err)
 	}
 	return idx, node, nil
 }
 
-func getNodeTxn(tx ReadTxn, nodeNameOrID string, entMeta *structs.EnterpriseMeta) (*structs.Node, error) {
+func getNodeTxn(tx ReadTxn, nodeNameOrID string, entMeta *acl.EnterpriseMeta, peerName string) (*structs.Node, error) {
 	node, err := tx.First(tableNodes, indexID, Query{
 		Value:          nodeNameOrID,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("node lookup failed: %s", err)
@@ -432,10 +513,11 @@ func getNodeTxn(tx ReadTxn, nodeNameOrID string, entMeta *structs.EnterpriseMeta
 	return nil, nil
 }
 
-func getNodeIDTxn(tx ReadTxn, id types.NodeID, entMeta *structs.EnterpriseMeta) (*structs.Node, error) {
+func getNodeIDTxn(tx ReadTxn, id types.NodeID, entMeta *acl.EnterpriseMeta, peerName string) (*structs.Node, error) {
 	node, err := tx.First(tableNodes, indexUUID+"_prefix", Query{
 		Value:          string(id),
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("node lookup by ID failed: %s", err)
@@ -447,7 +529,7 @@ func getNodeIDTxn(tx ReadTxn, id types.NodeID, entMeta *structs.EnterpriseMeta) 
 }
 
 // GetNodeID is used to retrieve a node registration by node ID.
-func (s *Store) GetNodeID(id types.NodeID, entMeta *structs.EnterpriseMeta) (uint64, *structs.Node, error) {
+func (s *Store) GetNodeID(id types.NodeID, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.Node, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -456,16 +538,15 @@ func (s *Store) GetNodeID(id types.NodeID, entMeta *structs.EnterpriseMeta) (uin
 		entMeta = structs.NodeEnterpriseMetaInDefaultPartition()
 	}
 
-	// Get the table index.
-	idx := catalogNodesMaxIndex(tx, entMeta)
+	idx := catalogNodesMaxIndex(tx, entMeta, peerName)
 
 	// Retrieve the node from the state store
-	node, err := getNodeIDTxn(tx, id, entMeta)
+	node, err := getNodeIDTxn(tx, id, entMeta, peerName)
 	return idx, node, err
 }
 
 // Nodes is used to return all of the known nodes.
-func (s *Store) Nodes(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.Nodes, error) {
+func (s *Store) Nodes(ws memdb.WatchSet, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.Nodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -474,11 +555,14 @@ func (s *Store) Nodes(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint6
 		entMeta = structs.NodeEnterpriseMetaInDefaultPartition()
 	}
 
-	// Get the table index.
-	idx := catalogNodesMaxIndex(tx, entMeta)
+	idx := catalogNodesMaxIndex(tx, entMeta, peerName)
 
 	// Retrieve all of the nodes
-	nodes, err := tx.Get(tableNodes, indexID+"_prefix", entMeta)
+	q := Query{
+		PeerName:       peerName,
+		EnterpriseMeta: *entMeta,
+	}
+	nodes, err := tx.Get(tableNodes, indexID+"_prefix", q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed nodes lookup: %s", err)
 	}
@@ -493,7 +577,7 @@ func (s *Store) Nodes(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint6
 }
 
 // NodesByMeta is used to return all nodes with the given metadata key/value pairs.
-func (s *Store) NodesByMeta(ws memdb.WatchSet, filters map[string]string, entMeta *structs.EnterpriseMeta) (uint64, structs.Nodes, error) {
+func (s *Store) NodesByMeta(ws memdb.WatchSet, filters map[string]string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.Nodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -502,8 +586,7 @@ func (s *Store) NodesByMeta(ws memdb.WatchSet, filters map[string]string, entMet
 		entMeta = structs.NodeEnterpriseMetaInDefaultPartition()
 	}
 
-	// Get the table index.
-	idx := catalogNodesMaxIndex(tx, entMeta)
+	idx := catalogNodesMaxIndex(tx, entMeta, peerName)
 
 	if len(filters) == 0 {
 		return idx, nil, nil // NodesByMeta is never called with an empty map, but just in case make it return no results.
@@ -521,6 +604,7 @@ func (s *Store) NodesByMeta(ws memdb.WatchSet, filters map[string]string, entMet
 		Key:            firstKey,
 		Value:          firstValue,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed nodes lookup: %s", err)
@@ -539,7 +623,7 @@ func (s *Store) NodesByMeta(ws memdb.WatchSet, filters map[string]string, entMet
 }
 
 // DeleteNode is used to delete a given node by its ID.
-func (s *Store) DeleteNode(idx uint64, nodeName string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) DeleteNode(idx uint64, nodeName string, entMeta *acl.EnterpriseMeta, peerName string) error {
 	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
@@ -549,7 +633,7 @@ func (s *Store) DeleteNode(idx uint64, nodeName string, entMeta *structs.Enterpr
 	}
 
 	// Call the node deletion.
-	if err := s.deleteNodeTxn(tx, idx, nodeName, entMeta); err != nil {
+	if err := s.deleteNodeTxn(tx, idx, nodeName, entMeta, peerName); err != nil {
 		return err
 	}
 
@@ -559,9 +643,9 @@ func (s *Store) DeleteNode(idx uint64, nodeName string, entMeta *structs.Enterpr
 // deleteNodeCASTxn is used to try doing a node delete operation with a given
 // raft index. If the CAS index specified is not equal to the last observed index for
 // the given check, then the call is a noop, otherwise a normal check delete is invoked.
-func (s *Store) deleteNodeCASTxn(tx WriteTxn, idx, cidx uint64, nodeName string, entMeta *structs.EnterpriseMeta) (bool, error) {
+func (s *Store) deleteNodeCASTxn(tx WriteTxn, idx, cidx uint64, nodeName string, entMeta *acl.EnterpriseMeta, peerName string) (bool, error) {
 	// Look up the node.
-	node, err := getNodeTxn(tx, nodeName, entMeta)
+	node, err := getNodeTxn(tx, nodeName, entMeta, peerName)
 	if err != nil {
 		return false, err
 	}
@@ -577,7 +661,7 @@ func (s *Store) deleteNodeCASTxn(tx WriteTxn, idx, cidx uint64, nodeName string,
 	}
 
 	// Call the actual deletion if the above passed.
-	if err := s.deleteNodeTxn(tx, idx, nodeName, entMeta); err != nil {
+	if err := s.deleteNodeTxn(tx, idx, nodeName, entMeta, peerName); err != nil {
 		return false, err
 	}
 
@@ -586,21 +670,22 @@ func (s *Store) deleteNodeCASTxn(tx WriteTxn, idx, cidx uint64, nodeName string,
 
 // deleteNodeTxn is the inner method used for removing a node from
 // the store within a given transaction.
-func (s *Store) deleteNodeTxn(tx WriteTxn, idx uint64, nodeName string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) deleteNodeTxn(tx WriteTxn, idx uint64, nodeName string, entMeta *acl.EnterpriseMeta, peerName string) error {
 	// TODO: accept non-pointer value
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
 
 	// Look up the node.
-	node, err := tx.First(tableNodes, indexID, Query{
+	nodeRaw, err := tx.First(tableNodes, indexID, Query{
 		Value:          nodeName,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return fmt.Errorf("node lookup failed: %s", err)
 	}
-	if node == nil {
+	if nodeRaw == nil {
 		return nil
 	}
 
@@ -608,6 +693,7 @@ func (s *Store) deleteNodeTxn(tx WriteTxn, idx uint64, nodeName string, entMeta 
 	services, err := tx.Get(tableServices, indexNode, Query{
 		Value:          nodeName,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed service lookup: %s", err)
@@ -617,17 +703,17 @@ func (s *Store) deleteNodeTxn(tx WriteTxn, idx uint64, nodeName string, entMeta 
 		svc := service.(*structs.ServiceNode)
 		deleteServices = append(deleteServices, svc)
 
-		if err := catalogUpdateServiceIndexes(tx, svc.ServiceName, idx, &svc.EnterpriseMeta); err != nil {
+		if err := catalogUpdateServiceIndexes(tx, idx, svc.ServiceName, &svc.EnterpriseMeta, svc.PeerName); err != nil {
 			return err
 		}
-		if err := catalogUpdateServiceKindIndexes(tx, svc.ServiceKind, idx, &svc.EnterpriseMeta); err != nil {
+		if err := catalogUpdateServiceKindIndexes(tx, idx, svc.ServiceKind, &svc.EnterpriseMeta, svc.PeerName); err != nil {
 			return err
 		}
 	}
 
 	// Do the delete in a separate loop so we don't trash the iterator.
 	for _, svc := range deleteServices {
-		if err := s.deleteServiceTxn(tx, idx, nodeName, svc.ServiceID, &svc.EnterpriseMeta); err != nil {
+		if err := s.deleteServiceTxn(tx, idx, nodeName, svc.ServiceID, &svc.EnterpriseMeta, svc.PeerName); err != nil {
 			return err
 		}
 	}
@@ -637,6 +723,7 @@ func (s *Store) deleteNodeTxn(tx WriteTxn, idx uint64, nodeName string, entMeta 
 	checks, err := tx.Get(tableChecks, indexNode, Query{
 		Value:          nodeName,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed check lookup: %s", err)
@@ -648,57 +735,61 @@ func (s *Store) deleteNodeTxn(tx WriteTxn, idx uint64, nodeName string, entMeta 
 
 	// Do the delete in a separate loop so we don't trash the iterator.
 	for _, chk := range deleteChecks {
-		if err := s.deleteCheckTxn(tx, idx, nodeName, chk.CheckID, &chk.EnterpriseMeta); err != nil {
+		if err := s.deleteCheckTxn(tx, idx, nodeName, chk.CheckID, &chk.EnterpriseMeta, chk.PeerName); err != nil {
 			return err
 		}
 	}
 
-	// Delete any coordinates associated with this node.
-	coords, err := tx.Get(tableCoordinates, indexNode, Query{
-		Value:          nodeName,
-		EnterpriseMeta: *entMeta,
-	})
-	if err != nil {
-		return fmt.Errorf("failed coordinate lookup: %s", err)
-	}
-	var coordsToDelete []*structs.Coordinate
-	for coord := coords.Next(); coord != nil; coord = coords.Next() {
-		coordsToDelete = append(coordsToDelete, coord.(*structs.Coordinate))
-	}
-	for _, coord := range coordsToDelete {
-		if err := deleteCoordinateTxn(tx, idx, coord); err != nil {
-			return fmt.Errorf("failed deleting coordinate: %s", err)
+	if peerName == "" {
+		// Delete any coordinates associated with this node.
+		coords, err := tx.Get(tableCoordinates, indexNode, Query{
+			Value:          nodeName,
+			EnterpriseMeta: *entMeta,
+			PeerName:       structs.DefaultPeerKeyword,
+		})
+		if err != nil {
+			return fmt.Errorf("failed coordinate lookup: %s", err)
+		}
+		var coordsToDelete []*structs.Coordinate
+		for coord := coords.Next(); coord != nil; coord = coords.Next() {
+			coordsToDelete = append(coordsToDelete, coord.(*structs.Coordinate))
+		}
+		for _, coord := range coordsToDelete {
+			if err := deleteCoordinateTxn(tx, idx, coord); err != nil {
+				return fmt.Errorf("failed deleting coordinate: %s", err)
+			}
 		}
 	}
 
 	// Delete the node and update the index.
-	if err := tx.Delete(tableNodes, node); err != nil {
+	if err := tx.Delete(tableNodes, nodeRaw); err != nil {
 		return fmt.Errorf("failed deleting node: %s", err)
 	}
-	if err := catalogUpdateNodesIndexes(tx, idx, entMeta); err != nil {
+	node := nodeRaw.(*structs.Node)
+	if err := catalogUpdateNodesIndexes(tx, idx, entMeta, node.PeerName); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
-	// Cleanup the node.<nodeName> index
-	_, nodeIndex, err := catalogNodeWatchIndex(tx, nodeName, entMeta)
-	if err == nil && nodeIndex != nil {
-		// we found node.<nodeName> index, garbage collect it
-		if errW := tx.Delete(tableIndex, nodeIndex); errW != nil {
-			return fmt.Errorf("[FAILED] deleting nodeIndex %s: %s", nodeName, err)
+
+	// Clean up node entry from index table
+	if err := tx.Delete(tableIndex, &IndexEntry{Key: nodeIndexName(nodeName, entMeta, node.PeerName)}); err != nil {
+		return fmt.Errorf("failed deleting nodeIndex %q: %w", nodeIndexName(nodeName, entMeta, node.PeerName), err)
+	}
+
+	if err := catalogUpdateNodeExtinctionIndex(tx, idx, entMeta, node.PeerName); err != nil {
+		return err
+	}
+
+	if peerName == "" {
+		// Invalidate any sessions for this node.
+		toDelete, err := allNodeSessionsTxn(tx, nodeName, entMeta.PartitionOrDefault())
+		if err != nil {
+			return err
 		}
-	}
-	if err := catalogUpdateNodeExtinctionIndex(tx, idx, entMeta); err != nil {
-		return err
-	}
 
-	// Invalidate any sessions for this node.
-	toDelete, err := allNodeSessionsTxn(tx, nodeName, entMeta.PartitionOrDefault())
-	if err != nil {
-		return err
-	}
-
-	for _, session := range toDelete {
-		if err := s.deleteSessionTxn(tx, idx, session.ID, &session.EnterpriseMeta); err != nil {
-			return fmt.Errorf("failed to delete session '%s': %v", session.ID, err)
+		for _, session := range toDelete {
+			if err := s.deleteSessionTxn(tx, idx, session.ID, &session.EnterpriseMeta); err != nil {
+				return fmt.Errorf("failed to delete session '%s': %v", session.ID, err)
+			}
 		}
 	}
 
@@ -724,7 +815,13 @@ var errCASCompareFailed = errors.New("compare-and-set: comparison failed")
 // Returns an error if the write didn't happen and nil if write was successful.
 func ensureServiceCASTxn(tx WriteTxn, idx uint64, node string, svc *structs.NodeService) error {
 	// Retrieve the existing service.
-	existing, err := tx.First(tableServices, indexID, NodeServiceQuery{EnterpriseMeta: svc.EnterpriseMeta, Node: node, Service: svc.ID})
+	existing, err := tx.First(tableServices, indexID,
+		NodeServiceQuery{
+			EnterpriseMeta: svc.EnterpriseMeta,
+			Node:           node,
+			Service:        svc.ID,
+			PeerName:       svc.PeerName,
+		})
 	if err != nil {
 		return fmt.Errorf("failed service lookup: %s", err)
 	}
@@ -753,6 +850,7 @@ func ensureServiceTxn(tx WriteTxn, idx uint64, node string, preserveIndexes bool
 		EnterpriseMeta: svc.EnterpriseMeta,
 		Node:           node,
 		Service:        svc.ID,
+		PeerName:       svc.PeerName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed service lookup: %s", err)
@@ -762,9 +860,18 @@ func ensureServiceTxn(tx WriteTxn, idx uint64, node string, preserveIndexes bool
 		return fmt.Errorf("Invalid Service Meta for node %s and serviceID %s: %v", node, svc.ID, err)
 	}
 
-	// Check if this service is covered by a gateway's wildcard specifier
-	if err = checkGatewayWildcardsAndUpdate(tx, idx, svc); err != nil {
-		return fmt.Errorf("failed updating gateway mapping: %s", err)
+	if svc.PeerName == "" {
+		// Do not associate non-typical services with gateways or consul services
+		if svc.Kind == structs.ServiceKindTypical && svc.Service != "consul" {
+			// Check if this service is covered by a gateway's wildcard specifier, we force the service kind to a gateway-service here as that take precedence
+			sn := structs.NewServiceName(svc.Service, &svc.EnterpriseMeta)
+			if err = checkGatewayWildcardsAndUpdate(tx, idx, &sn, structs.GatewayServiceKindService); err != nil {
+				return fmt.Errorf("failed updating gateway mapping: %s", err)
+			}
+			if err = checkGatewayAndUpdate(tx, idx, &sn, structs.GatewayServiceKindService); err != nil {
+				return fmt.Errorf("failed updating gateway mapping: %s", err)
+			}
+		}
 	}
 	if err := upsertKindServiceName(tx, idx, svc.Kind, svc.CompoundServiceName()); err != nil {
 		return fmt.Errorf("failed to persist service name: %v", err)
@@ -800,28 +907,30 @@ func ensureServiceTxn(tx WriteTxn, idx uint64, node string, preserveIndexes bool
 		}
 	}
 
-	// If there's a terminating gateway config entry for this service, populate the tagged addresses
-	// with virtual IP mappings.
-	termGatewayVIPsSupported, err := terminatingGatewayVirtualIPsSupported(tx, nil)
-	if err != nil {
-		return err
-	}
-	if termGatewayVIPsSupported && svc.Kind == structs.ServiceKindTerminatingGateway {
-		_, conf, err := configEntryTxn(tx, nil, structs.TerminatingGateway, svc.Service, &svc.EnterpriseMeta)
+	if svc.PeerName == "" {
+		// If there's a terminating gateway config entry for this service, populate the tagged addresses
+		// with virtual IP mappings.
+		termGatewayVIPsSupported, err := terminatingGatewayVirtualIPsSupported(tx, nil)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve terminating gateway config: %s", err)
+			return err
 		}
-		if conf != nil {
-			termGatewayConf := conf.(*structs.TerminatingGatewayConfigEntry)
-			addrs, err := getTermGatewayVirtualIPs(tx, termGatewayConf.Services, &svc.EnterpriseMeta)
+		if termGatewayVIPsSupported && svc.Kind == structs.ServiceKindTerminatingGateway {
+			_, conf, err := configEntryTxn(tx, nil, structs.TerminatingGateway, svc.Service, &svc.EnterpriseMeta)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to retrieve terminating gateway config: %s", err)
 			}
-			if svc.TaggedAddresses == nil {
-				svc.TaggedAddresses = make(map[string]structs.ServiceAddress)
-			}
-			for key, addr := range addrs {
-				svc.TaggedAddresses[key] = addr
+			if conf != nil {
+				termGatewayConf := conf.(*structs.TerminatingGatewayConfigEntry)
+				addrs, err := getTermGatewayVirtualIPs(tx, termGatewayConf.Services, &svc.EnterpriseMeta)
+				if err != nil {
+					return err
+				}
+				if svc.TaggedAddresses == nil {
+					svc.TaggedAddresses = make(map[string]structs.ServiceAddress)
+				}
+				for key, addr := range addrs {
+					svc.TaggedAddresses[key] = addr
+				}
 			}
 		}
 	}
@@ -834,6 +943,7 @@ func ensureServiceTxn(tx WriteTxn, idx uint64, node string, preserveIndexes bool
 	n, err := tx.First(tableNodes, indexID, Query{
 		Value:          node,
 		EnterpriseMeta: svc.EnterpriseMeta,
+		PeerName:       svc.PeerName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed node lookup: %s", err)
@@ -867,6 +977,7 @@ func ensureServiceTxn(tx WriteTxn, idx uint64, node string, preserveIndexes bool
 // assignServiceVirtualIP assigns a virtual IP to the target service and updates
 // the global virtual IP counter if necessary.
 func assignServiceVirtualIP(tx WriteTxn, sn structs.ServiceName) (string, error) {
+	// TODO(peering): support VIPs
 	serviceVIP, err := tx.First(tableServiceVirtualIPs, indexID, sn)
 	if err != nil {
 		return "", fmt.Errorf("failed service virtual IP lookup: %s", err)
@@ -991,15 +1102,15 @@ func terminatingGatewayVirtualIPsSupported(tx ReadTxn, ws memdb.WatchSet) (bool,
 }
 
 // Services returns all services along with a list of associated tags.
-func (s *Store) Services(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.Services, error) {
+func (s *Store) Services(ws memdb.WatchSet, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.Services, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
 	// Get the table index.
-	idx := catalogServicesMaxIndex(tx, entMeta)
+	idx := catalogServicesMaxIndex(tx, entMeta, peerName)
 
 	// List all the services.
-	services, err := catalogServiceListNoWildcard(tx, entMeta)
+	services, err := catalogServiceListNoWildcard(tx, entMeta, peerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed querying services: %s", err)
 	}
@@ -1031,17 +1142,24 @@ func (s *Store) Services(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (ui
 	return idx, results, nil
 }
 
-func (s *Store) ServiceList(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceList, error) {
+func (s *Store) ServiceList(ws memdb.WatchSet, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.ServiceList, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	return serviceListTxn(tx, ws, entMeta)
+	return serviceListTxn(tx, ws, entMeta, peerName)
 }
 
-func serviceListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceList, error) {
-	idx := catalogServicesMaxIndex(tx, entMeta)
+func serviceListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.ServiceList, error) {
+	if entMeta == nil {
+		entMeta = structs.NodeEnterpriseMetaInDefaultPartition()
+	}
 
-	services, err := tx.Get(tableServices, indexID+"_prefix", entMeta)
+	idx := catalogServicesMaxIndex(tx, entMeta, peerName)
+
+	services, err := tx.Get(tableServices, indexID+"_prefix", Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed querying services: %s", err)
 	}
@@ -1062,7 +1180,7 @@ func serviceListTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMe
 }
 
 // ServicesByNodeMeta returns all services, filtered by the given node metadata.
-func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string, entMeta *structs.EnterpriseMeta) (uint64, structs.Services, error) {
+func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.Services, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -1072,8 +1190,9 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string,
 	}
 
 	// Get the table index.
-	idx := catalogServicesMaxIndex(tx, entMeta)
-	if nodeIdx := catalogNodesMaxIndex(tx, entMeta); nodeIdx > idx {
+	idx := catalogServicesMaxIndex(tx, entMeta, peerName)
+
+	if nodeIdx := catalogNodesMaxIndex(tx, entMeta, peerName); nodeIdx > idx {
 		idx = nodeIdx
 	}
 
@@ -1093,6 +1212,7 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string,
 		Key:            firstKey,
 		Value:          firstValue,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed nodes lookup: %s", err)
@@ -1101,7 +1221,7 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string,
 
 	// We don't want to track an unlimited number of services, so we pull a
 	// top-level watch to use as a fallback.
-	allServices, err := catalogServiceListNoWildcard(tx, entMeta)
+	allServices, err := catalogServiceListNoWildcard(tx, entMeta, peerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed services lookup: %s", err)
 	}
@@ -1116,7 +1236,7 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string,
 		}
 
 		// List all the services on the node
-		services, err := catalogServiceListByNode(tx, n.Node, entMeta, false)
+		services, err := catalogServiceListByNode(tx, n.Node, entMeta, n.PeerName, false)
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed querying services: %s", err)
 		}
@@ -1157,8 +1277,8 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string,
 //   * return when the last instance of a service is removed
 //   * block until an instance for this service is available, or another
 //     service is unregistered.
-func maxIndexForService(tx ReadTxn, serviceName string, serviceExists, checks bool, entMeta *structs.EnterpriseMeta) uint64 {
-	idx, _ := maxIndexAndWatchChForService(tx, serviceName, serviceExists, checks, entMeta)
+func maxIndexForService(tx ReadTxn, serviceName string, serviceExists, checks bool, entMeta *acl.EnterpriseMeta, peerName string) uint64 {
+	idx, _ := maxIndexAndWatchChForService(tx, serviceName, serviceExists, checks, entMeta, peerName)
 	return idx
 }
 
@@ -1176,20 +1296,20 @@ func maxIndexForService(tx ReadTxn, serviceName string, serviceExists, checks bo
 // returned for the chan. This allows for blocking watchers to _only_ watch this
 // one chan in the common case, falling back to watching all touched MemDB
 // indexes in more complicated cases.
-func maxIndexAndWatchChForService(tx ReadTxn, serviceName string, serviceExists, checks bool, entMeta *structs.EnterpriseMeta) (uint64, <-chan struct{}) {
+func maxIndexAndWatchChForService(tx ReadTxn, serviceName string, serviceExists, checks bool, entMeta *acl.EnterpriseMeta, peerName string) (uint64, <-chan struct{}) {
 	if !serviceExists {
-		res, err := catalogServiceLastExtinctionIndex(tx, entMeta)
+		res, err := catalogServiceLastExtinctionIndex(tx, entMeta, peerName)
 		if missingIdx, ok := res.(*IndexEntry); ok && err == nil {
 			// Note safe to only watch the extinction index as it's not updated when new instances come along so return nil watchCh
 			return missingIdx.Value, nil
 		}
 	}
 
-	ch, res, err := catalogServiceMaxIndex(tx, serviceName, entMeta)
+	ch, res, err := catalogServiceMaxIndex(tx, serviceName, entMeta, peerName)
 	if idx, ok := res.(*IndexEntry); ok && err == nil {
 		return idx.Value, ch
 	}
-	return catalogMaxIndex(tx, entMeta, checks), nil
+	return catalogMaxIndex(tx, entMeta, peerName, checks), nil
 }
 
 // Wrapper for maxIndexAndWatchChForService that operates on a list of ServiceNodes
@@ -1203,7 +1323,7 @@ func maxIndexAndWatchChsForServiceNodes(tx ReadTxn,
 	for i := 0; i < len(nodes); i++ {
 		sn := structs.NewServiceName(nodes[i].ServiceName, &nodes[i].EnterpriseMeta)
 		if ok := seen[sn]; !ok {
-			idx, svcCh := maxIndexAndWatchChForService(tx, sn.Name, true, watchChecks, &sn.EnterpriseMeta)
+			idx, svcCh := maxIndexAndWatchChForService(tx, sn.Name, true, watchChecks, &sn.EnterpriseMeta, nodes[i].PeerName)
 			if idx > maxIdx {
 				maxIdx = idx
 			}
@@ -1220,7 +1340,7 @@ func maxIndexAndWatchChsForServiceNodes(tx ReadTxn,
 // ConnectServiceNodes returns the nodes associated with a Connect
 // compatible destination for the given service name. This will include
 // both proxies and native integrations.
-func (s *Store) ConnectServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceNodes, error) {
+func (s *Store) ConnectServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.ServiceNodes, error) {
 	tx := s.db.ReadTxn()
 	defer tx.Abort()
 
@@ -1228,12 +1348,16 @@ func (s *Store) ConnectServiceNodes(ws memdb.WatchSet, serviceName string, entMe
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
-	q := Query{Value: serviceName, EnterpriseMeta: *entMeta}
+	q := Query{
+		Value:          serviceName,
+		PeerName:       peerName,
+		EnterpriseMeta: *entMeta,
+	}
 	return serviceNodesTxn(tx, ws, indexConnect, q)
 }
 
 // ServiceNodes returns the nodes associated with a given service name.
-func (s *Store) ServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceNodes, error) {
+func (s *Store) ServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.ServiceNodes, error) {
 	tx := s.db.ReadTxn()
 	defer tx.Abort()
 
@@ -1241,7 +1365,11 @@ func (s *Store) ServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *str
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
-	q := Query{Value: serviceName, EnterpriseMeta: *entMeta}
+	q := Query{
+		Value:          serviceName,
+		PeerName:       peerName,
+		EnterpriseMeta: *entMeta,
+	}
 	return serviceNodesTxn(tx, ws, indexService, q)
 }
 
@@ -1264,9 +1392,9 @@ func serviceNodesTxn(tx ReadTxn, ws memdb.WatchSet, index string, q Query) (uint
 	// We append rather than replace since it allows users to migrate a service
 	// to the mesh with a mix of sidecars and gateways until all its instances have a sidecar.
 	var idx uint64
-	if connect {
+	if connect && q.PeerName == "" {
 		// Look up gateway nodes associated with the service
-		gwIdx, nodes, err := serviceGatewayNodes(tx, ws, serviceName, structs.ServiceKindTerminatingGateway, &q.EnterpriseMeta)
+		gwIdx, nodes, err := serviceGatewayNodes(tx, ws, serviceName, structs.ServiceKindTerminatingGateway, &q.EnterpriseMeta, structs.DefaultPeerKeyword)
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed gateway nodes lookup: %v", err)
 		}
@@ -1289,7 +1417,7 @@ func serviceNodesTxn(tx ReadTxn, ws memdb.WatchSet, index string, q Query) (uint
 	}
 
 	// Fill in the node details.
-	results, err = parseServiceNodes(tx, ws, results, &q.EnterpriseMeta)
+	results, err = parseServiceNodes(tx, ws, results, &q.EnterpriseMeta, q.PeerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed parsing service nodes: %s", err)
 	}
@@ -1297,7 +1425,7 @@ func serviceNodesTxn(tx ReadTxn, ws memdb.WatchSet, index string, q Query) (uint
 	// Get the table index.
 	// TODO (gateways) (freddy) Why do we always consider the main service index here?
 	//      This doesn't seem to make sense for Connect when there's more than 1 result
-	svcIdx := maxIndexForService(tx, serviceName, len(results) > 0, false, &q.EnterpriseMeta)
+	svcIdx := maxIndexForService(tx, serviceName, len(results) > 0, false, &q.EnterpriseMeta, q.PeerName)
 	if idx < svcIdx {
 		idx = svcIdx
 	}
@@ -1307,7 +1435,7 @@ func serviceNodesTxn(tx ReadTxn, ws memdb.WatchSet, index string, q Query) (uint
 
 // ServiceTagNodes returns the nodes associated with a given service, filtering
 // out services that don't contain the given tags.
-func (s *Store) ServiceTagNodes(ws memdb.WatchSet, service string, tags []string, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceNodes, error) {
+func (s *Store) ServiceTagNodes(ws memdb.WatchSet, service string, tags []string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.ServiceNodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -1316,8 +1444,11 @@ func (s *Store) ServiceTagNodes(ws memdb.WatchSet, service string, tags []string
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
 
-	q := Query{Value: service, EnterpriseMeta: *entMeta}
-	services, err := tx.Get(tableServices, indexService, q)
+	services, err := tx.Get(tableServices, indexService, Query{
+		Value:          service,
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed service lookup: %s", err)
 	}
@@ -1335,12 +1466,12 @@ func (s *Store) ServiceTagNodes(ws memdb.WatchSet, service string, tags []string
 	}
 
 	// Fill in the node details.
-	results, err = parseServiceNodes(tx, ws, results, entMeta)
+	results, err = parseServiceNodes(tx, ws, results, entMeta, peerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed parsing service nodes: %s", err)
 	}
 	// Get the table index.
-	idx := maxIndexForService(tx, service, serviceExists, false, entMeta)
+	idx := maxIndexForService(tx, service, serviceExists, false, entMeta, peerName)
 
 	return idx, results, nil
 }
@@ -1377,12 +1508,16 @@ func serviceTagsFilter(sn *structs.ServiceNode, tags []string) bool {
 
 // ServiceAddressNodes returns the nodes associated with a given service, filtering
 // out services that don't match the given serviceAddress
-func (s *Store) ServiceAddressNodes(ws memdb.WatchSet, address string, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceNodes, error) {
+func (s *Store) ServiceAddressNodes(ws memdb.WatchSet, address string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.ServiceNodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
 	// List all the services.
-	services, err := tx.Get(tableServices, indexID+"_prefix", entMeta)
+	q := Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
+	services, err := tx.Get(tableServices, indexID+"_prefix", q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed service lookup: %s", err)
 	}
@@ -1405,7 +1540,7 @@ func (s *Store) ServiceAddressNodes(ws memdb.WatchSet, address string, entMeta *
 	}
 
 	// Fill in the node details.
-	results, err = parseServiceNodes(tx, ws, results, entMeta)
+	results, err = parseServiceNodes(tx, ws, results, entMeta, peerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed parsing service nodes: %s", err)
 	}
@@ -1414,10 +1549,14 @@ func (s *Store) ServiceAddressNodes(ws memdb.WatchSet, address string, entMeta *
 
 // parseServiceNodes iterates over a services query and fills in the node details,
 // returning a ServiceNodes slice.
-func parseServiceNodes(tx ReadTxn, ws memdb.WatchSet, services structs.ServiceNodes, entMeta *structs.EnterpriseMeta) (structs.ServiceNodes, error) {
+func parseServiceNodes(tx ReadTxn, ws memdb.WatchSet, services structs.ServiceNodes, entMeta *acl.EnterpriseMeta, peerName string) (structs.ServiceNodes, error) {
 	// We don't want to track an unlimited number of nodes, so we pull a
 	// top-level watch to use as a fallback.
-	allNodes, err := tx.Get(tableNodes, indexID+"_prefix", entMeta)
+	q := Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
+	allNodes, err := tx.Get(tableNodes, indexID+"_prefix", q)
 	if err != nil {
 		return nil, fmt.Errorf("failed nodes lookup: %s", err)
 	}
@@ -1435,6 +1574,7 @@ func parseServiceNodes(tx ReadTxn, ws memdb.WatchSet, services structs.ServiceNo
 		watchCh, n, err := tx.FirstWatch(tableNodes, indexID, Query{
 			Value:          sn.Node,
 			EnterpriseMeta: sn.EnterpriseMeta,
+			PeerName:       sn.PeerName,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed node lookup: %s", err)
@@ -1459,15 +1599,15 @@ func parseServiceNodes(tx ReadTxn, ws memdb.WatchSet, services structs.ServiceNo
 
 // NodeService is used to retrieve a specific service associated with the given
 // node.
-func (s *Store) NodeService(nodeName string, serviceID string, entMeta *structs.EnterpriseMeta) (uint64, *structs.NodeService, error) {
+func (s *Store) NodeService(ws memdb.WatchSet, nodeName string, serviceID string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.NodeService, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
 	// Get the table index.
-	idx := catalogServicesMaxIndex(tx, entMeta)
+	idx := catalogServicesMaxIndex(tx, entMeta, peerName)
 
 	// Query the service
-	service, err := getNodeServiceTxn(tx, nodeName, serviceID, entMeta)
+	service, err := getNodeServiceTxn(tx, ws, nodeName, serviceID, entMeta, peerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed querying service for node %q: %s", nodeName, err)
 	}
@@ -1475,30 +1615,81 @@ func (s *Store) NodeService(nodeName string, serviceID string, entMeta *structs.
 	return idx, service, nil
 }
 
-func getNodeServiceTxn(tx ReadTxn, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) (*structs.NodeService, error) {
+func getNodeServiceTxn(tx ReadTxn, ws memdb.WatchSet, nodeName, serviceID string, entMeta *acl.EnterpriseMeta, peerName string) (*structs.NodeService, error) {
+	sn, err := getServiceNodeTxn(tx, ws, nodeName, serviceID, entMeta, peerName)
+	if err != nil {
+		return nil, err
+	}
+	if sn != nil {
+		return sn.ToNodeService(), nil
+	}
+	return nil, nil
+}
+
+func getServiceNodeTxn(tx ReadTxn, ws memdb.WatchSet, nodeName, serviceID string, entMeta *acl.EnterpriseMeta, peerName string) (*structs.ServiceNode, error) {
 	// TODO: pass non-pointer type for ent meta
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
 
 	// Query the service
-	service, err := tx.First(tableServices, indexID, NodeServiceQuery{
+	watch, service, err := tx.FirstWatch(tableServices, indexID, NodeServiceQuery{
 		EnterpriseMeta: *entMeta,
 		Node:           nodeName,
 		Service:        serviceID,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed querying service for node %q: %s", nodeName, err)
 	}
+	ws.Add(watch)
 
 	if service != nil {
-		return service.(*structs.ServiceNode).ToNodeService(), nil
+		return service.(*structs.ServiceNode), nil
 	}
 
 	return nil, nil
 }
 
-func (s *Store) nodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *structs.EnterpriseMeta, allowWildcard bool) (bool, uint64, *structs.Node, memdb.ResultIterator, error) {
+// ServiceNode is used to retrieve a specific service by service ID and node ID or name.
+func (s *Store) ServiceNode(nodeID, nodeName, serviceID string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.ServiceNode, error) {
+	var (
+		node *structs.Node
+		err  error
+	)
+	if nodeID != "" {
+		_, node, err = s.GetNodeID(types.NodeID(nodeID), entMeta, peerName)
+		if err != nil {
+			return 0, nil, fmt.Errorf("Failure looking up node by ID %s: %w", nodeID, err)
+		}
+	} else if nodeName != "" {
+		_, node, err = s.GetNode(nodeName, entMeta, peerName)
+		if err != nil {
+			return 0, nil, fmt.Errorf("Failure looking up node by name %s: %w", nodeName, err)
+		}
+	} else {
+		return 0, nil, fmt.Errorf("Node ID or name required to lookup the service")
+	}
+	if node == nil {
+		return 0, nil, ErrNodeNotFound
+	}
+
+	tx := s.db.Txn(false)
+	defer tx.Abort()
+
+	// Get the table index.
+	idx := catalogServicesMaxIndex(tx, entMeta, peerName)
+
+	// Query the service
+	service, err := getServiceNodeTxn(tx, nil, node.Node, serviceID, entMeta, peerName)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed querying service for node %q: %w", node.Node, err)
+	}
+
+	return idx, service, nil
+}
+
+func (s *Store) nodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *acl.EnterpriseMeta, peerName string, allowWildcard bool) (bool, uint64, *structs.Node, memdb.ResultIterator, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -1508,7 +1699,11 @@ func (s *Store) nodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *st
 	}
 
 	// Query the node by node name
-	watchCh, n, err := tx.FirstWatch(tableNodes, indexID, Query{Value: nodeNameOrID, EnterpriseMeta: *entMeta})
+	watchCh, n, err := tx.FirstWatch(tableNodes, indexID, Query{
+		Value:          nodeNameOrID,
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	})
 	if err != nil {
 		return true, 0, nil, nil, fmt.Errorf("node lookup failed: %s", err)
 	}
@@ -1518,20 +1713,18 @@ func (s *Store) nodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *st
 	} else {
 		if len(nodeNameOrID) < minUUIDLookupLen {
 			ws.Add(watchCh)
-			idx := catalogNodeMaxExtinctionIndex(tx, entMeta)
-			return true, idx, nil, nil, nil
+			return true, 0, nil, nil, nil
 		}
 
 		// Attempt to lookup the node by its node ID
 		iter, err := tx.Get(tableNodes, indexUUID+"_prefix", Query{
 			Value:          resizeNodeLookupKey(nodeNameOrID),
 			EnterpriseMeta: *entMeta,
+			PeerName:       peerName,
 		})
 		if err != nil {
 			ws.Add(watchCh)
-			// TODO(sean@): We could/should log an error re: the uuid_prefix lookup
-			// failing once a logger has been introduced to the catalog.
-			idx := catalogNodeMaxExtinctionIndex(tx, entMeta)
+			idx := catalogNodeLastExtinctionIndex(tx, entMeta, peerName)
 			return true, idx, nil, nil, nil
 		}
 
@@ -1539,7 +1732,7 @@ func (s *Store) nodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *st
 		if n == nil {
 			// No nodes matched, even with the Node ID: add a watch on the node name.
 			ws.Add(watchCh)
-			idx := catalogNodeMaxExtinctionIndex(tx, entMeta)
+			idx := catalogNodeLastExtinctionIndex(tx, entMeta, peerName)
 			return true, idx, nil, nil, nil
 		}
 
@@ -1558,21 +1751,21 @@ func (s *Store) nodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *st
 	nodeName := node.Node
 
 	// Read all of the services
-	services, err := catalogServiceListByNode(tx, nodeName, entMeta, allowWildcard)
+	services, err := catalogServiceListByNode(tx, nodeName, entMeta, peerName, allowWildcard)
 	if err != nil {
 		return true, 0, nil, nil, fmt.Errorf("failed querying services for node %q: %s", nodeName, err)
 	}
 	ws.Add(services.WatchCh())
 
-	// Get the node index.
-	idx := catalogNodeMaxIndex(tx, nodeName, entMeta)
+	// Get the table index.
+	idx := catalogNodeMaxIndex(tx, nodeName, entMeta, peerName)
 
 	return false, idx, node, services, nil
 }
 
 // NodeServices is used to query service registrations by node name or UUID.
-func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *structs.EnterpriseMeta) (uint64, *structs.NodeServices, error) {
-	done, idx, node, services, err := s.nodeServices(ws, nodeNameOrID, entMeta, false)
+func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.NodeServices, error) {
+	done, idx, node, services, err := s.nodeServices(ws, nodeNameOrID, entMeta, peerName, false)
 	if done || err != nil {
 		return idx, nil, err
 	}
@@ -1595,8 +1788,8 @@ func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *st
 }
 
 // NodeServices is used to query service registrations by node name or UUID.
-func (s *Store) NodeServiceList(ws memdb.WatchSet, nodeNameOrID string, entMeta *structs.EnterpriseMeta) (uint64, *structs.NodeServiceList, error) {
-	done, idx, node, services, err := s.nodeServices(ws, nodeNameOrID, entMeta, true)
+func (s *Store) NodeServiceList(ws memdb.WatchSet, nodeNameOrID string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.NodeServiceList, error) {
+	done, idx, node, services, err := s.nodeServices(ws, nodeNameOrID, entMeta, peerName, true)
 	if done || err != nil {
 		return idx, nil, err
 	}
@@ -1622,12 +1815,12 @@ func (s *Store) NodeServiceList(ws memdb.WatchSet, nodeNameOrID string, entMeta 
 }
 
 // DeleteService is used to delete a given service associated with a node.
-func (s *Store) DeleteService(idx uint64, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) DeleteService(idx uint64, nodeName, serviceID string, entMeta *acl.EnterpriseMeta, peerName string) error {
 	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	// Call the service deletion
-	if err := s.deleteServiceTxn(tx, idx, nodeName, serviceID, entMeta); err != nil {
+	if err := s.deleteServiceTxn(tx, idx, nodeName, serviceID, entMeta, peerName); err != nil {
 		return err
 	}
 
@@ -1637,9 +1830,9 @@ func (s *Store) DeleteService(idx uint64, nodeName, serviceID string, entMeta *s
 // deleteServiceCASTxn is used to try doing a service delete operation with a given
 // raft index. If the CAS index specified is not equal to the last observed index for
 // the given service, then the call is a noop, otherwise a normal delete is invoked.
-func (s *Store) deleteServiceCASTxn(tx WriteTxn, idx, cidx uint64, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) (bool, error) {
+func (s *Store) deleteServiceCASTxn(tx WriteTxn, idx, cidx uint64, nodeName, serviceID string, entMeta *acl.EnterpriseMeta, peerName string) (bool, error) {
 	// Look up the service.
-	service, err := getNodeServiceTxn(tx, nodeName, serviceID, entMeta)
+	service, err := getNodeServiceTxn(tx, nil, nodeName, serviceID, entMeta, peerName)
 	if err != nil {
 		return false, fmt.Errorf("service lookup failed: %s", err)
 	}
@@ -1655,7 +1848,7 @@ func (s *Store) deleteServiceCASTxn(tx WriteTxn, idx, cidx uint64, nodeName, ser
 	}
 
 	// Call the actual deletion if the above passed.
-	if err := s.deleteServiceTxn(tx, idx, nodeName, serviceID, entMeta); err != nil {
+	if err := s.deleteServiceTxn(tx, idx, nodeName, serviceID, entMeta, peerName); err != nil {
 		return false, err
 	}
 
@@ -1664,13 +1857,19 @@ func (s *Store) deleteServiceCASTxn(tx WriteTxn, idx, cidx uint64, nodeName, ser
 
 // deleteServiceTxn is the inner method called to remove a service
 // registration within an existing transaction.
-func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID string, entMeta *acl.EnterpriseMeta, peerName string) error {
 	// TODO: pass non-pointer type for ent meta
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
 
-	service, err := tx.First(tableServices, indexID, NodeServiceQuery{EnterpriseMeta: *entMeta, Node: nodeName, Service: serviceID})
+	service, err := tx.First(tableServices, indexID,
+		NodeServiceQuery{
+			EnterpriseMeta: *entMeta,
+			Node:           nodeName,
+			Service:        serviceID,
+			PeerName:       peerName,
+		})
 	if err != nil {
 		return fmt.Errorf("failed service lookup: %s", err)
 	}
@@ -1688,6 +1887,7 @@ func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID st
 		Node:           nodeName,
 		Service:        serviceID,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	}
 	checks, err := tx.Get(tableChecks, indexNodeService, nsq)
 	if err != nil {
@@ -1700,13 +1900,13 @@ func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID st
 
 	// Do the delete in a separate loop so we don't trash the iterator.
 	for _, check := range deleteChecks {
-		if err := s.deleteCheckTxn(tx, idx, nodeName, check.CheckID, &check.EnterpriseMeta); err != nil {
+		if err := s.deleteCheckTxn(tx, idx, nodeName, check.CheckID, &check.EnterpriseMeta, check.PeerName); err != nil {
 			return err
 		}
 	}
 
 	// Update the index.
-	if err := catalogUpdateCheckIndexes(tx, idx, entMeta); err != nil {
+	if err := catalogUpdateCheckIndexes(tx, idx, entMeta, peerName); err != nil {
 		return err
 	}
 
@@ -1714,46 +1914,56 @@ func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID st
 	if err := tx.Delete(tableServices, service); err != nil {
 		return fmt.Errorf("failed deleting service: %s", err)
 	}
-	if err := catalogUpdateServicesIndexes(tx, idx, entMeta); err != nil {
-		return fmt.Errorf("failed updating index: %s", err)
-	}
-
-	if err := catalogUpdateNodeIndexes(tx, nodeName, idx, entMeta); err != nil {
-		return err
-	}
 
 	svc := service.(*structs.ServiceNode)
+	if err := catalogUpdateServicesIndexes(tx, idx, entMeta, svc.PeerName); err != nil {
+		return fmt.Errorf("failed updating services indexes: %w", err)
+	}
+	if err := catalogUpdateServiceKindIndexes(tx, idx, svc.ServiceKind, &svc.EnterpriseMeta, svc.PeerName); err != nil {
+		return fmt.Errorf("failed updating service-kind indexes: %w", err)
+	}
+	// Update the node indexes as the service information is included in node catalog queries.
+	if err := catalogUpdateNodesIndexes(tx, idx, entMeta, peerName); err != nil {
+		return fmt.Errorf("failed updating nodes indexes: %w", err)
+	}
+	if err := catalogUpdateNodeIndexes(tx, idx, nodeName, entMeta, peerName); err != nil {
+		return fmt.Errorf("failed updating node indexes: %w", err)
+	}
+
 	name := svc.CompoundServiceName()
 
-	if err := catalogUpdateServiceKindIndexes(tx, svc.ServiceKind, idx, &svc.EnterpriseMeta); err != nil {
-		return err
-	}
 	if err := cleanupMeshTopology(tx, idx, svc); err != nil {
 		return fmt.Errorf("failed to clean up mesh-topology associations for %q: %v", name.String(), err)
 	}
 
-	q := Query{Value: svc.ServiceName, EnterpriseMeta: *entMeta}
+	q := Query{
+		Value:          svc.ServiceName,
+		EnterpriseMeta: *entMeta,
+		PeerName:       svc.PeerName,
+	}
 	if remainingService, err := tx.First(tableServices, indexService, q); err == nil {
 		if remainingService != nil {
 			// We have at least one remaining service, update the index
-			if err := catalogUpdateServiceIndexes(tx, svc.ServiceName, idx, entMeta); err != nil {
+			if err := catalogUpdateServiceIndexes(tx, idx, svc.ServiceName, entMeta, svc.PeerName); err != nil {
 				return err
 			}
 		} else {
 			// There are no more service instances, cleanup the service.<serviceName> index
-			_, serviceIndex, err := catalogServiceMaxIndex(tx, svc.ServiceName, entMeta)
+			_, serviceIndex, err := catalogServiceMaxIndex(tx, svc.ServiceName, entMeta, svc.PeerName)
 			if err == nil && serviceIndex != nil {
 				// we found service.<serviceName> index, garbage collect it
-				if errW := tx.Delete(tableIndex, serviceIndex); errW != nil {
+				if err := tx.Delete(tableIndex, serviceIndex); err != nil {
 					return fmt.Errorf("[FAILED] deleting serviceIndex %s: %s", svc.ServiceName, err)
 				}
 			}
 
-			if err := catalogUpdateServiceExtinctionIndex(tx, idx, entMeta); err != nil {
+			if err := catalogUpdateServiceExtinctionIndex(tx, idx, entMeta, svc.PeerName); err != nil {
 				return err
 			}
-			if err := cleanupGatewayWildcards(tx, idx, svc); err != nil {
-				return fmt.Errorf("failed to clean up gateway-service associations for %q: %v", name.String(), err)
+			if svc.PeerName == "" {
+				if err := cleanupGatewayWildcards(tx, idx, svc); err != nil {
+					return fmt.Errorf("failed to clean up gateway-service associations for %q: %v", name.String(), err)
+				}
 			}
 			if err := freeServiceVirtualIP(tx, svc.ServiceName, nil, entMeta); err != nil {
 				return fmt.Errorf("failed to clean up virtual IP for %q: %v", name.String(), err)
@@ -1771,7 +1981,7 @@ func (s *Store) deleteServiceTxn(tx WriteTxn, idx uint64, nodeName, serviceID st
 
 // freeServiceVirtualIP is used to free a virtual IP for a service after the last instance
 // is removed.
-func freeServiceVirtualIP(tx WriteTxn, svc string, excludeGateway *structs.ServiceName, entMeta *structs.EnterpriseMeta) error {
+func freeServiceVirtualIP(tx WriteTxn, svc string, excludeGateway *structs.ServiceName, entMeta *acl.EnterpriseMeta) error {
 	supported, err := virtualIPsSupported(tx, nil)
 	if err != nil {
 		return err
@@ -1838,20 +2048,24 @@ func (s *Store) EnsureCheck(idx uint64, hc *structs.HealthCheck) error {
 }
 
 // updateAllServiceIndexesOfNode updates the Raft index of all the services associated with this node
-func updateAllServiceIndexesOfNode(tx WriteTxn, idx uint64, nodeID string, entMeta *structs.EnterpriseMeta) error {
+func updateAllServiceIndexesOfNode(tx WriteTxn, idx uint64, nodeID string, entMeta *acl.EnterpriseMeta, peerName string) error {
+	if peerName == "" {
+		peerName = structs.LocalPeerKeyword
+	}
 	services, err := tx.Get(tableServices, indexNode, Query{
 		Value:          nodeID,
 		EnterpriseMeta: *entMeta.WithWildcardNamespace(),
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed updating services for node %s: %s", nodeID, err)
 	}
 	for service := services.Next(); service != nil; service = services.Next() {
 		svc := service.(*structs.ServiceNode)
-		if err := catalogUpdateServiceIndexes(tx, svc.ServiceName, idx, &svc.EnterpriseMeta); err != nil {
+		if err := catalogUpdateServiceIndexes(tx, idx, svc.ServiceName, &svc.EnterpriseMeta, svc.PeerName); err != nil {
 			return err
 		}
-		if err := catalogUpdateServiceKindIndexes(tx, svc.ServiceKind, idx, &svc.EnterpriseMeta); err != nil {
+		if err := catalogUpdateServiceKindIndexes(tx, idx, svc.ServiceKind, &svc.EnterpriseMeta, svc.PeerName); err != nil {
 			return err
 		}
 	}
@@ -1862,7 +2076,7 @@ func updateAllServiceIndexesOfNode(tx WriteTxn, idx uint64, nodeID string, entMe
 // Returns a bool indicating if a write happened and any error.
 func (s *Store) ensureCheckCASTxn(tx WriteTxn, idx uint64, hc *structs.HealthCheck) (bool, error) {
 	// Retrieve the existing entry.
-	_, existing, err := getNodeCheckTxn(tx, hc.Node, hc.CheckID, &hc.EnterpriseMeta)
+	_, existing, err := getNodeCheckTxn(tx, hc.Node, hc.CheckID, &hc.EnterpriseMeta, hc.PeerName)
 	if err != nil {
 		return false, fmt.Errorf("failed health check lookup: %s", err)
 	}
@@ -1896,6 +2110,7 @@ func (s *Store) ensureCheckTxn(tx WriteTxn, idx uint64, preserveIndexes bool, hc
 		EnterpriseMeta: hc.EnterpriseMeta,
 		Node:           hc.Node,
 		CheckID:        string(hc.CheckID),
+		PeerName:       hc.PeerName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed health check lookup: %s", err)
@@ -1919,6 +2134,7 @@ func (s *Store) ensureCheckTxn(tx WriteTxn, idx uint64, preserveIndexes bool, hc
 	node, err := tx.First(tableNodes, indexID, Query{
 		Value:          hc.Node,
 		EnterpriseMeta: hc.EnterpriseMeta,
+		PeerName:       hc.PeerName,
 	})
 	if err != nil {
 		return fmt.Errorf("failed node lookup: %s", err)
@@ -1935,6 +2151,7 @@ func (s *Store) ensureCheckTxn(tx WriteTxn, idx uint64, preserveIndexes bool, hc
 			EnterpriseMeta: hc.EnterpriseMeta,
 			Node:           hc.Node,
 			Service:        hc.ServiceID,
+			PeerName:       hc.PeerName,
 		})
 		if err != nil {
 			return fmt.Errorf("failed service lookup: %s", err)
@@ -1950,10 +2167,10 @@ func (s *Store) ensureCheckTxn(tx WriteTxn, idx uint64, preserveIndexes bool, hc
 		if existing != nil && existing.(*structs.HealthCheck).IsSame(hc) {
 			modified = false
 		} else {
-			if err = catalogUpdateServiceIndexes(tx, svc.ServiceName, idx, &svc.EnterpriseMeta); err != nil {
+			if err = catalogUpdateServiceIndexes(tx, idx, svc.ServiceName, &svc.EnterpriseMeta, svc.PeerName); err != nil {
 				return err
 			}
-			if err := catalogUpdateServiceKindIndexes(tx, svc.ServiceKind, idx, &svc.EnterpriseMeta); err != nil {
+			if err := catalogUpdateServiceKindIndexes(tx, idx, svc.ServiceKind, &svc.EnterpriseMeta, svc.PeerName); err != nil {
 				return err
 			}
 		}
@@ -1963,7 +2180,7 @@ func (s *Store) ensureCheckTxn(tx WriteTxn, idx uint64, preserveIndexes bool, hc
 		} else {
 			// Since the check has been modified, it impacts all services of node
 			// Update the status for all the services associated with this node
-			err = updateAllServiceIndexesOfNode(tx, idx, hc.Node, &hc.EnterpriseMeta)
+			err = updateAllServiceIndexesOfNode(tx, idx, hc.Node, &hc.EnterpriseMeta, hc.PeerName)
 			if err != nil {
 				return err
 			}
@@ -1971,7 +2188,7 @@ func (s *Store) ensureCheckTxn(tx WriteTxn, idx uint64, preserveIndexes bool, hc
 	}
 
 	// Delete any sessions for this check if the health is critical.
-	if hc.Status == api.HealthCritical {
+	if hc.Status == api.HealthCritical && hc.PeerName == "" {
 		sessions, err := checkSessionsTxn(tx, hc)
 		if err != nil {
 			return err
@@ -1997,18 +2214,18 @@ func (s *Store) ensureCheckTxn(tx WriteTxn, idx uint64, preserveIndexes bool, hc
 
 // NodeCheck is used to retrieve a specific check associated with the given
 // node.
-func (s *Store) NodeCheck(nodeName string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) (uint64, *structs.HealthCheck, error) {
+func (s *Store) NodeCheck(nodeName string, checkID types.CheckID, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.HealthCheck, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	return getNodeCheckTxn(tx, nodeName, checkID, entMeta)
+	return getNodeCheckTxn(tx, nodeName, checkID, entMeta, peerName)
 }
 
 // nodeCheckTxn is used as the inner method to handle reading a health check
 // from the state store.
-func getNodeCheckTxn(tx ReadTxn, nodeName string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) (uint64, *structs.HealthCheck, error) {
+func getNodeCheckTxn(tx ReadTxn, nodeName string, checkID types.CheckID, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.HealthCheck, error) {
 	// Get the table index.
-	idx := catalogChecksMaxIndex(tx, entMeta)
+	idx := catalogChecksMaxIndex(tx, entMeta, peerName)
 
 	// TODO: accept non-pointer value
 	if entMeta == nil {
@@ -2016,7 +2233,13 @@ func getNodeCheckTxn(tx ReadTxn, nodeName string, checkID types.CheckID, entMeta
 	}
 
 	// Return the check.
-	check, err := tx.First(tableChecks, indexID, NodeCheckQuery{EnterpriseMeta: *entMeta, Node: nodeName, CheckID: string(checkID)})
+	check, err := tx.First(tableChecks, indexID,
+		NodeCheckQuery{
+			EnterpriseMeta: *entMeta,
+			Node:           nodeName,
+			CheckID:        string(checkID),
+			PeerName:       peerName,
+		})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed check lookup: %s", err)
 	}
@@ -2029,7 +2252,7 @@ func getNodeCheckTxn(tx ReadTxn, nodeName string, checkID types.CheckID, entMeta
 
 // NodeChecks is used to retrieve checks associated with the
 // given node from the state store.
-func (s *Store) NodeChecks(ws memdb.WatchSet, nodeName string, entMeta *structs.EnterpriseMeta) (uint64, structs.HealthChecks, error) {
+func (s *Store) NodeChecks(ws memdb.WatchSet, nodeName string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.HealthChecks, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -2038,10 +2261,14 @@ func (s *Store) NodeChecks(ws memdb.WatchSet, nodeName string, entMeta *structs.
 	}
 
 	// Get the table index.
-	idx := catalogChecksMaxIndex(tx, entMeta)
+	idx := catalogChecksMaxIndex(tx, entMeta, peerName)
 
 	// Return the checks.
-	iter, err := catalogListChecksByNode(tx, Query{Value: nodeName, EnterpriseMeta: *entMeta})
+	iter, err := catalogListChecksByNode(tx, Query{
+		Value:          nodeName,
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed check lookup: %s", err)
 	}
@@ -2057,17 +2284,21 @@ func (s *Store) NodeChecks(ws memdb.WatchSet, nodeName string, entMeta *structs.
 // ServiceChecks is used to get all checks associated with a
 // given service ID. The query is performed against a service
 // _name_ instead of a service ID.
-func (s *Store) ServiceChecks(ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta) (uint64, structs.HealthChecks, error) {
+func (s *Store) ServiceChecks(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.HealthChecks, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
 	// Get the table index.
-	idx := catalogChecksMaxIndex(tx, entMeta)
+	idx := catalogChecksMaxIndex(tx, entMeta, peerName)
 
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
-	q := Query{Value: serviceName, EnterpriseMeta: *entMeta}
+	q := Query{
+		Value:          serviceName,
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
 	iter, err := tx.Get(tableChecks, indexService, q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed check lookup: %s", err)
@@ -2084,35 +2315,37 @@ func (s *Store) ServiceChecks(ws memdb.WatchSet, serviceName string, entMeta *st
 // ServiceChecksByNodeMeta is used to get all checks associated with a
 // given service ID, filtered by the given node metadata values. The query
 // is performed against a service _name_ instead of a service ID.
-func (s *Store) ServiceChecksByNodeMeta(ws memdb.WatchSet, serviceName string,
-	filters map[string]string, entMeta *structs.EnterpriseMeta) (uint64, structs.HealthChecks, error) {
-
+func (s *Store) ServiceChecksByNodeMeta(ws memdb.WatchSet, serviceName string, filters map[string]string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.HealthChecks, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
 	// Get the table index.
-	idx := maxIndexForService(tx, serviceName, true, true, entMeta)
+	idx := maxIndexForService(tx, serviceName, true, true, entMeta, peerName)
 
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
-	q := Query{Value: serviceName, EnterpriseMeta: *entMeta}
+	q := Query{
+		Value:          serviceName,
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
 	iter, err := tx.Get(tableChecks, indexService, q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed check lookup: %s", err)
 	}
 	ws.Add(iter.WatchCh())
 
-	return parseChecksByNodeMeta(tx, ws, idx, iter, filters, entMeta)
+	return parseChecksByNodeMeta(tx, ws, idx, iter, filters, entMeta, peerName)
 }
 
 // ChecksInState is used to query the state store for all checks
 // which are in the provided state.
-func (s *Store) ChecksInState(ws memdb.WatchSet, state string, entMeta *structs.EnterpriseMeta) (uint64, structs.HealthChecks, error) {
+func (s *Store) ChecksInState(ws memdb.WatchSet, state string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.HealthChecks, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	idx, iter, err := checksInStateTxn(tx, ws, state, entMeta)
+	idx, iter, err := checksInStateTxn(tx, ws, state, entMeta, peerName)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -2126,21 +2359,21 @@ func (s *Store) ChecksInState(ws memdb.WatchSet, state string, entMeta *structs.
 
 // ChecksInStateByNodeMeta is used to query the state store for all checks
 // which are in the provided state, filtered by the given node metadata values.
-func (s *Store) ChecksInStateByNodeMeta(ws memdb.WatchSet, state string, filters map[string]string, entMeta *structs.EnterpriseMeta) (uint64, structs.HealthChecks, error) {
+func (s *Store) ChecksInStateByNodeMeta(ws memdb.WatchSet, state string, filters map[string]string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.HealthChecks, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	idx, iter, err := checksInStateTxn(tx, ws, state, entMeta)
+	idx, iter, err := checksInStateTxn(tx, ws, state, entMeta, peerName)
 	if err != nil {
 		return 0, nil, err
 	}
 
-	return parseChecksByNodeMeta(tx, ws, idx, iter, filters, entMeta)
+	return parseChecksByNodeMeta(tx, ws, idx, iter, filters, entMeta, peerName)
 }
 
-func checksInStateTxn(tx ReadTxn, ws memdb.WatchSet, state string, entMeta *structs.EnterpriseMeta) (uint64, memdb.ResultIterator, error) {
+func checksInStateTxn(tx ReadTxn, ws memdb.WatchSet, state string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, memdb.ResultIterator, error) {
 	// Get the table index.
-	idx := catalogChecksMaxIndex(tx, entMeta)
+	idx := catalogChecksMaxIndex(tx, entMeta, peerName)
 
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
@@ -2150,9 +2383,17 @@ func checksInStateTxn(tx ReadTxn, ws memdb.WatchSet, state string, entMeta *stru
 	var iter memdb.ResultIterator
 	var err error
 	if state == api.HealthAny {
-		iter, err = tx.Get(tableChecks, indexID+"_prefix", entMeta)
+		q := Query{
+			EnterpriseMeta: *entMeta,
+			PeerName:       peerName,
+		}
+		iter, err = tx.Get(tableChecks, indexID+"_prefix", q)
 	} else {
-		q := Query{Value: state, EnterpriseMeta: *entMeta}
+		q := Query{
+			Value:          state,
+			EnterpriseMeta: *entMeta,
+			PeerName:       peerName,
+		}
 		iter, err = tx.Get(tableChecks, indexStatus, q)
 	}
 	if err != nil {
@@ -2165,13 +2406,26 @@ func checksInStateTxn(tx ReadTxn, ws memdb.WatchSet, state string, entMeta *stru
 
 // parseChecksByNodeMeta is a helper function used to deduplicate some
 // repetitive code for returning health checks filtered by node metadata fields.
-func parseChecksByNodeMeta(tx ReadTxn, ws memdb.WatchSet,
-	idx uint64, iter memdb.ResultIterator, filters map[string]string,
-	entMeta *structs.EnterpriseMeta) (uint64, structs.HealthChecks, error) {
+func parseChecksByNodeMeta(
+	tx ReadTxn,
+	ws memdb.WatchSet,
+	idx uint64,
+	iter memdb.ResultIterator,
+	filters map[string]string,
+	entMeta *acl.EnterpriseMeta,
+	peerName string,
+) (uint64, structs.HealthChecks, error) {
+	if entMeta == nil {
+		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
+	}
 
 	// We don't want to track an unlimited number of nodes, so we pull a
 	// top-level watch to use as a fallback.
-	allNodes, err := tx.Get(tableNodes, indexID+"_prefix", entMeta)
+	q := Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
+	allNodes, err := tx.Get(tableNodes, indexID+"_prefix", q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed nodes lookup: %s", err)
 	}
@@ -2184,6 +2438,7 @@ func parseChecksByNodeMeta(tx ReadTxn, ws memdb.WatchSet,
 		watchCh, node, err := tx.FirstWatch(tableNodes, indexID, Query{
 			Value:          healthCheck.Node,
 			EnterpriseMeta: healthCheck.EnterpriseMeta,
+			PeerName:       healthCheck.PeerName,
 		})
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed node lookup: %s", err)
@@ -2203,12 +2458,12 @@ func parseChecksByNodeMeta(tx ReadTxn, ws memdb.WatchSet,
 }
 
 // DeleteCheck is used to delete a health check registration.
-func (s *Store) DeleteCheck(idx uint64, node string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) DeleteCheck(idx uint64, node string, checkID types.CheckID, entMeta *acl.EnterpriseMeta, peerName string) error {
 	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	// Call the check deletion
-	if err := s.deleteCheckTxn(tx, idx, node, checkID, entMeta); err != nil {
+	if err := s.deleteCheckTxn(tx, idx, node, checkID, entMeta, peerName); err != nil {
 		return err
 	}
 
@@ -2218,9 +2473,16 @@ func (s *Store) DeleteCheck(idx uint64, node string, checkID types.CheckID, entM
 // deleteCheckCASTxn is used to try doing a check delete operation with a given
 // raft index. If the CAS index specified is not equal to the last observed index for
 // the given check, then the call is a noop, otherwise a normal check delete is invoked.
-func (s *Store) deleteCheckCASTxn(tx WriteTxn, idx, cidx uint64, node string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) (bool, error) {
+func (s *Store) deleteCheckCASTxn(
+	tx WriteTxn,
+	idx, cidx uint64,
+	node string,
+	checkID types.CheckID,
+	entMeta *acl.EnterpriseMeta,
+	peerName string,
+) (bool, error) {
 	// Try to retrieve the existing health check.
-	_, hc, err := getNodeCheckTxn(tx, node, checkID, entMeta)
+	_, hc, err := getNodeCheckTxn(tx, node, checkID, entMeta, peerName)
 	if err != nil {
 		return false, fmt.Errorf("check lookup failed: %s", err)
 	}
@@ -2236,7 +2498,7 @@ func (s *Store) deleteCheckCASTxn(tx WriteTxn, idx, cidx uint64, node string, ch
 	}
 
 	// Call the actual deletion if the above passed.
-	if err := s.deleteCheckTxn(tx, idx, node, checkID, entMeta); err != nil {
+	if err := s.deleteCheckTxn(tx, idx, node, checkID, entMeta, peerName); err != nil {
 		return false, err
 	}
 
@@ -2245,9 +2507,14 @@ func (s *Store) deleteCheckCASTxn(tx WriteTxn, idx, cidx uint64, node string, ch
 
 // NodeServiceQuery is a type used to query the checks table.
 type NodeServiceQuery struct {
-	Node    string
-	Service string
-	structs.EnterpriseMeta
+	Node     string
+	Service  string
+	PeerName string
+	acl.EnterpriseMeta
+}
+
+func (q NodeServiceQuery) PeerOrEmpty() string {
+	return q.PeerName
 }
 
 // NamespaceOrDefault exists because structs.EnterpriseMeta uses a pointer
@@ -2264,13 +2531,19 @@ func (q NodeServiceQuery) PartitionOrDefault() string {
 
 // deleteCheckTxn is the inner method used to call a health
 // check deletion within an existing transaction.
-func (s *Store) deleteCheckTxn(tx WriteTxn, idx uint64, node string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) deleteCheckTxn(tx WriteTxn, idx uint64, node string, checkID types.CheckID, entMeta *acl.EnterpriseMeta, peerName string) error {
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
 
 	// Try to retrieve the existing health check.
-	hc, err := tx.First(tableChecks, indexID, NodeCheckQuery{EnterpriseMeta: *entMeta, Node: node, CheckID: string(checkID)})
+	hc, err := tx.First(tableChecks, indexID,
+		NodeCheckQuery{
+			EnterpriseMeta: *entMeta,
+			Node:           node,
+			CheckID:        string(checkID),
+			PeerName:       peerName,
+		})
 	if err != nil {
 		return fmt.Errorf("check lookup failed: %s", err)
 	}
@@ -2281,24 +2554,29 @@ func (s *Store) deleteCheckTxn(tx WriteTxn, idx uint64, node string, checkID typ
 	if existing != nil {
 		// When no service is linked to this service, update all services of node
 		if existing.ServiceID != "" {
-			if err := catalogUpdateServiceIndexes(tx, existing.ServiceName, idx, &existing.EnterpriseMeta); err != nil {
+			if err := catalogUpdateServiceIndexes(tx, idx, existing.ServiceName, &existing.EnterpriseMeta, existing.PeerName); err != nil {
 				return err
 			}
-
-			svcRaw, err := tx.First(tableServices, indexID, NodeServiceQuery{EnterpriseMeta: existing.EnterpriseMeta, Node: existing.Node, Service: existing.ServiceID})
+			svcRaw, err := tx.First(tableServices, indexID,
+				NodeServiceQuery{
+					EnterpriseMeta: existing.EnterpriseMeta,
+					Node:           existing.Node,
+					Service:        existing.ServiceID,
+					PeerName:       existing.PeerName,
+				})
 			if err != nil {
 				return fmt.Errorf("failed retrieving service from state store: %v", err)
 			}
 
 			svc := svcRaw.(*structs.ServiceNode)
-			if err := catalogUpdateServiceKindIndexes(tx, svc.ServiceKind, idx, &svc.EnterpriseMeta); err != nil {
+			if err := catalogUpdateServiceKindIndexes(tx, idx, svc.ServiceKind, &svc.EnterpriseMeta, svc.PeerName); err != nil {
 				return err
 			}
 		} else {
-			if err := updateAllServiceIndexesOfNode(tx, idx, existing.Node, &existing.EnterpriseMeta); err != nil {
+			if err := updateAllServiceIndexesOfNode(tx, idx, existing.Node, &existing.EnterpriseMeta, existing.PeerName); err != nil {
 				return fmt.Errorf("Failed to update services linked to deleted healthcheck: %s", err)
 			}
-			if err := catalogUpdateServicesIndexes(tx, idx, entMeta); err != nil {
+			if err := catalogUpdateServicesIndexes(tx, idx, entMeta, existing.PeerName); err != nil {
 				return err
 			}
 		}
@@ -2309,20 +2587,22 @@ func (s *Store) deleteCheckTxn(tx WriteTxn, idx uint64, node string, checkID typ
 		return fmt.Errorf("failed removing check: %s", err)
 	}
 
-	if err := catalogUpdateCheckIndexes(tx, idx, entMeta); err != nil {
+	if err := catalogUpdateCheckIndexes(tx, idx, entMeta, peerName); err != nil {
 		return err
 	}
 
-	// Delete any sessions for this check.
-	sessions, err := checkSessionsTxn(tx, existing)
-	if err != nil {
-		return err
-	}
+	if peerName == "" {
+		// Delete any sessions for this check.
+		sessions, err := checkSessionsTxn(tx, existing)
+		if err != nil {
+			return err
+		}
 
-	// Do the delete in a separate loop so we don't trash the iterator.
-	for _, sess := range sessions {
-		if err := s.deleteSessionTxn(tx, idx, sess.Session, &sess.EnterpriseMeta); err != nil {
-			return fmt.Errorf("failed deleting session: %s", err)
+		// Do the delete in a separate loop so we don't trash the iterator.
+		for _, sess := range sessions {
+			if err := s.deleteSessionTxn(tx, idx, sess.Session, &sess.EnterpriseMeta); err != nil {
+				return fmt.Errorf("failed deleting session: %s", err)
+			}
 		}
 	}
 
@@ -2330,12 +2610,12 @@ func (s *Store) deleteCheckTxn(tx WriteTxn, idx uint64, node string, checkID typ
 }
 
 // CombinedCheckServiceNodes is used to query all nodes and checks for both typical and Connect endpoints of a service
-func (s *Store) CombinedCheckServiceNodes(ws memdb.WatchSet, service structs.ServiceName) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) CombinedCheckServiceNodes(ws memdb.WatchSet, service structs.ServiceName, peerName string) (uint64, structs.CheckServiceNodes, error) {
 	var (
 		resp   structs.CheckServiceNodes
 		maxIdx uint64
 	)
-	idx, csn, err := s.CheckServiceNodes(ws, service.Name, &service.EnterpriseMeta)
+	idx, csn, err := s.CheckServiceNodes(ws, service.Name, &service.EnterpriseMeta, peerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to get downstream nodes for %q: %v", service, err)
 	}
@@ -2343,8 +2623,7 @@ func (s *Store) CombinedCheckServiceNodes(ws memdb.WatchSet, service structs.Ser
 		maxIdx = idx
 	}
 	resp = append(resp, csn...)
-
-	idx, csn, err = s.CheckConnectServiceNodes(ws, service.Name, &service.EnterpriseMeta)
+	idx, csn, err = s.CheckConnectServiceNodes(ws, service.Name, &service.EnterpriseMeta, peerName)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to get downstream connect nodes for %q: %v", service, err)
 	}
@@ -2357,23 +2636,23 @@ func (s *Store) CombinedCheckServiceNodes(ws memdb.WatchSet, service structs.Ser
 }
 
 // CheckServiceNodes is used to query all nodes and checks for a given service.
-func (s *Store) CheckServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
-	return s.checkServiceNodes(ws, serviceName, false, entMeta)
+func (s *Store) CheckServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error) {
+	return s.checkServiceNodes(ws, serviceName, false, entMeta, peerName)
 }
 
 // CheckConnectServiceNodes is used to query all nodes and checks for Connect
 // compatible endpoints for a given service.
-func (s *Store) CheckConnectServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
-	return s.checkServiceNodes(ws, serviceName, true, entMeta)
+func (s *Store) CheckConnectServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error) {
+	return s.checkServiceNodes(ws, serviceName, true, entMeta, peerName)
 }
 
 // CheckIngressServiceNodes is used to query all nodes and checks for ingress
 // endpoints for a given service.
-func (s *Store) CheckIngressServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) CheckIngressServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	maxIdx, nodes, err := serviceGatewayNodes(tx, ws, serviceName, structs.ServiceKindIngressGateway, entMeta)
+	maxIdx, nodes, err := serviceGatewayNodes(tx, ws, serviceName, structs.ServiceKindIngressGateway, entMeta, structs.DefaultPeerKeyword)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed gateway nodes lookup: %v", err)
 	}
@@ -2395,7 +2674,7 @@ func (s *Store) CheckIngressServiceNodes(ws memdb.WatchSet, serviceName string, 
 
 	var results structs.CheckServiceNodes
 	for sn := range names {
-		idx, n, err := checkServiceNodesTxn(tx, ws, sn.Name, false, &sn.EnterpriseMeta)
+		idx, n, err := checkServiceNodesTxn(tx, ws, sn.Name, false, &sn.EnterpriseMeta, structs.DefaultPeerKeyword)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -2405,14 +2684,14 @@ func (s *Store) CheckIngressServiceNodes(ws memdb.WatchSet, serviceName string, 
 	return maxIdx, results, nil
 }
 
-func (s *Store) checkServiceNodes(ws memdb.WatchSet, serviceName string, connect bool, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) checkServiceNodes(ws memdb.WatchSet, serviceName string, connect bool, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	return checkServiceNodesTxn(tx, ws, serviceName, connect, entMeta)
+	return checkServiceNodesTxn(tx, ws, serviceName, connect, entMeta, peerName)
 }
 
-func checkServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, connect bool, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func checkServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, connect bool, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error) {
 	index := indexService
 	if connect {
 		index = indexConnect
@@ -2426,6 +2705,7 @@ func checkServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, con
 	q := Query{
 		Value:          serviceName,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	}
 	iter, err := tx.Get(tableServices, index, q)
 	if err != nil {
@@ -2460,9 +2740,10 @@ func checkServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, con
 	// We append rather than replace since it allows users to migrate a service
 	// to the mesh with a mix of sidecars and gateways until all its instances have a sidecar.
 	var idx uint64
-	if connect {
+	if connect && peerName == "" {
 		// Look up gateway nodes associated with the service
-		gwIdx, nodes, err := serviceGatewayNodes(tx, ws, serviceName, structs.ServiceKindTerminatingGateway, entMeta)
+		// TODO(peering): we'll have to do something here
+		gwIdx, nodes, err := serviceGatewayNodes(tx, ws, serviceName, structs.ServiceKindTerminatingGateway, entMeta, structs.DefaultPeerKeyword)
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed gateway nodes lookup: %v", err)
 		}
@@ -2494,7 +2775,7 @@ func checkServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, con
 			// We know service values should exist since the serviceNames map is only
 			// populated if there is at least one result above. so serviceExists arg
 			// below is always true.
-			svcIdx, svcCh := maxIndexAndWatchChForService(tx, n.Name, true, true, &n.EnterpriseMeta)
+			svcIdx, svcCh := maxIndexAndWatchChForService(tx, n.Name, true, true, &n.EnterpriseMeta, peerName)
 			// Take the max index represented
 			idx = lib.MaxUint64(idx, svcIdx)
 			if svcCh != nil {
@@ -2515,7 +2796,7 @@ func checkServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, con
 		// use target serviceName here but it actually doesn't matter. No chan will
 		// be returned as we can't use the optimization in this case (and don't need
 		// to as there is only one chan to watch anyway).
-		svcIdx, _ := maxIndexAndWatchChForService(tx, serviceName, false, true, entMeta)
+		svcIdx, _ := maxIndexAndWatchChForService(tx, serviceName, false, true, entMeta, peerName)
 		idx = lib.MaxUint64(idx, svcIdx)
 	}
 
@@ -2541,12 +2822,12 @@ func checkServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, con
 		ws.Add(iter.WatchCh())
 	}
 
-	return parseCheckServiceNodes(tx, fallbackWS, idx, results, entMeta, err)
+	return parseCheckServiceNodes(tx, fallbackWS, idx, results, entMeta, peerName, err)
 }
 
 // CheckServiceTagNodes is used to query all nodes and checks for a given
 // service, filtering out services that don't contain the given tag.
-func (s *Store) CheckServiceTagNodes(ws memdb.WatchSet, serviceName string, tags []string, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) CheckServiceTagNodes(ws memdb.WatchSet, serviceName string, tags []string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -2555,7 +2836,7 @@ func (s *Store) CheckServiceTagNodes(ws memdb.WatchSet, serviceName string, tags
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
 
-	q := Query{Value: serviceName, EnterpriseMeta: *entMeta}
+	q := Query{Value: serviceName, EnterpriseMeta: *entMeta, PeerName: peerName}
 	iter, err := tx.Get(tableServices, indexService, q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed service lookup: %s", err)
@@ -2574,12 +2855,12 @@ func (s *Store) CheckServiceTagNodes(ws memdb.WatchSet, serviceName string, tags
 	}
 
 	// Get the table index.
-	idx := maxIndexForService(tx, serviceName, serviceExists, true, entMeta)
-	return parseCheckServiceNodes(tx, ws, idx, results, entMeta, err)
+	idx := maxIndexForService(tx, serviceName, serviceExists, true, entMeta, peerName)
+	return parseCheckServiceNodes(tx, ws, idx, results, entMeta, peerName, err)
 }
 
 // GatewayServices is used to query all services associated with a gateway
-func (s *Store) GatewayServices(ws memdb.WatchSet, gateway string, entMeta *structs.EnterpriseMeta) (uint64, structs.GatewayServices, error) {
+func (s *Store) GatewayServices(ws memdb.WatchSet, gateway string, entMeta *acl.EnterpriseMeta) (uint64, structs.GatewayServices, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -2621,23 +2902,37 @@ func (s *Store) ServiceNamesOfKind(ws memdb.WatchSet, kind structs.ServiceKind) 
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	return serviceNamesOfKindTxn(tx, ws, kind)
+	wildcardMeta := structs.WildcardEnterpriseMetaInPartition(structs.WildcardSpecifier)
+	return serviceNamesOfKindTxn(tx, ws, kind, *wildcardMeta)
 }
 
-func serviceNamesOfKindTxn(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKind) (uint64, []*KindServiceName, error) {
-	var names []*KindServiceName
-	iter, err := tx.Get(tableKindServiceNames, indexKindOnly, kind)
+func serviceNamesOfKindTxn(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKind, entMeta acl.EnterpriseMeta) (uint64, []*KindServiceName, error) {
+	iter, err := tx.Get(tableKindServiceNames, indexKind, Query{Value: string(kind), EnterpriseMeta: entMeta})
 	if err != nil {
 		return 0, nil, err
 	}
+
+	// TODO(peering): Maybe delete this watch and rely on the max idx tables below, to avoid waking up on unrelated changes
 	ws.Add(iter.WatchCh())
 
-	idx := kindServiceNamesMaxIndex(tx, ws, kind)
+	var names []*KindServiceName
 	for name := iter.Next(); name != nil; name = iter.Next() {
 		ksn := name.(*KindServiceName)
 		names = append(names, ksn)
 	}
 
+	var idx uint64
+	switch {
+	case entMeta.PartitionOrDefault() == structs.WildcardSpecifier:
+		idx = kindServiceNamesMaxIndex(tx, ws, kind.Normalized())
+
+	case entMeta.NamespaceOrDefault() == structs.WildcardSpecifier:
+		idx = kindServiceNamesMaxIndex(tx, ws, partitionedIndexEntryName(kind.Normalized(), entMeta.PartitionOrDefault()))
+
+	default:
+		idx = kindServiceNamesMaxIndex(tx, ws, partitionedAndNamespacedIndexEntryName(kind.Normalized(), &entMeta))
+
+	}
 	return idx, names, nil
 }
 
@@ -2651,8 +2946,10 @@ func serviceNamesOfKindTxn(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKi
 func parseCheckServiceNodes(
 	tx ReadTxn, ws memdb.WatchSet, idx uint64,
 	services structs.ServiceNodes,
-	entMeta *structs.EnterpriseMeta,
-	err error) (uint64, structs.CheckServiceNodes, error) {
+	entMeta *acl.EnterpriseMeta,
+	peerName string,
+	err error,
+) (uint64, structs.CheckServiceNodes, error) {
 	if err != nil {
 		return 0, nil, err
 	}
@@ -2663,9 +2960,16 @@ func parseCheckServiceNodes(
 		return idx, nil, nil
 	}
 
+	if entMeta == nil {
+		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
+	}
+
 	// We don't want to track an unlimited number of nodes, so we pull a
 	// top-level watch to use as a fallback.
-	allNodes, err := tx.Get(tableNodes, indexID+"_prefix", entMeta)
+	allNodes, err := tx.Get(tableNodes, indexID+"_prefix", Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed nodes lookup: %s", err)
 	}
@@ -2674,7 +2978,10 @@ func parseCheckServiceNodes(
 	// We need a similar fallback for checks. Since services need the
 	// status of node + service-specific checks, we pull in a top-level
 	// watch over all checks.
-	allChecks, err := tx.Get(tableChecks, indexID+"_prefix", entMeta)
+	allChecks, err := tx.Get(tableChecks, indexID+"_prefix", Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed checks lookup: %s", err)
 	}
@@ -2686,6 +2993,7 @@ func parseCheckServiceNodes(
 		watchCh, n, err := tx.FirstWatch(tableNodes, indexID, Query{
 			Value:          sn.Node,
 			EnterpriseMeta: sn.EnterpriseMeta,
+			PeerName:       sn.PeerName,
 		})
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed node lookup: %s", err)
@@ -2704,6 +3012,7 @@ func parseCheckServiceNodes(
 			Node:           sn.Node,
 			Service:        "", // node checks have no service
 			EnterpriseMeta: *sn.EnterpriseMeta.WithWildcardNamespace(),
+			PeerName:       sn.PeerName,
 		}
 		iter, err := tx.Get(tableChecks, indexNodeService, q)
 		if err != nil {
@@ -2719,6 +3028,7 @@ func parseCheckServiceNodes(
 			Node:           sn.Node,
 			Service:        sn.ServiceID,
 			EnterpriseMeta: sn.EnterpriseMeta,
+			PeerName:       sn.PeerName,
 		}
 		iter, err = tx.Get(tableChecks, indexNodeService, q)
 		if err != nil {
@@ -2742,7 +3052,7 @@ func parseCheckServiceNodes(
 
 // NodeInfo is used to generate a dump of a single node. The dump includes
 // all services and checks which are registered against the node.
-func (s *Store) NodeInfo(ws memdb.WatchSet, node string, entMeta *structs.EnterpriseMeta) (uint64, structs.NodeDump, error) {
+func (s *Store) NodeInfo(ws memdb.WatchSet, node string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.NodeDump, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
@@ -2751,55 +3061,72 @@ func (s *Store) NodeInfo(ws memdb.WatchSet, node string, entMeta *structs.Enterp
 	}
 
 	// Get the table index.
-	idx := catalogMaxIndex(tx, entMeta, true)
+	idx := catalogMaxIndex(tx, entMeta, peerName, true)
 
 	// Query the node by the passed node
 	nodes, err := tx.Get(tableNodes, indexID, Query{
 		Value:          node,
 		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
 	})
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed node lookup: %s", err)
 	}
 	ws.Add(nodes.WatchCh())
-	return parseNodes(tx, ws, idx, nodes, entMeta)
+	return parseNodes(tx, ws, idx, nodes, entMeta, peerName)
 }
 
 // NodeDump is used to generate a dump of all nodes. This call is expensive
 // as it has to query every node, service, and check. The response can also
 // be quite large since there is currently no filtering applied.
-func (s *Store) NodeDump(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.NodeDump, error) {
+func (s *Store) NodeDump(ws memdb.WatchSet, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.NodeDump, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
+	if entMeta == nil {
+		entMeta = structs.NodeEnterpriseMetaInDefaultPartition()
+	}
+
 	// Get the table index.
-	idx := catalogMaxIndex(tx, entMeta, true)
+	idx := catalogMaxIndex(tx, entMeta, peerName, true)
 
 	// Fetch all of the registered nodes
-	nodes, err := tx.Get(tableNodes, indexID+"_prefix", entMeta)
+	q := Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
+	nodes, err := tx.Get(tableNodes, indexID+"_prefix", q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed node lookup: %s", err)
 	}
 	ws.Add(nodes.WatchCh())
-	return parseNodes(tx, ws, idx, nodes, entMeta)
+	return parseNodes(tx, ws, idx, nodes, entMeta, peerName)
 }
 
-func (s *Store) ServiceDump(ws memdb.WatchSet, kind structs.ServiceKind, useKind bool, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) ServiceDump(ws memdb.WatchSet, kind structs.ServiceKind, useKind bool, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
 	if useKind {
-		return serviceDumpKindTxn(tx, ws, kind, entMeta)
+		return serviceDumpKindTxn(tx, ws, kind, entMeta, peerName)
 	} else {
-		return serviceDumpAllTxn(tx, ws, entMeta)
+		return serviceDumpAllTxn(tx, ws, entMeta, peerName)
 	}
 }
 
-func serviceDumpAllTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func serviceDumpAllTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error) {
 	// Get the table index
-	idx := catalogMaxIndexWatch(tx, ws, entMeta, true)
+	idx := catalogMaxIndexWatch(tx, ws, entMeta, "", true)
 
-	services, err := tx.Get(tableServices, indexID+"_prefix", entMeta)
+	if entMeta == nil {
+		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
+	}
+
+	q := Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
+	services, err := tx.Get(tableServices, indexID+"_prefix", q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed service lookup: %s", err)
 	}
@@ -2810,19 +3137,23 @@ func serviceDumpAllTxn(tx ReadTxn, ws memdb.WatchSet, entMeta *structs.Enterpris
 		results = append(results, sn)
 	}
 
-	return parseCheckServiceNodes(tx, nil, idx, results, entMeta, err)
+	return parseCheckServiceNodes(tx, nil, idx, results, entMeta, peerName, err)
 }
 
-func serviceDumpKindTxn(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func serviceDumpKindTxn(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error) {
 	// unlike when we are dumping all services here we only need to watch the kind specific index entry for changing (or nodes, checks)
 	// updating any services, nodes or checks will bump the appropriate service kind index so there is no need to watch any of the individual
 	// entries
-	idx := catalogServiceKindMaxIndex(tx, ws, kind, entMeta)
+	idx := catalogServiceKindMaxIndex(tx, ws, kind, entMeta, peerName)
 
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
-	q := Query{Value: string(kind), EnterpriseMeta: *entMeta}
+	q := Query{
+		Value:          string(kind),
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
 	services, err := tx.Get(tableServices, indexKind, q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed service lookup: %s", err)
@@ -2834,14 +3165,15 @@ func serviceDumpKindTxn(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKind,
 		results = append(results, sn)
 	}
 
-	return parseCheckServiceNodes(tx, nil, idx, results, entMeta, err)
+	return parseCheckServiceNodes(tx, nil, idx, results, entMeta, peerName, err)
 }
 
 // parseNodes takes an iterator over a set of nodes and returns a struct
 // containing the nodes along with all of their associated services
 // and/or health checks.
+// TODO(peering): support parsing by peerName
 func parseNodes(tx ReadTxn, ws memdb.WatchSet, idx uint64,
-	iter memdb.ResultIterator, entMeta *structs.EnterpriseMeta) (uint64, structs.NodeDump, error) {
+	iter memdb.ResultIterator, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.NodeDump, error) {
 
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
@@ -2849,7 +3181,11 @@ func parseNodes(tx ReadTxn, ws memdb.WatchSet, idx uint64,
 
 	// We don't want to track an unlimited number of services, so we pull a
 	// top-level watch to use as a fallback.
-	allServices, err := tx.Get(tableServices, indexID+"_prefix", entMeta)
+	q := Query{
+		EnterpriseMeta: *entMeta,
+		PeerName:       peerName,
+	}
+	allServices, err := tx.Get(tableServices, indexID+"_prefix", q)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed services lookup: %s", err)
 	}
@@ -2871,13 +3207,14 @@ func parseNodes(tx ReadTxn, ws memdb.WatchSet, idx uint64,
 			ID:              node.ID,
 			Node:            node.Node,
 			Partition:       node.Partition,
+			PeerName:        node.PeerName,
 			Address:         node.Address,
 			TaggedAddresses: node.TaggedAddresses,
 			Meta:            node.Meta,
 		}
 
 		// Query the node services
-		services, err := catalogServiceListByNode(tx, node.Node, entMeta, true)
+		services, err := catalogServiceListByNode(tx, node.Node, entMeta, node.PeerName, true)
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed services lookup: %s", err)
 		}
@@ -2888,7 +3225,11 @@ func parseNodes(tx ReadTxn, ws memdb.WatchSet, idx uint64,
 		}
 
 		// Query the service level checks
-		checks, err := catalogListChecksByNode(tx, Query{Value: node.Node, EnterpriseMeta: *entMeta})
+		checks, err := catalogListChecksByNode(tx, Query{
+			Value:          node.Node,
+			EnterpriseMeta: *entMeta,
+			PeerName:       node.PeerName,
+		})
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed node lookup: %s", err)
 		}
@@ -2906,6 +3247,7 @@ func parseNodes(tx ReadTxn, ws memdb.WatchSet, idx uint64,
 
 // checkSessionsTxn returns the IDs of all sessions associated with a health check
 func checkSessionsTxn(tx ReadTxn, hc *structs.HealthCheck) ([]*sessionCheck, error) {
+	// TODO(peering): what are implications for imported health checks?
 	mappings, err := tx.Get(tableSessionChecks, indexNodeCheck, MultiQuery{Value: []string{hc.Node, string(hc.CheckID)},
 		EnterpriseMeta: *structs.DefaultEnterpriseMetaInPartition(hc.PartitionOrDefault())})
 	if err != nil {
@@ -2920,7 +3262,7 @@ func checkSessionsTxn(tx ReadTxn, hc *structs.HealthCheck) ([]*sessionCheck, err
 }
 
 // updateGatewayServices associates services with gateways as specified in a gateway config entry
-func updateGatewayServices(tx WriteTxn, idx uint64, conf structs.ConfigEntry, entMeta *structs.EnterpriseMeta) error {
+func updateGatewayServices(tx WriteTxn, idx uint64, conf structs.ConfigEntry, entMeta *acl.EnterpriseMeta) error {
 	var (
 		noChange        bool
 		gatewayServices structs.GatewayServices
@@ -2990,7 +3332,7 @@ func updateGatewayServices(tx WriteTxn, idx uint64, conf structs.ConfigEntry, en
 	return nil
 }
 
-func getTermGatewayVirtualIPs(tx WriteTxn, services []structs.LinkedService, entMeta *structs.EnterpriseMeta) (map[string]structs.ServiceAddress, error) {
+func getTermGatewayVirtualIPs(tx WriteTxn, services []structs.LinkedService, entMeta *acl.EnterpriseMeta) (map[string]structs.ServiceAddress, error) {
 	addrs := make(map[string]structs.ServiceAddress, len(services))
 	for _, s := range services {
 		sn := structs.ServiceName{Name: s.Name, EnterpriseMeta: *entMeta}
@@ -3005,7 +3347,7 @@ func getTermGatewayVirtualIPs(tx WriteTxn, services []structs.LinkedService, ent
 	return addrs, nil
 }
 
-func updateTerminatingGatewayVirtualIPs(tx WriteTxn, idx uint64, conf *structs.TerminatingGatewayConfigEntry, entMeta *structs.EnterpriseMeta) error {
+func updateTerminatingGatewayVirtualIPs(tx WriteTxn, idx uint64, conf *structs.TerminatingGatewayConfigEntry, entMeta *acl.EnterpriseMeta) error {
 	// Build the current map of services with virtual IPs for this gateway
 	services := conf.Services
 	addrs, err := getTermGatewayVirtualIPs(tx, services, entMeta)
@@ -3087,7 +3429,7 @@ func ingressConfigGatewayServices(
 	tx ReadTxn,
 	gateway structs.ServiceName,
 	conf structs.ConfigEntry,
-	entMeta *structs.EnterpriseMeta,
+	entMeta *acl.EnterpriseMeta,
 ) (bool, structs.GatewayServices, error) {
 	entry, ok := conf.(*structs.IngressGatewayConfigEntry)
 	if !ok {
@@ -3132,7 +3474,7 @@ func terminatingConfigGatewayServices(
 	tx ReadTxn,
 	gateway structs.ServiceName,
 	conf structs.ConfigEntry,
-	entMeta *structs.EnterpriseMeta,
+	entMeta *acl.EnterpriseMeta,
 ) (bool, structs.GatewayServices, error) {
 	entry, ok := conf.(*structs.TerminatingGatewayConfigEntry)
 	if !ok {
@@ -3153,6 +3495,10 @@ func terminatingConfigGatewayServices(
 
 	var gatewayServices structs.GatewayServices
 	for _, svc := range entry.Services {
+		kind, err := GatewayServiceKind(tx, svc.Name, &svc.EnterpriseMeta)
+		if err != nil {
+			return false, nil, fmt.Errorf("failed to get gateway service kind for service %s: %v", svc.Name, err)
+		}
 		mapping := &structs.GatewayService{
 			Gateway:     gateway,
 			Service:     structs.NewServiceName(svc.Name, &svc.EnterpriseMeta),
@@ -3161,6 +3507,7 @@ func terminatingConfigGatewayServices(
 			CertFile:    svc.CertFile,
 			CAFile:      svc.CAFile,
 			SNI:         svc.SNI,
+			ServiceKind: kind,
 		}
 
 		gatewayServices = append(gatewayServices, mapping)
@@ -3168,8 +3515,36 @@ func terminatingConfigGatewayServices(
 	return false, gatewayServices, nil
 }
 
+func GatewayServiceKind(tx ReadTxn, name string, entMeta *acl.EnterpriseMeta) (structs.GatewayServiceKind, error) {
+	serviceIter, err := tx.First(tableServices, indexService, Query{
+		Value:          name,
+		EnterpriseMeta: *entMeta,
+	})
+	if err != nil {
+		return structs.GatewayServiceKindUnknown, err
+	}
+	if serviceIter != nil {
+		return structs.GatewayServiceKindService, err
+	}
+
+	_, entry, err := configEntryTxn(tx, nil, structs.ServiceDefaults, name, entMeta)
+	if err != nil {
+		return structs.GatewayServiceKindUnknown, err
+	}
+	if entry != nil {
+		sd, ok := entry.(*structs.ServiceConfigEntry)
+		if !ok {
+			return structs.GatewayServiceKindUnknown, fmt.Errorf("invalid config entry type %T", entry)
+		}
+		if sd.Destination != nil {
+			return structs.GatewayServiceKindDestination, nil
+		}
+	}
+	return structs.GatewayServiceKindUnknown, nil
+}
+
 // updateGatewayNamespace is used to target all services within a namespace
-func updateGatewayNamespace(tx WriteTxn, idx uint64, service *structs.GatewayService, entMeta *structs.EnterpriseMeta) error {
+func updateGatewayNamespace(tx WriteTxn, idx uint64, service *structs.GatewayService, entMeta *acl.EnterpriseMeta) error {
 	if entMeta == nil {
 		entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 	}
@@ -3201,6 +3576,41 @@ func updateGatewayNamespace(tx WriteTxn, idx uint64, service *structs.GatewaySer
 		mapping := service.Clone()
 
 		mapping.Service = structs.NewServiceName(sn.ServiceName, &service.Service.EnterpriseMeta)
+		mapping.FromWildcard = true
+
+		err = updateGatewayService(tx, idx, mapping)
+		if err != nil {
+			return err
+		}
+	}
+	entries, err := tx.Get(tableConfigEntries, indexID+"_prefix", ConfigEntryKindQuery{Kind: structs.ServiceDefaults, EnterpriseMeta: *entMeta})
+	if err != nil {
+		return fmt.Errorf("failed querying entries: %s", err)
+	}
+	for entry := entries.Next(); entry != nil; entry = entries.Next() {
+		e := entry.(*structs.ServiceConfigEntry)
+		if e.Destination == nil {
+			continue
+		}
+
+		sn := structs.ServiceName{
+			Name:           e.Name,
+			EnterpriseMeta: e.EnterpriseMeta,
+		}
+		existing, err := tx.First(tableGatewayServices, indexID, service.Gateway, sn, service.Port)
+		if err != nil {
+			return fmt.Errorf("gateway service lookup failed: %s", err)
+		}
+		if existing != nil {
+			// If there's an existing service associated with this gateway then we skip it.
+			// This means the service was specified on its own, and the service entry overrides the wildcard entry.
+			continue
+		}
+
+		mapping := service.Clone()
+
+		mapping.Service = structs.NewServiceName(e.Name, &service.Service.EnterpriseMeta)
+		mapping.ServiceKind = structs.GatewayServiceKindDestination
 		mapping.FromWildcard = true
 
 		err = updateGatewayService(tx, idx, mapping)
@@ -3255,16 +3665,11 @@ func updateGatewayService(tx WriteTxn, idx uint64, mapping *structs.GatewayServi
 // checkWildcardForGatewaysAndUpdate checks whether a service matches a
 // wildcard definition in gateway config entries and if so adds it the the
 // gateway-services table.
-func checkGatewayWildcardsAndUpdate(tx WriteTxn, idx uint64, svc *structs.NodeService) error {
-	// Do not associate non-typical services with gateways or consul services
-	if svc.Kind != structs.ServiceKindTypical || svc.Service == "consul" {
-		return nil
-	}
-
+func checkGatewayWildcardsAndUpdate(tx WriteTxn, idx uint64, svc *structs.ServiceName, kind structs.GatewayServiceKind) error {
 	sn := structs.ServiceName{Name: structs.WildcardSpecifier, EnterpriseMeta: svc.EnterpriseMeta}
 	svcGateways, err := tx.Get(tableGatewayServices, indexService, sn)
 	if err != nil {
-		return fmt.Errorf("failed gateway lookup for %q: %s", svc.Service, err)
+		return fmt.Errorf("failed gateway lookup for %q: %s", svc.Name, err)
 	}
 	for service := svcGateways.Next(); service != nil; service = svcGateways.Next() {
 		if wildcardSvc, ok := service.(*structs.GatewayService); ok && wildcardSvc != nil {
@@ -3272,14 +3677,40 @@ func checkGatewayWildcardsAndUpdate(tx WriteTxn, idx uint64, svc *structs.NodeSe
 			// Copy the wildcard mapping and modify it
 			gatewaySvc := wildcardSvc.Clone()
 
-			gatewaySvc.Service = structs.NewServiceName(svc.Service, &svc.EnterpriseMeta)
+			gatewaySvc.Service = structs.NewServiceName(svc.Name, &svc.EnterpriseMeta)
 			gatewaySvc.FromWildcard = true
+			gatewaySvc.ServiceKind = kind
 
 			if err = updateGatewayService(tx, idx, gatewaySvc); err != nil {
 				return fmt.Errorf("Failed to associate service %q with gateway %q", gatewaySvc.Service.String(), gatewaySvc.Gateway.String())
 			}
 		}
 	}
+	return nil
+}
+
+// checkGatewayAndUpdate checks whether a service matches a
+// wildcard definition in gateway config entries and if so adds it the the
+// gateway-services table.
+func checkGatewayAndUpdate(tx WriteTxn, idx uint64, svc *structs.ServiceName, kind structs.GatewayServiceKind) error {
+	sn := structs.ServiceName{Name: svc.Name, EnterpriseMeta: svc.EnterpriseMeta}
+	svcGateways, err := tx.First(tableGatewayServices, indexService, sn)
+	if err != nil {
+		return fmt.Errorf("failed gateway lookup for %q: %s", svc.Name, err)
+	}
+
+	if service, ok := svcGateways.(*structs.GatewayService); ok && service != nil {
+		// Copy the wildcard mapping and modify it
+		gatewaySvc := service.Clone()
+
+		gatewaySvc.Service = structs.NewServiceName(svc.Name, &svc.EnterpriseMeta)
+		gatewaySvc.ServiceKind = kind
+
+		if err = updateGatewayService(tx, idx, gatewaySvc); err != nil {
+			return fmt.Errorf("Failed to associate service %q with gateway %q", gatewaySvc.Service.String(), gatewaySvc.Gateway.String())
+		}
+	}
+
 	return nil
 }
 
@@ -3313,6 +3744,12 @@ func cleanupGatewayWildcards(tx WriteTxn, idx uint64, svc *structs.ServiceNode) 
 			if err := deleteGatewayServiceTopologyMapping(tx, idx, m); err != nil {
 				return fmt.Errorf("failed to reconcile mesh topology for gateway: %v", err)
 			}
+		} else {
+			kind, err := GatewayServiceKind(tx, m.Service.Name, &m.Service.EnterpriseMeta)
+			if err != nil {
+				return fmt.Errorf("failed to get gateway service kind for service %s: %v", svc.ServiceName, err)
+			}
+			checkGatewayAndUpdate(tx, idx, &structs.ServiceName{Name: m.Service.Name, EnterpriseMeta: m.Service.EnterpriseMeta}, kind)
 		}
 	}
 	return nil
@@ -3363,7 +3800,11 @@ func (s *Store) collectGatewayServices(tx ReadTxn, ws memdb.WatchSet, iter memdb
 // TODO(ingress): How to handle index rolling back when a config entry is
 // deleted that references a service?
 // We might need something like the service_last_extinction index?
-func serviceGatewayNodes(tx ReadTxn, ws memdb.WatchSet, service string, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceNodes, error) {
+func serviceGatewayNodes(tx ReadTxn, ws memdb.WatchSet, service string, kind structs.ServiceKind, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.ServiceNodes, error) {
+	if peerName != "" {
+		return 0, nil, nil
+	}
+
 	// Look up gateway name associated with the service
 	gws, err := tx.Get(tableGatewayServices, indexService, structs.NewServiceName(service, entMeta))
 	if err != nil {
@@ -3405,7 +3846,7 @@ func serviceGatewayNodes(tx ReadTxn, ws memdb.WatchSet, service string, kind str
 		}
 
 		// This prevents the index from sliding back if case all instances of the gateway service are deregistered
-		svcIdx := maxIndexForService(tx, mapping.Gateway.Name, exists, false, &mapping.Gateway.EnterpriseMeta)
+		svcIdx := maxIndexForService(tx, mapping.Gateway.Name, exists, false, &mapping.Gateway.EnterpriseMeta, structs.DefaultPeerKeyword)
 		maxIdx = lib.MaxUint64(maxIdx, svcIdx)
 
 		// Ensure that blocking queries wake up if the gateway-service mapping exists, but the gateway does not exist yet
@@ -3468,7 +3909,7 @@ func (s *Store) ServiceTopology(
 	dc, service string,
 	kind structs.ServiceKind,
 	defaultAllow acl.EnforcementDecision,
-	entMeta *structs.EnterpriseMeta,
+	entMeta *acl.EnterpriseMeta,
 ) (uint64, *structs.ServiceTopology, error) {
 	tx := s.db.ReadTxn()
 	defer tx.Abort()
@@ -3501,7 +3942,11 @@ func (s *Store) ServiceTopology(
 		if entMeta == nil {
 			entMeta = structs.DefaultEnterpriseMetaInDefaultPartition()
 		}
-		q := Query{Value: service, EnterpriseMeta: *entMeta}
+		q := Query{
+			Value:          service,
+			EnterpriseMeta: *entMeta,
+			PeerName:       structs.TODOPeerKeyword,
+		}
 
 		idx, proxies, err := serviceNodesTxn(tx, ws, indexConnect, q)
 		if err != nil {
@@ -3552,7 +3997,7 @@ func (s *Store) ServiceTopology(
 
 	// Only transparent proxies / connect native services have upstreams from intentions
 	if hasTransparent || connectNative {
-		idx, intentionUpstreams, err := s.intentionTopologyTxn(tx, ws, sn, false, defaultAllow)
+		idx, intentionUpstreams, err := s.intentionTopologyTxn(tx, ws, sn, false, defaultAllow, structs.IntentionTargetService)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -3586,14 +4031,7 @@ func (s *Store) ServiceTopology(
 		Partition: entMeta.PartitionOrDefault(),
 		Name:      service,
 	}
-	_, srcIntentions, err := compatIntentionMatchOneTxn(
-		tx,
-		ws,
-		matchEntry,
-
-		// The given service is a source relative to its upstreams
-		structs.IntentionMatchSource,
-	)
+	_, srcIntentions, err := compatIntentionMatchOneTxn(tx, ws, matchEntry, structs.IntentionMatchSource, structs.IntentionTargetService)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to query intentions for %s", sn.String())
 	}
@@ -3616,7 +4054,7 @@ func (s *Store) ServiceTopology(
 		upstreamDecisions[un.String()] = decision
 	}
 
-	idx, unfilteredUpstreams, err := s.combinedServiceNodesTxn(tx, ws, upstreamNames)
+	idx, unfilteredUpstreams, err := s.combinedServiceNodesTxn(tx, ws, upstreamNames, structs.DefaultPeerKeyword)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to get upstreams for %q: %v", sn.String(), err)
 	}
@@ -3676,7 +4114,7 @@ func (s *Store) ServiceTopology(
 		downstreamSources[dn.String()] = structs.TopologySourceRegistration
 	}
 
-	idx, intentionDownstreams, err := s.intentionTopologyTxn(tx, ws, sn, true, defaultAllow)
+	idx, intentionDownstreams, err := s.intentionTopologyTxn(tx, ws, sn, true, defaultAllow, structs.IntentionTargetService)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -3705,14 +4143,7 @@ func (s *Store) ServiceTopology(
 		downstreamSources[svc.Name.String()] = source
 	}
 
-	_, dstIntentions, err := compatIntentionMatchOneTxn(
-		tx,
-		ws,
-		matchEntry,
-
-		// The given service is a destination relative to its downstreams
-		structs.IntentionMatchDestination,
-	)
+	_, dstIntentions, err := compatIntentionMatchOneTxn(tx, ws, matchEntry, structs.IntentionMatchDestination, structs.IntentionTargetService)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to query intentions for %s", sn.String())
 	}
@@ -3734,7 +4165,7 @@ func (s *Store) ServiceTopology(
 		downstreamDecisions[dn.String()] = decision
 	}
 
-	idx, unfilteredDownstreams, err := s.combinedServiceNodesTxn(tx, ws, downstreamNames)
+	idx, unfilteredDownstreams, err := s.combinedServiceNodesTxn(tx, ws, downstreamNames, structs.DefaultPeerKeyword)
 
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to get downstreams for %q: %v", sn.String(), err)
@@ -3783,14 +4214,14 @@ func (s *Store) ServiceTopology(
 
 // combinedServiceNodesTxn returns typical and connect endpoints for a list of services.
 // This enabled aggregating checks statuses across both.
-func (s *Store) combinedServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, names []structs.ServiceName) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) combinedServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, names []structs.ServiceName, peerName string) (uint64, structs.CheckServiceNodes, error) {
 	var (
 		maxIdx uint64
 		resp   structs.CheckServiceNodes
 	)
 	for _, u := range names {
 		// Collect typical then connect instances
-		idx, csn, err := checkServiceNodesTxn(tx, ws, u.Name, false, &u.EnterpriseMeta)
+		idx, csn, err := checkServiceNodesTxn(tx, ws, u.Name, false, &u.EnterpriseMeta, peerName)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -3799,7 +4230,7 @@ func (s *Store) combinedServiceNodesTxn(tx ReadTxn, ws memdb.WatchSet, names []s
 		}
 		resp = append(resp, csn...)
 
-		idx, csn, err = checkServiceNodesTxn(tx, ws, u.Name, true, &u.EnterpriseMeta)
+		idx, csn, err = checkServiceNodesTxn(tx, ws, u.Name, true, &u.EnterpriseMeta, peerName)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -3900,10 +4331,11 @@ func linkedFromRegistrationTxn(tx ReadTxn, ws memdb.WatchSet, service structs.Se
 
 // updateMeshTopology creates associations between the input service and its upstreams in the topology table
 func updateMeshTopology(tx WriteTxn, idx uint64, node string, svc *structs.NodeService, existing interface{}) error {
+	// TODO(peering): make this peering aware
 	oldUpstreams := make(map[structs.ServiceName]bool)
 	if e, ok := existing.(*structs.ServiceNode); ok {
 		for _, u := range e.ServiceProxy.Upstreams {
-			upstreamMeta := structs.NewEnterpriseMetaWithPartition(e.PartitionOrDefault(), u.DestinationNamespace)
+			upstreamMeta := acl.NewEnterpriseMetaWithPartition(e.PartitionOrDefault(), u.DestinationNamespace)
 			sn := structs.NewServiceName(u.DestinationName, &upstreamMeta)
 
 			oldUpstreams[sn] = true
@@ -3919,7 +4351,7 @@ func updateMeshTopology(tx WriteTxn, idx uint64, node string, svc *structs.NodeS
 		}
 
 		// TODO (freddy): Account for upstream datacenter
-		upstreamMeta := structs.NewEnterpriseMetaWithPartition(svc.PartitionOrDefault(), u.DestinationNamespace)
+		upstreamMeta := acl.NewEnterpriseMetaWithPartition(svc.PartitionOrDefault(), u.DestinationNamespace)
 		upstream := structs.NewServiceName(u.DestinationName, &upstreamMeta)
 
 		obj, err := tx.First(tableMeshTopology, indexID, upstream, downstream)
@@ -3980,6 +4412,7 @@ func updateMeshTopology(tx WriteTxn, idx uint64, node string, svc *structs.NodeS
 // cleanupMeshTopology removes a service from the mesh topology table
 // This is only safe to call when there are no more known instances of this proxy
 func cleanupMeshTopology(tx WriteTxn, idx uint64, service *structs.ServiceNode) error {
+	// TODO(peering): make this peering aware?
 	if service.ServiceKind != structs.ServiceKindConnectProxy {
 		return nil
 	}
@@ -4087,6 +4520,7 @@ func truncateGatewayServiceTopologyMappings(tx WriteTxn, idx uint64, gateway str
 }
 
 func upsertKindServiceName(tx WriteTxn, idx uint64, kind structs.ServiceKind, name structs.ServiceName) error {
+	// TODO(peering): make this peering aware
 	q := KindServiceNameQuery{Name: name.Name, Kind: kind, EnterpriseMeta: name.EnterpriseMeta}
 	existing, err := tx.First(tableKindServiceNames, indexID, q)
 	if err != nil {
@@ -4109,10 +4543,7 @@ func upsertKindServiceName(tx WriteTxn, idx uint64, kind structs.ServiceKind, na
 	if err := tx.Insert(tableKindServiceNames, &ksn); err != nil {
 		return fmt.Errorf("failed inserting %s/%s into %s: %s", kind, name.String(), tableKindServiceNames, err)
 	}
-	if err := indexUpdateMaxTxn(tx, idx, kindServiceNameIndexName(kind)); err != nil {
-		return fmt.Errorf("failed updating %s index: %v", tableKindServiceNames, err)
-	}
-	return nil
+	return updateKindServiceNamesIndex(tx, idx, kind, name.EnterpriseMeta)
 }
 
 func cleanupKindServiceName(tx WriteTxn, idx uint64, name structs.ServiceName, kind structs.ServiceKind) error {
@@ -4120,9 +4551,42 @@ func cleanupKindServiceName(tx WriteTxn, idx uint64, name structs.ServiceName, k
 	if _, err := tx.DeleteAll(tableKindServiceNames, indexID, q); err != nil {
 		return fmt.Errorf("failed to delete %s from %s: %s", name, tableKindServiceNames, err)
 	}
+	return updateKindServiceNamesIndex(tx, idx, kind, name.EnterpriseMeta)
+}
 
-	if err := indexUpdateMaxTxn(tx, idx, kindServiceNameIndexName(kind)); err != nil {
-		return fmt.Errorf("failed updating %s index: %v", tableKindServiceNames, err)
+// CatalogDump returns all the contents of the node, service and check tables.
+// In Enterprise, this will return entries across all partitions and namespaces.
+// TODO(peering) make this peering aware?
+func (s *Store) CatalogDump() (*structs.CatalogContents, error) {
+	tx := s.db.Txn(false)
+	contents := &structs.CatalogContents{}
+
+	nodes, err := tx.Get(tableNodes, indexID)
+	if err != nil {
+		return nil, fmt.Errorf("failed nodes lookup: %s", err)
 	}
-	return nil
+	for node := nodes.Next(); node != nil; node = nodes.Next() {
+		n := node.(*structs.Node)
+		contents.Nodes = append(contents.Nodes, n)
+	}
+
+	services, err := tx.Get(tableServices, indexID)
+	if err != nil {
+		return nil, fmt.Errorf("failed services lookup: %s", err)
+	}
+	for service := services.Next(); service != nil; service = services.Next() {
+		svc := service.(*structs.ServiceNode)
+		contents.Services = append(contents.Services, svc)
+	}
+
+	checks, err := tx.Get(tableChecks, indexID)
+	if err != nil {
+		return nil, fmt.Errorf("failed checks lookup: %s", err)
+	}
+	for check := checks.Next(); check != nil; check = checks.Next() {
+		c := check.(*structs.HealthCheck)
+		contents.Checks = append(contents.Checks, c)
+	}
+
+	return contents, nil
 }

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -7,80 +7,106 @@ import (
 	"fmt"
 	"strings"
 
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-memdb"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
 func withEnterpriseSchema(_ *memdb.DBSchema) {}
 
-func serviceIndexName(name string, _ *structs.EnterpriseMeta) string {
-	return fmt.Sprintf("service.%s", name)
+func serviceIndexName(name string, _ *acl.EnterpriseMeta, peerName string) string {
+	return peeredIndexEntryName(fmt.Sprintf("service.%s", name), peerName)
 }
 
-func serviceKindIndexName(kind structs.ServiceKind, _ *structs.EnterpriseMeta) string {
-	return "service_kind." + kind.Normalized()
+func serviceKindIndexName(kind structs.ServiceKind, _ *acl.EnterpriseMeta, peerName string) string {
+	base := "service_kind." + kind.Normalized()
+	return peeredIndexEntryName(base, peerName)
 }
 
-func nodeIndexName(name string, _ *structs.EnterpriseMeta) string {
-	return fmt.Sprintf("node.%s", name)
+func nodeIndexName(name string, _ *acl.EnterpriseMeta, peerName string) string {
+	return peeredIndexEntryName(fmt.Sprintf("node.%s", name), peerName)
 }
 
-func catalogUpdateNodesIndexes(tx WriteTxn, idx uint64, entMeta *structs.EnterpriseMeta) error {
-	// overall nodes index
+func catalogUpdateNodesIndexes(tx WriteTxn, idx uint64, _ *acl.EnterpriseMeta, peerName string) error {
+	// overall nodes index for snapshot and ListNodes RPC
 	if err := indexUpdateMaxTxn(tx, idx, tableNodes); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
+	// peered index
+	if err := indexUpdateMaxTxn(tx, idx, peeredIndexEntryName(tableNodes, peerName)); err != nil {
+		return fmt.Errorf("failed updating partitioned+peered index for nodes table: %w", err)
+	}
+
 	return nil
 }
 
-func catalogUpdateNodeIndexes(tx WriteTxn, nodeName string, idx uint64, _ *structs.EnterpriseMeta) error {
+// catalogUpdateNodeIndexes upserts the max index for a single node
+func catalogUpdateNodeIndexes(tx WriteTxn, idx uint64, nodeName string, _ *acl.EnterpriseMeta, peerName string) error {
 	// per-node index
-	if err := indexUpdateMaxTxn(tx, idx, nodeIndexName(nodeName, nil)); err != nil {
-		return fmt.Errorf("failed updating index: %s", err)
+	if err := indexUpdateMaxTxn(tx, idx, nodeIndexName(nodeName, nil, peerName)); err != nil {
+		return fmt.Errorf("failed updating node index: %w", err)
 	}
 
 	return nil
 }
 
-func catalogUpdateServicesIndexes(tx WriteTxn, idx uint64, _ *structs.EnterpriseMeta) error {
-	// overall services index
+// catalogUpdateServicesIndexes upserts the max index for the entire services table with varying levels
+// of granularity (no-op if `idx` is lower than what exists for that index key):
+// 	- all services
+// 	- all services in a specified peer (including internal)
+func catalogUpdateServicesIndexes(tx WriteTxn, idx uint64, _ *acl.EnterpriseMeta, peerName string) error {
+	// overall services index for snapshot
 	if err := indexUpdateMaxTxn(tx, idx, tableServices); err != nil {
-		return fmt.Errorf("failed updating index: %s", err)
+		return fmt.Errorf("failed updating index for services table: %w", err)
+	}
+
+	// peered services index
+	if err := indexUpdateMaxTxn(tx, idx, peeredIndexEntryName(tableServices, peerName)); err != nil {
+		return fmt.Errorf("failed updating peered index for services table: %w", err)
 	}
 
 	return nil
 }
 
-func catalogUpdateServiceKindIndexes(tx WriteTxn, kind structs.ServiceKind, idx uint64, _ *structs.EnterpriseMeta) error {
+// catalogUpdateServiceKindIndexes upserts the max index for the ServiceKind with varying levels
+// of granularity (no-op if `idx` is lower than what exists for that index key):
+// 	- all services of ServiceKind
+// 	- all services of ServiceKind in a specified peer (including internal)
+func catalogUpdateServiceKindIndexes(tx WriteTxn, idx uint64, kind structs.ServiceKind, _ *acl.EnterpriseMeta, peerName string) error {
+	base := "service_kind." + kind.Normalized()
 	// service-kind index
-	if err := indexUpdateMaxTxn(tx, idx, serviceKindIndexName(kind, nil)); err != nil {
-		return fmt.Errorf("failed updating index: %s", err)
+	if err := indexUpdateMaxTxn(tx, idx, base); err != nil {
+		return fmt.Errorf("failed updating index for service kind: %w", err)
 	}
 
+	// peered index
+	if err := indexUpdateMaxTxn(tx, idx, peeredIndexEntryName(base, peerName)); err != nil {
+		return fmt.Errorf("failed updating peered index for service kind: %w", err)
+	}
 	return nil
 }
 
-func catalogUpdateServiceIndexes(tx WriteTxn, serviceName string, idx uint64, _ *structs.EnterpriseMeta) error {
+func catalogUpdateServiceIndexes(tx WriteTxn, idx uint64, serviceName string, _ *acl.EnterpriseMeta, peerName string) error {
 	// per-service index
-	if err := indexUpdateMaxTxn(tx, idx, serviceIndexName(serviceName, nil)); err != nil {
+	if err := indexUpdateMaxTxn(tx, idx, serviceIndexName(serviceName, nil, peerName)); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
 	return nil
 }
 
-func catalogUpdateServiceExtinctionIndex(tx WriteTxn, idx uint64, _ *structs.EnterpriseMeta) error {
-	if err := tx.Insert(tableIndex, &IndexEntry{indexServiceExtinction, idx}); err != nil {
-		return fmt.Errorf("failed updating missing service extinction index: %s", err)
+func catalogUpdateServiceExtinctionIndex(tx WriteTxn, idx uint64, _ *acl.EnterpriseMeta, peerName string) error {
+	if err := indexUpdateMaxTxn(tx, idx, peeredIndexEntryName(indexServiceExtinction, peerName)); err != nil {
+		return fmt.Errorf("failed updating missing service extinction peered index: %w", err)
 	}
 	return nil
 }
 
-func catalogUpdateNodeExtinctionIndex(tx WriteTxn, idx uint64, _ *structs.EnterpriseMeta) error {
-	if err := tx.Insert(tableIndex, &IndexEntry{indexNodeExtinction, idx}); err != nil {
-		return fmt.Errorf("failed updating missing node extinction index: %s", err)
+func catalogUpdateNodeExtinctionIndex(tx WriteTxn, idx uint64, _ *acl.EnterpriseMeta, peerName string) error {
+	if err := indexUpdateMaxTxn(tx, idx, peeredIndexEntryName(indexNodeExtinction, peerName)); err != nil {
+		return fmt.Errorf("failed updating missing node extinction peered index: %w", err)
 	}
 	return nil
 }
@@ -94,18 +120,17 @@ func catalogInsertNode(tx WriteTxn, node *structs.Node) error {
 		return fmt.Errorf("failed inserting node: %s", err)
 	}
 
-	if err := catalogUpdateNodesIndexes(tx, node.ModifyIndex, node.GetEnterpriseMeta()); err != nil {
-		return err
+	if err := catalogUpdateNodesIndexes(tx, node.ModifyIndex, node.GetEnterpriseMeta(), node.PeerName); err != nil {
+		return fmt.Errorf("failed updating nodes indexes: %w", err)
 	}
-
-	if err := catalogUpdateNodeIndexes(tx, node.Node, node.ModifyIndex, node.GetEnterpriseMeta()); err != nil {
-		return err
+	if err := catalogUpdateNodeIndexes(tx, node.ModifyIndex, node.Node, node.GetEnterpriseMeta(), node.PeerName); err != nil {
+		return fmt.Errorf("failed updating node indexes: %w", err)
 	}
 
 	// Update the node's service indexes as the node information is included
 	// in health queries and we would otherwise miss node updates in some cases
 	// for those queries.
-	if err := updateAllServiceIndexesOfNode(tx, node.ModifyIndex, node.Node, node.GetEnterpriseMeta()); err != nil {
+	if err := updateAllServiceIndexesOfNode(tx, node.ModifyIndex, node.Node, node.GetEnterpriseMeta(), node.PeerName); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
@@ -118,90 +143,110 @@ func catalogInsertService(tx WriteTxn, svc *structs.ServiceNode) error {
 		return fmt.Errorf("failed inserting service: %s", err)
 	}
 
-	if err := catalogUpdateServicesIndexes(tx, svc.ModifyIndex, &svc.EnterpriseMeta); err != nil {
-		return err
+	if err := catalogUpdateServicesIndexes(tx, svc.ModifyIndex, &svc.EnterpriseMeta, svc.PeerName); err != nil {
+		return fmt.Errorf("failed updating services indexes: %w", err)
 	}
 
-	if err := catalogUpdateServiceIndexes(tx, svc.ServiceName, svc.ModifyIndex, &svc.EnterpriseMeta); err != nil {
-		return err
+	if err := catalogUpdateServiceIndexes(tx, svc.ModifyIndex, svc.ServiceName, &svc.EnterpriseMeta, svc.PeerName); err != nil {
+		return fmt.Errorf("failed updating service indexes: %w", err)
 	}
 
-	if err := catalogUpdateServiceKindIndexes(tx, svc.ServiceKind, svc.ModifyIndex, &svc.EnterpriseMeta); err != nil {
-		return err
+	if err := catalogUpdateServiceKindIndexes(tx, svc.ModifyIndex, svc.ServiceKind, &svc.EnterpriseMeta, svc.PeerName); err != nil {
+		return fmt.Errorf("failed updating service-kind indexes: %w", err)
 	}
 
-	// Update the node's index as the service information is included in node catalog queries.
-	if err := catalogUpdateNodeIndexes(tx, svc.Node, svc.ModifyIndex, &svc.EnterpriseMeta); err != nil {
-		return err
+	// Update the node indexes as the service information is included in node catalog queries.
+	if err := catalogUpdateNodesIndexes(tx, svc.ModifyIndex, &svc.EnterpriseMeta, svc.PeerName); err != nil {
+		return fmt.Errorf("failed updating nodes indexes: %w", err)
+	}
+	if err := catalogUpdateNodeIndexes(tx, svc.ModifyIndex, svc.Node, &svc.EnterpriseMeta, svc.PeerName); err != nil {
+		return fmt.Errorf("failed updating node indexes: %w", err)
 	}
 
 	return nil
 }
 
-func catalogNodesMaxIndex(tx ReadTxn, entMeta *structs.EnterpriseMeta) uint64 {
-	return maxIndexTxn(tx, tableNodes)
+func catalogNodesMaxIndex(tx ReadTxn, _ *acl.EnterpriseMeta, peerName string) uint64 {
+	return maxIndexTxn(tx, peeredIndexEntryName(tableNodes, peerName))
 }
 
-func catalogNodeMaxIndex(tx ReadTxn, nodeName string, _ *structs.EnterpriseMeta) uint64 {
-	return maxIndexTxn(tx, nodeIndexName(nodeName, nil))
+func catalogNodeMaxIndex(tx ReadTxn, nodeName string, _ *acl.EnterpriseMeta, peerName string) uint64 {
+	return maxIndexTxn(tx, nodeIndexName(nodeName, nil, peerName))
 }
 
-func catalogNodeWatchIndex(tx ReadTxn, nodeName string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
-	return tx.FirstWatch(tableIndex, "id", nodeIndexName(nodeName, nil))
+func catalogNodeLastExtinctionIndex(tx ReadTxn, _ *acl.EnterpriseMeta, peerName string) uint64 {
+	return maxIndexTxn(tx, peeredIndexEntryName(indexNodeExtinction, peerName))
 }
 
-func catalogNodeMaxExtinctionIndex(tx ReadTxn, _ *structs.EnterpriseMeta) uint64 {
-	return maxIndexTxn(tx, indexNodeExtinction)
+func catalogServicesMaxIndex(tx ReadTxn, _ *acl.EnterpriseMeta, peerName string) uint64 {
+	return maxIndexTxn(tx, peeredIndexEntryName(tableServices, peerName))
 }
 
-func catalogServicesMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta) uint64 {
-	return maxIndexTxn(tx, tableServices)
+func catalogServiceMaxIndex(tx ReadTxn, serviceName string, _ *acl.EnterpriseMeta, peerName string) (<-chan struct{}, interface{}, error) {
+	return tx.FirstWatch(tableIndex, indexID, serviceIndexName(serviceName, nil, peerName))
 }
 
-func catalogServiceMaxIndex(tx ReadTxn, serviceName string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
-	return tx.FirstWatch(tableIndex, "id", serviceIndexName(serviceName, nil))
+func catalogServiceKindMaxIndex(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKind, _ *acl.EnterpriseMeta, peerName string) uint64 {
+	return maxIndexWatchTxn(tx, ws, serviceKindIndexName(kind, nil, peerName))
 }
 
-func catalogServiceKindMaxIndex(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) uint64 {
-	return maxIndexWatchTxn(tx, ws, serviceKindIndexName(kind, nil))
-}
-
-func catalogServiceListNoWildcard(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
-	return tx.Get(tableServices, indexID)
-}
-
-func catalogServiceListByNode(tx ReadTxn, node string, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
-	return tx.Get(tableServices, indexNode, Query{Value: node})
-}
-
-func catalogServiceLastExtinctionIndex(tx ReadTxn, _ *structs.EnterpriseMeta) (interface{}, error) {
-	return tx.First(tableIndex, "id", indexServiceExtinction)
-}
-
-func catalogMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta, checks bool) uint64 {
-	if checks {
-		return maxIndexTxn(tx, tableNodes, tableServices, tableChecks)
+func catalogServiceListNoWildcard(tx ReadTxn, _ *acl.EnterpriseMeta, peerName string) (memdb.ResultIterator, error) {
+	q := Query{
+		PeerName: peerName,
 	}
-	return maxIndexTxn(tx, tableNodes, tableServices)
+	return tx.Get(tableServices, indexID+"_prefix", q)
 }
 
-func catalogMaxIndexWatch(tx ReadTxn, ws memdb.WatchSet, _ *structs.EnterpriseMeta, checks bool) uint64 {
+func catalogServiceListByNode(tx ReadTxn, node string, _ *acl.EnterpriseMeta, peerName string, _ bool) (memdb.ResultIterator, error) {
+	return tx.Get(tableServices, indexNode, Query{Value: node, PeerName: peerName})
+}
+
+func catalogServiceLastExtinctionIndex(tx ReadTxn, _ *acl.EnterpriseMeta, peerName string) (interface{}, error) {
+	return tx.First(tableIndex, indexID, peeredIndexEntryName(indexServiceExtinction, peerName))
+}
+
+func catalogMaxIndex(tx ReadTxn, _ *acl.EnterpriseMeta, peerName string, checks bool) uint64 {
 	if checks {
-		return maxIndexWatchTxn(tx, ws, tableNodes, tableServices, tableChecks)
+		return maxIndexTxn(tx,
+			peeredIndexEntryName(tableChecks, peerName),
+			peeredIndexEntryName(tableServices, peerName),
+			peeredIndexEntryName(tableNodes, peerName),
+		)
 	}
-	return maxIndexWatchTxn(tx, ws, tableNodes, tableServices)
+	return maxIndexTxn(tx,
+		peeredIndexEntryName(tableServices, peerName),
+		peeredIndexEntryName(tableNodes, peerName),
+	)
 }
 
-func catalogUpdateCheckIndexes(tx WriteTxn, idx uint64, _ *structs.EnterpriseMeta) error {
-	// update the universal index entry
-	if err := tx.Insert(tableIndex, &IndexEntry{tableChecks, idx}); err != nil {
+func catalogMaxIndexWatch(tx ReadTxn, ws memdb.WatchSet, _ *acl.EnterpriseMeta, peerName string, checks bool) uint64 {
+	if checks {
+		return maxIndexWatchTxn(tx, ws,
+			peeredIndexEntryName(tableChecks, peerName),
+			peeredIndexEntryName(tableServices, peerName),
+			peeredIndexEntryName(tableNodes, peerName),
+		)
+	}
+	return maxIndexWatchTxn(tx, ws,
+		peeredIndexEntryName(tableServices, peerName),
+		peeredIndexEntryName(tableNodes, peerName),
+	)
+}
+
+func catalogUpdateCheckIndexes(tx WriteTxn, idx uint64, _ *acl.EnterpriseMeta, peerName string) error {
+	// update the overall index entry for snapshot
+	if err := indexUpdateMaxTxn(tx, idx, tableChecks); err != nil {
+		return fmt.Errorf("failed updating index: %s", err)
+	}
+
+	if err := indexUpdateMaxTxn(tx, idx, peeredIndexEntryName(tableChecks, peerName)); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 	return nil
 }
 
-func catalogChecksMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta) uint64 {
-	return maxIndexTxn(tx, tableChecks)
+func catalogChecksMaxIndex(tx ReadTxn, _ *acl.EnterpriseMeta, peerName string) uint64 {
+	return maxIndexTxn(tx, peeredIndexEntryName(tableChecks, peerName))
 }
 
 func catalogListChecksByNode(tx ReadTxn, q Query) (memdb.ResultIterator, error) {
@@ -214,18 +259,18 @@ func catalogInsertCheck(tx WriteTxn, chk *structs.HealthCheck, idx uint64) error
 		return fmt.Errorf("failed inserting check: %s", err)
 	}
 
-	if err := catalogUpdateCheckIndexes(tx, idx, &chk.EnterpriseMeta); err != nil {
+	if err := catalogUpdateCheckIndexes(tx, idx, &chk.EnterpriseMeta, chk.PeerName); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func validateRegisterRequestTxn(_ ReadTxn, _ *structs.RegisterRequest, _ bool) (*structs.EnterpriseMeta, error) {
+func validateRegisterRequestTxn(_ ReadTxn, _ *structs.RegisterRequest, _ bool) (*acl.EnterpriseMeta, error) {
 	return nil, nil
 }
 
-func (s *Store) ValidateRegisterRequest(_ *structs.RegisterRequest) (*structs.EnterpriseMeta, error) {
+func (s *Store) ValidateRegisterRequest(_ *structs.RegisterRequest) (*acl.EnterpriseMeta, error) {
 	return nil, nil
 }
 
@@ -246,4 +291,11 @@ func indexFromKindServiceName(arg interface{}) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("type must be KindServiceNameQuery or *KindServiceName: %T", arg)
 	}
+}
+
+func updateKindServiceNamesIndex(tx WriteTxn, idx uint64, kind structs.ServiceKind, entMeta acl.EnterpriseMeta) error {
+	if err := indexUpdateMaxTxn(tx, idx, kindServiceNameIndexName(kind.Normalized())); err != nil {
+		return fmt.Errorf("failed updating %s table index: %v", tableKindServiceNames, err)
+	}
+	return nil
 }

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1690,7 +1690,8 @@ func TestStateStore_EnsureService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx != 30 {
+	// Index matches the requested node's latest service update.
+	if idx != 20 {
 		t.Fatalf("bad index: %d", idx)
 	}
 

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -555,7 +555,7 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 	)
 
 	run := func(t *testing.T, peerName string) {
-		verifyNode := func(t *testing.T, s *Store, nodeLookup string) {
+		verifyNode := func(t *testing.T, s *Store, nodeLookup string, expectIdx uint64) {
 			idx, out, err := s.GetNode(nodeLookup, nil, peerName)
 			require.NoError(t, err)
 			byID := false
@@ -566,7 +566,7 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			}
 
 			require.NotNil(t, out)
-			require.Equal(t, uint64(1), idx)
+			require.Equal(t, expectIdx, idx)
 
 			require.Equal(t, "1.2.3.4", out.Address)
 			if byID {
@@ -661,8 +661,8 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			require.NoError(t, restore.Commit())
 
 			// Retrieve the node and verify its contents.
-			verifyNode(t, s, nodeID)
-			verifyNode(t, s, nodeName)
+			verifyNode(t, s, nodeID, 1)
+			verifyNode(t, s, nodeName, 1)
 		})
 
 		// Add in a service definition.
@@ -686,8 +686,8 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			require.NoError(t, restore.Commit())
 
 			// Verify that the service got registered.
-			verifyNode(t, s, nodeID)
-			verifyNode(t, s, nodeName)
+			verifyNode(t, s, nodeID, 2)
+			verifyNode(t, s, nodeName, 2)
 			verifyService(t, s, nodeID)
 			verifyService(t, s, nodeName)
 		})
@@ -726,8 +726,8 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			require.NoError(t, restore.Commit())
 
 			// Verify that the check got registered.
-			verifyNode(t, s, nodeID)
-			verifyNode(t, s, nodeName)
+			verifyNode(t, s, nodeID, 2)
+			verifyNode(t, s, nodeName, 2)
 			verifyService(t, s, nodeID)
 			verifyService(t, s, nodeName)
 			verifyCheck(t, s)
@@ -776,8 +776,8 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			require.NoError(t, restore.Commit())
 
 			// Verify that the additional check got registered.
-			verifyNode(t, s, nodeID)
-			verifyNode(t, s, nodeName)
+			verifyNode(t, s, nodeID, 2)
+			verifyNode(t, s, nodeName, 2)
 			verifyService(t, s, nodeID)
 			verifyService(t, s, nodeName)
 			verifyChecks(t, s)
@@ -976,7 +976,7 @@ func TestNodeRenamingNodes(t *testing.T) {
 		Address: "1.1.1.2",
 	}
 	if err := s.EnsureNode(10, in2Modify); err != nil {
-		t.Fatalf("Renaming node2 into node1 should fail")
+		t.Fatalf("Renaming node2 into node1 should not fail: " + err.Error())
 	}
 
 	// Retrieve the node again
@@ -1550,20 +1550,16 @@ func TestStateStore_DeleteNode(t *testing.T) {
 	}
 
 	// Indexes were updated.
-	for _, tbl := range []string{tableNodes, tableServices, tableChecks} {
-		if idx := s.maxIndex(tbl); idx != 3 {
-			t.Fatalf("bad index: %d (%s)", idx, tbl)
-		}
-	}
+	assert.Equal(t, uint64(3), catalogChecksMaxIndex(tx, nil, ""))
+	assert.Equal(t, uint64(3), catalogServicesMaxIndex(tx, nil, ""))
+	assert.Equal(t, uint64(3), catalogNodesMaxIndex(tx, nil, ""))
 
 	// Deleting a nonexistent node should be idempotent and not return
 	// an error
 	if err := s.DeleteNode(4, "node1", nil, ""); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx := s.maxIndex(tableNodes); idx != 3 {
-		t.Fatalf("bad index: %d", idx)
-	}
+	assert.Equal(t, uint64(3), catalogNodesMaxIndex(s.db.ReadTxn(), nil, ""))
 }
 
 func TestStateStore_Node_Snapshot(t *testing.T) {
@@ -1690,7 +1686,7 @@ func TestStateStore_EnsureService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	// Index matches the requested node's latest service update.
+	// expect node1's max idx
 	if idx != 20 {
 		t.Fatalf("bad index: %d", idx)
 	}
@@ -1714,9 +1710,7 @@ func TestStateStore_EnsureService(t *testing.T) {
 	}
 
 	// Index tables were updated.
-	if idx := s.maxIndex(tableServices); idx != 30 {
-		t.Fatalf("bad index: %d", idx)
-	}
+	assert.Equal(t, uint64(30), catalogServicesMaxIndex(s.db.ReadTxn(), nil, ""))
 
 	// Update a service registration.
 	ns1.Address = "1.1.1.2"
@@ -1745,9 +1739,7 @@ func TestStateStore_EnsureService(t *testing.T) {
 	}
 
 	// Index tables were updated.
-	if idx := s.maxIndex(tableServices); idx != 40 {
-		t.Fatalf("bad index: %d", idx)
-	}
+	assert.Equal(t, uint64(40), catalogServicesMaxIndex(s.db.ReadTxn(), nil, ""))
 }
 
 func TestStateStore_EnsureService_connectProxy(t *testing.T) {
@@ -2572,21 +2564,15 @@ func TestStateStore_DeleteService(t *testing.T) {
 	}
 
 	// Index tables were updated.
-	if idx := s.maxIndex(tableServices); idx != 4 {
-		t.Fatalf("bad index: %d", idx)
-	}
-	if idx := s.maxIndex(tableChecks); idx != 4 {
-		t.Fatalf("bad index: %d", idx)
-	}
+	assert.Equal(t, uint64(4), catalogChecksMaxIndex(tx, nil, ""))
+	assert.Equal(t, uint64(4), catalogServicesMaxIndex(tx, nil, ""))
 
 	// Deleting a nonexistent service should be idempotent and not return an
 	// error, nor fire a watch.
 	if err := s.DeleteService(5, "node1", "service1", nil, ""); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx := s.maxIndex(tableServices); idx != 4 {
-		t.Fatalf("bad index: %d", idx)
-	}
+	assert.Equal(t, uint64(4), catalogServicesMaxIndex(tx, nil, ""))
 	if watchFired(ws) {
 		t.Fatalf("bad")
 	}
@@ -2907,9 +2893,7 @@ func TestStateStore_EnsureCheck(t *testing.T) {
 	testCheckOutput(t, 5, 5, "bbbmodified")
 
 	// Index tables were updated
-	if idx := s.maxIndex(tableChecks); idx != 5 {
-		t.Fatalf("bad index: %d", idx)
-	}
+	assert.Equal(t, uint64(5), catalogChecksMaxIndex(s.db.ReadTxn(), nil, ""))
 }
 
 func TestStateStore_EnsureCheck_defaultStatus(t *testing.T) {
@@ -3388,9 +3372,7 @@ func TestStateStore_DeleteCheck(t *testing.T) {
 	if idx, check, err := s.NodeCheck("node1", "check1", nil, ""); idx != 3 || err != nil || check != nil {
 		t.Fatalf("Node check should have been deleted idx=%d, node=%v, err=%s", idx, check, err)
 	}
-	if idx := s.maxIndex(tableChecks); idx != 3 {
-		t.Fatalf("bad index for checks: %d", idx)
-	}
+	assert.Equal(t, uint64(3), catalogChecksMaxIndex(s.db.ReadTxn(), nil, ""))
 	if !watchFired(ws) {
 		t.Fatalf("bad")
 	}
@@ -3408,18 +3390,14 @@ func TestStateStore_DeleteCheck(t *testing.T) {
 	}
 
 	// Index tables were updated.
-	if idx := s.maxIndex(tableChecks); idx != 3 {
-		t.Fatalf("bad index: %d", idx)
-	}
+	assert.Equal(t, uint64(3), catalogChecksMaxIndex(s.db.ReadTxn(), nil, ""))
 
 	// Deleting a nonexistent check should be idempotent and not return an
 	// error.
 	if err := s.DeleteCheck(4, "node1", "check1", nil, ""); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx := s.maxIndex(tableChecks); idx != 3 {
-		t.Fatalf("bad index: %d", idx)
-	}
+	assert.Equal(t, uint64(3), catalogChecksMaxIndex(s.db.ReadTxn(), nil, ""))
 	if watchFired(ws) {
 		t.Fatalf("bad")
 	}

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -263,25 +263,25 @@ func (s *Store) Abandon() {
 }
 
 // maxIndex is a helper used to retrieve the highest known index
-// amongst a set of tables in the db.
-func (s *Store) maxIndex(tables ...string) uint64 {
+// amongst a set of index keys (e.g. table names) in the db.
+func (s *Store) maxIndex(keys ...string) uint64 {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
-	return maxIndexTxn(tx, tables...)
+	return maxIndexTxn(tx, keys...)
 }
 
 // maxIndexTxn is a helper used to retrieve the highest known index
-// amongst a set of tables in the db.
-func maxIndexTxn(tx ReadTxn, tables ...string) uint64 {
-	return maxIndexWatchTxn(tx, nil, tables...)
+// amongst a set of index keys (e.g. table names) in the db.
+func maxIndexTxn(tx ReadTxn, keys ...string) uint64 {
+	return maxIndexWatchTxn(tx, nil, keys...)
 }
 
-func maxIndexWatchTxn(tx ReadTxn, ws memdb.WatchSet, tables ...string) uint64 {
+func maxIndexWatchTxn(tx ReadTxn, ws memdb.WatchSet, keys ...string) uint64 {
 	var lindex uint64
-	for _, table := range tables {
-		ch, ti, err := tx.FirstWatch(tableIndex, "id", table)
+	for _, key := range keys {
+		ch, ti, err := tx.FirstWatch(tableIndex, "id", key)
 		if err != nil {
-			panic(fmt.Sprintf("unknown index: %s err: %s", table, err))
+			panic(fmt.Sprintf("unknown index: %s err: %s", key, err))
 		}
 		if idx, ok := ti.(*IndexEntry); ok && idx.Value > lindex {
 			lindex = idx.Value


### PR DESCRIPTION
Fixes #12398 by adding fine-grained `node.[node]` entries to the `index` table, allowing blocking queries to return fine-grained indexes that prevent them from returning immediately when unrelated nodes/services are updated.