### PR TITLE
Fix syntax for envoy bootstrap prometheus secret config

### DIFF
--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -653,9 +653,7 @@ func (c *BootstrapConfig) generateListenerConfig(args *BootstrapTplArgs, bindAdd
 								}
 							],
 							"validationContextSdsSecretConfig": {
-								"trustedCa": {
-									"name": "prometheus_validation_context"
-								}
+								"name": "prometheus_validation_context"
 							}
 						}
 					}

--- a/command/connect/envoy/bootstrap_config_test.go
+++ b/command/connect/envoy/bootstrap_config_test.go
@@ -342,9 +342,7 @@ const (
 				}
 			  ],
 			  "validationContextSdsSecretConfig": {
-				"trustedCa": {
-				  "name": "prometheus_validation_context"
-				}
+				"name": "prometheus_validation_context"
 			  }
 			}
 		  }

--- a/command/connect/envoy/testdata/prometheus-metrics-tls-ca-file.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics-tls-ca-file.golden
@@ -151,9 +151,7 @@
                     }
                   ],
                   "validationContextSdsSecretConfig": {
-                    "trustedCa": {
-                      "name": "prometheus_validation_context"
-                    }
+                    "name": "prometheus_validation_context"
                   }
                 }
               }

--- a/command/connect/envoy/testdata/prometheus-metrics-tls-ca-path.golden
+++ b/command/connect/envoy/testdata/prometheus-metrics-tls-ca-path.golden
@@ -151,9 +151,7 @@
                     }
                   ],
                   "validationContextSdsSecretConfig": {
-                    "trustedCa": {
-                      "name": "prometheus_validation_context"
-                    }
+                    "name": "prometheus_validation_context"
                   }
                 }
               }


### PR DESCRIPTION
Follow-up to https://github.com/hashicorp/consul/pull/13481 - testing this uncovered a bug with the syntax for the validation context in the generated bootstrap config for the envoy prometheus TLS listener.
