### PR TITLE
[OSS] Add upsert handling for receiving CheckServiceNode

### DIFF
--- a/acl/enterprisemeta_oss.go
+++ b/acl/enterprisemeta_oss.go
@@ -100,6 +100,10 @@ func (m *EnterpriseMeta) UnsetPartition() {
 	// do nothing
 }
 
+func (m *EnterpriseMeta) OverridePartition(_ string) {
+	// do nothing
+}
+
 func NewEnterpriseMetaWithPartition(_, _ string) EnterpriseMeta {
 	return emptyEnterpriseMeta
 }

--- a/agent/consul/fsm/snapshot_oss.go
+++ b/agent/consul/fsm/snapshot_oss.go
@@ -112,17 +112,7 @@ func (s *snapshot) persistNodes(sink raft.SnapshotSink,
 		n := node.(*structs.Node)
 		nodeEntMeta := n.GetEnterpriseMeta()
 
-		req := structs.RegisterRequest{
-			ID:              n.ID,
-			Node:            n.Node,
-			Datacenter:      n.Datacenter,
-			Address:         n.Address,
-			TaggedAddresses: n.TaggedAddresses,
-			NodeMeta:        n.Meta,
-			RaftIndex:       n.RaftIndex,
-			EnterpriseMeta:  *nodeEntMeta,
-			PeerName:        n.PeerName,
-		}
+		req := n.ToRegisterRequest()
 
 		// Register the node itself
 		if _, err := sink.Write([]byte{byte(structs.RegisterRequestType)}); err != nil {

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/hashicorp/consul/agent/rpc/peering"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
@@ -207,7 +208,13 @@ func (s *Server) establishStream(ctx context.Context, logger hclog.Logger, peer 
 			return err
 		}
 
-		err = s.peeringService.HandleStream(peer.ID, peer.PeerID, stream)
+		err = s.peeringService.HandleStream(peering.HandleStreamRequest{
+			LocalID:   peer.ID,
+			RemoteID:  peer.PeerID,
+			PeerName:  peer.Name,
+			Partition: peer.Partition,
+			Stream:    stream,
+		})
 		if err == nil {
 			// This will cancel the retry-er context, letting us break out of this loop when we want to shut down the stream.
 			cancel()

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -123,4 +123,9 @@ func (a *peeringApply) PeeringTerminateByID(req *pbpeering.PeeringTerminateByIDR
 	return err
 }
 
+func (a *peeringApply) CatalogRegister(req *structs.RegisterRequest) error {
+	_, err := a.srv.leaderRaftApply("Catalog.Register", structs.RegisterRequestType, req)
+	return err
+}
+
 var _ peering.Apply = (*peeringApply)(nil)

--- a/agent/rpc/peering/stream_test.go
+++ b/agent/rpc/peering/stream_test.go
@@ -32,16 +32,22 @@ func TestStreamResources_Server_FirstRequest(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		srv := NewService(testutil.Logger(t), nil)
-		client := newMockClient(context.Background())
+		store := state.NewStateStoreWithEventPublisher(nil)
+
+		srv := NewService(testutil.Logger(t), &testStreamBackend{
+			store: store,
+			pub:   store.EventPublisher(),
+		})
+
+		client := NewMockClient(context.Background())
 
 		errCh := make(chan error, 1)
-		client.errCh = errCh
+		client.ErrCh = errCh
 
 		go func() {
-			// Pass errors from server handler into errCh so that they can be seen by the client on Recv().
+			// Pass errors from server handler into ErrCh so that they can be seen by the client on Recv().
 			// This matches gRPC's behavior when an error is returned by a server.
-			err := srv.StreamResources(client.replicationStream)
+			err := srv.StreamResources(client.ReplicationStream)
 			if err != nil {
 				errCh <- err
 			}
@@ -103,6 +109,18 @@ func TestStreamResources_Server_FirstRequest(t *testing.T) {
 			},
 			wantErr: status.Error(codes.InvalidArgument, "subscription request to unknown resource URL: nomad.Job"),
 		},
+		{
+			name: "unknown peer",
+			input: &pbpeering.ReplicationMessage{
+				Payload: &pbpeering.ReplicationMessage_Request_{
+					Request: &pbpeering.ReplicationMessage_Request{
+						PeerID:      "63b60245-c475-426b-b314-4588d210859d",
+						ResourceURL: pbpeering.TypeURLService,
+					},
+				},
+			},
+			wantErr: status.Error(codes.InvalidArgument, "initial subscription for unknown PeerID: 63b60245-c475-426b-b314-4588d210859d"),
+		},
 	}
 
 	for _, tc := range tt {
@@ -127,21 +145,30 @@ func TestStreamResources_Server_Terminate(t *testing.T) {
 	}
 	srv.streams.timeNow = it.Now
 
-	client := newMockClient(context.Background())
+	client := NewMockClient(context.Background())
 
 	errCh := make(chan error, 1)
-	client.errCh = errCh
+	client.ErrCh = errCh
 
 	go func() {
-		// Pass errors from server handler into errCh so that they can be seen by the client on Recv().
+		// Pass errors from server handler into ErrCh so that they can be seen by the client on Recv().
 		// This matches gRPC's behavior when an error is returned by a server.
-		if err := srv.StreamResources(client.replicationStream); err != nil {
+		if err := srv.StreamResources(client.ReplicationStream); err != nil {
 			errCh <- err
 		}
 	}()
 
+	peering := pbpeering.Peering{
+		Name: "my-peer",
+	}
+	require.NoError(t, store.PeeringWrite(0, &peering))
+
+	_, p, err := store.PeeringRead(nil, state.Query{Value: "my-peer"})
+	require.NoError(t, err)
+
 	// Receive a subscription from a peer
-	peerID := "63b60245-c475-426b-b314-4588d210859d"
+	peerID := p.ID
+
 	sub := &pbpeering.ReplicationMessage{
 		Payload: &pbpeering.ReplicationMessage_Request_{
 			Request: &pbpeering.ReplicationMessage_Request{
@@ -150,7 +177,7 @@ func TestStreamResources_Server_Terminate(t *testing.T) {
 			},
 		},
 	}
-	err := client.Send(sub)
+	err = client.Send(sub)
 	require.NoError(t, err)
 
 	testutil.RunStep(t, "new stream gets tracked", func(t *testing.T) {
@@ -209,14 +236,23 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 	}
 	srv.streams.timeNow = it.Now
 
-	client := newMockClient(context.Background())
+	client := NewMockClient(context.Background())
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- srv.StreamResources(client.replicationStream)
+		errCh <- srv.StreamResources(client.ReplicationStream)
 	}()
 
-	peerID := "63b60245-c475-426b-b314-4588d210859d"
+	peering := pbpeering.Peering{
+		Name: "my-peer",
+	}
+	require.NoError(t, store.PeeringWrite(0, &peering))
+
+	_, p, err := store.PeeringRead(nil, state.Query{Value: "my-peer"})
+	require.NoError(t, err)
+
+	peerID := p.ID
+
 	sub := &pbpeering.ReplicationMessage{
 		Payload: &pbpeering.ReplicationMessage_Request_{
 			Request: &pbpeering.ReplicationMessage_Request{
@@ -225,7 +261,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			},
 		},
 	}
-	err := client.Send(sub)
+	err = client.Send(sub)
 	require.NoError(t, err)
 
 	testutil.RunStep(t, "new stream gets tracked", func(t *testing.T) {
@@ -483,15 +519,15 @@ func TestStreamResources_Server_ServiceUpdates(t *testing.T) {
 		pub:   publisher,
 	})
 
-	client := newMockClient(context.Background())
+	client := NewMockClient(context.Background())
 
 	errCh := make(chan error, 1)
-	client.errCh = errCh
+	client.ErrCh = errCh
 
 	go func() {
-		// Pass errors from server handler into errCh so that they can be seen by the client on Recv().
+		// Pass errors from server handler into ErrCh so that they can be seen by the client on Recv().
 		// This matches gRPC's behavior when an error is returned by a server.
-		if err := srv.StreamResources(client.replicationStream); err != nil {
+		if err := srv.StreamResources(client.ReplicationStream); err != nil {
 			errCh <- err
 		}
 	}()
@@ -683,7 +719,7 @@ func (b *testStreamBackend) Apply() Apply {
 	return nil
 }
 
-func Test_processResponse(t *testing.T) {
+func Test_processResponse_Validation(t *testing.T) {
 	type testCase struct {
 		name    string
 		in      *pbpeering.ReplicationMessage_Response
@@ -691,8 +727,14 @@ func Test_processResponse(t *testing.T) {
 		wantErr bool
 	}
 
+	store := state.NewStateStoreWithEventPublisher(nil)
+	srv := NewService(testutil.Logger(t), &testStreamBackend{
+		store: store,
+		pub:   store.EventPublisher(),
+	})
+
 	run := func(t *testing.T, tc testCase) {
-		reply, err := processResponse(tc.in)
+		reply, err := srv.processResponse("", "", tc.in)
 		if tc.wantErr {
 			require.Error(t, err)
 		} else {

--- a/agent/rpc/peering/stream_test.go
+++ b/agent/rpc/peering/stream_test.go
@@ -32,11 +32,12 @@ func TestStreamResources_Server_FirstRequest(t *testing.T) {
 	}
 
 	run := func(t *testing.T, tc testCase) {
-		store := state.NewStateStoreWithEventPublisher(nil)
+		publisher := stream.NewEventPublisher(10 * time.Second)
+		store := newStateStore(t, publisher)
 
 		srv := NewService(testutil.Logger(t), &testStreamBackend{
 			store: store,
-			pub:   store.EventPublisher(),
+			pub:   publisher,
 		})
 
 		client := NewMockClient(context.Background())
@@ -727,10 +728,11 @@ func Test_processResponse_Validation(t *testing.T) {
 		wantErr bool
 	}
 
-	store := state.NewStateStoreWithEventPublisher(nil)
+	publisher := stream.NewEventPublisher(10 * time.Second)
+	store := newStateStore(t, publisher)
 	srv := NewService(testutil.Logger(t), &testStreamBackend{
 		store: store,
-		pub:   store.EventPublisher(),
+		pub:   publisher,
 	})
 
 	run := func(t *testing.T, tc testCase) {

--- a/agent/rpc/peering/subscription_view.go
+++ b/agent/rpc/peering/subscription_view.go
@@ -47,6 +47,8 @@ func (e *exportedServiceRequest) CacheInfo() cache.RequestInfo {
 // NewMaterializer implements submatview.Request
 func (e *exportedServiceRequest) NewMaterializer() (submatview.Materializer, error) {
 	reqFn := func(index uint64) *pbsubscribe.SubscribeRequest {
+		// TODO(peering): We need to be able to receive both connect proxies and typical service instances for a given name.
+		//                Using the Topic_ServiceHealth will ignore proxies unless the ServiceName is a proxy name.
 		r := &pbsubscribe.SubscribeRequest{
 			Topic:      pbsubscribe.Topic_ServiceHealth,
 			Key:        e.req.ServiceName,

--- a/agent/rpc/peering/testing.go
+++ b/agent/rpc/peering/testing.go
@@ -75,52 +75,52 @@ func TestPeeringToken(peerID string) structs.PeeringToken {
 	}
 }
 
-type mockClient struct {
-	mu    sync.Mutex
-	errCh chan error
+type MockClient struct {
+	mu sync.Mutex
 
-	replicationStream *mockStream
+	ErrCh             chan error
+	ReplicationStream *MockStream
 }
 
-func (c *mockClient) Send(r *pbpeering.ReplicationMessage) error {
-	c.replicationStream.recvCh <- r
+func (c *MockClient) Send(r *pbpeering.ReplicationMessage) error {
+	c.ReplicationStream.recvCh <- r
 	return nil
 }
 
-func (c *mockClient) Recv() (*pbpeering.ReplicationMessage, error) {
+func (c *MockClient) Recv() (*pbpeering.ReplicationMessage, error) {
 	select {
-	case err := <-c.errCh:
+	case err := <-c.ErrCh:
 		return nil, err
-	case r := <-c.replicationStream.sendCh:
+	case r := <-c.ReplicationStream.sendCh:
 		return r, nil
 	case <-time.After(10 * time.Millisecond):
 		return nil, io.EOF
 	}
 }
 
-func (c *mockClient) RecvWithTimeout(dur time.Duration) (*pbpeering.ReplicationMessage, error) {
+func (c *MockClient) RecvWithTimeout(dur time.Duration) (*pbpeering.ReplicationMessage, error) {
 	select {
-	case err := <-c.errCh:
+	case err := <-c.ErrCh:
 		return nil, err
-	case r := <-c.replicationStream.sendCh:
+	case r := <-c.ReplicationStream.sendCh:
 		return r, nil
 	case <-time.After(dur):
 		return nil, io.EOF
 	}
 }
 
-func (c *mockClient) Close() {
-	close(c.replicationStream.recvCh)
+func (c *MockClient) Close() {
+	close(c.ReplicationStream.recvCh)
 }
 
-func newMockClient(ctx context.Context) *mockClient {
-	return &mockClient{
-		replicationStream: newTestReplicationStream(ctx),
+func NewMockClient(ctx context.Context) *MockClient {
+	return &MockClient{
+		ReplicationStream: newTestReplicationStream(ctx),
 	}
 }
 
-// mockStream mocks peering.PeeringService_StreamResourcesServer
-type mockStream struct {
+// MockStream mocks peering.PeeringService_StreamResourcesServer
+type MockStream struct {
 	sendCh chan *pbpeering.ReplicationMessage
 	recvCh chan *pbpeering.ReplicationMessage
 
@@ -128,10 +128,10 @@ type mockStream struct {
 	mu  sync.Mutex
 }
 
-var _ pbpeering.PeeringService_StreamResourcesServer = (*mockStream)(nil)
+var _ pbpeering.PeeringService_StreamResourcesServer = (*MockStream)(nil)
 
-func newTestReplicationStream(ctx context.Context) *mockStream {
-	return &mockStream{
+func newTestReplicationStream(ctx context.Context) *MockStream {
+	return &MockStream{
 		sendCh: make(chan *pbpeering.ReplicationMessage, 1),
 		recvCh: make(chan *pbpeering.ReplicationMessage, 1),
 		ctx:    ctx,
@@ -139,13 +139,13 @@ func newTestReplicationStream(ctx context.Context) *mockStream {
 }
 
 // Send implements pbpeering.PeeringService_StreamResourcesServer
-func (s *mockStream) Send(r *pbpeering.ReplicationMessage) error {
+func (s *MockStream) Send(r *pbpeering.ReplicationMessage) error {
 	s.sendCh <- r
 	return nil
 }
 
 // Recv implements pbpeering.PeeringService_StreamResourcesServer
-func (s *mockStream) Recv() (*pbpeering.ReplicationMessage, error) {
+func (s *MockStream) Recv() (*pbpeering.ReplicationMessage, error) {
 	r := <-s.recvCh
 	if r == nil {
 		return nil, io.EOF
@@ -154,32 +154,32 @@ func (s *mockStream) Recv() (*pbpeering.ReplicationMessage, error) {
 }
 
 // Context implements grpc.ServerStream and grpc.ClientStream
-func (s *mockStream) Context() context.Context {
+func (s *MockStream) Context() context.Context {
 	return s.ctx
 }
 
 // SendMsg implements grpc.ServerStream and grpc.ClientStream
-func (s *mockStream) SendMsg(m interface{}) error {
+func (s *MockStream) SendMsg(m interface{}) error {
 	return nil
 }
 
 // RecvMsg implements grpc.ServerStream and grpc.ClientStream
-func (s *mockStream) RecvMsg(m interface{}) error {
+func (s *MockStream) RecvMsg(m interface{}) error {
 	return nil
 }
 
 // SetHeader implements grpc.ServerStream
-func (s *mockStream) SetHeader(metadata.MD) error {
+func (s *MockStream) SetHeader(metadata.MD) error {
 	return nil
 }
 
 // SendHeader implements grpc.ServerStream
-func (s *mockStream) SendHeader(metadata.MD) error {
+func (s *MockStream) SendHeader(metadata.MD) error {
 	return nil
 }
 
 // SetTrailer implements grpc.ServerStream
-func (s *mockStream) SetTrailer(metadata.MD) {}
+func (s *MockStream) SetTrailer(metadata.MD) {}
 
 type incrementalTime struct {
 	base time.Time

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -855,6 +855,20 @@ func (n *Node) BestAddress(wan bool) string {
 	return n.Address
 }
 
+func (n *Node) ToRegisterRequest() RegisterRequest {
+	return RegisterRequest{
+		ID:              n.ID,
+		Node:            n.Node,
+		Datacenter:      n.Datacenter,
+		Address:         n.Address,
+		TaggedAddresses: n.TaggedAddresses,
+		NodeMeta:        n.Meta,
+		RaftIndex:       n.RaftIndex,
+		EnterpriseMeta:  *n.GetEnterpriseMeta(),
+		PeerName:        n.PeerName,
+	}
+}
+
 type Nodes []*Node
 
 // IsSame return whether nodes are similar without taking into account


### PR DESCRIPTION
Each response with an UPSERT op will contain snapshots of data for a
given ResourceID. For services, this will correspond to all instances
of a service name.

This commit adds handling for storing all of these instances to the
state store, following the snapshotting logic in persistNodes.

Note that this commit does not handle deleting previously imported data
that is not in the latest snapshot. A follow-up will add that handling.
