### PR TITLE
ui: [Backport 1.9.x] Fixup displaying a Nspace default policy when expanding the preview pane

### DIFF
--- a/.changelog/12316.txt
+++ b/.changelog/12316.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Ensure we always display the Policy default preview in the Namespace editing form
+```

--- a/ui/packages/consul-ui/app/serializers/nspace.js
+++ b/ui/packages/consul-ui/app/serializers/nspace.js
@@ -2,6 +2,29 @@ import Serializer from './application';
 import { get } from '@ember/object';
 import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/nspace';
 
+const normalizeACLs = item => {
+  if (get(item, 'ACLs.PolicyDefaults')) {
+    item.ACLs.PolicyDefaults = item.ACLs.PolicyDefaults.map(function(item) {
+      if (typeof item.template === 'undefined') {
+        item.template = '';
+      }
+      return item;
+    });
+  }
+  // Both of these might come though unset so we make sure we at least
+  // have an empty array here so we can add children to them if we
+  // need to whilst saving nspaces
+  ['PolicyDefaults', 'RoleDefaults'].forEach(function(prop) {
+    if (typeof item.ACLs === 'undefined') {
+      item.ACLs = [];
+    }
+    if (typeof item.ACLs[prop] === 'undefined') {
+      item.ACLs[prop] = [];
+    }
+  });
+  return item;
+};
+
 export default class NspaceSerializer extends Serializer {
   primaryKey = PRIMARY_KEY;
   slugKey = SLUG_KEY;
@@ -11,24 +34,7 @@ export default class NspaceSerializer extends Serializer {
       return this.attachHeaders(
         headers,
         body.map(function(item) {
-          if (get(item, 'ACLs.PolicyDefaults')) {
-            item.ACLs.PolicyDefaults = item.ACLs.PolicyDefaults.map(function(item) {
-              item.template = '';
-              return item;
-            });
-          }
-          // Both of these might come though unset so we make sure we at least
-          // have an empty array here so we can add children to them if we
-          // need to whilst saving nspaces
-          ['PolicyDefaults', 'RoleDefaults'].forEach(function(prop) {
-            if (typeof item.ACLs === 'undefined') {
-              item.ACLs = [];
-            }
-            if (typeof item.ACLs[prop] === 'undefined') {
-              item.ACLs[prop] = [];
-            }
-          });
-          return item;
+          return normalizeACLs(item);
         })
       );
     });
@@ -39,7 +45,7 @@ export default class NspaceSerializer extends Serializer {
     // queries on form views yet, and by the time we do Serializers should
     // have been refactored to not use attachHeaders
     return respond((headers, body) => {
-      return body;
+      return normalizeACLs(body);
     });
   }
 
@@ -54,7 +60,7 @@ export default class NspaceSerializer extends Serializer {
 
   respondForUpdateRecord(respond, serialized, data) {
     return respond((headers, body) => {
-      return body;
+      return normalizeACLs(body);
     });
   }
 


### PR DESCRIPTION
See https://github.com/hashicorp/consul/pull/12316, manually cherry picked onto 1.9.x,

no-changelog label added as our change log checker doesn't work if the base branch is not main, it does have a changelog