### PR TITLE
update gateway-services table with endpoints

### DIFF
--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1036,6 +1036,7 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 		Name:     "foo",
 		Protocol: "http",
 		Meta:     map[string]string{"foo": "bar"},
+		Endpoint: &structs.EndpointConfig{Address: "172.168.2.0/24", Port: 9003},
 	}))
 	require.NoError(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
 		Kind:     structs.ServiceDefaults,
@@ -1053,8 +1054,10 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 
 	expected := structs.ServiceConfigResponse{
 		ProxyConfig: map[string]interface{}{
-			"foo":      int64(1),
-			"protocol": "http",
+			"foo":              int64(1),
+			"protocol":         "http",
+			"destination_port": "9003",
+			"prefix_ranges":    "172.168.2.0/24",
 		},
 		UpstreamConfigs: map[string]map[string]interface{}{
 			"bar": {

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -599,6 +599,7 @@ type GatewayService struct {
 	KeyFile      string   `json:",omitempty"`
 	SNI          string   `json:",omitempty"`
 	FromWildcard bool     `json:",omitempty"`
+	IsEndpoint   bool     `json:",omitempty"`
 	RaftIndex
 }
 


### PR DESCRIPTION
### Description
This part of the work needed to add destinations (formerly endpoints) to the terminating gateway. Destinations are defined using a service-default config entry and represent an external entity (a set of addresses and a port) which can be reachable through a given terminating gateway.

In this PR we add the association between a given destination and a terminating gateway. This include the use case of a terminating gateway that define a wildcard in his LinkedServices.

### PR Checklist

* [X] updated test coverage
* [X] not a security concern
