### PR TITLE
updated docs

### DIFF
--- a/website/content/docs/nia/cli/index.mdx
+++ b/website/content/docs/nia/cli/index.mdx
@@ -11,6 +11,8 @@ Consul-Terraform-Sync (CTS) is controlled via an easy to use command-line interf
 
 ## Daemon
 
+~> Running daemon mode without a command is deprecated in CTS 0.6.0 and will be removed at a much later date in a major release. For information on the preferred way to run daemon mode see the [`start` command docs](/docs/nia/cli/start)
+
 When running as a daemon, there is no default configuration to run CTS in a meaningful way. Setting a configuration flag `-config-file` or `-config-dir` is required. For example:
 
 ```shell-session
@@ -77,6 +79,25 @@ Example:
 ```shell-session
 consul-terraform-sync task disable -http-addr=http://localhost:2000 task_a
 ```
+
+## Autocompletion
+
+The `consul-terraform-sync` command features opt-in autocompletion for flags, subcommands, and
+arguments (where supported).
+
+Enable autocompletion by running:
+
+```shell-session
+$ consul-terraform-sync -autocomplete-install
+```
+
+~> Be sure to **restart your shell** after installing autocompletion!
+
+When you start typing a CTS command, press the `<tab>` character to show a
+list of available completions. Type `-<tab>` to show available flag completions.
+
+If the `CTS_*` environment variables are set, the autocompletion will
+automatically query the running CTS server and return helpful argument suggestions.
 
 ### General Options
 

--- a/website/content/docs/nia/cli/index.mdx
+++ b/website/content/docs/nia/cli/index.mdx
@@ -11,7 +11,7 @@ Consul-Terraform-Sync (CTS) is controlled via an easy to use command-line interf
 
 ## Daemon
 
-~> Running CTS as a daemon without using a command is deprecated in CTS 0.6.0 and will be removed at a much later date in a major release. For information on the preferred way to run daemon mode see the [`start` command docs](/docs/nia/cli/start)
+~> Running CTS as a daemon without using a command is deprecated in CTS 0.6.0 and will be removed at a much later date in a major release. For information on the preferred way to run CTS as a daemon see the [`start` command docs](/docs/nia/cli/start)
 
 When running as a daemon, there is no default configuration to run CTS in a meaningful way. Setting a configuration flag `-config-file` or `-config-dir` is required. For example:
 

--- a/website/content/docs/nia/cli/index.mdx
+++ b/website/content/docs/nia/cli/index.mdx
@@ -21,20 +21,6 @@ $ consul-terraform-sync -config-file=config.hcl
 
 To view a list of available flags, use the `-help` or `-h` flag.
 
-Flag: `-inspect-task [task-name]`
-
-Behavior: This has similar behavior as `-inspect` mode for the selected task. The flag can be specified multiple times to inspect multiple tasks. No changes are applied in this mode.
-
-Usage: Useful to debug one or more tasks to confirm configuration is accurate and the selected tasks would update network infrastructure as expected.
-
-#### Once Mode
-
-Flag: `-once`
-
-Behavior: CTS will run all tasks once with buffer periods disabled and exit. On encountering an error before completing, CTS will exit with a non-zero status.
-
-Usage: Intended to be run before long-running mode in order to confirm configuration is accurate and tasks update network infrastructure as expected.
-
 ## Commands
 
 In addition to running the daemon, CTS has a set of commands that act as a client to the daemon server. The commands provide a user-friendly experience interacting with the daemon. The commands use the CTS APIs but does not correspond one-to-one with it. Please see the individual commands in the left navigation for more details.

--- a/website/content/docs/nia/cli/index.mdx
+++ b/website/content/docs/nia/cli/index.mdx
@@ -11,7 +11,7 @@ Consul-Terraform-Sync (CTS) is controlled via an easy to use command-line interf
 
 ## Daemon
 
-~> Running daemon mode without a command is deprecated in CTS 0.6.0 and will be removed at a much later date in a major release. For information on the preferred way to run daemon mode see the [`start` command docs](/docs/nia/cli/start)
+~> Running CTS as a daemon without using a command is deprecated in CTS 0.6.0 and will be removed at a much later date in a major release. For information on the preferred way to run daemon mode see the [`start` command docs](/docs/nia/cli/start)
 
 When running as a daemon, there is no default configuration to run CTS in a meaningful way. Setting a configuration flag `-config-file` or `-config-dir` is required. For example:
 
@@ -20,28 +20,6 @@ $ consul-terraform-sync -config-file=config.hcl
 ```
 
 To view a list of available flags, use the `-help` or `-h` flag.
-
-### Modes
-
-CTS can be run as a daemon in different modes.
-
-#### Long-running Mode
-
-Flag: none
-
-Behavior: This is the default mode in which CTS passes through a once-mode phase and then turns into a long running process. During the once-mode phase, the daemon will exit with a non-zero status if it encounters an error. After successfully passing through once-mode phase, it will begin a long-running process in which errors are logged and exiting is not expected behavior. Once beginning the long-running process, the daemon serves any API and command requests.
-
-Usage: Intended to be run as a long running process after running once-mode successfully for given configuration and tasks.
-
-#### Inspect Mode
-
-Flag: `-inspect`
-
-Behavior: CTS will display the proposed state changes for all tasks once and exit. No changes are applied in this mode. On encountering an error before completing, CTS will exit with a non-zero status.
-
-Usage: Intended to be run before daemon-mode in order to confirm configuration is accurate and tasks would update network infrastructure as expected.
-
----
 
 Flag: `-inspect-task [task-name]`
 
@@ -55,7 +33,7 @@ Flag: `-once`
 
 Behavior: CTS will run all tasks once with buffer periods disabled and exit. On encountering an error before completing, CTS will exit with a non-zero status.
 
-Usage: Intended to be run before daemon-mode in order to confirm configuration is accurate and tasks update network infrastructure as expected.
+Usage: Intended to be run before long-running mode in order to confirm configuration is accurate and tasks update network infrastructure as expected.
 
 ## Commands
 

--- a/website/content/docs/nia/cli/start.mdx
+++ b/website/content/docs/nia/cli/start.mdx
@@ -55,8 +55,8 @@ The `start` command supports the following options:
 
 | Name            | Required | Type    | Description                     |Default                  |
 | --------------- | -------- | ------- | ------------------------------- | ----------------------- |
-| `-config-dir` &nbsp;| Optional | string | A directory to load files for configuring CTS. Configuration files require an .hcl or .json file extension in order to specify their format. This option can be specified multiple times to load different directories. | none |
-| `-config-file` &nbsp;| Optional | string | A file to load for configuring CTS. Configuration file requires an .hcl or .json extension in order to specify their format. This option can be specified multiple times to load different configuration files. | none |
+| `-config-dir ` &nbsp; &nbsp; &nbsp;| Optional | string | A directory to load files for configuring CTS. Configuration files require an .hcl or .json file extension in order to specify their format. This option can be specified multiple times to load different directories. | none |
+| `-config-file` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;| Optional | string | A file to load for configuring CTS. Configuration file requires an .hcl or .json extension in order to specify their format. This option can be specified multiple times to load different configuration files. | none |
 | `-inspect` | Optional | boolean | Run CTS in Inspect mode to print the proposed state changes for all tasks, and then exit. No changes are applied in this mode. | false |
-| `-inspect-task` &nbsp;| Optional | string | Run CTS in Inspect mode to print the proposed state changes for the task, and then exit. The flag can be specified multiple times to inspect multiple tasks. No changes are applied in this mode. | none |
+| `-inspect-task` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Optional | string | Run CTS in Inspect mode to print the proposed state changes for the task, and then exit. The flag can be specified multiple times to inspect multiple tasks. No changes are applied in this mode. | none |
 | `-once` | Optional | boolean | Render templates and run tasks once. Does not start the process in long-running mode and disables buffer periods. | false |

--- a/website/content/docs/nia/cli/start.mdx
+++ b/website/content/docs/nia/cli/start.mdx
@@ -1,0 +1,62 @@
+---
+layout: docs
+page_title: Start Command
+description: >-
+  Consul-Terraform-Sync supports start command for running CTS in daemon mode
+---
+
+# start
+
+The start command runs Consul-Terraform-Sync (CTS) in Daemon mode. When running as a daemon, there is no default configuration to run CTS in a meaningful way. Setting a configuration flag `-config-file` or `-config-dir` is required. For example:
+
+```shell-session
+$ consul-terraform-sync start -config-file=config.hcl
+```
+
+To view a list of available flags, use the `-help` or `-h` flag.
+
+### Modes
+
+CTS can be run as a daemon in different modes.
+
+#### Long-running Mode
+
+Flag: none
+
+Behavior: This is the default mode in which CTS passes through a once-mode phase and then turns into a long running process. During the once-mode phase, the daemon will exit with a non-zero status if it encounters an error. After successfully passing through once-mode phase, it will begin a long-running process in which errors are logged and exiting is not expected behavior. Once beginning the long-running process, the daemon serves any API and command requests.
+
+#### Inspect Mode
+
+Flag: `-inspect`
+
+Behavior: CTS will display the proposed state changes for all tasks once and exit. No changes are applied in this mode. On encountering an error before completing, CTS will exit with a non-zero status.
+
+Usage: Intended to be run before daemon-mode in order to confirm configuration is accurate and tasks would update network infrastructure as expected.
+
+---
+
+Flag: `-inspect-task [task-name]`
+
+Behavior: This has similar behavior as `-inspect` mode for the selected task. The flag can be specified multiple times to inspect multiple tasks. No changes are applied in this mode.
+
+Usage: Useful to debug one or more tasks to confirm configuration is accurate and the selected tasks would update network infrastructure as expected.
+
+#### Once Mode
+
+Flag: `-once`
+
+Behavior: CTS will run all tasks once with buffer periods disabled and exit. On encountering an error before completing, CTS will exit with a non-zero status.
+
+Usage: Intended to be run before daemon-mode in order to confirm configuration is accurate and tasks update network infrastructure as expected.
+
+### Options
+
+The `start` command supports the following options:
+
+| Name            | Required | Type    | Description                     |Default                  |
+| --------------- | -------- | ------- | ------------------------------- | ----------------------- |
+| `-config-dir` | Optional | string | A directory to load files for configuring CTS. Configuration files require an .hcl or .json file extension in order to specify their format. This option can be specified multiple times to load different directories. | none |
+| `-config-file` | Optional | string | A file to load for configuring CTS. Configuration file requires an .hcl or .json extension in order to specify their format. This option can be specified multiple times to load different configuration files. | none |
+| `-inspect` | Optional | boolean | Run CTS in Inspect mode to print the proposed state changes for all tasks, and then exit. No changes are applied in this mode. | false |
+| `-inspect-task` | Optional | string | Run CTS in Inspect mode to print the proposed state changes for the task, and then exit. No changes are applied in this mode. | none |
+| `-once` | Optional | boolean | Render templates and run tasks once. Does not run the process as a daemon and disables buffer periods. | false |

--- a/website/content/docs/nia/cli/start.mdx
+++ b/website/content/docs/nia/cli/start.mdx
@@ -2,12 +2,12 @@
 layout: docs
 page_title: Start Command
 description: >-
-  Consul-Terraform-Sync supports start command for running CTS in daemon mode
+  Consul-Terraform-Sync supports start command for starting CTS as a daemon
 ---
 
 # start
 
-The start command runs Consul-Terraform-Sync (CTS) in Daemon mode. When running as a daemon, there is no default configuration to run CTS in a meaningful way. Setting a configuration flag `-config-file` or `-config-dir` is required. For example:
+The `start` command starts Consul-Terraform-Sync (CTS) as a daemon. When running as a daemon, there is no default configuration to start CTS in a meaningful way. Setting a configuration flag `-config-file` or `-config-dir` is required. For example:
 
 ```shell-session
 $ consul-terraform-sync start -config-file=config.hcl
@@ -23,7 +23,7 @@ CTS can be run as a daemon in different modes.
 
 Flag: none
 
-Behavior: This is the default mode in which CTS passes through a once-mode phase and then turns into a long running process. During the once-mode phase, the daemon will exit with a non-zero status if it encounters an error. After successfully passing through once-mode phase, it will begin a long-running process in which errors are logged and exiting is not expected behavior. Once beginning the long-running process, the daemon serves any API and command requests.
+Behavior: This is the default mode in which CTS passes through a once-mode phase and then turns into a long-running process. During the once-mode phase, the daemon will exit with a non-zero status if it encounters an error. After successfully passing through once-mode phase, it will begin a long-running process in which errors are logged and exiting is not expected behavior. Once beginning the long-running process, the daemon serves any API and command requests.
 
 #### Inspect Mode
 
@@ -31,7 +31,7 @@ Flag: `-inspect`
 
 Behavior: CTS will display the proposed state changes for all tasks once and exit. No changes are applied in this mode. On encountering an error before completing, CTS will exit with a non-zero status.
 
-Usage: Intended to be run before daemon-mode in order to confirm configuration is accurate and tasks would update network infrastructure as expected.
+Usage: Intended to be run before long-running mode in order to confirm configuration is accurate and tasks would update network infrastructure as expected.
 
 ---
 
@@ -47,7 +47,7 @@ Flag: `-once`
 
 Behavior: CTS will run all tasks once with buffer periods disabled and exit. On encountering an error before completing, CTS will exit with a non-zero status.
 
-Usage: Intended to be run before daemon-mode in order to confirm configuration is accurate and tasks update network infrastructure as expected.
+Usage: Intended to be run before long-running mode in order to confirm configuration is accurate and tasks update network infrastructure as expected.
 
 ### Options
 
@@ -55,8 +55,8 @@ The `start` command supports the following options:
 
 | Name            | Required | Type    | Description                     |Default                  |
 | --------------- | -------- | ------- | ------------------------------- | ----------------------- |
-| `-config-dir` | Optional | string | A directory to load files for configuring CTS. Configuration files require an .hcl or .json file extension in order to specify their format. This option can be specified multiple times to load different directories. | none |
-| `-config-file` | Optional | string | A file to load for configuring CTS. Configuration file requires an .hcl or .json extension in order to specify their format. This option can be specified multiple times to load different configuration files. | none |
+| `-config-dir` &nbsp;| Optional | string | A directory to load files for configuring CTS. Configuration files require an .hcl or .json file extension in order to specify their format. This option can be specified multiple times to load different directories. | none |
+| `-config-file` &nbsp;| Optional | string | A file to load for configuring CTS. Configuration file requires an .hcl or .json extension in order to specify their format. This option can be specified multiple times to load different configuration files. | none |
 | `-inspect` | Optional | boolean | Run CTS in Inspect mode to print the proposed state changes for all tasks, and then exit. No changes are applied in this mode. | false |
-| `-inspect-task` | Optional | string | Run CTS in Inspect mode to print the proposed state changes for the task, and then exit. No changes are applied in this mode. | none |
-| `-once` | Optional | boolean | Render templates and run tasks once. Does not run the process as a daemon and disables buffer periods. | false |
+| `-inspect-task` &nbsp;| Optional | string | Run CTS in Inspect mode to print the proposed state changes for the task, and then exit. The flag can be specified multiple times to inspect multiple tasks. No changes are applied in this mode. | none |
+| `-once` | Optional | boolean | Render templates and run tasks once. Does not start the process in long-running mode and disables buffer periods. | false |

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -761,6 +761,10 @@
           {
             "title": "task",
             "path": "nia/cli/task"
+          },
+          {
+            "title": "start",
+            "path": "nia/cli/start"
           }
         ]
       },


### PR DESCRIPTION
- added docs for start command
- deprecated running without a command
- added instructions for autocomplete setup

Start Command: https://consul-6ewood6ws-hashicorp.vercel.app/docs/nia/cli/start
No Command Deprecation Daemon: https://consul-6ewood6ws-hashicorp.vercel.app/docs/nia/cli
 