### PR TITLE
structs: ensure exported-services PeerName field can be addressed as peer_name

### DIFF
--- a/agent/structs/config_entry_exports.go
+++ b/agent/structs/config_entry_exports.go
@@ -14,7 +14,7 @@ type ExportedServicesConfigEntry struct {
 
 	// Services is a list of services to be exported and the list of partitions
 	// to expose them to.
-	Services []ExportedService
+	Services []ExportedService `json:",omitempty"`
 
 	Meta               map[string]string `json:",omitempty"`
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
@@ -31,7 +31,7 @@ type ExportedService struct {
 	Namespace string `json:",omitempty"`
 
 	// Consumers is a list of downstream consumers of the service to be exported.
-	Consumers []ServiceConsumer
+	Consumers []ServiceConsumer `json:",omitempty"`
 }
 
 // ServiceConsumer represents a downstream consumer of the service to be exported.
@@ -39,10 +39,10 @@ type ExportedService struct {
 type ServiceConsumer struct {
 	// Partition is the admin partition to export the service to.
 	// Deprecated: PeerName should be used for both remote peers and local partitions.
-	Partition string
+	Partition string `json:",omitempty"`
 
 	// PeerName is the name of the peer to export the service to.
-	PeerName string
+	PeerName string `json:",omitempty" alias:"peer_name"`
 }
 
 func (e *ExportedServicesConfigEntry) ToMap() map[string]map[string][]string {

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1770,6 +1770,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 							},
 							{
 								partition = "baz"
+							},
+							{
+								peer_name = "flarm"
 							}
 						]
 					},
@@ -1801,6 +1804,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 							},
 							{
 								Partition = "baz"
+							},
+							{
+								PeerName = "flarm"
 							}
 						]
 					},
@@ -1831,6 +1837,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 							},
 							{
 								Partition: "baz",
+							},
+							{
+								PeerName: "flarm",
 							},
 						},
 					},

--- a/api/config_entry_exports.go
+++ b/api/config_entry_exports.go
@@ -16,7 +16,7 @@ type ExportedServicesConfigEntry struct {
 
 	// Services is a list of services to be exported and the list of partitions
 	// to expose them to.
-	Services []ExportedService
+	Services []ExportedService `json:",omitempty"`
 
 	Meta map[string]string `json:",omitempty"`
 
@@ -40,7 +40,7 @@ type ExportedService struct {
 	Namespace string `json:",omitempty"`
 
 	// Consumers is a list of downstream consumers of the service to be exported.
-	Consumers []ServiceConsumer
+	Consumers []ServiceConsumer `json:",omitempty"`
 }
 
 // ServiceConsumer represents a downstream consumer of the service to be exported.
@@ -48,10 +48,10 @@ type ExportedService struct {
 type ServiceConsumer struct {
 	// Partition is the admin partition to export the service to.
 	// Deprecated: PeerName should be used for both remote peers and local partitions.
-	Partition string
+	Partition string `json:",omitempty"`
 
 	// PeerName is the name of the peer to export the service to.
-	PeerName string
+	PeerName string `json:",omitempty" alias:"peer_name"`
 }
 
 func (e *ExportedServicesConfigEntry) GetKind() string            { return ExportedServices }

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -2891,6 +2891,9 @@ func TestParseConfigEntry(t *testing.T) {
 							},
 							{
 								partition = "baz"
+							},
+							{
+								peer_name = "flarm"
 							}
 						]
 					},
@@ -2922,6 +2925,9 @@ func TestParseConfigEntry(t *testing.T) {
 							},
 							{
 								Partition = "baz"
+							},
+							{
+								PeerName = "flarm"
 							}
 						]
 					},
@@ -2954,6 +2960,9 @@ func TestParseConfigEntry(t *testing.T) {
 							},
 							{
 								"partition": "baz"
+							},
+							{
+								"peer_name": "flarm"
 							}
 						]
 					},
@@ -2987,6 +2996,9 @@ func TestParseConfigEntry(t *testing.T) {
 							},
 							{
 								"Partition": "baz"
+							},
+							{
+								"PeerName": "flarm"
 							}
 						]
 					},
@@ -3018,6 +3030,9 @@ func TestParseConfigEntry(t *testing.T) {
 							},
 							{
 								Partition: "baz",
+							},
+							{
+								PeerName: "flarm",
 							},
 						},
 					},


### PR DESCRIPTION
### Description

Ensures that the newly added `PeerName` field in the `exported-services` configuration entry kind can be accessed both in `CamelCase` form as well as `snake_case` form (e.g. `peer_name`) like all other compound word fields in config entries.

