### PR TITLE
peering: track imported services

### DIFF
--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/consul/proto/pbpeering"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/types"
 )
 
 func TestLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T) {
@@ -309,11 +310,6 @@ func insertTestPeeringData(t *testing.T, store *state.Store, peer string, lastId
 				Node:        "aaa",
 				PeerName:    peer,
 			},
-			{
-				CheckID:  structs.SerfCheckID,
-				Node:     "aaa",
-				PeerName: peer,
-			},
 		},
 	}))
 
@@ -335,11 +331,6 @@ func insertTestPeeringData(t *testing.T, store *state.Store, peer string, lastId
 				ServiceID:   "b-service-1",
 				Node:        "bbb",
 				PeerName:    peer,
-			},
-			{
-				CheckID:  structs.SerfCheckID,
-				Node:     "bbb",
-				PeerName: peer,
 			},
 		},
 	}))
@@ -363,13 +354,269 @@ func insertTestPeeringData(t *testing.T, store *state.Store, peer string, lastId
 				Node:        "ccc",
 				PeerName:    peer,
 			},
-			{
-				CheckID:  structs.SerfCheckID,
-				Node:     "ccc",
-				PeerName: peer,
-			},
 		},
 	}))
 
 	return lastIdx
+}
+
+// TODO(peering): once we move away from leader only request for PeeringList, move this test to consul/server_test maybe
+func TestLeader_Peering_ImportedServicesCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	// TODO(peering): Configure with TLS
+	_, s1 := testServerWithConfig(t, func(c *Config) {
+		c.NodeName = "s1.dc1"
+		c.Datacenter = "dc1"
+		c.TLSConfig.Domain = "consul"
+	})
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Create a peering by generating a token
+	ctx, cancel := context.WithTimeout(context.Background(), 10000000*time.Second)
+	t.Cleanup(cancel)
+
+	conn, err := grpc.DialContext(ctx, s1.config.RPCAddr.String(),
+		grpc.WithContextDialer(newServerDialer(s1.config.RPCAddr.String())),
+		grpc.WithInsecure(),
+		grpc.WithBlock())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	peeringClient := pbpeering.NewPeeringServiceClient(conn)
+
+	req := pbpeering.GenerateTokenRequest{
+		PeerName: "my-peer-s2",
+	}
+	resp, err := peeringClient.GenerateToken(ctx, &req)
+	require.NoError(t, err)
+
+	tokenJSON, err := base64.StdEncoding.DecodeString(resp.PeeringToken)
+	require.NoError(t, err)
+
+	var token structs.PeeringToken
+	require.NoError(t, json.Unmarshal(tokenJSON, &token))
+
+	var (
+		s2PeerID = "cc56f0b8-3885-4e78-8d7b-614a0c45712d"
+		lastIdx  = uint64(0)
+	)
+
+	// Bring up s2 and store s1's token so that it attempts to dial.
+	_, s2 := testServerWithConfig(t, func(c *Config) {
+		c.NodeName = "s2.dc2"
+		c.Datacenter = "dc2"
+		c.PrimaryDatacenter = "dc2"
+	})
+	testrpc.WaitForLeader(t, s2.RPC, "dc2")
+
+	// Simulate a peering initiation event by writing a peering with data from a peering token.
+	// Eventually the leader in dc2 should dial and connect to the leader in dc1.
+	p := &pbpeering.Peering{
+		ID:                  s2PeerID,
+		Name:                "my-peer-s1",
+		PeerID:              token.PeerID,
+		PeerCAPems:          token.CA,
+		PeerServerName:      token.ServerName,
+		PeerServerAddresses: token.ServerAddresses,
+	}
+	require.True(t, p.ShouldDial())
+
+	lastIdx++
+	require.NoError(t, s2.fsm.State().PeeringWrite(lastIdx, p))
+
+	/// add services to S1 to be synced to S2
+	lastIdx++
+	require.NoError(t, s1.FSM().State().EnsureRegistration(lastIdx, &structs.RegisterRequest{
+		ID:      types.NodeID(generateUUID()),
+		Node:    "aaa",
+		Address: "10.0.0.1",
+		Service: &structs.NodeService{
+			Service: "a-service",
+			ID:      "a-service-1",
+			Port:    8080,
+		},
+		Checks: structs.HealthChecks{
+			{
+				CheckID:     "a-service-1-check",
+				ServiceName: "a-service",
+				ServiceID:   "a-service-1",
+				Node:        "aaa",
+			},
+		},
+	}))
+
+	lastIdx++
+	require.NoError(t, s1.FSM().State().EnsureRegistration(lastIdx, &structs.RegisterRequest{
+		ID: types.NodeID(generateUUID()),
+
+		Node:    "bbb",
+		Address: "10.0.0.2",
+		Service: &structs.NodeService{
+			Service: "b-service",
+			ID:      "b-service-1",
+			Port:    8080,
+		},
+		Checks: structs.HealthChecks{
+			{
+				CheckID:     "b-service-1-check",
+				ServiceName: "b-service",
+				ServiceID:   "b-service-1",
+				Node:        "bbb",
+			},
+		},
+	}))
+
+	lastIdx++
+	require.NoError(t, s1.FSM().State().EnsureRegistration(lastIdx, &structs.RegisterRequest{
+		ID: types.NodeID(generateUUID()),
+
+		Node:    "ccc",
+		Address: "10.0.0.3",
+		Service: &structs.NodeService{
+			Service: "c-service",
+			ID:      "c-service-1",
+			Port:    8080,
+		},
+		Checks: structs.HealthChecks{
+			{
+				CheckID:     "c-service-1-check",
+				ServiceName: "c-service",
+				ServiceID:   "c-service-1",
+				Node:        "ccc",
+			},
+		},
+	}))
+	/// finished adding services
+
+	type testCase struct {
+		name                          string
+		description                   string
+		exportedService               structs.ExportedServicesConfigEntry
+		expectedImportedServicesCount uint64
+	}
+
+	testCases := []testCase{
+		{
+			name:        "wildcard",
+			description: "for a wildcard exported services, we want to see all services synced",
+			exportedService: structs.ExportedServicesConfigEntry{
+				Name: "default",
+				Services: []structs.ExportedService{
+					{
+						Name: structs.WildcardSpecifier,
+						Consumers: []structs.ServiceConsumer{
+							{
+								PeerName: "my-peer-s2",
+							},
+						},
+					},
+				},
+			},
+			expectedImportedServicesCount: 4, // 3 services from above + the "consul" service
+		},
+		{
+			name:        "no sync",
+			description: "update the config entry to allow no service sync",
+			exportedService: structs.ExportedServicesConfigEntry{
+				Name: "default",
+			},
+			expectedImportedServicesCount: 0, // we want to see this decremented from 4 --> 0
+		},
+		{
+			name:        "just a, b services",
+			description: "export just two services",
+			exportedService: structs.ExportedServicesConfigEntry{
+				Name: "default",
+				Services: []structs.ExportedService{
+					{
+						Name: "a-service",
+						Consumers: []structs.ServiceConsumer{
+							{
+								PeerName: "my-peer-s2",
+							},
+						},
+					},
+					{
+						Name: "b-service",
+						Consumers: []structs.ServiceConsumer{
+							{
+								PeerName: "my-peer-s2",
+							},
+						},
+					},
+				},
+			},
+			expectedImportedServicesCount: 2,
+		},
+		{
+			name:        "unexport b service",
+			description: "by unexporting b we want to see the count decrement eventually",
+			exportedService: structs.ExportedServicesConfigEntry{
+				Name: "default",
+				Services: []structs.ExportedService{
+					{
+						Name: "a-service",
+						Consumers: []structs.ServiceConsumer{
+							{
+								PeerName: "my-peer-s2",
+							},
+						},
+					},
+				},
+			},
+			expectedImportedServicesCount: 1,
+		},
+		{
+			name:        "export c service",
+			description: "now export the c service and expect the count to increment",
+			exportedService: structs.ExportedServicesConfigEntry{
+				Name: "default",
+				Services: []structs.ExportedService{
+					{
+						Name: "a-service",
+						Consumers: []structs.ServiceConsumer{
+							{
+								PeerName: "my-peer-s2",
+							},
+						},
+					},
+					{
+						Name: "c-service",
+						Consumers: []structs.ServiceConsumer{
+							{
+								PeerName: "my-peer-s2",
+							},
+						},
+					},
+				},
+			},
+			expectedImportedServicesCount: 2,
+		},
+	}
+
+	conn2, err := grpc.DialContext(ctx, s2.config.RPCAddr.String(),
+		grpc.WithContextDialer(newServerDialer(s2.config.RPCAddr.String())),
+		grpc.WithInsecure(),
+		grpc.WithBlock())
+	require.NoError(t, err)
+	defer conn2.Close()
+
+	peeringClient2 := pbpeering.NewPeeringServiceClient(conn2)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lastIdx++
+			require.NoError(t, s1.fsm.State().EnsureConfigEntry(lastIdx, &tc.exportedService))
+
+			retry.Run(t, func(r *retry.R) {
+				resp2, err := peeringClient2.PeeringList(ctx, &pbpeering.PeeringListRequest{})
+				require.NoError(r, err)
+				require.NotEmpty(r, resp2.Peerings)
+				require.Equal(r, tc.expectedImportedServicesCount, resp2.Peerings[0].ImportedServiceCount)
+			})
+		})
+	}
 }

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -375,7 +375,7 @@ func TestLeader_Peering_ImportedServicesCount(t *testing.T) {
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Create a peering by generating a token
-	ctx, cancel := context.WithTimeout(context.Background(), 10000000*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
 
 	conn, err := grpc.DialContext(ctx, s1.config.RPCAddr.String(),

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -301,8 +301,15 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 			}
 
 			if resp := msg.GetResponse(); resp != nil {
+
+				st, found := s.Tracker.MutableStreamStatus(streamReq.LocalID)
+				if !found {
+					logger.Trace("failed to find stream status, abandoning process response")
+					return fmt.Errorf("failed to find stream status, abandoning process response")
+				}
+
 				// TODO(peering): Ensure there's a nonce
-				reply, err := s.processResponse(streamReq.PeerName, streamReq.Partition, resp)
+				reply, err := s.processResponse(streamReq.PeerName, streamReq.Partition, st, resp, logger)
 				if err != nil {
 					logger.Error("failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 					status.TrackReceiveError(err.Error())

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -301,15 +301,8 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 			}
 
 			if resp := msg.GetResponse(); resp != nil {
-
-				st, found := s.Tracker.MutableStreamStatus(streamReq.LocalID)
-				if !found {
-					logger.Trace("failed to find stream status, abandoning process response")
-					return fmt.Errorf("failed to find stream status, abandoning process response")
-				}
-
 				// TODO(peering): Ensure there's a nonce
-				reply, err := s.processResponse(streamReq.PeerName, streamReq.Partition, st, resp, logger)
+				reply, err := s.processResponse(streamReq.PeerName, streamReq.Partition, status, resp, logger)
 				if err != nil {
 					logger.Error("failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 					status.TrackReceiveError(err.Error())

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -1219,7 +1219,7 @@ func expectReplEvents(t *testing.T, client *MockClient, checkFns ...func(t *test
 }
 
 func TestHandleUpdateService(t *testing.T) {
-	srv, _ := newTestServer(t, func(c *Config) {
+	srv, store := newTestServer(t, func(c *Config) {
 		backend := c.Backend.(*testStreamBackend)
 		backend.leader = func() bool {
 			return false
@@ -1227,19 +1227,31 @@ func TestHandleUpdateService(t *testing.T) {
 	})
 
 	type testCase struct {
-		name   string
-		seed   []*structs.RegisterRequest
-		input  *pbservice.IndexedCheckServiceNodes
-		expect map[string]structs.CheckServiceNodes
+		name                          string
+		seed                          []*structs.RegisterRequest
+		input                         *pbservice.IndexedCheckServiceNodes
+		expect                        map[string]structs.CheckServiceNodes
+		expectedImportedServicesCount int
 	}
 
 	peerName := "billing"
+	peerID := "1fabcd52-1d46-49b0-b1d8-71559aee47f5"
 	remoteMeta := pbcommon.NewEnterpriseMetaFromStructs(*structs.DefaultEnterpriseMetaInPartition("billing-ap"))
 
 	// "api" service is imported from the billing-ap partition, corresponding to the billing peer.
 	// Locally it is stored to the default partition.
 	defaultMeta := *acl.DefaultEnterpriseMeta()
 	apiSN := structs.NewServiceName("api", &defaultMeta)
+
+	// create a peering in the state store
+	store.PeeringWrite(31, &pbpeering.Peering{
+		ID:   peerID,
+		Name: peerName},
+	)
+
+	// connect the stream
+	_, err := srv.Tracker.Connected(peerID)
+	require.NoError(t, err)
 
 	run := func(t *testing.T, tc testCase) {
 		// Seed the local catalog with some data to reconcile against.
@@ -1257,6 +1269,11 @@ func TestHandleUpdateService(t *testing.T) {
 				requireEqualInstances(t, expect, got)
 			})
 		}
+
+		// assert the imported services count modifications
+		mss, err := srv.Server.Tracker.MutableStreamStatus(peerID)
+		require.NoError(t, err)
+		require.Equal(t, tc.expectedImportedServicesCount, mss.GetImportedServicesCount())
 	}
 
 	tt := []testCase{
@@ -1390,6 +1407,7 @@ func TestHandleUpdateService(t *testing.T) {
 					},
 				},
 			},
+			expectedImportedServicesCount: 1,
 		},
 		{
 			name: "upsert two service instances to different nodes",
@@ -1521,6 +1539,7 @@ func TestHandleUpdateService(t *testing.T) {
 					},
 				},
 			},
+			expectedImportedServicesCount: 1,
 		},
 		{
 			name: "receiving a nil input leads to deleting data in the catalog",
@@ -1578,6 +1597,7 @@ func TestHandleUpdateService(t *testing.T) {
 			expect: map[string]structs.CheckServiceNodes{
 				"api": {},
 			},
+			expectedImportedServicesCount: 0,
 		},
 		{
 			name: "deleting one service name from a node does not delete other service names",
@@ -1668,6 +1688,7 @@ func TestHandleUpdateService(t *testing.T) {
 					},
 				},
 			},
+			expectedImportedServicesCount: 0, // IRL, this count would be 1, but we pre-seed the redis service
 		},
 		{
 			name: "service checks are cleaned up when not present in a response",

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -985,7 +985,7 @@ func Test_processResponse_Validation(t *testing.T) {
 	))
 
 	run := func(t *testing.T, tc testCase) {
-		reply, err := srv.processResponse(peerName, "", tc.in)
+		reply, err := srv.processResponse(peerName, "", nil, tc.in, srv.Logger)
 		if tc.wantErr {
 			require.Error(t, err)
 		} else {
@@ -1261,13 +1261,17 @@ func TestHandleUpdateService(t *testing.T) {
 	require.NoError(t, err)
 
 	run := func(t *testing.T, tc testCase) {
+
+		mst, found := srv.Tracker.MutableStreamStatus(peerID)
+		require.True(t, found)
+
 		// Seed the local catalog with some data to reconcile against.
 		for _, reg := range tc.seed {
 			require.NoError(t, srv.Backend.CatalogRegister(reg))
 		}
 
 		// Simulate an update arriving for billing/api.
-		require.NoError(t, srv.handleUpdateService(peerName, acl.DefaultPartitionName, apiSN, tc.input))
+		require.NoError(t, srv.handleUpdateService(peerName, acl.DefaultPartitionName, apiSN, mst, tc.input, srv.Logger))
 
 		for svc, expect := range tc.expect {
 			t.Run(svc, func(t *testing.T) {

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -75,18 +75,6 @@ func (t *Tracker) StreamStatus(id string) (resp Status, found bool) {
 	return s.GetStatus(), true
 }
 
-// MutableStreamStatus gives a handle of the MutableStatus for a given peer ID
-func (t *Tracker) MutableStreamStatus(id string) (status *MutableStatus, found bool) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
-	s, ok := t.streams[id]
-	if !ok {
-		return nil, false
-	}
-	return s, true
-}
-
 func (t *Tracker) ConnectedStreams() map[string]chan struct{} {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -76,15 +76,15 @@ func (t *Tracker) StreamStatus(id string) (resp Status, found bool) {
 }
 
 // MutableStreamStatus gives a handle of the MutableStatus for a given peer ID
-func (t *Tracker) MutableStreamStatus(id string) (status *MutableStatus, err error) {
+func (t *Tracker) MutableStreamStatus(id string) (status *MutableStatus, found bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
 	s, ok := t.streams[id]
 	if !ok {
-		return nil, fmt.Errorf("did not find a stream for id: %q", id)
+		return nil, false
 	}
-	return s, nil
+	return s, true
 }
 
 func (t *Tracker) ConnectedStreams() map[string]chan struct{} {

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -337,7 +337,17 @@ func (s *Server) PeeringRead(ctx context.Context, req *pbpeering.PeeringReadRequ
 	if peering == nil {
 		return &pbpeering.PeeringReadResponse{Peering: nil}, nil
 	}
+
 	cp := copyPeeringWithNewState(peering, s.reconciledStreamStateHint(peering.ID, peering.State))
+
+	// add imported services count
+	st, found := s.Tracker.StreamStatus(peering.ID)
+	if !found {
+		s.Logger.Trace("did not find peer in stream tracker when reading peer", "peerID", peering.ID)
+	} else {
+		cp.ImportedServiceCount = uint64(len(st.ImportedServices))
+	}
+
 	return &pbpeering.PeeringReadResponse{Peering: cp}, nil
 }
 
@@ -369,6 +379,15 @@ func (s *Server) PeeringList(ctx context.Context, req *pbpeering.PeeringListRequ
 	var cPeerings []*pbpeering.Peering
 	for _, p := range peerings {
 		cp := copyPeeringWithNewState(p, s.reconciledStreamStateHint(p.ID, p.State))
+
+		// add imported services count
+		st, found := s.Tracker.StreamStatus(p.ID)
+		if !found {
+			s.Logger.Trace("did not find peer in stream tracker when listing peers", "peerID", p.ID)
+		} else {
+			cp.ImportedServiceCount = uint64(len(st.ImportedServices))
+		}
+
 		cPeerings = append(cPeerings, cp)
 	}
 	return &pbpeering.PeeringListResponse{Peerings: cPeerings}, nil
@@ -586,17 +605,19 @@ func (s *Server) getExistingOrCreateNewPeerID(peerName, partition string) (strin
 
 func copyPeeringWithNewState(p *pbpeering.Peering, state pbpeering.PeeringState) *pbpeering.Peering {
 	return &pbpeering.Peering{
-		ID:                  p.ID,
-		Name:                p.Name,
-		Partition:           p.Partition,
-		DeletedAt:           p.DeletedAt,
-		Meta:                p.Meta,
-		PeerID:              p.PeerID,
-		PeerCAPems:          p.PeerCAPems,
-		PeerServerAddresses: p.PeerServerAddresses,
-		PeerServerName:      p.PeerServerName,
-		CreateIndex:         p.CreateIndex,
-		ModifyIndex:         p.ModifyIndex,
+		ID:                   p.ID,
+		Name:                 p.Name,
+		Partition:            p.Partition,
+		DeletedAt:            p.DeletedAt,
+		Meta:                 p.Meta,
+		PeerID:               p.PeerID,
+		PeerCAPems:           p.PeerCAPems,
+		PeerServerAddresses:  p.PeerServerAddresses,
+		PeerServerName:       p.PeerServerName,
+		CreateIndex:          p.CreateIndex,
+		ModifyIndex:          p.ModifyIndex,
+		ImportedServiceCount: p.ImportedServiceCount,
+		ExportedServiceCount: p.ExportedServiceCount,
 
 		State: state,
 	}


### PR DESCRIPTION
### Description

For now, we are choosing to track the imported services count in the stream tracker shim. In the future, the tracking should make its way through raft.

### Testing & Reproduction steps
* stream tracker tests updated
* NOTE: `leader_peering_test` contains a more e2e test approach to peering sync; let's keep this test in the leader for now since the `PeeringList` call needs to always get served by the leader