### PR TITLE
xds: connect sidecar proxies can control min/max TLS versions and cipher suites from service-defaults now

### DIFF
--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -824,6 +824,7 @@ func (s *Store) ReadResolvedServiceConfigEntries(
 	entMeta *structs.EnterpriseMeta,
 	upstreamIDs []structs.ServiceID,
 	proxyMode structs.ProxyMode,
+	noUpstreamsDesired bool,
 ) (uint64, *configentry.ResolvedServiceConfigSet, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
@@ -886,7 +887,7 @@ func (s *Store) ReadResolvedServiceConfigEntries(
 	// The upstreams passed as arguments to this endpoint are the upstreams explicitly defined in a proxy registration.
 	// If no upstreams were passed, then we should only return the resolved config if the proxy is in transparent mode.
 	// Otherwise we would return a resolved upstream config to a proxy with no configured upstreams.
-	if noUpstreamArgs && !tproxy {
+	if (noUpstreamArgs && !tproxy) || noUpstreamsDesired {
 		return maxIndex, &res, nil
 	}
 

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -702,6 +702,22 @@ func TestManager_SyncState_No_Notify(t *testing.T) {
 
 	}
 
+	// update the resolved service config
+	notifyCH <- cache.UpdateEvent{
+		CorrelationID: resolvedServiceConfigWatchID,
+		Result:        &structs.ServiceConfigResponse{},
+		Err:           nil,
+	}
+
+	// at this point the snapshot should not be valid and not be sent
+	after = time.After(200 * time.Millisecond)
+	select {
+	case <-snapSent:
+		t.Fatal("snap should not be valid")
+	case <-after:
+
+	}
+
 	// prepare to read a snapshot update as the next update should make the snapshot valid
 	readEvent <- true
 

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -147,6 +147,13 @@ func TestManager_BasicLifecycle(t *testing.T) {
 			},
 		},
 	})
+	resolvedServiceConfigCacheKey := testGenCacheKey(&structs.ServiceConfigRequest{
+		Datacenter:     "dc1",
+		QueryOptions:   structs.QueryOptions{Token: "my-token"},
+		Name:           "web",
+		NoUpstreams:    true,
+		EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+	})
 
 	dbChainCacheKey := testGenCacheKey(&structs.DiscoveryChainRequest{
 		Name:                 "db",
@@ -241,6 +248,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 					WatchedServiceChecks:   map[structs.ServiceID][]structs.CheckType{},
 					Intentions:             TestIntentions().Matches[0],
 					IntentionsSet:          true,
+					TLSConfigSet:           true,
 				},
 				Datacenter: "dc1",
 				Locality:   GatewayKey{Datacenter: "dc1", Partition: structs.PartitionOrDefault("")},
@@ -300,6 +308,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 					WatchedServiceChecks:   map[structs.ServiceID][]structs.CheckType{},
 					Intentions:             TestIntentions().Matches[0],
 					IntentionsSet:          true,
+					TLSConfigSet:           true,
 				},
 				Datacenter: "dc1",
 				Locality:   GatewayKey{Datacenter: "dc1", Partition: structs.PartitionOrDefault("")},
@@ -319,6 +328,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 			types.roots.Set(rootsCacheKey, roots)
 			types.leaf.Set(leafCacheKey, leaf)
 			types.intentions.Set(intentionCacheKey, TestIntentions())
+			types.resolvedServiceConfig.Set(resolvedServiceConfigCacheKey, &structs.ServiceConfigResponse{})
 			tt.setup(t, types)
 
 			expectSnapCopy, err := copystructure.Copy(tt.expectSnap)

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -121,8 +121,8 @@ type configSnapshotConnectProxy struct {
 	MeshConfig    *structs.MeshConfigEntry
 	MeshConfigSet bool
 
-	ServiceDefaults    *structs.ServiceConfigEntry
-	ServiceDefaultsSet bool
+	TLSConfig    *structs.ProxyTLSConfig
+	TLSConfigSet bool
 }
 
 func (c *configSnapshotConnectProxy) IsEmpty() bool {
@@ -143,7 +143,7 @@ func (c *configSnapshotConnectProxy) IsEmpty() bool {
 		len(c.PassthroughUpstreams) == 0 &&
 		len(c.IntentionUpstreams) == 0 &&
 		!c.MeshConfigSet &&
-		!c.ServiceDefaultsSet
+		!c.TLSConfigSet
 }
 
 type configSnapshotTerminatingGateway struct {
@@ -456,7 +456,7 @@ func (s *ConfigSnapshot) Valid() bool {
 		return s.Roots != nil &&
 			s.ConnectProxy.Leaf != nil &&
 			s.ConnectProxy.IntentionsSet &&
-			s.ConnectProxy.ServiceDefaultsSet
+			s.ConnectProxy.TLSConfigSet
 
 	case structs.ServiceKindTerminatingGateway:
 		return s.Roots != nil

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -120,6 +120,9 @@ type configSnapshotConnectProxy struct {
 
 	MeshConfig    *structs.MeshConfigEntry
 	MeshConfigSet bool
+
+	ServiceDefaults    *structs.ServiceConfigEntry
+	ServiceDefaultsSet bool
 }
 
 func (c *configSnapshotConnectProxy) IsEmpty() bool {
@@ -139,7 +142,8 @@ func (c *configSnapshotConnectProxy) IsEmpty() bool {
 		len(c.UpstreamConfig) == 0 &&
 		len(c.PassthroughUpstreams) == 0 &&
 		len(c.IntentionUpstreams) == 0 &&
-		!c.MeshConfigSet
+		!c.MeshConfigSet &&
+		!c.ServiceDefaultsSet
 }
 
 type configSnapshotTerminatingGateway struct {
@@ -451,7 +455,8 @@ func (s *ConfigSnapshot) Valid() bool {
 		}
 		return s.Roots != nil &&
 			s.ConnectProxy.Leaf != nil &&
-			s.ConnectProxy.IntentionsSet
+			s.ConnectProxy.IntentionsSet &&
+			s.ConnectProxy.ServiceDefaultsSet
 
 	case structs.ServiceKindTerminatingGateway:
 		return s.Roots != nil

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -45,6 +45,7 @@ const (
 	serviceIntentionsIDPrefix          = "service-intentions:"
 	intentionUpstreamsID               = "intention-upstreams"
 	meshConfigEntryID                  = "mesh"
+	serviceDefaultsWatchID             = "service-defaults"
 	svcChecksWatchIDPrefix             = cachetype.ServiceHTTPChecksName + ":"
 	preparedQueryIDPrefix              = string(structs.UpstreamDestTypePreparedQuery) + ":"
 	defaultPreparedQueryPollInterval   = 30 * time.Second

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -45,7 +45,7 @@ const (
 	serviceIntentionsIDPrefix          = "service-intentions:"
 	intentionUpstreamsID               = "intention-upstreams"
 	meshConfigEntryID                  = "mesh"
-	serviceDefaultsWatchID             = "service-defaults"
+	resolvedServiceConfigWatchID       = "resolved-service-config"
 	svcChecksWatchIDPrefix             = cachetype.ServiceHTTPChecksName + ":"
 	preparedQueryIDPrefix              = string(structs.UpstreamDestTypePreparedQuery) + ":"
 	defaultPreparedQueryPollInterval   = 30 * time.Second

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -504,6 +504,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				rootsWatchID:                 genVerifyRootsWatch("dc1"),
 				leafWatchID:                  genVerifyLeafWatch("web", "dc1"),
 				intentionsWatchID:            genVerifyIntentionWatch("web", "dc1"),
+				resolvedServiceConfigWatchID: genVerifyResolvedConfigWatch("web", "dc1"),
 				"upstream:" + pqUID.String(): genVerifyPreparedQueryWatch("query", "dc1"),
 				fmt.Sprintf("discovery-chain:%s", apiUID.String()): genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
 					Name:                 "api",
@@ -567,6 +568,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					CorrelationID: intentionsWatchID,
 					Result:        ixnMatch,
 					Err:           nil,
+				},
+				{
+					CorrelationID: resolvedServiceConfigWatchID,
+					Result:        &structs.ServiceConfigResponse{},
 				},
 				{
 					CorrelationID: fmt.Sprintf("discovery-chain:%s", apiUID.String()),
@@ -643,6 +648,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 
 				require.True(t, snap.ConnectProxy.IntentionsSet)
 				require.Equal(t, ixnMatch.Matches[0], snap.ConnectProxy.Intentions)
+				require.True(t, snap.ConnectProxy.TLSConfigSet)
 			},
 		}
 
@@ -1674,9 +1680,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						rootsWatchID: genVerifyRootsWatch("dc1"),
 						intentionUpstreamsID: genVerifyServiceSpecificRequest(intentionUpstreamsID,
 							"api", "", "dc1", false),
-						leafWatchID:       genVerifyLeafWatch("api", "dc1"),
-						intentionsWatchID: genVerifyIntentionWatch("api", "dc1"),
-						meshConfigEntryID: genVerifyMeshConfigWatch("dc1"),
+						leafWatchID:                  genVerifyLeafWatch("api", "dc1"),
+						intentionsWatchID:            genVerifyIntentionWatch("api", "dc1"),
+						meshConfigEntryID:            genVerifyMeshConfigWatch("dc1"),
+						resolvedServiceConfigWatchID: genVerifyResolvedConfigWatch("api", "dc1"),
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.False(t, snap.Valid(), "proxy without roots/leaf/intentions is not valid")
@@ -1715,6 +1722,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							},
 							Err: nil,
 						},
+						{
+							CorrelationID: resolvedServiceConfigWatchID,
+							Result:        &structs.ServiceConfigResponse{},
+						},
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "proxy with roots/leaf/intentions is valid")
@@ -1726,6 +1737,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.True(t, snap.TerminatingGateway.IsEmpty())
 						require.True(t, snap.ConnectProxy.MeshConfigSet)
 						require.Nil(t, snap.ConnectProxy.MeshConfig)
+						require.True(t, snap.ConnectProxy.TLSConfigSet)
 					},
 				},
 			},
@@ -1760,9 +1772,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						rootsWatchID: genVerifyRootsWatch("dc1"),
 						intentionUpstreamsID: genVerifyServiceSpecificRequest(intentionUpstreamsID,
 							"api", "", "dc1", false),
-						leafWatchID:       genVerifyLeafWatch("api", "dc1"),
-						intentionsWatchID: genVerifyIntentionWatch("api", "dc1"),
-						meshConfigEntryID: genVerifyMeshConfigWatch("dc1"),
+						leafWatchID:                  genVerifyLeafWatch("api", "dc1"),
+						intentionsWatchID:            genVerifyIntentionWatch("api", "dc1"),
+						meshConfigEntryID:            genVerifyMeshConfigWatch("dc1"),
+						resolvedServiceConfigWatchID: genVerifyResolvedConfigWatch("api", "dc1"),
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.False(t, snap.Valid(), "proxy without roots/leaf/intentions is not valid")
@@ -1801,6 +1814,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							},
 							Err: nil,
 						},
+						{
+							CorrelationID: resolvedServiceConfigWatchID,
+							Result:        &structs.ServiceConfigResponse{},
+						},
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "proxy with roots/leaf/intentions is valid")
@@ -1812,6 +1829,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.True(t, snap.TerminatingGateway.IsEmpty())
 						require.True(t, snap.ConnectProxy.MeshConfigSet)
 						require.NotNil(t, snap.ConnectProxy.MeshConfig)
+						require.True(t, snap.ConnectProxy.TLSConfigSet)
 					},
 				},
 				// Receiving an intention should lead to spinning up a discovery chain watch
@@ -2319,9 +2337,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						rootsWatchID: genVerifyRootsWatch("dc1"),
 						intentionUpstreamsID: genVerifyServiceSpecificRequest(intentionUpstreamsID,
 							"api", "", "dc1", false),
-						leafWatchID:       genVerifyLeafWatch("api", "dc1"),
-						intentionsWatchID: genVerifyIntentionWatch("api", "dc1"),
-						meshConfigEntryID: genVerifyMeshConfigWatch("dc1"),
+						leafWatchID:                  genVerifyLeafWatch("api", "dc1"),
+						intentionsWatchID:            genVerifyIntentionWatch("api", "dc1"),
+						meshConfigEntryID:            genVerifyMeshConfigWatch("dc1"),
+						resolvedServiceConfigWatchID: genVerifyResolvedConfigWatch("api", "dc1"),
 						"discovery-chain:" + upstreamIDForDC2(dbUID).String(): genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
 							Name:                 "db",
 							EvaluateInDatacenter: "dc2",
@@ -2369,6 +2388,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							},
 							Err: nil,
 						},
+						{
+							CorrelationID: resolvedServiceConfigWatchID,
+							Result:        &structs.ServiceConfigResponse{},
+						},
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.True(t, snap.Valid(), "proxy with roots/leaf/intentions is valid")
@@ -2380,6 +2403,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						require.True(t, snap.TerminatingGateway.IsEmpty())
 						require.True(t, snap.ConnectProxy.MeshConfigSet)
 						require.NotNil(t, snap.ConnectProxy.MeshConfig)
+						require.True(t, snap.ConnectProxy.TLSConfigSet)
 					},
 				},
 				// Discovery chain updates should be stored

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -25,13 +25,14 @@ import (
 // TestCacheTypes encapsulates all the different cache types proxycfg.State will
 // watch/request for controlling one during testing.
 type TestCacheTypes struct {
-	roots             *ControllableCacheType
-	leaf              *ControllableCacheType
-	intentions        *ControllableCacheType
-	health            *ControllableCacheType
-	query             *ControllableCacheType
-	compiledChain     *ControllableCacheType
-	serviceHTTPChecks *ControllableCacheType
+	roots                 *ControllableCacheType
+	leaf                  *ControllableCacheType
+	intentions            *ControllableCacheType
+	health                *ControllableCacheType
+	query                 *ControllableCacheType
+	compiledChain         *ControllableCacheType
+	serviceHTTPChecks     *ControllableCacheType
+	resolvedServiceConfig *ControllableCacheType
 }
 
 // NewTestCacheTypes creates a set of ControllableCacheTypes for all types that
@@ -39,13 +40,14 @@ type TestCacheTypes struct {
 func NewTestCacheTypes(t testing.T) *TestCacheTypes {
 	t.Helper()
 	ct := &TestCacheTypes{
-		roots:             NewControllableCacheType(t),
-		leaf:              NewControllableCacheType(t),
-		intentions:        NewControllableCacheType(t),
-		health:            NewControllableCacheType(t),
-		query:             NewControllableCacheType(t),
-		compiledChain:     NewControllableCacheType(t),
-		serviceHTTPChecks: NewControllableCacheType(t),
+		roots:                 NewControllableCacheType(t),
+		leaf:                  NewControllableCacheType(t),
+		intentions:            NewControllableCacheType(t),
+		health:                NewControllableCacheType(t),
+		query:                 NewControllableCacheType(t),
+		compiledChain:         NewControllableCacheType(t),
+		serviceHTTPChecks:     NewControllableCacheType(t),
+		resolvedServiceConfig: NewControllableCacheType(t),
 	}
 	ct.query.blocking = false
 	return ct
@@ -62,6 +64,7 @@ func TestCacheWithTypes(t testing.T, types *TestCacheTypes) *cache.Cache {
 	c.RegisterType(cachetype.PreparedQueryName, types.query)
 	c.RegisterType(cachetype.CompiledDiscoveryChainName, types.compiledChain)
 	c.RegisterType(cachetype.ServiceHTTPChecksName, types.serviceHTTPChecks)
+	c.RegisterType(cachetype.ResolvedServiceConfigName, types.resolvedServiceConfig)
 
 	return c
 }

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -240,37 +240,7 @@ func (e *IngressGatewayConfigEntry) validateServiceSDS(lis IngressListener, svc 
 }
 
 func validateGatewayTLSConfig(tlsCfg GatewayTLSConfig) error {
-	if tlsCfg.TLSMinVersion != types.TLSVersionUnspecified {
-		if err := types.ValidateTLSVersion(tlsCfg.TLSMinVersion); err != nil {
-			return err
-		}
-	}
-
-	if tlsCfg.TLSMaxVersion != types.TLSVersionUnspecified {
-		if err := types.ValidateTLSVersion(tlsCfg.TLSMaxVersion); err != nil {
-			return err
-		}
-
-		if tlsCfg.TLSMinVersion != types.TLSVersionUnspecified {
-			if err, maxLessThanMin := tlsCfg.TLSMaxVersion.LessThan(tlsCfg.TLSMinVersion); err == nil && maxLessThanMin {
-				return fmt.Errorf("configuring max version %s less than the configured min version %s is invalid", tlsCfg.TLSMaxVersion, tlsCfg.TLSMinVersion)
-			}
-		}
-	}
-
-	if len(tlsCfg.CipherSuites) != 0 {
-		if _, ok := types.TLSVersionsWithConfigurableCipherSuites[tlsCfg.TLSMinVersion]; !ok {
-			return fmt.Errorf("configuring CipherSuites is only applicable to conncetions negotiated with TLS 1.2 or earlier, TLSMinVersion is set to %s", tlsCfg.TLSMinVersion)
-		}
-
-		// NOTE: it would be nice to emit a warning but not return an error from
-		// here if TLSMaxVersion is unspecified, TLS_AUTO or TLSv1_3
-		if err := types.ValidateEnvoyCipherSuites(tlsCfg.CipherSuites); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return validateProxyTLSConfig(tlsCfg.TLSMinVersion, tlsCfg.TLSMaxVersion, tlsCfg.CipherSuites)
 }
 
 func (e *IngressGatewayConfigEntry) Validate() error {

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -240,7 +240,7 @@ func (e *IngressGatewayConfigEntry) validateServiceSDS(lis IngressListener, svc 
 }
 
 func validateGatewayTLSConfig(tlsCfg GatewayTLSConfig) error {
-	return validateProxyTLSConfig(tlsCfg.TLSMinVersion, tlsCfg.TLSMaxVersion, tlsCfg.CipherSuites)
+	return validateTLSConfig(tlsCfg.TLSMinVersion, tlsCfg.TLSMaxVersion, tlsCfg.CipherSuites)
 }
 
 func (e *IngressGatewayConfigEntry) Validate() error {

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -316,12 +316,14 @@ func TestDecodeConfigEntry(t *testing.T) {
 				mesh_gateway {
 					mode = "remote"
 				}
-				tls_min_version = "TLSv1_1"
-				tls_max_version = "TLSv1_2"
-				cipher_suites = [
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-				]
+				tls {
+					tls_min_version = "TLSv1_1"
+					tls_max_version = "TLSv1_2"
+					cipher_suites = [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				}
 				upstream_config {
 					overrides = [
 						{
@@ -363,12 +365,14 @@ func TestDecodeConfigEntry(t *testing.T) {
 				MeshGateway {
 					Mode = "remote"
 				}
-				TLSMinVersion = "TLSv1_1"
-				TLSMaxVersion = "TLSv1_2"
-				CipherSuites = [
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-				]
+				TLS {
+					TLSMinVersion = "TLSv1_1"
+					TLSMaxVersion = "TLSv1_2"
+					CipherSuites = [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				}
 				UpstreamConfig {
 					Overrides = [
 						{
@@ -410,11 +414,13 @@ func TestDecodeConfigEntry(t *testing.T) {
 				MeshGateway: MeshGatewayConfig{
 					Mode: MeshGatewayModeRemote,
 				},
-				TLSMinVersion: types.TLSv1_1,
-				TLSMaxVersion: types.TLSv1_2,
-				CipherSuites: []types.TLSCipherSuite{
-					types.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-					types.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				TLS: &ProxyTLSConfig{
+					TLSMinVersion: types.TLSv1_1,
+					TLSMaxVersion: types.TLSv1_2,
+					CipherSuites: []types.TLSCipherSuite{
+						types.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+						types.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					},
 				},
 				UpstreamConfig: &UpstreamConfiguration{
 					Overrides: []*UpstreamConfig{

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -316,6 +316,12 @@ func TestDecodeConfigEntry(t *testing.T) {
 				mesh_gateway {
 					mode = "remote"
 				}
+				tls_min_version = "TLSv1_1"
+				tls_max_version = "TLSv1_2"
+				cipher_suites = [
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+				]
 				upstream_config {
 					overrides = [
 						{
@@ -357,6 +363,12 @@ func TestDecodeConfigEntry(t *testing.T) {
 				MeshGateway {
 					Mode = "remote"
 				}
+				TLSMinVersion = "TLSv1_1"
+				TLSMaxVersion = "TLSv1_2"
+				CipherSuites = [
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+				]
 				UpstreamConfig {
 					Overrides = [
 						{
@@ -397,6 +409,12 @@ func TestDecodeConfigEntry(t *testing.T) {
 				ExternalSNI: "abc-123",
 				MeshGateway: MeshGatewayConfig{
 					Mode: MeshGatewayModeRemote,
+				},
+				TLSMinVersion: types.TLSv1_1,
+				TLSMaxVersion: types.TLSv1_2,
+				CipherSuites: []types.TLSCipherSuite{
+					types.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					types.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 				},
 				UpstreamConfig: &UpstreamConfiguration{
 					Overrides: []*UpstreamConfig{

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -753,7 +753,7 @@ func (s *ResourceGenerator) injectConnectTLSOnFilterChains(cfgSnap *proxycfg.Con
 			CommonTlsContext: makeCommonTLSContextFromLeaf(
 				cfgSnap,
 				cfgSnap.Leaf(),
-				makeTLSParametersFromProxyTLSConfig(cfgSnap.ConnectProxy.ServiceDefaults),
+				makeTLSParametersFromProxyTLSConfig(cfgSnap.ConnectProxy.TLSConfig),
 			),
 			RequireClientCertificate: &wrappers.BoolValue{Value: true},
 		}
@@ -1691,12 +1691,12 @@ var tlsVersionsWithConfigurableCipherSuites = map[types.TLSVersion]struct{}{
 	types.TLSv1_2: {},
 }
 
-func makeTLSParametersFromProxyTLSConfig(serviceConf *structs.ServiceConfigEntry) *envoy_tls_v3.TlsParameters {
-	if serviceConf == nil {
+func makeTLSParametersFromProxyTLSConfig(tlsConf *structs.ProxyTLSConfig) *envoy_tls_v3.TlsParameters {
+	if tlsConf == nil {
 		return &envoy_tls_v3.TlsParameters{}
 	}
 
-	return makeTLSParametersFromTLSConfig(serviceConf.TLSMinVersion, serviceConf.TLSMaxVersion, serviceConf.CipherSuites)
+	return makeTLSParametersFromTLSConfig(tlsConf.TLSMinVersion, tlsConf.TLSMaxVersion, tlsConf.CipherSuites)
 }
 
 func makeTLSParametersFromTLSConfig(

--- a/agent/xds/listeners_ingress.go
+++ b/agent/xds/listeners_ingress.go
@@ -214,23 +214,8 @@ func resolveListenerTLSConfig(gatewayTLSCfg *structs.GatewayTLSConfig, listenerC
 		}
 	}
 
-	var TLSVersionsWithConfigurableCipherSuites = map[types.TLSVersion]struct{}{
-		// Remove these two if Envoy ever sets TLS 1.3 as default minimum
-		types.TLSVersionUnspecified: {},
-		types.TLSVersionAuto:        {},
-
-		types.TLSv1_0: {},
-		types.TLSv1_1: {},
-		types.TLSv1_2: {},
-	}
-
-	// Validate. Configuring cipher suites is only applicable to connections negotiated
-	// via TLS 1.2 or earlier. Other cases shouldn't be possible as we validate them at
-	// input but be resilient to bugs later.
-	if len(mergedCfg.CipherSuites) != 0 {
-		if _, ok := TLSVersionsWithConfigurableCipherSuites[mergedCfg.TLSMinVersion]; !ok {
-			return nil, fmt.Errorf("configuring CipherSuites is only applicable to connections negotiated with TLS 1.2 or earlier, TLSMinVersion is set to %s in listener or gateway config", mergedCfg.TLSMinVersion)
-		}
+	if err := validateListenerTLSConfig(mergedCfg.TLSMinVersion, mergedCfg.CipherSuites); err != nil {
+		return nil, err
 	}
 
 	return &mergedCfg, nil
@@ -365,32 +350,8 @@ func makeSDSOverrideFilterChains(cfgSnap *proxycfg.ConfigSnapshot,
 	return chains, nil
 }
 
-var envoyTLSVersions = map[types.TLSVersion]envoy_tls_v3.TlsParameters_TlsProtocol{
-	types.TLSVersionAuto: envoy_tls_v3.TlsParameters_TLS_AUTO,
-	types.TLSv1_0:        envoy_tls_v3.TlsParameters_TLSv1_0,
-	types.TLSv1_1:        envoy_tls_v3.TlsParameters_TLSv1_1,
-	types.TLSv1_2:        envoy_tls_v3.TlsParameters_TLSv1_2,
-	types.TLSv1_3:        envoy_tls_v3.TlsParameters_TLSv1_3,
-}
-
 func makeTLSParametersFromGatewayTLSConfig(tlsCfg structs.GatewayTLSConfig) *envoy_tls_v3.TlsParameters {
-	tlsParams := envoy_tls_v3.TlsParameters{}
-
-	if tlsCfg.TLSMinVersion != types.TLSVersionUnspecified {
-		if minVersion, ok := envoyTLSVersions[tlsCfg.TLSMinVersion]; ok {
-			tlsParams.TlsMinimumProtocolVersion = minVersion
-		}
-	}
-	if tlsCfg.TLSMaxVersion != types.TLSVersionUnspecified {
-		if maxVersion, ok := envoyTLSVersions[tlsCfg.TLSMaxVersion]; ok {
-			tlsParams.TlsMaximumProtocolVersion = maxVersion
-		}
-	}
-	if len(tlsCfg.CipherSuites) != 0 {
-		tlsParams.CipherSuites = types.MarshalEnvoyTLSCipherSuiteStrings(tlsCfg.CipherSuites)
-	}
-
-	return &tlsParams
+	return makeTLSParametersFromTLSConfig(tlsCfg.TLSMinVersion, tlsCfg.TLSMaxVersion, tlsCfg.CipherSuites)
 }
 
 func makeCommonTLSContextFromGatewayTLSConfig(tlsCfg structs.GatewayTLSConfig) *envoy_tls_v3.CommonTlsContext {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -48,11 +48,9 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
 					{
-						CorrelationID: "service-defaults",
-						Result: &structs.ConfigEntryResponse{
-							Entry: &structs.ServiceConfigEntry{
-								Kind:          structs.ServiceDefaults,
-								Name:          "db",
+						CorrelationID: "resolved-service-config",
+						Result: &structs.ServiceConfigResponse{
+							TLS: &structs.ProxyTLSConfig{
 								TLSMinVersion: types.TLSv1_3,
 							},
 						},
@@ -65,11 +63,9 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
 					{
-						CorrelationID: "service-defaults",
-						Result: &structs.ConfigEntryResponse{
-							Entry: &structs.ServiceConfigEntry{
-								Kind:          structs.ServiceDefaults,
-								Name:          "db",
+						CorrelationID: "resolved-service-config",
+						Result: &structs.ServiceConfigResponse{
+							TLS: &structs.ProxyTLSConfig{
 								TLSMaxVersion: types.TLSv1_2,
 							},
 						},
@@ -82,11 +78,9 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
 					{
-						CorrelationID: "service-defaults",
-						Result: &structs.ConfigEntryResponse{
-							Entry: &structs.ServiceConfigEntry{
-								Kind: structs.ServiceDefaults,
-								Name: "db",
+						CorrelationID: "resolved-service-config",
+						Result: &structs.ServiceConfigResponse{
+							TLS: &structs.ProxyTLSConfig{
 								CipherSuites: []types.TLSCipherSuite{
 									types.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 									types.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -44,6 +44,60 @@ func TestListenersFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name: "connect-proxy-with-tls-listener-min-version",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+					{
+						CorrelationID: "service-defaults",
+						Result: &structs.ConfigEntryResponse{
+							Entry: &structs.ServiceConfigEntry{
+								Kind:          structs.ServiceDefaults,
+								Name:          "db",
+								TLSMinVersion: types.TLSv1_3,
+							},
+						},
+					},
+				})
+			},
+		},
+		{
+			name: "connect-proxy-with-tls-listener-max-version",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+					{
+						CorrelationID: "service-defaults",
+						Result: &structs.ConfigEntryResponse{
+							Entry: &structs.ServiceConfigEntry{
+								Kind:          structs.ServiceDefaults,
+								Name:          "db",
+								TLSMaxVersion: types.TLSv1_2,
+							},
+						},
+					},
+				})
+			},
+		},
+		{
+			name: "connect-proxy-with-tls-listener-cipher-suites",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+					{
+						CorrelationID: "service-defaults",
+						Result: &structs.ConfigEntryResponse{
+							Entry: &structs.ServiceConfigEntry{
+								Kind: structs.ServiceDefaults,
+								Name: "db",
+								CipherSuites: []types.TLSCipherSuite{
+									types.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+									types.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+								},
+							},
+						},
+					},
+				})
+			},
+		},
+		{
 			name: "listener-bind-address",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {

--- a/agent/xds/testdata/listeners/connect-proxy-with-tls-listener-cipher-suites.envoy-1-20-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tls-listener-cipher-suites.envoy-1-20-x.golden
@@ -1,0 +1,122 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "public_listener",
+                "cluster": "local_app"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+                  "cipherSuites": [
+                    "ECDHE-ECDSA-AES128-GCM-SHA256",
+                    "ECDHE-ECDSA-CHACHA20-POLY1305"
+                  ]
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/connect-proxy-with-tls-listener-max-version.envoy-1-20-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tls-listener-max-version.envoy-1-20-x.golden
@@ -1,0 +1,119 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "public_listener",
+                "cluster": "local_app"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+                  "tlsMaximumProtocolVersion": "TLSv1_2"
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/connect-proxy-with-tls-listener-min-version.envoy-1-20-x.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-tls-listener-min-version.envoy-1-20-x.golden
@@ -1,0 +1,119 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "public_listener",
+                "cluster": "local_app"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+                  "tlsMinimumProtocolVersion": "TLSv1_3"
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -220,12 +220,7 @@ type ServiceConfigEntry struct {
 	Expose           ExposeConfig            `json:",omitempty"`
 	ExternalSNI      string                  `json:",omitempty" alias:"external_sni"`
 	UpstreamConfig   *UpstreamConfiguration  `json:",omitempty" alias:"upstream_config"`
-
-	TLSMinVersion string `json:",omitempty" alias:"tls_min_version"`
-	TLSMaxVersion string `json:",omitempty" alias:"tls_max_version"`
-	// Define a subset of cipher suites to restrict
-	// Only applicable to connections negotiated via TLS 1.2 or earlier
-	CipherSuites []string `json:",omitempty" alias:"cipher_suites"`
+	TLS              *ProxyTLSConfig         `json:",omitempty"`
 
 	Meta        map[string]string `json:",omitempty"`
 	CreateIndex uint64
@@ -250,9 +245,17 @@ type ProxyConfigEntry struct {
 	Config           map[string]interface{}  `json:",omitempty"`
 	MeshGateway      MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
 	Expose           ExposeConfig            `json:",omitempty"`
-	Meta             map[string]string       `json:",omitempty"`
-	CreateIndex      uint64
-	ModifyIndex      uint64
+	TLS              *ProxyTLSConfig         `json:",omitempty"`
+
+	Meta        map[string]string `json:",omitempty"`
+	CreateIndex uint64
+	ModifyIndex uint64
+}
+
+type ProxyTLSConfig struct {
+	TLSMinVersion string   `json:",omitempty" alias:"tls_min_version"`
+	TLSMaxVersion string   `json:",omitempty" alias:"tls_max_version"`
+	CipherSuites  []string `json:",omitempty" alias:"cipher_suites"`
 }
 
 func (p *ProxyConfigEntry) GetKind() string            { return p.Kind }

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -221,6 +221,12 @@ type ServiceConfigEntry struct {
 	ExternalSNI      string                  `json:",omitempty" alias:"external_sni"`
 	UpstreamConfig   *UpstreamConfiguration  `json:",omitempty" alias:"upstream_config"`
 
+	TLSMinVersion string `json:",omitempty" alias:"tls_min_version"`
+	TLSMaxVersion string `json:",omitempty" alias:"tls_max_version"`
+	// Define a subset of cipher suites to restrict
+	// Only applicable to connections negotiated via TLS 1.2 or earlier
+	CipherSuites []string `json:",omitempty" alias:"cipher_suites"`
+
 	Meta        map[string]string `json:",omitempty"`
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -438,6 +438,12 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"OutboundListenerPort": 808,
 					"DialedDirectly": true
 				},
+				"TLSMinVersion": "TLSv1_1",
+				"TLSMaxVersion": "TLSv1_2",
+				"CipherSuites": [
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+				],
 				"UpstreamConfig": {
 					"Overrides": [
 						{
@@ -484,7 +490,13 @@ func TestDecodeConfigEntry(t *testing.T) {
 				MeshGateway: MeshGatewayConfig{
 					Mode: MeshGatewayModeRemote,
 				},
-				Mode: ProxyModeTransparent,
+				Mode:          ProxyModeTransparent,
+				TLSMinVersion: "TLSv1_1",
+				TLSMaxVersion: "TLSv1_2",
+				CipherSuites: []string{
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				},
 				TransparentProxy: &TransparentProxyConfig{
 					OutboundListenerPort: 808,
 					DialedDirectly:       true,

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -394,7 +394,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"CipherSuites": [
 						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-					],
+					]
 				},
 				"TransparentProxy": {
 					"OutboundListenerPort": 808,
@@ -460,7 +460,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"CipherSuites": [
 						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-					],
+					]
 				},
 				"UpstreamConfig": {
 					"Overrides": [

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -388,6 +388,14 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"Mode": "remote"
 				},
 				"Mode": "transparent",
+				"TLS": {
+					"TLSMinVersion": "TLSv1_1",
+					"TLSMaxVersion": "TLSv1_2",
+					"CipherSuites": [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					],
+				},
 				"TransparentProxy": {
 					"OutboundListenerPort": 808,
 					"DialedDirectly": true
@@ -412,6 +420,14 @@ func TestDecodeConfigEntry(t *testing.T) {
 					Mode: MeshGatewayModeRemote,
 				},
 				Mode: ProxyModeTransparent,
+				TLS: &ProxyTLSConfig{
+					TLSMinVersion: "TLSv1_1",
+					TLSMaxVersion: "TLSv1_2",
+					CipherSuites: []string{
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					},
+				},
 				TransparentProxy: &TransparentProxyConfig{
 					OutboundListenerPort: 808,
 					DialedDirectly:       true,
@@ -438,12 +454,14 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"OutboundListenerPort": 808,
 					"DialedDirectly": true
 				},
-				"TLSMinVersion": "TLSv1_1",
-				"TLSMaxVersion": "TLSv1_2",
-				"CipherSuites": [
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-				],
+				"TLS": {
+					"TLSMinVersion": "TLSv1_1",
+					"TLSMaxVersion": "TLSv1_2",
+					"CipherSuites": [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					],
+				},
 				"UpstreamConfig": {
 					"Overrides": [
 						{
@@ -490,12 +508,14 @@ func TestDecodeConfigEntry(t *testing.T) {
 				MeshGateway: MeshGatewayConfig{
 					Mode: MeshGatewayModeRemote,
 				},
-				Mode:          ProxyModeTransparent,
-				TLSMinVersion: "TLSv1_1",
-				TLSMaxVersion: "TLSv1_2",
-				CipherSuites: []string{
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				Mode: ProxyModeTransparent,
+				TLS: &ProxyTLSConfig{
+					TLSMinVersion: "TLSv1_1",
+					TLSMaxVersion: "TLSv1_2",
+					CipherSuites: []string{
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					},
 				},
 				TransparentProxy: &TransparentProxyConfig{
 					OutboundListenerPort: 808,

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -214,6 +214,14 @@ func TestParseConfigEntry(t *testing.T) {
 					mode = "remote"
 				}
 				mode = "direct"
+				tls {
+					tls_min_version = "TLSv1_1"
+					tls_max_version = "TLSv1_2"
+					cipher_suites = [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				}
 				transparent_proxy = {
 					outbound_listener_port = 10101
 					dialed_directly = true
@@ -237,6 +245,14 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode = "remote"
 				}
 				Mode = "direct"
+				TLS {
+					TLSMinVersion = "TLSv1_1"
+					TLSMaxVersion = "TLSv1_2"
+					CipherSuites = [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				}
 				TransparentProxy = {
 					outbound_listener_port = 10101
 					dialed_directly = true
@@ -261,6 +277,14 @@ func TestParseConfigEntry(t *testing.T) {
 					"mode": "remote"
 				},
 				"mode": "direct",
+				"tls": {
+					"tls_min_version": "TLSv1_1",
+					"tls_max_version": "TLSv1_2",
+					"cipher_suites": [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				},
 				"transparent_proxy": {
 					"outbound_listener_port": 10101,
 					"dialed_directly": true
@@ -286,6 +310,14 @@ func TestParseConfigEntry(t *testing.T) {
 					"Mode": "remote"
 				},
 				"Mode": "direct",
+				"TLS": {
+					"TLSMinVersion": "TLSv1_1",
+					"TLSMaxVersion": "TLSv1_2",
+					"CipherSuites": [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				},
 				"TransparentProxy": {
 					"OutboundListenerPort": 10101,
 					"DialedDirectly": true
@@ -310,6 +342,14 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode: api.MeshGatewayModeRemote,
 				},
 				Mode: api.ProxyModeDirect,
+				TLS: &api.ProxyTLSConfig{
+					TLSMinVersion: "TLSv1_1",
+					TLSMaxVersion: "TLSv1_2",
+					CipherSuites: []string{
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					},
+				},
 				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 					DialedDirectly:       true,
@@ -333,6 +373,14 @@ func TestParseConfigEntry(t *testing.T) {
 					Mode: api.MeshGatewayModeRemote,
 				},
 				Mode: api.ProxyModeDirect,
+				TLS: &api.ProxyTLSConfig{
+					TLSMinVersion: "TLSv1_1",
+					TLSMaxVersion: "TLSv1_2",
+					CipherSuites: []string{
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					},
+				},
 				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 					DialedDirectly:       true,
@@ -503,12 +551,14 @@ func TestParseConfigEntry(t *testing.T) {
 					outbound_listener_port = 10101
 					dialed_directly = true
 				}
-				tls_min_version = "TLSv1_1"
-				tls_max_version = "TLSv1_2"
-				cipher_suites = [
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-				]
+				tls {
+					tls_min_version = "TLSv1_1"
+					tls_max_version = "TLSv1_2"
+					cipher_suites = [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				}
 				upstream_config {
 					overrides = [
 						{
@@ -568,12 +618,14 @@ func TestParseConfigEntry(t *testing.T) {
 					outbound_listener_port = 10101
 					dialed_directly = true
 				}
-				TLSMinVersion = "TLSv1_1"
-				TLSMaxVersion = "TLSv1_2"
-				CipherSuites = [
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-				]
+				TLS {
+					TLSMinVersion = "TLSv1_1"
+					TLSMaxVersion = "TLSv1_2"
+					CipherSuites = [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				}
 				UpstreamConfig {
 					Overrides = [
 						{
@@ -634,12 +686,14 @@ func TestParseConfigEntry(t *testing.T) {
 					"outbound_listener_port": 10101,
 					"dialed_directly": true
 				},
-				"tls_min_version": "TLSv1_1",
-				"tls_max_version": "TLSv1_2",
-				"cipher_suites": [
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-				],
+				"tls": {
+					"tls_min_version": "TLSv1_1",
+					"tls_max_version": "TLSv1_2",
+					"cipher_suites": [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				},
 				"upstream_config": {
 					"overrides": [
 						{
@@ -701,12 +755,14 @@ func TestParseConfigEntry(t *testing.T) {
 					"OutboundListenerPort": 10101,
 					"DialedDirectly": true
 				},
-				"TLSMinVersion": "TLSv1_1",
-				"TLSMaxVersion": "TLSv1_2",
-				"CipherSuites": [
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-				],
+				"TLS": {
+					"TLSMinVersion": "TLSv1_1",
+					"TLSMaxVersion": "TLSv1_2",
+					"CipherSuites": [
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+					]
+				},
 				"UpstreamConfig": {
 					"Overrides": [
 						{
@@ -767,11 +823,13 @@ func TestParseConfigEntry(t *testing.T) {
 					OutboundListenerPort: 10101,
 					DialedDirectly:       true,
 				},
-				TLSMinVersion: "TLSv1_1",
-				TLSMaxVersion: "TLSv1_2",
-				CipherSuites: []string{
-					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				TLS: &api.ProxyTLSConfig{
+					TLSMinVersion: "TLSv1_1",
+					TLSMaxVersion: "TLSv1_2",
+					CipherSuites: []string{
+						"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+						"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+					},
 				},
 				UpstreamConfig: &api.UpstreamConfiguration{
 					Overrides: []*api.UpstreamConfig{

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -503,6 +503,12 @@ func TestParseConfigEntry(t *testing.T) {
 					outbound_listener_port = 10101
 					dialed_directly = true
 				}
+				tls_min_version = "TLSv1_1"
+				tls_max_version = "TLSv1_2"
+				cipher_suites = [
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+				]
 				upstream_config {
 					overrides = [
 						{
@@ -562,6 +568,12 @@ func TestParseConfigEntry(t *testing.T) {
 					outbound_listener_port = 10101
 					dialed_directly = true
 				}
+				TLSMinVersion = "TLSv1_1"
+				TLSMaxVersion = "TLSv1_2"
+				CipherSuites = [
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+				]
 				UpstreamConfig {
 					Overrides = [
 						{
@@ -622,6 +634,12 @@ func TestParseConfigEntry(t *testing.T) {
 					"outbound_listener_port": 10101,
 					"dialed_directly": true
 				},
+				"tls_min_version": "TLSv1_1",
+				"tls_max_version": "TLSv1_2",
+				"cipher_suites": [
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+				],
 				"upstream_config": {
 					"overrides": [
 						{
@@ -683,6 +701,12 @@ func TestParseConfigEntry(t *testing.T) {
 					"OutboundListenerPort": 10101,
 					"DialedDirectly": true
 				},
+				"TLSMinVersion": "TLSv1_1",
+				"TLSMaxVersion": "TLSv1_2",
+				"CipherSuites": [
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+				],
 				"UpstreamConfig": {
 					"Overrides": [
 						{
@@ -742,6 +766,12 @@ func TestParseConfigEntry(t *testing.T) {
 				TransparentProxy: &api.TransparentProxyConfig{
 					OutboundListenerPort: 10101,
 					DialedDirectly:       true,
+				},
+				TLSMinVersion: "TLSv1_1",
+				TLSMaxVersion: "TLSv1_2",
+				CipherSuites: []string{
+					"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+					"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 				},
 				UpstreamConfig: &api.UpstreamConfiguration{
 					Overrides: []*api.UpstreamConfig{


### PR DESCRIPTION
Fixes #11966

Per-service you can edit the `tls{}` block of `service-defaults` to control these things. You can also update the same in `proxy-defaults` to apply to all services.

TODO:

- [ ] website update for `service-defaults`
- [ ] website update for `proxy-defaults`
- [ ] test for service vs proxy defaults overriding
- [ ] consider changing the default for `TLSMinVersion` to 1.2 and adding a backwards compatibility node in the upgrade guide