### PR TITLE
ci: upgrade bats and the circle machine executors to get integration tests to function again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -851,7 +851,7 @@ jobs:
       
   envoy-integration-test-1_19_3: &ENVOY_TESTS
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202201-02
     parallelism: 4
     resource_class: medium
     environment:

--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,8 +1,6 @@
 FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
 
-# Both :1.5.0 and :latest tags are broken on CircleCI as of 2021-10-22 with an
-# inability to locate the bats binary.
-FROM docker.mirror.hashicorp.services/bats/bats:v1.4.1
+FROM docker.mirror.hashicorp.services/bats/bats:1.6.0
 
 RUN apk add curl
 RUN apk add openssl

--- a/test/integration/connect/envoy/Dockerfile-test-sds-server
+++ b/test/integration/connect/envoy/Dockerfile-test-sds-server
@@ -1,7 +1,7 @@
 FROM golang:latest
 
 WORKDIR /go/src
-COPY ./test-sds-server .
+COPY ./ .
 
 RUN go build -v -o test-sds-server sds.go
 

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -416,6 +416,13 @@ function suite_setup {
     echo "Rebuilding 'bats-verify' image..."
     docker build -t bats-verify -f Dockerfile-bats .
 
+    # if this fails on CircleCI your first thing to try would be to upgrade
+    # the machine image to the latest version using this listing:
+    #
+    # https://circleci.com/docs/2.0/configuration-reference/#available-linux-machine-images
+    echo "Checking bats image..."
+    docker run --rm -t bats-verify -v
+
     # pre-build the consul+envoy container
     echo "Rebuilding 'consul-dev-envoy:${ENVOY_VERSION}' image..."
     docker build -t consul-dev-envoy:${ENVOY_VERSION} \
@@ -424,7 +431,7 @@ function suite_setup {
 
     # pre-build the test-sds-server container
     echo "Rebuilding 'test-sds-server' image..."
-    docker build -t test-sds-server -f Dockerfile-test-sds-server .
+    docker build -t test-sds-server -f Dockerfile-test-sds-server test-sds-server
 }
 
 function suite_teardown {


### PR DESCRIPTION
Bonus change: send less context when building the test-sds-server to
speed up the setup.

### Description
None of the `test-integration` envoy tests were functioning. Bats would either fail with an error implying that the `bats` binary had vanished, or that `/tmp` was somehow not writable.
