### PR TITLE
Manual cherrypick to docs

### DIFF
--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -26,6 +26,12 @@ to `true`. In prior Consul versions (1.10.x through 1.11.x), the config defaulte
 well as the flag will be removed in upcoming Consul 1.13. We recommend changing your instrumentation to use 1.10 and later
 style `consul.api.http...` metrics and removing the configuration flag from your setup.
 
+### Nomad Namespace Incompatibility
+
+Nomad Enterprise users should not upgrade to Consul Enterprise 1.12.0. 
+
+Consul 1.12.0 Enterprise introduced a change that prevents Nomad Enterprise from removing services from non-default Consul namespaces. To avoid errors, we recommend that Nomad Enterprise users wait to update Consul Enterprise until we fix this issue in a future release.
+
 ### TLS Configuration
 
 You can now configure TLS differently for each of Consul's exposed ports. As a


### PR DESCRIPTION
Due to build changes in Consul 1.12.0 the `+ent` modifier is missing
from the version reported by `/v1/agent/self`.

Nomad looks for the `ent` modifier when determining whether to reconcile
services in non-default namespaces. Without the modifier Nomad will only
end up removing services from the default Consul namespace.

(cherry picked from commit 9acce31237fd9f23363711f4ef25fd1de10fe726)