### PR TITLE
state: prohibit exported discovery chains to have cross-datacenter or cross-partition references

### DIFF
--- a/agent/consul/state/config_entry_test.go
+++ b/agent/consul/state/config_entry_test.go
@@ -843,24 +843,75 @@ func TestStore_Service_TerminatingGateway_Kind_Service_Destination_Wildcard(t *t
 }
 
 func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
+	ensureConfigEntry := func(s *Store, idx uint64, entry structs.ConfigEntry) error {
+		if err := entry.Normalize(); err != nil {
+			return err
+		}
+		if err := entry.Validate(); err != nil {
+			return err
+		}
+		return s.EnsureConfigEntry(0, entry)
+	}
+
 	type tcase struct {
 		entries        []structs.ConfigEntry
-		op             func(t *testing.T, s *Store) error
+		opAdd          structs.ConfigEntry
+		opDelete       configentry.KindName
 		expectErr      string
 		expectGraphErr bool
 	}
+
+	EMPTY_KN := configentry.KindName{}
+
+	run := func(t *testing.T, tc tcase) {
+		s := testConfigStateStore(t)
+		for _, entry := range tc.entries {
+			require.NoError(t, ensureConfigEntry(s, 0, entry))
+		}
+
+		nOps := 0
+		if tc.opAdd != nil {
+			nOps++
+		}
+		if tc.opDelete != EMPTY_KN {
+			nOps++
+		}
+		require.Equal(t, 1, nOps, "exactly one operation is required")
+
+		var err error
+		switch {
+		case tc.opAdd != nil:
+			err = ensureConfigEntry(s, 0, tc.opAdd)
+		case tc.opDelete != EMPTY_KN:
+			kn := tc.opDelete
+			err = s.DeleteConfigEntry(0, kn.Kind, kn.Name, &kn.EnterpriseMeta)
+		default:
+			t.Fatal("not possible")
+		}
+
+		if tc.expectErr != "" {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.expectErr)
+			_, ok := err.(*structs.ConfigEntryGraphError)
+			if tc.expectGraphErr {
+				require.True(t, ok, "%T is not a *ConfigEntryGraphError", err)
+			} else {
+				require.False(t, ok, "did not expect a *ConfigEntryGraphError here: %v", err)
+			}
+		} else {
+			require.NoError(t, err)
+		}
+	}
+
 	cases := map[string]tcase{
 		"splitter fails without default protocol": {
 			entries: []structs.ConfigEntry{},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceSplitterConfigEntry{
-					Kind: structs.ServiceSplitter,
-					Name: "main",
-					Splits: []structs.ServiceSplit{
-						{Weight: 100},
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceSplitterConfigEntry{
+				Kind: structs.ServiceSplitter,
+				Name: "main",
+				Splits: []structs.ServiceSplit{
+					{Weight: 100},
+				},
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -873,15 +924,12 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					Protocol: "tcp",
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceSplitterConfigEntry{
-					Kind: structs.ServiceSplitter,
-					Name: "main",
-					Splits: []structs.ServiceSplit{
-						{Weight: 100},
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceSplitterConfigEntry{
+				Kind: structs.ServiceSplitter,
+				Name: "main",
+				Splits: []structs.ServiceSplit{
+					{Weight: 100},
+				},
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -914,17 +962,14 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceSplitterConfigEntry{
-					Kind: structs.ServiceSplitter,
-					Name: "main",
-					Splits: []structs.ServiceSplit{
-						{Weight: 90, ServiceSubset: "v1"},
-						{Weight: 10, ServiceSubset: "v2"},
-					},
-					EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceSplitterConfigEntry{
+				Kind: structs.ServiceSplitter,
+				Name: "main",
+				Splits: []structs.ServiceSplit{
+					{Weight: 90, ServiceSubset: "v1"},
+					{Weight: 10, ServiceSubset: "v2"},
+				},
+				EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
 			},
 		},
 		"splitter works with http protocol (from proxy-defaults)": {
@@ -949,16 +994,13 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceSplitterConfigEntry{
-					Kind: structs.ServiceSplitter,
-					Name: "main",
-					Splits: []structs.ServiceSplit{
-						{Weight: 90, ServiceSubset: "v1"},
-						{Weight: 10, ServiceSubset: "v2"},
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceSplitterConfigEntry{
+				Kind: structs.ServiceSplitter,
+				Name: "main",
+				Splits: []structs.ServiceSplit{
+					{Weight: 90, ServiceSubset: "v1"},
+					{Weight: 10, ServiceSubset: "v2"},
+				},
 			},
 		},
 		"router fails with tcp protocol": {
@@ -978,24 +1020,21 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceRouterConfigEntry{
-					Kind: structs.ServiceRouter,
-					Name: "main",
-					Routes: []structs.ServiceRoute{
-						{
-							Match: &structs.ServiceRouteMatch{
-								HTTP: &structs.ServiceRouteHTTPMatch{
-									PathExact: "/other",
-								},
-							},
-							Destination: &structs.ServiceRouteDestination{
-								ServiceSubset: "other",
+			opAdd: &structs.ServiceRouterConfigEntry{
+				Kind: structs.ServiceRouter,
+				Name: "main",
+				Routes: []structs.ServiceRoute{
+					{
+						Match: &structs.ServiceRouteMatch{
+							HTTP: &structs.ServiceRouteHTTPMatch{
+								PathExact: "/other",
 							},
 						},
+						Destination: &structs.ServiceRouteDestination{
+							ServiceSubset: "other",
+						},
 					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+				},
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -1012,24 +1051,21 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceRouterConfigEntry{
-					Kind: structs.ServiceRouter,
-					Name: "main",
-					Routes: []structs.ServiceRoute{
-						{
-							Match: &structs.ServiceRouteMatch{
-								HTTP: &structs.ServiceRouteHTTPMatch{
-									PathExact: "/other",
-								},
-							},
-							Destination: &structs.ServiceRouteDestination{
-								ServiceSubset: "other",
+			opAdd: &structs.ServiceRouterConfigEntry{
+				Kind: structs.ServiceRouter,
+				Name: "main",
+				Routes: []structs.ServiceRoute{
+					{
+						Match: &structs.ServiceRouteMatch{
+							HTTP: &structs.ServiceRouteHTTPMatch{
+								PathExact: "/other",
 							},
 						},
+						Destination: &structs.ServiceRouteDestination{
+							ServiceSubset: "other",
+						},
 					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+				},
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -1063,9 +1099,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				return s.DeleteConfigEntry(0, structs.ServiceDefaults, "main", nil)
-			},
+			opDelete:       configentry.NewKindName(structs.ServiceDefaults, "main", nil),
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
 		},
@@ -1099,9 +1133,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				return s.DeleteConfigEntry(0, structs.ProxyDefaults, structs.ProxyConfigGlobal, nil)
-			},
+			opDelete:       configentry.NewKindName(structs.ProxyDefaults, structs.ProxyConfigGlobal, nil),
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
 		},
@@ -1140,9 +1172,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				return s.DeleteConfigEntry(0, structs.ProxyDefaults, structs.ProxyConfigGlobal, nil)
-			},
+			opDelete: configentry.NewKindName(structs.ProxyDefaults, structs.ProxyConfigGlobal, nil),
 		},
 		"cannot change to tcp protocol after splitter created": {
 			entries: []structs.ConfigEntry{
@@ -1172,13 +1202,10 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceConfigEntry{
-					Kind:     structs.ServiceDefaults,
-					Name:     "main",
-					Protocol: "tcp",
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceConfigEntry{
+				Kind:     structs.ServiceDefaults,
+				Name:     "main",
+				Protocol: "tcp",
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -1216,9 +1243,7 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				return s.DeleteConfigEntry(0, structs.ServiceDefaults, "main", nil)
-			},
+			opDelete:       configentry.NewKindName(structs.ServiceDefaults, "main", nil),
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
 		},
@@ -1255,13 +1280,10 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceConfigEntry{
-					Kind:     structs.ServiceDefaults,
-					Name:     "main",
-					Protocol: "tcp",
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceConfigEntry{
+				Kind:     structs.ServiceDefaults,
+				Name:     "main",
+				Protocol: "tcp",
 			},
 			expectErr:      "does not permit advanced routing or splitting behavior",
 			expectGraphErr: true,
@@ -1280,16 +1302,13 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					Protocol: "tcp",
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceSplitterConfigEntry{
-					Kind: structs.ServiceSplitter,
-					Name: "main",
-					Splits: []structs.ServiceSplit{
-						{Weight: 90},
-						{Weight: 10, Service: "other"},
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceSplitterConfigEntry{
+				Kind: structs.ServiceSplitter,
+				Name: "main",
+				Splits: []structs.ServiceSplit{
+					{Weight: 90},
+					{Weight: 10, Service: "other"},
+				},
 			},
 			expectErr:      "uses inconsistent protocols",
 			expectGraphErr: true,
@@ -1307,24 +1326,21 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					Protocol: "tcp",
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceRouterConfigEntry{
-					Kind: structs.ServiceRouter,
-					Name: "main",
-					Routes: []structs.ServiceRoute{
-						{
-							Match: &structs.ServiceRouteMatch{
-								HTTP: &structs.ServiceRouteHTTPMatch{
-									PathExact: "/other",
-								},
-							},
-							Destination: &structs.ServiceRouteDestination{
-								Service: "other",
+			opAdd: &structs.ServiceRouterConfigEntry{
+				Kind: structs.ServiceRouter,
+				Name: "main",
+				Routes: []structs.ServiceRoute{
+					{
+						Match: &structs.ServiceRouteMatch{
+							HTTP: &structs.ServiceRouteHTTPMatch{
+								PathExact: "/other",
 							},
 						},
+						Destination: &structs.ServiceRouteDestination{
+							Service: "other",
+						},
 					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+				},
 			},
 			expectErr:      "uses inconsistent protocols",
 			expectGraphErr: true,
@@ -1348,17 +1364,14 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					ConnectTimeout: 33 * time.Second,
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceResolverConfigEntry{
-					Kind: structs.ServiceResolver,
-					Name: "main",
-					Failover: map[string]structs.ServiceResolverFailover{
-						"*": {
-							Service: "other",
-						},
+			opAdd: &structs.ServiceResolverConfigEntry{
+				Kind: structs.ServiceResolver,
+				Name: "main",
+				Failover: map[string]structs.ServiceResolverFailover{
+					"*": {
+						Service: "other",
 					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+				},
 			},
 			expectErr:      "uses inconsistent protocols",
 			expectGraphErr: true,
@@ -1381,15 +1394,12 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					ConnectTimeout: 33 * time.Second,
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceResolverConfigEntry{
-					Kind: structs.ServiceResolver,
-					Name: "main",
-					Redirect: &structs.ServiceResolverRedirect{
-						Service: "other",
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceResolverConfigEntry{
+				Kind: structs.ServiceResolver,
+				Name: "main",
+				Redirect: &structs.ServiceResolverRedirect{
+					Service: "other",
+				},
 			},
 			expectErr:      "uses inconsistent protocols",
 			expectGraphErr: true,
@@ -1408,16 +1418,13 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceResolverConfigEntry{
-					Kind: structs.ServiceResolver,
-					Name: "main",
-					Redirect: &structs.ServiceResolverRedirect{
-						Service:       "other",
-						ServiceSubset: "v1",
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceResolverConfigEntry{
+				Kind: structs.ServiceResolver,
+				Name: "main",
+				Redirect: &structs.ServiceResolverRedirect{
+					Service:       "other",
+					ServiceSubset: "v1",
+				},
 			},
 		},
 		"cannot redirect to a subset that does not exist": {
@@ -1428,16 +1435,13 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					ConnectTimeout: 33 * time.Second,
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceResolverConfigEntry{
-					Kind: structs.ServiceResolver,
-					Name: "main",
-					Redirect: &structs.ServiceResolverRedirect{
-						Service:       "other",
-						ServiceSubset: "v1",
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceResolverConfigEntry{
+				Kind: structs.ServiceResolver,
+				Name: "main",
+				Redirect: &structs.ServiceResolverRedirect{
+					Service:       "other",
+					ServiceSubset: "v1",
+				},
 			},
 			expectErr:      `does not have a subset named "v1"`,
 			expectGraphErr: true,
@@ -1453,15 +1457,12 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceResolverConfigEntry{
-					Kind: structs.ServiceResolver,
-					Name: "main",
-					Redirect: &structs.ServiceResolverRedirect{
-						Service: "other",
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceResolverConfigEntry{
+				Kind: structs.ServiceResolver,
+				Name: "main",
+				Redirect: &structs.ServiceResolverRedirect{
+					Service: "other",
+				},
 			},
 			expectErr:      `detected circular resolver redirect`,
 			expectGraphErr: true,
@@ -1483,45 +1484,102 @@ func TestStore_ConfigEntry_GraphValidation(t *testing.T) {
 					},
 				},
 			},
-			op: func(t *testing.T, s *Store) error {
-				entry := &structs.ServiceSplitterConfigEntry{
-					Kind: "service-splitter",
-					Name: "main",
-					Splits: []structs.ServiceSplit{
-						{Weight: 100, Service: "other"},
-					},
-				}
-				return s.EnsureConfigEntry(0, entry)
+			opAdd: &structs.ServiceSplitterConfigEntry{
+				Kind: "service-splitter",
+				Name: "main",
+				Splits: []structs.ServiceSplit{
+					{Weight: 100, Service: "other"},
+				},
 			},
 			expectErr:      `detected circular reference`,
 			expectGraphErr: true,
 		},
+		/////////////////////////////////////////////////
+		"cannot peer export cross-dc redirect": {
+			entries: []structs.ConfigEntry{
+				&structs.ServiceResolverConfigEntry{
+					Kind: "service-resolver",
+					Name: "main",
+					Redirect: &structs.ServiceResolverRedirect{
+						Datacenter: "dc3",
+					},
+				},
+			},
+			opAdd: &structs.ExportedServicesConfigEntry{
+				Name: "default",
+				Services: []structs.ExportedService{{
+					Name:      "main",
+					Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+				}},
+			},
+			expectErr: `contains cross-datacenter resolver redirect`,
+		},
+		"cannot peer export cross-dc redirect via wildcard": {
+			entries: []structs.ConfigEntry{
+				&structs.ServiceResolverConfigEntry{
+					Kind: "service-resolver",
+					Name: "main",
+					Redirect: &structs.ServiceResolverRedirect{
+						Datacenter: "dc3",
+					},
+				},
+			},
+			opAdd: &structs.ExportedServicesConfigEntry{
+				Name: "default",
+				Services: []structs.ExportedService{{
+					Name:      "*",
+					Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+				}},
+			},
+			expectErr: `contains cross-datacenter resolver redirect`,
+		},
+		"cannot peer export cross-dc failover": {
+			entries: []structs.ConfigEntry{
+				&structs.ServiceResolverConfigEntry{
+					Kind: "service-resolver",
+					Name: "main",
+					Failover: map[string]structs.ServiceResolverFailover{
+						"*": {
+							Datacenters: []string{"dc3"},
+						},
+					},
+				},
+			},
+			opAdd: &structs.ExportedServicesConfigEntry{
+				Name: "default",
+				Services: []structs.ExportedService{{
+					Name:      "main",
+					Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+				}},
+			},
+			expectErr: `contains cross-datacenter failover`,
+		},
+		"cannot peer export cross-dc failover via wildcard": {
+			entries: []structs.ConfigEntry{
+				&structs.ServiceResolverConfigEntry{
+					Kind: "service-resolver",
+					Name: "main",
+					Failover: map[string]structs.ServiceResolverFailover{
+						"*": {
+							Datacenters: []string{"dc3"},
+						},
+					},
+				},
+			},
+			opAdd: &structs.ExportedServicesConfigEntry{
+				Name: "default",
+				Services: []structs.ExportedService{{
+					Name:      "*",
+					Consumers: []structs.ServiceConsumer{{PeerName: "my-peer"}},
+				}},
+			},
+			expectErr: `contains cross-datacenter failover`,
+		},
 	}
 
 	for name, tc := range cases {
-		name := name
-		tc := tc
-
 		t.Run(name, func(t *testing.T) {
-			s := testConfigStateStore(t)
-			for _, entry := range tc.entries {
-				require.NoError(t, entry.Normalize())
-				require.NoError(t, s.EnsureConfigEntry(0, entry))
-			}
-
-			err := tc.op(t, s)
-			if tc.expectErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectErr)
-				_, ok := err.(*structs.ConfigEntryGraphError)
-				if tc.expectGraphErr {
-					require.True(t, ok, "%T is not a *ConfigEntryGraphError", err)
-				} else {
-					require.False(t, ok, "did not expect a *ConfigEntryGraphError here: %v", err)
-				}
-			} else {
-				require.NoError(t, err)
-			}
+			run(t, tc)
 		})
 	}
 }

--- a/agent/grpc/public/services/peerstream/subscription_manager_test.go
+++ b/agent/grpc/public/services/peerstream/subscription_manager_test.go
@@ -289,8 +289,7 @@ func TestSubscriptionManager_RegisterDeregister(t *testing.T) {
 			Name: "mysql",
 			Failover: map[string]structs.ServiceResolverFailover{
 				"*": {
-					Service:     "failover",
-					Datacenters: []string{"dc2", "dc3"},
+					Service: "failover",
 				},
 			},
 		})
@@ -327,8 +326,7 @@ func TestSubscriptionManager_RegisterDeregister(t *testing.T) {
 								},
 								SpiffeID: []string{
 									"spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/mysql",
-									"spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/failover",
-									"spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc3/svc/failover",
+									"spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/failover",
 								},
 								Protocol: "tcp",
 							},

--- a/agent/proxycfg/testing_mesh_gateway.go
+++ b/agent/proxycfg/testing_mesh_gateway.go
@@ -548,10 +548,19 @@ func TestConfigSnapshotPeeredMeshGateway(t testing.T, variant string, nsFn func(
 			},
 			&structs.ServiceResolverConfigEntry{
 				Kind: structs.ServiceResolver,
-				Name: "api-dc2",
+				Name: "api",
+				Subsets: map[string]structs.ServiceResolverSubset{
+					"v2": {
+						Filter: "Service.Meta.version == v2",
+					},
+				},
+			},
+			&structs.ServiceResolverConfigEntry{
+				Kind: structs.ServiceResolver,
+				Name: "api-v2",
 				Redirect: &structs.ServiceResolverRedirect{
-					Service:    "api",
-					Datacenter: "dc2",
+					Service:       "api",
+					ServiceSubset: "v2",
 				},
 			},
 			&structs.ServiceSplitterConfigEntry{
@@ -576,7 +585,7 @@ func TestConfigSnapshotPeeredMeshGateway(t testing.T, variant string, nsFn func(
 						Match: httpMatch(&structs.ServiceRouteHTTPMatch{
 							PathPrefix: "/api",
 						}),
-						Destination: toService("api-dc2"),
+						Destination: toService("api-v2"),
 					},
 				},
 			},
@@ -602,13 +611,7 @@ func TestConfigSnapshotPeeredMeshGateway(t testing.T, variant string, nsFn func(
 		extraUpdates = append(extraUpdates,
 			UpdateEvent{
 				CorrelationID: datacentersWatchID,
-				Result:        &[]string{"dc1", "dc2"},
-			},
-			UpdateEvent{
-				CorrelationID: "mesh-gateway:dc2",
-				Result: &structs.IndexedNodesWithGateways{
-					Nodes: TestGatewayNodesDC2(t),
-				},
+				Result:        &[]string{"dc1"},
 			},
 			UpdateEvent{
 				CorrelationID: exportedServiceListWatchID,

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -907,6 +907,14 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 
 		target := chain.Targets[targetID]
 
+		if forMeshGateway && !cfgSnap.Locality.Matches(target.Datacenter, target.Partition) {
+			s.Logger.Warn("ignoring discovery chain target that crosses a datacenter or partition boundary in a mesh gateway",
+				"target", target,
+				"gatewayLocality", cfgSnap.Locality,
+			)
+			continue
+		}
+
 		// Determine if we have to generate the entire cluster differently.
 		failoverThroughMeshGateway := chain.WillFailoverThroughMeshGateway(node) && !forMeshGateway
 

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -177,7 +177,6 @@ func (s *ResourceGenerator) endpointsFromSnapshotMeshGateway(cfgSnap *proxycfg.C
 	keys := cfgSnap.MeshGateway.GatewayKeys()
 	resources := make([]proto.Message, 0, len(keys)+len(cfgSnap.MeshGateway.ServiceGroups))
 
-	endpointsPerRemoteGateway := make(map[string]structs.CheckServiceNodes)
 	for _, key := range keys {
 		if key.Matches(cfgSnap.Datacenter, cfgSnap.ProxyID.PartitionOrDefault()) {
 			continue // skip local
@@ -193,8 +192,6 @@ func (s *ResourceGenerator) endpointsFromSnapshotMeshGateway(cfgSnap *proxycfg.C
 			s.Logger.Error("skipping mesh gateway endpoints because no definition found", "datacenter", key)
 			continue
 		}
-
-		endpointsPerRemoteGateway[key.String()] = endpoints
 
 		{ // standard connect
 			clusterName := connect.GatewaySNI(key.Datacenter, key.Partition, cfgSnap.Roots.TrustDomain)
@@ -274,7 +271,7 @@ func (s *ResourceGenerator) endpointsFromSnapshotMeshGateway(cfgSnap *proxycfg.C
 	resources = append(resources, e...)
 
 	// Generate the endpoints for exported discovery chain targets.
-	e, err = s.makeExportedUpstreamEndpointsForMeshGateway(cfgSnap, endpointsPerRemoteGateway)
+	e, err = s.makeExportedUpstreamEndpointsForMeshGateway(cfgSnap)
 	if err != nil {
 		return nil, err
 	}
@@ -479,6 +476,7 @@ func (s *ResourceGenerator) endpointsFromDiscoveryChain(
 			gatewayEndpoints,
 			targetID,
 			gatewayKey,
+			forMeshGateway,
 		)
 		if !valid {
 			continue // skip the cluster if we're still populating the snapshot
@@ -500,6 +498,7 @@ func (s *ResourceGenerator) endpointsFromDiscoveryChain(
 					gatewayEndpoints,
 					failTargetID,
 					gatewayKey,
+					forMeshGateway,
 				)
 				if !valid {
 					continue // skip the failover target if we're still populating the snapshot
@@ -519,10 +518,7 @@ func (s *ResourceGenerator) endpointsFromDiscoveryChain(
 	return resources, nil
 }
 
-func (s *ResourceGenerator) makeExportedUpstreamEndpointsForMeshGateway(
-	cfgSnap *proxycfg.ConfigSnapshot,
-	endpointsPerRemoteGateway map[string]structs.CheckServiceNodes,
-) ([]proto.Message, error) {
+func (s *ResourceGenerator) makeExportedUpstreamEndpointsForMeshGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	var resources []proto.Message
 
 	populatedExportedClusters := make(map[string]struct{}) // key=clusterName
@@ -531,41 +527,38 @@ func (s *ResourceGenerator) makeExportedUpstreamEndpointsForMeshGateway(
 
 		chainEndpoints := make(map[string]structs.CheckServiceNodes)
 		for _, target := range chain.Targets {
-			if cfgSnap.Locality.Matches(target.Datacenter, target.Partition) {
-				// served locally
-				targetSvc := target.ServiceName()
+			if !cfgSnap.Locality.Matches(target.Datacenter, target.Partition) {
+				s.Logger.Warn("ignoring discovery chain target that crosses a datacenter or partition boundary in a mesh gateway",
+					"target", target,
+					"gatewayLocality", cfgSnap.Locality,
+				)
+				continue
+			}
 
-				endpoints, ok := cfgSnap.MeshGateway.ServiceGroups[targetSvc]
+			targetSvc := target.ServiceName()
+
+			endpoints, ok := cfgSnap.MeshGateway.ServiceGroups[targetSvc]
+			if !ok {
+				continue // ignore; not ready
+			}
+
+			if target.ServiceSubset == "" {
+				chainEndpoints[target.ID] = endpoints
+			} else {
+				resolver, ok := cfgSnap.MeshGateway.ServiceResolvers[targetSvc]
+				if !ok {
+					continue // ignore; not ready
+				}
+				subset, ok := resolver.Subsets[target.ServiceSubset]
 				if !ok {
 					continue // ignore; not ready
 				}
 
-				if target.ServiceSubset == "" {
-					chainEndpoints[target.ID] = endpoints
-				} else {
-					resolver, ok := cfgSnap.MeshGateway.ServiceResolvers[targetSvc]
-					if !ok {
-						continue // ignore; not ready
-					}
-					subset, ok := resolver.Subsets[target.ServiceSubset]
-					if !ok {
-						continue // ignore; not ready
-					}
-
-					subsetEndpoints, err := s.filterSubsetEndpoints(&subset, endpoints)
-					if err != nil {
-						return nil, err
-					}
-					chainEndpoints[target.ID] = subsetEndpoints
+				subsetEndpoints, err := s.filterSubsetEndpoints(&subset, endpoints)
+				if err != nil {
+					return nil, err
 				}
-			} else {
-				// serve remotely
-				gk := proxycfg.GatewayKey{
-					Datacenter: target.Datacenter,
-					Partition:  target.Partition,
-				}
-				// TODO(peering): handle hostname endpoints logic
-				chainEndpoints[target.ID] = cfgSnap.GetMeshGatewayEndpoints(gk)
+				chainEndpoints[target.ID] = subsetEndpoints
 			}
 		}
 
@@ -575,7 +568,7 @@ func (s *ResourceGenerator) makeExportedUpstreamEndpointsForMeshGateway(
 			cfgSnap.Locality,
 			nil,
 			chainEndpoints,
-			endpointsPerRemoteGateway,
+			nil,
 			true,
 		)
 		if err != nil {
@@ -652,6 +645,7 @@ func makeLoadAssignmentEndpointGroup(
 	gatewayHealth map[string]structs.CheckServiceNodes,
 	targetID string,
 	localKey proxycfg.GatewayKey,
+	forMeshGateway bool,
 ) (loadAssignmentEndpointGroup, bool) {
 	realEndpoints, ok := targetHealth[targetID]
 	if !ok {
@@ -666,12 +660,11 @@ func makeLoadAssignmentEndpointGroup(
 	case structs.MeshGatewayModeRemote:
 		gatewayKey.Datacenter = target.Datacenter
 		gatewayKey.Partition = target.Partition
-
 	case structs.MeshGatewayModeLocal:
 		gatewayKey = localKey
 	}
 
-	if gatewayKey.IsEmpty() || localKey.Matches(target.Datacenter, target.Partition) {
+	if forMeshGateway || gatewayKey.IsEmpty() || localKey.Matches(target.Datacenter, target.Partition) {
 		// Gateways are not needed if the request isn't for a remote DC or partition.
 		return loadAssignmentEndpointGroup{
 			Endpoints:   realEndpoints,

--- a/agent/xds/testdata/clusters/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
@@ -37,23 +37,6 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      "name": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-      "type": "EDS",
-      "edsClusterConfig": {
-        "edsConfig": {
-          "ads": {
-
-          },
-          "resourceApiVersion": "V3"
-        }
-      },
-      "connectTimeout": "5s",
-      "outlierDetection": {
-
-      }
-    },
-    {
-      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
       "name": "exported~alt.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "altStatName": "exported~alt.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
@@ -112,64 +95,6 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
-      "name": "exported~api.default.dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-      "altStatName": "exported~api.default.dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-      "type": "EDS",
-      "edsClusterConfig": {
-        "edsConfig": {
-          "ads": {
-
-          },
-          "resourceApiVersion": "V3"
-        }
-      },
-      "connectTimeout": "5s",
-      "circuitBreakers": {
-
-      },
-      "outlierDetection": {
-
-      },
-      "commonLbConfig": {
-        "healthyPanicThreshold": {
-
-        }
-      },
-      "transportSocket": {
-        "name": "tls",
-        "typedConfig": {
-          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
-          "commonTlsContext": {
-            "tlsParams": {
-
-            },
-            "tlsCertificates": [
-              {
-                "certificateChain": {
-                  "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
-                },
-                "privateKey": {
-                  "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
-                }
-              }
-            ],
-            "validationContext": {
-              "trustedCa": {
-                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
-              },
-              "matchSubjectAltNames": [
-                {
-                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc2/svc/api"
-                }
-              ]
-            }
-          },
-          "sni": "api.default.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
-        }
-      }
-    },
-    {
-      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
       "name": "exported~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "altStatName": "exported~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
@@ -223,6 +148,64 @@
             }
           },
           "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+        }
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+      "name": "exported~v2.api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName": "exported~v2.api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          },
+          "resourceApiVersion": "V3"
+        }
+      },
+      "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
+      "outlierDetection": {
+
+      },
+      "commonLbConfig": {
+        "healthyPanicThreshold": {
+
+        }
+      },
+      "transportSocket": {
+        "name": "tls",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+          "commonTlsContext": {
+            "tlsParams": {
+
+            },
+            "tlsCertificates": [
+              {
+                "certificateChain": {
+                  "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                },
+                "privateKey": {
+                  "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                }
+              }
+            ],
+            "validationContext": {
+              "trustedCa": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+              },
+              "matchSubjectAltNames": [
+                {
+                  "exact": "spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/api"
+                }
+              ]
+            }
+          },
+          "sni": "v2.api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
         }
       }
     }

--- a/agent/xds/testdata/endpoints/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
@@ -71,40 +71,6 @@
     },
     {
       "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-      "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-      "endpoints": [
-        {
-          "lbEndpoints": [
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "198.18.1.1",
-                    "portValue": 443
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "198.18.1.2",
-                    "portValue": 443
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
       "clusterName": "exported~alt.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
@@ -127,40 +93,6 @@
                   "socketAddress": {
                     "address": "10.10.1.2",
                     "portValue": 8080
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
-      "clusterName": "exported~api.default.dc2.internal.11111111-2222-3333-4444-555555555555.consul",
-      "endpoints": [
-        {
-          "lbEndpoints": [
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "198.18.1.1",
-                    "portValue": 443
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "198.18.1.2",
-                    "portValue": 443
                   }
                 }
               },

--- a/agent/xds/testdata/listeners/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
@@ -102,23 +102,6 @@
           }
         },
         {
-          "filterChainMatch": {
-            "serverNames": [
-              "*.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
-            ]
-          },
-          "filters": [
-            {
-              "name": "envoy.filters.network.tcp_proxy",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
-                "statPrefix": "mesh_gateway_remote.default.dc2",
-                "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul"
-              }
-            }
-          ]
-        },
-        {
           "filters": [
             {
               "name": "envoy.filters.network.sni_cluster",

--- a/agent/xds/testdata/routes/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
+++ b/agent/xds/testdata/routes/mesh-gateway-with-exported-peered-services-http-with-router.latest.golden
@@ -36,7 +36,7 @@
                 "prefix": "/api"
               },
               "route": {
-                "cluster": "exported~api.default.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "exported~v2.api.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
               }
             },
             {


### PR DESCRIPTION
### Description

Because peerings are pairwise, between two tuples of `(datacenter, partition)` having any exported reference via a discovery chain that crosses out of the peered datacenter or partition will ultimately not be able to work for various reasons. The biggest one is that there is no way in the ultimate destination to configure an intention that can allow an external SpiffeID to access a service.

This PR ensures that a user simply cannot do this, so they won't run into weird situations like this.
