### PR TITLE
update docs for single-dc-multi-k8s install

### DIFF
--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -25,7 +25,7 @@ The Helm chart uses the Helm release name as a prefix for the
 ACL resources that it creates, such as tokens and auth methods. If the names of the Helm releases
 are identical, subsequent Consul on Kubernetes clusters would overwrite existing ACL resources causing the clusters to fail.
 
-Prepare the Helm release names as environment variables for both the server and client installs for use in the proceeding install instructions. 
+Before you proceed with installation, prepare the Helm release names as environment variables for both the server and client installs to use. 
 
 ```shell-session
   $ export HELM_RELEASE_SERVER=server

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -14,9 +14,7 @@ In this example, we will use two Kubernetes clusters, but this approach could be
 
 ~> **Note:** This deployment topology requires that your Kubernetes clusters have a flat network
 for both pods and nodes, so that pods or nodes from one cluster can connect
-to pods or nodes in another. If you are looking to use Consul on Kubernetes in an environment where Kubernetes clusters
-are deployed across separate networks, it is recommended to use [Admin Partitions](/docs/enterprise/admin-partitions) 
-which is available with Consul Enterprise. 
+to pods or nodes in another. If a flat network is not available across all Kubernetes clusters, follow the instructions for using [Admin Partitions](/docs/enterprise/admin-partitions), which is a Consul Enterprise feature. 
 
 ## Prepare Helm release name ahead of installs
 

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -16,13 +16,12 @@ In this example, we will use two Kubernetes clusters, but this approach could be
 for both pods and nodes, so that pods or nodes from one cluster can connect
 to pods or nodes in another.
 
-~> **Note:** The Helm release name must be unique for each Kubernetes cluster.
-That is because the Helm chart will use the Helm release name as a prefix for the
+## Deploying Consul servers and clients in the first cluster
+~> The Helm release name must be unique for each Kubernetes cluster.
+The Helm chart uses the Helm release name as a prefix for the
 ACL resources that it creates, such as tokens and auth methods. If the names of the Helm releases
-are the same, the Helm installation in subsequent Kubernetes clusters will clobber existing ACL resources.
+are identical, subsequent Kubernetes clusters drain existing ACL resources and slow performance.
 
-
-## Deploying Consul sOervers and clients in the first cluster
 
 First, we will deploy the Consul servers with Consul clients in the first cluster.
 For that, we will use the following Helm configuration:

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -16,12 +16,23 @@ In this example, we will use two Kubernetes clusters, but this approach could be
 for both pods and nodes, so that pods or nodes from one cluster can connect
 to pods or nodes in another.
 
-## Deploying Consul servers and clients in the first cluster
+## Prepare Helm release name ahead of installs
+
 ~> The Helm release name must be unique for each Kubernetes cluster.
 The Helm chart uses the Helm release name as a prefix for the
 ACL resources that it creates, such as tokens and auth methods. If the names of the Helm releases
 are identical, subsequent Kubernetes clusters drain existing ACL resources and slow performance.
 
+Prepare the Helm release names as environment variables for both the server and client installs for use in the proceeding install instructions. 
+
+```shell-session
+  $ export HELM_RELEASE_SERVER=server
+  $ export HELM_RELEASE_CLIENT=client
+  ...
+  $ export HELM_RELEASE_CLIENT2=client2
+```
+
+## Deploying Consul servers and clients in the first cluster
 
 First, we will deploy the Consul servers with Consul clients in the first cluster.
 For that, we will use the following Helm configuration:
@@ -66,7 +77,7 @@ $ kubectl create secret generic consul-gossip-encryption-key --from-literal=key=
 
 Now we can install our Consul cluster with Helm:
 ```shell-session
-$ helm install cluster1 --values cluster1-config.yaml hashicorp/consul
+$ helm install ${HELM_RELEASE_SERVER} --values cluster1-config.yaml hashicorp/consul
 ```
 
 
@@ -76,7 +87,7 @@ and the ACL bootstrap token generated during installation,
 so that we can apply them to our second Kubernetes cluster.
 
 ```shell-session
-$ kubectl get secret consul-gossip-encryption-key cluster1-consul-ca-cert cluster1-consul-bootstrap-acl-token --output yaml > cluster1-credentials.yaml
+$ kubectl get secret consul-gossip-encryption-key ${HELM_RELEASE_SERVER}-consul-ca-cert ${HELM_RELEASE_SERVER}-consul-bootstrap-acl-token --output yaml > cluster1-credentials.yaml
 ```
 
 ## Deploying Consul clients in the second cluster
@@ -184,7 +195,7 @@ for more details.
 Now we're ready to install!
 
 ```shell-session
-$ helm install cluster2 --values cluster2-config.yaml hashicorp/consul
+$ helm install ${HELM_RELEASE_CLIENT} --values cluster2-config.yaml hashicorp/consul
 ```
 
 ## Verifying the Consul Service Mesh works

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -23,7 +23,7 @@ which is available with Consul Enterprise.
 ~> The Helm release name must be unique for each Kubernetes cluster.
 The Helm chart uses the Helm release name as a prefix for the
 ACL resources that it creates, such as tokens and auth methods. If the names of the Helm releases
-are identical, subsequent Consul on Kubernetes clusters would overwrite existing ACL resources causing the clusters to fail.
+are identical, subsequent Consul on Kubernetes clusters overwrite existing ACL resources and cause the clusters to fail.
 
 Before you proceed with installation, prepare the Helm release names as environment variables for both the server and client installs to use. 
 

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -21,7 +21,7 @@ to pods or nodes in another.
 ~> The Helm release name must be unique for each Kubernetes cluster.
 The Helm chart uses the Helm release name as a prefix for the
 ACL resources that it creates, such as tokens and auth methods. If the names of the Helm releases
-are identical, subsequent Kubernetes clusters drain existing ACL resources and slow performance.
+are identical, subsequent Consul on Kubernetes clusters would overwrite existing ACL resources causing the clusters to fail.
 
 Prepare the Helm release names as environment variables for both the server and client installs for use in the proceeding install instructions. 
 

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -70,7 +70,6 @@ Now we can install our Consul cluster with Helm:
 $ helm install cluster1 --values cluster1-config.yaml hashicorp/consul
 ```
 
-~> **Reminder:** The Helm release name must be unique for each Kubernetes cluster.
 
 Once the installation finishes and all components are running and ready,
 we need to extract the gossip encryption key we've created, the CA certificate

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -14,7 +14,9 @@ In this example, we will use two Kubernetes clusters, but this approach could be
 
 ~> **Note:** This deployment topology requires that your Kubernetes clusters have a flat network
 for both pods and nodes, so that pods or nodes from one cluster can connect
-to pods or nodes in another.
+to pods or nodes in another. If you are looking to use Consul on Kubernetes in an environment where Kubernetes clusters
+are deployed across separate networks, it is recommended to use [Admin Partitions](https://consul-qi1mf2651-hashicorp.vercel.app/docs/enterprise/admin-partitions) 
+which is available with Consul Enterprise. 
 
 ## Prepare Helm release name ahead of installs
 

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -16,7 +16,13 @@ In this example, we will use two Kubernetes clusters, but this approach could be
 for both pods and nodes, so that pods or nodes from one cluster can connect
 to pods or nodes in another.
 
-## Deploying Consul servers and clients in the first cluster
+~> **Note:** The Helm release name must be unique for each Kubernetes cluster.
+That is because the Helm chart will use the Helm release name as a prefix for the
+ACL resources that it creates, such as tokens and auth methods. If the names of the Helm releases
+are the same, the Helm installation in subsequent Kubernetes clusters will clobber existing ACL resources.
+
+
+## Deploying Consul sOervers and clients in the first cluster
 
 First, we will deploy the Consul servers with Consul clients in the first cluster.
 For that, we will use the following Helm configuration:
@@ -60,14 +66,11 @@ $ kubectl create secret generic consul-gossip-encryption-key --from-literal=key=
 ```
 
 Now we can install our Consul cluster with Helm:
-```shell
+```shell-session
 $ helm install cluster1 --values cluster1-config.yaml hashicorp/consul
 ```
 
-~> **Note:** The Helm release name must be unique for each Kubernetes cluster.
-That is because the Helm chart will use the Helm release name as a prefix for the
-ACL resources that it creates, such as tokens and auth methods. If the names of the Helm releases
-are the same, the Helm installation in subsequent clusters will clobber existing ACL resources.
+~> **Reminder:** The Helm release name must be unique for each Kubernetes cluster.
 
 Once the installation finishes and all components are running and ready,
 we need to extract the gossip encryption key we've created, the CA certificate

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -15,7 +15,7 @@ In this example, we will use two Kubernetes clusters, but this approach could be
 ~> **Note:** This deployment topology requires that your Kubernetes clusters have a flat network
 for both pods and nodes, so that pods or nodes from one cluster can connect
 to pods or nodes in another. If you are looking to use Consul on Kubernetes in an environment where Kubernetes clusters
-are deployed across separate networks, it is recommended to use [Admin Partitions](https://consul-qi1mf2651-hashicorp.vercel.app/docs/enterprise/admin-partitions) 
+are deployed across separate networks, it is recommended to use [Admin Partitions](/docs/enterprise/admin-partitions) 
 which is available with Consul Enterprise. 
 
 ## Prepare Helm release name ahead of installs

--- a/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/installation/deployment-configurations/single-dc-multi-k8s.mdx
@@ -20,7 +20,7 @@ which is available with Consul Enterprise.
 
 ## Prepare Helm release name ahead of installs
 
-~> The Helm release name must be unique for each Kubernetes cluster.
+The Helm release name must be unique for each Kubernetes cluster.
 The Helm chart uses the Helm release name as a prefix for the
 ACL resources that it creates, such as tokens and auth methods. If the names of the Helm releases
 are identical, subsequent Consul on Kubernetes clusters overwrite existing ACL resources and cause the clusters to fail.


### PR DESCRIPTION
### Description
Updating the documentation to emphasize the requirement that helm release names must be unique in each Kubernetes cluster when installing in a single-dc-multi-k8s environment.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
