### PR TITLE
ui: Show read-replica health status

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/server/card/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/server/card/index.hbs
@@ -24,7 +24,6 @@
       {{@item.Name}}
     </dd>
 
-{{#if (not @item.ReadReplica)}}
     <dt class={{class-map
       'health-status'
       (array 'healthy' @item.Healthy)
@@ -34,7 +33,6 @@
     <dd>
       {{if (contains @item.Status (array 'leader' 'voter')) 'Active voter' 'Backup voter'}}
     </dd>
-{{/if}}
 
   </dl>
 </div>


### PR DESCRIPTION
Previously we omitted the health status for read-replicas. We've decided that these should be shown just like all other servers.