### PR TITLE
ui: Catalog Health Overview DataSource

### DIFF
--- a/ui/packages/consul-ui/app/services/repository/dc.mdx
+++ b/ui/packages/consul-ui/app/services/repository/dc.mdx
@@ -2,6 +2,24 @@
 
 ```hbs preview-template
 <figure>
+  <figcaption>URI: <code>/:partition/:nspace/:dc/catalog/health</code></figcaption>
+  <DataSource
+    @src={{
+      uri '/${partition}/${nspace}/${dc}/catalog/health'
+      (hash
+        partition='partition'
+        nspace='ns'
+        dc='dc1'
+      )
+    }}
+    @onchange={{action (mut data) value="data"}}
+  />
+  <pre><code>{{json-stringify data null 4}}</code></pre>
+</figure>
+```
+
+```hbs preview-template
+<figure>
   <figcaption>URI: <code>/:partition/:nspace/:dc/datacenters</code></figcaption>
   <DataSource
     @src={{

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/catalog-overview
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/catalog-overview
@@ -1,0 +1,67 @@
+${[0].map(_ => {
+
+  const healthOf = num => {
+    return range(num).reduce((prev, _) => {
+      prev[fake.helpers.randomize(['Passing', 'Warning', 'Critical'])] ++;
+      return prev;
+    }, {Passing: 0, Warning: 0, Critical: 0});
+  }
+
+  const partitionCount = env('CONSUL_PARTITION_COUNT', Math.floor(Math.random() * 5));
+  const nspaceCount = env('CONSUL_NSPACE_COUNT', Math.floor(Math.random() * 10));
+  const nodes = env('CONSUL_NODE_COUNT', Math.floor(Math.random() * 10));
+  const services = env('CONSUL_SERVICE_COUNT', Math.floor(Math.random() * 10));
+  const checks = env('CONSUL_CHECK_COUNT', Math.floor(Math.random() * 10));
+
+  const partitions = range(partitionCount).map((_, i) => `${fake.hacker.noun()}-partition-${i}`);
+  const nspaces = range(nspaceCount).map((_, i) => `${fake.hacker.noun()}-nspace-${i}`);
+
+return `
+{
+  "Nodes": [
+${partitions.map(partition => {
+  const health = healthOf(nodes);
+return nspaces.map(nspace => `
+    {
+      "Total": ${nodes},
+      "Passing": ${health.Passing},
+      "Warning": ${health.Warning},
+      "Critical": ${health.Critical},
+      "Partition": "${partition}",
+      "Namespace": "${nspace}"
+    }
+`)}).flat()}
+  ],
+  "Services": [
+${partitions.map((partition, i) => {
+  const health = healthOf(services);
+return nspaces.map((nspace, j) => `
+    {
+      "Name": "${fake.hacker.noun()}-service-${i * j}",
+      "Total": ${services},
+      "Passing": ${health.Passing},
+      "Warning": ${health.Warning},
+      "Critical": ${health.Critical},
+      "Partition": "${partition}",
+      "Namespace": "${nspace}"
+    }
+`)}).flat()}
+  ],
+  "Checks": [
+${partitions.map((partition, i) => {
+  const health = healthOf(checks);
+return nspaces.map((nspace, j) => `
+    {
+      "Name": "${fake.hacker.noun()}-check-${i * j}",
+      "Total": ${services},
+      "Passing": ${health.Passing},
+      "Warning": ${health.Warning},
+      "Critical": ${health.Critical},
+      "Partition": "${partition}",
+      "Namespace": "${nspace}"
+    }
+`)}).flat()}
+  ]
+}
+`;
+})}


### PR DESCRIPTION
This PR adds a new currently non-existing endpoint in Consul.

The endpoint shows the health of the catalog as a whole (as opposed to the health of the Cluster itself). Again this is _per datacenter_, so whilst we've called it `catalog/health` is lives in the Dc Repository for the moment. The backend will give us a grouping of 'totals' per partition/namespace to we do an additional aggregation on the frontend to give us totals over:

1. All partitions
2. All namespaces
3. The entire datacenter/catalog

I set the poll to 30 seconds again.

Small note: We are getting to the point that these dataSource methods could very well just be functions rather than a method on a class - i.e. Repositories are becoming less tied to EmberData models and/or Ember Services.

[Rendered Docs](https://consul-ui-staging-azaji1z0i-hashicorp.vercel.app/ui/docs/repositories/dc)

This new one is the top one in the docs, still thinking of how I can improve these new repository docs, probably need some deeplinking happening or something 🤔 . One for the future.
