### PR TITLE
ui: Add a modal.opened property for inspecting whether the modal is open

### DIFF
--- a/ui/packages/consul-ui/app/components/modal-dialog/README.mdx
+++ b/ui/packages/consul-ui/app/components/modal-dialog/README.mdx
@@ -70,5 +70,6 @@ Then all modals will be rendered into the `<ModalLayer />`.
 | --- | --- | --- |
 | `open` | `Function` | Opens the modal dialog |
 | `close` | `Function` | Closes the modal dialog |
+| `opened` | `boolean` | Whether the modal is currently open or not |
 
 

--- a/ui/packages/consul-ui/app/components/modal-dialog/index.hbs
+++ b/ui/packages/consul-ui/app/components/modal-dialog/index.hbs
@@ -30,6 +30,7 @@
               {{yield (hash
                 open=(action "open")
                 close=(action "close")
+                opened=this.isOpen
                 aria=aria
               )}}
             </YieldSlot>
@@ -39,6 +40,7 @@
               {{yield (hash
                 open=(action "open")
                 close=(action "close")
+                opened=this.isOpen
                 aria=aria
               )}}
             </YieldSlot>
@@ -48,6 +50,7 @@
               {{yield (hash
                 open=(action "open")
                 close=(action "close")
+                opened=this.isOpen
                 aria=aria
               )}}
             </YieldSlot>

--- a/ui/packages/consul-ui/app/components/modal-dialog/index.js
+++ b/ui/packages/consul-ui/app/components/modal-dialog/index.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { set } from '@ember/object';
 import Slotted from 'block-slots';
 import A11yDialog from 'a11y-dialog';
 
@@ -6,13 +7,16 @@ export default Component.extend(Slotted, {
   tagName: '',
   onclose: function() {},
   onopen: function() {},
+  isOpen: false,
   actions: {
     connect: function($el) {
       this.dialog = new A11yDialog($el);
+      this.dialog.on('show', () => set(this, 'isOpen', true));
+      this.dialog.on('hide', () => set(this, 'isOpen', false));
       this.dialog.on('hide', () => this.onclose({ target: $el }));
       this.dialog.on('show', () => this.onopen({ target: $el }));
       if (this.open) {
-        this.dialog.show();
+        this.actions.open.apply(this, []);
       }
     },
     disconnect: function($el) {


### PR DESCRIPTION
### Description
Adds a `opened` boolean property for modals for inspecting whether the modal is currently open or not.

Notes:
- Our modals are super old and will at somepoint by upgraded to Octane, but now is not the time
- We usually prefer simple single word API properties/arguments if at all possible

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMike