### PR TITLE
[1.11.x] backport of a series of blocking query readability and functionality improvements

### DIFF
--- a/.changelog/12110.txt
+++ b/.changelog/12110.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+rpc: improve blocking queries for items that do not exist, by continuing to block until they exist (or the timeout).
+```

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -322,6 +322,9 @@ func (a *ACL) TokenRead(args *structs.ACLTokenGetRequest, reply *structs.ACLToke
 
 			reply.Index, reply.Token = index, token
 			reply.SourceDatacenter = args.Datacenter
+			if token == nil {
+				return errNotFound
+			}
 			return nil
 		})
 }
@@ -1045,6 +1048,9 @@ func (a *ACL) PolicyRead(args *structs.ACLPolicyGetRequest, reply *structs.ACLPo
 			}
 
 			reply.Index, reply.Policy = index, policy
+			if policy == nil {
+				return errNotFound
+			}
 			return nil
 		})
 }
@@ -1428,6 +1434,9 @@ func (a *ACL) RoleRead(args *structs.ACLRoleGetRequest, reply *structs.ACLRoleRe
 			}
 
 			reply.Index, reply.Role = index, role
+			if role == nil {
+				return errNotFound
+			}
 			return nil
 		})
 }
@@ -1795,12 +1804,14 @@ func (a *ACL) BindingRuleRead(args *structs.ACLBindingRuleGetRequest, reply *str
 	return a.srv.blockingQuery(&args.QueryOptions, &reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
 			index, rule, err := state.ACLBindingRuleGetByID(ws, args.BindingRuleID, &args.EnterpriseMeta)
-
 			if err != nil {
 				return err
 			}
 
 			reply.Index, reply.BindingRule = index, rule
+			if rule == nil {
+				return errNotFound
+			}
 			return nil
 		})
 }
@@ -2052,16 +2063,16 @@ func (a *ACL) AuthMethodRead(args *structs.ACLAuthMethodGetRequest, reply *struc
 	return a.srv.blockingQuery(&args.QueryOptions, &reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
 			index, method, err := state.ACLAuthMethodGetByName(ws, args.AuthMethodName, &args.EnterpriseMeta)
-
 			if err != nil {
 				return err
 			}
 
-			if method != nil {
-				_ = a.enterpriseAuthMethodTypeValidation(method.Type)
+			reply.Index, reply.AuthMethod = index, method
+			if method == nil {
+				return errNotFound
 			}
 
-			reply.Index, reply.AuthMethod = index, method
+			_ = a.enterpriseAuthMethodTypeValidation(method.Type)
 			return nil
 		})
 }

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -205,12 +205,10 @@ func (c *ConfigEntry) Get(args *structs.ConfigEntryQuery, reply *structs.ConfigE
 				return err
 			}
 
-			reply.Index = index
+			reply.Index, reply.Entry = index, entry
 			if entry == nil {
 				return errNotFound
 			}
-
-			reply.Entry = entry
 			return nil
 		})
 }

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -207,7 +207,7 @@ func (c *ConfigEntry) Get(args *structs.ConfigEntryQuery, reply *structs.ConfigE
 
 			reply.Index = index
 			if entry == nil {
-				return nil
+				return errNotFound
 			}
 
 			reply.Entry = entry

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sort"
@@ -9,6 +10,7 @@ import (
 
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
@@ -304,6 +306,67 @@ func TestConfigEntry_Get(t *testing.T) {
 	require.True(ok)
 	require.Equal("foo", serviceConf.Name)
 	require.Equal(structs.ServiceDefaults, serviceConf.Kind)
+}
+
+func TestConfigEntry_Get_BlockOnNonExistent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	_, s1 := testServerWithConfig(t)
+	codec := rpcClient(t, s1)
+	store := s1.fsm.State()
+
+	entry := &structs.ServiceConfigEntry{
+		Kind: structs.ServiceDefaults,
+		Name: "alpha",
+	}
+	require.NoError(t, store.EnsureConfigEntry(1, entry))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var count int
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		args := structs.ConfigEntryQuery{
+			Kind: structs.ServiceDefaults,
+			Name: "does-not-exist",
+		}
+		args.QueryOptions.MaxQueryTime = time.Second
+
+		for ctx.Err() == nil {
+			var out structs.ConfigEntryResponse
+
+			err := msgpackrpc.CallWithCodec(codec, "ConfigEntry.Get", &args, &out)
+			if err != nil {
+				return err
+			}
+			t.Log("blocking query index", out.QueryMeta.Index, out.Entry)
+			count++
+			args.QueryOptions.MinQueryIndex = out.QueryMeta.Index
+		}
+		return nil
+	})
+
+	g.Go(func() error {
+		for i := uint64(0); i < 200; i++ {
+			time.Sleep(5 * time.Millisecond)
+			entry := &structs.ServiceConfigEntry{
+				Kind: structs.ServiceDefaults,
+				Name: fmt.Sprintf("other%d", i),
+			}
+			if err := store.EnsureConfigEntry(i+2, entry); err != nil {
+				return err
+			}
+		}
+		cancel()
+		return nil
+	})
+
+	require.NoError(t, g.Wait())
+	require.Equal(t, 2, count)
 }
 
 func TestConfigEntry_Get_ACLDeny(t *testing.T) {

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -366,7 +366,11 @@ func TestConfigEntry_Get_BlockOnNonExistent(t *testing.T) {
 	})
 
 	require.NoError(t, g.Wait())
-	require.Equal(t, 2, count)
+	// The test is a bit racy because of the timing of the two goroutines, so
+	// we relax the check for the count to be within a small range.
+	if count < 2 || count > 3 {
+		t.Fatalf("expected count to be 2 or 3, got %d", count)
+	}
 }
 
 func TestConfigEntry_Get_ACLDeny(t *testing.T) {

--- a/agent/consul/coordinate_endpoint.go
+++ b/agent/consul/coordinate_endpoint.go
@@ -267,6 +267,7 @@ func (c *Coordinate) Node(args *structs.NodeSpecificRequest, reply *structs.Inde
 				})
 			}
 			reply.Index, reply.Coordinates = index, coords
+
 			return nil
 		})
 }

--- a/agent/consul/federation_state_endpoint.go
+++ b/agent/consul/federation_state_endpoint.go
@@ -122,12 +122,10 @@ func (c *FederationState) Get(args *structs.FederationStateQuery, reply *structs
 				return err
 			}
 
-			reply.Index = index
+			reply.Index, reply.State = index, fedState
 			if fedState == nil {
 				return errNotFound
 			}
-
-			reply.State = fedState
 			return nil
 		})
 }

--- a/agent/consul/federation_state_endpoint.go
+++ b/agent/consul/federation_state_endpoint.go
@@ -124,7 +124,7 @@ func (c *FederationState) Get(args *structs.FederationStateQuery, reply *structs
 
 			reply.Index = index
 			if fedState == nil {
-				return nil
+				return errNotFound
 			}
 
 			reply.State = fedState

--- a/agent/consul/gateway_locator.go
+++ b/agent/consul/gateway_locator.go
@@ -8,14 +8,15 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
+	memdb "github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/lib/stringslice"
 	"github.com/hashicorp/consul/logging"
-	"github.com/hashicorp/go-hclog"
-	memdb "github.com/hashicorp/go-memdb"
 )
 
 // GatewayLocator assists in selecting an appropriate mesh gateway when wan
@@ -269,7 +270,7 @@ func getRandomItem(items []string) string {
 }
 
 type serverDelegate interface {
-	blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta structs.QueryMetaCompat, fn queryFn) error
+	blockingQuery(queryOpts blockingQueryOptions, queryMeta blockingQueryResponseMeta, fn queryFn) error
 	IsLeader() bool
 	LeaderLastContact() time.Time
 	setDatacenterSupportsFederationStates()

--- a/agent/consul/gateway_locator_test.go
+++ b/agent/consul/gateway_locator_test.go
@@ -493,8 +493,8 @@ func (d *testServerDelegate) datacenterSupportsFederationStates() bool {
 
 // This is just enough to exercise the logic.
 func (d *testServerDelegate) blockingQuery(
-	queryOpts structs.QueryOptionsCompat,
-	queryMeta structs.QueryMetaCompat,
+	queryOpts blockingQueryOptions,
+	queryMeta blockingQueryResponseMeta,
 	fn queryFn,
 ) error {
 	minQueryIndex := queryOpts.GetMinQueryIndex()

--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -160,18 +160,13 @@ func (k *KVS) Get(args *structs.KeyRequest, reply *structs.IndexedDirEntries) er
 			}
 
 			if ent == nil {
-				// Must provide non-zero index to prevent blocking
-				// Index 1 is impossible anyways (due to Raft internals)
-				if index == 0 {
-					reply.Index = 1
-				} else {
-					reply.Index = index
-				}
+				reply.Index = index
 				reply.Entries = nil
-			} else {
-				reply.Index = ent.ModifyIndex
-				reply.Entries = structs.DirEntries{ent}
+				return errNotFound
 			}
+
+			reply.Index = ent.ModifyIndex
+			reply.Entries = structs.DirEntries{ent}
 			return nil
 		})
 }

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -944,7 +944,17 @@ type blockingQueryResponseMeta interface {
 //
 // The query function is expected to be a closure that has access to responseMeta
 // so that it can set the Index. The actual result of the query is opaque to blockingQuery.
-// If query function returns an error, the error is returned to the caller immediately.
+//
+// The query function can return errNotFound, which is a sentinel error. Returning
+// errNotFound indicates that the query found no results, which allows
+// blockingQuery to keep blocking until the query returns a non-nil error.
+// The query function must take care to set the actual result of the query to
+// nil in these cases, otherwise when blockingQuery times out it may return
+// a previous result. errNotFound will never be returned to the caller, it is
+// converted to nil before returning.
+//
+// If query function returns any other error, the error is returned to the caller
+// immediately.
 //
 // The query function must follow these rules:
 //

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -910,35 +910,82 @@ func (s *Server) raftApplyWithEncoder(
 	return resp, nil
 }
 
-// queryFn is used to perform a query operation. If a re-query is needed, the
-// passed-in watch set will be used to block for changes. The passed-in state
-// store should be used (vs. calling fsm.State()) since the given state store
-// will be correctly watched for changes if the state store is restored from
-// a snapshot.
+// queryFn is used to perform a query operation. See Server.blockingQuery for
+// the requirements of this function.
 type queryFn func(memdb.WatchSet, *state.Store) error
 
-// blockingQuery is used to process a potentially blocking query operation.
-func (s *Server) blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta structs.QueryMetaCompat, fn queryFn) error {
+// blockingQueryOptions are options used by Server.blockingQuery to modify the
+// behaviour of the query operation, or to populate response metadata.
+type blockingQueryOptions interface {
+	GetToken() string
+	GetMinQueryIndex() uint64
+	GetMaxQueryTime() time.Duration
+	GetRequireConsistent() bool
+}
+
+// blockingQueryResponseMeta is an interface used to populate the response struct
+// with metadata about the query and the state of the server.
+type blockingQueryResponseMeta interface {
+	SetLastContact(time.Duration)
+	SetKnownLeader(bool)
+	GetIndex() uint64
+	SetIndex(uint64)
+	SetResultsFilteredByACLs(bool)
+}
+
+// blockingQuery performs a blocking query if opts.GetMinQueryIndex is
+// greater than 0, otherwise performs a non-blocking query. Blocking queries will
+// block until responseMeta.Index is greater than opts.GetMinQueryIndex,
+// or opts.GetMaxQueryTime is reached. Non-blocking queries return immediately
+// after performing the query.
+//
+// If opts.GetRequireConsistent is true, blockingQuery will first verify it is
+// still the cluster leader before performing the query.
+//
+// The query function is expected to be a closure that has access to responseMeta
+// so that it can set the Index. The actual result of the query is opaque to blockingQuery.
+// If query function returns an error, the error is returned to the caller immediately.
+//
+// The query function must follow these rules:
+//
+//   1. to access data it must use the passed in state.Store.
+//   2. it must set the responseMeta.Index to an index greater than
+//      opts.GetMinQueryIndex if the results return by the query have changed.
+//   3. any channels added to the memdb.WatchSet must unblock when the results
+//      returned by the query have changed.
+//
+// To ensure optimal performance of the query, the query function should make a
+// best-effort attempt to follow these guidelines:
+//
+//   1. only set responseMeta.Index to an index greater than
+//      opts.GetMinQueryIndex when the results returned by the query have changed.
+//   2. any channels added to the memdb.WatchSet should only unblock when the
+//      results returned by the query have changed.
+func (s *Server) blockingQuery(
+	opts blockingQueryOptions,
+	responseMeta blockingQueryResponseMeta,
+	query queryFn,
+) error {
 	var ctx context.Context = &lib.StopChannelContext{StopCh: s.shutdownCh}
 
 	metrics.IncrCounter([]string{"rpc", "query"}, 1)
 
-	minQueryIndex := queryOpts.GetMinQueryIndex()
+	minQueryIndex := opts.GetMinQueryIndex()
 	// Perform a non-blocking query
 	if minQueryIndex == 0 {
-		if queryOpts.GetRequireConsistent() {
+		if opts.GetRequireConsistent() {
 			if err := s.consistentRead(); err != nil {
 				return err
 			}
 		}
 
 		var ws memdb.WatchSet
-		err := fn(ws, s.fsm.State())
-		s.setQueryMeta(queryMeta, queryOpts.GetToken())
+		err := query(ws, s.fsm.State())
+		s.setQueryMeta(responseMeta, opts.GetToken())
 		return err
 	}
 
-	timeout := s.rpcQueryTimeout(queryOpts.GetMaxQueryTime())
+	timeout := s.rpcQueryTimeout(opts.GetMaxQueryTime())
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -948,7 +995,7 @@ func (s *Server) blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta s
 	defer atomic.AddUint64(&s.queriesBlocking, ^uint64(0))
 
 	for {
-		if queryOpts.GetRequireConsistent() {
+		if opts.GetRequireConsistent() {
 			if err := s.consistentRead(); err != nil {
 				return err
 			}
@@ -964,13 +1011,13 @@ func (s *Server) blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta s
 		// whole state store is abandoned.
 		ws.Add(state.AbandonCh())
 
-		err := fn(ws, state)
-		s.setQueryMeta(queryMeta, queryOpts.GetToken())
+		err := query(ws, state)
+		s.setQueryMeta(responseMeta, opts.GetToken())
 		if err != nil {
 			return err
 		}
 
-		if queryMeta.GetIndex() > minQueryIndex {
+		if responseMeta.GetIndex() > minQueryIndex {
 			return nil
 		}
 
@@ -992,7 +1039,7 @@ func (s *Server) blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta s
 // setQueryMeta is used to populate the QueryMeta data for an RPC call
 //
 // Note: This method must be called *after* filtering query results with ACLs.
-func (s *Server) setQueryMeta(m structs.QueryMetaCompat, token string) {
+func (s *Server) setQueryMeta(m blockingQueryResponseMeta, token string) {
 	if s.IsLeader() {
 		m.SetLastContact(0)
 		m.SetKnownLeader(true)
@@ -1085,7 +1132,7 @@ func (s *Server) rpcQueryTimeout(queryTimeout time.Duration) time.Duration {
 //	  will only check whether it is blank or not). It's a safe assumption because
 //	  ResultsFilteredByACLs is only set to try when applying the already-resolved
 //	  token's policies.
-func maskResultsFilteredByACLs(token string, meta structs.QueryMetaCompat) {
+func maskResultsFilteredByACLs(token string, meta blockingQueryResponseMeta) {
 	if token == "" {
 		meta.SetResultsFilteredByACLs(false)
 	}

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -227,11 +227,9 @@ func (m *MockSink) Close() error {
 	return nil
 }
 
-func TestRPC_blockingQuery(t *testing.T) {
+func TestServer_blockingQuery(t *testing.T) {
 	t.Parallel()
-	dir, s := testServer(t)
-	defer os.RemoveAll(dir)
-	defer s.Shutdown()
+	_, s := testServerWithConfig(t)
 
 	// Perform a non-blocking query. Note that it's significant that the meta has
 	// a zero index in response - the implied opts.MinQueryIndex is also zero but
@@ -390,6 +388,93 @@ func TestRPC_blockingQuery(t *testing.T) {
 		err = s.blockingQuery(&opts, &meta, fn)
 		require.NoError(t, err)
 		require.True(t, meta.ResultsFilteredByACLs, "ResultsFilteredByACLs should be honored for authenticated calls")
+	})
+
+	t.Run("non-blocking query for item that does not exist", func(t *testing.T) {
+		opts := structs.QueryOptions{}
+		meta := structs.QueryMeta{}
+		calls := 0
+		fn := func(_ memdb.WatchSet, _ *state.Store) error {
+			calls++
+			return errNotFound
+		}
+
+		err := s.blockingQuery(&opts, &meta, fn)
+		require.NoError(t, err)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("blocking query for item that does not exist", func(t *testing.T) {
+		opts := structs.QueryOptions{MinQueryIndex: 3, MaxQueryTime: 100 * time.Millisecond}
+		meta := structs.QueryMeta{}
+		calls := 0
+		fn := func(ws memdb.WatchSet, _ *state.Store) error {
+			calls++
+			if calls == 1 {
+				meta.Index = 3
+
+				ch := make(chan struct{})
+				close(ch)
+				ws.Add(ch)
+				return errNotFound
+			}
+			meta.Index = 5
+			return errNotFound
+		}
+
+		err := s.blockingQuery(&opts, &meta, fn)
+		require.NoError(t, err)
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("blocking query for item that existed and is removed", func(t *testing.T) {
+		opts := structs.QueryOptions{MinQueryIndex: 3, MaxQueryTime: 100 * time.Millisecond}
+		meta := structs.QueryMeta{}
+		calls := 0
+		fn := func(ws memdb.WatchSet, _ *state.Store) error {
+			calls++
+			if calls == 1 {
+				meta.Index = 3
+
+				ch := make(chan struct{})
+				close(ch)
+				ws.Add(ch)
+				return nil
+			}
+			meta.Index = 5
+			return errNotFound
+		}
+
+		start := time.Now()
+		err := s.blockingQuery(&opts, &meta, fn)
+		require.True(t, time.Since(start) < opts.MaxQueryTime, "query timed out")
+		require.NoError(t, err)
+		require.Equal(t, 2, calls)
+	})
+
+	t.Run("blocking query for non-existent item that is created", func(t *testing.T) {
+		opts := structs.QueryOptions{MinQueryIndex: 3, MaxQueryTime: 100 * time.Millisecond}
+		meta := structs.QueryMeta{}
+		calls := 0
+		fn := func(ws memdb.WatchSet, _ *state.Store) error {
+			calls++
+			if calls == 1 {
+				meta.Index = 3
+
+				ch := make(chan struct{})
+				close(ch)
+				ws.Add(ch)
+				return errNotFound
+			}
+			meta.Index = 5
+			return nil
+		}
+
+		start := time.Now()
+		err := s.blockingQuery(&opts, &meta, fn)
+		require.True(t, time.Since(start) < opts.MaxQueryTime, "query timed out")
+		require.NoError(t, err)
+		require.Equal(t, 2, calls)
 	})
 }
 

--- a/agent/consul/session_endpoint.go
+++ b/agent/consul/session_endpoint.go
@@ -198,6 +198,7 @@ func (s *Session) Get(args *structs.SessionSpecificRequest,
 				reply.Sessions = structs.Sessions{session}
 			} else {
 				reply.Sessions = nil
+				return errNotFound
 			}
 			s.srv.filterACLWithAuthorizer(authz, reply)
 			return nil

--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -821,6 +821,7 @@ func TestTxn_Read(t *testing.T) {
 		},
 		QueryMeta: structs.QueryMeta{
 			KnownLeader: true,
+			Index:       1,
 		},
 	}
 	require.Equal(expected, out)

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -370,7 +370,9 @@ func (q QueryBackend) String() string {
 // QueryMeta allows a query response to include potentially
 // useful metadata about a query
 type QueryMeta struct {
-	// Index in the raft log of the latest item returned by the query.
+	// Index in the raft log of the latest item returned by the query. If the
+	// query did not return any results the Index will be a value that will
+	// change when a new item is added.
 	Index uint64
 
 	// If AllowStale is used, this is time elapsed since

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/hashicorp/raft"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTxnEndpoint_Bad_JSON(t *testing.T) {
@@ -385,6 +386,7 @@ func TestTxnEndpoint_KV_Actions(t *testing.T) {
 				},
 				QueryMeta: structs.QueryMeta{
 					KnownLeader: true,
+					Index:       1,
 				},
 			}
 			assert.Equal(t, expected, txnResp)


### PR DESCRIPTION
This is an omnibus PR including all blocking query fixes found in:
- https://github.com/hashicorp/consul/pull/12109
- https://github.com/hashicorp/consul/pull/12343
- https://github.com/hashicorp/consul/pull/12110
- https://github.com/hashicorp/consul/pull/12389