### PR TITLE
introduce EmptyReadRequest for status_endpoint

### DIFF
--- a/agent/consul/stats_fetcher.go
+++ b/agent/consul/stats_fetcher.go
@@ -5,11 +5,12 @@ import (
 	"net"
 	"sync"
 
-	"github.com/hashicorp/consul/agent/pool"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
 	autopilot "github.com/hashicorp/raft-autopilot"
+
+	"github.com/hashicorp/consul/agent/pool"
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 // StatsFetcher has two functions for autopilot. First, lets us fetch all the
@@ -42,7 +43,7 @@ func NewStatsFetcher(logger hclog.Logger, pool *pool.ConnPool, datacenter string
 // RPC to each server, so we let it finish and then clean up the in-flight
 // tracking.
 func (f *StatsFetcher) fetch(server *autopilot.Server, replyCh chan *autopilot.ServerStats) {
-	var args struct{}
+	var args EmptyReadRequest
 	var reply structs.RaftStats
 
 	// defer some cleanup to notify everything else that the fetching is no longer occurring

--- a/agent/consul/status_endpoint.go
+++ b/agent/consul/status_endpoint.go
@@ -55,7 +55,7 @@ func (s *Status) Peers(args *structs.DCSpecificRequest, reply *[]string) error {
 	return nil
 }
 
-// EmptyReadRequest implements the interface used by ServiceCallObserver
+// EmptyReadRequest implements the interface used by middleware.RequestRecorder
 // to communicate properties of requests.
 type EmptyReadRequest struct{}
 
@@ -63,7 +63,7 @@ func (e EmptyReadRequest) IsRead() bool {
 	return true
 }
 
-// Used by Autopilot to query the raft stats of the local server.
+// RaftStats is used by Autopilot to query the raft stats of the local server.
 func (s *Status) RaftStats(args EmptyReadRequest, reply *structs.RaftStats) error {
 	stats := s.server.raft.Stats()
 


### PR DESCRIPTION
### overview

As pointed out by Daniel in https://github.com/hashicorp/consul/pull/12445/commits/d60a7c3fa6dceb046d073f24c6d20065332b0089 , we prolly need to introduce some interface that knows about `IsRead()` to make the interceptor duck typing report accurately. I cherry picked that commit and add some string changes on top of it. Note that I also manually tested that `Status.Ping` and `Status.RaftStats` report as `request_type: read`.