### PR TITLE
Allow the /v1/internal/acl/authorize endpoint to authorize the “peering" resource

### DIFF
--- a/acl/authorizer.go
+++ b/acl/authorizer.go
@@ -49,6 +49,7 @@ const (
 	ResourceQuery     Resource = "query"
 	ResourceService   Resource = "service"
 	ResourceSession   Resource = "session"
+	ResourcePeering   Resource = "peering"
 )
 
 // Authorizer is the interface for policy enforcement.
@@ -539,6 +540,14 @@ func Enforce(authz Authorizer, rsc Resource, segment string, access string, ctx 
 			return authz.SessionRead(segment, ctx), nil
 		case "write":
 			return authz.SessionWrite(segment, ctx), nil
+		}
+	case ResourcePeering:
+		// TODO (peering) switch this over to using PeeringRead & PeeringWrite methods once implemented
+		switch lowerAccess {
+		case "read":
+			return authz.OperatorRead(ctx), nil
+		case "write":
+			return authz.OperatorWrite(ctx), nil
 		}
 	default:
 		if processed, decision, err := enforceEnterprise(authz, rsc, segment, lowerAccess, ctx); processed {

--- a/acl/authorizer_test.go
+++ b/acl/authorizer_test.go
@@ -463,6 +463,34 @@ func TestACL_Enforce(t *testing.T) {
 			err:      "Invalid access level",
 		},
 		{
+			// TODO (peering) Update to use PeeringRead
+			method:   "OperatorRead",
+			resource: ResourcePeering,
+			access:   "read",
+			ret:      Allow,
+		},
+		{
+			// TODO (peering) Update to use PeeringRead
+			method:   "OperatorRead",
+			resource: ResourcePeering,
+			access:   "read",
+			ret:      Deny,
+		},
+		{
+			// TODO (peering) Update to use PeeringWrite
+			method:   "OperatorWrite",
+			resource: ResourcePeering,
+			access:   "write",
+			ret:      Allow,
+		},
+		{
+			// TODO (peering) Update to use PeeringWrite
+			method:   "OperatorWrite",
+			resource: ResourcePeering,
+			access:   "write",
+			ret:      Deny,
+		},
+		{
 			method:   "PreparedQueryRead",
 			resource: ResourceQuery,
 			segment:  "foo",


### PR DESCRIPTION
### Description
The UI uses the endpoint to determine if a user has permissions to do certain operations. This resource will be checked to see if a user has the ability to read/manage peerings.

Currently the permissions checked are just `operator:{read,write}`. Once we implement ACLs for peering this will need to be changed. In the mean time though, have this implemented like so will unblock frontend folks from working on integration.

### Testing & Reproduction steps
* Unit tests
* Run a dev agent with ACLs enabled. Bootstrap ACLs and then `curl -X POST -H "X-Consul-Token: $CONSUL_HTTP_TOKEN" localhost:8500/v1/internal/acl/authorize -d '[{"resource": "peering", "access": "read"}, {"resource": "peering", "access": "write"}]'`

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
