### PR TITLE
Naive fix for #13494

### DIFF
--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -55,16 +55,8 @@ var CommandsSummaries = []prometheus.SummaryDefinition{
 		Help: "Measures the time it takes to apply the given autopilot update to the FSM.",
 	},
 	{
-		Name: []string{"consul", "fsm", "intention"},
-		Help: "Deprecated - use fsm_intention instead",
-	},
-	{
 		Name: []string{"fsm", "intention"},
 		Help: "Measures the time it takes to apply an intention operation to the FSM.",
-	},
-	{
-		Name: []string{"consul", "fsm", "ca"},
-		Help: "Deprecated - use fsm_ca instead",
 	},
 	{
 		Name: []string{"fsm", "ca"},
@@ -347,12 +339,6 @@ func (c *FSM) applyIntentionOperation(buf []byte, index uint64) interface{} {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	// TODO(kit): We should deprecate this first metric that writes the metrics_prefix itself,
-	//  the config we use to flag this out, telemetry.disable_compat_1.9 is on the agent - how do
-	//  we access it here?
-	defer metrics.MeasureSinceWithLabels([]string{"consul", "fsm", "intention"}, time.Now(),
-		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
-
 	defer metrics.MeasureSinceWithLabels([]string{"fsm", "intention"}, time.Now(),
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 
@@ -384,8 +370,6 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	defer metrics.MeasureSinceWithLabels([]string{"consul", "fsm", "ca"}, time.Now(),
-		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	defer metrics.MeasureSinceWithLabels([]string{"fsm", "ca"}, time.Now(),
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -20,10 +20,6 @@ import (
 
 var IntentionSummaries = []prometheus.SummaryDefinition{
 	{
-		Name: []string{"consul", "intention", "apply"},
-		Help: "",
-	},
-	{
 		Name: []string{"intention", "apply"},
 		Help: "",
 	},
@@ -88,7 +84,6 @@ func (s *Intention) Apply(args *structs.IntentionRequest, reply *string) error {
 	if done, err := s.srv.ForwardRPC("Intention.Apply", args, reply); done {
 		return err
 	}
-	defer metrics.MeasureSince([]string{"consul", "intention", "apply"}, time.Now())
 	defer metrics.MeasureSince([]string{"intention", "apply"}, time.Now())
 
 	if err := s.legacyUpgradeCheck(); err != nil {

--- a/agent/consul/usagemetrics/usagemetrics.go
+++ b/agent/consul/usagemetrics/usagemetrics.go
@@ -17,35 +17,35 @@ import (
 
 var Gauges = []prometheus.GaugeDefinition{
 	{
-		Name: []string{"consul", "state", "nodes"},
+		Name: []string{"state", "nodes"},
 		Help: "Measures the current number of nodes registered with Consul. It is only emitted by Consul servers. Added in v1.9.0.",
 	},
 	{
-		Name: []string{"consul", "state", "services"},
+		Name: []string{"state", "services"},
 		Help: "Measures the current number of unique services registered with Consul, based on service name. It is only emitted by Consul servers. Added in v1.9.0.",
 	},
 	{
-		Name: []string{"consul", "state", "service_instances"},
+		Name: []string{"state", "service_instances"},
 		Help: "Measures the current number of unique services registered with Consul, based on service name. It is only emitted by Consul servers. Added in v1.9.0.",
 	},
 	{
-		Name: []string{"consul", "members", "clients"},
+		Name: []string{"members", "clients"},
 		Help: "Measures the current number of client agents registered with Consul. It is only emitted by Consul servers. Added in v1.9.6.",
 	},
 	{
-		Name: []string{"consul", "members", "servers"},
+		Name: []string{"members", "servers"},
 		Help: "Measures the current number of server agents registered with Consul. It is only emitted by Consul servers. Added in v1.9.6.",
 	},
 	{
-		Name: []string{"consul", "kv", "entries"},
+		Name: []string{"kv", "entries"},
 		Help: "Measures the current number of server agents registered with Consul. It is only emitted by Consul servers. Added in v1.10.3.",
 	},
 	{
-		Name: []string{"consul", "state", "connect_instances"},
+		Name: []string{"state", "connect_instances"},
 		Help: "Measures the current number of unique connect service instances registered with Consul, labeled by Kind. It is only emitted by Consul servers. Added in v1.10.4.",
 	},
 	{
-		Name: []string{"consul", "state", "config_entries"},
+		Name: []string{"state", "config_entries"},
 		Help: "Measures the current number of unique configuration entries registered with Consul, labeled by Kind. It is only emitted by Consul servers. Added in v1.10.4.",
 	},
 }

--- a/agent/consul/usagemetrics/usagemetrics_oss.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss.go
@@ -13,7 +13,7 @@ import (
 
 func (u *UsageMetricsReporter) emitNodeUsage(nodeUsage state.NodeUsage) {
 	metrics.SetGaugeWithLabels(
-		[]string{"consul", "state", "nodes"},
+		[]string{"state", "nodes"},
 		float32(nodeUsage.Nodes),
 		u.metricLabels,
 	)
@@ -34,13 +34,13 @@ func (u *UsageMetricsReporter) emitMemberUsage(members []serf.Member) {
 	}
 
 	metrics.SetGaugeWithLabels(
-		[]string{"consul", "members", "clients"},
+		[]string{"members", "clients"},
 		float32(clients),
 		u.metricLabels,
 	)
 
 	metrics.SetGaugeWithLabels(
-		[]string{"consul", "members", "servers"},
+		[]string{"members", "servers"},
 		float32(servers),
 		u.metricLabels,
 	)
@@ -48,20 +48,20 @@ func (u *UsageMetricsReporter) emitMemberUsage(members []serf.Member) {
 
 func (u *UsageMetricsReporter) emitServiceUsage(serviceUsage state.ServiceUsage) {
 	metrics.SetGaugeWithLabels(
-		[]string{"consul", "state", "services"},
+		[]string{"state", "services"},
 		float32(serviceUsage.Services),
 		u.metricLabels,
 	)
 
 	metrics.SetGaugeWithLabels(
-		[]string{"consul", "state", "service_instances"},
+		[]string{"state", "service_instances"},
 		float32(serviceUsage.ServiceInstances),
 		u.metricLabels,
 	)
 
 	for k, i := range serviceUsage.ConnectServiceInstances {
 		metrics.SetGaugeWithLabels(
-			[]string{"consul", "state", "connect_instances"},
+			[]string{"state", "connect_instances"},
 			float32(i),
 			append(u.metricLabels, metrics.Label{Name: "kind", Value: k}),
 		)
@@ -70,7 +70,7 @@ func (u *UsageMetricsReporter) emitServiceUsage(serviceUsage state.ServiceUsage)
 
 func (u *UsageMetricsReporter) emitKVUsage(kvUsage state.KVUsage) {
 	metrics.SetGaugeWithLabels(
-		[]string{"consul", "state", "kv_entries"},
+		[]string{"state", "kv_entries"},
 		float32(kvUsage.KVCount),
 		u.metricLabels,
 	)
@@ -79,7 +79,7 @@ func (u *UsageMetricsReporter) emitKVUsage(kvUsage state.KVUsage) {
 func (u *UsageMetricsReporter) emitConfigEntryUsage(configUsage state.ConfigEntryUsage) {
 	for k, i := range configUsage.ConfigByKind {
 		metrics.SetGaugeWithLabels(
-			[]string{"consul", "state", "config_entries"},
+			[]string{"state", "config_entries"},
 			float32(i),
 			append(u.metricLabels, metrics.Label{Name: "kind", Value: k}),
 		)


### PR DESCRIPTION
I don't expect this to actually be merged as is, because compatibility
concerns need to be addressed.

Nevertheless, is it useful as a way to demonstrate the eventual desired
end state once the entire deprecation and removal process is complete,
over multiple release cycles, and to show the scope of the metrics
needing changes.

See #13494