### PR TITLE
ui: Alignment of L7 permissions

### DIFF
--- a/ui/packages/consul-ui/app/components/horizontal-kv-list/layout.scss
+++ b/ui/packages/consul-ui/app/components/horizontal-kv-list/layout.scss
@@ -1,6 +1,7 @@
 %horizontal-kv-list {
   display: inline-flex;
   flex-wrap: nowrap;
+  align-items: center;
 }
 %horizontal-kv-list-reversed {
   flex-direction: row-reverse;


### PR DESCRIPTION
### Description
Updating L7 permissions to be center aligned within the row.

<img width="289" alt="CleanShot 2022-05-23 at 13 22 30@2x" src="https://user-images.githubusercontent.com/16551527/169874125-82f9feba-3f4e-47b1-99c2-6300953e3390.png">

```scss
%horizontal-kv-list {
  display: inline-flex;
  flex-wrap: nowrap;
  /* New: */
  align-items: center;
}
```

### Testing
Manual/visual QA in Chrome, Safari, and FF

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
