### PR TITLE
Make memdb indexers generic

### DIFF
--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-memdb"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
@@ -209,18 +209,13 @@ func (s *Store) ACLAuthMethodUpsertValidateEnterprise(method *structs.ACLAuthMet
 	return nil
 }
 
-func indexAuthMethodFromACLToken(raw interface{}) ([]byte, error) {
-	p, ok := raw.(*structs.ACLToken)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.ACLToken index", raw)
-	}
-
-	if p.AuthMethod == "" {
+func indexAuthMethodFromACLToken(t *structs.ACLToken) ([]byte, error) {
+	if t.AuthMethod == "" {
 		return nil, errMissingValueForIndex
 	}
 
 	var b indexBuilder
-	b.String(strings.ToLower(p.AuthMethod))
+	b.String(strings.ToLower(t.AuthMethod))
 
 	return b.Bytes(), nil
 }

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -7,14 +7,14 @@ import (
 	"testing"
 	"time"
 
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
-	pbacl "github.com/hashicorp/consul/proto/pbacl"
+	"github.com/hashicorp/consul/proto/pbacl"
 )
 
 const (
@@ -3702,18 +3702,18 @@ func TestTokenPoliciesIndex(t *testing.T) {
 		Name:         "global",
 		AllowMissing: true,
 		Unique:       false,
-		Indexer: indexerSingle{
-			readIndex:  readIndex(indexFromTimeQuery),
-			writeIndex: writeIndex(indexExpiresGlobalFromACLToken),
+		Indexer: indexerSingle[*TimeQuery, *structs.ACLToken]{
+			readIndex:  indexFromTimeQuery,
+			writeIndex: indexExpiresGlobalFromACLToken,
 		},
 	}
 	localIndex := &memdb.IndexSchema{
 		Name:         "local",
 		AllowMissing: true,
 		Unique:       false,
-		Indexer: indexerSingle{
-			readIndex:  readIndex(indexFromTimeQuery),
-			writeIndex: writeIndex(indexExpiresLocalFromACLToken),
+		Indexer: indexerSingle[*TimeQuery, *structs.ACLToken]{
+			readIndex:  indexFromTimeQuery,
+			writeIndex: indexExpiresLocalFromACLToken,
 		},
 	}
 	schema := &memdb.DBSchema{

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -47,7 +47,7 @@ func nodesTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingleWithPrefix{
+				Indexer: indexerSingleWithPrefix[Query, *structs.Node, any]{
 					readIndex:   indexWithPeerName(indexFromQuery),
 					writeIndex:  indexWithPeerName(indexFromNode),
 					prefixIndex: prefixIndexFromQueryWithPeer,
@@ -57,7 +57,7 @@ func nodesTableSchema() *memdb.TableSchema {
 				Name:         indexUUID,
 				AllowMissing: true,
 				Unique:       true,
-				Indexer: indexerSingleWithPrefix{
+				Indexer: indexerSingleWithPrefix[Query, *structs.Node, Query]{
 					readIndex:   indexWithPeerName(indexFromUUIDQuery),
 					writeIndex:  indexWithPeerName(indexIDFromNode),
 					prefixIndex: prefixIndexFromUUIDWithPeerQuery,
@@ -67,7 +67,7 @@ func nodesTableSchema() *memdb.TableSchema {
 				Name:         indexMeta,
 				AllowMissing: true,
 				Unique:       false,
-				Indexer: indexerMulti{
+				Indexer: indexerMulti[KeyValueQuery, *structs.Node]{
 					readIndex:       indexWithPeerName(indexFromKeyValueQuery),
 					writeIndexMulti: multiIndexWithPeerName(indexMetaFromNode),
 				},
@@ -76,12 +76,7 @@ func nodesTableSchema() *memdb.TableSchema {
 	}
 }
 
-func indexFromNode(raw interface{}) ([]byte, error) {
-	n, ok := raw.(*structs.Node)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.Node index", raw)
-	}
-
+func indexFromNode(n *structs.Node) ([]byte, error) {
 	if n.Node == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -91,12 +86,7 @@ func indexFromNode(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexIDFromNode(raw interface{}) ([]byte, error) {
-	n, ok := raw.(*structs.Node)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.Node index", raw)
-	}
-
+func indexIDFromNode(n *structs.Node) ([]byte, error) {
 	if n.ID == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -109,12 +99,7 @@ func indexIDFromNode(raw interface{}) ([]byte, error) {
 	return v, nil
 }
 
-func indexMetaFromNode(raw interface{}) ([][]byte, error) {
-	n, ok := raw.(*structs.Node)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.Node index", raw)
-	}
-
+func indexMetaFromNode(n *structs.Node) ([][]byte, error) {
 	// NOTE: this is case-sensitive!
 
 	vals := make([][]byte, 0, len(n.Meta))
@@ -145,7 +130,7 @@ func servicesTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingleWithPrefix{
+				Indexer: indexerSingleWithPrefix[NodeServiceQuery, *structs.ServiceNode, any]{
 					readIndex:   indexWithPeerName(indexFromNodeServiceQuery),
 					writeIndex:  indexWithPeerName(indexFromServiceNode),
 					prefixIndex: prefixIndexFromQueryWithPeer,
@@ -155,7 +140,7 @@ func servicesTableSchema() *memdb.TableSchema {
 				Name:         indexNode,
 				AllowMissing: false,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[Query, nodeIdentifier]{
 					readIndex:  indexWithPeerName(indexFromQuery),
 					writeIndex: indexWithPeerName(indexFromNodeIdentity),
 				},
@@ -164,7 +149,7 @@ func servicesTableSchema() *memdb.TableSchema {
 				Name:         indexService,
 				AllowMissing: true,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[Query, *structs.ServiceNode]{
 					readIndex:  indexWithPeerName(indexFromQuery),
 					writeIndex: indexWithPeerName(indexServiceNameFromServiceNode),
 				},
@@ -173,7 +158,7 @@ func servicesTableSchema() *memdb.TableSchema {
 				Name:         indexConnect,
 				AllowMissing: true,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[Query, *structs.ServiceNode]{
 					readIndex:  indexWithPeerName(indexFromQuery),
 					writeIndex: indexWithPeerName(indexConnectNameFromServiceNode),
 				},
@@ -182,7 +167,7 @@ func servicesTableSchema() *memdb.TableSchema {
 				Name:         indexKind,
 				AllowMissing: false,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[Query, *structs.ServiceNode]{
 					readIndex:  indexWithPeerName(indexFromQuery),
 					writeIndex: indexWithPeerName(indexKindFromServiceNode),
 				},
@@ -191,24 +176,14 @@ func servicesTableSchema() *memdb.TableSchema {
 	}
 }
 
-func indexFromNodeServiceQuery(arg interface{}) ([]byte, error) {
-	q, ok := arg.(NodeServiceQuery)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for NodeServiceQuery index", arg)
-	}
-
+func indexFromNodeServiceQuery(q NodeServiceQuery) ([]byte, error) {
 	var b indexBuilder
 	b.String(strings.ToLower(q.Node))
 	b.String(strings.ToLower(q.Service))
 	return b.Bytes(), nil
 }
 
-func indexFromServiceNode(raw interface{}) ([]byte, error) {
-	n, ok := raw.(*structs.ServiceNode)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.ServiceNode index", raw)
-	}
-
+func indexFromServiceNode(n *structs.ServiceNode) ([]byte, error) {
 	if n.Node == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -219,14 +194,11 @@ func indexFromServiceNode(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexFromNodeIdentity(raw interface{}) ([]byte, error) {
-	n, ok := raw.(interface {
-		NodeIdentity() structs.Identity
-	})
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for index, type must provide NodeIdentity()", raw)
-	}
+type nodeIdentifier interface {
+	NodeIdentity() structs.Identity
+}
 
+func indexFromNodeIdentity(n nodeIdentifier) ([]byte, error) {
 	id := n.NodeIdentity()
 	if id.ID == "" {
 		return nil, errMissingValueForIndex
@@ -237,12 +209,7 @@ func indexFromNodeIdentity(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexServiceNameFromServiceNode(raw interface{}) ([]byte, error) {
-	n, ok := raw.(*structs.ServiceNode)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.ServiceNode index", raw)
-	}
-
+func indexServiceNameFromServiceNode(n *structs.ServiceNode) ([]byte, error) {
 	if n.Node == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -252,12 +219,7 @@ func indexServiceNameFromServiceNode(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexConnectNameFromServiceNode(raw interface{}) ([]byte, error) {
-	n, ok := raw.(*structs.ServiceNode)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.ServiceNode index", raw)
-	}
-
+func indexConnectNameFromServiceNode(n *structs.ServiceNode) ([]byte, error) {
 	name, ok := connectNameFromServiceNode(n)
 	if !ok {
 		return nil, errMissingValueForIndex
@@ -284,33 +246,28 @@ func connectNameFromServiceNode(sn *structs.ServiceNode) (string, bool) {
 	}
 }
 
-func indexKindFromServiceNode(raw interface{}) ([]byte, error) {
-	n, ok := raw.(*structs.ServiceNode)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.ServiceNode index", raw)
-	}
-
+func indexKindFromServiceNode(n *structs.ServiceNode) ([]byte, error) {
 	var b indexBuilder
 	b.String(strings.ToLower(string(n.ServiceKind)))
 	return b.Bytes(), nil
 }
 
 // indexWithPeerName adds peer name to the index.
-func indexWithPeerName(
-	fn func(interface{}) ([]byte, error),
-) func(interface{}) ([]byte, error) {
-	return func(raw interface{}) ([]byte, error) {
+func indexWithPeerName[T any](
+	fn func(T) ([]byte, error),
+) func(T) ([]byte, error) {
+	return func(raw T) ([]byte, error) {
+		pi, ok := any(raw).(peerIndexable)
+		if !ok {
+			return nil, fmt.Errorf("wrapped generic type must be peerIndexable: %T", raw)
+		}
+
 		v, err := fn(raw)
 		if err != nil {
 			return nil, err
 		}
 
-		n, ok := raw.(peerIndexable)
-		if !ok {
-			return nil, fmt.Errorf("type must be peerIndexable: %T", raw)
-		}
-
-		peername := n.PeerOrEmpty()
+		peername := pi.PeerOrEmpty()
 		if peername == "" {
 			peername = structs.LocalPeerKeyword
 		}
@@ -322,18 +279,18 @@ func indexWithPeerName(
 }
 
 // multiIndexWithPeerName adds peer name to multiple indices, and returns multiple indices.
-func multiIndexWithPeerName(
-	fn func(interface{}) ([][]byte, error),
-) func(interface{}) ([][]byte, error) {
-	return func(raw interface{}) ([][]byte, error) {
+func multiIndexWithPeerName[T any](
+	fn func(T) ([][]byte, error),
+) func(T) ([][]byte, error) {
+	return func(raw T) ([][]byte, error) {
+		n, ok := any(raw).(peerIndexable)
+		if !ok {
+			return nil, fmt.Errorf("type must be peerIndexable: %T", raw)
+		}
+
 		results, err := fn(raw)
 		if err != nil {
 			return nil, err
-		}
-
-		n, ok := raw.(peerIndexable)
-		if !ok {
-			return nil, fmt.Errorf("type must be peerIndexable: %T", raw)
 		}
 
 		peername := n.PeerOrEmpty()
@@ -361,7 +318,7 @@ func checksTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingleWithPrefix{
+				Indexer: indexerSingleWithPrefix[NodeCheckQuery, *structs.HealthCheck, any]{
 					readIndex:   indexWithPeerName(indexFromNodeCheckQuery),
 					writeIndex:  indexWithPeerName(indexFromHealthCheck),
 					prefixIndex: prefixIndexFromQueryWithPeer,
@@ -371,7 +328,7 @@ func checksTableSchema() *memdb.TableSchema {
 				Name:         indexStatus,
 				AllowMissing: false,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[Query, *structs.HealthCheck]{
 					readIndex:  indexWithPeerName(indexFromQuery),
 					writeIndex: indexWithPeerName(indexStatusFromHealthCheck),
 				},
@@ -380,7 +337,7 @@ func checksTableSchema() *memdb.TableSchema {
 				Name:         indexService,
 				AllowMissing: true,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[Query, *structs.HealthCheck]{
 					readIndex:  indexWithPeerName(indexFromQuery),
 					writeIndex: indexWithPeerName(indexServiceNameFromHealthCheck),
 				},
@@ -389,7 +346,7 @@ func checksTableSchema() *memdb.TableSchema {
 				Name:         indexNode,
 				AllowMissing: true,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[Query, nodeIdentifier]{
 					readIndex:  indexWithPeerName(indexFromQuery),
 					writeIndex: indexWithPeerName(indexFromNodeIdentity),
 				},
@@ -398,7 +355,7 @@ func checksTableSchema() *memdb.TableSchema {
 				Name:         indexNodeService,
 				AllowMissing: true,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[NodeServiceQuery, *structs.HealthCheck]{
 					readIndex:  indexWithPeerName(indexFromNodeServiceQuery),
 					writeIndex: indexWithPeerName(indexNodeServiceFromHealthCheck),
 				},
@@ -407,28 +364,18 @@ func checksTableSchema() *memdb.TableSchema {
 	}
 }
 
-func indexFromNodeCheckQuery(raw interface{}) ([]byte, error) {
-	hc, ok := raw.(NodeCheckQuery)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for NodeCheckQuery index", raw)
-	}
-
-	if hc.Node == "" || hc.CheckID == "" {
+func indexFromNodeCheckQuery(q NodeCheckQuery) ([]byte, error) {
+	if q.Node == "" || q.CheckID == "" {
 		return nil, errMissingValueForIndex
 	}
 
 	var b indexBuilder
-	b.String(strings.ToLower(hc.Node))
-	b.String(strings.ToLower(hc.CheckID))
+	b.String(strings.ToLower(q.Node))
+	b.String(strings.ToLower(q.CheckID))
 	return b.Bytes(), nil
 }
 
-func indexFromHealthCheck(raw interface{}) ([]byte, error) {
-	hc, ok := raw.(*structs.HealthCheck)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.HealthCheck index", raw)
-	}
-
+func indexFromHealthCheck(hc *structs.HealthCheck) ([]byte, error) {
 	if hc.Node == "" || hc.CheckID == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -439,12 +386,7 @@ func indexFromHealthCheck(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexNodeServiceFromHealthCheck(raw interface{}) ([]byte, error) {
-	hc, ok := raw.(*structs.HealthCheck)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.HealthCheck index", raw)
-	}
-
+func indexNodeServiceFromHealthCheck(hc *structs.HealthCheck) ([]byte, error) {
 	if hc.Node == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -455,12 +397,7 @@ func indexNodeServiceFromHealthCheck(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexStatusFromHealthCheck(raw interface{}) ([]byte, error) {
-	hc, ok := raw.(*structs.HealthCheck)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.HealthCheck index", raw)
-	}
-
+func indexStatusFromHealthCheck(hc *structs.HealthCheck) ([]byte, error) {
 	if hc.Status == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -470,12 +407,7 @@ func indexStatusFromHealthCheck(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexServiceNameFromHealthCheck(raw interface{}) ([]byte, error) {
-	hc, ok := raw.(*structs.HealthCheck)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.HealthCheck index", raw)
-	}
-
+func indexServiceNameFromHealthCheck(hc *structs.HealthCheck) ([]byte, error) {
 	if hc.ServiceName == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -761,7 +693,7 @@ func kindServiceNameTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[any, any]{
 					readIndex:  indexFromKindServiceName,
 					writeIndex: indexFromKindServiceName,
 				},
@@ -770,7 +702,7 @@ func kindServiceNameTableSchema() *memdb.TableSchema {
 				Name:         indexKind,
 				AllowMissing: false,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[any, any]{
 					readIndex:  indexFromKindServiceNameKindOnly,
 					writeIndex: indexFromKindServiceNameKindOnly,
 				},

--- a/agent/consul/state/config_entry_schema.go
+++ b/agent/consul/state/config_entry_schema.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/go-memdb"
@@ -27,7 +26,7 @@ func configTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingleWithPrefix{
+				Indexer: indexerSingleWithPrefix[any, structs.ConfigEntry, any]{
 					readIndex:   indexFromConfigEntryKindName,
 					writeIndex:  indexFromConfigEntry,
 					prefixIndex: indexFromConfigEntryKindName,
@@ -55,12 +54,7 @@ func configTableSchema() *memdb.TableSchema {
 	}
 }
 
-func indexFromConfigEntry(raw interface{}) ([]byte, error) {
-	c, ok := raw.(structs.ConfigEntry)
-	if !ok {
-		return nil, fmt.Errorf("type must be structs.ConfigEntry: %T", raw)
-	}
-
+func indexFromConfigEntry(c structs.ConfigEntry) ([]byte, error) {
 	if c.GetName() == "" || c.GetKind() == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -73,12 +67,7 @@ func indexFromConfigEntry(raw interface{}) ([]byte, error) {
 
 // indexKindFromConfigEntry indexes kinds without a namespace for any config
 // entries that span all namespaces.
-func indexKindFromConfigEntry(raw interface{}) ([]byte, error) {
-	c, ok := raw.(structs.ConfigEntry)
-	if !ok {
-		return nil, fmt.Errorf("type must be structs.ConfigEntry: %T", raw)
-	}
-
+func indexKindFromConfigEntry(c structs.ConfigEntry) ([]byte, error) {
 	if c.GetKind() == "" {
 		return nil, errMissingValueForIndex
 	}

--- a/agent/consul/state/config_entry_schema.go
+++ b/agent/consul/state/config_entry_schema.go
@@ -54,6 +54,29 @@ func configTableSchema() *memdb.TableSchema {
 	}
 }
 
+// configEntryIndexable is required because while structs.ConfigEntry
+// has a GetEnterpriseMeta method, it does not directly expose the
+// required NamespaceOrDefault and PartitionOrDefault methods of
+// enterpriseIndexable.
+//
+// Config entries that embed *acl.EnterpriseMeta will automatically
+// implement this interface.
+type configEntryIndexable interface {
+	structs.ConfigEntry
+	enterpriseIndexable
+}
+
+var _ configEntryIndexable = (*structs.ExportedServicesConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.IngressGatewayConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.MeshConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.ProxyConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.ServiceConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.ServiceIntentionsConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.ServiceResolverConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.ServiceRouterConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.ServiceSplitterConfigEntry)(nil)
+var _ configEntryIndexable = (*structs.TerminatingGatewayConfigEntry)(nil)
+
 func indexFromConfigEntry(c structs.ConfigEntry) ([]byte, error) {
 	if c.GetName() == "" || c.GetKind() == "" {
 		return nil, errMissingValueForIndex
@@ -67,7 +90,7 @@ func indexFromConfigEntry(c structs.ConfigEntry) ([]byte, error) {
 
 // indexKindFromConfigEntry indexes kinds without a namespace for any config
 // entries that span all namespaces.
-func indexKindFromConfigEntry(c structs.ConfigEntry) ([]byte, error) {
+func indexKindFromConfigEntry(c configEntryIndexable) ([]byte, error) {
 	if c.GetKind() == "" {
 		return nil, errMissingValueForIndex
 	}

--- a/agent/consul/state/coordinate.go
+++ b/agent/consul/state/coordinate.go
@@ -13,12 +13,7 @@ import (
 
 const tableCoordinates = "coordinates"
 
-func indexFromCoordinate(raw interface{}) ([]byte, error) {
-	c, ok := raw.(*structs.Coordinate)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.Coordinate index", raw)
-	}
-
+func indexFromCoordinate(c *structs.Coordinate) ([]byte, error) {
 	if c.Node == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -29,12 +24,7 @@ func indexFromCoordinate(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexNodeFromCoordinate(raw interface{}) ([]byte, error) {
-	c, ok := raw.(*structs.Coordinate)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.Coordinate index", raw)
-	}
-
+func indexNodeFromCoordinate(c *structs.Coordinate) ([]byte, error) {
 	if c.Node == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -44,12 +34,7 @@ func indexNodeFromCoordinate(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexFromCoordinateQuery(raw interface{}) ([]byte, error) {
-	q, ok := raw.(CoordinateQuery)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for CoordinateQuery index", raw)
-	}
-
+func indexFromCoordinateQuery(q CoordinateQuery) ([]byte, error) {
 	if q.Node == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -80,7 +65,7 @@ func coordinatesTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingleWithPrefix{
+				Indexer: indexerSingleWithPrefix[CoordinateQuery, *structs.Coordinate, any]{
 					readIndex:   indexFromCoordinateQuery,
 					writeIndex:  indexFromCoordinate,
 					prefixIndex: prefixIndexFromQueryNoNamespace,
@@ -90,7 +75,7 @@ func coordinatesTableSchema() *memdb.TableSchema {
 				Name:         indexNode,
 				AllowMissing: false,
 				Unique:       false,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[Query, *structs.Coordinate]{
 					readIndex:  indexFromQuery,
 					writeIndex: indexNodeFromCoordinate,
 				},

--- a/agent/consul/state/kvs.go
+++ b/agent/consul/state/kvs.go
@@ -41,12 +41,7 @@ func kvsTableSchema() *memdb.TableSchema {
 }
 
 // indexFromIDValue creates an index key from any struct that implements singleValueID
-func indexFromIDValue(raw interface{}) ([]byte, error) {
-	e, ok := raw.(singleValueID)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T, does not implement singleValueID", raw)
-	}
-
+func indexFromIDValue(e singleValueID) ([]byte, error) {
 	v := e.IDValue()
 	if v == "" {
 		return nil, errMissingValueForIndex

--- a/agent/consul/state/kvs_oss.go
+++ b/agent/consul/state/kvs_oss.go
@@ -13,11 +13,11 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-func kvsIndexer() indexerSingleWithPrefix {
-	return indexerSingleWithPrefix{
-		readIndex:   readIndex(indexFromIDValue),
-		writeIndex:  writeIndex(indexFromIDValue),
-		prefixIndex: prefixIndex(prefixIndexForIDValue),
+func kvsIndexer() indexerSingleWithPrefix[singleValueID, singleValueID, any] {
+	return indexerSingleWithPrefix[singleValueID, singleValueID, any]{
+		readIndex:   indexFromIDValue,
+		writeIndex:  indexFromIDValue,
+		prefixIndex: prefixIndexForIDValue,
 	}
 }
 

--- a/agent/consul/state/peering_oss.go
+++ b/agent/consul/state/peering_oss.go
@@ -10,23 +10,13 @@ import (
 	"github.com/hashicorp/consul/proto/pbpeering"
 )
 
-func indexPeeringFromQuery(raw interface{}) ([]byte, error) {
-	q, ok := raw.(Query)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for Query index", raw)
-	}
-
+func indexPeeringFromQuery(q Query) ([]byte, error) {
 	var b indexBuilder
 	b.String(strings.ToLower(q.Value))
 	return b.Bytes(), nil
 }
 
-func indexFromPeering(raw interface{}) ([]byte, error) {
-	p, ok := raw.(*pbpeering.Peering)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for structs.Peering index", raw)
-	}
-
+func indexFromPeering(p *pbpeering.Peering) ([]byte, error) {
 	if p.Name == "" {
 		return nil, errMissingValueForIndex
 	}
@@ -36,12 +26,7 @@ func indexFromPeering(raw interface{}) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
-func indexFromPeeringTrustBundle(raw interface{}) ([]byte, error) {
-	ptb, ok := raw.(*pbpeering.PeeringTrustBundle)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for pbpeering.PeeringTrustBundle index", raw)
-	}
-
+func indexFromPeeringTrustBundle(ptb *pbpeering.PeeringTrustBundle) ([]byte, error) {
 	if ptb.PeerName == "" {
 		return nil, errMissingValueForIndex
 	}

--- a/agent/consul/state/query.go
+++ b/agent/consul/state/query.go
@@ -60,12 +60,7 @@ func (q MultiQuery) PartitionOrDefault() string {
 
 // indexFromQuery builds an index key where Query.Value is lowercase, and is
 // a required value.
-func indexFromQuery(arg interface{}) ([]byte, error) {
-	q, ok := arg.(Query)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for Query index", arg)
-	}
-
+func indexFromQuery(q Query) ([]byte, error) {
 	var b indexBuilder
 	b.String(strings.ToLower(q.Value))
 	return b.Bytes(), nil
@@ -164,12 +159,8 @@ func (q KeyValueQuery) PartitionOrDefault() string {
 	return q.EnterpriseMeta.PartitionOrDefault()
 }
 
-func indexFromKeyValueQuery(arg interface{}) ([]byte, error) {
+func indexFromKeyValueQuery(q KeyValueQuery) ([]byte, error) {
 	// NOTE: this is case-sensitive!
-	q, ok := arg.(KeyValueQuery)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for Query index", arg)
-	}
 
 	var b indexBuilder
 	b.String(q.Key)

--- a/agent/consul/state/query_oss.go
+++ b/agent/consul/state/query_oss.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-func prefixIndexFromQuery(arg interface{}) ([]byte, error) {
+func prefixIndexFromQuery(arg any) ([]byte, error) {
 	var b indexBuilder
 	switch v := arg.(type) {
 	case *acl.EnterpriseMeta:
@@ -29,7 +29,7 @@ func prefixIndexFromQuery(arg interface{}) ([]byte, error) {
 	return nil, fmt.Errorf("unexpected type %T for Query prefix index", arg)
 }
 
-func prefixIndexFromQueryWithPeer(arg interface{}) ([]byte, error) {
+func prefixIndexFromQueryWithPeer(arg any) ([]byte, error) {
 	var b indexBuilder
 	switch v := arg.(type) {
 	case *acl.EnterpriseMeta:
@@ -58,12 +58,7 @@ func prefixIndexFromQueryNoNamespace(arg interface{}) ([]byte, error) {
 
 // indexFromAuthMethodQuery builds an index key where Query.Value is lowercase, and is
 // a required value.
-func indexFromAuthMethodQuery(arg interface{}) ([]byte, error) {
-	q, ok := arg.(AuthMethodQuery)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for Query index", arg)
-	}
-
+func indexFromAuthMethodQuery(q AuthMethodQuery) ([]byte, error) {
 	var b indexBuilder
 	b.String(strings.ToLower(q.Value))
 	return b.Bytes(), nil

--- a/agent/consul/state/schema.go
+++ b/agent/consul/state/schema.go
@@ -114,3 +114,16 @@ func indexDeletedFromBoolQuery(q BoolQuery) ([]byte, error) {
 	b.Bool(q.Value)
 	return b.Bytes(), nil
 }
+
+type enterpriseIndexable interface {
+	partitionIndexable
+	namespaceIndexable
+}
+
+type partitionIndexable interface {
+	PartitionOrDefault() string
+}
+
+type namespaceIndexable interface {
+	NamespaceOrDefault() string
+}

--- a/agent/consul/state/schema.go
+++ b/agent/consul/state/schema.go
@@ -84,7 +84,7 @@ func indexTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingle{
+				Indexer: indexerSingle[string, *IndexEntry]{
 					readIndex:  indexFromString,
 					writeIndex: indexNameFromIndexEntry,
 				},
@@ -93,38 +93,23 @@ func indexTableSchema() *memdb.TableSchema {
 	}
 }
 
-func indexNameFromIndexEntry(raw interface{}) ([]byte, error) {
-	p, ok := raw.(*IndexEntry)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for IndexEntry index", raw)
-	}
-
-	if p.Key == "" {
+func indexNameFromIndexEntry(e *IndexEntry) ([]byte, error) {
+	if e.Key == "" {
 		return nil, errMissingValueForIndex
 	}
 
 	var b indexBuilder
-	b.String(strings.ToLower(p.Key))
+	b.String(strings.ToLower(e.Key))
 	return b.Bytes(), nil
 }
 
-func indexFromString(raw interface{}) ([]byte, error) {
-	q, ok := raw.(string)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for string prefix query", raw)
-	}
-
+func indexFromString(s string) ([]byte, error) {
 	var b indexBuilder
-	b.String(strings.ToLower(q))
+	b.String(strings.ToLower(s))
 	return b.Bytes(), nil
 }
 
-func indexDeletedFromBoolQuery(raw interface{}) ([]byte, error) {
-	q, ok := raw.(BoolQuery)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T for BoolQuery index", raw)
-	}
-
+func indexDeletedFromBoolQuery(q BoolQuery) ([]byte, error) {
 	var b indexBuilder
 	b.Bool(q.Value)
 	return b.Bytes(), nil

--- a/agent/consul/state/session.go
+++ b/agent/consul/state/session.go
@@ -19,12 +19,7 @@ const (
 	indexNodeCheck = "node_check"
 )
 
-func indexFromSession(raw interface{}) ([]byte, error) {
-	e, ok := raw.(*structs.Session)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T, does not implement *structs.Session", raw)
-	}
-
+func indexFromSession(e *structs.Session) ([]byte, error) {
 	v := strings.ToLower(e.ID)
 	if v == "" {
 		return nil, errMissingValueForIndex
@@ -86,12 +81,7 @@ func sessionChecksTableSchema() *memdb.TableSchema {
 }
 
 // indexNodeFromSession creates an index key from *structs.Session
-func indexNodeFromSession(raw interface{}) ([]byte, error) {
-	e, ok := raw.(*structs.Session)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T, does not implement *structs.Session", raw)
-	}
-
+func indexNodeFromSession(e *structs.Session) ([]byte, error) {
 	v := strings.ToLower(e.Node)
 	if v == "" {
 		return nil, errMissingValueForIndex
@@ -103,12 +93,7 @@ func indexNodeFromSession(raw interface{}) ([]byte, error) {
 }
 
 // indexFromNodeCheckIDSession creates an index key from  sessionCheck
-func indexFromNodeCheckIDSession(raw interface{}) ([]byte, error) {
-	e, ok := raw.(*sessionCheck)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T, does not implement sessionCheck", raw)
-	}
-
+func indexFromNodeCheckIDSession(e *sessionCheck) ([]byte, error) {
 	var b indexBuilder
 	v := strings.ToLower(e.Node)
 	if v == "" {
@@ -132,12 +117,7 @@ func indexFromNodeCheckIDSession(raw interface{}) ([]byte, error) {
 }
 
 // indexSessionCheckFromSession creates an index key from  sessionCheck
-func indexSessionCheckFromSession(raw interface{}) ([]byte, error) {
-	e, ok := raw.(*sessionCheck)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T, does not implement *sessionCheck", raw)
-	}
-
+func indexSessionCheckFromSession(e *sessionCheck) ([]byte, error) {
 	var b indexBuilder
 	v := strings.ToLower(e.Session)
 	if v == "" {

--- a/agent/consul/state/session_oss.go
+++ b/agent/consul/state/session_oss.go
@@ -14,48 +14,44 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-func sessionIndexer() indexerSingleWithPrefix {
-	return indexerSingleWithPrefix{
-		readIndex:   readIndex(indexFromQuery),
-		writeIndex:  writeIndex(indexFromSession),
-		prefixIndex: prefixIndex(prefixIndexFromQuery),
+func sessionIndexer() indexerSingleWithPrefix[Query, *structs.Session, any] {
+	return indexerSingleWithPrefix[Query, *structs.Session, any]{
+		readIndex:   indexFromQuery,
+		writeIndex:  indexFromSession,
+		prefixIndex: prefixIndexFromQuery,
 	}
 }
 
-func nodeSessionsIndexer() indexerSingle {
-	return indexerSingle{
-		readIndex:  readIndex(indexFromIDValueLowerCase),
-		writeIndex: writeIndex(indexNodeFromSession),
+func nodeSessionsIndexer() indexerSingle[singleValueID, *structs.Session] {
+	return indexerSingle[singleValueID, *structs.Session]{
+		readIndex:  indexFromIDValueLowerCase,
+		writeIndex: indexNodeFromSession,
 	}
 }
 
-func idCheckIndexer() indexerSingle {
-	return indexerSingle{
+func idCheckIndexer() indexerSingle[*sessionCheck, *sessionCheck] {
+	return indexerSingle[*sessionCheck, *sessionCheck]{
 		readIndex:  indexFromNodeCheckIDSession,
 		writeIndex: indexFromNodeCheckIDSession,
 	}
 }
 
-func sessionCheckIndexer() indexerSingle {
-	return indexerSingle{
+func sessionCheckIndexer() indexerSingle[Query, *sessionCheck] {
+	return indexerSingle[Query, *sessionCheck]{
 		readIndex:  indexFromQuery,
 		writeIndex: indexSessionCheckFromSession,
 	}
 }
 
-func nodeChecksIndexer() indexerSingle {
-	return indexerSingle{
+func nodeChecksIndexer() indexerSingle[multiValueID, *sessionCheck] {
+	return indexerSingle[multiValueID, *sessionCheck]{
 		readIndex:  indexFromMultiValueID,
 		writeIndex: indexFromNodeCheckID,
 	}
 }
 
 // indexFromNodeCheckID creates an index key from a sessionCheck structure
-func indexFromNodeCheckID(raw interface{}) ([]byte, error) {
-	e, ok := raw.(*sessionCheck)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type %T, does not implement *structs.Session", raw)
-	}
+func indexFromNodeCheckID(e *sessionCheck) ([]byte, error) {
 	var b indexBuilder
 	v := strings.ToLower(e.Node)
 	if v == "" {


### PR DESCRIPTION
### Description
We have many indexer functions in Consul which take `interface{}` and type assert before building the index.

Example:
```go
p, ok := raw.(*structs.ACLToken)
if !ok {
	return nil, fmt.Errorf("unexpected type %T for structs.ACLToken index", raw)
}
```

We can use generics to get rid of the initial plumbing and pass around functions with better defined signatures.

This has two benefits:
1. Less verbosity (see lines removed from this PR)
2. Developers can parse the argument types to memdb schemas without having to introspect the function for the type assertion

### Testing & Reproduction steps
* This PR adds no new functionality; tests should pass as-is

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
