### PR TITLE
Update vault to 1.9.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ references:
     GIT_COMMITTER_NAME: circleci-consul
     S3_ARTIFACT_BUCKET: consul-dev-artifacts-v2
     BASH_ENV: .circleci/bash_env.sh
-    VAULT_BINARY_VERSION: 1.2.2
+    VAULT_BINARY_VERSION: 1.9.4
 
 steps:
   install-gotestsum: &install-gotestsum


### PR DESCRIPTION
Vault hasn't been updated for a while, and we should be testing
against a newer version. I'd update to 1.10.0, but we would run afoul
of https://github.com/hashicorp/vault/issues/14863. We should update
to 1.10.1 as soon as it comes our, or better yet move to using latest.

Signed-off-by: Mark Anderson <manderson@hashicorp.com>