### PR TITLE
Fix path to consul-ecs Terraform modules

### DIFF
--- a/website/content/docs/ecs/compatibility.mdx
+++ b/website/content/docs/ecs/compatibility.mdx
@@ -10,8 +10,6 @@ For every release of Consul on ECS, the `consul-ecs` binary and `consul-ecs` Ter
 
 ## Supported Consul versions
 
-
-
 | Consul Version | Compatible consul-ecs Versions  |
 | -------------- | ------------------------------- |
 | 1.12.x | 0.5.x        |

--- a/website/content/docs/ecs/enterprise.mdx
+++ b/website/content/docs/ecs/enterprise.mdx
@@ -84,7 +84,7 @@ is not provided when `consul_partitions_enabled = true`, will default to the `de
 
 ```hcl
 module "acl_controller" {
-  source = "hashicorp/consul/aws//modules/acl-controller"
+  source = "hashicorp/consul-ecs/aws//modules/acl-controller"
 
   ...
 
@@ -109,7 +109,7 @@ The following example demonstrates how to create a `mesh-task` assigned to the a
 
 ```hcl
 module "my_task" {
-  source = "hashicorp/consul/aws//modules/mesh-task"
+  source = "hashicorp/consul-ecs/aws//modules/mesh-task"
   family = "my_task"
 
   ...

--- a/website/content/docs/ecs/terraform/migrate-existing-tasks.mdx
+++ b/website/content/docs/ecs/terraform/migrate-existing-tasks.mdx
@@ -68,7 +68,7 @@ The `mesh-task` module is used as follows:
 
 ```hcl
 module "my_task" {
-  source  = "hashicorp/consul/aws//modules/mesh-task"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
   version = "<latest version>"
 
   family                = "my_task"

--- a/website/content/docs/ecs/terraform/secure-configuration.mdx
+++ b/website/content/docs/ecs/terraform/secure-configuration.mdx
@@ -80,7 +80,7 @@ the AWS IAM auth method.
 
     ```hcl
     module "acl_controller" {
-      source                            = "hashicorp/consul/aws//modules/acl-controller"
+      source                            = "hashicorp/consul-ecs/aws//modules/acl-controller"
       version                           = "<version>"
 
       consul_bootstrap_token_secret_arn = aws_secretsmanager_secret.bootstrap_token.arn
@@ -141,7 +141,7 @@ should be the same as the `name_prefix` you provide to the ACL controller module
 
 ```hcl
 module "my_task" {
-  source  = "hashicorp/consul/aws//modules/mesh-task"
+  source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
   version = "<version>"
 
   ...


### PR DESCRIPTION
### Description
The path to the `consul-ecs` Terraform modules were incorrect in some of the examples. This PR corrects those paths.

### PR Checklist

* [x] ~updated test coverage~
* [x] external facing docs updated
* [x] not a security concern
