### PR TITLE
ui: Add sorting peer listing by State

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/peer/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/peer/search-bar/index.hbs
@@ -78,6 +78,8 @@ as |key value|}}
             {{#let (from-entries (array
                   (array "Name:asc" (t "common.sort.alpha.asc"))
                   (array "Name:desc" (t "common.sort.alpha.desc"))
+                  (array "State:asc" (t "components.consul.peer.search-bar.sort.state.asc"))
+                  (array "State:desc" (t "components.consul.peer.search-bar.sort.state.desc"))
                 ))
               as |selectable|
             }}
@@ -87,6 +89,10 @@ as |key value|}}
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
+          <Optgroup @label={{t "components.consul.peer.search-bar.sort.state.name"}}>
+            <Option @value="State:asc" @selected={{eq "State:asc" @sort.value}}>{{t "components.consul.peer.search-bar.sort.state.asc"}}</Option>
+            <Option @value="State:desc" @selected={{eq "State:desc" @sort.value}}>{{t "components.consul.peer.search-bar.sort.state.desc"}}</Option>
+          </Optgroup>
           <Optgroup @label={{t "common.consul.name"}}>
             <Option @value="Name:asc" @selected={{eq "Name:asc" @sort.value}}>{{t "common.sort.alpha.asc"}}</Option>
             <Option @value="Name:desc" @selected={{eq "Name:desc" @sort.value}}>{{t "common.sort.alpha.desc"}}</Option>

--- a/ui/packages/consul-ui/app/models/peer.js
+++ b/ui/packages/consul-ui/app/models/peer.js
@@ -1,5 +1,18 @@
 import Model, { attr } from '@ember-data/model';
 
+export const schema = {
+  State: {
+    defaultValue: 'PENDING',
+    allowedValues: [
+      'PENDING',
+      'ESTABLISHING',
+      'ACTIVE',
+      'FAILING',
+      'TERMINATED',
+      'DELETING'
+    ],
+  },
+};
 export default class Peer extends Model {
   @attr('string') uri;
   @attr() meta;

--- a/ui/packages/consul-ui/app/sort/comparators/peer.js
+++ b/ui/packages/consul-ui/app/sort/comparators/peer.js
@@ -1,3 +1,26 @@
-export default ({ properties }) => key => {
+import { schema } from 'consul-ui/models/peer';
+
+export default ({ properties }) => (key = 'State:asc') => {
+  if (key.startsWith('State:')) {
+    return function(itemA, itemB) {
+      const [, dir] = key.split(':');
+      let a, b;
+      if (dir === 'asc') {
+        b = itemA;
+        a = itemB;
+      } else {
+        a = itemA;
+        b = itemB;
+      }
+      switch (true) {
+        case schema.State.allowedValues.indexOf(a.State) < schema.State.allowedValues.indexOf(b.State):
+          return 1;
+        case schema.State.allowedValues.indexOf(a.State) > schema.State.allowedValues.indexOf(b.State):
+          return -1;
+        case schema.State.allowedValues.indexOf(a.State) === schema.State.allowedValues.indexOf(b.State):
+          return 0;
+      }
+    };
+  }
   return properties(['Name'])(key);
 };

--- a/ui/packages/consul-ui/app/templates/dc/peers/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/peers/index.hbs
@@ -20,7 +20,7 @@
 {{#let
 
   (hash
-    value=(or sortBy "Name:asc")
+    value=(or sortBy "State:asc")
     change=(action (mut sortBy) value="target.selected")
   )
 

--- a/ui/packages/consul-ui/translations/components/consul/en-us.yaml
+++ b/ui/packages/consul-ui/translations/components/consul/en-us.yaml
@@ -1,3 +1,10 @@
+peer:
+  search-bar:
+    sort:
+      state:
+        name: Status
+        asc: Pending to Deleting
+        desc: Deleting to Pending
 service:
   search-bar:
     kind: Service Type


### PR DESCRIPTION
### Description
Adds sorting peer listing by State (defaults to State also)

<img width="1361" alt="Screenshot 2022-07-07 at 11 35 44" src="https://user-images.githubusercontent.com/554604/177754273-d025b326-5016-47ee-9451-92f2888b8372.png">


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMike