### PR TITLE
Fix panic for replicating a node without a Node ID

### DIFF
--- a/agent/grpc-external/services/peerstream/health_snapshot_test.go
+++ b/agent/grpc-external/services/peerstream/health_snapshot_test.go
@@ -69,8 +69,8 @@ func TestHealthSnapshot(t *testing.T) {
 				},
 			},
 			expect: &healthSnapshot{
-				Nodes: map[types.NodeID]*nodeSnapshot{
-					"abc-123": {
+				Nodes: map[string]*nodeSnapshot{
+					"abc": {
 						Node: newNode("abc-123", "abc", "my-peer"),
 						Services: map[structs.ServiceID]*serviceSnapshot{
 							structs.NewServiceID("xyz-123", nil): {
@@ -88,14 +88,14 @@ func TestHealthSnapshot(t *testing.T) {
 			name: "multiple",
 			in: []structs.CheckServiceNode{
 				{
-					Node:    newNode("abc-123", "abc", ""),
+					Node:    newNode("", "abc", ""),
 					Service: newService("xyz-123", 8080, ""),
 					Checks: structs.HealthChecks{
 						newCheck("abc", "xyz-123", ""),
 					},
 				},
 				{
-					Node:    newNode("abc-123", "abc", ""),
+					Node:    newNode("", "abc", ""),
 					Service: newService("xyz-789", 8181, ""),
 					Checks: structs.HealthChecks{
 						newCheck("abc", "xyz-789", ""),
@@ -110,9 +110,9 @@ func TestHealthSnapshot(t *testing.T) {
 				},
 			},
 			expect: &healthSnapshot{
-				Nodes: map[types.NodeID]*nodeSnapshot{
-					"abc-123": {
-						Node: newNode("abc-123", "abc", "my-peer"),
+				Nodes: map[string]*nodeSnapshot{
+					"abc": {
+						Node: newNode("", "abc", "my-peer"),
 						Services: map[structs.ServiceID]*serviceSnapshot{
 							structs.NewServiceID("xyz-123", nil): {
 								Service: newService("xyz-123", 8080, "my-peer"),
@@ -128,7 +128,7 @@ func TestHealthSnapshot(t *testing.T) {
 							},
 						},
 					},
-					"def-456": {
+					"def": {
 						Node: newNode("def-456", "def", "my-peer"),
 						Services: map[structs.ServiceID]*serviceSnapshot{
 							structs.NewServiceID("xyz-456", nil): {

--- a/agent/grpc-external/services/peerstream/replication.go
+++ b/agent/grpc-external/services/peerstream/replication.go
@@ -290,8 +290,8 @@ func (s *Server) handleUpdateService(
 		deletedNodeChecks = make(map[nodeCheckTuple]struct{})
 	)
 	for _, csn := range storedInstances {
-		if _, ok := snap.Nodes[csn.Node.ID]; !ok {
-			unusedNodes[string(csn.Node.ID)] = struct{}{}
+		if _, ok := snap.Nodes[csn.Node.Node]; !ok {
+			unusedNodes[csn.Node.Node] = struct{}{}
 
 			// Since the node is not in the snapshot we can know the associated service
 			// instance is not in the snapshot either, since a service instance can't
@@ -316,7 +316,7 @@ func (s *Server) handleUpdateService(
 
 		// Delete the service instance if not in the snapshot.
 		sid := csn.Service.CompoundServiceID()
-		if _, ok := snap.Nodes[csn.Node.ID].Services[sid]; !ok {
+		if _, ok := snap.Nodes[csn.Node.Node].Services[sid]; !ok {
 			err := s.Backend.CatalogDeregister(&structs.DeregisterRequest{
 				Node:           csn.Node.Node,
 				ServiceID:      csn.Service.ID,
@@ -335,7 +335,7 @@ func (s *Server) handleUpdateService(
 
 		// Reconcile checks.
 		for _, chk := range csn.Checks {
-			if _, ok := snap.Nodes[csn.Node.ID].Services[sid].Checks[chk.CheckID]; !ok {
+			if _, ok := snap.Nodes[csn.Node.Node].Services[sid].Checks[chk.CheckID]; !ok {
 				// Checks without a ServiceID are node checks.
 				// If the node exists but the check does not then the check was deleted.
 				if chk.ServiceID == "" {


### PR DESCRIPTION
### Description
Node IDs are not required in Consul's data model (this is unfortunate and has caused us many issues over the years). 

Therefore the peering code cannot require the node id. This PR transitions our healthSnapshot tracking of nodes to use the only unique identifying information a node has as the key for the map to track nodes - the nodes name.

### Testing & Reproduction steps
* Unit tests were updated to include nodes without IDs to prove that the health snapshot gets built properly.

Manual Test:

1. Setup peering.
2. Export a service that doesn't exist.
3. Create that service through the API without specifying the node id. Before this would cause the peer importing the service to panic. Now it doesn't

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
