### PR TITLE
docs: backport failed cherry pick for cluster peering to 1.12.x

### DIFF
--- a/website/content/docs/connect/cluster-peering/create-manage-peering.mdx
+++ b/website/content/docs/connect/cluster-peering/create-manage-peering.mdx
@@ -57,7 +57,7 @@ In the peer parameter, specify a name for the first cluster. The `PeeringToken` 
 
 When you connect server agents through cluster peering, they will peer their default partitions. To establish peering connections for other partitions through server agents, you must specify the partitions you want to peer using the `Partition` field of the request body.
 
-## Connect service endpoints
+## Export service endpoints
 
 After you establish a connection between the clusters, you need to create a configuration entry that defines the services that are available for other clusters. Consul uses this configuration entry to advertise service information and support service mesh connections across clusters.
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -21,7 +21,11 @@ The following Custom Resource Definitions (CRDs) are used to create and manage a
 
 ## Prerequisites
 
-To create and use cluster peering connections with Kubernetes, you need at least two Kubernetes clusters running in a flat network with Consul on Kubernetes v.0.45 or later, and Consul 1.13 Alpha 2 or later.
+You must implement the following requirements to create and use cluster peering connections with Kubernetes: 
+ - Consul 1.13 Alpha 2 or later
+ - At least two Kubernetes clusters 
+ - The Kubernetes clusters must be running in a flat network 
+ - The network must be running on Consul on Kubernetes v.0.45 or later 
 
 ### Helm chart configuration
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -21,7 +21,7 @@ The following Custom Resource Definitions (CRDs) are used to create and manage a
 
 ## Prerequisites
 
-To create and use cluster peering connections with Kubernetes, you need at least two Kubernetes clusters running in a flat network with Consul on Kubernetes v.0.45 or later and Consul 1.13 Alpha 2.
+To create and use cluster peering connections with Kubernetes, you need at least two Kubernetes clusters running in a flat network with Consul on Kubernetes v.0.45 or later, and Consul 1.13 Alpha 2 or later.
 
 ### Helm chart configuration
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -21,7 +21,7 @@ The following Custom Resource Definitions (CRDs) are used to create and manage a
 
 ## Prerequisites
 
-To create and use cluster peering connections with Kubernetes, you need at least two Kubernetes clusters running in a flat network with Consul on Kubernetes v.0.45 or later.
+To create and use cluster peering connections with Kubernetes, you need at least two Kubernetes clusters running in a flat network with Consul on Kubernetes v.0.45 or later and Consul 1.13 Alpha 2.
 
 ### Helm chart configuration
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -31,7 +31,7 @@ You must implement the following requirements to create and use cluster peering 
 
 To establish cluster peering through Kubernetes, deploy clusters with the following Helm values.
 
-<CodeTabs heading="values.yaml">
+<CodeTabs filename="values.yaml">
 <CodeBlockConfig lineNumbers>
   
 ```yaml

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -31,8 +31,7 @@ You must implement the following requirements to create and use cluster peering 
 
 To establish cluster peering through Kubernetes, deploy clusters with the following Helm values.
 
-<CodeTabs filename="values.yaml">
-<CodeBlockConfig lineNumbers>
+<CodeBlockConfig filename="values.yaml">
   
 ```yaml
 global:
@@ -47,7 +46,6 @@ meshGateway:
 ```
   
 </CodeBlockConfig>
-</CodeTabs>
 
 Install Consul on Kubernetes on each Kubernetes cluster by applying `values.yaml` using the Helm CLI.
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -27,8 +27,12 @@ To create and use cluster peering connections with Kubernetes, you need at least
 
 To establish cluster peering through Kubernetes, deploy clusters with the following Helm values.
 
+<CodeTabs heading="values.yaml">
+<CodeBlockConfig lineNumbers>
+  
 ```yaml
 global:
+  image: "hashicorp/consul:1.13.0-alpha2"
   peering:
     enabled: true
 connectInject:
@@ -37,13 +41,26 @@ meshGateway:
   enabled: true
   replicas: 1
 ```
+  
+</CodeBlockConfig>
+</CodeTabs>
+
+Install Consul on Kubernetes on each Kubernetes cluster by applying `values.yaml` using the Helm CLI.
+
+```shell-session
+$ export HELM_RELEASE_NAME=cluster-name
+```
+
+```shell-session
+$ helm install ${HELM_RELEASE_NAME} hashicorp/consul --version "0.45.0" --values values.yaml
+```
 
 ## Create a peering connection
 
 To peer Kubernetes clusters running Consul, you need to create a peering token and share it with the other cluster.
 
-1. In “cluster-01,” create the `PeeringAcceptor` custom resource.
-
+1. In `cluster-01`, create the `PeeringAcceptor` custom resource.
+ 
     <CodeBlockConfig filename="acceptor.yml">
 
     ```yaml


### PR DESCRIPTION
### Description
Describe why you're making this change, in plain English.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
