### PR TITLE
fix: ingress multiple grpc test

### DIFF
--- a/agent/proxycfg/testing_ingress_gateway.go
+++ b/agent/proxycfg/testing_ingress_gateway.go
@@ -854,7 +854,7 @@ func TestConfigSnapshotIngress_GRPCMultipleServices(t testing.T) *ConfigSnapshot
 				},
 			},
 		}
-	}, []UpdateEvent{
+	}, []cache.UpdateEvent{
 		{
 			CorrelationID: gatewayServicesWatchID,
 			Result: &structs.IndexedGatewayServices{


### PR DESCRIPTION
### Description
The automated backport PR #13326 was merged in without tests passing, causing the release 1.12 branch to fail to build. This remediates the build issues.

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] not a security concern
* [ ] ~checklist [folder](./../docs/config) consulted~
