### PR TITLE
feat: xDS Generation for Terminating Gateway Destinations

### DIFF
--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1134,6 +1134,31 @@ func TestConfigEntry_ResolveServiceConfig_TransparentProxy(t *testing.T) {
 			},
 		},
 		{
+			name: "from service-defaults with endpoint",
+			entries: []structs.ConfigEntry{
+				&structs.ServiceConfigEntry{
+					Kind: structs.ServiceDefaults,
+					Name: "foo",
+					Mode: structs.ProxyModeTransparent,
+					Destination: &structs.DestinationConfig{
+						Address: "hello.world.com",
+						Port:    443,
+					},
+				},
+			},
+			request: structs.ServiceConfigRequest{
+				Name:       "foo",
+				Datacenter: "dc1",
+			},
+			expect: structs.ServiceConfigResponse{
+				Mode: structs.ProxyModeTransparent,
+				Destination: structs.DestinationConfig{
+					Address: "hello.world.com",
+					Port:    443,
+				},
+			},
+		},
+		{
 			name: "service-defaults overrides proxy-defaults",
 			entries: []structs.ConfigEntry{
 				&structs.ProxyConfigEntry{
@@ -1207,11 +1232,10 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams(t *testing.T) {
 	wildcard := structs.NewServiceID(structs.WildcardSpecifier, structs.WildcardEnterpriseMetaInDefaultPartition())
 
 	tt := []struct {
-		name     string
-		entries  []structs.ConfigEntry
-		request  structs.ServiceConfigRequest
-		proxyCfg structs.ConnectProxyConfig
-		expect   structs.ServiceConfigResponse
+		name    string
+		entries []structs.ConfigEntry
+		request structs.ServiceConfigRequest
+		expect  structs.ServiceConfigResponse
 	}{
 		{
 			name: "upstream config entries from Upstreams and service-defaults",

--- a/agent/consul/merge_service_config.go
+++ b/agent/consul/merge_service_config.go
@@ -155,6 +155,9 @@ func computeResolvedServiceConfig(
 		if serviceConf.Mode != structs.ProxyModeDefault {
 			thisReply.Mode = serviceConf.Mode
 		}
+		if serviceConf.Destination != nil {
+			thisReply.Destination = *serviceConf.Destination
+		}
 
 		thisReply.Meta = serviceConf.Meta
 	}

--- a/agent/proxycfg/testing_terminating_gateway.go
+++ b/agent/proxycfg/testing_terminating_gateway.go
@@ -6,12 +6,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-func TestConfigSnapshotTerminatingGateway(
-	t testing.T,
-	populateServices bool,
-	nsFn func(ns *structs.NodeService),
-	extraUpdates []UpdateEvent,
-) *ConfigSnapshot {
+func TestConfigSnapshotTerminatingGateway(t testing.T, populateServices bool, nsFn func(ns *structs.NodeService), extraUpdates []UpdateEvent) *ConfigSnapshot {
 	roots, _ := TestCerts(t)
 
 	var (
@@ -34,6 +29,7 @@ func TestConfigSnapshotTerminatingGateway(
 		},
 	}
 
+	tgtwyServices := []*structs.GatewayService{}
 	if populateServices {
 		webNodes := TestUpstreamNodes(t, web.Name)
 		webNodes[0].Service.Meta = map[string]string{"version": "1"}
@@ -156,28 +152,30 @@ func TestConfigSnapshotTerminatingGateway(
 			},
 		}
 
+		tgtwyServices = append(tgtwyServices,
+			&structs.GatewayService{
+				Service: web,
+				CAFile:  "ca.cert.pem",
+			},
+			&structs.GatewayService{
+				Service:  api,
+				CAFile:   "ca.cert.pem",
+				CertFile: "api.cert.pem",
+				KeyFile:  "api.key.pem",
+			},
+			&structs.GatewayService{
+				Service: db,
+			},
+			&structs.GatewayService{
+				Service: cache,
+			},
+		)
+
 		baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{
 			{
 				CorrelationID: gatewayServicesWatchID,
 				Result: &structs.IndexedGatewayServices{
-					Services: []*structs.GatewayService{
-						{
-							Service: web,
-							CAFile:  "ca.cert.pem",
-						},
-						{
-							Service:  api,
-							CAFile:   "ca.cert.pem",
-							CertFile: "api.cert.pem",
-							KeyFile:  "api.key.pem",
-						},
-						{
-							Service: db,
-						},
-						{
-							Service: cache,
-						},
-					},
+					Services: tgtwyServices,
 				},
 			},
 			{
@@ -340,6 +338,123 @@ func TestConfigSnapshotTerminatingGateway(
 			},
 		},
 	}, nsFn, nil, testSpliceEvents(baseEvents, extraUpdates))
+}
+
+func TestConfigSnapshotTerminatingGatewayDestinations(t testing.T, populateDestinations bool, extraUpdates []UpdateEvent) *ConfigSnapshot {
+	roots, _ := TestCerts(t)
+
+	var (
+		externalIPTCP       = structs.NewServiceName("external-IP-TCP", nil)
+		externalHostnameTCP = structs.NewServiceName("external-hostname-TCP", nil)
+	)
+
+	baseEvents := []UpdateEvent{
+		{
+			CorrelationID: rootsWatchID,
+			Result:        roots,
+		},
+		{
+			CorrelationID: gatewayServicesWatchID,
+			Result: &structs.IndexedGatewayServices{
+				Services: nil,
+			},
+		},
+	}
+
+	tgtwyServices := []*structs.GatewayService{}
+
+	if populateDestinations {
+		tgtwyServices = append(tgtwyServices,
+			&structs.GatewayService{
+				Service:     externalIPTCP,
+				ServiceKind: structs.GatewayServiceKindDestination,
+			},
+			&structs.GatewayService{
+				Service:     externalHostnameTCP,
+				ServiceKind: structs.GatewayServiceKindDestination,
+			},
+		)
+
+		baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{
+			{
+				CorrelationID: gatewayServicesWatchID,
+				Result: &structs.IndexedGatewayServices{
+					Services: tgtwyServices,
+				},
+			},
+			// no intentions defined for these services
+			{
+				CorrelationID: serviceIntentionsIDPrefix + externalIPTCP.String(),
+				Result: &structs.IndexedIntentionMatches{
+					Matches: []structs.Intentions{
+						nil,
+					},
+				},
+			},
+			{
+				CorrelationID: serviceIntentionsIDPrefix + externalHostnameTCP.String(),
+				Result: &structs.IndexedIntentionMatches{
+					Matches: []structs.Intentions{
+						nil,
+					},
+				},
+			},
+			// ========
+			{
+				CorrelationID: serviceLeafIDPrefix + externalIPTCP.String(),
+				Result: &structs.IssuedCert{
+					CertPEM:       "placeholder.crt",
+					PrivateKeyPEM: "placeholder.key",
+				},
+			},
+			{
+				CorrelationID: serviceLeafIDPrefix + externalHostnameTCP.String(),
+				Result: &structs.IssuedCert{
+					CertPEM:       "placeholder.crt",
+					PrivateKeyPEM: "placeholder.key",
+				},
+			},
+			// ========
+			{
+				CorrelationID: serviceConfigIDPrefix + externalIPTCP.String(),
+				Result: &structs.ServiceConfigResponse{
+					Mode:        structs.ProxyModeTransparent,
+					ProxyConfig: map[string]interface{}{"protocol": "tcp"},
+					Destination: structs.DestinationConfig{
+						Address: "192.168.0.1",
+						Port:    80,
+					},
+				},
+			},
+			{
+				CorrelationID: serviceConfigIDPrefix + externalHostnameTCP.String(),
+				Result: &structs.ServiceConfigResponse{
+					Mode:        structs.ProxyModeTransparent,
+					ProxyConfig: map[string]interface{}{"protocol": "tcp"},
+					Destination: structs.DestinationConfig{
+						Address: "*.hashicorp.com",
+						Port:    8089,
+					},
+				},
+			},
+		})
+	}
+
+	return testConfigSnapshotFixture(t, &structs.NodeService{
+		Kind:    structs.ServiceKindTerminatingGateway,
+		Service: "terminating-gateway",
+		Address: "1.2.3.4",
+		Port:    8443,
+		Proxy: structs.ConnectProxyConfig{
+			Mode: structs.ProxyModeTransparent,
+		},
+		TaggedAddresses: map[string]structs.ServiceAddress{
+			structs.TaggedAddressWAN: {
+				Address: "198.18.0.1",
+				Port:    443,
+			},
+		},
+	}, nil, nil, testSpliceEvents(baseEvents, extraUpdates))
 }
 
 func TestConfigSnapshotTerminatingGatewayServiceSubsets(t testing.T) *ConfigSnapshot {

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -301,6 +301,16 @@ type DestinationConfig struct {
 	Port int `json:",omitempty"`
 }
 
+func (d *DestinationConfig) HasHostname() bool {
+	ip := net.ParseIP(d.Address)
+	return ip == nil
+}
+
+func (d *DestinationConfig) HasIP() bool {
+	ip := net.ParseIP(d.Address)
+	return ip != nil
+}
+
 // ProxyConfigEntry is the top-level struct for global proxy configuration defaults.
 type ProxyConfigEntry struct {
 	Kind             string
@@ -1043,6 +1053,7 @@ type ServiceConfigResponse struct {
 	Expose            ExposeConfig           `json:",omitempty"`
 	TransparentProxy  TransparentProxyConfig `json:",omitempty"`
 	Mode              ProxyMode              `json:",omitempty"`
+	Destination       DestinationConfig      `json:",omitempty"`
 	Meta              map[string]string      `json:",omitempty"`
 	QueryMeta
 }

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -620,6 +620,12 @@ func TestClustersFromSnapshot(t *testing.T) {
 			name:   "transparent-proxy-dial-instances-directly",
 			create: proxycfg.TestConfigSnapshotTransparentProxyDialDirectly,
 		},
+		{
+			name: "transparent-proxy-terminating-gateway-destinations-only",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshotTerminatingGatewayDestinations(t, true, nil)
+			},
+		},
 	}
 
 	latestEnvoyVersion := proxysupport.EnvoyVersions[0]

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -22,6 +22,7 @@ import (
 	envoy_connection_limit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/connection_limit/v3"
 	envoy_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_sni_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sni_cluster/v3"
+	envoy_sni_dynamic_forward_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/sni_dynamic_forward_proxy/v3"
 	envoy_tcp_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
@@ -1198,13 +1199,7 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 			)
 		}
 
-		clusterChain, err := s.makeFilterChainTerminatingGateway(
-			cfgSnap,
-			clusterName,
-			svc,
-			intentions,
-			cfg.Protocol,
-		)
+		clusterChain, err := s.makeFilterChainTerminatingGateway(cfgSnap, clusterName, svc, intentions, cfg.Protocol, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to make filter chain for cluster %q: %v", clusterName, err)
 		}
@@ -1216,19 +1211,43 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 			for subsetName := range resolver.Subsets {
 				subsetClusterName := connect.ServiceSNI(svc.Name, subsetName, svc.NamespaceOrDefault(), svc.PartitionOrDefault(), cfgSnap.Datacenter, cfgSnap.Roots.TrustDomain)
 
-				subsetClusterChain, err := s.makeFilterChainTerminatingGateway(
-					cfgSnap,
-					subsetClusterName,
-					svc,
-					intentions,
-					cfg.Protocol,
-				)
+				subsetClusterChain, err := s.makeFilterChainTerminatingGateway(cfgSnap, subsetClusterName, svc, intentions, cfg.Protocol, nil)
 				if err != nil {
 					return nil, fmt.Errorf("failed to make filter chain for cluster %q: %v", subsetClusterName, err)
 				}
 				l.FilterChains = append(l.FilterChains, subsetClusterChain)
 			}
 		}
+	}
+
+	for _, svc := range cfgSnap.TerminatingGateway.ValidDestinations() {
+		clusterName := connect.ServiceSNI(svc.Name, "", svc.NamespaceOrDefault(), svc.PartitionOrDefault(), cfgSnap.Datacenter, cfgSnap.Roots.TrustDomain)
+
+		intentions := cfgSnap.TerminatingGateway.Intentions[svc]
+		svcConfig := cfgSnap.TerminatingGateway.ServiceConfigs[svc]
+
+		cfg, err := ParseProxyConfig(svcConfig.ProxyConfig)
+		if err != nil {
+			// Don't hard fail on a config typo, just warn. The parse func returns
+			// default config if there is an error so it's safe to continue.
+			s.Logger.Warn(
+				"failed to parse Connect.Proxy.Config for linked destination",
+				"destination", svc.String(),
+				"error", err,
+			)
+		}
+
+		var dest *structs.DestinationConfig
+		if cfgSnap.TerminatingGateway.DestinationServices[svc].ServiceKind == structs.GatewayServiceKindDestination {
+			dest = &svcConfig.Destination
+		} else {
+			return nil, fmt.Errorf("invalid gateway service for destination %s", svc.Name)
+		}
+		clusterChain, err := s.makeFilterChainTerminatingGateway(cfgSnap, clusterName, svc, intentions, cfg.Protocol, dest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make filter chain for cluster %q: %v", clusterName, err)
+		}
+		l.FilterChains = append(l.FilterChains, clusterChain)
 	}
 
 	// Before we add the fallback, sort these chains by the matched name. All
@@ -1264,13 +1283,7 @@ func (s *ResourceGenerator) makeTerminatingGatewayListener(
 	return l, nil
 }
 
-func (s *ResourceGenerator) makeFilterChainTerminatingGateway(
-	cfgSnap *proxycfg.ConfigSnapshot,
-	cluster string,
-	service structs.ServiceName,
-	intentions structs.Intentions,
-	protocol string,
-) (*envoy_listener_v3.FilterChain, error) {
+func (s *ResourceGenerator) makeFilterChainTerminatingGateway(cfgSnap *proxycfg.ConfigSnapshot, cluster string, service structs.ServiceName, intentions structs.Intentions, protocol string, dest *structs.DestinationConfig) (*envoy_listener_v3.FilterChain, error) {
 	tlsContext := &envoy_tls_v3.DownstreamTlsContext{
 		CommonTlsContext: makeCommonTLSContext(
 			cfgSnap.TerminatingGateway.ServiceLeaves[service],
@@ -1284,10 +1297,19 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(
 		return nil, err
 	}
 
-	filterChain := &envoy_listener_v3.FilterChain{
-		FilterChainMatch: makeSNIFilterChainMatch(cluster),
-		Filters:          make([]*envoy_listener_v3.Filter, 0, 3),
-		TransportSocket:  transportSocket,
+	var filterChain *envoy_listener_v3.FilterChain
+	if dest != nil {
+		filterChain = &envoy_listener_v3.FilterChain{
+			FilterChainMatch: makeDestinationFilterChainMatch(cluster, dest),
+			Filters:          make([]*envoy_listener_v3.Filter, 0, 3),
+			TransportSocket:  transportSocket,
+		}
+	} else {
+		filterChain = &envoy_listener_v3.FilterChain{
+			FilterChainMatch: makeSNIFilterChainMatch(cluster),
+			Filters:          make([]*envoy_listener_v3.Filter, 0, 3),
+			TransportSocket:  transportSocket,
+		}
 	}
 
 	// This controls if we do L4 or L7 intention checks.
@@ -1306,16 +1328,28 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(
 		filterChain.Filters = append(filterChain.Filters, authFilter)
 	}
 
+	// For Destinations of Hostname types, we use the dynamic forward proxy filter since this could be
+	// a wildcard match. We also send to the dynamic forward cluster
+	if dest != nil && dest.HasHostname() {
+		dynamicFilter, err := makeSNIDynamicForwardProxyFilter(dest.Port)
+		if err != nil {
+			return nil, err
+		}
+		filterChain.Filters = append(filterChain.Filters, dynamicFilter)
+		cluster = dynamicForwardProxyClusterName
+	}
+
 	// Lastly we setup the actual proxying component. For L4 this is a straight
 	// tcp proxy. For L7 this is a very hands-off HTTP proxy just to inject an
 	// HTTP filter to do intention checks here instead.
 	opts := listenerFilterOpts{
-		protocol:   protocol,
-		filterName: fmt.Sprintf("%s.%s.%s.%s", service.Name, service.NamespaceOrDefault(), service.PartitionOrDefault(), cfgSnap.Datacenter),
-		routeName:  cluster, // Set cluster name for route config since each will have its own
-		cluster:    cluster,
-		statPrefix: "upstream.",
-		routePath:  "",
+		protocol:               protocol,
+		filterName:             fmt.Sprintf("%s.%s.%s.%s", service.Name, service.NamespaceOrDefault(), service.PartitionOrDefault(), cfgSnap.Datacenter),
+		routeName:              cluster, // Set cluster name for route config since each will have its own
+		cluster:                cluster,
+		statPrefix:             "upstream.",
+		routePath:              "",
+		useDynamicForwardProxy: dest != nil && dest.HasHostname(),
 	}
 
 	if useHTTPFilter {
@@ -1346,6 +1380,23 @@ func (s *ResourceGenerator) makeFilterChainTerminatingGateway(
 	filterChain.Filters = append(filterChain.Filters, filter)
 
 	return filterChain, nil
+}
+
+func makeDestinationFilterChainMatch(cluster string, dest *structs.DestinationConfig) *envoy_listener_v3.FilterChainMatch {
+	// For hostname and wildcard destinations, we match on the address.
+
+	// For IP Destinations, use the alias SNI name to match
+	ip := net.ParseIP(dest.Address)
+	if ip != nil {
+		return &envoy_listener_v3.FilterChainMatch{
+			ServerNames: []string{cluster},
+		}
+	}
+
+	// For hostname and wildcard destinations, we match on the address in the Destination
+	return &envoy_listener_v3.FilterChainMatch{
+		ServerNames: []string{dest.Address},
+	}
 }
 
 func (s *ResourceGenerator) makeMeshGatewayListener(name, addr string, port int, cfgSnap *proxycfg.ConfigSnapshot) (*envoy_listener_v3.Listener, error) {
@@ -1650,18 +1701,19 @@ func (s *ResourceGenerator) getAndModifyUpstreamConfigForPeeredListener(
 }
 
 type listenerFilterOpts struct {
-	useRDS               bool
-	protocol             string
-	filterName           string
-	routeName            string
-	cluster              string
-	statPrefix           string
-	routePath            string
-	requestTimeoutMs     *int
-	ingressGateway       bool
-	httpAuthzFilter      *envoy_http_v3.HttpFilter
-	forwardClientDetails bool
-	forwardClientPolicy  envoy_http_v3.HttpConnectionManager_ForwardClientCertDetails
+	useRDS                 bool
+	protocol               string
+	filterName             string
+	routeName              string
+	cluster                string
+	statPrefix             string
+	routePath              string
+	requestTimeoutMs       *int
+	ingressGateway         bool
+	httpAuthzFilter        *envoy_http_v3.HttpFilter
+	forwardClientDetails   bool
+	forwardClientPolicy    envoy_http_v3.HttpConnectionManager_ForwardClientCertDetails
+	useDynamicForwardProxy bool
 }
 
 func makeListenerFilter(opts listenerFilterOpts) (*envoy_listener_v3.Filter, error) {
@@ -1692,6 +1744,13 @@ func makeSNIFilterChainMatch(sniMatches ...string) *envoy_listener_v3.FilterChai
 
 func makeSNIClusterFilter() (*envoy_listener_v3.Filter, error) {
 	return makeFilter("envoy.filters.network.sni_cluster", &envoy_sni_cluster_v3.SniCluster{})
+}
+
+func makeSNIDynamicForwardProxyFilter(upstreamPort int) (*envoy_listener_v3.Filter, error) {
+	return makeFilter("envoy.filters.network.sni_dynamic_forward_proxy", &envoy_sni_dynamic_forward_proxy_v3.FilterConfig{
+		DnsCacheConfig: getCommonDNSCacheConfiguration(),
+		PortSpecifier:  &envoy_sni_dynamic_forward_proxy_v3.FilterConfig_PortValue{PortValue: uint32(upstreamPort)},
+	})
 }
 
 func makeTCPProxyFilter(filterName, cluster, statPrefix string) (*envoy_listener_v3.Filter, error) {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -800,6 +800,12 @@ func TestListenersFromSnapshot(t *testing.T) {
 			name:   "transparent-proxy-terminating-gateway",
 			create: proxycfg.TestConfigSnapshotTransparentProxyTerminatingGatewayCatalogDestinationsOnly,
 		},
+		{
+			name: "transparent-proxy-terminating-gateway-destinations-only",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshotTerminatingGatewayDestinations(t, true, nil)
+			},
+		},
 	}
 
 	latestEnvoyVersion := proxysupport.EnvoyVersions[0]

--- a/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway-destinations-only.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway-destinations-only.latest.golden
@@ -1,0 +1,50 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "dynamic_forward_proxy_cluster",
+      "clusterType": {
+        "name": "envoy.clusters.dynamic_forward_proxy",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig",
+          "dnsCacheConfig": {
+            "name": "dynamic_forward_proxy_cache_config"
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "lbPolicy": "CLUSTER_PROVIDED"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "external-IP-TCP.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "STATIC",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "external-IP-TCP.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "192.168.0.1",
+                      "portValue": 80
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "outlierDetection": {
+
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/transparent-proxy-terminating-gateway-destinations-only.latest.golden
+++ b/agent/xds/testdata/listeners/transparent-proxy-terminating-gateway-destinations-only.latest.golden
@@ -1,0 +1,164 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "default:1.2.3.4:8443",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8443
+        }
+      },
+      "filterChains": [
+        {
+          "filterChainMatch": {
+            "serverNames": [
+              "*.hashicorp.com"
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.sni_dynamic_forward_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.sni_dynamic_forward_proxy.v3.FilterConfig",
+                "dnsCacheConfig": {
+                  "name": "dynamic_forward_proxy_cache_config"
+                },
+                "portValue": 8089
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.external-hostname-TCP.default.default.dc1",
+                "cluster": "dynamic_forward_proxy_cluster"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "placeholder.crt\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "placeholder.key\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        },
+        {
+          "filterChainMatch": {
+            "serverNames": [
+              "external-IP-TCP.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+            ]
+          },
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.external-IP-TCP.default.default.dc1",
+                "cluster": "external-IP-TCP.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "placeholder.crt\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "placeholder.key\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        },
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.sni_cluster",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.sni_cluster.v3.SniCluster"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "terminating_gateway.default",
+                "cluster": ""
+              }
+            }
+          ]
+        }
+      ],
+      "listenerFilters": [
+        {
+          "name": "envoy.filters.listener.tls_inspector",
+          "typedConfig": {
+            "@type": "type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector"
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
### Description
We are currently adding support for Destinations (nodeless egress services) in Consul Terminating Gateways. This PR adds the xDS generation at the Terminating gateway side of the connection, including listeners and clusters.

Since traffic may be encrypted from the client, all traffic appears as TCP. For hostname traffic, which may be part of a wildcard definition, we route traffic based on SNI to a dynamic forward proxy. For IP traffic, we use a placeholder SNI on the listener to identify the destination and route to a static envoy cluster.

### Testing & Reproduction steps
The forward proxy configuration was tested with a local envoy instance based on [this setup](https://github.com/DanStough/envoy-examples/tree/main/tcp-dynamic-forward-proxy).

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] not a security concern
