### PR TITLE
chore: remove broken link from pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,3 @@ Please be mindful not to leak any customer or confidential information. HashiCor
 * [ ] updated test coverage
 * [ ] external facing docs updated
 * [ ] not a security concern
-* [ ] checklist [folder](./../docs/config) consulted


### PR DESCRIPTION
Let's do away with the checklist folder link entirely because:

1. there's only one checklist here: https://github.com/hashicorp/consul/tree/main/docs/config
2. GH notifies PR authors if code of conduct or other docs are modified, hence prompting folks to look at them
