### PR TITLE
test: switch many tests to avoid using the disk

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1049,6 +1049,7 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 
 	// Apply dev mode
 	cfg.DevMode = runtimeCfg.DevMode
+	cfg.DisablePersistence = cfg.DevMode
 
 	// Override with our runtimeCfg
 	// todo(fs): these are now always set in the runtime runtimeCfg so we can simplify this

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -161,6 +161,7 @@ func newBuilder(opts LoadOpts) (*builder, error) {
 
 	if boolVal(opts.DevMode) {
 		b.Head = append(b.Head, DevSource())
+		b.Head = append(b.Head, DisablePersistenceSource())
 	}
 
 	// Since the merge logic is to overwrite all fields with later

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -175,6 +175,16 @@ func DevSource() Source {
 	}
 }
 
+func DisablePersistenceSource() Source {
+	return FileSource{
+		Name:   "dev",
+		Format: "hcl",
+		Data: `
+		disable_keyring_file = true
+	`,
+	}
+}
+
 // NonUserSource contains the values the user cannot configure.
 // This needs to be merged in the tail.
 // TODO: return a LiteralSource (no decoding) instead of a FileSource

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -98,6 +98,9 @@ type Config struct {
 	// DevMode is used to enable a development server mode.
 	DevMode bool
 
+	// DisablePersistence is used to disable use of the disk (for dev and testing purposes).
+	DisablePersistence bool
+
 	// NodeID is a unique identifier for this node across space and time.
 	NodeID types.NodeID
 

--- a/agent/consul/coordinate_endpoint_test.go
+++ b/agent/consul/coordinate_endpoint_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -42,16 +41,14 @@ func TestCoordinate_Update(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.CoordinateUpdatePeriod = 500 * time.Millisecond
 		c.CoordinateUpdateBatchSize = 5
 		c.CoordinateUpdateMaxBatches = 2
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
 	codec := rpcClient(t, s1)
-	defer codec.Close()
+
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	// Register some nodes.
@@ -188,16 +185,14 @@ func TestCoordinate_Update_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -242,11 +237,9 @@ func TestCoordinate_ListDatacenters(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -277,12 +270,10 @@ func TestCoordinate_ListNodes(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
+
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Register some nodes.
@@ -346,16 +337,14 @@ func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -463,12 +452,10 @@ func TestCoordinate_Node(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
+
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	// Register some nodes.
@@ -521,16 +508,14 @@ func TestCoordinate_Node_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 

--- a/agent/consul/discovery_chain_endpoint_test.go
+++ b/agent/consul/discovery_chain_endpoint_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -22,17 +21,14 @@ func TestDiscoveryChainEndpoint_Get(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
@@ -250,11 +246,9 @@ func TestDiscoveryChainEndpoint_Get_BlockOnNoChange(t *testing.T) {
 
 	t.Parallel()
 
-	_, s1 := testServerWithConfig(t, func(c *Config) {
-		c.DevMode = true // keep it in ram to make it 10x faster on macos
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 	})
-
 	codec := rpcClient(t, s1)
 
 	waitForLeaderEstablishment(t, s1)

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -24,11 +24,9 @@ func TestHealth_ChecksInState(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -75,11 +73,9 @@ func TestHealth_ChecksInState_NodeMetaFilter(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -175,11 +171,9 @@ func TestHealth_ChecksInState_DistanceSort(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	if err := s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.2"}); err != nil {
@@ -257,11 +251,9 @@ func TestHealth_NodeChecks(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -303,11 +295,9 @@ func TestHealth_ServiceChecks(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -354,11 +344,9 @@ func TestHealth_ServiceChecks_NodeMetaFilter(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -464,11 +452,9 @@ func TestHealth_ServiceChecks_DistanceSort(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	if err := s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.2"}); err != nil {
@@ -557,11 +543,9 @@ func TestHealth_ServiceNodes(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -684,11 +668,9 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -750,11 +732,9 @@ func TestHealth_ServiceNodes_NodeMetaFilter(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -885,11 +865,9 @@ func TestHealth_ServiceNodes_DistanceSort(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	if err := s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.2"}); err != nil {
@@ -979,16 +957,13 @@ func TestHealth_ServiceNodes_ConnectProxy_ACL(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -1077,12 +1052,8 @@ func TestHealth_ServiceNodes_Gateway(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 	{
@@ -1195,11 +1166,9 @@ func TestHealth_ServiceNodes_Ingress(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -1285,16 +1254,14 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -1590,11 +1557,9 @@ func TestHealth_RPC_Filter(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -22,11 +21,8 @@ func TestIntentionApply_new(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -111,11 +107,8 @@ func TestIntentionApply_defaultSourceType(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -160,11 +153,8 @@ func TestIntentionApply_createWithID(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -194,11 +184,8 @@ func TestIntentionApply_updateGood(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -280,11 +267,8 @@ func TestIntentionApply_updateNonExist(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -313,11 +297,8 @@ func TestIntentionApply_deleteGood(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -371,11 +352,8 @@ func TestIntentionApply_WithoutIDs(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -859,16 +837,13 @@ func TestIntentionApply_aclDeny(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1248,16 +1223,13 @@ func TestIntentionApply_aclDelete(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1313,16 +1285,13 @@ func TestIntentionApply_aclUpdate(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1366,16 +1335,13 @@ func TestIntentionApply_aclManagement(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1410,16 +1376,13 @@ func TestIntentionApply_aclUpdateChange(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1460,16 +1423,13 @@ func TestIntentionGet_acl(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1561,12 +1521,9 @@ func TestIntentionList(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
+
 	waitForLeaderEstablishment(t, s1)
 
 	// Test with no intentions inserted yet
@@ -1589,11 +1546,8 @@ func TestIntentionList_acl(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, testServerACLConfig)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t, testServerACLConfig)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1677,11 +1631,8 @@ func TestIntentionMatch_good(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1749,9 +1700,7 @@ func TestIntentionMatch_BlockOnNoChange(t *testing.T) {
 
 	t.Parallel()
 
-	_, s1 := testServerWithConfig(t, func(c *Config) {
-		c.DevMode = true // keep it in ram to make it 10x faster on macos
-	})
+	s1 := testServerWithConfigNoPersistence(t) // keep it in ram to make it 10x faster on macos
 
 	codec := rpcClient(t, s1)
 
@@ -1928,11 +1877,8 @@ func TestIntentionCheck_defaultNoACL(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1958,16 +1904,13 @@ func TestIntentionCheck_defaultACLDeny(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -1994,16 +1937,13 @@ func TestIntentionCheck_defaultACLAllow(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "allow"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 
@@ -2030,16 +1970,13 @@ func TestIntentionCheck_aclDeny(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -26,11 +26,9 @@ func TestInternal_NodeInfo(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -84,11 +82,9 @@ func TestInternal_NodeDump(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -180,11 +176,9 @@ func TestInternal_NodeDump_Filter(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -247,14 +241,12 @@ func TestInternal_KeyringOperation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.SerfLANConfig.MemberlistConfig.SecretKey = keyBytes1
 		c.SerfWANConfig.MemberlistConfig.SecretKey = keyBytes1
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -287,13 +279,11 @@ func TestInternal_KeyringOperation(t *testing.T) {
 	}
 
 	// Start a second agent to test cross-dc queries
-	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.SerfLANConfig.MemberlistConfig.SecretKey = keyBytes1
 		c.SerfWANConfig.MemberlistConfig.SecretKey = keyBytes1
 		c.Datacenter = "dc2"
 	})
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
 
 	// Try to join
 	joinWAN(t, s2, s1)
@@ -334,25 +324,21 @@ func TestInternal_KeyringOperationList_LocalOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.SerfLANConfig.MemberlistConfig.SecretKey = keyBytes1
 		c.SerfWANConfig.MemberlistConfig.SecretKey = keyBytes1
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Start a second agent to test cross-dc queries
-	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.SerfLANConfig.MemberlistConfig.SecretKey = keyBytes1
 		c.SerfWANConfig.MemberlistConfig.SecretKey = keyBytes1
 		c.Datacenter = "dc2"
 	})
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
 
 	// Try to join
 	joinWAN(t, s2, s1)
@@ -419,14 +405,12 @@ func TestInternal_KeyringOperationWrite_LocalOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.SerfLANConfig.MemberlistConfig.SecretKey = keyBytes1
 		c.SerfWANConfig.MemberlistConfig.SecretKey = keyBytes1
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -568,18 +552,15 @@ func TestInternal_EventFire_Token(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir, srv := testServerWithConfig(t, func(c *Config) {
+
+	srv := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDownPolicy = "deny"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir)
-	defer srv.Shutdown()
-
 	codec := rpcClient(t, srv)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, srv.RPC, "dc1")
 
@@ -608,11 +589,9 @@ func TestInternal_ServiceDump(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -705,11 +684,9 @@ func TestInternal_ServiceDump_Kind(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -766,18 +743,15 @@ func TestInternal_ServiceDump_ACL(t *testing.T) {
 
 	t.Parallel()
 
-	dir, s := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir)
-	defer s.Shutdown()
-	codec := rpcClient(t, s)
-	defer codec.Close()
+	codec := rpcClient(t, s1)
 
-	testrpc.WaitForLeader(t, s.RPC, "dc1")
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	registrations := []*structs.RegisterRequest{
 		// Service `redis` on `node1`
@@ -971,11 +945,9 @@ func TestInternal_GatewayServiceDump_Terminating(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -1175,16 +1147,14 @@ func TestInternal_GatewayServiceDump_Terminating_ACL(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -1306,11 +1276,9 @@ func TestInternal_GatewayServiceDump_Ingress(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -1521,16 +1489,14 @@ func TestInternal_GatewayServiceDump_Ingress_ACL(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -1666,12 +1632,9 @@ func TestInternal_GatewayIntentions(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -1780,11 +1743,8 @@ func TestInternal_GatewayIntentions_aclDeny(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	dir1, s1 := testServerWithConfig(t, testServerACLConfig)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t, testServerACLConfig)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken(TestDefaultInitialManagementToken))
 
@@ -1904,14 +1864,11 @@ func TestInternal_ServiceTopology(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
+	codec := rpcClient(t, s1)
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-
-	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	// wildcard deny intention
 	// ingress-gateway on node edge - upstream: api
@@ -2130,14 +2087,11 @@ func TestInternal_ServiceTopology_RoutingConfig(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
+	codec := rpcClient(t, s1)
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-
-	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	// dashboard -> routing-config -> { counting, counting-v2 }
 	registerTestRoutingConfigTopologyEntries(t, codec)
@@ -2185,19 +2139,16 @@ func TestInternal_ServiceTopology_ACL(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = TestDefaultInitialManagementToken
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-
-	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	// wildcard deny intention
 	// ingress-gateway on node edge - upstream: api
@@ -2280,14 +2231,11 @@ func TestInternal_IntentionUpstreams(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
+	codec := rpcClient(t, s1)
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-
-	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	// Services:
 	// api and api-proxy on node foo
@@ -2325,10 +2273,7 @@ func TestInternal_IntentionUpstreams_BlockOnNoChange(t *testing.T) {
 
 	t.Parallel()
 
-	_, s1 := testServerWithConfig(t, func(c *Config) {
-		c.DevMode = true // keep it in ram to make it 10x faster on macos
-	})
-
+	s1 := testServerWithConfigNoPersistence(t) // keep it in ram to make it 10x faster on macos
 	codec := rpcClient(t, s1)
 
 	waitForLeaderEstablishment(t, s1)
@@ -2407,19 +2352,16 @@ func TestInternal_IntentionUpstreams_ACL(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = TestDefaultInitialManagementToken
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-
-	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	// Services:
 	// api and api-proxy on node foo

--- a/agent/consul/kvs_endpoint_test.go
+++ b/agent/consul/kvs_endpoint_test.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -20,11 +19,9 @@ func TestKVS_Apply(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -81,16 +78,14 @@ func TestKVS_Apply_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -134,11 +129,9 @@ func TestKVS_Get(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -186,16 +179,14 @@ func TestKVS_Get_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -231,11 +222,9 @@ func TestKVSEndpoint_List(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -310,11 +299,9 @@ func TestKVSEndpoint_List_Blocking(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -356,7 +343,11 @@ func TestKVSEndpoint_List_Blocking(t *testing.T) {
 	start := time.Now()
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		codec := rpcClient(t, s1)
+		codec, err := rpcClientNoClose(s1)
+		if err != nil {
+			t.Errorf("err: %v", err)
+			return
+		}
 		defer codec.Close()
 		arg := structs.KVSRequest{
 			Datacenter: "dc1",
@@ -410,16 +401,14 @@ func TestKVSEndpoint_List_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -489,17 +478,15 @@ func TestKVSEndpoint_List_ACLEnableKeyListPolicy(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 		c.ACLEnableKeyListPolicy = true
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -604,11 +591,9 @@ func TestKVSEndpoint_ListKeys(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -681,16 +666,14 @@ func TestKVSEndpoint_ListKeys_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -754,11 +737,9 @@ func TestKVS_Apply_LockDelay(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -830,11 +811,9 @@ func TestKVS_Issue_1626(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -44,7 +44,7 @@ func TestCAManager_Initialize_Vault_Secondary_SharedVault(t *testing.T) {
 
 	vault := ca.NewTestVaultServer(t)
 
-	_, serverDC1 := testServerWithConfig(t, func(c *Config) {
+	serverDC1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.CAConfig = &structs.CAConfiguration{
 			Provider: "vault",
 			Config: map[string]interface{}{
@@ -70,7 +70,7 @@ func TestCAManager_Initialize_Vault_Secondary_SharedVault(t *testing.T) {
 	})
 
 	runStep(t, "start secondary DC", func(t *testing.T) {
-		_, serverDC2 := testServerWithConfig(t, func(c *Config) {
+		serverDC2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.Datacenter = "dc2"
 			c.PrimaryDatacenter = "dc1"
 			c.CAConfig = &structs.CAConfiguration{
@@ -540,7 +540,8 @@ func TestCAManager_Initialize_Logging(t *testing.T) {
 	}
 
 	t.Parallel()
-	_, conf1 := testServerConfig(t)
+
+	conf1 := testServerConfigNoPersistence(t)
 
 	// Setup dummy logger to catch output
 	var buf bytes.Buffer
@@ -569,7 +570,7 @@ func TestCAManager_UpdateConfiguration_Vault_Primary(t *testing.T) {
 	ca.SkipIfVaultNotPresent(t)
 	vault := ca.NewTestVaultServer(t)
 
-	_, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.CAConfig = &structs.CAConfiguration{
 			Provider: "vault",
@@ -633,7 +634,7 @@ func TestCAManager_Initialize_Vault_WithIntermediateAsPrimaryCA(t *testing.T) {
 	meshRootPath := "pki-root"
 	primaryCert := setupPrimaryCA(t, vclient, meshRootPath, "")
 
-	_, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.CAConfig = &structs.CAConfiguration{
 			Provider: "vault",
 			Config: map[string]interface{}{
@@ -663,7 +664,7 @@ func TestCAManager_Initialize_Vault_WithIntermediateAsPrimaryCA(t *testing.T) {
 	// TODO: rotate root
 
 	runStep(t, "run secondary DC", func(t *testing.T) {
-		_, sDC2 := testServerWithConfig(t, func(c *Config) {
+		sDC2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.Datacenter = "dc2"
 			c.PrimaryDatacenter = "dc1"
 			c.CAConfig = &structs.CAConfiguration{
@@ -701,7 +702,7 @@ func TestCAManager_Verify_Vault_NoChangeToSecondaryConfig(t *testing.T) {
 
 	vault := ca.NewTestVaultServer(t)
 
-	_, sDC1 := testServerWithConfig(t, func(c *Config) {
+	sDC1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.CAConfig = &structs.CAConfiguration{
 			Provider: "vault",
 			Config: map[string]interface{}{
@@ -715,7 +716,7 @@ func TestCAManager_Verify_Vault_NoChangeToSecondaryConfig(t *testing.T) {
 	defer sDC1.Shutdown()
 	testrpc.WaitForActiveCARoot(t, sDC1.RPC, "dc1", nil)
 
-	_, sDC2 := testServerWithConfig(t, func(c *Config) {
+	sDC2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Datacenter = "dc2"
 		c.PrimaryDatacenter = "dc1"
 		c.CAConfig = &structs.CAConfiguration{
@@ -780,7 +781,7 @@ func TestCAManager_Initialize_Vault_WithExternalTrustedCA(t *testing.T) {
 	primaryCAPath := "pki-primary"
 	primaryCert := setupPrimaryCA(t, vclient, primaryCAPath, rootPEM)
 
-	_, serverDC1 := testServerWithConfig(t, func(c *Config) {
+	serverDC1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.CAConfig = &structs.CAConfiguration{
 			Provider: "vault",
 			Config: map[string]interface{}{
@@ -808,7 +809,7 @@ func TestCAManager_Initialize_Vault_WithExternalTrustedCA(t *testing.T) {
 		origLeaf = leafCert
 	})
 
-	_, serverDC2 := testServerWithConfig(t, func(c *Config) {
+	serverDC2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Datacenter = "dc2"
 		c.PrimaryDatacenter = "dc1"
 		c.CAConfig = &structs.CAConfiguration{

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -339,6 +339,7 @@ func TestCAManager_RenewIntermediate_Vault_Primary(t *testing.T) {
 		}
 	})
 	defer func() {
+		s1.Shutdown()
 		s1.leaderRoutineManager.Wait()
 	}()
 

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1299,7 +1299,6 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 
 	s2.tokens.UpdateReplicationToken("root", tokenStore.TokenSourceConfig)
 
-	testrpc.WaitForLeader(t, s2.RPC, "dc2")
 	waitForLeaderEstablishment(t, s2)
 
 	// Create the WAN link

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -28,14 +28,13 @@ func TestLeader_RegisterMember(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
 	dir2, c1 := testClient(t)
 	defer os.RemoveAll(dir2)
@@ -103,14 +102,13 @@ func TestLeader_FailedMember(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
 	dir2, c1 := testClient(t)
 	defer os.RemoveAll(dir2)
@@ -171,14 +169,13 @@ func TestLeader_LeftMember(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
 	dir2, c1 := testClient(t)
 	defer os.RemoveAll(dir2)
@@ -214,14 +211,13 @@ func TestLeader_ReapMember(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
 	dir2, c1 := testClient(t)
 	defer os.RemoveAll(dir2)
@@ -276,14 +272,13 @@ func TestLeader_ReapOrLeftMember_IgnoreSelf(t *testing.T) {
 
 	run := func(t *testing.T, status serf.MemberStatus, nameFn func(string) string) {
 		t.Parallel()
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.PrimaryDatacenter = "dc1"
 			c.ACLsEnabled = true
 			c.ACLInitialManagementToken = "root"
 			c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		nodeName := s1.config.NodeName
 		if nameFn != nil {
@@ -355,35 +350,30 @@ func TestLeader_CheckServersMeta(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "allow"
 		c.Bootstrap = true
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
-	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "allow"
 		c.Bootstrap = false
 	})
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
 
-	dir3, s3 := testServerWithConfig(t, func(c *Config) {
+	s3 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "allow"
 		c.Bootstrap = false
 	})
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
 
 	// Try to join
 	joinLAN(t, s1, s2)
@@ -463,35 +453,30 @@ func TestLeader_ReapServer(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "allow"
 		c.Bootstrap = true
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
-	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "allow"
 		c.Bootstrap = false
 	})
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
 
-	dir3, s3 := testServerWithConfig(t, func(c *Config) {
+	s3 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "allow"
 		c.Bootstrap = false
 	})
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
 
 	// Try to join
 	joinLAN(t, s1, s2)
@@ -542,14 +527,13 @@ func TestLeader_Reconcile_ReapMember(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -595,14 +579,13 @@ func TestLeader_Reconcile(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
 	dir2, c1 := testClient(t)
 	defer os.RemoveAll(dir2)
@@ -639,9 +622,8 @@ func TestLeader_Reconcile_Races(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -736,17 +718,20 @@ func TestLeader_LeftServer(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
-	dir2, s2 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 
-	dir3, s3 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = false
+	})
+
+	s3 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = false
+	})
 
 	// Put s1 last so we don't trigger a leader election.
 	servers := []*Server{s2, s3, s1}
@@ -779,17 +764,21 @@ func TestLeader_LeftLeader(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
-	dir2, s2 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 
-	dir3, s3 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = false
+	})
+
+	s3 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = false
+	})
+
 	servers := []*Server{s1, s2, s3}
 
 	// Try to join
@@ -845,13 +834,10 @@ func TestLeader_LeftLeader(t *testing.T) {
 
 func TestLeader_MultiBootstrap(t *testing.T) {
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
-	dir2, s2 := testServer(t)
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
+
+	s2 := testServerWithConfigNoPersistence(t)
 
 	servers := []*Server{s1, s2}
 
@@ -881,17 +867,21 @@ func TestLeader_TombstoneGC_Reset(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
-	dir2, s2 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 
-	dir3, s3 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = false
+	})
+
+	s3 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = false
+	})
+
 	servers := []*Server{s1, s2, s3}
 
 	// Try to join
@@ -947,7 +937,8 @@ func TestLeader_ReapTombstones(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
@@ -955,8 +946,6 @@ func TestLeader_ReapTombstones(t *testing.T) {
 		c.TombstoneTTL = 50 * time.Millisecond
 		c.TombstoneTTLGranularity = 10 * time.Millisecond
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -1022,26 +1011,21 @@ func TestLeader_RollRaftServer(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Bootstrap = true
 		c.Datacenter = "dc1"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
-	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Bootstrap = false
 		c.Datacenter = "dc1"
 	})
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
 
-	dir3, s3 := testServerWithConfig(t, func(c *Config) {
+	s3 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Bootstrap = false
 		c.Datacenter = "dc1"
 	})
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
 
 	servers := []*Server{s1, s2, s3}
 
@@ -1064,12 +1048,11 @@ func TestLeader_RollRaftServer(t *testing.T) {
 	}
 
 	// Replace the dead server with a new one
-	dir4, s4 := testServerWithConfig(t, func(c *Config) {
+	s4 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Bootstrap = false
 		c.Datacenter = "dc1"
 	})
-	defer os.RemoveAll(dir4)
-	defer s4.Shutdown()
+
 	joinLAN(t, s4, s1)
 	servers[1] = s4
 
@@ -1092,17 +1075,9 @@ func TestLeader_ChangeServerID(t *testing.T) {
 		c.Datacenter = "dc1"
 		c.RaftConfig.ProtocolVersion = 3
 	}
-	dir1, s1 := testServerWithConfig(t, conf)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
-	dir2, s2 := testServerWithConfig(t, conf)
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
-
-	dir3, s3 := testServerWithConfig(t, conf)
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t, conf)
+	s2 := testServerWithConfigNoPersistence(t, conf)
+	s3 := testServerWithConfigNoPersistence(t, conf)
 
 	servers := []*Server{s1, s2, s3}
 
@@ -1130,7 +1105,7 @@ func TestLeader_ChangeServerID(t *testing.T) {
 	})
 
 	// Bring up a new server with s3's address that will get a different ID
-	dir4, s4 := testServerWithConfig(t, func(c *Config) {
+	s4 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Bootstrap = false
 		c.BootstrapExpect = 3
 		c.Datacenter = "dc1"
@@ -1139,8 +1114,6 @@ func TestLeader_ChangeServerID(t *testing.T) {
 		c.RPCAddr = s3.config.RPCAddr
 		c.RPCAdvertise = s3.config.RPCAdvertise
 	})
-	defer os.RemoveAll(dir4)
-	defer s4.Shutdown()
 
 	joinLAN(t, s4, s1)
 	testrpc.WaitForLeader(t, s4.RPC, "dc1")
@@ -1168,17 +1141,20 @@ func TestLeader_ChangeNodeID(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
-	dir2, s2 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 
-	dir3, s3 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = false
+	})
+
+	s3 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = false
+	})
 
 	servers := []*Server{s1, s2, s3}
 
@@ -1204,13 +1180,12 @@ func TestLeader_ChangeNodeID(t *testing.T) {
 	})
 
 	// Bring up a new server with s3's name that will get a different ID
-	dir4, s4 := testServerWithConfig(t, func(c *Config) {
+	s4 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Bootstrap = false
 		c.Datacenter = "dc1"
 		c.NodeName = s3.config.NodeName
 	})
-	defer os.RemoveAll(dir4)
-	defer s4.Shutdown()
+
 	joinLAN(t, s4, s1)
 	servers[2] = s4
 
@@ -1257,9 +1232,8 @@ func TestLeader_ACL_Initialization(t *testing.T) {
 				c.ACLsEnabled = true
 				c.ACLInitialManagementToken = tt.initialManagement
 			}
-			dir1, s1 := testServerWithConfig(t, conf)
-			defer os.RemoveAll(dir1)
-			defer s1.Shutdown()
+			s1 := testServerWithConfigNoPersistence(t, conf)
+
 			testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 			if tt.initialManagement != "" {
@@ -1296,7 +1270,7 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 	// secondary. Hopefully it should transition to ENABLED instead of being
 	// stuck in LEGACY.
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	dir1, s1 := testServerWithConfigAndPersistence(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
@@ -1309,7 +1283,7 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 
 	waitForLeaderEstablishment(t, s1)
 
-	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+	dir2, s2 := testServerWithConfigAndPersistence(t, func(c *Config) {
 		c.Datacenter = "dc2"
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
@@ -1351,7 +1325,7 @@ func TestLeader_ACLUpgrade_IsStickyEvenIfSerfTagsRegress(t *testing.T) {
 
 	// Restart just s2
 
-	dir2new, s2new := testServerWithConfig(t, func(c *Config) {
+	dir2new, s2new := testServerWithConfigAndPersistence(t, func(c *Config) {
 		c.Datacenter = "dc2"
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
@@ -1385,14 +1359,13 @@ func TestLeader_ConfigEntryBootstrap(t *testing.T) {
 		},
 	}
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.Build = "1.5.0"
 		c.ConfigEntryBootstrap = []structs.ConfigEntry{
 			global_entry_init,
 		}
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	retry.Run(t, func(t *retry.R) {
@@ -1511,7 +1484,7 @@ func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
 				}
 			}()
 
-			_, config := testServerConfig(t)
+			config := testServerConfigNoPersistence(t)
 			config.Build = "1.6.0"
 			config.ConfigEntryBootstrap = tc.entries
 			if tc.serverCB != nil {
@@ -1568,13 +1541,11 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 	}
 
 	t.Run("one node primary with old version", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		updateSerfTags(s1, "ft_fs", "0")
 
@@ -1590,13 +1561,11 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 	})
 
 	t.Run("one node primary with new version", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
@@ -1623,26 +1592,22 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 	})
 
 	t.Run("two node primary with mixed versions", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		updateSerfTags(s1, "ft_fs", "0")
 
 		waitForLeaderEstablishment(t, s1)
 
-		dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node2"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 			c.Bootstrap = false
 		})
-		defer os.RemoveAll(dir2)
-		defer s2.Shutdown()
 
 		// Put s1 last so we don't trigger a leader election.
 		servers := []*Server{s2, s1}
@@ -1670,24 +1635,20 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 	})
 
 	t.Run("two node primary with new version", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
-		dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node2"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 			c.Bootstrap = false
 		})
-		defer os.RemoveAll(dir2)
-		defer s2.Shutdown()
 
 		// Put s1 last so we don't trigger a leader election.
 		servers := []*Server{s2, s1}
@@ -1728,17 +1689,15 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 	})
 
 	t.Run("primary and secondary with new version", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
-		dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node2"
 			c.Datacenter = "dc2"
 			c.PrimaryDatacenter = "dc1"
@@ -1746,8 +1705,6 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 			c.FederationStateReplicationBurst = 100
 			c.FederationStateReplicationApplyLimit = 1000000
 		})
-		defer os.RemoveAll(dir2)
-		defer s2.Shutdown()
 
 		waitForLeaderEstablishment(t, s2)
 
@@ -1798,19 +1755,17 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 	})
 
 	t.Run("primary and secondary with mixed versions", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		updateSerfTags(s1, "ft_fs", "0")
 
 		waitForLeaderEstablishment(t, s1)
 
-		dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node2"
 			c.Datacenter = "dc2"
 			c.PrimaryDatacenter = "dc1"
@@ -1818,8 +1773,6 @@ func TestDatacenterSupportsFederationStates(t *testing.T) {
 			c.FederationStateReplicationBurst = 100
 			c.FederationStateReplicationApplyLimit = 1000000
 		})
-		defer os.RemoveAll(dir2)
-		defer s2.Shutdown()
 
 		waitForLeaderEstablishment(t, s2)
 
@@ -1900,14 +1853,12 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 	defaultEntMeta := structs.DefaultEnterpriseMetaInDefaultPartition()
 
 	t.Run("one node primary with old version", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 			c.OverrideInitialSerfTags = disableServiceIntentions
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
@@ -1924,13 +1875,11 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 	})
 
 	t.Run("one node primary with new version", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
@@ -1979,25 +1928,21 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 	})
 
 	t.Run("two node primary with mixed versions", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 			c.OverrideInitialSerfTags = disableServiceIntentions
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
-		dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node2"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 			c.Bootstrap = false
 		})
-		defer os.RemoveAll(dir2)
-		defer s2.Shutdown()
 
 		// Put s1 last so we don't trigger a leader election.
 		servers := []*Server{s2, s1}
@@ -2032,24 +1977,20 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 	})
 
 	t.Run("two node primary with new version", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
-		dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node2"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 			c.Bootstrap = false
 		})
-		defer os.RemoveAll(dir2)
-		defer s2.Shutdown()
 
 		// Put s1 last so we don't trigger a leader election.
 		servers := []*Server{s2, s1}
@@ -2089,17 +2030,15 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 	})
 
 	t.Run("primary and secondary with new version", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
-		dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node2"
 			c.Datacenter = "dc2"
 			c.PrimaryDatacenter = "dc1"
@@ -2107,8 +2046,6 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 			c.ConfigReplicationBurst = 100
 			c.ConfigReplicationApplyLimit = 1000000
 		})
-		defer os.RemoveAll(dir2)
-		defer s2.Shutdown()
 
 		waitForLeaderEstablishment(t, s2)
 
@@ -2145,18 +2082,16 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 	})
 
 	t.Run("primary and secondary with mixed versions", func(t *testing.T) {
-		dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node1"
 			c.Datacenter = "dc1"
 			c.PrimaryDatacenter = "dc1"
 			c.OverrideInitialSerfTags = disableServiceIntentions
 		})
-		defer os.RemoveAll(dir1)
-		defer s1.Shutdown()
 
 		waitForLeaderEstablishment(t, s1)
 
-		dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
 			c.NodeName = "node2"
 			c.Datacenter = "dc2"
 			c.PrimaryDatacenter = "dc1"
@@ -2164,8 +2099,6 @@ func TestDatacenterSupportsIntentionsAsConfigEntries(t *testing.T) {
 			c.ConfigReplicationBurst = 100
 			c.ConfigReplicationApplyLimit = 1000000
 		})
-		defer os.RemoveAll(dir2)
-		defer s2.Shutdown()
 
 		waitForLeaderEstablishment(t, s2)
 
@@ -2211,22 +2144,15 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 		c.Datacenter = "dc1"
 		c.Build = "1.11.2"
 	}
-	dir1, s1 := testServerWithConfig(t, conf)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	codec := rpcClient(t, s1)
-	defer codec.Close()
 
-	dir2, s2 := testServerWithConfig(t, conf)
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t, conf)
 
-	dir3, s3 := testServerWithConfig(t, func(c *Config) {
+	s2 := testServerWithConfigNoPersistence(t, conf)
+
+	s3 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		conf(c)
 		c.Build = "1.10.0"
 	})
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
 
 	// Try to join and wait for all servers to get promoted
 	joinLAN(t, s2, s1)
@@ -2353,17 +2279,13 @@ func TestLeader_ACL_Initialization_AnonymousToken(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	_, s1 := testServerWithConfigAndPersistence(t, func(c *Config) {
 		c.Bootstrap = true
 		c.Datacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -2395,7 +2317,7 @@ func TestLeader_ACL_Initialization_AnonymousToken(t *testing.T) {
 
 	// Restart the server to re-initialize ACLs when establishing leadership
 	require.NoError(t, s1.Shutdown())
-	dir2, newS1 := testServerWithConfig(t, func(c *Config) {
+	_, newS1 := testServerWithConfigAndPersistence(t, func(c *Config) {
 		// Keep existing data dir and node info since it's a restart
 		c.DataDir = s1.config.DataDir
 		c.NodeName = s1.config.NodeName
@@ -2404,8 +2326,6 @@ func TestLeader_ACL_Initialization_AnonymousToken(t *testing.T) {
 		c.Datacenter = "dc1"
 		c.ACLsEnabled = true
 	})
-	defer os.RemoveAll(dir2)
-	defer newS1.Shutdown()
 	testrpc.WaitForTestAgent(t, newS1.RPC, "dc1")
 
 	retry.Run(t, func(r *retry.R) {

--- a/agent/consul/operator_raft_endpoint_test.go
+++ b/agent/consul/operator_raft_endpoint_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -23,11 +22,9 @@ func TestOperator_RaftGetConfiguration(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -69,16 +66,14 @@ func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -132,11 +127,9 @@ func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -196,16 +189,14 @@ func TestOperator_RaftRemovePeerByAddress_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -237,13 +228,11 @@ func TestOperator_RaftRemovePeerByID(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -302,17 +291,15 @@ func TestOperator_RaftRemovePeerByID_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 		c.RaftConfig.ProtocolVersion = 3
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 

--- a/agent/consul/rtt_test.go
+++ b/agent/consul/rtt_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,7 +10,7 @@ import (
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/testrpc"
 
-	"github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
+	msgpackrpc "github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 )
 
@@ -137,9 +136,8 @@ func TestRTT_sortNodesByDistanceFrom(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir, server := testServer(t)
-	defer os.RemoveAll(dir)
-	defer server.Shutdown()
+
+	server := testServerWithConfigNoPersistence(t)
 
 	codec := rpcClient(t, server)
 	defer codec.Close()
@@ -194,9 +192,8 @@ func TestRTT_sortNodesByDistanceFrom_Nodes(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir, server := testServer(t)
-	defer os.RemoveAll(dir)
-	defer server.Shutdown()
+
+	server := testServerWithConfigNoPersistence(t)
 
 	codec := rpcClient(t, server)
 	defer codec.Close()
@@ -248,13 +245,11 @@ func TestRTT_sortNodesByDistanceFrom_ServiceNodes(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir, server := testServer(t)
-	defer os.RemoveAll(dir)
-	defer server.Shutdown()
-	testrpc.WaitForTestAgent(t, server.RPC, "dc1")
 
+	server := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, server)
-	defer codec.Close()
+
+	testrpc.WaitForTestAgent(t, server.RPC, "dc1")
 
 	seedCoordinates(t, codec, server)
 	nodes := structs.ServiceNodes{
@@ -302,12 +297,10 @@ func TestRTT_sortNodesByDistanceFrom_HealthChecks(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir, server := testServer(t)
-	defer os.RemoveAll(dir)
-	defer server.Shutdown()
 
+	server := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, server)
-	defer codec.Close()
+
 	testrpc.WaitForLeader(t, server.RPC, "dc1")
 
 	seedCoordinates(t, codec, server)
@@ -356,12 +349,10 @@ func TestRTT_sortNodesByDistanceFrom_CheckServiceNodes(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir, server := testServer(t)
-	defer os.RemoveAll(dir)
-	defer server.Shutdown()
 
+	server := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, server)
-	defer codec.Close()
+
 	testrpc.WaitForTestAgent(t, server.RPC, "dc1")
 
 	seedCoordinates(t, codec, server)

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -344,7 +344,7 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
 	}
-	if config.DataDir == "" && !config.DevMode {
+	if config.DataDir == "" && !config.DevMode && !config.DisablePersistence {
 		return nil, fmt.Errorf("Config must provide a DataDir")
 	}
 	if err := config.CheckACL(); err != nil {
@@ -724,7 +724,7 @@ func (s *Server) setupRaft() error {
 	var log raft.LogStore
 	var stable raft.StableStore
 	var snap raft.SnapshotStore
-	if s.config.DevMode {
+	if s.config.DevMode || s.config.DisablePersistence {
 		store := raft.NewInmemStore()
 		s.raftInmem = store
 		stable = store

--- a/agent/consul/session_endpoint_test.go
+++ b/agent/consul/session_endpoint_test.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -20,12 +19,9 @@ func TestSession_Apply(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -85,12 +81,9 @@ func TestSession_DeleteApply(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -154,17 +147,14 @@ func TestSession_Apply_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -222,12 +212,9 @@ func TestSession_Get(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -271,12 +258,9 @@ func TestSession_Get_Compat(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -321,12 +305,9 @@ func TestSession_List(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -379,17 +360,13 @@ func TestSession_Get_List_NodeSessions_ACLFilter(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -509,12 +486,9 @@ func TestSession_ApplyTimers(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -560,15 +534,12 @@ func TestSession_Renew(t *testing.T) {
 	ttl := 1 * time.Second
 	TTL := ttl.String()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.SessionTTLMin = ttl
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
-
 	codec := rpcClient(t, s1)
-	defer codec.Close()
+
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"})
 	ids := []string{}
@@ -725,17 +696,14 @@ func TestSession_Renew_ACLDeny(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -792,15 +760,12 @@ func TestSession_Renew_Compat(t *testing.T) {
 	ttl := 5 * time.Second
 	TTL := ttl.String()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.SessionTTLMin = ttl
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
-
 	codec := rpcClient(t, s1)
-	defer codec.Close()
+
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"})
 	var id string
@@ -849,12 +814,9 @@ func TestSession_NodeSessions(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -913,12 +875,9 @@ func TestSession_Apply_BadTTL(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 

--- a/agent/consul/status_endpoint_test.go
+++ b/agent/consul/status_endpoint_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -76,11 +75,9 @@ func TestStatusLeader(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	arg := struct{}{}
 	var leader string
@@ -107,15 +104,17 @@ func TestStatusLeader_ForwardDC(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerDC(t, "primary")
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	codec := rpcClient(t, s1)
-	defer codec.Close()
 
-	dir2, s2 := testServerDC(t, "secondary")
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "primary"
+		c.Bootstrap = true
+	})
+	codec := rpcClient(t, s1)
+
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "secondary"
+		c.Bootstrap = true
+	})
 
 	joinWAN(t, s2, s1)
 
@@ -133,11 +132,9 @@ func TestStatusLeader_ForwardDC(t *testing.T) {
 
 func TestStatusPeers(t *testing.T) {
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	arg := struct{}{}
 	var peers []string
@@ -155,15 +152,17 @@ func TestStatusPeers_ForwardDC(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServerDC(t, "primary")
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	codec := rpcClient(t, s1)
-	defer codec.Close()
 
-	dir2, s2 := testServerDC(t, "secondary")
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "primary"
+		c.Bootstrap = true
+	})
+	codec := rpcClient(t, s1)
+
+	s2 := testServerWithConfigNoPersistence(t, func(c *Config) {
+		c.Datacenter = "secondary"
+		c.Bootstrap = true
+	})
 
 	joinWAN(t, s2, s1)
 

--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -60,11 +59,9 @@ func TestTxn_CheckNotExists(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -116,11 +113,9 @@ func TestTxn_Apply(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -314,14 +309,12 @@ func TestTxn_Apply_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -613,11 +606,9 @@ func TestTxn_Apply_LockDelay(t *testing.T) {
 	}
 
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
@@ -705,11 +696,8 @@ func TestTxn_Read(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+	s1 := testServerWithConfigNoPersistence(t)
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -830,16 +818,13 @@ func TestTxn_Read_ACLDeny(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	s1 := testServerWithConfigNoPersistence(t, func(c *Config) {
 		c.PrimaryDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLInitialManagementToken = "root"
 		c.ACLResolverSettings.ACLDefaultPolicy = "deny"
 	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 


### PR DESCRIPTION
This drastically speeds up some tests on macos by 2x, 4x, or in isolated examples 10x.