### PR TITLE
peering: avoid a race between peering establishment and termination

### DIFF
--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -510,7 +510,7 @@ func newDefaultDeps(t *testing.T, c *Config) Deps {
 
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
 		Name:   c.NodeName,
-		Level:  hclog.Trace,
+		Level:  testutil.TestLogLevel,
 		Output: testutil.NewLogBuffer(t),
 	})
 

--- a/proto/pbpeering/peering.go
+++ b/proto/pbpeering/peering.go
@@ -93,6 +93,10 @@ func (x ReplicationMessage_Response_Operation) GoString() string {
 	return x.String()
 }
 
+func (x PeeringState) GoString() string {
+	return x.String()
+}
+
 func (r *TrustBundleReadRequest) CacheInfo() cache.RequestInfo {
 	info := cache.RequestInfo{
 		// TODO(peering): Revisit whether this is the token to use once request types accept a token.


### PR DESCRIPTION
### Description

When repeatedly standing up a peered pair of clusters locally I was pretty reliably encountering a peering race condition leading to one peer triggering a TERMINATION at the wrong time (which is terminal).

I made the race go away by moving some data access around.

### Details

If you read the current peerings from the state store, then read the current established streams you could lose the data race and have the sequence of events be:

1. list peerings [A,B,C]
2. persist new peering [D]
3. accept new stream for [D]
4. list streams [A,B,C,D]
5. terminate [D]

Which is wrong. If we instead ensure that (4) happens before (1), given that you can't get an established stream without first passing a "does this peering exist in the state store?" inquiry then this happens:

1. list streams [A,B,C]
2. list peerings [A,B,C]
3. persist new peering [D]
4. accept new stream for [D]
5. terminate []

Or even this is fine:

1. list streams [A,B,C]
2. persist new peering [D]
3. accept new stream for [D]
4. list peerings [A,B,C,D]
5. terminate []

Sadly I could not really figure out a way to introduce a test for the racy behavior without changing the non-test code a lot so I left out test updates.