### PR TITLE
build: run mog separately after the protobufs are generated

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -41,6 +41,7 @@ GOLDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)
 PROTOFILES?=$(shell find . -name '*.proto' | grep -v 'vendor/' | grep -v '.protobuf' )
 PROTOGOFILES=$(PROTOFILES:.proto=.pb.go)
 PROTOGOBINFILES=$(PROTOFILES:.proto=.pb.binary.go)
+PROTO_MOG_ORDER=$(shell go list -tags '$(GOTAGS)' -deps ./proto/pb... | grep "consul/proto")
 
 ifeq ($(FORCE_REBUILD),1)
 NOCACHE=--no-cache
@@ -372,7 +373,21 @@ protoc-install:
 		chmod +x $(PROTOC_ROOT)/bin/protoc ; \
 	fi
 
-proto: protoc-install $(PROTOGOFILES) $(PROTOGOBINFILES)
+.PHONY: proto
+proto: -protoc-files mog
+
+.PHONY: mog
+mog:
+	@for FULL_PKG in $(PROTO_MOG_ORDER); do \
+		PKG="$${FULL_PKG/#github.com\/hashicorp\/consul\//.\/}" ; \
+		find "$$PKG" -name '*.gen.go' -delete ; \
+		echo "mog -ignore-package-load-errors -tags '$(GOTAGS)' -source \"$${PKG}/*.pb.go\"" ; \
+		mog -ignore-package-load-errors -tags '$(GOTAGS)' -source "$${PKG}/*.pb.go" ; \
+	done
+	@echo "Generated all mog Go files"
+
+.PHONY: -protoc-files
+-protoc-files: protoc-install $(PROTOGOFILES) $(PROTOGOBINFILES)
 	@echo "Generated all protobuf Go files"
 
 %.pb.go %.pb.binary.go: %.proto
@@ -403,6 +418,6 @@ envoy-regen:
 	@find "command/connect/envoy/testdata" -name '*.golden' -delete
 	@go test -tags '$(GOTAGS)' ./command/connect/envoy -update
 
-.PHONY: all bin dev dist cov test test-internal cover lint ui static-assets tools proto-tools protoc-check
+.PHONY: all bin dev dist cov test test-internal cover lint ui static-assets tools proto-tools
 .PHONY: docker-images go-build-image ui-build-image static-assets-docker consul-docker ui-docker
-.PHONY: version proto test-envoy-integ
+.PHONY: version test-envoy-integ

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ GOPROTOTOOLS = \
 	github.com/golang/protobuf/protoc-gen-go@$(GOPROTOVERSION) \
 	github.com/hashicorp/protoc-gen-go-binary@master \
 	github.com/favadi/protoc-go-inject-tag@v1.3.0 \
-	github.com/hashicorp/mog@glob-match
+	github.com/hashicorp/mog@v0.2.0
 
 GOTAGS ?=
 GOPATH=$(shell go env GOPATH)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -374,10 +374,10 @@ protoc-install:
 	fi
 
 .PHONY: proto
-proto: -protoc-files mog
+proto: -protoc-files -mog-files
 
-.PHONY: mog
-mog:
+.PHONY: -mog-files
+-mog-files:
 	@for FULL_PKG in $(PROTO_MOG_ORDER); do \
 		PKG="$${FULL_PKG/#github.com\/hashicorp\/consul\//.\/}" ; \
 		find "$$PKG" -name '*.gen.go' -delete ; \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ GOPROTOTOOLS = \
 	github.com/golang/protobuf/protoc-gen-go@$(GOPROTOVERSION) \
 	github.com/hashicorp/protoc-gen-go-binary@master \
 	github.com/favadi/protoc-go-inject-tag@v1.3.0 \
-	github.com/hashicorp/mog@v0.1.2
+	github.com/hashicorp/mog@glob-match
 
 GOTAGS ?=
 GOPATH=$(shell go env GOPATH)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -381,8 +381,8 @@ mog:
 	@for FULL_PKG in $(PROTO_MOG_ORDER); do \
 		PKG="$${FULL_PKG/#github.com\/hashicorp\/consul\//.\/}" ; \
 		find "$$PKG" -name '*.gen.go' -delete ; \
-		echo "mog -ignore-package-load-errors -tags '$(GOTAGS)' -source \"$${PKG}/*.pb.go\"" ; \
-		mog -ignore-package-load-errors -tags '$(GOTAGS)' -source "$${PKG}/*.pb.go" ; \
+		echo "mog -tags '$(GOTAGS)' -source \"$${PKG}/*.pb.go\"" ; \
+		mog -tags '$(GOTAGS)' -source "$${PKG}/*.pb.go" ; \
 	done
 	@echo "Generated all mog Go files"
 

--- a/build-support/scripts/proto-gen.sh
+++ b/build-support/scripts/proto-gen.sh
@@ -88,7 +88,6 @@ function main {
    local proto_go_path=${proto_path%%.proto}.pb.go
    local proto_go_bin_path=${proto_path%%.proto}.pb.binary.go
    local proto_go_rpcglue_path=${proto_path%%.proto}.rpcglue.pb.go
-   local mog_input_path="$(dirname "${proto_path}")"
 
    local go_proto_out="paths=source_relative"
    if is_set "${grpc}"
@@ -101,14 +100,14 @@ function main {
       go_proto_out="${go_proto_out}:"
    fi
 
-   rm -f "${proto_go_path}" ${proto_go_bin_path}" ${proto_go_rpcglue_path}" "${mog_input_path}/*.gen.go"
+   rm -f "${proto_go_path}" ${proto_go_bin_path}" ${proto_go_rpcglue_path}"
 
    # How we run protoc probably needs some documentation.
    #
    # This is the path to where
    #  -I="${golang_proto_path}/protobuf" \
    local -i ret=0
-   status_stage "Generating ${proto_path} into ${proto_go_path} and ${proto_go_bin_path} ${mog_input_path}/*.gen.go"
+   status_stage "Generating ${proto_path} into ${proto_go_path} and ${proto_go_bin_path}"
    echo "debug_run ${protoc_bin} \
           -I=\"${golang_proto_path}\" \
           -I=\"${golang_proto_mod_path}\" \
@@ -136,14 +135,6 @@ function main {
    if test $? -ne 0
    then
       err "Failed to run protoc-go-inject-tag for ${proto_path}"
-      return 1
-   fi
-
-   debug_run mog -source ./${mog_input_path} -tags ${GOTAGS} -ignore-package-load-errors
-
-   if test $? -ne 0
-   then
-      err "Failed to generate mog outputs from ${mog_input_path}"
       return 1
    fi
 


### PR DESCRIPTION
Also ensure that we run mog serially on each package in dependency order.

Depends on https://github.com/hashicorp/mog/pull/9 landing first.
