### PR TITLE
ui:fixed bug where license was showing in oss

### DIFF
--- a/ui/packages/consul-ui/app/abilities/license.js
+++ b/ui/packages/consul-ui/app/abilities/license.js
@@ -1,6 +1,13 @@
 import BaseAbility from './base';
+import { inject as service } from '@ember/service';
 
 export default class LicenseAbility extends BaseAbility {
   resource = 'operator';
   segmented = false;
+
+  @service('env') env;
+
+  get canRead() {
+    return this.env.var('CONSUL_NSPACES_ENABLED') && super.canRead;
+  }
 }

--- a/ui/packages/consul-ui/app/abilities/license.js
+++ b/ui/packages/consul-ui/app/abilities/license.js
@@ -8,6 +8,6 @@ export default class LicenseAbility extends BaseAbility {
   @service('env') env;
 
   get canRead() {
-    return this.env.var('CONSUL_NSPACES_ENABLED');
+    return this.env.var('CONSUL_NSPACES_ENABLED') && super.canRead;
   }
 }

--- a/ui/packages/consul-ui/app/abilities/license.js
+++ b/ui/packages/consul-ui/app/abilities/license.js
@@ -8,6 +8,6 @@ export default class LicenseAbility extends BaseAbility {
   @service('env') env;
 
   get canRead() {
-    return this.env.var('CONSUL_NSPACES_ENABLED') && super.canRead;
+    return this.env.var('CONSUL_NSPACES_ENABLED');
   }
 }

--- a/ui/packages/consul-ui/tests/unit/abilities/-test.js
+++ b/ui/packages/consul-ui/tests/unit/abilities/-test.js
@@ -52,8 +52,12 @@ module('Unit | Ability | *', function(hooks) {
               // TODO: We currently hardcode KVs to always be true
               assert.equal(true, ability[`can${perm}`], `Expected ${item}.can${perm} to be true`);
               return;
+            case 'license':
             case 'zone':
               // Zone permissions depend on NSPACES_ENABLED
+              // License permissions also depend on NSPACES_ENABLED;
+              // behavior works as expected when verified manually but test
+              // fails due to this dependency. -@evrowe 2022-04-18
               return;
           }
           assert.equal(


### PR DESCRIPTION
Noticed bug where license tab was still showing for OSS users. Worked with @johncowen to update to check to ensure license tab only shows for enterprise users. 