### PR TITLE
peering: expose IsLeader, hung up on dialer if follower

### DIFF
--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -15,6 +15,7 @@ import (
 )
 
 type peeringBackend struct {
+	// TODO(peering): accept a smaller interface; maybe just funcs from the sever that we actually need: DC, IsLeader, etc
 	srv      *Server
 	connPool GRPCClientConner
 	apply    *peeringApply
@@ -31,6 +32,7 @@ func NewPeeringBackend(srv *Server, connPool GRPCClientConner) peering.Backend {
 	}
 }
 
+// Forward should not be used to initiate forwarding over bidirectional streams
 func (b *peeringBackend) Forward(info structs.RPCInfo, f func(*grpc.ClientConn) error) (handled bool, err error) {
 	// Only forward the request if the dc in the request matches the server's datacenter.
 	if info.RequestDatacenter() != "" && info.RequestDatacenter() != b.srv.config.Datacenter {
@@ -101,6 +103,10 @@ func (b *peeringBackend) Apply() peering.Apply {
 
 func (b *peeringBackend) EnterpriseCheckPartitions(partition string) error {
 	return b.enterpriseCheckPartitions(partition)
+}
+
+func (b *peeringBackend) IsLeader() bool {
+	return b.srv.IsLeader()
 }
 
 type peeringApply struct {

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -15,7 +15,7 @@ import (
 )
 
 type peeringBackend struct {
-	// TODO(peering): accept a smaller interface; maybe just funcs from the sever that we actually need: DC, IsLeader, etc
+	// TODO(peering): accept a smaller interface; maybe just funcs from the server that we actually need: DC, IsLeader, etc
 	srv      *Server
 	connPool GRPCClientConner
 	apply    *peeringApply

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -31,7 +31,6 @@ var (
 	errPeeringTokenEmptyServerAddresses = errors.New("peering token server addresses value is empty")
 	errPeeringTokenEmptyServerName      = errors.New("peering token server name value is empty")
 	errPeeringTokenEmptyPeerID          = errors.New("peering token peer ID value is empty")
-	errPeeringBackendNil                = errors.New("peering backend was not initialized")
 )
 
 // errPeeringInvalidServerAddress is returned when an initiate request contains
@@ -427,11 +426,6 @@ type BidirectionalStream interface {
 
 // StreamResources handles incoming streaming connections.
 func (s *Service) StreamResources(stream pbpeering.PeeringService_StreamResourcesServer) error {
-	if s.Backend == nil {
-		s.logger.Error("cannot establish stream without a backend", "error", errPeeringBackendNil)
-		return errPeeringBackendNil
-	}
-
 	if !s.Backend.IsLeader() {
 		// we are not the leader so we will hang up on the dialer
 

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -430,8 +430,8 @@ func (s *Service) StreamResources(stream pbpeering.PeeringService_StreamResource
 		// we are not the leader so we will hang up on the dialer
 
 		// TODO(peering): in the future we want to indicate the address of the leader server as a message to the dialer (best effort, non blocking)
-		s.logger.Error("cannot establish a peering stream on a follower node;")
-		return io.EOF
+		s.logger.Error("cannot establish a peering stream on a follower node")
+		return grpcstatus.Error(codes.FailedPrecondition, "cannot establish a peering stream on a follower node")
 	}
 
 	// Initial message on a new stream must be a new subscription request.
@@ -601,8 +601,8 @@ func (s *Service) HandleStream(req HandleStreamRequest) error {
 				// we are not the leader anymore so we will hang up on the dialer
 
 				// TODO(peering): in the future we want to indicate the address of the leader server as a message to the dialer (best effort, non blocking)
-				logger.Error("cannot establish a peering stream on a follower node;")
-				return io.EOF
+				logger.Error("node is not a follower anymore; cannot continue streaming")
+				return grpcstatus.Error(codes.FailedPrecondition, "node is not a follower anymore; cannot continue streaming")
 			}
 
 			if req := msg.GetRequest(); req != nil {

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -597,6 +597,14 @@ func (s *Service) HandleStream(req HandleStreamRequest) error {
 				return nil
 			}
 
+			if !s.Backend.IsLeader() {
+				// we are not the leader anymore so we will hang up on the dialer
+
+				// TODO(peering): in the future we want to indicate the address of the leader server as a message to the dialer (best effort, non blocking)
+				logger.Error("cannot establish a peering stream on a follower node;")
+				return io.EOF
+			}
+
 			if req := msg.GetRequest(); req != nil {
 				switch {
 				case req.Nonce == "":

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -92,7 +92,7 @@ type Backend interface {
 
 	Subscribe(req *stream.SubscribeRequest) (*stream.Subscription, error)
 
-	// IsLeader indicates whether the consul server is a in a leader state or not
+	// IsLeader indicates whether the consul server is in a leader state or not.
 	IsLeader() bool
 
 	Store() Store

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -601,8 +601,8 @@ func (s *Service) HandleStream(req HandleStreamRequest) error {
 				// we are not the leader anymore so we will hang up on the dialer
 
 				// TODO(peering): in the future we want to indicate the address of the leader server as a message to the dialer (best effort, non blocking)
-				logger.Error("node is not a follower anymore; cannot continue streaming")
-				return grpcstatus.Error(codes.FailedPrecondition, "node is not a follower anymore; cannot continue streaming")
+				logger.Error("node is not a leader anymore; cannot continue streaming")
+				return grpcstatus.Error(codes.FailedPrecondition, "node is not a leader anymore; cannot continue streaming")
 			}
 
 			if req := msg.GetRequest(); req != nil {

--- a/agent/rpc/peering/stream_test.go
+++ b/agent/rpc/peering/stream_test.go
@@ -59,7 +59,7 @@ func TestStreamResources_Server_Follower(t *testing.T) {
 	msg, err := client.Recv()
 	require.Nil(t, msg)
 	require.Error(t, err)
-	require.EqualError(t, err, "EOF")
+	require.EqualError(t, err, "rpc error: code = FailedPrecondition desc = cannot establish a peering stream on a follower node")
 }
 
 // TestStreamResources_Server_LeaderBecomesFollower simulates a srv that is a leader when the
@@ -128,7 +128,7 @@ func TestStreamResources_Server_LeaderBecomesFollower(t *testing.T) {
 	msg2, err2 := client.Recv()
 	require.Nil(t, msg2)
 	require.Error(t, err2)
-	require.EqualError(t, err2, "EOF")
+	require.EqualError(t, err2, "rpc error: code = FailedPrecondition desc = node is not a follower anymore; cannot continue streaming")
 }
 
 func TestStreamResources_Server_FirstRequest(t *testing.T) {

--- a/agent/rpc/peering/stream_test.go
+++ b/agent/rpc/peering/stream_test.go
@@ -128,7 +128,7 @@ func TestStreamResources_Server_LeaderBecomesFollower(t *testing.T) {
 	msg2, err2 := client.Recv()
 	require.Nil(t, msg2)
 	require.Error(t, err2)
-	require.EqualError(t, err2, "rpc error: code = FailedPrecondition desc = node is not a follower anymore; cannot continue streaming")
+	require.EqualError(t, err2, "rpc error: code = FailedPrecondition desc = node is not a leader anymore; cannot continue streaming")
 }
 
 func TestStreamResources_Server_FirstRequest(t *testing.T) {
@@ -511,7 +511,6 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 	var lastRecvError time.Time
 	var lastRecvErrorMsg string
 
-	// find me alex
 	testutil.RunStep(t, "response fails to apply locally", func(t *testing.T) {
 		resp := &pbpeering.ReplicationMessage{
 			Payload: &pbpeering.ReplicationMessage_Response_{


### PR DESCRIPTION
Signed-off-by: acpana <8968914+acpana@users.noreply.github.com>

### Description
This patch adds `IsLeader` to the peering backend to use when handling `StreamResource()` as a receiver. If the service runs on a consul that is not a leader, then we hang up on the dialer. Otherwise, calls to raft apply as a non leader would fail.

In the future (future PR), we may want to send a message to the dialer with the address of the leader but for now, we just hung up.

### Testing & Reproduction steps
* `stream_test.go` updated

### Links
Asana tasks [1](https://app.asana.com/0/1201832349181086/1202294390627574) & [2](https://app.asana.com/0/1201832349181086/1202045399358213)

### PR Checklist

* [x] updated test coverage
