### PR TITLE
set vault namespaces on vault client prior to logging in with the vault auth method

### DIFF
--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -104,6 +104,15 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 		return err
 	}
 
+	// We don't want to set the namespace if it's empty to prevent potential
+	// unknown behavior (what does Vault do with an empty namespace). The Vault
+	// client also makes sure the inputs are not empty strings so let's do the
+	// same.
+	if config.Namespace != "" {
+		v.namespace = config.Namespace
+		client.SetNamespace(config.Namespace)
+	}
+
 	if config.AuthMethod != nil {
 		loginResp, err := vaultLogin(client, config.AuthMethod)
 		if err != nil {
@@ -113,14 +122,6 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	}
 	client.SetToken(config.Token)
 
-	// We don't want to set the namespace if it's empty to prevent potential
-	// unknown behavior (what does Vault do with an empty namespace). The Vault
-	// client also makes sure the inputs are not empty strings so let's do the
-	// same.
-	if config.Namespace != "" {
-		v.namespace = config.Namespace
-		client.SetNamespace(config.Namespace)
-	}
 	v.config = config
 	v.client = client
 	v.isPrimary = cfg.IsPrimary


### PR DESCRIPTION
The namespace needs tobe set before trying to call the auth method.  Otherwise it will hit the general auth handler for most routes and look for a client token.  It returns this error:

```
2022-04-13T16:59:50.366Z [ERROR] connect.ca: Failed to initialize Connect CA: error="error configuring provider: Error making API request.

URL: PUT https://vault-cluster.private.vault.a718f64a-c2d8-4d80-a330-54bce161cf25.aws.hashicorp.cloud:8200/v1/auth/kubernetes/login
Code: 400. Errors:

* missing client token"
```