### PR TITLE
ui: Adds Peer initiation form

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/README.mdx
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/README.mdx
@@ -1,0 +1,26 @@
+# Consul::Peer::Form::Initiate
+
+```hbs preview-template
+<DataSource @src={{
+  uri '/${partition/${nspace}/${dc}/peer/${name}'
+    (hash
+      partition=''
+      nspace=''
+      dc='dc1'
+      name=''
+    )
+  }}
+as |source|>
+{{#if source.data}}
+  <Consul::Peer::Form::Initiate
+    @item={{source.data}}
+    @onchange={{noop}}
+  as |form|>
+    <form.Fieldsets />
+    <form.Actions
+      @onclose={{noop}}
+    />
+  </Consul::Peer::Form::Initiate>
+{{/if}}
+</DataSource>
+```

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/actions/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/actions/index.hbs
@@ -1,0 +1,7 @@
+<Action
+  form={{@id}}
+  @type="submit"
+  ...attributes
+>
+  Add peer
+</Action>

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/fieldsets/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/fieldsets/index.hbs
@@ -1,0 +1,53 @@
+<div
+  class={{class-map
+    'consul-peer-form-initiate-fieldsets'
+  }}
+  ...attributes
+>
+  {{#let
+    (hash
+      help='Enter a name to locally identify the new peer.'
+      Name=(array
+        (hash
+          test=(t 'common.validations.dns-hostname.test')
+          error=(t 'common.validations.dns-hostname.error' name="Name")
+        )
+      )
+    )
+
+    (hash
+      help='Enter the token received from the operator of the desired peer.'
+      PeeringToken=(array)
+    )
+
+  as |Name PeeringToken|}}
+    <p>
+      Enter a token generated in the desired peer.
+    </p>
+      <StateMachine
+        @src={{require '/machines/validate.xstate' from="/components/consul/peer/form/generate/fieldsets"}}
+      as |fsm|>
+
+      <fieldset>
+        <TextInput
+          @name="Name"
+          @label="Name of peer"
+          @item={{@item}}
+          @validations={{Name}}
+          @chart={{fsm}}
+        />
+        <TextInput
+          @expanded={{true}}
+          @name="Token"
+          @item={{@item}}
+          @validations={{PeeringToken}}
+          @chart={{fsm}}
+        />
+        {{yield (hash
+          valid=(not (state-matches fsm.state 'error'))
+        )}}
+      </fieldset>
+
+    </StateMachine>
+  {{/let}}
+</div>

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/index.hbs
@@ -1,0 +1,41 @@
+<div
+  class={{class-map
+    'consul-peer-form-initiate'
+  }}
+  ...attributes
+>
+  <DataWriter
+    @sink={{uri
+      '/${partition}/${nspace}/${dc}/peer'
+      (hash
+        partition=(or @item.Partition '')
+        nspace=(or @item.Namespace '')
+        dc=(or @item.Datacenter '')
+      )
+    }}
+    @type={{'peer'}}
+    @label={{'peer'}}
+    @onchange={{fn (optional @onsubmit) @item}}
+    as |writer|>
+      <BlockSlot @name="content">
+{{#let
+  (unique-id)
+as |id|}}
+        <form
+          id={{id}}
+          {{on 'submit' (fn writer.persist @item)}}
+        >
+          {{yield (hash
+            Fieldsets=(component "consul/peer/form/initiate/fieldsets"
+             item=@item
+            )
+            Actions=(component "consul/peer/form/initiate/actions"
+             item=@item
+             id=id
+            )
+          )}}
+        </form>
+{{/let}}
+      </BlockSlot>
+  </DataWriter>
+</div>

--- a/ui/packages/consul-ui/translations/common/en-us.yaml
+++ b/ui/packages/consul-ui/translations/common/en-us.yaml
@@ -72,3 +72,12 @@ sort:
   status:
     asc: Unhealthy to Healthy
     desc: Healthy to Unhealthy
+validations:
+  dns-hostname:
+    help: |
+      Must be a valid DNS hostname. Must contain 1-64 characters (numbers, letters, and hyphens), and must begin with a letter.
+    test: "^[a-zA-Z0-9]([a-zA-Z0-9-]'{0,62}'[a-zA-Z0-9])?$"
+    error: "{name} must be a valid DNS hostname."
+  immutable:
+    help: Once created, this cannot be changed.
+


### PR DESCRIPTION
### Description

[Minimal Rendered Docs](https://consul-ui-staging-5mojgk8oa-hashicorp.vercel.app/ui/docs/consul-peerings/consul/peer/form/initiate)

This adds a 'Peer Initiation Form' for initiating the peering connection between two peers using a peering token. 

Notes:

1. The form is split into `Fieldsets` and `Actions` contextual components, this means that the buttons/actions for the form don't necessarily need to be directly under the 'fieldsets'. In our upcoming case they need to be in a completely separate DOM area in our modals footer. This (along with the use of the HTML5 `form=""` attribute) means we can move the buttons/actons whereever we need them. Whilst this is perfect for this use case, all our forms should ideally use this approach meaning the buttons to control the form can be anywhere on the page, whether that is directly under the form or in a modal, or something else.
2. Validation RegEx has been moved into the translations which might initially feel a little strange, but the more you think about it the translation file is 1. A centralized place for strings and 2. validations use characters that might be dependant on the translation, and whilst we don't require this just yet (if at all in future) thinking about it like this makes it less weird. Lastly, we use this validation regex elsewhere so a PR for the future would be for the other places we use this to pull from this same place.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMike