### PR TITLE
Actually block when syncing subscriptions

### DIFF
--- a/agent/rpc/peering/subscription_manager.go
+++ b/agent/rpc/peering/subscription_manager.go
@@ -134,7 +134,7 @@ func (m *subscriptionManager) syncSubscriptionsAndBlock(ctx context.Context, pee
 	}
 
 	// Block for any changes to the state store.
-	ws.WatchCh(ctx)
+	ws.WatchCtx(ctx)
 	return nil
 }
 


### PR DESCRIPTION
By changing to use `WatchCtx` we will actually block for changes to the peering list. `WatchCh` creates a goroutine to collect errors from `WatchCtx` and returns immediately.

The existing behavior wouldn't result in a tight loop because of the rate limiting in the surrounding function, but it would still lead to more work than is necessary.
