### PR TITLE
fix flaky test panic

### DIFF
--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -156,6 +156,9 @@ func TestLeader_FailedMember(t *testing.T) {
 		if err != nil {
 			r.Fatalf("err: %v", err)
 		}
+		if len(checks) != 1 {
+			r.Fatalf("client missing check")
+		}
 		if got, want := checks[0].Status, api.HealthCritical; got != want {
 			r.Fatalf("got status %q want %q", got, want)
 		}
@@ -702,6 +705,9 @@ func TestLeader_Reconcile_Races(t *testing.T) {
 		_, checks, err := state.NodeChecks(nil, c1.config.NodeName, nil)
 		if err != nil {
 			r.Fatalf("err: %v", err)
+		}
+		if len(checks) != 1 {
+			r.Fatalf("client missing check")
 		}
 		if got, want := checks[0].Status, api.HealthCritical; got != want {
 			r.Fatalf("got state %q want %q", got, want)


### PR DESCRIPTION
```
--- FAIL: TestLeader_FailedMember (0.63s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 20378 [running]:
testing.tRunner.func1.2({0x1ed1bc0, 0xc037bb4d08})
	/usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x1ed1bc0, 0xc037bb4d08})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/hashicorp/consul/sdk/testutil/retry.run.func2.1()
	/home/circleci/project/sdk/testutil/retry/retry.go:145 +0x45
panic({0x1ed1bc0, 0xc037bb4d08})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/hashicorp/consul/agent/consul.TestLeader_FailedMember.func3(0xc07e225ec05a2004)
	/home/circleci/project/agent/consul/leader_test.go:159 +0x1bd
github.com/hashicorp/consul/sdk/testutil/retry.run.func2(0xc034e7ae10, 0x0)
	/home/circleci/project/sdk/testutil/retry/retry.go:148 +0x42
github.com/hashicorp/consul/sdk/testutil/retry.run({0x234fb80, 0xc034e7ae10}, {0x23777c0, 0xc0037afd40}, 0x7)
	/home/circleci/project/sdk/testutil/retry/retry.go:149 +0xb8
github.com/hashicorp/consul/sdk/testutil/retry.Run({0x23777c0, 0xc0037afd40}, 0xc02127df60)
	/home/circleci/project/sdk/testutil/retry/retry.go:103 +0x6b
github.com/hashicorp/consul/agent/consul.TestLeader_FailedMember(0xc0037afd40)
	/home/circleci/project/agent/consul/leader_test.go:154 +0x585
testing.tRunner(0xc0037afd40, 0x2107290)
	/usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x35a
```