### PR TITLE
Add a Github action to remind people about backport automation

### DIFF
--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -1,0 +1,24 @@
+# This workflow sends a reminder comment to PRs that have labels starting with
+# `backport/` to check that the backport has run successfully.
+
+on:
+  pull_request:
+    types: [ labeled ]
+    # Runs on PRs to main and all release branches
+    branches:
+      - main
+      - release/*
+
+jobs:
+  backport-label-check:
+    if: "startsWith(github.event.label.name, 'backport/')"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment on PR
+        run: |
+          github_message="After merging, confirm that you see messages like: 🍒✅ Cherry pick of commit ... onto ... succeeded!"
+          curl -s -H "Authorization: token ${{ secrets.PR_COMMENT_TOKEN }}" \
+            -X POST \
+            -d "{ \"body\": \"${github_message}\"}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${{ github.event.pull_request.number }}/comments"


### PR DESCRIPTION
### Description
Adds an automated comment on PRs labelled with `backport/*` to check that the backport automation has run. 

Users who are unauthorized to run the backport CircleCI workflows will never trigger the right workflows which posts success/failure messages. This GHA should raise more awareness of the gap in our CI while maintaining that it is the merger's responsibility to ensure backports have run.