### PR TITLE
Update pr-labeler.yml

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
Changing from `pull_request` to `pull_request_target` so that forks can get the write permissions to add labels. See [this thread](https://github.com/actions/labeler/issues/121) in the action repo.

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [X] not a security concern
  * In general using `pull_request_target` could be insecure, but scope to an action that doesn't build any forked code, this should be safe. 
* [ ] ~checklist [folder](./../docs/config) consulted~
