### PR TITLE
Fix KVSGet method to handle QueryOptions properly

### DIFF
--- a/.changelog/13344.txt
+++ b/.changelog/13344.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+kvs: Fixed a bug where query options were not being applied to KVS.Get RPC operations.
+```

--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -69,7 +69,7 @@ func (s *HTTPHandlers) KVSGet(resp http.ResponseWriter, req *http.Request, args 
 
 	// Make the RPC
 	var out structs.IndexedDirEntries
-	if err := s.agent.RPC(method, &args, &out); err != nil {
+	if err := s.agent.RPC(method, args, &out); err != nil {
 		return nil, err
 	}
 	setMeta(resp, &out.QueryMeta)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/13303

### Description
Originally reported by @wjordan [here](https://github.com/hashicorp/consul/pull/11500#issuecomment-990110027), I requested the bugfix be removed from https://github.com/hashicorp/consul/pull/11500 assuming it was a separate issue. Unfortunately it turns out that broke KVS.Get RPC operations in 1.12.1.

### Cause
The KV.Get endpoint was being passed `**structs.KeyRequest`, which when handled by a client's RPC method, was not fulfilling this assertion: https://github.com/hashicorp/consul/blob/c48120d005539b687391b6861f24c13d553f5b05/agent/pool/pool.go#L632-L635

causing the ReadTimeout to be set to the default value of `rpc_hold_timeout` ([source](https://github.com/hashicorp/consul/blob/f507f62f3cebd0ff9a4259d44487e75b2596492a/agent/consul/client_test.go#L532)).

### Testing & Reproduction steps
Set up a cluster with server and client using [vagrant](https://learn.hashicorp.com/tutorials/consul/get-started-create-datacenter).

```sh
# 1.12.1
$ consul join 192.168.56.10
Successfully joined cluster by contacting 1 nodes.

$ consul members
Node       Address             Status  Type    Build   Protocol  DC   Partition  Segment
agent-one  192.168.56.10:8301  alive   server  1.12.1  2         dc1  default    <all>
agent-two  192.168.56.11:8301  alive   client  1.12.1  2         dc1  default    <default>

$ consul kv put test foo
Success! Data written to: test

$ time curl "http://localhost:8500/v1/kv/test"
[{"LockIndex":0,"Key":"test","Flags":0,"Value":"Zm9v","CreateIndex":11,"ModifyIndex":11}]
real	0m0.013s
user	0m0.000s
sys	0m0.004s

$ time curl "http://localhost:8500/v1/kv/test?index=99&stale=&wait=60000ms"
rpc error making call: i/o deadline reached
real	0m7.013s <- deadline of rpc_hold_timeout
user	0m0.004s
sys	0m0.000s
```

```sh
# 1.13.0dev patch (version comes from main; ignore)
$ consul join 192.168.56.10
Successfully joined cluster by contacting 1 nodes.

$ consul members
Node       Address             Status  Type    Build      Protocol  DC   Partition  Segment
agent-one  192.168.56.10:8301  alive   server  1.12.1     2         dc1  default    <all>
agent-two  192.168.56.11:8301  alive   client  1.13.0dev  2         dc1  default    <default>

$ consul kv put test foo
Success! Data written to: test

$ time curl "http://localhost:8500/v1/kv/test"
[{"LockIndex":0,"Key":"test","Flags":0,"Value":"Zm9v","CreateIndex":12,"ModifyIndex":12}]
real	0m0.044s
user	0m0.012s
sys	0m0.004s

$ time curl "http://localhost:8500/v1/kv/test?index=99&stale=&wait=60000ms"
[{"LockIndex":0,"Key":"test","Flags":0,"Value":"Zm9v","CreateIndex":12,"ModifyIndex":12}]
real	1m2.708s <- wait=60000ms correctly applied
user	0m0.008s
sys	0m0.000s
```
