### PR TITLE
Remove deprecated built-in proxy tutorial reference

### DIFF
--- a/website/content/docs/connect/proxies/built-in.mdx
+++ b/website/content/docs/connect/proxies/built-in.mdx
@@ -13,10 +13,6 @@ The [Envoy proxy](/docs/connect/proxies/envoy) should be used for production dep
 Consul comes with a built-in L4 proxy for testing and development with Consul
 Connect service mesh.
 
-## Getting Started
-
-To get started with the built-in proxy and see a working example you can follow the [Getting Started](https://learn.hashicorp.com/tutorials/consul/get-started-service-networking) tutorial.
-
 ## Proxy Config Key Reference
 
 Below is a complete example of all the configuration options available


### PR DESCRIPTION
Respective page being edited: https://www.consul.io/docs/connect/proxies/built-in