### PR TITLE
test: fix more flakes in the compatibility test

### DIFF
--- a/test/integration/consul-container/upgrade/util_test.go
+++ b/test/integration/consul-container/upgrade/util_test.go
@@ -18,9 +18,21 @@ func LongFailer() *retry.Timer {
 	return &retry.Timer{Timeout: retryTimeout, Wait: retryFrequency}
 }
 
-func waitForLeader(t *testing.T, Cluster *cluster.Cluster) {
+func waitForLeader(t *testing.T, Cluster *cluster.Cluster, client *api.Client) {
 	retry.RunWith(LongFailer(), t, func(r *retry.R) {
 		leader, err := Cluster.Leader()
+		require.NoError(r, err)
+		require.NotEmpty(r, leader)
+	})
+
+	if client != nil {
+		waitForLeaderFromClient(t, client)
+	}
+}
+
+func waitForLeaderFromClient(t *testing.T, client *api.Client) {
+	retry.RunWith(LongFailer(), t, func(r *retry.R) {
+		leader, err := cluster.GetLeader(client)
 		require.NoError(r, err)
 		require.NotEmpty(r, leader)
 	})


### PR DESCRIPTION
### Description

I discovered a few more things that would reduce flakes (or the threat of flakes) in the compat tests.

- waited until the _client_ could detect a leader sometimes
- ensures each test cluster used a uniquely random serf encryption key to prevent stray old carryover containers from automatically joining new clusters by accident
- fixed some errant references to `t` instead of `r` in `retry.RunWith` (the actual bug most likely)