### PR TITLE
fix 'releases/*.*.x' to 'release/*.*.x'

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -10,7 +10,7 @@ on:
       - labeled
     branches:
       - main
-      - 'releases/*.*.x'
+      - 'release/*.*.x'
 
 jobs:
   backport:

--- a/.github/workflows/oss-merge-trigger.yml
+++ b/.github/workflows/oss-merge-trigger.yml
@@ -5,7 +5,7 @@ on:
       - closed
     branches:
       - main
-      - 'releases/*.*.x'
+      - 'release/*.*.x'
 
 jobs:
   trigger-oss-merge:


### PR DESCRIPTION
### Description
Backport assistant jobs and oss-merge were not matching on release branches because of a typo