### PR TITLE
Export top-level HCP Enabled go-template variable for UI

### DIFF
--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -31,6 +31,7 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 	d := map[string]interface{}{
 		"ContentPath":       cfg.UIConfig.ContentPath,
 		"ACLsEnabled":       cfg.ACLsEnabled,
+		"HCPEnabled":        cfg.UIConfig.HCPEnabled,
 		"UIConfig":          uiCfg,
 		"LocalDatacenter":   cfg.Datacenter,
 		"PrimaryDatacenter": cfg.PrimaryDatacenter,

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -39,6 +39,7 @@ func TestUIServerIndex(t *testing.T) {
 			wantContains: []string{"<!-- CONSUL_VERSION:"},
 			wantUICfgJSON: `{
 				"ACLsEnabled": false,
+				"HCPEnabled": false,
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
@@ -73,6 +74,7 @@ func TestUIServerIndex(t *testing.T) {
 			},
 			wantUICfgJSON: `{
 				"ACLsEnabled": false,
+				"HCPEnabled": false,
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
@@ -95,6 +97,7 @@ func TestUIServerIndex(t *testing.T) {
 			wantContains: []string{"<!-- CONSUL_VERSION:"},
 			wantUICfgJSON: `{
 				"ACLsEnabled": true,
+				"HCPEnabled": false,
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
@@ -114,6 +117,7 @@ func TestUIServerIndex(t *testing.T) {
 			wantContains: []string{"<!-- CONSUL_VERSION:"},
 			wantUICfgJSON: `{
 				"ACLsEnabled": false,
+				"HCPEnabled": true,
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
@@ -143,6 +147,7 @@ func TestUIServerIndex(t *testing.T) {
 			},
 			wantUICfgJSON: `{
 				"ACLsEnabled": false,
+				"HCPEnabled": false,
 				"SSOEnabled": true,
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
@@ -413,6 +418,7 @@ func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code)
 		expected := `{
 		"ACLsEnabled": false,
+		"HCPEnabled": false,
 		"LocalDatacenter": "dc1",
 		"PrimaryDatacenter": "dc1",
 		"ContentPath": "/ui/",
@@ -437,6 +443,7 @@ func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
 		require.Equal(t, http.StatusOK, rec.Code)
 		expected := `{
 			"ACLsEnabled": false,
+			"HCPEnabled": false,
 			"LocalDatacenter": "dc1",
 			"PrimaryDatacenter": "dc1",
 			"ContentPath": "/ui/",


### PR DESCRIPTION
### Description

Exporting HCPEnabled as a top level variable into the go-template for the UI to pick up.

### Testing & Reproduction steps

Amended tests included. Note: The tests here prove that the correct JSON is outputted into the index.html file, and no further, which is perfect. From there on in, the work is the UIs responsibility to pick the JSON up.

This PR was PRed separately from https://github.com/hashicorp/consul/pull/12771 ~(the base branch)~ for an easy way to ensure the extra tests info here gets run through CI before merge.

Edit: I decided it would be better to set the get this merged into `main` separate from https://github.com/hashicorp/consul/pull/12771 so we can get it merged into both OSS and Ent easier before bringing it all together on https://github.com/hashicorp/consul/pull/12771 so I rebased and changed the base branch here back to main.

### Links

Continuation/stitching together of:
- https://github.com/hashicorp/consul/pull/12796
- https://github.com/hashicorp/consul/pull/12771

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
