### PR TITLE
ui: fix overview's renew license link

### DIFF
--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -42,7 +42,7 @@ dc:
               </a>
             </li>
             <li>
-              <a href="{CONSUL_DOCS_URL}/docs/enterprise/license/faq#q-how-can-i-renew-a-license" target="_blank" rel="noopener noreferrer">
+              <a href="{CONSUL_DOCS_URL}/enterprise/license/faq#q-how-can-i-renew-a-license" target="_blank" rel="noopener noreferrer">
                 Renewing a license
               </a>
             </li>


### PR DESCRIPTION
The previous link was directing us to:
https://www.consul.io/docs/docs/enterprise/license/faq#q-how-can-i-renew-a-license

It needs to go to:
https://www.consul.io/docs/enterprise/license/faq#q-how-can-i-renew-a-license