### PR TITLE
Acpana/peering hint state

### DIFF
--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -912,7 +912,7 @@ func newTestServer(t *testing.T, cb func(conf *consul.Config)) testingServer {
 	testrpc.WaitForLeader(t, server.RPC, conf.Datacenter)
 
 	backend := consul.NewPeeringBackend(server, deps.GRPCConnPool)
-	handler := &peering.Service{Backend: backend}
+	handler := peering.NewService(deps.Logger, peering.Config{Datacenter: conf.Datacenter, ConnectEnabled: conf.ConnectEnabled}, backend)
 
 	grpcServer := gogrpc.NewServer()
 	pbpeering.RegisterPeeringServiceServer(grpcServer, handler)

--- a/api/peering_test.go
+++ b/api/peering_test.go
@@ -140,11 +140,21 @@ func TestAPI_Peering_GenerateToken(t *testing.T) {
 func TestAPI_Peering_GenerateToken_Read_Establish_Delete(t *testing.T) {
 	t.Parallel()
 
-	c, s := makeClientWithCA(t)
+	c, s := makeClient(t) // this is "dc1"
 	defer s.Stop()
 	s.WaitForSerfCheck(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultCtxDuration)
+	// make a "client" server in second DC for peering
+	c2, s2 := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
+		conf.Datacenter = "dc2"
+	})
+	defer s2.Stop()
+
+	testutil.RunStep(t, "register services to get synced dc2", func(t *testing.T) {
+		testNodeServiceCheckRegistrations(t, c2, "dc2")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	var token1 string
@@ -175,12 +185,6 @@ func TestAPI_Peering_GenerateToken_Read_Establish_Delete(t *testing.T) {
 		require.Equal(t, map[string]string{"foo": "bar"}, resp.Meta)
 	})
 
-	// make a "client" server in second DC for peering
-	c2, s2 := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
-		conf.Datacenter = "dc2"
-	})
-	defer s2.Stop()
-
 	testutil.RunStep(t, "establish peering", func(t *testing.T) {
 		i := PeeringEstablishRequest{
 			Datacenter:   c2.config.Datacenter,
@@ -201,8 +205,28 @@ func TestAPI_Peering_GenerateToken_Read_Establish_Delete(t *testing.T) {
 			// require that the peering state is not undefined
 			require.Equal(r, PeeringStateInitial, resp.State)
 			require.Equal(r, map[string]string{"foo": "bar"}, resp.Meta)
+		})
+	})
 
-			// TODO(peering) -- let's go all the way and test in code either here or somewhere else that PeeringState does move to Active
+	testutil.RunStep(t, "look for active state of peering in dc2", func(t *testing.T) {
+		retry.Run(t, func(r *retry.R) {
+			peerings, qm, err := c2.Peerings().List(ctx, nil)
+
+			require.NoError(r, err)
+			require.NotNil(r, qm)
+			require.NotNil(r, peerings)
+			require.Equal(r, PeeringStateActive, peerings[0].State)
+		})
+	})
+
+	testutil.RunStep(t, "look for active state of peering in dc1", func(t *testing.T) {
+		retry.Run(t, func(r *retry.R) {
+			peerings, qm, err := c.Peerings().List(ctx, nil)
+
+			require.NoError(r, err)
+			require.NotNil(r, qm)
+			require.NotNil(r, peerings)
+			require.Equal(r, PeeringStateActive, peerings[0].State)
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: acpana <8968914+acpana@users.noreply.github.com>

### Description
We need to show that a peering is active for UI usage. This is a hack to look at the stream tracker and see if it's connected. If so, we call that a `PeeringState.Active`. 

In the future, we want to monitor the health of a peering and do the reconciliation there.

### Testing & Reproduction steps
*completed the api test: it now encompasses a full peering 💯 
