### PR TITLE
structs: add convenience methods to sort slices of ServiceName values

### DIFF
--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2127,6 +2127,14 @@ func ServiceGatewayVirtualIPTag(sn ServiceName) string {
 
 type ServiceList []ServiceName
 
+// Len implements sort.Interface.
+func (s ServiceList) Len() int { return len(s) }
+
+// Swap implements sort.Interface.
+func (s ServiceList) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+func (s ServiceList) Sort() { sort.Sort(s) }
+
 type IndexedServiceList struct {
 	Services ServiceList
 	QueryMeta

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -114,6 +114,12 @@ func ServiceNameFromString(input string) ServiceName {
 	return ServiceName{Name: id}
 }
 
+// Less implements sort.Interface.
+func (s ServiceList) Less(i, j int) bool {
+	a, b := s[i], s[j]
+	return a.Name < b.Name
+}
+
 func (cid CheckID) String() string {
 	return string(cid.ID)
 }


### PR DESCRIPTION
### Description

Being able to stable-sort `[]structs.ServiceName` will be convenient in future units of work.

### PR Checklist

* [x] updated test coverage
* [x] not a security concern
