### PR TITLE
docs: Consul K8s compat matrix update for 0.45.0+ to include Consul 1.11 compatibility

### DIFF
--- a/website/content/docs/k8s/installation/compatibility.mdx
+++ b/website/content/docs/k8s/installation/compatibility.mdx
@@ -14,11 +14,11 @@ For every release of Consul on Kubernetes, a Helm chart, `consul-k8s-control-pla
 
 Starting with Consul Kubernetes 0.33.0, Consul Kubernetes versions all of its components (`consul-k8s` CLI, `consul-k8s-control-plane`, and Helm chart) with a single semantic version.
 
-| Consul Version | Compatible consul-k8s Versions  |
-| -------------- | ------------------------------- |
-| 1.12.x         | 0.43.0 - latest                 |
-| 1.11.x         | 0.39.0 - 0.42.0, 0.44.0         |
-| 1.10.x         | 0.33.0 - 0.38.0                 |
+| Consul Version | Compatible consul-k8s Versions   |
+| -------------- | -------------------------------- |
+| 1.12.x         | 0.43.0 - latest                  |
+| 1.11.x         | 0.39.0 - 0.42.0, 0.44.0 - latest |
+| 1.10.x         | 0.33.0 - 0.38.0                  |
 
 ### Prior to version 0.33.0
 


### PR DESCRIPTION
### Description

Consul 1.11, was tested on Consul K8s 0.44.0, but we are also ensuring that compatibility exists ithin our Helm chart for latest releases to ensure that Consul API Gateway works with 1.11. on Consul K8s. 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
