### PR TITLE
pre register new rpc metric, rename metric

### DIFF
--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -92,7 +92,7 @@ func TestAgent_NewRPCMetrics(t *testing.T) {
 		respRec := httptest.NewRecorder()
 		recordPromMetrics(t, a, respRec)
 
-		assertMetricExists(t, respRec, metricsPrefix+"_rpc_server_request")
+		assertMetricExists(t, respRec, metricsPrefix+"_rpc_server_call")
 	})
 }
 

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"github.com/hashicorp/go-hclog"
 )
@@ -21,6 +22,13 @@ const RPCTypeInternal = "internal"
 
 var metricRPCRequest = []string{"rpc", "server", "request"}
 var requestLogName = "rpc.server.request"
+
+var NewRPCCounters = []prometheus.CounterDefinition{
+	{
+		Name: metricRPCRequest,
+		Help: "Increments when a server makes an RPC service call. The labels on the metric have more information",
+	},
+}
 
 type RequestRecorder struct {
 	Logger hclog.Logger

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -20,7 +20,7 @@ import (
 // used for this historically is "RPC", so we continue to use that here.
 const RPCTypeInternal = "internal"
 
-var metricRPCRequest = []string{"rpc", "server", "request"}
+var metricRPCRequest = []string{"rpc", "server", "call"}
 var requestLogName = "rpc.server.request"
 
 var NewRPCCounters = []prometheus.CounterDefinition{

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/router"
+	"github.com/hashicorp/consul/agent/rpc/middleware"
 	"github.com/hashicorp/consul/agent/submatview"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/agent/xds"
@@ -264,6 +265,7 @@ func getPrometheusDefs(cfg lib.TelemetryConfig, isServer bool) ([]prometheus.Gau
 		grpc.StatsCounters,
 		local.StateCounters,
 		raftCounters,
+		middleware.NewRPCCounters,
 	}
 	// Flatten definitions
 	// NOTE(kit): Do we actually want to create a set here so we can ensure definition names are unique?


### PR DESCRIPTION
### Overview

We want to pre register all prometheus metrics so we don't expire them by default. The first commit does that for our new rpc metric.

The second commit renames the metric bc there already exists a `rpc.request` and we want to avoid confusion with that.
