### PR TITLE
ui: Ignore Service/Node permissions for Overview just use operator

### DIFF
--- a/ui/packages/consul-ui/app/abilities/overview.js
+++ b/ui/packages/consul-ui/app/abilities/overview.js
@@ -1,8 +1,9 @@
 import BaseAbility from './base';
 
 export default class OverviewAbility extends BaseAbility {
+  resource = 'operator';
+  segmented = false;
   get canAccess() {
-    return ['read services', 'read nodes', 'read license']
-      .some(item => this.permissions.can(item))
+    return this.canRead;
   }
 }


### PR DESCRIPTION
Previously we were checking `service:read` and `node:read` here for permissions to view the new Overview Page.

Originally this was done for the Service Health overview, that isn't built yet, but also we currently hardcode the `service` and `node` permissions to allow due to the fact that the API we use to get those details doesn't work quite how we want it (see https://github.com/hashicorp/consul/issues/11098).

All in all this means that you can always access the Overview page currently even if you shouldn't have access (the page will show you a 403 error if you don't have access)

This PR removes the `service` and `node` permission checking, we don't need to do that until the Service Health Overview tab is built. This means that we may as well just fallback to checking for `operator` privileges instead of checking for 'view licence' abilities (which checks `operator`).

The result of this change is that you no longer see the 'Overview' menu item if you don't have `operator` privileges.