### PR TITLE
[OSS] ca: move `ConnectCA.Sign` authorization logic to `CAManager`

### DIFF
--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 
-	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
@@ -145,54 +144,17 @@ func (s *ConnectCA) Sign(
 		return err
 	}
 
-	// Parse the CSR
 	csr, err := connect.ParseCSR(args.CSR)
 	if err != nil {
 		return err
 	}
 
-	// Parse the SPIFFE ID
-	spiffeID, err := connect.ParseCertURI(csr.URIs[0])
-	if err != nil {
-		return err
-	}
-
-	// Verify that the ACL token provided has permission to act as this service
 	authz, err := s.srv.ResolveToken(args.Token)
 	if err != nil {
 		return err
 	}
 
-	var authzContext acl.AuthorizerContext
-	var entMeta structs.EnterpriseMeta
-
-	serviceID, isService := spiffeID.(*connect.SpiffeIDService)
-	agentID, isAgent := spiffeID.(*connect.SpiffeIDAgent)
-	if !isService && !isAgent {
-		return fmt.Errorf("SPIFFE ID in CSR must be a service or agent ID")
-	}
-
-	if isService {
-		entMeta.Merge(serviceID.GetEnterpriseMeta())
-		entMeta.FillAuthzContext(&authzContext)
-		if err := authz.ToAllowAuthorizer().ServiceWriteAllowed(serviceID.Service, &authzContext); err != nil {
-			return err
-		}
-
-		// Verify that the DC in the service URI matches us. We might relax this
-		// requirement later but being restrictive for now is safer.
-		if serviceID.Datacenter != s.srv.config.Datacenter {
-			return fmt.Errorf("SPIFFE ID in CSR from a different datacenter: %s, "+
-				"we are %s", serviceID.Datacenter, s.srv.config.Datacenter)
-		}
-	} else if isAgent {
-		agentID.GetEnterpriseMeta().FillAuthzContext(&authzContext)
-		if err := authz.ToAllowAuthorizer().NodeWriteAllowed(agentID.Agent, &authzContext); err != nil {
-			return err
-		}
-	}
-
-	cert, err := s.srv.caManager.SignCertificate(csr, spiffeID)
+	cert, err := s.srv.caManager.AuthorizeAndSignCertificate(csr, authz)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
OSS sync of enterprise changes at 8d6fd125
