### PR TITLE
peering, internal: support UIServices, UINodes, UINodeInfo 

### DIFF
--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -77,9 +77,9 @@ func (m *Internal) NodeDump(args *structs.DCSpecificRequest,
 			// this maxIndex will be the max of the NodeDump calls and the PeeringList call
 			var maxIndex uint64
 			// Get data for local nodes
-			index, dump, err := state.NodeDump(ws, &args.EnterpriseMeta, "")
+			index, dump, err := state.NodeDump(ws, &args.EnterpriseMeta, structs.DefaultPeerKeyword)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not get a node dump for local nodes: %w", err)
 			}
 
 			if index > maxIndex {
@@ -101,7 +101,7 @@ func (m *Internal) NodeDump(args *structs.DCSpecificRequest,
 			for _, p := range listedPeerings {
 				index, importedDump, err := state.NodeDump(ws, &args.EnterpriseMeta, p.Name)
 				if err != nil {
-					return err
+					return fmt.Errorf("could not get a node dump for peer's %q nodes: %w", p.Name, err)
 				}
 				reply.ImportedDump = append(reply.ImportedDump, importedDump...)
 
@@ -162,9 +162,9 @@ func (m *Internal) ServiceDump(args *structs.ServiceDumpRequest, reply *structs.
 			var maxIndex uint64
 
 			// get a local dump for services
-			index, nodes, err := state.ServiceDump(ws, args.ServiceKind, args.UseServiceKind, &args.EnterpriseMeta, "")
+			index, nodes, err := state.ServiceDump(ws, args.ServiceKind, args.UseServiceKind, &args.EnterpriseMeta, structs.DefaultPeerKeyword)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not get a service dump for local nodes: %w", err)
 			}
 
 			if index > maxIndex {
@@ -185,7 +185,7 @@ func (m *Internal) ServiceDump(args *structs.ServiceDumpRequest, reply *structs.
 			for _, p := range listedPeerings {
 				index, importedNodes, err := state.ServiceDump(ws, args.ServiceKind, args.UseServiceKind, &args.EnterpriseMeta, p.Name)
 				if err != nil {
-					return err
+					return fmt.Errorf("could not get a service dump for peer's %q nodes: %w", p.Name, err)
 				}
 
 				if index > maxIndex {

--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -113,13 +113,13 @@ func (m *Internal) NodeDump(args *structs.DCSpecificRequest,
 
 			raw, err := filter.Execute(reply.Dump)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not filter local node dump: %w", err)
 			}
 			reply.Dump = raw.(structs.NodeDump)
 
 			importedRaw, err := filter.Execute(reply.ImportedDump)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not filter peer node dump: %w", err)
 			}
 			reply.ImportedDump = importedRaw.(structs.NodeDump)
 
@@ -175,7 +175,7 @@ func (m *Internal) ServiceDump(args *structs.ServiceDumpRequest, reply *structs.
 			// get a list of all peerings
 			index, listedPeerings, err := state.PeeringList(ws, args.EnterpriseMeta)
 			if err != nil {
-				m.logger.Error("could not list peers for service dump", err)
+				return fmt.Errorf("could not list peers for service dump %w", err)
 			}
 
 			if index > maxIndex {
@@ -208,13 +208,13 @@ func (m *Internal) ServiceDump(args *structs.ServiceDumpRequest, reply *structs.
 
 			raw, err := filter.Execute(reply.Nodes)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not filter local service dump: %w", err)
 			}
 			reply.Nodes = raw.(structs.CheckServiceNodes)
 
 			importedRaw, err := filter.Execute(reply.ImportedNodes)
 			if err != nil {
-				return err
+				return fmt.Errorf("could not filter peer service dump: %w", err)
 			}
 			reply.ImportedNodes = importedRaw.(structs.CheckServiceNodes)
 

--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -101,7 +101,7 @@ func (m *Internal) NodeDump(args *structs.DCSpecificRequest,
 			for _, p := range listedPeerings {
 				index, importedDump, err := state.NodeDump(ws, &args.EnterpriseMeta, p.Name)
 				if err != nil {
-					return fmt.Errorf("could not get a node dump for peer's %q nodes: %w", p.Name, err)
+					return fmt.Errorf("could not get a node dump for peer %q: %w", p.Name, err)
 				}
 				reply.ImportedDump = append(reply.ImportedDump, importedDump...)
 
@@ -185,7 +185,7 @@ func (m *Internal) ServiceDump(args *structs.ServiceDumpRequest, reply *structs.
 			for _, p := range listedPeerings {
 				index, importedNodes, err := state.ServiceDump(ws, args.ServiceKind, args.UseServiceKind, &args.EnterpriseMeta, p.Name)
 				if err != nil {
-					return fmt.Errorf("could not get a service dump for peer's %q nodes: %w", p.Name, err)
+					return fmt.Errorf("could not get a service dump for peer %q: %w", p.Name, err)
 				}
 
 				if index > maxIndex {

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -99,13 +99,11 @@ func TestInternal_NodeInfo(t *testing.T) {
 		}
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.NodeInfo", &req, &out))
 
+		// here we use ImportedNodes as well
 		nodes := out.Dump
-		require.Equal(t, 0, len(nodes))
-
-		importedNodes := out.ImportedDump
-		require.Equal(t, 1, len(importedNodes))
-		require.Equal(t, "foo", importedNodes[0].Node)
-		require.Equal(t, "peer1", importedNodes[0].PeerName)
+		require.Equal(t, 1, len(nodes))
+		require.Equal(t, "foo", nodes[0].Node)
+		require.Equal(t, "peer1", nodes[0].PeerName)
 	})
 }
 

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -289,9 +289,13 @@ func validateRegisterRequestPeerNamesTxn(_ ReadTxn, args *structs.RegisterReques
 	}
 
 	{
+		// todo alex -- is this correct?
 		// TODO(peering): validate the node's peering exists (skip check on restore)
-		peerName := args.PeerName
-		peerNames[peerName] = struct{}{}
+		if len(peerNames) == 0 {
+			peerName := args.PeerName
+			peerNames[peerName] = struct{}{}
+		}
+
 	}
 
 	if len(peerNames) > 1 {

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -289,13 +289,9 @@ func validateRegisterRequestPeerNamesTxn(_ ReadTxn, args *structs.RegisterReques
 	}
 
 	{
-		// todo alex -- is this correct?
 		// TODO(peering): validate the node's peering exists (skip check on restore)
-		if len(peerNames) == 0 {
-			peerName := args.PeerName
-			peerNames[peerName] = struct{}{}
-		}
-
+		peerName := args.PeerName
+		peerNames[peerName] = struct{}{}
 	}
 
 	if len(peerNames) > 1 {

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -289,9 +289,15 @@ func validateRegisterRequestPeerNamesTxn(_ ReadTxn, args *structs.RegisterReques
 	}
 
 	{
-		// todo alex -- is this correct?
 		// TODO(peering): validate the node's peering exists (skip check on restore)
-		if len(peerNames) == 0 {
+		if len(peerNames) == 1 {
+			if _, ok := peerNames[""]; ok {
+				// we only have an empty peerName so let's discard it
+				peerNames = make(map[string]struct{})
+				peerNames[args.PeerName] = struct{}{}
+			}
+
+		} else {
 			peerName := args.PeerName
 			peerNames[peerName] = struct{}{}
 		}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -289,15 +289,9 @@ func validateRegisterRequestPeerNamesTxn(_ ReadTxn, args *structs.RegisterReques
 	}
 
 	{
+		// todo alex -- is this correct?
 		// TODO(peering): validate the node's peering exists (skip check on restore)
-		if len(peerNames) == 1 {
-			if _, ok := peerNames[""]; ok {
-				// we only have an empty peerName so let's discard it
-				peerNames = make(map[string]struct{})
-				peerNames[args.PeerName] = struct{}{}
-			}
-
-		} else {
+		if len(peerNames) == 0 {
 			peerName := args.PeerName
 			peerNames[peerName] = struct{}{}
 		}

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2239,8 +2239,9 @@ type IndexedCheckServiceNodes struct {
 }
 
 type IndexedNodesWithGateways struct {
-	Nodes    CheckServiceNodes
-	Gateways GatewayServices
+	ImportedNodes CheckServiceNodes
+	Nodes         CheckServiceNodes
+	Gateways      GatewayServices
 	QueryMeta
 }
 
@@ -2250,7 +2251,8 @@ type DatacenterIndexedCheckServiceNodes struct {
 }
 
 type IndexedNodeDump struct {
-	Dump NodeDump
+	ImportedDump NodeDump
+	Dump         NodeDump
 	QueryMeta
 }
 

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -434,7 +434,12 @@ func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig, dc s
 	for _, csn := range dump {
 		var peerName string
 		// all entities will have the same peer name so it is safe to use the node's peer name
-		peerName = csn.Node.PeerName
+		if csn.Node == nil {
+			// this can happen for gateway dumps that call this summarize func
+			peerName = structs.DefaultPeerKeyword
+		} else {
+			peerName = csn.Node.PeerName
+		}
 
 		if cfg != nil && csn.GatewayService != nil {
 			gwsvc := csn.GatewayService

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -130,10 +130,6 @@ RPC:
 		}
 	}
 
-	if out.ImportedDump == nil {
-		out.ImportedDump = make(structs.NodeDump, 0)
-	}
-
 	return append(out.Dump, out.ImportedDump...), nil
 }
 
@@ -438,11 +434,7 @@ func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig, dc s
 	for _, csn := range dump {
 		var peerName string
 		// all entities will have the same peer name so it is safe to use the node's peer name
-		if csn.Node != nil {
-			peerName = csn.Node.PeerName
-		} else {
-			peerName = structs.DefaultPeerKeyword
-		}
+		peerName = csn.Node.PeerName
 
 		if cfg != nil && csn.GatewayService != nil {
 			gwsvc := csn.GatewayService

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -136,25 +136,25 @@ func TestUINodes(t *testing.T) {
 
 	// Should be 3 nodes, and all the empty lists should be non-nil
 	nodes := obj.(structs.NodeDump)
-	require.Equal(t, 3, len(nodes))
+	require.Len(t, nodes, 3)
 	require.Equal(t, a.Config.NodeName, nodes[0].Node)
 	require.NotNil(t, nodes[0].Services)
-	require.Equal(t, 1, len(nodes[0].Services))
+	require.Len(t, nodes[0].Services, 1)
 	require.NotNil(t, nodes[0].Checks)
-	require.Equal(t, 1, len(nodes[0].Checks))
+	require.Len(t, nodes[0].Checks, 1)
 	require.Equal(t, "test", nodes[1].Node)
 	require.NotNil(t, nodes[1].Services)
-	require.Equal(t, 0, len(nodes[1].Services))
+	require.Len(t, nodes[1].Services, 0)
 	require.NotNil(t, nodes[1].Checks)
-	require.Equal(t, 0, len(nodes[1].Checks))
+	require.Len(t, nodes[1].Checks, 0)
 
 	// peered node
 	require.Equal(t, "foo-peer", nodes[2].Node)
 	require.Equal(t, "peer1", nodes[2].PeerName)
 	require.NotNil(t, nodes[2].Services)
-	require.Equal(t, 0, len(nodes[2].Services))
+	require.Len(t, nodes[2].Services, 0)
 	require.NotNil(t, nodes[1].Checks)
-	require.Equal(t, 0, len(nodes[2].Checks))
+	require.Len(t, nodes[2].Services, 0)
 }
 
 func TestUINodes_Filter(t *testing.T) {

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -359,7 +359,7 @@ func TestUIServices(t *testing.T) {
 				Tags:    []string{},
 			},
 		},
-		// register peer node foo
+		// register peer node foo with peer service
 		{
 			Datacenter: "dc1",
 			Node:       "foo",
@@ -374,12 +374,6 @@ func TestUIServices(t *testing.T) {
 				"os":  "linux",
 			},
 			PeerName: "peer1",
-		},
-		// register peer service
-		{
-			Datacenter:     "dc1",
-			Node:           "foo",
-			SkipNodeUpdate: true,
 			Service: &structs.NodeService{
 				Kind:     structs.ServiceKindTypical,
 				ID:       "serviceID",

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/stretchr/testify/assert"
@@ -19,12 +21,14 @@ import (
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/proto/pbpeering"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/types"
 )
 
-func TestUiIndex(t *testing.T) {
+func TestUIIndex(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -74,7 +78,7 @@ func TestUiIndex(t *testing.T) {
 	}
 }
 
-func TestUiNodes(t *testing.T) {
+func TestUINodes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -84,15 +88,42 @@ func TestUiNodes(t *testing.T) {
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
-	args := &structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "test",
-		Address:    "127.0.0.1",
+	args := []*structs.RegisterRequest{
+		{
+			Datacenter: "dc1",
+			Node:       "test",
+			Address:    "127.0.0.1",
+		},
+		{
+			Datacenter: "dc1",
+			Node:       "foo-peer",
+			Address:    "127.0.0.3",
+			PeerName:   "peer1",
+		},
 	}
 
-	var out struct{}
-	if err := a.RPC("Catalog.Register", args, &out); err != nil {
-		t.Fatalf("err: %v", err)
+	for _, reg := range args {
+		var out struct{}
+		err := a.RPC("Catalog.Register", reg, &out)
+		require.NoError(t, err)
+	}
+
+	// establish "peer1"
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		peerOne := &pbpeering.PeeringWriteRequest{
+			Peering: &pbpeering.Peering{
+				Name:                "peer1",
+				State:               pbpeering.PeeringState_INITIAL,
+				PeerCAPems:          nil,
+				PeerServerName:      "fooservername",
+				PeerServerAddresses: []string{"addr1"},
+			},
+		}
+		_, err := a.rpcClientPeering.PeeringWrite(ctx, peerOne)
+		require.NoError(t, err)
 	}
 
 	req, _ := http.NewRequest("GET", "/v1/internal/ui/nodes/dc1", nil)
@@ -103,20 +134,30 @@ func TestUiNodes(t *testing.T) {
 	}
 	assertIndex(t, resp)
 
-	// Should be 2 nodes, and all the empty lists should be non-nil
+	// Should be 3 nodes, and all the empty lists should be non-nil
 	nodes := obj.(structs.NodeDump)
-	if len(nodes) != 2 ||
-		nodes[0].Node != a.Config.NodeName ||
-		nodes[0].Services == nil || len(nodes[0].Services) != 1 ||
-		nodes[0].Checks == nil || len(nodes[0].Checks) != 1 ||
-		nodes[1].Node != "test" ||
-		nodes[1].Services == nil || len(nodes[1].Services) != 0 ||
-		nodes[1].Checks == nil || len(nodes[1].Checks) != 0 {
-		t.Fatalf("bad: %v", obj)
-	}
+	require.Equal(t, 3, len(nodes))
+	require.Equal(t, a.Config.NodeName, nodes[0].Node)
+	require.NotNil(t, nodes[0].Services)
+	require.Equal(t, 1, len(nodes[0].Services))
+	require.NotNil(t, nodes[0].Checks)
+	require.Equal(t, 1, len(nodes[0].Checks))
+	require.Equal(t, "test", nodes[1].Node)
+	require.NotNil(t, nodes[1].Services)
+	require.Equal(t, 0, len(nodes[1].Services))
+	require.NotNil(t, nodes[1].Checks)
+	require.Equal(t, 0, len(nodes[1].Checks))
+
+	// peered node
+	require.Equal(t, "foo-peer", nodes[2].Node)
+	require.Equal(t, "peer1", nodes[2].PeerName)
+	require.NotNil(t, nodes[2].Services)
+	require.Equal(t, 0, len(nodes[2].Services))
+	require.NotNil(t, nodes[1].Checks)
+	require.Equal(t, 0, len(nodes[2].Checks))
 }
 
-func TestUiNodes_Filter(t *testing.T) {
+func TestUINodes_Filter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -162,7 +203,7 @@ func TestUiNodes_Filter(t *testing.T) {
 	require.Empty(t, nodes[0].Checks)
 }
 
-func TestUiNodeInfo(t *testing.T) {
+func TestUINodeInfo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -214,7 +255,7 @@ func TestUiNodeInfo(t *testing.T) {
 	}
 }
 
-func TestUiServices(t *testing.T) {
+func TestUIServices(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
@@ -318,11 +359,59 @@ func TestUiServices(t *testing.T) {
 				Tags:    []string{},
 			},
 		},
+		// register peer node foo
+		{
+			Datacenter: "dc1",
+			Node:       "foo",
+			ID:         types.NodeID("e0155642-135d-4739-9853-a1ee6c9f945b"),
+			Address:    "127.0.0.2",
+			TaggedAddresses: map[string]string{
+				"lan": "127.0.0.2",
+				"wan": "198.18.0.2",
+			},
+			NodeMeta: map[string]string{
+				"env": "production",
+				"os":  "linux",
+			},
+			PeerName: "peer1",
+		},
+		// register peer service
+		{
+			Datacenter:     "dc1",
+			Node:           "foo",
+			SkipNodeUpdate: true,
+			Service: &structs.NodeService{
+				Kind:     structs.ServiceKindTypical,
+				ID:       "serviceID",
+				Service:  "service",
+				Port:     1235,
+				Address:  "198.18.1.2",
+				PeerName: "peer1",
+			},
+		},
 	}
 
 	for _, args := range requests {
 		var out struct{}
 		require.NoError(t, a.RPC("Catalog.Register", args, &out))
+	}
+
+	// establish "peer1"
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		peerOne := &pbpeering.PeeringWriteRequest{
+			Peering: &pbpeering.Peering{
+				Name:                "peer1",
+				State:               pbpeering.PeeringState_INITIAL,
+				PeerCAPems:          nil,
+				PeerServerName:      "fooservername",
+				PeerServerAddresses: []string{"addr1"},
+			},
+		}
+		_, err := a.rpcClientPeering.PeeringWrite(ctx, peerOne)
+		require.NoError(t, err)
 	}
 
 	// Register a terminating gateway associated with api and cache
@@ -393,7 +482,7 @@ func TestUiServices(t *testing.T) {
 
 		// Should be 2 nodes, and all the empty lists should be non-nil
 		summary := obj.([]*ServiceListingSummary)
-		require.Len(t, summary, 6)
+		require.Len(t, summary, 7)
 
 		// internal accounting that users don't see can be blown away
 		for _, sum := range summary {
@@ -491,6 +580,21 @@ func TestUiServices(t *testing.T) {
 					ChecksCritical:  1,
 					ExternalSources: []string{"k8s"},
 					EnterpriseMeta:  *structs.DefaultEnterpriseMetaInDefaultPartition(),
+				},
+			},
+			{
+				ServiceSummary: ServiceSummary{
+					Kind:           structs.ServiceKindTypical,
+					Name:           "service",
+					Datacenter:     "dc1",
+					Tags:           nil,
+					Nodes:          []string{"foo"},
+					InstanceCount:  1,
+					ChecksPassing:  0,
+					ChecksWarning:  0,
+					ChecksCritical: 0,
+					EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+					PeerName:       "peer1",
 				},
 			},
 		}

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -137,6 +137,8 @@ func TestUINodes(t *testing.T) {
 	// Should be 3 nodes, and all the empty lists should be non-nil
 	nodes := obj.(structs.NodeDump)
 	require.Len(t, nodes, 3)
+
+	// check local nodes, services and checks
 	require.Equal(t, a.Config.NodeName, nodes[0].Node)
 	require.NotNil(t, nodes[0].Services)
 	require.Len(t, nodes[0].Services, 1)


### PR DESCRIPTION
### Description
We need to add peering support for the following UI endpoints: `UIServices`, `UINodes`, `UINodeInfo` in order to add data about peered services and nodes thru the UI.

Out of the 3, `UINodeInfo` is the simplest because it either takes a `PeerName` or `""`. `""` is denoted to mean local fetch, aka, local look ups, aka services or nodes that are not peered.

> Note: If `UIServices` or `UINodes` RPC endpoints receive a request for a specific peer (i.e. `args.PeerName != ""), we error out since we don't support that case right now bc it's not needed.

### Testing & Reproduction steps
* updated `_test` files

### Links
 * https://app.asana.com/0/1202437710094276/1202439043013559
 * https://app.asana.com/0/1202437710094276/1202454391493007
