### PR TITLE
[1.12] Backport of "Fix verifications by using updated arm package names (#13601)"

### DIFF
--- a/.github/scripts/verify_artifact.sh
+++ b/.github/scripts/verify_artifact.sh
@@ -73,7 +73,7 @@ function verify_rpm {
       docker_platform="linux/amd64"
       docker_image="amd64/centos:7"
       ;;
-    *.arm.rpm)
+    *.armv7hl.rpm)
       docker_platform="linux/arm/v7"
       docker_image="arm32v7/fedora:36"
       ;;
@@ -120,7 +120,7 @@ function verify_deb {
       docker_platform="linux/amd64"
       docker_image="amd64/debian:bullseye"
       ;;
-    *_arm.deb)
+    *_armhf.deb)
       docker_platform="linux/arm/v7"
       docker_image="arm32v7/debian:bullseye"
       ;;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -350,7 +350,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["i386", "amd64", "arm", "arm64"]
+        arch: ["i386", "amd64", "armhf", "arm64"]
       # fail-fast: true
     env:
       version: ${{ needs.get-product-version.outputs.product-version }}
@@ -387,7 +387,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["i386", "x86_64", "arm", "aarch64"]
+        arch: ["i386", "x86_64", "armv7hl", "aarch64"]
       # fail-fast: true
     env:
       version: ${{ needs.get-product-version.outputs.product-version }}


### PR DESCRIPTION
This is a manual backport of #13601. The description of the original PR is below:

### Description
The linux packaging action recently updated the way arm packages get named so our verifications broke. They were looking for packages with just `arm` in the name, but they are now `armhf` for debian and `armv7hl` for rpms.  

### Testing & Reproduction steps
I temporarily added a branch target for this to see it get fixed. I'll remove the branch target before merging.

### Links
 Upstream PR that changed the packaging action: https://github.com/hashicorp/actions-packaging-linux/pull/6.
