### PR TITLE
ui: Add filtering peer listing by State

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/peer/components.scss
+++ b/ui/packages/consul-ui/app/components/consul/peer/components.scss
@@ -1,0 +1,76 @@
+%pill-pending::before,
+%pill-establishing::before,
+%pill-active::before,
+%pill-failing::before,
+%pill-terminated::before,
+%pill-deleting::before {
+  --icon-size: icon-000;
+  content: '';
+}
+%pill-pending,
+%pill-establishing,
+%pill-active,
+%pill-failing,
+%pill-terminated,
+%pill-deleting {
+  font-weight: var(--typo-weight-medium);
+  font-size: var(--typo-size-700);
+}
+
+%pill-pending::before {
+  --icon-name: icon-running;
+  --icon-color: rgb(var(--tone-gray-800));
+}
+%pill-pending {
+  background-color: rgb(var(--tone-strawberry-050));
+  color: rgb(var(--tone-strawberry-500));
+}
+
+%pill-establishing::before {
+  --icon-name: icon-running;
+  --icon-color: rgb(var(--tone-gray-800));
+}
+%pill-establishing {
+  background-color: rgb(var(--tone-blue-050));
+  color: rgb(var(--tone-blue-500));
+}
+
+%pill-active::before {
+  --icon-name: icon-check;
+  --icon-color: rgb(var(--tone-green-800));
+}
+%pill-active {
+  background-color: rgb(var(--tone-green-050));
+  color: rgb(var(--tone-green-600));
+}
+
+%pill-failing::before {
+  --icon-name: icon-x;
+  --icon-color: rgb(var(--tone-red-500));
+}
+%pill-failing {
+  background-color: rgb(var(--tone-red-050));
+  color: rgb(var(--tone-red-500));
+}
+
+%pill-terminated::before {
+  --icon-name: icon-x-square;
+  --icon-color: rgb(var(--tone-gray-800));
+}
+%pill-terminated {
+  background-color: rgb(var(--tone-gray-150));
+  color: rgb(var(--tone-gray-800));
+}
+
+
+%pill-deleting::before {
+  --icon-name: icon-loading;
+  --icon-color: rgb(var(--tone-green-800));
+}
+%pill-deleting {
+  background-color: rgb(var(--tone-yellow-050));
+  color: rgb(var(--tone-yellow-800));
+}
+
+
+

--- a/ui/packages/consul-ui/app/components/consul/peer/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/peer/index.scss
@@ -1,0 +1,4 @@
+@import './components';
+
+@import './search-bar';
+

--- a/ui/packages/consul-ui/app/components/consul/peer/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/peer/search-bar/index.hbs
@@ -64,6 +64,38 @@ as |key value|}}
         </search.Select>
       </search.Search>
     </:search>
+    <:filter as |search|>
+      <search.Select
+        class="type-state"
+        @position="left"
+        @onchange={{action @filter.state.change}}
+        @multiple={{true}}
+      as |components|>
+        <BlockSlot @name="selected">
+          <span>
+            {{t "components.consul.peer.search-bar.state.name"}}
+          </span>
+        </BlockSlot>
+        <BlockSlot @name="options">
+  {{#let components.Optgroup components.Option as |Optgroup Option|}}
+    {{#each (array
+      'pending'
+      'establishing'
+      'active'
+      'failing'
+      'terminated'
+      'deleting'
+    ) as |state|}}
+          <Option class="value-{{state}}" @value={{state}} @selected={{includes state @filter.state.value}}>
+            <span>
+              {{t (concat "components.consul.peer.search-bar.state.options." state)}}
+            </span>
+          </Option>
+    {{/each}}
+  {{/let}}
+        </BlockSlot>
+      </search.Select>
+    </:filter>
     <:sort as |search|>
       <search.Select
         class="type-sort"

--- a/ui/packages/consul-ui/app/components/consul/peer/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/peer/search-bar/index.hbs
@@ -78,19 +78,23 @@ as |key value|}}
         </BlockSlot>
         <BlockSlot @name="options">
   {{#let components.Optgroup components.Option as |Optgroup Option|}}
-    {{#each (array
-      'pending'
-      'establishing'
-      'active'
-      'failing'
-      'terminated'
-      'deleting'
-    ) as |state|}}
+    {{#each
+      (get
+        (require '/models/peer'
+          path='schema'
+          from='/components/consul/peer/search-bar'
+        )
+        'State.allowedValues'
+      ) as |upperState|}}
+      {{#let
+        (string-to-lower-case upperState)
+      as |state|}}
           <Option class="value-{{state}}" @value={{state}} @selected={{includes state @filter.state.value}}>
             <span>
               {{t (concat "components.consul.peer.search-bar.state.options." state)}}
             </span>
           </Option>
+      {{/let}}
     {{/each}}
   {{/let}}
         </BlockSlot>

--- a/ui/packages/consul-ui/app/components/consul/peer/search-bar/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/peer/search-bar/index.scss
@@ -1,0 +1,24 @@
+.consul-peer-search-bar {
+  li button span {
+    @extend %pill-500;
+  }
+  .value-pending span {
+    @extend %pill-pending;
+  }
+  .value-establishing span {
+    @extend %pill-establishing;
+  }
+  .value-active span {
+    @extend %pill-active;
+  }
+  .value-failing span {
+    @extend %pill-failing;
+  }
+  .value-terminated span {
+    @extend %pill-terminated;
+  }
+  .value-deleting span {
+    @extend %pill-deleting;
+  }
+}
+

--- a/ui/packages/consul-ui/app/filter/predicates/peer.js
+++ b/ui/packages/consul-ui/app/filter/predicates/peer.js
@@ -1,0 +1,10 @@
+export default {
+  state: {
+    pending: (item, value) => item.State.toLowerCase() === value,
+    establishing: (item, value) => item.State.toLowerCase() === value,
+    active: (item, value) => item.State.toLowerCase() === value,
+    failing: (item, value) => item.State.toLowerCase() === value,
+    terminated: (item, value) => item.State.toLowerCase() === value,
+    deleting: (item, value) => item.State.toLowerCase() === value,
+  },
+};

--- a/ui/packages/consul-ui/app/helpers/require.js
+++ b/ui/packages/consul-ui/app/helpers/require.js
@@ -30,15 +30,15 @@ export default helper(([path = ''], options) => {
       return module(css);
     case fullPath.endsWith('.xstate'):
       return module;
-    case fullPath.endsWith('.element'):
+    case fullPath.endsWith('.element'): {
       if(container.has(fullPath)) {
         return container.get(fullPath);
       }
       const component = module(HTMLElement);
       container.set(fullPath, component);
       return component;
-    default: {
-      return module;
     }
+    default:
+      return module;
   }
 });

--- a/ui/packages/consul-ui/app/helpers/require.js
+++ b/ui/packages/consul-ui/app/helpers/require.js
@@ -12,12 +12,15 @@ const container = new Map();
 // `css` already has a caching mechanism under the hood so rely on that, plus
 // we get the advantage of laziness here, i.e. we only call css as and when we
 // need to
-export default helper(([path = ''], { from }) => {
-  const fullPath = resolve(`${appName}${from}`, path);
+export default helper(([path = ''], options) => {
+  let fullPath = resolve(`${appName}${options.from}`, path);
+  if(path.charAt(0) === '/') {
+    fullPath = `${appName}${fullPath}`;
+  }
 
   let module;
   if(require.has(fullPath)) {
-    module = require(fullPath).default;
+    module = require(fullPath)[options.export || 'default'];
   } else {
     throw new Error(`Unable to resolve '${fullPath}' does the file exist?`)
   }
@@ -27,13 +30,15 @@ export default helper(([path = ''], { from }) => {
       return module(css);
     case fullPath.endsWith('.xstate'):
       return module;
-    default: {
+    case fullPath.endsWith('.element'):
       if(container.has(fullPath)) {
         return container.get(fullPath);
       }
       const component = module(HTMLElement);
       container.set(fullPath, component);
       return component;
+    default: {
+      return module;
     }
   }
 });

--- a/ui/packages/consul-ui/app/routes/dc/peers/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/peers/index.js
@@ -3,6 +3,7 @@ import Route from 'consul-ui/routing/route';
 export default class PeersRoute extends Route {
   queryParams = {
     sortBy: 'sort',
+    state: 'state',
     searchproperty: {
       as: 'searchproperty',
       empty: [['Name']],

--- a/ui/packages/consul-ui/app/services/filter.js
+++ b/ui/packages/consul-ui/app/services/filter.js
@@ -10,6 +10,7 @@ import intention from 'consul-ui/filter/predicates/intention';
 import token from 'consul-ui/filter/predicates/token';
 import policy from 'consul-ui/filter/predicates/policy';
 import authMethod from 'consul-ui/filter/predicates/auth-method';
+import peer from 'consul-ui/filter/predicates/peer';
 
 const predicates = {
   service: andOr(service),
@@ -21,6 +22,7 @@ const predicates = {
   intention: andOr(intention),
   token: andOr(token),
   policy: andOr(policy),
+  peer: andOr(peer),
 };
 
 export default class FilterService extends Service {

--- a/ui/packages/consul-ui/app/styles/base/icons/icons/index.scss
+++ b/ui/packages/consul-ui/app/styles/base/icons/icons/index.scss
@@ -501,7 +501,7 @@
 // @import './rotate-ccw/index.scss';
 // @import './rotate-cw/index.scss';
 // @import './rss/index.scss';
-// @import './running/index.scss';
+@import './running/index.scss';
 // @import './save/index.scss';
 // @import './scissors/index.scss';
 // @import './search/index.scss';
@@ -620,7 +620,7 @@
 // @import './x-diamond-fill/index.scss';
 // @import './x-hexagon/index.scss';
 // @import './x-hexagon-fill/index.scss';
-// @import './x-square/index.scss';
+@import './x-square/index.scss';
 // @import './x-square-fill/index.scss';
 // @import './youtube/index.scss';
 // @import './youtube-color/index.scss';

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -104,7 +104,8 @@
 @import 'consul-ui/components/topology-metrics/series';
 @import 'consul-ui/components/topology-metrics/stats';
 @import 'consul-ui/components/topology-metrics/status';
+@import 'consul-ui/components/consul/intention/list/table';
+@import 'consul-ui/components/consul/peer';
 @import 'consul-ui/components/peerings/badge';
 @import 'consul-ui/components/consul/node/peer-info';
-@import 'consul-ui/components/consul/intention/list/table';
 @import 'consul-ui/components/consul/service/peer-info';

--- a/ui/packages/consul-ui/app/templates/dc/peers/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/peers/index.hbs
@@ -25,6 +25,10 @@
   )
 
   (hash
+    state=(hash
+      value=(if state (split state ',') undefined)
+      change=(action (mut state) value="target.selectedItems")
+    )
     searchproperty=(hash
       value=(if (not-eq searchproperty undefined)
         (split searchproperty ',')

--- a/ui/packages/consul-ui/translations/components/consul/en-us.yaml
+++ b/ui/packages/consul-ui/translations/components/consul/en-us.yaml
@@ -1,5 +1,14 @@
 peer:
   search-bar:
+    state:
+      name: Status
+      options:
+        pending: Pending
+        establishing: Establishing
+        active: Active
+        failing: Failing
+        terminated: Terminated
+        deleting: Deleting
     sort:
       state:
         name: Status


### PR DESCRIPTION
### Description
Adds filtering peer listing by State

<img width="1431" alt="Screenshot 2022-07-07 at 12 45 39" src="https://user-images.githubusercontent.com/554604/177766694-69270eb2-8c11-43a7-8091-1dab54502fd3.png">

Please note there are a few things that may be tweaked here moving forwards, i.e. specific icons etc. Right now we are just matching the previously used icons.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMike