### PR TITLE
ui: Add Peer Form

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/form/README.mdx
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/README.mdx
@@ -1,0 +1,21 @@
+# Consul::Peer::Form
+
+```hbs preview-template
+<Consul::Peer::Form
+  @params={{hash
+    dc='dc1'
+    nspace=''
+    partition=''
+  }}
+as |form|>
+  <form.Form
+    @onchange={{noop}}
+    @onsubmit={{noop}}
+  as |form|>
+    <form.Fieldsets />
+    <form.Actions
+      @onclose={{noop}}
+    />
+  </form.Form>
+</Consul::Peer::Form>
+```

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/chart.xstate.js
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/chart.xstate.js
@@ -12,15 +12,9 @@ export default {
         target: 'generate',
       },
     ],
-    SUCCESS: [
-      {
-        target: 'success',
-      },
-    ],
   },
   states: {
     initiate: {},
     generate: {},
-    success: {},
   },
 };

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/chart.xstate.js
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/chart.xstate.js
@@ -1,0 +1,26 @@
+export default {
+  id: 'consul-peer-form',
+  initial: 'generate',
+  on: {
+    INITIATE: [
+      {
+        target: 'initiate',
+      },
+    ],
+    GENERATE: [
+      {
+        target: 'generate',
+      },
+    ],
+    SUCCESS: [
+      {
+        target: 'success',
+      },
+    ],
+  },
+  states: {
+    initiate: {},
+    generate: {},
+    success: {},
+  },
+};

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/index.hbs
@@ -1,0 +1,63 @@
+<div
+  class={{class-map
+    'consul-peer-form'
+  }}
+  ...attributes
+>
+  <StateMachine
+    @src={{require './chart.xstate' from='/components/consul/peer/form'}}
+  as |fsm|>
+
+    <TabNav
+      @items={{array
+        (hash
+          label='Generate token'
+          selected=(state-matches fsm.state 'generate')
+          state="GENERATE"
+        )
+        (hash
+          label='Initiate peering'
+          selected=(state-matches fsm.state 'initiate')
+          state="INITIATE"
+        )
+      }}
+      @onTabClicked={{pick 'state' fsm.dispatch}}
+    />
+
+    <fsm.State @matches={{array 'generate'}}>
+
+      <DataSource
+        @src={{uri '/${partition}/${nspace}/${dc}/peer/'
+          @params
+        }}
+      as |source|>
+          {{yield (hash
+            Form=(component 'consul/peer/form/generate'
+              item=source.data
+            )
+          )
+          }}
+      </DataSource>
+
+    </fsm.State>
+
+    <fsm.State @matches="initiate">
+
+      <DataSource
+        @src={{uri '/${partition}/${nspace}/${dc}/peer/'
+          @params
+        }}
+      as |source|>
+          {{yield (hash
+              Form=(component 'consul/peer/form/initiate'
+                item=source.data
+              )
+            )
+          }}
+      </DataSource>
+
+    </fsm.State>
+
+
+  </StateMachine>
+</div>

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/index.scss
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/index.scss
@@ -1,3 +1,11 @@
+.consul-peer-form {
+  & {
+    width: 416px;
+  }
+  nav {
+    margin-bottom: 20px;
+  }
+}
 
 .consul-peer-form-token-actions {
   button:first-of-type {

--- a/ui/packages/consul-peerings/app/components/consul/peer/index.scss
+++ b/ui/packages/consul-peerings/app/components/consul/peer/index.scss
@@ -2,4 +2,5 @@
 
 @import './list';
 @import './search-bar';
+@import './form';
 


### PR DESCRIPTION
### Description

[Minimal Rendered Docs](https://consul-ui-staging-abzatq35a-hashicorp.vercel.app/ui/docs/consul-peerings/consul/peer/form)

Adds PeerForm. A wrapping 'form' that wraps all of the various states of the peer establishment forms into one easier to use component. Similarly to other related PRs this PR yields separate fieldsets and actions for the form depending on the selected tab.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMike
