### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/agent/connect/parsing.go
+++ b/agent/connect/parsing.go
@@ -198,7 +198,7 @@ func EncodeSigningKeyID(keyID []byte) string { return HexString(keyID) }
 // HexString returns a standard colon-separated hex value for the input
 // byte slice. This should be used with cert serial numbers and so on.
 func HexString(input []byte) string {
-	return strings.Replace(fmt.Sprintf("% x", input), " ", ":", -1)
+	return strings.ReplaceAll(fmt.Sprintf("% x", input), " ", ":")
 }
 
 // IsHexString returns true if the input is the output of HexString(). Meant

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -511,8 +511,8 @@ func newClient(t *testing.T, config *Config) *Client {
 
 func newTestResolverConfig(t testutil.TestingTB, suffix string, dc, agentType string) resolver.Config {
 	n := t.Name()
-	s := strings.Replace(n, "/", "", -1)
-	s = strings.Replace(s, "_", "", -1)
+	s := strings.ReplaceAll(n, "/", "")
+	s = strings.ReplaceAll(s, "_", "")
 	return resolver.Config{
 		Datacenter: dc,
 		AgentType:  agentType,

--- a/agent/consul/state/query.go
+++ b/agent/consul/state/query.go
@@ -105,7 +105,7 @@ func parseUUIDString(uuid string) ([]byte, error) {
 	}
 
 	// The sanitized length is the length of the original string without the "-".
-	sanitized := strings.Replace(uuid, "-", "", -1)
+	sanitized := strings.ReplaceAll(uuid, "-", "")
 	sanitizedLength := len(sanitized)
 	if sanitizedLength%2 != 0 {
 		return nil, fmt.Errorf("UUID (without hyphens) must be even length")

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -1170,8 +1170,8 @@ RPC:
 // encodeKVasRFC1464 encodes a key-value pair according to RFC1464
 func encodeKVasRFC1464(key, value string) (txt string) {
 	// For details on these replacements c.f. https://www.ietf.org/rfc/rfc1464.txt
-	key = strings.Replace(key, "`", "``", -1)
-	key = strings.Replace(key, "=", "`=", -1)
+	key = strings.ReplaceAll(key, "`", "``")
+	key = strings.ReplaceAll(key, "=", "`=")
 
 	// Backquote the leading spaces
 	leadingSpacesRE := regexp.MustCompile("^ +")
@@ -1183,7 +1183,7 @@ func encodeKVasRFC1464(key, value string) (txt string) {
 	numTrailingSpaces := len(trailingSpacesRE.FindString(key))
 	key = trailingSpacesRE.ReplaceAllString(key, strings.Repeat("` ", numTrailingSpaces))
 
-	value = strings.Replace(value, "`", "``", -1)
+	value = strings.ReplaceAll(value, "`", "``")
 
 	return key + "=" + value
 }

--- a/agent/grpc-internal/client_test.go
+++ b/agent/grpc-internal/client_test.go
@@ -375,8 +375,8 @@ func TestClientConnPool_ForwardToLeader_Failover(t *testing.T) {
 
 func newConfig(t *testing.T, dc, agentType string) resolver.Config {
 	n := t.Name()
-	s := strings.Replace(n, "/", "", -1)
-	s = strings.Replace(s, "_", "", -1)
+	s := strings.ReplaceAll(n, "/", "")
+	s = strings.ReplaceAll(s, "_", "")
 	return resolver.Config{
 		Datacenter: dc,
 		AgentType:  agentType,

--- a/agent/http.go
+++ b/agent/http.go
@@ -183,7 +183,7 @@ func (s *HTTPHandlers) handler() http.Handler {
 		// Omit the leading slash.
 		// Distinguish thing like /v1/query from /v1/query/<query_id> by having
 		// an extra underscore.
-		path_label := strings.Replace(pattern[1:], "/", "_", -1)
+		path_label := strings.ReplaceAll(pattern[1:], "/", "_")
 
 		// Register the wrapper.
 		wrapper := func(resp http.ResponseWriter, req *http.Request) {
@@ -386,7 +386,7 @@ func (s *HTTPHandlers) wrap(handler endpoint, methods []string) http.HandlerFunc
 					logURL += "<hidden>"
 					continue
 				}
-				logURL = strings.Replace(logURL, token, "<hidden>", -1)
+				logURL = strings.ReplaceAll(logURL, token, "<hidden>")
 			}
 			httpLogger.Warn("This request used the token query parameter "+
 				"which is deprecated and will be removed in Consul 1.17",

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -2436,7 +2436,7 @@ func makeStatPrefix(prefix, filterName string) string {
 	// Replace colons here because Envoy does that in the metrics for the actual
 	// clusters but doesn't in the stat prefix here while dashboards assume they
 	// will match.
-	return fmt.Sprintf("%s%s", prefix, strings.Replace(filterName, ":", "_", -1))
+	return fmt.Sprintf("%s%s", prefix, strings.ReplaceAll(filterName, ":", "_"))
 }
 
 func makeTracingFromUserConfig(configJSON string) (*envoy_http_v3.HttpConnectionManager_Tracing, error) {

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -633,7 +633,7 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 	if err != nil {
 		return nil, err
 	}
-	caPEM = strings.Replace(strings.Join(pems, ""), "\n", "\\n", -1)
+	caPEM = strings.ReplaceAll(strings.Join(pems, ""), "\n", "\\n")
 
 	return &BootstrapTplArgs{
 		GRPC:                  xdsAddr,

--- a/sdk/testutil/io.go
+++ b/sdk/testutil/io.go
@@ -21,7 +21,7 @@ func TempDir(t TestingTB, name string) string {
 		panic("argument t must be non-nil")
 	}
 	name = t.Name() + "-" + name
-	name = strings.Replace(name, "/", "_", -1)
+	name = strings.ReplaceAll(name, "/", "_")
 	d, err := os.MkdirTemp("", name)
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -47,7 +47,7 @@ func TempFile(t testing.TB, name string) *os.File {
 		panic("argument t must be non-nil")
 	}
 	name = t.Name() + "-" + name
-	name = strings.Replace(name, "/", "_", -1)
+	name = strings.ReplaceAll(name, "/", "_")
 	f, err := os.CreateTemp("", name)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -310,7 +310,7 @@ func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, er
 		prefix := "consul"
 		if t != nil {
 			// Use test name for tmpdir if available
-			prefix = strings.Replace(t.Name(), "/", "_", -1)
+			prefix = strings.ReplaceAll(t.Name(), "/", "_")
 		}
 		tmpdir, err = os.MkdirTemp("", prefix)
 		if err != nil {


### PR DESCRIPTION
### Description

Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.

### PR Checklist

* [x] not a security concern
