### PR TITLE
build: wire up remaining 5 helper tools into the same auto-install logic used for protobuf tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,9 +185,7 @@ jobs:
       - run: go env
       - run:
           name: Install golangci-lint
-          command: |
-            download=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-            wget -O- -q $download | sh -x -s -- -d -b /home/circleci/go/bin v1.46.2
+          command: make lint-tools
       - run: go mod download
       - run:
           name: lint
@@ -675,7 +673,6 @@ jobs:
       - attach_workspace:
           at: ./pkg
       - run: mv pkg/packages/consul-ui/dist pkg/web_ui # 'make static-assets' looks for the 'pkg/web_ui' path
-      - run: make tools
       - run: make static-assets
       - persist_to_workspace:
           root: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,11 +85,6 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Install project dependencies
-        run: |
-          go install github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@38087fe
-          go install github.com/hashicorp/go-bindata/go-bindata@bf7910a
-
       - name: Setup with node and yarn
         uses: actions/setup-node@v2
         with:
@@ -184,11 +179,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
-
-      - name: Install project dependencies
-        run: |
-          go install github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@38087fe
-          go install github.com/hashicorp/go-bindata/go-bindata@bf7910a
 
       - name: Setup with node and yarn
         uses: actions/setup-node@v2

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,34 +2,16 @@
 # https://www.consul.io/docs/install#compiling-from-source
 
 SHELL = bash
-GOTOOLS = \
-	github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@master \
-	github.com/hashicorp/go-bindata/go-bindata@master \
-	github.com/vektra/mockery/v2@latest \
-	github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2 \
-	github.com/hashicorp/lint-consul-retry@master
 
 ###
-# BUF_VERSION can be either a valid string for "go install <module>@<version>"
+# These version variables can either be a valid string for "go install <module>@<version>"
 # or the string @DEV to imply use what is currently installed locally.
 ###
+GOLANGCI_LINT_VERSION='v1.46.2'
+MOCKERY_VERSION='v2.12.2'
 BUF_VERSION='v1.4.0'
-
-###
-# PROTOC_GEN_GO_GRPC_VERSION can be either a valid string for "go install <module>@<version>"
-# or the string @DEV to imply use what is currently installed locally.
-###
 PROTOC_GEN_GO_GRPC_VERSION="v1.2.0"
-
-###
-# MOG_VERSION can be either a valid string for "go install <module>@<version>"
-# or the string @DEV to imply use whatever is currently installed locally.
-###
 MOG_VERSION='v0.3.0'
-###
-# PROTOC_GO_INJECT_TAG_VERSION can be either a valid string for "go install <module>@<version>"
-# or the string @DEV to imply use whatever is currently installed locally.
-###
 PROTOC_GO_INJECT_TAG_VERSION='v1.3.0'
 
 GOTAGS ?=
@@ -283,29 +265,34 @@ other-consul:
 		exit 1 ; \
 	fi
 
-lint:
-	@echo "--> Running go golangci-lint"
+lint: lint-tools
+	@echo "--> Running golangci-lint"
 	@golangci-lint run --build-tags '$(GOTAGS)' && \
 		(cd api && golangci-lint run --build-tags '$(GOTAGS)') && \
 		(cd sdk && golangci-lint run --build-tags '$(GOTAGS)')
+	@echo "--> Running lint-consul-retry"
+	@lint-consul-retry
 
 # If you've run "make ui" manually then this will get called for you. This is
 # also run as part of the release build script when it verifies that there are no
 # changes to the UI assets that aren't checked in.
-static-assets:
+static-assets: bindata-tools
 	@go-bindata-assetfs -pkg uiserver -prefix pkg -o $(ASSETFS_PATH) ./pkg/web_ui/...
 	@go fmt $(ASSETFS_PATH)
-
 
 # Build the static web ui and build static assets inside a Docker container
 ui: ui-docker static-assets-docker
 
 tools: proto-tools
-	@if [[ -d .gotools ]]; then rm -rf .gotools ; fi
-	@for TOOL in $(GOTOOLS); do \
-		echo "=== TOOL: $$TOOL" ; \
-		go install -v $$TOOL ; \
-	done
+	@$(SHELL) $(CURDIR)/build-support/scripts/devtools.sh
+
+.PHONY: lint-tools
+lint-tools:
+	@$(SHELL) $(CURDIR)/build-support/scripts/devtools.sh -lint
+
+.PHONY: bindata-tools
+bindata-tools:
+	@$(SHELL) $(CURDIR)/build-support/scripts/devtools.sh -bindata
 
 proto-tools:
 	@$(SHELL) $(CURDIR)/build-support/scripts/protobuf.sh \
@@ -326,7 +313,7 @@ docker-images: go-build-image ui-build-image
 
 go-build-image:
 	@echo "Building Golang build container"
-	@docker build $(NOCACHE) $(QUIET) --build-arg 'GOTOOLS=$(GOTOOLS)' -t $(GO_BUILD_TAG) - < build-support/docker/Build-Go.dockerfile
+	@docker build $(NOCACHE) $(QUIET) -t $(GO_BUILD_TAG) - < build-support/docker/Build-Go.dockerfile
 
 ui-build-image:
 	@echo "Building UI build container"
@@ -376,12 +363,12 @@ endif
 
 .PHONY: proto
 proto:
-	@$(SHELL) $(CURDIR)/build-support/scripts/protobuf.sh 
-			
+	@$(SHELL) $(CURDIR)/build-support/scripts/protobuf.sh
+
 .PHONY: proto-format
 proto-format: proto-tools
 	@buf format -w
-	
+
 .PHONY: proto-lint
 proto-lint: proto-tools
 	@buf lint --config proto/buf.yaml --path proto

--- a/build-support/functions/25-tools.sh
+++ b/build-support/functions/25-tools.sh
@@ -1,0 +1,59 @@
+function install_unversioned_tool {
+    local command="$1"
+    local install="$2"
+
+    if ! command -v "${command}" &>/dev/null ; then
+        status_stage "installing tool: ${install}"
+        go install "${install}"
+    else
+        debug "skipping tool: ${install} (installed)"
+    fi
+
+    return 0
+}
+
+function install_versioned_tool {
+    local command="$1"
+    local module="$2"
+    local version="$3"
+    local installbase="$4"
+
+    local should_install=
+    local got
+
+    local expect="${module}@${version}"
+    local install="${installbase}@${version}"
+
+    if [[ -z "$version" ]]; then
+        err "cannot install '${command}' no version selected"
+        return 1
+    fi
+
+    if [[ "$version" = "@DEV" ]]; then
+        if ! command -v "${command}" &>/dev/null ; then
+            err "dev version of '${command}' requested but not installed"
+            return 1
+        fi
+        status "skipping tool: ${installbase} (using development version)"
+        return 0
+    fi
+
+    if command -v "${command}" &>/dev/null ; then
+        got="$(go version -m $(which "${command}") | grep '\bmod\b' | grep "${module}" |
+            awk '{print $2 "@" $3}')"
+        if [[ "$expect" != "$got" ]]; then
+            should_install=1
+        fi
+    else
+        should_install=1
+    fi
+
+    if [[ -n $should_install ]]; then
+        status_stage "installing tool: ${install}"
+        go install "${install}"
+    else
+        debug "skipping tool: ${install} (installed)"
+    fi
+    return 0
+}
+

--- a/build-support/scripts/devtools.sh
+++ b/build-support/scripts/devtools.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+readonly SCRIPT_NAME="$(basename ${BASH_SOURCE[0]})"
+readonly SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+readonly SOURCE_DIR="$(dirname "$(dirname "${SCRIPT_DIR}")")"
+readonly FN_DIR="$(dirname "${SCRIPT_DIR}")/functions"
+
+source "${SCRIPT_DIR}/functions.sh"
+
+unset CDPATH
+
+set -euo pipefail
+
+usage() {
+cat <<-EOF
+Usage: ${SCRIPT_NAME} [<options ...>]
+
+Description:
+    Installs various supporting Go tools.
+
+Options:
+    -lint                    Just install tools for linting.
+    -bindata                 Just install tools for static assets.
+    -h | --help              Print this help text.
+EOF
+}
+
+function err_usage {
+    err "$1"
+    err ""
+    err "$(usage)"
+}
+
+function main {
+    while test $# -gt 0
+    do
+        case "$1" in
+            -bindata )
+                bindata_install
+                return 0
+                ;;
+
+            -lint )
+                lint_install
+                return 0
+                ;;
+
+            -h | --help )
+                usage
+                return 0
+                ;;
+        esac
+    done
+
+    # ensure these tools are installed
+    tools_install
+}
+
+function lint_install {
+    local golangci_lint_version
+    golangci_lint_version="$(make --no-print-directory print-GOLANGCI_LINT_VERSION)"
+
+    install_unversioned_tool \
+        'lint-consul-retry' \
+        'github.com/hashicorp/lint-consul-retry@master'
+
+    install_versioned_tool \
+        'golangci-lint' \
+        'github.com/golangci/golangci-lint' \
+        "${golangci_lint_version}" \
+        'github.com/golangci/golangci-lint/cmd/golangci-lint'
+}
+
+function bindata_install {
+    install_unversioned_tool \
+        'go-bindata' \
+        'github.com/hashicorp/go-bindata/go-bindata@bf7910a'
+
+    install_unversioned_tool \
+        'go-bindata-assetfs' \
+        'github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs@38087fe'
+}
+
+function tools_install {
+    local mockery_version
+
+    mockery_version="$(make --no-print-directory print-MOCKERY_VERSION)"
+
+    install_versioned_tool \
+        'mockery' \
+        'github.com/vektra/mockery/v2' \
+        "${mockery_version}" \
+        'github.com/vektra/mockery/v2'
+
+    lint_install
+    bindata_install
+
+    return 0
+}
+
+main "$@"
+exit $?

--- a/build-support/scripts/protobuf.sh
+++ b/build-support/scripts/protobuf.sh
@@ -148,65 +148,6 @@ function proto_tools_install {
     return 0
 }
 
-function install_unversioned_tool {
-    local command="$1"
-    local install="$2"
-
-    if ! command -v "${command}" &>/dev/null ; then
-        status_stage "installing tool: ${install}"
-        go install "${install}"
-    else
-        debug "skipping tool: ${install} (installed)"
-    fi
-
-    return 0
-}
-
-function install_versioned_tool {
-    local command="$1"
-    local module="$2"
-    local version="$3"
-    local installbase="$4"
-
-    local should_install=
-    local got
-
-    local expect="${module}@${version}"
-    local install="${installbase}@${version}"
-
-    if [[ -z "$version" ]]; then
-        err "cannot install '${command}' no version selected"
-        return 1
-    fi
-
-    if [[ "$version" = "@DEV" ]]; then
-        if ! command -v "${command}" &>/dev/null ; then
-            err "dev version of '${command}' requested but not installed"
-            return 1
-        fi
-        status "skipping tool: ${installbase} (using development version)"
-        return 0
-    fi
-
-    if command -v "${command}" &>/dev/null ; then
-        got="$(go version -m $(which "${command}") | grep '\bmod\b' | grep "${module}" |
-            awk '{print $2 "@" $3}')"
-        if [[ "$expect" != "$got" ]]; then
-            should_install=1
-        fi
-    else
-        should_install=1
-    fi
-
-    if [[ -n $should_install ]]; then
-        status_stage "installing tool: ${install}"
-        go install "${install}"
-    else
-        debug "skipping tool: ${install} (installed)"
-    fi
-    return 0
-}
-
 function postprocess_protobuf_code {
     local proto_path="${1:-}"
     if [[ -z "${proto_path}" ]]; then


### PR DESCRIPTION
### Description

When doing the recent updates to the protobuf toolchain some auto-install logic was added to the build to ensure that supporting go tools matched the desired versions at use time.

This PR uses the same machinery for the bindata tools, mock generation, and linting tools.
