### PR TITLE
Fix race during proxy closing

### DIFF
--- a/connect/proxy/proxy.go
+++ b/connect/proxy/proxy.go
@@ -123,6 +123,9 @@ func (p *Proxy) Serve() error {
 			cfg = newCfg
 
 		case <-p.stopChan:
+			if p.service != nil {
+				p.service.Close()
+			}
 			return nil
 		}
 	}
@@ -153,7 +156,4 @@ func (p *Proxy) startListener(name string, l *Listener) error {
 // called only once.
 func (p *Proxy) Close() {
 	close(p.stopChan)
-	if p.service != nil {
-		p.service.Close()
-	}
 }


### PR DESCRIPTION
### Description
The race detector had picked up on this in another PR of mine.

The `Proxy` type within the `connect/proxy` package has a `service` field to track the connect service being served. The `Serve` method is what is responsible for changing the value of this field from nil to some service once its watches have given it data.

Closing or shutting down the `Proxy` and stopping the `Serve` method starts by closing a channel. The `Serve` method will pick up on this an exit. The `Close` method on the proxy itself was also checking if the `service` field was not nil and if so it was executing `Close` on that as well. From the point-of-view of ownership, the `Serve` method owns that data and it should not be accessed unsynchronized from outside of that method.

This PR does just that. I moved calling `p.service.Close()` from within the `Proxy.Close` method into the `Serve` method just before it exits in response to the stop channel being closed. This eliminates the race but should keep functionality identical.

### Testing & Reproduction steps
* I ran this test a few hundred times locally under the race detector and it never failed.

### Links
[CircleCI run that detected the race](https://app.circleci.com/pipelines/github/hashicorp/consul/32380/workflows/915ced87-1dbe-4d24-afc5-983257188a2e/jobs/701756/tests#failed-test-0)
