### PR TITLE
Update version string on active release branches

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.11.3"
+	Version = "1.11.x"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
### Description

Pushing per-commit dev images to the `hashicorppreview` dockerhub org was introduced in https://github.com/hashicorp/consul/pull/13084. On merges to a release branch in the format `release/$MAJOR.$MINOR.x`, artifacts including docker images are built, tagged, and pushed to `hashicorppreview` under the tags `$VERSION` and `$VERSION-$GITCOMMIT`. [Note that `$VERSION` includes the prerelease string as a suffix.] The team has automation that runs to pull down these images and run tests against them.

This PR suggests changing the `$VERSION` string (and docker tag) on the active release branches [1.10.x, 1.11.x, 1.12.x] to mirror the release branch naming convention, `$MAJOR.$MINOR.x`. Since the tip of the release branch contains the latest patch code changes, using a `.x` instead of pointing to a specific patch version is what we've adopted for release branch naming, and would like to adopt for dev_tags. The version string is updated prior to building for a release, so this should have no adverse effects. 

### Testing & Reproduction steps

`hashicorppreview/consul:1.13.0-dev` will become `hashicorppreview/consul:1.13.x-dev`
`hashicorppreview/consul:1.13.0-dev-364758ef2f50519cb12585f7148fdcc8f213f27d` will become `hashicorppreview/consul:1.13.x-dev-364758ef2f50519cb12585f7148fdcc8f213f27d`

### Description
Describe why you're making this change, in plain English.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
