### PR TITLE
server: broadcast the public grpc port using lan serf and update the consul service in the catalog with the same data

### DIFF
--- a/.changelog/13687.txt
+++ b/.changelog/13687.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+server: broadcast the public grpc port using lan serf and update the consul service in the catalog with the same data
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1193,6 +1193,8 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	cfg.RPCAddr = runtimeCfg.RPCBindAddr
 	cfg.RPCAdvertise = runtimeCfg.RPCAdvertiseAddr
 
+	cfg.GRPCPort = runtimeCfg.GRPCPort
+
 	cfg.Segment = runtimeCfg.SegmentName
 	if len(runtimeCfg.Segments) > 0 {
 		segments, err := segmentConfig(runtimeCfg)

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -130,6 +130,9 @@ type Config struct {
 	// RPCSrcAddr is the source address for outgoing RPC connections.
 	RPCSrcAddr *net.TCPAddr
 
+	// GRPCPort is the port the public gRPC server listens on.
+	GRPCPort int
+
 	// (Enterprise-only) The network segment this agent is part of.
 	Segment string
 

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -1069,6 +1069,11 @@ func (s *Server) handleAliveMember(member serf.Member, nodeEntMeta *acl.Enterpri
 			},
 		}
 
+		grpcPortStr := member.Tags["grpc_port"]
+		if v, err := strconv.Atoi(grpcPortStr); err == nil && v > 0 {
+			service.Meta["grpc_port"] = grpcPortStr
+		}
+
 		// Attempt to join the consul server
 		if err := s.joinConsulServer(member, parts); err != nil {
 			return err

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -103,6 +103,9 @@ func (s *Server) setupSerfConfig(opts setupSerfOptions) (*serf.Config, error) {
 	conf.Tags["build"] = s.config.Build
 	addr := opts.Listener.Addr().(*net.TCPAddr)
 	conf.Tags["port"] = fmt.Sprintf("%d", addr.Port)
+	if s.config.GRPCPort > 0 {
+		conf.Tags["grpc_port"] = fmt.Sprintf("%d", s.config.GRPCPort)
+	}
 	if s.config.Bootstrap {
 		conf.Tags["bootstrap"] = "1"
 	}

--- a/agent/metadata/server.go
+++ b/agent/metadata/server.go
@@ -23,25 +23,26 @@ func (k *Key) Equal(x *Key) bool {
 
 // Server is used to return details of a consul server
 type Server struct {
-	Name         string // <node>.<dc>
-	ShortName    string // <node>
-	ID           string
-	Datacenter   string
-	Segment      string
-	Port         int
-	SegmentAddrs map[string]string
-	SegmentPorts map[string]int
-	WanJoinPort  int
-	LanJoinPort  int
-	Bootstrap    bool
-	Expect       int
-	Build        version.Version
-	Version      int
-	RaftVersion  int
-	Addr         net.Addr
-	Status       serf.MemberStatus
-	ReadReplica  bool
-	FeatureFlags map[string]int
+	Name           string // <node>.<dc>
+	ShortName      string // <node>
+	ID             string
+	Datacenter     string
+	Segment        string
+	Port           int
+	SegmentAddrs   map[string]string
+	SegmentPorts   map[string]int
+	WanJoinPort    int
+	LanJoinPort    int
+	PublicGRPCPort int
+	Bootstrap      bool
+	Expect         int
+	Build          version.Version
+	Version        int
+	RaftVersion    int
+	Addr           net.Addr
+	Status         serf.MemberStatus
+	ReadReplica    bool
+	FeatureFlags   map[string]int
 
 	// If true, use TLS when connecting to this server
 	UseTLS bool
@@ -136,6 +137,18 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 		}
 	}
 
+	publicGRPCPort := 0
+	publicGRPCPortStr, ok := m.Tags["grpc_port"]
+	if ok {
+		publicGRPCPort, err = strconv.Atoi(publicGRPCPortStr)
+		if err != nil {
+			return false, nil
+		}
+		if publicGRPCPort < 1 {
+			return false, nil
+		}
+	}
+
 	vsnStr := m.Tags["vsn"]
 	vsn, err := strconv.Atoi(vsnStr)
 	if err != nil {
@@ -160,24 +173,25 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 	addr := &net.TCPAddr{IP: m.Addr, Port: port}
 
 	parts := &Server{
-		Name:         m.Name,
-		ShortName:    strings.TrimSuffix(m.Name, "."+datacenter),
-		ID:           m.Tags["id"],
-		Datacenter:   datacenter,
-		Segment:      segment,
-		Port:         port,
-		SegmentAddrs: segmentAddrs,
-		SegmentPorts: segmentPorts,
-		WanJoinPort:  wanJoinPort,
-		LanJoinPort:  int(m.Port),
-		Bootstrap:    bootstrap,
-		Expect:       expect,
-		Addr:         addr,
-		Build:        *buildVersion,
-		Version:      vsn,
-		RaftVersion:  raftVsn,
-		Status:       m.Status,
-		UseTLS:       useTLS,
+		Name:           m.Name,
+		ShortName:      strings.TrimSuffix(m.Name, "."+datacenter),
+		ID:             m.Tags["id"],
+		Datacenter:     datacenter,
+		Segment:        segment,
+		Port:           port,
+		SegmentAddrs:   segmentAddrs,
+		SegmentPorts:   segmentPorts,
+		WanJoinPort:    wanJoinPort,
+		LanJoinPort:    int(m.Port),
+		PublicGRPCPort: publicGRPCPort,
+		Bootstrap:      bootstrap,
+		Expect:         expect,
+		Addr:           addr,
+		Build:          *buildVersion,
+		Version:        vsn,
+		RaftVersion:    raftVsn,
+		Status:         m.Status,
+		UseTLS:         useTLS,
 		// DEPRECATED - remove nonVoter check once support for that tag is removed
 		ReadReplica:  nonVoter || readReplica,
 		FeatureFlags: featureFlags,


### PR DESCRIPTION
### Description

Currently servers exchange information about their WAN serf port and RPC port with serf tags, so that they all learn of each other's addressing information. We intend to make larger use of the new public-facing gRPC port exposed on all of the servers, so this PR addresses that by passing around the gRPC port via serf tags and then ensuring the generated `consul` service in the catalog has metadata about that new port as well for ease of non-serf-based lookup.
