### PR TITLE
Avoid using sys/mounts to enable namespaces

### DIFF
--- a/.changelog/12655.txt
+++ b/.changelog/12655.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+Removed impediments to using a namespace prefixed IntermediatePKIPath
+in a CA definition. 
+```


### PR DESCRIPTION
void doing list of /sys/mounts

From an internal ticket "Support standard "Vault namespace in the path" semantics for Connect Vault CA Provid\
er"

Vault allows the namespace to be specified as a prefix in the path of
a PKI definition, but this doesn't currently work for
```IntermediatePKIPath``` specifications, because we attempt to list
all of the paths to check if ours is already defined. This doesn't
really work in a namespaced world.

This changes the IntermediatePKIPath code to follow the same pattern
as the root key, where we directly get the key rather than listing.

This code is difficult to write automated tests for because it relies
on features of Vault Enterprise, which isn't currently part of our
test framework, so it was tested manually.

Signed-off-by: Mark Anderson <manderson@hashicorp.com>
