### PR TITLE
docs: fixed broken url

### DIFF
--- a/website/content/docs/k8s/connect/connect-ca-provider.mdx
+++ b/website/content/docs/k8s/connect/connect-ca-provider.mdx
@@ -21,7 +21,7 @@ To configure an external CA provider via the Consul Helm chart, you need to foll
 1. Create a Kubernetes secret containing the configuration file.
 1. Reference the Kubernetes secret in the [`server.extraVolumes`](/docs/k8s/helm#v-server-extravolumes) value in the Helm chart.
 
-To configure the Vault Connect Provider please see [Vault as the Service Mesh Certificate Provider on Kubernetes](/docs/k8s/installation/vault/connect-ca).
+To configure the Vault Connect Provider please see [Vault as the Service Mesh Certificate Provider on Kubernetes](/docs/k8s/installation/vault/data-integration/connect-ca).
 
 
 ~> **NOTE:** The following instructions are only valid for Consul-k8s 0.37.0 and prior.

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1274,4 +1274,9 @@ module.exports = [
     destination: '/docs/api-gateway/consul-api-gateway-install',
     permanent: true,
   },
+  {
+    source: '/docs/k8s/installation/vault/connect-ca',
+    destination: '/docs/k8s/installation/vault/data-integration/connect-ca',
+    permanent: true,
+  },
 ]


### PR DESCRIPTION
This PR fixes the broken url in the [Configuring a Connect CA Provider](https://www.consul.io/docs/k8s/connect/connect-ca-provider)