### PR TITLE
redirect.js: fixing redirect to new compatibility matrix for k8s

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1089,7 +1089,12 @@ module.exports = [
   },
   {
     source: '/docs/compatibility',
-    destination: '/docs/installation/compatibility',
+    destination: '/docs/upgrading/compatibility',
+    permanent: true,
+  },
+  {
+    source: '/docs/k8s/upgrade/compatibility',
+    destination: '/docs/k8s/installation/compatibility',
     permanent: true,
   },
   {


### PR DESCRIPTION
Reverting previous change from https://github.com/hashicorp/consul/pull/12751 and adding new redirect to new Consul K8s compatibility matrix. 