### PR TITLE
ui: allow searching services by admin-partition

### DIFF
--- a/ui/packages/consul-ui/app/search/predicates/service.js
+++ b/ui/packages/consul-ui/app/search/predicates/service.js
@@ -2,4 +2,5 @@ export default {
   Name: item => item.Name,
   Tags: item => item.Tags || [],
   PeerName: item => item.PeerName,
+  Partition: item => item.Partition,
 };

--- a/ui/packages/consul-ui/tests/unit/search/predicates/service-test.js
+++ b/ui/packages/consul-ui/tests/unit/search/predicates/service-test.js
@@ -60,4 +60,39 @@ module('Unit | Search | Predicate | service', function() {
     ).search('hit');
     assert.equal(actual.length, 0);
   });
+  test('items can be found by Partition', function(assert) {
+    const search = new ExactSearch(
+      [
+        {
+          Name: 'name-a',
+          Partition: 'default',
+        },
+        {
+          Name: 'name-b',
+          Partition: 'lorem-ipsum',
+        },
+      ],
+      {
+        finders: predicates,
+      }
+    );
+
+    assert.deepEqual(
+      search.search('').map(i => i.Name),
+      ['name-a', 'name-b'],
+      'both items included in search'
+    );
+
+    assert.deepEqual(
+      search.search('def').map(i => i.Name),
+      ['name-a'],
+      'only item from default partition is included'
+    );
+
+    assert.deepEqual(
+      search.search('tomster').map(i => i.Name),
+      [],
+      'no item included when no Partition matches'
+    );
+  });
 });

--- a/ui/packages/consul-ui/translations/common/en-us.yaml
+++ b/ui/packages/consul-ui/translations/common/en-us.yaml
@@ -47,6 +47,7 @@ consul:
   readreplica: Read replica
   redundancyzone: Redundancy zone
   peername: Peer
+  partition: Admin Partitions
 search:
   search: Search
   searchproperty: Search Across

--- a/ui/packages/consul-ui/vendor/consul-ui/routes.js
+++ b/ui/packages/consul-ui/vendor/consul-ui/routes.js
@@ -54,7 +54,7 @@
               kind: 'kind',
               searchproperty: {
                 as: 'searchproperty',
-                empty: [['Name', 'Tags', 'PeerName']],
+                empty: [['Partition', 'Name', 'Tags', 'PeerName']],
               },
               search: {
                 as: 'filter',


### PR DESCRIPTION
### Description
Add `Admin Partitions` search property to services list

<img width="1055" alt="Screenshot 2022-06-30 at 17 26 24" src="https://user-images.githubusercontent.com/242299/176716498-dca562d6-6084-48c9-a3af-d1dbdbc1918e.png">



* [x] updated test coverage
* ~~[ ] external facing docs updated~~
* [x] not a security concern

cc @johncowen 