### PR TITLE
[docs] update connect ca vault provider docs to include vault auth method field

### DIFF
--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -1366,9 +1366,26 @@ bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr
       as well as permission to mount the backend at this path if it is not already
       mounted.
 
-    #### Common CA Config Options
+    - `auth_method` ((#vault_ca_auth_method))
+      Vault auth method to use for logging in to Vault.
+      Please see [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for more information
+      on how to configure individual auth methods. If auth method is provided, Consul will obtain a
+      new token from Vault when the token can no longer be renewed.
 
-    There are also a number of common configuration options supported by all providers:
+       - `type` The type of Vault auth method.
+
+       - `mount_path` The mount path of the auth method.
+      If not provided the auth method type will be used as the mount path.
+
+       - `params` The parameters to configure the auth method.
+      Please see [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for information on how
+      to configure the auth method you wish to use. If using the Kubernetes auth method, Consul will
+      read the service account token from the default mount path `/var/run/secrets/kubernetes.io/serviceaccount/token`
+      if the `jwt` parameter is not provided.
+
+#### Common CA Config Options
+
+There are also a number of common configuration options supported by all providers:
 
     - `csr_max_concurrent` ((#ca_csr_max_concurrent)) Sets a limit on the number
       of Certificate Signing Requests that can be processed concurrently. Defaults

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -99,7 +99,7 @@ The configuration options are listed below.
 
 - `AuthMethod` / `auth_method` (`map: nil`) - Vault auth method to use for logging in to Vault.
   Please see [Vault Auth Methods](https://www.vaultproject.io/docs/auth) for more information
-  on how to configure individual auth methods. If auth method is provided, Consul will obtain a
+  on how to configure individual auth methods. If auth method is provided, Consul will obtain
   a new token from Vault when the token can no longer be renewed.
 
    - `Type`/ `type` (`string: ""`) - The type of Vault auth method.
@@ -122,9 +122,9 @@ The configuration options are listed below.
   exist, Consul will mount a new PKI secrets engine at the specified path with the
   `RootCertTTL` value as the root certificate's TTL. If the `RootCertTTL` is not set,
   a [`max_lease_ttl`](https://www.vaultproject.io/api/system/mounts#max_lease_ttl)
-  of 87600 hours, or 10 years is applied by default as of Consul 1.11 and later. Prior to Consul 1.11, 
-  the root certificate TTL was set to 8760 hour, or 1 year, and was not configurable. 
-  The root certificate will expire at the end of the specified period. 
+  of 87600 hours, or 10 years is applied by default as of Consul 1.11 and later. Prior to Consul 1.11,
+  the root certificate TTL was set to 8760 hour, or 1 year, and was not configurable.
+  The root certificate will expire at the end of the specified period.
 
   When WAN Federation is enabled, each secondary datacenter must use the same Vault cluster and share the same `root_pki_path`
   with the primary datacenter.
@@ -140,10 +140,10 @@ The configuration options are listed below.
   The path to a PKI secrets engine for the generated intermediate certificate.
   This certificate will be signed by the configured root PKI path. If this
   path does not exist, Consul will attempt to mount and configure this
-  automatically. 
+  automatically.
 
-  When WAN Federation is enabled, every secondary 
-  datacenter must specify a unique `intermediate_pki_path`. 
+  When WAN Federation is enabled, every secondary
+  datacenter must specify a unique `intermediate_pki_path`.
 
 - `CAFile` / `ca_file` (`string: ""`) - Specifies an optional path to the CA
   certificate used for Vault communication. If unspecified, this will fallback


### PR DESCRIPTION
Update the connect CA documentation for vault provider to include updated vault auth method field.