### PR TITLE
ui: Add peer token generation form

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/README.mdx
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/README.mdx
@@ -1,0 +1,28 @@
+# Consul::Peer::Form::Generate
+
+```hbs preview-template
+
+<DataSource @src={{
+  uri '/${partition/${nspace}/${dc}/peer/${name}'
+    (hash
+      partition=''
+      nspace=''
+      dc='dc1'
+      name=''
+    )
+  }}
+as |source|>
+{{#if source.data}}
+  <Consul::Peer::Form::Generate
+    @item={{source.data}}
+    @onchange={{noop}}
+    @regenerate={{false}}
+  as |form|>
+    <form.Fieldsets />
+    <form.Actions
+      @onclose={{noop}}
+    />
+  </Consul::Peer::Form::Generate>
+{{/if}}
+</DataSource>
+```

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/actions/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/actions/index.hbs
@@ -1,0 +1,10 @@
+<Action
+  form={{@id}}
+  @type="submit"
+  {{disabled (or
+    (eq @item.Name.length 0)
+  )}}
+  ...attributes
+>
+  Generate token
+</Action>

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/chart.xstate.js
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/chart.xstate.js
@@ -1,11 +1,6 @@
 export default {
   id: 'consul-peer-generate-form',
   initial: 'idle',
-  on: {
-    RESET: {
-      target: 'idle'
-    }
-  },
   states: {
     idle: {
       on: {

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/chart.xstate.js
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/chart.xstate.js
@@ -1,0 +1,31 @@
+export default {
+  id: 'consul-peer-generate-form',
+  initial: 'idle',
+  on: {
+    RESET: {
+      target: 'idle'
+    }
+  },
+  states: {
+    idle: {
+      on: {
+        LOAD: {
+          target: 'loading'
+        }
+      }
+    },
+    loading: {
+      on: {
+        SUCCESS: {
+          target: 'success'
+        },
+        ERROR: {
+          target: 'error'
+        }
+      }
+    },
+    success: {
+    },
+    error: {},
+  },
+};

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/fieldsets/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/fieldsets/index.hbs
@@ -1,0 +1,40 @@
+<div
+  class={{class-map
+    'consul-peer-form-generate-fieldsets'
+  }}
+  ...attributes
+>
+  <StateMachine
+    @src={{require '/machines/validate.xstate' from="/components/consul/peer/form/generate/fieldsets"}}
+  as |fsm|>
+    {{#let
+      (hash
+        help=(concat
+          (t 'common.validations.dns-hostname.help')
+          (t 'common.validations.immutable.help')
+        )
+        Name=(array
+          (hash
+            test=(t 'common.validations.dns-hostname.test')
+            error=(t 'common.validations.dns-hostname.error' name="Name")
+          )
+        )
+      )
+    as |Name|}}
+      <fieldset>
+        <TextInput
+          @label="Name of peer"
+          @name="Name"
+          @item={{@item}}
+          @validations={{Name}}
+          @chart={{fsm}}
+          @oninput={{pick 'target.value' (set @item 'Name')}}
+        />
+        {{yield (hash
+          valid=(not (state-matches fsm.state 'error'))
+        )}}
+      </fieldset>
+
+    {{/let}}
+  </StateMachine>
+</div>

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/index.hbs
@@ -1,0 +1,56 @@
+<div
+  class={{class-map
+    'consul-peer-form-generate'
+  }}
+  ...attributes
+>
+  <StateMachine
+    @src={{require './chart.xstate' from="/components/consul/peer/form/generate"}}
+    @initial={{if @regenerate 'loading' 'idle'}}
+  as |fsm|>
+
+  {{#let
+    (unique-id)
+  as |id reset|}}
+    <form
+      {{on 'submit' (fn fsm.dispatch 'LOAD')}}
+      id={{id}}
+    >
+
+      <fsm.State @matches={{array 'idle'}}>
+        {{yield (hash
+          Fieldsets=(component "consul/peer/form/generate/fieldsets"
+            item=@item
+          )
+          Actions=(component "consul/peer/form/generate/actions"
+            item=@item
+            id=id
+          )
+        )}}
+      </fsm.State>
+
+      <fsm.State @matches={{'loading'}}>
+        <DataSource
+          @src={{uri '/${partition}/${nspace}/${dc}/peering/token-for/${name}'
+            (hash
+              partition=@item.Partition
+              nspace=''
+              dc=@item.Datacenter
+              name=@item.Name
+            )
+          }}
+          @onchange={{queue
+            @onchange
+            (pick 'data' (fn fsm.dispatch 'SUCCESS'))
+          }}
+        />
+      </fsm.State>
+
+      <fsm.State @matches={{'success'}}>
+      </fsm.State>
+
+    </form>
+  {{/let}}
+
+  </StateMachine>
+</div>


### PR DESCRIPTION
### Description

[Minimal Rendered Docs](https://consul-ui-staging-eu2os86zq-hashicorp.vercel.app/ui/docs/consul-peerings/consul/peer/form/generate)

Similar to https://github.com/hashicorp/consul/pull/13754 this PR adds a Peer Token Generation form.

Notes (similar to #13754):
1. The form is split into Fieldsets and Actions contextual components, this means that the buttons/actions for the form don't necessarily need to be directly under the 'fieldsets'. In our upcoming case they need to be in a completely separate DOM area in our modals footer. This (along with the use of the HTML5 form="" attribute) means we can move the buttons/actons whereever we need them. Whilst this is perfect for this use case, all our forms should ideally use this approach meaning the buttons to control the form can be anywhere on the page, whether that is directly under the form or in a modal, or something else.
2. Validation RegEx has been moved into the translations which might initially feel a little strange, but the more you think about it the translation file is 1. A centralized place for strings and 2. validations use characters that might be dependant on the translation, and whilst we don't require this just yet (if at all in future) thinking about it like this makes it less weird. Lastly, we use this validation regex elsewhere so a PR for the future would be for the other places we use this to pull from this same place.

Lastly this uses the validations from the translations file from #13754, so in the above docs link you will see the placeholder test instead of the actual text until these are all merged down.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMIke