### PR TITLE
Note for ACLs and Restore

### DIFF
--- a/website/content/commands/snapshot/restore.mdx
+++ b/website/content/commands/snapshot/restore.mdx
@@ -19,6 +19,8 @@ designed to handle server failures during a restore. This command is primarily
 intended to be used when recovering from a disaster, restoring into a fresh
 cluster of Consul servers.
 
+->**Note:** If ACLs were enabled in your environment, you will need to bootstrap the ACL system before restoring.
+
 The table below shows this command's [required ACLs](/api#authentication). Configuration of
 [blocking queries](/api/features/blocking) and [agent caching](/api/features/caching)
 are not supported from commands, but may be from the corresponding HTTP endpoint.


### PR DESCRIPTION
I have several customers who were frustrated they couldn't figure out why their restores were not working and the documentation did not tell them  you need to bootstrap the ACL system before restore if using ACLs.