### PR TITLE
When a host header is defined override `req.Host` in the metrics ui

### DIFF
--- a/.changelog/13071.txt
+++ b/.changelog/13071.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix a bug when configuring an `add_headers` directive named `Host` the header is not set for `v1/internal/ui/metrics-proxy/` endpoint.
+```

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -740,7 +740,11 @@ func (s *HTTPHandlers) UIMetricsProxy(resp http.ResponseWriter, req *http.Reques
 
 	// Add any configured headers
 	for _, h := range cfg.AddHeaders {
-		req.Header.Set(h.Name, h.Value)
+		if strings.ToLower(h.Name) == "host" {
+			req.Host = h.Value
+		} else {
+			req.Header.Set(h.Name, h.Value)
+		}
 	}
 
 	log.Debug("proxying request", "to", u.String())


### PR DESCRIPTION
### Description
Fix #10164
[The behaviour of `req.Header.Set` in the go `http` package ignore the Header when it's named Host](https://github.com/golang/go/issues/7682). To se the Host header this need to be set in `req.Host`. 
This PR add the ability to do so for the ui internal endpoint, so users can add an `add_header` directive in Consul config to overwrite the Host header so a proxy can be configured.

Note:
Header names are case insensitive as defined in [here](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)