### PR TITLE
backport/1.9.x: Update CI and release Go versions to 1.17.9

### DIFF
--- a/.changelog/12767.txt
+++ b/.changelog/12767.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+tls: With the upgrade to Go 1.17, the ordering of `tls_cipher_suites` will no longer be honored, and `tls_prefer_server_cipher_suites` is now ignored.
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 references:
   images:
-    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.16.12
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/cimg/go:1.17.9
     ember: &EMBER_IMAGE docker.mirror.hashicorp.services/circleci/node:12-browsers
 
   paths:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,15 +67,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.16.12", goos: "linux", goarch: "386"}
-          - {go: "1.16.12", goos: "linux", goarch: "amd64"}
-          - {go: "1.16.12", goos: "linux", goarch: "arm"}
-          - {go: "1.16.12", goos: "linux", goarch: "arm64"}
-          - {go: "1.16.12", goos: "freebsd", goarch: "386"}
-          - {go: "1.16.12", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.16.12", goos: "windows", goarch: "386"}
-          - {go: "1.16.12", goos: "windows", goarch: "amd64"}
-          - {go: "1.16.12", goos: "solaris", goarch: "amd64"}
+          - {go: "1.17.9", goos: "linux", goarch: "386"}
+          - {go: "1.17.9", goos: "linux", goarch: "amd64"}
+          - {go: "1.17.9", goos: "linux", goarch: "arm"}
+          - {go: "1.17.9", goos: "linux", goarch: "arm64"}
+          - {go: "1.17.9", goos: "freebsd", goarch: "386"}
+          - {go: "1.17.9", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.17.9", goos: "windows", goarch: "386"}
+          - {go: "1.17.9", goos: "windows", goarch: "amd64"}
+          - {go: "1.17.9", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -176,7 +176,7 @@ jobs:
       matrix:
         goos: [ darwin ]
         goarch: [ "amd64" ]
-        go: [ "1.16.12" ]
+        go: [ "1.17.9" ]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.16.12
+ARG GOLANG_VERSION=1.17.9
 FROM golang:${GOLANG_VERSION}
 
 ARG GOTOOLS="github.com/elazarl/go-bindata-assetfs/... \

--- a/build-support/docker/Test-Flake.dockerfile
+++ b/build-support/docker/Test-Flake.dockerfile
@@ -1,6 +1,6 @@
 FROM travisci/ci-garnet:packer-1512502276-986baf0
 
-ENV GOLANG_VERSION 1.16.12
+ENV GOLANG_VERSION 1.17.9
 
 RUN mkdir -p /home/travis/go && chown -R travis /home/travis/go
 


### PR DESCRIPTION
DO NOT MERGE until we've updated our CI mirror to include the Go 1.17.9 docker image