### PR TITLE
Reimplement fs.FileInfo interface

### DIFF
--- a/agent/uiserver/buffered_file.go
+++ b/agent/uiserver/buffered_file.go
@@ -1,20 +1,29 @@
 package uiserver
 
 import (
-	"io"
+	"bytes"
 	"io/fs"
+	"os"
+	"time"
 )
 
 // bufferedFile implements fs.File and allows us to modify a file from disk by
 // writing out the new version into a buffer and then serving file reads from
 // that.
 type bufferedFile struct {
-	buf  io.Reader
+	buf  *bytes.Buffer
 	info fs.FileInfo
 }
 
+func newBufferedFile(buf *bytes.Buffer, info fs.FileInfo) *bufferedFile {
+	return &bufferedFile{
+		buf:  buf,
+		info: info,
+	}
+}
+
 func (b *bufferedFile) Stat() (fs.FileInfo, error) {
-	return b.info, nil
+	return b, nil
 }
 
 func (b *bufferedFile) Read(bytes []byte) (int, error) {
@@ -25,9 +34,26 @@ func (b *bufferedFile) Close() error {
 	return nil
 }
 
-func newBufferedFile(buf io.Reader, info fs.FileInfo) *bufferedFile {
-	return &bufferedFile{
-		buf:  buf,
-		info: info,
-	}
+func (b *bufferedFile) Name() string {
+	return b.info.Name()
+}
+
+func (b *bufferedFile) Size() int64 {
+	return int64(b.buf.Len())
+}
+
+func (b *bufferedFile) Mode() os.FileMode {
+	return b.info.Mode()
+}
+
+func (b *bufferedFile) ModTime() time.Time {
+	return b.info.ModTime()
+}
+
+func (b *bufferedFile) IsDir() bool {
+	return false
+}
+
+func (b *bufferedFile) Sys() any {
+	return nil
 }


### PR DESCRIPTION
As part of https://github.com/hashicorp/consul/pull/10996 I mistakenly [removed](https://github.com/hashicorp/consul/pull/10996/files#diff-e08d8bd07f9b22333fae07454bca37554aac398e9d65b4bcc6b43da337ee4f17L37-L66) `bufferedFile`'s implementation of `fs.FileInfo` (formerly `os.FileInfo`), assuming `fs.File` was enough.


Unfortunately, this caused issues loading UI assets because the buffer backing `index.html` diverges from the original FileInfo when the template is executed. The `Size()` of the `bufferedFile` reports the size of `index.html` before the template executes, leading to a mismatch of the content length reported by go's file server.

![image](https://user-images.githubusercontent.com/30640057/171294735-41c6283d-91c1-46d9-8d5d-f9de6194a508.png)