### PR TITLE
docs: updated connect docs and re-deploying missed changes

### DIFF
--- a/website/content/docs/connect/configuration.mdx
+++ b/website/content/docs/connect/configuration.mdx
@@ -7,28 +7,41 @@ description: >-
   connections, automatically wrapping and verifying TLS connections.
 ---
 
-# Connect Configuration
+# Service Mesh Configuration
 
-There are many configuration options exposed for Connect. The only option
-that must be set is the "enabled" option on Consul Servers to enable Connect.
+There are many configuration options exposed for Consul service mesh. The only option
+that must be set is the "connect.enabled" option on Consul Servers to enable Consul service mesh.
 All other configurations are optional and have reasonable defaults.
 
--> **Tip:** Connect is enabled by default when running Consul in
+As a reminder, Consul Connect is used interchangeably
+with the name Consul Service Mesh and is what this document will use to refer to for Service Mesh functionality within Consul.
+
+-> **Tip:** Service mesh is enabled by default when running Consul in
 dev mode with `consul agent -dev`.
 
 ## Agent Configuration
 
-The first step to use Connect is to enable Connect for your Consul
+The first step to use service mesh is to enable Connect for your Consul
 cluster. By default, Connect is disabled. Enabling Connect requires changing
 the configuration of only your Consul _servers_ (not client agents). To enable
 Connect, add the following to a new or existing
 [server configuration file](/docs/agent/config/config-files). In an existing cluster, this configuration change requires a Consul server restart, which you can perform one server at a time to maintain availability. In HCL:
+
+
+<CodeTabs heading="Enable Consul service mesh" tabs={[ "HCL", "JSON" ]}>
 
 ```hcl
 connect {
   enabled = true
 }
 ```
+
+```json
+"connect": {
+ "enabled": true
+}
+```
+</CodeTabs>
 
 This will enable Connect and configure your Consul cluster to use the
 built-in certificate authority for creating and managing certificates.

--- a/website/content/docs/connect/configuration.mdx
+++ b/website/content/docs/connect/configuration.mdx
@@ -10,18 +10,17 @@ description: >-
 # Service Mesh Configuration
 
 There are many configuration options exposed for Consul service mesh. The only option
-that must be set is the "connect.enabled" option on Consul Servers to enable Consul service mesh.
+that must be set is the `connect.enabled` option on Consul servers to enable Consul service mesh.
 All other configurations are optional and have reasonable defaults.
 
-As a reminder, Consul Connect is used interchangeably
-with the name Consul Service Mesh and is what this document will use to refer to for Service Mesh functionality within Consul.
+Consul Connect is the component shipped with Consul that enables service mesh functionality. The terms _Consul Connect_ and _Consul service mesh_ are used interchangeably throughout this documentation. 
 
 -> **Tip:** Service mesh is enabled by default when running Consul in
 dev mode with `consul agent -dev`.
 
 ## Agent Configuration
 
-The first step to use service mesh is to enable Connect for your Consul
+Begin by enabling Connect for your Consul
 cluster. By default, Connect is disabled. Enabling Connect requires changing
 the configuration of only your Consul _servers_ (not client agents). To enable
 Connect, add the following to a new or existing

--- a/website/content/docs/connect/connect-internals.mdx
+++ b/website/content/docs/connect/connect-internals.mdx
@@ -8,14 +8,11 @@ description: >-
 
 # How Service Mesh Works
 
-This page details the inner workings of some of Consul sevice mehs's core features.
-Understanding how these features work isn't a prerequisite for using Consul service mesh,
-but will help you build a mental model of what's going on under the hood, which
-may help you reason about service mesh's behavior in more complex deployment
-scenarios.
+This topic describes how many of the core features of Consul's service mesh functionality works.
+It is not a prerequisite,
+but this information will help you understand how Consul service mesh behaves in more complex scenarios.
 
-As a reminder, Consul Connect is used interchangeably
-with the name Consul Service Mesh and is what this document will use to refer to for Service Mesh functionality within Consul.
+Consul Connect is the component shipped with Consul that enables service mesh functionality. The terms _Consul Connect_ and _Consul service mesh_ are used interchangeably throughout this documentation.
 
 To try service mesh locally, complete the [Getting Started with Consul service
 mesh](https://learn.hashicorp.com/tutorials/consul/service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)

--- a/website/content/docs/connect/connect-internals.mdx
+++ b/website/content/docs/connect/connect-internals.mdx
@@ -6,15 +6,18 @@ description: >-
   and performance, intention and certificate authority replication.
 ---
 
-# How Connect Works
+# How Service Mesh Works
 
-This page details the inner workings of some of Connect's core features.
-Understanding how these features work isn't a prerequisite for using Connect,
+This page details the inner workings of some of Consul sevice mehs's core features.
+Understanding how these features work isn't a prerequisite for using Consul service mesh,
 but will help you build a mental model of what's going on under the hood, which
-may help you reason about Connect's behavior in more complex deployment
+may help you reason about service mesh's behavior in more complex deployment
 scenarios.
 
-To try Connect locally, complete the [Getting Started with Consul service
+As a reminder, Consul Connect is used interchangeably
+with the name Consul Service Mesh and is what this document will use to refer to for Service Mesh functionality within Consul.
+
+To try service mesh locally, complete the [Getting Started with Consul service
 mesh](https://learn.hashicorp.com/tutorials/consul/service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
 tutorial.
 

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -142,7 +142,7 @@
         "path": "connect"
       },
       {
-        "title": "How Connect Works",
+        "title": "How Service Mesh Works",
         "path": "connect/connect-internals"
       },
       {


### PR DESCRIPTION
### Description
This PR is intended to re-deploy changes in the Enterprise docs (PR #12847 )
The Connect pages were also updated to help reduce confusion about service mesh vs connect. 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
