### PR TITLE
ui: Improve peered service empty downstreams message

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 
 export default class TopologyMetrics extends Component {
   @service('env') env;
+  @service() abilities;
 
   // =attributes
   @tracked centerDimensions;
@@ -87,8 +88,12 @@ export default class TopologyMetrics extends Component {
         Namespace: '',
       });
     } else if (downstreams.length === 0) {
+      const canUsePeers = this.abilities.can('use peers');
+
       items.push({
-        Name: 'No downstreams, or the downstreams are imported services.',
+        Name: canUsePeers
+          ? 'No downstreams, or the downstreams are imported services.'
+          : 'No downstreams.',
         Datacenter: '',
         Namespace: '',
       });


### PR DESCRIPTION
### Description
Improves the empty downstreams message in service-topology to only mention "imported services" when the peering feature is enabled.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
