### PR TITLE
peerstream: fix test assertions

### DIFF
--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -478,7 +478,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			LastNackMessage:    lastNackMsg,
 			LastReceiveSuccess: lastRecvSuccess,
 			ImportedServices: map[string]struct{}{
-				api.String(): struct{}{},
+				api.String(): {},
 			},
 		}
 
@@ -540,7 +540,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			LastReceiveError:        lastRecvError,
 			LastReceiveErrorMessage: lastRecvErrorMsg,
 			ImportedServices: map[string]struct{}{
-				api.String(): struct{}{},
+				api.String(): {},
 			},
 		}
 
@@ -572,7 +572,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			LastReceiveErrorMessage: io.EOF.Error(),
 			LastReceiveError:        lastRecvError,
 			ImportedServices: map[string]struct{}{
-				api.String(): struct{}{},
+				api.String(): {},
 			},
 		}
 

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -469,13 +469,17 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 
 		lastRecvSuccess = it.base.Add(time.Duration(sequence) * time.Second).UTC()
 
+		api := structs.NewServiceName("api", nil)
+
 		expect := Status{
 			Connected:          true,
 			LastAck:            lastSendSuccess,
 			LastNack:           lastNack,
 			LastNackMessage:    lastNackMsg,
 			LastReceiveSuccess: lastRecvSuccess,
-			ImportedServices:   map[string]struct{}{"api": {}},
+			ImportedServices: map[string]struct{}{
+				api.String(): struct{}{},
+			},
 		}
 
 		retry.Run(t, func(r *retry.R) {
@@ -525,6 +529,8 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 		lastRecvError = it.base.Add(time.Duration(sequence) * time.Second).UTC()
 		lastRecvErrorMsg = `unsupported operation: "OPERATION_UNSPECIFIED"`
 
+		api := structs.NewServiceName("api", nil)
+
 		expect := Status{
 			Connected:               true,
 			LastAck:                 lastSendSuccess,
@@ -533,7 +539,9 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			LastReceiveSuccess:      lastRecvSuccess,
 			LastReceiveError:        lastRecvError,
 			LastReceiveErrorMessage: lastRecvErrorMsg,
-			ImportedServices:        map[string]struct{}{"api": {}},
+			ImportedServices: map[string]struct{}{
+				api.String(): struct{}{},
+			},
 		}
 
 		retry.Run(t, func(r *retry.R) {
@@ -552,6 +560,8 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 		sequence++
 		disconnectTime := it.base.Add(time.Duration(sequence) * time.Second).UTC()
 
+		api := structs.NewServiceName("api", nil)
+
 		expect := Status{
 			Connected:               false,
 			LastAck:                 lastSendSuccess,
@@ -561,7 +571,9 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			LastReceiveSuccess:      lastRecvSuccess,
 			LastReceiveErrorMessage: io.EOF.Error(),
 			LastReceiveError:        lastRecvError,
-			ImportedServices:        map[string]struct{}{"api": {}},
+			ImportedServices: map[string]struct{}{
+				api.String(): struct{}{},
+			},
 		}
 
 		retry.Run(t, func(r *retry.R) {


### PR DESCRIPTION
This ensures the test cases pass in both OSS and Enterprise. Example of how the assertion fails in enterprise:

```
   	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -36,3 +36,3 @@
        	            	  ImportedServices: (map[string]struct {}) (len=1) {
        	            	-  (string) (len=3) "api": (struct {}) {
        	            	+  (string) (len=19) "default/default/api": (struct {}) {
        	            	   }
```