### PR TITLE
state: peering ID assignment cannot happen inside of the state store

### DIFF
--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -476,6 +476,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 
 	// Peerings
 	require.NoError(t, fsm.state.PeeringWrite(31, &pbpeering.Peering{
+		ID:   "1fabcd52-1d46-49b0-b1d8-71559aee47f5",
 		Name: "baz",
 	}))
 

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -143,6 +143,17 @@ type peeringApply struct {
 	srv *Server
 }
 
+func (a *peeringApply) CheckPeeringUUID(id string) (bool, error) {
+	state := a.srv.fsm.State()
+	if _, existing, err := state.PeeringReadByID(nil, id); err != nil {
+		return false, err
+	} else if existing != nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (a *peeringApply) PeeringWrite(req *pbpeering.PeeringWriteRequest) error {
 	_, err := a.srv.raftApplyProtobuf(structs.PeeringWriteType, req)
 	return err

--- a/agent/consul/state/peering.go
+++ b/agent/consul/state/peering.go
@@ -1,12 +1,12 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
@@ -191,50 +191,47 @@ func (s *Store) peeringListTxn(ws memdb.WatchSet, tx ReadTxn, entMeta acl.Enterp
 	return idx, result, nil
 }
 
-func generatePeeringUUID(tx ReadTxn) (string, error) {
-	for {
-		uuid, err := uuid.GenerateUUID()
-		if err != nil {
-			return "", fmt.Errorf("failed to generate UUID: %w", err)
-		}
-		existing, err := peeringReadByIDTxn(tx, nil, uuid)
-		if err != nil {
-			return "", fmt.Errorf("failed to read peering: %w", err)
-		}
-		if existing == nil {
-			return uuid, nil
-		}
-	}
-}
-
 func (s *Store) PeeringWrite(idx uint64, p *pbpeering.Peering) error {
 	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
-	q := Query{
-		Value:          p.Name,
-		EnterpriseMeta: *structs.NodeEnterpriseMetaInPartition(p.Partition),
+	// Check that the ID and Name are set.
+	if p.ID == "" {
+		return errors.New("Missing Peering ID")
 	}
-	existingRaw, err := tx.First(tablePeering, indexName, q)
-	if err != nil {
-		return fmt.Errorf("failed peering lookup: %w", err)
+	if p.Name == "" {
+		return errors.New("Missing Peering Name")
 	}
 
-	existing, ok := existingRaw.(*pbpeering.Peering)
-	if existingRaw != nil && !ok {
-		return fmt.Errorf("invalid type %T", existingRaw)
+	// ensure the name is unique (cannot conflict with another peering with a different ID)
+	_, existing, err := peeringReadTxn(tx, nil, Query{
+		Value:          p.Name,
+		EnterpriseMeta: *structs.NodeEnterpriseMetaInPartition(p.Partition),
+	})
+	if err != nil {
+		return err
 	}
 
 	if existing != nil {
+		if p.ID != existing.ID {
+			return fmt.Errorf("A peering already exists with the name %q and a different ID %q", p.Name, existing.ID)
+		}
 		// Prevent modifications to Peering marked for deletion
 		if !existing.IsActive() {
 			return fmt.Errorf("cannot write to peering that is marked for deletion")
 		}
 
 		p.CreateIndex = existing.CreateIndex
-		p.ID = existing.ID
-
+		p.ModifyIndex = idx
 	} else {
+		idMatch, err := peeringReadByIDTxn(tx, nil, p.ID)
+		if err != nil {
+			return err
+		}
+		if idMatch != nil {
+			return fmt.Errorf("A peering already exists with the ID %q and a different name %q", p.Name, existing.ID)
+		}
+
 		if !p.IsActive() {
 			return fmt.Errorf("cannot create a new peering marked for deletion")
 		}
@@ -242,13 +239,8 @@ func (s *Store) PeeringWrite(idx uint64, p *pbpeering.Peering) error {
 		// TODO(peering): consider keeping PeeringState enum elsewhere?
 		p.State = pbpeering.PeeringState_INITIAL
 		p.CreateIndex = idx
-
-		p.ID, err = generatePeeringUUID(tx)
-		if err != nil {
-			return fmt.Errorf("failed to generate peering id: %w", err)
-		}
+		p.ModifyIndex = idx
 	}
-	p.ModifyIndex = idx
 
 	if err := tx.Insert(tablePeering, p); err != nil {
 		return fmt.Errorf("failed inserting peering: %w", err)

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/proto/pbpeering"
 	"github.com/hashicorp/consul/proto/pbservice"
 	"github.com/hashicorp/consul/proto/prototest"
@@ -224,6 +225,7 @@ func TestPeeringService_Read(t *testing.T) {
 
 	// insert peering directly to state store
 	p := &pbpeering.Peering{
+		ID:                  testUUID(t),
 		Name:                "foo",
 		State:               pbpeering.PeeringState_INITIAL,
 		PeerCAPems:          nil,
@@ -279,6 +281,7 @@ func TestPeeringService_Delete(t *testing.T) {
 	s := newTestServer(t, nil)
 
 	p := &pbpeering.Peering{
+		ID:                  testUUID(t),
 		Name:                "foo",
 		State:               pbpeering.PeeringState_INITIAL,
 		PeerCAPems:          nil,
@@ -316,6 +319,7 @@ func TestPeeringService_List(t *testing.T) {
 	// Note that the state store holds reference to the underlying
 	// variables; do not modify them after writing.
 	foo := &pbpeering.Peering{
+		ID:                  testUUID(t),
 		Name:                "foo",
 		State:               pbpeering.PeeringState_INITIAL,
 		PeerCAPems:          nil,
@@ -324,6 +328,7 @@ func TestPeeringService_List(t *testing.T) {
 	}
 	require.NoError(t, s.Server.FSM().State().PeeringWrite(10, foo))
 	bar := &pbpeering.Peering{
+		ID:                  testUUID(t),
 		Name:                "bar",
 		State:               pbpeering.PeeringState_ACTIVE,
 		PeerCAPems:          nil,
@@ -405,6 +410,7 @@ func TestPeeringService_TrustBundleListByService(t *testing.T) {
 
 	lastIdx++
 	require.NoError(t, s.Server.FSM().State().PeeringWrite(lastIdx, &pbpeering.Peering{
+		ID:                  testUUID(t),
 		Name:                "foo",
 		State:               pbpeering.PeeringState_INITIAL,
 		PeerServerName:      "test",
@@ -413,6 +419,7 @@ func TestPeeringService_TrustBundleListByService(t *testing.T) {
 
 	lastIdx++
 	require.NoError(t, s.Server.FSM().State().PeeringWrite(lastIdx, &pbpeering.Peering{
+		ID:                  testUUID(t),
 		Name:                "bar",
 		State:               pbpeering.PeeringState_INITIAL,
 		PeerServerName:      "test-bar",
@@ -513,6 +520,7 @@ func Test_StreamHandler_UpsertServices(t *testing.T) {
 	)
 
 	require.NoError(t, s.Server.FSM().State().PeeringWrite(0, &pbpeering.Peering{
+		ID:   testUUID(t),
 		Name: "my-peer",
 	}))
 
@@ -998,7 +1006,9 @@ func newDefaultDeps(t *testing.T, c *consul.Config) consul.Deps {
 }
 
 func setupTestPeering(t *testing.T, store *state.Store, name string, index uint64) string {
+	t.Helper()
 	err := store.PeeringWrite(index, &pbpeering.Peering{
+		ID:   testUUID(t),
 		Name: name,
 	})
 	require.NoError(t, err)
@@ -1008,4 +1018,10 @@ func setupTestPeering(t *testing.T, store *state.Store, name string, index uint6
 	require.NotNil(t, p)
 
 	return p.ID
+}
+
+func testUUID(t *testing.T) string {
+	v, err := lib.GenerateUUID(nil)
+	require.NoError(t, err)
+	return v
 }

--- a/agent/rpc/peering/stream_test.go
+++ b/agent/rpc/peering/stream_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/consul/stream"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/proto/pbcommon"
 	"github.com/hashicorp/consul/proto/pbpeering"
 	"github.com/hashicorp/consul/proto/pbservice"
@@ -1030,6 +1031,10 @@ type testApplier struct {
 	store *state.Store
 }
 
+func (a *testApplier) CheckPeeringUUID(id string) (bool, error) {
+	panic("not implemented")
+}
+
 func (a *testApplier) PeeringWrite(req *pbpeering.PeeringWriteRequest) error {
 	panic("not implemented")
 }
@@ -1216,6 +1221,7 @@ func writeEstablishedPeering(t *testing.T, store *state.Store, idx uint64, peerN
 	require.NoError(t, err)
 
 	peering := pbpeering.Peering{
+		ID:     testUUID(t),
 		Name:   peerName,
 		PeerID: remotePeerID,
 	}
@@ -2169,5 +2175,10 @@ func requireEqualInstances(t *testing.T, expect, got structs.CheckServiceNodes) 
 			require.Equal(t, expect[i].Checks[j].PartitionOrDefault(), got[i].Checks[j].PartitionOrDefault(), "partition mismatch")
 		}
 	}
+}
 
+func testUUID(t *testing.T) string {
+	v, err := lib.GenerateUUID(nil)
+	require.NoError(t, err)
+	return v
 }

--- a/agent/rpc/peering/subscription_manager_test.go
+++ b/agent/rpc/peering/subscription_manager_test.go
@@ -589,6 +589,7 @@ func (b *testSubscriptionBackend) ensureCARoots(t *testing.T, roots ...*structs.
 
 func setupTestPeering(t *testing.T, store *state.Store, name string, index uint64) string {
 	err := store.PeeringWrite(index, &pbpeering.Peering{
+		ID:   testUUID(t),
 		Name: name,
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
### Description

Move peering ID assignment outisde of the FSM, so that the ID is written to the raft log and the same ID is used by all voters, and after restarts.

When ID assignment happens randomly inside of an FSM function, that is executed separately on each server, plus if you restart the server before the next FSM snapshot is created then the ID is different _after restart_.