### PR TITLE
Add HashiBox to community tools

### DIFF
--- a/website/content/docs/download-tools.mdx
+++ b/website/content/docs/download-tools.mdx
@@ -55,6 +55,7 @@ These Consul tools are created and managed by the amazing members of the Consul 
 - [Gonsul](https://github.com/miniclip/gonsul) - A Git to Consul standalone tool made in Go. Updates Consul KV from a repo with multiple strategies.
 - [gradle-consul-plugin](https://github.com/amirkibbar/red-apple) - A Consul Gradle plugin
 - [hashi-ui](https://github.com/jippi/hashi-ui) - A modern user interface for the Consul and Nomad
+- [HashiBox](https://github.com/nunchistudio/hashibox) - Vagrant environment to simulate highly-available cloud with Consul, Nomad, Vault, and optional support for Waypoint. OSS & Enterprise supported.
 - [helios-consul](https://github.com/SVT/helios-consul) - Service registrar plugin for Helios
 - [Jenkins Consul Plugin](https://plugins.jenkins.io/consul) - Jenkins plugin for service discovery and K/V store
 - [marathon-consul](https://github.com/allegro/marathon-consul) - Service registry bridge for Marathon


### PR DESCRIPTION
This PR adds [HashiBox](https://github.com/nunchistudio/hashibox) to the community tools.

HashiBox is a local environment to simulate a highly-available cloud with [Consul](https://www.consul.io/), [Nomad](https://www.nomadproject.io/), and [Vault](https://www.vaultproject.io/). OSS and Enterprise versions of each product are supported.