### PR TITLE
docs: add link to k8s cli install page

### DIFF
--- a/website/content/docs/k8s/k8s-cli.mdx
+++ b/website/content/docs/k8s/k8s-cli.mdx
@@ -9,7 +9,9 @@ description: >-
 
 Consul K8s CLI is a tool for quickly installing and interacting with Consul on Kubernetes. 
 The Consul K8s CLI allows you to manage the lifecycle of Consul without requiring the usage of `Helm`, [Consul CLI](/commands/index), and `kubectl`. 
-The Consul K8s CLI offers a Kubernetes native experience for managing Consul.
+The Consul K8s CLI offers a Kubernetes native experience for managing Consul. 
+
+-> **Note**: For guidance on how to install the Consul K8s CLI, visit the [Installing the Consul K8s CLI](/docs/k8s/installation/install-cli) documentation page. 
 
 This topic describes the subcommands and available options for using Consul K8s CLI.
 

--- a/website/content/docs/k8s/k8s-cli.mdx
+++ b/website/content/docs/k8s/k8s-cli.mdx
@@ -11,7 +11,7 @@ Consul K8s CLI is a tool for quickly installing and interacting with Consul on K
 The Consul K8s CLI allows you to manage the lifecycle of Consul without requiring the usage of `Helm`, [Consul CLI](/commands/index), and `kubectl`. 
 The Consul K8s CLI offers a Kubernetes native experience for managing Consul. 
 
--> **Note**: For guidance on how to install the Consul K8s CLI, visit the [Installing the Consul K8s CLI](/docs/k8s/installation/install-cli) documentation page. 
+-> **Note**: For guidance on how to install the Consul K8s CLI, visit the [Installing the Consul K8s CLI](/docs/k8s/installation/install-cli) documentation. 
 
 This topic describes the subcommands and available options for using Consul K8s CLI.
 


### PR DESCRIPTION
This PR adds a note box that points the user to the installation page. This makes it easier for consumers to find the installation guidance. 

![image](https://user-images.githubusercontent.com/29551334/159588246-59ecff16-a2d0-4f97-8c5c-4696be23622b.png)
