### PR TITLE
Merge pull request #13469 from hashicorp/correct-redhat-tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,7 @@ jobs:
           version: ${{env.version}}
           target: ubi
           arch: amd64
-          redhat_tag: scan.connect.redhat.com/ospid-612d01d49f14588c41ebf67c/${{env.repo}}:${{env.version}}-ubi
+          redhat_tag: scan.connect.redhat.com/ospid-60f9fdbec3a80eac643abedf/${{env.repo}}:${{env.version}}-ubi
           smoke_test: .github/scripts/verify_docker.sh v${{ env.version }}
 
   verify-linux:


### PR DESCRIPTION
This is a manual backport of #13469. The original description is below:

### Description
The `redhat_tag` used here contains the wrong OSPID which means the images can't be published.

### Testing & Reproduction steps
Testing for this can only take place during a push to red hat. However, the new OSPID has been copy/pasted directly from the Consul project page on Red Hat Partner Connect, so it is correct.

### Links
Internal people can see [this slack thread](https://hashicorp.slack.com/archives/CR024M999/p1655349640576519) for links to failed pushes to red hat caused by this issue.

### PR Checklist

* [ ] updated test coverage (n/a)
* [ ] external facing docs updated (n/a)
* [x] not a security concern
