### PR TITLE
test: regenerate golden files

### DIFF
--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -418,7 +418,6 @@
         "DisableHostname": false,
         "DogstatsdAddr": "",
         "DogstatsdTags": [],
-        "RetryFailedConfiguration": false,
         "FilterDefault": false,
         "MetricsPrefix": "",
         "PrometheusOpts": {
@@ -429,6 +428,7 @@
             "Registerer": null,
             "SummaryDefinitions": []
         },
+        "RetryFailedConfiguration": false,
         "StatsdAddr": "",
         "StatsiteAddr": ""
     },

--- a/agent/xds/testdata/listeners/ingress-grpc-multiple-services.latest.golden
+++ b/agent/xds/testdata/listeners/ingress-grpc-multiple-services.latest.golden
@@ -49,9 +49,13 @@
                   }
                 ],
                 "tracing": {
-                  "randomSampling": {}
+                  "randomSampling": {
+
+                  }
                 },
-                "http2ProtocolOptions": {}
+                "http2ProtocolOptions": {
+
+                }
               }
             }
           ]


### PR DESCRIPTION
### Description

I noticed that some of the golden test files were slightly different in terms of whitespace than what gets freshly generated. The tests all pass, but it clutters up PRs that do indeed need to regen the golden files for other reasons.

    make envoy-regen
    go test ./agent/config -update
