### PR TITLE
docs: Envoy 'compatibility' typo

### DIFF
--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -30,7 +30,7 @@ Envoy must be run with the `--max-obj-name-len` option set to `256` or greater f
 
 ## Supported Versions
 
-The following matrix describes Envoy compatability for the currently supported **n-2 major Consul releases**. For previous Consul version compatability please view the respective versioned docs for this page. 
+The following matrix describes Envoy compatibility for the currently supported **n-2 major Consul releases**. For previous Consul version compatability please view the respective versioned docs for this page. 
 
 Consul supports **four major Envoy releases** at the beginning of each major Consul release. Consul maintains compatibility with Envoy patch releases for each major version so that users can benefit from bug and security fixes in Envoy. As a policy, Consul will add support for a new major versions of Envoy in a Consul major release. Support for newer versions of Envoy will not be added to existing releases.
 


### PR DESCRIPTION
Typo on Envoy support matrix paragraph