### PR TITLE
peering: count imported services

### DIFF
--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -830,7 +830,7 @@ func (s *Service) HandleStream(req HandleStreamRequest) error {
 
 			if resp := msg.GetResponse(); resp != nil {
 				// TODO(peering): Ensure there's a nonce
-				reply, err := s.processResponse(req.PeerName, req.Partition, resp)
+				reply, err := s.processResponse(req.LocalID, req.PeerName, req.Partition, resp)
 				if err != nil {
 					logger.Error("failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 					status.trackReceiveError(err.Error())


### PR DESCRIPTION
Signed-off-by: acpana <8968914+acpana@users.noreply.github.com>

### Description
For now, we are choosing to track the imported services count in the stream tracker shim. In the future, the tracking should make its way through raft.

This information will eventually be used by the UI.

### Testing & Reproduction steps
* stream tracker testing updated

#### pr todo

* [ ] reset counter on streamTracker `.delete()`
* [ ] fix 32bit test