### PR TITLE
Removes extraneous "configure"

### DIFF
--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -10,7 +10,7 @@ description: >-
 ## Overview
 
 Consul on Kubernetes provides a few options for customizing how connect-inject behavior should be configured. 
-This allows the user to configure natively configure Consul on select Kubernetes resources (i.e. pods, services).  
+This allows the user to natively configure Consul on select Kubernetes resources (i.e. pods, services).  
 
 - [Annotations](#annotations)
 - [Labels](#labels)


### PR DESCRIPTION
### Description
Typo on the website
