### PR TITLE
xds: have mesh gateways forward peered SpiffeIDs using the XFCC header

### DIFF
--- a/agent/xds/testdata/listeners/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
@@ -44,6 +44,14 @@
                   "randomSampling": {
 
                   }
+                },
+                "forwardClientCertDetails": "SANITIZE_SET",
+                "setCurrentClientCertDetails": {
+                  "subject": true,
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "uri": true
                 }
               }
             }

--- a/agent/xds/testdata/listeners/mesh-gateway-with-exported-peered-services-http-with-splitter-crossing-partitions.latest.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-with-exported-peered-services-http-with-splitter-crossing-partitions.latest.golden
@@ -44,6 +44,14 @@
                   "randomSampling": {
 
                   }
+                },
+                "forwardClientCertDetails": "SANITIZE_SET",
+                "setCurrentClientCertDetails": {
+                  "subject": true,
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "uri": true
                 }
               }
             }

--- a/agent/xds/testdata/listeners/mesh-gateway-with-exported-peered-services-http.latest.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-with-exported-peered-services-http.latest.golden
@@ -44,6 +44,14 @@
                   "randomSampling": {
 
                   }
+                },
+                "forwardClientCertDetails": "SANITIZE_SET",
+                "setCurrentClientCertDetails": {
+                  "subject": true,
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "uri": true
                 }
               }
             }
@@ -126,6 +134,14 @@
                   "randomSampling": {
 
                   }
+                },
+                "forwardClientCertDetails": "SANITIZE_SET",
+                "setCurrentClientCertDetails": {
+                  "subject": true,
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "uri": true
                 }
               }
             }
@@ -208,6 +224,14 @@
                   "randomSampling": {
 
                   }
+                },
+                "forwardClientCertDetails": "SANITIZE_SET",
+                "setCurrentClientCertDetails": {
+                  "subject": true,
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "uri": true
                 }
               }
             }


### PR DESCRIPTION
### Description

When a service mesh connection is terminated at a peered mesh gateway (for http-like protocols), the ultimate destination that the mesh gateway sends the traffic to will lose the ability to introspect the TLS connection to see the origin's SpiffeID value.

This uses the X-Forwarded-Client-Cert header to send that data along by first clearing the XFCC header and ensuring the mesh-gateway added value goes first in the list.

Example header that makes it to the final destination:
```
# first entry is added by our mesh gateway, second entry is appended by default with pre-existing code
By=spiffe://8c7db6d3-e4ee-aa8c-488c-dbedd3772b78.consul/gateway/mesh/dc/dc2;
    Hash=2a2db78ac351a05854a0abd350631bf98cc0eb827d21f4ed5935ccd287779eb6;
    Cert="-----BEGIN%20CERTIFICATE-----<SNIP>";
    Chain="-----BEGIN%20CERTIFICATE-----<SNIP>";
    Subject="";
    URI=spiffe://5583c38e-c1c0-fd1e-2079-170bb2f396ad.consul/ns/default/dc/dc1/svc/pong,
By=spiffe://8c7db6d3-e4ee-aa8c-488c-dbedd3772b78.consul/ns/default/dc/dc2/svc/ping;
    Hash=845c295520d48b53ecd522d9f6ae099f4220bfa33266f8f7be2e25929b3dcda9;
    Cert="-----BEGIN%20CERTIFICATE-----<SNIP>";
    Chain="-----BEGIN%20CERTIFICATE-----<SNIP>";
    Subject="";URI=spiffe://8c7db6d3-e4ee-aa8c-488c-dbedd3772b78.consul/gateway/mesh/dc/dc2
```

