### PR TITLE
docs: Clarify version restriction for snapshot restore

### DIFF
--- a/website/content/api-docs/snapshot.mdx
+++ b/website/content/api-docs/snapshot.mdx
@@ -77,7 +77,8 @@ This endpoint restores a point-in-time snapshot of the Consul server state.
 Restores involve a potentially dangerous low-level Raft operation that is not
 designed to handle server failures during a restore. This operation is primarily
 intended to be used when recovering from a disaster, restoring into a fresh
-cluster of Consul servers.
+cluster of Consul servers running the same version as the cluster from where the
+snapshot was taken.
 
 The body of the request should be a snapshot archive returned from a previous
 call to the `GET` method.

--- a/website/content/commands/snapshot/restore.mdx
+++ b/website/content/commands/snapshot/restore.mdx
@@ -17,7 +17,8 @@ from the given file.
 Restores involve a potentially dangerous low-level Raft operation that is not
 designed to handle server failures during a restore. This command is primarily
 intended to be used when recovering from a disaster, restoring into a fresh
-cluster of Consul servers.
+cluster of Consul servers running the same version as the cluster from where the
+snapshot was taken.
 
 The table below shows this command's [required ACLs](/api#authentication). Configuration of
 [blocking queries](/api-docs/features/blocking) and [agent caching](/api-docs/features/caching)


### PR DESCRIPTION
### Description
Clarify that Consul snapshots must be restored into clusters running the same version as the cluster from where the snapshot was taken.

This is to address a support case where a customer encountered errors when attempting to restore a snapshot taken from a Consul 1.4.x cluster into a cluster running Consul 1.11.x.

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
