### PR TITLE
test: fix incorrect use of t instead of r in retry test

### DIFF
--- a/agent/dns/dns_test.go
+++ b/agent/dns/dns_test.go
@@ -3,8 +3,9 @@ package dns
 import (
 	"testing"
 
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 
 func TestDNS_Recursor_StrategyRandom(t *testing.T) {
@@ -18,7 +19,7 @@ func TestDNS_Recursor_StrategyRandom(t *testing.T) {
 		}
 
 		// Ensure the slices contain the same elements
-		require.ElementsMatch(t, configuredRecursors, recursorsToQuery)
+		require.ElementsMatch(r, configuredRecursors, recursorsToQuery)
 
 		// Ensure the elements are not in the same order
 		require.NotEqual(r, configuredRecursors, recursorsToQuery)


### PR DESCRIPTION
### Description

I fixed `lint-consul-retry` in https://github.com/hashicorp/lint-consul-retry/pull/1 to also detect incorrect use of `retry.RunWith` which discovered this existing issue in `TestDNS_Recursor_StrategyRandom`
