### PR TITLE
peering: track exported services

### DIFF
--- a/agent/grpc-external/services/peerstream/replication.go
+++ b/agent/grpc-external/services/peerstream/replication.go
@@ -36,10 +36,14 @@ import (
 // If there are no instances in the event, we consider that to be a de-registration.
 func makeServiceResponse(
 	logger hclog.Logger,
+	mst *MutableStatus,
 	update cache.UpdateEvent,
 ) (*pbpeerstream.ReplicationMessage_Response, error) {
+	serviceName := strings.TrimPrefix(update.CorrelationID, subExportedService)
+	sn := structs.ServiceNameFromString(serviceName)
 	csn, ok := update.Result.(*pbservice.IndexedCheckServiceNodes)
 	if !ok {
+		logger.Error("did not increment or decrement exported services count", "service_name", serviceName)
 		return nil, fmt.Errorf("invalid type for service response: %T", update.Result)
 	}
 
@@ -51,9 +55,6 @@ func makeServiceResponse(
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal: %w", err)
 	}
-
-	serviceName := strings.TrimPrefix(update.CorrelationID, subExportedService)
-
 	// If no nodes are present then it's due to one of:
 	// 1. The service is newly registered or exported and yielded a transient empty update.
 	// 2. All instances of the service were de-registered.
@@ -61,7 +62,8 @@ func makeServiceResponse(
 	//
 	// We don't distinguish when these three things occurred, but it's safe to send a DELETE Op in all cases, so we do that.
 	// Case #1 is a no-op for the importing peer.
-	if len(export.Nodes) == 0 {
+	if len(csn.Nodes) == 0 {
+		mst.RemoveExportedService(sn)
 		return &pbpeerstream.ReplicationMessage_Response{
 			ResourceURL: pbpeerstream.TypeURLExportedService,
 			// TODO(peering): Nonce management
@@ -71,6 +73,7 @@ func makeServiceResponse(
 		}, nil
 	}
 
+	mst.TrackExportedService(sn)
 	// If there are nodes in the response, we push them as an UPSERT operation.
 	return &pbpeerstream.ReplicationMessage_Response{
 		ResourceURL: pbpeerstream.TypeURLExportedService,

--- a/agent/grpc-external/services/peerstream/replication.go
+++ b/agent/grpc-external/services/peerstream/replication.go
@@ -63,7 +63,9 @@ func makeServiceResponse(
 	// We don't distinguish when these three things occurred, but it's safe to send a DELETE Op in all cases, so we do that.
 	// Case #1 is a no-op for the importing peer.
 	if len(csn.Nodes) == 0 {
+		logger.Trace("decrementing exported services count", "service_name", sn.String())
 		mst.RemoveExportedService(sn)
+
 		return &pbpeerstream.ReplicationMessage_Response{
 			ResourceURL: pbpeerstream.TypeURLExportedService,
 			// TODO(peering): Nonce management
@@ -73,7 +75,9 @@ func makeServiceResponse(
 		}, nil
 	}
 
+	logger.Trace("incrementing exported services count", "service_name", sn.String())
 	mst.TrackExportedService(sn)
+
 	// If there are nodes in the response, we push them as an UPSERT operation.
 	return &pbpeerstream.ReplicationMessage_Response{
 		ResourceURL: pbpeerstream.TypeURLExportedService,

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -424,7 +424,7 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 			var resp *pbpeerstream.ReplicationMessage_Response
 			switch {
 			case strings.HasPrefix(update.CorrelationID, subExportedService):
-				resp, err = makeServiceResponse(logger, update)
+				resp, err = makeServiceResponse(logger, status, update)
 				if err != nil {
 					// Log the error and skip this response to avoid locking up peering due to a bad update event.
 					logger.Error("failed to create service response", "error", err)

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -346,6 +346,7 @@ func (s *Server) PeeringRead(ctx context.Context, req *pbpeering.PeeringReadRequ
 		s.Logger.Trace("did not find peer in stream tracker when reading peer", "peerID", peering.ID)
 	} else {
 		cp.ImportedServiceCount = uint64(len(st.ImportedServices))
+		cp.ExportedServiceCount = uint64(len(st.ExportedServices))
 	}
 
 	return &pbpeering.PeeringReadResponse{Peering: cp}, nil
@@ -386,6 +387,7 @@ func (s *Server) PeeringList(ctx context.Context, req *pbpeering.PeeringListRequ
 			s.Logger.Trace("did not find peer in stream tracker when listing peers", "peerID", p.ID)
 		} else {
 			cp.ImportedServiceCount = uint64(len(st.ImportedServices))
+			cp.ExportedServiceCount = uint64(len(st.ExportedServices))
 		}
 
 		cPeerings = append(cPeerings, cp)


### PR DESCRIPTION
### Description

This patch exposes the `ExportedServicesCount` thru our List/Read endpoints for peerings.

This PR is quite similar to https://github.com/hashicorp/consul/pull/13718 .

### Testing & Reproduction steps
* updated the `stream_tracker`
* updated the `leader_peering_test`

