### PR TITLE
Fix ENT drift in files

### DIFF
--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -1256,7 +1256,6 @@ func registerLocalAndRemoteServicesVIPEnabled(t *testing.T, state *state.Store) 
 			Proxy: structs.ConnectProxyConfig{
 				DestinationServiceName: "web",
 			},
-			LocallyRegisteredAsSidecar: true,
 		},
 		PeerName: "peer-a",
 	}))
@@ -1292,7 +1291,6 @@ func registerLocalAndRemoteServicesVIPEnabled(t *testing.T, state *state.Store) 
 			Proxy: structs.ConnectProxyConfig{
 				DestinationServiceName: "web",
 			},
-			LocallyRegisteredAsSidecar: true,
 		},
 		PeerName: "peer-b",
 	}))

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -2787,15 +2787,13 @@ func TestInternal_PeeredUpstreams(t *testing.T) {
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
-	state := s1.fsm.State()
-
 	// Services
 	//   api        local
 	//   web        peer: peer-a
 	//   web-proxy  peer: peer-a
 	//   web        peer: peer-b
 	//   web-proxy  peer: peer-b
-	registerLocalAndRemoteServicesVIPEnabled(t, state)
+	registerLocalAndRemoteServicesVIPEnabled(t, s1.fsm.State())
 
 	codec := rpcClient(t, s1)
 


### PR DESCRIPTION
These files were edited in the enterprise-side PR but not the OSS; this PR is to sync them again.

Original: https://github.com/hashicorp/consul/pull/13642