### PR TITLE
server: fix spurious blocking query suppression for discovery chains

### DIFF
--- a/.changelog/12512.txt
+++ b/.changelog/12512.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: fix spurious blocking query suppression for discovery chains
+```

--- a/agent/consul/discovery_chain_endpoint.go
+++ b/agent/consul/discovery_chain_endpoint.go
@@ -66,7 +66,7 @@ func (c *DiscoveryChain) Get(args *structs.DiscoveryChainRequest, reply *structs
 				OverrideProtocol:       args.OverrideProtocol,
 				OverrideConnectTimeout: args.OverrideConnectTimeout,
 			}
-			index, chain, err := state.ServiceDiscoveryChain(ws, args.Name, entMeta, req)
+			index, chain, entries, err := state.ServiceDiscoveryChain(ws, args.Name, entMeta, req)
 			if err != nil {
 				return err
 			}
@@ -93,7 +93,7 @@ func (c *DiscoveryChain) Get(args *structs.DiscoveryChainRequest, reply *structs
 			reply.Index = index
 			reply.Chain = chain
 
-			if chain.IsDefault() {
+			if entries.IsEmpty() {
 				return errNotFound
 			}
 


### PR DESCRIPTION
Minor fix for behavior in #12362

`IsDefault` sometimes returns `true` even if there was a `proxy-defaults` or `service-defaults` config entry that was consulted. This PR fixes that.
