### PR TITLE
docs/nia: Add CTS service address config

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -109,6 +109,7 @@ consul {
   transport {}
   service_registration {
     service_name = "cts"
+    address = "172.22.0.2"
     default_check {
       address = "http://172.22.0.2:8558"
     }
@@ -190,6 +191,7 @@ Service registration requires that the [Consul token](/docs/nia/configuration#co
 | --------- | -------- | ---- | ----------- | ------- |
 | `enabled` | Optional | boolean | Enables CTS to register itself as a service with Consul.| `true` |
 | `service_name` | Optional | string | The service name for CTS. | `Consul-Terraform-Sync` |
+| `address` | Optional | string | The IP address or hostname for CTS. | IP address of the Consul agent node |
 | `namespace` | Optional | string |  <EnterpriseAlert inline /> The namespace to register CTS in. | In order of precedence: <br/> 1. Inferred from the CTS ACL token <br/> 2. The `default` namespace. |
 | `default_check.enabled` | Optional | boolean | Enables CTS to create the default health check. | `true` |
 | `default_check.address` | Optional | string | The address to use for the default HTTP health check. Needs to include the scheme (`http`/`https`) and the port, if applicable. | `http://localhost:<port>` or `https://localhost:<port>`. Determined from the [port configuration](/docs/nia/configuration#port) and whether [TLS is enabled](/docs/nia/configuration#enabled-2) on the CTS API. |


### PR DESCRIPTION
### Description
Documentation changes to add CTS `service_registration.address` configuration.

### Links
https://consul-2orj2ou3f-hashicorp.vercel.app/docs/nia/configuration#consul
https://consul-2orj2ou3f-hashicorp.vercel.app/docs/nia/configuration#service-registration