### PR TITLE
peering: disable requirement for mesh gateways initially

### DIFF
--- a/agent/rpc/peering/replication.go
+++ b/agent/rpc/peering/replication.go
@@ -46,7 +46,12 @@ func pushServiceResponse(
 		return nil
 	}
 
-	serviceName := strings.TrimPrefix(update.CorrelationID, subExportedService)
+	var serviceName string
+	if strings.HasPrefix(update.CorrelationID, subExportedService) {
+		serviceName = strings.TrimPrefix(update.CorrelationID, subExportedService)
+	} else {
+		serviceName = strings.TrimPrefix(update.CorrelationID, subExportedProxyService) + syntheticProxyNameSuffix
+	}
 
 	// If no nodes are present then it's due to one of:
 	// 1. The service is newly registered or exported and yielded a transient empty update.


### PR DESCRIPTION
### Description

The next milestone for peering should function for simple cases without mesh gateways being involved at all. This PR temporarily disables the newly added behavior so that other work can continue in parallel.

### Links

[Asana](https://app.asana.com/0/1201832349181086/1202323705986724/f)
