### PR TITLE
UI: update improve server fault tolerance link

### DIFF
--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -6,7 +6,7 @@ dc:
       unassigned: Unassigned Zones
       tolerance:
         link: |
-          <a href="{CONSUL_DOCS_URL}/architecture/consensus" target="_blank" rel="noopener noreferrer">Learn more</a>
+          <a href="{CONSUL_DOCS_URL}/architecture/improving-consul-resilience#strategies-to-increase-fault-tolerance" target="_blank" rel="noopener noreferrer">Learn how to improve fault tolerance</a>
         header: Server fault tolerance
         immediate:
           header: Immediate


### PR DESCRIPTION
PR #12792 applied the correct link to the 1.12.x branch: https://github.com/hashicorp/consul/pull/12898/files#diff-6ddfe3e26515d476fa53a1ce3c3db3e9ea0800f8dafb17f829c4858e49fa7589R8-R9

This PR applies the same link to `main`. Therefore, **there is no need to backport this to 1.12.x**.