### PR TITLE
chore(ci): fix rate-limiting for backport-assistant

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -27,7 +27,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to latest release branch
         run: |
-          resp=$(curl -f -s "https://api.github.com/repos/$GITHUB_REPOSITORY/labels?per_page=100")
+          # Use standard token here 
+          resp=$(curl -f -s -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "https://api.github.com/repos/$GITHUB_REPOSITORY/labels?per_page=100")
           ret="$?"
           if [[ "$ret" -ne 0 ]]; then
               echo "The GitHub API returned $ret"


### PR DESCRIPTION
### Description
We've seen this step fail in some cases. Adding the token will prevent rate limiting and fix access to private repositories.

### Testing & Reproduction steps
N/A

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [X] not a security concern
* [ ] ~checklist [folder](./../docs/config) consulted~
