### PR TITLE
Fix goroutine leaks in proxycfg when using ingress gateway

### DIFF
--- a/.changelog/13847.txt
+++ b/.changelog/13847.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fixed a goroutine/memory leak that would occur when using the ingress gateway.
+```

--- a/agent/proxycfg/ingress_gateway.go
+++ b/agent/proxycfg/ingress_gateway.go
@@ -148,6 +148,16 @@ func (s *handlerIngressGateway) handleUpdate(ctx context.Context, u UpdateEvent,
 
 		for uid, cancelFn := range snap.IngressGateway.WatchedDiscoveryChains {
 			if _, ok := watchedSvcs[uid]; !ok {
+				for targetID, cancelUpstreamFn := range snap.IngressGateway.WatchedUpstreams[uid] {
+					s.logger.Debug("stopping watch of target",
+						"upstream", uid,
+						"target", targetID,
+					)
+					delete(snap.IngressGateway.WatchedUpstreams[uid], targetID)
+					delete(snap.IngressGateway.WatchedUpstreamEndpoints[uid], targetID)
+					cancelUpstreamFn()
+				}
+
 				cancelFn()
 				delete(snap.IngressGateway.WatchedDiscoveryChains, uid)
 			}


### PR DESCRIPTION
This PR fixes 2 separate goroutine leaks happening in `agent/proxycfg` that occur when registering an ingress gateway:
- Whenever the list of gateway services was updated, a new goroutine was spawned via `cache.Notify()` for every service (even ones that were already being watched) because we were wrongly checking the `WatchedDiscoveryChains` in `snap.ConnectProxy` instead of `snap.IngressGateway`.
- When cleaning up services removed from the gateway services list, we were only canceling the watches for discovery chains and not their associated upstreams as well.
