### PR TITLE
ui: Fix intl keys in order to render correct messages for empty states

### DIFF
--- a/.changelog/13409.txt
+++ b/.changelog/13409.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix incorrect text on certain page empty states
+```

--- a/ui/packages/consul-ui/app/templates/dc/acls/auth-methods/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/acls/auth-methods/index.hbs
@@ -90,13 +90,13 @@ as |route|>
             >
               <BlockSlot @name="header">
                 <h2>
-                  {{t 'routes.dc.auth-methods.index.empty.header'
+                  {{t 'routes.dc.acls.auth-methods.index.empty.header'
                     items=items.length
                   }}
                 </h2>
               </BlockSlot>
               <BlockSlot @name="body">
-                {{t 'routes.dc.auth-methods.index.empty.body'
+                {{t 'routes.dc.acls.auth-methods.index.empty.body'
                   items=items.length
                   htmlSafe=true
                 }}

--- a/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
@@ -94,13 +94,13 @@ as |route|>
                 >
                   <BlockSlot @name="header">
                     <h2>
-                      {{t 'routes.dc.services.intentions.index.empty.header'
+                      {{t 'routes.dc.services.show.intentions.index.empty.header'
                         items=items.length
                       }}
                     </h2>
                   </BlockSlot>
                   <BlockSlot @name="body">
-                    {{t 'routes.dc.services.intentions.index.empty.body'
+                    {{t 'routes.dc.services.show.intentions.index.empty.body'
                       items=items.length
                       htmlSafe=true
                     }}

--- a/ui/packages/consul-ui/app/utils/intl/missing-message.js
+++ b/ui/packages/consul-ui/app/utils/intl/missing-message.js
@@ -1,3 +1,4 @@
+/* eslint no-console: ["error", { allow: ["debug"] }] */
 import { runInDebug } from '@ember/debug';
 
 // if we can't find the message, take the last part of the identifier and

--- a/ui/packages/consul-ui/app/utils/intl/missing-message.js
+++ b/ui/packages/consul-ui/app/utils/intl/missing-message.js
@@ -1,6 +1,11 @@
+import { runInDebug } from '@ember/debug';
+
 // if we can't find the message, take the last part of the identifier and
 // ucfirst it so it looks human
 export default function missingMessage(key, locales) {
+  runInDebug(
+    _ => console.debug(`Translation key not found: ${key}`)
+  );
   const last = key
     .split('.')
     .pop()

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -75,11 +75,12 @@ dc:
         title: Metadata
       sessions:
         title: Lock Sessions
-        header: Welcome to Lock Sessions
-        body: |
-          <p>
-          Consul provides a session mechanism which can be used to build distributed locks. Sessions act as a binding layer between Nodes, Health Checks, and Key/Value data. There are currently no Lock Sessions present, or you may not have <code>key:read</code> or <code>session:read</code> permissions.
-          </p>
+        empty:
+          header: Welcome to Lock Sessions
+          body: |
+            <p>
+            Consul provides a session mechanism which can be used to build distributed locks. Sessions act as a binding layer between Nodes, Health Checks, and Key/Value data. There are currently no Lock Sessions present, or you may not have <code>key:read</code> or <code>session:read</code> permissions.
+            </p>
       services:
         title: Service Instances
         empty: |


### PR DESCRIPTION
### Description

Some of our i18n intl keys were wrong for our empty states. As missing intl keys default to show the last part of the key capitalised (`dc.nodes.sessions.empty.header` => `Header`). This resulted in some empty states showing `Header` and `Body` instead of the actual text.

we initially added the "capitalise the last part of the missing key as a default/missing piece of text" thing to help machine > human word replacement for lots of small pieces of text that were always going to be the last part of the key but capitalized, which seemed like a good approach at the time 😬 . This unfortunately means we don't notice when we don't type the intl key correctly.

So additionally here, I've added a dev time only log message (using `runInDebug` so it doesn't compile in) so we can go through and explicitly make sure every key has a corresponding piece of text. After which, longer term we can remove this "defaulting" and hard error instead, so this can never happen again.

Further replacement of the keys that we currently expect to "default" to have explicit corresponding text, will be done in a further PR.



### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
