### PR TITLE
Fixup dropped SecretID usage

### DIFF
--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -875,12 +875,11 @@ func TestTxn_Read_ACLDeny(t *testing.T) {
 	state.EnsureCheck(4, &check)
 
 	token := createTokenFull(t, codec, testTxnRules)
-	id := token.AccessorID
 
 	t.Run("simple read operations (results get filtered out)", func(t *testing.T) {
 		arg := structs.TxnReadRequest{
 			Datacenter:   "dc1",
-			QueryOptions: structs.QueryOptions{Token: id},
+			QueryOptions: structs.QueryOptions{Token: token.SecretID},
 			Ops: structs.TxnOps{
 				{
 					KV: &structs.TxnKVOp{
@@ -912,7 +911,7 @@ func TestTxn_Read_ACLDeny(t *testing.T) {
 	t.Run("complex operations (return permission denied errors)", func(t *testing.T) {
 		arg := structs.TxnReadRequest{
 			Datacenter:   "dc1",
-			QueryOptions: structs.QueryOptions{Token: id},
+			QueryOptions: structs.QueryOptions{Token: token.SecretID},
 			Ops: structs.TxnOps{
 				{
 					KV: &structs.TxnKVOp{


### PR DESCRIPTION

Looks like something got munged	at some point. Not sure how it slipped in, but my best guess is that because  TestTxn_Apply_ACLDeny is marked flaky we didn't block merge because it failed.

Signed-off-by: Mark Anderson <manderson@hashicorp.com>