### PR TITLE
ui: [Backport/1.12.x] Add documentation link to the Server Fault Tolerance panel (#12792)

### DIFF
--- a/ui/packages/consul-ui/app/styles/routes/dc/overview/serverstatus.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/overview/serverstatus.scss
@@ -28,10 +28,15 @@ section[data-route='dc.show.serverstatus'] {
 }
 %server-failure-tolerance > header {
   width: 100%;
-  padding-bottom: 0.500rem; /* 8px */
+  padding-bottom: 0.5rem; /* 8px */
   margin-bottom: 1rem; /* 16px */
   border-bottom: var(--decor-border-100);
   border-color: rgb(var(--tone-border));
+}
+%server-failure-tolerance > header a {
+  float: right;
+  margin-top: 4px;
+  font-weight: var(--typo-weight-semibold);
 }
 %server-failure-tolerance header em {
   @extend %pill-200;
@@ -40,7 +45,6 @@ section[data-route='dc.show.serverstatus'] {
 
   text-transform: uppercase;
   font-style: normal;
-
 }
 %server-failure-tolerance > section {
   width: 50%;
@@ -60,14 +64,14 @@ section[data-route='dc.show.serverstatus'] {
 }
 %server-failure-tolerance dl.warning dd::before {
   --icon-name: icon-alert-circle;
-  --icon-resolution: .5;
+  --icon-resolution: 0.5;
   --icon-size: icon-800;
   --icon-color: rgb(var(--tone-orange-400));
   content: '';
-  margin-right: 0.500rem; /* 8px */
+  margin-right: 0.5rem; /* 8px */
 }
 %server-failure-tolerance section:first-of-type dl {
-  padding-right: 1.500rem; /* 24px */
+  padding-right: 1.5rem; /* 24px */
 }
 %server-failure-tolerance dt {
   @extend %p2;
@@ -93,7 +97,6 @@ section[data-route='dc.show.serverstatus'] {
   margin-top: 18px;
   margin-bottom: 18px;
 }
-
 
 %redundancy-zones h3 {
   @extend %h300;
@@ -132,4 +135,3 @@ section[data-route='dc.show.serverstatus'] {
   vertical-align: revert;
   background-color: var(--transparent);
 }
-

--- a/ui/packages/consul-ui/app/templates/dc/show/serverstatus.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/show/serverstatus.hbs
@@ -87,6 +87,9 @@ as |item|}}
           >
 
             <header>
+              {{compute (fn route.t 'tolerance.link' (hash
+                htmlSafe=true
+              ))}}
               <h2>
                 {{compute (fn route.t 'tolerance.header')}}
               </h2>

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -42,7 +42,7 @@ dc:
               </a>
             </li>
             <li>
-              <a href="{CONSUL_DOCS_URL}/docs/enterprise/license/faq#q-how-can-i-renew-a-license" target="_blank" rel="noopener noreferrer">
+              <a href="{CONSUL_DOCS_URL}/enterprise/license/faq#q-how-can-i-renew-a-license" target="_blank" rel="noopener noreferrer">
                 Renewing a license
               </a>
             </li>

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -6,7 +6,7 @@ dc:
       unassigned: Unassigned Zones
       tolerance:
         link: |
-          <a href="{CONSUL_DOCS_URL}/architecture/consensus" target="_blank" rel="noopener noreferrer">Learn how to improve fault tolerance</a>
+          <a href="{CONSUL_DOCS_URL}/architecture/improving-consul-resilience#strategies-to-increase-fault-tolerance" target="_blank" rel="noopener noreferrer">Learn how to improve fault tolerance</a>
         header: Server fault tolerance
         immediate:
           header: Immediate

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -5,6 +5,8 @@ dc:
       title: Server status
       unassigned: Unassigned Zones
       tolerance:
+        link: |
+          <a href="{CONSUL_DOCS_URL}/architecture/consensus" target="_blank" rel="noopener noreferrer">Learn more</a>
         header: Server fault tolerance
         immediate:
           header: Immediate
@@ -35,17 +37,17 @@ dc:
         body: |
           <ul>
             <li>
-              <a href="{CONSUL_DOCS_URL}/enterprise/license/faq#q-is-there-a-grace-period-when-licenses-expire">
+              <a href="{CONSUL_DOCS_URL}/enterprise/license/faq#q-is-there-a-grace-period-when-licenses-expire" target="_blank" rel="noopener noreferrer">
                 License expiration
               </a>
             </li>
             <li>
-              <a href="{CONSUL_DOCS_URL}/enterprise/license/faq#q-how-can-i-renew-a-license" target="_blank" rel="noopener noreferrer">
+              <a href="{CONSUL_DOCS_URL}/docs/enterprise/license/faq#q-how-can-i-renew-a-license" target="_blank" rel="noopener noreferrer">
                 Renewing a license
               </a>
             </li>
             <li>
-              <a href="{CONSUL_DOCS_LEARN_URL}/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise">
+              <a href="{CONSUL_DOCS_LEARN_URL}/tutorials/nomad/hashicorp-enterprise-license?in=consul/enterprise" target="_blank" rel="noopener noreferrer">
                 Applying a new license
               </a>
             </li>

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -6,7 +6,7 @@ dc:
       unassigned: Unassigned Zones
       tolerance:
         link: |
-          <a href="{CONSUL_DOCS_URL}/architecture/consensus" target="_blank" rel="noopener noreferrer">Learn more</a>
+          <a href="{CONSUL_DOCS_URL}/architecture/consensus" target="_blank" rel="noopener noreferrer">Learn how to improve fault tolerance</a>
         header: Server fault tolerance
         immediate:
           header: Immediate


### PR DESCRIPTION
Backport of #12792

Adds a 'Learn more' link to the top of the Server Fault Tolerance panel. See original PR for more details.

no changelog due to base not being `main`