### PR TITLE
peering: update how cross-peer upstreams and represented in proxycfg and rendered in xds

### DIFF
--- a/agent/proxycfg/connect_proxy.go
+++ b/agent/proxycfg/connect_proxy.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
-	"github.com/hashicorp/consul/agent/configentry"
-	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/proto/pbpeering"
 )
@@ -33,6 +31,7 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 	snap.ConnectProxy.UpstreamConfig = make(map[UpstreamID]*structs.Upstream)
 	snap.ConnectProxy.PassthroughUpstreams = make(map[UpstreamID]map[string]map[string]struct{})
 	snap.ConnectProxy.PassthroughIndices = make(map[string]indexedTarget)
+	snap.ConnectProxy.PeerUpstreamEndpoints = make(map[UpstreamID]structs.CheckServiceNodes)
 
 	// Watch for root changes
 	err := s.dataSources.CARoots.Notify(ctx, &structs.DCSpecificRequest{
@@ -184,27 +183,31 @@ func (s *handlerConnectProxy) initialize(ctx context.Context) (ConfigSnapshot, e
 			fallthrough
 
 		case "":
-			// If DestinationPeer is not empty, insert a default discovery chain directly to the snapshot
 			if u.DestinationPeer != "" {
-				req := discoverychain.CompileRequest{
-					ServiceName:           u.DestinationName,
-					EvaluateInNamespace:   u.DestinationNamespace,
-					EvaluateInPartition:   u.DestinationPartition,
-					EvaluateInDatacenter:  dc,
-					EvaluateInTrustDomain: "trustdomain.consul", // TODO(peering): where to evaluate this?
-					Entries:               configentry.NewDiscoveryChainSet(),
-				}
-				chain, err := discoverychain.Compile(req)
+				// NOTE: An upstream that points to a peer by definition will
+				// only ever watch a single catalog query, so a map key of just
+				// "UID" is sufficient to cover the peer data watches here.
+
+				s.logger.Trace("initializing watch of peered upstream", "upstream", uid)
+
+				// TODO(peering): We'll need to track a CancelFunc for this
+				// once the tproxy support lands.
+				err := s.dataSources.Health.Notify(ctx, &structs.ServiceSpecificRequest{
+					PeerName:   uid.Peer,
+					Datacenter: dc,
+					QueryOptions: structs.QueryOptions{
+						Token: s.token,
+					},
+					ServiceName: u.DestinationName,
+					Connect:     true,
+					// Note that Identifier doesn't type-prefix for service any more as it's
+					// the default and makes metrics and other things much cleaner. It's
+					// simpler for us if we have the type to make things unambiguous.
+					Source:         *s.source,
+					EnterpriseMeta: uid.EnterpriseMeta,
+				}, upstreamPeerWatchIDPrefix+uid.String(), s.ch)
 				if err != nil {
-					return snap, fmt.Errorf("error while compiling default discovery chain: %w", err)
-				}
-
-				// Directly insert chain and empty function into the discovery chain maps
-				snap.ConnectProxy.ConfigSnapshotUpstreams.DiscoveryChain[uid] = chain
-				snap.ConnectProxy.ConfigSnapshotUpstreams.WatchedDiscoveryChains[uid] = func() {}
-
-				if err := (*handlerUpstreams)(s).resetWatchesFromChain(ctx, uid, chain, &snap.ConnectProxy.ConfigSnapshotUpstreams); err != nil {
-					return snap, fmt.Errorf("error while resetting watches from chain: %w", err)
+					return snap, err
 				}
 
 				// Check whether a watch for this peer exists to avoid duplicates.

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -36,6 +36,7 @@ const (
 	serviceResolverIDPrefix            = "service-resolver:"
 	serviceIntentionsIDPrefix          = "service-intentions:"
 	intentionUpstreamsID               = "intention-upstreams"
+	upstreamPeerWatchIDPrefix          = "upstream-peer:"
 	meshConfigEntryID                  = "mesh"
 	svcChecksWatchIDPrefix             = cachetype.ServiceHTTPChecksName + ":"
 	preparedQueryIDPrefix              = string(structs.UpstreamDestTypePreparedQuery) + ":"

--- a/agent/proxycfg/testing_peering.go
+++ b/agent/proxycfg/testing_peering.go
@@ -24,6 +24,8 @@ func TestConfigSnapshotPeering(t testing.T) *ConfigSnapshot {
 		refundsUID = NewUpstreamID(&refundsUpstream)
 	)
 
+	const peerTrustDomain = "1c053652-8512-4373-90cf-5a7f6263a994.consul"
+
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Upstreams = structs.Upstreams{
 			paymentsUpstream,
@@ -37,7 +39,7 @@ func TestConfigSnapshotPeering(t testing.T) *ConfigSnapshot {
 			},
 		},
 		{
-			CorrelationID: "upstream-target:payments.default.default.dc1:" + paymentsUID.String(),
+			CorrelationID: upstreamPeerWatchIDPrefix + paymentsUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: []structs.CheckServiceNode{
 					{
@@ -51,7 +53,13 @@ func TestConfigSnapshotPeering(t testing.T) *ConfigSnapshot {
 							Port:    443,
 							Connect: structs.ServiceConnect{
 								PeerMeta: &structs.PeeringServiceMeta{
-									SpiffeID: []string{"spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/payments"},
+									SNI: []string{
+										"payments.default.default.cloud.external." + peerTrustDomain,
+									},
+									SpiffeID: []string{
+										"spiffe://" + peerTrustDomain + "/ns/default/dc/cloud-dc/svc/payments",
+									},
+									Protocol: "tcp",
 								},
 							},
 						},
@@ -60,7 +68,7 @@ func TestConfigSnapshotPeering(t testing.T) *ConfigSnapshot {
 			},
 		},
 		{
-			CorrelationID: "upstream-target:refunds.default.default.dc1:" + refundsUID.String(),
+			CorrelationID: upstreamPeerWatchIDPrefix + refundsUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: []structs.CheckServiceNode{
 					{
@@ -74,7 +82,13 @@ func TestConfigSnapshotPeering(t testing.T) *ConfigSnapshot {
 							Port:    443,
 							Connect: structs.ServiceConnect{
 								PeerMeta: &structs.PeeringServiceMeta{
-									SpiffeID: []string{"spiffe://1c053652-8512-4373-90cf-5a7f6263a994.consul/ns/default/dc/cloud-dc/svc/refunds"},
+									SNI: []string{
+										"refunds.default.default.cloud.external." + peerTrustDomain,
+									},
+									SpiffeID: []string{
+										"spiffe://" + peerTrustDomain + "/ns/default/dc/cloud-dc/svc/refunds",
+									},
+									Protocol: "tcp",
 								},
 							},
 						},

--- a/agent/rpc/peering/subscription_manager.go
+++ b/agent/rpc/peering/subscription_manager.go
@@ -208,8 +208,17 @@ func (m *subscriptionManager) handleEvent(ctx context.Context, state *subscripti
 			Datacenter: m.config.Datacenter,
 			Service:    sn.Name,
 		}
+		sni := connect.PeeredServiceSNI(
+			sn.Name,
+			sn.NamespaceOrDefault(),
+			sn.PartitionOrDefault(),
+			state.peerName,
+			m.trustDomain,
+		)
 		peerMeta := &pbservice.PeeringServiceMeta{
+			SNI:      []string{sni},
 			SpiffeID: []string{spiffeID.URI().String()},
+			Protocol: "tcp",
 		}
 
 		// skip checks since we just generated one from scratch

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1253,6 +1253,13 @@ type PeeringServiceMeta struct {
 	Protocol string   `json:",omitempty"`
 }
 
+func (m *PeeringServiceMeta) PrimarySNI() string {
+	if m == nil || len(m.SNI) == 0 {
+		return ""
+	}
+	return m.SNI[0]
+}
+
 func (ns *NodeService) BestAddress(wan bool) (string, int) {
 	addr := ns.Address
 	port := ns.Port

--- a/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams.latest.golden
@@ -28,8 +28,8 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      "name": "payments.default.dc1.internal.trustdomain.consul",
-      "altStatName": "payments.default.dc1.internal.trustdomain.consul",
+      "name": "payments.default.default.cloud.external.1c053652-8512-4373-90cf-5a7f6263a994.consul",
+      "altStatName": "payments.default.default.cloud.external.1c053652-8512-4373-90cf-5a7f6263a994.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {
@@ -80,14 +80,14 @@
               ]
             }
           },
-          "sni": "payments.default.dc1.internal.trustdomain.consul"
+          "sni": "payments.default.default.cloud.external.1c053652-8512-4373-90cf-5a7f6263a994.consul"
         }
       }
     },
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      "name": "refunds.default.dc1.internal.trustdomain.consul",
-      "altStatName": "refunds.default.dc1.internal.trustdomain.consul",
+      "name": "refunds.default.default.cloud.external.1c053652-8512-4373-90cf-5a7f6263a994.consul",
+      "altStatName": "refunds.default.default.cloud.external.1c053652-8512-4373-90cf-5a7f6263a994.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {
@@ -138,7 +138,7 @@
               ]
             }
           },
-          "sni": "refunds.default.dc1.internal.trustdomain.consul"
+          "sni": "refunds.default.default.cloud.external.1c053652-8512-4373-90cf-5a7f6263a994.consul"
         }
       }
     }

--- a/agent/xds/xdscommon/xdscommon.go
+++ b/agent/xds/xdscommon/xdscommon.go
@@ -113,6 +113,8 @@ func MakePluginConfiguration(cfgSnap *proxycfg.ConfigSnapshot) PluginConfigurati
 			}
 		}
 
+		// TODO(peering): consider PeerUpstreamEndpoints in addition to DiscoveryChain
+
 		for uid, dc := range cfgSnap.ConnectProxy.DiscoveryChain {
 			if _, ok := connectProxies[uid]; !ok {
 				continue


### PR DESCRIPTION
### Description

This removes unnecessary, vestigal remnants of discovery chains.

This is a necessary precursor to more work on making the mesh gateway peering code work end-to-end.

