### PR TITLE
docs: provide option for installing using a specific version via Helm

### DIFF
--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -156,17 +156,20 @@ The Consul Helm only supports Helm 3.2+. Install the latest version of the Helm 
     kube-system       Active   18h
     ```
 
-1. Issue the following command to install Consul with the default configuration using Helm. You could also install Consul on a dedicated
-   namespace of your choosing by modifying the value of the `-n` flag for the Helm install.
+1. Install Consul on Kubernetes using Helm. The Helm chart does everything to set up a recommended Consul-on-Kubernetes deployment. After installation, a Consul cluster will be formed, a leader will be elected, and every node will have a running Consul agent. 
+    1. To install the latest version of Consul on Kubernetes, issue the following command to install Consul with the default configuration using Helm. You could also install Consul on a dedicated namespace of your choosing by modifying the value of the `-n` flag for the Helm install.
 
-   ```shell-session
-   $ helm install consul hashicorp/consul --set global.name=consul --create-namespace --namespace consul
-   NAME: consul
-   ...
-   ```
-
-The Helm chart does everything to set up a recommended Consul-on-Kubernetes deployment.
-After installation, a Consul cluster will be formed, a leader will be elected, and every node will have a running Consul agent.
+       ```shell-session
+       $ helm install consul hashicorp/consul --set global.name=consul --create-namespace --namespace consul
+       ```
+   
+    1. To install a specific version of Consul on Kubernetes, issue the following command which utilizes the `--version` flag to install with the default configuration using Helm.  
+   
+       ```shell-session
+       $ export VERSION=0.43.0
+       $ helm install consul hashicorp/consul --set global.name=consul --version ${VERSION} --create-namespace --namespace consul
+       ```
+  
 
 ### Customizing Your Installation
 

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -163,7 +163,7 @@ The Consul Helm only supports Helm 3.2+. Install the latest version of the Helm 
        $ helm install consul hashicorp/consul --set global.name=consul --create-namespace --namespace consul
        ```
    
-    1. To install a specific version of Consul on Kubernetes, issue the following command which utilizes the `--version` flag to install with the default configuration using Helm.  
+    1. To install a specific version of Consul on Kubernetes, issue the following command with `--version` flag to install the specified version with the default configuration using Helm.  
    
        ```shell-session
        $ export VERSION=0.43.0


### PR DESCRIPTION
### Description
Provide an option in default install that describes how to install with a specific version of the Helm chart. 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
