### PR TITLE
chore(ci): fix backport-assistant for stable website

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           backport-assistant backport -merge-method=rebase
         env:
-          BACKPORT_LABEL_REGEXP: "type/docs-cherrypick"
+          BACKPORT_LABEL_REGEXP: "type/docs-(?P<target>cherrypick)"
           BACKPORT_TARGET_TEMPLATE: "stable-website"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Run Backport Assistant for release branches


### PR DESCRIPTION
### Description
`backport-assistant` still [failing](https://github.com/hashicorp/consul/runs/6277835550?check_suite_focus=true), this time because of missing `target`, even though we want a literal. 

### Testing & Reproduction steps
N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
