### PR TITLE
peering: always send the mesh gateway SpiffeID even for tcp services

### DIFF
--- a/agent/grpc/public/services/peerstream/stream_test.go
+++ b/agent/grpc/public/services/peerstream/stream_test.go
@@ -720,6 +720,7 @@ func TestStreamResources_Server_ServiceUpdates(t *testing.T) {
 				require.Equal(t, "tcp", pm.Protocol)
 				spiffeIDs := []string{
 					"spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/mysql",
+					"spiffe://11111111-2222-3333-4444-555555555555.consul/gateway/mesh/dc/dc1",
 				}
 				require.Equal(t, spiffeIDs, pm.SpiffeID)
 			},

--- a/agent/grpc/public/services/peerstream/subscription_manager_test.go
+++ b/agent/grpc/public/services/peerstream/subscription_manager_test.go
@@ -275,6 +275,7 @@ func TestSubscriptionManager_RegisterDeregister(t *testing.T) {
 								},
 								SpiffeID: []string{
 									"spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/mysql",
+									"spiffe://11111111-2222-3333-4444-555555555555.consul/gateway/mesh/dc/dc1",
 									"spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/failover",
 								},
 								Protocol: "tcp",
@@ -335,6 +336,7 @@ func TestSubscriptionManager_RegisterDeregister(t *testing.T) {
 								},
 								SpiffeID: []string{
 									"spiffe://11111111-2222-3333-4444-555555555555.consul/ns/default/dc/dc1/svc/mysql",
+									"spiffe://11111111-2222-3333-4444-555555555555.consul/gateway/mesh/dc/dc1",
 								},
 								Protocol: "tcp",
 							},


### PR DESCRIPTION
### Description

If someone were to switch a peer-exported service from L4 to L7 there would be a brief SAN validation hiccup as traffic shifted to the mesh gateway for termination.

This PR sends the mesh gateway SpiffeID down all the time so the clients always expect a switch.
