### PR TITLE
ui: Adds licensing overview tab

### DIFF
--- a/ui/packages/consul-ui/app/helpers/temporal-format.js
+++ b/ui/packages/consul-ui/app/helpers/temporal-format.js
@@ -1,0 +1,9 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+
+export default class TemporalFormatHelper extends Helper {
+  @service('temporal') temporal;
+  compute([value], hash) {
+    return this.temporal.format(value, hash);
+  }
+}

--- a/ui/packages/consul-ui/app/helpers/temporal-within.js
+++ b/ui/packages/consul-ui/app/helpers/temporal-within.js
@@ -1,0 +1,9 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+
+export default class TemporalWithinHelper extends Helper {
+  @service('temporal') temporal;
+  compute(params, hash) {
+    return this.temporal.within(params, hash);
+  }
+}

--- a/ui/packages/consul-ui/app/services/temporal.js
+++ b/ui/packages/consul-ui/app/services/temporal.js
@@ -1,9 +1,31 @@
 import format from 'pretty-ms';
+import parse from 'parse-duration';
 import { assert } from '@ember/debug';
+import dayjs from 'dayjs';
+import realtiveTime from 'dayjs/plugin/relativeTime';
+dayjs.extend(realtiveTime);
 
 import Service from '@ember/service';
 
 export default class TemporalService extends Service {
+
+  format(value, options) {
+    const djs = dayjs(value);
+    if(dayjs().isBefore(djs)) {
+      return dayjs().to(djs, true);
+    } else {
+      return dayjs().from(djs, true);
+    }
+  }
+
+  within([value, d], options) {
+    return dayjs(value).isBefore(dayjs().add(d, 'ms'));
+  }
+
+  parse(value, options) {
+    return parse(value);
+  }
+
   durationFrom(value, options = {}) {
     switch (true) {
       case typeof value === 'number':
@@ -14,8 +36,12 @@ export default class TemporalService extends Service {
         return format(value / 1000000, { formatSubMilliseconds: true })
           .split(' ')
           .join('');
+      case typeof value === 'string':
+        return value;
+      default:
+        assert(`${value} is not a valid type`, false);
+        return value;
+
     }
-    assert(`${value} is not a valid type`, false);
-    return value;
   }
 }

--- a/ui/packages/consul-ui/app/services/temporal.js
+++ b/ui/packages/consul-ui/app/services/temporal.js
@@ -2,10 +2,10 @@ import format from 'pretty-ms';
 import parse from 'parse-duration';
 import { assert } from '@ember/debug';
 import dayjs from 'dayjs';
-import realtiveTime from 'dayjs/plugin/relativeTime';
-dayjs.extend(realtiveTime);
-
+import relativeTime from 'dayjs/plugin/relativeTime';
 import Service from '@ember/service';
+
+dayjs.extend(relativeTime);
 
 export default class TemporalService extends Service {
 

--- a/ui/packages/consul-ui/app/styles/base/icons/icons/index.scss
+++ b/ui/packages/consul-ui/app/styles/base/icons/icons/index.scss
@@ -304,7 +304,7 @@
 // @import './docker-color/index.scss';
 // @import './docs/index.scss';
 // @import './docs-download/index.scss';
-// @import './docs-link/index.scss';
+@import './docs-link/index.scss';
 // @import './dollar-sign/index.scss';
 // @import './dot/index.scss';
 // @import './dot-half/index.scss';

--- a/ui/packages/consul-ui/app/styles/routes.scss
+++ b/ui/packages/consul-ui/app/styles/routes.scss
@@ -4,3 +4,4 @@
 @import 'routes/dc/acls/index';
 @import 'routes/dc/intentions/index';
 @import 'routes/dc/overview/serverstatus';
+@import 'routes/dc/overview/license';

--- a/ui/packages/consul-ui/app/styles/routes/dc/overview/license.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/overview/license.scss
@@ -1,0 +1,61 @@
+section[data-route='dc.show.license'] {
+  @extend %license-route;
+}
+%license-route .validity {
+  @extend %license-validity;
+}
+%license-route aside {
+  @extend %license-route-learn-more;
+}
+
+%license-route h2 {
+  @extend %h200;
+}
+
+%license-validity dl {
+  @extend %horizontal-kv-list;
+  font-size: var(--typo-size-400);
+}
+%license-validity dl .expired + dd {
+  @extend %visually-hidden;
+}
+%license-validity dl dt::before {
+  content: '';
+  margin-right: 0.250rem; /* 4px */
+}
+%license-validity dl .expired::before {
+  --icon-name: icon-x-circle;
+  --icon-color: rgb(var(--red-500));
+}
+%license-validity dl .warning::before {
+  --icon-name: icon-alert-circle;
+  --icon-color: rgb(var(--orange-500));
+}
+%license-validity dl .valid:not(.warning)::before {
+  --icon-name: icon-check-circle;
+  --icon-color: rgb(var(--green-500));
+}
+
+
+%license-route-learn-more {
+  @extend %panel;
+  padding: var(--padding-y) var(--padding-x);
+  width: 40%;
+  min-width: 413px;
+  margin-top: 1rem; /* 16px */
+}
+%license-route-learn-more header > :first-child {
+  @extend %h300;
+}
+%license-route-learn-more header {
+  margin-bottom: 1rem; /* 16px */
+}
+%license-route-learn-more li {
+  margin-bottom: 0.250rem; /* 4px */
+}
+%license-route-learn-more a::before {
+  --icon-name: icon-docs-link;
+  content: '';
+  margin-right: 0.375rem; /* 6px */
+}
+

--- a/ui/packages/consul-ui/app/templates/dc/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/show.hbs
@@ -10,23 +10,38 @@ as |route|>
     <BlockSlot @name="toolbar">
     </BlockSlot>
     <BlockSlot @name="nav">
-{{#if false}}
+
+{{#let
+    (from-entries (array
+      (array 'serverstatus' true)
+      (array 'cataloghealth' false)
+      (array 'license' (can 'read license'))
+    ))
+as |tabs|}}
+
+  {{#let (without false
+    (values tabs)
+  ) as |tabsEnabled|}}
+
+{{#if (gt tabsEnabled.length 1)}}
       <TabNav @items={{
         compact
           (array
+(if tabs.serverstatus
             (hash
               label=(compute (fn route.t 'serverstatus.title'))
               href=(href-to "dc.show.serverstatus")
               selected=(is-href "dc.show.serverstatus")
             )
-(if false
+'')
+(if tabs.cataloghealth
             (hash
               label=(compute (fn route.t 'cataloghealth.title'))
               href=(href-to 'dc.show.cataloghealth')
               selected=(is-href 'dc.show.cataloghealth')
             )
 '')
-(if (can 'read license')
+(if tabs.license
             (hash
               label=(compute (fn route.t 'license.title'))
               href=(href-to 'dc.show.license')
@@ -36,6 +51,9 @@ as |route|>
 '')
       }}/>
 {{/if}}
+
+  {{/let}}
+{{/let}}
     </BlockSlot>
     <BlockSlot @name="content">
       <Outlet

--- a/ui/packages/consul-ui/app/templates/dc/show/license.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/show/license.hbs
@@ -1,0 +1,153 @@
+<Route
+  @name={{routeName}}
+as |route|>
+  <DataLoader
+    @src={{
+      uri '/${partition}/${nspace}/${dc}/license'
+      (hash
+        partition=route.params.partition
+        nspace=route.params.nspace
+        dc=route.params.dc
+      )
+    }}
+  as |loader|>
+
+{{#let
+  loader.data
+as |item|}}
+    <BlockSlot @name="error">
+      <ErrorState
+        @error={{loader.error}}
+        @login={{route.model.app.login.open}}
+      />
+    </BlockSlot>
+
+    <BlockSlot @name="disconnected" as |after|>
+      {{#if (eq loader.error.status "404")}}
+        <Notice
+          {{notification
+            sticky=true
+          }}
+          class="notification-update"
+          @type="warning"
+        as |notice|>
+          <notice.Header>
+            <strong>Warning!</strong>
+          </notice.Header>
+          <notice.Body>
+            <p>
+              This service has been deregistered and no longer exists in the catalog.
+            </p>
+          </notice.Body>
+        </Notice>
+      {{else if (eq loader.error.status "403")}}
+        <Notice
+          {{notification
+            sticky=true
+          }}
+          class="notification-update"
+          @type="error"
+        as |notice|>
+          <notice.Header>
+            <strong>Error!</strong>
+          </notice.Header>
+          <notice.Body>
+            <p>
+              You no longer have access to this service
+            </p>
+          </notice.Body>
+        </Notice>
+      {{else}}
+        <Notice
+          {{notification
+            sticky=true
+          }}
+          class="notification-update"
+          @type="warning"
+        as |notice|>
+          <notice.Header>
+            <strong>Warning!</strong>
+          </notice.Header>
+          <notice.Body>
+            <p>
+              An error was returned whilst loading this data, refresh to try again.
+            </p>
+          </notice.Body>
+        </Notice>
+      {{/if}}
+    </BlockSlot>
+
+    <BlockSlot @name="loaded">
+      <div class="tab-section">
+        <section
+          class={{class-map
+            'validity'
+            (array 'valid' item.Valid)
+          }}
+        >
+          <header>
+            <h2>
+              {{compute (fn route.t 'expiry.header')}}
+            </h2>
+          </header>
+
+          <p>
+            {{compute (fn route.t 'expiry.${type}.body'
+              (hash
+                type=(if item.Valid 'valid' 'expired')
+                date=(format-time item.License.expiration_time
+                  year='numeric'
+                  month='long'
+                  day='numeric'
+                )
+                time=(format-time item.License.expiration_time
+                  hour12=true
+                  hour='numeric'
+                  hourCycle='h12'
+                  minute='numeric'
+                  second='numeric'
+                  timeZoneName='short'
+                )
+                htmlSafe=true
+              )
+            )}}
+          </p>
+
+          <dl>
+            <dt class={{class-map
+                (array 'valid' item.Valid)
+                (array 'expired' (not item.Valid))
+                (array 'warning' (temporal-within item.License.expiration_time 2629800000))
+              }}
+            >
+              {{compute (fn route.t 'expiry.${type}.header'
+                (hash
+                  type=(if item.Valid 'valid' 'expired')
+                )
+              )}}
+            </dt>
+            <dd>
+              {{temporal-format item.License.expiration_time}}
+            </dd>
+          </dl>
+
+          <aside>
+            <header>
+              <h3>
+                {{compute (fn route.t 'documentation.title')}}
+              </h3>
+            </header>
+            {{compute (fn route.t 'documentation.body'
+              (hash
+                htmlSafe=true
+              )
+            )}}
+          </aside>
+
+        </section>
+      </div>
+    </BlockSlot>
+{{/let}}
+  </DataLoader>
+</Route>
+

--- a/ui/packages/consul-ui/mock-api/v1/operator/license
+++ b/ui/packages/consul-ui/mock-api/v1/operator/license
@@ -1,12 +1,12 @@
 {
-  "Valid": ${fake.random.boolean()},
+  "Valid": true,
   "License": {
     "license_id": "${fake.random.uuid()}",
     "customer_id": "${fake.random.uuid()}",
     "installation_id": "*",
     "issue_time": "2021-01-13T15:25:19.052900132Z",
     "start_time": "2021-01-13T00:00:00Z",
-    "expiration_time": "${env('CONSUL_LICENSE_EXPIRATION', '2022-01-13T23:59:59.999Z')}",
+    "expiration_time": "${env('CONSUL_LICENSE_EXPIRATION', '2022-05-02T23:59:59.999Z')}",
     "termination_time": "${env('CONSUL_LICENSE_TERMINATION', '2022-01-13T23:59:59.999Z')}",
     "product": "consul",
     "flags": {

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -16,6 +16,40 @@ dc:
       title: Health
     license:
       title: License
+      expiry:
+        header: Expiry
+        expired:
+          header: Expired
+          body: |
+            <p>
+              Your license expired on {date} at {time}.
+            </p>
+        valid:
+          header: ''
+          body: |
+            <p>
+              Your license expires on {date} at {time}.
+            </p>
+      documentation:
+        title: Learn More
+        body: |
+          <ul>
+            <li>
+              <a href="{CONSUL_DOCS_URL}/enterprise/license/faq#q-is-there-a-grace-period-when-licenses-expire">
+                License expiration
+              </a>
+            </li>
+            <li>
+              <a href="{CONSUL_DOCS_URL}/docs/enterprise/license/faq#q-how-can-i-renew-a-license">
+                Renewing a license
+              </a>
+            </li>
+            <li>
+              <a href="{CONSUL_DOCS_LEARN_URL}/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise">
+                Applying a new license
+              </a>
+            </li>
+          </ul>
 
   nodes:
     show:


### PR DESCRIPTION
This PR adds a licensing tab to the Cluster Overview page to give expiry information.

[Preview Link](https://consul-ui-staging-58syudcrt-hashicorp.vercel.app/ui/dc1/overview/license)