### PR TITLE
UI/fix/peering route param

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/selector/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/selector/index.hbs
@@ -10,9 +10,7 @@
   class={{if (is-href 'dc.peers' @dc.Name) 'is-active'}}
 >
     <a
-      href={{href-to 'dc.peers' @dc.Name
-        params=(hash peer=undefined)
-      }}
+      href={{href-to 'dc.peers' @dc.Name}}
     >
       Peers
     </a>

--- a/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/node/list/index.hbs
@@ -21,7 +21,7 @@ as |item index|>
         </Tooltip>
       </dd>
     </dl>
-    <a data-test-node href={{href-to "dc.nodes.show" item.Node params=(hash peer=item.PeerName)}}>
+    <a data-test-node href={{href-to "dc.nodes.show" item.SlugWithPeer}}>
       {{item.Node}}
     </a>
   </BlockSlot>

--- a/ui/packages/consul-ui/app/components/consul/service-instance/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service-instance/list/index.hbs
@@ -10,11 +10,11 @@ as |proxies|}}
 as |item index|>
   <BlockSlot @name="header">
     {{#if (eq @routeName "dc.services.show")}}
-      <a data-test-service-name href={{href-to @routeName item.Service.Service}}>
+      <a data-test-service-name href={{href-to @routeName item.ServiceSlugWithPeer}}>
         {{item.Service.ID}}
       </a>
     {{else}}
-      <a data-test-service-name href={{href-to @routeName item.Service.Service item.Node.Node (or item.Service.ID item.Service.Service)}}>
+      <a data-test-service-name href={{href-to @routeName item.ServiceSlugWithPeer item.Node.Node (or item.Service.ID item.Service.Service)}}>
         {{item.Service.ID}}
       </a>
     {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/service/list/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/list/index.hbs
@@ -27,15 +27,13 @@
 {{#if (gt item.InstanceCount 0)}}
   <a
     data-test-service-name
-    href={{href-to "dc.services.show.index" item.Name
+    href={{href-to "dc.services.show.index" item.SlugWithPeer
       params=(if (not-eq item.Partition @partition)
         (hash
           partition=item.Partition
           nspace=item.Namespace
-          peer=item.PeerName
         )
         (hash
-          peer=item.PeerName
         )
       )
     }}

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -81,7 +81,7 @@
 
   <:home-nav>
     <a
-      href={{href-to 'index' params=(hash peer=undefined)}}
+      href={{href-to 'index'}}
     ><Consul::Logo /></a>
   </:home-nav>
 
@@ -115,7 +115,7 @@
           }}
         >
           <Action
-            @href={{href-to 'dc.show' @dc.Name params=(hash peer=undefined)}}
+            @href={{href-to 'dc.show' @dc.Name}}
           >
             Overview
           </Action>
@@ -123,22 +123,22 @@
 {{/if}}
 {{#if (can "read services")}}
         <li data-test-main-nav-services class={{if (is-href 'dc.services' @dc.Name) 'is-active'}}>
-            <a href={{href-to 'dc.services' @dc.Name params=(hash peer=undefined)}}>Services</a>
+            <a href={{href-to 'dc.services' @dc.Name}}>Services</a>
         </li>
 {{/if}}
 {{#if (can "read nodes")}}
         <li data-test-main-nav-nodes class={{if (is-href 'dc.nodes' @dc.Name) 'is-active'}}>
-            <a href={{href-to 'dc.nodes' @dc.Name params=(hash peer=undefined)}}>Nodes</a>
+            <a href={{href-to 'dc.nodes' @dc.Name}}>Nodes</a>
         </li>
 {{/if}}
 {{#if (can "read kv")}}
         <li data-test-main-nav-kvs class={{if (is-href 'dc.kv' @dc.Name) 'is-active'}}>
-            <a href={{href-to 'dc.kv' @dc.Name params=(hash peer=undefined)}}>Key/Value</a>
+            <a href={{href-to 'dc.kv' @dc.Name}}>Key/Value</a>
         </li>
 {{/if}}
 {{#if (can "read intentions")}}
         <li data-test-main-nav-intentions class={{if (is-href 'dc.intentions' @dc.Name) 'is-active'}}>
-            <a href={{href-to 'dc.intentions' @dc.Name params=(hash peer=undefined)}}>Intentions</a>
+            <a href={{href-to 'dc.intentions' @dc.Name}}>Intentions</a>
         </li>
 {{/if}}
         <Consul::Acl::Selector

--- a/ui/packages/consul-ui/app/locations/fsm-with-optional.js
+++ b/ui/packages/consul-ui/app/locations/fsm-with-optional.js
@@ -8,8 +8,6 @@ if (env('CONSUL_NSPACES_ENABLED')) {
   OPTIONAL.nspace = /^~([a-zA-Z0-9]([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?)$/;
 }
 
-OPTIONAL.peer = /^:([a-zA-Z0-9]([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])?)$/;
-
 const trailingSlashRe = /\/$/;
 
 // see below re: ember double slashes
@@ -167,7 +165,7 @@ export default class FSMWithOptionalLocation {
 
   optionalParams() {
     let optional = this.optional || {};
-    return ['partition', 'nspace', 'peer'].reduce((prev, item) => {
+    return ['partition', 'nspace'].reduce((prev, item) => {
       let value = '';
       if (typeof optional[item] !== 'undefined') {
         value = optional[item].match;
@@ -197,9 +195,6 @@ export default class FSMWithOptionalLocation {
     }
     if (typeof hash.partition !== 'undefined') {
       hash.partition = `_${hash.partition}`;
-    }
-    if (typeof hash.peer !== 'undefined') {
-      hash.peer = `:${hash.peer}`;
     }
 
     if (typeof this.router === 'undefined') {

--- a/ui/packages/consul-ui/app/models/node.js
+++ b/ui/packages/consul-ui/app/models/node.js
@@ -2,6 +2,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 import { computed } from '@ember/object';
 import { filter } from '@ember/object/computed';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
+import replace from 'consul-ui/decorators/replace';
 
 export const PRIMARY_KEY = 'uid';
 export const SLUG_KEY = 'ID';
@@ -11,7 +12,7 @@ export default class Node extends Model {
   @attr('string') ID;
 
   @attr('string') Datacenter;
-  @attr('string') PeerName;
+  @replace('', undefined) @attr('string') PeerName;
   @attr('string') Partition;
   @attr('string') Address;
   @attr('string') Node;
@@ -33,6 +34,17 @@ export default class Node extends Model {
   @filter('Services', item => item.Service.Kind === 'connect-proxy') ProxyServiceInstances;
 
   @filter('Checks', item => item.ServiceID === '') NodeChecks;
+
+  @computed('Node', 'PeerName')
+  get SlugWithPeer() {
+    const { Node, PeerName } = this;
+
+    if (PeerName) {
+      return `peer:${PeerName}:${Node}`;
+    }
+
+    return Node;
+  }
 
   @computed('ChecksCritical', 'ChecksPassing', 'ChecksWarning')
   get Status() {

--- a/ui/packages/consul-ui/app/models/service-instance.js
+++ b/ui/packages/consul-ui/app/models/service-instance.js
@@ -52,6 +52,17 @@ export default class ServiceInstance extends Model {
   @filter('Checks.@each.Kind', (item, i, arr) => item.Kind === 'service') ServiceChecks;
   @filter('Checks.@each.Kind', (item, i, arr) => item.Kind === 'node') NodeChecks;
 
+  @computed('Service.{Service,PeerName}')
+  get ServiceSlugWithPeer() {
+    const { Service: Name, PeerName } = this.Service;
+
+    if (PeerName) {
+      return `peer:${PeerName}:${Name}`;
+    }
+
+    return Name;
+  }
+
   @computed('Service.Meta')
   get ExternalSources() {
     const sources = Object.entries(this.Service.Meta || {})

--- a/ui/packages/consul-ui/app/models/service.js
+++ b/ui/packages/consul-ui/app/models/service.js
@@ -58,6 +58,17 @@ export default class Service extends Model {
 
   @attr() meta; // {}
 
+  @computed('Name', 'PeerName')
+  get SlugWithPeer() {
+    const { Name, PeerName } = this;
+
+    if (PeerName) {
+      return `peer:${PeerName}:${Name}`;
+    }
+
+    return Name;
+  }
+
   @computed('ChecksPassing', 'ChecksWarning', 'ChecksCritical')
   get ChecksTotal() {
     return this.ChecksPassing + this.ChecksWarning + this.ChecksCritical;

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
@@ -95,7 +95,7 @@ as |item tomography|}}
           </BlockSlot>
           <BlockSlot @name="breadcrumbs">
               <ol>
-                  <li><a data-test-back href={{href-to 'dc.nodes' params=(hash peer=undefined)}}>All Nodes</a></li>
+                  <li><a data-test-back href={{href-to 'dc.nodes'}}>All Nodes</a></li>
               </ol>
           </BlockSlot>
           <BlockSlot @name="header">

--- a/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
@@ -128,7 +128,7 @@ as |item|}}
       <AppView>
           <BlockSlot @name="breadcrumbs">
               <ol>
-                  <li><a href={{href-to 'dc.services' params=(hash peer=undefined)}}>All Services</a></li>
+                  <li><a href={{href-to 'dc.services'}}>All Services</a></li>
                   <li><a data-test-back href={{href-to 'dc.services.show'}}>Service ({{item.Service.Service}})</a></li>
               </ol>
           </BlockSlot>
@@ -147,7 +147,7 @@ as |item|}}
           <BlockSlot @name="nav">
             <dl>
               <dt>Service Name</dt>
-              <dd><a href="{{href-to 'dc.services.show' item.Service.Service}}">{{item.Service.Service}}</a></dd>
+              <dd><a href="{{href-to 'dc.services.show' item.SlugWithPeer}}">{{item.Service.Service}}</a></dd>
             </dl>
             <dl>
               <dt>Node Name</dt>

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -136,7 +136,7 @@ as |items item dc|}}
           </BlockSlot>
           <BlockSlot @name="breadcrumbs">
             <ol>
-              <li><a data-test-back href={{href-to 'dc.services' params=(hash peer=undefined)}}>All Services</a></li>
+              <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
             </ol>
           </BlockSlot>
           <BlockSlot @name="header">

--- a/ui/packages/consul-ui/app/templates/dc/services/show/instances.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/instances.hbs
@@ -56,7 +56,7 @@ as |sort filters items proxyMeta|}}
           )
         }}
         @onchange={{action (mut proxies) value="data"}}
-      />
+        />
     {{/if}}
     {{! Service > Service Instance view doesn't require filtering of proxies }}
     <DataCollection

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/navigation.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/navigation.feature
@@ -22,7 +22,7 @@ Feature: dc / services / navigation
       dc: dc-1
     ---
     When I click service on the services
-    Then the url should match /:billing/dc-1/services/service-0
+    Then the url should match /dc-1/services/peer:billing:service-0
     And I click "[data-test-back]"
     Then the url should be /dc-1/services
 

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show-with-slashes.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show-with-slashes.feature
@@ -17,5 +17,5 @@ Feature: dc / services / show-with-slashes: Show Service that has slashes in its
     Then the url should be /dc1/services
     Then I see 1 service model
     And I click service on the services
-    Then the url should be /:billing/dc1/services/hashicorp%2Fservice%2Fservice-0/instances
+    Then the url should be /dc1/services/peer:billing:hashicorp%2Fservice%2Fservice-0/instances
 

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/navigation.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/navigation.feature
@@ -3,5 +3,5 @@ Feature: dc / services / show / navigation
   Scenario: Accessing peered service directly
     Given 1 datacenter model with the value "dc-1"
     And 1 service models
-    When I visit the service page with the url /:billing/dc-1/services/service-0
+    When I visit the service page with the url /dc-1/services/peer:billing:service-0
     Then I see peer like "billing"


### PR DESCRIPTION
### Description
This PR moves from using a route-param for indicating the peer of a peered service/node to using the service- / node-name portion of the `dc.services.show` / `dc.nodes.show`-route instead. This mirrors the mechanism we use for identifying a peer of an `Intention` and fixes the failures we are seeing in the `ent`-test-suite atm.

#### Why?
The Ember router expects the url nesting to reflect:

1. the outlet nesting of UI
2. nested data-loading

This means when we are dealing with the following routing structure we break the way the Ember router expects the url to be structured when we prepend a peering - name to the url like we do currently (`/:peer-name/dc-name/services/service-name`):

```javascript
this.route('dc', { path: '/:dc-name'}, function() {
  this.route('services', function() {
     this.route('show', { path: '/:name'} 
  });
} 

/* 
^ would usually create a URL that looked like this: /<dc-name>/services/<service-name>
we are creating the following URL for a peered service though: /:<peer-name>/<dc-name>/services/<service-name>
*/
```

The current implementation of indicating a `peering` in the URL breaks the assumptions that the Ember router makes around the URL-structure and this mismatch leaks across the entire application and currently breaks the `ent`-test-suite.

I.e. to "reset" a routing param when we transition from a peered service in the `dc.services.show` route into the `dc.services`  route (
`/:<peer-name>/<dc-name>/services/<service-name>` -> `/<dc-name>/services/<service-name>`) we explicitly need to reset the `peer`-route param via using the `href-to`-helper by explicitly passing a route-param of `peer=undefined`. Explicitly unsetting the peer breaks other assumptions that the application is making regarding `partitions` and `namespaces` that both also use a prepended route-param to scope the application by `partition` and `namespace`.

To fix this  issue we move the `peer`-indicator into the portion of the url where it belongs from an ember router nesting perspective and we get rid of the need to explicitly reset the peer param across the entire application. This also better reflects the fact that a peered service/node is uniquely identified not by its name but by the __combination__ of the `PeerName` and `Name`.

#### ~~Usage of `Peering::Provider` looks weird - why?~~ Updates in `routlet`-service - why?

The way the application is currently structured is working around the usual way of loading data in `Route`'s `model`-hooks and uses a declarative way of loading data via the `DataSource`/ `DataLoader`-components instead. This means we can't parse the `params` we receive via the URL in a Route's `model`-hook like we would do regularly but we need to do this in the template layer because that's the only place where we have access to the `route.params` we are interested in. An alternative would be to pass the `route`-params we receive in the `model`-hook into the controller layer and make them available to the template that way but this

a) would not use the same mechanism the rest of the application is using to access routing-params
b) need to be done in multiple places

Because of the reasons outlined I decided ~~to create a provider-component~~ to add a method to the `routlet`-service that encapsulates the logic of parsing a "peered"-`service`/`node`-name-combination to receive the two parts of the URL we are interested in `PeerName` and `Name`.

#### What's up with the `SlugWithPeer` computed in `Service`, `Node` and `ServiceInstance` ?
`SlugWithPeer` is a new tracked getter that I added to the `Service`, `ServiceInstance` and `Node`-models because we need to create links to the respective detail routes of these resources with their `peer` included in the URL.

Instead of creating links like `/<dc-name>/services/<service-name>` we will create `/<dc-name>/services/peer:<peer-name>:<service-name>` instead. This encodes the peer-name in the URL and allows us to send the correct query-data to the API to receive back a peered service, node or service-instance.

#### Why aren't we using a query-param instead?

We could achieve the same we are doing here with adding a query-parameter to the `dc.services.show` and`dc.nodes.show` routes that indicate the peering. We decided against this approach because a `PeerName` can be considered part of the unique identifier of a service as only the combination of `PeerName` and `Name` of a service or node will allow the API to query a peered `Service` or `Node`.


### Testing & Reproduction steps
* Running the test suite now doesn't show test failures anymore - this only applied to the `ent`-test-suite for the UI

### PR Checklist

* [x] updated test coverage
* ~~[ ] external facing docs updated~~
* [x] not a security concern

cc @johncowen 