### PR TITLE
feat(tgateway): allow finding system CAs on service level

### DIFF
--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -1436,6 +1436,11 @@ func TestCatalog_GatewayServices_Terminating(t *testing.T) {
 					KeyFile:  "client.key",
 					SNI:      "my-alt-domain",
 				},
+				{
+					Name:        "example",
+					UseSystemCA: true,
+					SNI:         "example.com",
+				},
 			},
 		},
 	}
@@ -1464,6 +1469,13 @@ func TestCatalog_GatewayServices_Terminating(t *testing.T) {
 				CertFile:    "api/client.crt",
 				KeyFile:     "api/client.key",
 				SNI:         "my-domain",
+			},
+			{
+				Service:     structs.NewServiceName("example", nil),
+				Gateway:     structs.NewServiceName("terminating", nil),
+				GatewayKind: structs.ServiceKindTerminatingGateway,
+				UseSystemCA: true,
+				SNI:         "example.com",
 			},
 			{
 				Service:      structs.NewServiceName("redis", nil),

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -343,6 +343,11 @@ func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 		  },
 		  {
 			"Name": "api"
+		  },
+		  {
+			"Name": "db",
+			"UseSystemCA": true,
+			"SNI": "external.db.com"
 		  }
 		]
 	}`))
@@ -375,6 +380,12 @@ func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 			},
 			{
 				Name:           "api",
+				EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+			},
+			{
+				Name:           "db",
+				UseSystemCA:    true,
+				SNI:            "external.db.com",
 				EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
 			},
 		}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -3490,6 +3490,7 @@ func terminatingConfigGatewayServices(
 			KeyFile:     svc.KeyFile,
 			CertFile:    svc.CertFile,
 			CAFile:      svc.CAFile,
+			UseSystemCA: svc.UseSystemCA,
 			SNI:         svc.SNI,
 		}
 

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -5071,11 +5071,11 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 		Name: "gateway",
 		Services: []structs.LinkedService{
 			{
-				Name:     "api",
-				CAFile:   "api/ca.crt",
-				CertFile: "api/client.crt",
-				KeyFile:  "api/client.key",
-				SNI:      "my-domain",
+				Name:        "api",
+				CertFile:    "api/client.crt",
+				KeyFile:     "api/client.key",
+				UseSystemCA: true,
+				SNI:         "my-domain",
 			},
 			{
 				Name: "db",
@@ -5103,10 +5103,10 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 			Service:     structs.NewServiceName("api", nil),
 			Gateway:     structs.NewServiceName("gateway", nil),
 			GatewayKind: structs.ServiceKindTerminatingGateway,
-			CAFile:      "api/ca.crt",
 			CertFile:    "api/client.crt",
 			KeyFile:     "api/client.key",
 			SNI:         "my-domain",
+			UseSystemCA: true,
 			RaftIndex: structs.RaftIndex{
 				CreateIndex: 22,
 				ModifyIndex: 22,
@@ -5139,9 +5139,9 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 			Service:     structs.NewServiceName("api", nil),
 			Gateway:     structs.NewServiceName("gateway", nil),
 			GatewayKind: structs.ServiceKindTerminatingGateway,
-			CAFile:      "api/ca.crt",
 			CertFile:    "api/client.crt",
 			KeyFile:     "api/client.key",
+			UseSystemCA: true,
 			SNI:         "my-domain",
 			RaftIndex: structs.RaftIndex{
 				CreateIndex: 22,
@@ -5189,9 +5189,9 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 			Service:     structs.NewServiceName("api", nil),
 			Gateway:     structs.NewServiceName("gateway", nil),
 			GatewayKind: structs.ServiceKindTerminatingGateway,
-			CAFile:      "api/ca.crt",
 			CertFile:    "api/client.crt",
 			KeyFile:     "api/client.key",
+			UseSystemCA: true,
 			SNI:         "my-domain",
 			RaftIndex: structs.RaftIndex{
 				CreateIndex: 22,

--- a/agent/proxycfg/testing_terminating_gateway.go
+++ b/agent/proxycfg/testing_terminating_gateway.go
@@ -544,6 +544,52 @@ func TestConfigSnapshotTerminatingGatewaySNI(t testing.T) *ConfigSnapshot {
 	})
 }
 
+func TestConfigSnapshotTerminatingGatewaySystemCA(t testing.T) *ConfigSnapshot {
+	return TestConfigSnapshotTerminatingGateway(t, true, nil, []cache.UpdateEvent{
+		{
+			CorrelationID: "gateway-services",
+			Result: &structs.IndexedGatewayServices{
+				Services: []*structs.GatewayService{
+					{
+						Service:     structs.NewServiceName("web", nil),
+						UseSystemCA: true,
+						SNI:         "foo.com",
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestConfigSnapshotTerminatingGatewayTransparentModeWithCA(t testing.T) *ConfigSnapshot {
+	var (
+		web = structs.NewServiceName("web", nil)
+	)
+	return TestConfigSnapshotTerminatingGateway(t, true, func(ns *structs.NodeService) {
+		ns.Proxy.Mode = structs.ProxyModeTransparent
+	}, []cache.UpdateEvent{
+		{
+			CorrelationID: "gateway-services",
+			Result: &structs.IndexedGatewayServices{
+				Services: []*structs.GatewayService{
+					{
+						Service:     web,
+						UseSystemCA: true,
+						SNI:         "foo.com",
+					},
+					{
+						Service:  structs.NewServiceName("api", nil),
+						CAFile:   "ca.cert.pem",
+						CertFile: "api.cert.pem",
+						KeyFile:  "api.key.pem",
+						SNI:      "bar.com",
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestConfigSnapshotTerminatingGatewayHostnameSubsets(t testing.T) *ConfigSnapshot {
 	var (
 		api   = structs.NewServiceName("api", nil)

--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -1002,7 +1002,7 @@ func TestTerminatingGatewayConfigEntry(t *testing.T) {
 					},
 				},
 			},
-			validateErr: "must have a CertFile, CAFile, and KeyFile",
+			validateErr: "must have a CertFile, KeyFile and authority source (CAFile or UseSystemCA)",
 		},
 		"not all TLS options provided-2": {
 			entry: &TerminatingGatewayConfigEntry{
@@ -1015,7 +1015,21 @@ func TestTerminatingGatewayConfigEntry(t *testing.T) {
 					},
 				},
 			},
-			validateErr: "must have a CertFile, CAFile, and KeyFile",
+			validateErr: "must have a CertFile, KeyFile and authority source (CAFile or UseSystemCA)",
+		},
+		"mismatch TLS CA options": {
+			entry: &TerminatingGatewayConfigEntry{
+				Kind: "terminating-gateway",
+				Name: "terminating-gw-west",
+				Services: []LinkedService{
+					{
+						Name:        "web",
+						CAFile:      "ca.crt",
+						UseSystemCA: true,
+					},
+				},
+			},
+			validateErr: "must either have a CAFile provided or enable System CAs",
 		},
 		"all TLS options provided": {
 			entry: &TerminatingGatewayConfigEntry{
@@ -1039,6 +1053,18 @@ func TestTerminatingGatewayConfigEntry(t *testing.T) {
 					{
 						Name:   "web",
 						CAFile: "ca.crt",
+					},
+				},
+			},
+		},
+		"only providing system certs is allowed": {
+			entry: &TerminatingGatewayConfigEntry{
+				Kind: "terminating-gateway",
+				Name: "terminating-gw-west",
+				Services: []LinkedService{
+					{
+						Name:        "web",
+						UseSystemCA: true,
 					},
 				},
 			},

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -1346,6 +1346,11 @@ func TestDecodeConfigEntry(t *testing.T) {
 						key_file = "/etc/all/tls.key",
 						sni = "my-alt-domain",
 					},
+					{
+						name = "logging",
+						use_system_ca = true,
+						sni = "external.logging.com",
+					},
 				]
 			`,
 			camel: `
@@ -1370,6 +1375,11 @@ func TestDecodeConfigEntry(t *testing.T) {
 						KeyFile = "/etc/all/tls.key",
 						SNI = "my-alt-domain",
 					},
+					{
+						Name = "logging",
+						UseSystemCA = true,
+						SNI = "external.logging.com",
+					},
 				]
 			`,
 			expect: &TerminatingGatewayConfigEntry{
@@ -1393,6 +1403,11 @@ func TestDecodeConfigEntry(t *testing.T) {
 						CertFile: "/etc/all/cert.pem",
 						KeyFile:  "/etc/all/tls.key",
 						SNI:      "my-alt-domain",
+					},
+					{
+						Name:        "logging",
+						UseSystemCA: true,
+						SNI:         "external.logging.com",
 					},
 				},
 			},

--- a/agent/xds/ca.go
+++ b/agent/xds/ca.go
@@ -1,0 +1,19 @@
+package xds
+
+import (
+	"errors"
+	"os"
+)
+
+func getSystemCAFile() (string, error) {
+	for _, file := range certFiles {
+		_, err := os.Stat(file)
+		if err == nil {
+			return file, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+	}
+	return "", errors.New("could not find any system provided certificate authority")
+}

--- a/agent/xds/ca_bsd.go
+++ b/agent/xds/ca_bsd.go
@@ -1,0 +1,11 @@
+// From Go src/crypto/x509/root_bsd.go
+//go:build dragonfly || freebsd || netbsd || openbsd
+
+package xds
+
+var certFiles = []string{
+	"/usr/local/etc/ssl/cert.pem",            // FreeBSD
+	"/etc/ssl/cert.pem",                      // OpenBSD
+	"/usr/local/share/certs/ca-root-nss.crt", // DragonFly
+	"/etc/openssl/certs/ca-certificates.crt", // NetBSD
+}

--- a/agent/xds/ca_darwin.go
+++ b/agent/xds/ca_darwin.go
@@ -1,0 +1,7 @@
+package xds
+
+var certFiles = []string{
+	"/usr/local/etc/openssl/cert.pem", // All require OpenSSL installed
+	"/usr/local/etc/openssl@3/cert.pem",
+	"/usr/local/etc/openssl@1.1/cert.pem",
+}

--- a/agent/xds/ca_fallback.go
+++ b/agent/xds/ca_fallback.go
@@ -1,0 +1,6 @@
+//go:build !(linux || dragonfly || freebsd || netbsd || openbsd || darwin || solaris)
+
+package xds
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{}

--- a/agent/xds/ca_linux.go
+++ b/agent/xds/ca_linux.go
@@ -1,0 +1,12 @@
+// From Go src/crypto/x509/root_linux.go
+package xds
+
+// Possible certificate files; stop after finding one.
+var certFiles = []string{
+	"/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+	"/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+	"/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+	"/etc/pki/tls/cacert.pem",                           // OpenELEC
+	"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+	"/etc/ssl/cert.pem",                                 // Alpine Linux
+}

--- a/agent/xds/ca_solaris.go
+++ b/agent/xds/ca_solaris.go
@@ -1,0 +1,8 @@
+// From Go src/crypto/x509/root_solaris.go
+package xds
+
+var certFiles = []string{
+	"/etc/certs/ca-certificates.crt",     // Solaris 11.2+
+	"/etc/ssl/certs/ca-certificates.crt", // Joyent SmartOS
+	"/etc/ssl/cacert.pem",                // OmniOS
+}

--- a/agent/xds/testdata/clusters/terminating-gateway-system-ca-darwin.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-system-ca-darwin.latest.golden
@@ -1,0 +1,142 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "api.altdomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "cache.mydomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "db.mydomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "UNHEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          },
+          "resourceApiVersion": "V3"
+        }
+      },
+      "connectTimeout": "5s",
+      "outlierDetection": {
+
+      },
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsParams": {
+
+            },
+            "validationContext": {
+              "trustedCa": {
+                "filename": "/usr/local/etc/openssl@3/cert.pem"
+              },
+              "matchSubjectAltNames": [
+                {
+                  "exact": "foo.com"
+                }
+              ]
+            }
+          },
+          "sni": "foo.com"
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/clusters/terminating-gateway-system-ca-linux.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-system-ca-linux.latest.golden
@@ -1,0 +1,142 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "api.altdomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "cache.mydomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "db.mydomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "UNHEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          },
+          "resourceApiVersion": "V3"
+        }
+      },
+      "connectTimeout": "5s",
+      "outlierDetection": {
+
+      },
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsParams": {
+
+            },
+            "validationContext": {
+              "trustedCa": {
+                "filename": "/etc/ssl/certs/ca-certificates.crt"
+              },
+              "matchSubjectAltNames": [
+                {
+                  "exact": "foo.com"
+                }
+              ]
+            }
+          },
+          "sni": "foo.com"
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/clusters/terminating-gateway-transparent-mode-with-ca.latest.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-transparent-mode-with-ca.latest.golden
@@ -1,0 +1,120 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "api.altdomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "cache.mydomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "HEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "LOGICAL_DNS",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "db.mydomain",
+                      "portValue": 8081
+                    }
+                  }
+                },
+                "healthStatus": "UNHEALTHY",
+                "loadBalancingWeight": 1
+              }
+            ]
+          }
+        ]
+      },
+      "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "web.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          },
+          "resourceApiVersion": "V3"
+        }
+      },
+      "connectTimeout": "5s",
+      "outlierDetection": {
+
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "nonce": "00000001"
+}

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -106,6 +106,7 @@ type GatewayService struct {
 	CAFile       string   `json:",omitempty"`
 	CertFile     string   `json:",omitempty"`
 	KeyFile      string   `json:",omitempty"`
+	UseSystemCA  bool     `json:",omitempty"`
 	SNI          string   `json:",omitempty"`
 	FromWildcard bool     `json:",omitempty"`
 }

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -1142,6 +1142,11 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 				KeyFile:  "client.key",
 				SNI:      "my-alt-domain",
 			},
+			{
+				Name:        "example",
+				UseSystemCA: true,
+				SNI:         "example.com",
+			},
 		},
 	}
 	retry.Run(t, func(r *retry.R) {
@@ -1159,6 +1164,13 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 			CertFile:    "api/client.crt",
 			KeyFile:     "api/client.key",
 			SNI:         "my-domain",
+		},
+		{
+			Service:     CompoundServiceName{Name: "example", Namespace: defaultNamespace, Partition: defaultPartition},
+			Gateway:     CompoundServiceName{Name: "terminating", Namespace: defaultNamespace, Partition: defaultPartition},
+			GatewayKind: ServiceKindTerminatingGateway,
+			UseSystemCA: true,
+			SNI:         "example.com",
 		},
 		{
 			Service:      CompoundServiceName{Name: "redis", Namespace: defaultNamespace, Partition: defaultPartition},

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -189,6 +189,10 @@ type LinkedService struct {
 	// from the gateway to the linked service.
 	KeyFile string `json:",omitempty" alias:"key_file"`
 
+	// UseSystemCA tells the gateway to try and use the System CA certs for verifying
+	// upstream TLS connections.
+	UseSystemCA bool `json:",omitempty" alias:"use_system_ca"`
+
 	// SNI is the optional name to specify during the TLS handshake with a linked service.
 	SNI string `json:",omitempty"`
 }


### PR DESCRIPTION
# !Draft!

### Description
First pass implementation of checking for SSL certificates that requires enabling it on a service-to-service level. See  https://github.com/hashicorp/consul/issues/11250. 

#### TODO:
* [ ] Figure out a way to set this as at proxydefaults or gateway level configuration.
* [ ] Figure out if the protocol of the external service can be inspected for https and System CAs can be enabled automatically.

### Assumptions
1. It doesn't make sense to specify TLS options in transparent proxy mode (end-destination TLS is the client's responsibility, envoy should manage mTLS tunnel).
1. CAFile takes precedent over System specification

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
