### PR TITLE
ui: Add documentation link to the Server Fault Tolerance panel

### DIFF
--- a/ui/packages/consul-ui/app/styles/routes/dc/overview/serverstatus.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/overview/serverstatus.scss
@@ -33,6 +33,11 @@ section[data-route='dc.show.serverstatus'] {
   border-bottom: var(--decor-border-100);
   border-color: rgb(var(--tone-border));
 }
+%server-failure-tolerance > header a {
+  float: right;
+  margin-top: 4px;
+  font-weight: var(--typo-weight-semibold);
+}
 %server-failure-tolerance header em {
   @extend %pill-200;
   font-size: 0.812rem; /* 13px */

--- a/ui/packages/consul-ui/app/templates/dc/show/serverstatus.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/show/serverstatus.hbs
@@ -87,6 +87,9 @@ as |item|}}
           >
 
             <header>
+              {{compute (fn route.t 'tolerance.link' (hash
+                htmlSafe=true
+              ))}}
               <h2>
                 {{compute (fn route.t 'tolerance.header')}}
               </h2>

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -5,6 +5,8 @@ dc:
       title: Server status
       unassigned: Unassigned Zones
       tolerance:
+        link: |
+          <a href="{CONSUL_DOCS_URL}/architecture/consensus" target="_blank" rel="noopener noreferrer">Learn more</a>
         header: Server fault tolerance
         immediate:
           header: Immediate
@@ -35,17 +37,17 @@ dc:
         body: |
           <ul>
             <li>
-              <a href="{CONSUL_DOCS_URL}/enterprise/license/faq#q-is-there-a-grace-period-when-licenses-expire">
+              <a href="{CONSUL_DOCS_URL}/enterprise/license/faq#q-is-there-a-grace-period-when-licenses-expire" target="_blank" rel="noopener noreferrer">
                 License expiration
               </a>
             </li>
             <li>
-              <a href="{CONSUL_DOCS_URL}/docs/enterprise/license/faq#q-how-can-i-renew-a-license">
+              <a href="{CONSUL_DOCS_URL}/docs/enterprise/license/faq#q-how-can-i-renew-a-license" target="_blank" rel="noopener noreferrer">
                 Renewing a license
               </a>
             </li>
             <li>
-              <a href="{CONSUL_DOCS_LEARN_URL}/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise">
+              <a href="{CONSUL_DOCS_LEARN_URL}/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise" target="_blank" rel="noopener noreferrer">
                 Applying a new license
               </a>
             </li>


### PR DESCRIPTION
Adds a 'Learn more' link to the top of the Server Fault Tolerance panel:

<img width="850" alt="Screenshot 2022-04-14 at 17 08 37" src="https://user-images.githubusercontent.com/554604/163429934-0e618c43-a0fa-4e87-aa73-2c9a3292bfcb.png">

I noticed some missing noreferrer etc on the links in the licensing page also, so I added those in whilst I was here.

cc @jherschman FYI on this one