### PR TITLE
[CI-only] Update tagging for dev_tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,5 +242,5 @@ jobs:
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}
           dev_tags: |
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-dev
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-${{ github.sha }}


### PR DESCRIPTION
### Description

Small update to remove the hardcoded `-dev` suffix from dev_tags, which is causing tags to be in the format `1.12.0-dev-dev` instead of just `1.12.0-dev`. I'll clean up the old tags before making the dockerhub repo public, which will be available https://hub.docker.com/r/hashicorppreview/consul. 

dev_tags were first introduced in https://github.com/hashicorp/consul/pull/13084 