### PR TITLE
ui: peering chores

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
@@ -165,6 +165,9 @@ as |nonDefaultPartitions|}}
             {{t (concat "common.brand." source)}}
           </Option>
     {{/each}}
+    <Option class="consul" @value='consul' @selected={{includes 'consul' @filter.source.value}}>
+      {{t 'common.brand.consul'}}
+    </Option>
     </Optgroup>
 {{/if}}
   {{/let}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -88,7 +88,7 @@ export default class TopologyMetrics extends Component {
       });
     } else if (downstreams.length === 0) {
       items.push({
-        Name: 'No downstreams.',
+        Name: 'No downstreams, or the downstreams are imported services.',
         Datacenter: '',
         Namespace: '',
       });

--- a/ui/packages/consul-ui/app/filter/predicates/service.js
+++ b/ui/packages/consul-ui/app/filter/predicates/service.js
@@ -20,9 +20,20 @@ export default {
     'not-registered': (item, value) => item.InstanceCount === 0,
   },
   source: (item, values) => {
+    let includeBecauseNoExternalSourcesOrPeered = false;
+
+    if (values.includes('consul')) {
+      includeBecauseNoExternalSourcesOrPeered =
+        !item.ExternalSources ||
+        item.ExternalSources.length === 0 ||
+        (item.ExternalSources.length === 1 && item.ExternalSources[0] === '') ||
+        item.PeerName;
+    }
+
     return (
       setHelpers.intersectionSize(values, new Set(item.ExternalSources || [])) !== 0 ||
-      values.includes(item.Partition)
+      values.includes(item.Partition) ||
+      includeBecauseNoExternalSourcesOrPeered
     );
   },
 };

--- a/ui/packages/consul-ui/tests/unit/filter/predicates/service-test.js
+++ b/ui/packages/consul-ui/tests/unit/filter/predicates/service-test.js
@@ -169,4 +169,50 @@ module('Unit | Filter | Predicates | service', function() {
     );
     assert.deepEqual(actual, expected);
   });
+
+  test('it returns items without an External Source or items with a peer name when source `consul` is specified', function(assert) {
+    const items = [
+      {
+        _Name: 'external',
+        ExternalSources: ['aws'],
+      },
+      {
+        _Name: 'empty-array',
+        ExternalSources: [],
+      },
+      {
+        _Name: 'peered-external',
+        ExternalSources: ['terraform'],
+        PeerName: 'peer-1',
+      },
+      {
+        _Name: 'peered',
+        ExternalSources: [],
+        PeerName: 'peer-2',
+      },
+      {
+        _Name: 'undefined',
+        ExternalSources: undefined,
+      },
+      {
+        _Name: 'empty-string',
+        ExternalSources: [''],
+      },
+      {
+        _Name: 'empty-string-with-additional-source',
+        ExternalSources: ['', 'nomad'],
+      },
+    ];
+
+    const filteredItems = items.filter(
+      predicate({
+        source: ['consul'],
+      })
+    );
+
+    const actual = filteredItems.map(i => i._Name);
+
+    const expected = ['empty-array', 'peered-external', 'peered', 'undefined', 'empty-string'];
+    assert.deepEqual(actual, expected, 'filtering works with source `consul`');
+  });
 });


### PR DESCRIPTION
### Description
Two small changes to move the peering UI forward:

* Update empty downstream topology message to take peers into account
<img width="826" alt="Screenshot 2022-06-29 at 17 41 13" src="https://user-images.githubusercontent.com/242299/176478571-d8be143b-dce7-45b5-9c7e-840bdd2ada23.png">
* Add a filter on the service listing that allows for filtering services that don't have any ExternalSources set (this will include peered services)
<img width="572" alt="Screenshot 2022-06-29 at 17 59 35" src="https://user-images.githubusercontent.com/242299/176482369-6e5a96f2-8c37-4044-8fa2-f5ed50be2316.png">

### PR Checklist

* [x] updated test coverage
* [ ] ~~external facing docs updated~~
* [x] not a security concern


cc @johncowen 