### PR TITLE
[OSS] proxycfg: remove dependency on `cache.UpdateEvent`

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -626,8 +626,8 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	// Start the proxy config manager.
 	a.proxyConfig, err = proxycfg.NewManager(proxycfg.ManagerConfig{
-		Cache:  a.cache,
-		Health: a.rpcClientHealth,
+		Cache:  &proxycfg.CacheWrapper{Cache: a.cache},
+		Health: &proxycfg.HealthWrapper{Health: a.rpcClientHealth},
 		Logger: a.logger.Named(logging.ProxyConfig),
 		State:  a.State,
 		Tokens: a.baseDeps.Tokens,

--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
@@ -220,7 +219,7 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 	return snap, nil
 }
 
-func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u cache.UpdateEvent, snap *ConfigSnapshot) error {
+func (s *handlerConnectProxy) handleUpdate(ctx context.Context, u UpdateEvent, snap *ConfigSnapshot) error {
 	if u.Err != nil {
 		return fmt.Errorf("error filling agent cache: %v", u.Err)
 	}

--- a/agent/proxycfg/glue.go
+++ b/agent/proxycfg/glue.go
@@ -1,0 +1,60 @@
+// TODO(agentless): these glue types belong in the agent package, but moving
+// them is a little tricky because the proxycfg tests use them. It should be
+// easier to break apart once we no longer depend on cache.Notify directly.
+package proxycfg
+
+import (
+	"context"
+
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/agent/rpcclient/health"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// HealthWrapper wraps health.Client so that the rest of the proxycfg package
+// doesn't need to reference cache.UpdateEvent (it will be extracted into a
+// shared library in the future).
+type HealthWrapper struct {
+	Health *health.Client
+}
+
+func (w *HealthWrapper) Notify(
+	ctx context.Context,
+	req structs.ServiceSpecificRequest,
+	correlationID string,
+	ch chan<- UpdateEvent,
+) error {
+	return w.Health.Notify(ctx, req, correlationID, dispatchCacheUpdate(ctx, ch))
+}
+
+// CacheWrapper wraps cache.Cache so that the rest of the proxycfg package
+// doesn't need to reference cache.UpdateEvent (it will be extracted into a
+// shared library in the future).
+type CacheWrapper struct {
+	Cache *cache.Cache
+}
+
+func (w *CacheWrapper) Notify(
+	ctx context.Context,
+	t string,
+	req cache.Request,
+	correlationID string,
+	ch chan<- UpdateEvent,
+) error {
+	return w.Cache.NotifyCallback(ctx, t, req, correlationID, dispatchCacheUpdate(ctx, ch))
+}
+
+func dispatchCacheUpdate(ctx context.Context, ch chan<- UpdateEvent) cache.Callback {
+	return func(ctx context.Context, e cache.UpdateEvent) {
+		u := UpdateEvent{
+			CorrelationID: e.CorrelationID,
+			Result:        e.Result,
+			Err:           e.Err,
+		}
+
+		select {
+		case ch <- u:
+		case <-ctx.Done():
+		}
+	}
+}

--- a/agent/proxycfg/ingress_gateway.go
+++ b/agent/proxycfg/ingress_gateway.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"
 )
@@ -70,7 +69,7 @@ func (s *handlerIngressGateway) initialize(ctx context.Context) (ConfigSnapshot,
 	return snap, nil
 }
 
-func (s *handlerIngressGateway) handleUpdate(ctx context.Context, u cache.UpdateEvent, snap *ConfigSnapshot) error {
+func (s *handlerIngressGateway) handleUpdate(ctx context.Context, u UpdateEvent, snap *ConfigSnapshot) error {
 	if u.Err != nil {
 		return fmt.Errorf("error filling agent cache: %v", u.Err)
 	}

--- a/agent/proxycfg/manager.go
+++ b/agent/proxycfg/manager.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 
-	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
@@ -59,7 +58,7 @@ type Manager struct {
 type ManagerConfig struct {
 	// Cache is the agent's cache instance that can be used to retrieve, store and
 	// monitor state for the proxies.
-	Cache *cache.Cache
+	Cache CacheNotifier
 	// Health provides service health updates on a notification channel.
 	Health Health
 	// state is the agent's local state to be watched for new proxy registrations.

--- a/agent/proxycfg/mesh_gateway.go
+++ b/agent/proxycfg/mesh_gateway.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/logging"
@@ -119,7 +118,7 @@ func (s *handlerMeshGateway) initializeCrossDCWatches(ctx context.Context) error
 	return nil
 }
 
-func (s *handlerMeshGateway) handleUpdate(ctx context.Context, u cache.UpdateEvent, snap *ConfigSnapshot) error {
+func (s *handlerMeshGateway) handleUpdate(ctx context.Context, u UpdateEvent, snap *ConfigSnapshot) error {
 	if u.Err != nil {
 		return fmt.Errorf("error filling agent cache: %v", u.Err)
 	}

--- a/agent/proxycfg/mesh_gateway_oss.go
+++ b/agent/proxycfg/mesh_gateway_oss.go
@@ -7,14 +7,12 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-hclog"
-
-	"github.com/hashicorp/consul/agent/cache"
 )
 
 func (s *handlerMeshGateway) initializeEntWatches(_ context.Context) error {
 	return nil
 }
 
-func (s *handlerMeshGateway) handleEntUpdate(_ hclog.Logger, _ context.Context, _ cache.UpdateEvent, _ *ConfigSnapshot) error {
+func (s *handlerMeshGateway) handleEntUpdate(_ hclog.Logger, _ context.Context, _ UpdateEvent, _ *ConfigSnapshot) error {
 	return nil
 }

--- a/agent/proxycfg/terminating_gateway.go
+++ b/agent/proxycfg/terminating_gateway.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"
 )
@@ -68,7 +67,7 @@ func (s *handlerTerminatingGateway) initialize(ctx context.Context) (ConfigSnaps
 	return snap, nil
 }
 
-func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u cache.UpdateEvent, snap *ConfigSnapshot) error {
+func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u UpdateEvent, snap *ConfigSnapshot) error {
 	if u.Err != nil {
 		return fmt.Errorf("error filling agent cache: %v", u.Err)
 	}

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -672,7 +672,7 @@ type noopCacheNotifier struct{}
 
 var _ CacheNotifier = (*noopCacheNotifier)(nil)
 
-func (*noopCacheNotifier) Notify(_ context.Context, _ string, _ cache.Request, _ string, _ chan<- cache.UpdateEvent) error {
+func (*noopCacheNotifier) Notify(_ context.Context, _ string, _ cache.Request, _ string, _ chan<- UpdateEvent) error {
 	return nil
 }
 
@@ -680,7 +680,7 @@ type noopHealth struct{}
 
 var _ Health = (*noopHealth)(nil)
 
-func (*noopHealth) Notify(_ context.Context, _ structs.ServiceSpecificRequest, _ string, _ chan<- cache.UpdateEvent) error {
+func (*noopHealth) Notify(_ context.Context, _ structs.ServiceSpecificRequest, _ string, _ chan<- UpdateEvent) error {
 	return nil
 }
 
@@ -698,7 +698,7 @@ func testConfigSnapshotFixture(
 	ns *structs.NodeService,
 	nsFn func(ns *structs.NodeService),
 	serverSNIFn ServerSNIFunc,
-	updates []cache.UpdateEvent,
+	updates []UpdateEvent,
 ) *ConfigSnapshot {
 	const token = ""
 
@@ -750,15 +750,15 @@ func testConfigSnapshotFixture(
 	return &snap
 }
 
-func testSpliceEvents(base, extra []cache.UpdateEvent) []cache.UpdateEvent {
+func testSpliceEvents(base, extra []UpdateEvent) []UpdateEvent {
 	if len(extra) == 0 {
 		return base
 	}
 	var (
-		hasExtra      = make(map[string]cache.UpdateEvent)
+		hasExtra      = make(map[string]UpdateEvent)
 		completeExtra = make(map[string]struct{})
 
-		allEvents []cache.UpdateEvent
+		allEvents []UpdateEvent
 	)
 
 	for _, e := range extra {

--- a/agent/proxycfg/testing_connect_proxy.go
+++ b/agent/proxycfg/testing_connect_proxy.go
@@ -4,14 +4,13 @@ import (
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
 // TestConfigSnapshot returns a fully populated snapshot
-func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), extraUpdates []cache.UpdateEvent) *ConfigSnapshot {
+func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), extraUpdates []UpdateEvent) *ConfigSnapshot {
 	roots, leaf := TestCerts(t)
 
 	// no entries implies we'll get a default chain
@@ -29,7 +28,7 @@ func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), extraUp
 		webSN = structs.ServiceIDString("web", nil)
 	)
 
-	baseEvents := []cache.UpdateEvent{
+	baseEvents := []UpdateEvent{
 		{
 			CorrelationID: rootsWatchID,
 			Result:        roots,
@@ -94,7 +93,7 @@ func TestConfigSnapshotDiscoveryChain(
 	t testing.T,
 	variation string,
 	nsFn func(ns *structs.NodeService),
-	extraUpdates []cache.UpdateEvent,
+	extraUpdates []UpdateEvent,
 	additionalEntries ...structs.ConfigEntry,
 ) *ConfigSnapshot {
 	roots, leaf := TestCerts(t)
@@ -108,7 +107,7 @@ func TestConfigSnapshotDiscoveryChain(
 		webSN = structs.ServiceIDString("web", nil)
 	)
 
-	baseEvents := testSpliceEvents([]cache.UpdateEvent{
+	baseEvents := testSpliceEvents([]UpdateEvent{
 		{
 			CorrelationID: rootsWatchID,
 			Result:        roots,
@@ -171,7 +170,7 @@ func TestConfigSnapshotExposeConfig(t testing.T, nsFn func(ns *structs.NodeServi
 		webSN = structs.ServiceIDString("web", nil)
 	)
 
-	baseEvents := []cache.UpdateEvent{
+	baseEvents := []UpdateEvent{
 		{
 			CorrelationID: rootsWatchID,
 			Result:        roots,
@@ -252,7 +251,7 @@ func TestConfigSnapshotGRPCExposeHTTP1(t testing.T) *ConfigSnapshot {
 		},
 		Meta:            nil,
 		TaggedAddresses: nil,
-	}, nil, nil, []cache.UpdateEvent{
+	}, nil, nil, []UpdateEvent{
 		{
 			CorrelationID: rootsWatchID,
 			Result:        roots,

--- a/agent/proxycfg/testing_ingress_gateway.go
+++ b/agent/proxycfg/testing_ingress_gateway.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
@@ -21,7 +20,7 @@ func TestConfigSnapshotIngressGateway(
 	variation string,
 	nsFn func(ns *structs.NodeService),
 	configFn func(entry *structs.IngressGatewayConfigEntry),
-	extraUpdates []cache.UpdateEvent,
+	extraUpdates []UpdateEvent,
 	additionalEntries ...structs.ConfigEntry,
 ) *ConfigSnapshot {
 	roots, placeholderLeaf := TestCerts(t)
@@ -47,7 +46,7 @@ func TestConfigSnapshotIngressGateway(
 		configFn(entry)
 	}
 
-	baseEvents := []cache.UpdateEvent{
+	baseEvents := []UpdateEvent{
 		{
 			CorrelationID: rootsWatchID,
 			Result:        roots,
@@ -71,7 +70,7 @@ func TestConfigSnapshotIngressGateway(
 	}
 
 	if populateServices {
-		baseEvents = testSpliceEvents(baseEvents, []cache.UpdateEvent{{
+		baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
 				Services: []*structs.GatewayService{
@@ -155,7 +154,7 @@ func TestConfigSnapshotIngressGatewaySDS_GatewayLevel_MixedTLS(t testing.T) *Con
 				},
 			},
 		}
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
@@ -270,7 +269,7 @@ func TestConfigSnapshotIngressGatewaySDS_GatewayAndListenerLevel_HTTP(t testing.
 				},
 			},
 		}
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
@@ -344,7 +343,7 @@ func TestConfigSnapshotIngressGatewaySDS_ServiceLevel(t testing.T) *ConfigSnapsh
 				},
 			},
 		}
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
@@ -434,7 +433,7 @@ func TestConfigSnapshotIngressGatewaySDS_ListenerAndServiceLevel(t testing.T) *C
 				},
 			},
 		}
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
@@ -519,7 +518,7 @@ func TestConfigSnapshotIngressGatewaySDS_MixedNoTLS(t testing.T) *ConfigSnapshot
 				},
 			},
 		}
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
@@ -601,7 +600,7 @@ func TestConfigSnapshotIngressGateway_MixedListeners(t testing.T) *ConfigSnapsho
 				},
 			},
 		}
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
@@ -717,7 +716,7 @@ func TestConfigSnapshotIngress_HTTPMultipleServices(t testing.T) *ConfigSnapshot
 				},
 			},
 		}
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
@@ -830,7 +829,7 @@ func TestConfigSnapshotIngress_MultipleListenersDuplicateService(t testing.T) *C
 				},
 			},
 		}
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{
@@ -893,7 +892,7 @@ func TestConfigSnapshotIngressGatewayWithChain(
 	}
 
 	var (
-		updates  []cache.UpdateEvent
+		updates  []UpdateEvent
 		configFn func(entry *structs.IngressGatewayConfigEntry)
 
 		populateServices                      bool
@@ -1088,7 +1087,7 @@ func TestConfigSnapshotIngressGatewayWithChain(
 			fooEntMeta.PartitionOrDefault(), "dc1",
 			connect.TestClusterID+".consul", nil, entries...)
 
-		updates = []cache.UpdateEvent{
+		updates = []UpdateEvent{
 			{
 				CorrelationID: gatewayServicesWatchID,
 				Result: &structs.IndexedGatewayServices{
@@ -1218,7 +1217,7 @@ func TestConfigSnapshotIngressGateway_TLSMinVersionListenersGatewayDefaults(t te
 					},
 				},
 			}
-		}, []cache.UpdateEvent{
+		}, []UpdateEvent{
 			{
 				CorrelationID: gatewayServicesWatchID,
 				Result: &structs.IndexedGatewayServices{
@@ -1336,7 +1335,7 @@ func TestConfigSnapshotIngressGateway_SingleTLSListener(t testing.T) *ConfigSnap
 					},
 				},
 			}
-		}, []cache.UpdateEvent{
+		}, []UpdateEvent{
 			{
 				CorrelationID: gatewayServicesWatchID,
 				Result: &structs.IndexedGatewayServices{
@@ -1436,7 +1435,7 @@ func TestConfigSnapshotIngressGateway_TLSMixedMinVersionListeners(t testing.T) *
 					},
 				},
 			}
-		}, []cache.UpdateEvent{
+		}, []UpdateEvent{
 			{
 				CorrelationID: gatewayServicesWatchID,
 				Result: &structs.IndexedGatewayServices{

--- a/agent/proxycfg/testing_mesh_gateway.go
+++ b/agent/proxycfg/testing_mesh_gateway.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *structs.NodeService), extraUpdates []cache.UpdateEvent) *ConfigSnapshot {
+func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *structs.NodeService), extraUpdates []UpdateEvent) *ConfigSnapshot {
 	roots, _ := TestCerts(t)
 
 	var (
@@ -38,7 +37,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 		useFederationStates = false
 		deleteCrossDCEntry = false
 	case "service-subsets":
-		extraUpdates = append(extraUpdates, cache.UpdateEvent{
+		extraUpdates = append(extraUpdates, UpdateEvent{
 			CorrelationID: serviceResolversWatchID,
 			Result: &structs.IndexedConfigEntries{
 				Kind: structs.ServiceResolver,
@@ -60,7 +59,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 			},
 		})
 	case "service-subsets2": // TODO(rb): make this merge with 'service-subsets'
-		extraUpdates = append(extraUpdates, cache.UpdateEvent{
+		extraUpdates = append(extraUpdates, UpdateEvent{
 			CorrelationID: serviceResolversWatchID,
 			Result: &structs.IndexedConfigEntries{
 				Kind: structs.ServiceResolver,
@@ -95,7 +94,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 			},
 		})
 	case "default-service-subsets2": // TODO(rb): rename to strip the 2 when the prior is merged with 'service-subsets'
-		extraUpdates = append(extraUpdates, cache.UpdateEvent{
+		extraUpdates = append(extraUpdates, UpdateEvent{
 			CorrelationID: serviceResolversWatchID,
 			Result: &structs.IndexedConfigEntries{
 				Kind: structs.ServiceResolver,
@@ -132,7 +131,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 			},
 		})
 	case "ignore-extra-resolvers":
-		extraUpdates = append(extraUpdates, cache.UpdateEvent{
+		extraUpdates = append(extraUpdates, UpdateEvent{
 			CorrelationID: serviceResolversWatchID,
 			Result: &structs.IndexedConfigEntries{
 				Kind: structs.ServiceResolver,
@@ -169,7 +168,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 			},
 		})
 	case "service-timeouts":
-		extraUpdates = append(extraUpdates, cache.UpdateEvent{
+		extraUpdates = append(extraUpdates, UpdateEvent{
 			CorrelationID: serviceResolversWatchID,
 			Result: &structs.IndexedConfigEntries{
 				Kind: structs.ServiceResolver,
@@ -192,7 +191,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 			},
 		})
 	case "non-hash-lb-injected":
-		extraUpdates = append(extraUpdates, cache.UpdateEvent{
+		extraUpdates = append(extraUpdates, UpdateEvent{
 			CorrelationID: "service-resolvers", // serviceResolversWatchID
 			Result: &structs.IndexedConfigEntries{
 				Kind: structs.ServiceResolver,
@@ -220,7 +219,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 			},
 		})
 	case "hash-lb-ignored":
-		extraUpdates = append(extraUpdates, cache.UpdateEvent{
+		extraUpdates = append(extraUpdates, UpdateEvent{
 			CorrelationID: "service-resolvers", // serviceResolversWatchID
 			Result: &structs.IndexedConfigEntries{
 				Kind: structs.ServiceResolver,
@@ -253,7 +252,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 		return nil
 	}
 
-	baseEvents := []cache.UpdateEvent{
+	baseEvents := []UpdateEvent{
 		{
 			CorrelationID: rootsWatchID,
 			Result:        roots,
@@ -278,7 +277,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 	}
 
 	if populateServices || useFederationStates {
-		baseEvents = testSpliceEvents(baseEvents, []cache.UpdateEvent{
+		baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{
 			{
 				CorrelationID: datacentersWatchID,
 				Result:        &[]string{"dc1", "dc2", "dc4", "dc6"},
@@ -291,7 +290,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 			foo = structs.NewServiceName("foo", nil)
 			bar = structs.NewServiceName("bar", nil)
 		)
-		baseEvents = testSpliceEvents(baseEvents, []cache.UpdateEvent{
+		baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{
 			{
 				CorrelationID: "mesh-gateway:dc2",
 				Result: &structs.IndexedNodesWithGateways{
@@ -349,7 +348,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 		})
 
 		if deleteCrossDCEntry {
-			baseEvents = testSpliceEvents(baseEvents, []cache.UpdateEvent{
+			baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{
 				{
 					// Have the cross-dc query mechanism not work for dc2 so
 					// fedstates will infill.
@@ -399,7 +398,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 			}
 		}
 
-		baseEvents = testSpliceEvents(baseEvents, []cache.UpdateEvent{
+		baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{
 			{
 				CorrelationID: federationStateListGatewaysWatchID,
 				Result: &structs.DatacenterIndexedCheckServiceNodes{

--- a/agent/proxycfg/testing_terminating_gateway.go
+++ b/agent/proxycfg/testing_terminating_gateway.go
@@ -3,8 +3,6 @@ package proxycfg
 import (
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/hashicorp/consul/agent/cache"
-	agentcache "github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -12,7 +10,7 @@ func TestConfigSnapshotTerminatingGateway(
 	t testing.T,
 	populateServices bool,
 	nsFn func(ns *structs.NodeService),
-	extraUpdates []agentcache.UpdateEvent,
+	extraUpdates []UpdateEvent,
 ) *ConfigSnapshot {
 	roots, _ := TestCerts(t)
 
@@ -23,7 +21,7 @@ func TestConfigSnapshotTerminatingGateway(
 		cache = structs.NewServiceName("cache", nil)
 	)
 
-	baseEvents := []agentcache.UpdateEvent{
+	baseEvents := []UpdateEvent{
 		{
 			CorrelationID: rootsWatchID,
 			Result:        roots,
@@ -158,7 +156,7 @@ func TestConfigSnapshotTerminatingGateway(
 			},
 		}
 
-		baseEvents = testSpliceEvents(baseEvents, []agentcache.UpdateEvent{
+		baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{
 			{
 				CorrelationID: gatewayServicesWatchID,
 				Result: &structs.IndexedGatewayServices{
@@ -356,7 +354,7 @@ func testConfigSnapshotTerminatingGatewayServiceSubsets(t testing.T, alsoAdjustC
 		cache = structs.NewServiceName("cache", nil)
 	)
 
-	events := []agentcache.UpdateEvent{
+	events := []UpdateEvent{
 		{
 			CorrelationID: serviceResolverIDPrefix + web.String(),
 			Result: &structs.ConfigEntryResponse{
@@ -384,7 +382,7 @@ func testConfigSnapshotTerminatingGatewayServiceSubsets(t testing.T, alsoAdjustC
 	}
 
 	if alsoAdjustCache {
-		events = testSpliceEvents(events, []agentcache.UpdateEvent{
+		events = testSpliceEvents(events, []UpdateEvent{
 			{
 				CorrelationID: serviceResolverIDPrefix + cache.String(),
 				Result: &structs.ConfigEntryResponse{
@@ -414,7 +412,7 @@ func testConfigSnapshotTerminatingGatewayServiceSubsets(t testing.T, alsoAdjustC
 func TestConfigSnapshotTerminatingGatewayDefaultServiceSubset(t testing.T) *ConfigSnapshot {
 	web := structs.NewServiceName("web", nil)
 
-	return TestConfigSnapshotTerminatingGateway(t, true, nil, []agentcache.UpdateEvent{
+	return TestConfigSnapshotTerminatingGateway(t, true, nil, []UpdateEvent{
 		{
 			CorrelationID: serviceResolverIDPrefix + web.String(),
 			Result: &structs.ConfigEntryResponse{
@@ -498,7 +496,7 @@ func testConfigSnapshotTerminatingGatewayLBConfig(t testing.T, variant string) *
 		return nil
 	}
 
-	return TestConfigSnapshotTerminatingGateway(t, true, nil, []cache.UpdateEvent{
+	return TestConfigSnapshotTerminatingGateway(t, true, nil, []UpdateEvent{
 		{
 			CorrelationID: serviceConfigIDPrefix + web.String(),
 			Result: &structs.ServiceConfigResponse{
@@ -521,7 +519,7 @@ func testConfigSnapshotTerminatingGatewayLBConfig(t testing.T, variant string) *
 }
 
 func TestConfigSnapshotTerminatingGatewaySNI(t testing.T) *ConfigSnapshot {
-	return TestConfigSnapshotTerminatingGateway(t, true, nil, []cache.UpdateEvent{
+	return TestConfigSnapshotTerminatingGateway(t, true, nil, []UpdateEvent{
 		{
 			CorrelationID: "gateway-services",
 			Result: &structs.IndexedGatewayServices{
@@ -550,7 +548,7 @@ func TestConfigSnapshotTerminatingGatewayHostnameSubsets(t testing.T) *ConfigSna
 		cache = structs.NewServiceName("cache", nil)
 	)
 
-	return TestConfigSnapshotTerminatingGateway(t, true, nil, []agentcache.UpdateEvent{
+	return TestConfigSnapshotTerminatingGateway(t, true, nil, []UpdateEvent{
 		{
 			CorrelationID: serviceResolverIDPrefix + api.String(),
 			Result: &structs.ConfigEntryResponse{
@@ -600,7 +598,7 @@ func TestConfigSnapshotTerminatingGatewayIgnoreExtraResolvers(t testing.T) *Conf
 		notfound = structs.NewServiceName("notfound", nil)
 	)
 
-	return TestConfigSnapshotTerminatingGateway(t, true, nil, []agentcache.UpdateEvent{
+	return TestConfigSnapshotTerminatingGateway(t, true, nil, []UpdateEvent{
 		{
 			CorrelationID: serviceResolverIDPrefix + web.String(),
 			Result: &structs.ConfigEntryResponse{
@@ -648,9 +646,9 @@ func TestConfigSnapshotTerminatingGatewayIgnoreExtraResolvers(t testing.T) *Conf
 	})
 }
 
-func TestConfigSnapshotTerminatingGatewayWithLambdaService(t testing.T, extraUpdateEvents ...agentcache.UpdateEvent) *ConfigSnapshot {
+func TestConfigSnapshotTerminatingGatewayWithLambdaService(t testing.T, extraUpdateEvents ...UpdateEvent) *ConfigSnapshot {
 	web := structs.NewServiceName("web", nil)
-	updateEvents := append(extraUpdateEvents, agentcache.UpdateEvent{
+	updateEvents := append(extraUpdateEvents, UpdateEvent{
 		CorrelationID: serviceConfigIDPrefix + web.String(),
 		Result: &structs.ServiceConfigResponse{
 			ProxyConfig: map[string]interface{}{"protocol": "http"},
@@ -669,7 +667,7 @@ func TestConfigSnapshotTerminatingGatewayWithLambdaServiceAndServiceResolvers(t 
 	web := structs.NewServiceName("web", nil)
 
 	return TestConfigSnapshotTerminatingGatewayWithLambdaService(t,
-		agentcache.UpdateEvent{
+		UpdateEvent{
 			CorrelationID: serviceResolverIDPrefix + web.String(),
 			Result: &structs.ConfigEntryResponse{
 				Entry: &structs.ServiceResolverConfigEntry{

--- a/agent/proxycfg/testing_tproxy.go
+++ b/agent/proxycfg/testing_tproxy.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
@@ -28,7 +27,7 @@ func TestConfigSnapshotTransparentProxy(t testing.T) *ConfigSnapshot {
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -141,7 +140,7 @@ func TestConfigSnapshotTransparentProxyHTTPUpstream(t testing.T) *ConfigSnapshot
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -245,7 +244,7 @@ func TestConfigSnapshotTransparentProxyCatalogDestinationsOnly(t testing.T) *Con
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -335,7 +334,7 @@ func TestConfigSnapshotTransparentProxyDialDirectly(t testing.T) *ConfigSnapshot
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -473,7 +472,7 @@ func TestConfigSnapshotTransparentProxyTerminatingGatewayCatalogDestinationsOnly
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []cache.UpdateEvent{
+	}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{

--- a/agent/proxycfg/testing_upstreams.go
+++ b/agent/proxycfg/testing_upstreams.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/mitchellh/go-testing-interface"
 
-	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
@@ -16,7 +15,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 	variation string,
 	upstreams structs.Upstreams,
 	additionalEntries ...structs.ConfigEntry,
-) []cache.UpdateEvent {
+) []UpdateEvent {
 	var (
 		dbUpstream = upstreams[0]
 
@@ -25,7 +24,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 
 	dbChain := setupTestVariationDiscoveryChain(t, variation, additionalEntries...)
 
-	events := []cache.UpdateEvent{
+	events := []UpdateEvent{
 		{
 			CorrelationID: "discovery-chain:" + dbUID.String(),
 			Result: &structs.DiscoveryChainResponse{
@@ -46,14 +45,14 @@ func setupTestVariationConfigEntriesAndSnapshot(
 	case "simple":
 	case "external-sni":
 	case "failover":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:fail.default.default.dc1:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesAlternate(t),
 			},
 		})
 	case "failover-through-remote-gateway-triggered":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc1:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesInStatus(t, "critical"),
@@ -61,26 +60,26 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		})
 		fallthrough
 	case "failover-through-remote-gateway":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc2:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesDC2(t),
 			},
 		})
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc2:" + dbUID.String(),
 			Result: &structs.IndexedNodesWithGateways{
 				Nodes: TestGatewayNodesDC2(t),
 			},
 		})
 	case "failover-through-double-remote-gateway-triggered":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc1:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesInStatus(t, "critical"),
 			},
 		})
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc2:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesInStatusDC2(t, "critical"),
@@ -88,26 +87,26 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		})
 		fallthrough
 	case "failover-through-double-remote-gateway":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc3:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesDC2(t),
 			},
 		})
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc2:" + dbUID.String(),
 			Result: &structs.IndexedNodesWithGateways{
 				Nodes: TestGatewayNodesDC2(t),
 			},
 		})
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc3:" + dbUID.String(),
 			Result: &structs.IndexedNodesWithGateways{
 				Nodes: TestGatewayNodesDC3(t),
 			},
 		})
 	case "failover-through-local-gateway-triggered":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc1:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesInStatus(t, "critical"),
@@ -115,26 +114,26 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		})
 		fallthrough
 	case "failover-through-local-gateway":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc2:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesDC2(t),
 			},
 		})
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc1:" + dbUID.String(),
 			Result: &structs.IndexedNodesWithGateways{
 				Nodes: TestGatewayNodesDC1(t),
 			},
 		})
 	case "failover-through-double-local-gateway-triggered":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc1:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesInStatus(t, "critical"),
 			},
 		})
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc2:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesInStatusDC2(t, "critical"),
@@ -142,26 +141,26 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		})
 		fallthrough
 	case "failover-through-double-local-gateway":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:db.default.default.dc3:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesDC2(t),
 			},
 		})
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc1:" + dbUID.String(),
 			Result: &structs.IndexedNodesWithGateways{
 				Nodes: TestGatewayNodesDC1(t),
 			},
 		})
 	case "splitter-with-resolver-redirect-multidc":
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:v1.db.default.default.dc1:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodes(t, "db"),
 			},
 		})
-		events = append(events, cache.UpdateEvent{
+		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:v2.db.default.default.dc2:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestUpstreamNodesDC2(t),

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/cache"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"
 )
@@ -18,7 +17,7 @@ type handlerUpstreams struct {
 	handlerState
 }
 
-func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u cache.UpdateEvent, snap *ConfigSnapshot) error {
+func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u UpdateEvent, snap *ConfigSnapshot) error {
 	if u.Err != nil {
 		return fmt.Errorf("error filling agent cache: %v", u.Err)
 	}

--- a/agent/rpcclient/health/health.go
+++ b/agent/rpcclient/health/health.go
@@ -26,12 +26,12 @@ type NetRPC interface {
 
 type CacheGetter interface {
 	Get(ctx context.Context, t string, r cache.Request) (interface{}, cache.ResultMeta, error)
-	Notify(ctx context.Context, t string, r cache.Request, cID string, ch chan<- cache.UpdateEvent) error
+	NotifyCallback(ctx context.Context, t string, r cache.Request, cID string, cb cache.Callback) error
 }
 
 type MaterializedViewStore interface {
 	Get(ctx context.Context, req submatview.Request) (submatview.Result, error)
-	Notify(ctx context.Context, req submatview.Request, cID string, ch chan<- cache.UpdateEvent) error
+	NotifyCallback(ctx context.Context, req submatview.Request, cID string, cb cache.Callback) error
 }
 
 func (c *Client) ServiceNodes(
@@ -91,14 +91,14 @@ func (c *Client) Notify(
 	ctx context.Context,
 	req structs.ServiceSpecificRequest,
 	correlationID string,
-	ch chan<- cache.UpdateEvent,
+	cb cache.Callback,
 ) error {
 	if c.useStreaming(req) {
 		sr := c.newServiceRequest(req)
-		return c.ViewStore.Notify(ctx, sr, correlationID, ch)
+		return c.ViewStore.NotifyCallback(ctx, sr, correlationID, cb)
 	}
 
-	return c.Cache.Notify(ctx, c.CacheName, &req, correlationID, ch)
+	return c.Cache.NotifyCallback(ctx, c.CacheName, &req, correlationID, cb)
 }
 
 func (c *Client) useStreaming(req structs.ServiceSpecificRequest) bool {

--- a/agent/rpcclient/health/health_test.go
+++ b/agent/rpcclient/health/health_test.go
@@ -152,7 +152,7 @@ func (f *fakeCache) Get(_ context.Context, t string, _ cache.Request) (interface
 	return result, cache.ResultMeta{}, nil
 }
 
-func (f *fakeCache) Notify(_ context.Context, t string, _ cache.Request, _ string, _ chan<- cache.UpdateEvent) error {
+func (f *fakeCache) NotifyCallback(_ context.Context, t string, _ cache.Request, _ string, _ cache.Callback) error {
 	f.calls = append(f.calls, t)
 	return nil
 }
@@ -175,7 +175,7 @@ func (f *fakeViewStore) Get(_ context.Context, req submatview.Request) (submatvi
 	return submatview.Result{Value: &structs.IndexedCheckServiceNodes{}}, nil
 }
 
-func (f *fakeViewStore) Notify(_ context.Context, req submatview.Request, _ string, _ chan<- cache.UpdateEvent) error {
+func (f *fakeViewStore) NotifyCallback(_ context.Context, req submatview.Request, _ string, _ cache.Callback) error {
 	f.calls = append(f.calls, req)
 	return nil
 }

--- a/agent/submatview/store_integration_test.go
+++ b/agent/submatview/store_integration_test.go
@@ -320,7 +320,12 @@ func (c *consumer) Consume(ctx context.Context, maxIndex uint64) error {
 
 	group, cctx := errgroup.WithContext(ctx)
 	group.Go(func() error {
-		return c.healthClient.Notify(cctx, req, "", updateCh)
+		return c.healthClient.Notify(cctx, req, "", func(ctx context.Context, event cache.UpdateEvent) {
+			select {
+			case updateCh <- event:
+			case <-ctx.Done():
+			}
+		})
 	})
 	group.Go(func() error {
 		var idx uint64

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -13,7 +13,6 @@ import (
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/xds/proxysupport"
@@ -41,7 +40,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-min-version-auto",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -60,7 +59,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-min-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -79,7 +78,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-max-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -98,7 +97,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-cipher-suites",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -406,7 +405,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "ingress-gateway-with-tls-outgoing-min-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshotIngressGateway(t, true, "tcp", "default", nil, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshotIngressGateway(t, true, "tcp", "default", nil, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -425,7 +424,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "ingress-gateway-with-tls-outgoing-max-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshotIngressGateway(t, true, "tcp", "default", nil, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshotIngressGateway(t, true, "tcp", "default", nil, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -444,7 +443,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "ingress-gateway-with-tls-outgoing-cipher-suites",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshotIngressGateway(t, true, "tcp", "default", nil, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshotIngressGateway(t, true, "tcp", "default", nil, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -13,7 +13,6 @@ import (
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/xds/proxysupport"
@@ -46,7 +45,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-min-version-auto",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -65,7 +64,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-incoming-min-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -84,7 +83,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-incoming-max-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -103,7 +102,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-incoming-cipher-suites",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -173,7 +172,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 					func(ns *structs.NodeService) {
 						ns.Proxy.Config["protocol"] = "http"
 					},
-					[]cache.UpdateEvent{
+					[]proxycfg.UpdateEvent{
 						{
 							CorrelationID: "mesh",
 							Result: &structs.ConfigEntryResponse{
@@ -580,7 +579,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "terminating-gateway-with-tls-incoming-min-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -599,7 +598,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "terminating-gateway-with-tls-incoming-max-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -618,7 +617,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "terminating-gateway-with-tls-incoming-cipher-suites",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -677,7 +676,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			name: "terminating-gateway-no-api-cert",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				api := structs.NewServiceName("api", nil)
-				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []cache.UpdateEvent{
+				return proxycfg.TestConfigSnapshotTerminatingGateway(t, true, nil, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "service-leaf:" + api.String(), // serviceLeafIDPrefix
 						Result:        nil,                            // tombstone this


### PR DESCRIPTION
### Description

OSS portion of enterprise PR 1857.

This removes (most) references to the `cache.UpdateEvent` type in the `proxycfg` package.

As we're going to be direct usage of the agent cache with interfaces that can be satisfied by alternative server-local datasources, it doesn't make sense to depend on this type everywhere anymore (particularly on the `state.ch` channel).

We also plan to extract `proxycfg` out of Consul into a shared library in the future, which would require removing this dependency.

Aside from a fairly rote find-and-replace, the main change is that the `cache.Cache` and `health.Client` types now accept a callback function parameter, rather than a `chan<- cache.UpdateEvents`. This allows us to do the type conversion without running another goroutine.
