### PR TITLE
Docs: Show CLI command-specific options before general options

### DIFF
--- a/website/content/commands/acl/auth-method/create.mdx
+++ b/website/content/commands/acl/auth-method/create.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl auth-method create [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-description=<string>` - A description of the auth method.
@@ -71,6 +65,8 @@ Usage: `consul acl auth-method create [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
 - `-namespace-rule-bind-namespace=<value>` - Namespace to bind on match. Can
@@ -80,7 +76,11 @@ Usage: `consul acl auth-method create [options] [args]`
   verified identity attributes returned from the auth method during login to
   determine if the namespace rule applies. Added in Consul 1.8.0.
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 


### PR DESCRIPTION
## Context

A number of our CLI docs pages show the command-specific options below the list of general options that apply across many commands. (Example screenshot below from [keyring command](https://www.consul.io/commands/keyring#usage))

I see several advantages to moving command-specific options above the general ones:
- The unique behavior and use of the command is easier to understand. The explanation of what the command does is adjacent to its flags, rather than being separated by general stuff.
- In many cases, the general flags will by familiar (from using other commands) are already handled (such as by setting environment variables for the Consul address and token).

![image](https://user-images.githubusercontent.com/85913323/166080174-c416b7c4-3129-4c6c-9e10-80fc88e53479.png)

## Status

[Preview](https://consul-6qvyke6un-hashicorp.vercel.app/commands/acl/auth-method/create)

This PR currently shows the proposed change applied to a single file to get alignment on approach. If we agree that this is the right approach, I can work on extending it to the many other command pages. Aligning on a single command is important to avoid rework in many places later.

![image](https://user-images.githubusercontent.com/85913323/166080321-8938ac47-ce96-47a6-a913-508ae3dd9b79.png)
