### PR TITLE
fix bad oss sync, use gauges not counters

### DIFF
--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -94,30 +94,6 @@ func TestAgent_NewRPCMetrics(t *testing.T) {
 
 		assertMetricExists(t, respRec, metricsPrefix+"_rpc_server_call")
 	})
-
-	t.Run("Check that new rpc metrics can be filtered out", func(t *testing.T) {
-		metricsPrefix := "new_rpc_metrics_2"
-		hcl := fmt.Sprintf(`
-		telemetry = {
-			prometheus_retention_time = "5s"
-			disable_hostname = true
-			metrics_prefix = "%s"
-			prefix_filter = ["-%s.rpc.server.call"]
-		}
-		`, metricsPrefix, metricsPrefix)
-
-		a := StartTestAgent(t, TestAgent{HCL: hcl})
-		defer a.Shutdown()
-
-		var out struct{}
-		err := a.RPC("Status.Ping", struct{}{}, &out)
-		require.NoError(t, err)
-
-		respRec := httptest.NewRecorder()
-		recordPromMetrics(t, a, respRec)
-
-		assertMetricNotExists(t, respRec, metricsPrefix+"_rpc_server_call")
-	})
 }
 
 // TestHTTPHandlers_AgentMetrics_ConsulAutopilot_Prometheus adds testing around

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -24,7 +24,7 @@ const RPCTypeNetRPC = "net/rpc"
 var metricRPCRequest = []string{"rpc", "server", "call"}
 var requestLogName = "rpc.server.request"
 
-var NewRPCCounters = []prometheus.CounterDefinition{
+var NewRPCGauges = []prometheus.GaugeDefinition{
 	{
 		Name: metricRPCRequest,
 		Help: "Increments when a server makes an RPC service call. The labels on the metric have more information",

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/router"
+	"github.com/hashicorp/consul/agent/rpc/middleware"
 	"github.com/hashicorp/consul/agent/submatview"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/agent/xds"
@@ -214,6 +215,7 @@ func getPrometheusDefs(cfg lib.TelemetryConfig, isServer bool) ([]prometheus.Gau
 		CertExpirationGauges,
 		Gauges,
 		raftGauges,
+		middleware.NewRPCGauges,
 	}
 
 	// TODO(ffmmm): conditionally add only leader specific metrics to gauges, counters, summaries, etc


### PR DESCRIPTION
We made those changes to not expire prom metrics in here: https://github.com/hashicorp/consul/pull/12582.

There was a small mix up with this OSS sync: https://github.com/hashicorp/consul/pull/12586/files#diff-92974f7ecae0d7201c3bd5ad4a8e8b0e49a66e40ee72d1661644fbc3cee199c1L28-L268 that removed the prom gauge pre declaration.

Adding it back and actually using a gauge!

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>