### PR TITLE
feat: Listener Generation for Terminating Gateway Destinations

### DIFF
--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1134,6 +1134,31 @@ func TestConfigEntry_ResolveServiceConfig_TransparentProxy(t *testing.T) {
 			},
 		},
 		{
+			name: "from service-defaults with endpoint",
+			entries: []structs.ConfigEntry{
+				&structs.ServiceConfigEntry{
+					Kind: structs.ServiceDefaults,
+					Name: "foo",
+					Mode: structs.ProxyModeTransparent,
+					Destination: &structs.DestinationConfig{
+						Address: "hello.world.com",
+						Port:    443,
+					},
+				},
+			},
+			request: structs.ServiceConfigRequest{
+				Name:       "foo",
+				Datacenter: "dc1",
+			},
+			expect: structs.ServiceConfigResponse{
+				Mode: structs.ProxyModeTransparent,
+				Destination: structs.DestinationConfig{
+					Address: "hello.world.com",
+					Port:    443,
+				},
+			},
+		},
+		{
 			name: "service-defaults overrides proxy-defaults",
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
@@ -1207,11 +1232,10 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams(t *testing.T) {
 	wildcard := structs.NewServiceID(structs.WildcardSpecifier, structs.WildcardEnterpriseMetaInDefaultPartition())
 
 	tt := []struct {
-		name     string
-		entries  []structs.ConfigEntry
-		request  structs.ServiceConfigRequest
-		proxyCfg structs.ConnectProxyConfig
-		expect   structs.ServiceConfigResponse
+		name    string
+		entries []structs.ConfigEntry
+		request structs.ServiceConfigRequest
+		expect  structs.ServiceConfigResponse
 	}{
 		{
 			name: "upstream config entries from Upstreams and service-defaults",

--- a/agent/consul/merge_service_config.go
+++ b/agent/consul/merge_service_config.go
@@ -155,6 +155,9 @@ func computeResolvedServiceConfig(
 		if serviceConf.Mode != structs.ProxyModeDefault {
 			thisReply.Mode = serviceConf.Mode
 		}
+		if serviceConf.Destination != nil {
+			thisReply.Destination = *serviceConf.Destination
+		}
 
 		thisReply.Meta = serviceConf.Meta
 	}

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -218,7 +218,13 @@ type configSnapshotTerminatingGateway struct {
 	// GatewayServices is a map of service name to the config entry association
 	// between the gateway and a service. TLS configuration stored here is
 	// used for TLS origination from the gateway to the linked service.
+	// This map does not include GatewayServices that represent Endpoints to external
+	// destinations.
 	GatewayServices map[structs.ServiceName]structs.GatewayService
+
+	// DestinationServices is a map of service name to GatewayServices that represent
+	// a destination to an external destination of the service mesh.
+	DestinationServices map[structs.ServiceName]structs.GatewayService
 
 	// HostnameServices is a map of service name to service instances with a hostname as the address.
 	// If hostnames are configured they must be provided to Envoy via CDS not EDS.
@@ -257,6 +263,33 @@ func (c *configSnapshotTerminatingGateway) ValidServices() []structs.ServiceName
 	return out
 }
 
+// ValidDestinations returns the list of service keys (that represent exclusively endpoints) that have enough data to be emitted.
+func (c *configSnapshotTerminatingGateway) ValidDestinations() []structs.ServiceName {
+	out := make([]structs.ServiceName, 0, len(c.DestinationServices))
+	for svc := range c.DestinationServices {
+		// It only counts if ALL of our watches have come back (with data or not).
+
+		// Skip the service if we don't have a cert to present for mTLS.
+		if cert, ok := c.ServiceLeaves[svc]; !ok || cert == nil {
+			continue
+		}
+
+		// Skip the service if we haven't gotten our intentions yet.
+		if _, intentionsSet := c.Intentions[svc]; !intentionsSet {
+			continue
+		}
+
+		// Skip the service if we haven't gotten our service config yet to know
+		// the protocol.
+		if _, ok := c.ServiceConfigs[svc]; !ok || c.ServiceConfigs[svc].Destination.Address == "" {
+			continue
+		}
+
+		out = append(out, svc)
+	}
+	return out
+}
+
 // isEmpty is a test helper
 func (c *configSnapshotTerminatingGateway) isEmpty() bool {
 	if c == nil {
@@ -274,6 +307,7 @@ func (c *configSnapshotTerminatingGateway) isEmpty() bool {
 		len(c.ServiceConfigs) == 0 &&
 		len(c.WatchedConfigs) == 0 &&
 		len(c.GatewayServices) == 0 &&
+		len(c.DestinationServices) == 0 &&
 		len(c.HostnameServices) == 0 &&
 		!c.MeshConfigSet
 }

--- a/agent/proxycfg/terminating_gateway.go
+++ b/agent/proxycfg/terminating_gateway.go
@@ -63,6 +63,7 @@ func (s *handlerTerminatingGateway) initialize(ctx context.Context) (ConfigSnaps
 	snap.TerminatingGateway.ServiceResolversSet = make(map[structs.ServiceName]bool)
 	snap.TerminatingGateway.ServiceGroups = make(map[structs.ServiceName]structs.CheckServiceNodes)
 	snap.TerminatingGateway.GatewayServices = make(map[structs.ServiceName]structs.GatewayService)
+	snap.TerminatingGateway.DestinationServices = make(map[structs.ServiceName]structs.GatewayService)
 	snap.TerminatingGateway.HostnameServices = make(map[structs.ServiceName]structs.CheckServiceNodes)
 	return snap, nil
 }
@@ -111,10 +112,15 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u UpdateEv
 			svcMap[svc.Service] = struct{}{}
 
 			// Store the gateway <-> service mapping for TLS origination
-			snap.TerminatingGateway.GatewayServices[svc.Service] = *svc
+			if svc.ServiceKind == structs.GatewayServiceKindDestination {
+				snap.TerminatingGateway.DestinationServices[svc.Service] = *svc
+			} else {
+				snap.TerminatingGateway.GatewayServices[svc.Service] = *svc
+			}
 
 			// Watch the health endpoint to discover endpoints for the service
-			if _, ok := snap.TerminatingGateway.WatchedServices[svc.Service]; !ok {
+			if _, ok := snap.TerminatingGateway.WatchedServices[svc.Service]; !ok && isGatewayServiceKindService(svc) {
+
 				ctx, cancel := context.WithCancel(ctx)
 				err := s.dataSources.Health.Notify(ctx, &structs.ServiceSpecificRequest{
 					Datacenter:     s.source.Datacenter,
@@ -213,7 +219,8 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u UpdateEv
 
 			// Watch service resolvers for the service
 			// These are used to create clusters and endpoints for the service subsets
-			if _, ok := snap.TerminatingGateway.WatchedResolvers[svc.Service]; !ok {
+			if _, ok := snap.TerminatingGateway.WatchedResolvers[svc.Service]; !ok && isGatewayServiceKindService(svc) {
+
 				ctx, cancel := context.WithCancel(ctx)
 				err := s.dataSources.ConfigEntry.Notify(ctx, &structs.ConfigEntryQuery{
 					Datacenter:     s.source.Datacenter,
@@ -239,6 +246,13 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u UpdateEv
 		for sn := range snap.TerminatingGateway.GatewayServices {
 			if _, ok := svcMap[sn]; !ok {
 				delete(snap.TerminatingGateway.GatewayServices, sn)
+			}
+		}
+
+		// Delete endpoint service mapping for services that were not in the update
+		for sn := range snap.TerminatingGateway.DestinationServices {
+			if _, ok := svcMap[sn]; !ok {
+				delete(snap.TerminatingGateway.DestinationServices, sn)
 			}
 		}
 
@@ -371,4 +385,8 @@ func (s *handlerTerminatingGateway) handleUpdate(ctx context.Context, u UpdateEv
 	}
 
 	return nil
+}
+
+func isGatewayServiceKindService(svc *structs.GatewayService) bool {
+	return svc.ServiceKind == structs.GatewayServiceKindService || svc.ServiceKind == structs.GatewayServiceKindUnknown
 }

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -1043,6 +1043,7 @@ type ServiceConfigResponse struct {
 	Expose            ExposeConfig           `json:",omitempty"`
 	TransparentProxy  TransparentProxyConfig `json:",omitempty"`
 	Mode              ProxyMode              `json:",omitempty"`
+	Destination       DestinationConfig      `json:",omitempty"`
 	Meta              map[string]string      `json:",omitempty"`
 	QueryMeta
 }

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -802,6 +802,12 @@ func TestListenersFromSnapshot(t *testing.T) {
 			name:   "transparent-proxy-terminating-gateway",
 			create: proxycfg.TestConfigSnapshotTransparentProxyTerminatingGatewayCatalogDestinationsOnly,
 		},
+		{
+			name: "transparent-proxy-terminating-gateway-destinations-only",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshotTerminatingGatewayDestinations(t, true, nil)
+			},
+		},
 	}
 
 	latestEnvoyVersion := proxysupport.EnvoyVersions[0]

--- a/agent/xds/testdata/listeners/transparent-proxy-terminating-gateway-destinations-only.latest.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-terminating-gateway-destinations-only.latest.golden
@@ -1,0 +1,182 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "default:1.2.3.4:8443",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8443
+        }
+      },
+      "filterChains": [
+        {
+          "filterChainMatch": {
+            "serverNames": [
+              "*.hashicorp.com"
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.external-hostname.default.default.dc1",
+                "cluster": "external-hostname.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "placeholder.crt\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "placeholder.key\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        },
+        {
+          "filterChainMatch": {
+            "serverNames": [
+              "external-IP.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "upstream.external-IP.default.default.dc1",
+                "rds": {
+                  "configSource": {
+                    "ads": {
+
+                    },
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "external-IP.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.rbac",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                      "rules": {
+
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "tracing": {
+                  "randomSampling": {
+
+                  }
+                },
+                "forwardClientCertDetails": "APPEND_FORWARD",
+                "setCurrentClientCertDetails": {
+                  "subject": true,
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "uri": true
+                }
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "placeholder.crt\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "placeholder.key\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        },
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.sni_cluster",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.sni_cluster.v3.SniCluster"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "terminating_gateway.default",
+                "cluster": ""
+              }
+            }
+          ]
+        }
+      ],
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
### Description
This PR adds xDS listener generation to Destinations (fka "Endpoints") for terminating gateways. To recap, destinations are external services that are not part of the Consul cluster. They are nodeless and also support IP CIDRs. Destinations are referenced the same as regular `services` in the Terminating Gateway Config Entry but are defined in `service-defaults` (#13159).

### Testing
Tests with Golden files are included for the three types of Destinations.

### Links

Related PRs:
1. #13217 Updates the gateway-service table to qualify different kinds ("default" and "destinations").
2. https://github.com/hashicorp/consul/pull/13341 to update the intentions to work with destinations.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] not a security concern
* [X] checklist [folder](./../docs/config) consulted
