### PR TITLE
Add a smaller interface for protobuf-generated message types to implement

### DIFF
--- a/agent/consul/auto_config_backend.go
+++ b/agent/consul/auto_config_backend.go
@@ -16,7 +16,7 @@ type autoConfigBackend struct {
 	Server *Server
 }
 
-func (b autoConfigBackend) ForwardRPC(method string, info structs.RPCInfo, reply interface{}) (bool, error) {
+func (b autoConfigBackend) ForwardRPC(method string, info structs.RPCRequest, reply interface{}) (bool, error) {
 	return b.Server.ForwardRPC(method, info, reply)
 }
 

--- a/agent/consul/auto_config_endpoint.go
+++ b/agent/consul/auto_config_endpoint.go
@@ -119,7 +119,7 @@ func (a *jwtAuthorizer) Authorize(req *pbautoconf.AutoConfigRequest) (AutoConfig
 type AutoConfigBackend interface {
 	CreateACLToken(template *structs.ACLToken) (*structs.ACLToken, error)
 	DatacenterJoinAddresses(partition, segment string) ([]string, error)
-	ForwardRPC(method string, info structs.RPCInfo, reply interface{}) (bool, error)
+	ForwardRPC(method string, info structs.RPCRequest, reply interface{}) (bool, error)
 	GetCARoots() (*structs.IndexedCARoots, error)
 	SignCertificate(csr *x509.CertificateRequest, id connect.CertURI) (*structs.IssuedCert, error)
 }

--- a/agent/consul/auto_config_endpoint_test.go
+++ b/agent/consul/auto_config_endpoint_test.go
@@ -45,7 +45,7 @@ func (m *mockAutoConfigBackend) DatacenterJoinAddresses(partition, segment strin
 	return addrs, ret.Error(1)
 }
 
-func (m *mockAutoConfigBackend) ForwardRPC(method string, req structs.RPCInfo, reply interface{}) (bool, error) {
+func (m *mockAutoConfigBackend) ForwardRPC(method string, req structs.RPCRequest, reply interface{}) (bool, error) {
 	ret := m.Called(method, req, reply)
 	return ret.Bool(0), ret.Error(1)
 }

--- a/agent/consul/subscribe_backend.go
+++ b/agent/consul/subscribe_backend.go
@@ -26,7 +26,7 @@ func (s subscribeBackend) ResolveTokenAndDefaultMeta(
 
 var _ subscribe.Backend = (*subscribeBackend)(nil)
 
-func (s subscribeBackend) Forward(info structs.RPCInfo, f func(*grpc.ClientConn) error) (handled bool, err error) {
+func (s subscribeBackend) Forward(info structs.RPCRequest, f func(*grpc.ClientConn) error) (handled bool, err error) {
 	return s.srv.ForwardGRPC(s.connPool, info, f)
 }
 

--- a/agent/rpc/subscribe/subscribe.go
+++ b/agent/rpc/subscribe/subscribe.go
@@ -37,7 +37,7 @@ var _ pbsubscribe.StateChangeSubscriptionServer = (*Server)(nil)
 
 type Backend interface {
 	ResolveTokenAndDefaultMeta(token string, entMeta *structs.EnterpriseMeta, authzContext *acl.AuthorizerContext) (acl.Authorizer, error)
-	Forward(info structs.RPCInfo, f func(*grpc.ClientConn) error) (handled bool, err error)
+	Forward(info structs.RPCRequest, f func(*grpc.ClientConn) error) (handled bool, err error)
 	Subscribe(req *stream.SubscribeRequest) (*stream.Subscription, error)
 }
 

--- a/agent/rpc/subscribe/subscribe_test.go
+++ b/agent/rpc/subscribe/subscribe_test.go
@@ -319,7 +319,7 @@ func (b testBackend) ResolveTokenAndDefaultMeta(
 	return b.authorizer(token, entMeta), nil
 }
 
-func (b testBackend) Forward(_ structs.RPCInfo, fn func(*gogrpc.ClientConn) error) (handled bool, err error) {
+func (b testBackend) Forward(_ structs.RPCRequest, fn func(*gogrpc.ClientConn) error) (handled bool, err error) {
 	if b.forwardConn != nil {
 		return true, fn(b.forwardConn)
 	}

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -202,6 +202,13 @@ func ValidStatus(s string) bool {
 	return s == api.HealthPassing || s == api.HealthWarning || s == api.HealthCritical
 }
 
+// RPCRequest is a shim that allows structs to implement a single method
+// for a given RPC request rather than all of RPCInfo at once.
+// This is relevant as we phase away from gogo-protobuf's embedding features.
+type RPCRequest interface {
+	RPCInfo() RPCInfo
+}
+
 // RPCInfo is used to describe common information about query
 type RPCInfo interface {
 	RequestDatacenter() string

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -207,11 +207,11 @@ func ValidStatus(s string) bool {
 // This is relevant as we phase away from gogo-protobuf's embedding features.
 type RPCRequest interface {
 	RPCInfo() RPCInfo
+	RequestDatacenter() string
 }
 
 // RPCInfo is used to describe common information about query
 type RPCInfo interface {
-	RequestDatacenter() string
 	IsRead() bool
 	AllowStaleRead() bool
 	TokenSecret() string
@@ -329,6 +329,10 @@ func (q QueryOptions) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime,
 	return time.Since(start) > rpcHoldTimeout
 }
 
+func (q QueryOptions) RPCInfo() RPCInfo {
+	return &q
+}
+
 type WriteRequest struct {
 	// Token is the ACL token ID. If not provided, the 'anonymous'
 	// token is assumed for backwards compatibility.
@@ -354,6 +358,10 @@ func (w *WriteRequest) SetTokenSecret(s string) {
 
 func (w WriteRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
 	return time.Since(start) > rpcHoldTimeout
+}
+
+func (w WriteRequest) RPCInfo() RPCInfo {
+	return &w
 }
 
 type QueryBackend int

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -202,9 +202,11 @@ func ValidStatus(s string) bool {
 	return s == api.HealthPassing || s == api.HealthWarning || s == api.HealthCritical
 }
 
-// RPCRequest is a shim that allows structs to implement a single method
-// for a given RPC request rather than all of RPCInfo at once.
-// This is relevant as we phase away from gogo-protobuf's embedding features.
+// RPCRequest is a shim that allows structs to implement a smaller interface
+// without embedding types like QueryOptions, WriteRequest, ReadRequest, etc.
+// This is relevant for protobuf types as we phase away from gogo-protobuf's
+// embedding features. Protobuf-generated types should have fields that implement
+// RPCInfo instead of implementing it themselves.
 type RPCRequest interface {
 	RPCInfo() RPCInfo
 	RequestDatacenter() string

--- a/agent/submatview/store_integration_test.go
+++ b/agent/submatview/store_integration_test.go
@@ -146,7 +146,7 @@ func (b backend) ResolveTokenAndDefaultMeta(string, *structs.EnterpriseMeta, *ac
 	return acl.AllowAll(), nil
 }
 
-func (b backend) Forward(structs.RPCInfo, func(*grpc.ClientConn) error) (handled bool, err error) {
+func (b backend) Forward(structs.RPCRequest, func(*grpc.ClientConn) error) (handled bool, err error) {
 	return false, nil
 }
 

--- a/proto/pbautoconf/auto_config.go
+++ b/proto/pbautoconf/auto_config.go
@@ -1,6 +1,10 @@
 package pbautoconf
 
-import "time"
+import (
+	"time"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
 
 func (req *AutoConfigRequest) RequestDatacenter() string {
 	return req.Datacenter
@@ -24,4 +28,8 @@ func (req *AutoConfigRequest) SetTokenSecret(token string) {
 
 func (req *AutoConfigRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
 	return time.Since(start) > rpcHoldTimeout
+}
+
+func (req *AutoConfigRequest) RPCInfo() structs.RPCInfo {
+	return req
 }

--- a/proto/pbcommon/common.go
+++ b/proto/pbcommon/common.go
@@ -82,6 +82,10 @@ func (q QueryOptions) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime,
 	return o.HasTimedOut(start, rpcHoldTimeout, maxQueryTime, defaultQueryTime)
 }
 
+func (q QueryOptions) RPCInfo() structs.RPCInfo {
+	return &q
+}
+
 // SetFilter is needed to implement the structs.QueryOptionsCompat interface
 func (q *QueryOptions) SetFilter(filter string) {
 	q.Filter = filter
@@ -140,6 +144,10 @@ func (w WriteRequest) HasTimedOut(start time.Time, rpcHoldTimeout, _, _ time.Dur
 	return time.Since(start) > rpcHoldTimeout
 }
 
+func (w *WriteRequest) RPCInfo() structs.RPCInfo {
+	return w
+}
+
 // IsRead implements structs.RPCInfo
 func (r *ReadRequest) IsRead() bool {
 	return true
@@ -164,6 +172,10 @@ func (r *ReadRequest) SetTokenSecret(token string) {
 // HasTimedOut implements structs.RPCInfo
 func (r *ReadRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
 	return time.Since(start) > rpcHoldTimeout
+}
+
+func (r *ReadRequest) RPCInfo() structs.RPCInfo {
+	return r
 }
 
 // RequestDatacenter implements structs.RPCInfo

--- a/proto/pbsubscribe/subscribe.go
+++ b/proto/pbsubscribe/subscribe.go
@@ -1,6 +1,10 @@
 package pbsubscribe
 
-import "time"
+import (
+	"time"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
 
 // RequestDatacenter implements structs.RPCInfo
 func (req *SubscribeRequest) RequestDatacenter() string {
@@ -30,4 +34,8 @@ func (req *SubscribeRequest) SetTokenSecret(token string) {
 // HasTimedOut implements structs.RPCInfo
 func (req *SubscribeRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
 	return time.Since(start) > rpcHoldTimeout
+}
+
+func (req *SubscribeRequest) RPCInfo() structs.RPCInfo {
+	return req
 }


### PR DESCRIPTION
Since we are phasing out gogo-protobuf moving forwards, we lose the convenience of generated files already implementing `RPCInfo`. This interface will reduce the number of methods that generated types will manually have to implement.