### PR TITLE
[OSS] consul connect envoy command changes for agentless

### DIFF
--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -14,6 +14,9 @@ type BootstrapTplArgs struct {
 	// the agent to deliver the correct configuration.
 	ProxyID string
 
+	// NodeName is the name of the node on which the proxy service instance is registered.
+	NodeName string
+
 	// ProxySourceService is the Consul service name to report for this proxy
 	// instance's source service label. For sidecars it should be the
 	// Proxy.DestinationServiceName. For gateways and similar it is the service
@@ -140,6 +143,9 @@ const bootstrapTemplate = `{
     "cluster": "{{ .ProxyCluster }}",
     "id": "{{ .ProxyID }}",
     "metadata": {
+      {{- if .NodeName }}
+      "node_name": "{{ .NodeName }}",
+      {{- end }}
       "namespace": "{{if ne .Namespace ""}}{{ .Namespace }}{{else}}default{{end}}",
       "partition": "{{if ne .Partition ""}}{{ .Partition }}{{else}}default{{end}}"
     }

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -41,6 +41,7 @@ type cmd struct {
 	meshGateway           bool
 	gateway               string
 	proxyID               string
+	nodeName              string
 	sidecarFor            string
 	adminAccessLogPath    string
 	adminBind             string
@@ -80,6 +81,9 @@ func (c *cmd) init() {
 
 	c.flags.StringVar(&c.proxyID, "proxy-id", os.Getenv("CONNECT_PROXY_ID"),
 		"The proxy's ID on the local agent.")
+
+	c.flags.StringVar(&c.nodeName, "node-name", "",
+		"[Experimental] The node name where the proxy service is registered. It requires proxy-id to be specified. ")
 
 	// Deprecated in favor of `gateway`
 	c.flags.BoolVar(&c.meshGateway, "mesh-gateway", false,
@@ -231,6 +235,12 @@ func (c *cmd) Run(args []string) int {
 }
 
 func (c *cmd) run(args []string) int {
+
+	if c.nodeName != "" && c.proxyID == "" {
+		c.UI.Error("'-node-name' requires '-proxy-id'")
+		return 1
+	}
+
 	// Fixup for deprecated mesh-gateway flag
 	if c.meshGateway && c.gateway != "" {
 		c.UI.Error("The mesh-gateway flag is deprecated and cannot be used alongside the gateway flag")
@@ -297,6 +307,10 @@ func (c *cmd) run(args []string) int {
 	}
 
 	if c.register {
+		if c.nodeName != "" {
+			c.UI.Error("'-register' cannot be used with '-node-name'")
+			return 1
+		}
 		if c.gateway == "" {
 			c.UI.Error("Auto-Registration can only be used for gateways")
 			return 1
@@ -478,6 +492,7 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 		GRPC:                  xdsAddr,
 		ProxyCluster:          cluster,
 		ProxyID:               c.proxyID,
+		NodeName:              c.nodeName,
 		ProxySourceService:    proxySourceService,
 		AgentCAPEM:            caPEM,
 		AdminAccessLogPath:    adminAccessLogPath,
@@ -501,6 +516,67 @@ func (c *cmd) generateConfig() ([]byte, error) {
 
 	var bsCfg BootstrapConfig
 
+	// Fetch any customization from the registration
+	var svcProxyConfig *api.AgentServiceConnectProxyConfig
+	var serviceName, ns, partition, datacenter string
+	if c.nodeName == "" {
+		svc, _, err := c.client.Agent().Service(c.proxyID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed fetch proxy config from local agent: %s", err)
+		}
+		svcProxyConfig = svc.Proxy
+		serviceName = svc.Service
+		ns = svc.Namespace
+		partition = svc.Partition
+		datacenter = svc.Datacenter
+	} else {
+		filter := fmt.Sprintf("ID == %q", c.proxyID)
+		svcList, _, err := c.client.Catalog().NodeServiceList(c.nodeName, &api.QueryOptions{Filter: filter})
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch proxy config from catalog for node %q: %w", c.nodeName, err)
+		}
+		if len(svcList.Services) != 1 {
+			return nil, fmt.Errorf("expected to find only one proxy service with ID: %q", c.proxyID)
+		}
+		svcProxyConfig = svcList.Services[0].Proxy
+		serviceName = svcList.Services[0].Service
+		ns = svcList.Services[0].Namespace
+		partition = svcList.Services[0].Partition
+		datacenter = svcList.Node.Datacenter
+		c.gatewayKind = svcList.Services[0].Kind
+	}
+	if svcProxyConfig == nil {
+		return nil, errors.New("service is not a Connect proxy or gateway")
+	}
+
+	if svcProxyConfig.DestinationServiceName != "" {
+		// Override cluster now we know the actual service name
+		args.ProxyCluster = svcProxyConfig.DestinationServiceName
+		args.ProxySourceService = svcProxyConfig.DestinationServiceName
+	} else {
+		// Set the source service name from the proxy's own registration
+		args.ProxySourceService = serviceName
+	}
+
+	// In most cases where namespaces and partitions are enabled they will already be set
+	// correctly because the http client that fetched this will provide them explicitly.
+	// However, if these arguments were not provided, they will be empty even
+	// though Namespaces and Partitions are actually being used.
+	// Overriding them ensures that we always set the Namespace and Partition args
+	// if the cluster is using them. This prevents us from defaulting to the "default"
+	// when a non-default partition or namespace was inferred from the ACL token.
+	if ns != "" {
+		args.Namespace = ns
+	}
+	if partition != "" {
+		args.Partition = partition
+	}
+
+	if datacenter != "" {
+		// The agent will definitely have the definitive answer here.
+		args.Datacenter = datacenter
+	}
+
 	// Setup ready listener for ingress gateway to pass healthcheck
 	if c.gatewayKind == api.ServiceKindIngressGateway {
 		lanAddr := c.lanAddress.String()
@@ -512,46 +588,9 @@ func (c *cmd) generateConfig() ([]byte, error) {
 		bsCfg.ReadyBindAddr = lanAddr
 	}
 
-	// Fetch any customization from the registration
-	svc, _, err := c.client.Agent().Service(c.proxyID, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed fetch proxy config from local agent: %s", err)
-	}
-	if svc.Proxy == nil {
-		return nil, errors.New("service is not a Connect proxy or gateway")
-	}
-
-	if svc.Proxy.DestinationServiceName != "" {
-		// Override cluster now we know the actual service name
-		args.ProxyCluster = svc.Proxy.DestinationServiceName
-		args.ProxySourceService = svc.Proxy.DestinationServiceName
-	} else {
-		// Set the source service name from the proxy's own registration
-		args.ProxySourceService = svc.Service
-	}
-
-	// In most cases where namespaces and partitions are enabled they will already be set
-	// correctly because the http client that fetched this will provide them explicitly.
-	// However, if these arguments were not provided, they will be empty even
-	// though Namespaces and Partitions are actually being used.
-	// Overriding them ensures that we always set the Namespace and Partition args
-	// if the cluster is using them. This prevents us from defaulting to the "default"
-	// when a non-default partition or namespace was inferred from the ACL token.
-	if svc.Namespace != "" {
-		args.Namespace = svc.Namespace
-	}
-	if svc.Partition != "" {
-		args.Partition = svc.Partition
-	}
-
-	if svc.Datacenter != "" {
-		// The agent will definitely have the definitive answer here.
-		args.Datacenter = svc.Datacenter
-	}
-
 	if !c.disableCentralConfig {
 		// Parse the bootstrap config
-		if err := mapstructure.WeakDecode(svc.Proxy.Config, &bsCfg); err != nil {
+		if err := mapstructure.WeakDecode(svcProxyConfig.Config, &bsCfg); err != nil {
 			return nil, fmt.Errorf("failed parsing Proxy.Config: %s", err)
 		}
 	}

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -155,11 +155,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/custom-bootstrap.golden
+++ b/command/connect/envoy/testdata/custom-bootstrap.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy"
   },
   "custom_field": "foo"

--- a/command/connect/envoy/testdata/defaults-nodemeta.golden
+++ b/command/connect/envoy/testdata/defaults-nodemeta.golden
@@ -12,6 +12,7 @@
     "cluster": "test",
     "id": "test-proxy",
     "metadata": {
+      "node_name": "test-node",
       "namespace": "default",
       "partition": "default"
     }
@@ -43,95 +44,6 @@
             }
           ]
         }
-      },
-      {
-        "name": "prometheus_backend",
-        "ignore_health_on_host_removal": false,
-        "connect_timeout": "5s",
-        "type": "STATIC",
-        "http_protocol_options": {},
-        "loadAssignment": {
-          "clusterName": "prometheus_backend",
-          "endpoints": [
-            {
-              "lbEndpoints": [
-                {
-                  "endpoint": {
-                    "address": {
-                      "socket_address": {
-                        "address": "127.0.0.1",
-                        "port_value": 20100
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
-    ],
-    "listeners": [
-      {
-        "name": "envoy_prometheus_metrics_listener",
-        "address": {
-          "socket_address": {
-            "address": "0.0.0.0",
-            "port_value": 9000
-          }
-        },
-        "filter_chains": [
-          {
-            "filters": [
-              {
-                "name": "envoy.filters.network.http_connection_manager",
-                "typedConfig": {
-                  "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "stat_prefix": "envoy_prometheus_metrics",
-                  "codec_type": "HTTP1",
-                  "route_config": {
-                    "name": "self_admin_route",
-                    "virtual_hosts": [
-                      {
-                        "name": "self_admin",
-                        "domains": [
-                          "*"
-                        ],
-                        "routes": [
-                          {
-                            "match": {
-                              "path": "/scrape-path"
-                            },
-                            "route": {
-                              "cluster": "prometheus_backend",
-                              "prefix_rewrite": "/stats/prometheus"
-                            }
-                          },
-                          {
-                            "match": {
-                              "prefix": "/"
-                            },
-                            "direct_response": {
-                              "status": 404
-                            }
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "http_filters": [
-                    {
-                      "name": "envoy.filters.http.router",
-                      "typedConfig": {
-                        "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
       }
     ]
   },

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/deprecated-grpc-addr-config.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -155,11 +155,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/existing-ca-path.golden
+++ b/command/connect/envoy/testdata/existing-ca-path.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -155,11 +155,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -164,11 +164,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -155,11 +155,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -141,11 +141,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/ingress-gateway-nodemeta.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-nodemeta.golden
@@ -9,9 +9,10 @@
     }
   },
   "node": {
-    "cluster": "test",
-    "id": "test-proxy",
+    "cluster": "ingress-gateway-1",
+    "id": "ingress-gateway-1",
     "metadata": {
+      "node_name": "test-node",
       "namespace": "default",
       "partition": "default"
     }
@@ -45,13 +46,13 @@
         }
       },
       {
-        "name": "prometheus_backend",
+        "name": "self_admin",
         "ignore_health_on_host_removal": false,
         "connect_timeout": "5s",
         "type": "STATIC",
         "http_protocol_options": {},
         "loadAssignment": {
-          "clusterName": "prometheus_backend",
+          "clusterName": "self_admin",
           "endpoints": [
             {
               "lbEndpoints": [
@@ -60,7 +61,7 @@
                     "address": {
                       "socket_address": {
                         "address": "127.0.0.1",
-                        "port_value": 20100
+                        "port_value": 19000
                       }
                     }
                   }
@@ -73,11 +74,11 @@
     ],
     "listeners": [
       {
-        "name": "envoy_prometheus_metrics_listener",
+        "name": "envoy_ready_listener",
         "address": {
           "socket_address": {
-            "address": "0.0.0.0",
-            "port_value": 9000
+            "address": "127.0.0.1",
+            "port_value": 8443
           }
         },
         "filter_chains": [
@@ -87,7 +88,7 @@
                 "name": "envoy.filters.network.http_connection_manager",
                 "typedConfig": {
                   "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-                  "stat_prefix": "envoy_prometheus_metrics",
+                  "stat_prefix": "envoy_ready",
                   "codec_type": "HTTP1",
                   "route_config": {
                     "name": "self_admin_route",
@@ -100,11 +101,11 @@
                         "routes": [
                           {
                             "match": {
-                              "path": "/scrape-path"
+                              "path": "/ready"
                             },
                             "route": {
-                              "cluster": "prometheus_backend",
-                              "prefix_rewrite": "/stats/prometheus"
+                              "cluster": "self_admin",
+                              "prefix_rewrite": "/ready"
                             }
                           },
                           {
@@ -231,11 +232,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test"
+        "fixed_value": "ingress-gateway-1"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test"
+        "fixed_value": "ingress-gateway-1"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/xds-addr-config.golden
+++ b/command/connect/envoy/testdata/xds-addr-config.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -142,11 +142,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -9,7 +9,7 @@
     }
   },
   "node": {
-    "cluster": "test-proxy",
+    "cluster": "test",
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
@@ -166,11 +166,11 @@
       },
       {
         "tag_name": "local_cluster",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.service",
-        "fixed_value": "test-proxy"
+        "fixed_value": "test"
       },
       {
         "tag_name": "consul.source.namespace",


### PR DESCRIPTION
Changes the sourcing of the envoy bootstrap configuration to not use agent APIs and instead use the catalog(server) API.
This is done by passing a node-name flag to the command, (which can only be used with proxy-id).

Also fixes a bug where the golden envoy bootstrap config files used for tests did not use the expected destination service name in certain places for connect proxy kind.

Manual testing/demo: https://gist.github.com/riddhi89/b5823d922f6b76477b2e685325a6c8be