### PR TITLE
Enable/Disable Peering Support in the UI

### DIFF
--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -35,6 +35,7 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 		"UIConfig":          uiCfg,
 		"LocalDatacenter":   cfg.Datacenter,
 		"PrimaryDatacenter": cfg.PrimaryDatacenter,
+		"PeeringEnabled":    true,
 	}
 
 	// Also inject additional provider scripts if needed, otherwise strip the

--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -35,7 +35,7 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 		"UIConfig":          uiCfg,
 		"LocalDatacenter":   cfg.Datacenter,
 		"PrimaryDatacenter": cfg.PrimaryDatacenter,
-		"PeeringEnabled":    true,
+		"PeeringEnabled":    cfg.PeeringEnabled,
 	}
 
 	// Also inject additional provider scripts if needed, otherwise strip the

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -43,6 +43,7 @@ func TestUIServerIndex(t *testing.T) {
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
+				"PeeringEnabled": true,
 				"UIConfig": {
 					"hcp_enabled": false,
 					"metrics_provider": "",
@@ -78,6 +79,7 @@ func TestUIServerIndex(t *testing.T) {
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
+				"PeeringEnabled": true,
 				"UIConfig": {
 					"hcp_enabled": false,
 					"metrics_provider": "foo",
@@ -101,6 +103,7 @@ func TestUIServerIndex(t *testing.T) {
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
+				"PeeringEnabled": true,
 				"UIConfig": {
 					"hcp_enabled": false,
 					"metrics_provider": "",
@@ -121,8 +124,32 @@ func TestUIServerIndex(t *testing.T) {
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
+				"PeeringEnabled": true,
 				"UIConfig": {
 					"hcp_enabled": true,
+					"metrics_provider": "",
+					"metrics_proxy_enabled": false,
+					"dashboard_url_templates": null
+				}
+			}`,
+		},
+		{
+			name: "peering disabled",
+			cfg: basicUIEnabledConfig(
+				withPeeringDisabled(),
+			),
+			path:         "/",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"<!-- CONSUL_VERSION:"},
+			wantUICfgJSON: `{
+				"ACLsEnabled": false,
+				"HCPEnabled": false,
+				"LocalDatacenter": "dc1",
+				"PrimaryDatacenter": "dc1",
+				"ContentPath": "/ui/",
+				"PeeringEnabled": false,
+				"UIConfig": {
+					"hcp_enabled": false,
 					"metrics_provider": "",
 					"metrics_proxy_enabled": false,
 					"dashboard_url_templates": null
@@ -152,6 +179,7 @@ func TestUIServerIndex(t *testing.T) {
 				"LocalDatacenter": "dc1",
 				"PrimaryDatacenter": "dc1",
 				"ContentPath": "/ui/",
+				"PeeringEnabled": true,
 				"UIConfig": {
 					"hcp_enabled": false,
 					"metrics_provider": "bar",
@@ -250,6 +278,7 @@ func basicUIEnabledConfig(opts ...cfgFunc) *config.RuntimeConfig {
 		},
 		Datacenter:        "dc1",
 		PrimaryDatacenter: "dc1",
+		PeeringEnabled:    true,
 	}
 	for _, f := range opts {
 		f(cfg)
@@ -286,6 +315,12 @@ func withMetricsProviderOptions(jsonStr string) cfgFunc {
 func withHCPEnabled() cfgFunc {
 	return func(cfg *config.RuntimeConfig) {
 		cfg.UIConfig.HCPEnabled = true
+	}
+}
+
+func withPeeringDisabled() cfgFunc {
+	return func(cfg *config.RuntimeConfig) {
+		cfg.PeeringEnabled = false
 	}
 }
 
@@ -422,6 +457,7 @@ func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
 		"LocalDatacenter": "dc1",
 		"PrimaryDatacenter": "dc1",
 		"ContentPath": "/ui/",
+		"PeeringEnabled": true,
 		"UIConfig": {
 			"hcp_enabled": false,
 			"metrics_provider": "",
@@ -447,6 +483,7 @@ func TestHandler_ServeHTTP_TransformIsEvaluatedOnEachRequest(t *testing.T) {
 			"LocalDatacenter": "dc1",
 			"PrimaryDatacenter": "dc1",
 			"ContentPath": "/ui/",
+			"PeeringEnabled": true,
 			"UIConfig": {
 				"hcp_enabled": false,
 				"metrics_provider": "",


### PR DESCRIPTION
### Description

The UI has support for peering but only when told it is enabled. This PR tells the UI that peering is enabled or disabled based on the configuration flag to enable or disable it.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
