### PR TITLE
[1.10] Post-release updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.10.12 (July 13, 2022)
+
+BUG FIXES:
+
+* agent: Fixed a bug in HTTP handlers where URLs were being decoded twice [[GH-13264](https://github.com/hashicorp/consul/issues/13264)]
+* fix a bug that caused an error when creating `grpc` or `http2` ingress gateway listeners with multiple services [[GH-13127](https://github.com/hashicorp/consul/issues/13127)]
+
 ## 1.10.11 (May 25, 2022)
 
 SECURITY:

--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.10.8"
+	Version = "1.10.13"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
### Description
Adds all the changelog entries from today's release: [`1.10.12`](https://github.com/hashicorp/consul/releases/tag/v1.10.12).

### Testing & Reproduction steps
The entries should match what is shown on the release page.

### Links
* [`1.10.12`](https://github.com/hashicorp/consul/releases/tag/v1.10.12)
