### PR TITLE
Docs: Rename and re-title docs page for installing Consul API Gateway

### DIFF
--- a/website/content/docs/api-gateway/common-errors.mdx
+++ b/website/content/docs/api-gateway/common-errors.mdx
@@ -64,4 +64,4 @@ Install the required CRDs by using the command in Step 1 of the [Consul API Gate
 --->
 [consul-common-errors]: /docs/troubleshoot/common-errors
 [troubleshooting]: https://learn.hashicorp.com/consul/day-2-operations/advanced-operations/troubleshooting
-[install-instructions]: /docs/api-gateway/api-gateway-usage#installation
+[install-instructions]: /docs/api-gateway/consul-api-gateway-install#installation

--- a/website/content/docs/api-gateway/consul-api-gateway-install.mdx
+++ b/website/content/docs/api-gateway/consul-api-gateway-install.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: Consul API Gateway Usage
+page_title: Consul API Gateway Install
 description:  >-
-  Using Consul API gateway functionality
+  Installing Consul API Gateway
 ---
 
-# Consul API Gateway Usage
+# Installing Consul API Gateway
 
 This topic describes how to use the Consul API Gateway add-on module. It includes instructions for installation and configuration.
 
 ## Requirements
 
-Refer to [Technical Specifications](/docs/api-gateway/tech-specs) for minimum software requirements.
+Ensure that the environment you are deploying Consul API Gateway in meets the requirements listed in the [Technical Specifications](/docs/api-gateway/tech-specs). This includes validating that the requirements for minimum versions of software are met.
 
 ## Installation
 
@@ -304,7 +304,6 @@ spec:
 ```
 
 </CodeBlockConfig>
-
 
 ### MeshService
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -382,8 +382,8 @@
         "path": "api-gateway"
       },
       {
-        "title": "Usage",
-        "path": "api-gateway/api-gateway-usage"
+        "title": "Installation",
+        "path": "api-gateway/consul-api-gateway-install"
       },
       {
         "title": "Technical Specifications",

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1269,4 +1269,9 @@ module.exports = [
     destination: '/docs/agent/config',
     permanent: true,
   },
+  {
+    source: '/docs/api-gateway/api-gateway-usage',
+    destination: '/docs/api-gateway/consul-api-gateway-install',
+    permanent: true,
+  },
 ]


### PR DESCRIPTION
Changing the file name, page name and title of the page containing installation instructions for Consul API Gateway. This should make it easier to find the install instructions when navigating the site and when doing web searches.