### PR TITLE
poc: turn on prometheus style metrics sink by default

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -942,7 +942,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 			StatsdAddr:                         stringVal(c.Telemetry.StatsdAddr),
 			StatsiteAddr:                       stringVal(c.Telemetry.StatsiteAddr),
 			PrometheusOpts: prometheus.PrometheusOpts{
-				Expiration: b.durationVal("prometheus_retention_time", c.Telemetry.PrometheusRetentionTime),
+				Expiration: b.durationValWithDefault("prometheus_retention_time", c.Telemetry.PrometheusRetentionTime, 1 * time.Hour),
 				Name:       stringVal(c.Telemetry.MetricsPrefix),
 			},
 		},

--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -30,6 +30,7 @@ func init() {
 	registerEndpoint("/v1/agent/reload", []string{"PUT"}, (*HTTPHandlers).AgentReload)
 	registerEndpoint("/v1/agent/monitor", []string{"GET"}, (*HTTPHandlers).AgentMonitor)
 	registerEndpoint("/v1/agent/metrics", []string{"GET"}, (*HTTPHandlers).AgentMetrics)
+	registerEndpoint("/v1/agent/metrics/prometheus", []string{"GET"}, (*HTTPHandlers).AgentMetricsPrometheus)
 	registerEndpoint("/v1/agent/metrics/stream", []string{"GET"}, (*HTTPHandlers).AgentMetricsStream)
 	registerEndpoint("/v1/agent/services", []string{"GET"}, (*HTTPHandlers).AgentServices)
 	registerEndpoint("/v1/agent/service/", []string{"GET"}, (*HTTPHandlers).AgentService)

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -436,22 +436,23 @@ This endpoint will dump the metrics for the most recent finished interval.
 For more information about metrics, see the [telemetry](/docs/agent/telemetry)
 page.
 
+// todo: update
 In order to enable [Prometheus](https://prometheus.io/) support, you need to use the
 configuration directive
 [`prometheus_retention_time`](/docs/agent/options#telemetry-prometheus_retention_time).
 
-Since Consul 1.7.2 this endpoint will also automatically switch output format if 
-the request contains an `Accept` header with a compatible MIME type such as 
+Since Consul 1.7.2 this endpoint will also automatically switch output format if
+the request contains an `Accept` header with a compatible MIME type such as
 `application/openmetrics-text`. Prometheus v2.5.0 and newer pass this header in scraping
-queries, and so will get a compatible format by default. Older versions of Prometheus may 
-work by default as several previously used MIME types are also detected, but the `?format` 
+queries, and so will get a compatible format by default. Older versions of Prometheus may
+work by default as several previously used MIME types are also detected, but the `?format`
 query parameter may also be used to specify the output format manually if needed.
 simplifying scrape configuration.
 
-Note: If using the default format and your metric includes labels that use the same key 
-name multiple times (i.e. tag=tag2 and tag=tag1), only the sorted last value (tag=tag2) 
-will be visible on this endpoint due to a display issue. The complete label set is correctly 
-applied and passed to external metrics providers even though it is not visible through this 
+Note: If using the default format and your metric includes labels that use the same key
+name multiple times (i.e. tag=tag2 and tag=tag1), only the sorted last value (tag=tag2)
+will be visible on this endpoint due to a display issue. The complete label set is correctly
+applied and passed to external metrics providers even though it is not visible through this
 endpoint.
 
 | Method | Path                               | Produces                                   |
@@ -723,7 +724,7 @@ The corresponding CLI command is [`consul force-leave`](/commands/force-leave).
 - `node` `(string: <required>)` - Specifies the name of the node to be forced into `left` state. This is specified as part of the URL.
 
 - `prune` `(bool: false)` - Specifies whether to forcibly remove the node from the list of members.
-  Pruning a node in the `left` or `failed` state removes it from the list altogether. 
+  Pruning a node in the `left` or `failed` state removes it from the list altogether.
   This is specified as part of the URL as a query parameter. Added in Consul 1.6.2.
 
 - `wan` `(bool: false)` - Specifies the node should only be removed from the WAN

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -2204,6 +2204,7 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
 
     A leading "**+**" will enable any metrics with the given prefix, and a leading "**-**" will block them. If there is overlap between two rules, the more specific rule will take precedence. Blocking will take priority if the same prefix is listed multiple times.
 
+// todo -- update
   - `prometheus_retention_time` ((#telemetry-prometheus_retention_time)) If the value is greater than `0s` (the default), this enables [Prometheus](https://prometheus.io/)
     export of metrics. The duration can be expressed using the duration semantics
     and will aggregates all counters for the duration specified (it might have an


### PR DESCRIPTION
### Overview

This PR shows a poc, minimal diff that turns on prometheus style metrics sink by default.

Per our own documentation ( [ref](https://www.consul.io/docs/agent/options#telemetry-prometheus_retention_time) ), there may be a performance impact to this. Not sure if we ever benchmarked it:

```
...
The duration [...] will aggregates all counters for the duration specified (it might have an impact on Consul's memory usage). 
...
```

### next steps

* [ ] pulse -- is this something that would be useful for folks?
* [ ] polish code 
* [ ] docs

### testing

* manually did some `curl`s over `/metrics`, `/metrics?format=prometheus` and `/metrics/prometheus` to show that they endpoints work as expected 💯 