### PR TITLE
ui: Don't automatically move rz read-replicas out of the rz

### DIFF
--- a/ui/packages/consul-ui/app/services/repository/dc.js
+++ b/ui/packages/consul-ui/app/services/repository/dc.js
@@ -130,16 +130,9 @@ export default class DcService extends RepositoryService {
                   // convert the string[] to Server[]
                   Servers: value.Servers.reduce((prev, item) => {
                     const server = body.Servers[item];
-                    // TODO: It is not currently clear whether we should be
-                    // taking ReadReplicas out of the RedundancyZones when we
-                    // encounter one in a Zone once this is cleared up either
-                    // way we can either remove this comment or make any
-                    // necessary amends here
-                    if(!server.ReadReplica) {
-                      // keep a record of things
-                      grouped.push(server.ID);
-                      prev.push(server);
-                    }
+                    // keep a record of things
+                    grouped.push(server.ID);
+                    prev.push(server);
                     return prev;
                   }, []),
                 }


### PR DESCRIPTION
There is a case where a read-replica could be configured to be in a redundancy zone. We originally decided to use the frontend to display this configuration with the read-replica as not being in the redundancy zone. Since then we've decided that we should show the users configuration rather than display that different to what it actually is rather than fix it up on the frontend.

This PR removes the little hack we made to fix up the config if this case happens.