### PR TITLE
server: ensure peer replication can successfully use TLS over external gRPC

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -761,15 +761,7 @@ func (a *Agent) Failed() <-chan struct{} {
 }
 
 func (a *Agent) buildExternalGRPCServer() {
-	// TLS is only enabled on the gRPC server if there's an HTTPS port configured.
-	var tls *tlsutil.Configurator
-	if a.config.HTTPSPort > 0 {
-		tls = a.tlsConfigurator
-	}
-	if a.tlsConfigurator != nil && a.tlsConfigurator.GRPCTLSConfigured() {
-		tls = a.tlsConfigurator
-	}
-	a.externalGRPCServer = external.NewServer(a.logger.Named("grpc.external"), tls)
+	a.externalGRPCServer = external.NewServer(a.logger.Named("grpc.external"), a.tlsConfigurator)
 }
 
 func (a *Agent) listenAndServeGRPC() error {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -766,6 +766,9 @@ func (a *Agent) buildExternalGRPCServer() {
 	if a.config.HTTPSPort > 0 {
 		tls = a.tlsConfigurator
 	}
+	if a.tlsConfigurator != nil && a.tlsConfigurator.GRPCTLSConfigured() {
+		tls = a.tlsConfigurator
+	}
 	a.externalGRPCServer = external.NewServer(a.logger.Named("grpc.external"), tls)
 }
 

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -20,15 +21,28 @@ import (
 )
 
 func TestLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T) {
+	t.Run("without-tls", func(t *testing.T) {
+		testLeader_PeeringSync_Lifecycle_ClientDeletion(t, false)
+	})
+	t.Run("with-tls", func(t *testing.T) {
+		testLeader_PeeringSync_Lifecycle_ClientDeletion(t, true)
+	})
+}
+func testLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T, enableTLS bool) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	// TODO(peering): Configure with TLS
 	_, s1 := testServerWithConfig(t, func(c *Config) {
-		c.NodeName = "s1.dc1"
+		c.NodeName = "bob"
 		c.Datacenter = "dc1"
 		c.TLSConfig.Domain = "consul"
+		if enableTLS {
+			c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
+			c.TLSConfig.GRPC.CertFile = "../../test/hostname/Bob.crt"
+			c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Bob.key"
+			c.TLSConfig.GRPC.VerifyOutgoing = true
+		}
 	})
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -68,9 +82,15 @@ func TestLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T) {
 
 	// Bring up s2 and store s1's token so that it attempts to dial.
 	_, s2 := testServerWithConfig(t, func(c *Config) {
-		c.NodeName = "s2.dc2"
+		c.NodeName = "betty"
 		c.Datacenter = "dc2"
 		c.PrimaryDatacenter = "dc2"
+		if enableTLS {
+			c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
+			c.TLSConfig.GRPC.CertFile = "../../test/hostname/Betty.crt"
+			c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Betty.key"
+			c.TLSConfig.GRPC.VerifyOutgoing = true
+		}
 	})
 	testrpc.WaitForLeader(t, s2.RPC, "dc2")
 
@@ -120,15 +140,28 @@ func TestLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T) {
 }
 
 func TestLeader_PeeringSync_Lifecycle_ServerDeletion(t *testing.T) {
+	t.Run("without-tls", func(t *testing.T) {
+		testLeader_PeeringSync_Lifecycle_ServerDeletion(t, false)
+	})
+	t.Run("with-tls", func(t *testing.T) {
+		testLeader_PeeringSync_Lifecycle_ServerDeletion(t, true)
+	})
+}
+func testLeader_PeeringSync_Lifecycle_ServerDeletion(t *testing.T, enableTLS bool) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	// TODO(peering): Configure with TLS
 	_, s1 := testServerWithConfig(t, func(c *Config) {
-		c.NodeName = "s1.dc1"
+		c.NodeName = "bob"
 		c.Datacenter = "dc1"
 		c.TLSConfig.Domain = "consul"
+		if enableTLS {
+			c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
+			c.TLSConfig.GRPC.CertFile = "../../test/hostname/Bob.crt"
+			c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Bob.key"
+			c.TLSConfig.GRPC.VerifyOutgoing = true
+		}
 	})
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -164,9 +197,15 @@ func TestLeader_PeeringSync_Lifecycle_ServerDeletion(t *testing.T) {
 
 	// Bring up s2 and store s1's token so that it attempts to dial.
 	_, s2 := testServerWithConfig(t, func(c *Config) {
-		c.NodeName = "s2.dc2"
+		c.NodeName = "betty"
 		c.Datacenter = "dc2"
 		c.PrimaryDatacenter = "dc2"
+		if enableTLS {
+			c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
+			c.TLSConfig.GRPC.CertFile = "../../test/hostname/Betty.crt"
+			c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Betty.key"
+			c.TLSConfig.GRPC.VerifyOutgoing = true
+		}
 	})
 	testrpc.WaitForLeader(t, s2.RPC, "dc2")
 
@@ -212,6 +251,113 @@ func TestLeader_PeeringSync_Lifecycle_ServerDeletion(t *testing.T) {
 		})
 		require.NoError(r, err)
 		require.Equal(r, pbpeering.PeeringState_TERMINATED, peering.State)
+	})
+}
+
+func TestLeader_PeeringSync_FailsForTLSError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Run("server-name-validation", func(t *testing.T) {
+		testLeader_PeeringSync_failsForTLSError(t, func(p *pbpeering.Peering) {
+			p.PeerServerName = "wrong.name"
+		}, `transport: authentication handshake failed: x509: certificate is valid for server.dc1.consul, bob.server.dc1.consul, not wrong.name`)
+	})
+	t.Run("bad-ca-roots", func(t *testing.T) {
+		wrongRoot, err := ioutil.ReadFile("../../test/client_certs/rootca.crt")
+		require.NoError(t, err)
+
+		testLeader_PeeringSync_failsForTLSError(t, func(p *pbpeering.Peering) {
+			p.PeerCAPems = []string{string(wrongRoot)}
+		}, `transport: authentication handshake failed: x509: certificate signed by unknown authority`)
+	})
+}
+
+func testLeader_PeeringSync_failsForTLSError(t *testing.T, peerMutateFn func(p *pbpeering.Peering), expectErr string) {
+	require.NotNil(t, peerMutateFn)
+
+	_, s1 := testServerWithConfig(t, func(c *Config) {
+		c.NodeName = "bob"
+		c.Datacenter = "dc1"
+		c.TLSConfig.Domain = "consul"
+
+		c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
+		c.TLSConfig.GRPC.CertFile = "../../test/hostname/Bob.crt"
+		c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Bob.key"
+		c.TLSConfig.GRPC.VerifyOutgoing = true
+	})
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Create a peering by generating a token
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	t.Cleanup(cancel)
+
+	conn, err := grpc.DialContext(ctx, s1.config.RPCAddr.String(),
+		grpc.WithContextDialer(newServerDialer(s1.config.RPCAddr.String())),
+		grpc.WithInsecure(),
+		grpc.WithBlock())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	peeringClient := pbpeering.NewPeeringServiceClient(conn)
+
+	req := pbpeering.GenerateTokenRequest{
+		PeerName: "my-peer-s2",
+	}
+	resp, err := peeringClient.GenerateToken(ctx, &req)
+	require.NoError(t, err)
+
+	tokenJSON, err := base64.StdEncoding.DecodeString(resp.PeeringToken)
+	require.NoError(t, err)
+
+	var token structs.PeeringToken
+	require.NoError(t, json.Unmarshal(tokenJSON, &token))
+
+	// S1 should not have a stream tracked for dc2 because s1 generated a token
+	// for baz, and therefore needs to wait to be dialed.
+	time.Sleep(1 * time.Second)
+	_, found := s1.peerStreamServer.StreamStatus(token.PeerID)
+	require.False(t, found)
+
+	var (
+		s2PeerID = "cc56f0b8-3885-4e78-8d7b-614a0c45712d"
+	)
+
+	// Bring up s2 and store s1's token so that it attempts to dial.
+	_, s2 := testServerWithConfig(t, func(c *Config) {
+		c.NodeName = "betty"
+		c.Datacenter = "dc2"
+		c.PrimaryDatacenter = "dc2"
+
+		c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
+		c.TLSConfig.GRPC.CertFile = "../../test/hostname/Betty.crt"
+		c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Betty.key"
+		c.TLSConfig.GRPC.VerifyOutgoing = true
+	})
+	testrpc.WaitForLeader(t, s2.RPC, "dc2")
+
+	// Simulate a peering initiation event by writing a peering with data from a peering token.
+	// Eventually the leader in dc2 should dial and connect to the leader in dc1.
+	p := &pbpeering.Peering{
+		ID:                  s2PeerID,
+		Name:                "my-peer-s1",
+		PeerID:              token.PeerID,
+		PeerCAPems:          token.CA,
+		PeerServerName:      token.ServerName,
+		PeerServerAddresses: token.ServerAddresses,
+	}
+	peerMutateFn(p)
+	require.True(t, p.ShouldDial())
+
+	// We maintain a pointer to the peering on the write so that we can get the ID without needing to re-query the state store.
+	require.NoError(t, s2.fsm.State().PeeringWrite(1000, p))
+
+	retry.Run(t, func(r *retry.R) {
+		status, found := s2.peerStreamTracker.StreamStatus(p.ID)
+		require.True(r, found)
+		require.False(r, status.Connected)
+		require.Contains(r, status.LastSendErrorMessage, expectErr)
 	})
 }
 

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -41,7 +41,6 @@ func testLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T, enableTLS boo
 			c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
 			c.TLSConfig.GRPC.CertFile = "../../test/hostname/Bob.crt"
 			c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Bob.key"
-			c.TLSConfig.GRPC.VerifyOutgoing = true
 		}
 	})
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -89,7 +88,6 @@ func testLeader_PeeringSync_Lifecycle_ClientDeletion(t *testing.T, enableTLS boo
 			c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
 			c.TLSConfig.GRPC.CertFile = "../../test/hostname/Betty.crt"
 			c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Betty.key"
-			c.TLSConfig.GRPC.VerifyOutgoing = true
 		}
 	})
 	testrpc.WaitForLeader(t, s2.RPC, "dc2")
@@ -160,7 +158,6 @@ func testLeader_PeeringSync_Lifecycle_ServerDeletion(t *testing.T, enableTLS boo
 			c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
 			c.TLSConfig.GRPC.CertFile = "../../test/hostname/Bob.crt"
 			c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Bob.key"
-			c.TLSConfig.GRPC.VerifyOutgoing = true
 		}
 	})
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -204,7 +201,6 @@ func testLeader_PeeringSync_Lifecycle_ServerDeletion(t *testing.T, enableTLS boo
 			c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
 			c.TLSConfig.GRPC.CertFile = "../../test/hostname/Betty.crt"
 			c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Betty.key"
-			c.TLSConfig.GRPC.VerifyOutgoing = true
 		}
 	})
 	testrpc.WaitForLeader(t, s2.RPC, "dc2")
@@ -285,7 +281,6 @@ func testLeader_PeeringSync_failsForTLSError(t *testing.T, peerMutateFn func(p *
 		c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
 		c.TLSConfig.GRPC.CertFile = "../../test/hostname/Bob.crt"
 		c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Bob.key"
-		c.TLSConfig.GRPC.VerifyOutgoing = true
 	})
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -333,7 +328,6 @@ func testLeader_PeeringSync_failsForTLSError(t *testing.T, peerMutateFn func(p *
 		c.TLSConfig.GRPC.CAFile = "../../test/hostname/CertAuth.crt"
 		c.TLSConfig.GRPC.CertFile = "../../test/hostname/Betty.crt"
 		c.TLSConfig.GRPC.KeyFile = "../../test/hostname/Betty.key"
-		c.TLSConfig.GRPC.VerifyOutgoing = true
 	})
 	testrpc.WaitForLeader(t, s2.RPC, "dc2")
 

--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -52,7 +52,7 @@ func (b *PeeringBackend) GetLeaderAddress() string {
 // GetAgentCACertificates gets the server's raw CA data from its TLS Configurator.
 func (b *PeeringBackend) GetAgentCACertificates() ([]string, error) {
 	// TODO(peering): handle empty CA pems
-	return b.srv.tlsConfigurator.ManualCAPems(), nil
+	return b.srv.tlsConfigurator.GRPCManualCAPems(), nil
 }
 
 // GetServerAddresses looks up server node addresses from the state store.

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 
 	"github.com/hashicorp/consul/agent/connect"
+	external "github.com/hashicorp/consul/agent/grpc-external"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/rpc/middleware"
 	"github.com/hashicorp/consul/agent/structs"
@@ -299,8 +300,14 @@ func newServerWithDeps(t *testing.T, c *Config, deps Deps) (*Server, error) {
 		}
 	}
 
-	srv, err := NewServer(c, deps, grpc.NewServer())
+	var tls *tlsutil.Configurator
+	if deps.TLSConfigurator != nil {
+		if deps.TLSConfigurator.GRPCTLSConfigured() {
+			tls = deps.TLSConfigurator
+		}
+	}
 
+	srv, err := NewServer(c, deps, external.NewServer(deps.Logger.Named("grpc.external"), tls))
 	if err != nil {
 		return nil, err
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -300,14 +300,7 @@ func newServerWithDeps(t *testing.T, c *Config, deps Deps) (*Server, error) {
 		}
 	}
 
-	var tls *tlsutil.Configurator
-	if deps.TLSConfigurator != nil {
-		if deps.TLSConfigurator.GRPCTLSConfigured() {
-			tls = deps.TLSConfigurator
-		}
-	}
-
-	srv, err := NewServer(c, deps, external.NewServer(deps.Logger.Named("grpc.external"), tls))
+	srv, err := NewServer(c, deps, external.NewServer(deps.Logger.Named("grpc.external"), deps.TLSConfigurator))
 	if err != nil {
 		return nil, err
 	}

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -31,16 +31,37 @@ func (t *Tracker) SetClock(clock func() time.Time) {
 	}
 }
 
+// Register a stream for a given peer but do not mark it as connected.
+func (t *Tracker) Register(id string) (*MutableStatus, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	status, _, err := t.registerLocked(id, false)
+	return status, err
+}
+
+func (t *Tracker) registerLocked(id string, initAsConnected bool) (*MutableStatus, bool, error) {
+	status, ok := t.streams[id]
+	if !ok {
+		status = newMutableStatus(t.timeNow, initAsConnected)
+		t.streams[id] = status
+		return status, true, nil
+	}
+	return status, false, nil
+}
+
 // Connected registers a stream for a given peer, and marks it as connected.
 // It also enforces that there is only one active stream for a peer.
 func (t *Tracker) Connected(id string) (*MutableStatus, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	return t.connectedLocked(id)
+}
 
-	status, ok := t.streams[id]
-	if !ok {
-		status = newMutableStatus(t.timeNow)
-		t.streams[id] = status
+func (t *Tracker) connectedLocked(id string) (*MutableStatus, error) {
+	status, newlyRegistered, err := t.registerLocked(id, true)
+	if err != nil {
+		return nil, err
+	} else if newlyRegistered {
 		return status, nil
 	}
 
@@ -144,10 +165,10 @@ type Status struct {
 	LastReceiveErrorMessage string
 }
 
-func newMutableStatus(now func() time.Time) *MutableStatus {
+func newMutableStatus(now func() time.Time, connected bool) *MutableStatus {
 	return &MutableStatus{
 		Status: Status{
-			Connected: true,
+			Connected: connected,
 		},
 		timeNow: now,
 		doneCh:  make(chan struct{}),

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -59,7 +59,7 @@ func TestPeeringService_GenerateToken(t *testing.T) {
 	// TODO(peering): see note on newTestServer, refactor to not use this
 	s := newTestServer(t, func(c *consul.Config) {
 		c.SerfLANConfig.MemberlistConfig.AdvertiseAddr = "127.0.0.1"
-		c.TLSConfig.InternalRPC.CAFile = cafile
+		c.TLSConfig.GRPC.CAFile = cafile
 		c.DataDir = dir
 	})
 	client := pbpeering.NewPeeringServiceClient(s.ClientConn(t))

--- a/test/integration/connect/envoy/case-wanfed-gw/primary/common.hcl
+++ b/test/integration/connect/envoy/case-wanfed-gw/primary/common.hcl
@@ -1,6 +1,10 @@
-ca_file                = "/workdir/primary/tls/consul-agent-ca.pem"
-cert_file              = "/workdir/primary/tls/primary-server-consul-0.pem"
-key_file               = "/workdir/primary/tls/primary-server-consul-0-key.pem"
-verify_incoming        = true
-verify_outgoing        = true
-verify_server_hostname = true
+tls {
+  internal_rpc {
+    ca_file                = "/workdir/primary/tls/consul-agent-ca.pem"
+    cert_file              = "/workdir/primary/tls/primary-server-consul-0.pem"
+    key_file               = "/workdir/primary/tls/primary-server-consul-0-key.pem"
+    verify_incoming        = true
+    verify_outgoing        = true
+    verify_server_hostname = true
+  }
+}

--- a/test/integration/connect/envoy/case-wanfed-gw/primary/server.hcl
+++ b/test/integration/connect/envoy/case-wanfed-gw/primary/server.hcl
@@ -3,9 +3,13 @@ connect {
   enabled                            = true
   enable_mesh_gateway_wan_federation = true
 }
-ca_file                = "/workdir/primary/tls/consul-agent-ca.pem"
-cert_file              = "/workdir/primary/tls/primary-server-consul-0.pem"
-key_file               = "/workdir/primary/tls/primary-server-consul-0-key.pem"
-verify_incoming        = true
-verify_outgoing        = true
-verify_server_hostname = true
+tls {
+  internal_rpc {
+    ca_file                = "/workdir/primary/tls/consul-agent-ca.pem"
+    cert_file              = "/workdir/primary/tls/primary-server-consul-0.pem"
+    key_file               = "/workdir/primary/tls/primary-server-consul-0-key.pem"
+    verify_incoming        = true
+    verify_outgoing        = true
+    verify_server_hostname = true
+  }
+}

--- a/test/integration/connect/envoy/case-wanfed-gw/secondary/common.hcl
+++ b/test/integration/connect/envoy/case-wanfed-gw/secondary/common.hcl
@@ -1,6 +1,10 @@
-ca_file                   = "/workdir/secondary/tls/consul-agent-ca.pem"
-cert_file                 = "/workdir/secondary/tls/secondary-server-consul-0.pem"
-key_file                  = "/workdir/secondary/tls/secondary-server-consul-0-key.pem"
-verify_incoming           = true
-verify_outgoing           = true
-verify_server_hostname    = true
+tls {
+  internal_rpc {
+    ca_file                = "/workdir/secondary/tls/consul-agent-ca.pem"
+    cert_file              = "/workdir/secondary/tls/secondary-server-consul-0.pem"
+    key_file               = "/workdir/secondary/tls/secondary-server-consul-0-key.pem"
+    verify_incoming        = true
+    verify_outgoing        = true
+    verify_server_hostname = true
+  }
+}

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -88,7 +88,7 @@ type ProtocolConfig struct {
 	// certificate authority. This is used to verify authenticity of server
 	// nodes.
 	//
-	// Note: this setting doesn't apply to the gRPC configuration, as Consul
+	// Note: this setting doesn't apply to the external gRPC configuration, as Consul
 	// makes no outgoing connections using this protocol.
 	VerifyOutgoing bool
 
@@ -231,6 +231,13 @@ func (c *Configurator) ManualCAPems() []string {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.internalRPC.manualCAPEMs
+}
+
+// GRPCManualCAPems returns the currently loaded CAs for the gRPC in PEM format.
+func (c *Configurator) GRPCManualCAPems() []string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.grpc.manualCAPEMs
 }
 
 // Update updates the internal configuration which is used to generate

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1998,8 +1998,6 @@ specially crafted certificate signed by the CA can be used to gain full access t
 
   - `grpc` ((#tls_grpc)) Provides settings for the gRPC/xDS interface. To enable
     the gRPC interface you must define a port via [`ports.grpc`](#grpc_port).
-    To enable TLS on the gRPC interface you also must define an HTTPS port via
-    [`ports.https`](#https_port).
 
     - `ca_file` ((#tls_grpc_ca_file)) Overrides [`tls.defaults.ca_file`](#tls_defaults_ca_file).
 

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -16,6 +16,14 @@ upgrade flow.
 
 ## Consul 1.13.0
 
+### gRPC TLS
+
+In prior Consul versions if HTTPS was enabled for the client API and exposed
+via `ports { https = NUMBER }` then the same TLS material was used to encrypt
+the gRPC port used for xDS. Now this is decoupled and activating TLS on the
+gRPC endpoint is controlled solely with the gRPC section of the new 
+[`tls` stanza](/docs/agent/config/config-files#tls-configuration-reference).
+
 ### 1.9 Telemetry Compatibility
 
 #### Removing configuration options

--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -24,6 +24,10 @@ the gRPC port used for xDS. Now this is decoupled and activating TLS on the
 gRPC endpoint is controlled solely with the gRPC section of the new 
 [`tls` stanza](/docs/agent/config/config-files#tls-configuration-reference).
 
+If you have not yet switched to the new `tls` stanza and were NOT using HTTPS
+for the API then updating to Consul 1.13 will activate TLS for gRPC since the
+deprecated TLS settings are used as defaults.
+
 ### 1.9 Telemetry Compatibility
 
 #### Removing configuration options


### PR DESCRIPTION
### Description

Ensure that the peer stream replication rpc can successfully be used with TLS activated.

Also:
- If key material is configured for the gRPC port but HTTPS is not enabled now TLS will still be activated for the gRPC port.
- peerstream replication stream opened by the establishing-side will now ignore `grpc.WithBlock` so that TLS errors will bubble up instead of being awkwardly delayed or suppressed

