### PR TITLE
Update go-discover to support ECS discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-connlimit v0.3.0
-	github.com/hashicorp/go-discover v0.0.0-20220411141802-20db45f7f0f9
+	github.com/hashicorp/go-discover v0.0.0-20220714221025-1c234a67149a
 	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/hashicorp/go-connlimit v0.3.0 h1:oAojHGjFxUTTTA8c5XXnDqWJ2HLuWbDiBPTp
 github.com/hashicorp/go-connlimit v0.3.0/go.mod h1:OUj9FGL1tPIhl/2RCfzYHrIiWj+VVPGNyVPnUX8AqS0=
 github.com/hashicorp/go-discover v0.0.0-20220411141802-20db45f7f0f9 h1:2GsEkBZf1q4LKZjtd4cO+V0xd85xGCMolX3ebC2+xd4=
 github.com/hashicorp/go-discover v0.0.0-20220411141802-20db45f7f0f9/go.mod h1:1xfdKvc3pe5WKxfUUHHOGaKMk7NLGhHY1jkyhKo6098=
+github.com/hashicorp/go-discover v0.0.0-20220714221025-1c234a67149a h1:xeDSq/xo0CfnSZnPUkNH/00Qy8Q8ySJW0Ij2u/pH680=
+github.com/hashicorp/go-discover v0.0.0-20220714221025-1c234a67149a/go.mod h1:1xfdKvc3pe5WKxfUUHHOGaKMk7NLGhHY1jkyhKo6098=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=

--- a/website/content/docs/install/cloud-auto-join.mdx
+++ b/website/content/docs/install/cloud-auto-join.mdx
@@ -107,7 +107,7 @@ In order to use discovery behind a proxy, you will need to set
 The following sections give the options specific to each supported cloud
 provider.
 
-### Amazon EC2
+### Amazon EC2 & ECS
 
 This returns the first private IP address of all servers in the given
 region which have the given `tag_key` and `tag_value`.
@@ -129,6 +129,10 @@ $ consul agent -retry-join "provider=aws tag_key=... tag_value=..."
 - `addr_type` (optional) - the type of address to discover: `private_v4`, `public_v4`, `public_v6`. Default is `private_v4`. (>= 1.0)
 - `access_key_id` (optional) - the AWS access key for authentication (see below for more information about authenticating).
 - `secret_access_key` (optional) - the AWS secret access key for authentication (see below for more information about authenticating).
+- `service` (optional) - The AWS service to filter. "ec2" or "ecs". Defaults to "ec2".
+- `ecs_cluster` (optional) - The AWS ECS Cluster Name or Full ARN to limit searching within. Default none, search all.
+- `ecs_family` (optional) - The AWS ECS Task Definition Family to limit searching within. Default none, search all.
+- `endpoint` (optional) - The endpoint URL of the AWS Service to use. If not set the AWS client will set this value, which defaults to the public DNS name for the service in the specified region.
 
 #### Authentication & Precedence
 
@@ -138,11 +142,19 @@ $ consul agent -retry-join "provider=aws tag_key=... tag_value=..."
 - ECS task role metadata (container-specific).
 - EC2 instance role metadata.
 
-The only required IAM permission is `ec2:DescribeInstances`, and it is
+To discover EC2 consul-servers, the only required IAM permission is `ec2:DescribeInstances`, and it is
 recommended that you make a dedicated key used only to auto-join the datacenter. If the
 region is omitted it will be discovered through the local instance's [EC2
 metadata
 endpoint](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html).
+
+To discover ECS consul-servers, the following IAM permissions are required on the AWS ECS Task Role associated with the Service performing discovery.
+- `ecs:ListClusters` (only used when `ecs_cluster` is not provided)
+- `ecs:ListServices` (only used when `ecs_cluster` is not provided)
+- `ecs:DescribeServices` (only used when `ecs_cluster` is not provided)
+- `ecs:ListTasks`
+- `ecs:DescribeTasks`
+If the region is omitted it will be discovered through the local instance's [ECS V4 metadata endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html).
 
 ### Microsoft Azure
 


### PR DESCRIPTION
### Description
Go-Discover now supports ECS container instance discovery. This change updates the go-discover dependency and corresponding documentation outlining new options.

### Testing & Reproduction steps
* TBD

### Links
Issue: [GH-6802](https://github.com/hashicorp/consul/issues/6802#issuecomment-1184948029)
Dependency: [PR-197](https://github.com/hashicorp/go-discover/pull/197)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
