### PR TITLE
peering: intentions list test

### DIFF
--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -62,9 +62,10 @@ func TestIntentionList(t *testing.T) {
 			ids = append(ids, reply)
 		}
 
+		// set up an intention for a peered service
 		// TODO(peering): when we handle Upserts, we can use the for loop above. But it may be that we
 		// rip out legacy intentions before supporting that use case so run a config entry request instead here.
-		testutil.RunStep(t, "set up peered intention", func(t *testing.T) {
+		{
 			configEntryIntention := structs.ServiceIntentionsConfigEntry{
 				Kind: structs.ServiceIntentions,
 				Name: "bar",
@@ -89,7 +90,7 @@ func TestIntentionList(t *testing.T) {
 			} else {
 				t.Fatal("ConfigApply returns a boolean type")
 			}
-		})
+		}
 
 		// Request
 		req, err := http.NewRequest("GET", "/v1/connect/intentions", nil)
@@ -118,6 +119,9 @@ func TestIntentionList(t *testing.T) {
 				value[3].ID,
 				value[4].ID,
 			})
+
+		// check that a source peer exists for the intention of the peered service
+		require.Equal(t, "peer1", value[3].SourcePeer)
 	})
 }
 

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -62,6 +62,35 @@ func TestIntentionList(t *testing.T) {
 			ids = append(ids, reply)
 		}
 
+		// TODO(peering): when we handle Upserts, we can use the for loop above. But it may be that we
+		// rip out legacy intentions before supporting that use case so run a config entry request instead here.
+		testutil.RunStep(t, "set up peered intention", func(t *testing.T) {
+			configEntryIntention := structs.ServiceIntentionsConfigEntry{
+				Kind: structs.ServiceIntentions,
+				Name: "bar",
+				Sources: []*structs.SourceIntention{
+					{
+						Name:   "peered",
+						Peer:   "peer1",
+						Action: structs.IntentionActionAllow,
+					},
+				},
+			}
+
+			req, err := http.NewRequest("PUT", "/v1/config", jsonReader(configEntryIntention))
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+
+			obj, err := a.srv.ConfigApply(resp, req)
+			require.NoError(t, err)
+
+			if applied, ok := obj.(bool); ok {
+				require.True(t, applied)
+			} else {
+				t.Fatal("ConfigApply returns a boolean type")
+			}
+		})
+
 		// Request
 		req, err := http.NewRequest("GET", "/v1/connect/intentions", nil)
 		require.NoError(t, err)
@@ -71,21 +100,23 @@ func TestIntentionList(t *testing.T) {
 		require.NoError(t, err)
 
 		value := obj.(structs.Intentions)
-		require.Len(t, value, 4)
+		require.Len(t, value, 5)
 
-		require.Equal(t, []string{"bar->db", "foo->db", "zim->gir", "*->db"},
+		require.Equal(t, []string{"bar->db", "foo->db", "zim->gir", "peered->bar", "*->db"},
 			[]string{
 				value[0].SourceName + "->" + value[0].DestinationName,
 				value[1].SourceName + "->" + value[1].DestinationName,
 				value[2].SourceName + "->" + value[2].DestinationName,
 				value[3].SourceName + "->" + value[3].DestinationName,
+				value[4].SourceName + "->" + value[4].DestinationName,
 			})
-		require.Equal(t, []string{ids[2], ids[1], "", ids[0]},
+		require.Equal(t, []string{ids[2], ids[1], "", "", ids[0]},
 			[]string{
 				value[0].ID,
 				value[1].ID,
 				value[2].ID,
 				value[3].ID,
+				value[4].ID,
 			})
 	})
 }


### PR DESCRIPTION
### Description
This diff adds a test to prove that the http api can list intentions for peered services. 

#### links

* [asana](https://app.asana.com/0/1201631904755166/1202439043013562/f)
