### PR TITLE
ci: name unnamed GHA workflows

### DIFF
--- a/.github/workflows/backport-reminder.yml
+++ b/.github/workflows/backport-reminder.yml
@@ -1,6 +1,8 @@
 # This workflow sends a reminder comment to PRs that have labels starting with
 # `backport/` to check that the backport has run successfully.
 
+name: Backport Assistant Reminder
+
 on:
   pull_request:
     types: [ labeled ]

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -1,6 +1,8 @@
 # This workflow checks that there is either a 'pr/no-changelog' label applied to a PR
 # or there is a .changelog/<pr number>.txt file associated with a PR for a changelog entry
 
+name: Changelog Checker
+
 on:
   pull_request:
     types: [opened, synchronize, labeled]

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,3 +1,5 @@
+name: Load Test
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/website-checker.yml
+++ b/.github/workflows/website-checker.yml
@@ -10,6 +10,8 @@
 # in the PR and if they need to be cherry-picked to the stable-website branch, the
 # 'type/docs-cherrypick' label needs to be applied.
 
+name: Website Checker
+
 on:
   pull_request_target:
     types: [opened]

--- a/.github/workflows/website-checker.yml
+++ b/.github/workflows/website-checker.yml
@@ -10,7 +10,6 @@
 # in the PR and if they need to be cherry-picked to the stable-website branch, the
 # 'type/docs-cherrypick' label needs to be applied.
 
-
 name: Website Checker
 
 on:

--- a/.github/workflows/website-checker.yml
+++ b/.github/workflows/website-checker.yml
@@ -10,6 +10,7 @@
 # in the PR and if they need to be cherry-picked to the stable-website branch, the
 # 'type/docs-cherrypick' label needs to be applied.
 
+
 name: Website Checker
 
 on:


### PR DESCRIPTION
### Description
This updates our GitHub Action workflows to all have `name` specified so that the filename isn't used instead, which is a little nicer on the eyes and easier to see which is which.

### Testing & Reproduction steps
See the checks for this PR. This illustrates the state before this change:
<img width="852" alt="Screen Shot 2022-05-19 at 6 14 39 PM" src="https://user-images.githubusercontent.com/40828/169429755-94948911-cce6-4a67-b9e3-af8578c894b5.png">
