### PR TITLE
Added Consul enterprise version image

### DIFF
--- a/website/content/docs/k8s/installation/vault/enterprise-license.mdx
+++ b/website/content/docs/k8s/installation/vault/enterprise-license.mdx
@@ -80,6 +80,7 @@ use the enterprise license key in Vault:
 
 ```yaml
 global:
+  image: hashicorp/consul-enterprise:1.11.0-ent
   secretsBackend:
     vault:
       enabled: true

--- a/website/content/docs/k8s/installation/vault/enterprise-license.mdx
+++ b/website/content/docs/k8s/installation/vault/enterprise-license.mdx
@@ -80,7 +80,7 @@ use the enterprise license key in Vault:
 
 ```yaml
 global:
-  image: hashicorp/consul-enterprise:1.11.0-ent
+  image: hashicorp/consul-enterprise:1.12.0-ent
   secretsBackend:
     vault:
       enabled: true


### PR DESCRIPTION
Not sure if there's a better way but I added this to ensure Consul is really looking for the Ent License when it comes up. Basically, I just set the image to deploy an Ent version of Consul so that it will then retrieve from Vault. Otherwise, user can't really tell if it's working or not. Maybe there's a better way to confirm?