### PR TITLE
Add reset store flag

### DIFF
--- a/website/content/docs/nia/cli/start.mdx
+++ b/website/content/docs/nia/cli/start.mdx
@@ -60,3 +60,4 @@ The `start` command supports the following options:
 | `-inspect` | Optional | boolean | Run CTS in Inspect mode to print the proposed state changes for all tasks, and then exit. No changes are applied in this mode. | false |
 | `-inspect-task` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Optional | string | Run CTS in Inspect mode to print the proposed state changes for the task, and then exit. The flag can be specified multiple times to inspect multiple tasks. No changes are applied in this mode. | none |
 | `-once` | Optional | boolean | Render templates and run tasks once. Does not start the process in long-running mode and disables buffer periods. | false |
+| `-reset-store` | Optional | boolean | <EnterpriseAlert inline /> Use only when running CTS in HA mode. When enabled, any time this CTS instance is elected to be the cluster leader, it will overwrite the state storage with its own state. | false |

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -190,7 +190,7 @@ Service registration requires that the [Consul token](/docs/nia/configuration#co
 | Parameter | Required | Type | Description | Default |
 | --------- | -------- | ---- | ----------- | ------- |
 | `enabled` | Optional | boolean | Enables CTS to register itself as a service with Consul.| `true` |
-| `service_name` | Optional | string | The service name for CTS. | `Consul-Terraform-Sync` |
+| `service_name` | Optional | string | The service name for CTS. | `consul-terraform-sync` |
 | `address` | Optional | string | The IP address or hostname for CTS. | IP address of the Consul agent node |
 | `namespace` | Optional | string |  <EnterpriseAlert inline /> The namespace to register CTS in. | In order of precedence: <br/> 1. Inferred from the CTS ACL token <br/> 2. The `default` namespace. |
 | `default_check.enabled` | Optional | boolean | Enables CTS to create the default health check. | `true` |

--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -241,7 +241,7 @@ service {
 
 ## Task
 
-A `task` block configures which task to execute in automation. When the task should execute can be determined by the `service` block (deprecated) and `condition` block. The `task` block may be specified multiple times to configure multiple tasks.
+A `task` block configures which task to execute in automation. When the task executes can be determined by the `condition` block. You can specify the `task` block multiple times to configure multiple tasks, or you can omit it entirely. If task blocks are not specified in your initial configuration, you can add them to a running CTS instance by using the [`/tasks` API endpoint](/docs/nia/api/tasks#tasks) or the [CLI's `task` command](/docs/nia/cli/task#task).
 
 ```hcl
 task {


### PR DESCRIPTION
### Description
Added a documentation for the `-reset-store` flag. The flag makes mention of 'HA mode' which isn't currently documented. 'HA mode' will be documented in a future PR.

### Links

### PR Checklist

* [x] external facing docs updated
* [x] not a security concern
