### PR TITLE
ui: Fix up peer ENT tests

### DIFF
--- a/ui/packages/consul-ui/app/adapters/node.js
+++ b/ui/packages/consul-ui/app/adapters/node.js
@@ -29,10 +29,10 @@ export default class NodeAdapter extends Adapter {
       X-Request-ID: ${uri}
 
       ${{
+        ...this.peeringQuery,
         ns,
         partition,
         index,
-        ...this.peeringQuery,
       }}
     `;
   }

--- a/ui/packages/consul-ui/app/adapters/service.js
+++ b/ui/packages/consul-ui/app/adapters/service.js
@@ -33,10 +33,10 @@ export default class ServiceAdapter extends Adapter {
         X-Request-ID: ${uri}
 
         ${{
+          ...this.peeringQuery,
           ns,
           partition,
           index,
-          ...this.peeringQuery,
         }}
     `;
     }

--- a/ui/packages/consul-ui/app/locations/fsm-with-optional.js
+++ b/ui/packages/consul-ui/app/locations/fsm-with-optional.js
@@ -301,11 +301,11 @@ export default class FSMWithOptionalLocation {
 
     if (withOptional) {
       const temp = url.split('/');
-      if (Object.keys(optional || {}).length === 0) {
-        optional = undefined;
-      }
-      optional = Object.values(optional || this.optional || {});
-      optional = optional.filter(item => Boolean(item)).map(item => item.value || item, []);
+      optional = {
+        ...this.optional,
+        ...(optional || {})
+      };
+      optional = Object.values(optional).filter(item => Boolean(item)).map(item => item.value || item, []);
       temp.splice(...[1, 0].concat(optional));
       url = temp.join('/');
     }

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/index.feature
@@ -45,7 +45,7 @@ Feature: dc / nodes / index
     ---
     Then the url should be /dc-1/nodes
     And the title should be "Nodes - Consul"
-    And a GET request was made to "/v1/internal/ui/nodes?dc=dc-1&with-peers=true"
+    And a GET request was made to "/v1/internal/ui/nodes?dc=dc-1&with-peers=true&ns=@namespace"
     Then I see 3 node models
   Scenario: Seeing the leader in node listing
     Given 3 node models from yaml

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/list.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/list.feature
@@ -16,7 +16,7 @@ Feature: dc / services / list
       dc: dc-1
     ---
     Then the url should be /dc-1/services
-    And a GET request was made to "/v1/internal/ui/services?dc=dc-1&with-peers=true"
+    And a GET request was made to "/v1/internal/ui/services?dc=dc-1&with-peers=true&ns=@namespace"
 
     Then I see 3 service models
 

--- a/ui/packages/consul-ui/tests/integration/adapters/node-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/node-test.js
@@ -14,9 +14,9 @@ module('Integration | Adapter | node', function(hooks) {
       const adapter = this.owner.lookup('adapter:node');
       const client = this.owner.lookup('service:client/http');
       const request = client.requestParams.bind(client);
-      const expected = `GET /v1/internal/ui/nodes?dc=${dc}${
+      const expected = `GET /v1/internal/ui/nodes?dc=${dc}&with-peers=true${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
-      }&with-peers=true`;
+      }`;
       const actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,

--- a/ui/packages/consul-ui/tests/integration/adapters/service-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/service-test.js
@@ -14,9 +14,9 @@ module('Integration | Adapter | service', function(hooks) {
       const adapter = this.owner.lookup('adapter:service');
       const client = this.owner.lookup('service:client/http');
       const request = client.requestParams.bind(client);
-      const expected = `GET /v1/internal/ui/services?dc=${dc}${
+      const expected = `GET /v1/internal/ui/services?dc=${dc}&with-peers=true${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
-      }&with-peers=true`;
+      }`;
       let actual = adapter.requestForQuery(request, {
         dc: dc,
         ns: nspace,


### PR DESCRIPTION
### Description

When specifying extra "optional params" when generating href's unless you specify a value for every possible optional parameter, the ones you didn't specify would not 'inherit' the value already existing in the URL. Technically this was due to us _overwriting_ and optional object rather than _merging_ it with the optional object generated from the existing URL values i.e. we needed to splat the objects onto one another instead of just overwriting/replacing.

Additionally we added the conditional namespace 'test markers' in some places where they were needed, and also moved the order of the query parameter for `with-peers` to pragmatically satisfy existing test assertions.

Note: We've discussed creating a new, less brittle, API URL assertion step so we can specify specific parts of the URL without order being important. When creating this new step, if we ensure we can also use it for the existing 2-3 steps for asserting API URL related things, that means we can remove those and reduce our amount of tests step by 2-3. For the moment this is a future improvement, not necessary here.

Last note: We reluctantly updated the 5 or so links in the main navigation to reset the peer when you clicked on any top level navigation. If we wanted to remove this now and do this centrally by only adding peer params when in either `dc.services` or `dc.nodes`, this is one of the places where we could do it (around the same area in `fsm-with-optional`)

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
