### PR TITLE
Allows keyring operations on client agents

### DIFF
--- a/.changelog/12442.txt
+++ b/.changelog/12442.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+agent: Allow client agents to perform keyring operations
+```

--- a/agent/keyring.go
+++ b/agent/keyring.go
@@ -233,9 +233,6 @@ func decodeStringKey(key string) ([]byte, error) {
 func (a *Agent) keyringProcess(args *structs.KeyringRequest) (*structs.KeyringResponses, error) {
 	var reply structs.KeyringResponses
 
-	if _, ok := a.delegate.(*consul.Server); !ok {
-		return nil, fmt.Errorf("keyring operations must run against a server node")
-	}
 	if err := a.RPC("Internal.KeyringOperation", args, &reply); err != nil {
 		return &reply, err
 	}


### PR DESCRIPTION
There's no need to restrict keyring operations to server agents anymore. Clients can forward the RPC without issues.
To test this I built a modified binary, then spun up 2 agents, a server and a client, and performed all keyring operations hitting client HTTP interface.
Server was started with: 
```
consul agent -dev -encrypt='XzpEw/zF56iMIgk5nAAydBo+S9LuGmbye7m28K7tTeg=' -node=server
```
Client:
```
consul agent -http-port=8901 -serf-lan-port=8902 -serf-lan-bind=127.0.0.1 -bind=127.0.0.1 -data-dir=`pwd` -dns-port=8900  -node='client'  -log-level=trace -encrypt='XzpEw/zF56iMIgk5nAAydBo+S9LuGmbye7m28K7tTeg=' -join='127.0.0.1:8301'
```
Then set `CONSUL-HTTP-ADDR=http://localhost:8901`. 
```
consul keyring -list
==> Gathering installed encryption keys...

WAN:
  XzpEw/zF56iMIgk5nAAydBo+S9LuGmbye7m28K7tTeg= [1/1]

dc1 (LAN):
  XzpEw/zF56iMIgk5nAAydBo+S9LuGmbye7m28K7tTeg= [2/2]
```
The client logs show:
```
2022-02-24T17:53:20.736Z [DEBUG] agent.http: Request finished: method=GET url=/v1/operator/keyring from=127.0.0.1:55823 latency=73.744754ms
2022-02-24T17:53:20.835Z [DEBUG] agent.client.serf.lan: serf: messageQueryType: _serf_list-keys
```
At the same time on the server: 
```
2022-02-24T17:53:20.664Z [INFO]  agent.server.serf.wan: serf: Received list-keys query
2022-02-24T17:53:20.665Z [DEBUG] agent.server.serf.wan: serf: messageQueryResponseType: server.dc1
2022-02-24T17:53:20.665Z [INFO]  agent.server.serf.lan: serf: Received list-keys query
2022-02-24T17:53:20.666Z [DEBUG] agent.server.serf.lan: serf: messageQueryResponseType: server
2022-02-24T17:53:20.736Z [DEBUG] agent.server.serf.lan: serf: messageQueryResponseType: client
```
Similar outputs for all other operations (install and remove)

fixes #12422 
  