### PR TITLE
add changelog for rpc metric improv project

### DIFF
--- a/.changelog/12311.txt
+++ b/.changelog/12311.txt
@@ -1,0 +1,3 @@
+```release-note:note
+Forked net/rpc to add middleware support: https://github.com/hashicorp/consul-net-rpc/ .
+```

--- a/.changelog/12573.txt
+++ b/.changelog/12573.txt
@@ -1,3 +1,3 @@
 ```release-note:feature
-rpc: (beta-only): add a new metric `consul.rpc.server.call` with labels
+rpc: (beta): add a new metric `consul.rpc.server.call` with labels
 for `method`, `errored`, `rpc_type`, `request_type`.

--- a/.changelog/12573.txt
+++ b/.changelog/12573.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+rpc: (beta-only): add middleware to net/rpc calls and record a new metric `consul.rpc.server.call` with labels
+for `method`, `errored`, `rpc_type`, `request_type`.
+```


### PR DESCRIPTION
Adds a changelog for: https://github.com/hashicorp/consul/pull/12573 and https://github.com/hashicorp/consul/pull/12311. I went with the OSS sync since there's no actual enterprise only features. But open to more guidance.

Signed-off-by: FFMMM <FFMMM@users.noreply.github.com>