### PR TITLE
[1.10.x] ci: upgrade bats and the circle machine executors to get integration tests to function again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -800,7 +800,7 @@ jobs:
 
   envoy-integration-test-1_15_5: &ENVOY_TESTS
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202201-02
     parallelism: 4
     resource_class: medium
     environment:

--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,8 +1,6 @@
 FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
 
-# Both :1.5.0 and :latest tags are broken on CircleCI as of 2021-10-22 with an
-# inability to locate the bats binary.
-FROM docker.mirror.hashicorp.services/bats/bats:v1.4.1
+FROM docker.mirror.hashicorp.services/bats/bats:1.6.0
 
 RUN apk add curl
 RUN apk add openssl

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -363,6 +363,13 @@ function suite_setup {
     echo "Rebuilding 'bats-verify' image..."
     docker build -t bats-verify -f Dockerfile-bats .
 
+    # if this fails on CircleCI your first thing to try would be to upgrade
+    # the machine image to the latest version using this listing:
+    #
+    # https://circleci.com/docs/2.0/configuration-reference/#available-linux-machine-images
+    echo "Checking bats image..."
+    docker run --rm -t bats-verify -v
+
     # pre-build the consul+envoy container
     echo "Rebuilding 'consul-dev-envoy:${ENVOY_VERSION}' image..."
     docker build -t consul-dev-envoy:${ENVOY_VERSION} \


### PR DESCRIPTION

Backport of #12918 to 1.10.x
