### PR TITLE
ci: add nightly action for UI testing release branches

### DIFF
--- a/.github/workflows/nightly-release-ui-test.yaml
+++ b/.github/workflows/nightly-release-ui-test.yaml
@@ -1,0 +1,269 @@
+name: nightly-release-ui-test
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch: {}
+
+env:
+  BRANCH_MATRIX: "[ release/1.10.x, release/1.11.x, release/1.12.x ]"
+  EMBER_PARTITION_TOTAL: 4
+  EMBER_PARTITION_MATRIX: "[ 1, 2, 3, 4 ]"
+
+jobs:
+  frontend-cache:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{ env.BRANCH_MATRIX }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.branch }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+  frontend-test-workspace-node:
+    runs-on: ubuntu-latest
+    needs: [frontend-cache]
+    strategy:
+      matrix:
+        branch: ${{ env.BRANCH_MATRIX }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.branch }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Workspace Tests
+        id: workspace-test
+        working-directory: ./ui
+        run: make test-workspace
+
+      - name: Node Tests
+        id: node-test
+        working-directory: ./ui/packages/consul-ui
+        run: make test-node
+
+  frontend-build-oss:
+    runs-on: ubuntu-latest
+    needs: [frontend-cache]
+    strategy:
+      matrix:
+        branch: ${{ env.BRANCH_MATRIX }}
+    env:
+      JOBS: 2
+      CONSUL_NSPACES_ENABLED: 0
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.branch }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Ember Build OSS
+        id: build-oss
+        working-directory: ./ui/packages/consul-ui
+        run: make build-ci
+
+      - name: Upload OSS Frontend
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-oss-${{ matrix.branch }}
+          path: .ui/packages/consul-ui/dist
+
+  frontend-test-oss:
+    runs-on: ubuntu-latest
+    needs: [frontend-build-oss]
+    strategy:
+      matrix:
+        branch: ${{ env.BRANCH_MATRIX }}
+        partion: ${{ env.EMBER_PARTITION_MATRIX }}
+    env:
+      CONSUL_NSPACES_ENABLED: 0
+      EMBER_TEST_REPORT: test-results/report-oss.xml #outputs test report for CircleCI test summary
+      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.branch }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Download OSS Frontend
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-oss-${{ matrix.branch }}
+          path: .ui/packages/consul-ui/dist
+
+      - name: Ember Test OSS
+        id: cache
+        working-directory: ./ui/packages/consul-ui
+        run: node_modules/.bin/ember exam --split=$EMBER_PARTITION_TOTAL --partition=${{ matrix.partition }} --path dist --silent -r xunit
+
+      # TODO: add test-reporter: https://github.com/marketplace/actions/test-reporter
+
+  frontend-build-ent:
+    runs-on: ubuntu-latest
+    needs: [frontend-cache]
+    strategy:
+      matrix:
+        branch: ${{ env.BRANCH_MATRIX }}
+    env:
+      JOBS: 2
+      CONSUL_NSPACES_ENABLED: 1
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.branch }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Ember Build ENT
+        id: build-oss
+        working-directory: ./ui/packages/consul-ui
+        run: make build-ci
+
+      - name: Upload ENT Frontend
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-ent-${{ matrix.branch }}
+          path: .ui/packages/consul-ui/dist
+
+  frontend-test-ent:
+    runs-on: ubuntu-latest
+    needs: [frontend-build-ent]
+    strategy:
+      matrix:
+        branch: ${{ env.BRANCH_MATRIX }}
+        partion: ${{ env.EMBER_PARTITION_MATRIX }}
+    env:
+      CONSUL_NSPACES_ENABLED: 1
+      EMBER_TEST_REPORT: test-results/report-oss.xml #outputs test report for CircleCI test summary
+      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.branch }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Download ENT Frontend
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-ent-${{ matrix.branch }}
+          path: .ui/packages/consul-ui/dist
+
+      - name: Ember Test ENT
+        id: cache
+        working-directory: ./ui/packages/consul-ui
+        run: node_modules/.bin/ember exam --split=$EMBER_PARTITION_TOTAL --partition=${{ matrix.partition }} --path dist --silent -r xunit
+
+        # TODO: add test-reporter: https://github.com/marketplace/actions/test-reporter
+
+  frontend-test-coverage-ent:
+    runs-on: ubuntu-latest
+    needs: [frontend-build-ent]
+    strategy:
+      matrix:
+        branch: ${{ env.BRANCH_MATRIX }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: ${{ matrix.branch }}
+
+      # Not necessary to use yarn, but enables caching
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: ./ui/yarn.lock
+
+      - name: Install
+        id: install
+        working-directory: ./ui
+        run: make deps
+
+      - name: Run ENT Code Coverage
+        working-directory: ./ui/packages/consul-ui
+        run: make test-coverage-ci
+
+  slack-failure-notification:
+    runs-on: ubuntu-latest
+    needs: [frontend-test-oss, frontend-test-ent]
+    if: ${{ failure() }}
+    steps:
+      - name: Slack Notification
+        id: slack
+        uses: slackapi/slack-github-action@main
+        with:
+          payload: "{\"message\":\"One or more nightly UI test have failed on a release branch for Consul. [Link to Failed Action](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}). \"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CONSUL_CORE_SLACK_WEBHOOK }}


### PR DESCRIPTION
### Description
We had some problems with our backport process sending commits to branches that would break tests, but tests are not run if a commit can be merged directly. This PR adds nightly tests for all current release branches to verify that the UI is working correctly.

This is a short-term fix until we can move our backport process away from CircleCI to something in GHA that runs tests synchronously against a target release branch.

### Testing & Reproduction steps
Honestly, I'm not sure how to test this one other than merging and triggering manually. I looked into [act](https://github.com/nektos/act), but it's not set up to deal with artifact caching. I'll own QA-ing the results.

### Links
The following is an [offending PR](https://github.com/hashicorp/consul/pull/12279) that got backported mistakenly. 
It had to be [reverted later](https://github.com/hashicorp/consul/issues/12351) even though tests were consistently failing.

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [X] not a security concern
* [ ] ~checklist [folder](./../docs/config) consulted~
