### PR TITLE
docs: make gossip threat model more visible

### DIFF
--- a/website/content/docs/security/security-models/core.mdx
+++ b/website/content/docs/security/security-models/core.mdx
@@ -407,7 +407,9 @@ The following are not part of the threat model for client agents:
   configured identity, and extract information from Consul when ACLs are disabled.
 
 - **DNS** - Malicious actors with access to a Consul agent DNS endpoint may be able to extract service catalog
-  information. Gossip - Malicious actors with access to a Consul agent Serf gossip endpoint may be able to impersonate
+  information.
+
+- **Gossip** - Malicious actors with access to a Consul agent Serf gossip endpoint may be able to impersonate
   agents within a datacenter. Gossip encryption should be enabled, with a regularly rotated gossip key.
 
 - **Proxy (xDS)** - Malicious actors with access to a Consul agent xDS endpoint may be able to extract Envoy service


### PR DESCRIPTION
As shown in the screenshot below, gossip should have its own section in "internal threats", not be included in the DNS section.

![image](https://user-images.githubusercontent.com/85913323/159740043-56599514-af2a-4b4c-9676-f4707ac03048.png)
