### PR TITLE
chore(ci): exempt backport PRs from changelog-checker

### DIFF
--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -12,8 +12,8 @@ on:
 jobs:
   # checks that a .changelog entry is present for a PR
   changelog-check:
-    # If there  a `pr/no-changelog` label we ignore this check
-    if: "!contains(github.event.pull_request.labels.*.name, 'pr/no-changelog')"
+    # If there  a `pr/no-changelog` label we ignore this check. Also, we ignore PRs created by the bot assigned to `backport-assistant`
+    if: "! ( contains(github.event.pull_request.labels.*.name, 'pr/no-changelog') || github.event.pull_request.user.login == 'hc-github-team-consul-core' )" 
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Description
Without further changes to `backport-assistant`, backport PRs will never contain the original `pr/no-changelog` label. This will cause GitHub checks on the PR to fail ([example](https://github.com/hashicorp/consul/pull/12926)), which will eventually also block auto-merging pull requests. Adding the `pr/no-changelog` label should be something that is handled on the front-end of the originating PR before merging. This PR exempts the bot PRs from the check. We can decide if upstream changes to `backport-assistant` are needed at a later point.

### Testing & Reproduction steps
N/A

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
