### PR TITLE
Add explicit docker version to setup_remote_docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,7 +533,8 @@ jobs:
       # get consul binary
       - attach_workspace:
           at: bin/
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.11
       - run: make ci.dev-docker
       - run: *notify-slack-failure
 
@@ -594,7 +595,8 @@ jobs:
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.11
       - run:
           name: Build Docker Image if Necessary
           command: |
@@ -852,7 +854,8 @@ jobs:
       # Get go binary from workspace
       - attach_workspace:
           at: .
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.11
       # Build the consul-dev image from the already built binary
       - run: docker build -t consul-dev -f ./build-support/docker/Consul-Dev.dockerfile .
       - run:

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -46,6 +46,9 @@ func runCmd(t *testing.T, c string, env ...string) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
+		cmd2 := exec.Command("docker", "info")
+		cmd2.Stdout = os.Stdout
+		cmd2.Stderr = os.Stderr
 		t.Fatalf("command failed: %v", err)
 	}
 }


### PR DESCRIPTION
The default version is 17.09.0-ce, which is quite old! [Reference](https://circleci.com/docs/2.0/building-docker-images/#docker-version)