### PR TITLE
Default discovery chain when upstream targets a DestinationPeer

### DIFF
--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -374,6 +374,7 @@ func (s *handlerUpstreams) watchUpstreamTarget(ctx context.Context, snap *Config
 
 	ctx, cancel := context.WithCancel(ctx)
 	err := s.health.Notify(ctx, structs.ServiceSpecificRequest{
+		PeerName:   opts.upstreamID.Peer,
 		Datacenter: opts.datacenter,
 		QueryOptions: structs.QueryOptions{
 			Token:  s.token,


### PR DESCRIPTION
### Description
When initializing proxy configs, if an upstream has a DestinationPeer, skip the discovery chain compilation step and write a default one

### Testing & Reproduction steps
Added test coverage for peered upstreams
