### PR TITLE
Add `consul session <subcommand>` commands to the CLI

### DIFF
--- a/command/commands_oss.go
+++ b/command/commands_oss.go
@@ -97,6 +97,12 @@ import (
 	"github.com/hashicorp/consul/command/services"
 	svcsderegister "github.com/hashicorp/consul/command/services/deregister"
 	svcsregister "github.com/hashicorp/consul/command/services/register"
+	session "github.com/hashicorp/consul/command/session"
+	sessioncreate "github.com/hashicorp/consul/command/session/create"
+	sessiondelete "github.com/hashicorp/consul/command/session/delete"
+	sessionlist "github.com/hashicorp/consul/command/session/list"
+	sessionread "github.com/hashicorp/consul/command/session/read"
+	sessionrenew "github.com/hashicorp/consul/command/session/renew"
 	"github.com/hashicorp/consul/command/snapshot"
 	snapinspect "github.com/hashicorp/consul/command/snapshot/inspect"
 	snaprestore "github.com/hashicorp/consul/command/snapshot/restore"
@@ -207,6 +213,12 @@ func init() {
 	Register("services", func(cli.Ui) (cli.Command, error) { return services.New(), nil })
 	Register("services register", func(ui cli.Ui) (cli.Command, error) { return svcsregister.New(ui), nil })
 	Register("services deregister", func(ui cli.Ui) (cli.Command, error) { return svcsderegister.New(ui), nil })
+	Register("session", func(ui cli.Ui) (cli.Command, error) {return session.New(ui), nil })
+	Register("session create", func(ui cli.Ui) (cli.Command, error) {return sessioncreate.New(ui), nil })
+	Register("session delete", func(ui cli.Ui) (cli.Command, error) {return sessiondelete.New(ui), nil })
+	Register("session list", func(ui cli.Ui) (cli.Command, error) {return sessionlist.New(ui), nil })
+	Register("session read", func(ui cli.Ui) (cli.Command, error) {return sessionread.New(ui), nil })
+	Register("session renew", func(ui cli.Ui) (cli.Command, error) {return sessionrenew.New(ui), nil })
 	Register("snapshot", func(cli.Ui) (cli.Command, error) { return snapshot.New(), nil })
 	Register("snapshot inspect", func(ui cli.Ui) (cli.Command, error) { return snapinspect.New(ui), nil })
 	Register("snapshot restore", func(ui cli.Ui) (cli.Command, error) { return snaprestore.New(ui), nil })

--- a/command/session/create/create.go
+++ b/command/session/create/create.go
@@ -1,0 +1,130 @@
+package create
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/mitchellh/cli"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI    cli.Ui
+	flags *flag.FlagSet
+	http  *flags.HTTPFlags
+	help  string
+
+	flagLockDelay     string
+	flagNode          string
+	flagName          string
+	flagBehavior      string
+	flagTTL           string
+	flagNodeChecks    []string
+	flagServiceChecks []string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.flagLockDelay, "lock-delay", "",
+		"Specifies the duration for the lock delay.")
+	c.flags.StringVar(&c.flagNode, "node", "",
+		"Specifies the name of the node.")
+	c.flags.StringVar(&c.flagName, "name", "",
+		"Specifies a human-readable name for the session.")
+	c.flags.StringVar(&c.flagBehavior, "behavior", "",
+		"Controls the behavior to take when a session is invalidated.")
+	c.flags.StringVar(&c.flagTTL, "ttl", "",
+		"Specifies the duration of a session (between 10s and 86400s).")
+	c.flags.Var((*flags.AppendSliceValue)(&c.flagNodeChecks), "node-check",
+		"Specifies a node health check ID. May be specified multiple times. It is highly recommended that, if you override this list, you include the default `serfHealth`.")
+
+	c.flags.Var((*flags.AppendSliceValue)(&c.flagServiceChecks), "service-check",
+		"Specifies a service check. May be specified multiple times. Format is the SERVICECHECKID or SERVICECHECKID:NAMESPACE.")
+
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flags, c.http.ClientFlags())
+	flags.Merge(c.flags, c.http.ServerFlags())
+	flags.Merge(c.flags, c.http.MultiTenancyFlags())
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	client, err := c.http.APIClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
+		return 1
+	}
+
+	serviceChecks := []api.ServiceCheck{}
+	for _, sc := range c.flagServiceChecks {
+		splits := strings.SplitN(sc, ":", 2)
+		serviceCheck := api.ServiceCheck{
+			ID: splits[0],
+		}
+		if len(splits) == 2 {
+			serviceCheck.Namespace = splits[1]
+		}
+		serviceChecks = append(serviceChecks, serviceCheck)
+	}
+
+	s := &api.SessionEntry{
+		Name:          c.flagName,
+		Node:          c.flagNode,
+		LockDelay:     0,
+		Behavior:      c.flagBehavior,
+		TTL:           c.flagTTL,
+		NodeChecks:    c.flagNodeChecks,
+		ServiceChecks: serviceChecks,
+	}
+	id, _, err := client.Session().Create(s, nil)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error creating session: %s", err))
+		return 1
+	}
+
+	c.UI.Info(id)
+
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return c.help
+}
+
+const (
+	synopsis = "Create a new session"
+	help     = `
+Usage: consul session create [options]
+
+    This endpoint initializes a new session. Sessions must be associated with a
+    node and may be associated with any number of checks.
+
+    Create a new session:
+
+        $ consul session create -lock-delay=15s \
+                                -name=my-service-lock \
+                                -node=foobar \
+                                -node-check=serfHealth \
+                                -node-check=a \
+                                -node-check=b \
+                                -node-check=c \
+                                -behavior=release \
+                                -ttl=30s
+`
+)

--- a/command/session/create/create_test.go
+++ b/command/session/create/create_test.go
@@ -1,0 +1,95 @@
+package create
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionCreate_noTabs(t *testing.T) {
+	t.Parallel()
+	if strings.ContainsRune(New(nil).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestSessionCreate(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	retry.Run(t, func(r *retry.R) {
+		ui.ErrorWriter.Reset()
+		ui.OutputWriter.Reset()
+
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-node-check=serfHealth",
+		}
+		require.Equal(r, 0, c.Run(args), ui.ErrorWriter.String())
+
+		s, _, err := client.Session().List(nil)
+		require.NoError(r, err)
+		require.Len(r, s, 1)
+		require.Equal(r, s[0].ID, strings.TrimSpace(ui.OutputWriter.String()))
+	})
+}
+
+func TestSessionCreate_Namespace(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	node, err := client.Agent().NodeName()
+	require.NoError(t, err)
+
+	_, err = client.Catalog().Register(
+		&api.CatalogRegistration{
+			Node:           node,
+			SkipNodeUpdate: true,
+			Check: &api.AgentCheck{
+				Name:   "hello",
+				Type:   "ttl",
+				Status: "pass",
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	retry.Run(t, func(r *retry.R) {
+		ui.ErrorWriter.Reset()
+		ui.OutputWriter.Reset()
+
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-service-check=hello:default",
+		}
+		require.Equal(r, 0, c.Run(args), ui.ErrorWriter.String())
+
+		s, _, err := client.Session().List(nil)
+		require.NoError(r, err)
+		require.Len(r, s, 1)
+		require.Equal(r, s[0].ID, strings.TrimSpace(ui.OutputWriter.String()))
+	})
+}

--- a/command/session/delete/delete.go
+++ b/command/session/delete/delete.go
@@ -1,0 +1,84 @@
+package delete
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/mitchellh/cli"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI    cli.Ui
+	flags *flag.FlagSet
+	http  *flags.HTTPFlags
+	help string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flags, c.http.ClientFlags())
+	flags.Merge(c.flags, c.http.ServerFlags())
+	flags.Merge(c.flags, c.http.MultiTenancyFlags())
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	var id string
+	switch c.flags.NArg() {
+	case 0:
+		c.UI.Error("Must specify a session UUID.")
+		return 1
+	case 1:
+		id = c.flags.Arg(0)
+	default:
+		c.UI.Error("Extra arguments after the session UUID.")
+		return 1
+	}
+
+	client, err := c.http.APIClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
+		return 1
+	}
+
+	if _, err := client.Session().Destroy(id, nil); err != nil {
+		c.UI.Error(fmt.Sprintf("Error destroying session %q: %s", id, err))
+		return 1
+	}
+
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return c.help
+}
+
+const (
+	synopsis = "Delete a session"
+	help = `
+Usage: consul session delete [options] SESSIONID
+
+    Delete a session by providing the ID.
+
+    Example:
+
+        $ consul session delete b2caae8a-e80e-15f4-17aa-2be947c7968e
+`
+)

--- a/command/session/delete/delete_test.go
+++ b/command/session/delete/delete_test.go
@@ -1,0 +1,45 @@
+package delete
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionDelete_noTabs(t *testing.T) {
+	t.Parallel()
+	if strings.ContainsRune(New(nil).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestSessionDelete(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	id, _, err := client.Session().CreateNoChecks(&api.SessionEntry{}, nil)
+	require.NoError(t, err)
+
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		id,
+	}
+	require.Equal(t, 0, c.Run(args), ui.ErrorWriter.String())
+
+	s, _, err := client.Session().List(nil)
+	require.NoError(t, err)
+	require.Len(t, s, 0)
+}

--- a/command/session/formatter.go
+++ b/command/session/formatter.go
@@ -1,0 +1,113 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul/api"
+)
+
+const (
+	PrettyFormat string = "pretty"
+	JSONFormat   string = "json"
+)
+
+type Formatter interface {
+	FormatSession(s *api.SessionEntry) (string, error)
+	FormatSessionList(s []*api.SessionEntry) (string, error)
+}
+
+func GetSupportedFormats() []string {
+	return []string{PrettyFormat, JSONFormat}
+}
+
+func NewFormatter(format string) (Formatter, error) {
+	switch format {
+	case PrettyFormat:
+		return newPrettyFormatter(), nil
+	case JSONFormat:
+		return newJSONFormatter(), nil
+	default:
+		return nil, fmt.Errorf("Unknown format: %s", format)
+	}
+}
+
+func  newPrettyFormatter() Formatter {
+	return &prettyFormatter{}
+}
+
+type prettyFormatter struct {}
+
+func (f *prettyFormatter) FormatSession(s *api.SessionEntry) (string, error) {
+	var buffer bytes.Buffer
+
+	buffer.WriteString(fmt.Sprintf("ID:          %s\n", s.ID))
+	if s.Name != "" {
+		buffer.WriteString(fmt.Sprintf("Name:        %s\n", s.Name))
+	}
+	buffer.WriteString(fmt.Sprintf("Node:        %s\n", s.Node))
+	buffer.WriteString(fmt.Sprintf("LockDelay:   %s\n", s.LockDelay.String()))
+	buffer.WriteString(fmt.Sprintf("Behavior:    %s\n", s.Behavior))
+	if s.TTL != "" {
+		buffer.WriteString(fmt.Sprintf("TTL:         %s\n", s.TTL))
+	}
+	if s.Namespace != "" {
+		buffer.WriteString(fmt.Sprintf("Namespace:   %s\n", s.Namespace))
+	}
+	if len(s.NodeChecks) != 0 {
+		buffer.WriteString(fmt.Sprintf("Node Checks: %s\n", strings.Join(s.NodeChecks, ", ")))
+	}
+	if len(s.ServiceChecks) != 0 {
+		buffer.WriteString("Service Checks:\n")
+
+		for _, sc := range s.ServiceChecks {
+			buffer.WriteString(fmt.Sprintf("  - ID: %s\n", sc.ID))
+			if sc.Namespace != "" {
+				buffer.WriteString(fmt.Sprintf("    Namespace: %s\n", sc.Namespace))
+			}
+		}
+	}
+
+	return buffer.String(), nil
+}
+
+func (f *prettyFormatter) FormatSessionList(s []*api.SessionEntry) (string, error) {
+	var buffer bytes.Buffer
+
+	for i, session := range s {
+		str, err := f.FormatSession(session)
+		if err != nil {
+			return "", err
+		}
+		buffer.WriteString(str)
+
+		if i != len(s) - 1 {
+			buffer.WriteString("\n")
+		}
+	}
+	return buffer.String(), nil
+}
+
+func newJSONFormatter() Formatter {
+	return &jsonFormatter{}
+}
+
+type jsonFormatter struct{}
+
+func (f *jsonFormatter) FormatSession(s *api.SessionEntry) (string, error) {
+	b, err := json.MarshalIndent(s, "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("Failed to marshal session: %s", err)
+	}
+	return string(b), err
+}
+
+func (f *jsonFormatter) FormatSessionList(s []*api.SessionEntry) (string, error) {
+	b, err := json.MarshalIndent(s, "", "    ")
+	if err != nil {
+		return "", fmt.Errorf("Failed to marshal sessions: %s", err)
+	}
+	return string(b), nil
+}

--- a/command/session/list/list.go
+++ b/command/session/list/list.go
@@ -1,0 +1,108 @@
+package list
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/hashicorp/consul/command/session"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI    cli.Ui
+	flags *flag.FlagSet
+	http  *flags.HTTPFlags
+	help  string
+
+	flagFormat string
+	flagNode   string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.flagNode, "node", "",
+		"List the active sessions for a given node.")
+	c.flags.StringVar(&c.flagFormat, "format", session.PrettyFormat,
+		fmt.Sprintf("Output format {%s}", strings.Join(session.GetSupportedFormats(), "|")))
+
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flags, c.http.ClientFlags())
+	flags.Merge(c.flags, c.http.ServerFlags())
+	flags.Merge(c.flags, c.http.MultiTenancyFlags())
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	client, err := c.http.APIClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
+		return 1
+	}
+
+	var s []*api.SessionEntry
+	if c.flagNode == "" {
+		s, _, err = client.Session().List(nil)
+	} else {
+		s, _, err = client.Session().Node(c.flagNode, nil)
+	}
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error listing sessions: %s", err))
+		return 1
+	}
+
+	formatter, err := session.NewFormatter(c.flagFormat)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to get formatter %q: %s", c.flagFormat, err))
+		return 1
+	}
+
+	out, err := formatter.FormatSessionList(s)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to format session: %s", err))
+		return 1
+	}
+	if out != "" {
+		c.UI.Info(out)
+	}
+
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return c.help
+}
+
+const (
+	synopsis = "List active sessions"
+	help     = `
+Usage: consul session list [options]
+
+    List all the active sessions.
+
+    List all sessions in the cluster:
+
+        $ consul acl session list
+
+    List all sessions for a given node:
+
+        $ consul acl session list -node=s1234.dc1
+`
+)

--- a/command/session/list/list_test.go
+++ b/command/session/list/list_test.go
@@ -1,0 +1,178 @@
+package list
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionListCommand_noTabs(t *testing.T) {
+	t.Parallel()
+
+	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestSessionListCommand(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	testrpc.WaitForTestAgent(t, a.RPC, ``)
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	var ids []string
+	for i := 0; i < 5; i++ {
+		id, _, err := client.Session().CreateNoChecks(
+			&api.SessionEntry{
+				Name: fmt.Sprintf("hello-world-%d", i),
+			},
+			nil,
+		)
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+
+	node, err := client.Agent().NodeName()
+	require.NoError(t, err)
+
+	cases := map[string]struct {
+		args           []string
+		expectSessions bool
+	}{
+		"global": {
+			args: []string{
+				"-http-addr=" + a.HTTPAddr(),
+			},
+			expectSessions: true,
+		},
+		"node": {
+			args: []string{
+				"-http-addr=" + a.HTTPAddr(),
+				"-node=" + node,
+			},
+			expectSessions: true,
+		},
+		"unknown-node": {
+			args: []string{
+				"-http-addr=" + a.HTTPAddr(),
+				"-node=1234",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			retry.Run(t, func(r *retry.R) {
+
+
+				ui.OutputWriter.Reset()
+				ui.ErrorWriter.Reset()
+
+				require.Equal(r, 0, c.Run(tc.args), ui.ErrorWriter.String())
+
+				output := ui.OutputWriter.String()
+
+				if tc.expectSessions {
+					for i, v := range ids {
+						require.Contains(r, output, fmt.Sprintf("hello-world-%d", i))
+						require.Contains(r, output, v)
+					}
+				}
+			})
+		})
+	}
+}
+
+func TestSessionListCommand_JSON(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	var ids []string
+	for i := 0; i < 5; i++ {
+		id, _, err := client.Session().CreateNoChecks(
+			&api.SessionEntry{
+				Name: fmt.Sprintf("hello-world-%d", i),
+			},
+			nil,
+		)
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+
+	node, err := client.Agent().NodeName()
+	require.NoError(t, err)
+
+	cases := map[string]struct {
+		args           []string
+		expectSessions bool
+	}{
+		"global": {
+			args: []string{
+				"-http-addr=" + a.HTTPAddr(),
+				"-format=json",
+			},
+			expectSessions: true,
+		},
+		"node": {
+			args: []string{
+				"-http-addr=" + a.HTTPAddr(),
+				"-format=json",
+				"-node=" + node,
+			},
+			expectSessions: true,
+		},
+		"unknown-node": {
+			args: []string{
+				"-http-addr=" + a.HTTPAddr(),
+				"-format=json",
+				"-node=1234",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			retry.Run(t, func(r *retry.R) {
+				ui.OutputWriter.Reset()
+				ui.ErrorWriter.Reset()
+
+				require.Equal(r, 0, c.Run(tc.args), ui.ErrorWriter.String())
+
+				output := ui.OutputWriter.String()
+
+				if tc.expectSessions {
+					for i, v := range ids {
+						require.Contains(r, output, fmt.Sprintf("hello-world-%d", i))
+						require.Contains(r, output, v)
+					}
+				}
+
+				var jsonOutput json.RawMessage
+				err := json.Unmarshal([]byte(output), &jsonOutput)
+				require.NoError(t, err, output)
+			})
+		})
+	}
+}

--- a/command/session/read/read.go
+++ b/command/session/read/read.go
@@ -1,0 +1,115 @@
+package read
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/cli"
+
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/hashicorp/consul/command/session"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI    cli.Ui
+	flags *flag.FlagSet
+	http  *flags.HTTPFlags
+	help  string
+
+	flagFormat string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.flagFormat, "format", session.PrettyFormat,
+	fmt.Sprintf("Output format {%s}.", strings.Join(session.GetSupportedFormats(), "|")))
+
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flags, c.http.ClientFlags())
+	flags.Merge(c.flags, c.http.ServerFlags())
+	flags.Merge(c.flags, c.http.MultiTenancyFlags())
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	var id string
+	switch c.flags.NArg() {
+	case 0:
+		c.UI.Error("Must specify a session UUID.")
+		return 1
+	case 1:
+		id = c.flags.Arg(0)
+	default:
+		c.UI.Error("Extra arguments after the session UUID.")
+		return 1
+	}
+
+	client, err := c.http.APIClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
+		return 1
+	}
+
+	s, _, err := client.Session().Info(id, nil)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error reading session information: %s", err))
+		return 1
+	}
+	if s == nil {
+		c.UI.Error(fmt.Sprintf("No session %q found", id))
+		return 1
+	}
+
+	formatter, err := session.NewFormatter(c.flagFormat)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to get formatter %q: %s", c.flagFormat, err))
+		return 1
+	}
+
+	out, err := formatter.FormatSession(s)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to format session: %s", err))
+		return 1
+	}
+	if out != "" {
+		c.UI.Info(out)
+	}
+
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return c.help
+}
+
+const (
+	synopsis = "Read session information"
+	help     = `
+Usage: consul session read [options] SESSIONID
+
+    This command will retrieve and print out the details of a single session.
+
+    Read:
+
+        $ consul acl session read b2caae8a-e80e-15f4-17aa-2be947c7968e
+
+    Read and format the result as JSON:
+
+        $ consul acl session read -format=json b2caae8a-e80e-15f4-17aa-2be947c7968e
+`
+)

--- a/command/session/read/read_test.go
+++ b/command/session/read/read_test.go
@@ -1,0 +1,110 @@
+package read
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+
+func TestSessionReadCommand_noTabs(t *testing.T) {
+	t.Parallel()
+
+	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestSessionReadCommand(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	id, _, err := client.Session().CreateNoChecks(
+		&api.SessionEntry{
+			Name: "hello-world",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		id,
+	}
+	require.Equal(t, 0, c.Run(args), ui.ErrorWriter.String())
+
+	output := ui.OutputWriter.String()
+	require.Contains(t, output, "hello-world")
+	require.Contains(t, output, id)
+}
+
+func TestSessionReadCommand_JSON(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	id, _, err := client.Session().CreateNoChecks(
+		&api.SessionEntry{
+			Name: "hello-world",
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-format=json",
+		id,
+	}
+	require.Equal(t, 0, c.Run(args), ui.ErrorWriter.String())
+
+	output := ui.OutputWriter.String()
+	require.Contains(t, output, "hello-world")
+	require.Contains(t, output, id)
+
+	var jsonOuput json.RawMessage
+	err = json.Unmarshal([]byte(output), &jsonOuput)
+	require.NoError(t, err)
+}
+
+func TestSessionReadCommand_notFound(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-format=json",
+		"1234",
+	}
+	require.Equal(t, 1, c.Run(args), ui.ErrorWriter.String())
+	require.Contains(t, ui.OutputWriter.String(), "")
+	require.Contains(t, ui.ErrorWriter.String(), `No session "1234" found`, )
+}

--- a/command/session/renew/renew.go
+++ b/command/session/renew/renew.go
@@ -1,0 +1,86 @@
+package renew
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/mitchellh/cli"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI    cli.Ui
+	flags *flag.FlagSet
+	http  *flags.HTTPFlags
+	help  string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flags, c.http.ClientFlags())
+	flags.Merge(c.flags, c.http.ServerFlags())
+	flags.Merge(c.flags, c.http.MultiTenancyFlags())
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	var id string
+	switch c.flags.NArg() {
+	case 0:
+		c.UI.Error("Must specify a session UUID.")
+		return 1
+	case 1:
+		id = c.flags.Arg(0)
+	default:
+		c.UI.Error("Extra arguments after the session UUID.")
+		return 1
+	}
+
+	client, err := c.http.APIClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
+		return 1
+	}
+
+	_, _, err = client.Session().Renew(id, nil)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error renewing session: %s", err))
+		return 1
+	}
+
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return c.help
+}
+
+const (
+	synopsis = "Renew a session"
+	help     = `
+Usage: consul session renew [options] SESSIONID
+
+    Renew the given session. This can be used for sessions that have a TTL, and
+    it extends the expiration by the TTL.
+
+    Example:
+
+        $ consul session renew b2caae8a-e80e-15f4-17aa-2be947c7968e
+`
+)

--- a/command/session/renew/renew_test.go
+++ b/command/session/renew/renew_test.go
@@ -1,0 +1,59 @@
+package renew
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionRenewCommand_noTabs(t *testing.T) {
+	t.Parallel()
+
+	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestSessionRenew_noTTL(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	cases := map[string]struct {
+		se *api.SessionEntry
+	}{
+		"no-ttl": {
+			se: &api.SessionEntry{},
+		},
+		"ttl": {
+			&api.SessionEntry{
+				TTL: "30s",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			id, _, err := client.Session().CreateNoChecks(tc.se, nil)
+			require.NoError(t, err)
+
+			args := []string{
+				"-http-addr=" + a.HTTPAddr(),
+				id,
+			}
+			require.Equal(t, 0, c.Run(args), ui.ErrorWriter.String())
+		})
+	}
+}

--- a/command/session/session.go
+++ b/command/session/session.go
@@ -1,0 +1,64 @@
+package session
+
+import (
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/mitchellh/cli"
+)
+
+func New(ui cli.Ui) *cmd {
+	return &cmd{}
+}
+
+type cmd struct{}
+
+func (c *cmd) Run(args []string) int {
+	return cli.RunResultHelp
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return flags.Usage(help, nil)
+}
+
+const (
+	synopsis = "Manage Consul's sessions"
+
+	help = `
+Usage: consul session <subcommands> [options] [args]
+
+    This command has subcommands for managing Consul's sessions.
+    Here are some simple examples, and more detailed examples are available
+    in the subcommands or the documentation.
+
+    Create a new session:
+
+        $ consul session create -lock-delay=15s \
+                                -name=my-service-lock \
+                                -node=foobar \
+                                -node-check=serfHealth \
+                                -node-check=a \
+                                -node-check=b \
+                                -node-check=c \
+                                -behavior=release \
+                                -ttl=30s
+
+    List all sessions in the cluster:
+
+        $ consul acl session list
+
+    Read a session information:
+
+        $ consul acl session read b2caae8a-e80e-15f4-17aa-2be947c7968e
+
+    Renew a session:
+
+        $ consul session renew b2caae8a-e80e-15f4-17aa-2be947c7968e
+
+    Delete a session:
+
+        $ consul session delete b2caae8a-e80e-15f4-17aa-2be947c7968e
+`
+)

--- a/website/content/commands/catalog/index.mdx
+++ b/website/content/commands/catalog/index.mdx
@@ -80,4 +80,4 @@ Subcommands:
 ```
 
 For more information, examples, and usage about a subcommand, click on the name
-of the subcommand in the sidebar or one of the links below:
+of the subcommand in the sidebar.

--- a/website/content/commands/index.mdx
+++ b/website/content/commands/index.mdx
@@ -31,6 +31,7 @@ Available commands are:
     acl            Interact with Consul's ACLs
     agent          Runs a Consul agent
     catalog        Interact with the catalog
+    config         Interact with Consul's Centralized Configurations
     connect        Interact with Consul Connect
     debug          Records a debugging archive for operators
     event          Fire a new event
@@ -53,6 +54,7 @@ Available commands are:
     reload         Triggers the agent to reload configuration files
     rtt            Estimates network round trip time between nodes
     services       Interact with services
+    session        Manage Consul's sessions
     snapshot       Saves, restores and inspects snapshots of Consul server state
     tls            Builtin helpers for creating CAs and certificates
     validate       Validate config files/directories

--- a/website/content/commands/session/create.mdx
+++ b/website/content/commands/session/create.mdx
@@ -1,0 +1,68 @@
+---
+layout: commands
+page_title: 'Commands: Session Create'
+---
+
+# Consul Session Create
+
+Command: `consul session create`
+
+Corresponding HTTP API Endpoint: [\[PUT\] /v1/session/create](/api-docs/session#create-session)
+
+The `session create` command creates a new session.
+
+The table below shows this command's [required ACLs](/api#authentication). Configuration of
+[blocking queries](/api-docs/features/blocking) and [agent caching](/api-docs/features/caching)
+are not supported from commands, but may be from the corresponding HTTP endpoint.
+
+| ACL Required    |
+| --------------- |
+| `session:write` |
+
+## Usage
+
+Usage: `consul session create [options]`
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
+
+#### Command Options
+
+- `-lock-delay=<duration>` - Specifies the duration for the lock delay.
+
+- `-node=<string>` - Specifies the name of the node.
+
+- `-name=<string>` - Specifies a human-readable name for the session.
+
+- `-behavior=<string>` - Controls the behavior to take when a session is invalidated. It can be either `release` or `delete`.
+
+- `-ttl=<duration>` - Specifies the duration of a session (between 10s and 86400s).
+
+- `-node-check=<string>` - Specifies a node health check ID. May be specified multiple times. It is highly recommended that, if you override this list, you include the default `serfHealth`.
+
+- `-service-check=<string>` - Specifies a service check. May be specified multiple times. Format is the `SERVICECHECKID` or `SERVICECHECKID:NAMESPACE`.
+
+#### Enterprise Options
+
+@include 'http_api_namespace_options.mdx'
+
+@include 'http_api_partition_options.mdx'
+
+## Examples
+
+Create a new session:
+
+```shell-session
+$ consul session create -lock-delay=15s \
+                        -name=my-service-lock \
+                        -node=foobar \
+                        -node-check=serfHealth \
+                        -node-check=a \
+                        -node-check=b \
+                        -node-check=c \
+                        -behavior=release \
+                        -ttl=30s
+```

--- a/website/content/commands/session/delete.mdx
+++ b/website/content/commands/session/delete.mdx
@@ -1,0 +1,44 @@
+---
+layout: commands
+page_title: 'Commands: Session Delete'
+---
+
+# Consul Session Delete
+
+Command: `consul session delete`
+
+Corresponding HTTP API Endpoint: [\[DELETE\] /v1/session/destroy/:uuid](/api-docs/session#delete-session)
+
+The `session delete` command deletes a session.
+
+The table below shows this command's [required ACLs](/api#authentication). Configuration of
+[blocking queries](/api-docs/features/blocking) and [agent caching](/api-docs/features/caching)
+are not supported from commands, but may be from the corresponding HTTP endpoint.
+
+| ACL Required    |
+| --------------- |
+| `session:write` |
+
+## Usage
+
+Usage: `consul session delete [options] SESSIONID`
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
+
+#### Enterprise Options
+
+@include 'http_api_namespace_options.mdx'
+
+@include 'http_api_partition_options.mdx'
+
+## Examples
+
+Delete a session:
+
+```shell-session
+$ consul session delete b2caae8a-e80e-15f4-17aa-2be947c7968e
+```

--- a/website/content/commands/session/index.mdx
+++ b/website/content/commands/session/index.mdx
@@ -1,0 +1,71 @@
+---
+layout: commands
+page_title: 'Commands: Session'
+---
+
+# Consul Sessions
+
+Command: `consul session`
+
+The `session` command is used to manage Consul's sessions.
+It exposes commands for creating, renewing, reading, deleting, and listing sessions.
+This command is available in Consul 1.13.0 and newer.
+
+Sessions may also be managed via the [HTTP API](/api-docs/session).
+
+## Usage
+
+Usage: `consul session <subcommand>`
+
+For the exact documentation for your Consul version, run `consul session -h` to view the complete list of subcommands.
+
+```text
+Usage: consul session <subcommand> [options] [args]
+
+  ...
+
+Subcommands:
+    create    Create a new session
+    delete    Delete a session
+    list      List active sessions
+    read      Read session information
+    renew     Renew a session
+```
+
+For more information, examples, and usage about a subcommand, click on the name
+of the subcommand in the sidebar.
+
+## Basic Examples
+
+Create a new session:
+
+```shell-session
+$ consul session create -lock-delay=15s \
+                        -name=my-service-lock \
+                        -behavior=release \
+                        -ttl=30s
+```
+
+List all sessions:
+
+```shell-session
+$ consul session list
+```
+
+Renew a session:
+
+```shell-session
+$ consul session renew b2caae8a-e80e-15f4-17aa-2be947c7968e
+```
+
+Read a session:
+
+```shell-session
+$ consul session read b2caae8a-e80e-15f4-17aa-2be947c7968e
+```
+
+Delete a session
+
+```shell-session
+$ consul session delete b2caae8a-e80e-15f4-17aa-2be947c7968e
+```

--- a/website/content/commands/session/list.mdx
+++ b/website/content/commands/session/list.mdx
@@ -1,0 +1,98 @@
+---
+layout: commands
+page_title: 'Commands: Session List'
+---
+
+# Consul Session List
+
+Command: `consul session list`
+
+Corresponding HTTP API Endpoint: [\[GET\] /v1/session/list](/api-docs/session#list-sessions), [\[GET\] /v1/session/node/:node](/api-docs/session#list-sessions-for-node).
+
+The `session list` command lists all sessions.
+
+The table below shows this command's [required ACLs](/api#authentication). Configuration of
+[blocking queries](/api-docs/features/blocking) and [agent caching](/api-docs/features/caching)
+are not supported from commands, but may be from the corresponding HTTP endpoint.
+
+| ACL Required   |
+| -------------- |
+| `session:read` |
+
+## Usage
+
+Usage: `consul session list [options]`
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
+
+#### Command Options
+
+- `-node` - Indicates whether to list all sessions in the cluster or only for a
+  given node.
+
+- `-format={pretty|json}` - Command output format. The default value is `pretty`.
+
+#### Enterprise Options
+
+@include 'http_api_namespace_options.mdx'
+
+@include 'http_api_partition_options.mdx'
+
+## Examples
+
+Default listing.
+
+```shell-session
+$ consul session list
+ID:          b2caae8a-e80e-15f4-17aa-2be947c7968e
+Node:        s1234
+LockDelay:   15s
+Behavior:    release
+Node Checks: serfHealth
+
+ID:          f3a5cc5d-6e20-b990-c85a-67f94c70a803
+Node:        s1234
+LockDelay:   15s
+Behavior:    release
+Node Checks: serfHealth
+```
+
+Format as JSON.
+
+```shell-session
+$ consul session list -format=json
+[
+    {
+        "CreateIndex": 62,
+        "ID": "b2caae8a-e80e-15f4-17aa-2be947c7968e",
+        "Name": "",
+        "Node": "s1234",
+        "LockDelay": 15000000000,
+        "Behavior": "release",
+        "TTL": "",
+        "Checks": null,
+        "NodeChecks": [
+            "serfHealth"
+        ],
+        "ServiceChecks": null
+    },
+    {
+        "CreateIndex": 560,
+        "ID": "f3a5cc5d-6e20-b990-c85a-67f94c70a803",
+        "Name": "",
+        "Node": "s1234",
+        "LockDelay": 15000000000,
+        "Behavior": "release",
+        "TTL": "",
+        "Checks": null,
+        "NodeChecks": [
+            "serfHealth"
+        ],
+        "ServiceChecks": null
+    }
+]
+```

--- a/website/content/commands/session/read.mdx
+++ b/website/content/commands/session/read.mdx
@@ -1,0 +1,73 @@
+---
+layout: commands
+page_title: 'Commands: Session Read'
+---
+
+# Consul Session Read
+
+Command: `consul session read`
+
+Corresponding HTTP API Endpoints: [\[GET\] /v1/session/info/:uuid](/api-docs/session#read-session).
+
+The `session read` command reads and displays a session details.
+
+The table below shows this command's [required ACLs](/api#authentication). Configuration of
+[blocking queries](/api-docs/features/blocking) and [agent caching](/api-docs/features/caching)
+are not supported from commands, but may be from the corresponding HTTP endpoint.
+
+| ACL Required   |
+| -------------- |
+| `session:read` |
+
+## Usage
+
+Usage: `consul session read [options] SESSIONID`
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
+
+#### Command Options
+
+- `-format={pretty|json}` - Command output format. The default value is `pretty`.
+
+#### Enterprise Options
+
+@include 'http_api_namespace_options.mdx'
+
+@include 'http_api_partition_options.mdx'
+
+## Examples
+
+Get session details:
+
+```shell-session
+$ consul session read b2caae8a-e80e-15f4-17aa-2be947c7968e
+ID:          b2caae8a-e80e-15f4-17aa-2be947c7968e
+Node:        s1234
+LockDelay:   15s
+Behavior:    release
+Node Checks: serfHealth
+```
+
+Format as JSON:
+
+```shell-session
+$ consul session read -format b2caae8a-e80e-15f4-17aa-2be947c7968e
+{
+    "CreateIndex": 62,
+    "ID": "b2caae8a-e80e-15f4-17aa-2be947c7968e",
+    "Name": "",
+    "Node": "s1234",
+    "LockDelay": 15000000000,
+    "Behavior": "release",
+    "TTL": "",
+    "Checks": null,
+    "NodeChecks": [
+        "serfHealth"
+    ],
+    "ServiceChecks": null
+}
+```

--- a/website/content/commands/session/renew.mdx
+++ b/website/content/commands/session/renew.mdx
@@ -1,0 +1,44 @@
+---
+layout: commands
+page_title: 'Commands: Session Renew'
+---
+
+# Consul Session Renew
+
+Command: `consul session renew`
+
+Corresponding HTTP API Endpoint: [\[PUT\] /v1/session/renew/:uuid](/api-docs/session#renew-session)
+
+The `session renew` command renews a session.
+
+The table below shows this command's [required ACLs](/api#authentication). Configuration of
+[blocking queries](/api-docs/features/blocking) and [agent caching](/api-docs/features/caching)
+are not supported from commands, but may be from the corresponding HTTP endpoint.
+
+| ACL Required    |
+| --------------- |
+| `session:write` |
+
+## Usage
+
+Usage: `consul session renew [options] SESSIONID`
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
+
+#### Enterprise Options
+
+@include 'http_api_namespace_options.mdx'
+
+@include 'http_api_partition_options.mdx'
+
+## Examples
+
+Renew a session:
+
+```shell-session
+$ consul session renew b2caae8a-e80e-15f4-17aa-2be947c7968e
+```

--- a/website/data/commands-nav-data.json
+++ b/website/data/commands-nav-data.json
@@ -462,6 +462,35 @@
     ]
   },
   {
+    "title": "session",
+    "routes": [
+      {
+        "title": "Overview",
+        "path": "session"
+      },
+      {
+        "title": "create",
+        "path": "session/create"
+      },
+      {
+        "title": "delete",
+        "path": "session/delete"
+      },
+      {
+        "title": "list",
+        "path": "session/list"
+      },
+      {
+        "title": "read",
+        "path": "session/read"
+      },
+      {
+        "title": "renew",
+        "path": "session/renew"
+      }
+    ]
+  },
+  {
     "title": "snapshot",
     "routes": [
       {


### PR DESCRIPTION
This patch adds a set of commands to the CLI to make it easier for
operators to interact with sessions:

     $ consul session create -lock-delay=15s \
                             -name=my-service-lock \
                             -behavior=release \
                             -ttl=30s
     e32f7ac2-b617-6c8d-3a91-00c4b0fa9f67
     $ consul session list
     ID:          e32f7ac2-b617-6c8d-3a91-00c4b0fa9f67
     Name:        my-service-lock
     Node:        Remis-MacBook-Pro.local
     LockDelay:   15s
     Behavior:    release
     TTL:         30s
     Node Checks: serfHealth

     $ consul session list -format=json
     [
         {
             "CreateIndex": 1613,
             "ID": "e32f7ac2-b617-6c8d-3a91-00c4b0fa9f67",
             "Name": "my-service-lock",
             "Node": "Remis-MacBook-Pro.local",
             "LockDelay": 15000000000,
             "Behavior": "release",
             "TTL": "30s",
             "Checks": null,
             "NodeChecks": [
                 "serfHealth"
             ],
             "ServiceChecks": null
         }
     ]
     $ consul session renew e32f7ac2-b617-6c8d-3a91-00c4b0fa9f67
     $ consul session read e32f7ac2-b617-6c8d-3a91-00c4b0fa9f67
     ID:          e32f7ac2-b617-6c8d-3a91-00c4b0fa9f67
     Name:        my-service-lock
     Node:        Remis-MacBook-Pro.local
     LockDelay:   15s
     Behavior:    release
     TTL:         30s
     Node Checks: serfHealth

     $ consul session delete e32f7ac2-b617-6c8d-3a91-00c4b0fa9f67
