### PR TITLE
ui: Add CustomElement Transform

### DIFF
--- a/ui/packages/consul-ui/lib/custom-element/index.js
+++ b/ui/packages/consul-ui/lib/custom-element/index.js
@@ -1,0 +1,63 @@
+'use strict';
+
+module.exports = {
+  name: require('./package').name,
+  getTransform: function() {
+    return {
+      name: 'custom-element',
+      plugin: class {
+        transform(ast) {
+          this.syntax.traverse(ast, {
+            ElementNode: (node) => {
+              if(node.tag === 'CustomElement') {
+                node.attributes = node.attributes
+                  // completely remove these ones, they are not used runtime
+                  // element is potentially only temporarily being removed
+                  .filter(item => !['element', 'description', 'slots', 'cssparts'].includes(`${item.name.substr(1)}`))
+                  .map(item => {
+                    switch(true) {
+                      // these ones are ones where we need to remove the documentation only
+                      // the attributes themselves are required at runtime
+                      case ['attrs', 'cssprops'].includes(`${item.name.substr(1)}`):
+                        item.value.params = item.value.params.map(item => {
+                          // we can't use arr.length here as we don't know
+                          // whether someone has used the documentation entry
+                          // in the array or not We use the hardcoded `3` for
+                          // the moment if that position needs to change per
+                          // property we can just add more cases for the
+                          // moment
+                          item.params = item.params.filter((item, i, arr) => i < 3);
+                          return item;
+                        });
+                        break;
+
+                    }
+                    return item;
+                  });
+              }
+            },
+          });
+          return ast;
+        }
+
+      },
+      baseDir: function() {
+        return __dirname;
+      },
+      cacheKey: function() {
+        return 'custom-element';
+      }
+    };
+  },
+  setupPreprocessorRegistry(type, registry) {
+    const transform = this.getTransform();
+    transform.parallelBabel = {
+      requireFile: __filename,
+      buildUsing: 'getTransform',
+      params: {}
+    };
+    registry.add('htmlbars-ast-plugin', transform);
+  },
+
+};
+

--- a/ui/packages/consul-ui/lib/custom-element/package.json
+++ b/ui/packages/consul-ui/lib/custom-element/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "custom-element",
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  },
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -185,6 +185,7 @@
       "lib/block-slots",
       "lib/colocated-components",
       "lib/commands",
+      "lib/custom-element",
       "lib/startup"
     ]
   }


### PR DESCRIPTION
https://github.com/hashicorp/consul/pull/12451 finished up the beginnings of an initial approach to using ShadowDOM and CustomElements in Ember.

ShadowDOM and CustomElements gives us almost complete isolation of application components, the clearest benefit of this right now is almost complete isolation of CSS. This has the huge benefit of having more control over the cascading nature of CSS. LightDOM CSS does not punch through the ShadowDOM boundary unless you want it to via the use of CSS parts and CSS custom properties.

The benefits here are huge, and longer term as we add more and more of these components the CSS is less likely to drift slightly as the project scales.

Here we are fixing/preventing the issue at source rather than curing after the fact.

This also means less tooling/approaches are required around things like CSS regression testing as the components are far less likely to break if you are changing an unrelated component/global CSS rule. So the problem _partly_ just goes away and therefore requires less testing.

No alarms and no surprises.

With that said, CSS regression testing and individual component testing still has its place, but once a component is built, unless you are actually changing the code, it is no where near as necessary. @evrowe I know we spoke only yesterday about how I'd been suggesting we should be using some sort of CSS regression testing for quite some time now. Just to be clear, I am still on the same page as you and most definitely pro to using it. But I realized off the back of our convo that moving forwards with this approach means its far less necessary and this is something I only realised after we spoke yesterday, so thanks for bringing it up. It's good to talk.

We can also use further Web Platform features such as native slots for conditional slotting, multiple slots of the same name and supporting a11y by providing an explicit bridge between the LightDOM and the ShadowDOM.

Back to this PR 😅 

We also added almost self-documentation features and fairly rudimentary type checking for Glimmerized web components while we were here. Both features can make for a higher quality codebase that is easier to onboard onto for other folks. I've been gathering insights and experience on this from various members of my team both past and present over the past few weeks to understand what benefit others see and how successful current approaches are in documenting and type checking web components. This was a good opportunity to use that to hopefully further increase the ease of onboarding for our already highly documented and reasonably 'type aware' application.

@jgwhite @randallmorey and others no longer here 😿 @ZahraTee and @junyper, thanks all for the help 🙇  

The one problem with the documentation of course is that we don't want to be bundling unnecessarily code/copy to our users if we can at all avoid it, and in writing the documentation in with the code for the component means bundling all this copy in where it's not needed, ouch!

This PR adds an Ember-Glimmer/Handlebars transform to drop the documentation copy out of the build, therefore it is not bundled into the code either at development time or production build time. 

Just one last quick note, this is part of the `ember-chocolate` addon that folks internally are aware of. As mentioned a in another PR I don't think this is quite the right time treat that as a separate addon, so I just PRed this bit here as an ember 'in repo addon' at some point in the future it will probably all be put back together as a proper addon. Oh there's also a similar piece that extracts the same attributes and commits it to the documentation README.mdx files so we can view those in GH or any other documentation system like docfy. That's not urgent though so it can wait.

P.S.

There's also a reference to this work here:

https://github.com/hashicorp/consul/pull/12452

> Two PRs that will need to be added ontop of here that I'll PR after review are:
> Compile out the documentation metadata from the Glimmer templates (mostly the descriptions)

> I'll do those 2 once these are approved

This PR is just one of those ^
