### PR TITLE
[1.11.x] Add support for Envoy 1.20.2

### DIFF
--- a/.changelog/12433.txt
+++ b/.changelog/12433.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: update Envoy supported version of 1.20 to 1.20.2
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -846,10 +846,10 @@ jobs:
     environment:
       ENVOY_VERSION: "1.19.1"
 
-  envoy-integration-test-1_20_1:
+  envoy-integration-test-1_20_2:
     <<: *ENVOY_TESTS
     environment:
-      ENVOY_VERSION: "1.20.1"
+      ENVOY_VERSION: "1.20.2"
 
   # run integration tests for the connect ca providers
   test-connect-ca-providers:
@@ -1100,7 +1100,7 @@ workflows:
       - envoy-integration-test-1_19_1:
           requires:
             - dev-build
-      - envoy-integration-test-1_20_1:
+      - envoy-integration-test-1_20_2:
           requires:
             - dev-build
 

--- a/agent/xds/envoy_versioning_test.go
+++ b/agent/xds/envoy_versioning_test.go
@@ -132,7 +132,7 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 	}
 	for _, v := range []string{
 		"1.19.0", "1.19.1",
-		"1.20.0", "1.20.1",
+		"1.20.0", "1.20.1", "1.20.2",
 	} {
 		cases[v] = testcase{expect: supportedProxyFeatures{}}
 	}

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -7,7 +7,7 @@ package proxysupport
 //
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
-	"1.20.1",
+	"1.20.2",
 	"1.19.1",
 	"1.18.4",
 	"1.17.4",

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -178,6 +178,13 @@ function assert_envoy_version {
   echo "---"
   echo "Got version=$VERSION"
   echo "Want version=$ENVOY_VERSION"
+
+  # 1.20.2 is a special snowflake in that the version for the release is actually
+  # reported as '1.20.2-dev'
+  if [ "$ENVOY_VERSION" = "1.20.2" ] ; then
+    ENVOY_VERSION="1.20.2-dev"
+  fi
+
   echo $VERSION | grep "/$ENVOY_VERSION/"
 }
 

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -10,7 +10,7 @@ readonly HASHICORP_DOCKER_PROXY="docker.mirror.hashicorp.services"
 DEBUG=${DEBUG:-}
 
 # ENVOY_VERSION to run each test against
-ENVOY_VERSION=${ENVOY_VERSION:-"1.20.1"}
+ENVOY_VERSION=${ENVOY_VERSION:-"1.20.2"}
 export ENVOY_VERSION
 
 if [ ! -z "$DEBUG" ] ; then


### PR DESCRIPTION
This updates our Envoy integration test matrix to include 1.20.2. The only notable change that was needed was to match against the Envoy version string which is:
```
4aaf9593152c6996b9da384c8918e9ad4f0abd4d/1.20.2-dev/Clean/RELEASE/BoringSSL
```
Note the `-dev` suffix. 

This little version issue causes all the tests that use the `assert_envoy_version` helper to fail. To work around it, I just temporarily re-write the `ENVOY_VERSION` variable to include the suffix.

All other integration tests passed. 

FUN FACT: The latest releases for Envoy 1.19 and 1.18 also have this `-dev` suffix that we'll need to deal with as well. 

