### PR TITLE
Fix logic for website checker

### DIFF
--- a/.github/workflows/website-checker.yml
+++ b/.github/workflows/website-checker.yml
@@ -23,7 +23,7 @@ jobs:
   website-check:
     # If there's already a `type/docs-cherrypick` label or an explicit `pr/no-docs` label, we ignore this check 
     if: >-
-      !contains(github.event.pull_request.labels.*.name, 'type/docs-cherrypick') ||
+      !contains(github.event.pull_request.labels.*.name, 'type/docs-cherrypick') &&
       !contains(github.event.pull_request.labels.*.name, 'pr/no-docs')
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Workflow should run when no docs/cherry-pick label && no pr/docs-label