### PR TITLE
acl: Adjust region handling in AWS IAM auth method

### DIFF
--- a/.changelog/12774.txt
+++ b/.changelog/12774.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: Improve handling of region-specific endpoints in the AWS IAM auth method. As part of this, the `STSRegion` was removed.
+```

--- a/.changelog/12774.txt
+++ b/.changelog/12774.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-acl: Improve handling of region-specific endpoints in the AWS IAM auth method. As part of this, the `STSRegion` was removed.
+acl: Improve handling of region-specific endpoints in the AWS IAM auth method. As part of this, the `STSRegion` field was removed from the auth method config.
 ```

--- a/agent/consul/authmethod/awsauth/aws.go
+++ b/agent/consul/authmethod/awsauth/aws.go
@@ -57,9 +57,6 @@ type Config struct {
 	// STSEndpoint is the AWS STS endpoint where sts:GetCallerIdentity requests will be sent.
 	// Note that the Host header in a signed request cannot be changed.
 	STSEndpoint string `json:",omitempty"`
-	// STSRegion is the region for the AWS STS service. This should only be set if STSEndpoint
-	// is set, and must match the region of the STSEndpoint.
-	STSRegion string `json:",omitempty"`
 
 	// AllowedSTSHeaderValues is a list of additional allowed headers on the sts:GetCallerIdentity
 	// request in the bearer token. A default list of necessary headers is allowed in any case.
@@ -75,7 +72,6 @@ func (c *Config) convertForLibrary() *iamauth.Config {
 		MaxRetries:             c.MaxRetries,
 		IAMEndpoint:            c.IAMEndpoint,
 		STSEndpoint:            c.STSEndpoint,
-		STSRegion:              c.STSRegion,
 		AllowedSTSHeaderValues: c.AllowedSTSHeaderValues,
 
 		ServerIDHeaderName:     IAMServerIDHeaderName,

--- a/agent/consul/authmethod/awsauth/aws_test.go
+++ b/agent/consul/authmethod/awsauth/aws_test.go
@@ -24,9 +24,8 @@ func TestNewValidator(t *testing.T) {
 		IAMEntityTags:          []string{"tag-1"},
 		ServerIDHeaderValue:    "x-some-header",
 		MaxRetries:             3,
-		IAMEndpoint:            "iam-endpoint",
-		STSEndpoint:            "sts-endpoint",
-		STSRegion:              "sts-region",
+		IAMEndpoint:            "http://iam-endpoint",
+		STSEndpoint:            "http://sts-endpoint",
 		AllowedSTSHeaderValues: []string{"header-value"},
 		ServerIDHeaderName:     "X-Consul-IAM-ServerID",
 		GetEntityMethodHeader:  "X-Consul-IAM-GetEntity-Method",
@@ -44,9 +43,8 @@ func TestNewValidator(t *testing.T) {
 			"IAMEntityTags":          []string{"tag-1"},
 			"ServerIDHeaderValue":    "x-some-header",
 			"MaxRetries":             3,
-			"IAMEndpoint":            "iam-endpoint",
-			"STSEndpoint":            "sts-endpoint",
-			"STSRegion":              "sts-region",
+			"IAMEndpoint":            "http://iam-endpoint",
+			"STSEndpoint":            "http://sts-endpoint",
 			"AllowedSTSHeaderValues": []string{"header-value"},
 		}
 
@@ -224,7 +222,6 @@ func setup(t *testing.T, config map[string]interface{}, server *iamauthtest.Serv
 	fakeAws := iamauthtest.NewTestServer(t, server)
 
 	config["STSEndpoint"] = fakeAws.URL + "/sts"
-	config["STSRegion"] = "fake-region"
 	config["IAMEndpoint"] = fakeAws.URL + "/iam"
 
 	method := &structs.ACLAuthMethod{
@@ -241,7 +238,7 @@ func setup(t *testing.T, config map[string]interface{}, server *iamauthtest.Serv
 		Creds:                  credentials.NewStaticCredentials("fake", "fake", ""),
 		IncludeIAMEntity:       v.config.EnableIAMEntityDetails,
 		STSEndpoint:            v.config.STSEndpoint,
-		STSRegion:              v.config.STSRegion,
+		STSRegion:              "fake-region",
 		Logger:                 nullLogger,
 		ServerIDHeaderValue:    v.config.ServerIDHeaderValue,
 		ServerIDHeaderName:     v.config.ServerIDHeaderName,

--- a/internal/iamauth/config.go
+++ b/internal/iamauth/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	MaxRetries             int
 	IAMEndpoint            string
 	STSEndpoint            string
-	STSRegion              string
 	AllowedSTSHeaderValues []string
 
 	// Customizable header names
@@ -63,6 +62,18 @@ func (c *Config) Validate() error {
 		c.GetEntityURLHeader == "") {
 		return fmt.Errorf("Must set all of GetEntityMethodHeader, GetEntityURLHeader, " +
 			"GetEntityHeadersHeader, and GetEntityBodyHeader when EnableIAMEntityDetails=true")
+	}
+
+	if c.STSEndpoint != "" {
+		if _, err := parseUrl(c.STSEndpoint); err != nil {
+			return fmt.Errorf("STSEndpoint is invalid: %s", err)
+		}
+	}
+
+	if c.IAMEndpoint != "" {
+		if _, err := parseUrl(c.IAMEndpoint); err != nil {
+			return fmt.Errorf("IAMEndpoint is invalid: %s", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This improves region handling in the AWS IAM auth method:

1. Server-side, do not send `sts:GetCallerIdentity` requests to the global STS endpoint, by default. This causes login failures when the `sts:GetCallerIdentity` request is signed for a region-specific endpoint. Instead, validate the STS URL in the bearer token and send the request to that URL.
2. Remove the `STSRegion` field from the auth method config, which is unused (note that an internal field of the same name still exists for generating the bearer token client-side. This one is still used)
3. Client-side, use the AWS SDK's native regional endpoint selection for STS. This cleans up semi-custom endpoint selection code from Vault.

Closes #12661