### PR TITLE
docs: add missing federation methods: mesh gateway and cluster peering

### DIFF
--- a/website/content/docs/enterprise/network-segments.mdx
+++ b/website/content/docs/enterprise/network-segments.mdx
@@ -57,9 +57,11 @@ Segments (Enterprise) creates multiple segments within one cluster.
 **Federated Cluster:** A set of connected clusters, each representing a unique Consul “datacenter”. These Consul servers are federated together
 over the WAN. Consul clients make use of resources in federated clusters by
 forwarding RPCs through the Consul servers in their local cluster, but they
-never interact with remote Consul servers directly. There are currently two
+never interact with remote Consul servers directly. There are currently four
 inter-cluster network models which can be viewed on HashiCorp Learn:
-[WAN gossip (OSS)](https://learn.hashicorp.com/tutorials/consul/federation-gossip-wan)
+[WAN gossip (OSS)](https://learn.hashicorp.com/tutorials/consul/federation-gossip-wan),
+[Mesh gateway (OSS)](https://learn.hashicorp.com/tutorials/consul/service-mesh-gateways),
+[Cluster peering (in tech preview)](https://www.consul.io/docs/connect/cluster-peering),
 and [Network Areas (Enterprise)](https://learn.hashicorp.com/tutorials/consul/federation-network-areas).
 
 **LAN Gossip Pool**: A set of Consul agents that have full mesh connectivity


### PR DESCRIPTION
### Description
The doc misses 2 federation methods: mesh gateway and cluster peering.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
