### PR TITLE
Middlware: `RequestRecorder` reports calls bellow 1ms as decimal value

### DIFF
--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -133,7 +133,7 @@ func assertMetricExistsWithValue(t *testing.T, respRec *httptest.ResponseRecorde
 	}
 }
 
-func assertMetricsWithLabelHasValueDifferentFrom(t *testing.T, respRec *httptest.ResponseRecorder, label, labelValue string, value string) {
+func assertMetricsWithLabelHaveValueDifferentFrom(t *testing.T, respRec *httptest.ResponseRecorder, label, labelValue string, value string) {
 	if respRec.Body.String() == "" {
 		t.Fatalf("Response body is empty.")
 	}
@@ -149,11 +149,10 @@ func assertMetricsWithLabelHasValueDifferentFrom(t *testing.T, respRec *httptest
 		if strings.Contains(line, labelWithValueTarget) {
 			s := strings.SplitN(line, " ", 2)
 			if s[1] == value {
-				t.Fatal("Should have not been zero")
+				t.Fatalf("Metric with label provided \"%s:%s\" has the same outcome as the provided value `%s`", label, labelValue, value)
 			}
 		}
 	}
-
 }
 
 func assertMetricNotExists(t *testing.T, respRec *httptest.ResponseRecorder, metric string) {
@@ -444,7 +443,7 @@ func TestHTTPHandlers_AgentMetrics_CACertExpiry_Prometheus(t *testing.T) {
 
 }
 
-func TestNotSureAboutTheName(t *testing.T) {
+func TestMetricsOutput(t *testing.T) {
 	skipIfShortTesting(t)
 
 	t.Run("RPC calls with elapsed time below 1ms are reported as decimal", func(t *testing.T) {
@@ -468,6 +467,6 @@ func TestNotSureAboutTheName(t *testing.T) {
 		respRec := httptest.NewRecorder()
 		recordPromMetrics(t, a, respRec)
 
-		assertMetricsWithLabelHasValueDifferentFrom(t, respRec, "method", "Status.Ping", "0")
+		assertMetricsWithLabelHaveValueDifferentFrom(t, respRec, "method", "Status.Ping", "0")
 	})
 }

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -148,8 +148,8 @@ func assertMetricsWithLabelHasValueDifferentFrom(t *testing.T, respRec *httptest
 
 		if strings.Contains(line, labelWithValueTarget) {
 			s := strings.SplitN(line, " ", 2)
-			if s[1] != value {
-				t.Fatal("Should have not been a zero")
+			if s[1] == value {
+				t.Fatal("Should have not been zero")
 			}
 		}
 	}

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -44,7 +44,7 @@ func assertMetricExists(t *testing.T, respRec *httptest.ResponseRecorder, metric
 	}
 }
 
-// assertMetricExistsWithLabels looks in the prometheus metrics reponse for the metric name and all the labels. eg:
+// assertMetricExistsWithLabels looks in the prometheus metrics response for the metric name and all the labels. eg:
 // new_rpc_metrics_rpc_server_call{errored="false",method="Status.Ping",request_type="unknown",rpc_type="net/rpc"}
 func assertMetricExistsWithLabels(t *testing.T, respRec *httptest.ResponseRecorder, metric string, labelNames []string) {
 	if respRec.Body.String() == "" {
@@ -197,11 +197,13 @@ func TestAgent_OneTwelveRPCMetrics(t *testing.T) {
 
 		respRec := httptest.NewRecorder()
 		recordPromMetrics(t, a, respRec)
+		fmt.Printf("AAAAAA\n%+v\nAAAAAA", respRec)
 
 		// make sure the labels exist for this metric
 		assertMetricExistsWithLabels(t, respRec, metricsPrefix+"_rpc_server_call", []string{"errored", "method", "request_type", "rpc_type", "leader"})
 		// make sure we see 3 Status.Ping metrics corresponding to the calls we made above
 		assertLabelWithValueForMetricExistsNTime(t, respRec, metricsPrefix+"_rpc_server_call", "method", "Status.Ping", 3)
+		t.Fatal("asdasd")
 	})
 }
 

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -48,8 +49,16 @@ func NewRequestRecorder(logger hclog.Logger, isLeader func() bool, localDC strin
 	}
 }
 
+//func roundTo(n float64, decimals uint32) float64 {
+//	return math.Round(n*math.Pow(10, float64(decimals))) / math.Pow(10, float64(decimals))
+//}
+
 func (r *RequestRecorder) Record(requestName string, rpcType string, start time.Time, request interface{}, respErrored bool) {
-	elapsed := time.Since(start).Milliseconds()
+	elapsedDuration := time.Since(start)
+	elapsed := float64(elapsedDuration.Milliseconds())
+	if elapsed == 0 {
+		elapsed = math.Round(float64(elapsedDuration.Microseconds())) / math.Pow(10, 3)
+	}
 	reqType := requestType(request)
 	isLeader := r.getServerLeadership()
 

--- a/agent/rpc/middleware/interceptors.go
+++ b/agent/rpc/middleware/interceptors.go
@@ -49,15 +49,11 @@ func NewRequestRecorder(logger hclog.Logger, isLeader func() bool, localDC strin
 	}
 }
 
-//func roundTo(n float64, decimals uint32) float64 {
-//	return math.Round(n*math.Pow(10, float64(decimals))) / math.Pow(10, float64(decimals))
-//}
-
 func (r *RequestRecorder) Record(requestName string, rpcType string, start time.Time, request interface{}, respErrored bool) {
-	elapsedDuration := time.Since(start)
-	elapsed := float64(elapsedDuration.Milliseconds())
+	elapsedNs := time.Since(start)
+	elapsed := float64(elapsedNs.Milliseconds())
 	if elapsed == 0 {
-		elapsed = math.Round(float64(elapsedDuration.Microseconds())) / math.Pow(10, 3)
+		elapsed = math.Round(float64(elapsedNs.Microseconds())) / math.Pow(10, 3)
 	}
 	reqType := requestType(request)
 	isLeader := r.getServerLeadership()

--- a/docs/rpc/README.md
+++ b/docs/rpc/README.md
@@ -1,8 +1,8 @@
 # RPC
 
-This section is a work in progress.
 
-The RPC subsystem is exclusicely in Server Agents. It is comprised of two main components:
+
+The RPC subsystem is exclusively in Server Agents. It is comprised of two main components:
 
 1. the "RPC Server" (for lack of a better term) handles multiplexing of many different
    requests on a single TCP port.
@@ -19,7 +19,7 @@ The RPC subsystems handles requests from:
 ## Routing
 
 The "RPC Server" accepts requests to the [server port] and routes the requests based on
-configuration of the Server and the the first byte in the request. The diagram below shows
+configuration of the Server and the first byte in the request. The diagram below shows
 all the possible routing flows.
 
 [server port]: https://www.consul.io/docs/agent/config/config-files#server_rpc_port

--- a/docs/rpc/README.md
+++ b/docs/rpc/README.md
@@ -1,6 +1,6 @@
 # RPC
 
-
+This section is a work in progress.
 
 The RPC subsystem is exclusively in Server Agents. It is comprised of two main components:
 

--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -531,8 +531,6 @@ Label based RPC metrics were added in Consul 1.12.0 as a Beta feature to better 
 | ------------------------------------- | --------------------------------------------------------- | ------ | --------- |
 | `consul.rpc.server.call`              | Measures the elapsed time taken to complete an RPC call.  | ms     | summary   |
 
-Note that values of the `consul.rpc.server.call` may emit as `0 ms`. That means that the elapsed time < `1 ms`.
-
 ### Labels
 
 The the server workload metrics above come with the following labels:


### PR DESCRIPTION
### Description
`RequestRecorder` records service RPC calls as a decimal number when when are `<1ms`.
#12813 

### Testing & Reproduction steps
* Test created

A test has been created, however, I am not sure about the test name and arrange/preparation steps.
Also, with the changes the value is supposed to have 3 decimal digits, however it is returned as the following example: 
new_rpc_metrics_2_rpc_server_call{errored="false",leader="true",method="Status.Ping",request_type="read",rpc_type="net/rpc",quantile="0.5"} 0.08299999684095383
Do you have any idea why this is happening?

### PR Checklist

* [X] updated test coverage
* [X] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
