### PR TITLE
config: prevent top-level `verify_incoming` enabling mTLS on gRPC port

### DIFF
--- a/.changelog/13118.txt
+++ b/.changelog/13118.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+config: fix backwards compatibility bug where setting the (deprecated) top-level `verify_incoming` option would enable TLS client authentication on the gRPC port
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -2522,7 +2522,7 @@ func (b *builder) buildTLSConfig(rt RuntimeConfig, t TLS) (tlsutil.Config, error
 
 	// TLS is only enabled on the gRPC listener if there's an HTTPS port configured
 	// for historic and backwards-compatibility reasons.
-	if rt.HTTPSPort <= 0 && (t.GRPC != TLSProtocolConfig{}) {
+	if rt.HTTPSPort <= 0 && (t.GRPC != TLSProtocolConfig{} && t.GRPCModifiedByDeprecatedConfig == nil) {
 		b.warn("tls.grpc was provided but TLS will NOT be enabled on the gRPC listener without an HTTPS listener configured (e.g. via ports.https)")
 	}
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -870,4 +870,17 @@ type TLS struct {
 	InternalRPC TLSProtocolConfig `mapstructure:"internal_rpc"`
 	HTTPS       TLSProtocolConfig `mapstructure:"https"`
 	GRPC        TLSProtocolConfig `mapstructure:"grpc"`
+
+	// GRPCModifiedByDeprecatedConfig is a flag used to indicate that GRPC was
+	// modified by the deprecated field mapping (as apposed to a user-provided
+	// a grpc stanza). This prevents us from emitting a warning about an
+	// ineffectual grpc stanza when we modify GRPC to honor the legacy behaviour
+	// that setting `verify_incoming = true` at the top-level *does not* enable
+	// client certificate verification on the gRPC port.
+	//
+	// See: applyDeprecatedTLSConfig.
+	//
+	// Note: we use a *struct{} here because a simple bool isn't supported by our
+	// config merging logic.
+	GRPCModifiedByDeprecatedConfig *struct{} `mapstructure:"-"`
 }

--- a/agent/config/deprecated_test.go
+++ b/agent/config/deprecated_test.go
@@ -98,7 +98,7 @@ tls_prefer_server_cipher_suites = true
 
 	require.False(t, rt.TLS.InternalRPC.VerifyIncoming)
 	require.False(t, rt.TLS.HTTPS.VerifyIncoming)
-	require.True(t, rt.TLS.GRPC.VerifyIncoming)
+	require.False(t, rt.TLS.GRPC.VerifyIncoming)
 	require.True(t, rt.TLS.InternalRPC.VerifyOutgoing)
 	require.True(t, rt.TLS.HTTPS.VerifyOutgoing)
 	require.True(t, rt.TLS.InternalRPC.VerifyServerHostname)


### PR DESCRIPTION
### Description

Fixes #13088, a backwards-compatibility bug introduced in 1.12.
