### PR TITLE
docs: fixes broken url in acl overview page

### DIFF
--- a/website/content/docs/security/acl/index.mdx
+++ b/website/content/docs/security/acl/index.mdx
@@ -54,7 +54,7 @@ In addition to the rules that authenticate access to services, several attribute
 
 Refer to the following topics for details about policies:
 
-- [Policies](/docs/security/acl/policies)
+- [Policies](/docs/security/acl/acl-policies)
 - [ACL policy command line](/commands/acl/policy)
 - [ACL policy API](/api-docs/acl/policies)
 


### PR DESCRIPTION
This PR fixes a broken url in the ACL overview page. 