### PR TITLE
Fix topology view when displaying mixed connect-native/normal services.

### DIFF
--- a/.changelog/13023.txt
+++ b/.changelog/13023.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: the topology view now properly displays services with mixed connect and non-connect instances.
+```

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -578,7 +578,10 @@ func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig, dc s
 		sum.Kind = svc.Kind
 		sum.Datacenter = csn.Node.Datacenter
 		sum.InstanceCount += 1
-		sum.ConnectNative = svc.Connect.Native
+		// Consider a service connect native once at least one instance is
+		if svc.Connect.Native {
+			sum.ConnectNative = svc.Connect.Native
+		}
 		if svc.Kind == structs.ServiceKindConnectProxy {
 			sn := structs.NewServiceName(svc.Proxy.DestinationServiceName, &svc.EnterpriseMeta)
 			psn := structs.PeeredServiceName{Peer: peerName, ServiceName: sn}

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -563,7 +563,18 @@ func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig, dc s
 		sum := getService(psn)
 
 		svc := csn.Service
-		sum.Nodes = append(sum.Nodes, csn.Node.Node)
+
+		found := false
+		for _, existing := range sum.Nodes {
+			if existing == csn.Node.Node {
+				found = true
+				break
+			}
+		}
+		if !found {
+			sum.Nodes = append(sum.Nodes, csn.Node.Node)
+		}
+
 		sum.Kind = svc.Kind
 		sum.Datacenter = csn.Node.Datacenter
 		sum.InstanceCount += 1

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1687,19 +1687,43 @@ func TestUIServiceTopology(t *testing.T) {
 				SkipNodeUpdate: true,
 				Service: &structs.NodeService{
 					Kind:    structs.ServiceKindTypical,
-					ID:      "cproxy",
+					ID:      "cproxy-https",
 					Service: "cproxy",
 					Port:    1111,
 					Address: "198.18.1.70",
+					Tags:    []string{"https"},
 					Connect: structs.ServiceConnect{Native: true},
 				},
 				Checks: structs.HealthChecks{
 					&structs.HealthCheck{
 						Node:        "cnative",
-						CheckID:     "cnative:cproxy",
+						CheckID:     "cnative:cproxy-https",
 						Name:        "cproxy-liveness",
 						Status:      api.HealthPassing,
-						ServiceID:   "cproxy",
+						ServiceID:   "cproxy-https",
+						ServiceName: "cproxy",
+					},
+				},
+			},
+			"Service cproxy/http on cnative": {
+				Datacenter:     "dc1",
+				Node:           "cnative",
+				SkipNodeUpdate: true,
+				Service: &structs.NodeService{
+					Kind:    structs.ServiceKindTypical,
+					ID:      "cproxy-http",
+					Service: "cproxy",
+					Port:    1112,
+					Address: "198.18.1.70",
+					Tags:    []string{"http"},
+				},
+				Checks: structs.HealthChecks{
+					&structs.HealthCheck{
+						Node:        "cnative",
+						CheckID:     "cnative:cproxy-http",
+						Name:        "cproxy-liveness",
+						Status:      api.HealthPassing,
+						ServiceID:   "cproxy-http",
 						ServiceName: "cproxy",
 					},
 				},
@@ -2120,6 +2144,42 @@ func TestUIServiceTopology(t *testing.T) {
 							HasExact:       true,
 						},
 						Source: structs.TopologySourceRegistration,
+					},
+				},
+				FilteredByACLs: false,
+			},
+		},
+		{
+			name: "cbackend",
+			httpReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/cbackend?kind=", nil)
+				return req
+			}(),
+			want: &ServiceTopology{
+				Protocol:         "http",
+				TransparentProxy: false,
+				Upstreams:        []*ServiceTopologySummary{},
+				Downstreams: []*ServiceTopologySummary{
+					{
+						ServiceSummary: ServiceSummary{
+							Name:           "cproxy",
+							Datacenter:     "dc1",
+							Tags:           []string{"http", "https"},
+							Nodes:          []string{"cnative", "cnative"},
+							InstanceCount:  2,
+							ChecksPassing:  3,
+							ChecksWarning:  0,
+							ChecksCritical: 0,
+							ConnectNative:  true,
+							EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+						},
+						Intention: structs.IntentionDecisionSummary{
+							DefaultAllow:   true,
+							Allowed:        true,
+							HasPermissions: false,
+							HasExact:       true,
+						},
+						Source: structs.TopologySourceSpecificIntention,
 					},
 				},
 				FilteredByACLs: false,

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -2165,7 +2165,7 @@ func TestUIServiceTopology(t *testing.T) {
 							Name:           "cproxy",
 							Datacenter:     "dc1",
 							Tags:           []string{"http", "https"},
-							Nodes:          []string{"cnative", "cnative"},
+							Nodes:          []string{"cnative"},
 							InstanceCount:  2,
 							ChecksPassing:  3,
 							ChecksWarning:  0,


### PR DESCRIPTION
### Description

If a service is registered twice, once with connect-native and once
without, the topology views would prune the existing intentions. This
change brings the code more in line with the transparent proxy behavior.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
* [x] checklist [folder](./../docs/config) consulted
