### PR TITLE
build: speed up linting by 1.5x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
       - run:
           name: lint
           command: &lintcmd |
-            golangci-lint run --build-tags="$GOTAGS" -v --concurrency 2
+            golangci-lint run --build-tags="$GOTAGS" -v
       - run:
           name: lint api
           working_directory: api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
         default: ""
     docker:
       - image: *GOLANG_IMAGE
-    resource_class: large
+    resource_class: xlarge
     environment:
       GOTAGS: "" # No tags for OSS but there are for enterprise
       GOARCH: "<<parameters.go-arch>>"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,3 +69,4 @@ linters-settings:
 
 run:
   timeout: 10m
+  concurrency: 4


### PR DESCRIPTION
### Description

Calling the `make lint` target with an empty `golangci-lint` cache takes about 1m. I noticed that in CI we had been upping the concurrency from the default to 2, so I doubled that, and made it the general default so it applied to the `make lint` target which now takes about 35s for me.
