### PR TITLE
chore(ci): add no-op jobs for branch protection rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1081,6 +1081,7 @@ workflows:
           <<: *filter-ignore-non-go-branches
       - go-test-race: *filter-ignore-non-go-branches
       - go-test-32bit: *filter-ignore-non-go-branches
+      - noop
   build-distros:
     unless: << pipeline.parameters.trigger-load-test >>
     jobs:
@@ -1120,6 +1121,7 @@ workflows:
           requires:
             - dev-build
           context: consul-ci
+      - noop
   test-integrations:
     unless: << pipeline.parameters.trigger-load-test >>
     jobs:
@@ -1156,7 +1158,7 @@ workflows:
       - compatibility-integration-test:
           requires:
             - dev-build
-
+      - noop
   frontend:
     unless: << pipeline.parameters.trigger-load-test >>
     jobs:
@@ -1189,6 +1191,7 @@ workflows:
       - ember-coverage:
           requires:
             - ember-build-ent
+      - noop
   workflow-automation:
     unless: << pipeline.parameters.trigger-load-test >>
     jobs:


### PR DESCRIPTION
### Description
Right now branch protection rules for either UI or Go testing to pass cannot be applied Consul because CircleCI only selectively runs these checks depending on the branch name. This PR added `noop` jobs to each of the workflows so that each important check always appears in the PR, even if it does no meaningful work. The downside is that there will be a bit more noise in the CircleCi consul for each branch.

This PR and enabling the branch protections will make sure that tests pass on all of our automated PRs before they get merged in.

### Testing & Reproduction steps
N/A

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [X] not a security concern
* [ ] ~checklist [folder](./../docs/config) consulted~
