### PR TITLE
add notarize darwin arm64 workflow

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -84,8 +84,21 @@ event "notarize-darwin-amd64" {
   }
 }
 
-event "notarize-windows-386" {
+event "notarize-darwin-arm64" {
   depends = ["notarize-darwin-amd64"]
+  action "notarize-darwin-arm64" {
+    organization = "hashicorp"
+    repository   = "crt-workflows-common"
+    workflow     = "notarize-darwin-arm64"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "notarize-windows-386" {
+  depends = ["notarize-darwin-arm64"]
   action "notarize-windows-386" {
     organization = "hashicorp"
     repository = "crt-workflows-common"


### PR DESCRIPTION
### Description
Consul needs to have a workflow that notarizes the darwin arm64 binary. Currently there's no workflow to notarize it. 

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
