### PR TITLE
Add the `connect.enable_serverless_plugin` configuration option

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -669,6 +669,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 	connectEnabled := boolVal(c.Connect.Enabled)
 	connectCAProvider := stringVal(c.Connect.CAProvider)
 	connectCAConfig := c.Connect.CAConfig
+	serverlessPluginEnabled := boolVal(c.Connect.EnableServerlessPlugin)
 
 	// autoEncrypt and autoConfig implicitly turns on connect which is why
 	// they need to be above other settings that rely on connect.
@@ -979,6 +980,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		ConnectCAProvider:                      connectCAProvider,
 		ConnectCAConfig:                        connectCAConfig,
 		ConnectMeshGatewayWANFederationEnabled: connectMeshGatewayWANFederationEnabled,
+		ConnectServerlessPluginEnabled:         serverlessPluginEnabled,
 		ConnectSidecarMinPort:                  sidecarMinPort,
 		ConnectSidecarMaxPort:                  sidecarMaxPort,
 		ConnectTestCALeafRootChangeSpread:      b.durationVal("connect.test_ca_leaf_root_change_spread", c.Connect.TestCALeafRootChangeSpread),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -612,6 +612,7 @@ type Connect struct {
 	CAProvider                      *string                `mapstructure:"ca_provider"`
 	CAConfig                        map[string]interface{} `mapstructure:"ca_config"`
 	MeshGatewayWANFederationEnabled *bool                  `mapstructure:"enable_mesh_gateway_wan_federation"`
+	EnableServerlessPlugin          *bool                  `mapstructure:"enable_serverless_plugin"`
 
 	// TestCALeafRootChangeSpread controls how long after a CA roots change before new leaft certs will be generated.
 	// This is only tuned in tests, generally set to 1ns to make tests deterministic with when to expect updated leaf

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -486,6 +486,12 @@ type RuntimeConfig struct {
 	// and servers in a cluster for correct connect operation.
 	ConnectEnabled bool
 
+	// ConnectServerlessPluginEnabled opts the agent into the serverless plugin.
+	// This plugin allows services to be configured as AWS Lambdas. After the
+	// Lambda service is configured, Connect services can invoke the Lambda
+	// service like any other upstream.
+	ConnectServerlessPluginEnabled bool
+
 	// ConnectSidecarMinPort is the inclusive start of the range of ports
 	// allocated to the agent for asigning to sidecar services where no port is
 	// specified.

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5538,6 +5538,7 @@ func TestLoad_FullConfig(t *testing.T) {
 			"CSRMaxConcurrent":    float64(2),
 		},
 		ConnectMeshGatewayWANFederationEnabled: false,
+		ConnectServerlessPluginEnabled:         true,
 		DNSAddrs:                               []net.Addr{tcpAddr("93.95.95.81:7001"), udpAddr("93.95.95.81:7001")},
 		DNSARecordLimit:                        29907,
 		DNSAllowStale:                          true,

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -127,6 +127,7 @@
     "ConnectCAProvider": "",
     "ConnectEnabled": false,
     "ConnectMeshGatewayWANFederationEnabled": false,
+    "ConnectServerlessPluginEnabled": false,
     "ConnectSidecarMaxPort": 0,
     "ConnectSidecarMinPort": 0,
     "ConnectTestCALeafRootChangeSpread": "0s",

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -210,6 +210,7 @@ connect {
     }
     enable_mesh_gateway_wan_federation = false
     enabled = true
+    enable_serverless_plugin = true
 }
 gossip_lan {
     gossip_nodes    = 6

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -209,7 +209,8 @@
       "csr_max_concurrent": 2
     },
     "enable_mesh_gateway_wan_federation": false,
-    "enabled": true
+    "enabled": true,
+    "enable_serverless_plugin": true
   },
   "gossip_lan" : {
     "gossip_nodes": 6,


### PR DESCRIPTION
This configuration option will be used from the xDS code to selectively enable the serverless plugin.

Checklist:
 - [x] Add the field to the Config struct (or an appropriate sub-struct) in
   `agent/config/config.go`.
 - [x] Add the field to the actual RuntimeConfig struct in
   `agent/config/runtime.go`.
 - [x] Add an appropriate parser/setter in `agent/config/builder.go` to
   translate.
 - [x] Add the new field with a random value to both the JSON and HCL files in
   `agent/config/testdata/full-config.*`, which should cause the test to fail.
   Then update the expected value in `TestLoad_FullConfig` in
   `agent/config/runtime_test.go` to make the test pass again.
 - [x] Run `go test -run TestRuntimeConfig_Sanitize ./agent/config -update` to update
   the expected value for `TestRuntimeConfig_Sanitize`. Look at `git diff` to
   make sure the value changed as you expect.
 - [x] **If** your new config field needed some validation as it's only valid in
   some cases or with some values (often true). [Eric: Not required]
      - [ ] Add validation to Validate in `agent/config/builder.go`.
      - [ ] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
        `agent/config/runtime_test.go`.
 - [x] **If** your new config field needs a non-zero-value default. [Eric: Not required]
      - [ ] Add that to `DefaultSource` in `agent/config/defaults.go`.
      - [ ] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
        `agent/config/runtime_test.go`.
 - [x] **If** your config should take effect on a reload/HUP. [Eric: Not required]
      - [ ] Add necessary code to to trigger a safe (locked or atomic) update to
        any state the feature needs changing. This needs to be added to one or
        more of the following places:
         - `ReloadConfig` in `agent/agent.go` if it needs to affect the local
           client state or another client agent component.
         - `ReloadConfig` in `agent/consul/client.go` if it needs to affect
           state for client agent's RPC client.
      - [ ] Add a test to `agent/agent_test.go` similar to others with prefix
        `TestAgent_reloadConfig*`.
 - [x] Add documentation to `website/content/docs/agent/options.mdx`. [Eric: Not required yet]