### PR TITLE
CI: Verify built binaries in build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Push events on the main branch
       - main
-      - CTIA-8-verify-builds
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Push events on the main branch
       - main
+      - CTIA-8-verify-builds
 
 env:
   PKG_NAME: consul
@@ -264,42 +265,52 @@ jobs:
           arch: amd64
           redhat_tag: scan.connect.redhat.com/ospid-612d01d49f14588c41ebf67c/${{env.repo}}:${{env.version}}-ubi
   verify:
-    needs: build
+    needs:
+      - get-product-version
+      - build
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ "386", "amd64", "arm", "arm64" ]
+        arch: ["386", "amd64", "arm", "arm64"]
       fail-fast: true
+    env:
+      version: ${{needs.get-product-version.outputs.product-version}}
     name: Verify ${{ matrix.arch }} linux zip
     steps:
       - uses: actions/checkout@v2
-
       - name: Download artifact
-        run: |
-          echo "TODO: download ${{ matrix.arch }} linux zip"
-
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
       - name: Run verification for ${{ matrix.arch }} linux zip
+        if: ${{ matrix.arch == 'amd64' || matrix.arch == '386' }}
         run: |
-          echo "TODO: run verification for ${{ matrix.arch }} linux zip"
+          unzip ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
+          ./consul version
 
   verify-darwin:
-    needs: build-darwin
+    needs:
+      - get-product-version
+      - build-darwin
     runs-on: macos-latest
     strategy:
       matrix:
-        arch: [ "amd64", "arm64" ]
+        arch: ["amd64", "arm64"]
       fail-fast: true
+    env:
+      version: ${{needs.get-product-version.outputs.product-version}}
     name: Verify ${{ matrix.arch }} darwin zip
     steps:
       - uses: actions/checkout@v2
-
       - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.PKG_NAME }}_${{env.version}}_darwin_${{ matrix.arch }}.zip
+      - name: Run verification for ${{ matrix.arch }} linux zip
+        if: ${{ matrix.arch == 'amd64' }}
         run: |
-          echo "TODO: download ${{ matrix.arch }} darwin zip"
-
-      - name: Run verification for ${{ matrix.arch }} darwin zip
-        run: |
-          echo "TODO: run verification for ${{ matrix.arch }} darwin zip"
+          unzip ${{ env.PKG_NAME }}_${{env.version}}_darwin_${{ matrix.arch }}.zip
+          ./consul version
 
   verify-linux-packages-deb:
     needs: build
@@ -332,7 +343,7 @@ jobs:
     name: Verify ${{ matrix.arch }} rpm package
     steps:
       - uses: actions/checkout@v2
-          -
+
       - name: Download ${{ matrix.arch }} rpm package
         run: |
           echo "TODO: download ${{ matrix.arch }} rpm package"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Unzip for ${{ matrix.arch }} linux zip
         if: ${{ matrix.arch == 'arm64' || matrix.arch == 'arm' }}
         run: |
-          unzip ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
+          unzip ${{ env.PKG_NAME }}_${{ env.version }}_linux_${{ matrix.arch }}.zip
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
@@ -300,7 +300,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
+          name: ${{ env.PKG_NAME }}_${{ env.version }}_linux_${{ matrix.arch }}.zip
       - name: Run verification for ${{ matrix.arch }} linux zip
         if: ${{ matrix.arch == 'amd64' || matrix.arch == '386' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,6 +233,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Download artifact for arm verification
+        uses: actions/download-artifact@v2
+        if: ${{ matrix.arch == 'arm64' }}
+        with:
+          name: ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
+      - name: Unzip for ${{ matrix.arch }} linux zip
+        if: ${{ matrix.arch == 'arm64' }}
+        run: |
+          unzip ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
+          ls
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
@@ -245,6 +255,12 @@ jobs:
           dev_tags: |
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}
             docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-${{ github.sha }}
+      - name: Run verification in qemu docker for ${{ matrix.arch }} linux zip
+        if: ${{ matrix.arch == 'arm64' }}
+        run: |
+          ls
+          docker run --platform=linux/arm64 -v $(pwd):/workdir -w /workdir  \
+            arm64v8/debian ./consul version
 
   build-docker-redhat:
     name: Docker Build UBI Image for RedHat

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,3 +263,80 @@ jobs:
           target: ubi
           arch: amd64
           redhat_tag: scan.connect.redhat.com/ospid-612d01d49f14588c41ebf67c/${{env.repo}}:${{env.version}}-ubi
+  verify:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ "386", "amd64", "arm", "arm64" ]
+      fail-fast: true
+    name: Verify ${{ matrix.arch }} linux zip
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download artifact
+        run: |
+          echo "TODO: download ${{ matrix.arch }} linux zip"
+
+      - name: Run verification for ${{ matrix.arch }} linux zip
+        run: |
+          echo "TODO: run verification for ${{ matrix.arch }} linux zip"
+
+  verify-darwin:
+    needs: build-darwin
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [ "amd64", "arm64" ]
+      fail-fast: true
+    name: Verify ${{ matrix.arch }} darwin zip
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download artifact
+        run: |
+          echo "TODO: download ${{ matrix.arch }} darwin zip"
+
+      - name: Run verification for ${{ matrix.arch }} darwin zip
+        run: |
+          echo "TODO: run verification for ${{ matrix.arch }} darwin zip"
+
+  verify-linux-packages-deb:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ "amd64", "arm", "arm64", "i386" ]
+      fail-fast: true
+
+    name: Verify ${{ matrix.arch }} debian package
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download ${{ matrix.arch }} debian package
+        run: |
+          echo "TODO: download ${{ matrix.arch }} debian package"
+
+      - name: Verify ${{ matrix.arch }} debian package
+        run: |
+          echo "TODO: run verification for ${{ matrix.arch }} debian package"
+
+  verify-linux-packages-rpm:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ "aarch64", "arm", "i386", "x86_64" ]
+      fail-fast: true
+
+    name: Verify ${{ matrix.arch }} rpm package
+    steps:
+      - uses: actions/checkout@v2
+          -
+      - name: Download ${{ matrix.arch }} rpm package
+        run: |
+          echo "TODO: download ${{ matrix.arch }} rpm package"
+
+      - name: Verify ${{ matrix.arch }} rpm package
+        run: |
+          echo "TODO: run verification for ${{ matrix.arch }} rpm package"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["386", "amd64", "arm", "arm64"]
+        arch: ["386", "amd64"]
       fail-fast: true
     env:
       version: ${{needs.get-product-version.outputs.product-version}}
@@ -301,7 +301,6 @@ jobs:
         with:
           name: ${{ env.PKG_NAME }}_${{ env.version }}_linux_${{ matrix.arch }}.zip
       - name: Run verification for ${{ matrix.arch }} linux zip
-        if: ${{ matrix.arch == 'amd64' || matrix.arch == '386' }}
         run: |
           unzip ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
           ./consul version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,14 +235,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download artifact for arm verification
         uses: actions/download-artifact@v2
-        if: ${{ matrix.arch == 'arm64' }}
+        if: ${{ matrix.arch == 'arm64' || matrix.arch == 'arm' }}
         with:
           name: ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
       - name: Unzip for ${{ matrix.arch }} linux zip
-        if: ${{ matrix.arch == 'arm64' }}
+        if: ${{ matrix.arch == 'arm64' || matrix.arch == 'arm' }}
         run: |
           unzip ${{ env.PKG_NAME }}_${{env.version}}_linux_${{ matrix.arch }}.zip
-          ls
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
@@ -258,9 +257,13 @@ jobs:
       - name: Run verification in qemu docker for ${{ matrix.arch }} linux zip
         if: ${{ matrix.arch == 'arm64' }}
         run: |
-          ls
           docker run --platform=linux/arm64 -v $(pwd):/workdir -w /workdir  \
             arm64v8/debian ./consul version
+      - name: Run verification in qemu docker for ${{ matrix.arch }} linux zip
+        if: ${{ matrix.arch == 'arm' }}
+        run: |
+          docker run --platform=linux/arm/v7 -v $(pwd):/workdir -w /workdir  \
+            arm32v7/debian ./consul version
 
   build-docker-redhat:
     name: Docker Build UBI Image for RedHat


### PR DESCRIPTION
### Description

Smoke test the linux built binaries: 386, amd64, arm, and arm64

### limitation
Since qemu can't be installed in github action macOS runner, we can't smoke test the arm and arm64 binaries for darwin

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
