### PR TITLE
remove replace directive for istio.io/gogo-genproto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -192,5 +192,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v3 v3.0.0 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
-
-replace istio.io/gogo-genproto v0.0.0-20190124151557-6d926a6e6feb => github.com/istio/gogo-genproto v0.0.0-20190124151557-6d926a6e6feb


### PR DESCRIPTION
This was added in #7194 and is no longer a transitive dependency.
