### PR TITLE
chore(ci): squash backport-assistant commits in PRs

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Run Backport Assistant for stable-website
         run: |
-          backport-assistant backport -merge-method=rebase -automerge
+          backport-assistant backport -merge-method=squash -automerge
         env:
           BACKPORT_LABEL_REGEXP: "type/docs-(?P<target>cherrypick)"
           BACKPORT_TARGET_TEMPLATE: "stable-website"
@@ -39,13 +39,13 @@ jobs:
           # set BACKPORT_TARGET_TEMPLATE for backport-assistant
           # trims backport/ from the beginning with parameter substitution
           export BACKPORT_TARGET_TEMPLATE="release/${latest_backport_label#backport/}.x"
-          backport-assistant backport -merge-method=rebase -automerge
+          backport-assistant backport -merge-method=squash -automerge
         env:
           BACKPORT_LABEL_REGEXP: "type/docs-(?P<target>cherrypick)"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Run Backport Assistant for release branches
         run: |
-          backport-assistant backport -merge-method=rebase -automerge
+          backport-assistant backport -merge-method=squash -automerge
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"


### PR DESCRIPTION
### Description
After some internal discussion, we would like backport PRs to squash commits from the original PR. Right now even if the original PR is squash, the original commits will show up in the backport PR ([example](https://github.com/hashicorp/consul/pull/13130)).

The best-case scenario would be to cherry-pick squash commits, but our tooling does not support this at the moment. 

### Testing & Reproduction steps
N/A

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [X] not a security concern
* [ ] ~checklist [folder](./../docs/config) consulted~
