### PR TITLE
telemetry: remove unused arg

### DIFF
--- a/lib/telemetry_test.go
+++ b/lib/telemetry_test.go
@@ -21,7 +21,7 @@ func newCfg() TelemetryConfig {
 
 func TestConfigureSinks(t *testing.T) {
 	cfg := newCfg()
-	sinks, err := configureSinks(cfg, "hostname", nil)
+	sinks, err := configureSinks(cfg, nil)
 	require.Error(t, err)
 	// 3 sinks: statsd, statsite, inmem
 	require.Equal(t, 3, len(sinks))
@@ -29,7 +29,7 @@ func TestConfigureSinks(t *testing.T) {
 	cfg = TelemetryConfig{
 		DogstatsdAddr: "",
 	}
-	_, err = configureSinks(cfg, "hostname", nil)
+	_, err = configureSinks(cfg, nil)
 	require.NoError(t, err)
 
 }


### PR DESCRIPTION
### Description
It looks like we missed a lint issue in #13091 which only showed up in CI for its 1.12.x backport ([build log](https://app.circleci.com/pipelines/github/hashicorp/consul-enterprise/19330/workflows/a34a4902-ac10-45de-95bc-4bdd099c89b4/jobs/353135/parallel-runs/0/steps/0-105)).

### Testing & Reproduction steps
I updated the test.

### Links
[Build log](https://app.circleci.com/pipelines/github/hashicorp/consul-enterprise/19330/workflows/a34a4902-ac10-45de-95bc-4bdd099c89b4/jobs/353135/parallel-runs/0/steps/0-105)

### PR Checklist
* [x] updated test coverage