### PR TITLE
peering: block Intention.Apply ops

### DIFF
--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -77,7 +77,7 @@ func (s *Intention) Apply(args *structs.IntentionRequest, reply *string) error {
 		return ErrConnectNotEnabled
 	}
 
-	if args.Intention.SourcePeer != "" {
+	if args.Intention != nil && args.Intention.SourcePeer != "" {
 		return fmt.Errorf("SourcePeer field is not supported on this endpoint. Use config entries instead")
 	}
 

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -77,6 +77,10 @@ func (s *Intention) Apply(args *structs.IntentionRequest, reply *string) error {
 		return ErrConnectNotEnabled
 	}
 
+	if args.Intention.SourcePeer != "" {
+		return fmt.Errorf("SourcePeer field is not supported on this endpoint. Use config entries instead")
+	}
+
 	// Ensure that all service-intentions config entry writes go to the primary
 	// datacenter. These will then be replicated to all the other datacenters.
 	args.Datacenter = s.srv.config.PrimaryDatacenter

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -281,8 +281,7 @@ func TestIntentionApply_NoSourcePeer(t *testing.T) {
 
 	t.Parallel()
 
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
+	_, s1 := testServer(t)
 	codec := rpcClient(t, s1)
 
 	waitForLeaderEstablishment(t, s1)

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -283,9 +283,7 @@ func TestIntentionApply_NoSourcePeer(t *testing.T) {
 
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
 	codec := rpcClient(t, s1)
-	defer codec.Close()
 
 	waitForLeaderEstablishment(t, s1)
 

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -273,6 +273,44 @@ func TestIntentionApply_updateGood(t *testing.T) {
 	}
 }
 
+// TestIntentionApply_NoSourcePeer makes sure that no intention is created with a SourcePeer since this is not supported
+func TestIntentionApply_NoSourcePeer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	waitForLeaderEstablishment(t, s1)
+
+	// Setup a basic record to create
+	ixn := structs.IntentionRequest{
+		Datacenter: "dc1",
+		Op:         structs.IntentionOpCreate,
+		Intention: &structs.Intention{
+			SourceNS:        structs.IntentionDefaultNamespace,
+			SourceName:      "test",
+			SourcePeer:      "peer1",
+			DestinationNS:   structs.IntentionDefaultNamespace,
+			DestinationName: "test",
+			Action:          structs.IntentionActionAllow,
+			SourceType:      structs.IntentionSourceConsul,
+			Meta:            map[string]string{},
+		},
+	}
+	var reply string
+	err := msgpackrpc.CallWithCodec(codec, "Intention.Apply", &ixn, &reply)
+	require.Error(t, err)
+	require.Contains(t, err, "SourcePeer field is not supported on this endpoint. Use config entries instead")
+	require.Empty(t, reply)
+}
+
 // Shouldn't be able to update a non-existent intention
 func TestIntentionApply_updateNonExist(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Signed-off-by: acpana <8968914+acpana@users.noreply.github.com>

### Description

I know `Intentions.*` is on its way out but today someone can still hit these endpoints with a SourcePeer like `Intention.Apply` hoping to create a peer service intention. This diff blocks that (and any other `.Apply` op) which is good api hygiene at least. 
