### PR TITLE
ci: Backport arm64 bulids

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
     strategy:
       matrix:
         goos: [ darwin ]
-        goarch: [ "amd64" ]
+        goarch: [ "amd64", "arm64"]
         go: [ "1.17.9" ]
       fail-fast: true
 


### PR DESCRIPTION
### Description
This is a backport of #11844. The cherry-picks failed at the time.

### Testing & Reproduction steps
We should see a successful arm64 build once this is merged.

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [ ] ~not a security concern~
* [ ] ~checklist [folder](./../docs/config) consulted~
