### PR TITLE
peering: fix panic in test

### DIFF
--- a/api/peering_test.go
+++ b/api/peering_test.go
@@ -153,11 +153,12 @@ func TestAPI_Peering_GenerateToken_Read_Initiate_Delete(t *testing.T) {
 	var token1 string
 	// Generate a token happy path
 	resp, wm, err := peerings.GenerateToken(ctx, p1, options)
-	token1 = resp.PeeringToken
 
 	require.NoError(t, err)
 	require.NotEmpty(t, wm)
 	require.NotEmpty(t, resp)
+
+	token1 = resp.PeeringToken
 
 	// Read token generated on server
 	resp2, qm, err2 := peerings.Read(ctx, PeeringReadRequest{Name: "peer1"}, nil)


### PR DESCRIPTION
### Description
I was futzing around with the API tests and noticed that when the happy path isn't so happy, the tests could panic. It's a one-line change to move a reference to after the assertions are made. 

### Testing & Reproduction steps
If you build an older version that doesn't have support for peering and then run the `api` tests, this peering test case will panic. 

### PR Checklist

* [x] updated test coverage