### PR TITLE
updated docs

### DIFF
--- a/website/content/docs/nia/compatibility.mdx
+++ b/website/content/docs/nia/compatibility.mdx
@@ -15,8 +15,8 @@ Below are CTS versions with supported Consul versions. The latest CTS binary sup
 
 | CTS Version         | Consul OSS & Enterprise Version |
 | :------------------ | :------------------------------ |
-| CTS Enterprise 0.3+ | 1.8+                            |
-| CTS OSS 0.1+        | 1.8+                            |
+| CTS Enterprise 0.3+ | 1.8+, HCP-Consul                |
+| CTS OSS 0.1+        | 1.8+, HCP-Consul                |
 
 ## Terraform
 

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -55,7 +55,33 @@ tls {
   - `verify_incoming` - (bool: false) Enable mutual TLS. Requires all incoming connections to the CTS API to use a TLS connection and provide a certificate signed by a Certificate Authority specified by the `ca_cert` or `ca_path`.
   - `ca_cert` - (string) The path to a PEM-encoded certificate authority file used to verify the authenticity of the incoming client connections to the CTS API when `verify_incoming` is set to true. Takes precedence over `ca_path` if both are configured.
   - `ca_path` - (string) The path to a directory of PEM-encoded certificate authority files used to verify the authenticity of the incoming client connections to the CTS API when `verify_incoming` is set to true.
-- `license_path` <EnterpriseAlert inline /> - (string) Configures the path to the file containing the license. A license must be set to use enterprise features. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details.
+- `license_path` <EnterpriseAlert inline /> - (string) **Deprecated in CTS 0.6.0 and will be removed in a future release. Use [license block](/docs/nia/configuration#license) instead.**  Configures the path to the file containing the license. A license must be set to use enterprise features. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details.
+
+## License <EnterpriseAlert inline />
+
+The `license` block is used to configure how CTS attains a license. A license can be provided as a path to a license file, or CTS can be configured to automatically retrieve a license from Consul. A license path must be configured or automatic license retrieval enabled to use CTS with enterprise features. If this block is not provided, `license.auto_retrieval` will be set to true.
+
+```hcl
+license {
+  path = "path/to/license.lic"
+  auto_retrieval {
+    enabled = true
+  }
+}
+```
+
+### Base License Config
+| Parameter | Required | Type | Description | Default |
+| --------- | -------- | ---- | ----------- | ------- |
+| `path` |  Optional | string | Configures the path to the file containing a license. If a path to a license is configured this license will be use until, if enabled, a new license is automatically retrieved by CTS. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details. | none |
+
+### Auto-Retrieval
+
+The `auto_retrieval` block is used to configure the license auto-retrieval used by CTS. If enabled, CTS will attempt to retrieve a new license from its configured Consul backend each day.
+
+| Parameter | Required | Type | Description | Default |
+| --------- | -------- | ---- | ----------- | ------- |
+| `enabled` |  Optional | string | If set to true, enables license auto-retrieval | true |
 
 ## Consul
 

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -55,11 +55,12 @@ tls {
   - `verify_incoming` - (bool: false) Enable mutual TLS. Requires all incoming connections to the CTS API to use a TLS connection and provide a certificate signed by a Certificate Authority specified by the `ca_cert` or `ca_path`.
   - `ca_cert` - (string) The path to a PEM-encoded certificate authority file used to verify the authenticity of the incoming client connections to the CTS API when `verify_incoming` is set to true. Takes precedence over `ca_path` if both are configured.
   - `ca_path` - (string) The path to a directory of PEM-encoded certificate authority files used to verify the authenticity of the incoming client connections to the CTS API when `verify_incoming` is set to true.
-- `license_path` <EnterpriseAlert inline /> - (string) **Deprecated in CTS 0.6.0 and will be removed in a future release. Use [license block](/docs/nia/configuration#license) instead.**  Configures the path to the file containing the license. A license must be set to use enterprise features. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details.
+- `license_path` <EnterpriseAlert inline /> - (string) **Deprecated in CTS 0.6.0 and will be removed in a future release. Use [license block](/docs/nia/configuration#license-1) instead.**  Configures the path to the file containing the license. A license must be set to use enterprise features. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details.
+- `license` <EnterpriseAlert inline /> - (obj) The `license` block is used to configure how CTS attains a license, for more information see the [license block](/docs/nia/configuration#license) section
 
 ## License <EnterpriseAlert inline />
 
-The `license` block is used to configure how CTS attains a license. A license can be provided as a path to a license file, or CTS can be configured to automatically retrieve a license from Consul. A license path must be configured or automatic license retrieval enabled to use CTS with enterprise features. If this block is not provided, `license.auto_retrieval` will be set to true.
+The `license` block is used to configure how CTS attains a license. A license can be provided as a path to a license file, or CTS can be configured to automatically retrieve a license from Consul. A license path must be provided or automatic license retrieval enabled to use CTS Enterprise. If this block is not provided, `license.auto_retrieval.enabled` will be set to true.
 
 ```hcl
 license {
@@ -70,14 +71,16 @@ license {
 }
 ```
 
-### Base License Config
+### License Config
 | Parameter | Required | Type | Description | Default |
 | --------- | -------- | ---- | ----------- | ------- |
 | `path` |  Optional | string | Configures the path to the file containing a license. If a path to a license is configured this license will be use until, if enabled, a new license is automatically retrieved by CTS. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details. | none |
+| `auto_retrieval` |  Optional | object | Configures the license auto-retrieval used by CTS. See [Auto-Retrieval Config](/docs/nia/configuration#auto-retrieval-config) for details. | none |
 
-### Auto-Retrieval
 
-The `auto_retrieval` block is used to configure the license auto-retrieval used by CTS. If enabled, CTS will attempt to retrieve a new license from its configured Consul backend each day.
+### Auto-Retrieval Config
+
+The `auto_retrieval` block is used to configure the license auto-retrieval used by CTS. If enabled, CTS will attempt to retrieve a new license from its configured Consul Enterprise backend each day. In the case where a license was not able to be retrieved on the daily cadence, and the license is reaching expiry, CTS will attempt to retrieve a license at each logging period defined by the [Notification and Termination Behavior](/docs/nia/enterprise/license#notification-and-termination-behavior).
 
 ~> `auto_retrieval` is an important feature to have enabled when connecting to HCP-Consul. HCP-Consul has a relatively short license expiry, and in order to ensure that CTS can continue to work without restart, it is important that CTS be able to dynamically attain fresh licenses from HCP-Consul.
 

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -60,7 +60,7 @@ tls {
 
 ## License <EnterpriseAlert inline />
 
-The `license` block is used to configure how CTS attains a license. A license can be provided as a path to a license file, or CTS can be configured to automatically retrieve a license from Consul. A license path must be provided or automatic license retrieval enabled to use CTS Enterprise. If this block is not provided, `license.auto_retrieval.enabled` will be set to true.
+The `license` block is used to configure how CTS attains a license. A license can be provided as a path to a license file, or CTS can be configured to automatically retrieve a license from Consul. To use the license block for CTS Enterprise, a license path must be provided or automatic license retrieval enabled. If this block is not provided, `license.auto_retrieval.enabled` will be set to true.
 
 ```hcl
 license {

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -75,12 +75,12 @@ license {
 | Parameter | Required | Type | Description | Default |
 | --------- | -------- | ---- | ----------- | ------- |
 | `path` |  Optional | string | Configures the path to the file containing a license. If a path to a license is configured this license will be use until, if enabled, a new license is automatically retrieved by CTS. You can also set the license by defining the `CONSUL_LICENSE` and `CONSUL_LICENSE_PATH` environment variables. See [Setting the License](/docs/nia/enterprise/license#setting-the-license) for details. | none |
-| `auto_retrieval` |  Optional | object | Configures the license auto-retrieval used by CTS. See [Auto-Retrieval Config](/docs/nia/configuration#auto-retrieval-config) for details. | none |
+| `auto_retrieval` |  Optional | object | Configures the license auto-retrieval used by CTS. See [Auto-Retrieval Config](/docs/nia/configuration#auto-retrieval-config) for details. | See [Auto-Retrieval Config](/docs/nia/configuration#auto-retrieval-config) for defaults. |
 
 
 ### Auto-Retrieval Config
 
-The `auto_retrieval` block is used to configure the license auto-retrieval used by CTS. If enabled, CTS will attempt to retrieve a new license from its configured Consul Enterprise backend each day. In the case where a license was not able to be retrieved on the daily cadence, and the license is reaching expiry, CTS will attempt to retrieve a license at each logging period defined by the [Notification and Termination Behavior](/docs/nia/enterprise/license#notification-and-termination-behavior).
+The `auto_retrieval` block is used to configure the license auto-retrieval used by CTS. If enabled, CTS will attempt to retrieve a new license from its configured Consul Enterprise backend each day. In the case where a license was not able to be retrieved on the daily cadence, and the license is reaching expiry, CTS will attempt to retrieve a license at each period defined by the [License Expiry Handling](/docs/nia/enterprise/license#license-expiry-handling).
 
 ~> `auto_retrieval` is an important feature to have enabled when connecting to HCP-Consul. HCP-Consul has a relatively short license expiry, and in order to ensure that CTS can continue to work without restart, it is important that CTS be able to dynamically attain fresh licenses from HCP-Consul.
 

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -79,6 +79,8 @@ license {
 
 The `auto_retrieval` block is used to configure the license auto-retrieval used by CTS. If enabled, CTS will attempt to retrieve a new license from its configured Consul backend each day.
 
+~> `auto_retrieval` is an important feature to have enabled when connecting to HCP-Consul. HCP-Consul has a relatively short license expiry, and in order to ensure that CTS can continue to work without restart, it is important that CTS be able to dynamically attain fresh licenses from HCP-Consul.
+
 | Parameter | Required | Type | Description | Default |
 | --------- | -------- | ---- | ----------- | ------- |
 | `enabled` |  Optional | string | If set to true, enables license auto-retrieval | true |

--- a/website/content/docs/nia/enterprise/license.mdx
+++ b/website/content/docs/nia/enterprise/license.mdx
@@ -17,9 +17,10 @@ All CTS Enterprise features are available with a valid Consul Enterprise license
 
 To get a trial license for CTS, you can sign-up for the [trial license for Consul Enterprise](/docs/enterprise/license/faq#q-where-can-users-get-a-trial-license-for-consul-enterprise).
 
-## Setting the License
+## Setting the License Manually
+~> By default CTS is configured to automatically retrieve a license from its configured Consul Enterprise Backend, and also retrieve new licenses periodically. For more information see [License](/docs/nia/configuration#license-1) configuration.
 
-Choose one of the following methods (in order of precedence) to set the license:
+If a license needs to be manually set, choose one of the following methods (in order of precedence) to set the license:
 
 1. Set the `CONSUL_LICENSE` environment variable to the license string.
 
@@ -33,7 +34,15 @@ Choose one of the following methods (in order of precedence) to set the license:
    export CONSUL_LICENSE_PATH=<PATH>/<TO>/<FILE>
    ```
 
-1. Configure the [`license_path`](/docs/nia/configuration#license_path) option in the configuration file to point to the file containing the license.
+1. Configure the [`license`](/docs/nia/configuration#license-1) path option in the configuration file to point to the file containing the license.
+
+   ```hcl
+   license {
+     path = "<PATH>/<TO>/<FILE>"
+   }
+   ```
+
+1. Configure the [`license_path`](/docs/nia/configuration#license_path) option in the configuration file to point to the file containing the license. **Deprecated in CTS 0.6.0 and will be removed in a future release. Use [license block](/docs/nia/configuration#license-1) instead.**
 
    ```hcl
    license_path = "<PATH>/<TO>/<FILE>"
@@ -42,7 +51,8 @@ Choose one of the following methods (in order of precedence) to set the license:
 ~> **Note**: the [options to set the license and the order of precedence](/docs/enterprise/license/overview#binaries-without-built-in-licenses) are the same as Consul Enterprise server agents.
 Visit the [Enterprise License Tutorial](https://learn.hashicorp.com/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise) for detailed steps on how to install the license key.
 
-### Updating the License
+### Updating the License Manually
+~> By default CTS will automatically retrieve a license from its configured Consul Enterprise Backend. If however this is disabled, the following information describes how to handle a manually set license.
 
 The previous section describes options for [setting the license](#setting-the-license) needed to start running CTS Enterprise. Use the following procedure to update the license when it expires or is near the expiration date:
 
@@ -57,15 +67,15 @@ Licenses have an expiration date and a termination date. The termination date is
 
 The time between the expiration and termination dates is a grace period. Grace periods are generally 24-hours, but you should refer to your license agreement for complete terms of your grace period.
 
-When approaching expiration and termination, CTS Enterprise will provide notifications in the system logs:
+When approaching expiration and termination, by default, CTS Enterprise will attempt to retrieve a new license. If auto-retrieval is disabled, CTS Enterprise will provide notifications in the system logs:
 
-| Time period                                 | Behavior                          |
-| ------------------------------------------- | --------------------------------- |
-| 30 days before expiration                   | Warning-level log every 24-hours  |
-| 7 days before expiration                    | Warning-level log every 1 hour    |
-| 1 hour before expiration                    | Warning-level log every 1 minute  |
-| 1 day before expiration                     | Warning-level log every 5 minutes |
-| At or after expiration (before termination) | Error-level log every 1 minute    |
-| At or after termination                     | Error-level log and exit          |
+| Time period                                 | Behavior - auto-retrieval enabled (default) |Behavior - auto-retrieval disabled |
+| ------------------------------------------- |-------------------------------------------- |---------------------------------- |
+| 30 days before expiration                   | License retrieval attempt every 24-hours    |Warning-level log every 24-hours   |
+| 7 days before expiration                    | License retrieval attempt every 1 hour      |Warning-level log every 1 hour     |
+| 1 hour before expiration                    | License retrieval attempt every 1 minute    |Warning-level log every 1 minute   |
+| 1 day before expiration                     | License retrieval attempt every 5 minute    |Warning-level log every 5 minutes  |
+| At or after expiration (before termination) | License retrieval attempt every 1 minute    |Error-level log every 1 minute     |
+| At or after termination                     | Error-level log and exit                    |Error-level log and exit           |
 
 ~> **Note**: Notification frequency and [grace period](/docs/enterprise/license/faq#q-is-there-a-grace-period-when-licenses-expire) behavior is the same as Consul Enterprise.

--- a/website/content/docs/nia/enterprise/license.mdx
+++ b/website/content/docs/nia/enterprise/license.mdx
@@ -61,7 +61,7 @@ The previous section describes options for [setting the license](#setting-the-li
 
 Once CTS Enterprise starts again, it will pick up the new license and run the tasks with any changes that may have occurred between the stop and restart period.
 
-## Notification and Termination Behavior
+## License Expiry Handling
 
 Licenses have an expiration date and a termination date. The termination date is a time at or after the license expires. CTS Enterprise will cease to function once the termination date has passed.
 
@@ -71,11 +71,11 @@ When approaching expiration and termination, by default, CTS Enterprise will att
 
 | Time period                                 | Behavior - auto-retrieval enabled (default) |Behavior - auto-retrieval disabled |
 | ------------------------------------------- |-------------------------------------------- |---------------------------------- |
-| 30 days before expiration                   | License retrieval attempt every 24-hours    |Warning-level log every 24-hours   |
-| 7 days before expiration                    | License retrieval attempt every 1 hour      |Warning-level log every 1 hour     |
-| 1 hour before expiration                    | License retrieval attempt every 1 minute    |Warning-level log every 1 minute   |
-| 1 day before expiration                     | License retrieval attempt every 5 minute    |Warning-level log every 5 minutes  |
-| At or after expiration (before termination) | License retrieval attempt every 1 minute    |Error-level log every 1 minute     |
-| At or after termination                     | Error-level log and exit                    |Error-level log and exit           |
+| 30 days before expiration                   | License retrieval attempt every 24-hours    | Warning-level log every 24-hours  |
+| 7 days before expiration                    | License retrieval attempt every 1 hour      | Warning-level log every 1 hour    |
+| 1 day before expiration                     | License retrieval attempt every 5 minutes   | Warning-level log every 5 minutes |
+| 1 hour before expiration                    | License retrieval attempt every 1 minute    | Warning-level log every 1 minute  |
+| At or after expiration (before termination) | License retrieval attempt every 1 minute    | Error-level log every 1 minute    |
+| At or after termination                     | Error-level log and exit                    | Error-level log and exit          |
 
 ~> **Note**: Notification frequency and [grace period](/docs/enterprise/license/faq#q-is-there-a-grace-period-when-licenses-expire) behavior is the same as Consul Enterprise.


### PR DESCRIPTION
Added docs for new CTS license block

- Added new license section: https://consul-mnci7zjd6-hashicorp.vercel.app/docs/nia/configuration#license-1
- Deprecated license_path: https://consul-mnci7zjd6-hashicorp.vercel.app/docs/nia/configuration#license_path

Added HCP-Consul to compatibility
https://consul-mnci7zjd6-hashicorp.vercel.app/docs/nia/compatibility#consul

Added auto retrieval information to License page
https://consul-mnci7zjd6-hashicorp.vercel.app/docs/nia/enterprise/license#consul-terraform-sync-enterprise-license

