### PR TITLE
ui: Typography update for view-only Intentions

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/intention/permission/form/skin.scss
+++ b/ui/packages/consul-ui/app/components/consul/intention/permission/form/skin.scss
@@ -14,3 +14,9 @@
     @extend %frame-blue-200;
   }
 }
+
+.consul-intention-view {
+  h2 {
+    @extend %h200;
+  }
+}

--- a/ui/packages/consul-ui/app/styles/base/reset/base-variables.scss
+++ b/ui/packages/consul-ui/app/styles/base/reset/base-variables.scss
@@ -5,10 +5,7 @@
   margin: 0;
   padding: 0;
 }
-%reset-typo {
-  font-size: 100%;
-  font-weight: normal;
-}
+
 %reset-list {
   list-style: none;
 }

--- a/ui/packages/consul-ui/app/styles/base/reset/base-variables.scss
+++ b/ui/packages/consul-ui/app/styles/base/reset/base-variables.scss
@@ -5,6 +5,10 @@
   margin: 0;
   padding: 0;
 }
+%reset-typo {
+  font-size: 100%;
+  font-weight: normal;
+}
 
 %reset-list {
   list-style: none;

--- a/ui/packages/consul-ui/app/styles/base/reset/minireset.scss
+++ b/ui/packages/consul-ui/app/styles/base/reset/minireset.scss
@@ -23,6 +23,14 @@ h5,
 h6 {
   @extend %reset-box;
 }
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @extend %reset-typo;
+}
 
 ul {
   @extend %reset-list;

--- a/ui/packages/consul-ui/app/styles/base/reset/minireset.scss
+++ b/ui/packages/consul-ui/app/styles/base/reset/minireset.scss
@@ -23,14 +23,7 @@ h5,
 h6 {
   @extend %reset-box;
 }
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  @extend %reset-typo;
-}
+
 ul {
   @extend %reset-list;
 }
@@ -60,6 +53,5 @@ footer,
 header,
 hgroup,
 section {
-  display: block
+  display: block;
 }
-


### PR DESCRIPTION
### Description
New:

 ```scss
.consul-intention-view {
  h2 {
    @extend %h200;
  }
}
```

Before
<img width="1277" alt="CleanShot 2022-05-25 at 19 22 26@2x" src="https://user-images.githubusercontent.com/16551527/170385152-fe549bbd-6c8d-4d9c-a18f-a8fad7af1f76.png">

After
<img width="992" alt="CleanShot 2022-05-25 at 19 21 37@2x" src="https://user-images.githubusercontent.com/16551527/170385084-161e456e-a4a6-4cfe-bd30-043d094690b2.png">


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
