### PR TITLE
Enable API support for partitions during peering establishment

### DIFF
--- a/agent/peering_endpoint.go
+++ b/agent/peering_endpoint.go
@@ -130,6 +130,14 @@ func (s *HTTPHandlers) PeeringEstablish(resp http.ResponseWriter, req *http.Requ
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: "PeeringToken is required in the payload when establishing a peering."}
 	}
 
+	var entMeta acl.EnterpriseMeta
+	if err := s.parseEntMetaPartition(req, &entMeta); err != nil {
+		return nil, err
+	}
+	if args.Partition == "" {
+		args.Partition = entMeta.PartitionOrEmpty()
+	}
+
 	out, err := s.agent.rpcClientPeering.Establish(req.Context(), args)
 	if err != nil {
 		return nil, err

--- a/api/peering.go
+++ b/api/peering.go
@@ -98,8 +98,10 @@ type PeeringEstablishRequest struct {
 	PeerName string
 	// The peering token returned from the peer's GenerateToken endpoint.
 	PeeringToken string `json:",omitempty"`
-	Datacenter   string `json:",omitempty"`
-	Token        string `json:",omitempty"`
+	// Partition to be peered.
+	Partition  string `json:",omitempty"`
+	Datacenter string `json:",omitempty"`
+	Token      string `json:",omitempty"`
 	// Meta is a mapping of some string value to any other string value
 	Meta map[string]string `json:",omitempty"`
 }

--- a/proto/pbpeering/peering.gen.go
+++ b/proto/pbpeering/peering.gen.go
@@ -10,6 +10,7 @@ func EstablishRequestToAPI(s *EstablishRequest, t *api.PeeringEstablishRequest) 
 	}
 	t.PeerName = s.PeerName
 	t.PeeringToken = s.PeeringToken
+	t.Partition = s.Partition
 	t.Datacenter = s.Datacenter
 	t.Token = s.Token
 	t.Meta = s.Meta
@@ -20,6 +21,7 @@ func EstablishRequestFromAPI(t *api.PeeringEstablishRequest, s *EstablishRequest
 	}
 	s.PeerName = t.PeerName
 	s.PeeringToken = t.PeeringToken
+	s.Partition = t.Partition
 	s.Datacenter = t.Datacenter
 	s.Token = t.Token
 	s.Meta = t.Meta


### PR DESCRIPTION
### Description
The functionality exists within Consul Enterprise but these changes are necessary in the common code to support peering partitions.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
