### PR TITLE
peering: emit exported services count metric

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -367,8 +367,6 @@ func (s *Server) revokeLeadership() {
 	s.resetConsistentReadReady()
 
 	s.autopilot.DisableReconciliation()
-
-	s.stopPeeringMetrics()
 }
 
 // initializeACLs is used to setup the ACLs if we are the leader

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -367,6 +367,8 @@ func (s *Server) revokeLeadership() {
 	s.resetConsistentReadReady()
 
 	s.autopilot.DisableReconciliation()
+
+	s.stopPeeringMetrics()
 }
 
 // initializeACLs is used to setup the ACLs if we are the leader

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -91,7 +91,8 @@ func (s *Server) emitPeeringMetrics(ctx context.Context, logger hclog.Logger, ti
 				esc := status.GetExportedServicesCount()
 				part := peer.Partition
 				labels := []metrics.Label{
-					{Name: "peering", Value: peer.Name},
+					{Name: "peer_name", Value: peer.Name},
+					{Name: "peer_id", Value: peer.ID},
 				}
 				if part != "" {
 					labels = append(labels, metrics.Label{Name: "partition", Value: part})

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -75,12 +75,7 @@ func (s *Server) emitPeeringMetrics(ctx context.Context, logger hclog.Logger, ti
 			metrics.SetGauge(leaderExportedServicesCountKey, float32(0))
 			return nil
 		case <-ticker.C:
-			stateS := s.fsm.State()
-			ws := memdb.NewWatchSet()
-			ws.Add(stateS.AbandonCh())
-			ws.Add(ctx.Done())
-
-			_, peers, err := stateS.PeeringList(ws, *structs.NodeEnterpriseMetaInPartition(structs.WildcardSpecifier))
+			_, peers, err := s.fsm.State().PeeringList(nil, *structs.NodeEnterpriseMetaInPartition(structs.WildcardSpecifier))
 			if err != nil {
 				return err
 			}

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -75,8 +75,6 @@ func (s *Server) emitPeeringMetricsOnce(logger hclog.Logger, metricsImpl *metric
 	}
 
 	for _, peer := range peers {
-		logger.Info("emitting metrics for", "peer_name", peer.Name)
-
 		status, found := s.peerStreamServer.StreamStatus(peer.ID)
 		if !found {
 			logger.Trace("did not find status for", "peer_name", peer.Name)

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -114,14 +114,10 @@ func (s *Server) runPeeringSync(ctx context.Context) error {
 	return nil
 }
 
-func (s *Server) stopPeeringMetrics() {
-	// will be a no-op when not started
-	s.leaderRoutineManager.Stop(peeringStreamsMetricsRoutineName)
-}
-
 func (s *Server) stopPeeringStreamSync() {
 	// will be a no-op when not started
 	s.leaderRoutineManager.Stop(peeringStreamsRoutineName)
+	s.leaderRoutineManager.Stop(peeringStreamsMetricsRoutineName)
 }
 
 // syncPeeringsAndBlock is a long-running goroutine that is responsible for watching

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1009,7 +1009,7 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 
 	// set up a metrics sink
 	sink := metrics.NewInmemSink(testContextTimeout, testContextTimeout)
-	cfg := metrics.DefaultConfig("consul.peering.test")
+	cfg := metrics.DefaultConfig("us-west")
 	cfg.EnableHostname = false
 	met, err := metrics.New(cfg, sink)
 	require.NoError(t, err)
@@ -1023,13 +1023,13 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 		intv := intervals[0]
 
 		// the keys for a Gauge value look like: {serviceName}.{prefix}.{key_name};{label=value};...
-		keyMetric1 := fmt.Sprintf("consul.peering.test.consul.peering.exported_services;peer_name=my-peer-s1;peer_id=%s", s2PeerID1)
+		keyMetric1 := fmt.Sprintf("us-west.consul.peering.exported_services;peer_name=my-peer-s1;peer_id=%s", s2PeerID1)
 		metric1, ok := intv.Gauges[keyMetric1]
 		require.True(r, ok, fmt.Sprintf("did not find the key %q", keyMetric1))
 
 		require.Equal(r, float32(3), metric1.Value) // for a, b, c services
 
-		keyMetric2 := fmt.Sprintf("consul.peering.test.consul.peering.exported_services;peer_name=my-peer-s3;peer_id=%s", s2PeerID2)
+		keyMetric2 := fmt.Sprintf("us-west.consul.peering.exported_services;peer_name=my-peer-s3;peer_id=%s", s2PeerID2)
 		metric2, ok := intv.Gauges[keyMetric2]
 		require.True(r, ok, fmt.Sprintf("did not find the key %q", keyMetric2))
 

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1007,10 +1007,6 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 		mst2.TrackExportedService(structs.ServiceName{Name: "e-service"})
 	}
 
-	// the actual testing below:
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
-
 	// set up a metrics sink
 	sink := metrics.NewInmemSink(testContextTimeout, testContextTimeout)
 	cfg := metrics.DefaultConfig("consul.peering.test")
@@ -1018,11 +1014,8 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 	met, err := metrics.New(cfg, sink)
 	require.NoError(t, err)
 
-	// start emitting the metrics
-	go func() {
-		errM := s2.emitPeeringMetrics(ctx, s2.logger, ticker, met)
-		require.NoError(t, errM)
-	}()
+	errM := s2.emitPeeringMetricsOnce(s2.logger, met)
+	require.NoError(t, errM)
 
 	retry.Run(t, func(r *retry.R) {
 		intervals := sink.Data()

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -127,6 +127,7 @@ const (
 	virtualIPCheckRoutineName             = "virtual IP version check"
 	peeringStreamsRoutineName             = "streaming peering resources"
 	peeringDeletionRoutineName            = "peering deferred deletion"
+	peeringStreamsMetricsRoutineName      = "metrics for streaming peering resources"
 )
 
 var (

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -474,8 +474,8 @@ func getTrustDomain(store StateStore, logger hclog.Logger) (string, error) {
 	return connect.SpiffeIDSigningForCluster(cfg.ClusterID).Host(), nil
 }
 
-func (s *Server) StreamStatus(peer string) (resp Status, found bool) {
-	return s.Tracker.StreamStatus(peer)
+func (s *Server) StreamStatus(peerID string) (resp Status, found bool) {
+	return s.Tracker.StreamStatus(peerID)
 }
 
 // ConnectedStreams returns a map of connected stream IDs to the corresponding channel for tearing them down.

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -231,7 +231,8 @@ func getPrometheusDefs(cfg lib.TelemetryConfig, isServer bool) ([]prometheus.Gau
 	if isServer {
 		gauges = append(gauges,
 			consul.AutopilotGauges,
-			consul.LeaderCertExpirationGauges)
+			consul.LeaderCertExpirationGauges,
+			consul.LeaderPeeringMetrics)
 	}
 
 	// Flatten definitions

--- a/logging/names.go
+++ b/logging/names.go
@@ -51,6 +51,7 @@ const (
 	Snapshot           string = "snapshot"
 	Partition          string = "partition"
 	Peering            string = "peering"
+	PeeringMetrics     string = "peering_metrics"
 	TerminatingGateway string = "terminating_gateway"
 	TLSUtil            string = "tlsutil"
 	Transaction        string = "txn"


### PR DESCRIPTION
Signed-off-by: acpana <8968914+acpana@users.noreply.github.com>

### Description
This patch adds a `consul_peering_exported_services` metric with labels for the `peer name` and `partition` (for ENT). This, in addition to more metrics, will help drive a better understanding about the overall state of a peering.

To be clear, we can probably add more metrics using this pattern but we are starting with just the one for now.

### Testing & Reproduction steps
* `leader_peering_test` with mock sink and metrics instance.


#### pr todo:

* [x] add `peer_id` label to metrics
* ~[ ] add external facing docs about the metric~ --> adding this as a separate PR
