### PR TITLE
add codeowners to protect release dirs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 /website/content/api-docs/ @hashicorp/consul-docs
 
 
+# release configuration
+/.release/                              @hashicorp/release-engineering @hashicorp/github-consul-core
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-consul-core


### PR DESCRIPTION
Locks down changes to release directories so that they require approval from release engineering, and so they have service account rights for pipeline runs and backport-assistant functionality.
