### PR TITLE
docs: Redirect /agent/config to /agent/config/config-files

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1266,7 +1266,7 @@ module.exports = [
   },
   {
     source: '/docs/agent/options',
-    destination: '/docs/agent/config',
+    destination: '/docs/agent/config/config-files',
     permanent: true,
   },
   {


### PR DESCRIPTION
### Description
Redirect [`/docs/agent/config`](https://www.consul.io/docs/agent/config) to [`/docs/agent/config/config-files`](https://www.consul.io/docs/agent/config/config-files) so that external links to anchors for specific config parameters continue to work.