### PR TITLE
Fix a flaky test

### DIFF
--- a/agent/proxycfg-sources/local/sync_test.go
+++ b/agent/proxycfg-sources/local/sync_test.go
@@ -94,7 +94,7 @@ func TestSync(t *testing.T) {
 	// the user token).
 	cfgMgr.On("RegisteredProxies", source).
 		Return([]proxycfg.ProxyID{}).
-		Once()
+		Maybe()
 
 	state.AddService(&structs.NodeService{
 		ID:   serviceID,


### PR DESCRIPTION
### Description

This PR is just fixing a flaky test: agent/proxycfg-sources/local.TestSync

At the end of this test we were trying to ensure that updating a service in the local state causes it to re-register the service with the config manager.

The config manager in the same method will also call RegisteredProxies to determine if any need to be removed. This portion of the test is not attempting to verify that behavior.

Because the test is only blocked waiting for the Register event before it can end and assert all the mock expectations were met, we may not see the call to RegisteredProxies. This is especially apparent when tests are run with the race detector.

As we don’t actually care if that method is executed before the end of the test we can simply transition from expecting it to be called exactly once to a 0 or 1 times assertion.


