### PR TITLE
Update `consul-k8s` CLI docs with Envoy Debugging

### DIFF
--- a/website/content/docs/k8s/k8s-cli.mdx
+++ b/website/content/docs/k8s/k8s-cli.mdx
@@ -5,15 +5,15 @@ description: >-
   Consul K8s CLI is a tool for quickly installing and interacting with Consul on Kubernetes.
 ---
 
-# Consul K8s CLI Reference
+# Consul on Kubernetes CLI Reference
 
-Consul K8s CLI is a tool for quickly installing and interacting with Consul on Kubernetes. 
-The Consul K8s CLI allows you to manage the lifecycle of Consul without requiring the usage of `Helm`, [Consul CLI](/commands/index), and `kubectl`. 
-The Consul K8s CLI offers a Kubernetes native experience for managing Consul. 
+The Consul on Kubernetes CLI, `consul-k8s`, is a tool for managing Consul
+without requiring `Helm`, the [Consul CLI](/commands/index), or `kubectl`.
 
--> **Note**: For guidance on how to install the Consul K8s CLI, visit the [Installing the Consul K8s CLI](/docs/k8s/installation/install-cli) documentation. 
+-> **Note**: For guidance on how to install `consul-k8s`, visit the
+[Installing the Consul K8s CLI](/docs/k8s/installation/install-cli) documentation.
 
-This topic describes the subcommands and available options for using Consul K8s CLI.
+This topic describes the subcommands and available options for using `consul-k8s`.
 
 ## Usage
 
@@ -27,11 +27,12 @@ $ consul-k8s <SUBCOMMAND> <OPTIONS>
 
 You can use the following subcommands with `consul-k8s`.
 
-  - [install](#install)
-  - [uninstall](#uninstall)
-  - [status](#status)
-  - [upgrade](#upgrade) <sup>BETA</sup>
-  - [version](#version) 
+  - [`install`](#install)
+  - [`proxy`](#proxy)
+  - [`status`](#status)
+  - [`uninstall`](#uninstall)
+  - [`upgrade`](#upgrade)
+  - [`version`](#version)
 
 ### `install`
 
@@ -68,7 +69,7 @@ The following example command installs Consul according in the `myNS` namespace 
 $ consul-k8s install -preset=secure -namespace=myNS
 ```
 
-The following example commands install Consul on Kubernetes using custom values, files, or strings that are set via flags. The underlying Consul-on-Kubernetes Helm chart uses the flags to customize the installation. The flags are comparable to the `helm install` [flags](https://helm.sh/docs/helm/helm_install/#helm-install).  
+The following example commands install Consul on Kubernetes using custom values, files, or strings that are set via flags. The underlying Consul-on-Kubernetes Helm chart uses the flags to customize the installation. The flags are comparable to the `helm install` [flags](https://helm.sh/docs/helm/helm_install/#helm-install).
 
 ```shell-session
  $ consul-k8s install -set key=value
@@ -120,7 +121,7 @@ $ consul-k8s uninstall -namespace=my-ns -name=my-consul -wipe-data=true -auto-ap
 
 ### `status`
 
-The `status` command provides an overall status summary of the Consul on Kubernetes installation. It also provides the config that was used to deploy Consul K8s and provides a quick glance at the health of both Consul servers and clients. This command does not take in any flags. 
+The `status` command provides an overall status summary of the Consul on Kubernetes installation. It also provides the config that was used to deploy Consul K8s and provides a quick glance at the health of both Consul servers and clients. This command does not take in any flags.
 
 ```shell-session
 $ consul-k8s status
@@ -165,7 +166,7 @@ $ consul-k8s status
 
 ### `upgrade`
 
--> The `consul-k8s upgrade` **subcommand is currently in beta**: This subcommand is not recommended for production environments. 
+-> The `consul-k8s upgrade` **subcommand is currently in beta**: This subcommand is not recommended for production environments.
 
 The `upgrade` command upgrades the Consul on Kubernetes components to the current version of the `consul-k8s` cli. Prior to running `consul-k8s upgrade`, the `consul-k8s` CLI should first be upgraded to the latest version as described [Upgrade the Consul K8s CLI](#upgrade-the-consul-k8s-cli)
 

--- a/website/content/docs/k8s/k8s-cli.mdx
+++ b/website/content/docs/k8s/k8s-cli.mdx
@@ -23,18 +23,18 @@ Consul K8s CLI uses the following syntax:
 $ consul-k8s <SUBCOMMAND> <OPTIONS>
 ```
 
-## Subcommands
+## Commands
 
-You can use the following subcommands with `consul-k8s`.
+You can use the following commands with `consul-k8s`.
 
   - [`install`](#install) installs Consul to your Kubernetes cluster.
   - [`proxy`](#proxy) allows you to interact with proxies managed by Consul on your Kubernetes cluster.
-      - [`proxy list`](#proxy-list)
-      - [`proxy read`](#proxy-read)
-  - [`status`](#status) displays the
-  - [`uninstall`](#uninstall)
-  - [`upgrade`](#upgrade)
-  - [`version`](#version)
+      - [`proxy list`](#proxy-list) displays all relevant proxies.
+      - [`proxy read`](#proxy-read) displays the configuration of proxies on a given Pod.
+  - [`status`](#status) displays the status of your Consul installation along with its configuration.
+  - [`uninstall`](#uninstall) uninstalls Consul from your Kubernetes cluster.
+  - [`upgrade`](#upgrade) modifies your Consul installation's configuration.
+  - [`version`](#version) displays the version of Consul on Kubernetes that is installed.
 
 ### `install`
 

--- a/website/content/docs/k8s/k8s-cli.mdx
+++ b/website/content/docs/k8s/k8s-cli.mdx
@@ -27,16 +27,18 @@ $ consul-k8s <SUBCOMMAND> <OPTIONS>
 
 You can use the following subcommands with `consul-k8s`.
 
-  - [`install`](#install)
-  - [`proxy`](#proxy)
-  - [`status`](#status)
+  - [`install`](#install) installs Consul to your Kubernetes cluster.
+  - [`proxy`](#proxy) allows you to interact with proxies managed by Consul on your Kubernetes cluster.
+      - [`proxy list`](#proxy-list)
+      - [`proxy read`](#proxy-read)
+  - [`status`](#status) displays the
   - [`uninstall`](#uninstall)
   - [`upgrade`](#upgrade)
   - [`version`](#version)
 
 ### `install`
 
-The `install` command installs Consul on Kubernetes.
+The `install` command installs Consul to your Kubernetes cluster.
 
 ```shell-session
 $ consul-k8s install <OPTIONS>
@@ -57,7 +59,7 @@ The following options are available.
 | `-timeout`                                                                                                                                    | Specifies how long to wait for the installation process to complete before timing out. The value is specified with an integer and string value indicating a unit of time. <br/> The following units are supported: <br/> `ms` (milliseconds)<br/>`s` (seconds)<br/>`m` (minutes) <br/>In the following example, installation will timeout after one minute:<br/> `consul-k8s install -timeout 1m` | `10m`                                  |  Optional  |
 | `-wait`                                                                                                                                       | Boolean value that determines if Consul should wait for resources in the installation to be ready before exiting the command.                                                                                                                                                                                                                                                                     | `true`                                |  Optional |
 | `-verbose`, `-v`                                                                                                                              | Boolean value that specifies whether to output verbose logs from the install command with the status of resources being installed.                                                                                                                                                                                                                                                                     | `false`                                |  Optional |
-| `--help`                                                                                                                                      | Prints usage information for this option.                                                                                                                                                                                                                                                                                                                                                         | none                                    | Optional |
+| `-help`, `-h`                                                                                                                                 | Prints usage information for this option.                                                                                                                                                                                                                                                                                                                                                         | none                                    | Optional |
 
 See [Global Options](#global-options) for additional commands that you can use when installing Consul on Kubernetes.
 
@@ -89,6 +91,101 @@ The following example commands install Consul on Kubernetes using custom values,
 ```shell-session
  $ consul-k8s install -set-string key=value-bool
 ```
+
+### `proxy`
+
+The `proxy` command exposes two subcommands for interacting proxies managed by
+Consul in your Kubernetes Cluster.
+
+- [`proxy list`](#proxy-list) List all Kubernetes pods running proxies managed by Consul.
+- [`proxy read`](#proxy-read) Inspect the Envoy configuration for a given Pod.
+
+### `proxy list`
+
+```shell-session
+$ consul-k8s proxy list <OPTIONS>
+```
+
+| Flag                                         | Description                                           | Default                                                                                                                | Required |
+| -------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------- |
+| `-all-namespaces`, `-A` &nbsp; &nbsp; &nbsp; | `Boolean` List pods in all Kubernetes namespaces.     | `false`                                                                                                                | Optional |
+| `-namespace`, `-n`                           | `String` The Kubernetes namespace to list proxies in. | Current [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) namespace. | Optional |
+
+See [Global Options](#global-options) for additional commands that you can use
+when installing Consul on Kubernetes.
+
+This command will list proxies alongside their `Type`. Types of proxies include
+
+- `Sidecar`: these will be the majority of pods in the cluster. They run the
+  proxy in a sidecar pattern to network the pod as a service in the mesh.
+- `API Gateway`: these pods run a proxy to manage connections with networks
+  outside of the Consul cluster. [Read more about API gateways](/docs/api-gateway)
+- `Ingress Gateway`: these pods run a proxy to manage ingress into the
+  Kubernetes cluster. [Read more about ingress gateways](/docs/k8s/connect/ingress-gateways)
+- `Terminating Gateway`: these pods run a proxy to control connections to
+  external services. [Read more about terminating gateways](/docs/k8s/connect/terminating-gateways)
+- `Mesh Gateway`: these pods run a proxy to manage connections between
+  Consul clusters connected using mesh federation. [Read more about Consul Mesh Federation](/docs/k8s/installation/multi-cluster/kubernetes)
+
+#### Example Commands
+
+Display all pods in the current Kubernetes namespace which run proxies managed
+by Consul. Note that `Sidecar` pods are pods which are running the proxy in a
+sidecar pattern and are services running in the mesh.
+
+```shell-session
+$ consul-k8s proxy list
+```
+
+```
+Namespace: default
+
+Name                     	Type
+backend-658b679b45-d5xlb 	Sidecar
+client-767ccfc8f9-6f6gx  	Sidecar
+client-767ccfc8f9-f8nsn  	Sidecar
+client-767ccfc8f9-ggrtx  	Sidecar
+frontend-676564547c-v2mfq	Sidecar
+```
+
+Display all pods in the `consul` Kubernetes namespace which run proxies managed
+by Consul. Note that these pods are labeled with the type `Ingress Gateway`.
+They run a proxy managed by Consul for controlling ingress into the Kubernetes
+cluster.
+
+```shell-session
+$ consul-k8s proxy list -n consul
+```
+
+```
+Namespace: consul
+
+Name                                   	Type
+consul-ingress-gateway-6fb5544485-br6fl	Ingress Gateway
+consul-ingress-gateway-6fb5544485-m54sp	Ingress Gateway
+```
+
+Display all pods across all
+
+```shell-session
+$ consul-k8s proxy list -A
+```
+
+```
+Namespace: All Namespaces
+
+Namespace	Name                                   	Type
+consul   	consul-ingress-gateway-6fb5544485-br6fl	Ingress Gateway
+consul   	consul-ingress-gateway-6fb5544485-m54sp	Ingress Gateway
+default  	backend-658b679b45-d5xlb               	Sidecar
+default  	client-767ccfc8f9-6f6gx                	Sidecar
+default  	client-767ccfc8f9-f8nsn                	Sidecar
+default  	client-767ccfc8f9-ggrtx                	Sidecar
+default  	frontend-676564547c-v2mfq              	Sidecar
+```
+
+### `proxy read`
+
 
 ### `status`
 

--- a/website/content/docs/k8s/k8s-cli.mdx
+++ b/website/content/docs/k8s/k8s-cli.mdx
@@ -90,35 +90,6 @@ The following example commands install Consul on Kubernetes using custom values,
  $ consul-k8s install -set-string key=value-bool
 ```
 
-### `uninstall`
-
-The `uninstall` command removes Consul from Kubernetes.
-
-```shell-session
-$ consul-k8s uninstall <OPTIONS>
-```
-
-The following options are available.
-
-| Flag                                                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                | Default                                                                      | Required |
-| --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------- |
-| `-auto-approve` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Boolean value that enables you to skip the removal confirmation prompt.                                                                                                                                                                                                                                                                                                                                    | `false`                                                                      | Optional |
-| `-name`                                                                                                                                       | String value for the name of the installation to remove.                                                                                                                                                                                                                                                                                                                                                   | none                                                                         | Optional |
-| `-namespace`                                                                                                                                  | String value that specifies the namespace of the Consul installation to remove.                                                                                                                                                                                                                                                                                                                            | `consul`                                                                     | Optional |
-| `-timeout`                                                                                                                                    | Specifies how long to wait for the removal process to complete before timing out. The value is specified with an integer and string value indicating a unit of time. <br/> The following units are supported: <br/> `ms` (milliseconds)<br/>`s` (seconds)<br/>`m` (minutes) <br/>`h` (hours) <br/>In the following example, removal will timeout after one minute:<br/> `consul-k8s uninstall -timeout 1m` | `10m`                                                                     | Optional    |
-| `-wipe-data`                                                                                                                                  | Boolean value that deletes PVCs and secrets associated with the Consul installation during installation. <br/> Data will be removed without a verification prompt if the `-auto-approve` flag is set to `true`.                                                                                                                                                                                             |  `false` <br/> Instructions for removing data will be printed to the console. | Optional |
-| `--help`                                                                                                                                      | Prints usage information for this option.                                                                                                                                                                                                                                                                                                                                                                  | none                                                                         | Optional |
-
-See [Global Options](#global-options) for additional commands that you can use when uninstalling Consul from Kubernetes.
-
-#### Example Command
-
-The following example command immediately uninstalls Consul from the `my-ns` namespace with the name `my-consul` and removes PVCs and secrets associated with the installation without asking for verification:
-
-```shell-session
-$ consul-k8s uninstall -namespace=my-ns -name=my-consul -wipe-data=true -auto-approve=true
-```
-
 ### `status`
 
 The `status` command provides an overall status summary of the Consul on Kubernetes installation. It also provides the config that was used to deploy Consul K8s and provides a quick glance at the health of both Consul servers and clients. This command does not take in any flags.
@@ -162,6 +133,35 @@ $ consul-k8s status
 
  ✓ Consul servers healthy (1/1)
  ✓ Consul clients healthy (3/3)
+```
+
+### `uninstall`
+
+The `uninstall` command removes Consul from Kubernetes.
+
+```shell-session
+$ consul-k8s uninstall <OPTIONS>
+```
+
+The following options are available.
+
+| Flag                                                                                                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                | Default                                                                      | Required |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------- |
+| `-auto-approve` &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | Boolean value that enables you to skip the removal confirmation prompt.                                                                                                                                                                                                                                                                                                                                    | `false`                                                                      | Optional |
+| `-name`                                                                                                                                       | String value for the name of the installation to remove.                                                                                                                                                                                                                                                                                                                                                   | none                                                                         | Optional |
+| `-namespace`                                                                                                                                  | String value that specifies the namespace of the Consul installation to remove.                                                                                                                                                                                                                                                                                                                            | `consul`                                                                     | Optional |
+| `-timeout`                                                                                                                                    | Specifies how long to wait for the removal process to complete before timing out. The value is specified with an integer and string value indicating a unit of time. <br/> The following units are supported: <br/> `ms` (milliseconds)<br/>`s` (seconds)<br/>`m` (minutes) <br/>`h` (hours) <br/>In the following example, removal will timeout after one minute:<br/> `consul-k8s uninstall -timeout 1m` | `10m`                                                                     | Optional    |
+| `-wipe-data`                                                                                                                                  | Boolean value that deletes PVCs and secrets associated with the Consul installation during installation. <br/> Data will be removed without a verification prompt if the `-auto-approve` flag is set to `true`.                                                                                                                                                                                             |  `false` <br/> Instructions for removing data will be printed to the console. | Optional |
+| `--help`                                                                                                                                      | Prints usage information for this option.                                                                                                                                                                                                                                                                                                                                                                  | none                                                                         | Optional |
+
+See [Global Options](#global-options) for additional commands that you can use when uninstalling Consul from Kubernetes.
+
+#### Example Command
+
+The following example command immediately uninstalls Consul from the `my-ns` namespace with the name `my-consul` and removes PVCs and secrets associated with the installation without asking for verification:
+
+```shell-session
+$ consul-k8s uninstall -namespace=my-ns -name=my-consul -wipe-data=true -auto-approve=true
 ```
 
 ### `upgrade`

--- a/website/content/docs/k8s/k8s-cli.mdx
+++ b/website/content/docs/k8s/k8s-cli.mdx
@@ -130,8 +130,7 @@ This command will list proxies alongside their `Type`. Types of proxies include
 #### Example Commands
 
 Display all pods in the current Kubernetes namespace which run proxies managed
-by Consul. Note that `Sidecar` pods are pods which are running the proxy in a
-sidecar pattern and are services running in the mesh.
+by Consul.
 
 ```shell-session
 $ consul-k8s proxy list
@@ -149,9 +148,7 @@ frontend-676564547c-v2mfq	Sidecar
 ```
 
 Display all pods in the `consul` Kubernetes namespace which run proxies managed
-by Consul. Note that these pods are labeled with the type `Ingress Gateway`.
-They run a proxy managed by Consul for controlling ingress into the Kubernetes
-cluster.
+by Consul.
 
 ```shell-session
 $ consul-k8s proxy list -n consul
@@ -185,6 +182,171 @@ default  	frontend-676564547c-v2mfq              	Sidecar
 ```
 
 ### `proxy read`
+
+The `proxy read` command allows you to inspect the configuration of any Envoy proxies running on a given Pod.
+
+```shell-session
+$ consul-k8s proxy read <PODNAME> <OPTIONS>
+```
+
+The command takes a required value, `<PODNAME>`. This should be the full name
+of a Kubernetes Pod.
+
+The following options are available.
+
+| Flag                                           | Description                                                                                                                    | Default                                                                                                                | Required |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | -------- |
+| `-namespace`, `-n` &nbsp; &nbsp; &nbsp; &nbsp; | `String` The namespace where the target Pod can be found.                                                                      | Current [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) namespace. | Optional |
+| `-output`, `-o`                                | `String` Output the Envoy configuration as 'table', 'json', or 'raw'.                                                          | `'table'`                                                                                                              | Optional |
+| `-clusters`                                    | `Boolean` Filter output to only show clusters.                                                                                 | `false`                                                                                                                | Optional |
+| `-endpoints`                                   | `Boolean` Filter output to only show endpoints.                                                                                | `false`                                                                                                                | Optional |
+| `-listeners`                                   | `Boolean` Filter output to only show listeners.                                                                                | `false`                                                                                                                | Optional |
+| `-routes`                                      | `Boolean` Filter output to only show routes.                                                                                   | `false`                                                                                                                | Optional |
+| `-secrets`                                     | `Boolean` Filter output to only show secrets.                                                                                  | `false`                                                                                                                | Optional |
+| `-address`                                     | `String` Filter clusters, endpoints, and listeners output to only those with endpoint addresses which contain the given value. | `""`                                                                                                                   | Optional |
+| `-fqdn`                                        | `String` Filter cluster output to only clusters with a fully qualified domain name which contains the given value.             | `""`                                                                                                                   | Optional |
+| `-port`                                        | `Int` Filter endpoints output to only endpoints with the given port number.                                                    | `-1` which does not filter by port                                                                                     | Optional |
+
+#### Example commands
+
+Get the configuration summary for the Envoy proxy running on the Pod
+`backend-658b679b45-d5xlb`.
+
+```shell-session
+$ consul-k8s proxy read backend-658b679b45-d5xlb
+```
+
+```
+Envoy configuration for backend-658b679b45-d5xlb in namespace default:
+
+==> Clusters (5)
+Name                	FQDN                                                                     	Endpoints          	Type        	Last Updated
+local_agent         	local_agent                                                              	192.168.79.187:8502	STATIC      	2022-05-13T04:22:39.553Z
+client              	client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul  	                   	EDS         	2022-07-21T12:12:27.335Z
+frontend            	frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul	                   	EDS         	2022-07-21T12:12:27.242Z
+local_app           	local_app                                                                	127.0.0.1:8080     	STATIC      	2022-05-13T04:22:39.655Z
+original-destination	original-destination                                                     	                   	ORIGINAL_DST	2022-05-13T04:22:39.743Z
+
+
+==> Endpoints (6)
+Address:Port        	Cluster    	Weight	Status
+192.168.79.187:8502 	local_agent	1.00  	HEALTHY
+192.168.18.110:20000	           	1.00  	HEALTHY
+192.168.52.101:20000	           	1.00  	HEALTHY
+192.168.65.131:20000	           	1.00  	HEALTHY
+192.168.63.120:20000	           	1.00  	HEALTHY
+127.0.0.1:8080      	local_app  	1.00  	HEALTHY
+
+
+==> Listeners (2)
+Name             	Address:Port        	Direction	Filter Chain Match             	Filters                                                                     	Last Updated
+public_listener  	192.168.69.179:20000	INBOUND  	Any                            	* -> local_app/                                                             	2022-07-21T12:12:42.148Z
+outbound_listener	127.0.0.1:15001     	OUTBOUND 	10.100.134.173/32, 240.0.0.3/32	-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul  	2022-07-18T15:31:03.246Z
+                 	                    	         	10.100.31.2/32, 240.0.0.5/32   	-> frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul
+                 	                    	         	Any                            	-> original-destination
+
+
+==> Routes (1)
+Name           	Destination Cluster	Last Updated
+public_listener	local_app/         	2022-07-21T12:12:42.147Z
+
+
+==> Secrets (0)
+Name	Type	Last Updated
+
+```
+
+Get the Envoy configuration summary for all clusters with a fully qualified
+domain name which includes `"default"`. Display only clusters and listeners.
+
+```shell-session
+$ consul-k8s proxy read backend-658b679b45-d5xlb -fqdn default -clusters -listeners
+```
+
+```
+Envoy configuration for backend-658b679b45-d5xlb in namespace default:
+
+==> Filters applied
+    Fully qualified domain names containing: default
+
+==> Clusters (2)
+Name    	FQDN                                                                     	Endpoints	Type	Last Updated
+client  	client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul  	         	EDS 	2022-07-21T12:12:27.335Z
+frontend	frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul	         	EDS 	2022-07-21T12:12:27.242Z
+
+
+==> Listeners (2)
+Name             	Address:Port        	Direction	Filter Chain Match             	Filters                                                                     	Last Updated
+public_listener  	192.168.69.179:20000	INBOUND  	Any                            	* -> local_app/                                                             	2022-07-21T12:12:42.148Z
+outbound_listener	127.0.0.1:15001     	OUTBOUND 	10.100.134.173/32, 240.0.0.3/32	-> client.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul  	2022-07-18T15:31:03.246Z
+                 	                    	         	10.100.31.2/32, 240.0.0.5/32   	-> frontend.default.dc1.internal.bc3815c2-1a0f-f3ff-a2e9-20d791f08d00.consul
+                 	                    	         	Any                            	-> original-destination
+
+```
+
+Get the raw Envoy configuration dump for the Envoy proxy running on the Pod
+`backend-658b679b45-d5xlb`. The raw configuration will be output for each
+service as a JSON map. The [JQ command line tool](https://stedolan.github.io/jq/)
+can be used to index into the configuration for the service you want to inspect.
+
+See the [Envoy config dump documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/admin/v3/config_dump.proto)
+for more information on the structure of the config dump.
+
+```shell-session
+$ consul-k8s proxy read backend-658b679b45-d5xlb -o raw
+```
+
+```
+{
+  "backend-658b679b45-d5xlb": {
+    "configs": [
+      {
+        "@type": "type.googleapis.com/envoy.admin.v3.BootstrapConfigDump",
+        "bootstrap": {
+          // [-- snip 1201 lines --]
+        },
+        "last_updated": "2022-05-13T04:22:39.488Z"
+      },
+      {
+        "@type": "type.googleapis.com/envoy.admin.v3.ClustersConfigDump",
+        "static_clusters": [
+          // [-- snip 42 lines --]
+        ],
+        "dynamic_active_clusters": [
+          // [-- snip 144 lines --]
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/envoy.admin.v3.EndpointsConfigDump",
+        "static_endpoint_configs": [
+          // [-- snip 29 lines --]
+        ],
+        "dynamic_endpoint_configs": [
+          // [-- snip 120 lines --]
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/envoy.admin.v3.ListenersConfigDump",
+        "dynamic_listeners": [
+          // [-- snip 216 lines --]
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/envoy.admin.v3.ScopedRoutesConfigDump"
+      },
+      {
+        "@type": "type.googleapis.com/envoy.admin.v3.RoutesConfigDump",
+        "static_route_configs": [
+          // [-- snip 25 lines --]
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/envoy.admin.v3.SecretsConfigDump"
+      }
+    ]
+  }
+}
+```
 
 
 ### `status`


### PR DESCRIPTION
### Description

With the upcoming release of Consul on Kubernetes 0.47.0, the `consul-k8s` CLI will gain two new commands:

- `proxy list` for listing the names of all Pods running Envoy proxies managed by Consul.
- `proxy read <PODNAME>` for inspecting the Envoy configuration of a given Pod.

This PR updates the commands page for the `consul-k8s` CLI with documentation for the new commands.

In addition, this PR makes some changes to existing documentation with the intent of improving clarity:

- Change of wording of the intro section.
- Addition of descriptive text to the table of contents.
- Removal of the "Required" column from flag tables. All flags are optional.

### Links

- [Relevant RFC](https://docs.google.com/document/d/1vZdEDLMicdhYGSaVh4Vzx8sViw_zb8FojlK10O6N5Y8/edit)
- [Consul-K8s Feature Branch](https://github.com/hashicorp/consul-k8s/pull/1271)

### PR Checklist

* [-] updated test coverage (No code added)
* [x] external facing docs updated
* [x] not a security concern
