### PR TITLE
[docs] update terminating gateway docs for trust store path

### DIFF
--- a/website/content/docs/k8s/connect/terminating-gateways.mdx
+++ b/website/content/docs/k8s/connect/terminating-gateways.mdx
@@ -205,13 +205,15 @@ metadata:
 spec:
   services:
     - name: example-https
-      caFile: /etc/ssl/cert.pem
+      caFile: /etc/ssl/certs/ca-certificates.crt
 ```
 
 </CodeBlockConfig>
 
-~> If TLS is enabled a `caFile` must be provided, it must point to the system trust store of the terminating gateway
-container (`/etc/ssl/cert.pem`).
+~> If TLS is enabled a `caFile` must be provided, it must point to the system trust store of the terminating gateway container (`/etc/ssl/certs/ca-certificates.crt`).
+
+~> If TLS is enabled and you are using Consul Helm chart 0.43 or older, or an Envoy image with an alpine base
+image, use the following location for the ca certificate file `caFile: /etc/ssl/cert.pem`.
 
 Apply the `TerminatingGateway` resource with `kubectl apply`:
 

--- a/website/content/docs/k8s/connect/terminating-gateways.mdx
+++ b/website/content/docs/k8s/connect/terminating-gateways.mdx
@@ -210,10 +210,11 @@ spec:
 
 </CodeBlockConfig>
 
-~> If TLS is enabled a `caFile` must be provided, it must point to the system trust store of the terminating gateway container (`/etc/ssl/certs/ca-certificates.crt`).
+If TLS is enabled, you must include the `caFile` parameter  that points to the system trust store of the terminating gateway container. By default, the trust store is located in the `/etc/ssl/certs/ca-certificates.crt` directory.
 
-~> If TLS is enabled and you are using Consul Helm chart 0.43 or older, or an Envoy image with an alpine base
-image, use the following location for the ca certificate file `caFile: /etc/ssl/cert.pem`.
+Configure the `caFile` parameter to point to the `/etc/ssl/cert.pem` directory if TLS is enabled and you are using one of the following components:
+ * Consul Helm chart 0.43 or older 
+ * Or an Envoy image with an alpine base image
 
 Apply the `TerminatingGateway` resource with `kubectl apply`:
 


### PR DESCRIPTION
### Description
Describe why you're making this change, in plain English.

With Consul Helm chart `0.44.0` the default envoy proxy image is no longer based on the alpine base image, the trust store location is changed in this base image and needs to be updated in our docs when specifying the config-entry.

This should help users avoid situations like: https://github.com/hashicorp/consul-k8s/issues/1262

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
