### PR TITLE
feat: add endpoint struct to ServiceConfigEntry

### DIFF
--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -207,13 +207,6 @@ func (e *ServiceConfigEntry) Validate() error {
 		if e.Endpoint.Port < 1 || e.Endpoint.Port > 65535 {
 			validationErr = multierror.Append(validationErr, fmt.Errorf("Invalid Port number %d", e.Endpoint.Port))
 		}
-
-		// If either client cert config file was specified then the CA file, client cert, and key file must be specified
-		// Specifying only a CAFile is allowed for one-way TLS
-		if (e.Endpoint.CertFile != "" || e.Endpoint.KeyFile != "") &&
-			!(e.Endpoint.CAFile != "" && e.Endpoint.CertFile != "" && e.Endpoint.KeyFile != "") {
-			validationErr = multierror.Append(validationErr, errors.New("Endpoint must have a CertFile, CAFile, and KeyFile specified for TLS origination"))
-		}
 	}
 
 	return validationErr
@@ -236,22 +229,6 @@ func validateEndpointAddress(address string) error {
 		return fmt.Errorf("Could not validate address %s as an IP, CIDR block or Hostname", address)
 	}
 	return nil
-}
-
-func (e *ServiceConfigEntry) Warnings() []string {
-	if e == nil {
-		return nil
-	}
-	warnings := make([]string, 0)
-
-	if e.Endpoint != nil {
-		if (e.Endpoint.CAFile != "" || e.Endpoint.CertFile != "" || e.Endpoint.KeyFile != "") && e.Endpoint.SNI == "" {
-			warning := fmt.Sprintf("TLS is configured but SNI is not set for the endpoint. Enabling SNI is strongly recommended when using TLS.")
-			warnings = append(warnings, warning)
-		}
-	}
-
-	return warnings
 }
 
 func (e *ServiceConfigEntry) CanRead(authz acl.Authorizer) error {
@@ -321,21 +298,6 @@ type EndpointConfig struct {
 
 	// Port allowed within this endpoint
 	Port int `json:",omitempty"`
-
-	// CAFile is the optional path to a CA certificate to use for TLS connections
-	// from the gateway to the linked service
-	CAFile string `json:",omitempty" alias:"ca_file"`
-
-	// CertFile is the optional path to a client certificate to use for TLS    connections
-	// from the gateway to the linked service
-	CertFile string `json:",omitempty" alias:"cert_file"`
-
-	// KeyFile is the optional path to a private key to use for TLS connections
-	// from the gateway to the linked service
-	KeyFile string `json:",omitempty" alias:"key_file"`
-
-	// SNI is the optional name to specify during the TLS handshake with a linked service.
-	SNI string `json:",omitempty"`
 }
 
 // ProxyConfigEntry is the top-level struct for global proxy configuration defaults.

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -436,10 +436,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 				endpoint {
 					address = "1.2.3.4/24"
 					port = 8080
-					ca_file = "ca.pem"
-					cert_file = "cert.pem"
-					key_file = "key.pem"
-					sni = "external.com"
 				}
 			`,
 			camel: `
@@ -449,10 +445,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 				Endpoint {
 					Address = "1.2.3.4/24"
 					Port = 8080
-					CAFile = "ca.pem"
-					CertFile = "cert.pem"
-					KeyFile = "key.pem"
-					SNI = "external.com"
 				}
 			`,
 			expect: &ServiceConfigEntry{
@@ -460,12 +452,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 				Name:     "external",
 				Protocol: "tcp",
 				Endpoint: &EndpointConfig{
-					Address:  "1.2.3.4/24",
-					Port:     8080,
-					CAFile:   "ca.pem",
-					CertFile: "cert.pem",
-					KeyFile:  "key.pem",
-					SNI:      "external.com",
+					Address: "1.2.3.4/24",
+					Port:    8080,
 				},
 			},
 		},
@@ -2510,82 +2498,6 @@ func TestServiceConfigEntry(t *testing.T) {
 				},
 			},
 			validateErr: "Invalid Port number",
-		},
-		"validate: not all TLS options provided-1": {
-			entry: &ServiceConfigEntry{
-				Kind:     ServiceDefaults,
-				Name:     "external",
-				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
-					Address:  "2001:db8::8a2e:370:7334/64",
-					Port:     443,
-					CertFile: "client.crt",
-				},
-			},
-			validateErr: "must have a CertFile, CAFile, and KeyFile",
-		},
-		"validate: not all TLS options provided-2": {
-			entry: &ServiceConfigEntry{
-				Kind:     ServiceDefaults,
-				Name:     "external",
-				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
-					Address: "2001:db8::8a2e:370:7334/64",
-					Port:    443,
-					KeyFile: "tls.key",
-				},
-			},
-			validateErr: "must have a CertFile, CAFile, and KeyFile",
-		},
-		"validate: all TLS options provided": {
-			entry: &ServiceConfigEntry{
-				Kind:     ServiceDefaults,
-				Name:     "external",
-				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
-					Address:  "2001:db8::8a2e:370:7334/64",
-					Port:     443,
-					CAFile:   "ca.crt",
-					CertFile: "client.crt",
-					KeyFile:  "tls.key",
-				},
-			},
-		},
-		"validate: only providing ca file is allowed": {
-			entry: &ServiceConfigEntry{
-				Kind:     ServiceDefaults,
-				Name:     "external",
-				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
-					Address: "2001:db8::8a2e:370:7334/64",
-					Port:    443,
-					CAFile:  "ca.crt",
-				},
-			},
-		},
-		"validate: wildcard is allowed for hostname": {
-			entry: &ServiceConfigEntry{
-				Kind:     ServiceDefaults,
-				Name:     "external",
-				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
-					Address: "*.external.com",
-					Port:    443,
-					CAFile:  "ca.crt",
-				},
-			},
-		},
-		"validate: hostname": {
-			entry: &ServiceConfigEntry{
-				Kind:     ServiceDefaults,
-				Name:     "external",
-				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
-					Address: "api.external.com",
-					Port:    443,
-					CAFile:  "ca.crt",
-				},
-			},
 		},
 		"validate: invalid hostname 1": {
 			entry: &ServiceConfigEntry{

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -428,6 +428,48 @@ func TestDecodeConfigEntry(t *testing.T) {
 			},
 		},
 		{
+			name: "service-defaults-with-endpoint",
+			snake: `
+				kind = "service-defaults"
+				name = "external"
+				protocol = "tcp"
+				endpoint {
+					address = "1.2.3.4/24"
+					port = 8080
+					ca_file = "ca.pem"
+					cert_file = "cert.pem"
+					key_file = "key.pem"
+					sni = "external.com"
+				}
+			`,
+			camel: `
+				Kind = "service-defaults"
+				Name = "external"
+				Protocol = "tcp"
+				Endpoint {
+					Address = "1.2.3.4/24"
+					Port = 8080
+					CAFile = "ca.pem"
+					CertFile = "cert.pem"
+					KeyFile = "key.pem"
+					SNI = "external.com"
+				}
+			`,
+			expect: &ServiceConfigEntry{
+				Kind:     "service-defaults",
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address:  "1.2.3.4/24",
+					Port:     8080,
+					CAFile:   "ca.pem",
+					CertFile: "cert.pem",
+					KeyFile:  "key.pem",
+					SNI:      "external.com",
+				},
+			},
+		},
+		{
 			name: "service-router: kitchen sink",
 			snake: `
 				kind = "service-router"
@@ -2389,6 +2431,195 @@ func TestServiceConfigEntry(t *testing.T) {
 					Defaults: &UpstreamConfig{ConnectTimeoutMs: 0},
 				},
 				EnterpriseMeta: *DefaultEnterpriseMetaInDefaultPartition(),
+			},
+		},
+		"validate: missing endpoint address": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "",
+					Port:    443,
+				},
+			},
+			validateErr: "Could not validate address",
+		},
+		"validate: endpoint ipv4 address": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "1.2.3.4",
+					Port:    443,
+				},
+			},
+		},
+		"validate: endpoint ipv4 CIDR address": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "10.0.0.1/16",
+					Port:    8080,
+				},
+			},
+		},
+		"validate: endpoint ipv6 address": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "2001:0db8:0000:8a2e:0370:7334:1234:5678",
+					Port:    443,
+				},
+			},
+		},
+		"valid endpoint shortened ipv6 address": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "2001:db8::8a2e:370:7334",
+					Port:    443,
+				},
+			},
+		},
+		"validate: endpoint ipv6 CIDR address": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "2001:db8::8a2e:370:7334/64",
+					Port:    443,
+				},
+			},
+		},
+		"validate: invalid endpoint port": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "2001:db8::8a2e:370:7334/64",
+				},
+			},
+			validateErr: "Invalid Port number",
+		},
+		"validate: not all TLS options provided-1": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address:  "2001:db8::8a2e:370:7334/64",
+					Port:     443,
+					CertFile: "client.crt",
+				},
+			},
+			validateErr: "must have a CertFile, CAFile, and KeyFile",
+		},
+		"validate: not all TLS options provided-2": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "2001:db8::8a2e:370:7334/64",
+					Port:    443,
+					KeyFile: "tls.key",
+				},
+			},
+			validateErr: "must have a CertFile, CAFile, and KeyFile",
+		},
+		"validate: all TLS options provided": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address:  "2001:db8::8a2e:370:7334/64",
+					Port:     443,
+					CAFile:   "ca.crt",
+					CertFile: "client.crt",
+					KeyFile:  "tls.key",
+				},
+			},
+		},
+		"validate: only providing ca file is allowed": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "2001:db8::8a2e:370:7334/64",
+					Port:    443,
+					CAFile:  "ca.crt",
+				},
+			},
+		},
+		"validate: wildcard is allowed for hostname": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "*.external.com",
+					Port:    443,
+					CAFile:  "ca.crt",
+				},
+			},
+		},
+		"validate: hostname": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "api.external.com",
+					Port:    443,
+					CAFile:  "ca.crt",
+				},
+			},
+		},
+		"validate: invalid hostname 1": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "*external.com",
+					Port:    443,
+				},
+			},
+			validateErr: "Could not validate address",
+		},
+		"validate: invalid hostname 2": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "tcp",
+				Endpoint: &EndpointConfig{
+					Address: "..hello.",
+					Port:    443,
+				},
+			},
+			validateErr: "Could not validate address",
+		},
+		"validate: all web traffic allowed": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "http",
+				Endpoint: &EndpointConfig{
+					Address: "*",
+					Port:    443,
+				},
 			},
 		},
 	}

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -186,21 +186,6 @@ type EndpointConfig struct {
 
 	// Port allowed within this endpoint
 	Port int `json:",omitempty"`
-
-	// CAFile is the optional path to a CA certificate to use for TLS connections
-	// from the gateway to the linked service
-	CAFile string `json:",omitempty" alias:"ca_file"`
-
-	// CertFile is the optional path to a client certificate to use for TLS    connections
-	// from the gateway to the linked service
-	CertFile string `json:",omitempty" alias:"cert_file"`
-
-	// KeyFile is the optional path to a private key to use for TLS connections
-	// from the gateway to the linked service
-	KeyFile string `json:",omitempty" alias:"key_file"`
-
-	// SNI is the optional name to specify during the TLS handshake with a linked service.
-	SNI string `json:",omitempty"`
 }
 
 type PassiveHealthCheck struct {

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -179,6 +179,30 @@ type UpstreamConfig struct {
 	MeshGateway MeshGatewayConfig `json:",omitempty" alias:"mesh_gateway" `
 }
 
+// EndpointConfig represents a virtual service, i.e. one that is external to Consul
+type EndpointConfig struct {
+	// Address of the endpoint; hostname, IP, or CIDR
+	Address string `json:",omitempty"`
+
+	// Port allowed within this endpoint
+	Port int `json:",omitempty"`
+
+	// CAFile is the optional path to a CA certificate to use for TLS connections
+	// from the gateway to the linked service
+	CAFile string `json:",omitempty" alias:"ca_file"`
+
+	// CertFile is the optional path to a client certificate to use for TLS    connections
+	// from the gateway to the linked service
+	CertFile string `json:",omitempty" alias:"cert_file"`
+
+	// KeyFile is the optional path to a private key to use for TLS connections
+	// from the gateway to the linked service
+	KeyFile string `json:",omitempty" alias:"key_file"`
+
+	// SNI is the optional name to specify during the TLS handshake with a linked service.
+	SNI string `json:",omitempty"`
+}
+
 type PassiveHealthCheck struct {
 	// Interval between health check analysis sweeps. Each sweep may remove
 	// hosts or return hosts to the pool.
@@ -220,10 +244,10 @@ type ServiceConfigEntry struct {
 	Expose           ExposeConfig            `json:",omitempty"`
 	ExternalSNI      string                  `json:",omitempty" alias:"external_sni"`
 	UpstreamConfig   *UpstreamConfiguration  `json:",omitempty" alias:"upstream_config"`
-
-	Meta        map[string]string `json:",omitempty"`
-	CreateIndex uint64
-	ModifyIndex uint64
+	Endpoint         *EndpointConfig         `json:",omitempty"`
+	Meta             map[string]string       `json:",omitempty"`
+	CreateIndex      uint64
+	ModifyIndex      uint64
 }
 
 func (s *ServiceConfigEntry) GetKind() string            { return s.Kind }

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -106,10 +106,16 @@ func TestAPI_ConfigEntries(t *testing.T) {
 			},
 		}
 
+		endpoint := &EndpointConfig{
+			Address: "my.example.com",
+			Port:    80,
+		}
+
 		service2 := &ServiceConfigEntry{
 			Kind:     ServiceDefaults,
 			Name:     "bar",
 			Protocol: "tcp",
+			Endpoint: endpoint,
 		}
 
 		// set it
@@ -185,6 +191,7 @@ func TestAPI_ConfigEntries(t *testing.T) {
 				require.Equal(t, service2.Kind, readService.Kind)
 				require.Equal(t, service2.Name, readService.Name)
 				require.Equal(t, service2.Protocol, readService.Protocol)
+				require.Equal(t, endpoint, readService.Endpoint)
 			}
 		}
 
@@ -513,6 +520,37 @@ func TestDecodeConfigEntry(t *testing.T) {
 							Interval:    4 * time.Second,
 						},
 					},
+				},
+			},
+		},
+		{
+			name: "service-defaults-endpoint",
+			body: `
+			{
+				"Kind": "service-defaults",
+				"Name": "external",
+				"Protocol": "http",
+				"Endpoint": {
+					"Address": "1.2.3.4/24",
+					"Port": 443,
+					"CAFile": "ca.pem",
+					"CertFile": "crt.pem",
+					"KeyFile": "key.pem",
+					"SNI": "external.com"
+				}
+			}
+			`,
+			expect: &ServiceConfigEntry{
+				Kind:     "service-defaults",
+				Name:     "external",
+				Protocol: "http",
+				Endpoint: &EndpointConfig{
+					Address:  "1.2.3.4/24",
+					Port:     443,
+					CAFile:   "ca.pem",
+					CertFile: "crt.pem",
+					KeyFile:  "key.pem",
+					SNI:      "external.com",
 				},
 			},
 		},

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -532,11 +532,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				"Protocol": "http",
 				"Endpoint": {
 					"Address": "1.2.3.4/24",
-					"Port": 443,
-					"CAFile": "ca.pem",
-					"CertFile": "crt.pem",
-					"KeyFile": "key.pem",
-					"SNI": "external.com"
+					"Port": 443
 				}
 			}
 			`,
@@ -545,12 +541,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 				Name:     "external",
 				Protocol: "http",
 				Endpoint: &EndpointConfig{
-					Address:  "1.2.3.4/24",
-					Port:     443,
-					CAFile:   "ca.pem",
-					CertFile: "crt.pem",
-					KeyFile:  "key.pem",
-					SNI:      "external.com",
+					Address: "1.2.3.4/24",
+					Port:    443,
 				},
 			},
 		},

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -491,7 +491,7 @@ func TestParseConfigEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "service-defaults: kitchen sink",
+			name: "service-defaults: kitchen sink (upstreams edition)",
 			snake: `
 				kind = "service-defaults"
 				name = "main"
@@ -789,6 +789,118 @@ func TestParseConfigEntry(t *testing.T) {
 							Interval:    4 * time.Second,
 						},
 					},
+				},
+			},
+		},
+		{
+			name: "service-defaults: kitchen sink (endpoint edition)",
+			snake: `
+				kind = "service-defaults"
+				name = "main"
+				meta {
+					"foo" = "bar"
+					"gir" = "zim"
+				}
+				protocol = "grpc"
+				mesh_gateway {
+					mode = "remote"
+				}
+				mode = "transparent"
+				transparent_proxy = {
+					outbound_listener_port = 10101
+					dialed_directly = true
+				}
+				endpoint = {
+					address = "10.0.0.0/16",
+					port = 443
+				}
+			`,
+			camel: `
+				Kind = "service-defaults"
+				Name = "main"
+				Meta {
+					"foo" = "bar"
+					"gir" = "zim"
+				}
+				Protocol = "grpc"
+				MeshGateway {
+					Mode = "remote"
+				}
+				Mode = "transparent"
+				TransparentProxy = {
+					outbound_listener_port = 10101
+					dialed_directly = true
+				}
+				Endpoint = {
+					Address = "10.0.0.0/16",
+					Port = 443
+				}
+			`,
+			snakeJSON: `
+			{
+				"kind": "service-defaults",
+				"name": "main",
+				"meta" : {
+					"foo": "bar",
+					"gir": "zim"
+				},
+				"protocol": "grpc",
+				"mesh_gateway": {
+					"mode": "remote"
+				},
+				"mode": "transparent",
+				"transparent_proxy": {
+					"outbound_listener_port": 10101,
+					"dialed_directly": true
+				},
+				"endpoint": {
+					"address": "10.0.0.0/16",
+					"port": 443
+				}
+			}
+			`,
+			camelJSON: `
+			{
+				"Kind": "service-defaults",
+				"Name": "main",
+				"Meta" : {
+					"foo": "bar",
+					"gir": "zim"
+				},
+				"Protocol": "grpc",
+				"MeshGateway": {
+					"Mode": "remote"
+				},
+				"Mode": "transparent",
+				"TransparentProxy": {
+					"OutboundListenerPort": 10101,
+					"DialedDirectly": true
+				},
+				"Endpoint": {
+					"Address": "10.0.0.0/16",
+					"Port": 443
+				}
+			}
+			`,
+			expect: &api.ServiceConfigEntry{
+				Kind: "service-defaults",
+				Name: "main",
+				Meta: map[string]string{
+					"foo": "bar",
+					"gir": "zim",
+				},
+				Protocol: "grpc",
+				MeshGateway: api.MeshGatewayConfig{
+					Mode: api.MeshGatewayModeRemote,
+				},
+				Mode: api.ProxyModeTransparent,
+				TransparentProxy: &api.TransparentProxyConfig{
+					OutboundListenerPort: 10101,
+					DialedDirectly:       true,
+				},
+				Endpoint: &api.EndpointConfig{
+					Address: "10.0.0.0/16",
+					Port:    443,
 				},
 			},
 		},

--- a/test/integration/connect/envoy/Dockerfile-bats
+++ b/test/integration/connect/envoy/Dockerfile-bats
@@ -1,6 +1,6 @@
 FROM docker.mirror.hashicorp.services/fortio/fortio AS fortio
 
-FROM docker.mirror.hashicorp.services/bats/bats:1.6.0
+FROM docker.mirror.hashicorp.services/bats/bats:1.7.0
 
 RUN apk add curl
 RUN apk add openssl


### PR DESCRIPTION
### Description
First PR of many covering new terminating gateway functionality allowing external traffic w/o node registration and transparent proxying enabled.

This PR adds an `endpoint` field to `service-defaults` which represents a service external to Consul. It can be a hostname (w/ or w/o a wildcard), ipv4/ipv6 address or ipv4/ipv6 CIDR. Service defaults will represent the "virtual service", which will be consumed by the existing `Services` definition in `TerminatingGatewayConfigEntry`.

### Testing & Reproduction steps
Unit tests added. Higher-level testing will happen when we start integrating the watch with the terminating gateway xDS generation.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] not a security concern
* [X] checklist [folder](./../docs/config) consulted
