### PR TITLE
Respect SNI with terminating gateways and log a warning if it isn't set alongside TLS

### DIFF
--- a/.changelog/12672.txt
+++ b/.changelog/12672.txt
@@ -1,0 +1,3 @@
+```release-note:security
+connect: Properly set SNI when configured for services behind a terminating gateway.
+```

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -89,6 +89,14 @@ func (c *ConfigEntry) Apply(args *structs.ConfigEntryRequest, reply *bool) error
 		return err
 	}
 
+	// Log any applicable warnings about the contents of the config entry.
+	if warnEntry, ok := args.Entry.(structs.WarningConfigEntry); ok {
+		warnings := warnEntry.Warnings()
+		for _, warning := range warnings {
+			c.logger.Warn(warning)
+		}
+	}
+
 	if err := args.Entry.CanWrite(authz); err != nil {
 		return err
 	}

--- a/agent/proxycfg/testing_terminating_gateway.go
+++ b/agent/proxycfg/testing_terminating_gateway.go
@@ -526,6 +526,30 @@ func testConfigSnapshotTerminatingGatewayLBConfig(t testing.T, variant string) *
 	})
 }
 
+func TestConfigSnapshotTerminatingGatewaySNI(t testing.T) *ConfigSnapshot {
+	return TestConfigSnapshotTerminatingGateway(t, true, nil, []cache.UpdateEvent{
+		{
+			CorrelationID: "gateway-services",
+			Result: &structs.IndexedGatewayServices{
+				Services: []*structs.GatewayService{
+					{
+						Service: structs.NewServiceName("web", nil),
+						CAFile:  "ca.cert.pem",
+						SNI:     "foo.com",
+					},
+					{
+						Service:  structs.NewServiceName("api", nil),
+						CAFile:   "ca.cert.pem",
+						CertFile: "api.cert.pem",
+						KeyFile:  "api.key.pem",
+						SNI:      "bar.com",
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestConfigSnapshotTerminatingGatewayHostnameSubsets(t testing.T) *ConfigSnapshot {
 	var (
 		api   = structs.NewServiceName("api", nil)

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -82,6 +82,14 @@ type UpdatableConfigEntry interface {
 	ConfigEntry
 }
 
+// WarningConfigEntry is an optional interface implemented by a ConfigEntry
+// if it wants to be able to emit warnings when it is being upserted.
+type WarningConfigEntry interface {
+	Warnings() []string
+
+	ConfigEntry
+}
+
 // ServiceConfiguration is the top-level struct for the configuration of a service
 // across the entire cluster.
 type ServiceConfigEntry struct {

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -570,6 +570,22 @@ func (e *TerminatingGatewayConfigEntry) GetEnterpriseMeta() *EnterpriseMeta {
 	return &e.EnterpriseMeta
 }
 
+func (e *TerminatingGatewayConfigEntry) Warnings() []string {
+	if e == nil {
+		return nil
+	}
+
+	warnings := make([]string, 0)
+	for _, svc := range e.Services {
+		if (svc.CAFile != "" || svc.CertFile != "" || svc.KeyFile != "") && svc.SNI == "" {
+			warning := fmt.Sprintf("TLS is configured but SNI is not set for service %q. Enabling SNI is strongly recommended when using TLS.", svc.Name)
+			warnings = append(warnings, warning)
+		}
+	}
+
+	return warnings
+}
+
 // GatewayService is used to associate gateways with their linked services.
 type GatewayService struct {
 	Gateway      ServiceName

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -582,6 +582,10 @@ func TestClustersFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshotTerminatingGatewayHostnameSubsets,
 		},
 		{
+			name:   "terminating-gateway-sni",
+			create: proxycfg.TestConfigSnapshotTerminatingGatewaySNI,
+		},
+		{
 			name:   "terminating-gateway-ignore-extra-resolvers",
 			create: proxycfg.TestConfigSnapshotTerminatingGatewayIgnoreExtraResolvers,
 		},

--- a/agent/xds/testdata/clusters/terminating-gateway-sni.envoy-1-20-x.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-sni.envoy-1-20-x.golden
@@ -1,0 +1,174 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "api.altdomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      },
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsParams": {
+
+            },
+            "tlsCertificates": [
+              {
+                "certificateChain": {
+                  "filename": "api.cert.pem"
+                },
+                "privateKey": {
+                  "filename": "api.key.pem"
+                }
+              }
+            ],
+            "validationContext": {
+              "trustedCa": {
+                "filename": "ca.cert.pem"
+              },
+              "matchSubjectAltNames": [
+                {
+                  "exact": "bar.com"
+                }
+              ]
+            }
+          },
+          "sni": "bar.com"
+        }
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "cache.mydomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "db.mydomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "UNHEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          },
+          "resourceApiVersion": "V3"
+        }
+      },
+      "connectTimeout": "5s",
+      "outlierDetection": {
+
+      },
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsParams": {
+
+            },
+            "validationContext": {
+              "trustedCa": {
+                "filename": "ca.cert.pem"
+              },
+              "matchSubjectAltNames": [
+                {
+                  "exact": "foo.com"
+                }
+              ]
+            }
+          },
+          "sni": "foo.com"
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "nonce": "00000001"
+}

--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -30,6 +30,9 @@ from the terminating gateway will be encrypted using one-way TLS authentication.
 and [private key](/docs/connect/config-entries/terminating-gateway#keyfile) are also specified connections
 from the terminating gateway will be encrypted using mutual TLS authentication.
 
+~> Setting the `SNI` field is strongly recommended when enabling TLS to a service. If this field is not set,
+Consul will not attempt to verify the Subject Alternative Name fields in the service's certificate.
+
 If none of these are provided, Consul will **only** encrypt connections to the gateway and not
 from the gateway to the destination service.
 

--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -166,6 +166,7 @@ Services = [
   {
     Name   = "billing"
     CAFile = "/etc/certs/ca-chain.cert.pem"
+    SNI    = "billing.service.com"
   }
 ]
 ```
@@ -179,6 +180,7 @@ spec:
   services:
     - name: billing
       caFile: /etc/certs/ca-chain.cert.pem
+      sni: billing.service.com
 ```
 
 ```json
@@ -189,6 +191,7 @@ spec:
     {
       "Name": "billing",
       "CAFile": "/etc/certs/ca-chain.cert.pem"
+      "SNI": "billing.service.com"
     }
   ]
 }
@@ -217,6 +220,7 @@ Services = [
     Namespace = "finance"
     Name      = "billing"
     CAFile    = "/etc/certs/ca-chain.cert.pem"
+    SNI       = "billing.service.com"
   }
 ]
 ```
@@ -231,6 +235,7 @@ spec:
     - name: billing
       namespace: finance
       caFile: /etc/certs/ca-chain.cert.pem
+      sni: billing.service.com
 ```
 
 ```json
@@ -242,7 +247,8 @@ spec:
     {
       "Namespace": "finance",
       "Name": "billing",
-      "CAFile": "/etc/certs/ca-chain.cert.pem"
+      "CAFile": "/etc/certs/ca-chain.cert.pem",
+      "SNI": "billing.service.com"
     }
   ]
 }
@@ -276,6 +282,7 @@ Services = [
     CAFile   = "/etc/certs/ca-chain.cert.pem"
     KeyFile  = "/etc/certs/gateway.key.pem"
     CertFile = "/etc/certs/gateway.cert.pem"
+    SNI      = "billing.service.com"
   }
 ]
 ```
@@ -291,6 +298,7 @@ spec:
       caFile: /etc/certs/ca-chain.cert.pem
       keyFile: /etc/certs/gateway.key.pem
       certFile: /etc/certs/gateway.cert.pem
+      sni: billing.service.com
 ```
 
 ```json
@@ -302,7 +310,8 @@ spec:
       "Name": "billing",
       "CAFile": "/etc/certs/ca-chain.cert.pem",
       "KeyFile": "/etc/certs/gateway.key.pem",
-      "CertFile": "/etc/certs/gateway.cert.pem"
+      "CertFile": "/etc/certs/gateway.cert.pem",
+      "SNI": "billing.service.com"
     }
   ]
 }
@@ -333,6 +342,7 @@ Services = [
     CAFile    = "/etc/certs/ca-chain.cert.pem"
     KeyFile   = "/etc/certs/gateway.key.pem"
     CertFile  = "/etc/certs/gateway.cert.pem"
+    SNI       = "billing.service.com"
   }
 ]
 ```
@@ -349,6 +359,7 @@ spec:
       caFile: /etc/certs/ca-chain.cert.pem
       keyFile: /etc/certs/gateway.key.pem
       certFile: /etc/certs/gateway.cert.pem
+      sni: billing.service.com
 ```
 
 ```json
@@ -362,7 +373,8 @@ spec:
       "Name": "billing",
       "CAFile": "/etc/certs/ca-chain.cert.pem",
       "KeyFile": "/etc/certs/gateway.key.pem",
-      "CertFile": "/etc/certs/gateway.cert.pem"
+      "CertFile": "/etc/certs/gateway.cert.pem",
+      "SNI": "billing.service.com"
     }
   ]
 }
@@ -399,7 +411,7 @@ Services = [
   },
   {
     Name      = "billing"
-    CAFile    = "/etc/billing-ca/ca-chain.cert.pem",
+    CAFile    = "/etc/billing-ca/ca-chain.cert.pem"
     SNI       =  "billing.service.com"
   }
 ]


### PR DESCRIPTION
This PR adds a note to the terminating gateway docs strongly recommended using SNI when TLS is configured. It also adds a warning log message when configuring a service on a terminating gateway with TLS without SNI set.
