### PR TITLE
ui: List Primary and Local DCs first in the Datacenter selector

### DIFF
--- a/.changelog/12478.txt
+++ b/.changelog/12478.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: In the datacenter selector order Datacenters by Primary, Local then alpanumerically
+```

--- a/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
@@ -4,7 +4,7 @@
 >
   <DisclosureMenu
     aria-label="Datacenter"
-    @items={{sort-by 'Name' @dcs}}
+    @items={{sort-by 'Primary:desc' 'Local:desc' 'Name:asc' @dcs}}
   as |disclosure|>
     <disclosure.Action
       {{on 'click' disclosure.toggle}}


### PR DESCRIPTION
This PR orders the Datacenter selector/menu as:

1. Primary DC first
2. Local DC second
3. All the rest alphabetically

We figured Primary should go before Local (local is the one the UI is running on) but if anyone reads this and thinks otherwise please ping ty!

