### PR TITLE
peering: allow protobuf requests to populate the default partition or namespace

### DIFF
--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -112,6 +112,10 @@ func (b *peeringBackend) EnterpriseCheckPartitions(partition string) error {
 	return b.enterpriseCheckPartitions(partition)
 }
 
+func (b *peeringBackend) EnterpriseCheckNamespaces(namespace string) error {
+	return b.enterpriseCheckNamespaces(namespace)
+}
+
 func (b *peeringBackend) IsLeader() bool {
 	return b.srv.IsLeader()
 }

--- a/agent/consul/peering_backend_oss.go
+++ b/agent/consul/peering_backend_oss.go
@@ -5,11 +5,19 @@ package consul
 
 import (
 	"fmt"
+	"strings"
 )
 
 func (b *peeringBackend) enterpriseCheckPartitions(partition string) error {
-	if partition != "" {
-		return fmt.Errorf("Partitions are a Consul Enterprise feature")
+	if partition == "" || strings.EqualFold(partition, "default") {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("Partitions are a Consul Enterprise feature")
+}
+
+func (b *peeringBackend) enterpriseCheckNamespaces(namespace string) error {
+	if namespace == "" || strings.EqualFold(namespace, "default") {
+		return nil
+	}
+	return fmt.Errorf("Namespaces are a Consul Enterprise feature")
 }

--- a/agent/consul/peering_backend_oss_test.go
+++ b/agent/consul/peering_backend_oss_test.go
@@ -49,3 +49,38 @@ func TestPeeringBackend_RejectsPartition(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Partitions are a Consul Enterprise feature")
 }
+
+func TestPeeringBackend_IgnoresDefaultPartition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	_, s1 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = true
+	})
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// make a grpc client to dial s1 directly
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	t.Cleanup(cancel)
+
+	conn, err := gogrpc.DialContext(ctx, s1.config.RPCAddr.String(),
+		gogrpc.WithContextDialer(newServerDialer(s1.config.RPCAddr.String())),
+		gogrpc.WithInsecure(),
+		gogrpc.WithBlock())
+	require.NoError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	peeringClient := pbpeering.NewPeeringServiceClient(conn)
+
+	req := pbpeering.GenerateTokenRequest{
+		Datacenter: "dc1",
+		PeerName:   "my-peer",
+		Partition:  "DeFaUlT",
+	}
+	_, err = peeringClient.GenerateToken(ctx, &req)
+	require.NoError(t, err)
+}

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -100,6 +100,8 @@ type Backend interface {
 
 	EnterpriseCheckPartitions(partition string) error
 
+	EnterpriseCheckNamespaces(namespace string) error
+
 	Subscribe(req *stream.SubscribeRequest) (*stream.Subscription, error)
 
 	// IsLeader indicates whether the consul server is in a leader state or not.
@@ -436,6 +438,9 @@ func (s *Service) TrustBundleRead(ctx context.Context, req *pbpeering.TrustBundl
 
 func (s *Service) TrustBundleListByService(ctx context.Context, req *pbpeering.TrustBundleListByServiceRequest) (*pbpeering.TrustBundleListByServiceResponse, error) {
 	if err := s.Backend.EnterpriseCheckPartitions(req.Partition); err != nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, err.Error())
+	}
+	if err := s.Backend.EnterpriseCheckNamespaces(req.Namespace); err != nil {
 		return nil, grpcstatus.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/agent/rpc/peering/service_oss_test.go
+++ b/agent/rpc/peering/service_oss_test.go
@@ -21,7 +21,7 @@ func TestPeeringService_RejectsPartition(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		t.Cleanup(cancel)
 
-		req := &pbpeering.PeeringReadRequest{Name: "foo", Partition: "default"}
+		req := &pbpeering.PeeringReadRequest{Name: "foo", Partition: "test"}
 		resp, err := client.PeeringRead(ctx, req)
 		require.Contains(t, err.Error(), "Partitions are a Consul Enterprise feature")
 		require.Nil(t, resp)
@@ -31,9 +31,32 @@ func TestPeeringService_RejectsPartition(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		t.Cleanup(cancel)
 
-		req := &pbpeering.PeeringListRequest{Partition: "default"}
+		req := &pbpeering.PeeringListRequest{Partition: "test"}
 		resp, err := client.PeeringList(ctx, req)
 		require.Contains(t, err.Error(), "Partitions are a Consul Enterprise feature")
 		require.Nil(t, resp)
+	})
+}
+
+func TestPeeringService_IgnoresDefaultPartition(t *testing.T) {
+	s := newTestServer(t, nil)
+	client := pbpeering.NewPeeringServiceClient(s.ClientConn(t))
+
+	t.Run("read", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+
+		req := &pbpeering.PeeringReadRequest{Name: "foo", Partition: "DeFaUlT"}
+		_, err := client.PeeringRead(ctx, req)
+		require.NoError(t, err)
+	})
+
+	t.Run("list", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+
+		req := &pbpeering.PeeringListRequest{Partition: "DeFaUlT"}
+		_, err := client.PeeringList(ctx, req)
+		require.NoError(t, err)
 	})
 }

--- a/agent/rpc/peering/stream_test.go
+++ b/agent/rpc/peering/stream_test.go
@@ -990,7 +990,11 @@ func (b *testStreamBackend) DecodeToken([]byte) (*structs.PeeringToken, error) {
 	return nil, nil
 }
 
-func (b *testStreamBackend) EnterpriseCheckPartitions(partition string) error {
+func (b *testStreamBackend) EnterpriseCheckPartitions(_ string) error {
+	return nil
+}
+
+func (b *testStreamBackend) EnterpriseCheckNamespaces(_ string) error {
 	return nil
 }
 


### PR DESCRIPTION
### Description

Locally I was trying to run a peered service mesh using the OSS binary and was getting this:

```
2022-06-07T19:08:08.794Z [WARN]  agent.cache: handling error in Cache.Notify: cache-type=peer-trust-bundle error="rpc error: code = InvalidArgument desc = Partitions are a Consul Enterprise feature" index=0
```

This was because we were using `PartitionOrDefault()` to pass an argument to a protobuf request. The field-stripping logic isn't part of the protobuf stack, so in all cases `"default"` was being sent to the server which was rejecting the request.

This PR changes the logic to be cool with getting `""` or `"default"` for either Partition or Namespace fields on requests.
