### PR TITLE
docs: Correcting an uncapitalized word setup at the beginning of titles to be capitalized in vault section.

### DIFF
--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -316,7 +316,7 @@ function build_consul {
       status "Ensuring Go modules are up to date"
       # ensure our go module cache is correct
       go_mod_assert || return 1
-      # setup to bind mount our hosts module cache into the container
+      # Setup to bind mount our hosts module cache into the container
       volume_mount="--mount=type=bind,source=${MAIN_GOPATH}/pkg/mod,target=/go/pkg/mod"
    fi
 

--- a/website/content/docs/k8s/installation/vault/data-integration/bootstrap-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/bootstrap-token.mdx
@@ -20,7 +20,7 @@ To use an ACL bootstrap token stored in Vault, we will follow the steps outlined
   1. Store the secret in Vault.
   1. Create a Vault policy that authorizes the desired level of access to the secret.
   
-### setup per Consul datacenter
+### Setup per Consul datacenter
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
@@ -55,7 +55,7 @@ Apply the Vault policy by issuing the `vault policy write` CLI command:
 $ vault policy write boostrap-token-policy boostrap-token-policy.hcl
 ```
 
-## setup per Consul datacenter
+## Setup per Consul datacenter
 ### Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access
 
 Next, you will create Kubernetes auth roles for the Consul `server-acl-init` container that runs as part of the Consul server statefulset:

--- a/website/content/docs/k8s/installation/vault/data-integration/connect-ca.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/connect-ca.mdx
@@ -24,7 +24,7 @@ To use an Vault as the Service Mesh Certificate Provider on Kubernetes, we will 
 ### One time setup in Vault
   1. Create a Vault policy that authorizes the desired level of access to the secret.
 
-### setup per Consul datacenter
+### Setup per Consul datacenter
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
@@ -40,7 +40,7 @@ you will first need to decide on the type of policy that is suitable for you.
 To see the permissions that Consul would need in Vault, please see [Vault ACL policies](/docs/connect/ca/vault#vault-acl-policies)
 documentation.
 
-## setup per Consul datacenter
+## Setup per Consul datacenter
 ### Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access
 
 Next, you will create Kubernetes auth roles for the Consul servers:

--- a/website/content/docs/k8s/installation/vault/data-integration/enterprise-license.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/enterprise-license.mdx
@@ -19,7 +19,7 @@ To use an enterprise license stored in Vault, we will follow the steps outlined 
   1. Store the secret in Vault.
   1. Create a Vault policy that authorizes the desired level of access to the secret.
 
-### setup per Consul datacenter
+### Setup per Consul datacenter
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
@@ -54,7 +54,7 @@ Apply the Vault policy by issuing the `vault policy write` CLI command:
 $ vault policy write license-policy license-policy.hcl
 ```
 
-## setup per Consul datacenter
+## Setup per Consul datacenter
 ### Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access
 
 Next, you will create Kubernetes auth roles for the Consul server and client:

--- a/website/content/docs/k8s/installation/vault/data-integration/gossip.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/gossip.mdx
@@ -19,7 +19,7 @@ To use a gossip encryption key stored in Vault, we will follow the steps outline
   1. Store the secret in Vault.
   1. Create a Vault policy that authorizes the desired level of access to the secret.
   
-### setup per Consul datacenter
+### Setup per Consul datacenter
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
@@ -52,7 +52,7 @@ Apply the Vault policy by issuing the `vault policy write` CLI command:
 $ vault policy write gossip-policy gossip-policy.hcl
 ```
 
-## setup per Consul datacenter
+## Setup per Consul datacenter
 ### Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access
 
 Next, we will create Kubernetes auth roles for the Consul server and client:

--- a/website/content/docs/k8s/installation/vault/data-integration/index.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/index.mdx
@@ -20,7 +20,7 @@ Generally, for each secret you wish to store in Vault, the process to integrate 
   1. Store the secret in Vault.
   1. Create a Vault policy that authorizes the desired level of access to the secret.
   
-#### setup per Consul datacenter
+#### Setup per Consul datacenter
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
@@ -35,7 +35,7 @@ Following the general integraiton steps, a more detailed workflow for integratio
   1. Create a Vault policy that authorizes the desired level of access to the secret.
       - Create a Vault policy that you name `gossip-policy` which allows `read` access to the path `secret/consul/gossip`.
 
-#### setup per Consul datacenter
+#### Setup per Consul datacenter
 
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
       - Both Consul servers and Consul clients need access to the gossip encryption key, so you create two Vault Kubernetes:

--- a/website/content/docs/k8s/installation/vault/data-integration/partition-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/partition-token.mdx
@@ -19,7 +19,7 @@ To use an ACL partition token stored in Vault, we will follow the steps outlined
   1. Store the secret in Vault.
   1. Create a Vault policy that authorizes the desired level of access to the secret.
 
-### setup per Consul datacenter
+### Setup per Consul datacenter
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
@@ -54,7 +54,7 @@ Apply the Vault policy by issuing the `vault policy write` CLI command:
 $ vault policy write partition-token-policy partition-token-policy.hcl
 ```
 
-## setup per Consul datacenter
+## Setup per Consul datacenter
 ### Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access
 
 Next, you will create Kubernetes auth roles for the Consul `server-acl-init` job:

--- a/website/content/docs/k8s/installation/vault/data-integration/replication-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/replication-token.mdx
@@ -19,7 +19,7 @@ To use an ACL replication token stored in Vault, we will follow the steps outlin
   1. Store the secret in Vault.
   1. Create a Vault policy that authorizes the desired level of access to the secret.
 
-### setup per Consul datacenter
+### Setup per Consul datacenter
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
@@ -54,7 +54,7 @@ Apply the Vault policy by issuing the `vault policy write` CLI command:
 $ vault policy write replication-token-policy replication-token-policy.hcl
 ```
 
-## setup per Consul datacenter
+## Setup per Consul datacenter
 ### Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access
 
 Next, you will create Kubernetes auth roles for the Consul `server-acl-init` job:

--- a/website/content/docs/k8s/installation/vault/data-integration/server-tls.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/server-tls.mdx
@@ -47,7 +47,7 @@ To use an Vault as the Server TLS Certificate Provider on Kubernetes, we will ne
 ### One time setup in Vault
   1. Create a Vault policy that authorizes the desired level of access to the secret.
 
-### setup per Consul datacenter
+### Setup per Consul datacenter
   1. (Added) Create a Vault PKI role that establishes the domains that it is allowed to issue certificates for
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
@@ -108,7 +108,7 @@ $ vault policy write ca-policy ca-policy.hcl
 
 -> **Note:** The PKI secret path referenced by the above Policy will be your `global.tls.caCert.secretName` Helm value.
 
-## setup per Consul datacenter
+## Setup per Consul datacenter
 ### Create a Vault PKI role that establishes the domains that it is allowed to issue certificates for
 
 Next, a Vault role for the PKI engine will set the default certificate issuance parameters:

--- a/website/content/docs/k8s/installation/vault/data-integration/snapshot-agent-config.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/snapshot-agent-config.mdx
@@ -20,7 +20,7 @@ To use an ACL replication token stored in Vault, we will follow the steps outlin
   1. Store the secret in Vault.
   1. Create a Vault policy that authorizes the desired level of access to the secret.
 
-### setup per Consul datacenter
+### Setup per Consul datacenter
 
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
@@ -56,7 +56,7 @@ Apply the Vault policy by issuing the `vault policy write` CLI command:
 $ vault policy write snapshot-agent-config-policy snapshot-agent-config-policy.hcl
 ```
 
-## setup per Consul datacenter
+## Setup per Consul datacenter
 ### Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access
 
 Next, you will create a Kubernetes auth role for the Consul snapshot agent:


### PR DESCRIPTION
Fixing a search and replace mistake