### PR TITLE
[1.11.x] build: enforce protoc binary is the expected version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,8 @@ jobs:
       - run:
           name: Install protobuf
           command: |
-            wget https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-linux-x86_64.zip
+            protoc_version="$(make print-PROTOC_VERSION)"
+            wget https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip
             sudo unzip -d /usr/local protoc-*.zip
             sudo chmod +x /usr/local/bin/protoc
             rm protoc-*.zip


### PR DESCRIPTION
Backport of #12641 to 1.11.x

This should also work for 1.10.x and 1.9.x cleanly