### PR TITLE
Add tag to resources provisioned during load test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -983,6 +983,7 @@ jobs:
               LOCAL_COMMIT_SHA="<< pipeline.parameters.commit >>"
             fi
             echo "export LOCAL_COMMIT_SHA=${LOCAL_COMMIT_SHA}" >> $BASH_ENV
+            git checkout ${LOCAL_COMMIT_SHA}
 
             short_ref=$(git rev-parse --short ${LOCAL_COMMIT_SHA})
             echo "export TF_VAR_ami_owners=$LOAD_TEST_AMI_OWNERS" >> $BASH_ENV
@@ -1002,7 +1003,8 @@ jobs:
           working_directory: .circleci/terraform/load-test
           name: terraform init
           command: |
-            echo "commit is ${LOCAL_COMMIT_SHA}"
+            short_ref=$(git rev-parse --short HEAD)
+            echo "Testing commit id: $short_ref"
             terraform init \
             -backend-config="bucket=${BUCKET}" \
             -backend-config="key=${LOCAL_COMMIT_SHA}" \
@@ -1018,7 +1020,7 @@ jobs:
           when: always
           name: terraform destroy
           command: |
-            terraform destroy -auto-approve
+            for i in $(seq 1 5); do terraform destroy -auto-approve && s=0 && break || s=$? && sleep 20; done; (exit $s)
       - run: *notify-slack-failure
 
   # The noop job is a used as a very fast job in the verify-ci workflow because every workflow

--- a/.circleci/terraform/load-test/main.tf
+++ b/.circleci/terraform/load-test/main.tf
@@ -7,10 +7,16 @@ provider "aws" {
   assume_role {
     role_arn = var.role_arn
   }
+
+  default_tags {
+    tags = {
+      Environment = "ConsulLoadTest"
+    }
+  }
 }
 
 module "load-test" {
-  source = "github.com/hashicorp/consul/test/load/terraform"
+  source = "../../../test/load/terraform"
 
   vpc_az               = ["us-east-2a", "us-east-2b"]
   vpc_name             = var.vpc_name
@@ -21,4 +27,5 @@ module "load-test" {
   ami_owners           = var.ami_owners
   consul_download_url  = var.consul_download_url
   cluster_name         = var.cluster_name
+  cluster_tag_key      = var.cluster_tag_key
 }

--- a/.circleci/terraform/load-test/variables.tf
+++ b/.circleci/terraform/load-test/variables.tf
@@ -22,3 +22,9 @@ variable "cluster_name" {
   type        = string
   default     = "consul-example"
 }
+
+variable "cluster_tag_key" {
+  description = "The tag the EC2 Instances will look for to automatically discover each other and form a cluster."
+  type        = string
+  default     = "consul-ci-load-test"
+}

--- a/test/load/terraform/variables.tf
+++ b/test/load/terraform/variables.tf
@@ -106,6 +106,5 @@ variable "consul_download_url" {
 variable "consul_version" {
   type        = string
   description = "Version of the Consul binary to install"
-  default     = "1.9.0"
+  default     = "1.12.0"
 }
-


### PR DESCRIPTION
### Description
The PR addresses the following 3 issues in the current load test
1.  The current circleCI load-test job always checkouts the main branch, although the CI passes the commit of a PR:

https://github.com/hashicorp/consul/blob/fd7a403e1190ef7f8cfc35a13bf388945d94e37e/.circleci/config.yml#L980-L987
This makes it difficult to run load test against any PR or any change made to the `./test/load/terraform`.

2. The tag key `consul-servers` is too general and applied to both client and server agent, so the PR change the key name to `consul-ci-load-test`:
<img width="885" alt="Screen Shot 2022-05-26 at 10 19 48 PM" src="https://user-images.githubusercontent.com/463631/170615893-436670df-9ada-4e70-99e5-d8e82cf30834.png">


3. `terraform destroy` may fail transiently; add a retry to make sure resources are always destroyed. 


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
