### PR TITLE
build: ensure 'make linux' puts the binary in the expected location

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -178,8 +178,8 @@ endif
 
 # linux builds a linux binary independent of the source platform
 linux:
-	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./bin -ldflags "$(GOLDFLAGS)" -tags "$(GOTAGS)"
+	@mkdir -p ./pkg/bin/linux_amd64
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./pkg/bin/linux_amd64 -ldflags "$(GOLDFLAGS)" -tags "$(GOTAGS)"
 
 # dist builds binaries for all platforms and packages them for distribution
 dist:


### PR DESCRIPTION
Fixes regression from #10833

Fixes `dev-docker` and `test-docker` make targets