### PR TITLE
[1.12] Set Go version to latest 1.17 series

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ references:
     S3_ARTIFACT_BUCKET: consul-dev-artifacts-v2
     BASH_ENV: .circleci/bash_env.sh
     VAULT_BINARY_VERSION: 1.9.4
-    GO_VERSION: 1.18.1
+    GO_VERSION: 1.17.12
 
 steps:
   install-gotestsum: &install-gotestsum


### PR DESCRIPTION
### Description
In #13783 I accidentally bumped the Golang version to 1.18. This resets it back to 1.17.12 which is the latest for the 1.17 release series.

### Testing & Reproduction steps
CI should pass.

### Links
[go1.17 version history](https://go.dev/doc/devel/release#go1.17)