### PR TITLE
website: redirect change consul k8s compatibility matrix link

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1089,7 +1089,7 @@ module.exports = [
   },
   {
     source: '/docs/compatibility',
-    destination: '/docs/upgrading/compatibility',
+    destination: '/docs/installation/compatibility',
     permanent: true,
   },
   {


### PR DESCRIPTION
Somehow we are still re-directing to old compat matrix version which is cached somehow for Google search results. 