### PR TITLE
ui: Remove peering detail page

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/list/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/list/index.hbs
@@ -2,21 +2,11 @@
   class="consul-peer-list"
   ...attributes
   @items={{@items}}
-  @linkable="linkable peer"
 as |item index|>
   <BlockSlot @name="header">
-{{#if (can 'delete peer' item=item)}}
-      <a
-        data-test-peer={{item.Name}}
-        href={{href-to 'dc.peers.edit' item.Name}}
-      >
-        {{item.Name}}
-      </a>
-{{else}}
-      <p>
-        {{item.Name}}
-      </p>
-{{/if}}
+    <p>
+      {{item.Name}}
+    </p>
   </BlockSlot>
   <BlockSlot @name="details">
     <div class="peers__list__peer-detail">
@@ -52,14 +42,6 @@ as |item index|>
 {{#if (can 'delete peer' item=item)}}
 
     <Actions as |Action|>
-      <Action
-        data-test-edit-action
-        @href={{href-to 'dc.peers.edit' item.Name}}
-      >
-        <BlockSlot @name="label">
-          View
-        </BlockSlot>
-      </Action>
       <Action
         data-test-delete-action
         @onclick={{fn @ondelete item}}

--- a/ui/packages/consul-peerings/vendor/consul-peerings/routes.js
+++ b/ui/packages/consul-peerings/vendor/consul-peerings/routes.js
@@ -21,16 +21,6 @@
           },
         },
       },
-      edit: {
-        _options: {
-          path: '/:name'
-        },
-        addresses: {
-          _options: {
-            path: '/addresses',
-          },
-        },
-      },
     },
   },
 }))(


### PR DESCRIPTION
### Description
This PR removes all the peering detail views, peer rows are now not clickable, but peers are still deletable.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

/cc @LevelbossMike