### PR TITLE
Nia/cts tasks not required

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -241,7 +241,7 @@ service {
 
 ## Task
 
-A `task` block configures which task to execute in automation. When the task should execute can be determined by the `service` block (deprecated) and `condition` block. The `task` block may be specified multiple times to configure multiple tasks, or it can be omitted entirely. If no task blocks are specified, tasks can be dynamically added to a running CTS through use of the task [API](/docs/nia/api/tasks#tasks) and [CLI](/docs/nia/cli/task#task).
+A `task` block configures which task to execute in automation. When the task executes can be determined by the `condition` block. You can specify the `task` block multiple times to configure multiple tasks, or you can omit it entirely. If task blocks are not specified in your initial configuration, you can add them to a running CTS instance by using the [`/tasks` API endpoint](/docs/nia/api/tasks#tasks) or the [CLI's `task` command](/docs/nia/cli/task#task).
 
 ```hcl
 task {

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -241,7 +241,7 @@ service {
 
 ## Task
 
-A `task` block configures which task to execute in automation. When the task should execute can be determined by the `service` block (deprecated) and `condition` block. The `task` block may be specified multiple times to configure multiple tasks.
+A `task` block configures which task to execute in automation. When the task should execute can be determined by the `service` block (deprecated) and `condition` block. The `task` block may be specified multiple times to configure multiple tasks, or it can be omitted entirely. If no task blocks are specified, tasks can be dynamically added to a running CTS through use of the task [API](/docs/nia/api/tasks#tasks) and [CLI](/docs/nia/cli/task#task).
 
 ```hcl
 task {


### PR DESCRIPTION
### Description
Adds description to Task configuration to indicate that Task blocks are not required to run CTS. We never explicitly indicated that they **were** required before, but this description will help facilitate a new workflow we are proposing in the future which includes starting CTS without any initial tasks, and managing tasks via the CLI and API.

### Links
https://consul-j2w1jrubt-hashicorp.vercel.app/docs/nia/configuration#task

### PR Checklist

* [x] external facing docs updated
* [x] not a security concern
