### PR TITLE
ui: Surface peer info in nodes.show view

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/peer/info/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/peer/info/index.hbs
@@ -1,5 +1,5 @@
-{{#if @service.PeerName}}
-  <div class="consul-service-peer-info" data-test-service-peer-info>
+{{#if @item.PeerName}}
+  <div class="consul-peer-info" data-test-peer-info>
 
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" {{tooltip "Peer" }}>
       <path
@@ -18,6 +18,6 @@
         d="M11 7C10.4477 7 10 7.44772 10 8C10 8.55229 10.4477 9 11 9H11.01C11.5623 9 12.01 8.55229 12.01 8C12.01 7.44772 11.5623 7 11.01 7H11Z"
         fill="#77838A" />
     </svg>
-    <span class="consul-service-peer-info__description">Imported from <span data-test-peer-name>{{@service.PeerName}}</span></span>
+    <span class="consul-peer-info__description">Imported from <span data-test-peer-name>{{@item.PeerName}}</span></span>
   </div>
 {{/if}}

--- a/ui/packages/consul-ui/app/components/consul/peer/info/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/peer/info/index.scss
@@ -1,4 +1,4 @@
-.consul-service-peer-info {
+.consul-peer-info {
   background: rgb(var(--gray-100));
   color: rgb(var(--gray-600));
   padding: 0px 8px;
@@ -7,7 +7,7 @@
   display: flex;
   align-items: center;
 
-  .consul-service-peer-info__description {
+  .consul-peer-info__description {
     margin-left: 4px;
   }
 }

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -107,5 +107,5 @@
 @import 'consul-ui/components/consul/peer';
 @import 'consul-ui/components/peerings/badge';
 @import 'consul-ui/components/consul/node/peer-info';
-@import 'consul-ui/components/consul/service/peer-info';
+@import 'consul-ui/components/consul/peer/info';
 @import 'consul-ui/components/consul/peer/form';

--- a/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/show.hbs
@@ -103,6 +103,7 @@ as |item tomography|}}
                 <route.Title @title={{item.Node}} />
               </h1>
               <label for="toolbar-toggle"></label>
+              <Consul::Peer::Info @item={{item}} />
           </BlockSlot>
           <BlockSlot @name="nav">
             <TabNav @items={{

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -145,7 +145,7 @@ as |items item dc|}}
               </h1>
               <Consul::ExternalSource @item={{item.Service}} @withInfo={{true}} />
               <Consul::Kind @item={{item.Service}} @withInfo={{true}} />
-              <Consul::Service::PeerInfo @service={{item.Service}} />
+              <Consul::Peer::Info @item={{item.Service}} />
           </BlockSlot>
           <BlockSlot @name="nav">
             {{#if (not-eq item.Service.Kind 'mesh-gateway')}}

--- a/ui/packages/consul-ui/tests/pages/dc/services/show.js
+++ b/ui/packages/consul-ui/tests/pages/dc/services/show.js
@@ -19,7 +19,7 @@ export default function(
     metricsAnchor: {
       href: attribute('href', '[data-test-metrics-anchor]'),
     },
-    peer: text('[data-test-service-peer-info] [data-test-peer-name]'),
+    peer: text('[data-test-peer-info] [data-test-peer-name]'),
     tabs: tabs('tab', [
       'topology',
       'instances',


### PR DESCRIPTION
### Description
Surfaces the peer name for a peered node in the `nodes.show`-view

<img width="743" alt="Screenshot 2022-07-21 at 14 47 50" src="https://user-images.githubusercontent.com/242299/180216967-bf3489bf-8494-4919-b848-f9b9ade993fe.png">


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

cc @johncowen 