### PR TITLE
chore(ci): add initial support for backport assistant

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -1,0 +1,33 @@
+# This action creates downstream PRs for PRs with backport labels defined.
+# See docs here: https://github.com/hashicorp/backport-assistant
+
+name: Backport Assistant Runner
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.2.3
+    steps:
+      - name: Run Backport Assistant for stable-website
+        # Update this to auto-merge when we have confidence in the process working and kill Circle
+        run: |
+          backport-assistant backport -merge-method=rebase
+        env:
+          BACKPORT_LABEL_REGEXP: "type/docs-cherrypick"
+          BACKPORT_TARGET_TEMPLATE: "stable-website"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Run Backport Assistant for release branches
+        # Update this to auto-merge when we have confidence in the process working and kill Circle
+        run: |
+          backport-assistant backport -merge-method=rebase
+        env:
+          BACKPORT_LABEL_REGEXP: "backport\/(?P<target>\\d+\\.\\d+)"
+          BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Teams at Hashicorp are adopting [backport-assistant](https://github.com/hashicorp/backport-assistant) for managing commit backports to release branches. 

Right now, this work is performed by bespoke shell scripts in Consul. Furthermore, there have been issues with backporting changes that tests would have been caught by testing if commits hadn't been merged directly.

The purpose of the PR is two-fold, to pay down tech debt with CircleCI and address deficiencies in the current process of testing backport changes.

### Execution Plan

I'm proposing activating this feature in parallel with the current cherry-pick.sh action. As advertised, this action will open PRs for backport changes. Even if the cherry-pick script merges directly to the target release branches, my assumption is that it will run tests against the non-existent changes with the base branch. 

This will create the added burden of closing empty PRs in the near term, but after a couple of days, we should be able to have the confidence to turn off the cherry-pick script and use this method. In addition, we can add another job to detect backport changes to the website.

### Security Implications

IAW the `backport-assistant` guide, I created a GH PAT for this action. Since GHA mask tokens and this action only runs against protected branches, I think there is minimal risk in leaking the token through an action or running the action against a fork.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
