### PR TITLE
add queryBackend to the api query meta.

### DIFF
--- a/.changelog/12791.txt
+++ b/.changelog/12791.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+api: add QueryBackend to QueryMeta so an api user can determine if a query was served using which backend (streaming or blocking query).
+```

--- a/api/api.go
+++ b/api/api.go
@@ -81,10 +81,10 @@ const (
 	// the HTTP Partition to be used by default. This can still be overridden.
 	HTTPPartitionEnvName = "CONSUL_PARTITION"
 
-	//QueryBackendStreaming Query backend of type streaming
+	// QueryBackendStreaming Query backend of type streaming
 	QueryBackendStreaming = "streaming"
 
-	//QueryBackendBlockingQuery Query backend of type blocking query
+	// QueryBackendBlockingQuery Query backend of type blocking query
 	QueryBackendBlockingQuery = "blocking-query"
 )
 
@@ -283,7 +283,7 @@ type QueryMeta struct {
 	// response is.
 	CacheAge time.Duration
 
-	// QueryBackend represent which backend served the request (1: blocking-query, 2: streaming).
+	// QueryBackend represent which backend served the request.
 	QueryBackend string
 
 	// DefaultACLPolicy is used to control the ACL interaction when there is no

--- a/api/api.go
+++ b/api/api.go
@@ -80,6 +80,12 @@ const (
 	// HTTPPartitionEnvName defines an environment variable name which sets
 	// the HTTP Partition to be used by default. This can still be overridden.
 	HTTPPartitionEnvName = "CONSUL_PARTITION"
+
+	//QueryBackendStreaming Query backend of type streaming
+	QueryBackendStreaming = "streaming"
+
+	//QueryBackendBlockingQuery Query backend of type blocking query
+	QueryBackendBlockingQuery = "blocking-query"
 )
 
 type StatusError struct {
@@ -278,7 +284,7 @@ type QueryMeta struct {
 	CacheAge time.Duration
 
 	// QueryBackend represent which backend served the request (1: blocking-query, 2: streaming).
-	QueryBackend int
+	QueryBackend string
 
 	// DefaultACLPolicy is used to control the ACL interaction when there is no
 	// defined policy. This can be "allow" which means ACLs are used to
@@ -1099,13 +1105,9 @@ func parseQueryMeta(resp *http.Response, q *QueryMeta) error {
 		q.CacheAge = time.Duration(age) * time.Second
 	}
 
-	if queryBackendStr := header.Get("X-Consul-Query-Backend"); queryBackendStr != "" {
-		switch queryBackendStr {
-		case "blocking-query":
-			q.QueryBackend = 1
-		case "streaming":
-			q.QueryBackend = 2
-		}
+	switch v := header.Get("X-Consul-Query-Backend"); v {
+	case QueryBackendStreaming, QueryBackendBlockingQuery:
+		q.QueryBackend = v
 	}
 	return nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -277,6 +277,9 @@ type QueryMeta struct {
 	// response is.
 	CacheAge time.Duration
 
+	// QueryBackend represent which backend served the request (1: blocking-query, 2: streaming).
+	QueryBackend int
+
 	// DefaultACLPolicy is used to control the ACL interaction when there is no
 	// defined policy. This can be "allow" which means ACLs are used to
 	// deny-list, or "deny" which means ACLs are allow-lists.
@@ -1096,6 +1099,14 @@ func parseQueryMeta(resp *http.Response, q *QueryMeta) error {
 		q.CacheAge = time.Duration(age) * time.Second
 	}
 
+	if queryBackendStr := header.Get("X-Consul-Query-Backend"); queryBackendStr != "" {
+		switch queryBackendStr {
+		case "blocking-query":
+			q.QueryBackend = 1
+		case "streaming":
+			q.QueryBackend = 2
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This help find out if query was served using a streaming backend or a blocking query backend