### PR TITLE
Update API version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/google/tcpproxy v0.0.0-20180808230851-dfa16c61dad2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/hashicorp/consul-net-rpc v0.0.0-20220207223504-4cffceffcd29
-	github.com/hashicorp/consul/api v1.11.0
+	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/go-bexpr v0.1.2
 	github.com/hashicorp/go-checkpoint v0.5.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/hashicorp/consul-net-rpc v0.0.0-20220207223504-4cffceffcd29
 	github.com/hashicorp/consul/api v1.12.0
-	github.com/hashicorp/consul/sdk v0.8.0
+	github.com/hashicorp/consul/sdk v0.9.0
 	github.com/hashicorp/go-bexpr v0.1.2
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.1


### PR DESCRIPTION
This only matters for projects that import `consul` module as a dependency. While that's not generally recommended or supported as only the `api` module is considered "public" there are times when building tooling where it can be necessary.

Right now projects that just depend on `consul` will fail to build with 

```
# github.com/hashicorp/consul/agent/structs
../../../../go/pkg/mod/github.com/hashicorp/consul@v1.11.4/agent/structs/connect_proxy_config.go:478:3: unknown field 'DestinationPartition' in struct literal of type api.Upstream
../../../../go/pkg/mod/github.com/hashicorp/consul@v1.11.4/agent/structs/connect_proxy_config.go:582:26: u.DestinationPartition undefined (type api.Upstream has no field or method DestinationPartition)
../../../../go/pkg/mod/github.com/hashicorp/consul@v1.11.4/agent/structs/structs.go:2557:2: cannot use promoted field BasicHandle.DecodeOptions.RawToString in struct literal of type codec.MsgpackHandle
```

This fixes that.