### PR TITLE
Update main to reflect 1.13.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.12.0"
+	Version = "1.13.0"
 
 	// https://semver.org/#spec-item-10
 	VersionMetadata = ""


### PR DESCRIPTION
### Description
Currently, the version reported is `1.12.0-dev`. Since `1.12.0` is now GA, the version reported should be `1.13.0-dev`. Going forward, we should do this bump after every major release. For the other release series (eg. `release/1.12.x`), the reported version will still be `1.12.X-dev` where `X` should match the latest in the series. 

### Testing & Reproduction steps
`make version`