### PR TITLE
test: ensure this package uses freeport for port allocation

### DIFF
--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/proto/pbpeering"
+	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/tlsutil"
@@ -63,6 +64,8 @@ func TestPeeringService_GenerateToken(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	t.Cleanup(cancel)
 
+	expectedAddr := s.Server.Listener.Addr().String()
+
 	// TODO(peering): for more failure cases, consider using a table test
 	// check meta tags
 	reqE := pbpeering.GenerateTokenRequest{PeerName: "peerB", Datacenter: "dc1", Meta: generateTooManyMetaKeys()}
@@ -81,7 +84,7 @@ func TestPeeringService_GenerateToken(t *testing.T) {
 	require.NoError(t, json.Unmarshal(tokenJSON, token))
 	require.Equal(t, "server.dc1.consul", token.ServerName)
 	require.Len(t, token.ServerAddresses, 1)
-	require.Equal(t, "127.0.0.1:2345", token.ServerAddresses[0])
+	require.Equal(t, expectedAddr, token.ServerAddresses[0])
 	require.Equal(t, []string{ca}, token.CA)
 
 	require.NotEmpty(t, token.PeerID)
@@ -313,14 +316,23 @@ func newTestServer(t *testing.T, cb func(conf *consul.Config)) testingServer {
 	conf := consul.DefaultConfig()
 	dir := testutil.TempDir(t, "consul")
 
+	ports := freeport.GetN(t, 3) // {rpc, serf_lan, serf_wan}
+
 	conf.Bootstrap = true
 	conf.Datacenter = "dc1"
 	conf.DataDir = dir
-	conf.RPCAddr = &net.TCPAddr{IP: []byte{127, 0, 0, 1}, Port: 2345}
+	conf.RPCAddr = &net.TCPAddr{IP: []byte{127, 0, 0, 1}, Port: ports[0]}
 	conf.RaftConfig.ElectionTimeout = 200 * time.Millisecond
 	conf.RaftConfig.LeaderLeaseTimeout = 100 * time.Millisecond
 	conf.RaftConfig.HeartbeatTimeout = 200 * time.Millisecond
 	conf.TLSConfig.Domain = "consul"
+
+	conf.SerfLANConfig.MemberlistConfig.BindAddr = "127.0.0.1"
+	conf.SerfLANConfig.MemberlistConfig.BindPort = ports[1]
+	conf.SerfLANConfig.MemberlistConfig.AdvertisePort = ports[1]
+	conf.SerfWANConfig.MemberlistConfig.BindAddr = "127.0.0.1"
+	conf.SerfWANConfig.MemberlistConfig.BindPort = ports[2]
+	conf.SerfWANConfig.MemberlistConfig.AdvertisePort = ports[2]
 
 	nodeID, err := uuid.GenerateUUID()
 	if err != nil {


### PR DESCRIPTION
### Description

I noticed that this package fails its tests with bind address errors if there is a consul agent running on the same machine. This means those tests are using hard coded ports rather than picking ports not known to collide

- `agent/rpc/peering`
