### PR TITLE
Merge pull request #13469 from hashicorp/correct-redhat-tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,7 @@ jobs:
           version: ${{env.version}}
           target: ubi
           arch: amd64
-          redhat_tag: scan.connect.redhat.com/ospid-612d01d49f14588c41ebf67c/${{env.repo}}:${{env.version}}-ubi
+          redhat_tag: scan.connect.redhat.com/ospid-60f9fdbec3a80eac643abedf/${{env.repo}}:${{env.version}}-ubi
           smoke_test: .github/scripts/verify_docker.sh v${{ env.version }}
 
   verify-linux:
@@ -358,14 +358,14 @@ jobs:
     name: Verify ${{ matrix.arch }} debian package
     steps:
       - uses: actions/checkout@v2
-        
+
       - name: Set package version
         run: |
-          echo "pkg_version=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/\-/~/g')" >> $GITHUB_ENV 
+          echo "pkg_version=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/\-/~/g')" >> $GITHUB_ENV
 
       - name: Set package name
         run: |
-          echo "pkg_name=consul_${{ env.pkg_version }}-1_${{ matrix.arch }}.deb" >> $GITHUB_ENV 
+          echo "pkg_name=consul_${{ env.pkg_version }}-1_${{ matrix.arch }}.deb" >> $GITHUB_ENV
 
       - name: Download workflow artifacts
         uses: actions/download-artifact@v3
@@ -398,12 +398,12 @@ jobs:
 
       - name: Set package version
         run: |
-          echo "pkg_version=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/\-/~/g')" >> $GITHUB_ENV 
+          echo "pkg_version=$(echo ${{ needs.get-product-version.outputs.product-version }} | sed 's/\-/~/g')" >> $GITHUB_ENV
 
       - name: Set package name
         run: |
-          echo "pkg_name=consul-${{ env.pkg_version }}-1.${{ matrix.arch }}.rpm" >> $GITHUB_ENV 
-        
+          echo "pkg_name=consul-${{ env.pkg_version }}-1.${{ matrix.arch }}.rpm" >> $GITHUB_ENV
+
       - name: Download workflow artifacts
         uses: actions/download-artifact@v3
         with:
@@ -414,5 +414,5 @@ jobs:
         with:
           platforms: all
 
-      - name: Verify ${{ matrix.arch }} rpm 
+      - name: Verify ${{ matrix.arch }} rpm
         run: ./.github/scripts/verify_artifact.sh ${{ env.pkg_name }} v${{ env.version }}


### PR DESCRIPTION
This is a manual backport of #13469. The original description is below:

### Description
The `redhat_tag` used here contains the wrong OSPID which means the images can't be published.

### Testing & Reproduction steps
Testing for this can only take place during a push to red hat. However, the new OSPID has been copy/pasted directly from the Consul project page on Red Hat Partner Connect, so it is correct.

### Links
Internal people can see [this slack thread](https://hashicorp.slack.com/archives/CR024M999/p1655349640576519) for links to failed pushes to red hat caused by this issue.

### PR Checklist

* [ ] updated test coverage (n/a)
* [ ] external facing docs updated (n/a)
* [x] not a security concern
