### PR TITLE
backport/1.10.x: Update CI and release Go versions to 1.17.9

### DIFF
--- a/.changelog/12766.txt
+++ b/.changelog/12766.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+tls: With the upgrade to Go 1.17, the ordering of `tls_cipher_suites` will no longer be honored, and `tls_prefer_server_cipher_suites` is now ignored.
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ references:
   images:
     # When updating the Go version, remember to also update the versions in the
     # workflows section for go-test-lib jobs.
-    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.16.12
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.17.9
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:14-browsers
 
   paths:
@@ -1035,9 +1035,9 @@ workflows:
           go-version: "1.16"
           requires: [dev-build]
       - go-test-lib:
-          name: "go-test-api go1.15"
+          name: "go-test-api go1.17"
           path: api
-          go-version: "1.15"
+          go-version: "1.17"
           requires: [dev-build]
       - go-test-lib:
           name: "go-test-sdk go1.16"
@@ -1045,9 +1045,9 @@ workflows:
           go-version: "1.16"
           <<: *filter-ignore-non-go-branches
       - go-test-lib:
-          name: "go-test-sdk go1.15"
+          name: "go-test-sdk go1.17"
           path: sdk
-          go-version: "1.15"
+          go-version: "1.17"
           <<: *filter-ignore-non-go-branches
       - go-test-race: *filter-ignore-non-go-branches
       - go-test-32bit: *filter-ignore-non-go-branches

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,15 +67,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.16.12", goos: "linux", goarch: "386"}
-          - {go: "1.16.12", goos: "linux", goarch: "amd64"}
-          - {go: "1.16.12", goos: "linux", goarch: "arm"}
-          - {go: "1.16.12", goos: "linux", goarch: "arm64"}
-          - {go: "1.16.12", goos: "freebsd", goarch: "386"}
-          - {go: "1.16.12", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.16.12", goos: "windows", goarch: "386"}
-          - {go: "1.16.12", goos: "windows", goarch: "amd64"}
-          - {go: "1.16.12", goos: "solaris", goarch: "amd64"}
+          - {go: "1.17.9", goos: "linux", goarch: "386"}
+          - {go: "1.17.9", goos: "linux", goarch: "amd64"}
+          - {go: "1.17.9", goos: "linux", goarch: "arm"}
+          - {go: "1.17.9", goos: "linux", goarch: "arm64"}
+          - {go: "1.17.9", goos: "freebsd", goarch: "386"}
+          - {go: "1.17.9", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.17.9", goos: "windows", goarch: "386"}
+          - {go: "1.17.9", goos: "windows", goarch: "amd64"}
+          - {go: "1.17.9", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -176,7 +176,7 @@ jobs:
       matrix:
         goos: [ darwin ]
         goarch: [ "amd64" ]
-        go: [ "1.16.12" ]
+        go: [ "1.17.9" ]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.16.12
+ARG GOLANG_VERSION=1.17.9
 FROM golang:${GOLANG_VERSION}
 
 ARG GOTOOLS="github.com/elazarl/go-bindata-assetfs/... \

--- a/build-support/docker/Test-Flake.dockerfile
+++ b/build-support/docker/Test-Flake.dockerfile
@@ -1,6 +1,6 @@
 FROM travisci/ci-garnet:packer-1512502276-986baf0
 
-ENV GOLANG_VERSION 1.16.12
+ENV GOLANG_VERSION 1.17.9
 
 RUN mkdir -p /home/travis/go && chown -R travis /home/travis/go
 


### PR DESCRIPTION
DO NOT MERGE until we've updated our CI mirror to include the Go 1.17.9 docker image