### PR TITLE
ui: Remove horizontal scrollbar from peering list rows

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/peer/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/peer/index.scss
@@ -1,4 +1,5 @@
 @import './components';
 
+@import './list';
 @import './search-bar';
 

--- a/ui/packages/consul-ui/app/components/consul/peer/list/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/peer/list/index.scss
@@ -1,6 +1,6 @@
 .peers__list__peer-detail {
   display: flex;
   align-content: center;
-  overflow-x: scroll;
   gap: 18px;
 }
+

--- a/ui/packages/consul-ui/app/styles/routes.scss
+++ b/ui/packages/consul-ui/app/styles/routes.scss
@@ -5,4 +5,3 @@
 @import 'routes/dc/intentions/index';
 @import 'routes/dc/overview/serverstatus';
 @import 'routes/dc/overview/license';
-@import 'routes/dc/peers';


### PR DESCRIPTION
### Description
In https://github.com/hashicorp/consul/pull/13685#pullrequestreview-1031744420 we noticed that a horizontal scroll had been added to the peering list rows in https://github.com/hashicorp/consul/pull/13425. This had the effect of pushing rendering/stacking out of place if you have scrollbars showing permanently.

This PR removes the CSS that was causing this.

Additionally, I noticed that I could move the rest of the CSS for the peer listing alongside the component that we now have for the listing so it's easier to find, so I moved the other related CSS other there.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMike
