### PR TITLE
docs: backport error value changes to 1.10.x 

### DIFF
--- a/website/content/commands/monitor.mdx
+++ b/website/content/commands/monitor.mdx
@@ -32,6 +32,6 @@ Usage: `consul monitor [options]`
 - `-log-level` - The log level of the messages to show. By default this
   is "info". This log level can be more verbose than what the agent is
   configured to run at. Available log levels are "trace", "debug", "info",
-  "warn", and "err".
+  "warn", and "error".
 - `-log-json` - Toggles whether the messages are streamed in JSON format.
   By default this is false.

--- a/website/content/commands/snapshot/agent.mdx
+++ b/website/content/commands/snapshot/agent.mdx
@@ -229,7 +229,7 @@ if desired.
   provided, this will be disabled. Defaults to "72h".
 
 - `-log-level` - Controls verbosity of snapshot agent logs. Valid options are
-  "TRACE", "DEBUG", "INFO", "WARN", "ERR". Defaults to "INFO".
+  "trace", "debug", "info", "warn", "error". Defaults to "info".
 
 - `-service` - The service name to used when registering the agent with Consul.
   Registering helps monitor running agents and the leader registers an additional

--- a/website/content/docs/agent/options.mdx
+++ b/website/content/docs/agent/options.mdx
@@ -393,7 +393,7 @@ The options below are all specified on the command-line.
 
 - `-log-level` ((#\_log_level)) - The level of logging to show after the
   Consul agent has started. This defaults to "info". The available log levels are
-  "trace", "debug", "info", "warn", and "err". You can always connect to an agent
+  "trace", "debug", "info", "warn", and "error". You can always connect to an agent
   via [`consul monitor`](/commands/monitor) and use any log level. Also,
   the log level can be changed during a config reload.
 


### PR DESCRIPTION
### Description

Manual back port of https://github.com/hashicorp/consul/pull/13507 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
