### PR TITLE
[OSS] xds: remove `HTTPCheckFetcher` dependency

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -824,7 +824,6 @@ func (a *Agent) listenAndServeGRPC() error {
 			return a.delegate.ResolveTokenAndDefaultMeta(id, nil, nil)
 		},
 		a,
-		a,
 	)
 	a.xdsServer.Register(a.publicGRPCServer)
 

--- a/agent/proxycfg/testing_connect_proxy.go
+++ b/agent/proxycfg/testing_connect_proxy.go
@@ -1,12 +1,15 @@
 package proxycfg
 
 import (
+	"time"
+
 	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/types"
 )
 
 // TestConfigSnapshot returns a fully populated snapshot
@@ -220,6 +223,33 @@ func TestConfigSnapshotExposeConfig(t testing.T, nsFn func(ns *structs.NodeServi
 		Meta:            nil,
 		TaggedAddresses: nil,
 	}, nsFn, nil, baseEvents)
+}
+
+func TestConfigSnapshotExposeChecks(t testing.T) *ConfigSnapshot {
+	return TestConfigSnapshot(t,
+		func(ns *structs.NodeService) {
+			ns.Address = "1.2.3.4"
+			ns.Port = 8080
+			ns.Proxy.Upstreams = nil
+			ns.Proxy.Expose = structs.ExposeConfig{
+				Checks: true,
+			}
+		},
+		[]UpdateEvent{
+			{
+				CorrelationID: svcChecksWatchIDPrefix + structs.ServiceIDString("web", nil),
+				Result: []structs.CheckType{{
+					CheckID:   types.CheckID("http"),
+					Name:      "http",
+					HTTP:      "http://127.0.0.1:8181/debug",
+					ProxyHTTP: "http://:21500/debug",
+					Method:    "GET",
+					Interval:  10 * time.Second,
+					Timeout:   1 * time.Second,
+				}},
+			},
+		},
+	)
 }
 
 func TestConfigSnapshotGRPCExposeHTTP1(t testing.T) *ConfigSnapshot {

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -146,7 +146,7 @@ func (s *ResourceGenerator) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.C
 	// Add service health checks to the list of paths to create clusters for if needed
 	if cfgSnap.Proxy.Expose.Checks {
 		psid := structs.NewServiceID(cfgSnap.Proxy.DestinationServiceID, &cfgSnap.ProxyID.EnterpriseMeta)
-		for _, check := range s.CheckFetcher.ServiceHTTPBasedChecks(psid) {
+		for _, check := range cfgSnap.ConnectProxy.WatchedServiceChecks[psid] {
 			p, err := parseCheckPath(check)
 			if err != nil {
 				s.Logger.Warn("failed to create cluster for", "check", check.CheckID, "error", err)

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -638,7 +638,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 					setupTLSRootsAndLeaf(t, snap)
 
 					// Need server just for logger dependency
-					g := newResourceGenerator(testutil.Logger(t), nil, nil, false)
+					g := newResourceGenerator(testutil.Logger(t), nil, false)
 					g.ProxyFeatures = sf
 
 					clusters, err := g.clustersFromSnapshot(snap)

--- a/agent/xds/delta.go
+++ b/agent/xds/delta.go
@@ -106,7 +106,6 @@ func (s *Server) processDelta(stream ADSDeltaStream, reqCh <-chan *envoy_discove
 
 	generator := newResourceGenerator(
 		s.Logger.Named(logging.XDS).With("xdsVersion", "v3"),
-		s.CheckFetcher,
 		s.CfgFetcher,
 		true,
 	)

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -504,7 +504,7 @@ func TestEndpointsFromSnapshot(t *testing.T) {
 					setupTLSRootsAndLeaf(t, snap)
 
 					// Need server just for logger dependency
-					g := newResourceGenerator(testutil.Logger(t), nil, nil, false)
+					g := newResourceGenerator(testutil.Logger(t), nil, false)
 					g.ProxyFeatures = sf
 
 					endpoints, err := g.endpointsFromSnapshot(snap)

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -398,7 +398,7 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 	// Add service health checks to the list of paths to create listeners for if needed
 	if cfgSnap.Proxy.Expose.Checks {
 		psid := structs.NewServiceID(cfgSnap.Proxy.DestinationServiceID, &cfgSnap.ProxyID.EnterpriseMeta)
-		for _, check := range s.CheckFetcher.ServiceHTTPBasedChecks(psid) {
+		for _, check := range cfgSnap.ConnectProxy.WatchedServiceChecks[psid] {
 			p, err := parseCheckPath(check)
 			if err != nil {
 				s.Logger.Warn("failed to create listener for", "check", check.CheckID, "error", err)

--- a/agent/xds/resources.go
+++ b/agent/xds/resources.go
@@ -14,7 +14,6 @@ import (
 // resources for a single client.
 type ResourceGenerator struct {
 	Logger         hclog.Logger
-	CheckFetcher   HTTPCheckFetcher
 	CfgFetcher     ConfigFetcher
 	IncrementalXDS bool
 
@@ -23,13 +22,11 @@ type ResourceGenerator struct {
 
 func newResourceGenerator(
 	logger hclog.Logger,
-	checkFetcher HTTPCheckFetcher,
 	cfgFetcher ConfigFetcher,
 	incrementalXDS bool,
 ) *ResourceGenerator {
 	return &ResourceGenerator{
 		Logger:         logger,
-		CheckFetcher:   checkFetcher,
 		CfgFetcher:     cfgFetcher,
 		IncrementalXDS: incrementalXDS,
 	}

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -197,7 +197,7 @@ func TestRoutesFromSnapshot(t *testing.T) {
 					// golden files for every test case and so not be any use!
 					setupTLSRootsAndLeaf(t, snap)
 
-					g := newResourceGenerator(testutil.Logger(t), nil, nil, false)
+					g := newResourceGenerator(testutil.Logger(t), nil, false)
 					g.ProxyFeatures = sf
 
 					routes, err := g.routesFromSnapshot(snap)

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -85,12 +85,6 @@ const (
 // coupling this to the agent.
 type ACLResolverFunc func(id string) (acl.Authorizer, error)
 
-// HTTPCheckFetcher is the interface the agent needs to expose
-// for the xDS server to fetch a service's HTTP check definitions
-type HTTPCheckFetcher interface {
-	ServiceHTTPBasedChecks(serviceID structs.ServiceID) []structs.CheckType
-}
-
 // ConfigFetcher is the interface the agent needs to expose
 // for the xDS server to fetch agent config, currently only one field is fetched
 type ConfigFetcher interface {
@@ -113,7 +107,6 @@ type Server struct {
 	Logger       hclog.Logger
 	CfgSrc       ProxyConfigSource
 	ResolveToken ACLResolverFunc
-	CheckFetcher HTTPCheckFetcher
 	CfgFetcher   ConfigFetcher
 
 	// AuthCheckFrequency is how often we should re-check the credentials used
@@ -165,7 +158,6 @@ func NewServer(
 	serverlessPluginEnabled bool,
 	cfgMgr ProxyConfigSource,
 	resolveToken ACLResolverFunc,
-	checkFetcher HTTPCheckFetcher,
 	cfgFetcher ConfigFetcher,
 ) *Server {
 	return &Server{
@@ -173,7 +165,6 @@ func NewServer(
 		Logger:                  logger,
 		CfgSrc:                  cfgMgr,
 		ResolveToken:            resolveToken,
-		CheckFetcher:            checkFetcher,
 		CfgFetcher:              cfgFetcher,
 		AuthCheckFrequency:      DefaultAuthCheckFrequency,
 		activeStreams:           &activeStreamCounters{},

--- a/agent/xds/serverless_plugin_oss_test.go
+++ b/agent/xds/serverless_plugin_oss_test.go
@@ -73,7 +73,7 @@ func TestServerlessPluginFromSnapshot(t *testing.T) {
 					// golden files for every test case and so not be any use!
 					setupTLSRootsAndLeaf(t, snap)
 
-					g := newResourceGenerator(testutil.Logger(t), nil, nil, false)
+					g := newResourceGenerator(testutil.Logger(t), nil, false)
 					g.ProxyFeatures = sf
 
 					res, err := g.allResourcesFromSnapshot(snap)

--- a/agent/xds/xds_protocol_helpers_test.go
+++ b/agent/xds/xds_protocol_helpers_test.go
@@ -160,7 +160,6 @@ func newTestServerDeltaScenario(
 		serverlessPluginEnabled,
 		mgr,
 		resolveToken,
-		nil, /*checkFetcher HTTPCheckFetcher*/
 		nil, /*cfgFetcher ConfigFetcher*/
 	)
 	if authCheckFrequency > 0 {


### PR DESCRIPTION
### Description
This is the OSS portion of enterprise PR 1994.

Rather than directly interrogating the agent-local state for HTTP checks using the `HTTPCheckFetcher` interface, we now rely on the config snapshot containing the checks.

This reduces the number of changes required to support server xDS sessions.

It's not clear why the fetching approach was chosen in https://github.com/hashicorp/consul/pull/6446 (https://github.com/hashicorp/consul/commit/931d167ebb2300839b218d08871f22323c60175d) when the same PR added the data to the config snapshot 🤷

### Testing & Reproduction steps
Running `go test ./agent/xds` passes as before ✅

#### Manually 🛠

```hcl
# web.hcl
service {
  name = "web"
  port = 8080

  checks = [
    {
      http = "http://localhost:8081/"
      interval = "10s"
    }
  ]

  connect {
    sidecar_service {
      proxy {
        expose {
          checks = true
        }
      }
    }
  }
}
```

```shell
$ consul agent -dev -config-file=web.hcl
$ consul connect envoy -sidecar-for web
```

You should see the generated cluster in the Envoy config dump:

```shell
$ curl http://localhost:19000/config_dump | grep exposed_cluster_8081
```

If you start up an HTTP server on the check's port, you should be able to reach it over the auto-assigned Envoy listener port:

```shell
$ python3 -m http.server 8081
$ curl http://localhost:21500/
```