### PR TITLE
Add new index for PeeredServiceName and ServiceVirtualIP

### DIFF
--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
-	bexpr "github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-uuid"
@@ -1036,6 +1036,7 @@ func (c *Catalog) VirtualIPForService(args *structs.ServiceSpecificRequest, repl
 	}
 
 	state := c.srv.fsm.State()
-	*reply, err = state.VirtualIPForService(structs.NewServiceName(args.ServiceName, &args.EnterpriseMeta))
+	psn := structs.PeeredServiceName{Peer: args.PeerName, ServiceName: structs.NewServiceName(args.ServiceName, &args.EnterpriseMeta)}
+	*reply, err = state.VirtualIPForService(psn)
 	return err
 }

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -451,7 +451,8 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		Port:    8000,
 		Connect: connectConf,
 	})
-	vip, err := fsm.state.VirtualIPForService(structs.NewServiceName("frontend", nil))
+	psn := structs.PeeredServiceName{ServiceName: structs.NewServiceName("frontend", nil)}
+	vip, err := fsm.state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, vip, "240.0.0.1")
 
@@ -462,7 +463,8 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		Port:    9000,
 		Connect: connectConf,
 	})
-	vip, err = fsm.state.VirtualIPForService(structs.NewServiceName("backend", nil))
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("backend", nil)}
+	vip, err = fsm.state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, vip, "240.0.0.2")
 
@@ -592,10 +594,12 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	require.Equal(t, uint64(25), checks[0].ModifyIndex)
 
 	// Verify virtual IPs are consistent.
-	vip, err = fsm2.state.VirtualIPForService(structs.NewServiceName("frontend", nil))
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("frontend", nil)}
+	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, vip, "240.0.0.1")
-	vip, err = fsm2.state.VirtualIPForService(structs.NewServiceName("backend", nil))
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("backend", nil)}
+	vip, err = fsm2.state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, vip, "240.0.0.2")
 

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -2258,7 +2258,8 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	vip, err := state.VirtualIPForService(structs.NewServiceName("api", nil))
+	psn := structs.PeeredServiceName{ServiceName: structs.NewServiceName("api", nil)}
+	vip, err := state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, "", vip)
 
@@ -2287,7 +2288,8 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 
 	// Make sure the service referenced in the terminating gateway config doesn't have
 	// a virtual IP yet.
-	vip, err = state.VirtualIPForService(structs.NewServiceName("bar", nil))
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("bar", nil)}
+	vip, err = state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, "", vip)
 
@@ -2316,8 +2318,8 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-
-	vip, err = state.VirtualIPForService(structs.NewServiceName("api", nil))
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("api", nil)}
+	vip, err = state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, "240.0.0.1", vip)
 
@@ -2345,7 +2347,8 @@ func TestLeader_EnableVirtualIPs(t *testing.T) {
 
 	// Make sure the baz service (only referenced in the config entry so far)
 	// has a virtual IP.
-	vip, err = state.VirtualIPForService(structs.NewServiceName("baz", nil))
+	psn = structs.PeeredServiceName{ServiceName: structs.NewServiceName("baz", nil)}
+	vip, err = state.VirtualIPForService(psn)
 	require.NoError(t, err)
 	require.Equal(t, "240.0.0.2", vip)
 }

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -299,3 +299,15 @@ func updateKindServiceNamesIndex(tx WriteTxn, idx uint64, kind structs.ServiceKi
 	}
 	return nil
 }
+
+func indexFromPeeredServiceName(psn structs.PeeredServiceName) ([]byte, error) {
+	peer := structs.LocalPeerKeyword
+	if psn.Peer != "" {
+		peer = psn.Peer
+	}
+
+	var b indexBuilder
+	b.String(strings.ToLower(peer))
+	b.String(strings.ToLower(psn.ServiceName.Name))
+	return b.Bytes(), nil
+}

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -669,8 +669,19 @@ func testIndexerTableServices() map[string]indexerTestCase {
 
 func testIndexerTableServiceVirtualIPs() map[string]indexerTestCase {
 	obj := ServiceVirtualIP{
-		Service: structs.ServiceName{
-			Name: "foo",
+		Service: structs.PeeredServiceName{
+			ServiceName: structs.ServiceName{
+				Name: "foo",
+			},
+		},
+		IP: net.ParseIP("127.0.0.1"),
+	}
+	peeredObj := ServiceVirtualIP{
+		Service: structs.PeeredServiceName{
+			ServiceName: structs.ServiceName{
+				Name: "foo",
+			},
+			Peer: "Billing",
 		},
 		IP: net.ParseIP("127.0.0.1"),
 	}
@@ -678,14 +689,33 @@ func testIndexerTableServiceVirtualIPs() map[string]indexerTestCase {
 	return map[string]indexerTestCase{
 		indexID: {
 			read: indexValue{
-				source: structs.ServiceName{
-					Name: "foo",
+				source: structs.PeeredServiceName{
+					ServiceName: structs.ServiceName{
+						Name: "foo",
+					},
 				},
-				expected: []byte("foo\x00"),
+				expected: []byte("internal\x00foo\x00"),
 			},
 			write: indexValue{
 				source:   obj,
-				expected: []byte("foo\x00"),
+				expected: []byte("internal\x00foo\x00"),
+			},
+			extra: []indexerTestCase{
+				{
+					read: indexValue{
+						source: structs.PeeredServiceName{
+							ServiceName: structs.ServiceName{
+								Name: "foo",
+							},
+							Peer: "Billing",
+						},
+						expected: []byte("billing\x00foo\x00"),
+					},
+					write: indexValue{
+						source:   peeredObj,
+						expected: []byte("billing\x00foo\x00"),
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
For TProxy we will be leveraging the VirtualIP table, which need to become peer-aware

### Testing & Reproduction steps
* Updated tests to reflect new shape of indexes
* Added more test cases to show proper indexing of peered services