### PR TITLE
Update ui_endpoint.go metrics proxy error message

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -689,7 +689,7 @@ func (s *HTTPHandlers) UIMetricsProxy(resp http.ResponseWriter, req *http.Reques
 		if denied {
 			log.Error("target URL path is not allowed",
 				"base_url", cfg.BaseURL,
-				"path", subPath,
+				"path", u.Path,
 				"target_url", u.String(),
 				"path_allowlist", cfg.PathAllowlist,
 			)


### PR DESCRIPTION
correct error logging in UIMetricsProxy function receiver to output the full url path instead of the previously parsed subPath. This is important because the path that is actually checked against the cfg.PathAllowList will include any path prefix component, and the user will need to know to add that path to the path_allowlist.

For example, if the metrics_proxy is 

> https://example.com/prometheus

then the error will read 

> [ERROR] agent.ui_metrics_proxy: target URL path is not allowed: base_url=https://example.com/prometheus path=/api/v1/query target_url=https://example.com/prometheus/api/v1/query path_allowlist=[/api/v1/query, /api/v1/query_range]