### PR TITLE
Upgrade golangci-lint for go v1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
           name: Install golangci-lint
           command: |
             download=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-            wget -O- -q $download | sh -x -s -- -d -b /home/circleci/go/bin v1.45.2
+            wget -O- -q $download | sh -x -s -- -d -b /home/circleci/go/bin v1.46.2
       - run: go mod download
       - run:
           name: lint

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ GOTOOLS = \
 	github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@master \
 	github.com/hashicorp/go-bindata/go-bindata@master \
 	github.com/vektra/mockery/v2@latest \
-	github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2 \
+	github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2 \
 	github.com/hashicorp/lint-consul-retry@master
 
 PROTOC_VERSION=3.15.8

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -1524,7 +1524,7 @@ func TestACLResolver_Client(t *testing.T) {
 		// then the policy will be resolved but resolution will return ACL not found
 		// resolution will stop with the not found error (even though we still have the
 		// policies within the cache)
-		authz, err = r.ResolveToken("a1a54629-5050-4d17-8a4e-560d2423f835")
+		_, err = r.ResolveToken("a1a54629-5050-4d17-8a4e-560d2423f835")
 		require.EqualError(t, err, acl.ErrNotFound.Error())
 
 		require.True(t, modified)


### PR DESCRIPTION
### Description

- unparam is still missing in this golangci-lint release

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
