### PR TITLE
change action to pull v1 instead of main

### DIFF
--- a/.changelog/12846.txt
+++ b/.changelog/12846.txt
@@ -1,0 +1,3 @@
+```release-note:note
+ci: change action to pull v1 instead of main
+```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Generate metadata file
         id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@main
+        uses: hashicorp/actions-generate-metadata@v1
         with:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}


### PR DESCRIPTION
The `generate-metadata` action needs to be pulling from tags for better release management. We run the risk of disruption if we pushed changes to the `main` branch of the generate-metadata action thus disrupting release workflows for Consul. 

Read more on [Using tags for release management](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management)

I added the backport labels for this PR, but I'm unsure which release branches Consul is using, so feel free to adjust!