### PR TITLE
peering: Add heartbeating to peering streams

### DIFF
--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -480,6 +480,7 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 				// NOTE: IDEs and govet think that the reassigned cancel below never gets
 				// called, but it does by the defer when the heartbeat ctx is first created.
 				// They just can't trace the execution properly for some reason (possibly golang/go#29587).
+				// nolint:govet
 				incomingHeartbeatCtx, incomingHeartbeatCtxCancel =
 					context.WithTimeout(context.Background(), s.incomingHeartbeatTimeout)
 			}

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -313,6 +313,9 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 				},
 			}
 			if err := streamSend(term); err != nil {
+				// Nolint directive needed due to bug in govet that doesn't see that the cancel
+				// func of the incomingHeartbeatTimer _does_ get called.
+				//nolint:govet
 				return fmt.Errorf("failed to send to stream: %v", err)
 			}
 
@@ -480,7 +483,7 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 				// NOTE: IDEs and govet think that the reassigned cancel below never gets
 				// called, but it does by the defer when the heartbeat ctx is first created.
 				// They just can't trace the execution properly for some reason (possibly golang/go#29587).
-				// nolint:govet
+				//nolint:govet
 				incomingHeartbeatCtx, incomingHeartbeatCtxCancel =
 					context.WithTimeout(context.Background(), s.incomingHeartbeatTimeout)
 			}

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -272,7 +272,6 @@ func TestStreamResources_Server_FirstRequest(t *testing.T) {
 			run(t, tc)
 		})
 	}
-
 }
 
 func TestStreamResources_Server_Terminate(t *testing.T) {
@@ -867,6 +866,192 @@ func TestStreamResources_Server_CARootUpdates(t *testing.T) {
 			},
 		)
 	})
+}
+
+// Test that when the client doesn't send a heartbeat in time, the stream is terminated.
+func TestStreamResources_Server_TerminatesOnHeartbeatTimeout(t *testing.T) {
+
+	// Set a short timeout
+	old := incomingHeartbeatTimeout
+	defer func() { incomingHeartbeatTimeout = old }()
+	incomingHeartbeatTimeout = 5 * time.Millisecond
+
+	it := incrementalTime{
+		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	srv, store := newTestServer(t, func(c *Config) {
+		c.Tracker.SetClock(it.Now)
+	})
+
+	p := writePeeringToBeDialed(t, store, 1, "my-peer")
+	require.Empty(t, p.PeerID, "should be empty if being dialed")
+	peerID := p.ID
+
+	// Set the initial roots and CA configuration.
+	_, _ = writeInitialRootsAndCA(t, store)
+
+	client := makeClient(t, srv, peerID)
+
+	// TODO(peering): test fails if we don't drain the stream with this call because the
+	// server gets blocked sending the termination message. Figure out a way to let
+	// messages queue and filter replication messages.
+	receiveRoots, err := client.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, receiveRoots.GetResponse())
+	require.Equal(t, pbpeerstream.TypeURLPeeringTrustBundle, receiveRoots.GetResponse().ResourceURL)
+
+	testutil.RunStep(t, "new stream gets tracked", func(t *testing.T) {
+		retry.Run(t, func(r *retry.R) {
+			status, ok := srv.StreamStatus(peerID)
+			require.True(r, ok)
+			require.True(r, status.Connected)
+		})
+	})
+
+	testutil.RunStep(t, "stream is disconnected due to heartbeat timeout", func(t *testing.T) {
+		retry.Run(t, func(r *retry.R) {
+			status, ok := srv.StreamStatus(peerID)
+			require.True(r, ok)
+			require.False(r, status.Connected)
+		})
+	})
+}
+
+// Test that the server sends heartbeats at the expected interval.
+func TestStreamResources_Server_SendsHeartbeats(t *testing.T) {
+
+	// Set a short interval.
+	old := outgoingHeartbeatInterval
+	defer func() { outgoingHeartbeatInterval = old }()
+	outgoingHeartbeatInterval = 5 * time.Millisecond
+
+	it := incrementalTime{
+		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	srv, store := newTestServer(t, func(c *Config) {
+		c.Tracker.SetClock(it.Now)
+	})
+
+	p := writePeeringToBeDialed(t, store, 1, "my-peer")
+	require.Empty(t, p.PeerID, "should be empty if being dialed")
+	peerID := p.ID
+
+	// Set the initial roots and CA configuration.
+	_, _ = writeInitialRootsAndCA(t, store)
+
+	client := makeClient(t, srv, peerID)
+
+	// TODO(peering): test fails if we don't drain the stream with this call because the
+	// server gets blocked sending the termination message. Figure out a way to let
+	// messages queue and filter replication messages.
+	receiveRoots, err := client.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, receiveRoots.GetResponse())
+	require.Equal(t, pbpeerstream.TypeURLPeeringTrustBundle, receiveRoots.GetResponse().ResourceURL)
+
+	testutil.RunStep(t, "new stream gets tracked", func(t *testing.T) {
+		retry.Run(t, func(r *retry.R) {
+			status, ok := srv.StreamStatus(peerID)
+			require.True(r, ok)
+			require.True(r, status.Connected)
+		})
+	})
+
+	testutil.RunStep(t, "sends first heartbeat", func(t *testing.T) {
+		retry.RunWith(&retry.Timer{
+			Timeout: outgoingHeartbeatInterval * 2,
+			Wait:    outgoingHeartbeatInterval / 2,
+		}, t, func(r *retry.R) {
+			heartbeat, err := client.Recv()
+			require.NoError(t, err)
+			require.NotNil(t, heartbeat.GetHeartbeat())
+		})
+	})
+
+	testutil.RunStep(t, "sends second heartbeat", func(t *testing.T) {
+		retry.RunWith(&retry.Timer{
+			Timeout: outgoingHeartbeatInterval * 2,
+			Wait:    outgoingHeartbeatInterval / 2,
+		}, t, func(r *retry.R) {
+			heartbeat, err := client.Recv()
+			require.NoError(t, err)
+			require.NotNil(t, heartbeat.GetHeartbeat())
+		})
+	})
+}
+
+// Test that as long as the server receives heartbeats it keeps the connection open.
+func TestStreamResources_Server_KeepsConnectionOpenWithHeartbeat(t *testing.T) {
+
+	// Set timeout to 10ms.
+	old := incomingHeartbeatTimeout
+	defer func() { incomingHeartbeatTimeout = old }()
+	incomingHeartbeatTimeout = 10 * time.Millisecond
+
+	it := incrementalTime{
+		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	srv, store := newTestServer(t, func(c *Config) {
+		c.Tracker.SetClock(it.Now)
+	})
+
+	p := writePeeringToBeDialed(t, store, 1, "my-peer")
+	require.Empty(t, p.PeerID, "should be empty if being dialed")
+	peerID := p.ID
+
+	// Set the initial roots and CA configuration.
+	_, _ = writeInitialRootsAndCA(t, store)
+
+	client := makeClient(t, srv, peerID)
+
+	// TODO(peering): test fails if we don't drain the stream with this call because the
+	// server gets blocked sending the termination message. Figure out a way to let
+	// messages queue and filter replication messages.
+	receiveRoots, err := client.Recv()
+	require.NoError(t, err)
+	require.NotNil(t, receiveRoots.GetResponse())
+	require.Equal(t, pbpeerstream.TypeURLPeeringTrustBundle, receiveRoots.GetResponse().ResourceURL)
+
+	testutil.RunStep(t, "new stream gets tracked", func(t *testing.T) {
+		retry.Run(t, func(r *retry.R) {
+			status, ok := srv.StreamStatus(peerID)
+			require.True(r, ok)
+			require.True(r, status.Connected)
+		})
+	})
+
+	heartbeatMsg := &pbpeerstream.ReplicationMessage{
+		Payload: &pbpeerstream.ReplicationMessage_Heartbeat_{
+			Heartbeat: &pbpeerstream.ReplicationMessage_Heartbeat{}}}
+
+	// Set up a goroutine to send the heartbeat every 1/2 of the timeout.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		// This is just a do while loop. We want to send the heartbeat right away to start
+		// because the test setup above takes some time and we might be close to the heartbeat
+		// timeout already.
+		for {
+			require.NoError(t, client.Send(heartbeatMsg))
+			select {
+			case <-time.After(incomingHeartbeatTimeout / 2):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Assert that the stream remains connected for 5 heartbeat timeouts.
+	require.Never(t, func() bool {
+		status, ok := srv.StreamStatus(peerID)
+		if !ok {
+			return true
+		}
+		return !status.Connected
+	}, incomingHeartbeatTimeout*5, incomingHeartbeatTimeout)
 }
 
 // makeClient sets up a *MockClient with the initial subscription

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -1027,7 +1027,10 @@ func TestStreamResources_Server_KeepsConnectionOpenWithHeartbeat(t *testing.T) {
 		for {
 			err := client.Send(heartbeatMsg)
 			if err != nil {
-				errCh <- err
+				select {
+				case errCh <- err:
+				case <-ctx.Done():
+				}
 				return
 			}
 			select {

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -870,18 +870,13 @@ func TestStreamResources_Server_CARootUpdates(t *testing.T) {
 
 // Test that when the client doesn't send a heartbeat in time, the stream is terminated.
 func TestStreamResources_Server_TerminatesOnHeartbeatTimeout(t *testing.T) {
-
-	// Set a short timeout
-	old := incomingHeartbeatTimeout
-	defer func() { incomingHeartbeatTimeout = old }()
-	incomingHeartbeatTimeout = 5 * time.Millisecond
-
 	it := incrementalTime{
 		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
 
 	srv, store := newTestServer(t, func(c *Config) {
 		c.Tracker.SetClock(it.Now)
+		c.incomingHeartbeatTimeout = 5 * time.Millisecond
 	})
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")
@@ -920,18 +915,14 @@ func TestStreamResources_Server_TerminatesOnHeartbeatTimeout(t *testing.T) {
 
 // Test that the server sends heartbeats at the expected interval.
 func TestStreamResources_Server_SendsHeartbeats(t *testing.T) {
-
-	// Set a short interval.
-	old := outgoingHeartbeatInterval
-	defer func() { outgoingHeartbeatInterval = old }()
-	outgoingHeartbeatInterval = 5 * time.Millisecond
-
 	it := incrementalTime{
 		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
+	outgoingHeartbeatInterval := 5 * time.Millisecond
 
 	srv, store := newTestServer(t, func(c *Config) {
 		c.Tracker.SetClock(it.Now)
+		c.outgoingHeartbeatInterval = outgoingHeartbeatInterval
 	})
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")
@@ -984,18 +975,14 @@ func TestStreamResources_Server_SendsHeartbeats(t *testing.T) {
 
 // Test that as long as the server receives heartbeats it keeps the connection open.
 func TestStreamResources_Server_KeepsConnectionOpenWithHeartbeat(t *testing.T) {
-
-	// Set timeout to 10ms.
-	old := incomingHeartbeatTimeout
-	defer func() { incomingHeartbeatTimeout = old }()
-	incomingHeartbeatTimeout = 10 * time.Millisecond
-
 	it := incrementalTime{
 		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
+	incomingHeartbeatTimeout := 10 * time.Millisecond
 
 	srv, store := newTestServer(t, func(c *Config) {
 		c.Tracker.SetClock(it.Now)
+		c.incomingHeartbeatTimeout = incomingHeartbeatTimeout
 	})
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")


### PR DESCRIPTION
### Description
Add a heartbeating mechanism to peering streams.

Follows closely waypoint's approach: https://github.com/hashicorp/waypoint/pull/98

Senders and receivers each send heartbeats at a defined interval (15s). If a heartbeat isn't received for 2 minutes, the connection is closed.

To dos in future PRs:
* Track last receipt of any message (including heartbeats) in the peering status
* Add jitter to heartbeat sending
