### PR TITLE
makefile: give better error for tool installed by wrong package

### DIFF
--- a/build-support/scripts/devtools.sh
+++ b/build-support/scripts/devtools.sh
@@ -188,8 +188,14 @@ function install_versioned_tool {
     fi
 
     if command -v "${command}" &>/dev/null ; then
-        got="$(go version -m $(which "${command}") | grep '\bmod\b' | grep "${module}" |
-            awk '{print $2 "@" $3}')"
+        mod_line="$(go version -m "$(which "${command}")" | grep '\smod\s')"
+        act_mod=$(echo "${mod_line}" | awk '{print $2}')
+        if [[ "$module" != "$act_mod" ]]; then
+            err "${command} is already installed by module \"${act_mod}\" but should be installed by module \"${module}\". Delete it and re-run to re-install."
+            return 1
+        fi
+
+        got="$(echo "${mod_line}" | grep "${module}" | awk '{print $2 "@" $3}')"
         if [[ "$expect" != "$got" ]]; then
             should_install=1
             install_reason="upgrade"


### PR DESCRIPTION
I had protoc-gen-go installed through `google.golang.org/protobuf` instead of
`github.com/golang/protobuf` and `make proto` was failing silently.
This change will ensure you get an error:

```
protoc-gen-go is already installed by module "google.golang.org/protobuf" but
should be installed by module "github.com/golang/protobuf".
Delete it and re-run to re-install.
```
