### PR TITLE
Update to go-grpc/grpc@v1.37.1 to resolve connection memory leak

### DIFF
--- a/.changelog/13051.txt
+++ b/.changelog/13051.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deps: Update go-grpc/grpc, resolving connection memory leak
+```

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/genproto v0.0.0-20200623002339-fbb79eadd5eb
-	google.golang.org/grpc v1.36.0
+	google.golang.org/grpc v1.37.1
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/square/go-jose.v2 v2.5.1
 	gotest.tools/v3 v3.0.3

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.10.1 h1:cgDRLG7bs59Zd+apAWuzLQL95obVYAymNJek76W3mgw=
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
@@ -924,8 +925,9 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
-google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.37.1 h1:ARnQJNWxGyYJpdf/JXscNlQr/uv607ZPU9Z7ogHi+iI=
+google.golang.org/grpc v1.37.1/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
### Description
Updates go-grpc/grpc to v1.37.1 to address memory leak issue in earlier versions.

### Testing & Reproduction steps

I am including the test case I used to validate the behavior, I have removed it from the PR as it is testing internal library behavior and likely will not survive long-term. The test uses reflection to do some digging for connection leaks. The test when ported to 1.11.x at least demonstrates the issue cleanly.

<details><summary>Test code</summary>

In `agent/grpc/private/client_test.go`:
```
func TestClientConnPool_IntegrationWithGRPCResolver_Rebalance5000(t *testing.T) {
	count := 5
	res := resolver.NewServerResolverBuilder(newConfig(t))
	registerWithGRPC(t, res)
	pool := NewClientConnPool(ClientConnPoolConfig{
			Servers:               res,
			UseTLSForDC:           useTLSForDcAlwaysTrue,
			DialingFromServer:     true,
			DialingFromDatacenter: "dc1",
	})

	for i := 0; i < count; i {
			name := fmt.Sprintf("server-%d", i)
			srv := newSimpleTestServer(t, name, "dc1", nil)
			res.AddServer(types.AreaWAN, srv.Metadata())
			t.Cleanup(srv.shutdown)
	}

	conn, err := pool.ClientConn("dc1")
	require.NoError(t, err)
	client := testservice.NewSimpleClient(conn)

	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
	t.Cleanup(cancel)

	_, err = client.Something(ctx, &testservice.Req{})
	require.NoError(t, err)

	t.Run("rebalance the dc", func(t *testing.T) {
			// Rebalance is random, but if we repeat it a few times it should give us a
			// new server.
			attempts := 1000
			for i := 0; i < attempts; i {
					res.NewRebalancer("dc1")()

					_, err := client.Something(ctx, &testservice.Req{})
					require.NoError(t, err)
			}
			// Confirm conns aren't leaking
			e := reflect.ValueOf(client).Elem()
			ccPtr := e.FieldByName("cc").Elem()
			conns := reflect.Indirect(ccPtr).FieldByName("conns").Len()
			assert.LessOrEqual(t, conns, 1, "excessive grpc connections remaining open")
			//time.Sleep(10 * time.Second)
	})
}
```
</details>

<details><summary>v1.11.5, arm64 grpc/grpc-go@v1.25.1</summary>

```
$ (pushd agent/grpc; go test -v -run '^TestClientConnPool_IntegrationWithGRPCResolver_Rebalance')
~/src/consul/agent/grpc ~/src/consul
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_Rebalance
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_Rebalance/rebalance_a_different_DC,_does_nothing
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_Rebalance/rebalance_the_dc
--- PASS: TestClientConnPool_IntegrationWithGRPCResolver_Rebalance (0.10s)
    --- PASS: TestClientConnPool_IntegrationWithGRPCResolver_Rebalance/rebalance_a_different_DC,_does_nothing (0.00s)
    --- PASS: TestClientConnPool_IntegrationWithGRPCResolver_Rebalance/rebalance_the_dc (0.07s)
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_Rebalance5000
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_Rebalance5000/rebalance_the_dc
    assertion_compare.go:342:
        	Error Trace:	client_test.go:438
        	Error:      	"1628" is not less than or equal to "1"
        	Test:       	TestClientConnPool_IntegrationWithGRPCResolver_Rebalance5000/rebalance_the_dc
        	Messages:   	[excessive grpc connections remaining open]
--- FAIL: TestClientConnPool_IntegrationWithGRPCResolver_Rebalance5000 (26.91s)
    --- FAIL: TestClientConnPool_IntegrationWithGRPCResolver_Rebalance5000/rebalance_the_dc (26.87s)
FAIL
exit status 1
FAIL	github.com/hashicorp/consul/agent/grpc	27.456s
```

</details>

<details><summary>v1.12.0, arm64 grpc/grpc-go@v1.37.1</summary>


```
$ (pushd agent/grpc/private; go test -v -run '^TestClientConnPool_IntegrationWithGRPCResolver_Rebalance')
~/src/consul/agent/grpc/private ~/src/consul
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_Rebalance
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_Rebalance/rebalance_a_different_DC,_does_nothing
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_Rebalance/rebalance_the_dc
--- PASS: TestClientConnPool_IntegrationWithGRPCResolver_Rebalance (0.10s)
    --- PASS: TestClientConnPool_IntegrationWithGRPCResolver_Rebalance/rebalance_a_different_DC,_does_nothing (0.00s)
    --- PASS: TestClientConnPool_IntegrationWithGRPCResolver_Rebalance/rebalance_the_dc (0.05s)
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_RebalanceRepeatedly
=== RUN   TestClientConnPool_IntegrationWithGRPCResolver_RebalanceRepeatedly/rebalance_the_dc
--- PASS: TestClientConnPool_IntegrationWithGRPCResolver_RebalanceRepeatedly (16.94s)
    --- PASS: TestClientConnPool_IntegrationWithGRPCResolver_RebalanceRepeatedly/rebalance_the_dc (16.92s)
PASS
ok  	github.com/hashicorp/consul/agent/grpc/private	17.712s
```


</details>

### Links

Fixes the issue discussed in hashicorp/consul#12288

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
* [x] checklist [folder](./../docs/config) consulted
