### PR TITLE
Ma/fix enterprise version string oss

### DIFF
--- a/.changelog/12961.txt
+++ b/.changelog/12961.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: agent/self now returns version with +ent suffix for Enterprise Consul
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -720,7 +720,7 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	// consul version metric with labels
 	metrics.SetGaugeWithLabels([]string{"version"}, 1, []metrics.Label{
-		{Name: "version", Value: a.config.Version},
+		{Name: "version", Value: a.config.VersionWithMetadata()},
 		{Name: "pre_release", Value: a.config.VersionPrerelease},
 	})
 
@@ -1272,7 +1272,7 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	if len(revision) > 8 {
 		revision = revision[:8]
 	}
-	cfg.Build = fmt.Sprintf("%s%s:%s", runtimeCfg.Version, runtimeCfg.VersionPrerelease, revision)
+	cfg.Build = fmt.Sprintf("%s%s:%s", runtimeCfg.VersionWithMetadata(), runtimeCfg.VersionPrerelease, revision)
 
 	cfg.TLSConfig = runtimeCfg.TLS
 
@@ -3212,9 +3212,10 @@ func (a *Agent) Stats() map[string]map[string]string {
 		revision = revision[:8]
 	}
 	stats["build"] = map[string]string{
-		"revision":   revision,
-		"version":    a.config.Version,
-		"prerelease": a.config.VersionPrerelease,
+		"revision":         revision,
+		"version":          a.config.Version,
+		"version_metadata": a.config.VersionMetadata,
+		"prerelease":       a.config.VersionPrerelease,
 	}
 
 	for outerKey, outerValue := range a.enterpriseStats() {

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -99,7 +99,8 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 		Partition:         s.agent.config.PartitionOrEmpty(),
 		Revision:          s.agent.config.Revision,
 		Server:            s.agent.config.ServerMode,
-		Version:           s.agent.config.Version,
+		// We expect the ent version to be part of the reported version string, and that's now part of the metadata, not the actual version.
+		Version: s.agent.config.VersionWithMetadata(),
 	}
 	return Self{
 		Config:      config,

--- a/agent/agent_endpoint_oss_test.go
+++ b/agent/agent_endpoint_oss_test.go
@@ -1,0 +1,49 @@
+//go:build !consulent
+// +build !consulent
+
+package agent
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/consul/testrpc"
+)
+
+func TestAgent_Self_VersionLacksEnt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	cases := map[string]struct {
+		hcl       string
+		expectXDS bool
+	}{
+		"normal": {
+			hcl: "primary_datacenter = \"dc1\"",
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, tc.hcl)
+			defer a.Shutdown()
+
+			testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+			req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
+			resp := httptest.NewRecorder()
+			a.srv.h.ServeHTTP(resp, req)
+
+			dec := json.NewDecoder(resp.Body)
+			var out map[string]map[string]interface{}
+			require.NoError(t, dec.Decode(&out))
+			require.NotContains(t, out["Config"]["Version"], "ent")
+		})
+	}
+}

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -803,6 +803,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		SyncCoordinateRateTarget:   float64Val(c.SyncCoordinateRateTarget),
 		Version:                    stringVal(c.Version),
 		VersionPrerelease:          stringVal(c.VersionPrerelease),
+		VersionMetadata:            stringVal(c.VersionMetadata),
 
 		// consul configuration
 		ConsulCoordinateUpdateBatchSize:  intVal(c.Consul.Coordinate.UpdateBatchSize),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -272,6 +272,7 @@ type Config struct {
 	SyncCoordinateRateTarget   *float64 `mapstructure:"sync_coordinate_rate_target"`
 	Version                    *string  `mapstructure:"version"`
 	VersionPrerelease          *string  `mapstructure:"version_prerelease"`
+	VersionMetadata            *string  `mapstructure:"version_metadata"`
 
 	// Enterprise Only
 	Audit Audit `mapstructure:"audit"`

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -209,13 +209,14 @@ func NonUserSource() Source {
 // versionSource creates a config source for the version parameters.
 // This should be merged in the tail since these values are not
 // user configurable.
-func versionSource(rev, ver, verPre string) Source {
+func versionSource(rev, ver, verPre, meta string) Source {
 	return LiteralSource{
 		Name: "version",
 		Config: Config{
 			Revision:          &rev,
 			Version:           &ver,
 			VersionPrerelease: &verPre,
+			VersionMetadata:   &meta,
 		},
 	}
 }
@@ -223,7 +224,7 @@ func versionSource(rev, ver, verPre string) Source {
 // defaultVersionSource returns the version config source for the embedded
 // version numbers.
 func defaultVersionSource() Source {
-	return versionSource(version.GitCommit, version.Version, version.VersionPrerelease)
+	return versionSource(version.GitCommit, version.Version, version.VersionPrerelease, version.VersionMetadata)
 }
 
 // DefaultConsulSource returns the default configuration for the consul agent.

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -61,6 +61,7 @@ type RuntimeConfig struct {
 	Revision                   string
 	Version                    string
 	VersionPrerelease          string
+	VersionMetadata            string
 
 	// consul config
 	ConsulCoordinateUpdateMaxBatches int
@@ -1627,6 +1628,14 @@ func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) 
 	}
 
 	return cfg, nil
+}
+
+func (c *RuntimeConfig) VersionWithMetadata() string {
+	version := c.Version
+	if c.VersionMetadata != "" {
+		version += "+" + c.VersionMetadata
+	}
+	return version
 }
 
 // Sanitized returns a JSON/HCL compatible representation of the runtime

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5660,6 +5660,7 @@ func TestLoad_FullConfig(t *testing.T) {
 		Revision:          "JNtPSav3",
 		Version:           "R909Hblt",
 		VersionPrerelease: "ZT1JOQLn",
+		VersionMetadata:   "GtTCa13",
 
 		// consul configuration
 		ConsulCoordinateUpdateBatchSize:  128,
@@ -6445,7 +6446,7 @@ func TestLoad_FullConfig(t *testing.T) {
 				ConfigFiles: []string{"testdata/full-config." + format},
 				HCL:         []string{fmt.Sprintf(`data_dir = "%s"`, dataDir)},
 			}
-			opts.Overrides = append(opts.Overrides, versionSource("JNtPSav3", "R909Hblt", "ZT1JOQLn"))
+			opts.Overrides = append(opts.Overrides, versionSource("JNtPSav3", "R909Hblt", "ZT1JOQLn", "GtTCa13"))
 			r, err := Load(opts)
 			require.NoError(t, err)
 			prototest.AssertDeepEqual(t, expected, r.RuntimeConfig)

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -458,6 +458,7 @@
     "UnixSocketUser": "",
     "UseStreamingBackend": false,
     "Version": "",
+    "VersionMetadata": "",
     "VersionPrerelease": "",
     "Watches": []
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -15,6 +16,9 @@ var (
 	// for tests to work.
 	Version = "1.12.0"
 
+	// https://semver.org/#spec-item-10
+	VersionMetadata = ""
+
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
@@ -26,13 +30,14 @@ var (
 func GetHumanVersion() string {
 	version := Version
 	release := VersionPrerelease
+	metadata := VersionMetadata
 
 	if release != "" {
-		suffix := "-" + release
-		if !strings.HasSuffix(version, suffix) {
-			// if we tagged a prerelease version then the release is in the version already
-			version += suffix
-		}
+		version += fmt.Sprintf("-%s", release)
+	}
+
+	if metadata != "" {
+		version += fmt.Sprintf("+%s", metadata)
 	}
 
 	// Strip off any single quotes added by the git information.


### PR DESCRIPTION
### Description
Changes to how the version string was handled created a small regression that was noticed after the release of Consul 1.12.0 Enterprise. This is the OSS companion of https://github.com/hashicorp/consul-enterprise/pull/1800 because most of the code paths are shared; however because we don't have the ent metadata flag this PR should not change any user visible output.

Many tools use the Config:Version field reported by the agent/self resource to determine whether Consul is an enterprise or OSS instance, expect something like 1.12.0+ent for enterprise and simply 1.12.0 for OSS. This was accidentally broken during the runup to 1.12.x

### Testing & Reproduction steps

In previous versions of Consul Enterprise we would expect the agent/self endpoint to return something like:
```
 curl 127.0.0.1:8500/v1/agent/self | jq '.Config.Version'
"1.11.1+ent"
```

In the released version of 1.12.0 we got.
```
 curl 127.0.0.1:8500/v1/agent/self | jq '.Config.Version'
"1.12.0"
````

* If any manual tests were done, document the steps and the conditions to replicate
Updated the metrics endpoint as well, but had trouble getting a stable metrics test working.

Expect:
```
curl 127.0.0.1:8500/v1/agent/metrics  | jq '.Gauges[] | select(.Name == "consul.version")' 

{
  "Name": "consul.version",
  "Value": 1,
  "Labels": {
    "pre_release": "dev",
    "version": "1.12.0"
  }
}
```
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding
Added test for the ent flag in version in in the self endpoint for both OSS and enterprise.

### Links

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern

Signed-off-by: Mark Anderson <manderson@hashicorp.com>

