### PR TITLE
Support x-forwarded-client-cert 

### DIFF
--- a/.changelog/12878.txt
+++ b/.changelog/12878.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Envoy now inserts x-forwarded-client-cert for incoming proxy connections
+```

--- a/.changelog/12878.txt
+++ b/.changelog/12878.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-agent: Envoy now inserts x-forwarded-client-cert for incoming proxy connections
+xds: Envoy now inserts x-forwarded-client-cert for incoming proxy connections
 ```

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -15,6 +15,8 @@ type MeshConfigEntry struct {
 
 	TLS *MeshTLSConfig `json:",omitempty"`
 
+	HTTP *MeshHTTPConfig `json:",omitempty"`
+
 	Meta               map[string]string `json:",omitempty"`
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 	RaftIndex
@@ -31,6 +33,10 @@ type TransparentProxyMeshConfig struct {
 type MeshTLSConfig struct {
 	Incoming *MeshDirectionalTLSConfig `json:",omitempty"`
 	Outgoing *MeshDirectionalTLSConfig `json:",omitempty"`
+}
+
+type MeshHTTPConfig struct {
+	SanitizeXForwardedClientCert bool `json:",omitempty"`
 }
 
 type MeshDirectionalTLSConfig struct {

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -44,6 +44,10 @@ type MeshDirectionalTLSConfig struct {
 	CipherSuites []types.TLSCipherSuite `json:",omitempty" alias:"cipher_suites"`
 }
 
+type MeshHTTPConfig struct {
+	SanitizeXForwardedClientCert bool `alias:"sanitize_x_forwarded_client_cert"`
+}
+
 func (e *MeshConfigEntry) GetKind() string {
 	return MeshConfig
 }

--- a/agent/structs/config_entry_mesh.go
+++ b/agent/structs/config_entry_mesh.go
@@ -35,10 +35,6 @@ type MeshTLSConfig struct {
 	Outgoing *MeshDirectionalTLSConfig `json:",omitempty"`
 }
 
-type MeshHTTPConfig struct {
-	SanitizeXForwardedClientCert bool `json:",omitempty"`
-}
-
 type MeshDirectionalTLSConfig struct {
 	TLSMinVersion types.TLSVersion `json:",omitempty" alias:"tls_min_version"`
 	TLSMaxVersion types.TLSVersion `json:",omitempty" alias:"tls_max_version"`

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1694,6 +1694,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 						]
 					}
 				}
+				http {
+					sanitize_x_forwarded_client_cert = true
+				}
 			`,
 			camel: `
 				Kind = "mesh"
@@ -1722,6 +1725,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 						]
 					}
 				}
+				HTTP {
+					SanitizeXForwardedClientCert = true
+				}	
 			`,
 			expect: &MeshConfigEntry{
 				Meta: map[string]string{
@@ -1748,6 +1754,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 							types.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 						},
 					},
+				},
+				HTTP: &MeshHTTPConfig{
+					SanitizeXForwardedClientCert: true,
 				},
 			},
 		},

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1153,9 +1153,8 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(
 
 		if meshConfig := cfgSnap.MeshConfig(); meshConfig == nil || meshConfig.HTTP == nil || !meshConfig.HTTP.SanitizeXForwardedClientCert {
 			opts.forwardClientDetails = true
-			// Note: filter Connection may not be mTLS, so then ALWAYS_FORWARD_ONLY. For mTLS connections we might want APPEND_FORWARD.
-			// Open question; how do I determine if this is mTLS or not?
-			opts.forwardClientPolicy = envoy_http_v3.HttpConnectionManager_ALWAYS_FORWARD_ONLY
+			// This assumes that we have a client cert (mTLS) (implied by the context of this function)
+			opts.forwardClientPolicy = envoy_http_v3.HttpConnectionManager_APPEND_FORWARD
 		}
 	}
 

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -167,6 +167,27 @@ func TestListenersFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name: "http-public-listener-no-xfcc",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshot(t,
+					func(ns *structs.NodeService) {
+						ns.Proxy.Config["protocol"] = "http"
+					},
+					[]cache.UpdateEvent{
+						{
+							CorrelationID: "mesh",
+							Result: &structs.ConfigEntryResponse{
+								Entry: &structs.MeshConfigEntry{
+									HTTP: &structs.MeshHTTPConfig{
+										SanitizeXForwardedClientCert: true,
+									},
+								},
+							},
+						},
+					})
+			},
+		},
+		{
 			name: "http-listener-with-timeouts",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {

--- a/agent/xds/testdata/listeners/http-listener-with-timeouts.latest.golden
+++ b/agent/xds/testdata/listeners/http-listener-with-timeouts.latest.golden
@@ -67,6 +67,14 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "APPEND_FORWARD",
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
                 "statPrefix": "public_listener",
                 "routeConfig": {
                   "name": "public_listener",

--- a/agent/xds/testdata/listeners/http-public-listener-no-xfcc.latest.golden
+++ b/agent/xds/testdata/listeners/http-public-listener-no-xfcc.latest.golden
@@ -67,14 +67,6 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "APPEND_FORWARD",
-                "setCurrentClientCertDetails": {
-                  "cert": true,
-                  "chain": true,
-                  "dns": true,
-                  "subject": true,
-                  "uri": true
-                },
                 "statPrefix": "public_listener",
                 "routeConfig": {
                   "name": "public_listener",

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.latest.golden
@@ -184,6 +184,14 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
                 "statPrefix": "upstream.web.default.default.dc1",
                 "rds": {
                   "configSource": {
@@ -258,6 +266,14 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
                 "statPrefix": "upstream.web.default.default.dc1",
                 "rds": {
                   "configSource": {
@@ -332,6 +348,14 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
                 "statPrefix": "upstream.web.default.default.dc1",
                 "rds": {
                   "configSource": {

--- a/agent/xds/testdata/listeners/terminating-gateway-service-subsets.latest.golden
+++ b/agent/xds/testdata/listeners/terminating-gateway-service-subsets.latest.golden
@@ -184,7 +184,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "forwardClientCertDetails": "APPEND_FORWARD",
                 "setCurrentClientCertDetails": {
                   "cert": true,
                   "chain": true,
@@ -266,7 +266,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "forwardClientCertDetails": "APPEND_FORWARD",
                 "setCurrentClientCertDetails": {
                   "cert": true,
                   "chain": true,
@@ -348,7 +348,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "forwardClientCertDetails": "APPEND_FORWARD",
                 "setCurrentClientCertDetails": {
                   "cert": true,
                   "chain": true,

--- a/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway-with-service-resolvers.latest.golden
+++ b/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway-with-service-resolvers.latest.golden
@@ -130,6 +130,14 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
                 "statPrefix": "upstream.web.default.default.dc1",
                 "rds": {
                   "configSource": {
@@ -212,6 +220,14 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
                 "statPrefix": "upstream.web.default.default.dc1",
                 "rds": {
                   "configSource": {
@@ -348,6 +364,14 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
                 "statPrefix": "upstream.web.default.default.dc1",
                 "rds": {
                   "configSource": {

--- a/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway-with-service-resolvers.latest.golden
+++ b/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway-with-service-resolvers.latest.golden
@@ -130,7 +130,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "forwardClientCertDetails": "APPEND_FORWARD",
                 "setCurrentClientCertDetails": {
                   "cert": true,
                   "chain": true,
@@ -220,7 +220,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "forwardClientCertDetails": "APPEND_FORWARD",
                 "setCurrentClientCertDetails": {
                   "cert": true,
                   "chain": true,
@@ -364,7 +364,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "forwardClientCertDetails": "APPEND_FORWARD",
                 "setCurrentClientCertDetails": {
                   "cert": true,
                   "chain": true,

--- a/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway.latest.golden
+++ b/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway.latest.golden
@@ -184,6 +184,14 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "setCurrentClientCertDetails": {
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "subject": true,
+                  "uri": true
+                },
                 "statPrefix": "upstream.web.default.default.dc1",
                 "rds": {
                   "configSource": {

--- a/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway.latest.golden
+++ b/agent/xds/testdata/serverless_plugin/listeners/lambda-terminating-gateway.latest.golden
@@ -184,7 +184,7 @@
               "name": "envoy.filters.network.http_connection_manager",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                "forwardClientCertDetails": "ALWAYS_FORWARD_ONLY",
+                "forwardClientCertDetails": "APPEND_FORWARD",
                 "setCurrentClientCertDetails": {
                   "cert": true,
                   "chain": true,

--- a/api/config_entry_mesh.go
+++ b/api/config_entry_mesh.go
@@ -1,6 +1,8 @@
 package api
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // MeshConfigEntry manages the global configuration for all service mesh
 // proxies.
@@ -18,6 +20,8 @@ type MeshConfigEntry struct {
 	TransparentProxy TransparentProxyMeshConfig `alias:"transparent_proxy"`
 
 	TLS *MeshTLSConfig `json:",omitempty"`
+
+	HTTP *MeshHTTPConfig `json:",omitempty"`
 
 	Meta map[string]string `json:",omitempty"`
 
@@ -44,6 +48,10 @@ type MeshDirectionalTLSConfig struct {
 	TLSMinVersion string   `json:",omitempty" alias:"tls_min_version"`
 	TLSMaxVersion string   `json:",omitempty" alias:"tls_max_version"`
 	CipherSuites  []string `json:",omitempty" alias:"cipher_suites"`
+}
+
+type MeshHTTPConfig struct {
+	SanitizeXForwardedClientCert bool `alias:"sanitize_x_forwarded_client_cert"`
 }
 
 func (e *MeshConfigEntry) GetKind() string            { return MeshConfig }

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -1278,6 +1278,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 							"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
 						]
 					}
+				},
+				"HTTP": {
+					"SanitizeXForwardedClientCert": true
 				}
 			}
 			`,
@@ -1306,6 +1309,9 @@ func TestDecodeConfigEntry(t *testing.T) {
 							"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 						},
 					},
+				},
+				HTTP: &MeshHTTPConfig{
+					SanitizeXForwardedClientCert: true,
 				},
 			},
 		},

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -126,6 +126,9 @@ meta {
 transparent_proxy {
 	mesh_destinations_only = true
 }
+http {
+    sanitize_x_forwarded_client_cert = true
+}
 `)
 
 		ui := cli.NewMockUi()
@@ -143,6 +146,9 @@ transparent_proxy {
 		proxy, ok := entry.(*api.MeshConfigEntry)
 		require.True(t, ok)
 		require.Equal(t, map[string]string{"foo": "bar", "gir": "zim"}, proxy.Meta)
+		require.True(t, proxy.TransparentProxy.MeshDestinationsOnly)
+
+		require.True(t, proxy.HTTP.SanitizeXForwardedClientCert)
 	})
 }
 

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -368,8 +368,9 @@ Note that the Kubernetes example does not include a `partition` field. Configura
           name: 'SanitizeXForwardedClientCert',
           yaml: false,
           type: 'bool: <optional>',
-          description: `Set the envoy forwardClientCertDetails to SANITIZE everywhere. Ordinarily Consul will configure Envoy to
-                        insert x-forwarded-client-cert headers where appropriate. This returns Consul to the pre 1.12.1 behavior`,
+          description: `Set the envoy \`forward_client_cert_details\` option to \`SANITIZE\` for all proxies. This
+                        configures Envoy to not send the \`x-forwarded-client-cert\` header to the next hop. If
+                        unspecified or \`false\`, the XFCC header is propagated to upstream applications.`,
         },
       ],
     },

--- a/website/content/docs/connect/config-entries/mesh.mdx
+++ b/website/content/docs/connect/config-entries/mesh.mdx
@@ -273,7 +273,7 @@ Note that the Kubernetes example does not include a `partition` field. Configura
           name: 'Incoming',
           yaml: false,
           type: 'TLSDirectionConfig: <optional>',
-          description: `TLS configuration for inbound mTLS connections targeting 
+          description: `TLS configuration for inbound mTLS connections targeting
                         the public listener on \`connect-proxy\` and \`terminating-gateway\`
                         proxy kinds.`,
           children: [
@@ -356,6 +356,20 @@ Note that the Kubernetes example does not include a `partition` field. Configura
                             Envoy.`,
             },
           ],
+        },
+      ],
+    },
+    {
+      name: 'HTTP',
+      type: 'HTTPConfig: <optional>',
+      description: 'HTTP configuration for the service mesh.',
+      children: [
+        {
+          name: 'SanitizeXForwardedClientCert',
+          yaml: false,
+          type: 'bool: <optional>',
+          description: `Set the envoy forwardClientCertDetails to SANITIZE everywhere. Ordinarily Consul will configure Envoy to
+                        insert x-forwarded-client-cert headers where appropriate. This returns Consul to the pre 1.12.1 behavior`,
         },
       ],
     },


### PR DESCRIPTION
### Description

Add x-fowarded-client-cert information where appropriate

Envoy provides support forwarding and annotating the x-forwarded-client-cert header via the forward_client_cert_details set_current_client_cert_details filter fields. It would be helpful for consul to support this directly in its config. The escape hatches are a bit cumbersome for this purpose.

### Testing & Reproduction steps

### Links
Closes #12852

Asana [consul-x-forwarded-client-cert](https://go.hashi.co/consul-x-fowarded-client-cert)

### PR Checklist

* [x] Unit tests
* [x] End to end tests verifying headers are correct
* [x] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
