### PR TITLE
ui: remove with-peers query param

### DIFF
--- a/ui/packages/consul-ui/app/adapters/node.js
+++ b/ui/packages/consul-ui/app/adapters/node.js
@@ -1,5 +1,4 @@
 import Adapter from './application';
-import { inject as service } from '@ember/service';
 
 // TODO: Update to use this.formatDatacenter()
 
@@ -11,25 +10,12 @@ import { inject as service } from '@ember/service';
 // to the node.
 
 export default class NodeAdapter extends Adapter {
-  @service abilities;
-
-  get peeringQuery() {
-    const query = {};
-
-    if (this.abilities.can('use peers')) {
-      query['with-peers'] = true;
-    }
-
-    return query;
-  }
-
   requestForQuery(request, { dc, ns, partition, index, id, uri }) {
     return request`
       GET /v1/internal/ui/nodes?${{ dc }}
       X-Request-ID: ${uri}
 
       ${{
-        ...this.peeringQuery,
         ns,
         partition,
         index,

--- a/ui/packages/consul-ui/app/adapters/service.js
+++ b/ui/packages/consul-ui/app/adapters/service.js
@@ -1,19 +1,6 @@
 import Adapter from './application';
-import { inject as service } from '@ember/service';
 
 export default class ServiceAdapter extends Adapter {
-  @service abilities;
-
-  get peeringQuery() {
-    const query = {};
-
-    if (this.abilities.can('use peers')) {
-      query['with-peers'] = true;
-    }
-
-    return query;
-  }
-
   requestForQuery(request, { dc, ns, partition, index, gateway, uri }) {
     if (typeof gateway !== 'undefined') {
       return request`
@@ -33,7 +20,6 @@ export default class ServiceAdapter extends Adapter {
         X-Request-ID: ${uri}
 
         ${{
-          ...this.peeringQuery,
           ns,
           partition,
           index,

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/nodes
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/nodes
@@ -17,7 +17,7 @@
           {
             "ID":"${fake.random.uuid()}",
             "Node":"node-${i}",
-            ${location.search["with-peers"] ? peerNameString : ''}
+            ${env('CONSUL_PEERING_ENABLE') ? peerNameString : ''}
             "Address":"${fake.internet.ip()}",
             "TaggedAddresses":{
               "lan":"${fake.internet.ip()}",

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/nodes
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/nodes
@@ -17,7 +17,7 @@
           {
             "ID":"${fake.random.uuid()}",
             "Node":"node-${i}",
-            ${env('CONSUL_PEERING_ENABLE') ? peerNameString : ''}
+            ${env('CONSUL_PEERINGS_ENABLE') ? peerNameString : ''}
             "Address":"${fake.internet.ip()}",
             "TaggedAddresses":{
               "lan":"${fake.internet.ip()}",

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/services
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/services
@@ -53,7 +53,7 @@ ${typeof location.search.ns !== 'undefined' ? `
 ${typeof location.search.partition !== 'undefined' ? `
             "Partition": "${fake.helpers.randomize([env('CONSUL_PARTITION_EXPORTER', location.search.partition), location.search.partition])}",
 ` : ``}
-            ${env('CONSUL_PEERING_ENABLE') ? peerNameString : ''}
+            ${env('CONSUL_PEERINGS_ENABLE') ? peerNameString : ''}
             "Tags": [
                 ${
                     range(

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/services
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/services
@@ -53,7 +53,7 @@ ${typeof location.search.ns !== 'undefined' ? `
 ${typeof location.search.partition !== 'undefined' ? `
             "Partition": "${fake.helpers.randomize([env('CONSUL_PARTITION_EXPORTER', location.search.partition), location.search.partition])}",
 ` : ``}
-            ${location.search['with-peers'] ? peerNameString : ''}
+            ${env('CONSUL_PEERING_ENABLE') ? peerNameString : ''}
             "Tags": [
                 ${
                     range(

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/navigation.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/navigation.feature
@@ -27,7 +27,7 @@ Feature: dc / intentions / navigation
     ID: 755b72bd-f5ab-4c92-90cc-bed0e7d8e9f0
     ---
     When I click intention on the intentionList.intentions component
-    Then a GET request was made to "/v1/internal/ui/services?dc=dc-1&with-peers=true&ns=*"
+    Then a GET request was made to "/v1/internal/ui/services?dc=dc-1&ns=*"
     And I click "[data-test-back]"
     Then the url should be /dc-1/intentions
   Scenario: Clicking the create button and back again

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/index.feature
@@ -45,7 +45,7 @@ Feature: dc / nodes / index
     ---
     Then the url should be /dc-1/nodes
     And the title should be "Nodes - Consul"
-    And a GET request was made to "/v1/internal/ui/nodes?dc=dc-1&with-peers=true&ns=@namespace"
+    And a GET request was made to "/v1/internal/ui/nodes?dc=dc-1&ns=@namespace"
     Then I see 3 node models
   Scenario: Seeing the leader in node listing
     Given 3 node models from yaml

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/list.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/list.feature
@@ -16,7 +16,7 @@ Feature: dc / services / list
       dc: dc-1
     ---
     Then the url should be /dc-1/services
-    And a GET request was made to "/v1/internal/ui/services?dc=dc-1&with-peers=true&ns=@namespace"
+    And a GET request was made to "/v1/internal/ui/services?dc=dc-1&ns=@namespace"
 
     Then I see 3 service models
 

--- a/ui/packages/consul-ui/tests/acceptance/page-navigation.feature
+++ b/ui/packages/consul-ui/tests/acceptance/page-navigation.feature
@@ -22,7 +22,7 @@ Feature: page-navigation
   Where:
     ---------------------------------------------------------------------------------------------------
     | Link       | URL               | Endpoint                                                       |
-    | nodes      | /dc1/nodes       | /v1/internal/ui/nodes?dc=dc1&with-peers=true&ns=@namespace      |
+    | nodes      | /dc1/nodes       | /v1/internal/ui/nodes?dc=dc1&ns=@namespace      |
   # FIXME
     # | kvs        | /dc1/kv          | /v1/kv/?keys&dc=dc1&separator=%2F&ns=@namespace               |
     | tokens       | /dc1/acls/tokens | /v1/acl/tokens?dc=dc1&ns=@namespace                           |

--- a/ui/packages/consul-ui/tests/acceptance/token-header.feature
+++ b/ui/packages/consul-ui/tests/acceptance/token-header.feature
@@ -11,7 +11,7 @@ Feature: token-header
       dc: dc1
     ---
     Then the url should be /dc1/services
-    And a GET request was made to "/v1/internal/ui/services?dc=dc1&with-peers=true&ns=@namespace" from yaml
+    And a GET request was made to "/v1/internal/ui/services?dc=dc1&ns=@namespace" from yaml
     ---
     headers:
       X-Consul-Token: ''
@@ -35,7 +35,7 @@ Feature: token-header
       dc: dc1
     ---
     Then the url should be /dc1/services
-    And a GET request was made to "/v1/internal/ui/services?dc=dc1&with-peers=true&ns=@namespace" from yaml
+    And a GET request was made to "/v1/internal/ui/services?dc=dc1&ns=@namespace" from yaml
     ---
     headers:
       X-Consul-Token: [Token]

--- a/ui/packages/consul-ui/tests/helpers/set-cookies.js
+++ b/ui/packages/consul-ui/tests/helpers/set-cookies.js
@@ -5,8 +5,8 @@ export default function(type, value, doc = document) {
     if (!doc.cookie.includes('CONSUL_ACLS_ENABLE=0')) {
       obj['CONSUL_ACLS_ENABLE'] = 1;
     }
-    if (!doc.cookie.includes('CONSUL_PEERING_ENABLE=0')) {
-      obj['CONSUL_PEERING_ENABLE'] = 1;
+    if (!doc.cookie.includes('CONSUL_PEERINGS_ENABLE=0')) {
+      obj['CONSUL_PEERINGS_ENABLE'] = 1;
     }
     switch (type) {
       case 'dc':

--- a/ui/packages/consul-ui/tests/helpers/set-cookies.js
+++ b/ui/packages/consul-ui/tests/helpers/set-cookies.js
@@ -5,6 +5,9 @@ export default function(type, value, doc = document) {
     if (!doc.cookie.includes('CONSUL_ACLS_ENABLE=0')) {
       obj['CONSUL_ACLS_ENABLE'] = 1;
     }
+    if (!doc.cookie.includes('CONSUL_PEERING_ENABLE=0')) {
+      obj['CONSUL_PEERING_ENABLE'] = 1;
+    }
     switch (type) {
       case 'dc':
         key = 'CONSUL_DATACENTER_COUNT';

--- a/ui/packages/consul-ui/tests/integration/adapters/node-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/node-test.js
@@ -14,7 +14,7 @@ module('Integration | Adapter | node', function(hooks) {
       const adapter = this.owner.lookup('adapter:node');
       const client = this.owner.lookup('service:client/http');
       const request = client.requestParams.bind(client);
-      const expected = `GET /v1/internal/ui/nodes?dc=${dc}&with-peers=true${
+      const expected = `GET /v1/internal/ui/nodes?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       const actual = adapter.requestForQuery(request, {

--- a/ui/packages/consul-ui/tests/integration/adapters/service-test.js
+++ b/ui/packages/consul-ui/tests/integration/adapters/service-test.js
@@ -14,7 +14,7 @@ module('Integration | Adapter | service', function(hooks) {
       const adapter = this.owner.lookup('adapter:service');
       const client = this.owner.lookup('service:client/http');
       const request = client.requestParams.bind(client);
-      const expected = `GET /v1/internal/ui/services?dc=${dc}&with-peers=true${
+      const expected = `GET /v1/internal/ui/services?dc=${dc}${
         shouldHaveNspace(nspace) ? `&ns=${nspace}` : ``
       }`;
       let actual = adapter.requestForQuery(request, {


### PR DESCRIPTION
### Description
Removes the unneeded `with-peers`-query-param when requesting `service`s and `node`s for their respective listing pages.

### PR Checklist

* [x] updated test coverage
* [ ] ~~external facing docs updated~~
* [x] not a security concern

cc @johncowen 
