### PR TITLE
ui: Gradual deprecation of old StateChart interface

### DIFF
--- a/ui/packages/consul-ui/app/components/state-chart/README.mdx
+++ b/ui/packages/consul-ui/app/components/state-chart/README.mdx
@@ -3,6 +3,8 @@ class: ember
 ---
 # StateChart
 
+**This component is deprecated and is currently undergoing an interface change in <StateMachine />**
+
 ```hbs
 <StateChart
   @chart={{xstateStateChartObject}}

--- a/ui/packages/consul-ui/app/components/state-machine/README.mdx
+++ b/ui/packages/consul-ui/app/components/state-machine/README.mdx
@@ -1,0 +1,61 @@
+---
+class: ember
+---
+# StateMachine
+
+```hbs
+<StateMachine
+  @chart={{xstateStateChartObject}}
+  as |fsm|>
+</StateMachine>
+```
+
+`<StateMachine />` is a renderless component that eases rendering of different states
+from within templates using XState State Machine and Statechart objects.
+
+**Please note**: This component is currently a gradual replacement for
+StateChart, which has a less ergonmic interface. Guard and Action component are
+currently omitted due to a preference to use entries to define those instead of
+components (which is WIP)
+
+### Arguments
+
+| Argument/Attribute | Type | Default | Description |
+| --- | --- | --- | --- |
+| `chart` | `object` |  | An xstate statechart/state machine object |
+| `initial` | `String` | The initial value of the state chart itself | The initial state of the machine/chart (defaults to whatever is defined on the object itself) |
+
+The component currently yields 1 contextual components:
+
+- `<fsm.State />`: Used for rendering matching certain states ([also see State Component](../state/README.mdx))
+
+and 2 further objects:
+
+- `fsm.dispatch`: An action to dispatch an xstate event
+- `fsm.state`: The state object itself for usage in the `state-matches` helper
+
+### Example
+
+```hbs
+<StateMachine
+  @chart={{xstateStateChartObject}}
+  as |fsm|>
+    <fsm.State @matches="idle">
+      Currently Idle
+    </fsm.State>
+    <fsm.State @matches="loading">
+      Currently Loading
+    </fsm.State>
+    <fsm.State @matches={{array 'loading' 'idle'}}>
+      Idle and loading
+      <button disabled={{state-matches fsm.state "loading"}} onclick={{action fsm.dispatch "START"}}>Load</button>
+    </fsm.State>
+</StateMachine>
+```
+
+### See
+
+- [Component Source Code](./index.js)
+- [Template Source Code](./index.hbs)
+
+---

--- a/ui/packages/consul-ui/app/components/state-machine/index.hbs
+++ b/ui/packages/consul-ui/app/components/state-machine/index.hbs
@@ -1,0 +1,7 @@
+{{yield
+  (hash
+    State=(component 'state' state=this.state)
+    dispatch=(action 'dispatch')
+    state=this.state
+  )
+}}

--- a/ui/packages/consul-ui/app/components/state-machine/index.js
+++ b/ui/packages/consul-ui/app/components/state-machine/index.js
@@ -1,0 +1,4 @@
+import Component from '../state-chart/index';
+
+export default Component.extend({});
+

--- a/ui/packages/consul-ui/app/components/state/README.mdx
+++ b/ui/packages/consul-ui/app/components/state/README.mdx
@@ -1,6 +1,3 @@
----
-class: ember
----
 # State
 
 `<State @state={{matchableStateObject}} @matches="idle">Currently Idle</State>`

--- a/ui/packages/consul-ui/app/components/state/index.hbs
+++ b/ui/packages/consul-ui/app/components/state/index.hbs
@@ -1,3 +1,5 @@
-{{#if rendering}}
+{{did-insert this.attributeChanged @state @matches @notMatches}}
+{{did-update this.attributeChanged @state @matches @notMatches}}
+{{#if render}}
   {{yield}}
 {{/if}}

--- a/ui/packages/consul-ui/app/components/state/index.js
+++ b/ui/packages/consul-ui/app/components/state/index.js
@@ -1,20 +1,20 @@
-import Component from '@ember/component';
-import { set } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-export default Component.extend({
-  service: service('state'),
-  tagName: '',
-  didReceiveAttrs: function() {
-    if (typeof this.state === 'undefined') {
+export default class State extends Component {
+  @service('state') state;
+
+  @tracked render = false;
+
+  @action
+  attributeChanged([state, matches, notMatches]) {
+    if (typeof state === 'undefined') {
       return;
     }
-    let match = true;
-    if (typeof this.matches !== 'undefined') {
-      match = this.service.matches(this.state, this.matches);
-    } else if (typeof this.notMatches !== 'undefined') {
-      match = !this.service.matches(this.state, this.notMatches);
-    }
-    set(this, 'rendering', match);
-  },
-});
+    this.render = typeof matches !== 'undefined' ?
+      this.state.matches(state, matches) :
+      !this.state.matches(state, notMatches);
+  }
+}

--- a/ui/packages/consul-ui/app/helpers/require.js
+++ b/ui/packages/consul-ui/app/helpers/require.js
@@ -1,27 +1,11 @@
 import { helper } from '@ember/component/helper';
+import require from 'require';
 
 import { css } from '@lit/reactive-element';
-
 import resolve from 'consul-ui/utils/path/resolve';
 
 
-import panel from 'consul-ui/components/panel/index.css';
-import distributionMeter from 'consul-ui/components/distribution-meter/index.css';
-import distributionMeterMeter from 'consul-ui/components/distribution-meter/meter/index.css';
-import distributionMeterMeterElement from 'consul-ui/components/distribution-meter/meter/element';
-import visuallyHidden from 'consul-ui/styles/base/decoration/visually-hidden.css';
-import baseKeyframes from 'consul-ui/styles/base/icons/base-keyframes.css';
-import chevronDown from 'consul-ui/styles/base/icons/icons/chevron-down/index.css';
-
-const fs = {
-  ['/components/panel/index.css']: panel,
-  ['/components/distribution-meter/index.css']: distributionMeter,
-  ['/components/distribution-meter/meter/index.css']: distributionMeterMeter,
-  ['/components/distribution-meter/meter/element']: distributionMeterMeterElement,
-  ['/styles/base/decoration/visually-hidden.css']: visuallyHidden,
-  ['/styles/base/icons/base-keyframes.css']: baseKeyframes,
-  ['/styles/base/icons/icons/chevron-down/index.css']: chevronDown
-};
+const appName = 'consul-ui';
 
 const container = new Map();
 
@@ -29,17 +13,27 @@ const container = new Map();
 // we get the advantage of laziness here, i.e. we only call css as and when we
 // need to
 export default helper(([path = ''], { from }) => {
-  const fullPath = resolve(from, path);
+  const fullPath = resolve(`${appName}${from}`, path);
+
+  let module;
+  if(require.has(fullPath)) {
+    module = require(fullPath).default;
+  } else {
+    throw new Error(`Unable to resolve '${fullPath}' does the file exist?`)
+  }
+
   switch(true) {
     case fullPath.endsWith('.css'):
-      return fs[fullPath](css)
+      return module(css);
+    case fullPath.endsWith('.xstate'):
+      return module;
     default: {
       if(container.has(fullPath)) {
         return container.get(fullPath);
       }
-      const module = fs[fullPath](HTMLElement);
-      container.set(fullPath, module);
-      return module;
+      const component = module(HTMLElement);
+      container.set(fullPath, component);
+      return component;
     }
   }
 });


### PR DESCRIPTION
### Description

TLDR

This is a a new `StateMachine` component inheriting from `StateChart` and has the exact same functionality for interface changing purposes, changes are:

1. exported `|State Guard Action dispatch state|` properties have changed to a object containing those properties instead instead > `|fsm|` (i.e. `fsm.State`, `fsm.dispatch` etc)
2. `Guard` and `Action` were removed, once we need them this will be managed via entry-like `@guards` and `@actions` args.

--- 

Our `<StateChart />` and related components could do with an upgrade, mainly due to the less than ergonomic interface which is proving difficult to work with. This is reasonably often, making it feel like a unicorn dies every time we use it 😅 . We are looking to use this quite a bit in our upcoming work.

We also use this component already in various places so we want to support the old interface whilst beginning to introduce the more ergonomic new interface. Therefore we chose to make a new `StateMachine` component inheriting from the old component and add the new interface to that (the StateMachine name is better anyway so I'm kinda lucky there), so its the same functionality just a different interface. Please note: We don't need Guard and Action for the current work they are doing, but the new interface will just provide these as attributes instead of using components for this, hence these are currently not supported by this new iteration. Once we need that functionality (if we need it in the near future) we can add that then.

I also noticed to upgrade `<State />` to Octane was relatively straightforwards and a quick win whilst we were here.

Lastly, I replaced our require helper with something more dynamic now I'm pretty sure this is fine moving forwards with embroider. We will be using this in future instead of our state-chart helper to provide the chart to the machine. Making it dynamic just means less hassle to do this.

P.S. Tests here are currently failing for unrelated reasons, that is being worked on separately and we can rebase here once thats ready (see https://github.com/hashicorp/consul/pull/13633).


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
