### PR TITLE
Fix panic on acl token read with -self and -expanded

### DIFF
--- a/.changelog/13787.txt
+++ b/.changelog/13787.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: when `acl token read` is used with the `-self` and `-expanded` flags, return an error instead of panicking
+```

--- a/command/acl/token/read/token_read.go
+++ b/command/acl/token/read/token_read.go
@@ -92,6 +92,13 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 	} else {
+		// TODO: consider updating this CLI command and underlying HTTP API endpoint
+		// to support expanded read of a "self" token, which is a much better user workflow.
+		if c.expanded {
+			c.UI.Error("Cannot use both -expanded and -self. Instead, use -expanded and -id=<accessor id>.")
+			return 1
+		}
+
 		t, _, err = client.ACL().TokenReadSelf(nil)
 		if err != nil {
 			c.UI.Error(fmt.Sprintf("Error reading token: %v", err))


### PR DESCRIPTION
Closes #13785

![image](https://user-images.githubusercontent.com/85913323/179323092-8d80916b-6343-4f6f-8973-fe06bbc4f5db.png)
