### PR TITLE
docs: rename Connect Service Mesh Kubernetes to Consul Service Mesh on Kubernetes

### DIFF
--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -1,19 +1,20 @@
 ---
 layout: docs
-page_title: Service Mesh - Kubernetes
+page_title: Consul Service Mesh on Kubernetes
 description: >-
-  Connect is a feature built into to Consul that enables automatic
+  Consul Service Mesh is a feature built into to Consul that enables automatic
   service-to-service authorization and connection encryption across your Consul
-  services. Connect can be used with Kubernetes to secure pod communication with
+  services. Consul Service Mesh can be used with Kubernetes to secure pod communication with
   other services.
 ---
 
-# Connect Service Mesh on Kubernetes
+# Consul Service Mesh on Kubernetes
 
-[Connect](/docs/connect) is a feature built into to Consul that enables
+[Consul Service Mesh](/docs/connect) is a feature built into to Consul that enables
 automatic service-to-service authorization and connection encryption across
-your Consul services. Connect can be used with Kubernetes to secure pod
-communication with other pods and external Kubernetes services.
+your Consul services. Consul Service Mesh can be used with Kubernetes to secure pod
+communication with other pods and external Kubernetes services. Consul Connect is used interchangeably with the name 
+Consul Service Mesh and is what will be used to refer to for Service Mesh functionality within Consul. 
 
 The Connect sidecar running Envoy can be automatically injected into pods in
 your cluster, making configuration for Kubernetes automatic.

--- a/website/content/docs/k8s/connect/index.mdx
+++ b/website/content/docs/k8s/connect/index.mdx
@@ -21,7 +21,7 @@ your cluster, making configuration for Kubernetes automatic.
 This functionality is provided by the
 [consul-k8s project](https://github.com/hashicorp/consul-k8s) and can be
 automatically installed and configured using the
-[Consul Helm chart](/docs/k8s/installation/install).
+[Consul Helm chart](/docs/k8s/installation/install#helm-chart-installation).
 
 ## Usage
 


### PR DESCRIPTION
Slight re-wording as the title seems a bit off. 