### PR TITLE
peering: replicate all SpiffeID values necessary for the importing side to do SAN validation

### DIFF
--- a/agent/consul/state/peering.go
+++ b/agent/consul/state/peering.go
@@ -3,6 +3,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -309,7 +310,7 @@ func (s *Store) PeeringTerminateByID(idx uint64, id string) error {
 // gateway's config entry, which we wouldn't want to replicate. How would
 // client peers know to route through terminating gateways when they're not
 // dialing through a remote mesh gateway?
-func (s *Store) ExportedServicesForPeer(ws memdb.WatchSet, peerID string) (uint64, *structs.ExportedServiceList, error) {
+func (s *Store) ExportedServicesForPeer(ws memdb.WatchSet, peerID string, dc string) (uint64, *structs.ExportedServiceList, error) {
 	tx := s.db.ReadTxn()
 	defer tx.Abort()
 
@@ -321,7 +322,7 @@ func (s *Store) ExportedServicesForPeer(ws memdb.WatchSet, peerID string) (uint6
 		return 0, &structs.ExportedServiceList{}, nil
 	}
 
-	return s.exportedServicesForPeerTxn(ws, tx, peering)
+	return s.exportedServicesForPeerTxn(ws, tx, peering, dc)
 }
 
 func (s *Store) ExportedServicesForAllPeersByName(ws memdb.WatchSet, entMeta acl.EnterpriseMeta) (uint64, map[string]structs.ServiceList, error) {
@@ -335,7 +336,7 @@ func (s *Store) ExportedServicesForAllPeersByName(ws memdb.WatchSet, entMeta acl
 
 	out := make(map[string]structs.ServiceList)
 	for _, peering := range peerings {
-		idx, list, err := s.exportedServicesForPeerTxn(ws, tx, peering)
+		idx, list, err := s.exportedServicesForPeerTxn(ws, tx, peering, "")
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed to list exported services for peer %q: %w", peering.ID, err)
 		}
@@ -351,7 +352,11 @@ func (s *Store) ExportedServicesForAllPeersByName(ws memdb.WatchSet, entMeta acl
 	return maxIdx, out, nil
 }
 
-func (s *Store) exportedServicesForPeerTxn(ws memdb.WatchSet, tx ReadTxn, peering *pbpeering.Peering) (uint64, *structs.ExportedServiceList, error) {
+// exportedServicesForPeerTxn will find all services that are exported to a
+// specific peering, and optionally include information about discovery chain
+// reachable targets for these exported services if the "dc" parameter is
+// specified.
+func (s *Store) exportedServicesForPeerTxn(ws memdb.WatchSet, tx ReadTxn, peering *pbpeering.Peering, dc string) (uint64, *structs.ExportedServiceList, error) {
 	maxIdx := peering.ModifyIndex
 
 	entMeta := structs.NodeEnterpriseMetaInPartition(peering.Partition)
@@ -437,42 +442,63 @@ func (s *Store) exportedServicesForPeerTxn(ws memdb.WatchSet, tx ReadTxn, peerin
 	normal := maps.SliceOfKeys(normalSet)
 	disco := maps.SliceOfKeys(discoSet)
 
-	structs.ServiceList(normal).Sort()
-	structs.ServiceList(disco).Sort()
-
-	serviceProtocols := make(map[structs.ServiceName]string)
-	populateProtocol := func(svc structs.ServiceName) error {
-		if _, ok := serviceProtocols[svc]; ok {
+	chainInfo := make(map[structs.ServiceName]structs.ExportedDiscoveryChainInfo)
+	populateChainInfo := func(svc structs.ServiceName) error {
+		if _, ok := chainInfo[svc]; ok {
 			return nil // already processed
 		}
 
+		var info structs.ExportedDiscoveryChainInfo
+
 		idx, protocol, err := protocolForService(tx, ws, svc)
 		if err != nil {
-			return fmt.Errorf("failed to get protocol for service: %w", err)
+			return fmt.Errorf("failed to get protocol for service %q: %w", svc, err)
 		}
 
 		if idx > maxIdx {
 			maxIdx = idx
 		}
+		info.Protocol = protocol
 
-		serviceProtocols[svc] = protocol
+		if dc != "" && !structs.IsProtocolHTTPLike(protocol) {
+			// We only need to populate the targets for replication purposes for L4 protocols, which
+			// do not ultimately get intercepted by the mesh gateways.
+			idx, targets, err := s.discoveryChainOriginalTargetsTxn(tx, ws, dc, svc.Name, &svc.EnterpriseMeta)
+			if err != nil {
+				return fmt.Errorf("failed to get discovery chain targets for service %q: %w", svc, err)
+			}
+
+			if idx > maxIdx {
+				maxIdx = idx
+			}
+
+			sort.Slice(targets, func(i, j int) bool {
+				return targets[i].ID < targets[j].ID
+			})
+
+			info.TCPTargets = targets
+		}
+
+		chainInfo[svc] = info
 		return nil
 	}
+
 	for _, svc := range normal {
-		if err := populateProtocol(svc); err != nil {
+		if err := populateChainInfo(svc); err != nil {
 			return 0, nil, err
 		}
 	}
 	for _, svc := range disco {
-		if err := populateProtocol(svc); err != nil {
+		if err := populateChainInfo(svc); err != nil {
 			return 0, nil, err
 		}
 	}
 
+	structs.ServiceList(normal).Sort()
+
 	list := &structs.ExportedServiceList{
-		Services:        normal,
-		DiscoChains:     disco,
-		ConnectProtocol: serviceProtocols,
+		Services:    normal,
+		DiscoChains: chainInfo,
 	}
 
 	return maxIdx, list, nil
@@ -521,25 +547,44 @@ func peeringsForServiceTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, en
 	return maxIdx, peerings, nil
 }
 
-// TrustBundleListByService returns the trust bundles for all peers that the given service is exported to.
-func (s *Store) TrustBundleListByService(ws memdb.WatchSet, service string, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error) {
+// TrustBundleListByService returns the trust bundles for all peers that the
+// given service is exported to, via a discovery chain target.
+func (s *Store) TrustBundleListByService(ws memdb.WatchSet, service, dc string, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error) {
 	tx := s.db.ReadTxn()
 	defer tx.Abort()
 
-	maxIdx, peers, err := peeringsForServiceTxn(tx, ws, service, entMeta)
+	realSvc := structs.NewServiceName(service, &entMeta)
+
+	maxIdx, chainNames, err := s.discoveryChainSourcesTxn(tx, ws, dc, realSvc)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to get peers for service %s: %v", service, err)
+		return 0, nil, fmt.Errorf("failed to list all discovery chains referring to %q: %w", realSvc, err)
 	}
 
+	peerNames := make(map[string]struct{})
+	for _, chainSvc := range chainNames {
+		idx, peers, err := peeringsForServiceTxn(tx, ws, chainSvc.Name, chainSvc.EnterpriseMeta)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to get peers for service %s: %v", chainSvc, err)
+		}
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+		for _, peer := range peers {
+			peerNames[peer.Name] = struct{}{}
+		}
+	}
+	peerNamesSlice := maps.SliceOfKeys(peerNames)
+	sort.Strings(peerNamesSlice)
+
 	var resp []*pbpeering.PeeringTrustBundle
-	for _, peer := range peers {
+	for _, peerName := range peerNamesSlice {
 		pq := Query{
-			Value:          strings.ToLower(peer.Name),
+			Value:          strings.ToLower(peerName),
 			EnterpriseMeta: *structs.NodeEnterpriseMetaInPartition(entMeta.PartitionOrDefault()),
 		}
 		idx, trustBundle, err := peeringTrustBundleReadTxn(tx, ws, pq)
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to read trust bundle for peer %s: %v", peer.Name, err)
+			return 0, nil, fmt.Errorf("failed to read trust bundle for peer %s: %v", peerName, err)
 		}
 		if idx > maxIdx {
 			maxIdx = idx
@@ -548,6 +593,7 @@ func (s *Store) TrustBundleListByService(ws memdb.WatchSet, service string, entM
 			resp = append(resp, trustBundle)
 		}
 	}
+
 	return maxIdx, resp, nil
 }
 

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -130,12 +130,12 @@ type Store interface {
 	PeeringList(ws memdb.WatchSet, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.Peering, error)
 	PeeringTrustBundleRead(ws memdb.WatchSet, q state.Query) (uint64, *pbpeering.PeeringTrustBundle, error)
 	PeeringTrustBundleList(ws memdb.WatchSet, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error)
-	ExportedServicesForPeer(ws memdb.WatchSet, peerID string) (uint64, *structs.ExportedServiceList, error)
+	ExportedServicesForPeer(ws memdb.WatchSet, peerID, dc string) (uint64, *structs.ExportedServiceList, error)
 	ServiceDump(ws memdb.WatchSet, kind structs.ServiceKind, useKind bool, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error)
 	CheckServiceNodes(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error)
 	NodeServices(ws memdb.WatchSet, nodeNameOrID string, entMeta *acl.EnterpriseMeta, peerName string) (uint64, *structs.NodeServices, error)
 	CAConfig(ws memdb.WatchSet) (uint64, *structs.CAConfiguration, error)
-	TrustBundleListByService(ws memdb.WatchSet, service string, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error)
+	TrustBundleListByService(ws memdb.WatchSet, service, dc string, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error)
 	AbandonCh() <-chan struct{}
 }
 
@@ -533,7 +533,7 @@ func (s *Service) TrustBundleListByService(ctx context.Context, req *pbpeering.T
 
 	switch {
 	case req.ServiceName != "":
-		idx, bundles, err = s.Backend.Store().TrustBundleListByService(nil, req.ServiceName, entMeta)
+		idx, bundles, err = s.Backend.Store().TrustBundleListByService(nil, req.ServiceName, s.config.Datacenter, entMeta)
 	case req.Kind == string(structs.ServiceKindMeshGateway):
 		idx, bundles, err = s.Backend.Store().PeeringTrustBundleList(nil, entMeta)
 	case req.Kind != "":

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -490,8 +490,8 @@ func TestPeeringService_TrustBundleListByService(t *testing.T) {
 	resp, err := client.TrustBundleListByService(context.Background(), &req)
 	require.NoError(t, err)
 	require.Len(t, resp.Bundles, 2)
-	require.Equal(t, []string{"foo-root-1"}, resp.Bundles[0].RootPEMs)
-	require.Equal(t, []string{"bar-root-1"}, resp.Bundles[1].RootPEMs)
+	require.Equal(t, []string{"bar-root-1"}, resp.Bundles[0].RootPEMs)
+	require.Equal(t, []string{"foo-root-1"}, resp.Bundles[1].RootPEMs)
 }
 
 func Test_StreamHandler_UpsertServices(t *testing.T) {
@@ -912,7 +912,10 @@ func newTestServer(t *testing.T, cb func(conf *consul.Config)) testingServer {
 	testrpc.WaitForLeader(t, server.RPC, conf.Datacenter)
 
 	backend := consul.NewPeeringBackend(server, deps.GRPCConnPool)
-	handler := &peering.Service{Backend: backend}
+	handler := peering.NewService(testutil.Logger(t), peering.Config{
+		Datacenter:     "dc1",
+		ConnectEnabled: true,
+	}, backend)
 
 	grpcServer := gogrpc.NewServer()
 	pbpeering.RegisterPeeringServiceServer(grpcServer, handler)

--- a/agent/rpc/peering/subscription_blocking.go
+++ b/agent/rpc/peering/subscription_blocking.go
@@ -23,7 +23,7 @@ func (m *subscriptionManager) notifyExportedServicesForPeerID(ctx context.Contex
 	// match the list of services exported to the peer.
 	m.syncViaBlockingQuery(ctx, "exported-services", func(ctx context.Context, store Store, ws memdb.WatchSet) (interface{}, error) {
 		// Get exported services for peer id
-		_, list, err := store.ExportedServicesForPeer(ws, peerID)
+		_, list, err := store.ExportedServicesForPeer(ws, peerID, m.config.Datacenter)
 		if err != nil {
 			return nil, fmt.Errorf("failed to watch exported services for peer %q: %w", peerID, err)
 		}

--- a/agent/rpc/peering/subscription_state.go
+++ b/agent/rpc/peering/subscription_state.go
@@ -26,7 +26,7 @@ type subscriptionState struct {
 	exportList *structs.ExportedServiceList
 
 	watchedServices map[structs.ServiceName]context.CancelFunc
-	connectServices map[structs.ServiceName]string // value:protocol
+	connectServices map[structs.ServiceName]structs.ExportedDiscoveryChainInfo
 
 	// eventVersions is a duplicate event suppression system keyed by the "id"
 	// not the "correlationID"
@@ -48,7 +48,7 @@ func newSubscriptionState(peerName, partition string) *subscriptionState {
 		peerName:        peerName,
 		partition:       partition,
 		watchedServices: make(map[structs.ServiceName]context.CancelFunc),
-		connectServices: make(map[structs.ServiceName]string),
+		connectServices: make(map[structs.ServiceName]structs.ExportedDiscoveryChainInfo),
 		eventVersions:   make(map[string]string),
 	}
 }

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/acl"
-
 	"github.com/hashicorp/consul/lib"
 )
 
@@ -289,4 +288,8 @@ func (t *DiscoveryTarget) String() string {
 
 func (t *DiscoveryTarget) ServiceID() ServiceID {
 	return NewServiceID(t.Service, t.GetEnterpriseMetadata())
+}
+
+func (t *DiscoveryTarget) ServiceName() ServiceName {
+	return NewServiceName(t.Service, t.GetEnterpriseMetadata())
 }

--- a/agent/structs/peering.go
+++ b/agent/structs/peering.go
@@ -19,26 +19,54 @@ type ExportedServiceList struct {
 	// service discovery and service mesh.
 	Services []ServiceName
 
-	// DiscoChains is a list of exported service that ONLY apply to service mesh.
-	DiscoChains []ServiceName
+	// DiscoChains is a map of service names to their exported discovery chains
+	// for service mesh purposes as defined in the exported-services
+	// configuration entry.
+	DiscoChains map[ServiceName]ExportedDiscoveryChainInfo
+}
 
-	// TODO(peering): reduce duplication here in the response
-	ConnectProtocol map[ServiceName]string
+// NOTE: this is not serialized via msgpack so it can be changed without concern.
+type ExportedDiscoveryChainInfo struct {
+	// Protocol is the overall protocol associated with this discovery chain.
+	Protocol string
+
+	// TCPTargets is the list of discovery chain targets that are reachable by
+	// this discovery chain.
+	//
+	// NOTE: this is only populated if Protocol=tcp.
+	TCPTargets []*DiscoveryTarget
+}
+
+func (i ExportedDiscoveryChainInfo) Equal(o ExportedDiscoveryChainInfo) bool {
+	switch {
+	case i.Protocol != o.Protocol:
+		return false
+	case len(i.TCPTargets) != len(o.TCPTargets):
+		return false
+	}
+
+	for j := 0; j < len(i.TCPTargets); j++ {
+		if i.TCPTargets[j].ID != o.TCPTargets[j].ID {
+			return false
+		}
+	}
+
+	return true
 }
 
 // ListAllDiscoveryChains returns all discovery chains (union of Services and
 // DiscoChains).
-func (list *ExportedServiceList) ListAllDiscoveryChains() map[ServiceName]string {
-	chainsByName := make(map[ServiceName]string)
+func (list *ExportedServiceList) ListAllDiscoveryChains() map[ServiceName]ExportedDiscoveryChainInfo {
+	chainsByName := make(map[ServiceName]ExportedDiscoveryChainInfo)
 	if list == nil {
 		return chainsByName
 	}
 
 	for _, svc := range list.Services {
-		chainsByName[svc] = list.ConnectProtocol[svc]
+		chainsByName[svc] = list.DiscoChains[svc]
 	}
-	for _, chainName := range list.DiscoChains {
-		chainsByName[chainName] = list.ConnectProtocol[chainName]
+	for chainName, info := range list.DiscoChains {
+		chainsByName[chainName] = info
 	}
 	return chainsByName
 }

--- a/lib/maps/maps.go
+++ b/lib/maps/maps.go
@@ -10,3 +10,14 @@ func SliceOfKeys[K comparable, V any](m map[K]V) []K {
 	}
 	return res
 }
+
+func SliceOfValues[K comparable, V any](m map[K]V) []V {
+	if len(m) == 0 {
+		return nil
+	}
+	res := make([]V, 0, len(m))
+	for _, v := range m {
+		res = append(res, v)
+	}
+	return res
+}

--- a/lib/maps/maps_test.go
+++ b/lib/maps/maps_test.go
@@ -39,3 +39,37 @@ func TestSliceOfKeys(t *testing.T) {
 		require.ElementsMatch(t, []id{{Name: "foo"}, {Name: "bar"}}, SliceOfKeys(m))
 	})
 }
+
+func TestSliceOfValues(t *testing.T) {
+	t.Run("string to int", func(t *testing.T) {
+		m := make(map[string]int)
+		require.Equal(t, []int(nil), SliceOfValues(m))
+		m["foo"] = 5
+		m["bar"] = 6
+		require.ElementsMatch(t, []int{5, 6}, SliceOfValues(m))
+	})
+
+	type blah struct {
+		V string
+	}
+
+	t.Run("int to struct", func(t *testing.T) {
+		m := make(map[int]blah)
+		require.Equal(t, []blah(nil), SliceOfValues(m))
+		m[5] = blah{V: "foo"}
+		m[6] = blah{V: "bar"}
+		require.ElementsMatch(t, []blah{{V: "foo"}, {V: "bar"}}, SliceOfValues(m))
+	})
+
+	type id struct {
+		Name string
+	}
+
+	t.Run("struct to struct pointer", func(t *testing.T) {
+		m := make(map[id]*blah)
+		require.Equal(t, []*blah(nil), SliceOfValues(m))
+		m[id{Name: "foo"}] = &blah{V: "oof"}
+		m[id{Name: "bar"}] = &blah{V: "rab"}
+		require.ElementsMatch(t, []*blah{{V: "oof"}, {V: "rab"}}, SliceOfValues(m))
+	})
+}


### PR DESCRIPTION
### Description

SAN validation is important for callers to verify that they are dialing the correct service mesh endpoint. They do this by verifying that the SpiffeID of the destination is expected (in a manner like "reverse intentions").

When traversing an exported peered service, the discovery chain evaluation at the other side may re-route the request to a variety of endpoints. Furthermore we intend to _terminate_ mTLS at the mesh gateway for arriving peered traffic that is http-like (L7), so the caller needs to know the mesh gateway's SpiffeID in that case as well.

The following new SpiffeID values will be shipped back in the peerstream replication:
- **tcp** : all possible SpiffeIDs resulting from the `service-resolver` component of the exported discovery chain
- **http-like**: the SpiffeID of the mesh gateway

### Links

- [Asana](https://app.asana.com/0/0/1202421810982479/f)
