### PR TITLE
ui: chore - fix CI test-suite

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
@@ -27,6 +27,7 @@
             </menu.Separator>
             {{#each menu.items as |item|}}
               <menu.Item
+                data-test-dc-item
                 aria-current={{if (eq @dc.Name item.Name) 'true'}}
                 class={{class-map
                   (array 'is-local' item.Local)

--- a/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
@@ -56,7 +56,9 @@
       </disclosure.Menu>
     </DisclosureMenu>
   {{else}}
-    <li class="dc-name" data-test-datacenter-single>{{@dcs.firstObject.Name}}</li>
+    <div class="dc-name" data-test-datacenter-single>
+      {{@dcs.firstObject.Name}}
+    </div>
   {{/if}}
 </li>
 

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/pageobject.js
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/pageobject.js
@@ -50,7 +50,7 @@ export default (collection, clickable, attribute, is, authForm, emptyState) => s
     ':checked',
     '[data-test-nspace-menu] > input[type="checkbox"]'
   );
-  page.navigation.dcs = collection('[data-test-datacenter-menu] li', {
+  page.navigation.dcs = collection('[data-test-datacenter-menu] [data-test-dc-item]', {
     name: clickable('a'),
   });
   return page;

--- a/ui/packages/consul-ui/tests/integration/components/hashicorp-consul-test.js
+++ b/ui/packages/consul-ui/tests/integration/components/hashicorp-consul-test.js
@@ -1,7 +1,6 @@
-import { module, skip, test } from 'qunit';
+import { module, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { render } from '@ember/test-helpers';
 
 module('Integration | Component | hashicorp consul', function(hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
### Description

Fixes current failures in CI that were missed because people with non-contributor rights, like yours truly, won't have the CI test-suite executed for them.

Here's the link to the actual failure in the OSS test-suite: https://github.com/hashicorp/consul/runs/7402516620?check_suite_focus=true#step:6:1401

Link to one of the failures in ENT test-suite: https://github.com/hashicorp/consul/runs/7402525270?check_suite_focus=true#step:6:5038 ← you can see that all 4 test-failures are failing because of the same reason as OSS version is failing.

The fix here is to make the datacenter-item selector in the datacenter-selector-page-object be more specific. I introduced a new `data-test-`-attribute for that that only gets added to the actual datacenter items in the listing but not the `Separator`-component I introduced in https://github.com/hashicorp/consul/pull/13753

I also fixed a linting issue that I missed because, 🥁  non-contributor PRs won't execute the CI pipeline lint task properly.

cc @johncowen 

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
