### PR TITLE
Add build tag for oss

### DIFF
--- a/command/registry_oss.go
+++ b/command/registry_oss.go
@@ -1,8 +1,12 @@
+//go:build !consulent
+// +build !consulent
+
 package command
 
 import (
-	"github.com/hashicorp/consul/command/cli"
 	mcli "github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul/command/cli"
 )
 
 func registerEnterpriseCommands(_ cli.Ui, _ map[string]mcli.CommandFactory) {}


### PR DESCRIPTION
I merged an oss PR https://github.com/hashicorp/consul/pull/12729 without the right build tag