### PR TITLE
Support vault namespaces in connect CA

### DIFF
--- a/.changelog/12904.txt
+++ b/.changelog/12904.txt
@@ -1,0 +1,4 @@
+```release-note:improvement
+Support Vault namespaces in Connect CA by adding RootPKINamespace and
+IntermediatePKINamespace fields to the config.
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -697,16 +697,18 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 			"intermediate_cert_ttl": "IntermediateCertTTL",
 
 			// Vault CA config
-			"address":               "Address",
-			"token":                 "Token",
-			"root_pki_path":         "RootPKIPath",
-			"intermediate_pki_path": "IntermediatePKIPath",
-			"ca_file":               "CAFile",
-			"ca_path":               "CAPath",
-			"cert_file":             "CertFile",
-			"key_file":              "KeyFile",
-			"tls_server_name":       "TLSServerName",
-			"tls_skip_verify":       "TLSSkipVerify",
+			"address":                    "Address",
+			"token":                      "Token",
+			"root_pki_path":              "RootPKIPath",
+			"root_pki_namespace":         "RootPKINamespace",
+			"intermediate_pki_path":      "IntermediatePKIPath",
+			"intermediate_pki_namespace": "IntermediatePKINamespace",
+			"ca_file":                    "CAFile",
+			"ca_path":                    "CAPath",
+			"cert_file":                  "CertFile",
+			"key_file":                   "KeyFile",
+			"tls_server_name":            "TLSServerName",
+			"tls_skip_verify":            "TLSSkipVerify",
 
 			// AWS CA config
 			"existing_arn":   "ExistingARN",

--- a/agent/connect/ca/provider.go
+++ b/agent/connect/ca/provider.go
@@ -94,7 +94,7 @@ type Provider interface {
 	// Sign signs a leaf certificate used by Connect proxies from a CSR. The PEM
 	// returned should include only the leaf certificate as all Intermediates
 	// needed to validate it will be added by Consul based on the active
-	// intemediate and any cross-signed intermediates managed by Consul. Note that
+	// intermediate and any cross-signed intermediates managed by Consul. Note that
 	// providers should return ErrRateLimited if they are unable to complete the
 	// operation due to upstream rate limiting so that clients can intelligently
 	// backoff.

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -54,8 +54,9 @@ var ErrBackendNotMounted = fmt.Errorf("backend not mounted")
 var ErrBackendNotInitialized = fmt.Errorf("backend not initialized")
 
 type VaultProvider struct {
-	config *structs.VaultCAProviderConfig
-	client *vaultapi.Client
+	config        *structs.VaultCAProviderConfig
+	client        *vaultapi.Client
+	baseNamespace string
 
 	stopWatcher func()
 
@@ -109,6 +110,7 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	// same.
 	if config.Namespace != "" {
 		client.SetNamespace(config.Namespace)
+		v.baseNamespace = config.Namespace
 	}
 
 	if config.AuthMethod != nil {
@@ -282,7 +284,7 @@ func (v *VaultProvider) GenerateRoot() (RootResult, error) {
 	}
 
 	// Set up the root PKI backend if necessary.
-	rootPEM, err := v.getCA(v.config.RootPKIPath)
+	rootPEM, err := v.getCA(v.config.RootPKINamespace, v.config.RootPKIPath)
 	switch err {
 	case ErrBackendNotMounted:
 
@@ -307,7 +309,7 @@ func (v *VaultProvider) GenerateRoot() (RootResult, error) {
 		if err != nil {
 			return RootResult{}, err
 		}
-		resp, err := v.client.Logical().Write(v.config.RootPKIPath+"root/generate/internal", map[string]interface{}{
+		resp, err := v.writeNamespaced(v.config.RootPKINamespace, v.config.RootPKIPath+"root/generate/internal", map[string]interface{}{
 			"common_name": connect.CACN("vault", uid, v.clusterID, v.isPrimary),
 			"uri_sans":    v.spiffeID.URI().String(),
 			"key_type":    v.config.PrivateKeyType,
@@ -328,7 +330,7 @@ func (v *VaultProvider) GenerateRoot() (RootResult, error) {
 		}
 	}
 
-	rootChain, err := v.getCAChain(v.config.RootPKIPath)
+	rootChain, err := v.getCAChain(v.config.RootPKINamespace, v.config.RootPKIPath)
 	if err != nil {
 		return RootResult{}, err
 	}
@@ -359,7 +361,7 @@ func (v *VaultProvider) setupIntermediatePKIPath() error {
 		return nil
 	}
 
-	_, err := v.getCA(v.config.IntermediatePKIPath)
+	_, err := v.getCA(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath)
 	if err != nil {
 		if err == ErrBackendNotMounted {
 			err := v.mountNamespaced(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath, &vaultapi.MountInput{
@@ -379,13 +381,13 @@ func (v *VaultProvider) setupIntermediatePKIPath() error {
 
 	// Create the role for issuing leaf certs if it doesn't exist yet
 	rolePath := v.config.IntermediatePKIPath + "roles/" + VaultCALeafCertRole
-	role, err := v.client.Logical().Read(rolePath)
+	role, err := v.readNamespaced(v.config.IntermediatePKINamespace, rolePath)
 
 	if err != nil {
 		return err
 	}
 	if role == nil {
-		_, err := v.client.Logical().Write(rolePath, map[string]interface{}{
+		_, err := v.writeNamespaced(v.config.IntermediatePKINamespace, rolePath, map[string]interface{}{
 			"allow_any_name":   true,
 			"allowed_uri_sans": "spiffe://*",
 			"key_type":         "any",
@@ -413,7 +415,7 @@ func (v *VaultProvider) generateIntermediateCSR() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	data, err := v.client.Logical().Write(v.config.IntermediatePKIPath+"intermediate/generate/internal", map[string]interface{}{
+	data, err := v.writeNamespaced(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath+"intermediate/generate/internal", map[string]interface{}{
 		"common_name": connect.CACN("vault", uid, v.clusterID, v.isPrimary),
 		"key_type":    v.config.PrivateKeyType,
 		"key_bits":    v.config.PrivateKeyBits,
@@ -445,7 +447,7 @@ func (v *VaultProvider) SetIntermediate(intermediatePEM, rootPEM string) error {
 		return err
 	}
 
-	_, err = v.client.Logical().Write(v.config.IntermediatePKIPath+"intermediate/set-signed", map[string]interface{}{
+	_, err = v.writeNamespaced(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath+"intermediate/set-signed", map[string]interface{}{
 		"certificate": intermediatePEM,
 	})
 	if err != nil {
@@ -461,7 +463,7 @@ func (v *VaultProvider) ActiveIntermediate() (string, error) {
 		return "", err
 	}
 
-	cert, err := v.getCA(v.config.IntermediatePKIPath)
+	cert, err := v.getCA(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath)
 
 	// This error is expected when calling initializeSecondaryCA for the
 	// first time. It means that the backend is mounted and ready, but
@@ -479,7 +481,11 @@ func (v *VaultProvider) ActiveIntermediate() (string, error) {
 // We have to use the raw NewRequest call here instead of Logical().Read
 // because the endpoint only returns the raw PEM contents of the CA cert
 // and not the typical format of the secrets endpoints.
-func (v *VaultProvider) getCA(path string) (string, error) {
+func (v *VaultProvider) getCA(namespace, path string) (string, error) {
+	defer v.client.SetNamespace(v.baseNamespace)
+	if namespace != "" {
+		v.client.SetNamespace(namespace)
+	}
 	req := v.client.NewRequest("GET", "/v1/"+path+"/ca/pem")
 	resp, err := v.client.RawRequest(req)
 	if resp != nil {
@@ -506,7 +512,12 @@ func (v *VaultProvider) getCA(path string) (string, error) {
 }
 
 // TODO: refactor to remove duplication with getCA
-func (v *VaultProvider) getCAChain(path string) (string, error) {
+func (v *VaultProvider) getCAChain(namespace, path string) (string, error) {
+	defer v.client.SetNamespace(v.baseNamespace)
+	if namespace != "" {
+		v.client.SetNamespace(namespace)
+	}
+
 	req := v.client.NewRequest("GET", "/v1/"+path+"/ca_chain")
 	resp, err := v.client.RawRequest(req)
 	if resp != nil {
@@ -538,7 +549,7 @@ func (v *VaultProvider) GenerateIntermediate() (string, error) {
 	}
 
 	// Sign the CSR with the root backend.
-	intermediate, err := v.client.Logical().Write(v.config.RootPKIPath+"root/sign-intermediate", map[string]interface{}{
+	intermediate, err := v.writeNamespaced(v.config.RootPKINamespace, v.config.RootPKIPath+"root/sign-intermediate", map[string]interface{}{
 		"csr":            csr,
 		"use_csr_values": true,
 		"format":         "pem_bundle",
@@ -552,7 +563,7 @@ func (v *VaultProvider) GenerateIntermediate() (string, error) {
 	}
 
 	// Set the intermediate backend to use the new certificate.
-	_, err = v.client.Logical().Write(v.config.IntermediatePKIPath+"intermediate/set-signed", map[string]interface{}{
+	_, err = v.writeNamespaced(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath+"intermediate/set-signed", map[string]interface{}{
 		"certificate": intermediate.Data["certificate"],
 	})
 	if err != nil {
@@ -574,7 +585,7 @@ func (v *VaultProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 	}
 
 	// Use the leaf cert role to sign a new cert for this CSR.
-	response, err := v.client.Logical().Write(v.config.IntermediatePKIPath+"sign/"+VaultCALeafCertRole, map[string]interface{}{
+	response, err := v.writeNamespaced(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath+"sign/"+VaultCALeafCertRole, map[string]interface{}{
 		"csr": pemBuf.String(),
 		"ttl": v.config.LeafCertTTL.String(),
 	})
@@ -607,7 +618,7 @@ func (v *VaultProvider) SignIntermediate(csr *x509.CertificateRequest) (string, 
 	}
 
 	// Sign the CSR with the root backend.
-	data, err := v.client.Logical().Write(v.config.RootPKIPath+"root/sign-intermediate", map[string]interface{}{
+	data, err := v.writeNamespaced(v.config.RootPKINamespace, v.config.RootPKIPath+"root/sign-intermediate", map[string]interface{}{
 		"csr":             pemBuf.String(),
 		"use_csr_values":  true,
 		"format":          "pem_bundle",
@@ -632,7 +643,7 @@ func (v *VaultProvider) SignIntermediate(csr *x509.CertificateRequest) (string, 
 // CrossSignCA takes a CA certificate and cross-signs it to form a trust chain
 // back to our active root.
 func (v *VaultProvider) CrossSignCA(cert *x509.Certificate) (string, error) {
-	rootPEM, err := v.getCA(v.config.RootPKIPath)
+	rootPEM, err := v.getCA(v.config.RootPKINamespace, v.config.RootPKIPath)
 	if err != nil {
 		return "", err
 	}
@@ -651,7 +662,7 @@ func (v *VaultProvider) CrossSignCA(cert *x509.Certificate) (string, error) {
 	}
 
 	// Have the root PKI backend sign this cert.
-	response, err := v.client.Logical().Write(v.config.RootPKIPath+"root/sign-self-issued", map[string]interface{}{
+	response, err := v.writeNamespaced(v.config.RootPKINamespace, v.config.RootPKIPath+"root/sign-self-issued", map[string]interface{}{
 		"certificate": pemBuf.String(),
 	})
 	if err != nil {
@@ -713,9 +724,12 @@ func (v *VaultProvider) PrimaryUsesIntermediate() {}
 
 // We use raw path here
 func (v *VaultProvider) mountNamespaced(namespace, path string, mountInfo *vaultapi.MountInput) error {
-	fullPath := makePathHelper(namespace, path)
+	defer v.client.SetNamespace(v.baseNamespace)
+	if namespace != "" {
+		v.client.SetNamespace(namespace)
+	}
 
-	r := v.client.NewRequest("POST", fullPath)
+	r := v.client.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s", path))
 	if err := r.SetJSONBody(mountInfo); err != nil {
 		return err
 	}
@@ -727,9 +741,12 @@ func (v *VaultProvider) mountNamespaced(namespace, path string, mountInfo *vault
 }
 
 func (v *VaultProvider) unmountNamespaced(namespace, path string) error {
-	fullPath := makePathHelper(namespace, path)
+	defer v.client.SetNamespace(v.baseNamespace)
+	if namespace != "" {
+		v.client.SetNamespace(namespace)
+	}
 
-	r := v.client.NewRequest("DELETE", fullPath)
+	r := v.client.NewRequest("DELETE", fmt.Sprintf("/v1/sys/mounts/%s", path))
 	resp, err := v.client.RawRequest(r)
 	if resp != nil {
 		defer resp.Body.Close()
@@ -745,6 +762,24 @@ func makePathHelper(namespace, path string) string {
 		fullPath = fmt.Sprintf("/v1/sys/mounts/%s", path)
 	}
 	return fullPath
+}
+
+func (v *VaultProvider) readNamespaced(namespace string, resource string) (*vaultapi.Secret, error) {
+	defer v.client.SetNamespace(v.baseNamespace)
+	if namespace != "" {
+		v.client.SetNamespace(namespace)
+	}
+	result, err := v.client.Logical().Read(resource)
+	return result, err
+}
+
+func (v *VaultProvider) writeNamespaced(namespace string, resource string, data map[string]interface{}) (*vaultapi.Secret, error) {
+	defer v.client.SetNamespace(v.baseNamespace)
+	if namespace != "" {
+		v.client.SetNamespace(namespace)
+	}
+	result, err := v.client.Logical().Write(resource, data)
+	return result, err
 }
 
 func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderConfig, error) {

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -517,11 +517,13 @@ type CAConsulProviderState struct {
 type VaultCAProviderConfig struct {
 	CommonCAProviderConfig `mapstructure:",squash"`
 
-	Address             string
-	Token               string
-	RootPKIPath         string
-	IntermediatePKIPath string
-	Namespace           string
+	Address                  string
+	Token                    string
+	RootPKIPath              string
+	RootPKINamespace         string
+	IntermediatePKIPath      string
+	IntermediatePKINamespace string
+	Namespace                string
 
 	CAFile        string
 	CAPath        string

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -137,7 +137,7 @@ The configuration options are listed below.
   that authorized it.
 
 - `RootPKINamespace` / `root_pki_namespace` (`string: <optional>`) - The absolute namespace
-  that the RootPKIPath is in.
+  that the RootPKIPath is in. Setting this overrides the Namespace option for the RootPKIPath. Introduced in 1.12.1
 
 - `IntermediatePKIPath` / `intermediate_pki_path` (`string: <required>`) -
   The path to a PKI secrets engine for the generated intermediate certificate.
@@ -149,7 +149,7 @@ The configuration options are listed below.
   datacenter must specify a unique `intermediate_pki_path`.
 
 - `IntermediatePKINamespace` / `intermedial_pki_namespace` (`string: <optional>`) - The absolute namespace
-  that the IntermediatePKIPath is in.
+  that the IntermediatePKIPath is in. Setting this overrides the Namespace option for the IntermediatePKIPath. Introduced in 1.12.1
 
 - `CAFile` / `ca_file` (`string: ""`) - Specifies an optional path to the CA
   certificate used for Vault communication. If unspecified, this will fallback

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -136,6 +136,9 @@ The configuration options are listed below.
   must contain a valid chain, where each certificate is followed by the certificate
   that authorized it.
 
+- `RootPKINamespace` / `root_pki_namespace` (`string: <optional>`) - The absolute namespace
+  that the RootPKIPath is in.
+
 - `IntermediatePKIPath` / `intermediate_pki_path` (`string: <required>`) -
   The path to a PKI secrets engine for the generated intermediate certificate.
   This certificate will be signed by the configured root PKI path. If this
@@ -144,6 +147,9 @@ The configuration options are listed below.
 
   When WAN Federation is enabled, every secondary
   datacenter must specify a unique `intermediate_pki_path`.
+
+- `IntermediatePKINamespace` / `intermedial_pki_namespace` (`string: <optional>`) - The absolute namespace
+  that the IntermediatePKIPath is in.
 
 - `CAFile` / `ca_file` (`string: ""`) - Specifies an optional path to the CA
   certificate used for Vault communication. If unspecified, this will fallback

--- a/website/content/docs/connect/ca/vault.mdx
+++ b/website/content/docs/connect/ca/vault.mdx
@@ -137,7 +137,7 @@ The configuration options are listed below.
   that authorized it.
 
 - `RootPKINamespace` / `root_pki_namespace` (`string: <optional>`) - The absolute namespace
-  that the RootPKIPath is in. Setting this overrides the Namespace option for the RootPKIPath. Introduced in 1.12.1
+  that the `RootPKIPath` is in. Setting this overrides the `Namespace` option for the `RootPKIPath`. Introduced in 1.12.1
 
 - `IntermediatePKIPath` / `intermediate_pki_path` (`string: <required>`) -
   The path to a PKI secrets engine for the generated intermediate certificate.
@@ -149,7 +149,7 @@ The configuration options are listed below.
   datacenter must specify a unique `intermediate_pki_path`.
 
 - `IntermediatePKINamespace` / `intermedial_pki_namespace` (`string: <optional>`) - The absolute namespace
-  that the IntermediatePKIPath is in. Setting this overrides the Namespace option for the IntermediatePKIPath. Introduced in 1.12.1
+  that the `IntermediatePKIPath` is in. Setting this overrides the `Namespace` option for the `IntermediatePKIPath`. Introduced in 1.12.1
 
 - `CAFile` / `ca_file` (`string: ""`) - Specifies an optional path to the CA
   certificate used for Vault communication. If unspecified, this will fallback


### PR DESCRIPTION
Follow on to some missed items from #12655

### Description

From an internal ticket "Support standard "Vault namespace in the
path" semantics for Connect Vault CA Provider"

Vault allows the namespace to be specified as a prefix in the path of
a PKI definition, but our usage of the Vault API includes calls that
don't support a namespaced key. In particular the sys.* family of
calls simply appends the key, instead of prefixing the namespace in
front of the path.

Unfortunately it is difficult to reliably parse a path with a
namespace; only vault knows what namespaces are present, and the '/'
separator can be inside a key name, as well as separating path
elements. This is in use in the wild; for example
'dc1/intermediate-key' is a relatively common naming schema.

Instead we add two new fields: RootPKINamespace and
IntermediatePKINamespace, which are the absolute namespace paths
'prefixed' in front of the respective PKI Paths.

### Testing & Reproduction steps
[ ] manual testing

### Links
[Asana task](https://go.hashi.co/ui/edit/consul-vault-namespace)

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
* [x] checklist [folder](./../docs/config) consulted


Signed-off-by: Mark Anderson <manderson@hashicorp.com>
