### PR TITLE
proxycfg: check Ingress Gateway watches during discovery chain

### DIFF
--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -1821,6 +1821,10 @@ func (s *state) watchDiscoveryChain(snap *ConfigSnapshot, opts discoveryChainWat
 		return nil
 	}
 
+	if _, ok := snap.IngressGateway.WatchedDiscoveryChains[opts.id]; ok {
+		return nil
+	}
+
 	ctx, cancel := context.WithCancel(s.ctx)
 	err := s.cache.Notify(ctx, cachetype.CompiledDiscoveryChainName, &structs.DiscoveryChainRequest{
 		Datacenter:             s.source.Datacenter,


### PR DESCRIPTION
### Description

Greetings, I'm not sure if you still accept fixes for the v1.10 branch but I thought you might find this fix useful.

We've been suffering from a memory leak on our Consul Clients hosting the Ingress Gateway service and only them. After investigation, we found out that the number of goroutines was ever-growing:

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/781688/176714145-d0aa9aad-d0cf-4e78-9034-449a8a5a9970.png">

We went to take some profiling dumps and found out a lot of goroutines were parked:

![image](https://user-images.githubusercontent.com/781688/176712563-d47e8053-fbbc-452a-8740-1e361987b281.png)

And the heap was taken by `watchDiscoveryChain` and `notifyBlockingQuery`:

![image](https://user-images.githubusercontent.com/781688/176712721-fb651ce2-3f9c-4c5b-9111-5b6cc27f6ee5.png)

This leads us to look into `agent/proxycfg/state.go`:

https://github.com/hashicorp/consul/blob/de95b6f546f7f1b891cfd596dd4e3293a3a3abcd/agent/proxycfg/state.go#L1819-L1851

I immediately see at the beginning a key existence check for `snap.ConnectProxy.WatchedDiscoveryChains`, and then, when creating the watch request, an assignment in either `snap.IngressGateway.WatchedDiscoveryChains` or
`snap.ConnectProxy.WatchedDiscoveryChains`.

This made us add the extra check for existence in `snap.IngressGateway.WatchedDiscoveryChains`. Since then, we've observed a pretty stable goroutines amount and no more OOMKill:

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/781688/176713760-6fda0b0d-adfd-4623-9e6a-430ac094ee4f.png"> 

We are not in the right configuration to upgrade yet from v1.10 which is why we hope this could still be useful for the community if anyone else is also experiencing this issue.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
