### PR TITLE
chore(ci): fix false positive metrics check

### DIFF
--- a/.github/scripts/metrics_checker.sh
+++ b/.github/scripts/metrics_checker.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 ### It is still up to the reviewer to make sure that any tests added are needed and meaningful.
 
 # search for any "new" or modified metric emissions
-metrics_modified=$(git --no-pager diff HEAD origin/main | grep -i "SetGauge\|EmitKey\|IncrCounter\|AddSample\|MeasureSince\|UpdateFilter")
+metrics_modified=$(git --no-pager diff origin/main...HEAD | grep -i "SetGauge\|EmitKey\|IncrCounter\|AddSample\|MeasureSince\|UpdateFilter")
 # search for PR body or title metric references
 metrics_in_pr_body=$(echo "${PR_BODY-""}" | grep -i "metric")
 metrics_in_pr_title=$(echo "${PR_TITLE-""}" | grep -i "metric")


### PR DESCRIPTION
### Description
The metrics check is reporting sometimes reporting false change detections because it's looking at the raw diff of branches rather than the merge diff. [Stack overflow explanation.](https://stackoverflow.com/questions/37763836/how-to-make-git-diff-show-the-same-result-as-githubs-pull-request-diff)

### Testing & Reproduction steps
N/A

### Links
N/A

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [X] not a security concern
