### PR TITLE
peering: refactor reconcile, cleanup

### DIFF
--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -747,10 +747,11 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 	/// finished adding services
 
 	type testCase struct {
-		name                                  string
-		description                           string
-		exportedService                       structs.ExportedServicesConfigEntry
-		expectedImportedExportedServicesCount uint64 // same count for a server that imports the services form a server that exports them
+		name                       string
+		description                string
+		exportedService            structs.ExportedServicesConfigEntry
+		expectedImportedServsCount uint64
+		expectedExportedServsCount uint64
 	}
 
 	testCases := []testCase{
@@ -770,7 +771,8 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 					},
 				},
 			},
-			expectedImportedExportedServicesCount: 4, // 3 services from above + the "consul" service
+			expectedImportedServsCount: 4, // 3 services from above + the "consul" service
+			expectedExportedServsCount: 4, // 3 services from above + the "consul" service
 		},
 		{
 			name:        "no sync",
@@ -778,7 +780,8 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 			exportedService: structs.ExportedServicesConfigEntry{
 				Name: "default",
 			},
-			expectedImportedExportedServicesCount: 0, // we want to see this decremented from 4 --> 0
+			expectedImportedServsCount: 0, // we want to see this decremented from 4 --> 0
+			expectedExportedServsCount: 0, // we want to see this decremented from 4 --> 0
 		},
 		{
 			name:        "just a, b services",
@@ -804,7 +807,8 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 					},
 				},
 			},
-			expectedImportedExportedServicesCount: 2,
+			expectedImportedServsCount: 2,
+			expectedExportedServsCount: 2,
 		},
 		{
 			name:        "unexport b service",
@@ -822,7 +826,8 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 					},
 				},
 			},
-			expectedImportedExportedServicesCount: 1,
+			expectedImportedServsCount: 1,
+			expectedExportedServsCount: 1,
 		},
 		{
 			name:        "export c service",
@@ -848,7 +853,8 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 					},
 				},
 			},
-			expectedImportedExportedServicesCount: 2,
+			expectedImportedServsCount: 2,
+			expectedExportedServsCount: 2,
 		},
 	}
 
@@ -872,13 +878,13 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 				resp, err := peeringClient2.PeeringRead(ctx, &pbpeering.PeeringReadRequest{Name: "my-peer-s1"})
 				require.NoError(r, err)
 				require.NotNil(r, resp.Peering)
-				require.Equal(r, tc.expectedImportedExportedServicesCount, resp.Peering.ImportedServiceCount)
+				require.Equal(r, tc.expectedImportedServsCount, resp.Peering.ImportedServiceCount)
 
 				// on List
 				resp2, err2 := peeringClient2.PeeringList(ctx, &pbpeering.PeeringListRequest{})
 				require.NoError(r, err2)
 				require.NotEmpty(r, resp2.Peerings)
-				require.Equal(r, tc.expectedImportedExportedServicesCount, resp2.Peerings[0].ImportedServiceCount)
+				require.Equal(r, tc.expectedExportedServsCount, resp2.Peerings[0].ImportedServiceCount)
 			})
 
 			// Check that exported services count on S1 are what we expect
@@ -887,13 +893,13 @@ func TestLeader_Peering_ImportedExportedServicesCount(t *testing.T) {
 				resp, err := peeringClient.PeeringRead(ctx, &pbpeering.PeeringReadRequest{Name: "my-peer-s2"})
 				require.NoError(r, err)
 				require.NotNil(r, resp.Peering)
-				require.Equal(r, tc.expectedImportedExportedServicesCount, resp.Peering.ExportedServiceCount)
+				require.Equal(r, tc.expectedImportedServsCount, resp.Peering.ExportedServiceCount)
 
 				// on List
 				resp2, err2 := peeringClient.PeeringList(ctx, &pbpeering.PeeringListRequest{})
 				require.NoError(r, err2)
 				require.NotEmpty(r, resp2.Peerings)
-				require.Equal(r, tc.expectedImportedExportedServicesCount, resp2.Peerings[0].ExportedServiceCount)
+				require.Equal(r, tc.expectedExportedServsCount, resp2.Peerings[0].ExportedServiceCount)
 			})
 		})
 	}

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -173,6 +173,14 @@ type Status struct {
 	ExportedServices map[string]struct{}
 }
 
+func (s *Status) GetImportedServicesCount() uint64 {
+	return uint64(len(s.ImportedServices))
+}
+
+func (s *Status) GetExportedServicesCount() uint64 {
+	return uint64(len(s.ExportedServices))
+}
+
 func newMutableStatus(now func() time.Time, connected bool) *MutableStatus {
 	return &MutableStatus{
 		Status: Status{

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
@@ -610,22 +611,13 @@ func (s *Server) getExistingOrCreateNewPeerID(peerName, partition string) (strin
 }
 
 func copyPeeringWith(p *pbpeering.Peering, state pbpeering.PeeringState, isc, esc uint64) *pbpeering.Peering {
-	return &pbpeering.Peering{
-		ID:                  p.ID,
-		Name:                p.Name,
-		Partition:           p.Partition,
-		DeletedAt:           p.DeletedAt,
-		Meta:                p.Meta,
-		PeerID:              p.PeerID,
-		PeerCAPems:          p.PeerCAPems,
-		PeerServerAddresses: p.PeerServerAddresses,
-		PeerServerName:      p.PeerServerName,
-		CreateIndex:         p.CreateIndex,
-		ModifyIndex:         p.ModifyIndex,
+	var copyP pbpeering.Peering
+	proto.Merge(&copyP, p)
 
-		ImportedServiceCount: isc,
-		ExportedServiceCount: esc,
+	// add new state, imported & exported services counts
+	copyP.State = state
+	copyP.ImportedServiceCount = isc
+	copyP.ExportedServiceCount = esc
 
-		State: state,
-	}
+	return &copyP
 }

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -385,7 +385,7 @@ func (s *Server) PeeringList(ctx context.Context, req *pbpeering.PeeringListRequ
 func (s *Server) reconcilePeering(peering *pbpeering.Peering) *pbpeering.Peering {
 	streamState, found := s.Tracker.StreamStatus(peering.ID)
 	if !found {
-		s.Logger.Trace("did not find peer in stream tracker; cannot populate imported and"+
+		s.Logger.Warn("did not find peer in stream tracker; cannot populate imported and"+
 			" exported services count or reconcile peering state", "peerID", peering.ID)
 		return peering
 	} else {
@@ -402,17 +402,6 @@ func (s *Server) reconcilePeering(peering *pbpeering.Peering) *pbpeering.Peering
 
 		return cp
 	}
-}
-
-func (s *Server) getImportedExportedServicesCount(pID string) (isc, esc uint64) {
-	// add imported services count
-	st, found := s.Tracker.StreamStatus(pID)
-	if !found {
-		s.Logger.Trace("did not find peer in stream tracker; cannot populate imported and exported services count", "peerID", pID)
-		return
-	}
-
-	return uint64(len(st.ImportedServices)), uint64(len(st.ExportedServices))
 }
 
 // TODO(peering): As of writing, this method is only used in tests to set up Peerings in the state store.

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -389,7 +389,7 @@ func (s *Server) reconcilePeering(peering *pbpeering.Peering) *pbpeering.Peering
 }
 
 // TODO(peering): Maybe get rid of this when actually monitoring the stream health
-// reconciledStreamStateHint peaks into the streamTracker and determines whether a peering should be marked
+// reconciledStreamStateHint uses the streamTracker to determine whether a peering should be marked
 // as PeeringState.Active or not
 func (s *Server) reconciledStreamStateHint(pID string, pState pbpeering.PeeringState) pbpeering.PeeringState {
 	streamState, found := s.Tracker.StreamStatus(pID)

--- a/api/peering_test.go
+++ b/api/peering_test.go
@@ -152,9 +152,7 @@ func TestAPI_Peering_GenerateToken_Read_Establish_Delete(t *testing.T) {
 	})
 	defer s2.Stop()
 
-	testutil.RunStep(t, "register services to get synced dc2", func(t *testing.T) {
-		testNodeServiceCheckRegistrations(t, c2, "dc2")
-	})
+	testNodeServiceCheckRegistrations(t, c2, "dc2")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()


### PR DESCRIPTION
### Description

This is a small refactor that addresses:

* refactoring the way we copy a peer on `PeeringRead` and `PeeringList`
* punted/ missed feedback from https://github.com/hashicorp/consul/pull/13619 & https://github.com/hashicorp/consul/pull/13784
