### PR TITLE
[CI-only] Update dev image tagging on 1.11.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:
       - release/1.11.x
+      - dev-tags-1.11.x
 
 env:
   PKG_NAME: consul
@@ -239,7 +240,7 @@ jobs:
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
-
+      
     steps:
       - uses: actions/checkout@v2
 
@@ -247,6 +248,13 @@ jobs:
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
+
+      // Strip everything but MAJOR.MINOR from the version string and add a `-dev` suffix
+      // This naming convention will be used ONLY for per-commit dev images
+      - name: Set docker dev tag
+        run: |
+        version="${{ env.version }}"
+        echo "dev_tag=${version%.*}-dev" >> $GITHUB_ENV
 
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
@@ -258,8 +266,8 @@ jobs:
             docker.io/hashicorp/${{env.repo}}:${{env.version}}
             public.ecr.aws/hashicorp/${{env.repo}}:${{env.version}}
           dev_tags: |
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}
-            docker.io/hashicorppreview/${{ env.repo }}:${{ env.version }}-${{ github.sha }}
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.dev_tag }}
+            docker.io/hashicorppreview/${{ env.repo }}:${{ env.dev_tag }}-${{ github.sha }}
           smoke_test: .github/scripts/verify_docker.sh v${{ env.version }}
 
   build-docker-redhat:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:
       - release/1.11.x
-      - dev-tags-1.11.x
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,12 +249,12 @@ jobs:
         with:
           platforms: all
 
-      // Strip everything but MAJOR.MINOR from the version string and add a `-dev` suffix
-      // This naming convention will be used ONLY for per-commit dev images
+      # Strip everything but MAJOR.MINOR from the version string and add a `-dev` suffix
+      # This naming convention will be used ONLY for per-commit dev images
       - name: Set docker dev tag
         run: |
-        version="${{ env.version }}"
-        echo "dev_tag=${version%.*}-dev" >> $GITHUB_ENV
+          version="${{ env.version }}"
+          echo "dev_tag=${version%.*}-dev" >> $GITHUB_ENV
 
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -11,7 +11,7 @@ project "consul" {
     repository = "consul"
     release_branches = [
       "main",
-      "release/1.11.x"
+      "release/1.11.x",
       "dev-tags-1.11.x"
     ]
   }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -11,8 +11,7 @@ project "consul" {
     repository = "consul"
     release_branches = [
       "main",
-      "release/1.11.x",
-      "dev-tags-1.11.x"
+      "release/1.11.x"
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -12,6 +12,7 @@ project "consul" {
     release_branches = [
       "main",
       "release/1.11.x"
+      "dev-tags-1.11.x"
     ]
   }
 }

--- a/version/version.go
+++ b/version/version.go
@@ -10,11 +10,11 @@ var (
 	// compiler.
 	GitCommit string
 
-	// The main version number that is being run at the moment.
+	// The next version number that will be released in this series.
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.11.3"
+	Version = "1.11.7"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
### Description
Pushing per-commit dev images to the `hashicorppreview` dockerhub org was introduced in https://github.com/hashicorp/consul/pull/13084, but the tag names have been unclear. 

This PR has been created to follow the guidance outlined in https://docs.google.com/document/d/1ovhf8DmlXbsuc45HkN7LdsrS2J3evfSvcy2LPiyUgZ8/edit for dev image naming, and for keeping the version string in `version.go` up to date. There are two parts to this:

1.  Keeping the version strings in `version.go` on each active release branch, and on `main`, updated after a release to point to the next minor or major version string. For example, after releasing consul `1.11.6` from branch `release/1.11.x`, the version string in `version.go` on `release/1.11.x` should be updated to `1.11.7`. 
2. `dev_tags`, the set of tags that are created for per-commit docker image builds, will be stripped of the patch version. For example, on `release/1.11.x`, the dev_tags that will be published off of this release branch will be named `hashicorppreview/consul:1.11-dev` and `hashicorppreview/consul:1.11-dev-$COMMITSHA`. `hashicorppreview/consul:1.11-dev` will be kept up to date with the latest builds from branch `release/1.11.x`. 

### Testing & Reproduction steps

Dev tags published on this release branch will be named in the following format: `hashicorppreview/consul:1.11-dev`, `hashicorppreview/consul:1.11-$COMMITSHA-dev`. See https://hub.docker.com/r/hashicorppreview/consul/tags?page=1&name=1.11-dev to pull the dev image built from commit 263422cc6dd8ebb7418274f6a654373ec0e7403c (https://github.com/hashicorp/consul/runs/6994186153) from this PR. 

### Other PR's in this series

Changes to target release/1.12.x: https://github.com/hashicorp/consul/pull/13540
Changes to target main: https://github.com/hashicorp/consul/pull/13541