### PR TITLE
agent: allow for service discovery queries involving peer name to use streaming

### DIFF
--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -51,6 +51,7 @@ func (e EventPayloadCheckServiceNode) Subject() stream.Subject {
 	return EventSubjectService{
 		Key:            e.Value.Service.Service,
 		EnterpriseMeta: e.Value.Service.EnterpriseMeta,
+		PeerName:       e.Value.Service.PeerName,
 
 		overrideKey:       e.overrideKey,
 		overrideNamespace: e.overrideNamespace,

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -613,16 +613,8 @@ func TestHealthServiceNodes(t *testing.T) {
 
 	testingPeerNames := []string{"", "my-peer"}
 
-	suffix := func(peerName string) string {
-		if peerName == "" {
-			return ""
-		}
-		// TODO(peering): after streaming works, remove the "&near=_agent" part
-		return "&peer=" + peerName + "&near=_agent"
-	}
-
 	for _, peerName := range testingPeerNames {
-		req, err := http.NewRequest("GET", "/v1/health/service/consul?dc=dc1"+suffix(peerName), nil)
+		req, err := http.NewRequest("GET", "/v1/health/service/consul?dc=dc1"+peerQuerySuffix(peerName), nil)
 		require.NoError(t, err)
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.HealthServiceNodes(resp, req)
@@ -639,7 +631,7 @@ func TestHealthServiceNodes(t *testing.T) {
 			require.Len(t, nodes, 0)
 		}
 
-		req, err = http.NewRequest("GET", "/v1/health/service/nope?dc=dc1"+suffix(peerName), nil)
+		req, err = http.NewRequest("GET", "/v1/health/service/nope?dc=dc1"+peerQuerySuffix(peerName), nil)
 		require.NoError(t, err)
 		resp = httptest.NewRecorder()
 		obj, err = a.srv.HealthServiceNodes(resp, req)
@@ -684,7 +676,7 @@ func TestHealthServiceNodes(t *testing.T) {
 	}
 
 	for _, peerName := range testingPeerNames {
-		req, err := http.NewRequest("GET", "/v1/health/service/test?dc=dc1"+suffix(peerName), nil)
+		req, err := http.NewRequest("GET", "/v1/health/service/test?dc=dc1"+peerQuerySuffix(peerName), nil)
 		require.NoError(t, err)
 		resp := httptest.NewRecorder()
 		obj, err := a.srv.HealthServiceNodes(resp, req)
@@ -699,7 +691,7 @@ func TestHealthServiceNodes(t *testing.T) {
 		// Test caching
 		{
 			// List instances with cache enabled
-			req, err := http.NewRequest("GET", "/v1/health/service/test?cached"+suffix(peerName), nil)
+			req, err := http.NewRequest("GET", "/v1/health/service/test?cached"+peerQuerySuffix(peerName), nil)
 			require.NoError(t, err)
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.HealthServiceNodes(resp, req)
@@ -713,7 +705,7 @@ func TestHealthServiceNodes(t *testing.T) {
 
 		{
 			// List instances with cache enabled
-			req, err := http.NewRequest("GET", "/v1/health/service/test?cached"+suffix(peerName), nil)
+			req, err := http.NewRequest("GET", "/v1/health/service/test?cached"+peerQuerySuffix(peerName), nil)
 			require.NoError(t, err)
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.HealthServiceNodes(resp, req)
@@ -742,7 +734,7 @@ func TestHealthServiceNodes(t *testing.T) {
 		for _, peerName := range testingPeerNames {
 			retry.Run(t, func(r *retry.R) {
 				// List it again
-				req, err := http.NewRequest("GET", "/v1/health/service/test?cached"+suffix(peerName), nil)
+				req, err := http.NewRequest("GET", "/v1/health/service/test?cached"+peerQuerySuffix(peerName), nil)
 				require.NoError(r, err)
 				resp := httptest.NewRecorder()
 				obj, err := a.srv.HealthServiceNodes(resp, req)
@@ -802,13 +794,6 @@ use_streaming_backend = true
 		},
 	}
 
-	suffix := func(peerName string) string {
-		if peerName == "" {
-			return ""
-		}
-		return "&peer=" + peerName
-	}
-
 	verify := func(t *testing.T, expectN int, nodes structs.CheckServiceNodes) {
 		require.Len(t, nodes, expectN)
 
@@ -856,7 +841,7 @@ use_streaming_backend = true
 			}
 
 			// Initial request should return two instances
-			req, _ := http.NewRequest("GET", "/v1/health/service/test?dc=dc1"+suffix(peerName), nil)
+			req, _ := http.NewRequest("GET", "/v1/health/service/test?dc=dc1"+peerQuerySuffix(peerName), nil)
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.HealthServiceNodes(resp, req)
 			require.NoError(t, err)
@@ -911,7 +896,7 @@ use_streaming_backend = true
 
 			{
 				timeout := 30 * time.Second
-				url := fmt.Sprintf("/v1/health/service/test?dc=dc1&index=%d&wait=%s"+suffix(peerName), idx, timeout)
+				url := fmt.Sprintf("/v1/health/service/test?dc=dc1&index=%d&wait=%s"+peerQuerySuffix(peerName), idx, timeout)
 				req, _ := http.NewRequest("GET", url, nil)
 				resp := httptest.NewRecorder()
 				obj, err := a.srv.HealthServiceNodes(resp, req)
@@ -941,7 +926,7 @@ use_streaming_backend = true
 			start = time.Now()
 			{
 				timeout := 200 * time.Millisecond
-				url := fmt.Sprintf("/v1/health/service/test?dc=dc1&index=%d&wait=%s"+suffix(peerName),
+				url := fmt.Sprintf("/v1/health/service/test?dc=dc1&index=%d&wait=%s"+peerQuerySuffix(peerName),
 					idx, timeout)
 				req, _ := http.NewRequest("GET", url, nil)
 				resp := httptest.NewRecorder()
@@ -1005,13 +990,6 @@ use_streaming_backend = true
 		},
 	}
 
-	suffix := func(peerName string) string {
-		if peerName == "" {
-			return ""
-		}
-		return "&peer=" + peerName
-	}
-
 	// TODO(peering): will have to seed this data differently in the future
 	register := func(t *testing.T, a *TestAgent, name, tag string) {
 		args := &structs.RegisterRequest{
@@ -1049,7 +1027,7 @@ use_streaming_backend = true
 			// Initial request with a filter should return one.
 			var lastIndex uint64
 			testutil.RunStep(t, "read original", func(t *testing.T) {
-				req, err := http.NewRequest("GET", "/v1/health/service/web?dc=dc1&"+filterUrlPart+suffix(peerName), nil)
+				req, err := http.NewRequest("GET", "/v1/health/service/web?dc=dc1&"+filterUrlPart+peerQuerySuffix(peerName), nil)
 				require.NoError(t, err)
 
 				resp := httptest.NewRecorder()
@@ -1082,7 +1060,7 @@ use_streaming_backend = true
 					errCh = make(chan error, 1)
 				)
 				go func() {
-					url := fmt.Sprintf("/v1/health/service/web?dc=dc1&index=%d&wait=%s&%s"+suffix(peerName), lastIndex, timeout, filterUrlPart)
+					url := fmt.Sprintf("/v1/health/service/web?dc=dc1&index=%d&wait=%s&%s"+peerQuerySuffix(peerName), lastIndex, timeout, filterUrlPart)
 					req, err := http.NewRequest("GET", url, nil)
 					if err != nil {
 						errCh <- err
@@ -1902,4 +1880,11 @@ func TestFilterNonPassing(t *testing.T) {
 	if len(out) != 1 && reflect.DeepEqual(out[0], nodes[2]) {
 		t.Fatalf("bad: %v", out)
 	}
+}
+
+func peerQuerySuffix(peerName string) string {
+	if peerName == "" {
+		return ""
+	}
+	return "&peer=" + peerName
 }

--- a/agent/rpcclient/health/view.go
+++ b/agent/rpcclient/health/view.go
@@ -31,6 +31,7 @@ func newMaterializerRequest(srvReq structs.ServiceSpecificRequest) func(index ui
 			Index:      index,
 			Namespace:  srvReq.EnterpriseMeta.NamespaceOrEmpty(),
 			Partition:  srvReq.EnterpriseMeta.PartitionOrEmpty(),
+			PeerName:   srvReq.PeerName,
 		}
 		if srvReq.Connect {
 			req.Topic = pbsubscribe.Topic_ServiceHealthConnect

--- a/proto/pbservice/ids.go
+++ b/proto/pbservice/ids.go
@@ -22,12 +22,14 @@ func (m *CheckServiceNode) UniqueID() string {
 	switch {
 	case m.Node != nil:
 		builder.WriteString(m.Node.Partition + "/")
+		builder.WriteString(m.Node.PeerName + "/")
 	case m.Service != nil:
 		partition := ""
 		if m.Service.EnterpriseMeta != nil {
 			partition = m.Service.EnterpriseMeta.Partition
 		}
 		builder.WriteString(partition + "/")
+		builder.WriteString(m.Service.PeerName + "/")
 	}
 
 	if m.Node != nil {

--- a/proto/pbservice/ids_test.go
+++ b/proto/pbservice/ids_test.go
@@ -22,40 +22,124 @@ func TestCheckServiceNode_UniqueID(t *testing.T) {
 		{
 			name: "full",
 			csn: &CheckServiceNode{
-				Node: &Node{Node: "the-node-name"},
+				Node: &Node{
+					Node:      "the-node-name",
+					PeerName:  "my-peer",
+					Partition: "the-partition",
+				},
 				Service: &NodeService{
-					ID:             "the-service-id",
-					EnterpriseMeta: &pbcommon.EnterpriseMeta{Namespace: "the-namespace"},
+					ID: "the-service-id",
+					EnterpriseMeta: &pbcommon.EnterpriseMeta{
+						Partition: "the-partition",
+						Namespace: "the-namespace",
+					},
+					PeerName: "my-peer",
 				},
 			},
-			expected: "/the-node-name/the-namespace/the-service-id",
+			expected: "the-partition/my-peer/the-node-name/the-namespace/the-service-id",
 		},
 		{
 			name: "without node",
 			csn: &CheckServiceNode{
 				Service: &NodeService{
-					ID:             "the-service-id",
-					EnterpriseMeta: &pbcommon.EnterpriseMeta{Namespace: "the-namespace"},
+					ID: "the-service-id",
+					EnterpriseMeta: &pbcommon.EnterpriseMeta{
+						Partition: "the-partition",
+						Namespace: "the-namespace",
+					},
+					PeerName: "my-peer",
 				},
 			},
-			expected: "/the-namespace/the-service-id",
+			expected: "the-partition/my-peer/the-namespace/the-service-id",
 		},
 		{
 			name: "without service",
 			csn: &CheckServiceNode{
-				Node: &Node{Node: "the-node-name"},
+				Node: &Node{
+					Node:      "the-node-name",
+					PeerName:  "my-peer",
+					Partition: "the-partition",
+				},
 			},
-			expected: "/the-node-name/",
+			expected: "the-partition/my-peer/the-node-name/",
 		},
 		{
 			name: "without namespace",
 			csn: &CheckServiceNode{
-				Node: &Node{Node: "the-node-name"},
+				Node: &Node{
+					Node:      "the-node-name",
+					PeerName:  "my-peer",
+					Partition: "the-partition",
+				},
+				Service: &NodeService{
+					ID:       "the-service-id",
+					PeerName: "my-peer",
+					EnterpriseMeta: &pbcommon.EnterpriseMeta{
+						Partition: "the-partition",
+					},
+				},
+			},
+			expected: "the-partition/my-peer/the-node-name//the-service-id",
+		},
+		{
+			name: "without peer name",
+			csn: &CheckServiceNode{
+				Node: &Node{
+					Node:      "the-node-name",
+					Partition: "the-partition",
+				},
+				Service: &NodeService{
+					ID: "the-service-id",
+					EnterpriseMeta: &pbcommon.EnterpriseMeta{
+						Partition: "the-partition",
+						Namespace: "the-namespace",
+					},
+				},
+			},
+			expected: "the-partition//the-node-name/the-namespace/the-service-id",
+		},
+		{
+			name: "without partition",
+			csn: &CheckServiceNode{
+				Node: &Node{
+					Node:     "the-node-name",
+					PeerName: "my-peer",
+				},
+				Service: &NodeService{
+					ID:       "the-service-id",
+					PeerName: "my-peer",
+					EnterpriseMeta: &pbcommon.EnterpriseMeta{
+						Namespace: "the-namespace",
+					},
+				},
+			},
+			expected: "/my-peer/the-node-name/the-namespace/the-service-id",
+		},
+		{
+			name: "without partition or namespace",
+			csn: &CheckServiceNode{
+				Node: &Node{
+					Node:     "the-node-name",
+					PeerName: "my-peer",
+				},
+				Service: &NodeService{
+					ID:       "the-service-id",
+					PeerName: "my-peer",
+				},
+			},
+			expected: "/my-peer/the-node-name//the-service-id",
+		},
+		{
+			name: "without partition or namespace or peer name",
+			csn: &CheckServiceNode{
+				Node: &Node{
+					Node: "the-node-name",
+				},
 				Service: &NodeService{
 					ID: "the-service-id",
 				},
 			},
-			expected: "/the-node-name//the-service-id",
+			expected: "//the-node-name//the-service-id",
 		},
 	}
 	for _, tc := range testCases {
@@ -63,5 +147,4 @@ func TestCheckServiceNode_UniqueID(t *testing.T) {
 			fn(t, &tc)
 		})
 	}
-
 }

--- a/proto/pbsubscribe/subscribe.pb.go
+++ b/proto/pbsubscribe/subscribe.pb.go
@@ -170,7 +170,7 @@ type SubscribeRequest struct {
 	//
 	// Partition is an enterprise-only feature.
 	Partition string `protobuf:"bytes,7,opt,name=Partition,proto3" json:"Partition,omitempty"`
-	// TODO(peering): docs
+	// PeerName is the name of the peer that the requested service was imported from.
 	PeerName string `protobuf:"bytes,8,opt,name=PeerName,proto3" json:"PeerName,omitempty"`
 }
 

--- a/proto/pbsubscribe/subscribe.proto
+++ b/proto/pbsubscribe/subscribe.proto
@@ -85,7 +85,7 @@ message SubscribeRequest {
     // Partition is an enterprise-only feature.
     string Partition = 7;
 
-    // TODO(peering): docs
+    // PeerName is the name of the peer that the requested service was imported from.
     string PeerName = 8;
 }
 


### PR DESCRIPTION
### Description

Requesting service discovery data for peered services that have been imported should make use of streaming if enabled.

### Links

[Asana](https://app.asana.com/0/1201832349181086/1201834451438964/f)

### PR Checklist

* [x] updated test coverage
* [ ] ~external facing docs updated~
* [x] not a security concern
* [ ] ~checklist [folder](./../docs/config) consulted~
