### PR TITLE
docs: update acl token generation with uuidgen

### DIFF
--- a/website/content/docs/k8s/installation/vault/data-integration/bootstrap-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/bootstrap-token.mdx
@@ -25,9 +25,9 @@ To use an ACL bootstrap token stored in Vault, we will follow the steps outlined
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
 ## One time setup in Vault
-### Store the Secret in Vault
+### Generate and Store the Secret in Vault
 
-First, store the ACL bootstrap token in Vault:
+First, generate and store the ACL bootstrap token in Vault:
 
 ```shell-session
 $ vault kv put secret/consul/bootstrap-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"

--- a/website/content/docs/k8s/installation/vault/data-integration/bootstrap-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/bootstrap-token.mdx
@@ -8,7 +8,7 @@ description: >-
 # Storing the ACL Bootstrap Token in Vault
 
 ## Prerequisites
-Prior to setting up the data integration between Vault and Consul on Kubernetes, you will need to have:  
+Prior to setting up the data integration between Vault and Consul on Kubernetes, you will need to have:
 1. Read and completed the steps in the [Systems Integration](/docs/k8s/installation/vault/systems-integration) section of [Vault as a Secrets Backend](/docs/k8s/installation/vault).
 2. Read the [Data Integration Overview](/docs/k8s/installation/vault/data-integration) section of [Vault as a Secrets Backend](/docs/k8s/installation/vault).
 
@@ -19,7 +19,7 @@ To use an ACL bootstrap token stored in Vault, we will follow the steps outlined
 
   1. Store the secret in Vault.
   1. Create a Vault policy that authorizes the desired level of access to the secret.
-  
+
 ### Setup per Consul datacenter
   1. Create Vault Kubernetes auth roles that link the policy to each Consul on Kubernetes service account that requires access.
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
@@ -30,7 +30,7 @@ To use an ACL bootstrap token stored in Vault, we will follow the steps outlined
 First, store the ACL bootstrap token in Vault:
 
 ```shell-session
-$ vault kv put secret/consul/boostrap-token token="<ACL bootstrap Token>"
+$ vault kv put secret/consul/bootstrap-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 ```
 
 ### Create a Vault policy that authorizes the desired level of access to the secret

--- a/website/content/docs/k8s/installation/vault/data-integration/partition-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/partition-token.mdx
@@ -8,7 +8,7 @@ description: >-
 # Storing the ACL Partition Token in Vault
 
 ## Prerequisites
-Prior to setting up the data integration between Vault and Consul on Kubernetes, you will need to have:  
+Prior to setting up the data integration between Vault and Consul on Kubernetes, you will need to have:
 1. Read and completed the steps in the [Systems Integration](/docs/k8s/installation/vault/systems-integration) section of [Vault as a Secrets Backend](/docs/k8s/installation/vault).
 2. Read the [Data Integration Overview](/docs/k8s/installation/vault/data-integration) section of [Vault as a Secrets Backend](/docs/k8s/installation/vault).
 
@@ -29,7 +29,7 @@ To use an ACL partition token stored in Vault, we will follow the steps outlined
 First, store the ACL partition token in Vault:
 
 ```shell-session
-$ vault kv put secret/consul/partition-token token="<ACL partition Token>"
+$ vault kv put secret/consul/partition-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 ```
 
 ### Create a Vault policy that authorizes the desired level of access to the secret

--- a/website/content/docs/k8s/installation/vault/data-integration/partition-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/partition-token.mdx
@@ -24,9 +24,9 @@ To use an ACL partition token stored in Vault, we will follow the steps outlined
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
 ## One time setup in Vault
-### Store the Secret in Vault
+### Generate and Store the Secret in Vault
 
-First, store the ACL partition token in Vault:
+First, generate and store the ACL partition token in Vault:
 
 ```shell-session
 $ vault kv put secret/consul/partition-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"

--- a/website/content/docs/k8s/installation/vault/data-integration/replication-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/replication-token.mdx
@@ -24,9 +24,9 @@ To use an ACL replication token stored in Vault, we will follow the steps outlin
   1. Configure the Vault Kubernetes auth role in the Consul on Kubernetes helm chart.
 
 ## One time setup in Vault
-### Store the Secret in Vault
+### Generate and Store the Secret in Vault
 
-First, store the ACL replication token in Vault:
+First, generate and store the ACL replication token in Vault:
 
 ```shell-session
 $ vault kv put secret/consul/replication-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"

--- a/website/content/docs/k8s/installation/vault/data-integration/replication-token.mdx
+++ b/website/content/docs/k8s/installation/vault/data-integration/replication-token.mdx
@@ -8,7 +8,7 @@ description: >-
 # Storing the ACL Replication Token in Vault
 
 ## Prerequisites
-Prior to setting up the data integration between Vault and Consul on Kubernetes, you will need to have:  
+Prior to setting up the data integration between Vault and Consul on Kubernetes, you will need to have:
 1. Read and completed the steps in the [Systems Integration](/docs/k8s/installation/vault/systems-integration) section of [Vault as a Secrets Backend](/docs/k8s/installation/vault).
 2. Read the [Data Integration Overview](/docs/k8s/installation/vault/data-integration) section of [Vault as a Secrets Backend](/docs/k8s/installation/vault).
 
@@ -29,7 +29,7 @@ To use an ACL replication token stored in Vault, we will follow the steps outlin
 First, store the ACL replication token in Vault:
 
 ```shell-session
-$ vault kv put secret/consul/replication-token token="<ACL replication Token>"
+$ vault kv put secret/consul/replication-token token="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 ```
 
 ### Create a Vault policy that authorizes the desired level of access to the secret


### PR DESCRIPTION
Updates documentation to include uuidgen as a means to generate the uuid for ACL tokens when using Vault as a secrets backend.