### PR TITLE
Fix verifications by using updated arm package names

### DIFF
--- a/.github/scripts/verify_artifact.sh
+++ b/.github/scripts/verify_artifact.sh
@@ -73,7 +73,7 @@ function verify_rpm {
       docker_platform="linux/amd64"
       docker_image="amd64/centos:7"
       ;;
-    *.arm.rpm)
+    *.armv7hl.rpm)
       docker_platform="linux/arm/v7"
       docker_image="arm32v7/fedora:36"
       ;;
@@ -120,7 +120,7 @@ function verify_deb {
       docker_platform="linux/amd64"
       docker_image="amd64/debian:bullseye"
       ;;
-    *_arm.deb)
+    *_armhf.deb)
       docker_platform="linux/arm/v7"
       docker_image="arm32v7/debian:bullseye"
       ;;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,7 +339,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["i386", "amd64", "arm", "arm64"]
+        arch: ["i386", "amd64", "armhf", "arm64"]
       # fail-fast: true
     env:
       version: ${{ needs.get-product-version.outputs.product-version }}
@@ -376,7 +376,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["i386", "x86_64", "arm", "aarch64"]
+        arch: ["i386", "x86_64", "armv7hl", "aarch64"]
       # fail-fast: true
     env:
       version: ${{ needs.get-product-version.outputs.product-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Push events on the main branch
       - main
+      - eculver/fix-pkg-name
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Push events on the main branch
       - main
-      - eculver/fix-pkg-name
 
 env:
   PKG_NAME: consul


### PR DESCRIPTION
### Description
The linux packaging action recently updated the way arm packages get named so our verifications broke. They were looking for packages with just `arm` in the name, but they are now `armhf` for debian and `armv7hl` for rpms.  

### Testing & Reproduction steps
I temporarily added a branch target for this to see it get fixed. I'll remove the branch target before merging.

### Links
 Upstream PR that changed the packaging action: https://github.com/hashicorp/actions-packaging-linux/pull/6.