### PR TITLE
build: add 'make help' to simply list available make targets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -393,6 +393,12 @@ envoy-regen:
 	@find "command/connect/envoy/testdata" -name '*.golden' -delete
 	@go test -tags '$(GOTAGS)' ./command/connect/envoy -update
 
+.PHONY: help
+help:
+	$(info available make targets)
+	$(info ----------------------)
+	@grep "^[a-z0-9-][a-z0-9.-]*:" GNUmakefile  | cut -d':' -f1 | sort
+
 .PHONY: all bin dev dist cov test test-internal cover lint ui tools
 .PHONY: docker-images go-build-image ui-build-image consul-docker ui-docker
 .PHONY: version test-envoy-integ


### PR DESCRIPTION
### Description

There are a lot of useful and sometimes hidden `make` targets in our large makefile. This easily surfaces those targets with `make help`.
