### PR TITLE
catalog: compare node names case insensitively in ACL authz evaluation

### DIFF
--- a/.changelog/12462.txt
+++ b/.changelog/12462.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+catalog: compare node names case insensitively in ACL authz evaluation
+```

--- a/acl/authorizer.go
+++ b/acl/authorizer.go
@@ -21,6 +21,10 @@ const (
 	Default
 )
 
+func (d EnforcementDecision) GoString() string {
+	return d.String()
+}
+
 func (d EnforcementDecision) String() string {
 	switch d {
 	case Allow:

--- a/acl/policy_authorizer.go
+++ b/acl/policy_authorizer.go
@@ -1,6 +1,8 @@
 package acl
 
 import (
+	"strings"
+
 	"github.com/armon/go-radix"
 )
 
@@ -472,6 +474,7 @@ func (p *policyAuthorizer) ACLWrite(*AuthorizerContext) EnforcementDecision {
 // AgentRead checks for permission to read from agent endpoints for a given
 // node.
 func (p *policyAuthorizer) AgentRead(node string, _ *AuthorizerContext) EnforcementDecision {
+	node = strings.ToLower(node)
 	if rule, ok := getPolicy(node, p.agentRules); ok {
 		return enforce(rule.access, AccessRead)
 	}
@@ -481,6 +484,7 @@ func (p *policyAuthorizer) AgentRead(node string, _ *AuthorizerContext) Enforcem
 // AgentWrite checks for permission to make changes via agent endpoints for a
 // given node.
 func (p *policyAuthorizer) AgentWrite(node string, _ *AuthorizerContext) EnforcementDecision {
+	node = strings.ToLower(node)
 	if rule, ok := getPolicy(node, p.agentRules); ok {
 		return enforce(rule.access, AccessWrite)
 	}
@@ -711,6 +715,7 @@ func (p *policyAuthorizer) OperatorWrite(*AuthorizerContext) EnforcementDecision
 
 // NodeRead checks if reading (discovery) of a node is allowed
 func (p *policyAuthorizer) NodeRead(name string, _ *AuthorizerContext) EnforcementDecision {
+	name = strings.ToLower(name)
 	if rule, ok := getPolicy(name, p.nodeRules); ok {
 		return enforce(rule.access, AccessRead)
 	}
@@ -723,6 +728,7 @@ func (p *policyAuthorizer) NodeReadAll(_ *AuthorizerContext) EnforcementDecision
 
 // NodeWrite checks if writing (registering) a node is allowed
 func (p *policyAuthorizer) NodeWrite(name string, _ *AuthorizerContext) EnforcementDecision {
+	name = strings.ToLower(name)
 	if rule, ok := getPolicy(name, p.nodeRules); ok {
 		return enforce(rule.access, AccessWrite)
 	}
@@ -773,6 +779,7 @@ func (p *policyAuthorizer) serviceWriteAny(_ *AuthorizerContext) EnforcementDeci
 
 // SessionRead checks for permission to read sessions for a given node.
 func (p *policyAuthorizer) SessionRead(node string, _ *AuthorizerContext) EnforcementDecision {
+	node = strings.ToLower(node)
 	if rule, ok := getPolicy(node, p.sessionRules); ok {
 		return enforce(rule.access, AccessRead)
 	}
@@ -781,6 +788,7 @@ func (p *policyAuthorizer) SessionRead(node string, _ *AuthorizerContext) Enforc
 
 // SessionWrite checks for permission to create sessions for a given node.
 func (p *policyAuthorizer) SessionWrite(node string, _ *AuthorizerContext) EnforcementDecision {
+	node = strings.ToLower(node)
 	// Check for an exact rule or catch-all
 	if rule, ok := getPolicy(node, p.sessionRules); ok {
 		return enforce(rule.access, AccessWrite)

--- a/acl/policy_authorizer.go
+++ b/acl/policy_authorizer.go
@@ -164,14 +164,14 @@ func defaultIsAllow(decision EnforcementDecision) EnforcementDecision {
 func (p *policyAuthorizer) loadRules(policy *PolicyRules) error {
 	// Load the agent policy (exact matches)
 	for _, ap := range policy.Agents {
-		if err := insertPolicyIntoRadix(ap.Node, ap.Policy, nil, p.agentRules, false); err != nil {
+		if err := insertPolicyIntoRadix(strings.ToLower(ap.Node), ap.Policy, nil, p.agentRules, false); err != nil {
 			return err
 		}
 	}
 
 	// Load the agent policy (prefix matches)
 	for _, ap := range policy.AgentPrefixes {
-		if err := insertPolicyIntoRadix(ap.Node, ap.Policy, nil, p.agentRules, true); err != nil {
+		if err := insertPolicyIntoRadix(strings.ToLower(ap.Node), ap.Policy, nil, p.agentRules, true); err != nil {
 			return err
 		}
 	}
@@ -192,14 +192,14 @@ func (p *policyAuthorizer) loadRules(policy *PolicyRules) error {
 
 	// Load the node policy (exact matches)
 	for _, np := range policy.Nodes {
-		if err := insertPolicyIntoRadix(np.Name, np.Policy, &np.EnterpriseRule, p.nodeRules, false); err != nil {
+		if err := insertPolicyIntoRadix(strings.ToLower(np.Name), np.Policy, &np.EnterpriseRule, p.nodeRules, false); err != nil {
 			return err
 		}
 	}
 
 	// Load the node policy (prefix matches)
 	for _, np := range policy.NodePrefixes {
-		if err := insertPolicyIntoRadix(np.Name, np.Policy, &np.EnterpriseRule, p.nodeRules, true); err != nil {
+		if err := insertPolicyIntoRadix(strings.ToLower(np.Name), np.Policy, &np.EnterpriseRule, p.nodeRules, true); err != nil {
 			return err
 		}
 	}

--- a/acl/policy_authorizer_test.go
+++ b/acl/policy_authorizer_test.go
@@ -440,6 +440,103 @@ func TestPolicyAuthorizer(t *testing.T) {
 				{name: "AllDenied", prefix: "*", check: checkDenyIntentionWrite},
 			},
 		},
+		"node and agent casing doesn't matter": {
+			policy: &Policy{PolicyRules: PolicyRules{
+				Agents: []*AgentRule{
+					{
+						Node:   "foo",
+						Policy: PolicyWrite,
+					},
+					{
+						Node:   "FOO",
+						Policy: PolicyDeny,
+					},
+					{
+						Node:   "OOF",
+						Policy: PolicyWrite,
+					},
+					{
+						Node:   "oof",
+						Policy: PolicyDeny,
+					},
+				},
+				AgentPrefixes: []*AgentRule{
+					{
+						Node:   "ba",
+						Policy: PolicyWrite,
+					},
+					{
+						Node:   "BA",
+						Policy: PolicyDeny,
+					},
+					{
+						Node:   "RA",
+						Policy: PolicyWrite,
+					},
+					{
+						Node:   "ra",
+						Policy: PolicyDeny,
+					},
+				},
+				Nodes: []*NodeRule{
+					{
+						Name:   "foo",
+						Policy: PolicyWrite,
+					},
+					{
+						Name:   "FOO",
+						Policy: PolicyDeny,
+					},
+					{
+						Name:   "OOF",
+						Policy: PolicyWrite,
+					},
+					{
+						Name:   "oof",
+						Policy: PolicyDeny,
+					},
+				},
+				NodePrefixes: []*NodeRule{
+					{
+						Name:   "ba",
+						Policy: PolicyWrite,
+					},
+					{
+						Name:   "BA",
+						Policy: PolicyDeny,
+					},
+					{
+						Name:   "RA",
+						Policy: PolicyWrite,
+					},
+					{
+						Name:   "ra",
+						Policy: PolicyDeny,
+					},
+				},
+			}},
+			checks: []aclCheck{
+				{name: "AgentReadDenyAlwaysWins", prefix: "foo", check: checkDenyAgentRead},
+				{name: "AgentWriteDenyAlwaysWins", prefix: "FOO", check: checkDenyAgentWrite},
+				{name: "AgentReadDenyAlwaysWins", prefix: "OOF", check: checkDenyAgentRead},
+				{name: "AgentWriteDenyAlwaysWins", prefix: "oof", check: checkDenyAgentWrite},
+
+				{name: "AgentReadDenyAlwaysWins", prefix: "bar", check: checkDenyAgentRead},
+				{name: "AgentWriteDenyAlwaysWins", prefix: "BAR", check: checkDenyAgentWrite},
+				{name: "AgentReadDenyAlwaysWins", prefix: "RAB", check: checkDenyAgentRead},
+				{name: "AgentWriteDenyAlwaysWins", prefix: "rab", check: checkDenyAgentWrite},
+
+				{name: "NodeReadDenyAlwaysWins", prefix: "foo", check: checkDenyNodeRead},
+				{name: "NodeWriteDenyAlwaysWins", prefix: "FOO", check: checkDenyNodeWrite},
+				{name: "NodeReadDenyAlwaysWins", prefix: "OOF", check: checkDenyNodeRead},
+				{name: "NodeWriteDenyAlwaysWins", prefix: "oof", check: checkDenyNodeWrite},
+
+				{name: "NodeReadDenyAlwaysWins", prefix: "bar", check: checkDenyNodeRead},
+				{name: "NodeWriteDenyAlwaysWins", prefix: "BAR", check: checkDenyNodeWrite},
+				{name: "NodeReadDenyAlwaysWins", prefix: "RAB", check: checkDenyNodeRead},
+				{name: "NodeWriteDenyAlwaysWins", prefix: "rab", check: checkDenyNodeWrite},
+			},
+		},
 	}
 
 	for name, tcase := range cases {

--- a/acl/policy_merger.go
+++ b/acl/policy_merger.go
@@ -1,5 +1,7 @@
 package acl
 
+import "strings"
+
 type policyRulesMergeContext struct {
 	aclRule                  string
 	agentRules               map[string]*AgentRule
@@ -48,6 +50,8 @@ func (p *policyRulesMergeContext) merge(policy *PolicyRules) {
 	}
 
 	for _, ap := range policy.Agents {
+		ap.Node = strings.ToLower(ap.Node)
+
 		update := true
 		if permission, found := p.agentRules[ap.Node]; found {
 			update = takesPrecedenceOver(ap.Policy, permission.Policy)
@@ -59,6 +63,8 @@ func (p *policyRulesMergeContext) merge(policy *PolicyRules) {
 	}
 
 	for _, ap := range policy.AgentPrefixes {
+		ap.Node = strings.ToLower(ap.Node)
+
 		update := true
 		if permission, found := p.agentPrefixRules[ap.Node]; found {
 			update = takesPrecedenceOver(ap.Policy, permission.Policy)
@@ -122,6 +128,8 @@ func (p *policyRulesMergeContext) merge(policy *PolicyRules) {
 	}
 
 	for _, np := range policy.Nodes {
+		np.Name = strings.ToLower(np.Name)
+
 		update := true
 		if permission, found := p.nodeRules[np.Name]; found {
 			update = takesPrecedenceOver(np.Policy, permission.Policy)
@@ -133,6 +141,8 @@ func (p *policyRulesMergeContext) merge(policy *PolicyRules) {
 	}
 
 	for _, np := range policy.NodePrefixes {
+		np.Name = strings.ToLower(np.Name)
+
 		update := true
 		if permission, found := p.nodePrefixRules[np.Name]; found {
 			update = takesPrecedenceOver(np.Policy, permission.Policy)
@@ -206,6 +216,8 @@ func (p *policyRulesMergeContext) merge(policy *PolicyRules) {
 	}
 
 	for _, sp := range policy.Sessions {
+		sp.Node = strings.ToLower(sp.Node)
+
 		update := true
 		if permission, found := p.sessionRules[sp.Node]; found {
 			update = takesPrecedenceOver(sp.Policy, permission.Policy)
@@ -217,6 +229,8 @@ func (p *policyRulesMergeContext) merge(policy *PolicyRules) {
 	}
 
 	for _, sp := range policy.SessionPrefixes {
+		sp.Node = strings.ToLower(sp.Node)
+
 		update := true
 		if permission, found := p.sessionPrefixRules[sp.Node]; found {
 			update = takesPrecedenceOver(sp.Policy, permission.Policy)

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -818,6 +818,10 @@ func TestMergePolicies(t *testing.T) {
 							Node:   "baz",
 							Policy: PolicyWrite,
 						},
+						{
+							Node:   "BLAH",
+							Policy: PolicyWrite,
+						},
 					},
 					AgentPrefixes: []*AgentRule{
 						{
@@ -832,6 +836,10 @@ func TestMergePolicies(t *testing.T) {
 							Node:   "222",
 							Policy: PolicyWrite,
 						},
+						{
+							Node:   "THREE",
+							Policy: PolicyWrite,
+						},
 					},
 				}},
 				{PolicyRules: PolicyRules{
@@ -844,6 +852,10 @@ func TestMergePolicies(t *testing.T) {
 							Node:   "baz",
 							Policy: PolicyDeny,
 						},
+						{
+							Node:   "blah",
+							Policy: PolicyDeny,
+						},
 					},
 					AgentPrefixes: []*AgentRule{
 						{
@@ -852,6 +864,10 @@ func TestMergePolicies(t *testing.T) {
 						},
 						{
 							Node:   "222",
+							Policy: PolicyDeny,
+						},
+						{
+							Node:   "three",
 							Policy: PolicyDeny,
 						},
 					},
@@ -871,6 +887,10 @@ func TestMergePolicies(t *testing.T) {
 						Node:   "baz",
 						Policy: PolicyDeny,
 					},
+					{
+						Node:   "blah",
+						Policy: PolicyDeny,
+					},
 				},
 				AgentPrefixes: []*AgentRule{
 					{
@@ -883,6 +903,10 @@ func TestMergePolicies(t *testing.T) {
 					},
 					{
 						Node:   "222",
+						Policy: PolicyDeny,
+					},
+					{
+						Node:   "three",
 						Policy: PolicyDeny,
 					},
 				},

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -3585,6 +3585,24 @@ func TestVetRegisterWithACL(t *testing.T) {
 	}
 	require.NoError(t, vetRegisterWithACL(perms, args, ns))
 
+	// Use a wildly different casing for the node name, which should also go
+	// through. The ACLs still work, and the node-to-check comparison should
+	// still work.
+	args = &structs.RegisterRequest{
+		Node:    "NoDe",
+		Address: "127.0.0.1",
+		Service: &structs.NodeService{
+			Service: "service",
+			ID:      "my-id",
+		},
+		Checks: []*structs.HealthCheck{
+			{
+				Node: "node",
+			},
+		},
+	}
+	require.NoError(t, vetRegisterWithACL(perms, args, ns))
+
 	// Add a service-level check.
 	args = &structs.RegisterRequest{
 		Node:    "node",


### PR DESCRIPTION
Extension of #12444 but with the slightly backwards incompatible change
of having node and agent resources be case insensitive.