### PR TITLE
docs: improve large version change upgrade path

### DIFF
--- a/website/content/docs/upgrading/instructions/index.mdx
+++ b/website/content/docs/upgrading/instructions/index.mdx
@@ -9,30 +9,39 @@ description: >-
 # Upgrade Instructions
 
 This document is intended to help users who find themselves many versions behind to upgrade safely.
-Our recommended upgrade path is moving from version 0.8.5 to 1.2.4 to 1.6.9 to 1.8.13 to the current version. To get
-started, you will want to choose the version you are currently on below and then follow the instructions
-until you are on the latest version. The upgrade guides will mention notable changes and link to relevant
-changelogs – we recommend reviewing the changelog for versions between the one you are on and the
-one you are upgrading to at each step to familiarize yourself with changes.
+
+## Upgrade Path
+
+Our recommended upgrade path is to move through the following sequence of versions:
+- 0.8.5 (final 0.8.x)
+- 1.2.4 (final 1.2.x)
+- 1.6.10 (final 1.6.x)
+- 1.8.19 (final 1.8.x)
+- Latest 1.10.x
+- Latest current version (1.11.x or 1.12.x)
 
 ## Getting Started
 
-To get instructions for your upgrade, please choose the release series you are _currently using_:
+To get instructions for your upgrade, follow the instructions given below for
+your _currently installed_ release series until you are on the latest current version.
+The upgrade guides will mention notable changes and link to relevant changelogs –
+we recommend reviewing the changelog for versions between the one you are on and the
+one you are upgrading to at each step to familiarize yourself with changes.
 
-- [0.8.x](/docs/upgrading/instructions/upgrade-to-1-2-x)
-- [0.9.x](/docs/upgrading/instructions/upgrade-to-1-2-x)
-- [1.0.x](/docs/upgrading/instructions/upgrade-to-1-2-x)
-- [1.1.x](/docs/upgrading/instructions/upgrade-to-1-2-x)
-- [1.2.x](/docs/upgrading/instructions/upgrade-to-1-6-x)
-- [1.3.x](/docs/upgrading/instructions/upgrade-to-1-6-x)
-- [1.4.x](/docs/upgrading/instructions/upgrade-to-1-6-x)
-- [1.5.x](/docs/upgrading/instructions/upgrade-to-1-6-x)
-- [1.6.x](/docs/upgrading/instructions/upgrade-to-1-8-x)
-- [1.7.x](/docs/upgrading/instructions/upgrade-to-1-8-x)
-- [1.8.x](/docs/upgrading/instructions/upgrade-to-1-10-x)
+Select your _currently installed_ release series:
 - [1.9.x](/docs/upgrading/instructions/upgrade-to-1-10-x)
+- [1.8.x](/docs/upgrading/instructions/upgrade-to-1-10-x)
+- [1.7.x](/docs/upgrading/instructions/upgrade-to-1-8-x)
+- [1.6.x](/docs/upgrading/instructions/upgrade-to-1-8-x)
+- [1.5.x](/docs/upgrading/instructions/upgrade-to-1-6-x)
+- [1.4.x](/docs/upgrading/instructions/upgrade-to-1-6-x)
+- [1.3.x](/docs/upgrading/instructions/upgrade-to-1-6-x)
+- [1.2.x](/docs/upgrading/instructions/upgrade-to-1-6-x)
+- [1.1.x](/docs/upgrading/instructions/upgrade-to-1-2-x)
+- [1.0.x](/docs/upgrading/instructions/upgrade-to-1-2-x)
+- [0.9.x](/docs/upgrading/instructions/upgrade-to-1-2-x)
+- [0.8.x](/docs/upgrading/instructions/upgrade-to-1-2-x)
 
 If you are using <= 0.7.x, please contact support for assistance:
-
 - OSS users without paid support plans can request help in our [Community Forum](https://discuss.hashicorp.com/c/consul/29)
 - Enterprise and OSS users with paid support plans can contact [HashiCorp Support](https://support.hashicorp.com/)

--- a/website/content/docs/upgrading/instructions/upgrade-to-1-10-x.mdx
+++ b/website/content/docs/upgrading/instructions/upgrade-to-1-10-x.mdx
@@ -1,22 +1,22 @@
 ---
 layout: docs
-page_title: Upgrading to 1.10.0
+page_title: Upgrading to Latest 1.10.x
 description: >-
   Specific versions of Consul may have additional information about the upgrade
   process beyond the standard flow.
 ---
 
-# Upgrading to 1.10.0
+# Upgrading to Latest 1.10.x
 
 <EnterpriseAlert />
 
 ## Introduction
 
-This guide explains how to best upgrade a single Consul Enterprise datacenter to v1.10.0
+This guide explains how to best upgrade a single Consul Enterprise datacenter to latest v1.10.x
 from a version of Consul that is forward compatible with v1.10. If you are on a major
-version of Consul prior to 1.8, you will need to complete and [upgrade to 1.8.13](/docs/upgrading/instructions/upgrade-to-1-8-x)
-or higher before continuing with this guide. If you are already on a major version of 1.8 or 1.9, then
-this guide will go over the procedures required for upgrading to v1.10. This process
+version of Consul prior to 1.8, you must first [upgrade to latest 1.8.x](/docs/upgrading/instructions/upgrade-to-1-8-x)
+before continuing with this guide. If you are already on a major version of 1.8 or 1.9, then
+this guide will go over the procedures required for upgrading to v1.10.x. This process
 will require intermediate version upgrades to a forward-compatible release of v1.8 or v1.9,
 as well as other licensing related configuration changes. If you have multiple Consul datacenters,
 upgrade them in the normal order and take the following instructions into account for each upgrade.
@@ -141,11 +141,11 @@ environment variable. See the [licensing documentation](/docs/enterprise/license
 for more information about how to configure the license.
 You can also refer to the [Apply Enterprise License](https://learn.hashicorp.com/tutorials/consul/deployment-guide#apply-enterprise-license) tutorial for additional information.
 
-**9.** Upgrade all server agents to v1.10.0.
+**9.** Upgrade all server agents to latest v1.10.x.
 
-**10.** Upgrade all client agents to v1.10.0.
+**10.** Upgrade all client agents to latest v1.10.x.
 
-**11.** Upgrade all [snapshot agents](/commands/snapshot/agent) to v1.10.0.
+**11.** Upgrade all [snapshot agents](/commands/snapshot/agent) to latest v1.10.x.
 
 </Tab>
 <Tab heading="ACLs Disabled">
@@ -194,11 +194,11 @@ the snapshot would make it possible to restore the previous state.
 **10.** Pre-configure the server agents with a license. This is the same process that
 was executed for the servers in step 5.
 
-**11.** Upgrade all server agents to v1.10.0.
+**11.** Upgrade all server agents to latest v1.10.x.
 
-**12.** Upgrade all client agents to v1.10.0.
+**12.** Upgrade all client agents to latest v1.10.x.
 
-**13.** Upgrade all [snapshot agents](/commands/snapshot/agent) to v1.10.0.
+**13.** Upgrade all [snapshot agents](/commands/snapshot/agent) to latest v1.10.x.
 
 </Tab>
 <Tab heading="Kubernetes">

--- a/website/content/docs/upgrading/instructions/upgrade-to-1-2-x.mdx
+++ b/website/content/docs/upgrading/instructions/upgrade-to-1-2-x.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: Upgrading to 1.2.4
+page_title: Upgrading to Latest 1.2.x
 description: >-
   Specific versions of Consul may have additional information about the upgrade
   process beyond the standard flow.
 ---
 
-# Upgrading to 1.2.4
+# Upgrading to Latest 1.2.x
 
 ## Introduction
 

--- a/website/content/docs/upgrading/instructions/upgrade-to-1-6-x.mdx
+++ b/website/content/docs/upgrading/instructions/upgrade-to-1-6-x.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: Upgrading to 1.6.9
+page_title: Upgrading to Latest 1.6.x
 description: >-
   Specific versions of Consul may have additional information about the upgrade
   process beyond the standard flow.
 ---
 
-# Upgrading to 1.6.9
+# Upgrading to Latest 1.6.x
 
 ## Introduction
 
 This guide explains how to best upgrade a multi-datacenter Consul deployment that is using
-a version of Consul >= 1.2.4 and < 1.6.9 while maintaining replication. If you are on a version
+a version of Consul >= 1.2.4 and < 1.6.10 while maintaining replication. If you are on a version
 older than 1.2.4, please review our [Upgrading to 1.2.4](/docs/upgrading/instructions/upgrade-to-1-2-x)
 guide. Due to changes to the ACL system, an ACL token migration will need to be performed
 as part of this upgrade. The 1.6.x series is the last series that had support for legacy
@@ -29,7 +29,7 @@ referring to them as DC1 and DC2. DC1 will be the primary datacenter.
 
 ## Requirements
 
-- All Consul servers should be on a version of Consul >= 1.2.4 and < 1.6.9.
+- All Consul servers should be on a version of Consul >= 1.2.4 and < 1.6.10.
 
 ## Assumptions
 
@@ -98,7 +98,7 @@ You should receive output similar to this:
 }
 ```
 
-**3.** Upgrade DC2 agents to version 1.6.9 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process). _**Leave all DC1 agents at 1.2.4.**_ You should start observing log messages like this after that:
+**3.** Upgrade DC2 agents to version 1.6.10 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process). _**Leave all DC1 agents at 1.2.4.**_ You should start observing log messages like this after that:
 
 ```log
 2020/09/08 15:51:29 [DEBUG] acl: Cannot upgrade to new ACLs, servers in acl datacenter have not upgraded - found servers: true, mode: 3
@@ -158,7 +158,7 @@ Failed to retrieve the token list: Unexpected response code: 500 (The ACL system
 
 This is because Consul in legacy mode. ACL CLI commands will not work and you have to hit the old ACL HTTP endpoints (which is why `curl` is being used above rather than the `consul` CLI client).
 
-**5.** Upgrade DC1 agents to version 1.6.9 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process).
+**5.** Upgrade DC1 agents to version 1.6.10 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process).
 
 Once this is complete, you should observe a log entry like this from your server agents:
 

--- a/website/content/docs/upgrading/instructions/upgrade-to-1-8-x.mdx
+++ b/website/content/docs/upgrading/instructions/upgrade-to-1-8-x.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: Upgrading to 1.8.13
+page_title: Upgrading to Latest 1.8.x
 description: >-
   Specific versions of Consul may have additional information about the upgrade
   process beyond the standard flow.
 ---
 
-# Upgrading to 1.8.13
+# Upgrading to Latest 1.8.x
 
 ## Introduction
 
 This guide explains how to best upgrade a multi-datacenter Consul deployment that is using
-a version of Consul >= 1.6.9 and < 1.8.13 while maintaining replication. If you are on a version
+a version of Consul >= 1.6.9 and < 1.8.19 while maintaining replication. If you are on a version
 older than 1.6.9, please follow the link for the version you are on from [here](/docs/upgrading/instructions).
 
 In this guide, we will be using an example with two datacenters (DCs) and will be
@@ -19,7 +19,7 @@ referring to them as DC1 and DC2. DC1 will be the primary datacenter.
 
 ## Requirements
 
-- All Consul servers should be on a version of Consul >= 1.6.9 and < 1.8.13.
+- All Consul servers should be on a version of Consul >= 1.6.9 and < 1.8.19.
 
 ## Assumptions
 
@@ -87,7 +87,7 @@ You should receive output similar to this:
 }
 ```
 
-**3.** Upgrade the Consul agents in all DCs to version 1.8.13 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process).
+**3.** Upgrade the Consul agents in all DCs to version 1.8.19 by following our [General Upgrade Process](/docs/upgrading/instructions/general-process).
 
 **4.** Confirm that replication is still working in DC2 by issuing the following curl command from a
 consul server in that DC:

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1210,19 +1210,19 @@
             "path": "upgrading/instructions/general-process"
           },
           {
-            "title": "Upgrading to 1.2.4",
+            "title": "Upgrading to Latest 1.2.x",
             "path": "upgrading/instructions/upgrade-to-1-2-x"
           },
           {
-            "title": "Upgrading to 1.6.9",
+            "title": "Upgrading to Latest 1.6.x",
             "path": "upgrading/instructions/upgrade-to-1-6-x"
           },
           {
-            "title": "Upgrading to 1.8.13",
+            "title": "Upgrading to Latest 1.8.x",
             "path": "upgrading/instructions/upgrade-to-1-8-x"
           },
           {
-            "title": "Upgrading to 1.10.0",
+            "title": "Upgrading to Latest 1.10.x",
             "path": "upgrading/instructions/upgrade-to-1-10-x"
           }
         ]


### PR DESCRIPTION
The existing large version change upgrade docs present the following challenges:
- They mention upgrading to 1.10.0 and then the current version, even though users must [first upgrade to 1.10.7+](https://www.consul.io/docs/upgrading/upgrade-specific#1-10-compatibility) before upgrading to 1.11+
- (less importantly) They mention upgrading to release series which are not the latest version in their series

This PR is intended to make the ideal upgrade path clearer.