### PR TITLE
peerstream: set keepalive enforcement to 15s

### DIFF
--- a/agent/grpc-external/server.go
+++ b/agent/grpc-external/server.go
@@ -5,6 +5,8 @@ import (
 	recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+	"time"
 
 	agentmiddleware "github.com/hashicorp/consul/agent/grpc-middleware"
 	"github.com/hashicorp/consul/tlsutil"
@@ -25,6 +27,12 @@ func NewServer(logger agentmiddleware.Logger, tls *tlsutil.Configurator) *grpc.S
 			// Add middlware interceptors to recover in case of panics.
 			recovery.StreamServerInterceptor(recoveryOpts...),
 		),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			// This must be less than the keealive.ClientParameters Time setting, otherwise
+			// the server will disconnect the client for sending too many keepalive pings.
+			// Currently the client param is set to 30s.
+			MinTime: 15 * time.Second,
+		}),
 	}
 	if tls != nil && tls.GRPCTLSConfigured() {
 		creds := credentials.NewTLS(tls.IncomingGRPCConfig())


### PR DESCRIPTION
The client is set to send keepalive pings every 30s. The server
keepalive enforcement must be set to a number less than that,
otherwise it will disconnect clients for sending pings too often.
MinTime governs the minimum amount of time between pings.

Need to set this to match the client policy set in https://github.com/hashicorp/consul/pull/13733/files. Otherwise it defaults to 5m which caused the server to disconnect in my testing. This setting matches the internal gRPC server (https://github.com/hashicorp/consul/blob/main/agent/grpc-internal/handler.go#L37-L39).

Without this I'm seeing connection resets in my testing:

```
INFO[0108] [transport] transport: Got too many pings from the client, closing the connection.  system=system
```

See also https://www.evanjones.ca/grpc-is-tricky.html. 
