### PR TITLE
RelAPI Onboarding for 1.10.x

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,6 @@
+url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/consul"
+url_docker_registry_ecr = "https://gallery.ecr.aws/hashicorp/consul"
+url_license = "https://github.com/hashicorp/consul/blob/main/LICENSE"
+url_project_website = "https://www.consul.io"
+url_release_notes = "https://www.consul.io/docs/release-notes"
+url_source_repository = "https://github.com/hashicorp/consul"


### PR DESCRIPTION
Note: This is the same change as in https://github.com/hashicorp/consul/pull/12591. I forgot to add all of the right backporting labels. 

👋  This PR adds a `.release/release-metadata.hcl` file to the repo. This contains static metadata that will be processed and sent as part of the payload in RelAPI POST requests, which will be sent when staging and production releases are triggered.  

This can be merged now, but will not have any effect until after the RelAPI launch. Similar additions are being added across all projects that publish to releases.hashicorp.com. 