### PR TITLE
Add an internal env var for HCP to enable specific features/views in the ui

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1827,6 +1827,7 @@ func (b *builder) uiConfigVal(v RawUIConfig) UIConfig {
 		MetricsProviderOptionsJSON: stringVal(v.MetricsProviderOptionsJSON),
 		MetricsProxy:               b.uiMetricsProxyVal(v.MetricsProxy),
 		DashboardURLTemplates:      v.DashboardURLTemplates,
+		HCPEnabled:                 os.Getenv("CONSUL_HCP_ENABLED") == "true",
 	}
 }
 

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1433,6 +1433,7 @@ type UIConfig struct {
 	MetricsProviderOptionsJSON string
 	MetricsProxy               UIMetricsProxy
 	DashboardURLTemplates      map[string]string
+	HCPEnabled                 bool
 }
 
 type UIMetricsProxy struct {

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -438,6 +438,7 @@
         "DashboardURLTemplates": {},
         "Dir": "",
         "Enabled": false,
+        "HCPEnabled": false,
         "MetricsProvider": "",
         "MetricsProviderFiles": [],
         "MetricsProviderOptionsJSON": "",

--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -19,6 +19,7 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 		// browser.
 		"metrics_proxy_enabled":   cfg.UIConfig.MetricsProxy.BaseURL != "",
 		"dashboard_url_templates": cfg.UIConfig.DashboardURLTemplates,
+		"hcp_enabled":             cfg.UIConfig.HCPEnabled,
 	}
 
 	// Only set this if there is some actual JSON or we'll cause a JSON

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -43,6 +43,7 @@ func TestUIServerIndex(t *testing.T) {
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
 				"UIConfig": {
+					"hcp_enabled": false,
 					"metrics_provider": "",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
@@ -76,6 +77,7 @@ func TestUIServerIndex(t *testing.T) {
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
 				"UIConfig": {
+					"hcp_enabled": false,
 					"metrics_provider": "foo",
 					"metrics_provider_options": {
 						"a-very-unlikely-string":1
@@ -97,6 +99,26 @@ func TestUIServerIndex(t *testing.T) {
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
 				"UIConfig": {
+					"hcp_enabled": false,
+					"metrics_provider": "",
+					"metrics_proxy_enabled": false,
+					"dashboard_url_templates": null
+				}
+			}`,
+		},
+		{
+			name:         "hcp enabled",
+			cfg:          basicUIEnabledConfig(withHCPEnabled()),
+			path:         "/",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"<!-- CONSUL_VERSION:"},
+			wantUICfgJSON: `{
+				"ACLsEnabled": false,
+				"LocalDatacenter": "dc1",
+				"PrimaryDatacenter": "dc1",
+				"ContentPath": "/ui/",
+				"UIConfig": {
+					"hcp_enabled": true,
 					"metrics_provider": "",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
@@ -126,6 +148,7 @@ func TestUIServerIndex(t *testing.T) {
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
 				"UIConfig": {
+					"hcp_enabled": false,
 					"metrics_provider": "bar",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
@@ -252,6 +275,12 @@ func withMetricsProviderFiles(names ...string) cfgFunc {
 func withMetricsProviderOptions(jsonStr string) cfgFunc {
 	return func(cfg *config.RuntimeConfig) {
 		cfg.UIConfig.MetricsProviderOptionsJSON = jsonStr
+	}
+}
+
+func withHCPEnabled() cfgFunc {
+	return func(cfg *config.RuntimeConfig) {
+		cfg.UIConfig.HCPEnabled = true
 	}
 }
 
@@ -388,6 +417,7 @@ func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
 		"PrimaryDatacenter": "dc1",
 		"ContentPath": "/ui/",
 		"UIConfig": {
+			"hcp_enabled": false,
 			"metrics_provider": "",
 			"metrics_proxy_enabled": false,
 			"dashboard_url_templates": null
@@ -411,6 +441,7 @@ func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
 			"PrimaryDatacenter": "dc1",
 			"ContentPath": "/ui/",
 			"UIConfig": {
+				"hcp_enabled": false,
 				"metrics_provider": "",
 				"metrics_proxy_enabled": false,
 				"dashboard_url_templates": null


### PR DESCRIPTION
This PR adds an environment variable, `CONSUL_HCP_ENABLED`, to be used in HCP to enable specific features/views in the UI.