### PR TITLE
Fix leaked Vault LifetimeRenewers (#12607)

### DIFF
--- a/.changelog/12607.txt
+++ b/.changelog/12607.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect/ca: cancel old Vault renewal on CA configuration. Provide a 1 - 6 second backoff on repeated token renewal requests to prevent overwhelming Vault.
+```

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/require"
 
@@ -83,6 +83,52 @@ func TestVaultCAProvider_RenewToken(t *testing.T) {
 		require.NoError(r, err)
 		require.Greater(r, lastRenewal, firstRenewal)
 	})
+}
+
+func TestVaultCAProvider_RenewTokenStopWatcherOnConfigure(t *testing.T) {
+
+	SkipIfVaultNotPresent(t)
+
+	testVault, err := runTestVault(t)
+	require.NoError(t, err)
+	testVault.WaitUntilReady(t)
+
+	// Create a token with a short TTL to be renewed by the provider.
+	ttl := 1 * time.Second
+	tcr := &vaultapi.TokenCreateRequest{
+		TTL: ttl.String(),
+	}
+	secret, err := testVault.client.Auth().Token().Create(tcr)
+	require.NoError(t, err)
+	providerToken := secret.Auth.ClientToken
+
+	provider, err := createVaultProvider(t, true, testVault.Addr, providerToken, nil)
+	require.NoError(t, err)
+
+	var gotStopped = uint32(0)
+	provider.stopWatcher = func() {
+		atomic.StoreUint32(&gotStopped, 1)
+	}
+
+	// Check the last renewal time.
+	secret, err = testVault.client.Auth().Token().Lookup(providerToken)
+	require.NoError(t, err)
+	firstRenewal, err := secret.Data["last_renewal_time"].(json.Number).Int64()
+	require.NoError(t, err)
+
+	// Wait past the TTL and make sure the token has been renewed.
+	retry.Run(t, func(r *retry.R) {
+		secret, err = testVault.client.Auth().Token().Lookup(providerToken)
+		require.NoError(r, err)
+		lastRenewal, err := secret.Data["last_renewal_time"].(json.Number).Int64()
+		require.NoError(r, err)
+		require.Greater(r, lastRenewal, firstRenewal)
+	})
+
+	providerConfig := vaultProviderConfig(t, testVault.Addr, providerToken, nil)
+
+	require.NoError(t, provider.Configure(providerConfig))
+	require.Equal(t, uint32(1), atomic.LoadUint32(&gotStopped))
 }
 
 func TestVaultCAProvider_Bootstrap(t *testing.T) {
@@ -479,6 +525,28 @@ func testVaultProviderWithConfig(t *testing.T, isPrimary bool, rawConf map[strin
 }
 
 func createVaultProvider(t *testing.T, isPrimary bool, addr, token string, rawConf map[string]interface{}) (*VaultProvider, error) {
+	cfg := vaultProviderConfig(t, addr, token, rawConf)
+
+	provider := NewVaultProvider()
+
+	if !isPrimary {
+		cfg.IsPrimary = false
+		cfg.Datacenter = "dc2"
+	}
+
+	t.Cleanup(provider.Stop)
+	require.NoError(t, provider.Configure(cfg))
+	if isPrimary {
+		_, err := provider.GenerateRoot()
+		require.NoError(t, err)
+		_, err = provider.GenerateIntermediate()
+		require.NoError(t, err)
+	}
+
+	return provider, nil
+}
+
+func vaultProviderConfig(t *testing.T, addr, token string, rawConf map[string]interface{}) ProviderConfig {
 	conf := map[string]interface{}{
 		"Address":             addr,
 		"Token":               token,
@@ -491,8 +559,6 @@ func createVaultProvider(t *testing.T, isPrimary bool, addr, token string, rawCo
 		conf[k] = v
 	}
 
-	provider := NewVaultProvider()
-
 	cfg := ProviderConfig{
 		ClusterID:  connect.TestClusterID,
 		Datacenter: "dc1",
@@ -500,23 +566,5 @@ func createVaultProvider(t *testing.T, isPrimary bool, addr, token string, rawCo
 		RawConfig:  conf,
 	}
 
-	logger := hclog.New(&hclog.LoggerOptions{
-		Output: ioutil.Discard,
-	})
-	provider.SetLogger(logger)
-
-	if !isPrimary {
-		cfg.IsPrimary = false
-		cfg.Datacenter = "dc2"
-	}
-
-	require.NoError(t, provider.Configure(cfg))
-	if isPrimary {
-		_, err := provider.GenerateRoot()
-		require.NoError(t, err)
-		_, err = provider.GenerateIntermediate()
-		require.NoError(t, err)
-	}
-
-	return provider, nil
+	return cfg
 }


### PR DESCRIPTION
* Fix leaked Vault LifetimeRenewers

When the Vault CA Provider is reconfigured we do not stop the
LifetimeRenewers which can cause them to leak until the Consul processes
recycles. On Configure execute stopWatcher if it exists and is not nil
before starting a new renewal

* Add jitter before restarting the LifetimeWatcher

If we fail to login to Vault or our token is no longer valid we can
overwhelm a Vault instance with many requests very quickly by restarting
the LifetimeWatcher. Before restarting the LifetimeWatcher provide a
backoff time of 1 second or less.

* Use a retry.Waiter instead of RandomStagger

* changelog

* gofmt'd

* Swap out bool for atomic.Unit32 in test

* Provide some extra clarification in comment and changelog