### PR TITLE
ui: Make our old TabNav component easily usable with a state machine

### DIFF
--- a/ui/packages/consul-ui/app/components/tab-nav/README.mdx
+++ b/ui/packages/consul-ui/app/components/tab-nav/README.mdx
@@ -11,7 +11,9 @@ Each item in the list should be a hash of `label`, `href` and `selected`.
 - `label`: The text to show
 - `href`: a href, probably generated via `href-to`
 - `selected`: whether the item is in the selected state or not, probably
-  generated via `is-href`
+- `state`: when used with an @onclick using `StateMachine.dispatch`, the name
+  of the state to transition to.
+
 
 **Please note:** This component should probably be rebuilt using contextual
 components, alternatively this could be hand built with native HTML using the
@@ -33,6 +35,31 @@ components)
           (hash label="Metadata" href="#" selected=false)
       )
 }}/>
+</figure>
+```
+
+A TabNav with using a `StateMachine.dispatch`
+
+```hbs
+<figure>
+  <figcaption>A TabNav with using a StateMachine.dispatch</figcaption>
+  <TabNav @items={{
+    compact
+      (array
+        (hash
+          label="1"
+          selected=(state-matches fsm.state 'one')
+          state="ONE"
+        )
+        (hash
+          label="2"
+          selected=(state-matches fsm.state 'two')
+          state="TWO"
+        )
+      )
+    }}
+    @onclick={{fsm.dispatch}}
+  />
 </figure>
 ```
 

--- a/ui/packages/consul-ui/app/components/tab-nav/index.hbs
+++ b/ui/packages/consul-ui/app/components/tab-nav/index.hbs
@@ -32,7 +32,7 @@ as |select name|}}
     <Action
       {{on 'click'
         (if (not-eq @onclick undefined)
-          (fn @onclick (uppercase item.label))
+          (fn @onclick (or item.state (uppercase item.label)))
           (noop)
         )
       }}


### PR DESCRIPTION
### Description
Update our super old TabNav component to easily work with a state machine.

This approach was chosen to be the easiest to use right now, whilst keeping the old interface of the component, which is used in many other places in the UI. At some point we can upgrade the component completely, and then replace all the usages of it in our app in one go. The time to do that is not right now.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMike