### PR TITLE
ui: Revert to Services route as default

### DIFF
--- a/ui/packages/consul-ui/app/templates/application.hbs
+++ b/ui/packages/consul-ui/app/templates/application.hbs
@@ -50,7 +50,9 @@ as |source|>
 {{! until we get to the dc route we don't know any permissions }}
 {{! as we don't know the dc, any inital permission based }}
 {{! redirects are in the dc.show route}}
-  {{did-insert (route-action 'replaceWith' 'dc.show'
+
+{{! 2022-04-15: Temporarily reverting the services page to the default }}
+  {{did-insert (route-action 'replaceWith' 'dc.services.index'
     (hash
       dc=(env 'CONSUL_DATACENTER_LOCAL')
     )

--- a/ui/packages/consul-ui/tests/acceptance/dc/forwarding.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/forwarding.feature
@@ -10,4 +10,4 @@ Feature: dc / forwarding
     ---
     dc: datacenter
     ---
-    Then the url should be /datacenter/overview/server-status
+    Then the url should be /datacenter/services

--- a/ui/packages/consul-ui/tests/acceptance/index-forwarding.feature
+++ b/ui/packages/consul-ui/tests/acceptance/index-forwarding.feature
@@ -4,4 +4,4 @@ Feature: index-forwarding
   Scenario: Arriving at the index page when there is only one datacenter
     Given 1 datacenter model with the value "dc1"
     When I visit the index page
-    Then the url should be /dc1/overview/server-status
+    Then the url should be /dc1/services

--- a/ui/packages/consul-ui/tests/acceptance/page-navigation.feature
+++ b/ui/packages/consul-ui/tests/acceptance/page-navigation.feature
@@ -10,7 +10,7 @@ Feature: page-navigation
     ---
       dc: dc1
     ---
-    Then the url should be /dc1/overview/server-status
+    Then the url should be /dc1/services
   Scenario: Clicking [Link] in the navigation takes me to [URL]
     When I visit the services page for yaml
     ---

--- a/ui/packages/consul-ui/vendor/consul-ui/routes.js
+++ b/ui/packages/consul-ui/vendor/consul-ui/routes.js
@@ -7,32 +7,32 @@
       index: {
         _options: {
           path: '/',
-          redirect: '../show/serverstatus',
+          redirect: '../services',
         },
       },
       show: {
         _options: {
           path: '/overview',
-          abilities: ['access overview']
+          abilities: ['access overview'],
         },
         serverstatus: {
           _options: {
             path: '/server-status',
-            abilities: ['access overview', 'read zones']
+            abilities: ['access overview', 'read zones'],
           },
         },
         cataloghealth: {
           _options: {
             path: '/catalog-health',
-            abilities: ['access overview']
+            abilities: ['access overview'],
           },
         },
         license: {
           _options: {
             path: '/license',
-            abilities: ['access overview', 'read licence']
+            abilities: ['access overview', 'read licence'],
           },
-        }
+        },
       },
       services: {
         _options: { path: '/services' },


### PR DESCRIPTION
Reverting the default route for Consul UI to be the Services page for the initial 1.12 release