### PR TITLE
build: re-add proto-tools dep to make proto

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -362,7 +362,7 @@ else
 endif
 
 .PHONY: proto
-proto:
+proto: proto-tools
 	@$(SHELL) $(CURDIR)/build-support/scripts/protobuf.sh
 
 .PHONY: proto-format


### PR DESCRIPTION
### Description

During refactoring of how supplementary build tools are configured I accidentally removed the `proto-tools` dep from `make proto`. This adds it back.
