### PR TITLE
Merge changes from release/1.12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
       # Push events on the main branch
       - main
       - release/1.12.x
-      - release/1.12.0
 
 env:
   PKG_NAME: consul

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -16,7 +16,6 @@ project "consul" {
       "release/1.10.x",
       "release/1.11.x",
       "release/1.12.x",
-      "release/1.12.0",
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 BREAKING CHANGES:
 
+* connect: Removes support for Envoy 1.17.4 [[GH-12777](https://github.com/hashicorp/consul/issues/12777)]
+* connect: Removes support for Envoy 1.18.6 [[GH-12805](https://github.com/hashicorp/consul/issues/12805)]
 * sdk: several changes to the testutil configuration structs (removed `ACLMasterToken`, renamed `Master` to `InitialManagement`, and `AgentMaster` to `AgentRecovery`) [[GH-11827](https://github.com/hashicorp/consul/issues/11827)]
 * telemetry: the disable_compat_1.9 option now defaults to true. 1.9 style `consul.http...` metrics can still be enabled by setting `disable_compat_1.9 = false`. However, we will remove these metrics in 1.13. [[GH-12675](https://github.com/hashicorp/consul/issues/12675)]
 

--- a/version/version.go
+++ b/version/version.go
@@ -22,7 +22,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
+	VersionPrerelease = "dev"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
### Description
In preparing the 1.12.1 release, I noticed that the release branch was missing commits from `release/1.12.0` so this merges them in. There were conflicts in two files:
- `website/content/docs/api-gateway/consul-api-gateway-install.mdx` - had to refer to content in `release/1.12.x` and `main` to figure out what to take here, in some cases it was a 3-way merge :/
- `website/redirects.js` - this ends up being what is on `release/1.12.x` and `main` so I think it's correct.

### Testing & Reproduction steps
CI