### PR TITLE
fix: multiple grpc/http2 services for ingress listeners

### DIFF
--- a/.changelog/13127.txt
+++ b/.changelog/13127.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix a bug that caused an error when creating `grpc` or `http2` ingress gateway listeners with multiple services
+```

--- a/agent/proxycfg/testing_ingress_gateway.go
+++ b/agent/proxycfg/testing_ingress_gateway.go
@@ -800,6 +800,109 @@ func TestConfigSnapshotIngress_HTTPMultipleServices(t testing.T) *ConfigSnapshot
 	})
 }
 
+func TestConfigSnapshotIngress_GRPCMultipleServices(t testing.T) *ConfigSnapshot {
+	// We do not add baz/qux here so that we test the chain.IsDefault() case
+	entries := []structs.ConfigEntry{
+		&structs.ProxyConfigEntry{
+			Kind: structs.ProxyDefaults,
+			Name: structs.ProxyConfigGlobal,
+			Config: map[string]interface{}{
+				"protocol": "http",
+			},
+		},
+		&structs.ServiceResolverConfigEntry{
+			Kind:           structs.ServiceResolver,
+			Name:           "foo",
+			ConnectTimeout: 22 * time.Second,
+		},
+		&structs.ServiceResolverConfigEntry{
+			Kind:           structs.ServiceResolver,
+			Name:           "bar",
+			ConnectTimeout: 22 * time.Second,
+		},
+	}
+
+	var (
+		foo      = structs.NewServiceName("foo", nil)
+		fooUID   = NewUpstreamIDFromServiceName(foo)
+		fooChain = discoverychain.TestCompileConfigEntries(t, "foo", "default", "default", "dc1", connect.TestClusterID+".consul", nil, entries...)
+
+		bar      = structs.NewServiceName("bar", nil)
+		barUID   = NewUpstreamIDFromServiceName(bar)
+		barChain = discoverychain.TestCompileConfigEntries(t, "bar", "default", "default", "dc1", connect.TestClusterID+".consul", nil, entries...)
+	)
+
+	require.False(t, fooChain.Default)
+	require.False(t, barChain.Default)
+
+	return TestConfigSnapshotIngressGateway(t, false, "http", "default", nil, func(entry *structs.IngressGatewayConfigEntry) {
+		entry.Listeners = []structs.IngressListener{
+			{
+				Port:     8080,
+				Protocol: "grpc",
+				Services: []structs.IngressService{
+					{
+						Name: "foo",
+						Hosts: []string{
+							"test1.example.com",
+							"test2.example.com",
+							"test2.example.com:8080",
+						},
+					},
+					{Name: "bar"},
+				},
+			},
+		}
+	}, []UpdateEvent{
+		{
+			CorrelationID: gatewayServicesWatchID,
+			Result: &structs.IndexedGatewayServices{
+				Services: []*structs.GatewayService{
+					{
+						Service:  foo,
+						Port:     8080,
+						Protocol: "grpc",
+						Hosts: []string{
+							"test1.example.com",
+							"test2.example.com",
+							"test2.example.com:8080",
+						},
+					},
+					{
+						Service:  bar,
+						Port:     8080,
+						Protocol: "grpc",
+					},
+				},
+			},
+		},
+		{
+			CorrelationID: "discovery-chain:" + fooUID.String(),
+			Result: &structs.DiscoveryChainResponse{
+				Chain: fooChain,
+			},
+		},
+		{
+			CorrelationID: "upstream-target:" + fooChain.ID() + ":" + fooUID.String(),
+			Result: &structs.IndexedCheckServiceNodes{
+				Nodes: TestUpstreamNodes(t, "foo"),
+			},
+		},
+		{
+			CorrelationID: "discovery-chain:" + barUID.String(),
+			Result: &structs.DiscoveryChainResponse{
+				Chain: barChain,
+			},
+		},
+		{
+			CorrelationID: "upstream-target:" + barChain.ID() + ":" + barUID.String(),
+			Result: &structs.IndexedCheckServiceNodes{
+				Nodes: TestUpstreamNodes(t, "bar"),
+			},
+		},
+	})
+}
+
 func TestConfigSnapshotIngress_MultipleListenersDuplicateService(t testing.T) *ConfigSnapshot {
 	var (
 		foo      = structs.NewServiceName("foo", nil)

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -275,8 +275,8 @@ func (e *IngressGatewayConfigEntry) Validate() error {
 		}
 
 		// Validate that http features aren't being used with tcp or another non-supported protocol.
-		if listener.Protocol != "http" && len(listener.Services) > 1 {
-			return fmt.Errorf("Multiple services per listener are only supported for protocol = 'http' (listener on port %d)",
+		if !IsProtocolHTTPLike(listener.Protocol) && len(listener.Services) > 1 {
+			return fmt.Errorf("Multiple services per listener are only supported for L7 protocols, 'http', 'grpc' and 'http2' (listener on port %d)",
 				listener.Port)
 		}
 

--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -141,6 +141,26 @@ func TestIngressGatewayConfigEntry(t *testing.T) {
 				Listeners: []IngressListener{
 					{
 						Port:     1111,
+						Protocol: "http",
+						Services: []IngressService{
+							{
+								Name: "db1",
+							},
+							{
+								Name: "db2",
+							},
+						},
+					},
+				},
+			},
+		},
+		"http features: multiple services on tcp listener": {
+			entry: &IngressGatewayConfigEntry{
+				Kind: "ingress-gateway",
+				Name: "ingress-web",
+				Listeners: []IngressListener{
+					{
+						Port:     1111,
 						Protocol: "tcp",
 						Services: []IngressService{
 							{
@@ -153,7 +173,7 @@ func TestIngressGatewayConfigEntry(t *testing.T) {
 					},
 				},
 			},
-			validateErr: "Multiple services per listener are only supported for protocol",
+			validateErr: "Multiple services per listener are only supported for L7",
 		},
 		// ==========================
 		"tcp listener requires a defined service": {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -673,6 +673,10 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshotIngress_HTTPMultipleServices,
 		},
 		{
+			name:   "ingress-grpc-multiple-services",
+			create: proxycfg.TestConfigSnapshotIngress_GRPCMultipleServices,
+		},
+		{
 			name: "terminating-gateway-no-api-cert",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				api := structs.NewServiceName("api", nil)

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -143,6 +143,10 @@ func TestRoutesFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshotIngress_HTTPMultipleServices,
 		},
 		{
+			name:   "ingress-grpc-multiple-services",
+			create: proxycfg.TestConfigSnapshotIngress_GRPCMultipleServices,
+		},
+		{
 			name: "ingress-with-chain-and-router-header-manip",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshotIngressGatewayWithChain(t, "router-header-manip", nil, nil)

--- a/agent/xds/testdata/listeners/ingress-grpc-multiple-services.latest.golden
+++ b/agent/xds/testdata/listeners/ingress-grpc-multiple-services.latest.golden
@@ -1,0 +1,65 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "grpc:1.2.3.4:8080",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "ingress_upstream_8080",
+                "rds": {
+                  "configSource": {
+                    "ads": {
+
+                    },
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "8080"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.grpc_stats",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                      "statsForAllMethods": true
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.grpc_http1_bridge",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_http1_bridge.v3.Config"
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "tracing": {
+                  "randomSampling": {}
+                },
+                "http2ProtocolOptions": {}
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/routes/ingress-grpc-multiple-services.latest.golden
+++ b/agent/xds/testdata/routes/ingress-grpc-multiple-services.latest.golden
@@ -1,0 +1,50 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+      "name": "8080",
+      "virtualHosts": [
+        {
+          "name": "foo",
+          "domains": [
+            "test1.example.com",
+            "test2.example.com",
+            "test2.example.com:8080",
+            "test1.example.com:8080"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        },
+        {
+          "name": "bar",
+          "domains": [
+            "bar.ingress.*",
+            "bar.ingress.*:8080"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "validateClusters": true
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
### Description
https://github.com/hashicorp/consul/issues/12628 reported that there was a mismatch between the documentation and the consul CLI when it comes to using multiple grpc services per ingress listener. The error received is a validation on the config entry. Removing the validation for grpc/https allows traffic to be routed as expected, which is inline with the expectations in the docs.

### Testing & Reproduction steps
* I set up two grpc services (fortio and moul/grpcbin) IAW with the [tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-ingress-gateways), using `service-defaults` to set their protocols to `grpc`. Using the proposed code, I was able to route traffic to each of the services using the `authority` header.

`fortio-service.hcl`
```hcl
service {
 name = "fortio"
 id = "fortio-1"
 port = 8079

 connect {
   sidecar_service {}
 }

 check {
  id = "fortio-check"
  name = "Fortio Health Check"
  grpc = "127.0.0.1:8079"
  interval = "10s"
 }

}
```

`grpcbin-service.hcl`
```hcl
service {
 name = "grpcbin"
 id = "grpcbin-1"
 port = 9000

 connect {
   sidecar_service {}
 }
}
```

`ingress-gateway.hcl`
```hcl
Kind = "ingress-gateway"
Name = "ingress-service"

Listeners = [
 {
   Port = 10000
   Protocol = "grpc"
   Services = [
     {
       Name = "fortio"
       Hosts = ["fortio"]
     },
     {
       Name = "grpcbin"
       Hosts = ["grpcbin"]
     }
   ]
 }
]
```
Commands to the listener
`grpcurl -plaintext -authority fortio 192.168.205.20:10000 fgrpc.PingServer/Ping`
`grpcurl -plaintext -authority grpcbin 192.168.205.20:10000 hello.HelloService/SayHello`

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] not a security concern
* [X] checklist [folder](./../docs/config) consulted
