### PR TITLE
[middleware][rpc] lower log to trace

### DIFF
--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -54,7 +54,7 @@ func (r *RequestRecorder) Record(requestName string, rpcType string, start time.
 
 	// math.MaxInt64 < math.MaxFloat32 is true so we should be good!
 	r.recorderFunc(metricRPCRequest, float32(elapsed), labels)
-	r.Logger.Debug(requestLogName,
+	r.Logger.Trace(requestLogName,
 		"method", requestName,
 		"errored", respErrored,
 		"request_type", reqType,


### PR DESCRIPTION
### overview

Early feedback points out that `debug` level for the RPC calls can be too noisy. 

```
$ consul agent -dev -log-level trace

...

2022-04-06T10:18:09.541-0700 [TRACE] agent.server: rpc_server_call: method=Health.NodeChecks errored=false request_type=read rpc_type=net/rpc elapsed=0
...

```

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>