### PR TITLE
catalog: compare node names case insensitively in more places

### DIFF
--- a/.changelog/12444.txt
+++ b/.changelog/12444.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+compare node names case insensitively in more places
+```
+
+```release-note:bug
+state: fix bug blocking snapshot restore when a node check and node differed in casing of the node string
+```

--- a/.changelog/12444.txt
+++ b/.changelog/12444.txt
@@ -1,5 +1,5 @@
 ```release-note:bug
-compare node names case insensitively in more places
+catalog: compare node names case insensitively in more places
 ```
 
 ```release-note:bug

--- a/agent/checks/alias.go
+++ b/agent/checks/alias.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -246,7 +247,7 @@ func (c *CheckAlias) processChecks(checks []*structs.HealthCheck, CheckIfService
 	msg := "No checks found."
 	serviceFound := false
 	for _, chk := range checks {
-		if c.Node != "" && c.Node != chk.Node {
+		if c.Node != "" && !strings.EqualFold(c.Node, chk.Node) {
 			continue
 		}
 		serviceMatch := c.ServiceID.Matches(chk.CompoundServiceID())

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -285,7 +286,7 @@ func vetRegisterWithACL(
 		// note in state_store.go to ban this down there in Consul 0.8,
 		// but it's good to leave this here because it's required for
 		// correctness wrt. ACLs.
-		if check.Node != subj.Node {
+		if !strings.EqualFold(check.Node, subj.Node) {
 			return fmt.Errorf("Node '%s' for check '%s' doesn't match register request node '%s'",
 				check.Node, check.CheckID, subj.Node)
 		}

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -899,7 +900,7 @@ func (s *Server) reconcileReaped(known map[string]struct{}, nodeEntMeta *structs
 		}
 
 		// Check if this node is "known" by serf
-		if _, ok := known[check.Node]; ok {
+		if _, ok := known[strings.ToLower(check.Node)]; ok {
 			continue
 		}
 
@@ -1204,7 +1205,7 @@ func (s *Server) handleDeregisterMember(reason string, member serf.Member, nodeE
 	// deregister us later.
 	//
 	// TODO(partitions): check partitions here too? server names should be unique in general though
-	if member.Name == s.config.NodeName {
+	if strings.EqualFold(member.Name, s.config.NodeName) {
 		s.logger.Warn("deregistering self should be done by follower",
 			"name", s.config.NodeName,
 			"partition", getSerfMemberEnterpriseMeta(member).PartitionOrDefault(),

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -189,12 +189,8 @@ func TestLeader_LeftMember(t *testing.T) {
 	// Should be registered
 	retry.Run(t, func(r *retry.R) {
 		_, node, err := state.GetNode(c1.config.NodeName, nil)
-		if err != nil {
-			r.Fatalf("err: %v", err)
-		}
-		if node == nil {
-			r.Fatal("client not registered")
-		}
+		require.NoError(r, err)
+		require.NotNil(r, node, "client not registered")
 	})
 
 	// Node should leave
@@ -204,14 +200,11 @@ func TestLeader_LeftMember(t *testing.T) {
 	// Should be deregistered
 	retry.Run(t, func(r *retry.R) {
 		_, node, err := state.GetNode(c1.config.NodeName, nil)
-		if err != nil {
-			r.Fatalf("err: %v", err)
-		}
-		if node != nil {
-			r.Fatal("client still registered")
-		}
+		require.NoError(r, err)
+		require.Nil(r, node, "client still registered")
 	})
 }
+
 func TestLeader_ReapMember(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
@@ -239,12 +232,8 @@ func TestLeader_ReapMember(t *testing.T) {
 	// Should be registered
 	retry.Run(t, func(r *retry.R) {
 		_, node, err := state.GetNode(c1.config.NodeName, nil)
-		if err != nil {
-			r.Fatalf("err: %v", err)
-		}
-		if node == nil {
-			r.Fatal("client not registered")
-		}
+		require.NoError(r, err)
+		require.NotNil(r, node, "client not registered")
 	})
 
 	// Simulate a node reaping
@@ -264,9 +253,7 @@ func TestLeader_ReapMember(t *testing.T) {
 	reaped := false
 	for start := time.Now(); time.Since(start) < 5*time.Second; {
 		_, node, err := state.GetNode(c1.config.NodeName, nil)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		require.NoError(t, err)
 		if node == nil {
 			reaped = true
 			break
@@ -275,6 +262,85 @@ func TestLeader_ReapMember(t *testing.T) {
 	if !reaped {
 		t.Fatalf("client should not be registered")
 	}
+}
+
+func TestLeader_ReapOrLeftMember_IgnoreSelf(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	run := func(t *testing.T, status serf.MemberStatus, nameFn func(string) string) {
+		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+			c.PrimaryDatacenter = "dc1"
+			c.ACLsEnabled = true
+			c.ACLInitialManagementToken = "root"
+			c.ACLResolverSettings.ACLDefaultPolicy = "deny"
+		})
+		defer os.RemoveAll(dir1)
+		defer s1.Shutdown()
+
+		nodeName := s1.config.NodeName
+		if nameFn != nil {
+			nodeName = nameFn(nodeName)
+		}
+
+		state := s1.fsm.State()
+
+		// Should be registered
+		retry.Run(t, func(r *retry.R) {
+			_, node, err := state.GetNode(nodeName, nil)
+			require.NoError(r, err)
+			require.NotNil(r, node, "server not registered")
+		})
+
+		// Simulate THIS node reaping or leaving
+		mems := s1.LANMembersInAgentPartition()
+		var s1mem serf.Member
+		for _, m := range mems {
+			if strings.EqualFold(m.Name, nodeName) {
+				s1mem = m
+				s1mem.Status = status
+				s1mem.Name = nodeName
+				break
+			}
+		}
+		s1.reconcileCh <- s1mem
+
+		// Should NOT be deregistered; we have to poll quickly here because
+		// anti-entropy will put it back if it did get deleted.
+		reaped := false
+		for start := time.Now(); time.Since(start) < 5*time.Second; {
+			_, node, err := state.GetNode(nodeName, nil)
+			require.NoError(t, err)
+			if node == nil {
+				reaped = true
+				break
+			}
+		}
+		if reaped {
+			t.Fatalf("server should still be registered")
+		}
+	}
+
+	t.Run("original name", func(t *testing.T) {
+		t.Run("left", func(t *testing.T) {
+			run(t, serf.StatusLeft, nil)
+		})
+		t.Run("reap", func(t *testing.T) {
+			run(t, StatusReap, nil)
+		})
+	})
+
+	t.Run("uppercased name", func(t *testing.T) {
+		t.Run("left", func(t *testing.T) {
+			run(t, serf.StatusLeft, strings.ToUpper)
+		})
+		t.Run("reap", func(t *testing.T) {
+			run(t, StatusReap, strings.ToUpper)
+		})
+	})
 }
 
 func TestLeader_CheckServersMeta(t *testing.T) {

--- a/agent/consul/merge.go
+++ b/agent/consul/merge.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/go-version"
@@ -38,7 +39,7 @@ func (md *lanMergeDelegate) NotifyMerge(members []*serf.Member) error {
 			nodeID := types.NodeID(rawID)
 
 			// See if there's another node that conflicts with us.
-			if (nodeID == md.nodeID) && (m.Name != md.nodeName) {
+			if (nodeID == md.nodeID) && !strings.EqualFold(m.Name, md.nodeName) {
 				return fmt.Errorf("Member '%s' has conflicting node ID '%s' with this agent's ID",
 					m.Name, nodeID)
 			}

--- a/agent/consul/merge_test.go
+++ b/agent/consul/merge_test.go
@@ -58,6 +58,30 @@ func TestMerge_LAN(t *testing.T) {
 			},
 			expect: "wrong datacenter",
 		},
+		"node ID conflict with delegate's ID but same node name with same casing": {
+			members: []*serf.Member{
+				makeTestNode(t, testMember{
+					dc:     "dc1",
+					name:   "node0",
+					id:     thisNodeID,
+					server: true,
+					build:  "0.7.5",
+				}),
+			},
+			expect: "",
+		},
+		"node ID conflict with delegate's ID but same node name with different casing": {
+			members: []*serf.Member{
+				makeTestNode(t, testMember{
+					dc:     "dc1",
+					name:   "NoDe0",
+					id:     thisNodeID,
+					server: true,
+					build:  "0.7.5",
+				}),
+			},
+			expect: "",
+		},
 		"node ID conflict with delegate's ID": {
 			members: []*serf.Member{
 				makeTestNode(t, testMember{

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -439,7 +439,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	// position 0, provided the results are from the same datacenter.
 	if qs.Node != "" && reply.Datacenter == qs.Datacenter {
 		for i, node := range reply.Nodes {
-			if node.Node.Node == qs.Node {
+			if strings.EqualFold(node.Node.Node, qs.Node) {
 				reply.Nodes[0], reply.Nodes[i] = reply.Nodes[i], reply.Nodes[0]
 				break
 			}

--- a/agent/consul/server_oss.go
+++ b/agent/consul/server_oss.go
@@ -5,6 +5,7 @@ package consul
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -138,10 +139,11 @@ func (s *Server) reconcile() (err error) {
 	members := s.serfLAN.Members()
 	knownMembers := make(map[string]struct{})
 	for _, member := range members {
+		memberName := strings.ToLower(member.Name)
 		if err := s.reconcileMember(member); err != nil {
 			return err
 		}
-		knownMembers[member.Name] = struct{}{}
+		knownMembers[memberName] = struct{}{}
 	}
 
 	// Reconcile any members that have been reaped while we were not the

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -136,7 +136,7 @@ func (s *Store) ensureCheckIfNodeMatches(
 	nodePartition string,
 	check *structs.HealthCheck,
 ) error {
-	if check.Node != node || !structs.EqualPartitions(nodePartition, check.PartitionOrDefault()) {
+	if !strings.EqualFold(check.Node, node) || !structs.EqualPartitions(nodePartition, check.PartitionOrDefault()) {
 		return fmt.Errorf("check node %q does not match node %q",
 			printNodeName(check.Node, check.PartitionOrDefault()),
 			printNodeName(node, nodePartition),
@@ -330,7 +330,7 @@ func (s *Store) ensureNodeTxn(tx WriteTxn, idx uint64, preserveIndexes bool, nod
 		}
 		if existing != nil {
 			n = existing
-			if n.Node != node.Node {
+			if !strings.EqualFold(n.Node, node.Node) {
 				// Lets first get all nodes and check whether name do match, we do not allow clash on nodes without ID
 				dupNameError := ensureNoNodeWithSimilarNameTxn(tx, node, false)
 				if dupNameError != nil {

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -105,7 +105,7 @@ type nodeServiceTuple struct {
 
 func newNodeServiceTupleFromServiceNode(sn *structs.ServiceNode) nodeServiceTuple {
 	return nodeServiceTuple{
-		Node:      sn.Node,
+		Node:      strings.ToLower(sn.Node),
 		ServiceID: sn.ServiceID,
 		EntMeta:   sn.EnterpriseMeta,
 	}
@@ -113,7 +113,7 @@ func newNodeServiceTupleFromServiceNode(sn *structs.ServiceNode) nodeServiceTupl
 
 func newNodeServiceTupleFromServiceHealthCheck(hc *structs.HealthCheck) nodeServiceTuple {
 	return nodeServiceTuple{
-		Node:      hc.Node,
+		Node:      strings.ToLower(hc.Node),
 		ServiceID: hc.ServiceID,
 		EntMeta:   hc.EnterpriseMeta,
 	}

--- a/agent/consul/state/catalog_events_oss.go
+++ b/agent/consul/state/catalog_events_oss.go
@@ -3,22 +3,29 @@
 
 package state
 
-import "github.com/hashicorp/consul/agent/structs"
+import (
+	"strings"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
 
 func (nst nodeServiceTuple) nodeTuple() nodeTuple {
-	return nodeTuple{Node: nst.Node, Partition: ""}
+	return nodeTuple{
+		Node:      strings.ToLower(nst.Node),
+		Partition: "",
+	}
 }
 
 func newNodeTupleFromNode(node *structs.Node) nodeTuple {
 	return nodeTuple{
-		Node:      node.Node,
+		Node:      strings.ToLower(node.Node),
 		Partition: "",
 	}
 }
 
 func newNodeTupleFromHealthCheck(hc *structs.HealthCheck) nodeTuple {
 	return nodeTuple{
-		Node:      hc.Node,
+		Node:      strings.ToLower(hc.Node),
 		Partition: "",
 	}
 }

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -471,8 +471,11 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 	}
 
 	// Add in a top-level check.
+	//
+	// Verify that node name references in checks are case-insensitive during
+	// restore.
 	req.Check = &structs.HealthCheck{
-		Node:    nodeName,
+		Node:    strings.ToUpper(nodeName),
 		CheckID: "check1",
 		Name:    "check",
 		RaftIndex: structs.RaftIndex{
@@ -499,7 +502,7 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			t.Fatalf("bad: %#v", out)
 		}
 		c := out[0]
-		if c.Node != nodeName || c.CheckID != "check1" || c.Name != "check" ||
+		if c.Node != strings.ToUpper(nodeName) || c.CheckID != "check1" || c.Name != "check" ||
 			c.CreateIndex != 3 || c.ModifyIndex != 3 {
 			t.Fatalf("bad check returned: %#v", c)
 		}
@@ -545,7 +548,7 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			t.Fatalf("bad: %#v", out)
 		}
 		c1 := out[0]
-		if c1.Node != nodeName || c1.CheckID != "check1" || c1.Name != "check" ||
+		if c1.Node != strings.ToUpper(nodeName) || c1.CheckID != "check1" || c1.Name != "check" ||
 			c1.CreateIndex != 3 || c1.ModifyIndex != 3 {
 			t.Fatalf("bad check returned, should not be modified: %#v", c1)
 		}

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/serf/serf"
@@ -161,7 +162,7 @@ func (c *Client) CheckServers(datacenter string, fn func(*metadata.Server) bool)
 
 func isSerfMember(s *serf.Serf, nodeName string) bool {
 	for _, m := range s.Members() {
-		if m.Name == nodeName {
+		if strings.EqualFold(m.Name, nodeName) {
 			return true
 		}
 	}

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -452,7 +452,7 @@ func (r *RegisterRequest) ChangesNode(node *Node) bool {
 
 	// Check if any of the node-level fields are being changed.
 	if r.ID != node.ID ||
-		r.Node != node.Node ||
+		!strings.EqualFold(r.Node, node.Node) ||
 		r.PartitionOrDefault() != node.PartitionOrDefault() ||
 		r.Address != node.Address ||
 		r.Datacenter != node.Datacenter ||
@@ -796,7 +796,7 @@ type Nodes []*Node
 // RaftIndex fields.
 func (n *Node) IsSame(other *Node) bool {
 	return n.ID == other.ID &&
-		n.Node == other.Node &&
+		strings.EqualFold(n.Node, other.Node) &&
 		n.PartitionOrDefault() == other.PartitionOrDefault() &&
 		n.Address == other.Address &&
 		n.Datacenter == other.Datacenter &&
@@ -1431,7 +1431,7 @@ func (s *ServiceNode) IsSameService(other *ServiceNode) bool {
 	// TaggedAddresses          map[string]string
 	// NodeMeta                 map[string]string
 	if s.ID != other.ID ||
-		s.Node != other.Node ||
+		!strings.EqualFold(s.Node, other.Node) ||
 		s.ServiceKind != other.ServiceKind ||
 		s.ServiceID != other.ServiceID ||
 		s.ServiceName != other.ServiceName ||
@@ -1675,7 +1675,7 @@ func (t *HealthCheckDefinition) UnmarshalJSON(data []byte) (err error) {
 // useful for seeing if an update would be idempotent for all the functional
 // parts of the structure.
 func (c *HealthCheck) IsSame(other *HealthCheck) bool {
-	if c.Node != other.Node ||
+	if !strings.EqualFold(c.Node, other.Node) ||
 		c.CheckID != other.CheckID ||
 		c.Name != other.Name ||
 		c.Status != other.Status ||

--- a/command/rtt/rtt.go
+++ b/command/rtt/rtt.go
@@ -103,11 +103,11 @@ func (c *cmd) Run(args []string) int {
 		var area1, area2 string
 		for _, dc := range dcs {
 			for _, entry := range dc.Coordinates {
-				if dc.Datacenter == dc1 && entry.Node == node1 {
+				if dc.Datacenter == dc1 && strings.EqualFold(entry.Node, node1) {
 					area1 = dc.AreaID
 					coord1 = entry.Coord
 				}
-				if dc.Datacenter == dc2 && entry.Node == node2 {
+				if dc.Datacenter == dc2 && strings.EqualFold(entry.Node, node2) {
 					area2 = dc.AreaID
 					coord2 = entry.Coord
 				}
@@ -145,10 +145,10 @@ func (c *cmd) Run(args []string) int {
 		// Index all the coordinates by segment.
 		cs1, cs2 := make(lib.CoordinateSet), make(lib.CoordinateSet)
 		for _, entry := range entries {
-			if entry.Node == nodes[0] {
+			if strings.EqualFold(entry.Node, nodes[0]) {
 				cs1[entry.Segment] = entry.Coord
 			}
-			if entry.Node == nodes[1] {
+			if strings.EqualFold(entry.Node, nodes[1]) {
 				cs2[entry.Segment] = entry.Coord
 			}
 		}


### PR DESCRIPTION
Many places in consul already treated node names case insensitively.
The state store indexes already do it, but there are a few places that
did a direct byte comparison which have now been corrected.

One place of particular consideration is ensureCheckIfNodeMatches
which is executed during snapshot restore (among other places). If a
node check used a slightly different casing than the casing of the node
during register then the snapshot restore here would deterministically
fail. This has been fixed.

Primary approach:

    git grep -i "node.*[!=]=.*node" -- ':!*_test.go' ':!docs'
    git grep -i '\[[^]]*member[^]]*\]
    git grep -i '\[[^]]*\(member\|name\|node\)[^]]*\]' -- ':!*_test.go' ':!website' ':!ui' ':!agent/proxycfg/testing.go:' ':!*.md'