### PR TITLE
Add the ability to retry on reset connection to service-routers

### DIFF
--- a/agent/proxycfg/testing_upstreams.go
+++ b/agent/proxycfg/testing_upstreams.go
@@ -632,6 +632,16 @@ func setupTestVariationDiscoveryChain(
 					},
 					{
 						Match: httpMatch(&structs.ServiceRouteHTTPMatch{
+							PathPrefix: "/retry-reset",
+						}),
+						Destination: &structs.ServiceRouteDestination{
+							Service:      "retry-reset",
+							NumRetries:   15,
+							RetryOnReset: true,
+						},
+					},
+					{
+						Match: httpMatch(&structs.ServiceRouteHTTPMatch{
 							PathPrefix: "/retry-codes",
 						}),
 						Destination: &structs.ServiceRouteDestination{
@@ -642,11 +652,12 @@ func setupTestVariationDiscoveryChain(
 					},
 					{
 						Match: httpMatch(&structs.ServiceRouteHTTPMatch{
-							PathPrefix: "/retry-both",
+							PathPrefix: "/retry-all",
 						}),
 						Destination: &structs.ServiceRouteDestination{
-							Service:               "retry-both",
+							Service:               "retry-all",
 							RetryOnConnectFailure: true,
+							RetryOnReset:          true,
 							RetryOnStatusCodes:    []uint32{401, 409, 451},
 						},
 					},

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -409,6 +409,11 @@ type ServiceRouteDestination struct {
 	// 4 failure bubbling up to layer 7.
 	RetryOnConnectFailure bool `json:",omitempty" alias:"retry_on_connect_failure"`
 
+	// RetryOnReset allows for disconnects and connection resets to trigger a
+	// retry. This should be expressible in other proxies as it's just a layer
+	// 4 failure bubbling up to layer 7.
+	RetryOnReset bool `json:",omitempty" alias:"retry_on_reset"`
+
 	// RetryOnStatusCodes is a flat list of http response status codes that are
 	// eligible for retry. This again should be feasible in any reasonable proxy.
 	RetryOnStatusCodes []uint32 `json:",omitempty" alias:"retry_on_status_codes"`
@@ -455,7 +460,7 @@ func (e *ServiceRouteDestination) UnmarshalJSON(data []byte) error {
 }
 
 func (d *ServiceRouteDestination) HasRetryFeatures() bool {
-	return d.NumRetries > 0 || d.RetryOnConnectFailure || len(d.RetryOnStatusCodes) > 0
+	return d.NumRetries > 0 || d.RetryOnConnectFailure || d.RetryOnReset || len(d.RetryOnStatusCodes) > 0
 }
 
 // ServiceSplitterConfigEntry defines how incoming requests are split across

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -397,17 +397,21 @@ func makeUpstreamRouteForDiscoveryChain(
 					}
 
 					// The RetryOn magic values come from: https://www.envoyproxy.io/docs/envoy/v1.10.0/configuration/http_filters/router_filter#config-http-filters-router-x-envoy-retry-on
+					var retryStrings []string
 					if destination.RetryOnConnectFailure {
-						retryPolicy.RetryOn = "connect-failure"
+						retryStrings = append(retryStrings, "connect-failure")
 					}
+
+					if destination.RetryOnReset {
+						retryStrings = append(retryStrings, "reset")
+					}
+
 					if len(destination.RetryOnStatusCodes) > 0 {
-						if retryPolicy.RetryOn != "" {
-							retryPolicy.RetryOn = retryPolicy.RetryOn + ",retriable-status-codes"
-						} else {
-							retryPolicy.RetryOn = "retriable-status-codes"
-						}
+						retryStrings = append(retryStrings, "retriable-status-codes")
 						retryPolicy.RetriableStatusCodes = destination.RetryOnStatusCodes
 					}
+
+					retryPolicy.RetryOn = strings.Join(retryStrings, ",")
 
 					routeAction.Route.RetryPolicy = retryPolicy
 				}

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.latest.golden
@@ -288,6 +288,18 @@
             },
             {
               "match": {
+                "prefix": "/retry-reset"
+              },
+              "route": {
+                "cluster": "retry-reset.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "retryPolicy": {
+                  "retryOn": "reset",
+                  "numRetries": 15
+                }
+              }
+            },
+            {
+              "match": {
                 "prefix": "/retry-codes"
               },
               "route": {
@@ -305,12 +317,12 @@
             },
             {
               "match": {
-                "prefix": "/retry-both"
+                "prefix": "/retry-all"
               },
               "route": {
-                "cluster": "retry-both.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "cluster": "retry-all.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "retryPolicy": {
-                  "retryOn": "connect-failure,retriable-status-codes",
+                  "retryOn": "connect-failure,reset,retriable-status-codes",
                   "retriableStatusCodes": [
                     401,
                     409,

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router-header-manip.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router-header-manip.latest.golden
@@ -289,6 +289,18 @@
             },
             {
               "match": {
+                "prefix": "/retry-reset"
+              },
+              "route": {
+                "cluster": "retry-reset.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "retryPolicy": {
+                  "retryOn": "reset",
+                  "numRetries": 15
+                }
+              }
+            },
+            {
+              "match": {
                 "prefix": "/retry-codes"
               },
               "route": {
@@ -306,12 +318,12 @@
             },
             {
               "match": {
-                "prefix": "/retry-both"
+                "prefix": "/retry-all"
               },
               "route": {
-                "cluster": "retry-both.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "cluster": "retry-all.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "retryPolicy": {
-                  "retryOn": "connect-failure,retriable-status-codes",
+                  "retryOn": "connect-failure,reset,retriable-status-codes",
                   "retriableStatusCodes": [
                     401,
                     409,

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router.latest.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router.latest.golden
@@ -289,6 +289,18 @@
             },
             {
               "match": {
+                "prefix": "/retry-reset"
+              },
+              "route": {
+                "cluster": "retry-reset.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "retryPolicy": {
+                  "retryOn": "reset",
+                  "numRetries": 15
+                }
+              }
+            },
+            {
+              "match": {
                 "prefix": "/retry-codes"
               },
               "route": {
@@ -306,12 +318,12 @@
             },
             {
               "match": {
-                "prefix": "/retry-both"
+                "prefix": "/retry-all"
               },
               "route": {
-                "cluster": "retry-both.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "cluster": "retry-all.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
                 "retryPolicy": {
-                  "retryOn": "connect-failure,retriable-status-codes",
+                  "retryOn": "connect-failure,reset,retriable-status-codes",
                   "retriableStatusCodes": [
                     401,
                     409,


### PR DESCRIPTION
### Description
This adds a `RetryOnReset` option to `service-router` configs. 

My apps are getting an error intermittently when using consul connect: `upstream connect error or disconnect/reset before headers. reset reason: connection termination`. Envoy has an option to automatically retry in case of this kind of error. Consul does support does not support this option at the moment so I'm implementing it here.

### Testing & Reproduction steps
Create a `service-router` with the `RetryOnReset` option like below:

```json
{
    "Kind": "service-router",
    "Name": "test",
    "Routes": [
        {
            "Match": {
                "HTTP": {
                    "PathPrefix": "/"
                }
            },
            "Destination": {
                "NumRetries": 3,
                "RetryOnReset": true,
                "Service": "test"
            }
        }
    ]
}

```

### Links
Issue #10274 

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
* [x] checklist [folder](./../docs/config) consulted
