### PR TITLE
polish rpc.service.call metric behavior

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -2581,7 +2581,7 @@ func (b *builder) parsePrefixFilter(telemetry *Telemetry) ([]string, []string) {
 
 	// TODO(FFMMM): Once one twelve style RPC metrics get out of Beta, don't remove them by default.
 	operatorPassedOneTwelveRPCMetric := false
-	oneTwelveRPCMetric := *telemetry.MetricsPrefix + "." + strings.Join(middleware.NewRPCGauges[0].Name, ".")
+	oneTwelveRPCMetric := *telemetry.MetricsPrefix + "." + strings.Join(middleware.OneTwelveRPCGauges[0].Name, ".")
 
 	for _, rule := range telemetry.PrefixFilter {
 		if rule == "" {

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -108,9 +108,9 @@ func assertMetricNotExists(t *testing.T, respRec *httptest.ResponseRecorder, met
 	}
 }
 
-// TestAgent_NewRPCMetrics test for the new RPC metrics. These are the labeled metrics coming from
+// TestAgent_OneTwelveRPCMetrics test for the 1.12 style RPC metrics. These are the labeled metrics coming from
 // agent.rpc.middleware.interceptors package.
-func TestAgent_NewRPCMetrics(t *testing.T) {
+func TestAgent_OneTwelveRPCMetrics(t *testing.T) {
 	skipIfShortTesting(t)
 	// This test cannot use t.Parallel() since we modify global state, ie the global metrics instance
 
@@ -139,7 +139,7 @@ func TestAgent_NewRPCMetrics(t *testing.T) {
 
 	t.Run("Check that 1.12 rpc metrics are emitted when specified by operator.", func(t *testing.T) {
 		metricsPrefix := "new_rpc_metrics_2"
-		addRPCMetric := metricsPrefix + "." + strings.Join(middleware.NewRPCGauges[0].Name, ".")
+		addRPCMetric := metricsPrefix + "." + strings.Join(middleware.OneTwelveRPCGauges[0].Name, ".")
 		hcl := fmt.Sprintf(`
 		telemetry = {
 			prometheus_retention_time = "5s"

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"github.com/hashicorp/go-hclog"
 )
@@ -25,12 +24,13 @@ const RPCTypeNetRPC = "net/rpc"
 var metricRPCRequest = []string{"rpc", "server", "call"}
 var requestLogName = strings.Join(metricRPCRequest, ".")
 
-var NewRPCGauges = []prometheus.GaugeDefinition{
-	{
-		Name: metricRPCRequest,
-		Help: "Measures the time an RPC service call takes to make in milliseconds. Labels mark which RPC method was called and metadata about the call.",
-	},
-}
+// todo(rpc-metrics-improv): remove if unused for predeclaration in the end
+//var NewRPCGauges = []prometheus.GaugeDefinition{
+//	{
+//		Name: metricRPCRequest,
+//		Help: "Measures the time an RPC service call takes to make in milliseconds. Labels mark which RPC method was called and metadata about the call.",
+//	},
+//}
 
 type RequestRecorder struct {
 	Logger       hclog.Logger

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/prometheus"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 	"github.com/hashicorp/go-hclog"
 )
@@ -24,13 +25,12 @@ const RPCTypeNetRPC = "net/rpc"
 var metricRPCRequest = []string{"rpc", "server", "call"}
 var requestLogName = strings.Join(metricRPCRequest, ".")
 
-// todo(rpc-metrics-improv): remove if unused for predeclaration in the end
-//var NewRPCGauges = []prometheus.GaugeDefinition{
-//	{
-//		Name: metricRPCRequest,
-//		Help: "Measures the time an RPC service call takes to make in milliseconds. Labels mark which RPC method was called and metadata about the call.",
-//	},
-//}
+var NewRPCGauges = []prometheus.GaugeDefinition{
+	{
+		Name: metricRPCRequest,
+		Help: "Measures the time an RPC service call takes to make in milliseconds. Labels mark which RPC method was called and metadata about the call.",
+	},
+}
 
 type RequestRecorder struct {
 	Logger       hclog.Logger

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -25,7 +25,7 @@ const RPCTypeNetRPC = "net/rpc"
 var metricRPCRequest = []string{"rpc", "server", "call"}
 var requestLogName = strings.Join(metricRPCRequest, ".")
 
-var NewRPCGauges = []prometheus.GaugeDefinition{
+var OneTwelveRPCGauges = []prometheus.GaugeDefinition{
 	{
 		Name: metricRPCRequest,
 		Help: "Measures the time an RPC service call takes to make in milliseconds. Labels mark which RPC method was called and metadata about the call.",

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -22,27 +23,26 @@ const RPCTypeInternal = "internal"
 const RPCTypeNetRPC = "net/rpc"
 
 var metricRPCRequest = []string{"rpc", "server", "call"}
-var requestLogName = "rpc.server.request"
+var requestLogName = strings.Join(metricRPCRequest, ".")
 
 var NewRPCGauges = []prometheus.GaugeDefinition{
 	{
 		Name: metricRPCRequest,
-		Help: "Increments when a server makes an RPC service call. The labels on the metric have more information",
+		Help: "Measures the time an RPC service call takes to make in milliseconds. Labels mark which RPC method was called and metadata about the call.",
 	},
 }
 
 type RequestRecorder struct {
 	Logger       hclog.Logger
-	recorderFunc func(key []string, start time.Time, labels []metrics.Label)
+	recorderFunc func(key []string, val float32, labels []metrics.Label)
 }
 
 func NewRequestRecorder(logger hclog.Logger) *RequestRecorder {
-	return &RequestRecorder{Logger: logger, recorderFunc: metrics.MeasureSinceWithLabels}
+	return &RequestRecorder{Logger: logger, recorderFunc: metrics.SetGaugeWithLabels}
 }
 
 func (r *RequestRecorder) Record(requestName string, rpcType string, start time.Time, request interface{}, respErrored bool) {
 	elapsed := time.Since(start)
-
 	reqType := requestType(request)
 
 	labels := []metrics.Label{
@@ -52,9 +52,8 @@ func (r *RequestRecorder) Record(requestName string, rpcType string, start time.
 		{Name: "rpc_type", Value: rpcType},
 	}
 
-	// TODO(FFMMM): it'd be neat if we could actually pass the elapsed observed above
-	r.recorderFunc(metricRPCRequest, start, labels)
-
+	// math.MaxInt64 < math.MaxFloat32 is true so we should be good!
+	r.recorderFunc(metricRPCRequest, float32(elapsed.Milliseconds()), labels)
 	r.Logger.Debug(requestLogName,
 		"method", requestName,
 		"errored", respErrored,
@@ -64,10 +63,18 @@ func (r *RequestRecorder) Record(requestName string, rpcType string, start time.
 }
 
 func requestType(req interface{}) string {
-	if r, ok := req.(interface{ IsRead() bool }); ok && r.IsRead() {
-		return "read"
+	if r, ok := req.(interface{ IsRead() bool }); ok {
+		if r.IsRead() {
+			return "read"
+		} else {
+			return "write"
+		}
 	}
-	return "write"
+
+	// This logical branch should not happen. If it happens
+	// it means an underlying request is not implementing the interface.
+	// Rather than swallowing it up in a "read" or "write", let's be aware of it.
+	return "unreported"
 }
 
 func GetNetRPCInterceptor(recorder *RequestRecorder) rpc.ServerServiceCallInterceptor {

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/router"
-	"github.com/hashicorp/consul/agent/rpc/middleware"
 	"github.com/hashicorp/consul/agent/submatview"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/agent/xds"
@@ -215,7 +214,6 @@ func getPrometheusDefs(cfg lib.TelemetryConfig, isServer bool) ([]prometheus.Gau
 		CertExpirationGauges,
 		Gauges,
 		raftGauges,
-		middleware.NewRPCGauges,
 	}
 
 	// TODO(ffmmm): conditionally add only leader specific metrics to gauges, counters, summaries, etc


### PR DESCRIPTION
### overview

This diff polishes the behavior for the new rpc metric:

* it turns off the metric by default per conversations with product; we'll advertise this under beta as we roll out 1.12
  * refactors some builder code to prove that the `prefix_filter` serves all of the use cases
* i had to use a `SetGauge...` func bc the `MeasureSince...` does not actually work as a gauge 😢 ; prolly need to flag this into `go-metrics`
* renaming "new rpc" to "one twelve" rpc per feedback form matt s

### reviewer note

* best seen by commits! check out some of my inline comments 

### todo:

* [ ] fix full config and flag tests ⌨️ 🔨 