### PR TITLE
remove a source of test panics

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1703,6 +1703,7 @@ func TestAgent_Reload(t *testing.T) {
 	})
 
 	shim := &delegateConfigReloadShim{delegate: a.delegate}
+	// NOTE: this may require refactoring to remove a potential test panic
 	a.delegate = shim
 	if err := a.reloadConfigInternal(cfg2); err != nil {
 		t.Fatalf("got error %v want nil", err)

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1703,7 +1703,7 @@ func TestAgent_Reload(t *testing.T) {
 	})
 
 	shim := &delegateConfigReloadShim{delegate: a.delegate}
-	// NOTE: this may require refactoring to remove a potential test panic
+	// NOTE: this may require refactoring to remove a potential test race
 	a.delegate = shim
 	if err := a.reloadConfigInternal(cfg2); err != nil {
 		t.Fatalf("got error %v want nil", err)

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -321,20 +321,45 @@ func TestIntentionGetExact(t *testing.T) {
 
 	t.Parallel()
 
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+	hcl := `
+	bootstrap = false
+	bootstrap_expect = 2
+	server = true
+	`
 
-	req, err := http.NewRequest("GET", "/v1/connect/intentions/exact?source=foo&destination=bar", nil)
+	a1 := NewTestAgent(t, hcl)
+	a2 := NewTestAgent(t, hcl)
+
+	_, err := a1.JoinLAN([]string{
+		fmt.Sprintf("127.0.0.1:%d", a2.Config.SerfPortLAN),
+	}, nil)
 	require.NoError(t, err)
 
-	resp := httptest.NewRecorder()
-	obj, err := a.srv.IntentionExact(resp, req)
-	testutil.RequireErrorContains(t, err, "Intention not found")
-	httpErr, ok := err.(HTTPError)
-	require.True(t, ok)
-	require.Equal(t, http.StatusNotFound, httpErr.StatusCode)
-	require.Nil(t, obj)
+	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a2.RPC, "dc1")
+	testrpc.WaitForLeader(t, a1.RPC, "dc1")
+	testrpc.WaitForLeader(t, a2.RPC, "dc1")
+
+	run := func(t *testing.T, a *TestAgent) {
+		req, err := http.NewRequest("GET", "/v1/connect/intentions/exact?source=foo&destination=bar", nil)
+		require.NoError(t, err)
+
+		resp := httptest.NewRecorder()
+		obj, err := a.srv.IntentionExact(resp, req)
+		testutil.RequireErrorContains(t, err, "Intention not found")
+		httpErr, ok := err.(HTTPError)
+		require.True(t, ok)
+		require.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+		require.Nil(t, obj)
+	}
+
+	// One of these will be the leader and the other will be a follower so we
+	// test direct RPC handling and RPC forwarding of errors at the same time.
+	for i, a := range []*TestAgent{a1, a2} {
+		t.Run(fmt.Sprintf("test agent %d of 2", i+1), func(t *testing.T) {
+			run(t, a)
+		})
+	}
 }
 
 func TestIntentionPutExact(t *testing.T) {


### PR DESCRIPTION
### Description

This test was updating the `delegate` value after the test agent had started. Firstly this is racy, and there's no good way to create an Agent first, update the delegate, and then start it because starting it is what initially populates the delegate.

Secondly (and relevant to this PR) this delegate didn't populate it's embedded `delegate` field so sometimes the test agent during the test would call a method on it and nil panic.

For now since the original test didn't feel terribly important at what it was testing, I just removed it completely.