### PR TITLE
Delete definition of metric `consul.acl.blocked.node.deregistration`

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -46,10 +46,6 @@ var StateCounters = []prometheus.CounterDefinition{
 		Name: []string{"acl", "blocked", "node", "registration"},
 		Help: "Increments whenever a registration fails for a node (blocked by an ACL)",
 	},
-	{
-		Name: []string{"acl", "blocked", "node", "deregistration"},
-		Help: "Increments whenever a deregistration fails for a node (blocked by an ACL)",
-	},
 }
 
 const fullSyncReadMaxStale = 2 * time.Second


### PR DESCRIPTION
Although the metric is defined, there is no code which ever sets its
value - the code in question is genuinely asymmetric - there are 3 types
of object for which registration can be tracked, but only 2 for which
deregistration can be tracked.

This is already reflected in the documentation at:
https://www.consul.io/docs/agent/telemetry#metrics-reference
It's just this part of the code which is out of sync.