### PR TITLE
ui: peered services only show instance- and tags-tabs 

### DIFF
--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -117,12 +117,12 @@ as |items item dc|}}
       {{/if}}
   {{#let
   (hash
-      topology=(and dc.MeshEnabled item.IsMeshOrigin (or (gt proxies.length 0) (eq item.Service.Kind 'ingress-gateway')))
-      services=(eq item.Service.Kind 'terminating-gateway')
-      upstreams=(eq item.Service.Kind 'ingress-gateway')
+      topology=(and dc.MeshEnabled item.IsMeshOrigin (or (gt proxies.length 0) (eq item.Service.Kind 'ingress-gateway')) (not item.Service.PeerName))
+      services=(and (eq item.Service.Kind 'terminating-gateway') (not item.Service.PeerName))
+      upstreams=(and (eq item.Service.Kind 'ingress-gateway') (not item.Service.PeerName))
       instances=true
-      intentions=(and (not-eq item.Service.Kind 'terminating-gateway') (can 'read intention for service' item=item.Service))
-      routing=(and dc.MeshEnabled item.IsOrigin)
+      intentions=(and (not-eq item.Service.Kind 'terminating-gateway') (can 'read intention for service' item=item.Service) (not item.Service.PeerName))
+      routing=(and dc.MeshEnabled item.IsOrigin (not item.Service.PeerName))
       tags=true
   )
   as |tabs|}}

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show-with-slashes.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show-with-slashes.feature
@@ -17,5 +17,5 @@ Feature: dc / services / show-with-slashes: Show Service that has slashes in its
     Then the url should be /dc1/services
     Then I see 1 service model
     And I click service on the services
-    Then the url should be /:billing/dc1/services/hashicorp%2Fservice%2Fservice-0/topology
+    Then the url should be /:billing/dc1/services/hashicorp%2Fservice%2Fservice-0/instances
 


### PR DESCRIPTION
### Description
Peered service-instances will now only surface the `Instances` and `Tags` Tab on the `services.show`-view.

<img width="674" alt="Screenshot 2022-07-21 at 16 51 05" src="https://user-images.githubusercontent.com/242299/180244481-638d3229-b868-4fc1-a043-ee49740d12d4.png">

#### Notes
This change made the `show-with-slashes`-feature test fail. That is because the first service that we load from the mock-api by default, when the peering feature is on, will be peered. To "fix" the failing test, I updated the URL that we are checking against in the test. A peered service will not show the `topology`-tab anymore and show the `instances`-tab instead. Because the URL isn't relevant for the test, this feels fine and was easier than to change the mocked service in the test.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern

cc @johncowen 