### PR TITLE
[DRAFT] [NEED FEEDBACK] Support websocket through envoy

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1794,6 +1794,7 @@ func (b *builder) pathsVal(v []ExposePath) []structs.ExposePath {
 			Path:          stringVal(p.Path),
 			LocalPathPort: intVal(p.LocalPathPort),
 			Protocol:      stringVal(p.Protocol),
+			Websocket:     boolVal(p.Websocket),
 		}
 	}
 	return paths

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -581,6 +581,9 @@ type ExposePath struct {
 	// Protocol describes the upstream's service protocol.
 	Protocol *string `mapstructure:"protocol"`
 
+	// Websocket whether websocket upgrade is supported.
+	Websocket *bool `mapstructure:"websocket"`
+
 	// LocalPathPort is the port that the service is listening on for the given path.
 	LocalPathPort *int `mapstructure:"local_path_port"`
 }

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -602,6 +602,7 @@ services = [
                         local_path_port = 8080
                         listener_port = 21500
                         protocol = "http"
+                        websocket = true
                     }
                 ]
             }

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -573,7 +573,8 @@
               "path": "/health",
               "local_path_port": 8080,
               "listener_port": 21500,
-              "protocol": "http"
+              "protocol": "http",
+              "websocket": true
             }
           ]
         },

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1053,12 +1053,14 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 
 	expected := structs.ServiceConfigResponse{
 		ProxyConfig: map[string]interface{}{
-			"foo":      int64(1),
-			"protocol": "http",
+			"foo":       int64(1),
+			"protocol":  "http",
+			"websocket": false,
 		},
 		UpstreamConfigs: map[string]map[string]interface{}{
 			"bar": {
-				"protocol": "grpc",
+				"protocol":  "grpc",
+				"websocket": false,
 			},
 		},
 		Meta: map[string]string{"foo": "bar"},
@@ -1073,6 +1075,76 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 	proxyConf, ok := entry.(*structs.ProxyConfigEntry)
 	require.True(t, ok)
 	require.Equal(t, map[string]interface{}{"foo": 1}, proxyConf.Config)
+}
+
+func TestConfigEntry_ResolveServiceConfig_With_Websocket(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	// Create a dummy proxy/service config in the state store to look up.
+	state := s1.fsm.State()
+	require.NoError(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
+		Kind:      structs.ServiceDefaults,
+		Name:      "foo",
+		Protocol:  "http",
+		Websocket: true,
+	}))
+	require.NoError(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
+		Kind:      structs.ServiceDefaults,
+		Name:      "bar",
+		Protocol:  "grpc",
+		Websocket: false,
+	}))
+
+	//check that webrtc is accepted only with http
+	require.Error(t, state.EnsureConfigEntry(2, &structs.ServiceConfigEntry{
+		Kind:      structs.ServiceDefaults,
+		Name:      "bar",
+		Protocol:  "grpc",
+		Websocket: true,
+	}))
+
+	args := structs.ServiceConfigRequest{
+		Name:       "foo",
+		Datacenter: s1.config.Datacenter,
+	}
+	var out structs.ServiceConfigResponse
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.ResolveServiceConfig", &args, &out))
+
+	expected := structs.ServiceConfigResponse{
+		ProxyConfig: map[string]interface{}{
+			"protocol":  "http",
+			"websocket": true,
+		},
+		// Don't know what this is deterministically
+		QueryMeta: out.QueryMeta,
+	}
+	require.Equal(t, expected, out)
+
+	args = structs.ServiceConfigRequest{
+		Name:       "bar",
+		Datacenter: s1.config.Datacenter,
+	}
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.ResolveServiceConfig", &args, &out))
+
+	expected = structs.ServiceConfigResponse{
+		ProxyConfig: map[string]interface{}{
+			"protocol":  "grpc",
+			"websocket": false,
+		},
+		// Don't know what this is deterministically
+		QueryMeta: out.QueryMeta,
+	}
+	require.Equal(t, expected, out)
 }
 
 func TestConfigEntry_ResolveServiceConfig_TransparentProxy(t *testing.T) {
@@ -1682,8 +1754,9 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 
 		expected := structs.ServiceConfigResponse{
 			ProxyConfig: map[string]interface{}{
-				"global":   int64(1),
-				"protocol": "grpc",
+				"global":    int64(1),
+				"protocol":  "grpc",
+				"websocket": false,
 			},
 			QueryMeta: out.QueryMeta,
 		}
@@ -1747,8 +1820,9 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 
 		expected := structs.ServiceConfigResponse{
 			ProxyConfig: map[string]interface{}{
-				"global":   int64(1),
-				"protocol": "http",
+				"global":    int64(1),
+				"protocol":  "http",
+				"websocket": false,
 			},
 			QueryMeta: out.QueryMeta,
 		}
@@ -1791,7 +1865,8 @@ func TestConfigEntry_ResolveServiceConfig_Blocking(t *testing.T) {
 
 		expected := structs.ServiceConfigResponse{
 			ProxyConfig: map[string]interface{}{
-				"protocol": "http",
+				"protocol":  "http",
+				"websocket": false,
 			},
 			QueryMeta: out.QueryMeta,
 		}
@@ -1849,13 +1924,15 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams_Blocking(t *testing.T) {
 
 		expected := structs.ServiceConfigResponse{
 			ProxyConfig: map[string]interface{}{
-				"protocol": "http",
+				"protocol":  "http",
+				"websocket": false,
 			},
 			UpstreamIDConfigs: []structs.OpaqueUpstreamConfig{
 				{
 					Upstream: structs.NewServiceID("bar", nil),
 					Config: map[string]interface{}{
-						"protocol": "http",
+						"protocol":  "http",
+						"websocket": false,
 					},
 				},
 			},
@@ -1910,7 +1987,8 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams_Blocking(t *testing.T) {
 
 		expected := structs.ServiceConfigResponse{
 			ProxyConfig: map[string]interface{}{
-				"protocol": "http",
+				"protocol":  "http",
+				"websocket": false,
 			},
 			QueryMeta: out.QueryMeta, // don't care
 		}
@@ -1936,7 +2014,8 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams_Blocking(t *testing.T) {
 
 		expected := structs.ServiceConfigResponse{
 			ProxyConfig: map[string]interface{}{
-				"protocol": "http",
+				"protocol":  "http",
+				"websocket": false,
 			},
 			QueryMeta: out.QueryMeta, // don't care
 		}
@@ -2046,20 +2125,25 @@ func TestConfigEntry_ResolveServiceConfig_UpstreamProxyDefaultsProtocol(t *testi
 
 	expected := structs.ServiceConfigResponse{
 		ProxyConfig: map[string]interface{}{
-			"protocol": "http",
+			"protocol":  "http",
+			"websocket": false,
 		},
 		UpstreamConfigs: map[string]map[string]interface{}{
 			"bar": {
-				"protocol": "http",
+				"protocol":  "http",
+				"websocket": false,
 			},
 			"other": {
-				"protocol": "http",
+				"protocol":  "http",
+				"websocket": false,
 			},
 			"dne": {
-				"protocol": "http",
+				"protocol":  "http",
+				"websocket": false,
 			},
 			"alreadyprotocol": {
-				"protocol": "grpc",
+				"protocol":  "grpc",
+				"websocket": false,
 			},
 		},
 		// Don't know what this is deterministically

--- a/agent/consul/merge_service_config.go
+++ b/agent/consul/merge_service_config.go
@@ -146,6 +146,9 @@ func computeResolvedServiceConfig(
 			}
 			thisReply.ProxyConfig["protocol"] = serviceConf.Protocol
 		}
+		if serviceConf.Websocket {
+			thisReply.ProxyConfig["websocket"] = true
+		}
 		if serviceConf.TransparentProxy.OutboundListenerPort != 0 {
 			thisReply.TransparentProxy.OutboundListenerPort = serviceConf.TransparentProxy.OutboundListenerPort
 		}
@@ -238,14 +241,23 @@ func computeResolvedServiceConfig(
 		upstreamSvcDefaults := entries.GetServiceDefaults(
 			structs.NewServiceID(upstream.ID, &upstream.EnterpriseMeta),
 		)
+		var websocket bool
+
 		if upstreamSvcDefaults != nil {
 			if upstreamSvcDefaults.Protocol != "" {
 				protocol = upstreamSvcDefaults.Protocol
+			}
+			if upstreamSvcDefaults.Websocket {
+				websocket = true
 			}
 		}
 
 		if protocol != "" {
 			resolvedCfg["protocol"] = protocol
+		}
+
+		if websocket {
+			resolvedCfg["websocket"] = true
 		}
 
 		// Merge centralized defaults for all upstreams before configuration for specific upstreams

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -3547,6 +3547,7 @@ func ingressConfigGatewayServices(
 				Hosts:       service.Hosts,
 				Port:        listener.Port,
 				Protocol:    listener.Protocol,
+				Websocket:   listener.Websocket,
 			}
 
 			gatewayServices = append(gatewayServices, mapping)

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -625,8 +625,9 @@ func (c *configSnapshotIngressGateway) isEmpty() bool {
 }
 
 type IngressListenerKey struct {
-	Protocol string
-	Port     int
+	Protocol  string
+	Websocket bool
+	Port      int
 }
 
 func (k *IngressListenerKey) RouteName() string {
@@ -634,11 +635,11 @@ func (k *IngressListenerKey) RouteName() string {
 }
 
 func IngressListenerKeyFromGWService(s structs.GatewayService) IngressListenerKey {
-	return IngressListenerKey{Protocol: s.Protocol, Port: s.Port}
+	return IngressListenerKey{Protocol: s.Protocol, Websocket: s.Websocket, Port: s.Port}
 }
 
 func IngressListenerKeyFromListener(l structs.IngressListener) IngressListenerKey {
-	return IngressListenerKey{Protocol: l.Protocol, Port: l.Port}
+	return IngressListenerKey{Protocol: l.Protocol, Websocket: l.Websocket, Port: l.Port}
 }
 
 // ConfigSnapshot captures all the resulting config needed for a proxy instance.

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -1271,11 +1271,11 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 						// GW level TLS should be disabled
 						require.False(t, snap.IngressGateway.TLSConfig.Enabled)
 						// Mixed listener TLS
-						l, ok := snap.IngressGateway.Listeners[IngressListenerKey{"tcp", 8080}]
+						l, ok := snap.IngressGateway.Listeners[IngressListenerKey{"tcp", false, 8080}]
 						require.True(t, ok)
 						require.NotNil(t, l.TLS)
 						require.True(t, l.TLS.Enabled)
-						l, ok = snap.IngressGateway.Listeners[IngressListenerKey{"tcp", 9090}]
+						l, ok = snap.IngressGateway.Listeners[IngressListenerKey{"tcp", false, 9090}]
 						require.True(t, ok)
 						require.Nil(t, l.TLS)
 

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -46,6 +46,11 @@ type IngressListener struct {
 	// current supported values are: (tcp | http | http2 | grpc).
 	Protocol string
 
+	// Websocket enable or disable the possibility to upgrade a http
+	// connection to a websocket. Makes sense only for http protocol,
+	// disabled by default.
+	Websocket bool `json:",omitempty"`
+
 	// TLS config for this listener.
 	TLS *GatewayTLSConfig `json:",omitempty"`
 
@@ -601,6 +606,7 @@ type GatewayService struct {
 	GatewayKind  ServiceKind
 	Port         int                `json:",omitempty"`
 	Protocol     string             `json:",omitempty"`
+	Websocket    bool               `json:",omitempty"`
 	Hosts        []string           `json:",omitempty"`
 	CAFile       string             `json:",omitempty"`
 	CertFile     string             `json:",omitempty"`
@@ -639,6 +645,7 @@ func (g *GatewayService) IsSame(o *GatewayService) bool {
 		g.GatewayKind == o.GatewayKind &&
 		g.Port == o.Port &&
 		g.Protocol == o.Protocol &&
+		g.Websocket == o.Websocket &&
 		stringslice.Equal(g.Hosts, o.Hosts) &&
 		g.CAFile == o.CAFile &&
 		g.CertFile == o.CertFile &&
@@ -655,6 +662,7 @@ func (g *GatewayService) Clone() *GatewayService {
 		GatewayKind: g.GatewayKind,
 		Port:        g.Port,
 		Protocol:    g.Protocol,
+		Websocket:   g.Websocket,
 		// See https://github.com/go101/go101/wiki/How-to-efficiently-clone-a-slice%3F
 		Hosts:        append(g.Hosts[:0:0], g.Hosts...),
 		CAFile:       g.CAFile,

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -626,6 +626,10 @@ type ExposePath struct {
 	// Valid values are "http" and "http2", defaults to "http"
 	Protocol string `json:",omitempty"`
 
+	// Websocket enable or disable the possibility to upgrade a http
+	// connection to a websocket, disabled by default.
+	Websocket bool `json:",omitempty"`
+
 	// ParsedFromCheck is set if this path was parsed from a registered check
 	ParsedFromCheck bool `json:",omitempty" alias:"parsed_from_check"`
 }
@@ -678,6 +682,7 @@ func (p *ExposePath) ToAPI() api.ExposePath {
 		Path:            p.Path,
 		LocalPathPort:   p.LocalPathPort,
 		Protocol:        p.Protocol,
+		Websocket:       p.Websocket,
 		ParsedFromCheck: p.ParsedFromCheck,
 	}
 }

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -34,6 +34,9 @@ type CompiledDiscoveryChain struct {
 	// Protocol is the overall protocol shared by everything in the chain.
 	Protocol string `json:",omitempty"`
 
+	// Websocket whether websocket upgrade is supported.
+	Websocket bool
+
 	// ServiceMeta is the metadata from the underlying service-defaults config
 	// entry for the service named ServiceName.
 	ServiceMeta map[string]string `json:",omitempty"`

--- a/agent/xds/config.go
+++ b/agent/xds/config.go
@@ -49,6 +49,11 @@ type ProxyConfig struct {
 	// pooling, tracing, routing etc.
 	Protocol string `mapstructure:"protocol"`
 
+	// Websocket enable or disable the possibility to upgrade a http
+	// connection to a websocket. Makes sense only for http protocol,
+	// disabled by default.
+	Websocket bool `mapstructure:"websocket"`
+
 	// BindAddress overrides the address the proxy's listener binds to. This
 	// enables proxies in network namespaces to bind to a different address
 	// than the host address.

--- a/agent/xds/listeners_ingress.go
+++ b/agent/xds/listeners_ingress.go
@@ -70,6 +70,7 @@ func (s *ResourceGenerator) makeIngressGatewayListeners(address string, cfgSnap 
 				clusterName: clusterName,
 				filterName:  filterName,
 				protocol:    cfg.Protocol,
+				websocket:   cfg.Websocket,
 				tlsContext:  tlsContext,
 			})
 			if err != nil {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -190,6 +190,15 @@ func TestListenersFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name: "http-public-listener-websocket",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
+					ns.Proxy.Config["protocol"] = "http"
+					ns.Proxy.Config["websocket"] = "true"
+				}, nil)
+			},
+		},
+		{
 			name: "http-listener-with-timeouts",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.latest.golden
@@ -3,8 +3,8 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      "name": "78ebd528~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-      "altStatName": "78ebd528~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "name": "5eb5fb72~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName": "5eb5fb72~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.latest.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.latest.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-      "clusterName": "78ebd528~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "clusterName": "5eb5fb72~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [

--- a/agent/xds/testdata/listeners/http-public-listener-websocket.latest.golden
+++ b/agent/xds/testdata/listeners/http-public-listener-websocket.latest.golden
@@ -1,0 +1,164 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "public_listener",
+                "routeConfig": {
+                  "name": "public_listener",
+                  "virtualHosts": [
+                    {
+                      "name": "public_listener",
+                      "domains": [
+                        "*"
+                      ],
+                      "routes": [
+                        {
+                          "match": {
+                            "prefix": "/"
+                          },
+                          "route": {
+                            "cluster": "local_app"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.rbac",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                      "rules": {
+
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "tracing": {
+                  "randomSampling": {
+
+                  }
+                },
+                "forwardClientCertDetails": "APPEND_FORWARD",
+                "setCurrentClientCertDetails": {
+                  "subject": true,
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "uri": true
+                },
+                "upgradeConfigs": [
+                  {
+                    "upgradeType": "websocket"
+                  }
+                ]
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-overrides.latest.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-overrides.latest.golden
@@ -16,7 +16,7 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "78ebd528~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "5eb5fb72~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             }
           ]

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -118,6 +118,9 @@ type ExposePath struct {
 	// Valid values are "http" and "http2", defaults to "http"
 	Protocol string `json:",omitempty"`
 
+	// Websocket whether websocket upgrade is supported.
+	Websocket bool `json:",omitempty"`
+
 	// ParsedFromCheck is set if this path was parsed from a registered check
 	ParsedFromCheck bool
 }
@@ -162,6 +165,9 @@ type UpstreamConfig struct {
 	// aware features like per-request metrics and connection pooling, tracing,
 	// routing etc.
 	Protocol string `json:",omitempty"`
+
+	// Websocket whether websocket upgrade is supported.
+	Websocket bool `json:",omitempty"`
 
 	// ConnectTimeoutMs is the number of milliseconds to timeout making a new
 	// connection to this upstream. Defaults to 5000 (5 seconds) if not set.
@@ -223,6 +229,7 @@ type ServiceConfigEntry struct {
 	Partition        string                  `json:",omitempty"`
 	Namespace        string                  `json:",omitempty"`
 	Protocol         string                  `json:",omitempty"`
+	Websocket        bool                    `json:",omitempty"`
 	Mode             ProxyMode               `json:",omitempty"`
 	TransparentProxy *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
 	MeshGateway      MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -312,7 +312,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 							"LocalPathPort": 8080,
 							"ListenerPort": 21500,
 							"Path": "/healthz",
-							"Protocol": "http2"
+							"Protocol": "http2",
+							"Websocket": true
 						}
 					]
 				}
@@ -329,6 +330,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 							ListenerPort:  21500,
 							Path:          "/healthz",
 							Protocol:      "http2",
+							Websocket:     true,
 						},
 					},
 				},
@@ -347,7 +349,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 							"LocalPathPort": 8080,
 							"ListenerPort": 21500,
 							"Path": "/healthz",
-							"Protocol": "http2"
+							"Protocol": "http2",
+							"Websocket": true
 						}
 					]
 				}
@@ -364,6 +367,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 							ListenerPort:  21500,
 							Path:          "/healthz",
 							Protocol:      "http2",
+							Websocket:     true,
 						},
 					},
 				},
@@ -431,6 +435,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"gir": "zim"
 				},
 				"Protocol": "http",
+				"Websocket": true,
 				"ExternalSNI": "abc-123",
 				"MeshGateway": {
 					"Mode": "remote"
@@ -482,6 +487,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"gir": "zim",
 				},
 				Protocol:    "http",
+				Websocket:   true,
 				ExternalSNI: "abc-123",
 				MeshGateway: MeshGatewayConfig{
 					Mode: MeshGatewayModeRemote,


### PR DESCRIPTION
This PR aim to implement websocket support, referenced here https://github.com/hashicorp/consul/issues/8283 .

Rather than always enable the websocket support for everything (like in this old PR https://github.com/hashicorp/consul/pull/9639), I've created a new `websocket` parameter which can be used wherever `protocol` can be used, usually when you specify the service protocol of the service or when you override the path.
In this patch, websocket it's disabled by default.

Basic unit testing was added but I couldn't validate them since i couldn't perform a clean test run with intellij, make test or make test-docker.
I've manually tested in a 2 node server installation and envoy configuration gets created correctly and it's routing correctly.

Since this is the first time I approach consul codebase i ask, if possible, for guidance before committing more time, especially if the overall approach is correct. 