### PR TITLE
Tweak the Lambda Envoy configuration generated by the serverless patcher

### DIFF
--- a/.changelog/12681.txt
+++ b/.changelog/12681.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+xds: Add the ability to invoke AWS Lambdas through terminating gateways.
+```

--- a/agent/xds/serverless_plugin_oss_test.go
+++ b/agent/xds/serverless_plugin_oss_test.go
@@ -80,6 +80,15 @@ func TestServerlessPluginFromSnapshot(t *testing.T) {
 								}
 							},
 						},
+						{
+							name: "routes",
+							key:  xdscommon.RouteType,
+							sorter: func(msgs []proto.Message) func(int, int) bool {
+								return func(i, j int) bool {
+									return msgs[i].(*envoy_listener_v3.Listener).Name < msgs[j].(*envoy_listener_v3.Listener).Name
+								}
+							},
+						},
 					}
 
 					for _, entity := range entities {

--- a/agent/xds/serverlessplugin/patcher.go
+++ b/agent/xds/serverlessplugin/patcher.go
@@ -3,6 +3,7 @@ package serverlessplugin
 import (
 	envoy_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 
 	"github.com/hashicorp/consul/agent/xds/xdscommon"
 	"github.com/hashicorp/consul/api"
@@ -14,6 +15,11 @@ import (
 type patcher interface {
 	// CanPatch determines if the patcher can mutate resources for the given api.ServiceKind
 	CanPatch(api.ServiceKind) bool
+
+	// patchRoute patches a route to include the custom Envoy configuration
+	// PatchCluster patches a cluster to include the custom Envoy configuration
+	// required to integrate with the serverless integration.
+	PatchRoute(*envoy_route_v3.RouteConfiguration) (*envoy_route_v3.RouteConfiguration, bool, error)
 
 	// PatchCluster patches a cluster to include the custom Envoy configuration
 	// required to integrate with the serverless integration.

--- a/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway.envoy-1-20-x.golden
+++ b/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway.envoy-1-20-x.golden
@@ -211,7 +211,7 @@
 
                   }
                 },
-                "stripMatchingHostPort": true
+                "stripAnyHostPort": true
               }
             }
           ],

--- a/agent/xds/testdata/serverless_plugin/routes/lambda-terminating-gateway.envoy-1-20-x.golden
+++ b/agent/xds/testdata/serverless_plugin/routes/lambda-terminating-gateway.envoy-1-20-x.golden
@@ -1,0 +1,30 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+      "name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "virtualHosts": [
+        {
+          "name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+          "domains": [
+            "*"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "validateClusters": true
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
- Move from `strip_matching_host_port` to `strip_any_host_port`
- Remove `auto_host_rewrite` since it conflicts with `strip_any_host_port`