### PR TITLE
test: retry the compat tests as often as other tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -830,7 +830,15 @@ jobs:
             docker run consul:local consul version
             cd ./test/integration/consul-container
             echo "$subtests_formatted"
-            gotestsum -- -timeout=30m ./$subtests_formatted --target-version local --latest-version latest
+            gotestsum \
+              --format=short-verbose \
+              --debug \
+              --rerun-fails=3 \
+              -- \
+              -timeout=30m \
+              ./$subtests_formatted \
+              --target-version local \
+              --latest-version latest
             ls -lrt
           environment:
             # this is needed because of incompatibility between RYUK container and circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -822,21 +822,17 @@ jobs:
       - run:
           name: Compatibility Integration Tests
           command: |
-            subtests=$(ls -d test/integration/consul-container/*/ | grep -v libs | xargs -n 1 basename | circleci tests split)
-            echo "Running $(echo $subtests | wc -w) subtests"
-            echo "$subtests"
-            subtests_formatted=$(echo "$subtests" |  sed 's/^/.\//g' | xargs)
             mkdir -p /tmp/test-results/
-            docker run consul:local consul version
             cd ./test/integration/consul-container
-            echo "$subtests_formatted"
+            docker run --rm consul:local consul version
             gotestsum \
               --format=short-verbose \
               --debug \
               --rerun-fails=3 \
+              --packages="./..." \
               -- \
               -timeout=30m \
-              ./$subtests_formatted \
+              ./... \
               --target-version local \
               --latest-version latest
             ls -lrt


### PR DESCRIPTION
### Description

The upgrade compatibility tests need frequent retrying to pass because they are slightly flaky. To alleviate manual work borrow similar `gotestsum` logic from the main go tests CI job to rerun them automatically here.
