### PR TITLE
ui: DistributionMeter Component

### DIFF
--- a/ui/packages/consul-ui/app/components/custom-element/README.mdx
+++ b/ui/packages/consul-ui/app/components/custom-element/README.mdx
@@ -1,0 +1,87 @@
+# CustomElement
+
+A renderless component to aid with the creation of HTML custom elements a.k.a
+WebComponents.
+
+All of the CustomElement component arguments are only used at construction
+time (within the components constructor) therefore they are, by design, static.
+You shouldn't be dynamically updating these values at all. They are only for
+type checking and documention purposes and therefore once defined/hardcoded
+they should only change if you as the author wishes to change them.
+
+The component is built from various other components, also see their documentaton
+for further details (`<ShadowHost />`, `<ShadowTemplate />`).
+
+```hbs preview-template
+<CustomElement
+  @element="x-component"
+  @attrs={{array
+    (array 'type' '"awesome" | "sauce"' 'awesome' 'Set the type of the x-component')
+    (array 'x' 'number' 0 'The x-ness of the x-component')
+  }}
+  @cssprops={{array
+    (array '--awesome-x-sauce' 'length' '[x]' 'Makes the x-ness of the sauce available to CSS, automatically synced/tracked from the x attributes')
+    (array '--awesome-color' 'color' undefined 'This CSS property can be used to set the color of the awesome')
+  }}
+  @cssparts={{array
+    (array 'base' 'Style base from The Outside via ::part(base)')
+  }}
+  @slots={{array
+    (array 'header' "You'll want to document the slots also")
+    (array '' 'Including the default slot')
+  }}
+as |custom element|>
+  <x-component
+    {{did-insert custom.connect}}
+    {{will-destroy custom.disconnect}}
+    aria-hidden="true"
+    ...attributes
+  >
+    <custom.Template
+      @styles={{css-map
+      }}
+    >
+      <div part="base"
+        data-x={{element.attrs.x}}
+        data-type={{element.attrs.type}}
+      >
+        <slot name="header"></slot>
+        <slot></slot>
+      </div>
+    </custom.Template>
+  </x-component>
+</CustomElement>
+
+```
+
+## Arguments
+
+All `descriptions` in attributes will be compiled out at build time as well as the `@description` attribute itself.
+
+| Attribute     | Type           | Default | Description                                                                |
+| :------------ | :------------- | :------ | :------------------------------------------------------------------------- |
+| element       | string         |         | The custom tag to be used for the custom element. Must include a dash      |
+| description   | string         |         | Short 1 line description for the element. Think "git commit title" style   |
+| attrs         | attrInfo[]     |         | An array of attributes that can be used on the element                     |
+| slots         | slotsInfo[]    |         | An array of slots that can be used for the element (100% compiled out)     |
+| cssprops      | cssPropsInfo[] |         | An array of CSS properties that are relevant to the component              |
+| cssparts      | cssPartsInfo[] |         | An array of CSS parts that can be used for the element (100% compiled out) |
+| args          | argsInfo[]     |         | An array of Glimmer arguments used for the component (100% compiled out)   |
+
+## Exports
+
+### custom
+
+| Attribute  | Type     | Description                                                                         |
+| :--------- | :------- | :---------------------------------------------------------------------------------- |
+| connect    | function | A did-insert-able callback for tagging an element to be used for the custom element |
+| disconnect | function | A will-destroy-able callback for destroying an element used for the custom element  |
+
+### element
+
+| Attribute  | Type     | Description                                                                      |
+| :--------- | :------- | :------------------------------------------------------------------------------- |
+| attributes | object   | An object containing a reference to all the custom elements' observed properties |
+| *          |          | All other properties proxy through to the CustomElements class                   |
+
+

--- a/ui/packages/consul-ui/app/components/custom-element/index.hbs
+++ b/ui/packages/consul-ui/app/components/custom-element/index.hbs
@@ -1,0 +1,11 @@
+<ShadowHost as |shadow|>
+  {{yield
+    (hash
+      root=(fn this.setHost (fn shadow.host))
+      connect=(fn this.setHost (fn shadow.host))
+      Template=shadow.Template
+      disconnect=(fn this.disconnect)
+    )
+    this.element
+  }}
+</ShadowHost>

--- a/ui/packages/consul-ui/app/components/custom-element/index.js
+++ b/ui/packages/consul-ui/app/components/custom-element/index.js
@@ -1,0 +1,193 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { assert } from '@ember/debug';
+
+const ATTRIBUTE_CHANGE = 'custom-element.attributeChange';
+const elements = new Map();
+const proxies = new WeakMap();
+
+const typeCast = (attributeInfo, value) => {
+  let type = attributeInfo.type;
+  const d = attributeInfo.default;
+  value = value == null ? attributeInfo.default : value;
+  if(type.indexOf('|') !== -1) {
+    assert(`"${value} is not of type '${type}'"`, type.split('|').map(item => item.replaceAll('"', '').trim()).includes(value));
+    type = 'string';
+  }
+  switch(type) {
+    case '<length>':
+    case '<percentage>':
+    case '<dimension>':
+    case 'number': {
+      const num = parseFloat(value);
+      if(isNaN(num)) {
+        return typeof d === 'undefined' ? 0 : d;
+      } else {
+        return num;
+      }
+    }
+    case '<integer>':
+      return parseInt(value);
+    case '<string>':
+    case 'string':
+      return (value || '').toString();
+  }
+}
+
+const attributeChangingElement = (name, Cls = HTMLElement, attributes = {}, cssprops = {}) => {
+  const attrs = Object.keys(attributes);
+
+  const customClass = class extends Cls {
+    static get observedAttributes() {
+      return attrs;
+    }
+
+    attributeChangedCallback(name, oldValue, newValue) {
+      const prev = typeCast(attributes[name], oldValue);
+      const value = typeCast(attributes[name], newValue);
+
+      const cssProp = cssprops[`--${name}`];
+      if(typeof cssProp !== 'undefined' && cssProp.track === `[${name}]`) {
+        this.style.setProperty(
+          `--${name}`,
+          value
+        );
+      }
+
+      if(typeof super.attributeChangedCallback === 'function') {
+        super.attributeChangedCallback(name, prev, value);
+      }
+
+      this.dispatchEvent(
+        new CustomEvent(
+          ATTRIBUTE_CHANGE,
+          {
+            detail: {
+              name: name,
+              previousValue: prev,
+              value: value
+            }
+          }
+        )
+      );
+
+    }
+  }
+  customElements.define(name, customClass);
+  return () => {};
+}
+
+const infoFromArray = (arr, keys) => {
+  return (arr || []).reduce((prev, info) => {
+    let key;
+    const obj = {};
+    keys.forEach((item, i) => {
+      if(item === '_') {
+        key = i;
+        return;
+      }
+      obj[item] = info[i]
+    });
+    prev[info[key]] = obj;
+    return prev;
+  }, {});
+}
+const debounceRAF = (cb, prev) => {
+  if(typeof prev !== 'undefined') {
+    cancelAnimationFrame(prev);
+  }
+  return requestAnimationFrame(cb);
+}
+const createElementProxy = ($element, component) => {
+  return new Proxy($element, {
+    get: (target, prop, receiver) => {
+      switch(prop) {
+        case 'attrs':
+          return component.attributes;
+        default:
+          if(typeof target[prop] === 'function') {
+            // need to ensure we use a MultiWeakMap here
+            // if(this.methods.has(prop)) {
+            //   return this.methods.get(prop);
+            // }
+            const method = target[prop].bind(target);
+            // this.methods.set(prop, method);
+            return method;
+          }
+
+      }
+    }
+  });
+}
+
+export default class CustomElementComponent extends Component {
+
+  @tracked $element;
+  @tracked _attributes = {};
+
+  __attributes;
+  _attchange;
+
+
+  constructor(owner, args) {
+    super(...arguments);
+    if(!elements.has(args.element)) {
+      const cb = attributeChangingElement(
+        args.element,
+        args.class,
+        infoFromArray(args.attrs, ['_', 'type', 'default', 'description']),
+        infoFromArray(args.cssprops, ['_', 'type', 'track', 'description'])
+      )
+      elements.set(args.element, cb);
+    }
+  }
+
+  get attributes() {
+    return this._attributes;
+  }
+
+  get element() {
+    if(this.$element) {
+      if(proxies.has(this.$element)) {
+        return proxies.get(this.$element);
+      }
+      const proxy = createElementProxy(this.$element, this);
+      proxies.set(this.$element, proxy);
+      return proxy;
+    }
+    return undefined;
+  }
+
+  @action
+  setHost(attachShadow, $element) {
+    attachShadow($element);
+    this.$element = $element;
+    this.$element.addEventListener(ATTRIBUTE_CHANGE, this.attributeChange);
+
+    (this.args.attrs || []).forEach(entry => {
+      const value = $element.getAttribute(entry[0]);
+      $element.attributeChangedCallback(entry[0], value, value)
+    });
+  }
+
+  @action
+  disconnect() {
+    this.$element.removeEventListener(ATTRIBUTE_CHANGE, this.attributeChange);
+  }
+
+  @action
+  attributeChange(e) {
+    e.stopImmediatePropagation();
+    // currently if one single attribute changes
+    // they all change
+    this.__attributes = {
+      ...this.__attributes,
+      [e.detail.name]: e.detail.value
+    };
+    this._attchange = debounceRAF(() => {
+      // tell glimmer we changed the attrs
+      this._attributes = this.__attributes;
+    }, this._attchange);
+  }
+}

--- a/ui/packages/consul-ui/app/components/distribution-meter/README.mdx
+++ b/ui/packages/consul-ui/app/components/distribution-meter/README.mdx
@@ -1,0 +1,83 @@
+---
+type: custom-element
+---
+<!-- START component-docs:@tagName -->
+# DistributionMeter
+<!-- END component-docs:@tagName -->
+
+<!-- START component-docs:@description -->
+A meter-like component to show a distribution of values.
+<!-- END component-docs:@description -->
+
+```hbs preview-template
+<figure>
+  <figcaption>
+    Provide a widget so we can try switching between all types of meter
+  </figcaption>
+  <select
+    onchange={{action (mut this.type) value="target.value"}}
+  >
+    <option>linear</option>
+    <option>radial</option>
+    <option>circular</option>
+  </select>
+</figure>
+<figure>
+
+  <DataSource
+    @src={{uri '/partition/namespace/dc-1/services'}}
+  as |source|>
+    {{#let
+      (group-by "MeshStatus" (or source.data (array)))
+    as |grouped|}}
+      <DistributionMeter type={{or this.type 'linear'}} as |meter|>
+      {{#each (array 'passing' 'warning' 'critical') as |status|}}
+      {{#let
+        (concat (percentage-of (get grouped (concat status '.length')) source.data.length) '%')
+      as |percentage|}}
+        <meter.Meter
+          description={{capitalize status}}
+          percentage={{percentage}}
+          class={{class-map
+            status
+          }}
+        as |meter|></meter.Meter>
+      {{/let}}
+      {{/each}}
+      </DistributionMeter>
+    {{/let}}
+  </DataSource>
+</figure>
+```
+
+## Attributes
+
+<!-- START component-docs:@attrs -->
+| Attribute | Type                               | Default | Description                           |
+| :-------- | :--------------------------------- | :------ | :------------------------------------ |
+| type      | "linear" \| "radial" \| "circular" | linear  | The type of distribution meter to use |
+
+<!-- END component-docs:@attrs -->
+
+## Contextual Components
+
+<!-- START component-docs:@components -->
+
+### DistributionMeter::Meter
+
+#### Attributes
+
+| Attribute   | Type   | Default | Description                                |
+| :---------- | :----- | :------ | :----------------------------------------- |
+| percentage  | number | 0       | The percentage to be used for the meter    |
+| description | string |         | Textual value to describe the meters value |
+
+
+#### CSS Properties
+
+| Property                | Type       | Tracks       | Description                                                       |
+| :---------------------- | :--------- | :----------- | :---------------------------------------------------------------- |
+| --percentage            | percentage | [percentage] | Read-only alias of the percentage attribute                       |
+| --aggregated-percentage | percentage |              | Aggregated percentage of all meters within the distribution meter |
+
+<!-- END component-docs:@components -->

--- a/ui/packages/consul-ui/app/components/distribution-meter/index.css.js
+++ b/ui/packages/consul-ui/app/components/distribution-meter/index.css.js
@@ -1,0 +1,32 @@
+export default (css) => {
+  return css`
+    :host {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+    dl {
+      position: relative;
+      height: 100%;
+    }
+    :host([type='linear']) {
+      height: 3px;
+    }
+    :host([type='radial']),
+    :host([type='circular']) {
+      height: 300px;
+    }
+    :host([type='linear']) dl {
+      background-color: currentColor;
+      color: rgb(var(--tone-gray-100));
+      border-radius: var(--decor-radius-999);
+      transition-property: transform;
+      transition-timing-function: ease-out;
+      transition-duration: .1s;
+    }
+    :host([type='linear']) dl:hover {
+      transform: scaleY(3);
+      box-shadow: var(--decor-elevation-200);
+    }
+  `;
+}

--- a/ui/packages/consul-ui/app/components/distribution-meter/index.hbs
+++ b/ui/packages/consul-ui/app/components/distribution-meter/index.hbs
@@ -1,0 +1,30 @@
+<CustomElement
+  @element="distribution-meter"
+  @description="A meter-like component to show a distribution of values."
+  @attrs={{array
+    (array 'type' '"linear" | "radial" | "circular"' 'linear'
+      'The type of distribution meter to use'
+    )
+  }}
+as |custom element|>
+  <distribution-meter
+    {{did-insert custom.connect}}
+    {{will-destroy custom.disconnect}}
+    ...attributes
+  >
+    <custom.Template
+      @styles={{css-map
+        (require './index.css' from='/components/distribution-meter')
+      }}
+    >
+      <dl>
+        <slot></slot>
+      </dl>
+    </custom.Template>
+    {{yield (hash
+      Meter=(component 'distribution-meter/meter'
+        type=element.attrs.type
+      )
+    )}}
+  </distribution-meter>
+</CustomElement>

--- a/ui/packages/consul-ui/app/components/distribution-meter/meter/element.js
+++ b/ui/packages/consul-ui/app/components/distribution-meter/meter/element.js
@@ -8,7 +8,7 @@ export default (Component) => {
     attributeChangedCallback(name, prev, value) {
       const target = this;
       switch(name) {
-        case 'percentage':
+        case 'percentage': {
           let prevSibling = target;
           while(prevSibling) {
             const nextSibling = prevSibling.nextElementSibling;
@@ -18,7 +18,8 @@ export default (Component) => {
             prevSibling.setAttribute('aggregated-percentage', perc);
             prevSibling = prevSibling.previousElementSibling;
           }
-          break
+          break;
+        }
       }
     }
   }

--- a/ui/packages/consul-ui/app/components/distribution-meter/meter/element.js
+++ b/ui/packages/consul-ui/app/components/distribution-meter/meter/element.js
@@ -1,0 +1,25 @@
+const parseFloatWithDefault = (val, d = 0) => {
+  const num = parseFloat(val);
+  return isNaN(num) ? d : num;
+}
+
+export default (Component) => {
+  return class extends Component {
+    attributeChangedCallback(name, prev, value) {
+      const target = this;
+      switch(name) {
+        case 'percentage':
+          let prevSibling = target;
+          while(prevSibling) {
+            const nextSibling = prevSibling.nextElementSibling;
+            const aggregatedPercentage = nextSibling ? parseFloatWithDefault(nextSibling.style.getPropertyValue('--aggregated-percentage')) : 0;
+            const perc = parseFloatWithDefault(prevSibling.getAttribute('percentage')) + aggregatedPercentage;
+            prevSibling.style.setProperty('--aggregated-percentage', perc);
+            prevSibling.setAttribute('aggregated-percentage', perc);
+            prevSibling = prevSibling.previousElementSibling;
+          }
+          break
+      }
+    }
+  }
+}

--- a/ui/packages/consul-ui/app/components/distribution-meter/meter/index.css.js
+++ b/ui/packages/consul-ui/app/components/distribution-meter/meter/index.css.js
@@ -1,0 +1,79 @@
+export default (css) => {
+  return css`
+    /*@import '~/styles/base/decoration/visually-hidden.css';*/
+
+    :host(.critical) {
+      color: rgb(var(--tone-red-500));
+    }
+    :host(.warning) {
+      color: rgb(var(--tone-orange-500));
+    }
+    :host(.passing) {
+      color: rgb(var(--tone-green-500));
+    }
+
+    :host {
+      position: absolute;
+      top: 0;
+      height: 100%;
+
+      transition-timing-function: ease-out;
+      transition-duration: .5s;
+    }
+    dt, dd meter {
+      animation-name: visually-hidden;
+      animation-fill-mode: forwards;
+      animation-play-state: paused;
+    }
+
+    :host(.type-linear) {
+      transition-property: width;
+      width: calc(var(--aggregated-percentage) * 1%);
+      height: 100%;
+      background-color: currentColor;
+      border-radius: var(--decor-radius-999);
+    }
+
+    :host svg {
+      height: 100%;
+    }
+    :host(.type-radial),
+    :host(.type-circular) {
+      transition-property: none;
+    }
+    :host(.type-radial) dd,
+    :host(.type-circular) dd {
+      width: 100%;
+      height: 100%;
+    }
+    :host(.type-radial) circle,
+    :host(.type-circular) circle {
+      transition-timing-function: ease-out;
+      transition-duration: .5s;
+      pointer-events: stroke;
+      transition-property: stroke-dashoffset, stroke-width;
+      transform: rotate(-90deg);
+      transform-origin: 50%;
+      fill: transparent;
+      stroke: currentColor;
+      stroke-dasharray: 100, 100;
+      stroke-dashoffset: calc(calc(100 - var(--aggregated-percentage)) * 1px);
+    }
+    :host([aggregated-percentage='100']) circle {
+      stroke-dasharray: 0 !important;
+    }
+    :host([aggregated-percentage='0']) circle {
+      stroke-dasharray: 0, 100 !important;
+    }
+    :host(.type-radial) circle,
+    :host(.type-circular]) svg {
+      pointer-events: none;
+    }
+    :host(.type-radial) circle {
+      stroke-width: 32;
+    }
+    :host(.type-circular) circle {
+      stroke-width: 14;
+    }
+  `;
+}

--- a/ui/packages/consul-ui/app/components/distribution-meter/meter/index.hbs
+++ b/ui/packages/consul-ui/app/components/distribution-meter/meter/index.hbs
@@ -1,0 +1,64 @@
+<CustomElement
+  @element="distribution-meter-meter"
+  @class={{require './element'
+    from='/components/distribution-meter/meter'}}
+
+  @attrs={{array
+    (array 'percentage' 'number' 0
+      'The percentage to be used for the meter'
+    )
+    (array 'description' 'string' ''
+      'Textual value to describe the meters value'
+    )
+  }}
+
+  @cssprops={{array
+    (array '--percentage' 'percentage' '[percentage]'
+      'Read-only alias of the percentage attribute'
+    )
+    (array '--aggregated-percentage' 'percentage' undefined
+      'Aggregated percentage of all meters within the distribution meter'
+    )
+  }}
+as |custom element|>
+
+  <distribution-meter-meter
+    {{did-insert custom.connect}}
+    {{will-destroy custom.disconnect}}
+    class={{class-map
+      (array (concat 'type-' @type) @type)
+    }}
+    ...attributes
+  >
+    <custom.Template
+      @styles={{css-map
+        (require '/styles/base/decoration/visually-hidden.css'
+          from='/components/distribution-meter/meter')
+        (require './index.css'
+          from='/components/distribution-meter/meter')
+      }}
+    >
+      <dt>{{element.attrs.description}}</dt>
+      <dd aria-label={{concat element.attrs.percentage '%'}}>
+        <meter min="0" max="100" value={{element.attrs.percentage}}>
+          <slot>{{concat element.attrs.percentage '%'}}</slot>
+        </meter>
+        {{#if (or (eq @type 'circular') (eq @type 'radial'))}}
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 32 32"
+            clip-path="circle()"
+          >
+            <circle
+              r="16"
+              cx="16"
+              cy="16"
+            />
+          </svg>
+        {{/if}}
+      </dd>
+    </custom.Template>
+  </distribution-meter-meter>
+
+</CustomElement>
+

--- a/ui/packages/consul-ui/app/components/shadow-host/README.mdx
+++ b/ui/packages/consul-ui/app/components/shadow-host/README.mdx
@@ -1,0 +1,29 @@
+# ShadowHost
+
+`ShadowHost` is a small renderless mainly utility component for easily attaching
+ShadowDOM to any applicable DOM node. It mainly exists to provide a context for
+passing around a reference to the element to be used for the shadow template,
+but named appropriately for recognition.
+
+If you are looking to write a custom element, please use the `CustomElement`
+component. If you are simply attaching ShadowDOM to a native HTML element then
+this is the component for you.
+
+```hbs preview-template
+<ShadowHost as |shadow|>
+  <div
+    {{did-insert shadow.host}}
+  >
+    <shadow.Template>
+      <p>hi</p>
+    </shadow.Template>
+  </div>
+</ShadowHost>
+```
+
+## Exports
+
+| Attribute | Type                    | Description                                                                      |
+| :-------- | :---------------------- | :------------------------------------------------------------------------------- |
+| host      | function                | A did-insert-able callback for tagging an element to be used for the shadow root |
+| Template  | ShadowTemplateComponent | ShadowTemplate component pre-configured with the shadow host                     |

--- a/ui/packages/consul-ui/app/components/shadow-host/index.hbs
+++ b/ui/packages/consul-ui/app/components/shadow-host/index.hbs
@@ -1,0 +1,5 @@
+{{yield (hash
+  host=(fn this.attachShadow)
+  root=this.shadowRoot
+  Template=(component 'shadow-template' shadowRoot=this.shadowRoot)
+)}}

--- a/ui/packages/consul-ui/app/components/shadow-host/index.js
+++ b/ui/packages/consul-ui/app/components/shadow-host/index.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ShadowHostComponent extends Component {
+
+  @tracked shadowRoot;
+
+  @action
+  attachShadow($element) {
+    this.shadowRoot = $element.attachShadow({ mode: 'open' });
+  }
+
+}

--- a/ui/packages/consul-ui/app/components/shadow-template/README.mdx
+++ b/ui/packages/consul-ui/app/components/shadow-template/README.mdx
@@ -9,7 +9,7 @@ Shadow DOM we have a `@shadowRoot` argument to which you would pass the actual
 Shadow DOM element (which itself either open or closed). You can get a reference
 to this by using the `{{attach-shadow}}` modifier.
 
-Additionally a `@stylesheets` argument is made available for you to optionally
+Additionally a `@styles` argument is made available for you to optionally
 pass completely isolated, scoped, constructable stylesheets to be used for the
 Shadow DOM tree (you can also continue to use `<style>` within the template
 itself also if necessary).
@@ -43,7 +43,7 @@ the example below).
 >
   <ShadowTemplate
     @shadowRoot={{this.shadow}}
-    @stylesheets={{css '
+    @styles={{css '
       :host {
         background-color: rgb(var(--tone-strawberry-500) / 20%);
         padding: 1rem; /* 16px */
@@ -107,7 +107,7 @@ using Glimmer syntax i.e. `<ComponentName />` not `<component-name />` but a
 >
   <ShadowTemplate
     @shadowRoot={{this.shadow}}
-    @stylesheets={{css '
+    @styles={{css '
       header {
         color: purple;
       }
@@ -159,4 +159,4 @@ component-name::part(header)::before {
 | Argument | Type | Default | Description |
 | --- | --- | --- | --- |
 | `shadowRoot` | `ShadowRoot` |  | A reference to a shadow root (probably retrived using the `{{attach-shadow}}` modifier |
-| `stylesheets` | `CSSResultGroup` | | Stylesheets to be adopted by the ShadowRoot |
+| `styles` | `CSSResultGroup` | | Styles to be adopted by the ShadowRoot |

--- a/ui/packages/consul-ui/app/components/shadow-template/index.hbs
+++ b/ui/packages/consul-ui/app/components/shadow-template/index.hbs
@@ -1,9 +1,9 @@
 {{#if @shadowRoot}}
   {{#in-element @shadowRoot}}
-    {{#if @stylesheets}}
+    {{#if @styles}}
       {{adopt-styles
         @shadowRoot
-        @stylesheets
+        @styles
       }}
     {{/if}}
   {{yield}}

--- a/ui/packages/consul-ui/app/helpers/adopt-styles.js
+++ b/ui/packages/consul-ui/app/helpers/adopt-styles.js
@@ -6,13 +6,16 @@ export default class AdoptStylesHelper extends Helper {
   /**
    * Adopt/apply given styles to a `ShadowRoot` using constructable styleSheets if supported
    *
-   * @param {[ShadowRoot, CSSResultGroup]} params
+   * @param {[ShadowRoot, (CSSResultGroup | CSSResultGroup[])]} params
    */
   compute([$shadow, styles], hash) {
     assert(
       'adopt-styles can only be used to apply styles to ShadowDOM elements',
       $shadow instanceof ShadowRoot
     );
-    adoptStyles($shadow, [styles]);
+    if(!Array.isArray(styles)) {
+      styles = [styles];
+    }
+    adoptStyles($shadow, styles);
   }
 }

--- a/ui/packages/consul-ui/app/helpers/adopt-styles.mdx
+++ b/ui/packages/consul-ui/app/helpers/adopt-styles.mdx
@@ -24,5 +24,5 @@ Adopt/apply given styles to a `ShadowRoot` using constructable styleSheets if su
 
 | Argument | Type | Default | Description |
 | --- | --- | --- | --- |
-| `params` | `[ShadowRoot, CSSResultGroup]` |  | |
+| `params` | `[ShadowRoot, (CSSResultGroup \| CSSResultGroup[])]` |  | |
 

--- a/ui/packages/consul-ui/app/helpers/class-map.js
+++ b/ui/packages/consul-ui/app/helpers/class-map.js
@@ -9,6 +9,7 @@ import { helper } from '@ember/component/helper';
  */
 const classMap = entries => {
   const str = entries
+    .filter(Boolean)
     .filter(entry => (typeof entry === 'string' ? true : entry[entry.length - 1]))
     .map(entry => (typeof entry === 'string' ? entry : entry[0]))
     .join(' ');

--- a/ui/packages/consul-ui/app/helpers/css-map.js
+++ b/ui/packages/consul-ui/app/helpers/css-map.js
@@ -1,0 +1,16 @@
+import { helper } from '@ember/component/helper';
+import { CSSResult } from '@lit/reactive-element';
+
+/**
+ * Conditionally maps cssInfos to an array ready for ShadowDom::styles
+ * usage.
+ *
+ * @typedef {([CSSResult, boolean] | [CSSResult])} cssInfo
+ * @param {(cssInfo | string)[]} entries - An array of 'entry-like' arrays of `cssInfo`s to map
+ */
+const cssMap = entries => {
+  return entries
+    .filter(entry => (entry instanceof CSSResult ? true : entry[entry.length - 1]))
+    .map(entry => (entry instanceof CSSResult ? entry : entry[0]))
+};
+export default helper(cssMap);

--- a/ui/packages/consul-ui/app/helpers/percentage-of.js
+++ b/ui/packages/consul-ui/app/helpers/percentage-of.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function([of, num], hash) {
+  const perc = (of / num * 100);
+  if(isNaN(perc)) {
+    return 0;
+  }
+  return perc.toFixed(2);
+});

--- a/ui/packages/consul-ui/app/helpers/require.js
+++ b/ui/packages/consul-ui/app/helpers/require.js
@@ -26,12 +26,13 @@ export default helper(([path = ''], { from }) => {
   switch(true) {
     case fullPath.endsWith('.css'):
       return fs[fullPath](css)
-    default:
+    default: {
       if(container.has(fullPath)) {
         return container.get(fullPath);
       }
       const module = fs[fullPath](HTMLElement);
       container.set(fullPath, module);
       return module;
+    }
   }
 });

--- a/ui/packages/consul-ui/app/helpers/require.js
+++ b/ui/packages/consul-ui/app/helpers/require.js
@@ -1,0 +1,37 @@
+import { helper } from '@ember/component/helper';
+
+import { css } from '@lit/reactive-element';
+
+import resolve from 'consul-ui/utils/path/resolve';
+
+import distributionMeter from 'consul-ui/components/distribution-meter/index.css';
+import distributionMeterMeter from 'consul-ui/components/distribution-meter/meter/index.css';
+import distributionMeterMeterElement from 'consul-ui/components/distribution-meter/meter/element';
+import visuallyHidden from 'consul-ui/styles/base/decoration/visually-hidden.css';
+
+const fs = {
+  ['/components/distribution-meter/index.css']: distributionMeter,
+  ['/components/distribution-meter/meter/index.css']: distributionMeterMeter,
+  ['/components/distribution-meter/meter/element']: distributionMeterMeterElement,
+  ['/styles/base/decoration/visually-hidden.css']: visuallyHidden
+};
+
+const container = new Map();
+
+// `css` already has a caching mechanism under the hood so rely on that, plus
+// we get the advantage of laziness here, i.e. we only call css as and when we
+// need to
+export default helper(([path = ''], { from }) => {
+  const fullPath = resolve(from, path);
+  switch(true) {
+    case fullPath.endsWith('.css'):
+      return fs[fullPath](css)
+    default:
+      if(container.has(fullPath)) {
+        return container.get(fullPath);
+      }
+      const module = fs[fullPath](HTMLElement);
+      container.set(fullPath, module);
+      return module;
+  }
+});

--- a/ui/packages/consul-ui/app/styles/base/decoration/base-variables.scss
+++ b/ui/packages/consul-ui/app/styles/base/decoration/base-variables.scss
@@ -4,6 +4,7 @@
   --decor-radius-100: 2px;
   --decor-radius-200: 4px;
   --decor-radius-300: 7px;
+  --decor-radius-999: 9999px;
   --decor-radius-full: 100%;
 
   --decor-border-000: none;

--- a/ui/packages/consul-ui/app/styles/base/decoration/visually-hidden.css.js
+++ b/ui/packages/consul-ui/app/styles/base/decoration/visually-hidden.css.js
@@ -1,0 +1,18 @@
+export default (css) => {
+/*%visually-hidden {*/
+  return css`
+    @keyframes visually-hidden {
+      100% {
+        position: absolute;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        border: 0;
+      }
+    }
+  `;
+/*}*/
+}


### PR DESCRIPTION
[Rendered Docs](https://consul-ui-staging-paqi22d2o-hashicorp.vercel.app/ui/docs/components/distribution-meter#CONSUL_LATENCY=3000)

I turned up the BlockingQuery wakeup rate on that link ^ to 3 seconds so it's easy to see what it looks like when data is being updated. Note you'll randomly get a set of data with different states, sometimes those states will be 100% in critical for example, just wait for different data to come in if so)

Honestly pretty happy that all this is just 5-6 lines of JS.

Two PRs that will need to be added ontop of here that I'll PR after review are:

1. Compile out the documentation metadata from the Glimmer templates (mostly the descriptions)
2. Tool for extracting the metadata from the Glimmer templates and inserting it into the README.mdx files on git stage.

I'll do those 2 once these are approved, for the moment just pretend they exist already!

