### PR TITLE
Store and return RPC error in ACL cache entries

### DIFF
--- a/.changelog/12885.txt
+++ b/.changelog/12885.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: Fixed a bug where the ACL down policy wasn't being applied on remote errors from the primary datacenter.
+```

--- a/agent/structs/acl_cache.go
+++ b/agent/structs/acl_cache.go
@@ -27,6 +27,7 @@ type ACLCaches struct {
 type IdentityCacheEntry struct {
 	Identity  ACLIdentity
 	CacheTime time.Time
+	Error     error
 }
 
 func (e *IdentityCacheEntry) Age() time.Duration {
@@ -187,12 +188,12 @@ func (c *ACLCaches) GetRole(roleID string) *RoleCacheEntry {
 }
 
 // PutIdentity adds a new identity to the cache
-func (c *ACLCaches) PutIdentity(id string, ident ACLIdentity) {
+func (c *ACLCaches) PutIdentity(id string, ident ACLIdentity, err error) {
 	if c == nil || c.identities == nil {
 		return
 	}
 
-	c.identities.Add(id, &IdentityCacheEntry{Identity: ident, CacheTime: time.Now()})
+	c.identities.Add(id, &IdentityCacheEntry{Identity: ident, CacheTime: time.Now(), Error: err})
 }
 
 func (c *ACLCaches) PutPolicy(policyId string, policy *ACLPolicy) {

--- a/agent/structs/acl_cache_test.go
+++ b/agent/structs/acl_cache_test.go
@@ -47,7 +47,7 @@ func TestStructs_ACLCaches(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cache)
 
-		cache.PutIdentity("foo", &ACLToken{})
+		cache.PutIdentity("foo", &ACLToken{}, nil)
 		entry := cache.GetIdentity("foo")
 		require.NotNil(t, entry)
 		require.NotNil(t, entry.Identity)


### PR DESCRIPTION
This PR adds an `Error` field to the `IdentityCacheEntry` to preserve the error returned when attempting to resolve a token. Currently we return `acl.ErrNotFound` in this case which bubbles up to the client agent that made the request and the down policy ends up not being respected if it's set to `allow`.