### PR TITLE
test: fix flaky test TestEventBufferFuzz

### DIFF
--- a/agent/consul/stream/event_buffer_test.go
+++ b/agent/consul/stream/event_buffer_test.go
@@ -22,6 +22,10 @@ func TestEventBufferFuzz(t *testing.T) {
 
 	b := newEventBuffer()
 
+	// Load head here so all subscribers start from the same point or they might
+	// not run until several appends have already happened.
+	head := b.Head()
+
 	// Start a write goroutine that will publish 10000 messages with sequential
 	// indexes and some jitter in timing (to allow clients to "catch up" and block
 	// waiting for updates).
@@ -49,10 +53,6 @@ func TestEventBufferFuzz(t *testing.T) {
 
 	// Run n subscribers following and verifying
 	errCh := make(chan error, nReaders)
-
-	// Load head here so all subscribers start from the same point or they might
-	// not run until several appends have already happened.
-	head := b.Head()
 
 	for i := 0; i < nReaders; i++ {
 		go func(i int) {


### PR DESCRIPTION
### Description

This test was flaky and would sometimes do this during `-race` tests:

```
Failed
=== RUN   TestEventBufferFuzz
    event_buffer_test.go:30: Using seed 1653065273297638950
    event_buffer_test.go:87: 
        	Error Trace:	event_buffer_test.go:87
        	Error:      	Received unexpected error:
        	            	subscriber 00178 got bad event want=0, got=1
        	Test:       	TestEventBufferFuzz
    event_buffer_test.go:87: 
        	Error Trace:	event_buffer_test.go:87
        	Error:      	Received unexpected error:
        	            	subscriber 00176 got bad event want=0, got=1
        	Test:       	TestEventBufferFuzz
    event_buffer_test.go:87: 
        	Error Trace:	event_buffer_test.go:87
        	Error:      	Received unexpected error:
        	            	subscriber 00007 got bad event want=0, got=1
        	Test:       	TestEventBufferFuzz
    event_buffer_test.go:87: 
        	Error Trace:	event_buffer_test.go:87
        	Error:      	Received unexpected error:
        	            	subscriber 00095 got bad event want=0, got=1
        	Test:       	TestEventBufferFuzz
    event_buffer_test.go:87: 
        	Error Trace:	event_buffer_test.go:87
        	Error:      	Received unexpected error:
        	            	subscriber 00088 got bad event want=0, got=1
        	Test:       	TestEventBufferFuzz
```

I suspect it was a race between inserting data and grabbing the head pointer. By grabbing the head pointer before inserting data we can better guarantee that the first element is visible by all readers.
