### PR TITLE
Refactor config checks oss

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -194,8 +194,8 @@ func (c *ConfigEntry) Get(args *structs.ConfigEntryQuery, reply *structs.ConfigE
 	}
 	lookupEntry.GetEnterpriseMeta().Merge(&args.EnterpriseMeta)
 
-	if !lookupEntry.CanRead(authz) {
-		return acl.ErrPermissionDenied
+	if err := lookupEntry.CanRead(authz); err != nil {
+		return err
 	}
 
 	return c.srv.blockingQuery(
@@ -254,7 +254,8 @@ func (c *ConfigEntry) List(args *structs.ConfigEntryQuery, reply *structs.Indexe
 			// Filter the entries returned by ACL permissions.
 			filteredEntries := make([]structs.ConfigEntry, 0, len(entries))
 			for _, entry := range entries {
-				if !entry.CanRead(authz) {
+				if err := entry.CanRead(authz); err != nil {
+					// TODO we may wish to extract more details from this error to aid user comprehension
 					reply.QueryMeta.ResultsFilteredByACLs = true
 					continue
 				}
@@ -335,7 +336,8 @@ func (c *ConfigEntry) ListAll(args *structs.ConfigEntryListAllRequest, reply *st
 			// Filter the entries returned by ACL permissions or by the provided kinds.
 			filteredEntries := make([]structs.ConfigEntry, 0, len(entries))
 			for _, entry := range entries {
-				if !entry.CanRead(authz) {
+				if err := entry.CanRead(authz); err != nil {
+					// TODO we may wish to extract more details from this error to aid user comprehension
 					reply.QueryMeta.ResultsFilteredByACLs = true
 					continue
 				}

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -89,8 +89,8 @@ func (c *ConfigEntry) Apply(args *structs.ConfigEntryRequest, reply *bool) error
 		return err
 	}
 
-	if !args.Entry.CanWrite(authz) {
-		return acl.ErrPermissionDenied // TODO(acl-error-enhancements) Better errors await refactoring of CanWrite above.
+	if err := args.Entry.CanWrite(authz); err != nil {
+		return err
 	}
 
 	if args.Op != structs.ConfigEntryUpsert && args.Op != structs.ConfigEntryUpsertCAS {
@@ -388,8 +388,8 @@ func (c *ConfigEntry) Delete(args *structs.ConfigEntryRequest, reply *structs.Co
 		return err
 	}
 
-	if !args.Entry.CanWrite(authz) {
-		return acl.ErrPermissionDenied
+	if err := args.Entry.CanWrite(authz); err != nil {
+		return err
 	}
 
 	// Only delete and delete-cas ops are supported. If the caller erroneously

--- a/agent/http.go
+++ b/agent/http.go
@@ -273,7 +273,7 @@ func (s *HTTPHandlers) handler(enableDebug bool) http.Handler {
 			// If the token provided does not have the necessary permissions,
 			// write a forbidden response
 			// TODO(partitions): should this be possible in a partition?
-			// TODO((acl-error-enhancements)): We should return error details somehow here.
+			// TODO(acl-error-enhancements): We should return error details somehow here.
 			if authz.OperatorRead(nil) != acl.Allow {
 				resp.WriteHeader(http.StatusForbidden)
 				return

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -61,7 +61,7 @@ type ConfigEntry interface {
 	// CanRead and CanWrite return whether or not the given Authorizer
 	// has permission to read or write to the config entry, respectively.
 	CanRead(acl.Authorizer) error
-	CanWrite(acl.Authorizer) bool
+	CanWrite(acl.Authorizer) error
 
 	GetMeta() map[string]string
 	GetEnterpriseMeta() *EnterpriseMeta
@@ -189,10 +189,10 @@ func (e *ServiceConfigEntry) CanRead(authz acl.Authorizer) error {
 	return authz.ToAllowAuthorizer().ServiceReadAllowed(e.Name, &authzContext)
 }
 
-func (e *ServiceConfigEntry) CanWrite(authz acl.Authorizer) bool {
+func (e *ServiceConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.ServiceWrite(e.Name, &authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().ServiceWriteAllowed(e.Name, &authzContext)
 }
 
 func (e *ServiceConfigEntry) GetRaftIndex() *RaftIndex {
@@ -310,10 +310,10 @@ func (e *ProxyConfigEntry) CanRead(authz acl.Authorizer) error {
 	return nil
 }
 
-func (e *ProxyConfigEntry) CanWrite(authz acl.Authorizer) bool {
+func (e *ProxyConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.MeshWrite(&authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext)
 }
 
 func (e *ProxyConfigEntry) GetRaftIndex() *RaftIndex {

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -60,7 +60,7 @@ type ConfigEntry interface {
 
 	// CanRead and CanWrite return whether or not the given Authorizer
 	// has permission to read or write to the config entry, respectively.
-	CanRead(acl.Authorizer) bool
+	CanRead(acl.Authorizer) error
 	CanWrite(acl.Authorizer) bool
 
 	GetMeta() map[string]string
@@ -183,10 +183,10 @@ func (e *ServiceConfigEntry) Validate() error {
 	return validationErr
 }
 
-func (e *ServiceConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *ServiceConfigEntry) CanRead(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.ServiceRead(e.Name, &authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().ServiceReadAllowed(e.Name, &authzContext)
 }
 
 func (e *ServiceConfigEntry) CanWrite(authz acl.Authorizer) bool {
@@ -306,8 +306,8 @@ func (e *ProxyConfigEntry) Validate() error {
 	return e.validateEnterpriseMeta()
 }
 
-func (e *ProxyConfigEntry) CanRead(authz acl.Authorizer) bool {
-	return true
+func (e *ProxyConfigEntry) CanRead(authz acl.Authorizer) error {
+	return nil
 }
 
 func (e *ProxyConfigEntry) CanWrite(authz acl.Authorizer) bool {

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -251,7 +251,7 @@ func isValidHTTPMethod(method string) bool {
 	}
 }
 
-func (e *ServiceRouterConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *ServiceRouterConfigEntry) CanRead(authz acl.Authorizer) error {
 	return canReadDiscoveryChain(e, authz)
 }
 
@@ -594,7 +594,7 @@ func scaleWeight(v float32) int {
 	return int(math.Round(float64(v * 100.0)))
 }
 
-func (e *ServiceSplitterConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *ServiceSplitterConfigEntry) CanRead(authz acl.Authorizer) error {
 	return canReadDiscoveryChain(e, authz)
 }
 
@@ -1069,7 +1069,7 @@ func (e *ServiceResolverConfigEntry) Validate() error {
 	return nil
 }
 
-func (e *ServiceResolverConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *ServiceResolverConfigEntry) CanRead(authz acl.Authorizer) error {
 	return canReadDiscoveryChain(e, authz)
 }
 
@@ -1300,10 +1300,10 @@ type discoveryChainConfigEntry interface {
 	ListRelatedServices() []ServiceID
 }
 
-func canReadDiscoveryChain(entry discoveryChainConfigEntry, authz acl.Authorizer) bool {
+func canReadDiscoveryChain(entry discoveryChainConfigEntry, authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	entry.GetEnterpriseMeta().FillAuthzContext(&authzContext)
-	return authz.ServiceRead(entry.GetName(), &authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().ServiceReadAllowed(entry.GetName(), &authzContext)
 }
 
 func canWriteDiscoveryChain(entry discoveryChainConfigEntry, authz acl.Authorizer) bool {

--- a/agent/structs/config_entry_exports.go
+++ b/agent/structs/config_entry_exports.go
@@ -142,10 +142,10 @@ func (e *ExportedServicesConfigEntry) CanRead(authz acl.Authorizer) error {
 	return authz.ToAllowAuthorizer().MeshReadAllowed(&authzContext)
 }
 
-func (e *ExportedServicesConfigEntry) CanWrite(authz acl.Authorizer) bool {
+func (e *ExportedServicesConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.MeshWrite(&authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext)
 }
 
 func (e *ExportedServicesConfigEntry) GetRaftIndex() *RaftIndex {

--- a/agent/structs/config_entry_exports.go
+++ b/agent/structs/config_entry_exports.go
@@ -136,10 +136,10 @@ func (e *ExportedServicesConfigEntry) Validate() error {
 	return nil
 }
 
-func (e *ExportedServicesConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *ExportedServicesConfigEntry) CanRead(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.MeshRead(&authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().MeshReadAllowed(&authzContext)
 }
 
 func (e *ExportedServicesConfigEntry) CanWrite(authz acl.Authorizer) bool {

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -430,10 +430,10 @@ func (e *IngressGatewayConfigEntry) ListRelatedServices() []ServiceID {
 	return out
 }
 
-func (e *IngressGatewayConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *IngressGatewayConfigEntry) CanRead(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.ServiceRead(e.Name, &authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().ServiceReadAllowed(e.Name, &authzContext)
 }
 
 func (e *IngressGatewayConfigEntry) CanWrite(authz acl.Authorizer) bool {
@@ -572,10 +572,10 @@ func (e *TerminatingGatewayConfigEntry) Validate() error {
 	return nil
 }
 
-func (e *TerminatingGatewayConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *TerminatingGatewayConfigEntry) CanRead(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.ServiceRead(e.Name, &authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().ServiceReadAllowed(e.Name, &authzContext)
 }
 
 func (e *TerminatingGatewayConfigEntry) CanWrite(authz acl.Authorizer) bool {

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -436,10 +436,10 @@ func (e *IngressGatewayConfigEntry) CanRead(authz acl.Authorizer) error {
 	return authz.ToAllowAuthorizer().ServiceReadAllowed(e.Name, &authzContext)
 }
 
-func (e *IngressGatewayConfigEntry) CanWrite(authz acl.Authorizer) bool {
+func (e *IngressGatewayConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.MeshWrite(&authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext)
 }
 
 func (e *IngressGatewayConfigEntry) GetRaftIndex() *RaftIndex {
@@ -578,10 +578,10 @@ func (e *TerminatingGatewayConfigEntry) CanRead(authz acl.Authorizer) error {
 	return authz.ToAllowAuthorizer().ServiceReadAllowed(e.Name, &authzContext)
 }
 
-func (e *TerminatingGatewayConfigEntry) CanWrite(authz acl.Authorizer) bool {
+func (e *TerminatingGatewayConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.MeshWrite(&authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext)
 }
 
 func (e *TerminatingGatewayConfigEntry) GetRaftIndex() *RaftIndex {

--- a/agent/structs/config_entry_intentions.go
+++ b/agent/structs/config_entry_intentions.go
@@ -795,10 +795,10 @@ func (e *ServiceIntentionsConfigEntry) CanRead(authz acl.Authorizer) error {
 	return authz.ToAllowAuthorizer().IntentionReadAllowed(e.GetName(), &authzContext)
 }
 
-func (e *ServiceIntentionsConfigEntry) CanWrite(authz acl.Authorizer) bool {
+func (e *ServiceIntentionsConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.IntentionWrite(e.GetName(), &authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().IntentionWriteAllowed(e.GetName(), &authzContext)
 }
 
 func MigrateIntentions(ixns Intentions) []*ServiceIntentionsConfigEntry {

--- a/agent/structs/config_entry_intentions.go
+++ b/agent/structs/config_entry_intentions.go
@@ -789,10 +789,10 @@ func (e *ServiceIntentionsConfigEntry) GetEnterpriseMeta() *EnterpriseMeta {
 	return &e.EnterpriseMeta
 }
 
-func (e *ServiceIntentionsConfigEntry) CanRead(authz acl.Authorizer) bool {
+func (e *ServiceIntentionsConfigEntry) CanRead(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.IntentionRead(e.GetName(), &authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().IntentionReadAllowed(e.GetName(), &authzContext)
 }
 
 func (e *ServiceIntentionsConfigEntry) CanWrite(authz acl.Authorizer) bool {

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -68,10 +68,10 @@ func (e *MeshConfigEntry) CanRead(authz acl.Authorizer) error {
 	return nil
 }
 
-func (e *MeshConfigEntry) CanWrite(authz acl.Authorizer) bool {
+func (e *MeshConfigEntry) CanWrite(authz acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	e.FillAuthzContext(&authzContext)
-	return authz.MeshWrite(&authzContext) == acl.Allow
+	return authz.ToAllowAuthorizer().MeshWriteAllowed(&authzContext)
 }
 
 func (e *MeshConfigEntry) GetRaftIndex() *RaftIndex {

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -64,8 +64,8 @@ func (e *MeshConfigEntry) Validate() error {
 	return e.validateEnterpriseMeta()
 }
 
-func (e *MeshConfigEntry) CanRead(authz acl.Authorizer) bool {
-	return true
+func (e *MeshConfigEntry) CanRead(authz acl.Authorizer) error {
+	return nil
 }
 
 func (e *MeshConfigEntry) CanWrite(authz acl.Authorizer) bool {

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -194,8 +194,20 @@ func testConfigEntries_ListRelatedServices_AndACLs(t *testing.T, cases []configE
 				for _, a := range tc.expectACLs {
 					require.NotEmpty(t, a.name)
 					t.Run(a.name, func(t *testing.T) {
-						require.Equal(t, a.canRead, tc.entry.CanRead(a.authorizer), "unexpected CanRead result")
-						require.Equal(t, a.canWrite, tc.entry.CanWrite(a.authorizer), "unexpected CanWrite result")
+						canRead := tc.entry.CanRead(a.authorizer)
+						if a.canRead {
+							require.Nil(t, canRead)
+						} else {
+							require.Error(t, canRead)
+							require.True(t, acl.IsErrPermissionDenied(canRead))
+						}
+						canWrite := tc.entry.CanWrite(a.authorizer)
+						if a.canWrite {
+							require.Nil(t, canWrite)
+						} else {
+							require.Error(t, canWrite)
+							require.True(t, acl.IsErrPermissionDenied(canWrite))
+						}
 					})
 				}
 			}


### PR DESCRIPTION
Currently the config_entry.go subsystem delegates authorization decisions via the ConfigEntry interface CanRead and CanWrite code. Unfortunately this returns a true/false value and loses the details of the source.

This is not helpful, especially since it the config subsystem can be more complex to understand, since it covers so many domains.

This refactors CanRead/CanWrite to return a structured error message (PermissionDenied or the like) with more details about the reason for denial.

Part of #12241