### PR TITLE
[1.10.x] xds: fix some test assertions for enterprise

### DIFF
--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -37,6 +38,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		setup              func(snap *proxycfg.ConfigSnapshot)
 		overrideGoldenName string
 		generatorSetup     func(*ResourceGenerator)
+		stripTenancy       bool
 	}{
 		{
 			name:   "defaults",
@@ -629,6 +631,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 					t, "no-endpoints", "default", "dc1",
 					connect.TestClusterID+".consul", "dc1", nil)
 			},
+			stripTenancy: true,
 		},
 		{
 			name:   "transparent-proxy-catalog-destinations-only",
@@ -768,6 +771,12 @@ func TestListenersFromSnapshot(t *testing.T) {
 
 					t.Run("current", func(t *testing.T) {
 						gotJSON := protoToJSON(t, r)
+						if tt.stripTenancy {
+							// TPROXY upstreams use ServiceName strings as map keys instead of upstream
+							// identifiers, so enterprise sometimes prefixes them.
+							gotJSON = strings.ReplaceAll(gotJSON,
+								`"name": "default/`, `"name": "`)
+						}
 
 						gName := tt.name
 						if tt.overrideGoldenName != "" {


### PR DESCRIPTION
Backport of #12413 to `release/1.10.x`

The fix is slightly different to account for there not being partitions in 1.10.