### PR TITLE
wip: start instrumenting calls with new rpc metrics

### DIFF
--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -354,17 +354,17 @@ func (s *Server) fetchACLTokens(lastRemoteIndex uint64) (*structs.ACLTokenListRe
 }
 
 func (s *Server) replicateACLTokens(ctx context.Context, logger hclog.Logger, lastRemoteIndex uint64) (uint64, bool, error) {
-	tr := &aclTokenReplicator{}
+	tr := &aclTokenReplicator{rpcObserver: s.rpcObserver}
 	return s.replicateACLType(ctx, logger, tr, lastRemoteIndex)
 }
 
 func (s *Server) replicateACLPolicies(ctx context.Context, logger hclog.Logger, lastRemoteIndex uint64) (uint64, bool, error) {
-	tr := &aclPolicyReplicator{}
+	tr := &aclPolicyReplicator{rpcObserver: s.rpcObserver}
 	return s.replicateACLType(ctx, logger, tr, lastRemoteIndex)
 }
 
 func (s *Server) replicateACLRoles(ctx context.Context, logger hclog.Logger, lastRemoteIndex uint64) (uint64, bool, error) {
-	tr := &aclRoleReplicator{}
+	tr := &aclRoleReplicator{rpcObserver: s.rpcObserver}
 	return s.replicateACLType(ctx, logger, tr, lastRemoteIndex)
 }
 

--- a/agent/consul/acl_replication_types.go
+++ b/agent/consul/acl_replication_types.go
@@ -86,6 +86,7 @@ func (r *aclTokenReplicator) DeleteLocalBatch(srv *Server, batch []string) error
 		TokenIDs: batch,
 	}
 
+	// TODO(rpc-metrics): observe this apply
 	_, err := srv.raftApply(structs.ACLTokenDeleteRequestType, &req)
 	return err
 }
@@ -110,6 +111,7 @@ func (r *aclTokenReplicator) UpdateLocalBatch(ctx context.Context, srv *Server, 
 		FromReplication:   true,
 	}
 
+	// TODO(rpc-metrics): observe this apply
 	_, err := srv.raftApply(structs.ACLTokenSetRequestType, &req)
 	return err
 }
@@ -186,6 +188,7 @@ func (r *aclPolicyReplicator) DeleteLocalBatch(srv *Server, batch []string) erro
 		PolicyIDs: batch,
 	}
 
+	// TODO(rpc-metrics): observe this apply
 	_, err := srv.raftApply(structs.ACLPolicyDeleteRequestType, &req)
 	return err
 }
@@ -207,6 +210,7 @@ func (r *aclPolicyReplicator) UpdateLocalBatch(ctx context.Context, srv *Server,
 		Policies: r.updated[start:end],
 	}
 
+	// TODO(rpc-metrics): observe this apply
 	_, err := srv.raftApply(structs.ACLPolicySetRequestType, &req)
 	return err
 }
@@ -307,6 +311,7 @@ func (r *aclRoleReplicator) DeleteLocalBatch(srv *Server, batch []string) error 
 		RoleIDs: batch,
 	}
 
+	// TODO(rpc-metrics): observe this apply
 	_, err := srv.raftApply(structs.ACLRoleDeleteRequestType, &req)
 	return err
 }
@@ -329,6 +334,7 @@ func (r *aclRoleReplicator) UpdateLocalBatch(ctx context.Context, srv *Server, s
 		AllowMissingLinks: true,
 	}
 
+	// TODO(rpc-metrics): observe this apply
 	_, err := srv.raftApply(structs.ACLRoleSetRequestType, &req)
 	return err
 }

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -100,6 +100,7 @@ func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
 		"amount", len(req.TokenIDs),
 		"locality", locality,
 	)
+	// TODO(rpc-metrics): observe this apply
 	_, err = s.raftApply(structs.ACLTokenDeleteRequestType, &req)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to apply token expiration deletions: %v", err)

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -55,6 +55,7 @@ func (s *Server) reapExpiredLocalACLTokens() (int, error) {
 	return s.reapExpiredACLTokens(true, false)
 }
 func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
+	start := time.Now()
 	if !s.config.ACLsEnabled {
 		return 0, nil
 	}
@@ -100,8 +101,8 @@ func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
 		"amount", len(req.TokenIDs),
 		"locality", locality,
 	)
-	// TODO(rpc-metrics): observe this apply
 	_, err = s.raftApply(structs.ACLTokenDeleteRequestType, &req)
+	s.rpcObserver.Observe("ACL.TokenDelete", rpcTypeLeader, start, &req, err)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to apply token expiration deletions: %v", err)
 	}

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -31,11 +31,8 @@ func TestCatalog_Register(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	_, s1 := testServerWithConfig(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	arg := structs.RegisterRequest{
 		Datacenter: "dc1",
@@ -54,9 +51,8 @@ func TestCatalog_Register(t *testing.T) {
 	var out struct{}
 
 	err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, err)
+
 }
 
 func TestCatalog_RegisterService_InvalidAddress(t *testing.T) {

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -446,15 +446,12 @@ func TestClient_RPC_ConsulServerPing(t *testing.T) {
 
 func TestClient_RPC_TLS(t *testing.T) {
 	t.Parallel()
-	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
-	conf1.TLSConfig.VerifyOutgoing = true
-	configureTLS(conf1)
-	s1, err := newServer(t, conf1)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer s1.Shutdown()
+
+	_, s1 := testServerWithConfig(t, func(config *Config) {
+		config.TLSConfig.VerifyIncoming = true
+		config.TLSConfig.VerifyOutgoing = true
+		configureTLS(config)
+	})
 
 	_, conf2 := testClientConfig(t)
 	conf2.TLSConfig.VerifyOutgoing = true
@@ -552,12 +549,7 @@ func TestClient_RPC_RateLimit(t *testing.T) {
 	}
 
 	t.Parallel()
-	_, conf1 := testServerConfig(t)
-	s1, err := newServer(t, conf1)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer s1.Shutdown()
+	_, s1 := testServerWithConfig(t)
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	_, conf2 := testClientConfig(t)
@@ -659,15 +651,12 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 	}
 
 	t.Parallel()
-	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
-	conf1.TLSConfig.VerifyOutgoing = true
-	configureTLS(conf1)
-	s1, err := newServer(t, conf1)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer s1.Shutdown()
+
+	_, s1 := testServerWithConfig(t, func(conf1 *Config) {
+		conf1.TLSConfig.VerifyIncoming = true
+		conf1.TLSConfig.VerifyOutgoing = true
+		configureTLS(conf1)
+	})
 
 	_, conf2 := testClientConfig(t)
 	conf2.TLSConfig.VerifyOutgoing = true

--- a/agent/consul/config_replication.go
+++ b/agent/consul/config_replication.go
@@ -104,6 +104,7 @@ func (s *Server) reconcileLocalConfig(ctx context.Context, configs []structs.Con
 			Entry:      entry,
 		}
 
+		// TODO(rpc-metrics): observe this apply
 		_, err := s.raftApply(structs.ConfigEntryRequestType, &req)
 		if err != nil {
 			merr = multierror.Append(merr, fmt.Errorf("Failed to apply config entry %s: %w", op, err))

--- a/agent/consul/federation_state_replication.go
+++ b/agent/consul/federation_state_replication.go
@@ -154,6 +154,7 @@ func (r *FederationStateReplicator) PerformDeletions(ctx context.Context, deleti
 			State:      state,
 		}
 
+		// TODO(rpc-metrics): observe this apply
 		_, err := r.srv.raftApply(structs.FederationStateRequestType, &req)
 		if err != nil {
 			return false, err
@@ -195,6 +196,7 @@ func (r *FederationStateReplicator) PerformUpdates(ctx context.Context, updatesR
 			State:      state2,
 		}
 
+		// TODO(rpc-metrics): observe this apply
 		_, err := r.srv.raftApply(structs.FederationStateRequestType, &req)
 		if err != nil {
 			return false, err

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -796,6 +796,7 @@ func (s *Server) getOrCreateAutopilotConfig() *structs.AutopilotConfig {
 
 	config = s.config.AutopilotConfig
 	req := structs.AutopilotSetConfigRequest{Config: *config}
+	// TODO(rpc-metrics): observe this apply
 	if _, err = s.raftApply(structs.AutopilotRequestType, req); err != nil {
 		logger.Error("failed to initialize config", "error", err)
 		return nil
@@ -871,6 +872,7 @@ func (s *Server) bootstrapConfigEntries(entries []structs.ConfigEntry) error {
 				Entry:      entry,
 			}
 
+			// TODO(rpc-metrics): observe this apply
 			_, err := s.raftApply(structs.ConfigEntryRequestType, &req)
 			if err != nil {
 				return fmt.Errorf("Failed to apply configuration entry %q / %q: %v", entry.GetKind(), entry.GetName(), err)

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -91,6 +91,8 @@ func (c *caDelegateWithState) State() *state.Store {
 }
 
 func (c *caDelegateWithState) ApplyCARequest(req *structs.CARequest) (interface{}, error) {
+	// ApplyCARequest is often called by ConnectCA.SetConfiguration, so should
+	// already have metrics applied. The exception is CAManager.Initialize.
 	return c.Server.raftApplyMsgpack(structs.ConnectCARequestType, req)
 }
 

--- a/agent/consul/leader_federation_state_ae.go
+++ b/agent/consul/leader_federation_state_ae.go
@@ -118,6 +118,7 @@ func (s *Server) updateOurFederationState(curr *structs.FederationState) error {
 
 	if s.config.Datacenter == s.config.PrimaryDatacenter {
 		// We are the primary, so we can't do an RPC as we don't have a replication token.
+		// TODO(rpc-metrics): observe this apply
 		_, err := s.raftApply(structs.FederationStateRequestType, args)
 		if err != nil {
 			return err
@@ -223,6 +224,7 @@ func (s *Server) pruneStaleFederationStates() error {
 				Datacenter: dc,
 			},
 		}
+		// TODO(rpc-metrics): observe this apply
 		_, err := s.raftApply(structs.FederationStateRequestType, &req)
 		if err != nil {
 			return fmt.Errorf("Failed to delete federation state %s: %v", dc, err)

--- a/agent/consul/leader_intentions.go
+++ b/agent/consul/leader_intentions.go
@@ -170,6 +170,7 @@ func (s *Server) legacyIntentionsMigrationCleanupPhase(quiet bool) error {
 	req := structs.IntentionRequest{
 		Op: structs.IntentionOpDeleteAll,
 	}
+	// TODO(rpc-metrics): observe this apply
 	if _, err := s.raftApply(structs.IntentionRequestType, req); err != nil {
 		return err
 	}
@@ -410,6 +411,7 @@ func (s *Server) replicateLegacyIntentionsOnce(ctx context.Context, lastFetchInd
 	for _, ops := range txnOpSets {
 		txnReq := structs.TxnRequest{Ops: ops}
 
+		// TODO(rpc-metrics): observe this apply
 		resp, err := s.raftApply(structs.TxnRequestType, &txnReq)
 		if err != nil {
 			return 0, false, err

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -1194,9 +1194,12 @@ func maskResultsFilteredByACLs(token string, meta blockingQueryResponseMeta) {
 const rpcTypeNetRPC = "netrpc"
 
 func newNetRPCInterceptor(obs agentrpc.ServiceCallObserver) rpc.ServerServiceCallInterceptor {
-	return func(reqServiceMethod string, argv, replyv reflect.Value, handler func()) {
+	return func(reqServiceMethod string, argv, replyv reflect.Value, handler func() error) {
 		start := time.Now()
-		handler()
-		obs.Observe(reqServiceMethod, rpcTypeNetRPC, start, argv.Interface(), replyv.Interface())
+		var resp interface{} = handler()
+		if resp == nil {
+			resp = replyv.Interface()
+		}
+		obs.Observe(reqServiceMethod, rpcTypeNetRPC, start, argv.Interface(), resp)
 	}
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -250,7 +250,7 @@ type Server struct {
 	grpcHandler connHandler
 	rpcServer   *rpc.Server
 
-	rpcObserver agentrpc.ServiceCallObserver // TODO: initialize this.
+	rpcObserver agentrpc.ServiceCallObserver
 
 	// insecureRPCServer is a RPC server that is configure with
 	// IncomingInsecureRPCConfig to allow clients to call AutoEncrypt.Sign

--- a/agent/consul/session_ttl.go
+++ b/agent/consul/session_ttl.go
@@ -115,6 +115,7 @@ func (s *Server) invalidateSession(id string, entMeta *structs.EnterpriseMeta) {
 
 	// Retry with exponential backoff to invalidate the session
 	for attempt := uint(0); attempt < maxInvalidateAttempts; attempt++ {
+		// TODO(rpc-metrics): observe this apply
 		_, err := s.raftApply(structs.SessionRequestType, args)
 		if err == nil {
 			s.logger.Debug("Session TTL expired", "session", id)

--- a/agent/consul/status_endpoint.go
+++ b/agent/consul/status_endpoint.go
@@ -13,7 +13,7 @@ type Status struct {
 }
 
 // Ping is used to just check for connectivity
-func (s *Status) Ping(args struct{}, reply *struct{}) error {
+func (s *Status) Ping(args EmptyReadRequest, reply *struct{}) error {
 	return nil
 }
 
@@ -55,8 +55,16 @@ func (s *Status) Peers(args *structs.DCSpecificRequest, reply *[]string) error {
 	return nil
 }
 
+// EmptyReadRequest implements the interface used by ServiceCallObserver
+// to communicate properties of requests.
+type EmptyReadRequest struct{}
+
+func (e EmptyReadRequest) IsRead() bool {
+	return true
+}
+
 // Used by Autopilot to query the raft stats of the local server.
-func (s *Status) RaftStats(args struct{}, reply *structs.RaftStats) error {
+func (s *Status) RaftStats(args EmptyReadRequest, reply *structs.RaftStats) error {
 	stats := s.server.raft.Stats()
 
 	var err error

--- a/agent/consul/subscribe_backend_test.go
+++ b/agent/consul/subscribe_backend_test.go
@@ -28,13 +28,12 @@ func TestSubscribeBackend_IntegrationWithServer_TLSEnabled(t *testing.T) {
 
 	// TODO(rb): add tests for the wanfed/alpn variations
 
-	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
-	conf1.TLSConfig.VerifyOutgoing = true
-	conf1.RPCConfig.EnableStreaming = true
-	configureTLS(conf1)
-	server, err := newServer(t, conf1)
-	require.NoError(t, err)
+	_, server := testServerWithConfig(t, func(conf1 *Config) {
+		conf1.TLSConfig.VerifyIncoming = true
+		conf1.TLSConfig.VerifyOutgoing = true
+		conf1.RPCConfig.EnableStreaming = true
+		configureTLS(conf1)
+	})
 	defer server.Shutdown()
 
 	client, builder := newClientWithGRPCResolver(t, configureTLS, clientConfigVerifyOutgoing)
@@ -160,17 +159,14 @@ func TestSubscribeBackend_IntegrationWithServer_TLSReload(t *testing.T) {
 	t.Parallel()
 
 	// Set up a server with initially bad certificates.
-	_, conf1 := testServerConfig(t)
-	conf1.TLSConfig.VerifyIncoming = true
-	conf1.TLSConfig.VerifyOutgoing = true
-	conf1.TLSConfig.CAFile = "../../test/ca/root.cer"
-	conf1.TLSConfig.CertFile = "../../test/key/ssl-cert-snakeoil.pem"
-	conf1.TLSConfig.KeyFile = "../../test/key/ssl-cert-snakeoil.key"
-	conf1.RPCConfig.EnableStreaming = true
-
-	server, err := newServer(t, conf1)
-	require.NoError(t, err)
-	defer server.Shutdown()
+	_, server := testServerWithConfig(t, func(conf1 *Config) {
+		conf1.TLSConfig.VerifyIncoming = true
+		conf1.TLSConfig.VerifyOutgoing = true
+		conf1.TLSConfig.CAFile = "../../test/ca/root.cer"
+		conf1.TLSConfig.CertFile = "../../test/key/ssl-cert-snakeoil.pem"
+		conf1.TLSConfig.KeyFile = "../../test/key/ssl-cert-snakeoil.key"
+		conf1.RPCConfig.EnableStreaming = true
+	})
 
 	// Set up a client with valid certs and verify_outgoing = true
 	client, builder := newClientWithGRPCResolver(t, configureTLS, clientConfigVerifyOutgoing)

--- a/agent/consul/system_metadata.go
+++ b/agent/consul/system_metadata.go
@@ -22,6 +22,7 @@ func (s *Server) setSystemMetadataKey(key, val string) error {
 		Entry: &structs.SystemMetadataEntry{Key: key, Value: val},
 	}
 
+	// TODO(rpc-metrics): observe this apply
 	_, err := s.raftApply(structs.SystemMetadataRequestType, args)
 	return err
 }
@@ -32,6 +33,7 @@ func (s *Server) deleteSystemMetadataKey(key string) error {
 		Entry: &structs.SystemMetadataEntry{Key: key},
 	}
 
+	// TODO(rpc-metrics): observe this apply
 	_, err := s.raftApply(structs.SystemMetadataRequestType, args)
 	return err
 }

--- a/agent/rpc/logtest/logtest.go
+++ b/agent/rpc/logtest/logtest.go
@@ -1,0 +1,70 @@
+package logtest
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+)
+
+type TestingT interface {
+	Helper()
+	Fatalf(format string, args ...interface{})
+}
+
+type Expectation interface {
+	Match(line string) bool
+}
+
+type substringExpectation struct {
+	Substrings []string
+}
+
+func (p substringExpectation) Match(line string) bool {
+	for _, sub := range p.Substrings {
+		if !strings.Contains(line, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p substringExpectation) String() string {
+	return fmt.Sprintf("contains substrings: %v", strings.Join(p.Substrings, ", "))
+}
+
+func Line(patterns ...string) Expectation {
+	return substringExpectation{Substrings: patterns}
+}
+
+// Assert scans the log and tries to match each Expectation to a line in the log.
+// Expectations are matched in order, so if one is not found, the rest will be
+// ignored.
+// Assert fails the test if any of the expectations are not met.
+func Assert(t TestingT, log string, expectations ...Expectation) {
+	t.Helper()
+
+	if len(expectations) == 0 {
+		t.Fatalf("no expectations")
+	}
+
+	scan := bufio.NewScanner(strings.NewReader(log))
+	var count int
+	var index int
+
+	for scan.Scan() && index < len(expectations) {
+		count++
+		line := scan.Text()
+		if expectations[index].Match(line) {
+			index++
+		}
+	}
+	if scan.Err() != nil {
+		t.Fatalf("scanning the log failed :%v", scan.Err())
+	}
+	if index != len(expectations) {
+		t.Fatalf("scanned %d lines, but did not find one that matched expectation %d: %v",
+			count,
+			index+1,
+			expectations[index])
+	}
+}

--- a/agent/rpc/observer.go
+++ b/agent/rpc/observer.go
@@ -1,0 +1,45 @@
+package rpc
+
+import (
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-hclog"
+)
+
+type ServiceCallObserver struct {
+	Logger hclog.Logger
+}
+
+func (i *ServiceCallObserver) Observe(name string, rpcType string, start time.Time, request, response interface{}) {
+	errored := "false"
+	if _, ok := response.(error); ok {
+		errored = "true"
+	}
+	reqType := requestType(request)
+
+	labels := []metrics.Label{
+		{Name: "method", Value: name},
+		{Name: "errored", Value: errored},
+		{Name: "request_type", Value: reqType},
+		{Name: "rpc_type", Value: rpcType},
+	}
+	metrics.MeasureSinceWithLabels(metricRPCRequest, start, labels)
+
+	i.Logger.Debug(requestLogName,
+		"method", name,
+		"errored", errored,
+		"request_type", reqType,
+		"rpc_type", rpcType,
+		"elapsed", time.Since(start))
+}
+
+func requestType(req interface{}) string {
+	if r, ok := req.(interface{ IsRead() bool }); ok && r.IsRead() {
+		return "read"
+	}
+	return "write"
+}
+
+var metricRPCRequest = []string{"rpc", "server", "request"}
+var requestLogName = "rpc.server.request"

--- a/agent/rpc/observer.go
+++ b/agent/rpc/observer.go
@@ -11,7 +11,7 @@ type ServiceCallObserver struct {
 	Logger hclog.Logger
 }
 
-func (i *ServiceCallObserver) Observe(name string, rpcType string, start time.Time, request, response interface{}) {
+func (i ServiceCallObserver) Observe(name string, rpcType string, start time.Time, request, response interface{}) {
 	errored := "false"
 	if _, ok := response.(error); ok {
 		errored = "true"

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22
 	github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
-	github.com/hashicorp/consul-net-rpc v0.0.0-20220301010508-276d1f75285b
+	github.com/hashicorp/consul-net-rpc v0.0.0-20220302000633-fba3491ad3ed
 	github.com/hashicorp/consul/api v1.11.0
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/go-bexpr v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22
 	github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
-	github.com/hashicorp/consul-net-rpc v0.0.0-20220207223504-4cffceffcd29
+	github.com/hashicorp/consul-net-rpc v0.0.0-20220301010508-276d1f75285b
 	github.com/hashicorp/consul/api v1.11.0
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/go-bexpr v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul-net-rpc v0.0.0-20220207223504-4cffceffcd29 h1:0BbXmAgzy5vx2rjixiO1FLJBdYJfEvSixcjWOli2w+Q=
 github.com/hashicorp/consul-net-rpc v0.0.0-20220207223504-4cffceffcd29/go.mod h1:vWEAHAeAqfOwB3pSgHMQpIu8VH1jL+Ltg54Tw0wt/NI=
+github.com/hashicorp/consul-net-rpc v0.0.0-20220301010508-276d1f75285b h1:FMbZWxGbEu81F9SicC9TpBv3u8tFGwIE0ZFECutfmqI=
+github.com/hashicorp/consul-net-rpc v0.0.0-20220301010508-276d1f75285b/go.mod h1:vWEAHAeAqfOwB3pSgHMQpIu8VH1jL+Ltg54Tw0wt/NI=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.2 h1:ijMXI4qERbzxbCnkxmfUtwMyjrrk3y+Vt0MxojNCbBs=

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,6 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmo
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/hashicorp/consul-net-rpc v0.0.0-20220207223504-4cffceffcd29 h1:0BbXmAgzy5vx2rjixiO1FLJBdYJfEvSixcjWOli2w+Q=
-github.com/hashicorp/consul-net-rpc v0.0.0-20220207223504-4cffceffcd29/go.mod h1:vWEAHAeAqfOwB3pSgHMQpIu8VH1jL+Ltg54Tw0wt/NI=
 github.com/hashicorp/consul-net-rpc v0.0.0-20220301010508-276d1f75285b h1:FMbZWxGbEu81F9SicC9TpBv3u8tFGwIE0ZFECutfmqI=
 github.com/hashicorp/consul-net-rpc v0.0.0-20220301010508-276d1f75285b/go.mod h1:vWEAHAeAqfOwB3pSgHMQpIu8VH1jL+Ltg54Tw0wt/NI=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmo
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/hashicorp/consul-net-rpc v0.0.0-20220301010508-276d1f75285b h1:FMbZWxGbEu81F9SicC9TpBv3u8tFGwIE0ZFECutfmqI=
-github.com/hashicorp/consul-net-rpc v0.0.0-20220301010508-276d1f75285b/go.mod h1:vWEAHAeAqfOwB3pSgHMQpIu8VH1jL+Ltg54Tw0wt/NI=
+github.com/hashicorp/consul-net-rpc v0.0.0-20220302000633-fba3491ad3ed h1:3Kn797ehXM5NKqcT2AtnKR8eKOLv8p218NY9hR4lu+M=
+github.com/hashicorp/consul-net-rpc v0.0.0-20220302000633-fba3491ad3ed/go.mod h1:vWEAHAeAqfOwB3pSgHMQpIu8VH1jL+Ltg54Tw0wt/NI=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.2 h1:ijMXI4qERbzxbCnkxmfUtwMyjrrk3y+Vt0MxojNCbBs=


### PR DESCRIPTION
There are 3 places we need to instrument:
* `net/rpc.Server.ServeRequest` - uses the new `net/rpc` interceptor
* gRPC interceptor - no OSS code uses this yet, so will likely be done in enterprise first, nothing done in this PR
* any important `raft.Apply` calls that come from a leader goroutine (not from an RPC endpoint) - this PR enumerates all of those locations with a TODO, and implements the TODO by calling observe in most of them.

The `raft.Apply` calls from leader routines mostly fall into the following categories:
* gossip `reconcileMembers`
* replication in secondary DCs
* some form of garbage collection (ACL token TTL, session TTL, expired CA roots, KV tombstones, etc)
* bootstrapping (config entries, ACL tokens, etc)