### PR TITLE
ui: peer permission handling

### DIFF
--- a/ui/packages/consul-ui/app/abilities/peer.js
+++ b/ui/packages/consul-ui/app/abilities/peer.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 export default class PeerAbility extends BaseAbility {
   @service('env') env;
 
-  resource = 'operator';
+  resource = 'peering';
   segmented = false;
 
   get isLinkable() {

--- a/ui/packages/consul-ui/app/abilities/peer.js
+++ b/ui/packages/consul-ui/app/abilities/peer.js
@@ -12,7 +12,7 @@ export default class PeerAbility extends BaseAbility {
   }
   get canDelete() {
     // TODO: Need to confirm these states
-    return !['DELETING', 'TERMINATED', 'UNDEFINED'].includes(this.item.State);
+    return !['DELETING', 'TERMINATED', 'UNDEFINED'].includes(this.item.State) && this.canWrite;
   }
 
   get canUse() {

--- a/ui/packages/consul-ui/app/services/repository/permission.js
+++ b/ui/packages/consul-ui/app/services/repository/permission.js
@@ -57,6 +57,16 @@ const REQUIRED_PERMISSIONS = [
     Access: 'write',
   },
 ];
+const PEERING_PERMISSIONS = [
+  {
+    Resource: 'peering',
+    Access: 'read',
+  },
+  {
+    Resource: 'peering',
+    Access: 'write',
+  },
+];
 export default class PermissionService extends RepositoryService {
   @service('env') env;
   @service('abilities') _can;
@@ -146,7 +156,7 @@ export default class PermissionService extends RepositoryService {
 
   @dataSource('/:partition/:nspace/:dc/permissions')
   async findAll(params) {
-    params.resources = REQUIRED_PERMISSIONS;
+    params.resources = this.permissionsToRequest;
     this.permissions = await this.findByPermissions(params);
     /**/
     // Temporarily revert to pre-1.10 UI functionality by overwriting frontend
@@ -161,5 +171,13 @@ export default class PermissionService extends RepositoryService {
     });
     /**/
     return this.permissions;
+  }
+
+  get permissionsToRequest() {
+    if (this._can.can('use peers')) {
+      return [...REQUIRED_PERMISSIONS, ...PEERING_PERMISSIONS];
+    } else {
+      return REQUIRED_PERMISSIONS;
+    }
   }
 }


### PR DESCRIPTION
### Description
This PR adds peering permission handling for the peer resources.

* it adds the peering permission to the requested permissions in the `dc`-route when the peering feature is enabled
* it updates the peer - ability to use the `peering`-resource to determine permissions not `operator`
* it updates the `canDelete`-permission for a peer to also take the peering:write permission into account not only the peering's State.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

cc @johncowen 
