### PR TITLE
Watch imported services for transparent proxycfg snapshots

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4113,6 +4113,8 @@ func (a *Agent) registerCache() {
 
 	a.cache.RegisterType(cachetype.TrustBundleListName, &cachetype.TrustBundles{Client: a.rpcClientPeering})
 
+	a.cache.RegisterType(cachetype.PeeredUpstreamsName, &cachetype.PeeredUpstreams{RPC: a})
+
 	a.registerEntCache()
 }
 

--- a/agent/proxycfg/data_sources.go
+++ b/agent/proxycfg/data_sources.go
@@ -69,6 +69,8 @@ type DataSources struct {
 	// notification channel.
 	LeafCertificate LeafCertificate
 
+	// PeeredUpstreams provides imported-service upstream updates on a
+	// notification channel.
 	PeeredUpstreams PeeredUpstreams
 
 	// PreparedQuery provides updates about the results of a prepared query.

--- a/agent/proxycfg/internal/watch/watchmap.go
+++ b/agent/proxycfg/internal/watch/watchmap.go
@@ -1,0 +1,108 @@
+package watch
+
+import "context"
+
+// Map safely stores and retrieves values by validating that
+// there is a live watch for a key. InitWatch must be called
+// to associate a key with its cancel function before any
+// Set's are called.
+type Map[K comparable, V any] struct {
+	M map[K]watchedVal[V]
+}
+
+type watchedVal[V any] struct {
+	Val *V
+
+	// keeping cancel private has a beneficial side effect:
+	// copying Map with copystructure.Copy will zero out
+	// cancel, preventing it from being called by the
+	// receiver of a proxy config snapshot.
+	cancel context.CancelFunc
+}
+
+func NewMap[K comparable, V any]() Map[K, V] {
+	return Map[K, V]{M: make(map[K]watchedVal[V])}
+}
+
+// InitWatch associates a cancel function with a key,
+// allowing Set to be called for the key. The cancel
+// function is allowed to be nil.
+//
+// Any existing data for a key will be cancelled and
+// overwritten.
+func (m Map[K, V]) InitWatch(key K, cancel func()) {
+	if _, present := m.M[key]; present {
+		m.CancelWatch(key)
+	}
+	m.M[key] = watchedVal[V]{
+		cancel: cancel,
+	}
+}
+
+// CancelWatch first calls the cancel function
+// associated with the key then deletes the key
+// from the map. No-op if key is not present.
+func (m Map[K, V]) CancelWatch(key K) {
+	if entry, ok := m.M[key]; ok {
+		if entry.cancel != nil {
+			entry.cancel()
+		}
+		delete(m.M, key)
+	}
+}
+
+// IsWatched returns true if InitWatch has been
+// called for key and has not been cancelled by
+// CancelWatch.
+func (m Map[K, V]) IsWatched(key K) bool {
+	if _, present := m.M[key]; present {
+		return true
+	}
+	return false
+}
+
+// Set stores V if K exists in the map.
+// No-op if the key never was initialized with InitWatch
+// or if the entry got cancelled by CancelWatch.
+func (m Map[K, V]) Set(key K, val V) bool {
+	if entry, ok := m.M[key]; ok {
+		entry.Val = &val
+		m.M[key] = entry
+		return true
+	}
+	return false
+}
+
+// Get returns the underlying value for a key.
+// If an entry has been set, returns (V, true).
+// Otherwise, returns the zero value (V, false).
+//
+// Note that even if InitWatch has been called
+// for a key, unless Set has been called this
+// function will return false.
+func (m Map[K, V]) Get(key K) (V, bool) {
+	if entry, ok := m.M[key]; ok {
+		if entry.Val != nil {
+			return *entry.Val, true
+		}
+	}
+	var empty V
+	return empty, false
+}
+
+func (m Map[K, V]) Len() int {
+	return len(m.M)
+}
+
+// ForEachKey iterates through the map, calling f
+// for each iteration. It is up to the caller to
+// Get the value and nil-check if required.
+// Stops iterating if f returns false.
+// Order of iteration is non-deterministic.
+func (m Map[K, V]) ForEachKey(f func(K) bool) {
+	for k := range m.M {
+		if ok := f(k); !ok {
+			return
+		}
+	}
+}

--- a/agent/proxycfg/internal/watch/watchmap_test.go
+++ b/agent/proxycfg/internal/watch/watchmap_test.go
@@ -1,0 +1,113 @@
+package watch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMap(t *testing.T) {
+	m := NewMap[string, string]()
+
+	// Set without init is a no-op
+	{
+		m.Set("hello", "world")
+		require.Equal(t, 0, m.Len())
+	}
+
+	// Getting from empty map
+	{
+		got, ok := m.Get("hello")
+		require.False(t, ok)
+		require.Empty(t, got)
+	}
+
+	var called bool
+	cancelMock := func() {
+		called = true
+	}
+
+	// InitWatch successful
+	{
+		m.InitWatch("hello", cancelMock)
+		require.Equal(t, 1, m.Len())
+	}
+
+	// Get still returns false
+	{
+		got, ok := m.Get("hello")
+		require.False(t, ok)
+		require.Empty(t, got)
+	}
+
+	// Set successful
+	{
+		require.True(t, m.Set("hello", "world"))
+		require.Equal(t, 1, m.Len())
+	}
+
+	// Get successful
+	{
+		got, ok := m.Get("hello")
+		require.True(t, ok)
+		require.Equal(t, "world", got)
+	}
+
+	// CancelWatch successful
+	{
+		m.CancelWatch("hello")
+		require.Equal(t, 0, m.Len())
+		require.True(t, called)
+	}
+
+	// Get no-op
+	{
+		got, ok := m.Get("hello")
+		require.False(t, ok)
+		require.Empty(t, got)
+	}
+
+	// Set no-op
+	{
+		require.False(t, m.Set("hello", "world"))
+		require.Equal(t, 0, m.Len())
+	}
+}
+
+func TestMap_ForEach(t *testing.T) {
+	type testType struct {
+		s string
+	}
+
+	m := NewMap[string, any]()
+	inputs := map[string]any{
+		"hello": 13,
+		"foo":   struct{}{},
+		"bar":   &testType{s: "wow"},
+	}
+	for k, v := range inputs {
+		m.InitWatch(k, nil)
+		m.Set(k, v)
+	}
+	require.Equal(t, 3, m.Len())
+
+	// returning true continues iteration
+	{
+		var count int
+		m.ForEachKey(func(k string) bool {
+			count++
+			return true
+		})
+		require.Equal(t, 3, count)
+	}
+
+	// returning false exits loop
+	{
+		var count int
+		m.ForEachKey(func(k string) bool {
+			count++
+			return false
+		})
+		require.Equal(t, 1, count)
+	}
+}

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -11,6 +11,7 @@ import (
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
+	"github.com/hashicorp/consul/agent/proxycfg/internal/watch"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/proto/pbpeering"
@@ -230,8 +231,8 @@ func TestManager_BasicLifecycle(t *testing.T) {
 						},
 						PassthroughUpstreams:              map[UpstreamID]map[string]map[string]struct{}{},
 						PassthroughIndices:                map[string]indexedTarget{},
-						UpstreamPeerTrustBundles:          map[string]*pbpeering.PeeringTrustBundle{},
-						PeerUpstreamEndpoints:             map[UpstreamID]structs.CheckServiceNodes{},
+						UpstreamPeerTrustBundles:          watch.NewMap[PeerName, *pbpeering.PeeringTrustBundle](),
+						PeerUpstreamEndpoints:             watch.NewMap[UpstreamID, structs.CheckServiceNodes](),
 						PeerUpstreamEndpointsUseHostnames: map[UpstreamID]struct{}{},
 					},
 					PreparedQueryEndpoints: map[UpstreamID]structs.CheckServiceNodes{},
@@ -291,8 +292,8 @@ func TestManager_BasicLifecycle(t *testing.T) {
 						},
 						PassthroughUpstreams:              map[UpstreamID]map[string]map[string]struct{}{},
 						PassthroughIndices:                map[string]indexedTarget{},
-						UpstreamPeerTrustBundles:          map[string]*pbpeering.PeeringTrustBundle{},
-						PeerUpstreamEndpoints:             map[UpstreamID]structs.CheckServiceNodes{},
+						UpstreamPeerTrustBundles:          watch.NewMap[PeerName, *pbpeering.PeeringTrustBundle](),
+						PeerUpstreamEndpoints:             watch.NewMap[UpstreamID, structs.CheckServiceNodes](),
 						PeerUpstreamEndpointsUseHostnames: map[UpstreamID]struct{}{},
 					},
 					PreparedQueryEndpoints: map[UpstreamID]structs.CheckServiceNodes{},

--- a/agent/proxycfg/naming.go
+++ b/agent/proxycfg/naming.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
+type PeerName = string
+
 type UpstreamID struct {
 	Type       string
 	Name       string
@@ -32,7 +34,16 @@ func NewUpstreamID(u *structs.Upstream) UpstreamID {
 	return id
 }
 
-// TODO(peering): confirm we don't need peername here
+func NewUpstreamIDFromPeeredServiceName(psn structs.PeeredServiceName) UpstreamID {
+	id := UpstreamID{
+		Name:           psn.ServiceName.Name,
+		EnterpriseMeta: psn.ServiceName.EnterpriseMeta,
+		Peer:           psn.Peer,
+	}
+	id.normalize()
+	return id
+}
+
 func NewUpstreamIDFromServiceName(sn structs.ServiceName) UpstreamID {
 	id := UpstreamID{
 		Name:           sn.Name,

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mitchellh/copystructure"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/proxycfg/internal/watch"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/proto/pbpeering"
@@ -44,13 +45,9 @@ type ConfigSnapshotUpstreams struct {
 	// endpoints of an upstream.
 	WatchedUpstreamEndpoints map[UpstreamID]map[string]structs.CheckServiceNodes
 
-	// WatchedUpstreamPeerTrustBundles is a map of (PeerName -> CancelFunc) in order to cancel
-	// watches for peer trust bundles any time the list of upstream peers changes.
-	WatchedUpstreamPeerTrustBundles map[string]context.CancelFunc
-
 	// UpstreamPeerTrustBundles is a map of (PeerName -> PeeringTrustBundle).
 	// It is used to store trust bundles for upstream TLS transport sockets.
-	UpstreamPeerTrustBundles map[string]*pbpeering.PeeringTrustBundle
+	UpstreamPeerTrustBundles watch.Map[PeerName, *pbpeering.PeeringTrustBundle]
 
 	// WatchedGateways is a map of UpstreamID -> (map of GatewayKey.String() ->
 	// CancelFunc) in order to cancel watches for mesh gateways
@@ -80,10 +77,16 @@ type ConfigSnapshotUpstreams struct {
 	// This list only applies to proxies registered in 'transparent' mode.
 	IntentionUpstreams map[UpstreamID]struct{}
 
+	// PeeredUpstreams is a set of all upstream targets in a local partition.
+	//
+	// This list only applies to proxies registered in 'transparent' mode.
+	PeeredUpstreams map[UpstreamID]struct{}
+
 	// PeerUpstreamEndpoints is a map of UpstreamID -> (set of IP addresses)
 	// and used to determine the backing endpoints of an upstream in another
 	// peer.
-	PeerUpstreamEndpoints             map[UpstreamID]structs.CheckServiceNodes
+	PeerUpstreamEndpoints watch.Map[UpstreamID, structs.CheckServiceNodes]
+
 	PeerUpstreamEndpointsUseHostnames map[UpstreamID]struct{}
 }
 
@@ -152,8 +155,7 @@ func (c *configSnapshotConnectProxy) isEmpty() bool {
 		len(c.WatchedDiscoveryChains) == 0 &&
 		len(c.WatchedUpstreams) == 0 &&
 		len(c.WatchedUpstreamEndpoints) == 0 &&
-		len(c.WatchedUpstreamPeerTrustBundles) == 0 &&
-		len(c.UpstreamPeerTrustBundles) == 0 &&
+		c.UpstreamPeerTrustBundles.Len() == 0 &&
 		len(c.WatchedGateways) == 0 &&
 		len(c.WatchedGatewayEndpoints) == 0 &&
 		len(c.WatchedServiceChecks) == 0 &&
@@ -161,9 +163,10 @@ func (c *configSnapshotConnectProxy) isEmpty() bool {
 		len(c.UpstreamConfig) == 0 &&
 		len(c.PassthroughUpstreams) == 0 &&
 		len(c.IntentionUpstreams) == 0 &&
+		len(c.PeeredUpstreams) == 0 &&
 		!c.InboundPeerTrustBundlesSet &&
 		!c.MeshConfigSet &&
-		len(c.PeerUpstreamEndpoints) == 0 &&
+		c.PeerUpstreamEndpoints.Len() == 0 &&
 		len(c.PeerUpstreamEndpointsUseHostnames) == 0
 }
 
@@ -715,7 +718,6 @@ func (s *ConfigSnapshot) Clone() (*ConfigSnapshot, error) {
 		snap.ConnectProxy.WatchedUpstreams = nil
 		snap.ConnectProxy.WatchedGateways = nil
 		snap.ConnectProxy.WatchedDiscoveryChains = nil
-		snap.ConnectProxy.WatchedUpstreamPeerTrustBundles = nil
 	case structs.ServiceKindTerminatingGateway:
 		snap.TerminatingGateway.WatchedServices = nil
 		snap.TerminatingGateway.WatchedIntentions = nil
@@ -730,7 +732,6 @@ func (s *ConfigSnapshot) Clone() (*ConfigSnapshot, error) {
 		snap.IngressGateway.WatchedUpstreams = nil
 		snap.IngressGateway.WatchedGateways = nil
 		snap.IngressGateway.WatchedDiscoveryChains = nil
-		snap.IngressGateway.WatchedUpstreamPeerTrustBundles = nil
 		// only ingress-gateway
 		snap.IngressGateway.LeafCertWatchCancel = nil
 	}
@@ -803,7 +804,7 @@ func (s *ConfigSnapshot) MeshConfigTLSOutgoing() *structs.MeshDirectionalTLSConf
 }
 
 func (u *ConfigSnapshotUpstreams) UpstreamPeerMeta(uid UpstreamID) structs.PeeringServiceMeta {
-	nodes := u.PeerUpstreamEndpoints[uid]
+	nodes, _ := u.PeerUpstreamEndpoints.Get(uid)
 	if len(nodes) == 0 {
 		return structs.PeeringServiceMeta{}
 	}
@@ -833,7 +834,7 @@ func (u *ConfigSnapshotUpstreams) PeeredUpstreamIDs() []UpstreamID {
 			continue
 		}
 
-		if _, ok := u.UpstreamPeerTrustBundles[uid.Peer]; uid.Peer != "" && !ok {
+		if _, ok := u.UpstreamPeerTrustBundles.Get(uid.Peer); !ok {
 			// The trust bundle for this upstream is not available yet, skip for now.
 			continue
 		}

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -36,6 +36,7 @@ const (
 	serviceResolverIDPrefix            = "service-resolver:"
 	serviceIntentionsIDPrefix          = "service-intentions:"
 	intentionUpstreamsID               = "intention-upstreams"
+	peeredUpstreamsID                  = "peered-upstreams"
 	upstreamPeerWatchIDPrefix          = "upstream-peer:"
 	exportedServiceListWatchID         = "exported-service-list"
 	meshConfigEntryID                  = "mesh"

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -745,6 +745,7 @@ func testConfigSnapshotFixture(
 			IntentionUpstreams:              &noopDataSource[*structs.ServiceSpecificRequest]{},
 			InternalServiceDump:             &noopDataSource[*structs.ServiceDumpRequest]{},
 			LeafCertificate:                 &noopDataSource[*cachetype.ConnectCALeafRequest]{},
+			PeeredUpstreams:                 &noopDataSource[*structs.PartitionSpecificRequest]{},
 			PreparedQuery:                   &noopDataSource[*structs.PreparedQueryExecuteRequest]{},
 			ResolvedServiceConfig:           &noopDataSource[*structs.ServiceConfigRequest]{},
 			ServiceList:                     &noopDataSource[*structs.DCSpecificRequest]{},
@@ -971,6 +972,7 @@ type TestDataSources struct {
 	IntentionUpstreams              *TestDataSource[*structs.ServiceSpecificRequest, *structs.IndexedServiceList]
 	InternalServiceDump             *TestDataSource[*structs.ServiceDumpRequest, *structs.IndexedNodesWithGateways]
 	LeafCertificate                 *TestDataSource[*cachetype.ConnectCALeafRequest, *structs.IssuedCert]
+	PeeredUpstreams                 *TestDataSource[*structs.PartitionSpecificRequest, *structs.IndexedPeeredServiceList]
 	PreparedQuery                   *TestDataSource[*structs.PreparedQueryExecuteRequest, *structs.PreparedQueryExecuteResponse]
 	ResolvedServiceConfig           *TestDataSource[*structs.ServiceConfigRequest, *structs.ServiceConfigResponse]
 	ServiceList                     *TestDataSource[*structs.DCSpecificRequest, *structs.IndexedServiceList]
@@ -994,6 +996,7 @@ func (t *TestDataSources) ToDataSources() DataSources {
 		IntentionUpstreams:     t.IntentionUpstreams,
 		InternalServiceDump:    t.InternalServiceDump,
 		LeafCertificate:        t.LeafCertificate,
+		PeeredUpstreams:        t.PeeredUpstreams,
 		PreparedQuery:          t.PreparedQuery,
 		ResolvedServiceConfig:  t.ResolvedServiceConfig,
 		ServiceList:            t.ServiceList,

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -706,11 +706,12 @@ func (s *ResourceGenerator) makeUpstreamClusterForPeerService(
 				},
 			}
 		} else {
+			ep, _ := cfgSnap.ConnectProxy.PeerUpstreamEndpoints.Get(uid)
 			configureClusterWithHostnames(
 				s.Logger,
 				c,
 				"", /*TODO:make configurable?*/
-				cfgSnap.ConnectProxy.PeerUpstreamEndpoints[uid],
+				ep,
 				true,  /*isRemote*/
 				false, /*onlyPassing*/
 			)
@@ -720,7 +721,8 @@ func (s *ResourceGenerator) makeUpstreamClusterForPeerService(
 
 	rootPEMs := cfgSnap.RootPEMs()
 	if uid.Peer != "" {
-		rootPEMs = cfgSnap.ConnectProxy.UpstreamPeerTrustBundles[uid.Peer].ConcatenatedRootPEMs()
+		tbs, _ := cfgSnap.ConnectProxy.UpstreamPeerTrustBundles.Get(uid.Peer)
+		rootPEMs = tbs.ConcatenatedRootPEMs()
 	}
 
 	// Enable TLS upstream with the configured client certificate.
@@ -1054,13 +1056,9 @@ func (s *ResourceGenerator) makeUpstreamClustersForDiscoveryChain(
 		}
 
 		if configureTLS {
-			rootPEMs := cfgSnap.RootPEMs()
-			if uid.Peer != "" {
-				rootPEMs = cfgSnap.ConnectProxy.UpstreamPeerTrustBundles[uid.Peer].ConcatenatedRootPEMs()
-			}
 			commonTLSContext := makeCommonTLSContext(
 				cfgSnap.Leaf(),
-				rootPEMs,
+				cfgSnap.RootPEMs(),
 				makeTLSParametersFromProxyTLSConfig(cfgSnap.MeshConfigTLSOutgoing()),
 			)
 

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -47,7 +47,7 @@ func (s *ResourceGenerator) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.
 	// TODO: this estimate is wrong
 	resources := make([]proto.Message, 0,
 		len(cfgSnap.ConnectProxy.PreparedQueryEndpoints)+
-			len(cfgSnap.ConnectProxy.PeerUpstreamEndpoints)+
+			cfgSnap.ConnectProxy.PeerUpstreamEndpoints.Len()+
 			len(cfgSnap.ConnectProxy.WatchedUpstreamEndpoints))
 
 	// NOTE: Any time we skip a chain below we MUST also skip that discovery chain in clusters.go
@@ -110,7 +110,7 @@ func (s *ResourceGenerator) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			continue
 		}
 
-		endpoints, ok := cfgSnap.ConnectProxy.PeerUpstreamEndpoints[uid]
+		endpoints, ok := cfgSnap.ConnectProxy.PeerUpstreamEndpoints.Get(uid)
 		if ok {
 			la := makeLoadAssignment(
 				clusterName,


### PR DESCRIPTION
### Description
Now that peered upstreams are valid candidates for TProxy upstreams, we need to set up the right watches.

#### proxycfg/internal/watch/watchmap.go
Adds a new generic type which is a wrapper around a hashmap with added behavior:
- Key must be initialized with `InitWatch(key K, cancel func())` before `Set`
- `CancelWatch(key K)` can be called on a key to delete the entry and call `cancel()`

I hope this can be used for other "watch map"+"data map" combos to refactor parts of the code.

### Testing & Reproduction steps
* Added tests

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
