### PR TITLE
Nia/get all tasks endpoint

### DIFF
--- a/website/content/docs/nia/api/tasks.mdx
+++ b/website/content/docs/nia/api/tasks.mdx
@@ -9,6 +9,73 @@ description: >-
 
 The `/tasks` endpoints interact with the tasks that Consul-Terraform-Sync (CTS) is responsible for running.
 
+## Get Tasks
+
+This endpoint returns information about all existing tasks.
+
+| Method | Path                | Produces           |
+| ------ | ------------------- | ------------------ |
+| `GET`  | `/tasks` | `application/json` |
+
+### Response Statuses
+
+| Status | Reason                                               |
+| ------ | ---------------------------------------------------- |
+| 200    | Successfully retrieved and returned a list of tasks |
+
+### Response Fields
+
+| Name         | Type   | Description                                                                               |
+| ------------ | ------------- | ---------------------------------------------------------------------------------- |
+| `request_id` | string        | The ID of the request. Used for auditing and debugging purposes.                    |
+| `tasks`      | list[[Task](/docs/nia/api/tasks#task-object)]  | A list of Tasks  |
+
+### Example: Retrieve all tasks
+
+In this example, CTS contains a single task
+
+Request:
+
+```shell-session
+$ curl --request GET \
+  localhost:8558/v1/tasks
+```
+
+Response:
+
+```json
+{
+  "request_id": "0e0290f9-94df-3a4a-fd17-72467a16083c",
+  "tasks": [
+    {
+      "buffer_period": {
+        "enabled": true,
+        "max": "25s",
+        "min": "5s"
+      },
+      "condition": {
+        "services": {
+          "cts_user_defined_meta": {},
+          "datacenter": "",
+          "filter": "",
+          "names": ["api", "web"],
+          "namespace": "",
+          "use_as_module_input": true
+        }
+      },
+      "description": "Writes the service name, id, and IP address to a file",
+      "enabled": true,
+      "module": "path/to/module",
+      "module_input": {},
+      "name": "task_a",
+      "providers": ["my-provider"],
+      "variables": {},
+      "version": ""
+    }
+  ]
+}
+```
+
 ## Get Task
 
 This endpoint returns information about an existing task.


### PR DESCRIPTION
Added new section to API tasks for `GET v1/tasks` endpoint

LInk: https://consul-pnlew3pbh-hashicorp.vercel.app/docs/nia/api/tasks#get-tasks
