### PR TITLE
ui: make nodes searchable by peer-name

### DIFF
--- a/ui/packages/consul-ui/app/controllers/_peered-resource.js
+++ b/ui/packages/consul-ui/app/controllers/_peered-resource.js
@@ -1,0 +1,16 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class PeeredResourceController extends Controller {
+  @service abilities;
+
+  get _searchProperties() {
+    const { searchProperties } = this;
+
+    if (!this.abilities.can('use peers')) {
+      return searchProperties.filter(propertyName => propertyName !== 'PeerName');
+    } else {
+      return searchProperties;
+    }
+  }
+}

--- a/ui/packages/consul-ui/app/controllers/dc/nodes/index.js
+++ b/ui/packages/consul-ui/app/controllers/dc/nodes/index.js
@@ -1,0 +1,3 @@
+import PeeredResourceController from 'consul-ui/controllers/_peered-resource';
+
+export default class DcServicesController extends PeeredResourceController {}

--- a/ui/packages/consul-ui/app/controllers/dc/services/index.js
+++ b/ui/packages/consul-ui/app/controllers/dc/services/index.js
@@ -1,0 +1,3 @@
+import PeeredResourceController from 'consul-ui/controllers/_peered-resource';
+
+export default class DcServicesController extends PeeredResourceController {}

--- a/ui/packages/consul-ui/app/search/predicates/node.js
+++ b/ui/packages/consul-ui/app/search/predicates/node.js
@@ -1,5 +1,6 @@
 export default {
   Node: item => item.Node,
   Address: item => item.Address,
+  PeerName: item => item.PeerName,
   Meta: item => Object.entries(item.Meta || {}).reduce((prev, entry) => prev.concat(entry), []),
 };

--- a/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
@@ -44,10 +44,10 @@ as |route|>
       searchproperty=(hash
         value=(if (not-eq searchproperty undefined)
           (split searchproperty ',')
-          searchProperties
+          this._searchProperties
         )
         change=(action (mut searchproperty) value="target.selectedItems")
-        default=searchProperties
+        default=this._searchProperties
       )
     )
 

--- a/ui/packages/consul-ui/app/templates/dc/services/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/index.hbs
@@ -43,10 +43,10 @@ as |route|>
     searchproperty=(hash
       value=(if (not-eq searchproperty undefined)
         (split searchproperty ',')
-        searchProperties
+        this._searchProperties
       )
       change=(action (mut searchproperty) value="target.selectedItems")
-      default=searchProperties
+      default=this._searchProperties
     )
 
   )

--- a/ui/packages/consul-ui/vendor/consul-ui/routes.js
+++ b/ui/packages/consul-ui/vendor/consul-ui/routes.js
@@ -215,7 +215,7 @@
               status: 'status',
               searchproperty: {
                 as: 'searchproperty',
-                empty: [['Node', 'Address', 'Meta']],
+                empty: [['Node', 'Address', 'Meta', 'PeerName']],
               },
               search: {
                 as: 'filter',


### PR DESCRIPTION
### Description
Makes nodes searchable by peer-name.

This PR also fixes the issue that services would show the peer search filter although the peering feature was turned off.

Thea addition of the `PeeredResourceController` is necessary because the custom router dsl and search predicates abstraction doesn't seem to be customizable based on features being on or off.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

cc @johncowen 