### PR TITLE
[OSS-Preview] Add leader routine to clean up peerings

### DIFF
--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -57,6 +57,12 @@ func (s *Server) revokeEnterpriseLeadership() error {
 	return nil
 }
 
+func (s *Server) startTenancyDeferredDeletion(ctx context.Context) {
+}
+
+func (s *Server) stopTenancyDeferredDeletion() {
+}
+
 func (s *Server) validateEnterpriseRequest(entMeta *acl.EnterpriseMeta, write bool) error {
 	return nil
 }

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -107,7 +109,7 @@ func TestLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T) {
 			Value: "my-peer-s2",
 		})
 		require.NoError(r, err)
-		require.Equal(r, pbpeering.PeeringState_TERMINATED, peering.State)
+		require.Nil(r, peering)
 	})
 }
 
@@ -196,6 +198,162 @@ func TestLeader_PeeringSync_Lifecycle_ServerDeletion(t *testing.T) {
 			Value: "my-peer-s1",
 		})
 		require.NoError(r, err)
-		require.Equal(r, pbpeering.PeeringState_TERMINATED, peering.State)
+		require.Nil(r, peering)
 	})
+}
+
+func TestLeader_Peering_DeferredDeletion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	// TODO(peering): Configure with TLS
+	_, s1 := testServerWithConfig(t, func(c *Config) {
+		c.NodeName = "s1.dc1"
+		c.Datacenter = "dc1"
+		c.TLSConfig.Domain = "consul"
+	})
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	var (
+		peerName    = "my-peer-s2"
+		defaultMeta = acl.DefaultEnterpriseMeta()
+		lastIdx     = uint64(0)
+	)
+
+	// Simulate a peering initiation event by writing a peering to the state store.
+	lastIdx++
+	require.NoError(t, s1.fsm.State().PeeringWrite(lastIdx, &pbpeering.Peering{
+		Name: peerName,
+	}))
+
+	// Insert imported data: nodes, services, checks, trust bundle
+	lastIdx = insertTestPeeringData(t, s1.fsm.State(), peerName, lastIdx)
+
+	// Mark the peering for deletion to trigger the termination sequence.
+	lastIdx++
+	require.NoError(t, s1.fsm.State().PeeringWrite(lastIdx, &pbpeering.Peering{
+		Name:      peerName,
+		DeletedAt: structs.TimeToProto(time.Now()),
+	}))
+
+	// Ensure imported data is gone:
+	retry.Run(t, func(r *retry.R) {
+		_, csn, err := s1.fsm.State().ServiceDump(nil, "", false, defaultMeta, peerName)
+		require.NoError(r, err)
+		require.Len(r, csn, 0)
+
+		_, checks, err := s1.fsm.State().ChecksInState(nil, api.HealthAny, defaultMeta, peerName)
+		require.NoError(r, err)
+		require.Len(r, checks, 0)
+
+		_, nodes, err := s1.fsm.State().NodeDump(nil, defaultMeta, peerName)
+		require.NoError(r, err)
+		require.Len(r, nodes, 0)
+
+		_, tb, err := s1.fsm.State().PeeringTrustBundleRead(nil, state.Query{Value: peerName})
+		require.NoError(r, err)
+		require.Nil(r, tb)
+	})
+
+	// The leader routine should pick up the deletion and finish deleting the peering.
+	retry.Run(t, func(r *retry.R) {
+		_, peering, err := s1.fsm.State().PeeringRead(nil, state.Query{
+			Value: peerName,
+		})
+		require.NoError(r, err)
+		require.Nil(r, peering)
+	})
+}
+
+func insertTestPeeringData(t *testing.T, store *state.Store, peer string, lastIdx uint64) uint64 {
+	lastIdx++
+	require.NoError(t, store.PeeringTrustBundleWrite(lastIdx, &pbpeering.PeeringTrustBundle{
+		TrustDomain: "952e6bd1-f4d6-47f7-83ff-84b31babaa17",
+		PeerName:    peer,
+		RootPEMs:    []string{"certificate bundle"},
+	}))
+
+	lastIdx++
+	require.NoError(t, store.EnsureRegistration(lastIdx, &structs.RegisterRequest{
+		Node:     "aaa",
+		Address:  "10.0.0.1",
+		PeerName: peer,
+		Service: &structs.NodeService{
+			Service:  "a-service",
+			ID:       "a-service-1",
+			Port:     8080,
+			PeerName: peer,
+		},
+		Checks: structs.HealthChecks{
+			{
+				CheckID:     "a-service-1-check",
+				ServiceName: "a-service",
+				ServiceID:   "a-service-1",
+				Node:        "aaa",
+				PeerName:    peer,
+			},
+			{
+				CheckID:  structs.SerfCheckID,
+				Node:     "aaa",
+				PeerName: peer,
+			},
+		},
+	}))
+
+	lastIdx++
+	require.NoError(t, store.EnsureRegistration(lastIdx, &structs.RegisterRequest{
+		Node:     "bbb",
+		Address:  "10.0.0.2",
+		PeerName: peer,
+		Service: &structs.NodeService{
+			Service:  "b-service",
+			ID:       "b-service-1",
+			Port:     8080,
+			PeerName: peer,
+		},
+		Checks: structs.HealthChecks{
+			{
+				CheckID:     "b-service-1-check",
+				ServiceName: "b-service",
+				ServiceID:   "b-service-1",
+				Node:        "bbb",
+				PeerName:    peer,
+			},
+			{
+				CheckID:  structs.SerfCheckID,
+				Node:     "bbb",
+				PeerName: peer,
+			},
+		},
+	}))
+
+	lastIdx++
+	require.NoError(t, store.EnsureRegistration(lastIdx, &structs.RegisterRequest{
+		Node:     "ccc",
+		Address:  "10.0.0.3",
+		PeerName: peer,
+		Service: &structs.NodeService{
+			Service:  "c-service",
+			ID:       "c-service-1",
+			Port:     8080,
+			PeerName: peer,
+		},
+		Checks: structs.HealthChecks{
+			{
+				CheckID:     "c-service-1-check",
+				ServiceName: "c-service",
+				ServiceID:   "c-service-1",
+				Node:        "ccc",
+				PeerName:    peer,
+			},
+			{
+				CheckID:  structs.SerfCheckID,
+				Node:     "ccc",
+				PeerName: peer,
+			},
+		},
+	}))
+
+	return lastIdx
 }

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -109,7 +109,7 @@ func TestLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T) {
 			Value: "my-peer-s2",
 		})
 		require.NoError(r, err)
-		require.Nil(r, peering)
+		require.Equal(r, pbpeering.PeeringState_TERMINATED, peering.State)
 	})
 }
 
@@ -198,7 +198,7 @@ func TestLeader_PeeringSync_Lifecycle_ServerDeletion(t *testing.T) {
 			Value: "my-peer-s1",
 		})
 		require.NoError(r, err)
-		require.Nil(r, peering)
+		require.Equal(r, pbpeering.PeeringState_TERMINATED, peering.State)
 	})
 }
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -126,6 +126,7 @@ const (
 	backgroundCAInitializationRoutineName = "CA initialization"
 	virtualIPCheckRoutineName             = "virtual IP version check"
 	peeringStreamsRoutineName             = "streaming peering resources"
+	peeringDeletionRoutineName            = "peering deferred deletion"
 )
 
 var (

--- a/agent/peering_endpoint_test.go
+++ b/agent/peering_endpoint_test.go
@@ -12,12 +12,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/proto/pbpeering"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/require"
 )
 
 var validCA = `
@@ -346,7 +347,7 @@ func TestHTTP_Peering_Delete(t *testing.T) {
 	t.Run("now the token is deleted and reads should yield a 404", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			req, err := http.NewRequest("GET", "/v1/peering/foo", nil)
-			require.NoError(t, err)
+			require.NoError(r, err)
 			resp := httptest.NewRecorder()
 			a.srv.h.ServeHTTP(resp, req)
 			require.Equal(r, http.StatusNotFound, resp.Code)

--- a/agent/peering_endpoint_test.go
+++ b/agent/peering_endpoint_test.go
@@ -12,13 +12,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/encoding/protojson"
-
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/proto/pbpeering"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/stretchr/testify/require"
 )
 
 var validCA = `
@@ -344,18 +343,14 @@ func TestHTTP_Peering_Delete(t *testing.T) {
 		require.Equal(t, "", resp.Body.String())
 	})
 
-	t.Run("now the token is marked for deletion", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "/v1/peering/foo", nil)
-		require.NoError(t, err)
-		resp := httptest.NewRecorder()
-		a.srv.h.ServeHTTP(resp, req)
-		require.Equal(t, http.StatusOK, resp.Code)
-
-		var p pbpeering.Peering
-		body, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
-		require.NoError(t, protojson.Unmarshal(body, &p))
-		require.False(t, p.IsActive())
+	t.Run("now the token is deleted and reads should yield a 404", func(t *testing.T) {
+		retry.Run(t, func(r *retry.R) {
+			req, err := http.NewRequest("GET", "/v1/peering/foo", nil)
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+			a.srv.h.ServeHTTP(resp, req)
+			require.Equal(r, http.StatusNotFound, resp.Code)
+		})
 	})
 
 	t.Run("delete a token that does not exist", func(t *testing.T) {

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
@@ -36,6 +35,7 @@ import (
 	"github.com/hashicorp/consul/proto/prototest"
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"

--- a/api/peering_test.go
+++ b/api/peering_test.go
@@ -212,11 +212,12 @@ func TestAPI_Peering_GenerateToken_Read_Establish_Delete(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, wm)
 
-		// Read to see if the token is marked for deletion
-		resp, qm, err := c.Peerings().Read(ctx, "peer1", nil)
-		require.NoError(t, err)
-		require.NotNil(t, qm)
-		require.NotNil(t, resp)
-		require.False(t, resp.DeletedAt.IsZero())
+		// Read to see if the token is gone
+		retry.Run(t, func(r *retry.R) {
+			resp, qm, err := c.Peerings().Read(ctx, "peer1", nil)
+			require.NoError(r, err)
+			require.NotNil(r, qm)
+			require.Nil(r, resp)
+		})
 	})
 }


### PR DESCRIPTION
Tech preview backport for: #13445

### Description
Once a peering is marked for deletion a new leader routine will now
clean up all imported resources and then the peering itself.

A lot of the logic was grabbed from the namespace/partitions deferred
deletions but with a handful of simplifications:
- The rate limiting is not configurable.

- Deleting imported nodes/services/checks is done by deleting nodes with
  the Txn API. The services and checks are deleted as a side-effect.

- There is no "round rate limiter" like with namespaces and partitions.
  This is because peerings are purely local, and deleting a peering in
  the datacenter does not depend on deleting data from other DCs like
  with WAN-federated namespaces. All rate limiting is handled by the
  Raft rate limiter.