### PR TITLE
update raft to v1.3.8

### DIFF
--- a/.changelog/12844.txt
+++ b/.changelog/12844.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-raft: upgrade to v1.3.6 which fixes a bug where non cluster member can still be able to participate in an election.
+raft: upgrade to v1.3.8 which fixes a bug where non cluster member can still be able to participate in an election.
 ```

--- a/.changelog/12844.txt
+++ b/.changelog/12844.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+raft: upgrade to v1.3.6 which fixes a bug where non cluster member can still be able to participate in an election.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3907,6 +3907,7 @@ func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 		RaftSnapshotThreshold: newCfg.RaftSnapshotThreshold,
 		RaftSnapshotInterval:  newCfg.RaftSnapshotInterval,
 		HeartbeatTimeout:      newCfg.ConsulRaftHeartbeatTimeout,
+		ElectionTimeout:       newCfg.ConsulRaftElectionTimeout,
 		RaftTrailingLogs:      newCfg.RaftTrailingLogs,
 	}
 	if err := a.delegate.ReloadConfig(cc); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3906,6 +3906,7 @@ func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 		ConfigEntryBootstrap:  newCfg.ConfigEntryBootstrap,
 		RaftSnapshotThreshold: newCfg.RaftSnapshotThreshold,
 		RaftSnapshotInterval:  newCfg.RaftSnapshotInterval,
+		HeartbeatTimeout:      newCfg.ConsulRaftHeartbeatTimeout,
 		RaftTrailingLogs:      newCfg.RaftTrailingLogs,
 	}
 	if err := a.delegate.ReloadConfig(cc); err != nil {

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -604,6 +604,7 @@ type ReloadableConfig struct {
 	RaftSnapshotThreshold int
 	RaftSnapshotInterval  time.Duration
 	RaftTrailingLogs      int
+	HeartbeatTimeout      time.Duration
 }
 
 type RaftBoltDBConfig struct {

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -605,6 +605,7 @@ type ReloadableConfig struct {
 	RaftSnapshotInterval  time.Duration
 	RaftTrailingLogs      int
 	HeartbeatTimeout      time.Duration
+	ElectionTimeout       time.Duration
 }
 
 type RaftBoltDBConfig struct {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1573,6 +1573,8 @@ func computeRaftReloadableConfig(config ReloadableConfig) raft.ReloadableConfig 
 		TrailingLogs:      defaultConf.RaftConfig.TrailingLogs,
 		SnapshotInterval:  defaultConf.RaftConfig.SnapshotInterval,
 		SnapshotThreshold: defaultConf.RaftConfig.SnapshotThreshold,
+		ElectionTimeout:   defaultConf.RaftConfig.ElectionTimeout,
+		HeartbeatTimeout:  defaultConf.RaftConfig.HeartbeatTimeout,
 	}
 	if config.RaftSnapshotThreshold != 0 {
 		raftCfg.SnapshotThreshold = uint64(config.RaftSnapshotThreshold)
@@ -1583,10 +1585,10 @@ func computeRaftReloadableConfig(config ReloadableConfig) raft.ReloadableConfig 
 	if config.RaftTrailingLogs != 0 {
 		raftCfg.TrailingLogs = uint64(config.RaftTrailingLogs)
 	}
-	if config.HeartbeatTimeout > 5*time.Millisecond {
+	if config.HeartbeatTimeout >= 5*time.Millisecond {
 		raftCfg.HeartbeatTimeout = config.HeartbeatTimeout
 	}
-	if config.ElectionTimeout > 5*time.Millisecond {
+	if config.ElectionTimeout >= 5*time.Millisecond {
 		raftCfg.ElectionTimeout = config.ElectionTimeout
 	}
 	return raftCfg

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1583,6 +1583,9 @@ func computeRaftReloadableConfig(config ReloadableConfig) raft.ReloadableConfig 
 	if config.RaftTrailingLogs != 0 {
 		raftCfg.TrailingLogs = uint64(config.RaftTrailingLogs)
 	}
+	if config.HeartbeatTimeout > 5*time.Millisecond {
+		raftCfg.HeartbeatTimeout = config.HeartbeatTimeout
+	}
 	return raftCfg
 }
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1620,7 +1620,7 @@ func (s *Server) trackLeaderChanges() {
 				continue
 			}
 
-			s.grpcLeaderForwarder.UpdateLeaderAddr(s.config.Datacenter, string(leaderObs.Leader))
+			s.grpcLeaderForwarder.UpdateLeaderAddr(s.config.Datacenter, string(leaderObs.LeaderAddr))
 		case <-s.shutdownCh:
 			s.raft.DeregisterObserver(observer)
 			return

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1586,6 +1586,9 @@ func computeRaftReloadableConfig(config ReloadableConfig) raft.ReloadableConfig 
 	if config.HeartbeatTimeout > 5*time.Millisecond {
 		raftCfg.HeartbeatTimeout = config.HeartbeatTimeout
 	}
+	if config.ElectionTimeout > 5*time.Millisecond {
+		raftCfg.ElectionTimeout = config.ElectionTimeout
+	}
 	return raftCfg
 }
 

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -1858,6 +1858,8 @@ func TestServer_computeRaftReloadableConfig(t *testing.T) {
 				SnapshotThreshold: defaults.SnapshotThreshold,
 				SnapshotInterval:  defaults.SnapshotInterval,
 				TrailingLogs:      defaults.TrailingLogs,
+				ElectionTimeout:   defaults.ElectionTimeout,
+				HeartbeatTimeout:  defaults.HeartbeatTimeout,
 			},
 		},
 		{
@@ -1869,6 +1871,8 @@ func TestServer_computeRaftReloadableConfig(t *testing.T) {
 				SnapshotThreshold: 123456,
 				SnapshotInterval:  defaults.SnapshotInterval,
 				TrailingLogs:      defaults.TrailingLogs,
+				ElectionTimeout:   defaults.ElectionTimeout,
+				HeartbeatTimeout:  defaults.HeartbeatTimeout,
 			},
 		},
 		{
@@ -1880,6 +1884,8 @@ func TestServer_computeRaftReloadableConfig(t *testing.T) {
 				SnapshotThreshold: defaults.SnapshotThreshold,
 				SnapshotInterval:  13 * time.Minute,
 				TrailingLogs:      defaults.TrailingLogs,
+				ElectionTimeout:   defaults.ElectionTimeout,
+				HeartbeatTimeout:  defaults.HeartbeatTimeout,
 			},
 		},
 		{
@@ -1891,6 +1897,8 @@ func TestServer_computeRaftReloadableConfig(t *testing.T) {
 				SnapshotThreshold: defaults.SnapshotThreshold,
 				SnapshotInterval:  defaults.SnapshotInterval,
 				TrailingLogs:      78910,
+				ElectionTimeout:   defaults.ElectionTimeout,
+				HeartbeatTimeout:  defaults.HeartbeatTimeout,
 			},
 		},
 		{
@@ -1899,11 +1907,15 @@ func TestServer_computeRaftReloadableConfig(t *testing.T) {
 				RaftSnapshotThreshold: 123456,
 				RaftSnapshotInterval:  13 * time.Minute,
 				RaftTrailingLogs:      78910,
+				ElectionTimeout:       300 * time.Millisecond,
+				HeartbeatTimeout:      400 * time.Millisecond,
 			},
 			want: raft.ReloadableConfig{
 				SnapshotThreshold: 123456,
 				SnapshotInterval:  13 * time.Minute,
 				TrailingLogs:      78910,
+				ElectionTimeout:   300 * time.Millisecond,
+				HeartbeatTimeout:  400 * time.Millisecond,
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hil v0.0.0-20200423225030-a18a1cd20038
 	github.com/hashicorp/memberlist v0.3.1
-	github.com/hashicorp/raft v1.3.6
+	github.com/hashicorp/raft v1.3.7
 	github.com/hashicorp/raft-autopilot v0.1.6
 	github.com/hashicorp/raft-boltdb v0.0.0-20211202195631-7d34b9fb3f42 // indirect
 	github.com/hashicorp/raft-boltdb/v2 v2.2.2

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hil v0.0.0-20200423225030-a18a1cd20038
 	github.com/hashicorp/memberlist v0.3.1
-	github.com/hashicorp/raft v1.3.7
+	github.com/hashicorp/raft v1.3.8
 	github.com/hashicorp/raft-autopilot v0.1.6
 	github.com/hashicorp/raft-boltdb v0.0.0-20211202195631-7d34b9fb3f42 // indirect
 	github.com/hashicorp/raft-boltdb/v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/hashicorp/memberlist v0.3.1/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/raft v1.1.0/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft v1.1.1/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
 github.com/hashicorp/raft v1.2.0/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
-github.com/hashicorp/raft v1.3.6 h1:v5xW5KzByoerQlN/o31VJrFNiozgzGyDoMgDJgXpsto=
-github.com/hashicorp/raft v1.3.6/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
+github.com/hashicorp/raft v1.3.7 h1:mnuQAuSMNRjAvFc9IYxnGxZJ9LBBZyheMR8Kv8Ve71M=
+github.com/hashicorp/raft v1.3.7/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft-autopilot v0.1.6 h1:C1q3RNF2FfXNZfHWbvVAu0QixaQK8K5pX4O5lh+9z4I=
 github.com/hashicorp/raft-autopilot v0.1.6/go.mod h1:Af4jZBwaNOI+tXfIqIdbcAnh/UyyqIMj/pOISIfhArw=
 github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pNv7Wc3ycL6F5oOWn+tPGo2gWD4a5X+yp/ntwdKLjRk=

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/hashicorp/memberlist v0.3.1/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/raft v1.1.0/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft v1.1.1/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
 github.com/hashicorp/raft v1.2.0/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
-github.com/hashicorp/raft v1.3.7 h1:mnuQAuSMNRjAvFc9IYxnGxZJ9LBBZyheMR8Kv8Ve71M=
-github.com/hashicorp/raft v1.3.7/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
+github.com/hashicorp/raft v1.3.8 h1:lrhx4wesQLOSv3ERX/pK4cwfzQ0J2RgzsvAkBxHe1bA=
+github.com/hashicorp/raft v1.3.8/go.mod h1:4Ak7FSPnuvmb0GV6vgIAJ4vYT4bek9bb6Q+7HVbyzqM=
 github.com/hashicorp/raft-autopilot v0.1.6 h1:C1q3RNF2FfXNZfHWbvVAu0QixaQK8K5pX4O5lh+9z4I=
 github.com/hashicorp/raft-autopilot v0.1.6/go.mod h1:Af4jZBwaNOI+tXfIqIdbcAnh/UyyqIMj/pOISIfhArw=
 github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pNv7Wc3ycL6F5oOWn+tPGo2gWD4a5X+yp/ntwdKLjRk=


### PR DESCRIPTION
This update raft to [v1.3.7](https://github.com/hashicorp/raft/releases/tag/v1.3.7)
In this raft release `HeartbeatTimeout` and `ElectionTimeout` became reloadable config, so Consul needed to be tweaked to only reload those configs only when the given values are within the acceptable range.
Note that this also introduce https://github.com/hashicorp/raft/pull/477