### PR TITLE
ui: Use PagedCollection

### DIFF
--- a/ui/packages/consul-nspaces/app/components/consul/nspace/selector/index.hbs
+++ b/ui/packages/consul-nspaces/app/components/consul/nspace/selector/index.hbs
@@ -2,18 +2,26 @@
   {{#if (can "choose nspaces")}}
     {{#let
       (or @nspace 'default')
-    as |nspace|}}
+      (is-href 'dc.nspaces' @dc.Name)
+    as |nspace isManaging|}}
         <li
           class="nspaces"
           data-test-nspace-menu
         >
           <DisclosureMenu
             aria-label="Namespace"
+            @items={{append 
+              (hash 
+                Name="Manage Namespaces"
+                href=(href-to 'dc.nspaces' @dc.Name)
+              ) 
+              (reject-by 'DeletedAt' @nspaces)
+            }}
           as |disclosure|>
             <disclosure.Action
               {{on 'click' disclosure.toggle}}
             >
-              {{nspace}}
+              {{if isManaging 'Manage Namespaces' nspace}}
             </disclosure.Action>
             <disclosure.Menu as |panel|>
               {{#if (gt @nspaces.length 0)}}
@@ -40,34 +48,39 @@
                 />
               {{/if}}
               <panel.Menu as |menu|>
-                {{#each (reject-by 'DeletedAt' @nspaces) as |item|}}
+                {{#each menu.items as |item|}}
+
                   <menu.Item
-                    aria-current={{if (eq nspace item.Name) 'true'}}
+                    data-test-main-nav-nspaces={{not-eq item.href undefined}}
+                    aria-current={{if 
+                      (or 
+                        (and isManaging item.href)
+                        (and (not isManaging) (eq nspace item.Name))
+                      )
+                      'true'
+                    }}
                   >
                     <menu.Action
                       {{on 'click' disclosure.close}}
-                      @href={{href-to '.' params=(hash
-                        partition=(if (gt @partition.length 0) @partition undefined)
-                        nspace=item.Name
-                      )}}
+                      @href={{if item.href 
+                        item.href 
+                        (if isManaging 
+                          (href-to 'dc.services.index' params=(hash
+                            partition=(if (gt @partition.length 0) @partition undefined)
+                            nspace=item.Name
+                            dc=@dc.Name
+                          ))
+                          (href-to '.' params=(hash
+                            partition=(if (gt @partition.length 0) @partition undefined)
+                            nspace=item.Name
+                          ))
+                        )
+                      }}
                     >
                       {{item.Name}}
                     </menu.Action>
                   </menu.Item>
                 {{/each}}
-                {{#if (can 'manage nspaces')}}
-                  <menu.Separator />
-                  <menu.Item
-                    data-test-main-nav-nspaces
-                  >
-                    <menu.Action
-                      {{on 'click' disclosure.close}}
-                      @href={{href-to 'dc.nspaces' @dc.Name}}
-                    >
-                      Manage Namespaces
-                    </menu.Action>
-                  </menu.Item>
-                {{/if}}
               </panel.Menu>
             </disclosure.Menu>
           </DisclosureMenu>

--- a/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
+++ b/ui/packages/consul-partitions/app/components/consul/partition/selector/index.hbs
@@ -1,6 +1,7 @@
 {{#let
   (or @partition 'default')
-as |partition|}}
+  (is-href 'dc.partitions' @dc.Name)
+as |partition isManaging|}}
   {{#if (can "choose partitions" dc=@dc)}}
       <li
         class="partitions"
@@ -8,11 +9,18 @@ as |partition|}}
       >
         <DisclosureMenu
           aria-label="Admin Partition"
+          @items={{append 
+            (hash 
+              Name="Manage Partitions"
+              href=(href-to 'dc.partitions' @dc.Name)
+            ) 
+            (reject-by 'DeletedAt' @partitions)
+          }}
         as |disclosure|>
           <disclosure.Action
             {{on 'click' disclosure.toggle}}
           >
-            {{partition}}
+            {{if isManaging 'Manage Partition' partition}}
           </disclosure.Action>
           <disclosure.Menu as |panel|>
             <DataSource
@@ -25,34 +33,37 @@ as |partition|}}
               @onchange={{fn (optional @onchange)}}
             />
             <panel.Menu as |menu|>
-              {{#each (reject-by 'DeletedAt' @partitions) as |item|}}
+              {{#each menu.items as |item|}}
                 <menu.Item
-                  class={{if (eq partition item.Name) 'is-active'}}
+                  aria-current={{if 
+                    (or 
+                      (and isManaging item.href)
+                      (and (not isManaging) (eq partition item.Name))
+                    )
+                    'true'
+                  }}
                 >
                   <menu.Action
                     {{on 'click' disclosure.close}}
-                    @href={{href-to '.' params=(hash
-                      partition=item.Name
-                      nspace=undefined
-                    )}}
+                    @href={{if item.href 
+                      item.href 
+                      (if isManaging 
+                        (href-to 'dc.services.index' params=(hash
+                          partition=item.Name
+                          nspace=undefined
+                          dc=@dc.Name
+                        ))
+                        (href-to '.' params=(hash
+                          partition=item.Name
+                          nspace=undefined
+                        ))
+                      )
+                    }}
                   >
                     {{item.Name}}
                   </menu.Action>
                 </menu.Item>
               {{/each}}
-              {{#if (can 'manage partitions')}}
-                <menu.Separator />
-                <menu.Item
-                  data-test-main-nav-partitions
-                >
-                  <menu.Action
-                    {{on 'click' disclosure.close}}
-                    @href={{href-to 'dc.partitions.index' @dc.Name}}
-                  >
-                    Manage Partitions
-                  </menu.Action>
-                </menu.Item>
-              {{/if}}
             </panel.Menu>
           </disclosure.Menu>
         </DisclosureMenu>

--- a/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
@@ -4,6 +4,7 @@
 >
   <DisclosureMenu
     aria-label="Datacenter"
+    @items={{sort-by 'Name' @dcs}}
   as |disclosure|>
     <disclosure.Action
       {{on 'click' disclosure.toggle}}
@@ -16,7 +17,7 @@
         @onchange={{action (mut @dcs) value="data"}}
       />
         <panel.Menu as |menu|>
-          {{#each (sort-by 'Name' @dcs) as |item|}}
+          {{#each menu.items as |item|}}
             <menu.Item
               aria-current={{if (eq @dc.Name item.Name) 'true'}}
               class={{class-map

--- a/ui/packages/consul-ui/app/components/disclosure-menu/README.mdx
+++ b/ui/packages/consul-ui/app/components/disclosure-menu/README.mdx
@@ -38,14 +38,12 @@ common usecase of having a floating menu.
   <DisclosureMenu as |disclosure|>
     <disclosure.Action
       {{on 'click' disclosure.toggle}}
-      {{css-prop 'height' returns=(set this 'height')}}
     >
       {{if disclosure.expanded 'Close' 'Open'}}
     </disclosure.Action>
     <disclosure.Menu
       style={{style-map
         (array 'position' 'absolute')
-        (array 'top' this.height)
         (array 'background-color' 'rgb(var(--tone-gray-000))')
       }}
     as |panel|>
@@ -62,11 +60,53 @@ common usecase of having a floating menu.
 </figure>
 ```
 
+`DisclosureMenu` also supports virtually scrolling its menu items for when you have 1000s of items to display in the menu whilst avoiding DOM stuttering. The set up is a tinsy bit more involved. but eesnetially you provide the data items for the menu using the `@items` argument, and then you can loop through these in the menu to make/use your menu items. The `menu.items` property is automatically paged for you depending on the scroll position of the menu panel. Importantly, right now, you should provide a height value for each menu.item using the `--paged-row-height` CSS property, you can do this inline or within your CSS (preferred). If you don't do this the component is unable to calculate the size of the scroll track/thumb. In the future (when needed) we will provide a callback for each item so you can specify a function to calculate the size of each individual item to give us a little more flexibility on what we can do with this component.
+
+```hbs preview-template
+<DataSource
+  @src={{uri
+  '/${partition}/${nspace}/${dc}/nodes'
+    (hash
+      nspace=''
+      partition=''
+      dc='dc-1'
+    )
+  }}
+as |source|>
+  <DisclosureMenu
+    @items={{source.data}}
+  as |disclosure|>
+    <disclosure.Action
+      {{on 'click' disclosure.toggle}}
+    >
+      {{if disclosure.expanded 'Close' 'Open'}}
+    </disclosure.Action>
+    <disclosure.Menu
+      style={{style-map
+        (array 'position' 'absolute')
+        (array 'max-height' '360' 'px')
+        (array 'width' '560' 'px')
+        (array '--paged-row-height' '42px')
+      }}
+    as |panel|>
+      <panel.Menu as |menu|>
+        {{#each menu.items as |item|}}
+          <menu.Item>
+            <menu.Action>{{item.Node}}</menu.Action>
+          </menu.Item>
+        {{/each}}
+      </panel.Menu>
+    </disclosure.Menu>
+  </DisclosureMenu>
+</DataSource>
+```
+
 ## Arguments
 
 | Argument | Type | Default | Description |
 | --- | --- | --- | --- |
 | `expanded` | `Boolean` | false | The _initial_ state of the disclosure. Please note: this is the _initial_ state only, please use the `disclosure.open` and `disclosure.close` for controling the state. |
+| `items` | `object[]` |  | When using a paginated menu you should add all possible items to this arguments and then uses the disclosure.Panel.Menu.items property for `each`ing through, see above example |
 
 ## Exported API
 

--- a/ui/packages/consul-ui/app/components/disclosure-menu/index.hbs
+++ b/ui/packages/consul-ui/app/components/disclosure-menu/index.hbs
@@ -9,7 +9,11 @@
   as |disclosure|>
     {{yield (hash
       Action=(component 'disclosure-menu/action' disclosure=disclosure)
-      Menu=(component 'disclosure-menu/menu' disclosure=disclosure)
+      Menu=(component 'disclosure-menu/menu'
+        disclosure=disclosure
+        items=@items
+        rowHeight=@rowHeight
+      )
       disclosure=disclosure
       toggle=disclosure.toggle
       close=disclosure.close

--- a/ui/packages/consul-ui/app/components/disclosure-menu/index.scss
+++ b/ui/packages/consul-ui/app/components/disclosure-menu/index.scss
@@ -3,4 +3,6 @@
 }
 .disclosure-menu [aria-expanded] ~ * {
   @extend %menu-panel;
+  overflow-y: auto !important;
+  will-change: scrollPosition;
 }

--- a/ui/packages/consul-ui/app/components/disclosure-menu/menu/index.hbs
+++ b/ui/packages/consul-ui/app/components/disclosure-menu/menu/index.hbs
@@ -1,11 +1,25 @@
 <@disclosure.Details as |details|>
-<div
-  {{on-outside 'click' @disclosure.close}}
-  ...attributes
->
-  {{yield (hash
-    Menu=(component 'menu' disclosure=@disclosure)
-  )}}
-</div>
+  <PagedCollection
+    @items={{or @items (array)}}
+  as |pager|>
+    <div
+      {{on-outside 'click' @disclosure.close}}
+      {{did-insert pager.viewport}}
+      {{on-resize pager.resize}}
+      {{css-prop '--paged-row-height' returns=pager.rowHeight}}
+      {{css-prop 'max-height' returns=pager.maxHeight}}
+      class={{class-map
+        (array 'paged-collection-scroll' (contains pager.type (array 'virtual-scroll' 'native-scroll')))
+      }}
+      ...attributes
+    >
+      {{yield (hash
+        Menu=(component 'menu'
+          disclosure=@disclosure
+          pager=pager
+        )
+      )}}
+    </div>
+  </PagedCollection>
 </@disclosure.Details>
 

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.scss
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.scss
@@ -3,14 +3,21 @@
     @extend %main-nav-vertical-hoisted;
     left: 100px;
   }
-  nav .dcs .menu-panel {
-    min-width: 250px;
-  }
   nav li.partitions,
   nav li.nspaces {
     @extend %main-nav-vertical-popover-menu;
-    /*    --panel-height: 300px;
-    --row-height: 43px; */
+  }
+  nav li.dcs [aria-expanded] ~ * {
+    min-width: 250px;
+  }
+  nav li.dcs [aria-expanded] ~ * {
+    max-height: 560px;
+    --paged-row-height: 43px;
+  }
+  nav li.partitions [aria-expanded] ~ *,
+  nav li.nspaces [aria-expanded] ~ * {
+    max-height: 360px;
+    --paged-row-height: 43px;
   }
 
   [role='banner'] a svg {

--- a/ui/packages/consul-ui/app/components/menu/index.hbs
+++ b/ui/packages/consul-ui/app/components/menu/index.hbs
@@ -1,8 +1,10 @@
 <ul
   role="menu"
-  aria-labelledby={{@disclosure.button}}
-  id={{@disclosure.panel}}
-  ...attributes
+  style={{{style-map
+    (array 'height' (if (and @pager (not-eq @pager.type 'native-scroll')) @pager.totalHeight) 'px')
+    (array '--paged-start' (if (and @pager (not-eq @pager.type 'native-scroll')) @pager.startHeight) 'px')
+  }}}
+  {{did-insert (optional @pager.pane)}}
   {{aria-menu
     onclose=(or @onclose @disclosure.close)
     openEvent=(or @event @disclosure.event)
@@ -12,5 +14,6 @@
     Action=(component 'menu/action' disclosure=@disclosure)
     Item=(component 'menu/item')
     Separator=(component 'menu/separator')
+    items=@pager.items
   )}}
 </ul>


### PR DESCRIPTION
This PR is a follow on from https://github.com/hashicorp/consul/pull/12404 (note the base branch here)

[Preview Site](https://consul-ui-staging-p644eh34q-hashicorp.vercel.app/ui/dc1/services#CONSUL_DATACENTER_COUNT=1000;CONSUL_NSPACE_COUNT=1000;CONSUL_PARTITION_COUNT=1000;CONSUL_NSPACES_ENABLE=1;CONSUL_PARTITIONS_ENABLE=1): This link has 1000 each of Nspaces/Partitions/DCs. These are loaded when you first open the menu so there will be a little pause whilst the HTTP happens.

The PR integrates `PagedCollection` with our `DisclosureMenu` and then uses it in the 3 menus where we may get lots of items.

I also added more example documentation to our [DisclosureMenu documentation](https://consul-ui-staging-p644eh34q-hashicorp.vercel.app/ui/docs/components/disclosure-menu). You'll be able to see the new bits from the changeset here.

Here's a gif showing 5000 namespaces in the menu.

![5000-nspaces](https://user-images.githubusercontent.com/554604/155514821-7f57a810-1a55-4c00-a47f-322a7e700f10.gif)


Longer term there is a feature coming to also add a search bar to the top here, this run of work was just a first step towards that. PRs are on their way!
