### PR TITLE
Expose functions to set defaults and setting client transport with TLC config so you can easily pass in your http client to api.NewClient

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -680,11 +680,6 @@ func SetClientConfig(config *Config) error {
 		if err != nil {
 			return err
 		}
-	} else {
-		err := setClientTransportWithTLSConfig(config.HttpClient, config.Transport, config.TLSConfig)
-		if err != nil {
-			return err
-		}
 	}
 
 	if config.Namespace == "" {
@@ -752,13 +747,43 @@ func NewClient(config *Config) (*Client, error) {
 func NewHttpClient(transport *http.Transport, tlsConf TLSConfig) (*http.Client, error) {
 	client := &http.Client{}
 
-	err := setClientTransportWithTLSConfig(client, transport, tlsConf)
+	err := SetClientTransportWithTLSConfig(client, transport, tlsConf)
 
 	if err != nil {
 		return nil, err
 	}
 
 	return client, nil
+}
+
+// SetClientTransportWithTLSConfig configure Transport with TLS config on
+// the http client.
+func SetClientTransportWithTLSConfig(client *http.Client, transport *http.Transport, tlsConf TLSConfig) error {
+	// TODO (slackpad) - Once we get some run time on the HTTP/2 support we
+	// should turn it on by default if TLS is enabled. We would basically
+	// just need to call http2.ConfigureTransport(transport) here. We also
+	// don't want to introduce another external dependency on
+	// golang.org/x/net/http2 at this time. For a complete recipe for how
+	// to enable HTTP/2 support on a transport suitable for the API client
+	// library see agent/http_test.go:TestHTTPServer_H2.
+
+	if transport.TLSClientConfig == nil {
+		tlsClientConfig, err := SetupTLSConfig(&tlsConf)
+
+		if err != nil {
+			return err
+		}
+
+		transport.TLSClientConfig = tlsClientConfig
+	}
+
+	// NewHttpClient allows you to pass in an http client in the config.  It
+	// may already have Transport configured.  If so, we won't set Transport and
+	// clobber the existing setting.
+	if client.Transport == nil {
+		client.Transport = transport
+	}
+	return nil
 }
 
 // request is used to help build up a request
@@ -1183,34 +1208,4 @@ func requireNotFoundOrOK(resp *http.Response) (bool, *http.Response, error) {
 	default:
 		return false, nil, generateUnexpectedResponseCodeError(resp)
 	}
-}
-
-// setClientTransportWithTLSConfig configure Transport with TLS config on
-// the http client.
-func setClientTransportWithTLSConfig(client *http.Client, transport *http.Transport, tlsConf TLSConfig) error {
-	// TODO (slackpad) - Once we get some run time on the HTTP/2 support we
-	// should turn it on by default if TLS is enabled. We would basically
-	// just need to call http2.ConfigureTransport(transport) here. We also
-	// don't want to introduce another external dependency on
-	// golang.org/x/net/http2 at this time. For a complete recipe for how
-	// to enable HTTP/2 support on a transport suitable for the API client
-	// library see agent/http_test.go:TestHTTPServer_H2.
-
-	if transport.TLSClientConfig == nil {
-		tlsClientConfig, err := SetupTLSConfig(&tlsConf)
-
-		if err != nil {
-			return err
-		}
-
-		transport.TLSClientConfig = tlsClientConfig
-	}
-
-	// NewHttpClient allows you to pass in an http client in the config.  It
-	// may already have Transport configured.  If so, we won't set Transport and
-	// clobber the existing setting.
-	if client.Transport == nil {
-		client.Transport = transport
-	}
-	return nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -681,6 +681,11 @@ func NewClient(config *Config) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		err := SetClientTransportWithTLSConfig(config.HttpClient, config.Transport, config.TLSConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if config.Namespace == "" {
@@ -734,13 +739,10 @@ func NewClient(config *Config) (*Client, error) {
 	return &Client{config: *config, headers: make(http.Header)}, nil
 }
 
-// NewHttpClient returns an http client configured with the given Transport and TLS
-// config.
-func NewHttpClient(transport *http.Transport, tlsConf TLSConfig) (*http.Client, error) {
-	client := &http.Client{
-		Transport: transport,
-	}
-
+// SetClientTransportWithTLSConfig configure Transport with TLS config on
+// the http client.
+func SetClientTransportWithTLSConfig(client *http.Client, transport *http.Transport, tlsConf TLSConfig) error {
+	client.Transport = transport
 	// TODO (slackpad) - Once we get some run time on the HTTP/2 support we
 	// should turn it on by default if TLS is enabled. We would basically
 	// just need to call http2.ConfigureTransport(transport) here. We also
@@ -753,10 +755,24 @@ func NewHttpClient(transport *http.Transport, tlsConf TLSConfig) (*http.Client, 
 		tlsClientConfig, err := SetupTLSConfig(&tlsConf)
 
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		transport.TLSClientConfig = tlsClientConfig
+	}
+
+	return nil
+}
+
+// NewHttpClient returns an http client configured with the given Transport and TLS
+// config.
+func NewHttpClient(transport *http.Transport, tlsConf TLSConfig) (*http.Client, error) {
+	client := &http.Client{}
+
+	err := SetClientTransportWithTLSConfig(client, transport, tlsConf)
+
+	if err != nil {
+		return nil, err
 	}
 
 	return client, nil

--- a/internal/tools/proto-gen-rpc-glue/e2e/consul/go.mod
+++ b/internal/tools/proto-gen-rpc-glue/e2e/consul/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/consul/internal/tools/proto-gen-rpc-glue/e2e/consul
+module github.com/hashicorp/consul
 
 go 1.13
 

--- a/internal/tools/proto-gen-rpc-glue/e2e/consul/go.mod
+++ b/internal/tools/proto-gen-rpc-glue/e2e/consul/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/consul
+module github.com/hashicorp/consul/internal/tools/proto-gen-rpc-glue/e2e/consul
 
 go 1.13
 


### PR DESCRIPTION
### Background
Consul k8s has a kubernetes webhook controller called endpoints controller that listens for when new k8s services are created, deleted, and updated.  It will take the appropriate action to register, update, or deregister the service with Consul.  When it does this it will use the conul client agent that is available on the same host as the service.  We have had a couple of customers report that there are times when they are using cluster auto scale down or spot instances, where the node gets terminated and this controller process hangs for sometimes up to twenty minutes with the consul client agent not being available.  For the bug in consul-k8s where endpoints controller starts queueing requests in these scenarios, a simple timeout out would cause the current service record to fail and be reprocessed, at which point a new list of active consul agents would refresh and not include the offline consul agent...in effect, adding a timeout would cause a self-correcting requeue.

### Overview
We found that `api.NewClient()` uses the default go http client and does not enforce any client timeout.  `api.NewClient()` does allow passing in your own httpclient as part of the config.   So, it is set up to allow the endpoints controller to create its own httpClient with a timeout and pass that into the configuration.  We did find though that though that the default behavior of setting TLS properties on `client.Transport()` where private configured inside `api.NewHttpClient()` and there was not a way to access setting this default behavior.  

This PR does not change existing behavior within Consul and only exposes two functions that allow gaining access to setting default configuration and client.Transport settings that were only accessible if calling `api.NewClient()` without passing in an httpClient.

This [PR in consul-k8s](https://github.com/hashicorp/consul-k8s/pull/1178/files#diff-e26f3f069a83cd05579a03865c772ef61f179d3da5cf9636e6029c430d44f25bR15-R27) shows how we will use these functions to set up.

### Out of scope
- Setting any default timeouts within Consul itself (although we should consider researching and setting this in future work)
- Changing behavior in Consul