### PR TITLE
tests: ensure integration tests show logs from the containers to help debugging

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -333,12 +333,12 @@ ifeq ("$(GOTAGS)","")
 	@docker tag consul-dev:latest consul:local
 	@docker run --rm -t consul:local consul version
 	@cd ./test/integration/consul-container && \
-		go test -v -timeout=30m ./upgrade --target-version local --latest-version latest
+		go test -v -timeout=30m ./... --target-version local --latest-version latest
 else
 	@docker tag consul-dev:latest hashicorp/consul-enterprise:local
 	@docker run --rm -t hashicorp/consul-enterprise:local consul version
 	@cd ./test/integration/consul-container && \
-		go test -v -timeout=30m ./upgrade --tags $(GOTAGS) --target-version local --latest-version latest
+		go test -v -timeout=30m ./... --tags $(GOTAGS) --target-version local --latest-version latest
 endif
 
 .PHONY: test-metrics-integ

--- a/test/integration/consul-container/go.mod
+++ b/test/integration/consul-container/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/consul/api v1.11.0
 	github.com/hashicorp/consul/sdk v0.8.0
 	github.com/hashicorp/go-uuid v1.0.2
+	github.com/hashicorp/hcl v1.0.0
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.13.0
 )

--- a/test/integration/consul-container/go.sum
+++ b/test/integration/consul-container/go.sum
@@ -427,6 +427,7 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=

--- a/test/integration/consul-container/libs/node/log.go
+++ b/test/integration/consul-container/libs/node/log.go
@@ -1,0 +1,23 @@
+package node
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/testcontainers/testcontainers-go"
+)
+
+type NodeLogConsumer struct {
+	Prefix string
+}
+
+var _ testcontainers.LogConsumer = (*NodeLogConsumer)(nil)
+
+func (c *NodeLogConsumer) Accept(log testcontainers.Log) {
+	switch log.LogType {
+	case "STDOUT":
+		fmt.Fprint(os.Stdout, c.Prefix+" ~~ "+string(log.Content))
+	case "STDERR":
+		fmt.Fprint(os.Stderr, c.Prefix+" ~~ "+string(log.Content))
+	}
+}

--- a/test/integration/consul-container/libs/node/node.go
+++ b/test/integration/consul-container/libs/node/node.go
@@ -2,19 +2,18 @@ package node
 
 import (
 	"context"
+
 	"github.com/hashicorp/consul/api"
 )
 
-type (
-	// Node represent a Consul node abstraction
-	Node interface {
-		Terminate() error
-		GetClient() *api.Client
-		GetAddr() (string, int)
-		GetConfig() Config
-		Upgrade(ctx context.Context, config Config) error
-	}
-)
+// Node represent a Consul node abstraction
+type Node interface {
+	Terminate() error
+	GetClient() *api.Client
+	GetAddr() (string, int)
+	GetConfig() Config
+	Upgrade(ctx context.Context, config Config) error
+}
 
 // Config is a set of configurations required to create a Node
 type Config struct {

--- a/test/integration/consul-container/metrics/leader_test.go
+++ b/test/integration/consul-container/metrics/leader_test.go
@@ -23,7 +23,7 @@ func TestLeadershipMetrics(t *testing.T) {
 	configs = append(configs,
 		node.Config{
 			HCL: `node_name="` + utils.RandName("consul-server") + `"
-					log_level="TRACE"
+					log_level="DEBUG"
 					server=true
 					telemetry {
 						statsite_address = "127.0.0.1:2180"
@@ -37,7 +37,7 @@ func TestLeadershipMetrics(t *testing.T) {
 		configs = append(configs,
 			node.Config{
 				HCL: `node_name="` + utils.RandName("consul-server") + `"
-					log_level="TRACE"
+					log_level="DEBUG"
 					bootstrap_expect=3
 					server=true`,
 				Cmd:     []string{"agent", "-client=0.0.0.0"},

--- a/test/integration/consul-container/upgrade/healthcheck_test.go
+++ b/test/integration/consul-container/upgrade/healthcheck_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/api"
+
 	libcluster "github.com/hashicorp/consul/integration/consul-container/libs/cluster"
 	"github.com/hashicorp/consul/integration/consul-container/libs/node"
 	"github.com/hashicorp/consul/integration/consul-container/libs/utils"
@@ -74,7 +75,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 	configs = append(configs,
 		node.Config{
 			HCL: `node_name="` + utils.RandName("consul-server") + `"
-					log_level="TRACE"
+					log_level="DEBUG"
 					server=true`,
 			Cmd:     []string{"agent", "-client=0.0.0.0"},
 			Version: *utils.TargetImage,
@@ -84,7 +85,7 @@ func TestMixedServersMajorityLatestGAClient(t *testing.T) {
 		configs = append(configs,
 			node.Config{
 				HCL: `node_name="` + utils.RandName("consul-server") + `"
-					log_level="TRACE"
+					log_level="DEBUG"
 					bootstrap_expect=3
 					server=true`,
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
@@ -151,7 +152,7 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 		configs = append(configs,
 			node.Config{
 				HCL: `node_name="` + utils.RandName("consul-server") + `"
-					log_level="TRACE"
+					log_level="DEBUG"
 					bootstrap_expect=3
 					server=true`,
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
@@ -162,7 +163,7 @@ func TestMixedServersMajorityTargetGAClient(t *testing.T) {
 	configs = append(configs,
 		node.Config{
 			HCL: `node_name="` + utils.RandName("consul-server") + `"
-					log_level="TRACE"
+					log_level="DEBUG"
 					server=true`,
 			Cmd:     []string{"agent", "-client=0.0.0.0"},
 			Version: *utils.LatestImage,
@@ -227,7 +228,7 @@ func clientsCreate(t *testing.T, numClients int, version string, serfKey string)
 			node.Config{
 				HCL: fmt.Sprintf(`
 				node_name = %q
-				log_level = "TRACE"
+				log_level = "DEBUG"
 				encrypt = %q`, utils.RandName("consul-client"), serfKey),
 				Cmd:     []string{"agent", "-client=0.0.0.0"},
 				Version: version,
@@ -255,7 +256,7 @@ func serversCluster(t *testing.T, numServers int, version string) *libcluster.Cl
 	for i := 0; i < numServers; i++ {
 		configs = append(configs, node.Config{
 			HCL: `node_name="` + utils.RandName("consul-server") + `"
-					log_level="TRACE"
+					log_level="DEBUG"
 					bootstrap_expect=3
 					server=true`,
 			Cmd:     []string{"agent", "-client=0.0.0.0"},


### PR DESCRIPTION
### Description

When the upgrade compatibility integration tests fail there isn't a lot of detail to go on, so this PR redirects the logging to stdout/stderr so they can be captured and visible.

Some light refactor/cleanup was done in passing as well.
