### PR TITLE
Backport #12565 to v1.9.x

### DIFF
--- a/agent/consul/leader_routine_manager_test.go
+++ b/agent/consul/leader_routine_manager_test.go
@@ -76,3 +76,83 @@ func TestLeaderRoutineManager(t *testing.T) {
 		require.False(r, mgr.IsRunning("run"))
 	})
 }
+
+func TestManager_StopAll(t *testing.T) {
+	t.Parallel()
+	var runs uint32
+	var running uint32
+	mgr := NewLeaderRoutineManager(testutil.Logger(t))
+
+	run := func(ctx context.Context) error {
+		atomic.StoreUint32(&running, 1)
+		defer atomic.StoreUint32(&running, 0)
+		atomic.AddUint32(&runs, 1)
+		<-ctx.Done()
+		return nil
+	}
+
+	require.NoError(t, mgr.Start("run1", run))
+	require.NoError(t, mgr.Start("run2", run))
+
+	mgr.StopAll()
+
+	retry.Run(t, func(r *retry.R) {
+		require.False(r, mgr.IsRunning("run1"))
+		require.False(r, mgr.IsRunning("run2"))
+	})
+}
+
+// Test IsRunning when routine is a blocking call that does not
+// immediately return when cancelled
+func TestManager_StopBlocking(t *testing.T) {
+	t.Parallel()
+	var runs uint32
+	var running uint32
+	unblock := make(chan struct{}) // To simulate a blocking call
+	mgr := NewLeaderRoutineManager(testutil.Logger(t))
+
+	// A routine that will be still running for a while after cancelled
+	run := func(ctx context.Context) error {
+		atomic.StoreUint32(&running, 1)
+		defer atomic.StoreUint32(&running, 0)
+		atomic.AddUint32(&runs, 1)
+		<-ctx.Done()
+		<-unblock
+		return nil
+	}
+
+	require.NoError(t, mgr.Start("blocking", run))
+	retry.Run(t, func(r *retry.R) {
+		require.True(r, mgr.IsRunning("blocking"))
+		require.Equal(r, uint32(1), atomic.LoadUint32(&runs))
+		require.Equal(r, uint32(1), atomic.LoadUint32(&running))
+	})
+
+	doneCh := mgr.Stop("blocking")
+
+	// IsRunning should return false, however &running is still 1
+	retry.Run(t, func(r *retry.R) {
+		require.False(r, mgr.IsRunning("blocking"))
+		require.Equal(r, uint32(1), atomic.LoadUint32(&running))
+	})
+
+	// New routine should be able to replace old "cancelled but running" routine.
+	require.NoError(t, mgr.Start("blocking", func(ctx context.Context) error {
+		<-ctx.Done()
+		return nil
+	}))
+	defer mgr.Stop("blocking")
+
+	retry.Run(t, func(r *retry.R) {
+		require.True(r, mgr.IsRunning("blocking"))               // New routine
+		require.Equal(r, uint32(1), atomic.LoadUint32(&running)) // Old routine
+	})
+
+	// Complete the blocking routine
+	close(unblock)
+	<-doneCh
+
+	retry.Run(t, func(r *retry.R) {
+		require.Equal(r, uint32(0), atomic.LoadUint32(&running))
+	})
+}


### PR DESCRIPTION
This backports PR #12565 to the release/1.9.x branch.

The conflicts in auto-backporting were due to the relevant code getting moved out of agent/consul to lib/ and having some types renamed.