### PR TITLE
Backport of fix: multiple grpc/http2 services for ingress listeners into release/1.10.x

### DIFF
--- a/.changelog/13127.txt
+++ b/.changelog/13127.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix a bug that caused an error when creating `grpc` or `http2` ingress gateway listeners with multiple services
+```

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -1637,6 +1637,10 @@ func TestConfigSnapshotIngress_HTTPMultipleServices(t testing.T) *ConfigSnapshot
 	return testConfigSnapshotIngressGateway(t, true, "http", "http-multiple-services")
 }
 
+func TestConfigSnapshotIngress_GRPCMultipleServices(t testing.T) *ConfigSnapshot {
+	return testConfigSnapshotIngressGateway(t, false, "grpc", "grpc-multiple-services")
+}
+
 func TestConfigSnapshotIngressExternalSNI(t testing.T) *ConfigSnapshot {
 	return testConfigSnapshotIngressGateway(t, true, "tcp", "external-sni")
 }

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -158,8 +158,8 @@ func (e *IngressGatewayConfigEntry) Validate() error {
 		}
 
 		// Validate that http features aren't being used with tcp or another non-supported protocol.
-		if listener.Protocol != "http" && len(listener.Services) > 1 {
-			return fmt.Errorf("Multiple services per listener are only supported for protocol = 'http' (listener on port %d)",
+		if !IsProtocolHTTPLike(listener.Protocol) && len(listener.Services) > 1 {
+			return fmt.Errorf("Multiple services per listener are only supported for L7 protocols, 'http', 'grpc' and 'http2' (listener on port %d)",
 				listener.Port)
 		}
 

--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -141,6 +141,26 @@ func TestIngressGatewayConfigEntry(t *testing.T) {
 				Listeners: []IngressListener{
 					{
 						Port:     1111,
+						Protocol: "http",
+						Services: []IngressService{
+							{
+								Name: "db1",
+							},
+							{
+								Name: "db2",
+							},
+						},
+					},
+				},
+			},
+		},
+		"http features: multiple services on tcp listener": {
+			entry: &IngressGatewayConfigEntry{
+				Kind: "ingress-gateway",
+				Name: "ingress-web",
+				Listeners: []IngressListener{
+					{
+						Port:     1111,
 						Protocol: "tcp",
 						Services: []IngressService{
 							{
@@ -153,7 +173,7 @@ func TestIngressGatewayConfigEntry(t *testing.T) {
 					},
 				},
 			},
-			validateErr: "Multiple services per listener are only supported for protocol",
+			validateErr: "Multiple services per listener are only supported for L7",
 		},
 		// ==========================
 		"tcp listener requires a defined service": {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -505,6 +505,24 @@ func TestListenersFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name:   "ingress-grpc-multiple-services",
+			create: proxycfg.TestConfigSnapshotIngress_GRPCMultipleServices,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				snap.IngressGateway.Upstreams = map[proxycfg.IngressListenerKey]structs.Upstreams{
+					{Protocol: "grpc", Port: 8080}: {
+						{
+							DestinationName: "foo",
+							LocalBindPort:   8080,
+						},
+						{
+							DestinationName: "bar",
+							LocalBindPort:   8080,
+						},
+					},
+				}
+			},
+		},
+		{
 			name:   "terminating-gateway-no-api-cert",
 			create: proxycfg.TestConfigSnapshotTerminatingGateway,
 			setup: func(snap *proxycfg.ConfigSnapshot) {

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -190,6 +190,57 @@ func TestRoutesFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name:   "ingress-grpc-multiple-services",
+			create: proxycfg.TestConfigSnapshotIngress_HTTPMultipleServices,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				snap.IngressGateway.Upstreams = map[proxycfg.IngressListenerKey]structs.Upstreams{
+					{Protocol: "grpc", Port: 8080}: {
+						{
+							DestinationName: "foo",
+							LocalBindPort:   8080,
+							IngressHosts: []string{
+								"test1.example.com",
+								"test2.example.com",
+								"test2.example.com:8080",
+							},
+						},
+						{
+							DestinationName: "bar",
+							LocalBindPort:   8080,
+						},
+					},
+				}
+
+				// We do not add baz/qux here so that we test the chain.IsDefault() case
+				entries := []structs.ConfigEntry{
+					&structs.ProxyConfigEntry{
+						Kind: structs.ProxyDefaults,
+						Name: structs.ProxyConfigGlobal,
+						Config: map[string]interface{}{
+							"protocol": "grpc",
+						},
+					},
+					&structs.ServiceResolverConfigEntry{
+						Kind:           structs.ServiceResolver,
+						Name:           "foo",
+						ConnectTimeout: 22 * time.Second,
+					},
+					&structs.ServiceResolverConfigEntry{
+						Kind:           structs.ServiceResolver,
+						Name:           "bar",
+						ConnectTimeout: 22 * time.Second,
+					},
+				}
+				fooChain := discoverychain.TestCompileConfigEntries(t, "foo", "default", "default", "dc1", connect.TestClusterID+".consul", nil, entries...)
+				barChain := discoverychain.TestCompileConfigEntries(t, "bar", "default", "default", "dc1", connect.TestClusterID+".consul", nil, entries...)
+
+				snap.IngressGateway.DiscoveryChain = map[string]*structs.CompiledDiscoveryChain{
+					"foo": fooChain,
+					"bar": barChain,
+				}
+			},
+		},
+		{
 			name:   "terminating-gateway-lb-config",
 			create: proxycfg.TestConfigSnapshotTerminatingGateway,
 			setup: func(snap *proxycfg.ConfigSnapshot) {

--- a/agent/xds/testdata/listeners/ingress-grpc-multiple-services.envoy-1-20-x.golden
+++ b/agent/xds/testdata/listeners/ingress-grpc-multiple-services.envoy-1-20-x.golden
@@ -1,0 +1,63 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "grpc:1.2.3.4:8080",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "ingress_upstream_8080",
+                "rds": {
+                  "configSource": {
+                    "ads": {
+
+                    },
+                    "resourceApiVersion": "V3"
+                  },
+                  "routeConfigName": "8080"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.grpc_stats",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig",
+                      "statsForAllMethods": true
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.grpc_http1_bridge"
+                  },
+                  {
+                    "name": "envoy.filters.http.router"
+                  }
+                ],
+                "tracing": {
+                  "randomSampling": {
+
+                  }
+                },
+                "http2ProtocolOptions": {
+
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/ingress-grpc-multiple-services.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/listeners/ingress-grpc-multiple-services.v2compat.envoy-1-16-x.golden
@@ -1,0 +1,63 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "grpc:1.2.3.4:8080",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager",
+                "statPrefix": "ingress_upstream_8080",
+                "rds": {
+                  "configSource": {
+                    "ads": {
+
+                    },
+                    "resourceApiVersion": "V2"
+                  },
+                  "routeConfigName": "8080"
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.grpc_stats",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.config.filter.http.grpc_stats.v2alpha.FilterConfig",
+                      "statsForAllMethods": true
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.grpc_http1_bridge"
+                  },
+                  {
+                    "name": "envoy.filters.http.router"
+                  }
+                ],
+                "tracing": {
+                  "randomSampling": {
+
+                  }
+                },
+                "http2ProtocolOptions": {
+
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/routes/ingress-grpc-multiple-services.envoy-1-20-x.golden
+++ b/agent/xds/testdata/routes/ingress-grpc-multiple-services.envoy-1-20-x.golden
@@ -1,0 +1,50 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+      "name": "8080",
+      "virtualHosts": [
+        {
+          "name": "foo",
+          "domains": [
+            "test1.example.com",
+            "test2.example.com",
+            "test2.example.com:8080",
+            "test1.example.com:8080"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "foo.default.default.internal.dc1"
+              }
+            }
+          ]
+        },
+        {
+          "name": "bar",
+          "domains": [
+            "bar.ingress.*",
+            "bar.ingress.*:8080"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "bar.default.default.internal.dc1"
+              }
+            }
+          ]
+        }
+      ],
+      "validateClusters": true
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/routes/ingress-grpc-multiple-services.v2compat.envoy-1-16-x.golden
+++ b/agent/xds/testdata/routes/ingress-grpc-multiple-services.v2compat.envoy-1-16-x.golden
@@ -1,0 +1,50 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+      "name": "8080",
+      "virtualHosts": [
+        {
+          "name": "foo",
+          "domains": [
+            "test1.example.com",
+            "test2.example.com",
+            "test2.example.com:8080",
+            "test1.example.com:8080"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "foo.default.default.internal.dc1"
+              }
+            }
+          ]
+        },
+        {
+          "name": "bar",
+          "domains": [
+            "bar.ingress.*",
+            "bar.ingress.*:8080"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "bar.default.default.internal.dc1"
+              }
+            }
+          ]
+        }
+      ],
+      "validateClusters": true
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
This is a manual backport of https://github.com/hashicorp/consul/pull/13127. Due to the testing refactor, https://github.com/hashicorp/consul/pull/13246 failed.

At some point, the testing code was refactored into a common function for 1.12. This PR breaks it out into its own test case. 

Also, between 1.10 requires extra testing files for older versions of envoy.
