### PR TITLE
Fix Consul KV CLI 'GET' flags 'keys' and 'recurse' to be set together

### DIFF
--- a/.changelog/13493.txt
+++ b/.changelog/13493.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
+```release-note:bug
 cli: Fix Consul kv CLI 'GET' flags 'keys' and 'recurse' to be set together
 ```

--- a/.changelog/13493.txt
+++ b/.changelog/13493.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Fix Consul kv CLI 'GET' flags 'keys' and 'recurse' to be set together
+```

--- a/command/kv/get/kv_get.go
+++ b/command/kv/get/kv_get.go
@@ -112,7 +112,7 @@ func (c *cmd) Run(args []string) int {
 			if c.detailed {
 				var b bytes.Buffer
 				if err := prettyKVPair(&b, pair, false, true); err != nil {
-					c.UI.Error(fmt.Sprintf("Error rendering KV pair: %s", err))
+					c.UI.Error(fmt.Sprintf("Error rendering KV key: %s", err))
 					return 1
 				}
 				c.UI.Info(b.String())

--- a/command/kv/get/kv_get.go
+++ b/command/kv/get/kv_get.go
@@ -99,6 +99,32 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	switch {
+	case c.keys && c.recurse:
+		pairs, _, err := client.KV().List(key, &api.QueryOptions{
+			AllowStale: c.http.Stale(),
+		})
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error querying Consul agent: %s", err))
+			return 1
+		}
+
+		for i, pair := range pairs {
+			if c.detailed {
+				var b bytes.Buffer
+				if err := prettyKVPair(&b, pair, false, true); err != nil {
+					c.UI.Error(fmt.Sprintf("Error rendering KV pair: %s", err))
+					return 1
+				}
+				c.UI.Info(b.String())
+
+				if i < len(pairs)-1 {
+					c.UI.Info("")
+				}
+			} else {
+				c.UI.Info(fmt.Sprintf("%s", pair.Key))
+			}
+		}
+		return 0
 	case c.keys:
 		keys, _, err := client.KV().Keys(key, c.separator, &api.QueryOptions{
 			AllowStale: c.http.Stale(),
@@ -125,7 +151,7 @@ func (c *cmd) Run(args []string) int {
 		for i, pair := range pairs {
 			if c.detailed {
 				var b bytes.Buffer
-				if err := prettyKVPair(&b, pair, c.base64encode); err != nil {
+				if err := prettyKVPair(&b, pair, c.base64encode, false); err != nil {
 					c.UI.Error(fmt.Sprintf("Error rendering KV pair: %s", err))
 					return 1
 				}
@@ -161,7 +187,7 @@ func (c *cmd) Run(args []string) int {
 
 		if c.detailed {
 			var b bytes.Buffer
-			if err := prettyKVPair(&b, pair, c.base64encode); err != nil {
+			if err := prettyKVPair(&b, pair, c.base64encode, false); err != nil {
 				c.UI.Error(fmt.Sprintf("Error rendering KV pair: %s", err))
 				return 1
 			}
@@ -187,7 +213,7 @@ func (c *cmd) Help() string {
 	return c.help
 }
 
-func prettyKVPair(w io.Writer, pair *api.KVPair, base64EncodeValue bool) error {
+func prettyKVPair(w io.Writer, pair *api.KVPair, base64EncodeValue bool, keysOnly bool) error {
 	tw := tabwriter.NewWriter(w, 0, 2, 6, ' ', 0)
 	fmt.Fprintf(tw, "CreateIndex\t%d\n", pair.CreateIndex)
 	fmt.Fprintf(tw, "Flags\t%d\n", pair.Flags)
@@ -205,9 +231,9 @@ func prettyKVPair(w io.Writer, pair *api.KVPair, base64EncodeValue bool) error {
 	if pair.Namespace != "" {
 		fmt.Fprintf(tw, "Namespace\t%s\n", pair.Namespace)
 	}
-	if base64EncodeValue {
+	if !keysOnly && base64EncodeValue {
 		fmt.Fprintf(tw, "Value\t%s", base64.StdEncoding.EncodeToString(pair.Value))
-	} else {
+	} else if !keysOnly {
 		fmt.Fprintf(tw, "Value\t%s", pair.Value)
 	}
 	return tw.Flush()

--- a/command/kv/get/kv_get_test.go
+++ b/command/kv/get/kv_get_test.go
@@ -439,7 +439,7 @@ func TestKVGetCommand_KeysRecurse(t *testing.T) {
 	}
 	for k, v := range keys {
 		var pair *api.KVPair
-		switch k {
+		switch v {
 		case "":
 			pair = &api.KVPair{Key: k, Value: nil}
 		default:
@@ -461,12 +461,11 @@ func TestKVGetCommand_KeysRecurse(t *testing.T) {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
 	output := ui.OutputWriter.String()
-	fmt.Println(output)
 	for key, value := range keys {
 		if !strings.Contains(output, key) {
 			t.Fatalf("bad %#v missing %q", output, key)
 		}
-		if strings.Contains(output, key+":"+base64.StdEncoding.EncodeToString([]byte(value))) {
+		if strings.Contains(output, key+":"+string([]byte(value))) {
 			t.Fatalf("bad %#v expected no values for keys %q but received %q", output, key, value)
 		}
 	}
@@ -490,7 +489,7 @@ func TestKVGetCommand_DetailedKeysRecurse(t *testing.T) {
 	}
 	for k, v := range keys {
 		var pair *api.KVPair
-		switch k {
+		switch v {
 		case "":
 			pair = &api.KVPair{Key: k, Value: nil}
 		default:
@@ -515,17 +514,6 @@ func TestKVGetCommand_DetailedKeysRecurse(t *testing.T) {
 	output := ui.OutputWriter.String()
 	fmt.Println(output)
 	for key, value := range keys {
-		for _, key := range []string{
-			"CreateIndex",
-			"LockIndex",
-			"ModifyIndex",
-			"Flags",
-			"Session",
-		} {
-			if !strings.Contains(output, key) {
-				t.Fatalf("bad %#v, missing %q", output, key)
-			}
-		}
 		if value != "" && strings.Contains(output, value) {
 			t.Fatalf("bad %#v expected no values for keys %q but received %q", output, key, value)
 		}

--- a/command/kv/get/kv_get_test.go
+++ b/command/kv/get/kv_get_test.go
@@ -2,7 +2,6 @@ package get
 
 import (
 	"encoding/base64"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -465,7 +464,7 @@ func TestKVGetCommand_KeysRecurse(t *testing.T) {
 		if !strings.Contains(output, key) {
 			t.Fatalf("bad %#v missing %q", output, key)
 		}
-		if strings.Contains(output, key+":"+string([]byte(value))) {
+		if strings.Contains(output, key+":"+value) {
 			t.Fatalf("bad %#v expected no values for keys %q but received %q", output, key, value)
 		}
 	}
@@ -512,7 +511,6 @@ func TestKVGetCommand_DetailedKeysRecurse(t *testing.T) {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
 	output := ui.OutputWriter.String()
-	fmt.Println(output)
 	for key, value := range keys {
 		if value != "" && strings.Contains(output, value) {
 			t.Fatalf("bad %#v expected no values for keys %q but received %q", output, key, value)


### PR DESCRIPTION
…v get CLI

### Description
My attempt to fix the first [point](https://github.com/hashicorp/consul/issues/13412#issuecomment-1151603461) of @Amier3 in issue #13412 

### Testing & Reproduction steps
* Added two extra test cases

```
❯ consul kv put foo/
Success! Data written to: foo/
❯ consul kv put foo1/a "Hello World 1"
Success! Data written to: foo1/a

# Before 
❯ consul kv get -recurse -keys foo
foo/
foo1/
❯ consul kv get -recurse -keys -detailed foo
foo/
foo1/

# After 
❯ consul kv get -recurse -keys foo
foo/
foo1/a
❯ consul kv get -recurse -keys -detailed foo
CreateIndex      16
Flags            0
Key              foo/
LockIndex        0
ModifyIndex      16
Session          -


CreateIndex      17
Flags            0
Key              foo1/a
LockIndex        0
ModifyIndex      17
Session          -

```

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
