### PR TITLE
docs: Upgrade Consul K8s update link to combat matrix

### DIFF
--- a/website/content/docs/k8s/upgrade/index.mdx
+++ b/website/content/docs/k8s/upgrade/index.mdx
@@ -118,7 +118,7 @@ to update to the new version.
 1. Ensure you've read the [Upgrading Consul](/docs/upgrading) documentation.
 1. Ensure you've read any [specific instructions](/docs/upgrading/upgrade-specific) for the version you're upgrading
    to and the Consul [changelog](https://github.com/hashicorp/consul/blob/main/CHANGELOG.md) for that version.
-1. Read our [Compatibility Matrix](/docs/k8s/upgrade/compatibility) to ensure
+1. Read our [Compatibility Matrix](/docs/k8s/installation/compatibility) to ensure
    your current Helm chart version supports this Consul version. If it does not,
    you may need to also upgrade your Helm chart version at the same time.
 1. Set `global.image` in your `values.yaml` to the desired version:


### PR DESCRIPTION
Somehow https://www.consul.io/docs/k8s/upgrade/compatibility is still showing up which is outdated. Removing the link from this page so it perhaps no longer is served up. 