### PR TITLE
Fix broken links for roles and service identities

### DIFF
--- a/website/content/docs/security/acl/auth-methods/index.mdx
+++ b/website/content/docs/security/acl/auth-methods/index.mdx
@@ -69,8 +69,8 @@ token replication enabled.
 ## Binding Rules
 
 Binding rules allow an operator to express a systematic way of automatically
-linking [roles](/docs/security/acl/acl-system#acl-roles) and [service
-identities](/docs/security/acl/acl-system#acl-service-identities) to newly created
+linking [roles](/docs/security/acl/acl-roles) and [service
+identities](/docs/security/acl/acl-roles#service-identities) to newly created
 tokens without operator intervention.
 
 Successful authentication with an auth method returns a set of trusted
@@ -88,8 +88,8 @@ Each binding rule is composed of two portions:
   `"serviceaccount.namespace==default and serviceaccount.name!=vault"`
 
 - **Bind Type and Name** - A binding rule can bind a token to a
-  [role](/docs/security/acl/acl-system#acl-roles) or to a [service
-  identity](/docs/security/acl/acl-system#acl-service-identities) by name. The name
+  [role](/docs/security/acl/acl-roles) or to a [service
+  identity](/docs/security/acl/acl-roles#service-identities) by name. The name
   can be specified with a plain string or the bind name can be lightly
   templated using [HIL syntax](https://github.com/hashicorp/hil) to interpolate
   the same values that are usable by the `Selector` syntax. For example:


### PR DESCRIPTION
### Description
Fix broken links on `acl/auth-methods` page for roles and service identities

### Testing & Reproduction steps
N/A

### Links
N/A

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
