### PR TITLE
Add `Meta` to `ServiceConfigResponse`

### DIFF
--- a/.changelog/12529.txt
+++ b/.changelog/12529.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+server: Ensure that service-defaults `Meta` to is included in `ServiceConfigResponse`.
+```

--- a/.changelog/12529.txt
+++ b/.changelog/12529.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-server: Ensure that service-defaults `Meta` to is included in `ServiceConfigResponse`.
+server: Ensure that service-defaults `Meta` is returned with the response to the `ConfigEntry.ResolveServiceConfig` RPC.
 ```

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -591,6 +591,8 @@ func (c *ConfigEntry) computeResolvedServiceConfig(
 		if serviceConf.Mode != structs.ProxyModeDefault {
 			thisReply.Mode = serviceConf.Mode
 		}
+
+		thisReply.Meta = serviceConf.Meta
 	}
 
 	// First collect all upstreams into a set of seen upstreams.

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1029,12 +1029,11 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 			"foo": 1,
 		},
 	}))
-	meta := map[string]string{"foo": "bar"}
 	require.NoError(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
 		Name:     "foo",
 		Protocol: "http",
-		Meta:     meta,
+		Meta:     map[string]string{"foo": "bar"},
 	}))
 	require.NoError(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
@@ -1060,7 +1059,7 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 				"protocol": "grpc",
 			},
 		},
-		Meta: meta,
+		Meta: map[string]string{"foo": "bar"},
 		// Don't know what this is deterministically
 		QueryMeta: out.QueryMeta,
 	}

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1029,10 +1029,12 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 			"foo": 1,
 		},
 	}))
+	meta := map[string]string{"foo": "bar"}
 	require.NoError(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
 		Name:     "foo",
 		Protocol: "http",
+		Meta:     meta,
 	}))
 	require.NoError(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
@@ -1058,6 +1060,7 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 				"protocol": "grpc",
 			},
 		},
+		Meta: meta,
 		// Don't know what this is deterministically
 		QueryMeta: out.QueryMeta,
 	}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -985,7 +985,7 @@ type ServiceConfigResponse struct {
 	Expose            ExposeConfig           `json:",omitempty"`
 	TransparentProxy  TransparentProxyConfig `json:",omitempty"`
 	Mode              ProxyMode              `json:",omitempty"`
-	Meta              map[string]string
+	Meta              map[string]string      `json:",omitempty"`
 	QueryMeta
 }
 

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -985,6 +985,7 @@ type ServiceConfigResponse struct {
 	Expose            ExposeConfig           `json:",omitempty"`
 	TransparentProxy  TransparentProxyConfig `json:",omitempty"`
 	Mode              ProxyMode              `json:",omitempty"`
+	Meta              map[string]string
 	QueryMeta
 }
 


### PR DESCRIPTION
This ensures that terminating gateway proxycfg snapshots have `Meta` populated on `ServiceConfigs`. The `Meta` key on `ServiceConfigResponse` will end up being used to configure the serverless plugin.