### PR TITLE
docs: Consul Service Mesh overview - rename of title and K8s getting started

### DIFF
--- a/website/content/docs/connect/index.mdx
+++ b/website/content/docs/connect/index.mdx
@@ -11,13 +11,10 @@ description: |-
 Consul Service Mesh provides service-to-service connection authorization and
 encryption using mutual Transport Layer Security (TLS). Consul Connect is used interchangeably
 with the name Consul Service Mesh and is what this document will use to refer to for Service Mesh functionality within Consul. 
-Applications can use
-[sidecar proxies](/docs/connect/proxies) in a service mesh configuration to
-establish TLS connections for inbound and outbound connections without being aware
-of Connect at all. Applications may also [natively integrate with Connect](/docs/connect/native)
-for optimal performance and security. Connect can help you secure your services and provide data
-about service-to-service
-communications.
+Applications can use [sidecar proxies](/docs/connect/proxies) in a service mesh configuration to
+establish TLS connections for inbound and outbound connections without being aware of Connect at all. 
+Applications may also [natively integrate with Connect](/docs/connect/native) for optimal performance and security. 
+Connect can help you secure your services and provide data about service-to-service communications.
 
 Review the video below to learn more about Consul Connect from HashiCorp's co-founder Armon.
 

--- a/website/content/docs/connect/index.mdx
+++ b/website/content/docs/connect/index.mdx
@@ -6,10 +6,12 @@ description: |-
   encryption using mutual TLS.
 ---
 
-# Connect
+# Consul Service Mesh
 
-Consul Connect provides service-to-service connection authorization and
-encryption using mutual Transport Layer Security (TLS). Applications can use
+Consul Service Mesh provides service-to-service connection authorization and
+encryption using mutual Transport Layer Security (TLS). Consul Connect is used interchangeably
+with the name Consul Service Mesh and is what this document will use to refer to for Service Mesh functionality within Consul. 
+Applications can use
 [sidecar proxies](/docs/connect/proxies) in a service mesh configuration to
 establish TLS connections for inbound and outbound connections without being aware
 of Connect at all. Applications may also [natively integrate with Connect](/docs/connect/native)
@@ -48,7 +50,7 @@ collect data about it. Consul Connect can configure Envoy proxies to collect
 layer 7 metrics and export them to tools like Prometheus. Correctly instrumented
 applications can also send open tracing data through Envoy.
 
-## Getting Started With Connect
+## Getting Started With Consul Service Mesh
 
 There are several ways to try Connect in different environments.
 
@@ -56,6 +58,8 @@ There are several ways to try Connect in different environments.
   walks you through installing Consul as service mesh for Kubernetes using the Helm
   chart, deploying services in the service mesh, and using intentions to secure service
   communications.
+  
+- The [Getting Started With Consul Service Mesh for Kubernetes](https://learn.hashicorp.com/tutorials/consul/service-mesh-deploy?in=consul/gs-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) guide walks you through installing Consul on Kubernetes to set up a service mesh for establishing communication between Kubernetes services. 
 
 - The [Secure Service-to-Service Communication tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-with-envoy-proxy?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
   is a simple walk through of connecting two services on your local machine


### PR DESCRIPTION
Renaming Connect to Consul Service Mesh in the title, and adding a link to the getting started for Consul Service Mesh on Kubernetes guide. 