### PR TITLE
Remove references to modules in consul/website/content/docs/enterprise

### DIFF
--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -8,8 +8,7 @@ description: Consul Enterprise enables you to create partitions that can be admi
 
 <EnterpriseAlert>
   This feature requires{' '}
-  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}
-  with the Governance and Policy module.
+  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}.
 </EnterpriseAlert>
 
 This topic provides and overview of admin partitions, which are entities that define one or more administrative boundaries for single Consul deployments.

--- a/website/content/docs/enterprise/audit-logging.mdx
+++ b/website/content/docs/enterprise/audit-logging.mdx
@@ -9,8 +9,7 @@ description: >-
 
 <EnterpriseAlert>
   This feature requires{' '}
-  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}
-  with the Governance and Policy module.
+  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}.
 </EnterpriseAlert>
 
 Consul Enterprise v1.8.0 adds audit logging as a feature that captures a clear and

--- a/website/content/docs/enterprise/federation.mdx
+++ b/website/content/docs/enterprise/federation.mdx
@@ -11,8 +11,7 @@ description: >-
 
 <EnterpriseAlert>
   This feature requires{' '}
-  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}
-  with the Global Visibility, Routing, and Scale module.
+  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}.
 </EnterpriseAlert>
 
 Consul's core federation capability uses the same gossip mechanism that is used

--- a/website/content/docs/enterprise/namespaces.mdx
+++ b/website/content/docs/enterprise/namespaces.mdx
@@ -8,8 +8,7 @@ description: Consul Enterprise enables data isolation with Namespaces.
 
 <EnterpriseAlert>
   This feature requires{' '}
-  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}
-  with the Governance and Policy module.
+  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}.
 </EnterpriseAlert>
 
 With Consul Enterprise v1.7.0, data for different users or teams

--- a/website/content/docs/enterprise/network-segments.mdx
+++ b/website/content/docs/enterprise/network-segments.mdx
@@ -11,7 +11,7 @@ description: |-
 <EnterpriseAlert>
   This feature requires{' '}
   <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}
-  version 0.9.3+ with the Global Visibility, Routing, and Scale module.
+  version 0.9.3+.
 </EnterpriseAlert>
 
 Consul requires full connectivity between all agents (servers and clients) in a

--- a/website/content/docs/enterprise/read-scale.mdx
+++ b/website/content/docs/enterprise/read-scale.mdx
@@ -10,8 +10,7 @@ description: >-
 
 <EnterpriseAlert>
   This feature requires{' '}
-  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}
-  with the Global Visibility, Routing, and Scale module.
+  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}.
 </EnterpriseAlert>
 
 Consul Enterprise provides the ability to scale clustered Consul servers

--- a/website/content/docs/enterprise/redundancy.mdx
+++ b/website/content/docs/enterprise/redundancy.mdx
@@ -10,8 +10,7 @@ description: >-
 
 <EnterpriseAlert>
   This feature requires{' '}
-  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}
-  with the Global Visibility, Routing, and Scale module.
+  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}.
 </EnterpriseAlert>
 
 Consul Enterprise redundancy zones provide

--- a/website/content/docs/enterprise/sentinel.mdx
+++ b/website/content/docs/enterprise/sentinel.mdx
@@ -11,8 +11,7 @@ description: >-
 
 <EnterpriseAlert>
   This feature requires{' '}
-  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}
-  with the Governance and Policy module.
+  <a href="https://www.hashicorp.com/products/consul/">Consul Enterprise</a>{' '}.
 </EnterpriseAlert>
 
 Sentinel policies extend the ACL system in Consul beyond static "read", "write",


### PR DESCRIPTION
Removed references to modules in callout box at the top of the page. 

Edit requested by Neena Pemmaraju via Slack on 4/21/22