### PR TITLE
ci: Remove branch trigger for dev branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:
       - release/1.11.x
-      - backport/CTIA-17-verify-linux-packages/1.11
 
 env:
   PKG_NAME: consul


### PR DESCRIPTION
### Description
In #13376 I forgot to remove the trigger for its dev branch.