### PR TITLE
Create clients with specific version for integration tests

### DIFF
--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -2,7 +2,6 @@ package consul_container
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"testing"
 	"time"
@@ -18,21 +17,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var targetImage = flag.String("target-version", "local", "docker image to be used as UUT (unit under test)")
-var latestImage = flag.String("latest-version", "latest", "docker image to be used as latest")
-
 const retryTimeout = 10 * time.Second
 const retryFrequency = 500 * time.Millisecond
 
 // Test health check GRPC call using Current Clients and Latest GA Servers
 func TestLatestGAServersWithCurrentClients(t *testing.T) {
-	t.Parallel()
+
 	numServers := 3
 	Cluster, err := serversCluster(t, numServers, *latestImage)
 	require.NoError(t, err)
 	defer Terminate(t, Cluster)
 	numClients := 2
 	Clients, err := clientsCreate(numClients, *targetImage)
+	require.NoError(t, err)
+	require.Len(t, Clients, numClients)
 	client := Clients[0].GetClient()
 	err = Cluster.AddNodes(Clients)
 	retry.RunWith(&retry.Timer{Timeout: retryTimeout, Wait: retryFrequency}, t, func(r *retry.R) {
@@ -77,7 +75,7 @@ func TestLatestGAServersWithCurrentClients(t *testing.T) {
 
 // Test health check GRPC call using Current Servers and Latest GA Clients
 func TestCurrentServersWithLatestGAClients(t *testing.T) {
-	t.Parallel()
+
 	numServers := 3
 	Cluster, err := serversCluster(t, numServers, *targetImage)
 	require.NoError(t, err)
@@ -127,7 +125,7 @@ func TestCurrentServersWithLatestGAClients(t *testing.T) {
 
 // Test health check GRPC call using Mixed (majority latest) Servers and Latest GA Clients
 func TestMixedServersMajorityLatestGAClient(t *testing.T) {
-	t.Parallel()
+
 	var configs []node.Config
 	configs = append(configs,
 		node.Config{
@@ -200,7 +198,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 
 // Test health check GRPC call using Mixed (majority current) Servers and Latest GA Clients
 func TestMixedServersMajorityCurrentGAClient(t *testing.T) {
-	t.Parallel()
+
 	var configs []node.Config
 	configs = append(configs,
 		node.Config{

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -83,7 +83,7 @@ func TestLatestGAServersWithCurrentClients(t *testing.T) {
 
 // Test health check GRPC call using Current Servers and Latest GA Clients
 func TestCurrentServersWithLatestGAClients(t *testing.T) {
-	
+
 	numServers := 3
 	Cluster, err := serversCluster(t, numServers, *targetImage)
 	require.NoError(t, err)

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -157,7 +157,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 	defer Terminate(t, cluster)
 
 	numClients := 1
-	clients, err := clientsCreate(numClients,*latestImage)
+	clients, err := clientsCreate(numClients, *latestImage)
 	client := clients[0].GetClient()
 	err = cluster.AddNodes(clients)
 	retry.RunWith(&retry.Timer{Timeout: retryTimeout, Wait: retryFrequency}, t, func(r *retry.R) {

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -49,6 +49,14 @@ func TestLatestGAServersWithCurrentClients(t *testing.T) {
 
 	go func() {
 		service, q, err := client.Health().Service(serviceName, "", false, &api.QueryOptions{WaitIndex: index})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if q == nil {
+			err = fmt.Errorf("query is nil")
+			errCh <- err
+		}
 		if q.QueryBackend != api.QueryBackendStreaming {
 			err = fmt.Errorf("invalid backend for this test %s", q.QueryBackend)
 		}
@@ -75,7 +83,7 @@ func TestLatestGAServersWithCurrentClients(t *testing.T) {
 
 // Test health check GRPC call using Current Servers and Latest GA Clients
 func TestCurrentServersWithLatestGAClients(t *testing.T) {
-
+	
 	numServers := 3
 	Cluster, err := serversCluster(t, numServers, *targetImage)
 	require.NoError(t, err)

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -83,7 +83,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 			Version: *targetImage,
 		})
 
-	for i := 1; i < 2; i++ {
+	for i := 1; i < 3; i++ {
 		configs = append(configs,
 			node.Config{
 				HCL: `node_name="` + utils.RandName("consul-server") + `"
@@ -147,7 +147,7 @@ func TestMixedServersMajorityCurrentGAClient(t *testing.T) {
 
 	var configs []node.Config
 
-	for i := 1; i < 2; i++ {
+	for i := 0; i < 2; i++ {
 		configs = append(configs,
 			node.Config{
 				HCL: `node_name="` + utils.RandName("consul-server") + `"

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -32,7 +32,7 @@ func TestLatestGAServersWithCurrentClients(t *testing.T) {
 	require.NoError(t, err)
 	defer Terminate(t, Cluster)
 	numClients := 2
-	Clients, err := clientsCreate(numClients)
+	Clients, err := clientsCreate(numClients, *targetImage)
 	client := Clients[0].GetClient()
 	err = Cluster.AddNodes(Clients)
 	retry.RunWith(&retry.Timer{Timeout: retryTimeout, Wait: retryFrequency}, t, func(r *retry.R) {
@@ -84,7 +84,7 @@ func TestCurrentServersWithLatestGAClients(t *testing.T) {
 	defer Terminate(t, Cluster)
 	numClients := 1
 
-	Clients, err := clientsCreate(numClients)
+	Clients, err := clientsCreate(numClients, *latestImage)
 	client := Cluster.Nodes[0].GetClient()
 	err = Cluster.AddNodes(Clients)
 	retry.RunWith(&retry.Timer{Timeout: retryTimeout, Wait: retryFrequency}, t, func(r *retry.R) {
@@ -157,7 +157,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 	defer Terminate(t, cluster)
 
 	numClients := 1
-	clients, err := clientsCreate(numClients)
+	clients, err := clientsCreate(numClients,*latestImage)
 	client := clients[0].GetClient()
 	err = cluster.AddNodes(clients)
 	retry.RunWith(&retry.Timer{Timeout: retryTimeout, Wait: retryFrequency}, t, func(r *retry.R) {
@@ -230,7 +230,7 @@ func TestMixedServersMajorityCurrentGAClient(t *testing.T) {
 	defer Terminate(t, cluster)
 
 	numClients := 1
-	clients, err := clientsCreate(numClients)
+	clients, err := clientsCreate(numClients, *latestImage)
 	client := clients[0].GetClient()
 	err = cluster.AddNodes(clients)
 	retry.RunWith(&retry.Timer{Timeout: retryTimeout, Wait: retryFrequency}, t, func(r *retry.R) {
@@ -271,7 +271,7 @@ func TestMixedServersMajorityCurrentGAClient(t *testing.T) {
 	}
 }
 
-func clientsCreate(numClients int) ([]node.Node, error) {
+func clientsCreate(numClients int, version string) ([]node.Node, error) {
 	clients := make([]node.Node, numClients)
 	var err error
 	for i := 0; i < numClients; i++ {
@@ -280,7 +280,7 @@ func clientsCreate(numClients int) ([]node.Node, error) {
 				HCL: `node_name="` + utils.RandName("consul-client") + `"
 					log_level="TRACE"`,
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
-				Version: *targetImage,
+				Version: version,
 			})
 	}
 	return clients, err

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -24,6 +24,7 @@ var latestImage = flag.String("latest-version", "latest", "docker image to be us
 const retryTimeout = 10 * time.Second
 const retryFrequency = 500 * time.Millisecond
 
+// Test health check GRPC call using Current Clients and Latest GA Servers
 func TestLatestGAServersWithCurrentClients(t *testing.T) {
 	t.Parallel()
 	numServers := 3
@@ -74,6 +75,7 @@ func TestLatestGAServersWithCurrentClients(t *testing.T) {
 
 }
 
+// Test health check GRPC call using Current Servers and Latest GA Clients
 func TestCurrentServersWithLatestGAClients(t *testing.T) {
 	t.Parallel()
 	numServers := 3
@@ -123,6 +125,7 @@ func TestCurrentServersWithLatestGAClients(t *testing.T) {
 	}
 }
 
+// Test health check GRPC call using Mixed (majority latest) Servers and Latest GA Clients
 func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 	t.Parallel()
 	var configs []node.Config
@@ -195,6 +198,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 	}
 }
 
+// Test health check GRPC call using Mixed (majority current) Servers and Latest GA Clients
 func TestMixedServersMajorityCurrentGAClient(t *testing.T) {
 	t.Parallel()
 	var configs []node.Config

--- a/test/integration/consul-container/upgrade/version_oss.go
+++ b/test/integration/consul-container/upgrade/version_oss.go
@@ -1,0 +1,9 @@
+//go:build !consulent
+// +build !consulent
+
+package upgrade
+
+import "flag"
+
+var targetImage = flag.String("target-version", "local", "docker image to be used as UUT (unit under test)")
+var latestImage = flag.String("latest-version", "1.11", "docker image to be used as latest")

--- a/test/integration/consul-container/upgrade/version_oss.go
+++ b/test/integration/consul-container/upgrade/version_oss.go
@@ -1,7 +1,7 @@
 //go:build !consulent
 // +build !consulent
 
-package upgrade
+package consul_container
 
 import "flag"
 


### PR DESCRIPTION
### Description
This PR add the ability to create clients with specific version for integration tests based on containers and put version flags in a separate file with oss build tags (to be used in enterprise)
