### PR TITLE
[1.9.x] ci: run envoy integration tests on a real machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -741,11 +741,10 @@ jobs:
       - run: *notify-slack-failure
 
   envoy-integration-test-1_13_7: &ENVOY_TESTS
-    docker:
-      # We only really need bash and docker-compose which is installed on all
-      # Circle images but pick Go since we have to pick one of them.
-      - image: *GOLANG_IMAGE
-    parallelism: 2
+    machine:
+      image: ubuntu-2004:202101-01
+    parallelism: 4
+    resource_class: medium
     environment:
       ENVOY_VERSION: "1.13.7"
     steps: &ENVOY_INTEGRATION_TEST_STEPS
@@ -753,7 +752,7 @@ jobs:
       # Get go binary from workspace
       - attach_workspace:
           at: .
-      - setup_remote_docker
+      - run: *install-gotestsum
       # Build the consul-dev image from the already built binary
       - run: docker build -t consul-dev -f ./build-support/docker/Consul-Dev.dockerfile .
       - run:


### PR DESCRIPTION
Backport of #12715 to 1.9.x

Conflicts:
-	.circleci/config.yml