### PR TITLE
docs: mention filtered by ACLs in affected APIs

### DIFF
--- a/website/content/api-docs/agent/check.mdx
+++ b/website/content/api-docs/agent/check.mdx
@@ -21,6 +21,8 @@ there is no leader elected. The agent performs active
 [anti-entropy](/docs/architecture/anti-entropy), so in most situations
 everything will be in sync within a few seconds.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path            | Produces           |
 | ------ | --------------- | ------------------ |
 | `GET`  | `/agent/checks` | `application/json` |

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -213,6 +213,8 @@ to the nature of gossip, this is eventually consistent: the results may differ
 by agent. The strongly consistent view of nodes is instead provided by
 `/v1/catalog/nodes`.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
 | `GET`  | `/agent/members` | `application/json` |

--- a/website/content/api-docs/agent/service.mdx
+++ b/website/content/api-docs/agent/service.mdx
@@ -23,6 +23,8 @@ while there is no leader elected. The agent performs active
 [anti-entropy](/docs/architecture/anti-entropy), so in most situations
 everything will be in sync within a few seconds.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path              | Produces           |
 | ------ | ----------------- | ------------------ |
 | `GET`  | `/agent/services` | `application/json` |

--- a/website/content/api-docs/catalog.mdx
+++ b/website/content/api-docs/catalog.mdx
@@ -285,6 +285,8 @@ $ curl \
 
 This endpoint and returns the nodes registered in a given datacenter.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
 | `GET`  | `/catalog/nodes` | `application/json` |
@@ -382,6 +384,8 @@ the following selectors and filter operations being supported:
 
 This endpoint returns the services registered in a given datacenter.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path                | Produces           |
 | ------ | ------------------- | ------------------ |
 | `GET`  | `/catalog/services` | `application/json` |
@@ -437,6 +441,8 @@ a given service.
 ## List Nodes for Service
 
 This endpoint returns the nodes providing a service in a given datacenter.
+
+@include 'http_api_results_filtered_by_acls.mdx'
 
 | Method | Path                        | Produces           |
 | ------ | --------------------------- | ------------------ |
@@ -651,6 +657,8 @@ This will include both proxies and native integrations. A service may
 register both Connect-capable and incapable services at the same time,
 so this endpoint may be used to filter only the Connect-capable endpoints.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path                        | Produces           |
 | ------ | --------------------------- | ------------------ |
 | `GET`  | `/catalog/connect/:service` | `application/json` |
@@ -661,6 +669,8 @@ Parameters and response format are the same as
 ## Retrieve Map of Services for a Node
 
 This endpoint returns the node's registered services.
+
+@include 'http_api_results_filtered_by_acls.mdx'
 
 | Method | Path                  | Produces           |
 | ------ | --------------------- | ------------------ |
@@ -790,6 +800,8 @@ top level Node object. The following selectors and filter operations are support
 ## List Services for Node
 
 This endpoint returns the node's registered services.
+
+@include 'http_api_results_filtered_by_acls.mdx'
 
 | Method | Path                           | Produces           |
 | ------ | ------------------------------ | ------------------ |
@@ -924,6 +936,8 @@ top level object. The following selectors and filter operations are supported:
 -> **1.8.0+:** This API is available in Consul versions 1.8.0 and later.
 
 This endpoint returns the services associated with an ingress gateway or terminating gateway.
+
+@include 'http_api_results_filtered_by_acls.mdx'
 
 | Method | Path                                 | Produces           |
 | ------ | ------------------------------------ | ------------------ |

--- a/website/content/api-docs/config.mdx
+++ b/website/content/api-docs/config.mdx
@@ -161,6 +161,8 @@ $ curl \
 
 This endpoint returns all config entries of the given kind.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path            | Produces           |
 | ------ | --------------- | ------------------ |
 | `GET`  | `/config/:kind` | `application/json` |

--- a/website/content/api-docs/connect/intentions.mdx
+++ b/website/content/api-docs/connect/intentions.mdx
@@ -435,6 +435,8 @@ $ curl \
 
 This endpoint lists all intentions.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path                  | Produces           |
 | ------ | --------------------- | ------------------ |
 | `GET`  | `/connect/intentions` | `application/json` |

--- a/website/content/api-docs/event.mdx
+++ b/website/content/api-docs/event.mdx
@@ -93,6 +93,8 @@ agent may have a different view of the events. Events are broadcast using the
 [gossip protocol](/docs/architecture/gossip), so they have no global ordering
 nor do they make a promise of delivery.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |
 | `GET`  | `/event/list` | `application/json` |

--- a/website/content/api-docs/health.mdx
+++ b/website/content/api-docs/health.mdx
@@ -18,6 +18,8 @@ raw entries.
 
 This endpoint returns the checks specific to the node provided on the path.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path                 | Produces           |
 | ------ | -------------------- | ------------------ |
 | `GET`  | `/health/node/:node` | `application/json` |
@@ -113,6 +115,8 @@ the following selectors and filter operations being supported:
 This endpoint returns the checks associated with the service provided on the
 path.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path                      | Produces           |
 | ------ | ------------------------- | ------------------ |
 | `GET`  | `/health/checks/:service` | `application/json` |
@@ -202,6 +206,8 @@ the following selectors and filter operations being supported:
 This endpoint returns the service instances providing the service indicated on the path.
 Users can also build in support for dynamic load balancing and other features by
 incorporating the use of health checks.
+
+@include 'http_api_results_filtered_by_acls.mdx'
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
@@ -409,6 +415,8 @@ This will include both proxies and native integrations. A service may
 register both Connect-capable and incapable services at the same time,
 so this endpoint may be used to filter only the Connect-capable endpoints.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
 | `GET`  | `/health/connect/:service` | `application/json` |
@@ -422,6 +430,8 @@ Parameters and response format are the same as
 
 This endpoint returns the service instances providing an [ingress
 gateway](/docs/connect/gateways/ingress-gateway) for a service in a given datacenter.
+
+@include 'http_api_results_filtered_by_acls.mdx'
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
@@ -437,6 +447,8 @@ endpoint does not support the [streaming backend](/api/features/blocking#streami
 ## List Checks in State
 
 This endpoint returns the checks in the state provided on the path.
+
+@include 'http_api_results_filtered_by_acls.mdx'
 
 | Method | Path                   | Produces           |
 | ------ | ---------------------- | ------------------ |

--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -29,6 +29,12 @@ This endpoint returns the specified key. If no key exists at the given path, a
 For multi-key reads (up to a limit of 64 KV operations) please consider using
 [transactions](/api/txn) instead.
 
+If the [`recurse`](#recurse) or [`keys`](#keys) query parameters are `true`,
+this endpoint will return an array of keys. In this case,
+the HTTP response includes the `X-Consul-Results-Filtered-By-ACLs: true` header
+if the response array excludes results due to ACL policy configuration.
+Refer to the [HTTP API documentation](/api-docs#results-filtered-by-acls) for more information.
+
 | Method | Path       | Produces           |
 | ------ | ---------- | ------------------ |
 | `GET`  | `/kv/:key` | `application/json` |

--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -427,6 +427,8 @@ $ curl --request DELETE \
 This endpoint lists all the Namespaces. The output will be filtered based on the
 privileges of the ACL token used for the request.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |
 | `GET`  | `/namespaces` | `application/json` |

--- a/website/content/api-docs/query.mdx
+++ b/website/content/api-docs/query.mdx
@@ -299,6 +299,8 @@ $ curl \
 
 This endpoint returns a list of all prepared queries.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path     | Produces           |
 | ------ | -------- | ------------------ |
 | `GET`  | `/query` | `application/json` |
@@ -477,6 +479,10 @@ $ curl \
 
 This endpoint executes an existing prepared query. If no query exists by the
 given ID, an error is returned.
+
+The HTTP response includes the `X-Consul-Results-Filtered-By-ACLs: true` header
+if the [`Nodes`](#nodes) response array excludes results due to ACL policy configuration.
+Refer to the [HTTP API documentation](/api-docs#results-filtered-by-acls) for more information.
 
 | Method | Path                   | Produces           |
 | ------ | ---------------------- | ------------------ |

--- a/website/content/api-docs/session.mdx
+++ b/website/content/api-docs/session.mdx
@@ -230,6 +230,8 @@ If the session does not exist, an empty JSON list `[]` is returned.
 
 This endpoint returns the active sessions for a given node.
 
+@include 'http_api_results_filtered_by_acls.mdx'
+
 | Method | Path                  | Produces           |
 | :----- | :-------------------- | ------------------ |
 | `GET`  | `/session/node/:node` | `application/json` |
@@ -291,6 +293,8 @@ $ curl \
 ## List Sessions
 
 This endpoint returns the list of active sessions.
+
+@include 'http_api_results_filtered_by_acls.mdx'
 
 | Method | Path            | Produces           |
 | :----- | :-------------- | ------------------ |


### PR DESCRIPTION
PR #12489 mentioned the filtered by ACLs header in the coordinate API. This PR applies the same approach across all affected HTTP API endpoints.

All endpoints except 2 just reference the partial created in #12489. Two endpoints are special cases that required different wording, so those endpoints have a copy of the text in the partial rather than referencing the partial directly. These are previews of the special cases:
- [Read Key](https://consul-8r1g2fpun-hashicorp.vercel.app/api-docs/kv#read-key)
- [Execute Prepared Query](https://consul-8r1g2fpun-hashicorp.vercel.app/api-docs/query#execute-prepared-query)