### PR TITLE
Change CTS docs to use the `start` subcommand.

### DIFF
--- a/website/content/docs/nia/cli/index.mdx
+++ b/website/content/docs/nia/cli/index.mdx
@@ -16,7 +16,7 @@ Consul-Terraform-Sync (CTS) is controlled via an easy to use command-line interf
 When CTS runs as a daemon, there is no default configuration to start CTS. You must set a configuration flag -config-file or -config-dir. For example:
 
 ```shell-session
-$ consul-terraform-sync -config-file=config.hcl
+$ consul-terraform-sync start -config-file=config.hcl
 ```
 
 To review a list of available flags, use the `-help` or `-h` flag.

--- a/website/content/docs/nia/installation/run.mdx
+++ b/website/content/docs/nia/installation/run.mdx
@@ -18,7 +18,7 @@ description: >-
 3. Run Consul-Terraform-Sync (CTS).
 
   ```shell-session
-  $ consul-terraform-sync -config-file <config.hcl>
+  $ consul-terraform-sync start -config-file <config.hcl>
   ```
 
 4. Check status of tasks. Replace port number if configured in Step 2. See additional API endpoints [here](/docs/nia/api)


### PR DESCRIPTION
Usage of consul-terraform-sync without a subcommand is deprecated. The `start` subcommand provides the same functionality and is intended for future use. Since the command is present in version 0.6.0, this documentation can be deployed without a new CTS release.

https://consul-61bn1zauw-hashicorp.vercel.app/docs/nia/cli
https://consul-61bn1zauw-hashicorp.vercel.app/docs/nia/installation/run