### PR TITLE
rename "endpoint" to "destination"

### DIFF
--- a/agent/consul/state/catalog_events_test.go
+++ b/agent/consul/state/catalog_events_test.go
@@ -1473,6 +1473,18 @@ func TestServiceHealthEventsFromChanges(t *testing.T) {
 		},
 		WantEvents: []stream.Event{
 			testServiceHealthEvent(t, "srv1", evNodeUnchanged),
+			testServiceHealthDeregistrationEvent(t,
+				"tgate1",
+				evConnectTopic,
+				evServiceTermingGateway("srv1"),
+				evTerminatingGatewayVirtualIPs("srv1"),
+			),
+			testServiceHealthEvent(t,
+				"tgate1",
+				evConnectTopic,
+				evNodeUnchanged,
+				evServiceUnchanged,
+				evServiceTermingGateway("srv1")),
 		},
 	})
 	run(t, eventsTestCase{

--- a/agent/consul/state/catalog_events_test.go
+++ b/agent/consul/state/catalog_events_test.go
@@ -1648,9 +1648,9 @@ func TestServiceHealthEventsFromChanges(t *testing.T) {
 		},
 		Mutate: func(s *Store, tx *txn) error {
 			configEntryDest := &structs.ServiceConfigEntry{
-				Kind:     structs.ServiceDefaults,
-				Name:     "destination1",
-				Endpoint: &structs.EndpointConfig{Port: 9000, Address: "kafka.test.com"},
+				Kind:        structs.ServiceDefaults,
+				Name:        "destination1",
+				Destination: &structs.DestinationConfig{Port: 9000, Address: "kafka.test.com"},
 			}
 			return ensureConfigEntryTxn(tx, tx.Index, configEntryDest)
 		},
@@ -1680,9 +1680,9 @@ func TestServiceHealthEventsFromChanges(t *testing.T) {
 		},
 		Mutate: func(s *Store, tx *txn) error {
 			configEntryDest := &structs.ServiceConfigEntry{
-				Kind:     structs.ServiceDefaults,
-				Name:     "destination1",
-				Endpoint: &structs.EndpointConfig{Port: 9000, Address: "kafka.test.com"},
+				Kind:        structs.ServiceDefaults,
+				Name:        "destination1",
+				Destination: &structs.DestinationConfig{Port: 9000, Address: "kafka.test.com"},
 			}
 			return ensureConfigEntryTxn(tx, tx.Index, configEntryDest)
 		},

--- a/agent/consul/state/catalog_events_test.go
+++ b/agent/consul/state/catalog_events_test.go
@@ -1654,7 +1654,21 @@ func TestServiceHealthEventsFromChanges(t *testing.T) {
 			}
 			return ensureConfigEntryTxn(tx, tx.Index, configEntryDest)
 		},
-		WantEvents: []stream.Event{},
+		WantEvents: []stream.Event{
+			testServiceHealthDeregistrationEvent(t,
+				"tgate1",
+				evConnectTopic,
+				evServiceTermingGateway("destination1"),
+				evTerminatingGatewayVirtualIPs("destination1")),
+			testServiceHealthEvent(t,
+				"tgate1",
+				evConnectTopic,
+				evNodeUnchanged,
+				evServiceUnchanged,
+				evServiceTermingGateway("destination1"),
+				evTerminatingGatewayVirtualIPs("destination1"),
+			),
+		},
 	})
 
 	run(t, eventsTestCase{

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -5170,6 +5170,7 @@ func TestStateStore_GatewayServices_Terminating(t *testing.T) {
 				CreateIndex: 23,
 				ModifyIndex: 23,
 			},
+			Kind: structs.GatewayservicekindService,
 		},
 	}
 	assert.Equal(t, expect, out)
@@ -6421,6 +6422,7 @@ func TestStateStore_DumpGatewayServices(t *testing.T) {
 					CreateIndex: 22,
 					ModifyIndex: 22,
 				},
+				Kind: structs.GatewayservicekindService,
 			},
 		}
 		assert.Equal(t, expect, out)

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -383,8 +383,8 @@ func insertConfigEntryWithTxn(tx WriteTxn, idx uint64, conf structs.ConfigEntry)
 			return fmt.Errorf("failed to associate services to gateway: %v", err)
 		}
 	}
-	isEndpoint := conf.GetKind() == structs.ServiceDefaults && conf.(*structs.ServiceConfigEntry).Endpoint != nil
-	if isEndpoint {
+	isDestination := conf.GetKind() == structs.ServiceDefaults && conf.(*structs.ServiceConfigEntry).Destination != nil
+	if isDestination {
 		if err := checkGatewayWildcardsAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, true); err != nil {
 			return fmt.Errorf("failed updating gateway mapping: %s", err)
 		}

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -385,10 +385,10 @@ func insertConfigEntryWithTxn(tx WriteTxn, idx uint64, conf structs.ConfigEntry)
 	}
 	isDestination := conf.GetKind() == structs.ServiceDefaults && conf.(*structs.ServiceConfigEntry).Destination != nil
 	if isDestination {
-		if err := checkGatewayWildcardsAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, true); err != nil {
+		if err := checkGatewayWildcardsAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, structs.GatewayservicekindDestination); err != nil {
 			return fmt.Errorf("failed updating gateway mapping: %s", err)
 		}
-		if err := checkGatewayAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, true); err != nil {
+		if err := checkGatewayAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, structs.GatewayservicekindDestination); err != nil {
 			return fmt.Errorf("failed updating gateway mapping: %s", err)
 		}
 

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -388,6 +388,10 @@ func insertConfigEntryWithTxn(tx WriteTxn, idx uint64, conf structs.ConfigEntry)
 		if err := checkGatewayWildcardsAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, true); err != nil {
 			return fmt.Errorf("failed updating gateway mapping: %s", err)
 		}
+		if err := checkGatewayAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, true); err != nil {
+			return fmt.Errorf("failed updating gateway mapping: %s", err)
+		}
+
 	}
 
 	// Insert the config entry and update the index

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -344,6 +344,27 @@ func deleteConfigEntryTxn(tx WriteTxn, idx uint64, kind, name string, entMeta *a
 			return fmt.Errorf("failed updating gateway-services index: %v", err)
 		}
 	}
+
+	c := existing.(structs.ConfigEntry)
+	switch c.GetKind() {
+	case structs.ServiceDefaults:
+		if c.(*structs.ServiceConfigEntry).Destination != nil {
+			gsKind, err := GatewayServiceKind(tx, sn.Name, &sn.EnterpriseMeta)
+			if err != nil {
+				return fmt.Errorf("failed updating gateway mapping: %s", err)
+			}
+			if gsKind == structs.GatewayservicekindDestination {
+				gsKind = structs.GatewayservicekindUnknown
+			}
+			if err := checkGatewayWildcardsAndUpdate(tx, idx, &structs.ServiceName{Name: c.GetName(), EnterpriseMeta: *c.GetEnterpriseMeta()}, gsKind); err != nil {
+				return fmt.Errorf("failed updating gateway mapping: %s", err)
+			}
+			if err := checkGatewayAndUpdate(tx, idx, &structs.ServiceName{Name: c.GetName(), EnterpriseMeta: *c.GetEnterpriseMeta()}, gsKind); err != nil {
+				return fmt.Errorf("failed updating gateway mapping: %s", err)
+			}
+		}
+	}
+
 	// Also clean up associations in the mesh topology table for ingress gateways
 	if kind == structs.IngressGateway {
 		if _, err := tx.DeleteAll(tableMeshTopology, indexDownstream, sn); err != nil {
@@ -383,15 +404,25 @@ func insertConfigEntryWithTxn(tx WriteTxn, idx uint64, conf structs.ConfigEntry)
 			return fmt.Errorf("failed to associate services to gateway: %v", err)
 		}
 	}
-	isDestination := conf.GetKind() == structs.ServiceDefaults && conf.(*structs.ServiceConfigEntry).Destination != nil
-	if isDestination {
-		if err := checkGatewayWildcardsAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, structs.GatewayservicekindDestination); err != nil {
-			return fmt.Errorf("failed updating gateway mapping: %s", err)
-		}
-		if err := checkGatewayAndUpdate(tx, idx, &structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}, structs.GatewayservicekindDestination); err != nil {
-			return fmt.Errorf("failed updating gateway mapping: %s", err)
-		}
 
+	switch conf.GetKind() {
+	case structs.ServiceDefaults:
+		if conf.(*structs.ServiceConfigEntry).Destination != nil {
+			sn := structs.ServiceName{Name: conf.GetName(), EnterpriseMeta: *conf.GetEnterpriseMeta()}
+			gsKind, err := GatewayServiceKind(tx, sn.Name, &sn.EnterpriseMeta)
+			if gsKind == structs.GatewayservicekindUnknown {
+				gsKind = structs.GatewayservicekindDestination
+			}
+			if err != nil {
+				return fmt.Errorf("failed updating gateway mapping: %s", err)
+			}
+			if err := checkGatewayWildcardsAndUpdate(tx, idx, &sn, gsKind); err != nil {
+				return fmt.Errorf("failed updating gateway mapping: %s", err)
+			}
+			if err := checkGatewayAndUpdate(tx, idx, &sn, gsKind); err != nil {
+				return fmt.Errorf("failed updating gateway mapping: %s", err)
+			}
+		}
 	}
 
 	// Insert the config entry and update the index

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -75,6 +75,89 @@ func TestStore_ConfigEntry(t *testing.T) {
 	require.True(t, watchFired(ws))
 }
 
+func TestStore_ServiceDefaults_isDestination(t *testing.T) {
+	s := testConfigStateStore(t)
+
+	Gtwy := &structs.TerminatingGatewayConfigEntry{
+		Kind: structs.TerminatingGateway,
+		Name: "Gtwy1",
+		Services: []structs.LinkedService{
+			{
+				Name: "dest1",
+			},
+		},
+	}
+
+	// Create
+	require.NoError(t, s.EnsureConfigEntry(0, Gtwy))
+
+	destination := &structs.ServiceConfigEntry{
+		Kind:        structs.ServiceDefaults,
+		Name:        "dest1",
+		Destination: &structs.DestinationConfig{},
+	}
+
+	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
+	require.NoError(t, err)
+	require.Len(t, gatewayServices, 1)
+	require.False(t, gatewayServices[0].IsDestination)
+
+	ws := memdb.NewWatchSet()
+	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
+	// Create
+	require.NoError(t, s.EnsureConfigEntry(0, destination))
+	require.NoError(t, err)
+
+	//Watch is fired because we transitioned to a destination, by default we assume it's not.
+	require.True(t, watchFired(ws))
+
+	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
+	require.NoError(t, err)
+	require.Len(t, gatewayServices, 1)
+	require.True(t, gatewayServices[0].IsDestination)
+
+}
+
+func TestStore_ServiceDefaults_isDestination_Wildcard(t *testing.T) {
+	s := testConfigStateStore(t)
+
+	Gtwy := &structs.TerminatingGatewayConfigEntry{
+		Kind: structs.TerminatingGateway,
+		Name: "Gtwy1",
+		Services: []structs.LinkedService{
+			{
+				Name: "*",
+			},
+		},
+	}
+
+	// Create
+	require.NoError(t, s.EnsureConfigEntry(0, Gtwy))
+
+	destination := &structs.ServiceConfigEntry{
+		Kind:        structs.ServiceDefaults,
+		Name:        "dest1",
+		Destination: &structs.DestinationConfig{},
+	}
+
+	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
+	require.NoError(t, err)
+	require.Len(t, gatewayServices, 0)
+
+	ws := memdb.NewWatchSet()
+	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
+	// Create
+	require.NoError(t, s.EnsureConfigEntry(0, destination))
+	require.NoError(t, err)
+
+	require.True(t, watchFired(ws))
+
+	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
+	require.NoError(t, err)
+	require.Len(t, gatewayServices, 1)
+	require.True(t, gatewayServices[0].IsDestination)
+}
+
 func TestStore_ConfigEntryCAS(t *testing.T) {
 	s := testConfigStateStore(t)
 

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -100,7 +100,7 @@ func TestStore_ServiceDefaults_isDestination(t *testing.T) {
 	_, gatewayServices, err := s.GatewayServices(nil, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.False(t, gatewayServices[0].IsDestination)
+	require.Equal(t, gatewayServices[0].Kind, structs.GatewayservicekindUnknown)
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
@@ -114,7 +114,7 @@ func TestStore_ServiceDefaults_isDestination(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.True(t, gatewayServices[0].IsDestination)
+	require.Equal(t, gatewayServices[0].Kind, structs.GatewayservicekindDestination)
 
 }
 
@@ -155,7 +155,7 @@ func TestStore_ServiceDefaults_isDestination_Wildcard(t *testing.T) {
 	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
-	require.True(t, gatewayServices[0].IsDestination)
+	require.Equal(t, gatewayServices[0].Kind, structs.GatewayservicekindDestination)
 }
 
 func TestStore_ConfigEntryCAS(t *testing.T) {

--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -73,6 +73,7 @@ func TestStore_ConfigEntry(t *testing.T) {
 	serviceConf.Protocol = "http"
 	require.NoError(t, s.EnsureConfigEntry(5, serviceConf))
 	require.True(t, watchFired(ws))
+
 }
 
 func TestStore_ServiceDefaults_isDestination(t *testing.T) {
@@ -104,9 +105,10 @@ func TestStore_ServiceDefaults_isDestination(t *testing.T) {
 
 	ws := memdb.NewWatchSet()
 	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
+	require.NoError(t, err)
+
 	// Create
 	require.NoError(t, s.EnsureConfigEntry(0, destination))
-	require.NoError(t, err)
 
 	//Watch is fired because we transitioned to a destination, by default we assume it's not.
 	require.True(t, watchFired(ws))
@@ -115,6 +117,20 @@ func TestStore_ServiceDefaults_isDestination(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, gatewayServices, 1)
 	require.Equal(t, gatewayServices[0].Kind, structs.GatewayservicekindDestination)
+
+	ws = memdb.NewWatchSet()
+	_, _, err = s.GatewayServices(ws, "Gtwy1", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, s.DeleteConfigEntry(6, structs.ServiceDefaults, destination.Name, &destination.EnterpriseMeta))
+
+	//Watch is fired because we transitioned to a destination, by default we assume it's not.
+	require.True(t, watchFired(ws))
+
+	_, gatewayServices, err = s.GatewayServices(ws, "Gtwy1", nil)
+	require.NoError(t, err)
+	require.Len(t, gatewayServices, 1)
+	require.Equal(t, gatewayServices[0].Kind, structs.GatewayservicekindUnknown)
 
 }
 

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -105,7 +105,7 @@ type ServiceConfigEntry struct {
 	Expose           ExposeConfig           `json:",omitempty"`
 	ExternalSNI      string                 `json:",omitempty" alias:"external_sni"`
 	UpstreamConfig   *UpstreamConfiguration `json:",omitempty" alias:"upstream_config"`
-	Endpoint         *EndpointConfig        `json:",omitempty"`
+	Destination      *DestinationConfig     `json:",omitempty"`
 
 	Meta               map[string]string `json:",omitempty"`
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
@@ -179,8 +179,8 @@ func (e *ServiceConfigEntry) Validate() error {
 	validationErr := validateConfigEntryMeta(e.Meta)
 
 	// External endpoints are invalid with an existing service's upstream configuration
-	if e.UpstreamConfig != nil && e.Endpoint != nil {
-		validationErr = multierror.Append(validationErr, errors.New("UpstreamConfig and Endpoint are mutually exclusive for service defaults"))
+	if e.UpstreamConfig != nil && e.Destination != nil {
+		validationErr = multierror.Append(validationErr, errors.New("UpstreamConfig and Destination are mutually exclusive for service defaults"))
 		return validationErr
 	}
 
@@ -199,13 +199,13 @@ func (e *ServiceConfigEntry) Validate() error {
 		}
 	}
 
-	if e.Endpoint != nil {
-		if err := validateEndpointAddress(e.Endpoint.Address); err != nil {
-			validationErr = multierror.Append(validationErr, fmt.Errorf("Endpoint address is invalid %w", err))
+	if e.Destination != nil {
+		if err := validateEndpointAddress(e.Destination.Address); err != nil {
+			validationErr = multierror.Append(validationErr, fmt.Errorf("Destination address is invalid %w", err))
 		}
 
-		if e.Endpoint.Port < 1 || e.Endpoint.Port > 65535 {
-			validationErr = multierror.Append(validationErr, fmt.Errorf("Invalid Port number %d", e.Endpoint.Port))
+		if e.Destination.Port < 1 || e.Destination.Port > 65535 {
+			validationErr = multierror.Append(validationErr, fmt.Errorf("Invalid Port number %d", e.Destination.Port))
 		}
 	}
 
@@ -291,8 +291,8 @@ func (c *UpstreamConfiguration) Clone() *UpstreamConfiguration {
 	return &c2
 }
 
-// EndpointConfig represents a virtual service, i.e. one that is external to Consul
-type EndpointConfig struct {
+// DestinationConfig represents a virtual service, i.e. one that is external to Consul
+type DestinationConfig struct {
 	// Address of the endpoint; hostname, IP, or CIDR
 	Address string `json:",omitempty"`
 

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -589,7 +589,7 @@ func (e *TerminatingGatewayConfigEntry) Warnings() []string {
 type GatewayServiceKind string
 
 const (
-	GatewayservicekindUnknown     GatewayServiceKind = "gateway-service-unknown"
+	GatewayservicekindUnknown     GatewayServiceKind = ""
 	GatewayservicekindDestination GatewayServiceKind = "gateway-service-destination"
 	GatewayservicekindService     GatewayServiceKind = "gateway-service-service"
 )

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -636,6 +636,7 @@ func (g *GatewayService) IsSame(o *GatewayService) bool {
 		g.CertFile == o.CertFile &&
 		g.KeyFile == o.KeyFile &&
 		g.SNI == o.SNI &&
+		g.IsDestination == o.IsDestination &&
 		g.FromWildcard == o.FromWildcard
 }
 

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -586,20 +586,28 @@ func (e *TerminatingGatewayConfigEntry) Warnings() []string {
 	return warnings
 }
 
+type GatewayServiceKind string
+
+const (
+	GatewayservicekindUnknown     GatewayServiceKind = "gateway-service-unknown"
+	GatewayservicekindDestination GatewayServiceKind = "gateway-service-destination"
+	GatewayservicekindService     GatewayServiceKind = "gateway-service-service"
+)
+
 // GatewayService is used to associate gateways with their linked services.
 type GatewayService struct {
-	Gateway       ServiceName
-	Service       ServiceName
-	GatewayKind   ServiceKind
-	Port          int      `json:",omitempty"`
-	Protocol      string   `json:",omitempty"`
-	Hosts         []string `json:",omitempty"`
-	CAFile        string   `json:",omitempty"`
-	CertFile      string   `json:",omitempty"`
-	KeyFile       string   `json:",omitempty"`
-	SNI           string   `json:",omitempty"`
-	FromWildcard  bool     `json:",omitempty"`
-	IsDestination bool     `json:",omitempty"`
+	Gateway      ServiceName
+	Service      ServiceName
+	GatewayKind  ServiceKind
+	Port         int                `json:",omitempty"`
+	Protocol     string             `json:",omitempty"`
+	Hosts        []string           `json:",omitempty"`
+	CAFile       string             `json:",omitempty"`
+	CertFile     string             `json:",omitempty"`
+	KeyFile      string             `json:",omitempty"`
+	SNI          string             `json:",omitempty"`
+	FromWildcard bool               `json:",omitempty"`
+	Kind         GatewayServiceKind `json:",omitempty"`
 	RaftIndex
 }
 
@@ -636,7 +644,7 @@ func (g *GatewayService) IsSame(o *GatewayService) bool {
 		g.CertFile == o.CertFile &&
 		g.KeyFile == o.KeyFile &&
 		g.SNI == o.SNI &&
-		g.IsDestination == o.IsDestination &&
+		g.Kind == o.Kind &&
 		g.FromWildcard == o.FromWildcard
 }
 

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -588,18 +588,18 @@ func (e *TerminatingGatewayConfigEntry) Warnings() []string {
 
 // GatewayService is used to associate gateways with their linked services.
 type GatewayService struct {
-	Gateway      ServiceName
-	Service      ServiceName
-	GatewayKind  ServiceKind
-	Port         int      `json:",omitempty"`
-	Protocol     string   `json:",omitempty"`
-	Hosts        []string `json:",omitempty"`
-	CAFile       string   `json:",omitempty"`
-	CertFile     string   `json:",omitempty"`
-	KeyFile      string   `json:",omitempty"`
-	SNI          string   `json:",omitempty"`
-	FromWildcard bool     `json:",omitempty"`
-	IsEndpoint   bool     `json:",omitempty"`
+	Gateway       ServiceName
+	Service       ServiceName
+	GatewayKind   ServiceKind
+	Port          int      `json:",omitempty"`
+	Protocol      string   `json:",omitempty"`
+	Hosts         []string `json:",omitempty"`
+	CAFile        string   `json:",omitempty"`
+	CertFile      string   `json:",omitempty"`
+	KeyFile       string   `json:",omitempty"`
+	SNI           string   `json:",omitempty"`
+	FromWildcard  bool     `json:",omitempty"`
+	IsDestination bool     `json:",omitempty"`
 	RaftIndex
 }
 

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -442,7 +442,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				Kind = "service-defaults"
 				Name = "external"
 				Protocol = "tcp"
-				Endpoint {
+				Destination {
 					Address = "1.2.3.4/24"
 					Port = 8080
 				}
@@ -451,7 +451,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				Kind:     "service-defaults",
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "1.2.3.4/24",
 					Port:    8080,
 				},
@@ -2426,7 +2426,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "",
 					Port:    443,
 				},
@@ -2438,7 +2438,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "1.2.3.4",
 					Port:    443,
 				},
@@ -2449,7 +2449,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "10.0.0.1/16",
 					Port:    8080,
 				},
@@ -2460,7 +2460,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "2001:0db8:0000:8a2e:0370:7334:1234:5678",
 					Port:    443,
 				},
@@ -2471,7 +2471,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "2001:db8::8a2e:370:7334",
 					Port:    443,
 				},
@@ -2482,7 +2482,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "2001:db8::8a2e:370:7334/64",
 					Port:    443,
 				},
@@ -2493,7 +2493,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "2001:db8::8a2e:370:7334/64",
 				},
 			},
@@ -2504,7 +2504,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "*external.com",
 					Port:    443,
 				},
@@ -2516,7 +2516,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "tcp",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "..hello.",
 					Port:    443,
 				},
@@ -2528,7 +2528,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				Kind:     ServiceDefaults,
 				Name:     "external",
 				Protocol: "http",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "*",
 					Port:    443,
 				},

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -428,12 +428,12 @@ func TestDecodeConfigEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "service-defaults-with-endpoint",
+			name: "service-defaults-with-destination",
 			snake: `
 				kind = "service-defaults"
 				name = "external"
 				protocol = "tcp"
-				endpoint {
+				destination {
 					address = "1.2.3.4/24"
 					port = 8080
 				}
@@ -2421,7 +2421,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				EnterpriseMeta: *DefaultEnterpriseMetaInDefaultPartition(),
 			},
 		},
-		"validate: missing endpoint address": {
+		"validate: missing destination address": {
 			entry: &ServiceConfigEntry{
 				Kind:     ServiceDefaults,
 				Name:     "external",
@@ -2433,7 +2433,7 @@ func TestServiceConfigEntry(t *testing.T) {
 			},
 			validateErr: "Could not validate address",
 		},
-		"validate: endpoint ipv4 address": {
+		"validate: destination ipv4 address": {
 			entry: &ServiceConfigEntry{
 				Kind:     ServiceDefaults,
 				Name:     "external",
@@ -2444,7 +2444,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				},
 			},
 		},
-		"validate: endpoint ipv4 CIDR address": {
+		"validate: destination ipv4 CIDR address": {
 			entry: &ServiceConfigEntry{
 				Kind:     ServiceDefaults,
 				Name:     "external",
@@ -2455,7 +2455,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				},
 			},
 		},
-		"validate: endpoint ipv6 address": {
+		"validate: destination ipv6 address": {
 			entry: &ServiceConfigEntry{
 				Kind:     ServiceDefaults,
 				Name:     "external",
@@ -2466,7 +2466,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				},
 			},
 		},
-		"valid endpoint shortened ipv6 address": {
+		"valid destination shortened ipv6 address": {
 			entry: &ServiceConfigEntry{
 				Kind:     ServiceDefaults,
 				Name:     "external",
@@ -2477,7 +2477,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				},
 			},
 		},
-		"validate: endpoint ipv6 CIDR address": {
+		"validate: destination ipv6 CIDR address": {
 			entry: &ServiceConfigEntry{
 				Kind:     ServiceDefaults,
 				Name:     "external",
@@ -2488,7 +2488,7 @@ func TestServiceConfigEntry(t *testing.T) {
 				},
 			},
 		},
-		"validate: invalid endpoint port": {
+		"validate: invalid destination port": {
 			entry: &ServiceConfigEntry{
 				Kind:     ServiceDefaults,
 				Name:     "external",

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -179,8 +179,8 @@ type UpstreamConfig struct {
 	MeshGateway MeshGatewayConfig `json:",omitempty" alias:"mesh_gateway" `
 }
 
-// EndpointConfig represents a virtual service, i.e. one that is external to Consul
-type EndpointConfig struct {
+// DestinationConfig represents a virtual service, i.e. one that is external to Consul
+type DestinationConfig struct {
 	// Address of the endpoint; hostname, IP, or CIDR
 	Address string `json:",omitempty"`
 
@@ -229,7 +229,7 @@ type ServiceConfigEntry struct {
 	Expose           ExposeConfig            `json:",omitempty"`
 	ExternalSNI      string                  `json:",omitempty" alias:"external_sni"`
 	UpstreamConfig   *UpstreamConfiguration  `json:",omitempty" alias:"upstream_config"`
-	Endpoint         *EndpointConfig         `json:",omitempty"`
+	Destination      *DestinationConfig      `json:",omitempty"`
 	Meta             map[string]string       `json:",omitempty"`
 	CreateIndex      uint64
 	ModifyIndex      uint64

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -106,16 +106,16 @@ func TestAPI_ConfigEntries(t *testing.T) {
 			},
 		}
 
-		endpoint := &EndpointConfig{
+		endpoint := &DestinationConfig{
 			Address: "my.example.com",
 			Port:    80,
 		}
 
 		service2 := &ServiceConfigEntry{
-			Kind:     ServiceDefaults,
-			Name:     "bar",
-			Protocol: "tcp",
-			Endpoint: endpoint,
+			Kind:        ServiceDefaults,
+			Name:        "bar",
+			Protocol:    "tcp",
+			Destination: endpoint,
 		}
 
 		// set it
@@ -191,7 +191,7 @@ func TestAPI_ConfigEntries(t *testing.T) {
 				require.Equal(t, service2.Kind, readService.Kind)
 				require.Equal(t, service2.Name, readService.Name)
 				require.Equal(t, service2.Protocol, readService.Protocol)
-				require.Equal(t, endpoint, readService.Endpoint)
+				require.Equal(t, endpoint, readService.Destination)
 			}
 		}
 
@@ -530,7 +530,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				"Kind": "service-defaults",
 				"Name": "external",
 				"Protocol": "http",
-				"Endpoint": {
+				"Destination": {
 					"Address": "1.2.3.4/24",
 					"Port": 443
 				}
@@ -540,7 +540,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				Kind:     "service-defaults",
 				Name:     "external",
 				Protocol: "http",
-				Endpoint: &EndpointConfig{
+				Destination: &DestinationConfig{
 					Address: "1.2.3.4/24",
 					Port:    443,
 				},

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -793,7 +793,7 @@ func TestParseConfigEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "service-defaults: kitchen sink (endpoint edition)",
+			name: "service-defaults: kitchen sink (destination edition)",
 			snake: `
 				kind = "service-defaults"
 				name = "main"
@@ -810,7 +810,7 @@ func TestParseConfigEntry(t *testing.T) {
 					outbound_listener_port = 10101
 					dialed_directly = true
 				}
-				endpoint = {
+				destination = {
 					address = "10.0.0.0/16",
 					port = 443
 				}
@@ -853,7 +853,7 @@ func TestParseConfigEntry(t *testing.T) {
 					"outbound_listener_port": 10101,
 					"dialed_directly": true
 				},
-				"endpoint": {
+				"destination": {
 					"address": "10.0.0.0/16",
 					"port": 443
 				}

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -831,7 +831,7 @@ func TestParseConfigEntry(t *testing.T) {
 					outbound_listener_port = 10101
 					dialed_directly = true
 				}
-				Endpoint = {
+				Destination = {
 					Address = "10.0.0.0/16",
 					Port = 443
 				}
@@ -876,7 +876,7 @@ func TestParseConfigEntry(t *testing.T) {
 					"OutboundListenerPort": 10101,
 					"DialedDirectly": true
 				},
-				"Endpoint": {
+				"Destination": {
 					"Address": "10.0.0.0/16",
 					"Port": 443
 				}
@@ -898,7 +898,7 @@ func TestParseConfigEntry(t *testing.T) {
 					OutboundListenerPort: 10101,
 					DialedDirectly:       true,
 				},
-				Endpoint: &api.EndpointConfig{
+				Destination: &api.DestinationConfig{
 					Address: "10.0.0.0/16",
 					Port:    443,
 				},


### PR DESCRIPTION
### Description
This based on the choice to go with "destination" as name for the new external endpoints managed in the terminating gateway
