### PR TITLE
Add expanding on environment for stats tags

### DIFF
--- a/.changelog/13049.txt
+++ b/.changelog/13049.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Expand variables provided on envoy bootstrap stats tags
+```

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -505,6 +505,7 @@ func generateStatsTags(args *BootstrapTplArgs, initialTags []string, omitDepreca
 	)
 
 	for _, tag := range initialTags {
+		tag := os.ExpandEnv(tag)
 		parts := strings.SplitN(tag, "=", 2)
 		// If there is no equals, treat it as a boolean tag and just assign value of
 		// 1 e.g. "canary" will out put the tag "canary: 1"


### PR DESCRIPTION
This PR ands enviroment expansion for envoy stats tags. This, along with https://github.com/hashicorp/nomad/pull/12959 will allow us to do things like in the proxy configuration:

```
kind = "proxy-defaults"
name = "global"

Config {
      envoy_dogstatsd_url = "udp://172.26.64.1:9125"
      envoy_stats_tags = [
        "alloc_id=${NOMAD_ALLOC_ID}",
        "nomad_group=${NOMAD_GROUP_NAME}",
        "nomad_job=${NOMAD_JOB_NAME}",
        "nomad_namespace=${NOMAD_NAMESPACE}",
      ]
}
```
