### PR TITLE
docs: Use "error" to use standard log level value

### DIFF
--- a/website/content/commands/monitor.mdx
+++ b/website/content/commands/monitor.mdx
@@ -32,6 +32,6 @@ Usage: `consul monitor [options]`
 - `-log-level` - The log level of the messages to show. By default this
   is "info". This log level can be more verbose than what the agent is
   configured to run at. Available log levels are "trace", "debug", "info",
-  "warn", and "err".
+  "warn", and "error".
 - `-log-json` - Toggles whether the messages are streamed in JSON format.
   By default this is false.

--- a/website/content/commands/monitor.mdx
+++ b/website/content/commands/monitor.mdx
@@ -31,7 +31,7 @@ Usage: `consul monitor [options]`
 
 - `-log-level` - The log level of the messages to show. By default this
   is "info". This log level can be more verbose than what the agent is
-  configured to run at. Available log levels are `trace`, `debug`, `info`,
-  `warn`, and `error`.
+  configured to run at. Available log levels are "trace", "debug", "info",
+  "warn", and "error".
 - `-log-json` - Toggles whether the messages are streamed in JSON format.
   By default this is false.

--- a/website/content/commands/monitor.mdx
+++ b/website/content/commands/monitor.mdx
@@ -31,7 +31,7 @@ Usage: `consul monitor [options]`
 
 - `-log-level` - The log level of the messages to show. By default this
   is "info". This log level can be more verbose than what the agent is
-  configured to run at. Available log levels are "trace", "debug", "info",
-  "warn", and "error".
+  configured to run at. Available log levels are `trace`, `debug`, `info`,
+  `warn`, and `error`.
 - `-log-json` - Toggles whether the messages are streamed in JSON format.
   By default this is false.

--- a/website/content/commands/snapshot/agent.mdx
+++ b/website/content/commands/snapshot/agent.mdx
@@ -229,7 +229,7 @@ if desired.
   provided, this will be disabled. Defaults to "72h".
 
 - `-log-level` - Controls verbosity of snapshot agent logs. Valid options are
-  "TRACE", "DEBUG", "INFO", "WARN", "ERR". Defaults to "INFO".
+  "trace", "debug", "info", "warn", "error". Defaults to "info".
 
 - `-service` - The service name to used when registering the agent with Consul.
   Registering helps monitor running agents and the leader registers an additional

--- a/website/content/docs/agent/config/cli-flags.mdx
+++ b/website/content/docs/agent/config/cli-flags.mdx
@@ -468,7 +468,7 @@ information.
 
 - `-log-level` ((#\_log_level)) - The level of logging to show after the
   Consul agent has started. This defaults to "info". The available log levels are
-  "trace", "debug", "info", "warn", and "err". You can always connect to an agent
+  "trace", "debug", "info", "warn", and "error". You can always connect to an agent
   via [`consul monitor`](/commands/monitor) and use any log level. Also,
   the log level can be changed during a config reload.
 


### PR DESCRIPTION
### Description

"err" was used for backwards compatibility, but we should use "error" as the standard for now per [log_levels.go](https://github.com/hashicorp/consul/blob/401221de5852432d742f2bdb1c4f17fb0d0e7362/logging/log_levels.go#L10) 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
