### PR TITLE
improve error msg for deregister critical service

### DIFF
--- a/.changelog/12725.txt
+++ b/.changelog/12725.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: improve log messages when a service with a critical health check is deregistered due to exceeding the deregister_critical_service_after timeout
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1813,14 +1813,17 @@ func (a *Agent) reapServicesInternal() {
 		if timeout > 0 && cs.CriticalFor() > timeout {
 			reaped[serviceID] = true
 			if err := a.RemoveService(serviceID); err != nil {
-				a.logger.Error("unable to deregister service after check has been critical for too long",
+				a.logger.Error("failed to deregister service with critical health that exceeded health check's 'deregister_critical_service_after' timeout",
 					"service", serviceID.String(),
 					"check", checkID.String(),
-					"error", err)
+					"timeout", timeout.String(),
+					"error", err,
+				)
 			} else {
-				a.logger.Info("Check for service has been critical for too long; deregistered service",
+				a.logger.Info("deregistered service with critical health due to exceeding health check's 'deregister_critical_service_after' timeout",
 					"service", serviceID.String(),
 					"check", checkID.String(),
+					"timeout", timeout.String(),
 				)
 			}
 		}


### PR DESCRIPTION
## What

If a service is automatically registered because it has a critical health check
for longer than deregister_critical_service_after, the error message will now
include:
- mention of the deregister_critical_service_after option
- the value of deregister_critical_service_after for that check

## Why

A user reported confusion as to why a service was being automatically deregistered "at random". They were unaware of `deregister_critical_service_after` which:

1. isn't mentioned as the cause of the deregistration in log messages, and
2. isn't returned when reading a health check

This PR addresses problem (1). Problem (2) can be addressed in a follow-up PR (TODO: create an issue for this).

## Test Setup

I modified the `TestAgent_Service_Reap` automated test to output `INFO` level log messages with:
```
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3232,7 +3232,7 @@ func TestAgent_Service_Reap(t *testing.T) {
        a := StartTestAgent(t, TestAgent{Overrides: `
                check_reap_interval = "50ms"
                check_deregister_interval_min = "0s"
-       `})
+       `, LogLevel:hclog.LevelFromString("INFO")})
        defer a.Shutdown()
        testrpc.WaitForTestAgent(t, a.RPC, "dc1")
```

Then executed that test with `go test -v -run _Reap ./agent`. That test case sets `deregister_critical_service_after` to 200ms, so I would expect to see the 200ms timeout included in the error message.
```
	chkTypes := []*structs.CheckType{
		{
			Status:                         api.HealthPassing,
			TTL:                            25 * time.Millisecond,
			DeregisterCriticalServiceAfter: 200 * time.Millisecond,
		},
	}
```

## Test Results

Updated error message is printed when service is deregistered due to the health check's `deregister_critical_service_after` value.

```
jkirschner@HashiH0PW6D3:~/go/src/github.com/hashicorp/consul$ go test -v -run _Reap ./agent
=== RUN   TestAgent_Service_Reap
...
53:48.029 [WARN]  TestAgent: Check missed TTL, is now critical: check=service:redis
53:48.131 [WARN]  TestAgent: Check missed TTL, is now critical: check=service:redis
53:48.340 [INFO]  TestAgent: deregistered service with critical health due to exceeding health check's 'deregister_critical_service_after' timeout: service=redis check=service:redis timeout=200ms
...
PASS
```

