### PR TITLE
update multicluster docs for k8s to specify the correct k8sAuthMethodHost

### DIFF
--- a/website/content/docs/k8s/installation/multi-cluster/index.mdx
+++ b/website/content/docs/k8s/installation/multi-cluster/index.mdx
@@ -57,15 +57,19 @@ federated with Consul datacenters running on virtual machines (and vice versa).
 Because the communication between clusters is end-to-end encrypted, mesh gateways
 can even be exposed on the public internet.
 
-The only requirement is that the mesh gateways for each cluster can route to
-one another. For example, if using a load balancer service in front of each cluster's
-mesh gateway, the load balancer IP must be routable from the other mesh gateway pods.
+There are three networking requirements:
+1. When Consul servers in secondary datacenters first start up, they must be able to make calls directly to the
+   primary datacenter's mesh gateways.
+1. Once the Consul servers in secondary datacenters have made that initial call to the primary datacenter's mesh
+   gateways, the mesh gateways in the secondary datacenter will be able to start. From this point onwards, all
+   communication between servers will flow first to the local mesh gateways, and then to the remote mesh gateways.
+   This means all mesh gateways across datacenters must be able to route to one another.
 
-If using a public load balancer, this is guaranteed. If using a private load balancer
-then you'll need to make sure that its IP is routable from your other clusters.
-
-In addition, if ACLs are enabled, primary clusters must be able to make requests to the Kubernetes API URL of
-secondary clusters.
+   For example, if using a load balancer service in front of each cluster's mesh gateway pods, the load balancer IP
+   must be routable from the other mesh gateway pods.
+   If using a public load balancer, this is guaranteed. If using a private load balancer
+   then you'll need to make sure that its IP/DNS address is routable from your other clusters.
+1. If ACLs are enabled, primary clusters must be able to make requests to the Kubernetes API URLs of secondary clusters.
 
 ## Next Steps
 

--- a/website/content/docs/k8s/installation/multi-cluster/kubernetes.mdx
+++ b/website/content/docs/k8s/installation/multi-cluster/kubernetes.mdx
@@ -289,14 +289,13 @@ The automatically generated federation secret contains:
 
 ## Kubernetes API URL
 
-If ACLs are enabled, you must next determine the Kubernetes API URL for the secondary cluster. The API URL of the primary cluster
-must be specified in the config files for all secondary clusters because secondary clusters need
+If ACLs are enabled, you must next determine the Kubernetes API URL for each secondary cluster. The API URL of the secondary cluster must be specified in the config files for each secondary cluster because they  need
 to create global Consul ACL tokens (tokens that are valid in all datacenters) and these tokens can only be created
 by the primary datacenter. By setting the API URL, the secondary cluster will configure a [Consul auth method](/docs/security/acl/auth-methods)
 in the primary cluster so that components in the secondary cluster can use their Kubernetes ServiceAccount tokens
 to retrieve global Consul ACL tokens from the primary.
 
-To determine the Kubernetes API URL, first get the cluster name in your kubeconfig:
+To determine the Kubernetes API URL, first get the cluster name in your kubeconfig for your secondary:
 
 ```shell-session
 $ export CLUSTER=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"$(kubectl config current-context)\")].context.cluster}")
@@ -352,7 +351,7 @@ global:
 
   federation:
     enabled: true
-    k8sAuthMethodHost: <kubernetes-api-url>
+    k8sAuthMethodHost: <kubernetes-api-url-of-secondary>
     primaryDatacenter: dc1
   gossipEncryption:
     secretName: consul-federation
@@ -380,8 +379,7 @@ server:
 
 Modifications:
 
-1. If ACLs are enabled, change the value of `global.federation.k8sAuthMethodHost` to the full URL (including `https://`) of this cluster's
-   Kubernetes API.
+1. If ACLs are enabled, change the value of `global.federation.k8sAuthMethodHost` to the full URL (including `https://`) of the secondary cluster's Kubernetes API.
 1. `global.federation.primaryDatacenter` must be set to the name of the primary datacenter.
 1. The Consul datacenter name for the datacenter in this example is `dc2`. The datacenter name in **each** federated cluster **must be unique**.
 1. ACLs are enabled in the above config file. They can be disabled by removing


### PR DESCRIPTION
### Description
Describe why you're making this change, in plain English.
The docs are invalid for federation using k8s.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
* [ ] checklist [folder](./../docs/config) consulted
