### PR TITLE
Run arm64 builds on go1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,8 +257,8 @@ jobs:
       - run:
          command: |
             sudo rm -rf /usr/local/go
-            wget https://golang.org/dl/go1.17.5.linux-arm64.tar.gz
-            sudo tar -C /usr/local -xzvf go1.17.5.linux-arm64.tar.gz
+            wget https://dl.google.com/go/go1.18.1.linux-arm64.tar.gz
+            sudo tar -C /usr/local -xzvf go1.18.1.linux-arm64.tar.gz
       - run: *install-gotestsum
       - run: go mod download
       - run:


### PR DESCRIPTION
We recently updated the version of Go we build with to 1.18 in #12808. I think we may have missed this one place in the builds for arm64. 

I won't be attaching a changelog as this is part of #12808.