### PR TITLE
ui: Make peered intentions read-only

### DIFF
--- a/ui/packages/consul-ui/app/abilities/intention.js
+++ b/ui/packages/consul-ui/app/abilities/intention.js
@@ -4,7 +4,12 @@ export default class IntentionAbility extends BaseAbility {
   resource = 'intention';
 
   get canWrite() {
-    return super.canWrite && (typeof this.item === 'undefined' || !this.canViewCRD);
+    // Peered intentions aren't writable
+    if(typeof this.item !== 'undefined' && typeof this.item.SourcePeer !== 'undefined') {
+      return false;
+    }
+    return super.canWrite &&
+      (typeof this.item === 'undefined' || !this.canViewCRD);
   }
   get canViewCRD() {
     return (typeof this.item !== 'undefined' && this.item.IsManagedByCRD);

--- a/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/intention/list/table/index.hbs
@@ -96,7 +96,6 @@ as |item index|>
         {{/if}}
         </td>
     </BlockSlot>
-{{#if (and (or (can "write intention" item=item) (can "view CRD intention" item=item)) (not-eq item.Meta.external-source 'consul-api-gateway'))}}
     <BlockSlot @name="actions" as |index change checked|>
       <PopoverMenu
         @expanded={{if (eq checked index) true false}}
@@ -180,9 +179,18 @@ as |item index|>
                 </InformedAction>
               </div>
             </li>
+          {{else}}
+            <li role="none">
+              <a
+                role="menuitem"
+                tabindex="-1"
+                href={{href-to (or routeName 'dc.intentions.edit') item.ID}}
+              >
+                View
+              </a>
+            </li>
           {{/if}}
         </BlockSlot>
       </PopoverMenu>
     </BlockSlot>
-{{/if}}
 </TabularCollection>

--- a/ui/packages/consul-ui/app/models/intention.js
+++ b/ui/packages/consul-ui/app/models/intention.js
@@ -1,7 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 import { fragmentArray } from 'ember-data-model-fragments/attributes';
-import { nullValue } from 'consul-ui/decorators/replace';
+import replace, { nullValue } from 'consul-ui/decorators/replace';
 
 export const PRIMARY_KEY = 'uid';
 export const SLUG_KEY = 'ID';
@@ -13,7 +13,7 @@ export default class Intention extends Model {
   @attr('string') Datacenter;
   @attr('string') Description;
 
-  @attr('string') SourcePeer;
+  @replace('', undefined) @attr('string') PeerName;
   @attr('string', { defaultValue: () => '*' }) SourceName;
   @attr('string', { defaultValue: () => '*' }) DestinationName;
   @attr('string', { defaultValue: () => 'default' }) SourceNS;

--- a/ui/packages/consul-ui/app/models/intention.js
+++ b/ui/packages/consul-ui/app/models/intention.js
@@ -13,7 +13,7 @@ export default class Intention extends Model {
   @attr('string') Datacenter;
   @attr('string') Description;
 
-  @replace('', undefined) @attr('string') PeerName;
+  @replace('', undefined) @attr('string') SourcePeer;
   @attr('string', { defaultValue: () => '*' }) SourceName;
   @attr('string', { defaultValue: () => '*' }) DestinationName;
   @attr('string', { defaultValue: () => 'default' }) SourceNS;

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/delete.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/delete.feature
@@ -4,6 +4,7 @@ Feature: dc / intentions / deleting: Deleting items with confirmations, success 
     Given 1 datacenter model with the value "datacenter"
     And 1 intention model from yaml
     ---
+    SourcePeer: ""
     SourceName: name
     DestinationName: destination
     SourceNS: default

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/navigation.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/navigation.feature
@@ -7,6 +7,7 @@ Feature: dc / intentions / navigation
     - ID: 755b72bd-f5ab-4c92-90cc-bed0e7d8e9f0
       Action: allow
       Meta: ~
+      SourcePeer: ""
     - ID: 755b72bd-f5ab-4c92-90cc-bed0e7d8e9f1
       Action: deny
       Meta: ~

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/intentions/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/intentions/index.feature
@@ -21,13 +21,16 @@ Feature: dc / services / show / intentions / index: Intentions per service
       DestinationNS: default
       SourcePartition: default
       DestinationPartition: default
+      SourcePeer: ""
 
     - ID: 755b72bd-f5ab-4c92-90cc-bed0e7d8e9f1
       Action: deny
       Meta: ~
+      SourcePeer: ""
     - ID: 0755b72bd-f5ab-4c92-90cc-bed0e7d8e9f2
       Action: deny
       Meta: ~
+      SourcePeer: ""
     ---
     When I visit the service page for yaml
     ---
@@ -41,7 +44,7 @@ Feature: dc / services / show / intentions / index: Intentions per service
   Scenario: I can see intentions
     And I see 3 intention models on the intentionList component
     And I click intention on the intentionList.intentions component
-    Then the url should be /dc1/services/service-0/intentions/peer:billing:default:name:default:default:destination
+    Then the url should be /dc1/services/service-0/intentions/default:default:name:default:default:destination
   Scenario: I can delete intentions
     And I click actions on the intentionList.intentions component
     And I click delete on the intentionList.intentions component


### PR DESCRIPTION
### Description
Peered intentions are currently readonly. Clicking the rows will now take you to a readonly detail page based on the fact that intentions with SourcePeer set are not writable.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMIke