### PR TITLE
Replace deprecated ioutil pkg with os & io

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -18,11 +17,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
-	"github.com/hashicorp/go-connlimit"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
@@ -2025,7 +2020,7 @@ func (a *Agent) readPersistedServiceConfigs() (map[structs.ServiceID]*structs.Se
 	out := make(map[structs.ServiceID]*structs.ServiceConfigResponse)
 
 	configDir := filepath.Join(a.config.DataDir, serviceConfigDir)
-	files, err := ioutil.ReadDir(configDir)
+	files, err := os.ReadDir(configDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -2047,7 +2042,7 @@ func (a *Agent) readPersistedServiceConfigs() (map[structs.ServiceID]*structs.Se
 
 		// Read the contents into a buffer
 		file := filepath.Join(configDir, fi.Name())
-		buf, err := ioutil.ReadFile(file)
+		buf, err := os.ReadFile(file)
 		if err != nil {
 			return nil, fmt.Errorf("failed reading service config file %q: %w", file, err)
 		}
@@ -3207,7 +3202,7 @@ func (a *Agent) persistCheckState(check *checks.CheckTTL, status, output string)
 	tempFile := file + ".tmp"
 
 	// persistCheckState is called frequently, so don't use writeFileAtomic to avoid calling fsync here
-	if err := ioutil.WriteFile(tempFile, buf, 0600); err != nil {
+	if err := os.WriteFile(tempFile, buf, 0600); err != nil {
 		return fmt.Errorf("failed writing temp file %q: %s", tempFile, err)
 	}
 	if err := os.Rename(tempFile, file); err != nil {
@@ -3222,12 +3217,12 @@ func (a *Agent) loadCheckState(check *structs.HealthCheck) error {
 	cid := check.CompoundCheckID()
 	// Try to read the persisted state for this check
 	file := filepath.Join(a.config.DataDir, checkStateDir, cid.StringHashSHA256())
-	buf, err := ioutil.ReadFile(file)
+	buf, err := os.ReadFile(file)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// try the md5 based name. This can be removed once we no longer support upgrades from versions that use MD5 hashing
 			oldFile := filepath.Join(a.config.DataDir, checkStateDir, cid.StringHashMD5())
-			buf, err = ioutil.ReadFile(oldFile)
+			buf, err = os.ReadFile(oldFile)
 			if err != nil {
 				if os.IsNotExist(err) {
 					return nil
@@ -3429,7 +3424,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 
 	// Load any persisted services
 	svcDir := filepath.Join(a.config.DataDir, servicesDir)
-	files, err := ioutil.ReadDir(svcDir)
+	files, err := os.ReadDir(svcDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -3450,7 +3445,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 
 		// Read the contents into a buffer
 		file := filepath.Join(svcDir, fi.Name())
-		buf, err := ioutil.ReadFile(file)
+		buf, err := os.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed reading service file %q: %w", file, err)
 		}
@@ -3593,7 +3588,7 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig, snap map[structs.CheckID]
 
 	// Load any persisted checks
 	checkDir := filepath.Join(a.config.DataDir, checksDir)
-	files, err := ioutil.ReadDir(checkDir)
+	files, err := os.ReadDir(checkDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -3608,7 +3603,7 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig, snap map[structs.CheckID]
 
 		// Read the contents into a buffer
 		file := filepath.Join(checkDir, fi.Name())
-		buf, err := ioutil.ReadFile(file)
+		buf, err := os.ReadFile(file)
 		if err != nil {
 			return fmt.Errorf("failed reading check file %q: %w", file, err)
 		}

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,8 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/serf/serf"
 	"github.com/mitchellh/hashstructure"
@@ -1741,7 +1738,7 @@ func TestAgent_ReloadDoesNotTriggerWatch(t *testing.T) {
 	}
 
 	dc1 := "dc1"
-	tmpFileRaw, err := ioutil.TempFile("", "rexec")
+	tmpFileRaw, err := os.CreateTemp("", "rexec")
 	require.NoError(t, err)
 	tmpFile := tmpFileRaw.Name()
 	defer os.Remove(tmpFile)
@@ -1780,7 +1777,7 @@ func TestAgent_ReloadDoesNotTriggerWatch(t *testing.T) {
 		contentsStr := ""
 		// Wait for watch to be populated
 		for i := 1; i < 7; i++ {
-			contents, err := ioutil.ReadFile(tmpFile)
+			contents, err := os.ReadFile(tmpFile)
 			if err != nil {
 				t.Fatalf("should be able to read file, but had: %#v", err)
 			}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -28,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/tcpproxy"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/assert"
@@ -2264,7 +2262,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -2285,7 +2283,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	content, err = ioutil.ReadFile(file)
+	content, err = os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -2354,7 +2352,7 @@ func testAgent_persistedService_compat(t *testing.T, extraHCL string) {
 	if err := os.MkdirAll(filepath.Dir(file), 0700); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if err := ioutil.WriteFile(file, encoded, 0600); err != nil {
+	if err := os.WriteFile(file, encoded, 0600); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -2409,7 +2407,7 @@ func testAgent_persistedService_compat_hash(t *testing.T, extraHCL string) {
 	if err := os.MkdirAll(filepath.Dir(file), 0700); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if err := ioutil.WriteFile(file, encoded, 0600); err != nil {
+	if err := os.WriteFile(file, encoded, 0600); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -2428,7 +2426,7 @@ func testAgent_persistedService_compat_hash(t *testing.T, extraHCL string) {
 	if err := os.MkdirAll(filepath.Dir(configFile), 0700); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if err := ioutil.WriteFile(configFile, encodedConfig, 0600); err != nil {
+	if err := os.WriteFile(configFile, encodedConfig, 0600); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -2609,7 +2607,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	require.Equal(t, expected, content)
@@ -2624,7 +2622,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 		Source:  "local",
 	})
 	require.NoError(t, err)
-	content, err = ioutil.ReadFile(file)
+	content, err = os.ReadFile(file)
 	require.NoError(t, err)
 	require.Equal(t, expected, content)
 	a.Shutdown()
@@ -3642,7 +3640,7 @@ func TestAgent_persistCheckState(t *testing.T) {
 
 	// Check the persisted file exists and has the content
 	file := filepath.Join(a.Config.DataDir, checkStateDir, cid.StringHashSHA256())
-	buf, err := ioutil.ReadFile(file)
+	buf, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -5009,9 +5007,9 @@ func TestAutoConfig_Integration(t *testing.T) {
 	caFile := filepath.Join(cfgDir, "cacert.pem")
 	keyFile := filepath.Join(cfgDir, "key.pem")
 
-	require.NoError(t, ioutil.WriteFile(certFile, []byte(cert), 0600))
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(cacert), 0600))
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(key), 0600))
+	require.NoError(t, os.WriteFile(certFile, []byte(cert), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(cacert), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(key), 0600))
 
 	// generate a gossip key
 	gossipKey := make([]byte, 32)
@@ -5138,7 +5136,7 @@ func TestAutoConfig_Integration(t *testing.T) {
 		require.NotEqual(r, cert1, client.Agent.tlsConfigurator.Cert())
 
 		// check that the on disk certs match expectations
-		data, err := ioutil.ReadFile(filepath.Join(client.DataDir, "auto-config.json"))
+		data, err := os.ReadFile(filepath.Join(client.DataDir, "auto-config.json"))
 		require.NoError(r, err)
 		rdr := strings.NewReader(string(data))
 
@@ -5173,9 +5171,9 @@ func TestAgent_AutoEncrypt(t *testing.T) {
 	caFile := filepath.Join(cfgDir, "cacert.pem")
 	keyFile := filepath.Join(cfgDir, "key.pem")
 
-	require.NoError(t, ioutil.WriteFile(certFile, []byte(cert), 0600))
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(cacert), 0600))
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(key), 0600))
+	require.NoError(t, os.WriteFile(certFile, []byte(cert), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(cacert), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(key), 0600))
 
 	hclConfig := TestACLConfigWithParams(nil) + `
 		verify_incoming = true
@@ -5368,9 +5366,9 @@ func TestAgent_AutoReloadDoReload_WhenCertAndKeyUpdated(t *testing.T) {
 	caFile := filepath.Join(certsDir, "cacert.pem")
 	keyFile := filepath.Join(certsDir, "key.pem")
 
-	require.NoError(t, ioutil.WriteFile(certFile, []byte(cert), 0600))
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(ca), 0600))
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKey), 0600))
+	require.NoError(t, os.WriteFile(certFile, []byte(cert), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(ca), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKey), 0600))
 
 	// generate a gossip key
 	gossipKey := make([]byte, 32)
@@ -5410,8 +5408,8 @@ func TestAgent_AutoReloadDoReload_WhenCertAndKeyUpdated(t *testing.T) {
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	})
 	require.NoError(t, err)
-	require.NoError(t, ioutil.WriteFile(certFile, []byte(cert2), 0600))
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKey2), 0600))
+	require.NoError(t, os.WriteFile(certFile, []byte(cert2), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKey2), 0600))
 
 	retry.Run(t, func(r *retry.R) {
 		aeCert2 := srv.tlsConfigurator.Cert()
@@ -5449,9 +5447,9 @@ func TestAgent_AutoReloadDoNotReload_WhenCaUpdated(t *testing.T) {
 	caFile := filepath.Join(certsDir, "cacert.pem")
 	keyFile := filepath.Join(certsDir, "key.pem")
 
-	require.NoError(t, ioutil.WriteFile(certFile, []byte(cert), 0600))
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(ca), 0600))
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKey), 0600))
+	require.NoError(t, os.WriteFile(certFile, []byte(cert), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(ca), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKey), 0600))
 
 	// generate a gossip key
 	gossipKey := make([]byte, 32)
@@ -5484,7 +5482,7 @@ func TestAgent_AutoReloadDoNotReload_WhenCaUpdated(t *testing.T) {
 
 	ca2, _, err := tlsutil.GenerateCA(tlsutil.CAOpts{Signer: signer})
 	require.NoError(t, err)
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(ca2), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(ca2), 0600))
 
 	// wait a bit to see if it get updated.
 	time.Sleep(time.Second)
@@ -5523,9 +5521,9 @@ func TestAgent_AutoReloadDoReload_WhenCertThenKeyUpdated(t *testing.T) {
 	caFile := filepath.Join(certsDir, "cacert.pem")
 	keyFile := filepath.Join(certsDir, "key.pem")
 
-	require.NoError(t, ioutil.WriteFile(certFile, []byte(cert), 0600))
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(ca), 0600))
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKey), 0600))
+	require.NoError(t, os.WriteFile(certFile, []byte(cert), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(ca), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKey), 0600))
 
 	// generate a gossip key
 	gossipKey := make([]byte, 32)
@@ -5537,7 +5535,7 @@ func TestAgent_AutoReloadDoReload_WhenCertThenKeyUpdated(t *testing.T) {
 	hclConfig := TestACLConfigWithParams(nil)
 
 	configFile := testutil.TempDir(t, "config") + "/config.hcl"
-	require.NoError(t, ioutil.WriteFile(configFile, []byte(`
+	require.NoError(t, os.WriteFile(configFile, []byte(`
 		encrypt = "`+gossipKeyEncoded+`"
 		encrypt_verify_incoming = true
 		encrypt_verify_outgoing = true
@@ -5569,8 +5567,8 @@ func TestAgent_AutoReloadDoReload_WhenCertThenKeyUpdated(t *testing.T) {
 	})
 	require.NoError(t, err)
 	certFileNew := filepath.Join(certsDir, "cert_new.pem")
-	require.NoError(t, ioutil.WriteFile(certFileNew, []byte(certNew), 0600))
-	require.NoError(t, ioutil.WriteFile(configFile, []byte(`
+	require.NoError(t, os.WriteFile(certFileNew, []byte(certNew), 0600))
+	require.NoError(t, os.WriteFile(configFile, []byte(`
 		encrypt = "`+gossipKeyEncoded+`"
 		encrypt_verify_incoming = true
 		encrypt_verify_outgoing = true
@@ -5593,7 +5591,7 @@ func TestAgent_AutoReloadDoReload_WhenCertThenKeyUpdated(t *testing.T) {
 		require.Equal(r, cert1Key, cert.PrivateKey)
 	})
 
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKeyNew), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKeyNew), 0600))
 
 	// cert should change as we did not update the associated key
 	time.Sleep(1 * time.Second)
@@ -5632,9 +5630,9 @@ func TestAgent_AutoReloadDoReload_WhenKeyThenCertUpdated(t *testing.T) {
 	caFile := filepath.Join(certsDir, "cacert.pem")
 	keyFile := filepath.Join(certsDir, "key.pem")
 
-	require.NoError(t, ioutil.WriteFile(certFile, []byte(cert), 0600))
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(ca), 0600))
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKey), 0600))
+	require.NoError(t, os.WriteFile(certFile, []byte(cert), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(ca), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKey), 0600))
 
 	// generate a gossip key
 	gossipKey := make([]byte, 32)
@@ -5646,7 +5644,7 @@ func TestAgent_AutoReloadDoReload_WhenKeyThenCertUpdated(t *testing.T) {
 	hclConfig := TestACLConfigWithParams(nil)
 
 	configFile := testutil.TempDir(t, "config") + "/config.hcl"
-	require.NoError(t, ioutil.WriteFile(configFile, []byte(`
+	require.NoError(t, os.WriteFile(configFile, []byte(`
 		encrypt = "`+gossipKeyEncoded+`"
 		encrypt_verify_incoming = true
 		encrypt_verify_outgoing = true
@@ -5679,7 +5677,7 @@ func TestAgent_AutoReloadDoReload_WhenKeyThenCertUpdated(t *testing.T) {
 	})
 	require.NoError(t, err)
 	certFileNew := filepath.Join(certsDir, "cert_new.pem")
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKeyNew), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKeyNew), 0600))
 	// cert should not change as we did not update the associated key
 	time.Sleep(1 * time.Second)
 	retry.Run(t, func(r *retry.R) {
@@ -5689,8 +5687,8 @@ func TestAgent_AutoReloadDoReload_WhenKeyThenCertUpdated(t *testing.T) {
 		require.Equal(r, cert1Key, cert.PrivateKey)
 	})
 
-	require.NoError(t, ioutil.WriteFile(certFileNew, []byte(certNew), 0600))
-	require.NoError(t, ioutil.WriteFile(configFile, []byte(`
+	require.NoError(t, os.WriteFile(certFileNew, []byte(certNew), 0600))
+	require.NoError(t, os.WriteFile(configFile, []byte(`
 		encrypt = "`+gossipKeyEncoded+`"
 		encrypt_verify_incoming = true
 		encrypt_verify_outgoing = true
@@ -5724,7 +5722,7 @@ func TestAgent_AutoReloadDoReload_WhenKeyThenCertUpdated(t *testing.T) {
 		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	})
 	require.NoError(t, err)
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKeyNew2), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKeyNew2), 0600))
 	// cert should not change as we did not update the associated cert
 	time.Sleep(1 * time.Second)
 	retry.Run(t, func(r *retry.R) {
@@ -5734,7 +5732,7 @@ func TestAgent_AutoReloadDoReload_WhenKeyThenCertUpdated(t *testing.T) {
 		require.Equal(r, cert2Key, cert.PrivateKey)
 	})
 
-	require.NoError(t, ioutil.WriteFile(certFileNew, []byte(certNew2), 0600))
+	require.NoError(t, os.WriteFile(certFileNew, []byte(certNew2), 0600))
 
 	// cert should change as we did  update the associated key
 	time.Sleep(1 * time.Second)
@@ -5772,9 +5770,9 @@ func Test_coalesceTimerTwoPeriods(t *testing.T) {
 	caFile := filepath.Join(certsDir, "cacert.pem")
 	keyFile := filepath.Join(certsDir, "key.pem")
 
-	require.NoError(t, ioutil.WriteFile(certFile, []byte(cert), 0600))
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(ca), 0600))
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKey), 0600))
+	require.NoError(t, os.WriteFile(certFile, []byte(cert), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(ca), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKey), 0600))
 
 	// generate a gossip key
 	gossipKey := make([]byte, 32)
@@ -5786,7 +5784,7 @@ func Test_coalesceTimerTwoPeriods(t *testing.T) {
 	hclConfig := TestACLConfigWithParams(nil)
 
 	configFile := testutil.TempDir(t, "config") + "/config.hcl"
-	require.NoError(t, ioutil.WriteFile(configFile, []byte(`
+	require.NoError(t, os.WriteFile(configFile, []byte(`
 		encrypt = "`+gossipKeyEncoded+`"
 		encrypt_verify_incoming = true
 		encrypt_verify_outgoing = true
@@ -5822,8 +5820,8 @@ func Test_coalesceTimerTwoPeriods(t *testing.T) {
 	})
 	require.NoError(t, err)
 	certFileNew := filepath.Join(certsDir, "cert_new.pem")
-	require.NoError(t, ioutil.WriteFile(certFileNew, []byte(certNew), 0600))
-	require.NoError(t, ioutil.WriteFile(configFile, []byte(`
+	require.NoError(t, os.WriteFile(certFileNew, []byte(certNew), 0600))
+	require.NoError(t, os.WriteFile(configFile, []byte(`
 		encrypt = "`+gossipKeyEncoded+`"
 		encrypt_verify_incoming = true
 		encrypt_verify_outgoing = true
@@ -5846,7 +5844,7 @@ func Test_coalesceTimerTwoPeriods(t *testing.T) {
 		require.Equal(r, cert1Key, cert.PrivateKey)
 	})
 
-	require.NoError(t, ioutil.WriteFile(keyFile, []byte(privateKeyNew), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(privateKeyNew), 0600))
 
 	// cert should change as we did not update the associated key
 	time.Sleep(coalesceInterval * 2)
@@ -5859,7 +5857,7 @@ func Test_coalesceTimerTwoPeriods(t *testing.T) {
 
 func getExpectedCaPoolByFile(t *testing.T) *x509.CertPool {
 	pool := x509.NewCertPool()
-	data, err := ioutil.ReadFile("../test/ca/root.cer")
+	data, err := os.ReadFile("../test/ca/root.cer")
 	require.NoError(t, err)
 	if !pool.AppendCertsFromPEM(data) {
 		t.Fatal("could not add test ca ../test/ca/root.cer to pool")
@@ -5875,7 +5873,7 @@ func getExpectedCaPoolByDir(t *testing.T) *x509.CertPool {
 	for _, entry := range entries {
 		filename := path.Join("../test/ca_path", entry.Name())
 
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		require.NoError(t, err)
 
 		if !pool.AppendCertsFromPEM(data) {

--- a/agent/auto-config/auto_config.go
+++ b/agent/auto-config/auto_config.go
@@ -3,11 +3,9 @@ package autoconf
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
-
-	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/config"
@@ -208,7 +206,7 @@ func (ac *AutoConfig) introToken() (string, error) {
 	token := conf.IntroToken
 	if token == "" {
 		// load the intro token from the file
-		content, err := ioutil.ReadFile(conf.IntroTokenFile)
+		content, err := os.ReadFile(conf.IntroTokenFile)
 		if err != nil {
 			return "", fmt.Errorf("Failed to read intro token from file: %w", err)
 		}

--- a/agent/auto-config/auto_config_test.go
+++ b/agent/auto-config/auto_config_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -309,7 +308,7 @@ func TestInitialConfiguration_restored(t *testing.T) {
 	}
 	data, err := pbMarshaler.MarshalToString(response)
 	require.NoError(t, err)
-	require.NoError(t, ioutil.WriteFile(persistedFile, []byte(data), 0600))
+	require.NoError(t, os.WriteFile(persistedFile, []byte(data), 0600))
 
 	// recording the initial configuration even when restoring is going to update
 	// the agent token in the token store
@@ -1139,7 +1138,7 @@ func TestIntroToken(t *testing.T) {
 
 	tokenFromFile := "8ae34d3a-8adf-446a-b236-69874597cb5b"
 	tokenFromConfig := "3ad9b572-ea42-4e47-9cd0-53a398a98abf"
-	require.NoError(t, ioutil.WriteFile(tokenFile.Name(), []byte(tokenFromFile), 0600))
+	require.NoError(t, os.WriteFile(tokenFile.Name(), []byte(tokenFromFile), 0600))
 
 	type testCase struct {
 		config *config.RuntimeConfig

--- a/agent/auto-config/persist.go
+++ b/agent/auto-config/persist.go
@@ -2,7 +2,6 @@ package autoconf
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,7 +38,7 @@ func (ac *AutoConfig) readPersistedAutoConfig() (*pbautoconf.AutoConfigResponse,
 	path := filepath.Join(ac.config.DataDir, autoConfigFileName)
 	ac.logger.Debug("attempting to restore any persisted configuration", "path", path)
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err == nil {
 		rdr := strings.NewReader(string(content))
 
@@ -75,7 +74,7 @@ func (ac *AutoConfig) persistAutoConfig(resp *pbautoconf.AutoConfigResponse) err
 
 	path := filepath.Join(ac.config.DataDir, autoConfigFileName)
 
-	err = ioutil.WriteFile(path, []byte(serialized), 0660)
+	err = os.WriteFile(path, []byte(serialized), 0660)
 	if err != nil {
 		return fmt.Errorf("failed to write auto-config configurations: %w", err)
 	}

--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -16,16 +15,13 @@ import (
 	"syscall"
 	"time"
 
-	http2 "golang.org/x/net/http2"
-
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/go-hclog"
+	"golang.org/x/net/http2"
 
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/consul/agent/exec"
+	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/go-cleanhttp"
 )
 
 const (
@@ -859,7 +855,7 @@ func (c *CheckDocker) Start() {
 	}
 
 	if c.Logger == nil {
-		c.Logger = hclog.New(&hclog.LoggerOptions{Output: ioutil.Discard})
+		c.Logger = hclog.New(&hclog.LoggerOptions{Output: io.Discard})
 	}
 
 	if c.Shell == "" {

--- a/agent/checks/docker.go
+++ b/agent/checks/docker.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -106,7 +105,7 @@ func (c *DockerClient) call(method, uri string, v interface{}) (*circbuf.Buffer,
 		if err := json.NewEncoder(&b).Encode(v); err != nil {
 			return nil, 0, err
 		}
-		req.Body = ioutil.NopCloser(&b)
+		req.Body = io.NopCloser(&b)
 		req.Header.Set("Content-Type", "application/json")
 	}
 

--- a/agent/checks/grpc_test.go
+++ b/agent/checks/grpc_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"os"
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/hashicorp/go-hclog"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	hv1 "google.golang.org/grpc/health/grpc_health_v1"
@@ -110,7 +108,7 @@ func TestGRPC_Proxied(t *testing.T) {
 	notif := mock.NewNotify()
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   uniqueID(),
-		Output: ioutil.Discard,
+		Output: io.Discard,
 	})
 
 	statusHandler := NewStatusHandler(notif, logger, 0, 0, 0)
@@ -144,7 +142,7 @@ func TestGRPC_NotProxied(t *testing.T) {
 	notif := mock.NewNotify()
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   uniqueID(),
-		Output: ioutil.Discard,
+		Output: io.Discard,
 	})
 
 	statusHandler := NewStatusHandler(notif, logger, 0, 0, 0)

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -19,8 +18,6 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics/prometheus"
-	"github.com/hashicorp/go-bexpr"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-sockaddr/template"
 	"github.com/hashicorp/memberlist"
@@ -275,7 +272,7 @@ func (b *builder) sourcesFromPath(path string, format string) ([]Source, error) 
 
 // newSourceFromFile creates a Source from the contents of the file at path.
 func newSourceFromFile(path string, format string) (Source, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("config: failed to read %s: %s", path, err)
 	}

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -104,7 +103,7 @@ func TestNewBuilder_PopulatesSourcesFromConfigFiles_WithConfigFormat(t *testing.
 // TODO: this would be much nicer with gotest.tools/fs
 func setupConfigFiles(t *testing.T) []string {
 	t.Helper()
-	path, err := ioutil.TempDir("", t.Name())
+	path, err := os.MkdirTemp("", t.Name())
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(path) })
 
@@ -113,13 +112,13 @@ func setupConfigFiles(t *testing.T) []string {
 	require.NoError(t, err)
 
 	for _, dir := range []string{path, subpath} {
-		err = ioutil.WriteFile(filepath.Join(dir, "a.hcl"), []byte("content a"), 0644)
+		err = os.WriteFile(filepath.Join(dir, "a.hcl"), []byte("content a"), 0644)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(dir, "b.json"), []byte("content b"), 0644)
+		err = os.WriteFile(filepath.Join(dir, "b.json"), []byte("content b"), 0644)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(dir, "c.yaml"), []byte("content c"), 0644)
+		err = os.WriteFile(filepath.Join(dir, "c.yaml"), []byte("content c"), 0644)
 		require.NoError(t, err)
 	}
 	return []string{

--- a/agent/config/golden_test.go
+++ b/agent/config/golden_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,11 +25,11 @@ func golden(t *testing.T, actual, filename string) string {
 		if dir := filepath.Dir(path); dir != "." {
 			require.NoError(t, os.MkdirAll(dir, 0755))
 		}
-		err := ioutil.WriteFile(path, []byte(actual), 0644)
+		err := os.WriteFile(path, []byte(actual), 0644)
 		require.NoError(t, err)
 	}
 
-	expected, err := ioutil.ReadFile(path)
+	expected, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return string(expected)
 }

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -4509,7 +4508,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 	})
 
-	///////////////////////////////////
+	// /////////////////////////////////
 	// Defaults sanity checks
 
 	run(t, testCase{
@@ -4532,7 +4531,7 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 	})
 
-	///////////////////////////////////
+	// /////////////////////////////////
 	// Auto Config related tests
 	run(t, testCase{
 		desc: "auto config and auto encrypt error",
@@ -6987,7 +6986,7 @@ func writeFile(path string, data []byte) {
 	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		panic(err)
 	}
-	if err := ioutil.WriteFile(path, data, 0640); err != nil {
+	if err := os.WriteFile(path, data, 0640); err != nil {
 		panic(err)
 	}
 }

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -6,14 +6,13 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
 
@@ -502,7 +501,7 @@ func (v *VaultProvider) getCA(namespace, path string) (string, error) {
 		return "", err
 	}
 
-	bytes, err := ioutil.ReadAll(resp.Body)
+	bytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -531,7 +530,7 @@ func (v *VaultProvider) getCAChain(namespace, path string) (string, error) {
 		return "", err
 	}
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -4,12 +4,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	vaultapi "github.com/hashicorp/vault/api"
 	vaultconst "github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/stretchr/testify/require"
@@ -314,7 +313,7 @@ func TestVaultCAProvider_Bootstrap(t *testing.T) {
 		req := client.NewRequest("GET", "/v1/"+tc.backendPath+"ca/pem")
 		resp, err := client.RawRequest(req)
 		require.NoError(t, err)
-		bytes, err := ioutil.ReadAll(resp.Body)
+		bytes, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, cert, string(bytes)+"\n")
 

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -3,19 +3,16 @@ package ca
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/go-hclog"
-	vaultapi "github.com/hashicorp/vault/api"
-	"github.com/mitchellh/go-testing-interface"
-
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	vaultapi "github.com/hashicorp/vault/api"
 )
 
 // KeyTestCases is a list of the important CA key types that we should test
@@ -77,7 +74,7 @@ func CASigningKeyTypeCases() []CASigningKeyTypes {
 // TestConsulProvider creates a new ConsulProvider, taking care to stub out it's
 // Logger so that logging calls don't panic. If logging output is important
 func TestConsulProvider(t testing.T, d ConsulProviderStateDelegate) *ConsulProvider {
-	logger := hclog.New(&hclog.LoggerOptions{Output: ioutil.Discard})
+	logger := hclog.New(&hclog.LoggerOptions{Output: io.Discard})
 	provider := &ConsulProvider{Delegate: d, logger: logger}
 	return provider
 }
@@ -155,8 +152,8 @@ func runTestVault(t testing.T) (*TestVaultServer, error) {
 	}
 
 	cmd := exec.Command(vaultBinaryName, args...)
-	cmd.Stdout = ioutil.Discard
-	cmd.Stderr = ioutil.Discard
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}

--- a/agent/connect/testing_ca_test.go
+++ b/agent/connect/testing_ca_test.go
@@ -2,7 +2,6 @@ package connect
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,13 +33,13 @@ func testCAAndLeaf(t *testing.T, keyType string, keyBits int) {
 	leaf, _ := TestLeaf(t, "web", ca)
 
 	// Create a temporary directory for storing the certs
-	td, err := ioutil.TempDir("", "consul")
+	td, err := os.MkdirTemp("", "consul")
 	require.NoError(t, err)
 	defer os.RemoveAll(td)
 
 	// Write the cert
-	require.NoError(t, ioutil.WriteFile(filepath.Join(td, "ca.pem"), []byte(ca.RootCert), 0644))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(td, "leaf.pem"), []byte(leaf[:]), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(td, "ca.pem"), []byte(ca.RootCert), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(td, "leaf.pem"), []byte(leaf[:]), 0644))
 
 	// Use OpenSSL to verify so we have an external, known-working process
 	// that can verify this outside of our own implementations.
@@ -66,7 +65,7 @@ func testCAAndLeaf_xc(t *testing.T, keyType string, keyBits int) {
 	leaf2, _ := TestLeaf(t, "web", ca2)
 
 	// Create a temporary directory for storing the certs
-	td, err := ioutil.TempDir("", "consul")
+	td, err := os.MkdirTemp("", "consul")
 	assert.Nil(t, err)
 	defer os.RemoveAll(td)
 
@@ -74,9 +73,9 @@ func testCAAndLeaf_xc(t *testing.T, keyType string, keyBits int) {
 	xcbundle := []byte(ca1.RootCert)
 	xcbundle = append(xcbundle, '\n')
 	xcbundle = append(xcbundle, []byte(ca2.SigningCert)...)
-	assert.Nil(t, ioutil.WriteFile(filepath.Join(td, "ca.pem"), xcbundle, 0644))
-	assert.Nil(t, ioutil.WriteFile(filepath.Join(td, "leaf1.pem"), []byte(leaf1), 0644))
-	assert.Nil(t, ioutil.WriteFile(filepath.Join(td, "leaf2.pem"), []byte(leaf2), 0644))
+	assert.Nil(t, os.WriteFile(filepath.Join(td, "ca.pem"), xcbundle, 0644))
+	assert.Nil(t, os.WriteFile(filepath.Join(td, "leaf1.pem"), []byte(leaf1), 0644))
+	assert.Nil(t, os.WriteFile(filepath.Join(td, "leaf2.pem"), []byte(leaf2), 0644))
 
 	// OpenSSL verify the cross-signed leaf (leaf2)
 	{

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -287,7 +287,7 @@ func TestConnectCARoots_PEMEncoding(t *testing.T) {
 	resp := recorder.Result()
 	require.Equal(t, resp.Header.Get("Content-Type"), "application/pem-certificate-chain")
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
 	// expecting the root cert from dc1 and an intermediate in dc2

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -4,17 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/prometheus"
-	"github.com/hashicorp/go-bexpr"
-	"github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/acl/resolver"
@@ -125,7 +121,7 @@ func (a *ACL) fileBootstrapResetIndex() uint64 {
 	path := filepath.Join(a.srv.config.DataDir, aclBootstrapReset)
 
 	// Read the file
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			a.logger.Error("bootstrap: failed to read path",

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -2,14 +2,13 @@ package consul
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/square/go-jose.v2/jwt"
 
@@ -60,7 +59,7 @@ func TestACLEndpoint_BootstrapTokens(t *testing.T) {
 	require.NoError(t, err)
 
 	resetPath := filepath.Join(dir, "acl-bootstrap-reset")
-	require.NoError(t, ioutil.WriteFile(resetPath, []byte(fmt.Sprintf("%d", resetIdx)), 0600))
+	require.NoError(t, os.WriteFile(resetPath, []byte(fmt.Sprintf("%d", resetIdx)), 0600))
 
 	oldID := out.AccessorID
 	// Finally, make sure that another attempt is rejected.
@@ -2943,7 +2942,7 @@ func TestACLEndpoint_AuthMethodSet(t *testing.T) {
 
 	t.Parallel()
 
-	tempDir, err := ioutil.TempDir("", "consul")
+	tempDir, err := os.MkdirTemp("", "consul")
 	require.NoError(t, err)
 	t.Cleanup(func() { os.RemoveAll(tempDir) })
 	_, srv, codec := testACLServerWithConfig(t, nil, false)

--- a/agent/consul/authmethod/kubeauth/testing.go
+++ b/agent/consul/authmethod/kubeauth/testing.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/pem"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +43,7 @@ type TestAPIServer struct {
 func StartTestAPIServer(t testing.T) *TestAPIServer {
 	s := &TestAPIServer{}
 	s.srv = httptest.NewUnstartedServer(s)
-	s.srv.Config.ErrorLog = log.New(ioutil.Discard, "", 0)
+	s.srv.Config.ErrorLog = log.New(io.Discard, "", 0)
 	s.srv.StartTLS()
 
 	bs := s.srv.TLS.Certificates[0].Certificate[0]
@@ -163,7 +162,7 @@ func (s *TestAPIServer) handleTokenReview(w http.ResponseWriter, req *http.Reque
 	}
 	defer req.Body.Close()
 
-	b, err := ioutil.ReadAll(req.Body)
+	b, err := io.ReadAll(req.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/agent/consul/auto_config_endpoint_test.go
+++ b/agent/consul/auto_config_endpoint_test.go
@@ -4,9 +4,9 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -157,15 +157,15 @@ func TestAutoConfigInitialConfiguration(t *testing.T) {
 		c.AutoConfigAuthzAllowReuse = true
 
 		cafile := path.Join(c.DataDir, "cacert.pem")
-		err := ioutil.WriteFile(cafile, []byte(cacert), 0600)
+		err := os.WriteFile(cafile, []byte(cacert), 0600)
 		require.NoError(t, err)
 
 		certfile := path.Join(c.DataDir, "cert.pem")
-		err = ioutil.WriteFile(certfile, []byte(cert), 0600)
+		err = os.WriteFile(certfile, []byte(cert), 0600)
 		require.NoError(t, err)
 
 		keyfile := path.Join(c.DataDir, "key.pem")
-		err = ioutil.WriteFile(keyfile, []byte(key), 0600)
+		err = os.WriteFile(keyfile, []byte(key), 0600)
 		require.NoError(t, err)
 
 		c.TLSConfig.InternalRPC.CAFile = cafile
@@ -398,7 +398,7 @@ func TestAutoConfig_updateTLSSettingsInConfig(t *testing.T) {
 
 	dir := testutil.TempDir(t, "auto-config-tls-settings")
 	cafile := path.Join(dir, "cacert.pem")
-	err = ioutil.WriteFile(cafile, []byte(cacert), 0600)
+	err = os.WriteFile(cafile, []byte(cacert), 0600)
 	require.NoError(t, err)
 
 	type testCase struct {
@@ -604,7 +604,7 @@ func TestAutoConfig_updateTLSCertificatesInConfig(t *testing.T) {
 	// will error if it cannot load the CA certificate from disk
 	dir := testutil.TempDir(t, "auto-config-tls-certificate")
 	cafile := path.Join(dir, "cacert.pem")
-	err = ioutil.WriteFile(cafile, []byte(cacert), 0600)
+	err = os.WriteFile(cafile, []byte(cacert), 0600)
 	require.NoError(t, err)
 
 	// translate the roots response to protobuf to be embedded

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,7 +12,7 @@ import (
 	"time"
 
 	msgpackrpc "github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
-	uuid "github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 
@@ -1371,7 +1370,7 @@ func TestNewCARoot(t *testing.T) {
 func readTestData(t *testing.T, name string) string {
 	t.Helper()
 	path := filepath.Join("testdata", name)
-	bs, err := ioutil.ReadFile(path)
+	bs, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("failed reading fixture file %s: %s", name, err)
 	}

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -19,8 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1386,13 +1383,13 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := testutil.TempDir(t, "certs")
-	err = ioutil.WriteFile(filepath.Join(dir, "ca.pem"), []byte(caPEM), 0600)
+	err = os.WriteFile(filepath.Join(dir, "ca.pem"), []byte(caPEM), 0600)
 	require.NoError(t, err)
 
 	intermediatePEM, intermediatePK, err := tlsutil.GenerateCert(tlsutil.CertOpts{IsCA: true, CA: caPEM, Signer: caSigner, Days: 5})
 	require.NoError(t, err)
 
-	err = ioutil.WriteFile(filepath.Join(dir, "intermediate.pem"), []byte(intermediatePEM), 0600)
+	err = os.WriteFile(filepath.Join(dir, "intermediate.pem"), []byte(intermediatePEM), 0600)
 	require.NoError(t, err)
 
 	newCert := func(t *testing.T, caPEM, pk, node, name string) {
@@ -1411,9 +1408,9 @@ func TestRPC_AuthorizeRaftRPC(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(dir, node+"-"+name+".pem"), []byte(pem), 0600)
+		err = os.WriteFile(filepath.Join(dir, node+"-"+name+".pem"), []byte(pem), 0600)
 		require.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, node+"-"+name+".key"), []byte(key), 0600)
+		err = os.WriteFile(filepath.Join(dir, node+"-"+name+".key"), []byte(key), 0600)
 		require.NoError(t, err)
 	}
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -16,11 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/armon/go-metrics"
 	connlimit "github.com/hashicorp/go-connlimit"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/raft"
 	autopilot "github.com/hashicorp/raft-autopilot"
 	raftboltdb "github.com/hashicorp/raft-boltdb/v2"
@@ -906,7 +901,7 @@ func (s *Server) setupRaft() error {
 		peersFile := filepath.Join(path, "peers.json")
 		peersInfoFile := filepath.Join(path, "peers.info")
 		if _, err := os.Stat(peersInfoFile); os.IsNotExist(err) {
-			if err := ioutil.WriteFile(peersInfoFile, []byte(peersInfoContent), 0755); err != nil {
+			if err := os.WriteFile(peersInfoFile, []byte(peersInfoContent), 0755); err != nil {
 				return fmt.Errorf("failed to write peers.info file: %v", err)
 			}
 

--- a/agent/consul/snapshot_endpoint.go
+++ b/agent/consul/snapshot_endpoint.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"time"
 
@@ -138,7 +137,7 @@ func (s *Server) dispatchSnapshotRequest(args *structs.SnapshotRequest, in io.Re
 
 		// Give the caller back an empty reader since there's nothing to
 		// stream back.
-		return ioutil.NopCloser(bytes.NewReader([]byte(""))), nil
+		return io.NopCloser(bytes.NewReader([]byte(""))), nil
 
 	default:
 		return nil, fmt.Errorf("unrecognized snapshot op %q", args.Op)

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +20,6 @@ import (
 
 	"github.com/NYTimes/gziphandler"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
@@ -92,7 +90,7 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if body, err := ioutil.ReadAll(resp.Body); err != nil || len(body) == 0 {
+	if body, err := io.ReadAll(resp.Body); err != nil || len(body) == 0 {
 		t.Fatalf("bad: %s %v", body, err)
 	}
 }
@@ -111,7 +109,7 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 	socket := filepath.Join(tempDir, "test.sock")
 
 	// Create a regular file at the socket path
-	if err := ioutil.WriteFile(socket, []byte("hello world"), 0644); err != nil {
+	if err := os.WriteFile(socket, []byte("hello world"), 0644); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	fi, err := os.Stat(socket)
@@ -210,7 +208,7 @@ func TestSetupHTTPServer_HTTP2(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -738,7 +736,7 @@ func testPrettyPrint(pretty string, t *testing.T) {
 
 	expected, _ := json.MarshalIndent(r, "", "    ")
 	expected = append(expected, "\n"...)
-	actual, err := ioutil.ReadAll(resp.Body)
+	actual, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/keyring.go
+++ b/agent/keyring.go
@@ -5,14 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/serf"
 )
@@ -186,7 +184,7 @@ func loadKeyringFile(c *serf.Config) error {
 		return err
 	}
 
-	keyringData, err := ioutil.ReadFile(c.KeyringFile)
+	keyringData, err := os.ReadFile(c.KeyringFile)
 	if err != nil {
 		return err
 	}

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -267,7 +267,7 @@ func TestAgent_InitKeyring(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -281,7 +281,7 @@ func TestAgent_InitKeyring(t *testing.T) {
 	}
 
 	// Content should still be the same
-	content, err = ioutil.ReadFile(file)
+	content, err = os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/metrics_test.go
+++ b/agent/metrics_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -313,7 +313,7 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 	require.NoError(t, err)
 
 	caPath := filepath.Join(dir, "ca.pem")
-	err = ioutil.WriteFile(caPath, []byte(caPEM), 0600)
+	err = os.WriteFile(caPath, []byte(caPEM), 0600)
 	require.NoError(t, err)
 
 	signer, err := tlsutil.ParseSigner(caPK)
@@ -329,11 +329,11 @@ func TestHTTPHandlers_AgentMetrics_TLSCertExpiry_Prometheus(t *testing.T) {
 	require.NoError(t, err)
 
 	certPath := filepath.Join(dir, "cert.pem")
-	err = ioutil.WriteFile(certPath, []byte(pem), 0600)
+	err = os.WriteFile(certPath, []byte(pem), 0600)
 	require.NoError(t, err)
 
 	keyPath := filepath.Join(dir, "cert.key")
-	err = ioutil.WriteFile(keyPath, []byte(key), 0600)
+	err = os.WriteFile(keyPath, []byte(key), 0600)
 	require.NoError(t, err)
 
 	hcl := fmt.Sprintf(`

--- a/agent/nodeid.go
+++ b/agent/nodeid.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"crypto/sha512"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,7 +10,6 @@ import (
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/shirou/gopsutil/v3/host"
 )
@@ -36,7 +34,7 @@ func newNodeIDFromConfig(config *config.RuntimeConfig, logger hclog.Logger) (typ
 	// Load saved state, if any. Since a user could edit this, we also validate it.
 	filename := filepath.Join(config.DataDir, "node-id")
 	if _, err := os.Stat(filename); err == nil {
-		rawID, err := ioutil.ReadFile(filename)
+		rawID, err := os.ReadFile(filename)
 		if err != nil {
 			return "", err
 		}
@@ -56,7 +54,7 @@ func newNodeIDFromConfig(config *config.RuntimeConfig, logger hclog.Logger) (typ
 	if err := lib.EnsurePath(filename, false); err != nil {
 		return "", err
 	}
-	if err := ioutil.WriteFile(filename, []byte(id), 0600); err != nil {
+	if err := os.WriteFile(filename, []byte(id), 0600); err != nil {
 		return "", fmt.Errorf("failed to write NodeID to disk: %w", err)
 	}
 	return types.NodeID(id), nil

--- a/agent/nodeid_test.go
+++ b/agent/nodeid_test.go
@@ -2,7 +2,7 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +58,7 @@ func TestNewNodeIDFromConfig(t *testing.T) {
 	t.Run("invalid NodeID in file", func(t *testing.T) {
 		cfg.NodeID = ""
 		filename := filepath.Join(cfg.DataDir, "node-id")
-		err := ioutil.WriteFile(filename, []byte("adf4238a!882b!9ddc!4a9d!5b6758e4159e"), 0600)
+		err := os.WriteFile(filename, []byte("adf4238a!882b!9ddc!4a9d!5b6758e4159e"), 0600)
 		require.NoError(t, err)
 
 		_, err = newNodeIDFromConfig(cfg, logger)
@@ -70,7 +69,7 @@ func TestNewNodeIDFromConfig(t *testing.T) {
 	t.Run("valid NodeID in file", func(t *testing.T) {
 		cfg.NodeID = ""
 		filename := filepath.Join(cfg.DataDir, "node-id")
-		err := ioutil.WriteFile(filename, []byte("ADF4238a-882b-9ddc-4a9d-5b6758e4159e"), 0600)
+		err := os.WriteFile(filename, []byte("ADF4238a-882b-9ddc-4a9d-5b6758e4159e"), 0600)
 		require.NoError(t, err)
 
 		nodeID, err := newNodeIDFromConfig(cfg, logger)

--- a/agent/pool/peek_test.go
+++ b/agent/pool/peek_test.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -55,7 +55,7 @@ func TestPeekForTLS_not_TLS(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, isTLS)
 
-			all, err := ioutil.ReadAll(wrapped)
+			all, err := io.ReadAll(wrapped)
 			require.NoError(t, err)
 			require.Equal(t, tc.connData, all)
 		})
@@ -160,7 +160,7 @@ func testPeekForTLS_withTLS(t *testing.T, connData []byte) {
 			return
 		}
 
-		all, err := ioutil.ReadAll(tlsConn)
+		all, err := io.ReadAll(tlsConn)
 		if err != nil {
 			serverErrCh <- err
 			return

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -3,7 +3,6 @@ package proxycfg
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -11,8 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
-	"github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent/cache"
@@ -923,7 +920,7 @@ func golden(t testing.T, name string) string {
 	t.Helper()
 
 	golden := filepath.Join(projectRoot(), "../", "/xds/testdata", name+".golden")
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	require.NoError(t, err)
 
 	return string(expected)

--- a/agent/remote_exec.go
+++ b/agent/remote_exec.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	osexec "os/exec"
 	"path"
@@ -145,7 +144,7 @@ func (a *Agent) handleRemoteExec(msg *UserEvent) {
 	// Check if this is a script, we may need to spill to disk
 	var script string
 	if len(spec.Script) != 0 {
-		tmpFile, err := ioutil.TempFile("", "rexec")
+		tmpFile, err := os.CreateTemp("", "rexec")
 		if err != nil {
 			a.logger.Debug("failed to make tmp file", "error", err)
 			exitCode = 255

--- a/agent/routine-leak-checker/leak_test.go
+++ b/agent/routine-leak-checker/leak_test.go
@@ -2,7 +2,7 @@ package leakcheck
 
 import (
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -51,9 +51,9 @@ func setupPrimaryServer(t *testing.T) *agent.TestAgent {
 	keyPath := filepath.Join(d, "key.pem")
 	caPath := filepath.Join(d, "cacert.pem")
 
-	require.NoError(t, ioutil.WriteFile(certPath, []byte(certPEM), 0600))
-	require.NoError(t, ioutil.WriteFile(keyPath, []byte(keyPEM), 0600))
-	require.NoError(t, ioutil.WriteFile(caPath, []byte(caPEM), 0600))
+	require.NoError(t, os.WriteFile(certPath, []byte(certPEM), 0600))
+	require.NoError(t, os.WriteFile(keyPath, []byte(keyPEM), 0600))
+	require.NoError(t, os.WriteFile(caPath, []byte(caPEM), 0600))
 
 	aclParams := agent.DefaultTestACLConfigParams()
 	aclParams.PrimaryDatacenter = "primary"

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -5,13 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -57,7 +56,7 @@ func TestPeeringService_GenerateToken(t *testing.T) {
 	signer, _, _ := tlsutil.GeneratePrivateKey()
 	ca, _, _ := tlsutil.GenerateCA(tlsutil.CAOpts{Signer: signer})
 	cafile := path.Join(dir, "cacert.pem")
-	require.NoError(t, ioutil.WriteFile(cafile, []byte(ca), 0600))
+	require.NoError(t, os.WriteFile(cafile, []byte(ca), 0600))
 
 	// TODO(peering): see note on newTestServer, refactor to not use this
 	s := newTestServer(t, func(c *consul.Config) {

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -802,7 +801,7 @@ func expectJSONFile(t *testing.T, file string, expect interface{}, fixupContentB
 	expected, err := json.Marshal(expect)
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	if fixupContentBeforeCompareFn != nil {

--- a/agent/token/persistence.go
+++ b/agent/token/persistence.go
@@ -3,7 +3,6 @@ package token
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -142,7 +141,7 @@ func readPersistedFromFile(filename string) (persistedTokens, error) {
 		LegacyAgentMaster string `json:"agent_master"`
 	}
 
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	switch {
 	case os.IsNotExist(err):
 		// non-existence is not an error we care about

--- a/agent/token/persistence_test.go
+++ b/agent/token/persistence_test.go
@@ -1,12 +1,11 @@
 package token
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,7 +62,7 @@ func TestStore_Load(t *testing.T) {
 			"replication" : "lima"
 		}`
 
-		require.NoError(t, ioutil.WriteFile(tokenFile, []byte(tokens), 0600))
+		require.NoError(t, os.WriteFile(tokenFile, []byte(tokens), 0600))
 		require.NoError(t, store.Load(cfg, logger))
 
 		// no updates since token persistence is not enabled
@@ -92,7 +91,7 @@ func TestStore_Load(t *testing.T) {
 		}
 
 		tokens := `{"agent_master": "juliett"}`
-		require.NoError(t, ioutil.WriteFile(tokenFile, []byte(tokens), 0600))
+		require.NoError(t, os.WriteFile(tokenFile, []byte(tokens), 0600))
 		require.NoError(t, store.Load(cfg, logger))
 
 		require.Equal(t, "juliett", store.AgentRecoveryToken())
@@ -115,7 +114,7 @@ func TestStore_Load(t *testing.T) {
 			ACLReplicationToken:   "tango",
 		}
 
-		require.NoError(t, ioutil.WriteFile(tokenFile, []byte(tokens), 0600))
+		require.NoError(t, os.WriteFile(tokenFile, []byte(tokens), 0600))
 		require.NoError(t, store.Load(cfg, logger))
 
 		require.Equal(t, "mike", store.AgentToken())
@@ -139,7 +138,7 @@ func TestStore_Load(t *testing.T) {
 			ACLReplicationToken:   "zulu",
 		}
 
-		require.NoError(t, ioutil.WriteFile(tokenFile, []byte(tokens), 0600))
+		require.NoError(t, os.WriteFile(tokenFile, []byte(tokens), 0600))
 		require.NoError(t, store.Load(cfg, logger))
 
 		require.Equal(t, "uniform", store.AgentToken())
@@ -158,7 +157,7 @@ func TestStore_Load(t *testing.T) {
 			ACLReplicationToken:   "four",
 		}
 
-		require.NoError(t, ioutil.WriteFile(tokenFile, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, 0600))
+		require.NoError(t, os.WriteFile(tokenFile, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}, 0600))
 		err := store.Load(cfg, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to decode tokens file")
@@ -179,7 +178,7 @@ func TestStore_Load(t *testing.T) {
 			ACLReplicationToken:   "foxtrot",
 		}
 
-		require.NoError(t, ioutil.WriteFile(tokenFile, []byte("[1,2,3]"), 0600))
+		require.NoError(t, os.WriteFile(tokenFile, []byte("[1,2,3]"), 0600))
 		err := store.Load(cfg, logger)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to decode tokens file")

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -48,7 +48,7 @@ func TestUIIndex(t *testing.T) {
 
 	// Create file
 	path := filepath.Join(a.Config.UIConfig.Dir, "my-file")
-	if err := ioutil.WriteFile(path, []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -281,7 +281,7 @@ func TestUIServices(t *testing.T) {
 				},
 			},
 		},
-		//register api service on node foo
+		// register api service on node foo
 		{
 			Datacenter:     "dc1",
 			Node:           "foo",

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -3,7 +3,6 @@ package uiserver
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/html"
 
@@ -345,7 +343,7 @@ func TestCustomDir(t *testing.T) {
 	defer os.RemoveAll(uiDir)
 
 	path := filepath.Join(uiDir, "test-file")
-	require.NoError(t, ioutil.WriteFile(path, []byte("test"), 0644))
+	require.NoError(t, os.WriteFile(path, []byte("test"), 0644))
 
 	cfg := basicUIEnabledConfig()
 	cfg.UIConfig.Dir = uiDir
@@ -392,7 +390,7 @@ func TestCompiledJS(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, rec.Code)
 			require.Equal(t, rec.Result().Header["Content-Type"][0], "application/javascript")
-			wantCompiled, err := ioutil.ReadFile("testdata/compiled-metrics-providers-golden.js")
+			wantCompiled, err := os.ReadFile("testdata/compiled-metrics-providers-golden.js")
 			require.NoError(t, err)
 			require.Equal(t, rec.Body.String(), string(wantCompiled))
 		})

--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -1,7 +1,7 @@
 package agent
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/consul/api/watch"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,14 +19,14 @@ func TestMakeWatchHandler(t *testing.T) {
 	script := "bash -c 'echo $CONSUL_INDEX >> handler_index_out && cat >> handler_out'"
 	handler := makeWatchHandler(testutil.Logger(t), script)
 	handler(100, []string{"foo", "bar", "baz"})
-	raw, err := ioutil.ReadFile("handler_out")
+	raw, err := os.ReadFile("handler_out")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if string(raw) != "[\"foo\",\"bar\",\"baz\"]\n" {
 		t.Fatalf("bad: %s", raw)
 	}
-	raw, err = ioutil.ReadFile("handler_index_out")
+	raw, err = os.ReadFile("handler_index_out")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -47,7 +46,7 @@ func TestMakeHTTPWatchHandler(t *testing.T) {
 		if customHeader != "abc" {
 			t.Fatalf("bad: %s", idx)
 		}
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/agent/xds/golden_test.go
+++ b/agent/xds/golden_test.go
@@ -3,14 +3,12 @@ package xds
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
-	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,7 +86,7 @@ func golden(t *testing.T, name, subname, latestSubname, got string) string {
 	latestExpected := ""
 	if latestSubname != "" && subname != latestSubname {
 		latestGolden := filepath.Join("testdata", fmt.Sprintf("%s.%s.golden", name, latestSubname))
-		raw, err := ioutil.ReadFile(latestGolden)
+		raw, err := os.ReadFile(latestGolden)
 		require.NoError(t, err, "%q %q %q", name, subname, latestSubname)
 		latestExpected = string(raw)
 	}
@@ -110,11 +108,11 @@ func golden(t *testing.T, name, subname, latestSubname, got string) string {
 			return got
 		}
 
-		require.NoError(t, ioutil.WriteFile(golden, []byte(got), 0644))
+		require.NoError(t, os.WriteFile(golden, []byte(got), 0644))
 		return got
 	}
 
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	if latestExpected != "" && os.IsNotExist(err) {
 		// In readonly mode if a specific golden file isn't found, we fallback
 		// on the latest one.
@@ -127,7 +125,7 @@ func golden(t *testing.T, name, subname, latestSubname, got string) string {
 func loadTestResource(t *testing.T, name string) string {
 	t.Helper()
 
-	expected, err := ioutil.ReadFile(filepath.Join("testdata", name+".golden"))
+	expected, err := os.ReadFile(filepath.Join("testdata", name+".golden"))
 	require.NoError(t, err)
 	return string(expected)
 }

--- a/api/acl.go
+++ b/api/acl.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"time"
 
@@ -1047,7 +1046,7 @@ func (a *ACL) RulesTranslate(rules io.Reader) (string, error) {
 	parseQueryMeta(resp, qm)
 	qm.RequestTime = rtt
 
-	ruleBytes, err := ioutil.ReadAll(resp.Body)
+	ruleBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("Failed to read translated rule body: %v", err)
 	}
@@ -1074,7 +1073,7 @@ func (a *ACL) RulesTranslateToken(tokenID string) (string, error) {
 	parseQueryMeta(resp, qm)
 	qm.RequestTime = rtt
 
-	ruleBytes, err := ioutil.ReadAll(resp.Body)
+	ruleBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("Failed to read translated rule body: %v", err)
 	}

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -104,7 +103,7 @@ func TestAPI_AgentReload(t *testing.T) {
 
 	// Update the config file with a service definition
 	config := `{"service":{"name":"redis", "port":1234, "Meta": {"some": "meta"}}}`
-	err = ioutil.WriteFile(configFile.Name(), []byte(config), 0644)
+	err = os.WriteFile(configFile.Name(), []byte(config), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -17,8 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-rootcerts"
 )
 
@@ -741,7 +738,7 @@ func NewClient(config *Config) (*Client, error) {
 	// This is because when TokenFile is set it is read into the Token field.
 	// We want any derived clients to have to re-read the token file.
 	if config.TokenFile != "" {
-		data, err := ioutil.ReadFile(config.TokenFile)
+		data, err := os.ReadFile(config.TokenFile)
 		if err != nil {
 			return nil, fmt.Errorf("Error loading token file: %s", err)
 		}
@@ -1059,7 +1056,7 @@ func (c *Client) write(endpoint string, in, out interface{}, q *WriteOptions) (*
 		if err := decodeBody(resp, &out); err != nil {
 			return nil, err
 		}
-	} else if _, err := ioutil.ReadAll(resp.Body); err != nil {
+	} else if _, err := io.ReadAll(resp.Body); err != nil {
 		return nil, err
 	}
 	return wm, nil
@@ -1177,7 +1174,7 @@ func requireHttpCodes(resp *http.Response, httpCodes ...int) error {
 // is necessary to ensure that the http.Client's underlying RoundTripper is able
 // to re-use the TCP connection. See godoc on net/http.Client.Do.
 func closeResponseBody(resp *http.Response) error {
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.Body.Close()
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -614,15 +613,15 @@ func TestAPI_SetupTLSConfig(t *testing.T) {
 	assertDeepEqual(t, expectedCaPoolByDir, cc.RootCAs, cmpCertPool)
 
 	// Load certs in-memory
-	certPEM, err := ioutil.ReadFile("../test/hostname/Alice.crt")
+	certPEM, err := os.ReadFile("../test/hostname/Alice.crt")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	keyPEM, err := ioutil.ReadFile("../test/hostname/Alice.key")
+	keyPEM, err := os.ReadFile("../test/hostname/Alice.key")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	caPEM, err := ioutil.ReadFile("../test/hostname/CertAuth.crt")
+	caPEM, err := os.ReadFile("../test/hostname/CertAuth.crt")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1183,7 +1182,7 @@ func getExpectedCaPoolByDir(t *testing.T) *x509.CertPool {
 	for _, entry := range entries {
 		filename := path.Join("../test/ca_path", entry.Name())
 
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		require.NoError(t, err)
 
 		if !pool.AppendCertsFromPEM(data) {

--- a/api/debug.go
+++ b/api/debug.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 )
 
@@ -36,7 +35,7 @@ func (d *Debug) Heap() ([]byte, error) {
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding body: %s", err)
 	}
@@ -62,7 +61,7 @@ func (d *Debug) Profile(seconds int) ([]byte, error) {
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding body: %s", err)
 	}
@@ -107,7 +106,7 @@ func (d *Debug) Trace(seconds int) ([]byte, error) {
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding body: %s", err)
 	}
@@ -130,7 +129,7 @@ func (d *Debug) Goroutine() ([]byte, error) {
 
 	// We return a raw response because we're just passing through a response
 	// from the pprof handlers
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding body: %s", err)
 	}

--- a/api/mock_api_test.go
+++ b/api/mock_api_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -39,7 +38,7 @@ func (m *mockAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var body interface{}
 
 	if r.Body != nil {
-		bodyBytes, err := ioutil.ReadAll(r.Body)
+		bodyBytes, err := io.ReadAll(r.Body)
 		if err == nil && len(bodyBytes) > 0 {
 			body = bodyBytes
 

--- a/api/operator_license.go
+++ b/api/operator_license.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 )
@@ -71,7 +71,7 @@ func (op *Operator) LicenseGetSigned(q *QueryOptions) (string, error) {
 		return "", err
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/bench/results-0.7.1.svg
+++ b/bench/results-0.7.1.svg
@@ -1245,7 +1245,7 @@
 <text text-anchor="" x="665.18" y="251.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
 </g>
 <g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
-<title>io/ioutil.(*nopCloser).Close (1 samples, 0.04%)</title><rect x="455.7" y="529" width="0.5" height="15.0" fill="rgb(216,32,41)" rx="2" ry="2" />
+<title>io.(*nopCloser).Close (1 samples, 0.04%)</title><rect x="455.7" y="529" width="0.5" height="15.0" fill="rgb(216,32,41)" rx="2" ry="2" />
 <text text-anchor="" x="458.73" y="539.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
 </g>
 <g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">

--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -3,7 +3,7 @@ package authmethodcreate
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -468,7 +468,7 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 	})
 
 	caFile := filepath.Join(testDir, "ca.crt")
-	require.NoError(t, ioutil.WriteFile(caFile, []byte(ca.RootCert), 0600))
+	require.NoError(t, os.WriteFile(caFile, []byte(ca.RootCert), 0600))
 
 	t.Run("create k8s with cert file", func(t *testing.T) {
 		name := getTestName(t)
@@ -540,7 +540,7 @@ func TestAuthMethodCreateCommand_config(t *testing.T) {
 		name := getTestName(t)
 		configFile := filepath.Join(testDir, "config.json")
 		jsonConfig := `{"SessionID":"foo"}`
-		require.NoError(t, ioutil.WriteFile(configFile, []byte(jsonConfig), 0644))
+		require.NoError(t, os.WriteFile(configFile, []byte(jsonConfig), 0644))
 
 		args := []string{
 			"-http-addr=" + a.HTTPAddr(),

--- a/command/acl/authmethod/update/authmethod_update_test.go
+++ b/command/acl/authmethod/update/authmethod_update_test.go
@@ -3,7 +3,7 @@ package authmethodupdate
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -455,7 +455,7 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 	})
 
 	ca2File := filepath.Join(testDir, "ca2.crt")
-	require.NoError(t, ioutil.WriteFile(ca2File, []byte(ca2.RootCert), 0600))
+	require.NoError(t, os.WriteFile(ca2File, []byte(ca2.RootCert), 0600))
 
 	t.Run("update all fields with cert file", func(t *testing.T) {
 		name := createAuthMethod(t)
@@ -750,7 +750,7 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 	})
 
 	ca2File := filepath.Join(testDir, "ca2.crt")
-	require.NoError(t, ioutil.WriteFile(ca2File, []byte(ca2.RootCert), 0600))
+	require.NoError(t, os.WriteFile(ca2File, []byte(ca2.RootCert), 0600))
 
 	t.Run("update all fields with cert file", func(t *testing.T) {
 		name := createAuthMethod(t)
@@ -849,7 +849,7 @@ func TestAuthMethodUpdateCommand_config(t *testing.T) {
 		methodName := createAuthMethod(t)
 		configFile := filepath.Join(testDir, "config.json")
 		jsonConfig := `{"SessionID":"update"}`
-		require.NoError(t, ioutil.WriteFile(configFile, []byte(jsonConfig), 0644))
+		require.NoError(t, os.WriteFile(configFile, []byte(jsonConfig), 0644))
 
 		args := []string{
 			"-http-addr=" + a.HTTPAddr(),

--- a/command/acl/policy/create/policy_create_test.go
+++ b/command/acl/policy/create/policy_create_test.go
@@ -2,7 +2,7 @@ package policycreate
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -47,7 +47,7 @@ func TestPolicyCreateCommand(t *testing.T) {
 	cmd := New(ui)
 
 	rules := []byte("service \"\" { policy = \"write\" }")
-	err := ioutil.WriteFile(testDir+"/rules.hcl", rules, 0644)
+	err := os.WriteFile(testDir+"/rules.hcl", rules, 0644)
 	require.NoError(t, err)
 
 	args := []string{
@@ -87,7 +87,7 @@ func TestPolicyCreateCommand_JSON(t *testing.T) {
 	cmd := New(ui)
 
 	rules := []byte("service \"\" { policy = \"write\" }")
-	err := ioutil.WriteFile(testDir+"/rules.hcl", rules, 0644)
+	err := os.WriteFile(testDir+"/rules.hcl", rules, 0644)
 	require.NoError(t, err)
 
 	args := []string{

--- a/command/acl/policy/update/policy_update_test.go
+++ b/command/acl/policy/update/policy_update_test.go
@@ -2,7 +2,7 @@ package policyupdate
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -47,7 +47,7 @@ func TestPolicyUpdateCommand(t *testing.T) {
 	cmd := New(ui)
 
 	rules := []byte("service \"\" { policy = \"write\" }")
-	err := ioutil.WriteFile(testDir+"/rules.hcl", rules, 0644)
+	err := os.WriteFile(testDir+"/rules.hcl", rules, 0644)
 	assert.NoError(t, err)
 
 	// Create a policy
@@ -97,7 +97,7 @@ func TestPolicyUpdateCommand_JSON(t *testing.T) {
 	cmd := New(ui)
 
 	rules := []byte("service \"\" { policy = \"write\" }")
-	err := ioutil.WriteFile(testDir+"/rules.hcl", rules, 0644)
+	err := os.WriteFile(testDir+"/rules.hcl", rules, 0644)
 	assert.NoError(t, err)
 
 	// Create a policy

--- a/command/acl/role/formatter_test.go
+++ b/command/acl/role/formatter_test.go
@@ -3,7 +3,7 @@ package role
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -22,11 +22,11 @@ func golden(t *testing.T, name, got string) string {
 
 	golden := filepath.Join("testdata", name+".golden")
 	if *update && got != "" {
-		err := ioutil.WriteFile(golden, []byte(got), 0644)
+		err := os.WriteFile(golden, []byte(got), 0644)
 		require.NoError(t, err)
 	}
 
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	require.NoError(t, err)
 
 	return string(expected)

--- a/command/acl/rules/translate_test.go
+++ b/command/acl/rules/translate_test.go
@@ -2,7 +2,7 @@ package rules
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -52,7 +52,7 @@ func TestRulesTranslateCommand(t *testing.T) {
 
 	// From a file
 	t.Run("file", func(t *testing.T) {
-		err := ioutil.WriteFile(testDir+"/rules.hcl", []byte(rules), 0644)
+		err := os.WriteFile(testDir+"/rules.hcl", []byte(rules), 0644)
 		require.NoError(t, err)
 
 		args := []string{

--- a/command/acl/token/formatter_test.go
+++ b/command/acl/token/formatter_test.go
@@ -3,7 +3,7 @@ package token
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -23,11 +23,11 @@ func golden(t *testing.T, name, got string) string {
 
 	golden := filepath.Join("testdata", name+".golden")
 	if *update && got != "" {
-		err := ioutil.WriteFile(golden, []byte(got), 0644)
+		err := os.WriteFile(golden, []byte(got), 0644)
 		require.NoError(t, err)
 	}
 
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	require.NoError(t, err)
 
 	return string(expected)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-checkpoint"
-	"github.com/hashicorp/go-hclog"
 	mcli "github.com/mitchellh/cli"
 
 	"github.com/hashicorp/consul/agent"
@@ -191,7 +190,7 @@ func (c *cmd) run(args []string) int {
 	if config.Logging.LogJSON {
 		// Hide all non-error output when JSON logging is enabled.
 		ui.Ui = &cli.BasicUI{
-			BasicUi: mcli.BasicUi{ErrorWriter: c.ui.Stderr(), Writer: ioutil.Discard},
+			BasicUi: mcli.BasicUi{ErrorWriter: c.ui.Stderr(), Writer: io.Discard},
 		}
 	}
 

--- a/command/connect/ca/set/connect_ca_set.go
+++ b/command/connect/ca/set/connect_ca_set.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"
@@ -66,7 +66,7 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	bytes, err := ioutil.ReadFile(c.configFile.String())
+	bytes, err := os.ReadFile(c.configFile.String())
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading config file: %s", err))
 		return 1

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -3,7 +3,6 @@ package envoy
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -972,7 +971,7 @@ func TestGenerateConfig(t *testing.T) {
 			if len(tc.Files) > 0 {
 				for fn, fv := range tc.Files {
 					fullname := filepath.Join(testDir, fn)
-					require.NoError(t, ioutil.WriteFile(fullname, []byte(fv), 0600))
+					require.NoError(t, os.WriteFile(fullname, []byte(fv), 0600))
 				}
 			}
 
@@ -1023,10 +1022,10 @@ func TestGenerateConfig(t *testing.T) {
 			// If we got the arg handling write, verify output
 			golden := filepath.Join("testdata", tc.Name+".golden")
 			if *update {
-				ioutil.WriteFile(golden, actual, 0644)
+				os.WriteFile(golden, actual, 0644)
 			}
 
-			expected, err := ioutil.ReadFile(golden)
+			expected, err := os.ReadFile(golden)
 			require.NoError(t, err)
 			require.Equal(t, string(expected), string(actual))
 		})

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -234,7 +233,7 @@ func TestHelperProcess(t *testing.T) {
 			os.Exit(1)
 		}
 
-		d, err := ioutil.ReadFile(data.ConfigPath)
+		d, err := os.ReadFile(data.ConfigPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not read provided --config-path file %q: %v\n", data.ConfigPath, err)
 			os.Exit(1)

--- a/command/debug/debug.go
+++ b/command/debug/debug.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -334,7 +333,7 @@ func writeJSONFile(filename string, content interface{}) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, marshaled, 0644)
+	return os.WriteFile(filename, marshaled, 0644)
 }
 
 // captureInterval blocks for the duration of the command
@@ -436,7 +435,7 @@ func (c *cmd) captureGoRoutines(outputDir string) error {
 		return fmt.Errorf("failed to collect goroutine profile: %w", err)
 	}
 
-	return ioutil.WriteFile(filepath.Join(outputDir, "goroutine.prof"), gr, 0644)
+	return os.WriteFile(filepath.Join(outputDir, "goroutine.prof"), gr, 0644)
 }
 
 func (c *cmd) captureTrace(ctx context.Context, duration int) error {
@@ -479,7 +478,7 @@ func (c *cmd) captureHeap(outputDir string) error {
 		return fmt.Errorf("failed to collect heap profile: %w", err)
 	}
 
-	return ioutil.WriteFile(filepath.Join(outputDir, "heap.prof"), heap, 0644)
+	return os.WriteFile(filepath.Join(outputDir, "heap.prof"), heap, 0644)
 }
 
 func (c *cmd) captureLogs(ctx context.Context) error {
@@ -600,7 +599,7 @@ func (c *cmd) createArchiveTemp(path string) (tempName string, err error) {
 	dir := filepath.Dir(path)
 	name := filepath.Base(path)
 
-	f, err := ioutil.TempFile(dir, name+".tmp")
+	f, err := os.CreateTemp(dir, name+".tmp")
 	if err != nil {
 		return "", fmt.Errorf("failed to create compressed temp archive: %s", err)
 	}

--- a/command/flags/http.go
+++ b/command/flags/http.go
@@ -2,7 +2,7 @@ package flags
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/consul/api"
@@ -127,7 +127,7 @@ func (f *HTTPFlags) ReadTokenFile() (string, error) {
 		return "", nil
 	}
 
-	data, err := ioutil.ReadFile(tokenFile)
+	data, err := os.ReadFile(tokenFile)
 	if err != nil {
 		return "", err
 	}

--- a/command/helpers/helpers.go
+++ b/command/helpers/helpers.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
 func loadFromFile(path string) (string, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("Failed to read file: %v", err)
 	}

--- a/command/kv/imp/kv_import.go
+++ b/command/kv/imp/kv_import.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -118,7 +117,7 @@ func (c *cmd) dataFromArgs(args []string) (string, error) {
 
 	switch data[0] {
 	case '@':
-		data, err := ioutil.ReadFile(data[1:])
+		data, err := os.ReadFile(data[1:])
 		if err != nil {
 			return "", fmt.Errorf("Failed to read file: %s", err)
 		}

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -1,7 +1,7 @@
 package lock
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -63,7 +63,7 @@ func TestLockCommand(t *testing.T) {
 	}
 
 	// Check for the file
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestLockCommand_NoShell(t *testing.T) {
 	}
 
 	// Check for the file
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestLockCommand_TryLock(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestLockCommand_TrySemaphore(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -236,7 +236,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/login/login.go
+++ b/command/login/login.go
@@ -3,7 +3,7 @@ package login
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/consul/api"
@@ -112,7 +112,7 @@ func (c *cmd) bearerTokenLogin() int {
 		c.UI.Error("Missing required '-bearer-token-file' flag")
 		return 1
 	} else {
-		data, err := ioutil.ReadFile(c.bearerTokenFile)
+		data, err := os.ReadFile(c.bearerTokenFile)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 1

--- a/command/login/login_test.go
+++ b/command/login/login_test.go
@@ -2,7 +2,6 @@ package login
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,7 +172,7 @@ func TestLoginCommand(t *testing.T) {
 	t.Run("bearer-token-file is empty", func(t *testing.T) {
 		defer os.Remove(tokenSinkFile)
 
-		require.NoError(t, ioutil.WriteFile(bearerTokenFile, []byte(""), 0600))
+		require.NoError(t, os.WriteFile(bearerTokenFile, []byte(""), 0600))
 
 		ui := cli.NewMockUi()
 		cmd := New(ui)
@@ -191,7 +190,7 @@ func TestLoginCommand(t *testing.T) {
 		require.Contains(t, ui.ErrorWriter.String(), "No bearer token found in")
 	})
 
-	require.NoError(t, ioutil.WriteFile(bearerTokenFile, []byte("demo-token"), 0600))
+	require.NoError(t, os.WriteFile(bearerTokenFile, []byte("demo-token"), 0600))
 
 	t.Run("try login with no method configured", func(t *testing.T) {
 		defer os.Remove(tokenSinkFile)
@@ -285,7 +284,7 @@ func TestLoginCommand(t *testing.T) {
 		require.Empty(t, ui.ErrorWriter.String())
 		require.Empty(t, ui.OutputWriter.String())
 
-		raw, err := ioutil.ReadFile(tokenSinkFile)
+		raw, err := os.ReadFile(tokenSinkFile)
 		require.NoError(t, err)
 
 		token := strings.TrimSpace(string(raw))
@@ -309,7 +308,7 @@ func TestLoginCommand_k8s(t *testing.T) {
 	bearerTokenFile := filepath.Join(testDir, "bearer.token")
 
 	// the "B" jwt will be the one being reviewed
-	require.NoError(t, ioutil.WriteFile(bearerTokenFile, []byte(acl.TestKubernetesJWT_B), 0600))
+	require.NoError(t, os.WriteFile(bearerTokenFile, []byte(acl.TestKubernetesJWT_B), 0600))
 
 	// spin up a fake api server
 	testSrv := kubeauth.StartTestAPIServer(t)
@@ -372,7 +371,7 @@ func TestLoginCommand_k8s(t *testing.T) {
 		require.Empty(t, ui.ErrorWriter.String())
 		require.Empty(t, ui.OutputWriter.String())
 
-		raw, err := ioutil.ReadFile(tokenSinkFile)
+		raw, err := os.ReadFile(tokenSinkFile)
 		require.NoError(t, err)
 
 		token := strings.TrimSpace(string(raw))
@@ -487,7 +486,7 @@ func TestLoginCommand_jwt(t *testing.T) {
 			// Drop a JWT on disk.
 			jwtData, err := oidcauthtest.SignJWT(privKey, cl, privateCl)
 			require.NoError(t, err)
-			require.NoError(t, ioutil.WriteFile(bearerTokenFile, []byte(jwtData), 0600))
+			require.NoError(t, os.WriteFile(bearerTokenFile, []byte(jwtData), 0600))
 
 			defer os.Remove(tokenSinkFile)
 			ui := cli.NewMockUi()
@@ -506,7 +505,7 @@ func TestLoginCommand_jwt(t *testing.T) {
 			require.Empty(t, ui.ErrorWriter.String())
 			require.Empty(t, ui.OutputWriter.String())
 
-			raw, err := ioutil.ReadFile(tokenSinkFile)
+			raw, err := os.ReadFile(tokenSinkFile)
 			require.NoError(t, err)
 
 			token := strings.TrimSpace(string(raw))
@@ -660,7 +659,7 @@ func TestLoginCommand_aws_iam(t *testing.T) {
 			code := cmd.Run(args)
 			require.Equal(t, 0, code, ui.ErrorWriter.String())
 
-			raw, err := ioutil.ReadFile(tokenSinkFile)
+			raw, err := os.ReadFile(tokenSinkFile)
 			require.NoError(t, err)
 
 			token := strings.TrimSpace(string(raw))

--- a/command/logout/logout_test.go
+++ b/command/logout/logout_test.go
@@ -226,7 +226,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 	})
 
 	// go to the trouble of creating a login token
-	// require.NoError(t, ioutil.WriteFile(bearerTokenFile, []byte(acl.TestKubernetesJWT_B), 0600))
+	// require.NoError(t, os.WriteFile(bearerTokenFile, []byte(acl.TestKubernetesJWT_B), 0600))
 
 	// spin up a fake api server
 	testSrv := kubeauth.StartTestAPIServer(t)

--- a/command/operator/autopilot/state/operator_autopilot_state_test.go
+++ b/command/operator/autopilot/state/operator_autopilot_state_test.go
@@ -3,7 +3,7 @@ package state
 import (
 	"encoding/json"
 	"flag"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -25,11 +25,11 @@ func golden(t *testing.T, name, got string) string {
 
 	golden := filepath.Join("testdata", name+".golden")
 	if *update && got != "" {
-		err := ioutil.WriteFile(golden, []byte(got), 0644)
+		err := os.WriteFile(golden, []byte(got), 0644)
 		require.NoError(t, err)
 	}
 
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	require.NoError(t, err)
 
 	return string(expected)
@@ -111,7 +111,7 @@ func TestStateCommand_Formatter(t *testing.T) {
 	for _, name := range cases {
 		t.Run(name, func(t *testing.T) {
 			statePath := filepath.Join("testdata", name, "state.json")
-			input, err := ioutil.ReadFile(statePath)
+			input, err := os.ReadFile(statePath)
 			require.NoError(t, err)
 
 			var state api.AutopilotState

--- a/command/snapshot/inspect/snapshot_inspect.go
+++ b/command/snapshot/inspect/snapshot_inspect.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"sort"
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/hashicorp/consul/snapshot"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
 	"github.com/mitchellh/cli"
 )
@@ -123,7 +121,7 @@ func (c *cmd) Run(args []string) int {
 		readFile = f
 
 		// Assume the meta is colocated and error if not.
-		metaRaw, err := ioutil.ReadFile(path.Join(path.Dir(file), "meta.json"))
+		metaRaw, err := os.ReadFile(path.Join(path.Dir(file), "meta.json"))
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error reading meta.json from internal snapshot dir: %s", err))
 			return 1
@@ -162,7 +160,7 @@ func (c *cmd) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error outputting enhanced snapshot data: %s", err))
 		return 1
 	}
-	//Generate structs for the formatter with information we read in
+	// Generate structs for the formatter with information we read in
 	metaformat := &MetadataInfo{
 		ID:      meta.ID,
 		Size:    meta.Size,
@@ -171,7 +169,7 @@ func (c *cmd) Run(args []string) int {
 		Version: meta.Version,
 	}
 
-	//Restructures stats given above to be human readable
+	// Restructures stats given above to be human readable
 	formattedStats := generateStats(info)
 	formattedStatsKV := generateKVStats(info)
 

--- a/command/snapshot/inspect/snapshot_inspect_test.go
+++ b/command/snapshot/inspect/snapshot_inspect_test.go
@@ -2,7 +2,7 @@ package inspect
 
 import (
 	"flag"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,11 +21,11 @@ func golden(t *testing.T, name, got string) string {
 
 	golden := filepath.Join("testdata", name+".golden")
 	if *update && got != "" {
-		err := ioutil.WriteFile(golden, []byte(got), 0644)
+		err := os.WriteFile(golden, []byte(got), 0644)
 		require.NoError(t, err)
 	}
 
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	require.NoError(t, err)
 
 	return string(expected)

--- a/command/snapshot/restore/snapshot_restore_test.go
+++ b/command/snapshot/restore/snapshot_restore_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,7 +134,7 @@ func TestSnapshotRestoreCommand_TruncatedSnapshot(t *testing.T) {
 		require.NoError(t, err)
 		defer rc.Close()
 
-		inputData, err = ioutil.ReadAll(rc)
+		inputData, err = io.ReadAll(rc)
 		require.NoError(t, err)
 	}
 
@@ -150,7 +149,7 @@ func TestSnapshotRestoreCommand_TruncatedSnapshot(t *testing.T) {
 			c := New(ui)
 
 			file := filepath.Join(dir, "backup.tgz")
-			require.NoError(t, ioutil.WriteFile(file, data, 0644))
+			require.NoError(t, os.WriteFile(file, data, 0644))
 			args := []string{
 				"-http-addr=" + a.HTTPAddr(),
 				file,

--- a/command/snapshot/save/snapshot_save_test.go
+++ b/command/snapshot/save/snapshot_save_test.go
@@ -3,7 +3,7 @@ package save
 import (
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -136,7 +136,7 @@ func TestSnapshotSaveCommand_TruncatedStream(t *testing.T) {
 		require.NoError(t, err)
 		defer rc.Close()
 
-		inputData, err = ioutil.ReadAll(rc)
+		inputData, err = io.ReadAll(rc)
 		require.NoError(t, err)
 	}
 

--- a/command/tls/ca/create/tls_ca_create_test.go
+++ b/command/tls/ca/create/tls_ca_create_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -129,9 +128,9 @@ func expectFiles(t *testing.T, caPath, keyPath string) (*x509.Certificate, crypt
 		t.Fatalf("private key file %s: permissions: want: %o; have: %o", keyPath, want, have)
 	}
 
-	caData, err := ioutil.ReadFile(caPath)
+	caData, err := os.ReadFile(caPath)
 	require.NoError(t, err)
-	keyData, err := ioutil.ReadFile(keyPath)
+	keyData, err := os.ReadFile(keyPath)
 	require.NoError(t, err)
 
 	ca, err := connect.ParseCert(string(caData))

--- a/command/tls/cert/create/tls_cert_create.go
+++ b/command/tls/cert/create/tls_cert_create.go
@@ -4,8 +4,8 @@ import (
 	"crypto/x509"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/consul/command/flags"
@@ -150,12 +150,12 @@ func (c *cmd) Run(args []string) int {
 
 	caFile := strings.Replace(c.ca, "#DOMAIN#", c.domain, 1)
 	keyFile := strings.Replace(c.key, "#DOMAIN#", c.domain, 1)
-	cert, err := ioutil.ReadFile(caFile)
+	cert, err := os.ReadFile(caFile)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading CA: %s", err))
 		return 1
 	}
-	key, err := ioutil.ReadFile(keyFile)
+	key, err := os.ReadFile(keyFile)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error reading CA key: %s", err))
 		return 1

--- a/command/tls/cert/create/tls_cert_create_test.go
+++ b/command/tls/cert/create/tls_cert_create_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"crypto/x509"
 	"io/fs"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -251,9 +250,9 @@ func expectFiles(t *testing.T, certPath, keyPath string) (*x509.Certificate, cry
 		t.Fatalf("private key file %s: permissions: want: %o; have: %o", keyPath, want, have)
 	}
 
-	certData, err := ioutil.ReadFile(certPath)
+	certData, err := os.ReadFile(certPath)
 	require.NoError(t, err)
-	keyData, err := ioutil.ReadFile(keyPath)
+	keyData, err := os.ReadFile(keyPath)
 	require.NoError(t, err)
 
 	cert, err := connect.ParseCert(string(certData))

--- a/command/validate/validate_test.go
+++ b/command/validate/validate_test.go
@@ -1,14 +1,14 @@
 package validate
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/mitchellh/cli"
-	require "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateCommand_noTabs(t *testing.T) {
@@ -34,7 +34,7 @@ func TestValidateCommand_SucceedOnMinimalConfigFile(t *testing.T) {
 	td := testutil.TempDir(t, "consul")
 
 	fp := filepath.Join(td, "config.json")
-	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
+	err := os.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
 	require.Nilf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
@@ -49,7 +49,7 @@ func TestValidateCommand_SucceedWithMinimalJSONConfigFormat(t *testing.T) {
 	td := testutil.TempDir(t, "consul")
 
 	fp := filepath.Join(td, "json.conf")
-	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
+	err := os.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
 	require.Nilf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
@@ -64,7 +64,7 @@ func TestValidateCommand_SucceedWithMinimalHCLConfigFormat(t *testing.T) {
 	td := testutil.TempDir(t, "consul")
 
 	fp := filepath.Join(td, "hcl.conf")
-	err := ioutil.WriteFile(fp, []byte("bind_addr = \"10.0.0.1\"\ndata_dir = \""+td+"\""), 0644)
+	err := os.WriteFile(fp, []byte("bind_addr = \"10.0.0.1\"\ndata_dir = \""+td+"\""), 0644)
 	require.Nilf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
@@ -79,7 +79,7 @@ func TestValidateCommand_SucceedWithJSONAsHCL(t *testing.T) {
 	td := testutil.TempDir(t, "consul")
 
 	fp := filepath.Join(td, "json.conf")
-	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
+	err := os.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
 	require.Nilf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
@@ -93,7 +93,7 @@ func TestValidateCommand_SucceedOnMinimalConfigDir(t *testing.T) {
 	t.Parallel()
 	td := testutil.TempDir(t, "consul")
 
-	err := ioutil.WriteFile(filepath.Join(td, "config.json"), []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
+	err := os.WriteFile(filepath.Join(td, "config.json"), []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
 	require.Nilf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
@@ -108,7 +108,7 @@ func TestValidateCommand_FailForInvalidJSONConfigFormat(t *testing.T) {
 	td := testutil.TempDir(t, "consul")
 
 	fp := filepath.Join(td, "hcl.conf")
-	err := ioutil.WriteFile(fp, []byte(`bind_addr = "10.0.0.1"\ndata_dir = "`+td+`"`), 0644)
+	err := os.WriteFile(fp, []byte(`bind_addr = "10.0.0.1"\ndata_dir = "`+td+`"`), 0644)
 	require.Nilf(t, err, "err: %s", err)
 
 	cmd := New(cli.NewMockUi())
@@ -123,7 +123,7 @@ func TestValidateCommand_Quiet(t *testing.T) {
 	td := testutil.TempDir(t, "consul")
 
 	fp := filepath.Join(td, "config.json")
-	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
+	err := os.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
 	require.Nilf(t, err, "err: %s", err)
 
 	ui := cli.NewMockUi()

--- a/command/version/formatter_test.go
+++ b/command/version/formatter_test.go
@@ -3,7 +3,7 @@ package version
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -21,11 +21,11 @@ func golden(t *testing.T, name, got string) string {
 
 	golden := filepath.Join("testdata", name+".golden")
 	if *update && got != "" {
-		err := ioutil.WriteFile(golden, []byte(got), 0644)
+		err := os.WriteFile(golden, []byte(got), 0644)
 		require.NoError(t, err)
 	}
 
-	expected, err := ioutil.ReadFile(golden)
+	expected, err := os.ReadFile(golden)
 	require.NoError(t, err)
 
 	return string(expected)

--- a/command/watch/watch_test.go
+++ b/command/watch/watch_test.go
@@ -1,7 +1,6 @@
 package watch
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,7 +57,7 @@ func TestWatchCommand_loadToken(t *testing.T) {
 	testDir := testutil.TempDir(t, "watchtest")
 
 	fullname := filepath.Join(testDir, "token.txt")
-	require.NoError(t, ioutil.WriteFile(fullname, []byte(testToken), 0600))
+	require.NoError(t, os.WriteFile(fullname, []byte(testToken), 0600))
 
 	resetEnv := func() {
 		os.Unsetenv("CONSUL_HTTP_TOKEN")

--- a/connect/certgen/certgen.go
+++ b/connect/certgen/certgen.go
@@ -31,13 +31,11 @@ package main // import "github.com/hashicorp/consul/connect/certgen"
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/mitchellh/go-testing-interface"
 )
 
 func main() {
@@ -85,7 +83,7 @@ func main() {
 
 func writeFile(name, content string) {
 	fmt.Println("Writing ", name)
-	err := ioutil.WriteFile(name, []byte(content), 0600)
+	err := os.WriteFile(name, []byte(content), 0600)
 	if err != nil {
 		log.Fatalf("failed writing file: %s", err)
 	}

--- a/connect/service_test.go
+++ b/connect/service_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"sort"
@@ -241,7 +240,7 @@ func TestService_HTTPClient(t *testing.T) {
 		// Hook the service resolver to avoid needing full agent setup.
 		s.httpResolverFromAddr = func(addr string) (Resolver, error) {
 			// Require in this goroutine seems to block causing a timeout on the Get.
-			//require.Equal(t,"https://backend.service.consul:443", addr)
+			// require.Equal(t,"https://backend.service.consul:443", addr)
 			return &StaticResolver{
 				Addr:    testSvr.Addr,
 				CertURI: connect.TestSpiffeIDService(t, "backend"),
@@ -255,7 +254,7 @@ func TestService_HTTPClient(t *testing.T) {
 		r.Check(err)
 		defer resp.Body.Close()
 
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		r.Check(err)
 
 		got := string(bodyBytes)

--- a/connect/tls.go
+++ b/connect/tls.go
@@ -5,13 +5,11 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
-
-	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/api"
@@ -89,7 +87,7 @@ func devTLSConfigFromFiles(caFile, certFile,
 
 	roots := x509.NewCertPool()
 
-	bs, err := ioutil.ReadFile(caFile)
+	bs, err := os.ReadFile(caFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/go-sso/oidcauth/oidcauthtest/testing.go
+++ b/internal/go-sso/oidcauth/oidcauthtest/testing.go
@@ -14,7 +14,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -82,7 +82,7 @@ func Start(t TestingT) *Server {
 	s.jwks = jwks
 
 	s.httpServer = httptest.NewUnstartedServer(s)
-	s.httpServer.Config.ErrorLog = log.New(ioutil.Discard, "", 0)
+	s.httpServer.Config.ErrorLog = log.New(io.Discard, "", 0)
 	s.httpServer.StartTLS()
 	t.Cleanup(s.httpServer.Close)
 

--- a/internal/iamauth/auth.go
+++ b/internal/iamauth/auth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -13,9 +13,6 @@ import (
 	"github.com/hashicorp/consul/internal/iamauth/responses"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/lib/stringslice"
-	"github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-retryablehttp"
 )
 
 const (
@@ -205,7 +202,7 @@ func (a *Authenticator) submitRequest(ctx context.Context, req *http.Request) (s
 	}
 
 	// we check for status code afterwards to also print out response body
-	responseBody, err := ioutil.ReadAll(response.Body)
+	responseBody, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", err
 	}

--- a/internal/iamauth/util.go
+++ b/internal/iamauth/util.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -14,7 +14,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hashicorp/consul/internal/iamauth/responses"
-	"github.com/hashicorp/go-hclog"
 )
 
 type LoginInput struct {
@@ -64,7 +63,7 @@ func GenerateLoginData(in *LoginInput) (map[string]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		requestBody, err := ioutil.ReadAll(entityRequest.HTTPRequest.Body)
+		requestBody, err := io.ReadAll(entityRequest.HTTPRequest.Body)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +86,7 @@ func GenerateLoginData(in *LoginInput) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	requestBody, err := ioutil.ReadAll(stsRequest.HTTPRequest.Body)
+	requestBody, err := io.ReadAll(stsRequest.HTTPRequest.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/testing/golden/golden.go
+++ b/internal/testing/golden/golden.go
@@ -2,7 +2,6 @@ package golden
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,11 +25,11 @@ func Get(t *testing.T, actual, filename string) string {
 		if dir := filepath.Dir(path); dir != "." {
 			require.NoError(t, os.MkdirAll(dir, 0755))
 		}
-		err := ioutil.WriteFile(path, []byte(actual), 0644)
+		err := os.WriteFile(path, []byte(actual), 0644)
 		require.NoError(t, err)
 	}
 
-	expected, err := ioutil.ReadFile(path)
+	expected, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return string(expected)
 }

--- a/internal/tools/proto-gen-rpc-glue/main_test.go
+++ b/internal/tools/proto-gen-rpc-glue/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,11 +38,11 @@ func golden(t *testing.T, actual, path string) string {
 		if dir := filepath.Dir(path); dir != "." {
 			require.NoError(t, os.MkdirAll(dir, 0755))
 		}
-		err := ioutil.WriteFile(path, []byte(actual), 0644)
+		err := os.WriteFile(path, []byte(actual), 0644)
 		require.NoError(t, err)
 	}
 
-	expected, err := ioutil.ReadFile(path)
+	expected, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return string(expected)
 }

--- a/lib/file/atomic_test.go
+++ b/lib/file/atomic_test.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,7 @@ import (
 // tests that it just writes the file properly. I would love to test this
 // better but I'm not sure how. -mitchellh
 func TestWriteAtomic(t *testing.T) {
-	td, err := ioutil.TempDir("", "lib-file")
+	td, err := os.MkdirTemp("", "lib-file")
 	require.NoError(t, err)
 	defer os.RemoveAll(td)
 
@@ -25,7 +24,7 @@ func TestWriteAtomic(t *testing.T) {
 	require.NoError(t, WriteAtomic(path, expected))
 
 	// Read and verify
-	actual, err := ioutil.ReadFile(path)
+	actual, err := os.ReadFile(path)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 }

--- a/logging/logfile_test.go
+++ b/logging/logfile_test.go
@@ -1,7 +1,6 @@
 package logging
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -44,7 +43,7 @@ func TestLogFile_openNew(t *testing.T) {
 	_, err = logFile.Write([]byte(msg))
 	require.NoError(t, err)
 
-	content, err := ioutil.ReadFile(logFile.FileInfo.Name())
+	content, err := os.ReadFile(logFile.FileInfo.Name())
 	require.NoError(t, err)
 	require.Contains(t, string(content), msg)
 }
@@ -79,11 +78,11 @@ func TestLogFile_PruneFiles(t *testing.T) {
 	sort.Strings(logFiles)
 	require.Len(t, logFiles, 2)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, logFiles[0]))
+	content, err := os.ReadFile(filepath.Join(tempDir, logFiles[0]))
 	require.NoError(t, err)
 	require.Contains(t, string(content), "Second File")
 
-	content, err = ioutil.ReadFile(filepath.Join(tempDir, logFiles[1]))
+	content, err = os.ReadFile(filepath.Join(tempDir, logFiles[1]))
 	require.NoError(t, err)
 	require.Contains(t, string(content), "Third File")
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -24,7 +24,7 @@ func main() {
 }
 
 func realMain() int {
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 
 	ui := &cli.BasicUI{
 		BasicUi: mcli.BasicUi{Writer: os.Stdout, ErrorWriter: os.Stderr},

--- a/sdk/freeport/ephemeral_linux.go
+++ b/sdk/freeport/ephemeral_linux.go
@@ -5,7 +5,7 @@ package freeport
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 )
@@ -15,7 +15,7 @@ const ephemeralPortRangeProcFile = "/proc/sys/net/ipv4/ip_local_port_range"
 var ephemeralPortRangePatt = regexp.MustCompile(`^\s*(\d+)\s+(\d+)\s*$`)
 
 func getEphemeralPortRange() (int, int, error) {
-	out, err := ioutil.ReadFile(ephemeralPortRangeProcFile)
+	out, err := os.ReadFile(ephemeralPortRangeProcFile)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/sdk/testutil/io.go
+++ b/sdk/testutil/io.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -19,7 +18,7 @@ func TempDir(t testing.TB, name string) string {
 	}
 	name = t.Name() + "-" + name
 	name = strings.Replace(name, "/", "_", -1)
-	d, err := ioutil.TempDir("", name)
+	d, err := os.MkdirTemp("", name)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -45,7 +44,7 @@ func TempFile(t testing.TB, name string) *os.File {
 	}
 	name = t.Name() + "-" + name
 	name = strings.Replace(name, "/", "_", -1)
-	f, err := ioutil.TempFile("", name)
+	f, err := os.CreateTemp("", name)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -29,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-uuid"
 	"github.com/pkg/errors"
 
@@ -249,7 +247,7 @@ func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, er
 		// Use test name for tmpdir if available
 		prefix = strings.Replace(t.Name(), "/", "_", -1)
 	}
-	tmpdir, err := ioutil.TempDir("", prefix)
+	tmpdir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create tempdir")
 	}
@@ -269,7 +267,7 @@ func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, er
 
 	t.Logf("CONFIG JSON: %s", string(b))
 	configFile := filepath.Join(tmpdir, "config.json")
-	if err := ioutil.WriteFile(configFile, b, 0644); err != nil {
+	if err := os.WriteFile(configFile, b, 0644); err != nil {
 		cfg.ReturnPorts()
 		os.RemoveAll(tmpdir)
 		return nil, errors.Wrap(err, "failed writing config content")

--- a/sdk/testutil/server_methods.go
+++ b/sdk/testutil/server_methods.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"testing"
@@ -53,7 +52,7 @@ func (s *TestServer) GetKV(t testing.TB, key string) []byte {
 	resp := s.get(t, "/v1/kv/"+key)
 	defer resp.Body.Close()
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("failed to read body: %s", err)
 	}
@@ -93,7 +92,7 @@ func (s *TestServer) ListKV(t testing.TB, prefix string) []string {
 	resp := s.get(t, "/v1/kv/"+prefix+"?keys")
 	defer resp.Body.Close()
 
-	raw, err := ioutil.ReadAll(resp.Body)
+	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("failed to read body: %s", err)
 	}

--- a/snapshot/archive.go
+++ b/snapshot/archive.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/hashicorp/raft"
@@ -202,7 +201,7 @@ func read(in io.Reader, metadata *raft.SnapshotMeta, snap io.Writer) error {
 			// turn made the snapshot verification fail. By explicitly reading the
 			// whole thing first we ensure that we calculate the correct hash
 			// independent of how json.Decode works internally.
-			buf, err := ioutil.ReadAll(io.TeeReader(archive, metaHash))
+			buf, err := io.ReadAll(io.TeeReader(archive, metaHash))
 			if err != nil {
 				return fmt.Errorf("failed to read snapshot metadata: %v", err)
 			}

--- a/snapshot/archive_test.go
+++ b/snapshot/archive_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -75,7 +74,7 @@ func TestArchive_GoodData(t *testing.T) {
 		defer f.Close()
 
 		var metadata raft.SnapshotMeta
-		err = read(f, &metadata, ioutil.Discard)
+		err = read(f, &metadata, io.Discard)
 		if err != nil {
 			t.Fatalf("case %d: should've read the snapshot, but didn't: %v", i, err)
 		}
@@ -104,7 +103,7 @@ func TestArchive_BadData(t *testing.T) {
 		defer f.Close()
 
 		var metadata raft.SnapshotMeta
-		err = read(f, &metadata, ioutil.Discard)
+		err = read(f, &metadata, io.Discard)
 		if err == nil || !strings.Contains(err.Error(), c.Error) {
 			t.Fatalf("case %d (%s): %v", i, c.Name, err)
 		}

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -7,10 +7,8 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
 )
 
@@ -47,7 +45,7 @@ func New(logger hclog.Logger, r *raft.Raft) (*Snapshot, error) {
 	// Make a scratch file to receive the contents so that we don't buffer
 	// everything in memory. This gets deleted in Close() since we keep it
 	// around for re-reading.
-	archive, err := ioutil.TempFile("", "snapshot")
+	archive, err := os.CreateTemp("", "snapshot")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create snapshot file: %v", err)
 	}
@@ -134,7 +132,7 @@ func Verify(in io.Reader) (*raft.SnapshotMeta, error) {
 
 	// Read the archive, throwing away the snapshot data.
 	var metadata raft.SnapshotMeta
-	if err := read(decomp, &metadata, ioutil.Discard); err != nil {
+	if err := read(decomp, &metadata, io.Discard); err != nil {
 		return nil, fmt.Errorf("failed to read snapshot file: %v", err)
 	}
 
@@ -151,7 +149,7 @@ func Verify(in io.Reader) (*raft.SnapshotMeta, error) {
 // The docs for gzip.Reader say: "Clients should treat data returned by Read as
 // tentative until they receive the io.EOF marking the end of the data."
 func concludeGzipRead(decomp *gzip.Reader) error {
-	extra, err := ioutil.ReadAll(decomp) // ReadAll consumes the EOF
+	extra, err := io.ReadAll(decomp) // ReadAll consumes the EOF
 	if err != nil {
 		return err
 	} else if len(extra) != 0 {
@@ -175,7 +173,7 @@ func Read(logger hclog.Logger, in io.Reader) (*os.File, *raft.SnapshotMeta, erro
 
 	// Make a scratch file to receive the contents of the snapshot data so
 	// we can avoid buffering in memory.
-	snap, err := ioutil.TempFile("", "snapshot")
+	snap, err := os.CreateTemp("", "snapshot")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create temp snapshot file: %v", err)
 	}

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -4,7 +4,6 @@
 package envoy
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"sort"
@@ -57,7 +56,7 @@ func discoverCases() ([]string, error) {
 		return nil, err
 	}
 
-	dirs, err := ioutil.ReadDir(cwd)
+	dirs, err := os.ReadDir(cwd)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/connect/envoy/test-sds-server/sds.go
+++ b/test/integration/connect/envoy/test-sds-server/sds.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -17,7 +16,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
-	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 )
@@ -100,12 +98,12 @@ func loadCertsFromPath(cache *cache.LinearCache, log hclog.Logger, dir string) e
 		}
 
 		certName := strings.TrimSuffix(entry.Name(), ".crt")
-		cert, err := ioutil.ReadFile(filepath.Join(dir, entry.Name()))
+		cert, err := os.ReadFile(filepath.Join(dir, entry.Name()))
 		if err != nil {
 			return err
 		}
 		keyFile := certName + ".key"
-		key, err := ioutil.ReadFile(filepath.Join(dir, keyFile))
+		key, err := os.ReadFile(filepath.Join(dir, keyFile))
 		if err != nil {
 			return err
 		}

--- a/test/integration/consul-container/metrics/leader_test.go
+++ b/test/integration/consul-container/metrics/leader_test.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -100,7 +100,7 @@ func getMetrics(t *testing.T, addr string, port int, path string) (string, error
 	if err != nil {
 		return "", fmt.Errorf("error get metrics: %v", err)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "nil", fmt.Errorf("error read metrics: %v", err)
 	}

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/hashicorp/consul/logging"
@@ -484,7 +482,7 @@ func LoadCAs(caFile, caPath string) ([]string, error) {
 	pems := []string{}
 
 	readFn := func(path string) error {
-		pem, err := ioutil.ReadFile(path)
+		pem, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("Error loading from %s: %s", path, err)
 		}

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
 
@@ -1337,7 +1335,7 @@ func TestConfigurator_AuthorizeInternalRPCServerConn(t *testing.T) {
 
 	dir := testutil.TempDir(t, "ca")
 	caPath := filepath.Join(dir, "ca.pem")
-	err = ioutil.WriteFile(caPath, []byte(caPEM), 0600)
+	err = os.WriteFile(caPath, []byte(caPEM), 0600)
 	require.NoError(t, err)
 
 	// Cert and key are not used, but required to get past validation.
@@ -1349,10 +1347,10 @@ func TestConfigurator_AuthorizeInternalRPCServerConn(t *testing.T) {
 	})
 	require.NoError(t, err)
 	certFile := filepath.Join("cert.pem")
-	err = ioutil.WriteFile(certFile, []byte(pub), 0600)
+	err = os.WriteFile(certFile, []byte(pub), 0600)
 	require.NoError(t, err)
 	keyFile := filepath.Join("cert.key")
-	err = ioutil.WriteFile(keyFile, []byte(pk), 0600)
+	err = os.WriteFile(keyFile, []byte(pk), 0600)
 	require.NoError(t, err)
 
 	cfg := Config{
@@ -1397,7 +1395,7 @@ func TestConfigurator_AuthorizeInternalRPCServerConn(t *testing.T) {
 
 		dir := testutil.TempDir(t, "other")
 		caPath := filepath.Join(dir, "ca.pem")
-		err = ioutil.WriteFile(caPath, []byte(caPEM), 0600)
+		err = os.WriteFile(caPath, []byte(caPEM), 0600)
 		require.NoError(t, err)
 
 		signer, err := ParseSigner(caPK)
@@ -1560,7 +1558,7 @@ func startTLSServer(tlsConfigServer *tls.Config) (net.Conn, <-chan error, <-chan
 		// server read any data from the client until error or
 		// EOF, which will allow the client to Close(), and
 		// *then* we Close() the server.
-		io.Copy(ioutil.Discard, tlsServer)
+		io.Copy(io.Discard, tlsServer)
 		tlsServer.Close()
 	}()
 	return clientConn, errc, certc
@@ -1569,14 +1567,14 @@ func startTLSServer(tlsConfigServer *tls.Config) (net.Conn, <-chan error, <-chan
 func loadFile(t *testing.T, path string) string {
 	t.Helper()
 
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return string(data)
 }
 
 func getExpectedCaPoolByFile(t *testing.T) *x509.CertPool {
 	pool := x509.NewCertPool()
-	data, err := ioutil.ReadFile("../test/ca/root.cer")
+	data, err := os.ReadFile("../test/ca/root.cer")
 	if err != nil {
 		t.Fatal("could not open test file ../test/ca/root.cer for reading")
 	}
@@ -1596,7 +1594,7 @@ func getExpectedCaPoolByDir(t *testing.T) *x509.CertPool {
 	for _, entry := range entries {
 		filename := path.Join("../test/ca_path", entry.Name())
 
-		data, err := ioutil.ReadFile(filename)
+		data, err := os.ReadFile(filename)
 		if err != nil {
 			t.Fatalf("could not open test file %s for reading", filename)
 		}


### PR DESCRIPTION
### Description
As of Go 1.16, the same functionality is now provided by package io or
package os, and those implementations should be preferred in new code.

So replacing all usage of `ioutil` pkg with `io` & `os`.

### Testing & Reproduction steps
N/A

### Links
N/A

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
