### PR TITLE
Return error if ServerAddresses is empty

### DIFF
--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -71,7 +71,7 @@ func (b *PeeringBackend) GetServerAddresses() ([]string, error) {
 		addrs = append(addrs, node.Address+":"+grpcPortStr)
 	}
 	if len(addrs) == 0 {
-		return nil, fmt.Errorf("grpc port is not configured on any servers")
+		return nil, fmt.Errorf("a grpc bind port must be specified in the configuration for all servers")
 	}
 	return addrs, nil
 }

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -70,6 +70,9 @@ func (b *PeeringBackend) GetServerAddresses() ([]string, error) {
 		}
 		addrs = append(addrs, node.Address+":"+grpcPortStr)
 	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("grpc port is not configured on any servers")
+	}
 	return addrs, nil
 }
 


### PR DESCRIPTION
### Description
Encountered an issue while tracking a regression in K8s acceptance tests where a dialer was passed a token with no ServerAddresses.
