### PR TITLE
[CI-only] Support fossa scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
     branches:
       # Push events on the main branch
       - main
-      - support-fossa-scanning
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Push events on the main branch
       - main
+      - support-fossa-scanning
 
 env:
   PKG_NAME: consul

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -15,6 +15,7 @@ project "consul" {
       "release/1.10.x",
       "release/1.11.x",
       "release/1.12.x",
+      "support-fossa-scanning",
     ]
   }
 }
@@ -175,6 +176,15 @@ event "promote-dev-docker" {
 
   notification {
     on = "fail"
+  }
+}
+
+event "fossa-scan" {
+  depends = ["promote-dev-docker"]
+  action "fossa-scan" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "fossa-scan"
   }
 }
 

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -15,7 +15,6 @@ project "consul" {
       "release/1.10.x",
       "release/1.11.x",
       "release/1.12.x",
-      "support-fossa-scanning",
     ]
   }
 }


### PR DESCRIPTION
### Description

This is a CI-only change that opts consul into a new workflow in the CRT pipeline called fossa-scan. The fossa-scan workflow will pass regardless of any dependency licensing issues raised by fossa, but failures will be raised in #proj-oss-compliance-scanning. This will allow the legal team to look into any issues raised and reach out to consul directly if there are questions about any dependencies. 

### Testing & Reproduction steps
The fossa-scan workflow ran on the first commit here https://github.com/hashicorp/consul/runs/7240124999 and this produced the fossa report available here https://github.com/hashicorp/crt-workflows-common/runs/7240077599?check_suite_focus=true. The scan raised a few new issues that the legal team will look into here: https://hashicorp.slack.com/archives/C01JSHNP10B/p1657221786695829. 

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ X ] not a security concern
