### PR TITLE
[CI-only] Build and publish dev dockerhub images 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Push events on the main branch
       - main
-      - dev-image-publishing
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,3 +251,6 @@ jobs:
           tags: |
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}
+          dev_tags: |
+            hashicorppreview/${{ env.repo }}:${{ env.version }}-dev
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Push events on the main branch
       - main
+      - dev-image-publishing
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,5 +252,5 @@ jobs:
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}
           dev_tags: |
-            hashicorppreview/${{ env.repo }}:${{ env.version }}-dev
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-dev
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-${{ github.sha }}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -164,6 +164,20 @@ event "verify" {
   }
 }
 
+event "promote-dev-docker" {
+  depends = ["verify"]
+  action "promote-dev-docker" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "promote-dev-docker"
+    depends = ["verify"]
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
 ## These are promotion and post-publish events
 ## they should be added to the end of the file after the verify event stanza.
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -15,6 +15,7 @@ project "consul" {
       "release/1.10.x",
       "release/1.11.x",
       "release/1.12.x",
+      "dev-image-publishing",
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -15,7 +15,6 @@ project "consul" {
       "release/1.10.x",
       "release/1.11.x",
       "release/1.12.x",
-      "dev-image-publishing",
     ]
   }
 }


### PR DESCRIPTION
### Description

This introduces build/publishing of dev dockerhub images to the hashicorppreview dockerhub org. This will be kicked off when a PR is merged to any of the release branches (or main) listed in the `release_branches` array in `.release/ci.hcl`. 

### Testing & Reproduction steps
I tested out a publish from this test branch in commit: https://github.com/hashicorp/consul/commit/c29e03af47aaaa451e17be375b96aebffa54d2fa. You can see the images available here: https://hub.docker.com/repository/docker/hashicorppreview/consul/tags?page=1&ordering=last_updated (which I will delete after this PR is merged). 

### Links
Link to full documentation describing how dev images are created and published, their naming conventions, etc: https://go.hashi.co/dev-docker-images

