### PR TITLE
Set vault namespaces on vault client prior to logging in 

### DIFF
--- a/.changelog/12793.txt
+++ b/.changelog/12793.txt
@@ -1,4 +1,4 @@
-```release-note:breaking-change
+```release-note:bugfix
 The Connect CA Vault system now sets the Namespace (if present) prior
 to attempting to login to Vault. This means the AuthMethod needs to
 be in the specified namespace. Previously the AuthMethod needed to be

--- a/.changelog/12793.txt
+++ b/.changelog/12793.txt
@@ -1,0 +1,5 @@
+```release-note:breaking-change
+The Connect CA Vault system now sets the Namespace (if present) prior
+to attempting to login to Vault. This means the AuthMethod needs to
+be in the specified namespace. Previously the AuthMethod needed to be
+in the root namespace to work.

--- a/.changelog/12793.txt
+++ b/.changelog/12793.txt
@@ -1,4 +1,4 @@
-```release-note:bugfix
+```release-note:bug
 The Connect CA Vault system now sets the Namespace (if present) prior
 to attempting to login to Vault. This means the AuthMethod needs to
 be in the specified namespace. Previously the AuthMethod needed to be

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -103,6 +103,14 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 		return err
 	}
 
+	// We don't want to set the namespace if it's empty to prevent potential
+	// unknown behavior (what does Vault do with an empty namespace). The Vault
+	// client also makes sure the inputs are not empty strings so let's do the
+	// same.
+	if config.Namespace != "" {
+		client.SetNamespace(config.Namespace)
+	}
+
 	if config.AuthMethod != nil {
 		loginResp, err := vaultLogin(client, config.AuthMethod)
 		if err != nil {
@@ -112,13 +120,6 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	}
 	client.SetToken(config.Token)
 
-	// We don't want to set the namespace if it's empty to prevent potential
-	// unknown behavior (what does Vault do with an empty namespace). The Vault
-	// client also makes sure the inputs are not empty strings so let's do the
-	// same.
-	if config.Namespace != "" {
-		client.SetNamespace(config.Namespace)
-	}
 	v.config = config
 	v.client = client
 	v.isPrimary = cfg.IsPrimary


### PR DESCRIPTION
Set vault namespaces on vault client prior to logging in with the vault auth method

This is a potentially breaking change, but after discussion this seems
to have been a bug, blocking what is likely the most common usages;
where the auth and PKIPaths all live in the same namespace. As
implemented the auth can only be in the root namespace.

This was originally submitted as
https://github.com/hashicorp/consul/pull/12775
but was split out because we think it stands on it's own.

Signed-off-by: Mark Anderson <manderson@hashicorp.com>