### PR TITLE
Support vault namespaces in connect CA

### DIFF
--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -773,6 +773,9 @@ func (v *VaultProvider) unmountNamespaced(path string) error {
 		}
 
 		// namespace doesn't exist, try a different variant
+		// We match on the error string; this is more fragile in that it depends on vault behavior, but it preserves
+		// other errors. We could simply just retry on each error, which would be more robust but wouldn't necessarily
+		// return the most useful error message to the user.
 		if strings.Contains(err.Error(), "no handler for route") {
 			v.logger.Info(fmt.Sprintf("Attempted mount path %s for path %s, error %s", mountPath, path, err))
 			continue

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -719,6 +719,10 @@ func (v *VaultProvider) PrimaryUsesIntermediate() {}
 // This makes it a lexical split ambiguous; is /foo/bar/dc1/intermediate_key in ns /foo, /foo/bar, or /foo/bar/dc1?
 // The strategy here is to successively try each possible split, starting with the longest namespace possible.
 //
+// An alternate strategy would be to use the /sys/namespaces endpoint to find valid namespaces, and recursively explore
+// to figure out the correct split. However that potentially requires new permissions on vault, starting with the root
+// namespace on up.
+//
 func (v *VaultProvider) mountNamespaced(path string, mountInfo *vaultapi.MountInput) error {
 	paths := potentialMountPaths(path)
 
@@ -755,6 +759,7 @@ func (v *VaultProvider) mountNamespacedHelper(path string, mountInfo *vaultapi.M
 	return err
 }
 
+// Same strategy as with unmountNamespaced above
 func (v *VaultProvider) unmountNamespaced(path string) error {
 	paths := potentialMountPaths(path)
 

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -104,6 +104,15 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 		return err
 	}
 
+	// We don't want to set the namespace if it's empty to prevent potential
+	// unknown behavior (what does Vault do with an empty namespace). The Vault
+	// client also makes sure the inputs are not empty strings so let's do the
+	// same.
+	if config.Namespace != "" {
+		v.namespace = config.Namespace
+		client.SetNamespace(config.Namespace)
+	}
+
 	if config.AuthMethod != nil {
 		loginResp, err := vaultLogin(client, config.AuthMethod)
 		if err != nil {
@@ -113,14 +122,6 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	}
 	client.SetToken(config.Token)
 
-	// We don't want to set the namespace if it's empty to prevent potential
-	// unknown behavior (what does Vault do with an empty namespace). The Vault
-	// client also makes sure the inputs are not empty strings so let's do the
-	// same.
-	if config.Namespace != "" {
-		v.namespace = config.Namespace
-		client.SetNamespace(config.Namespace)
-	}
 	v.config = config
 	v.client = client
 	v.isPrimary = cfg.IsPrimary

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -852,3 +852,34 @@ func vaultProviderConfig(t *testing.T, addr, token string, rawConf map[string]in
 
 	return cfg
 }
+
+func TestVaultProvider_namespacedSysMountPath(t *testing.T) {
+
+	testcases := map[string]struct {
+		path string
+		out  string
+	}{
+		"simple path": {
+			path: "foo/",
+			out:  "/v1/sys/mounts/foo/",
+		},
+		"simple namespace": {
+			path: "foo/bar/",
+			out:  "/v1/foo/sys/mounts/bar/",
+		},
+		"two layer namespace": {
+			path: "foo/bar/baz/",
+			out:  "/v1/foo/bar/sys/mounts/baz/",
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			path := namespacedSysMountPath(testcase.path)
+
+			require.Equal(t, testcase.out, path)
+		})
+	}
+
+	return
+}

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -853,37 +853,6 @@ func vaultProviderConfig(t *testing.T, addr, token string, rawConf map[string]in
 	return cfg
 }
 
-func TestVaultProvider_potentialNamepaces(t *testing.T) {
-
-	testcases := map[string]struct {
-		path string
-		out  []string
-	}{
-		"simple path": {
-			path: "foo/",
-			out:  []string{},
-		},
-		"simple namespace": {
-			path: "foo/bar/",
-			out:  []string{"foo"},
-		},
-		"two layer namespace": {
-			path: "foo/bar/baz/",
-			out:  []string{"foo/bar", "foo"},
-		},
-	}
-
-	for name, testcase := range testcases {
-		t.Run(name, func(t *testing.T) {
-			path := potentialNamespaces(testcase.path)
-
-			require.Equal(t, testcase.out, path)
-		})
-	}
-
-	return
-}
-
 func TestVaultProvider_potentialMountPaths(t *testing.T) {
 
 	testcases := map[string]struct {

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -854,7 +854,6 @@ func vaultProviderConfig(t *testing.T, addr, token string, rawConf map[string]in
 }
 
 func TestVaultProvider_potentialMountPaths(t *testing.T) {
-
 	testcases := map[string]struct {
 		path string
 		out  []string
@@ -880,6 +879,4 @@ func TestVaultProvider_potentialMountPaths(t *testing.T) {
 			require.Equal(t, testcase.out, path)
 		})
 	}
-
-	return
 }


### PR DESCRIPTION
Follow on to some missed items from #12655

From an internal ticket "Support standard "Vault namespace in the
path" semantics for Connect Vault CA Provider"

Vault allows the namespace to be specified as a prefix in the path of
a PKI definition, but our usage of the Vault API includes calls that
don't support a namespaced key. In particular the sys.* family of
calls simply appends the key, instead of prefixing the namespace in
front of the path.

Signed-off-by: Mark Anderson <manderson@hashicorp.com>