### PR TITLE
Add a default max number of retries when joining

### DIFF
--- a/.changelog/12923.txt
+++ b/.changelog/12923.txt
@@ -1,0 +1,4 @@
+```release-note:breaking-change
+agent: Cap the number of attempts when joining the LAN gossip pool at 10. Agents will no longer attempt to retry indefinitely.
+The previous default can be restored by setting the retry-max agent option.
+```

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -49,6 +49,7 @@ func DefaultSource() Source {
 		protocol = ` + strconv.Itoa(consul.DefaultRPCProtocol) + `
 		retry_interval = "30s"
 		retry_interval_wan = "30s"
+		retry_max = 10
 
 		# segment_limit is the maximum number of network segments that may be declared. Default 64 is highly encouraged
 		segment_limit = 64

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -130,7 +130,7 @@ type RuntimeConfig struct {
 	// AutopilotMinQuorum sets the minimum number of servers required in a cluster
 	// before autopilot can prune dead servers.
 	//
-	//hcl: autopilot { min_quorum = int }
+	// hcl: autopilot { min_quorum = int }
 	AutopilotMinQuorum uint
 
 	// AutopilotRedundancyZoneTag is the Meta tag to use for separating servers
@@ -987,7 +987,7 @@ type RuntimeConfig struct {
 
 	// RetryJoinMaxAttemptsLAN specifies the maximum number of times to retry
 	// joining a host on startup. This is useful for cases where we know the
-	// node will be online eventually.
+	// node will be online eventually. The default is 10.
 	//
 	// hcl: retry_max = int
 	// flag: -retry-max int
@@ -1304,7 +1304,7 @@ type RuntimeConfig struct {
 	SkipLeaveOnInt bool
 
 	// AutoReloadConfig indicate if the config will be
-	//auto reloaded bases on config file modification
+	// auto reloaded bases on config file modification
 	// hcl: auto_reload_config = (true|false)
 	AutoReloadConfig bool
 

--- a/website/content/docs/agent/config/cli-flags.mdx
+++ b/website/content/docs/agent/config/cli-flags.mdx
@@ -263,7 +263,7 @@ information.
   server. This option may be provided multiple times, and is functionally equivalent
   to the [`recursors` configuration option](#recursors).
 
-## Join Options 
+## Join Options
 
 - `-join` ((#\_join)) - Address of another agent to join upon starting up.
   This can be specified multiple times to specify multiple agents to join. If Consul
@@ -343,8 +343,8 @@ information.
   Defaults to 30s.
 
 - `-retry-max` ((#\_retry_max)) - The maximum number of [`-join`](#_join)
-  attempts to be made before exiting with return code 1. By default, this is set
-  to 0 which is interpreted as infinite retries.
+  attempts to be made before exiting with return code 1. As of Consul 1.13.0 the
+  default is 10. Previously this was set to 0 which is interpreted as infinite retries.
 
 - `-join-wan` ((#\_join_wan)) - Address of another wan agent to join upon
   starting up. This can be specified multiple times to specify multiple WAN agents


### PR DESCRIPTION
### Description
Preivously Consul agents would retry joining a LAN pool indefinitely.
This is problematic when certain errors are encountered while joining.
For example, if the target node is reachable but the push/pull process
fails then there could continously be expensive push/pulls that lead to
errors.

Given that agents typically join Consul servers, when this class of
error is encountered then there can be multiple client agents stuck in
an erroring loop needlessly consuming server resources.

With the default 30s retry-join interval, 10 attempts leads to roughly a
5 minute timeout before the agent shuts down.

### Testing & Reproduction steps
* Ran `consul agent -dev -retry-join 8.8.8.8 -retry-interval 1s`
* Agent shut down after 10 "Failed to join" errors.

### PR Checklist

* [ ] updated test coverage
  * No unit tests were updated, should there be one?
* [x] external facing docs updated
* [x] not a security concern
* [x] checklist [folder](./../docs/config) consulted
