### PR TITLE
Turn off sec-scanner check

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,7 +5,7 @@ container {
 }
 
 binary {
-	secrets      = true
+	secrets      = false
 	go_modules   = false
 	osv          = true
 	oss_index    = true


### PR DESCRIPTION
### Description
Temporarily disable security-scanner's binary secrets scanning, which is reporting a false negative here: https://github.com/hashicorp/crt-workflows-common/runs/7082460830?check_suite_focus=true. 

Related slack thread with ProdSec who recommended this approach as a temporary fix: https://hashicorp.slack.com/archives/CR024M999/p1656368792165579?thread_ts=1656004894.759009&cid=CR024M999
