### PR TITLE
Add Linked Endpoints to Terminating Gateway Config Entry

### DIFF
--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -344,6 +344,17 @@ func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 		  {
 			"Name": "api"
 		  }
+		],
+		"Endpoints": [
+			{
+				"Name":     "external",
+				"Address":  "api.google.com",
+				"Port":     443,
+				"CAFile":   "/etc/external/ca.pem",
+				"CertFile": "/etc/external/cert.pem",
+				"KeyFile":  "/etc/external/tls.key",
+				"SNI":      "mydomain"
+			}
 		]
 	}`))
 
@@ -365,7 +376,7 @@ func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 		require.Len(t, out.Entries, 1)
 
 		got := out.Entries[0].(*structs.TerminatingGatewayConfigEntry)
-		expect := []structs.LinkedService{
+		expectedServices := []structs.LinkedService{
 			{
 				Name:           "web",
 				CAFile:         "/etc/web/ca.crt",
@@ -378,7 +389,21 @@ func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 				EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
 			},
 		}
-		require.Equal(t, expect, got.Services)
+		require.Equal(t, expectedServices, got.Services)
+
+		expectedEndpoints := []structs.LinkedEndpoint{
+			{
+				Name:     "external",
+				Address:  "api.google.com",
+				Port:     443,
+				CAFile:   "/etc/external/ca.pem",
+				CertFile: "/etc/external/cert.pem",
+				KeyFile:  "/etc/external/tls.key",
+				SNI:      "mydomain",
+			},
+		}
+		require.Equal(t, expectedEndpoints, got.Endpoints)
+
 	}
 }
 

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -1400,6 +1400,42 @@ func TestStore_ReadDiscoveryChainConfigEntries_SubsetSplit(t *testing.T) {
 
 // TODO(rb): add ServiceIntentions tests
 
+func TestStore_ReadWriteTerminatingGateways(t *testing.T) {
+	s := testConfigStateStore(t)
+	ws := memdb.NewWatchSet()
+
+	gatewayName := "terminating"
+	expected := &structs.TerminatingGatewayConfigEntry{
+		Kind: structs.TerminatingGateway,
+		Name: gatewayName,
+		Services: []structs.LinkedService{
+			{
+				Name: "web",
+			},
+		},
+		Endpoints: []structs.LinkedEndpoint{
+			{
+				Name:    "external-one",
+				Address: "api.google.com",
+				Port:    443,
+			},
+			{
+				Name:    "external-two",
+				Address: "10.0.0.1",
+				Port:    80,
+			},
+		},
+	}
+	require.NoError(t, s.EnsureConfigEntry(0, expected))
+
+	_, entry, err := s.ConfigEntry(ws, structs.TerminatingGateway, gatewayName, nil)
+	require.NoError(t, err)
+
+	actual, ok := entry.(*structs.TerminatingGatewayConfigEntry)
+	require.True(t, ok)
+	require.Equal(t, actual, expected)
+}
+
 func TestStore_ValidateGatewayNamesCannotBeShared(t *testing.T) {
 	s := testConfigStateStore(t)
 

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1347,6 +1347,17 @@ func TestDecodeConfigEntry(t *testing.T) {
 						sni = "my-alt-domain",
 					},
 				]
+				endpoints = [
+					{
+						name = "external",
+						address = "api.google.com",
+						port = 443,
+						ca_file = "/etc/external/ca.pem",
+						cert_file = "/etc/external/cert.pem",
+						key_file = "/etc/external/tls.key",
+						sni = "my-domain",
+					},
+				]
 			`,
 			camel: `
 				Kind = "terminating-gateway"
@@ -1371,6 +1382,17 @@ func TestDecodeConfigEntry(t *testing.T) {
 						SNI = "my-alt-domain",
 					},
 				]
+				Endpoints = [
+					{
+						Name = "external",
+						Address = "api.google.com",
+						Port = 443,
+						CAFile = "/etc/external/ca.pem",
+						CertFile = "/etc/external/cert.pem",
+						KeyFile = "/etc/external/tls.key",
+						SNI = "my-domain",
+					},
+				]
 			`,
 			expect: &TerminatingGatewayConfigEntry{
 				Kind: "terminating-gateway",
@@ -1393,6 +1415,17 @@ func TestDecodeConfigEntry(t *testing.T) {
 						CertFile: "/etc/all/cert.pem",
 						KeyFile:  "/etc/all/tls.key",
 						SNI:      "my-alt-domain",
+					},
+				},
+				Endpoints: []LinkedEndpoint{
+					{
+						Name:     "external",
+						Address:  "api.google.com",
+						Port:     443,
+						CAFile:   "/etc/external/ca.pem",
+						CertFile: "/etc/external/cert.pem",
+						KeyFile:  "/etc/external/tls.key",
+						SNI:      "my-domain",
 					},
 				},
 			},

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -147,6 +147,9 @@ type TerminatingGatewayConfigEntry struct {
 	// Services is a list of service names represented by the terminating gateway.
 	Services []LinkedService `json:",omitempty"`
 
+	// Endpoints is a list of external endpoints that are accessible through this gateway.
+	Endpoints []LinkedEndpoint `json:",omitempty"`
+
 	Meta map[string]string `json:",omitempty"`
 
 	// CreateIndex is the Raft index this entry was created at. This is a
@@ -187,6 +190,36 @@ type LinkedService struct {
 
 	// KeyFile is the optional path to a private key to use for TLS connections
 	// from the gateway to the linked service.
+	KeyFile string `json:",omitempty" alias:"key_file"`
+
+	// SNI is the optional name to specify during the TLS handshake with a linked service.
+	SNI string `json:",omitempty"`
+}
+
+// A LinkedEndpoint is a service represented by a terminating gateway
+type LinkedEndpoint struct {
+	// Name is the name of the endpoint
+	Name string `json:",omitempty"`
+
+	// Address of the endpoint
+	Address string `json:",omitempty"`
+
+	// Port allowed within this endpoint
+	Port int `json:",omitempty"`
+
+	// Protocol that this endpoint enforce
+	Protocol string `json:",omitempty"`
+
+	// CAFile is the optional path to a CA certificate to use for TLS connections
+	// from the gateway to the linked service
+	CAFile string `json:",omitempty" alias:"ca_file"`
+
+	// CertFile is the optional path to a client certificate to use for TLS    connections
+	// from the gateway to the linked service
+	CertFile string `json:",omitempty" alias:"cert_file"`
+
+	// KeyFile is the optional path to a private key to use for TLS connections
+	// from the gateway to the linked service
 	KeyFile string `json:",omitempty" alias:"key_file"`
 
 	// SNI is the optional name to specify during the TLS handshake with a linked service.


### PR DESCRIPTION
### Description
As part of the work to facilitate transparent proxying through Terminating Gateways, this PR adds "Endpoints" to the Terminating Gateway Config Entry, which explicitly enables external endpoints for the mesh without adding services to the Consul catalog.

### Testing & Reproduction steps
Test cases included. You can always `consul config write` a gateway with the new `endpoints` field.

### Links
PRD
RFC

### PR Checklist

* [x] updated test coverage
* [ ] !external facing docs updated!
* [x] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
