### PR TITLE
docs: consul-k8s Change "Consul Connect Service Mesh" to "Consul Service Mesh"

### DIFF
--- a/website/content/docs/k8s/index.mdx
+++ b/website/content/docs/k8s/index.mdx
@@ -12,15 +12,15 @@ description: >-
 
 Consul has many integrations with Kubernetes. You can deploy Consul
 to Kubernetes using the [Helm chart](/docs/k8s/installation/install#helm-chart-installation) or [Consul K8s CLI](/docs/k8s/installation/install#consul-k8s-cli-installation), sync services between Consul and
-Kubernetes, run Consul Connect Service Mesh, and more.
+Kubernetes, run Consul Service Mesh, and more.
 This section documents the official integrations between Consul and Kubernetes.
 
 ## Use Cases
 
-**Consul Connect Service Mesh:**
-Consul can automatically inject the [Consul Connect](/docs/connect)
+**Consul Service Mesh:**
+Consul can automatically inject the [Consul Service Mesh](/docs/connect)
 sidecar into pods so that they can accept and establish encrypted
-and authorized network connections via mutual TLS. And because Connect
+and authorized network connections via mutual TLS. And because Consul Service Mesh
 can run anywhere, pods can also communicate with external services (and
 vice versa) over a fully encrypted connection.
 


### PR DESCRIPTION
Glad I caught this, we should just say Consul Service Mesh. 