### PR TITLE
peering: add warning about AllowStaleRead

### DIFF
--- a/internal/tools/proto-gen-rpc-glue/e2e/source.pb.go
+++ b/internal/tools/proto-gen-rpc-glue/e2e/source.pb.go
@@ -43,6 +43,11 @@ type ExampleReadTODO struct {
 	Value string
 }
 
+// @consul-rpc-glue: LeaderReadTODO
+type ExampleLeaderReadTODO struct {
+	Value string
+}
+
 // @consul-rpc-glue: WriteTODO
 type ExampleWriteTODO struct {
 	Value string

--- a/internal/tools/proto-gen-rpc-glue/e2e/source.rpcglue.pb.go.golden
+++ b/internal/tools/proto-gen-rpc-glue/e2e/source.rpcglue.pb.go.golden
@@ -309,6 +309,50 @@ func (msg *ExampleReadTODO) Token() string {
 }
 
 // IsRead implements structs.RPCInfo
+func (msg *ExampleLeaderReadTODO) IsRead() bool {
+	// TODO(peering): figure out read semantics here
+	return true
+}
+
+// AllowStaleRead implements structs.RPCInfo
+func (msg *ExampleLeaderReadTODO) AllowStaleRead() bool {
+	// TODO(peering): figure out read semantics here
+	// TODO(peering): this needs to stay false for calls to head to the leader until we sync stream tracker information
+	// like ImportedServicesCount, ExportedServicesCount, as well as general Status fields thru raft to make available
+	// to followers as well
+	return false
+}
+
+// HasTimedOut implements structs.RPCInfo
+func (msg *ExampleLeaderReadTODO) HasTimedOut(start time.Time, rpcHoldTimeout time.Duration, a time.Duration, b time.Duration) (bool, error) {
+	// TODO(peering): figure out read semantics here
+	return time.Since(start) > rpcHoldTimeout, nil
+}
+
+// Timeout implements structs.RPCInfo
+func (msg *ExampleLeaderReadTODO) Timeout(rpcHoldTimeout time.Duration, a time.Duration, b time.Duration) time.Duration {
+	// TODO(peering): figure out read semantics here
+	return rpcHoldTimeout
+}
+
+// SetTokenSecret implements structs.RPCInfo
+func (msg *ExampleLeaderReadTODO) SetTokenSecret(s string) {
+	// TODO(peering): figure out read semantics here
+}
+
+// TokenSecret implements structs.RPCInfo
+func (msg *ExampleLeaderReadTODO) TokenSecret() string {
+	// TODO(peering): figure out read semantics here
+	return ""
+}
+
+// Token implements structs.RPCInfo
+func (msg *ExampleLeaderReadTODO) Token() string {
+	// TODO(peering): figure out read semantics here
+	return ""
+}
+
+// IsRead implements structs.RPCInfo
 func (msg *ExampleWriteTODO) IsRead() bool {
 	// TODO(peering): figure out write semantics here
 	return false

--- a/proto/pbpeering/peering.pb.go
+++ b/proto/pbpeering/peering.pb.go
@@ -379,7 +379,7 @@ func (x *PeeringTrustBundle) GetModifyIndex() uint64 {
 	return 0
 }
 
-// @consul-rpc-glue: Datacenter,ReadTODO
+// @consul-rpc-glue: Datacenter,LeaderReadTODO
 type PeeringReadRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -490,7 +490,7 @@ func (x *PeeringReadResponse) GetPeering() *Peering {
 	return nil
 }
 
-// @consul-rpc-glue: Datacenter,ReadTODO
+// @consul-rpc-glue: Datacenter,LeaderReadTODO
 type PeeringListRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/proto/pbpeering/peering.proto
+++ b/proto/pbpeering/peering.proto
@@ -136,7 +136,7 @@ message PeeringTrustBundle {
   uint64 ModifyIndex = 7;
 }
 
-// @consul-rpc-glue: Datacenter,ReadTODO
+// @consul-rpc-glue: Datacenter,LeaderReadTODO
 message PeeringReadRequest {
   string Name = 1;
   string Partition = 2;
@@ -152,7 +152,7 @@ message PeeringReadResponse {
 //TODO(peering) query metadata
 }
 
-// @consul-rpc-glue: Datacenter,ReadTODO
+// @consul-rpc-glue: Datacenter,LeaderReadTODO
 message PeeringListRequest {
   string Partition = 1;
 

--- a/proto/pbpeering/peering.rpcglue.pb.go
+++ b/proto/pbpeering/peering.rpcglue.pb.go
@@ -29,6 +29,9 @@ func (msg *PeeringReadRequest) IsRead() bool {
 // AllowStaleRead implements structs.RPCInfo
 func (msg *PeeringReadRequest) AllowStaleRead() bool {
 	// TODO(peering): figure out read semantics here
+	// TODO(peering): this needs to stay false for calls to head to the leader until we sync stream tracker information
+	// like ImportedServicesCount, ExportedServicesCount, as well as general Status fields thru raft to make available
+	// to followers as well
 	return false
 }
 
@@ -78,6 +81,9 @@ func (msg *PeeringListRequest) IsRead() bool {
 // AllowStaleRead implements structs.RPCInfo
 func (msg *PeeringListRequest) AllowStaleRead() bool {
 	// TODO(peering): figure out read semantics here
+	// TODO(peering): this needs to stay false for calls to head to the leader until we sync stream tracker information
+	// like ImportedServicesCount, ExportedServicesCount, as well as general Status fields thru raft to make available
+	// to followers as well
 	return false
 }
 


### PR DESCRIPTION
### Description

Freddy was mentioning that we need to add a warning about the constraint of having the leader field read request for peering calls.

This adds a TODO to add that context.
