### PR TITLE
Update docs for prometheus TLS options

### DIFF
--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -96,6 +96,22 @@ proxy configuration needed.
   be scrapable at `0.0.0.0:20200/scrape-metrics`.
 	Only applicable when `envoy_prometheus_bind_addr` is set in proxy config.
 
+- `-prometheus-ca-file` - Path to a CA file for Envoy to use when serving TLS on
+  the Prometheus metrics endpoint. Only applicable when `envoy_prometheus_bind_addr`
+  is set in proxy config.
+
+- `-prometheus-ca-path` - Path to a directory of CA certificates for Envoy to use when
+  serving the Prometheus metrics endpoint. Only applicable when `envoy_prometheus_bind_addr`
+  is set in proxy config.
+
+- `-prometheus-cert-file` - Path to a certificate file for Envoy to use when serving
+  TLS on the Prometheus metrics endpoint. Only applicable when `envoy_prometheus_bind_addr`
+  is set in proxy config.
+
+- `-prometheus-key-file` - Path to a private key file for Envoy to use when serving
+  TLS on the Prometheus metrics endpoint. Only applicable when `envoy_prometheus_bind_addr`
+  is set in proxy config.
+
 - `-- [pass-through options]` - Any options given after a double dash are passed
   directly through to the `envoy` invocation. See [Envoy's
   documentation](https://www.envoyproxy.io/docs) for more details. The command

--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -218,6 +218,18 @@ The following Kubernetes resource annotations could be used on a pod to control 
 - `consul.hashicorp.com/merged-metrics-port` - Override the default Helm value [`connectInject.metrics.defaultMergedMetricsPort`](/docs/k8s/helm#v-connectinject-metrics-defaultmergedmetricsport).
 - `consul.hashicorp.com/prometheus-scrape-port` - Override the default Helm value [`connectInject.metrics.defaultPrometheusScrapePort`](/docs/k8s/helm#v-connectinject-metrics-defaultprometheusscrapeport).
 - `consul.hashicorp.com/prometheus-scrape-path` - Override the default Helm value [`connectInject.metrics.defaultPrometheusScrapePath`](/docs/k8s/helm#v-connectinject-metrics-defaultprometheusscrapepath).
+- `consul.hashicorp.com/prometheus-ca-file` - Local filesystem path to a CA file for Envoy to use
+  when serving TLS on the Prometheus metrics endpoint. Only applicable when `envoy_prometheus_bind_addr`
+  is set in proxy config.
+- `consul.hashicorp.com/prometheus-ca-path` - Local filesystem path to a directory of CA certificates
+  for Envoy to use when serving TLS on the Prometheus metrics endpoint. Only applicable when
+  `envoy_prometheus_bind_addr` is set in proxy config.
+- `consul.hashicorp.com/prometheus-cert-file` - Local filesystem path to a certificate file for Envoy to use
+  when serving TLS on the Prometheus metrics endpoint. Only applicable when `envoy_prometheus_bind_addr`
+  is set in proxy config.
+- `consul.hashicorp.com/prometheus-key-file` - Local filesystem path to a private key file for Envoy to use
+  when serving TLS on the Prometheus metrics endpoint. Only applicable when `envoy_prometheus_bind_addr`
+  is set in proxy config.
 - `consul.hashicorp.com/service-metrics-port` - Set the port where the Connect service exposes metrics.
 - `consul.hashicorp.com/service-metrics-path` - Set the path where the Connect service exposes metrics.
 - `consul.hashicorp.com/connect-inject-mount-volume` - Comma separated list of container names to mount the connect-inject volume into. The volume will be mounted at `/consul/connect-inject`. The connect-inject volume contains Consul internals data needed by the other sidecar containers, for example the `consul` binary, and the Pod's Consul ACL token. This data can be valuable for advanced use-cases, such as making requests to the Consul API from within application containers.


### PR DESCRIPTION
Updates CLI/k8s annotation docs for the Envoy Prometheus TLS options added in https://github.com/hashicorp/consul/pull/13481.