### PR TITLE
Add internal endpoint to fetch peered upstream candidates from VirtualIP table

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -647,6 +647,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		IntentionUpstreams:              proxycfgglue.CacheIntentionUpstreams(a.cache),
 		InternalServiceDump:             proxycfgglue.CacheInternalServiceDump(a.cache),
 		LeafCertificate:                 proxycfgglue.CacheLeafCertificate(a.cache),
+		PeeredUpstreams:                 proxycfgglue.CachePeeredUpstreams(a.cache),
 		PreparedQuery:                   proxycfgglue.CachePrepraredQuery(a.cache),
 		ResolvedServiceConfig:           proxycfgglue.CacheResolvedServiceConfig(a.cache),
 		ServiceList:                     proxycfgglue.CacheServiceList(a.cache),

--- a/agent/cache-types/peered_upstreams.go
+++ b/agent/cache-types/peered_upstreams.go
@@ -8,19 +8,18 @@ import (
 )
 
 // Recommended name for registration.
-const IntentionUpstreamsName = "intention-upstreams"
+const PeeredUpstreamsName = "peered-upstreams"
 
-// IntentionUpstreams supports fetching upstreams for a given service name.
-type IntentionUpstreams struct {
+// PeeredUpstreams supports fetching imported upstream candidates of a given partition.
+type PeeredUpstreams struct {
 	RegisterOptionsBlockingRefresh
 	RPC RPC
 }
 
-func (i *IntentionUpstreams) Fetch(opts cache.FetchOptions, req cache.Request) (cache.FetchResult, error) {
+func (i *PeeredUpstreams) Fetch(opts cache.FetchOptions, req cache.Request) (cache.FetchResult, error) {
 	var result cache.FetchResult
 
-	// The request should be a ServiceSpecificRequest.
-	reqReal, ok := req.(*structs.ServiceSpecificRequest)
+	reqReal, ok := req.(*structs.PartitionSpecificRequest)
 	if !ok {
 		return result, fmt.Errorf(
 			"Internal cache failure: request wrong type: %T", req)
@@ -41,8 +40,8 @@ func (i *IntentionUpstreams) Fetch(opts cache.FetchOptions, req cache.Request) (
 	reqReal.AllowStale = true
 
 	// Fetch
-	var reply structs.IndexedServiceList
-	if err := i.RPC.RPC("Internal.IntentionUpstreams", reqReal, &reply); err != nil {
+	var reply structs.IndexedPeeredServiceList
+	if err := i.RPC.RPC("Internal.PeeredUpstreams", reqReal, &reply); err != nil {
 		return result, err
 	}
 

--- a/agent/cache-types/peered_upstreams_test.go
+++ b/agent/cache-types/peered_upstreams_test.go
@@ -1,0 +1,60 @@
+package cachetype
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func TestPeeredUpstreams(t *testing.T) {
+	rpc := TestRPC(t)
+	defer rpc.AssertExpectations(t)
+	typ := &PeeredUpstreams{RPC: rpc}
+
+	// Expect the proper RPC call. This also sets the expected value
+	// since that is return-by-pointer in the arguments.
+	var resp *structs.IndexedPeeredServiceList
+	rpc.On("RPC", "Internal.PeeredUpstreams", mock.Anything, mock.Anything).Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.PartitionSpecificRequest)
+			require.Equal(t, uint64(24), req.MinQueryIndex)
+			require.Equal(t, 1*time.Second, req.QueryOptions.MaxQueryTime)
+			require.True(t, req.AllowStale)
+
+			reply := args.Get(2).(*structs.IndexedPeeredServiceList)
+			reply.Index = 48
+			resp = reply
+		})
+
+	// Fetch
+	result, err := typ.Fetch(cache.FetchOptions{
+		MinIndex: 24,
+		Timeout:  1 * time.Second,
+	}, &structs.PartitionSpecificRequest{
+		Datacenter:     "dc1",
+		EnterpriseMeta: *acl.DefaultEnterpriseMeta(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, cache.FetchResult{
+		Value: resp,
+		Index: 48,
+	}, result)
+}
+
+func TestPeeredUpstreams_badReqType(t *testing.T) {
+	rpc := TestRPC(t)
+	defer rpc.AssertExpectations(t)
+	typ := &PeeredUpstreams{RPC: rpc}
+
+	// Fetch
+	_, err := typ.Fetch(cache.FetchOptions{}, cache.TestRequest(
+		t, cache.RequestInfo{Key: "foo", MinIndex: 64}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong type")
+}

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -1207,6 +1208,104 @@ func registerTestRoutingConfigTopologyEntries(t *testing.T, codec rpc.ClientCode
 		var out bool
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out))
 	}
+}
+
+func registerLocalAndRemoteServicesVIPEnabled(t *testing.T, state *state.Store) {
+	t.Helper()
+
+	_, entry, err := state.SystemMetadataGet(nil, structs.SystemMetadataVirtualIPsEnabled)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.Equal(t, "true", entry.Value)
+
+	// Register a local connect-native service
+	require.NoError(t, state.EnsureRegistration(10, &structs.RegisterRequest{
+		Node:    "foo",
+		Address: "127.0.0.1",
+		Service: &structs.NodeService{
+			Service: "api",
+			Connect: structs.ServiceConnect{
+				Native: true,
+			},
+		},
+	}))
+	// Should be assigned VIP
+	psn := structs.PeeredServiceName{ServiceName: structs.NewServiceName("api", nil)}
+	vip, err := state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Equal(t, "240.0.0.1", vip)
+
+	// Register an imported service and its proxy
+	require.NoError(t, state.EnsureRegistration(11, &structs.RegisterRequest{
+		Node:           "bar",
+		SkipNodeUpdate: true,
+		Service: &structs.NodeService{
+			Kind:    structs.ServiceKindTypical,
+			Service: "web",
+			ID:      "web-1",
+		},
+		PeerName: "peer-a",
+	}))
+	require.NoError(t, state.EnsureRegistration(12, &structs.RegisterRequest{
+		Node:    "bar",
+		Address: "127.0.0.2",
+		Service: &structs.NodeService{
+			Kind:    structs.ServiceKindConnectProxy,
+			ID:      "web-proxy",
+			Service: "web-proxy",
+			Proxy: structs.ConnectProxyConfig{
+				DestinationServiceName: "web",
+			},
+			LocallyRegisteredAsSidecar: true,
+		},
+		PeerName: "peer-a",
+	}))
+	// Should be assigned one VIP for the real service name
+	psn = structs.PeeredServiceName{Peer: "peer-a", ServiceName: structs.NewServiceName("web", nil)}
+	vip, err = state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Equal(t, "240.0.0.2", vip)
+	// web-proxy should not have a VIP
+	psn = structs.PeeredServiceName{Peer: "peer-a", ServiceName: structs.NewServiceName("web-proxy", nil)}
+	vip, err = state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Empty(t, vip)
+
+	// Register an imported service and its proxy from another peer
+	require.NoError(t, state.EnsureRegistration(11, &structs.RegisterRequest{
+		Node:           "gir",
+		SkipNodeUpdate: true,
+		Service: &structs.NodeService{
+			Kind:    structs.ServiceKindTypical,
+			Service: "web",
+			ID:      "web-1",
+		},
+		PeerName: "peer-b",
+	}))
+	require.NoError(t, state.EnsureRegistration(12, &structs.RegisterRequest{
+		Node:    "gir",
+		Address: "127.0.0.3",
+		Service: &structs.NodeService{
+			Kind:    structs.ServiceKindConnectProxy,
+			ID:      "web-proxy",
+			Service: "web-proxy",
+			Proxy: structs.ConnectProxyConfig{
+				DestinationServiceName: "web",
+			},
+			LocallyRegisteredAsSidecar: true,
+		},
+		PeerName: "peer-b",
+	}))
+	// Should be assigned one VIP for the real service name
+	psn = structs.PeeredServiceName{Peer: "peer-b", ServiceName: structs.NewServiceName("web", nil)}
+	vip, err = state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Equal(t, "240.0.0.3", vip)
+	// web-proxy should not have a VIP
+	psn = structs.PeeredServiceName{Peer: "peer-b", ServiceName: structs.NewServiceName("web-proxy", nil)}
+	vip, err = state.VirtualIPForService(psn)
+	require.NoError(t, err)
+	require.Empty(t, vip)
 }
 
 func registerIntentionUpstreamEntries(t *testing.T, codec rpc.ClientCodec, token string) {

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -303,7 +303,12 @@ func updateKindServiceNamesIndex(tx WriteTxn, idx uint64, kind structs.ServiceKi
 func indexFromPeeredServiceName(psn structs.PeeredServiceName) ([]byte, error) {
 	peer := structs.LocalPeerKeyword
 	if psn.Peer != "" {
-		peer = psn.Peer
+		// This prefix is unusual but necessary for reads which want
+		// to isolate peered resources.
+		// This allows you to prefix query for "peer:":
+		//   internal/name
+		//   peer:peername/name
+		peer = "peer:" + psn.Peer
 	}
 
 	var b indexBuilder

--- a/agent/consul/state/catalog_oss_test.go
+++ b/agent/consul/state/catalog_oss_test.go
@@ -700,6 +700,21 @@ func testIndexerTableServiceVirtualIPs() map[string]indexerTestCase {
 				source:   obj,
 				expected: []byte("internal\x00foo\x00"),
 			},
+			prefix: []indexValue{
+				{
+					source: Query{
+						Value: "foo",
+					},
+					expected: []byte("internal\x00foo\x00"),
+				},
+				{
+					source: Query{
+						Value:    "foo",
+						PeerName: "*", // test wildcard PeerName
+					},
+					expected: []byte("peer:"),
+				},
+			},
 			extra: []indexerTestCase{
 				{
 					read: indexValue{
@@ -709,11 +724,11 @@ func testIndexerTableServiceVirtualIPs() map[string]indexerTestCase {
 							},
 							Peer: "Billing",
 						},
-						expected: []byte("billing\x00foo\x00"),
+						expected: []byte("peer:billing\x00foo\x00"),
 					},
 					write: indexValue{
 						source:   peeredObj,
-						expected: []byte("billing\x00foo\x00"),
+						expected: []byte("peer:billing\x00foo\x00"),
 					},
 				},
 			},

--- a/agent/consul/state/catalog_schema.go
+++ b/agent/consul/state/catalog_schema.go
@@ -607,6 +607,8 @@ func (q NodeCheckQuery) PartitionOrDefault() string {
 type ServiceVirtualIP struct {
 	Service structs.PeeredServiceName
 	IP      net.IP
+
+	structs.RaftIndex
 }
 
 // FreeVirtualIP is used to store a virtual IP freed up by a service deregistration.
@@ -631,9 +633,11 @@ func serviceVirtualIPTableSchema() *memdb.TableSchema {
 				Name:         indexID,
 				AllowMissing: false,
 				Unique:       true,
-				Indexer: indexerSingle[structs.PeeredServiceName, ServiceVirtualIP]{
+				Indexer: indexerSingleWithPrefix[structs.PeeredServiceName, ServiceVirtualIP, Query]{
 					readIndex:  indexFromPeeredServiceName,
 					writeIndex: indexFromServiceVirtualIP,
+					// Read all peers in a cluster / partition
+					prefixIndex: prefixIndexFromQueryWithPeerWildcardable,
 				},
 			},
 		},

--- a/agent/proxycfg-glue/glue.go
+++ b/agent/proxycfg-glue/glue.go
@@ -83,6 +83,12 @@ func CacheLeafCertificate(c *cache.Cache) proxycfg.LeafCertificate {
 	return &cacheProxyDataSource[*cachetype.ConnectCALeafRequest]{c, cachetype.ConnectCALeafName}
 }
 
+// CachePeeredUpstreams satisfies the proxycfg.PeeredUpstreams interface
+// by sourcing data from the agent cache.
+func CachePeeredUpstreams(c *cache.Cache) proxycfg.PeeredUpstreams {
+	return &cacheProxyDataSource[*structs.PartitionSpecificRequest]{c, cachetype.PeeredUpstreamsName}
+}
+
 // CachePrepraredQuery satisfies the proxycfg.PreparedQuery interface by
 // sourcing data from the agent cache.
 func CachePrepraredQuery(c *cache.Cache) proxycfg.PreparedQuery {

--- a/agent/proxycfg/data_sources.go
+++ b/agent/proxycfg/data_sources.go
@@ -69,6 +69,8 @@ type DataSources struct {
 	// notification channel.
 	LeafCertificate LeafCertificate
 
+	PeeredUpstreams PeeredUpstreams
+
 	// PreparedQuery provides updates about the results of a prepared query.
 	PreparedQuery PreparedQuery
 
@@ -168,6 +170,12 @@ type InternalServiceDump interface {
 // leaf certificate.
 type LeafCertificate interface {
 	Notify(ctx context.Context, req *cachetype.ConnectCALeafRequest, correlationID string, ch chan<- UpdateEvent) error
+}
+
+// PeeredUpstreams is the interface used to consume updates about upstreams
+// for all peered targets in a given partition.
+type PeeredUpstreams interface {
+	Notify(ctx context.Context, req *structs.PartitionSpecificRequest, correlationID string, ch chan<- UpdateEvent) error
 }
 
 // PreparedQuery is the interface used to consume updates about the results of

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -682,6 +682,30 @@ func (r *ServiceDumpRequest) CacheMinIndex() uint64 {
 	return r.QueryOptions.MinQueryIndex
 }
 
+// PartitionSpecificRequest is used to query about a specific partition.
+type PartitionSpecificRequest struct {
+	Datacenter string
+
+	acl.EnterpriseMeta
+	QueryOptions
+}
+
+func (r *PartitionSpecificRequest) RequestDatacenter() string {
+	return r.Datacenter
+}
+
+func (r *PartitionSpecificRequest) CacheInfo() cache.RequestInfo {
+	return cache.RequestInfo{
+		Token:          r.Token,
+		Datacenter:     r.Datacenter,
+		MinIndex:       r.MinQueryIndex,
+		Timeout:        r.MaxQueryTime,
+		MaxAge:         r.MaxAge,
+		MustRevalidate: r.MustRevalidate,
+		Key:            r.EnterpriseMeta.PartitionOrDefault(),
+	}
+}
+
 // ServiceSpecificRequest is used to query about a specific service
 type ServiceSpecificRequest struct {
 	Datacenter string
@@ -2208,6 +2232,11 @@ func (s ServiceList) Sort() { sort.Sort(s) }
 
 type IndexedServiceList struct {
 	Services ServiceList
+	QueryMeta
+}
+
+type IndexedPeeredServiceList struct {
+	Services []PeeredServiceName
 	QueryMeta
 }
 


### PR DESCRIPTION
### Description
For initial cluster peering TProxy support we consider all imported services of a partition to be potential upstreams.

We leverage the VirtualIP table because it stores plain service names (e.g. "api", not "api-sidecar-proxy") and deduplicates them (one VIP per service name).

### Testing & Reproduction steps

* Added new tests

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
