### PR TITLE
peering: read endpoints can now return failing status

### DIFF
--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -160,9 +160,19 @@ func (s *Server) DrainStream(req HandleStreamRequest) {
 	}
 }
 
+func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
+	if err := s.realHandleStream(streamReq); err != nil {
+		s.Tracker.DisconnectedDueToError(streamReq.LocalID, err.Error())
+		return err
+	}
+	// TODO(peering) Also need to clear subscriptions associated with the peer
+	s.Tracker.DisconnectedGracefully(streamReq.LocalID)
+	return nil
+}
+
 // The localID provided is the locally-generated identifier for the peering.
 // The remoteID is an identifier that the remote peer recognizes for the peering.
-func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
+func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 	// TODO: pass logger down from caller?
 	logger := s.Logger.Named("stream").
 		With("peer_name", streamReq.PeerName).
@@ -174,9 +184,6 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 	if err != nil {
 		return fmt.Errorf("failed to register stream: %v", err)
 	}
-
-	// TODO(peering) Also need to clear subscriptions associated with the peer
-	defer s.Tracker.Disconnected(streamReq.LocalID)
 
 	var trustDomain string
 	if s.ConnectEnabled {
@@ -454,7 +461,7 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 					logger.Error("failed to persist resource", "resourceURL", resp.ResourceURL, "resourceID", resp.ResourceID)
 					status.TrackReceiveError(err.Error())
 				} else {
-					status.TrackReceiveSuccess()
+					status.TrackReceiveResourceSuccess()
 				}
 
 				if err := streamSend(reply); err != nil {
@@ -475,6 +482,8 @@ func (s *Server) HandleStream(streamReq HandleStreamRequest) error {
 			}
 
 			if msg.GetHeartbeat() != nil {
+				status.TrackReceiveHeartbeat()
+
 				// Reset the heartbeat timeout by creating a new context.
 				// We first must cancel the old context so there's no leaks. This is safe to do because we're only
 				// reading that context within this for{} loop, and so we won't accidentally trigger the heartbeat

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -443,6 +443,8 @@ func (s *Server) reconcilePeering(peering *pbpeering.Peering) *pbpeering.Peering
 		// reconcile pbpeering.PeeringState_Active
 		if streamState.Connected {
 			cp.State = pbpeering.PeeringState_ACTIVE
+		} else if streamState.DisconnectErrorMessage != "" {
+			cp.State = pbpeering.PeeringState_FAILING
 		}
 
 		// add imported & exported services counts


### PR DESCRIPTION
When the stream exits due to an error, e.g. the heartbeat failed or the connection quit, track this in the tracker. When the Read or List RPCs are called, use the tracker to set the status as failing.

Changes:
1. tracker: Differentiate a connection ending gracefully from a connection ending due to error by adding a field `DisconnectErrorMessage` that will be set to an error string if the connection ended due to an error.
2. tracker: rename `Disconnected()` => `DisconnectedGracefully()` and add `DisconnectedDueToErr()`
3. stream_resources: wrap `HandleStream()` to correctly set the tracker status based on why the connection was ended
4. add `TrackReceiveHeartbeat()`. This isn't used anywhere yet but can be used for better status info later.
5. rename `TrackReceiveSuccess() => TrackReceiveResourceSuccess()` to differentiate between receiving a replicated resource and a heartbeat