### PR TITLE
ui: Update faker to a maintained fork

### DIFF
--- a/ui/packages/consul-ui/app/services/i18n-debug.js
+++ b/ui/packages/consul-ui/app/services/i18n-debug.js
@@ -1,7 +1,7 @@
 import I18nService, { formatOptionsSymbol } from 'consul-ui/services/i18n';
 import ucfirst from 'consul-ui/utils/ucfirst';
 
-import faker from 'faker';
+import { faker } from '@faker-js/faker';
 
 // we currently use HTML in translations, so anything 'word-like' with these
 // chars won't get translated

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -146,7 +146,7 @@
     "eslint": "^7.12.1",
     "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-node": "^11.0.0",
-    "faker": "^5.5.3",
+    "@faker-js/faker": "^6.0.0-beta.0",
     "flat": "^5.0.0",
     "hast-util-to-string": "^1.0.4",
     "husky": "^4.2.5",

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -146,7 +146,7 @@
     "eslint": "^7.12.1",
     "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-node": "^11.0.0",
-    "@faker-js/faker": "^6.0.0",
+    "@faker-js/faker": "^6.1.1",
     "flat": "^5.0.0",
     "hast-util-to-string": "^1.0.4",
     "husky": "^4.2.5",

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -146,7 +146,7 @@
     "eslint": "^7.12.1",
     "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-node": "^11.0.0",
-    "@faker-js/faker": "^6.0.0-beta.0",
+    "@faker-js/faker": "^6.0.0",
     "flat": "^5.0.0",
     "hast-util-to-string": "^1.0.4",
     "husky": "^4.2.5",


### PR DESCRIPTION
The original Faker library is no longer maintained (as you may have heard).
That's why we created a community fork that takes on the further maintenance.
Read more about it here: https://fakerjs.dev/update.html

We have completed the typescript rewrite and now try to update a few dependent projects to ensure we didn't break backwards compatibility.

I don't have a working make setup, so I will use the CI to ensure that this works.

Ref: https://github.com/faker-js/faker/issues/542