### PR TITLE
[1.11] connect: Update supported Envoy versions to 1.20.4, 1.19.5, 1.18.6, 1.17.4

### DIFF
--- a/.changelog/13434.txt
+++ b/.changelog/13434.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Update supported Envoy versions to 1.20.4, 1.19.5, 1.18.6, 1.17.4
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -847,15 +847,15 @@ jobs:
     environment:
       ENVOY_VERSION: "1.18.6"
 
-  envoy-integration-test-1_19_3:
+  envoy-integration-test-1_19_5:
     <<: *ENVOY_TESTS
     environment:
-      ENVOY_VERSION: "1.19.3"
+      ENVOY_VERSION: "1.19.5"
 
-  envoy-integration-test-1_20_2:
+  envoy-integration-test-1_20_4:
     <<: *ENVOY_TESTS
     environment:
-      ENVOY_VERSION: "1.20.2"
+      ENVOY_VERSION: "1.20.4"
 
   # run integration tests for the connect ca providers
   test-connect-ca-providers:
@@ -1092,10 +1092,10 @@ workflows:
       - envoy-integration-test-1_18_6:
           requires:
             - dev-build
-      - envoy-integration-test-1_19_3:
+      - envoy-integration-test-1_19_5:
           requires:
             - dev-build
-      - envoy-integration-test-1_20_2:
+      - envoy-integration-test-1_20_4:
           requires:
             - dev-build
       - noop

--- a/agent/xds/envoy_versioning_test.go
+++ b/agent/xds/envoy_versioning_test.go
@@ -131,8 +131,8 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 		}}
 	}
 	for _, v := range []string{
-		"1.19.0", "1.19.1", "1.19.2", "1.19.3",
-		"1.20.0", "1.20.1", "1.20.2",
+		"1.19.0", "1.19.1", "1.19.2", "1.19.3", "1.19.4", "1.19.5",
+		"1.20.0", "1.20.1", "1.20.2", "1.20.3", "1.20.4",
 	} {
 		cases[v] = testcase{expect: supportedProxyFeatures{}}
 	}

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -7,8 +7,8 @@ package proxysupport
 //
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
-	"1.20.2",
-	"1.19.3",
+	"1.20.4",
+	"1.19.5",
 	"1.18.6",
 	"1.17.4",
 }

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -10,7 +10,7 @@ readonly HASHICORP_DOCKER_PROXY="docker.mirror.hashicorp.services"
 DEBUG=${DEBUG:-}
 
 # ENVOY_VERSION to run each test against
-ENVOY_VERSION=${ENVOY_VERSION:-"1.20.2"}
+ENVOY_VERSION=${ENVOY_VERSION:-"1.20.4"}
 export ENVOY_VERSION
 
 export DOCKER_BUILDKIT=1

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -36,7 +36,7 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
-| 1.11.x              | 1.20.2, 1.19.3, 1.18.6, 1.17.4<sup>1</sup>                                         |
+| 1.11.x              | 1.20.4, 1.19.5, 1.18.6, 1.17.4<sup>1</sup>                                         |
 | 1.10.x              | 1.18.6, 1.17.4<sup>1</sup>, 1.16.5<sup>1</sup> , 1.15.5<sup>1</sup>                |
 | 1.9.x               | 1.16.5<sup>1</sup>, 1.15.5<sup>1</sup>, 1.14.7<sup>1,2</sup>, 1.13.7<sup>1,2</sup> |
 


### PR DESCRIPTION
### Description
Envoy [released some security-oriented patches recently for 1.22.1, 1.21.3, 1.20.4 and 1.19.5](https://groups.google.com/g/envoy-security-announce/c/LQkjLzgmFJA/m/8VMcT_BhAQAJ?utm_medium=email&utm_source=footer&pli=1). This upgrades our integration tests to run against these latest versions and adds them to the support matrix in our docs.

_Note:_ Since this is for 1.11, only the 1.20.4 and 1.19.5 versions were added. 

### Testing & Reproduction steps
[CI run](https://app.circleci.com/pipelines/github/hashicorp/consul/33185/workflows/d28d4d0c-a42b-4d98-b0bc-f7586dd78c62).

### Links
[CTIA-31](https://hashicorp.atlassian.net/browse/CTIA-31).
