### PR TITLE
fix: non-leader agents return 404 on Get Intention exact api

### DIFF
--- a/agent/intentions_endpoint.go
+++ b/agent/intentions_endpoint.go
@@ -324,7 +324,7 @@ func (s *HTTPHandlers) IntentionGetExact(resp http.ResponseWriter, req *http.Req
 	var reply structs.IndexedIntentions
 	if err := s.agent.RPC("Intention.Get", &args, &reply); err != nil {
 		// We have to check the string since the RPC sheds the error type
-		if err.Error() == consul.ErrIntentionNotFound.Error() {
+		if strings.Contains(err.Error(), consul.ErrIntentionNotFound.Error()) {
 			return nil, HTTPError{StatusCode: http.StatusNotFound, Reason: err.Error()}
 		}
 

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -383,7 +383,8 @@ func TestIntentionGetExact(t *testing.T) {
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
-	notfound := func() {
+	notfound := func(t *testing.T) {
+	        t.Helper()
 		req, err := http.NewRequest("GET", "/v1/connect/intentions/exact?source=foo&destination=bar", nil)
 		require.NoError(t, err)
 
@@ -400,8 +401,9 @@ func TestIntentionGetExact(t *testing.T) {
 		notfound()
 	})
 
-	a.delegate = &testSrv{}
+	
 	t.Run("not found by RPC", func(t *testing.T) {
+	        a.delegate = &testSrv{}
 		notfound()
 	})
 }


### PR DESCRIPTION
###Description

- rpc call method appends extra error message, so change == to
  "Strings.Contains"


### Testing & Reproduction steps

Send http request to non-leader agent

### Links

fix #12578 

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
