### PR TITLE
docs: Fixing Prometheus link in docs/agent/telemetry

### DIFF
--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -18,7 +18,7 @@ When telemetry is being streamed to an external metrics store, the interval is d
 |External Store|Interval (seconds)|
 |:--------|:--------|
 |[dogstatsd](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent#how-it-works)|10s|
-|[Prometheus](https://vector.dev/docs/reference/configuration/sinks/prometheus_exporter/#flush_period_secshttps://vector.dev/docs/reference/configuration/sinks/prometheus_exporter/#flush_period_secs)| 60s|
+|[Prometheus](https://vector.dev/docs/reference/configuration/sinks/prometheus_exporter/#flush_period_secs)| 60s|
 |[statsd](https://github.com/statsd/statsd/blob/master/docs/metric_types.md#timing)|10s|
 
 To view this data, you must send a signal to the Consul process: on Unix,


### PR DESCRIPTION
## What/Why

Noticed a broken link while working on a project that consumes these docs. This PR fixes the link.

## Testing

- [ ] Go to https://consul-git-docs-amb-fix-prometheus-link-hashicorp.vercel.app/docs/agent/telemetry
- [ ] In the second row of the table in the first section, click the Prometheus link
- [ ] You should now be taken to the `flush_period_secs` of the linked page, like this:

![image](https://user-images.githubusercontent.com/43934258/156256875-6c50efeb-51ec-4d3b-8785-9d17a06703f9.png)
