### PR TITLE
peering: add config to enable/disable peering

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1341,6 +1341,8 @@ func newConsulConfig(runtimeCfg *config.RuntimeConfig, logger hclog.Logger) (*co
 	// function does not drift.
 	cfg.SerfLANConfig = consul.CloneSerfLANConfig(cfg.SerfLANConfig)
 
+	cfg.PeeringEnabled = runtimeCfg.PeeringEnabled
+
 	enterpriseConsulConfig(cfg, runtimeCfg)
 	return cfg, nil
 }

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1014,6 +1014,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		NodeMeta:                         c.NodeMeta,
 		NodeName:                         b.nodeName(c.NodeName),
 		ReadReplica:                      boolVal(c.ReadReplica),
+		PeeringEnabled:                   boolVal(c.Peering.Enabled),
 		PidFile:                          stringVal(c.PidFile),
 		PrimaryDatacenter:                primaryDatacenter,
 		PrimaryGateways:                  b.expandAllOptionalAddrs("primary_gateways", c.PrimaryGateways),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -197,6 +197,7 @@ type Config struct {
 	NodeID                           *string             `mapstructure:"node_id"`
 	NodeMeta                         map[string]string   `mapstructure:"node_meta"`
 	NodeName                         *string             `mapstructure:"node_name"`
+	Peering                          Peering             `mapstructure:"peering"`
 	Performance                      Performance         `mapstructure:"performance"`
 	PidFile                          *string             `mapstructure:"pid_file"`
 	Ports                            Ports               `mapstructure:"ports"`
@@ -886,4 +887,8 @@ type TLS struct {
 	// Note: we use a *struct{} here because a simple bool isn't supported by our
 	// config merging logic.
 	GRPCModifiedByDeprecatedConfig *struct{} `mapstructure:"-"`
+}
+
+type Peering struct {
+	Enabled *bool `mapstructure:"enabled"`
 }

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -104,9 +104,9 @@ func DefaultSource() Source {
 			kv_max_value_size = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
 			txn_max_req_len = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
 		}
-        peering {
-            enabled = true
-        }
+		peering = {
+			enabled = true
+		}
 		performance = {
 			leave_drain_time = "5s"
 			raft_multiplier = ` + strconv.Itoa(int(consul.DefaultRaftMultiplier)) + `

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -104,6 +104,9 @@ func DefaultSource() Source {
 			kv_max_value_size = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
 			txn_max_req_len = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
 		}
+        peering {
+            enabled = true
+        }
 		performance = {
 			leave_drain_time = "5s"
 			raft_multiplier = ` + strconv.Itoa(int(consul.DefaultRaftMultiplier)) + `

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -810,6 +810,14 @@ type RuntimeConfig struct {
 	// flag: -non-voting-server
 	ReadReplica bool
 
+	// PeeringEnabled enables cluster peering. This setting only applies for servers.
+	// When disabled, all peering RPC endpoints will return errors,
+	// peering requests from other clusters will receive errors, and any peerings already stored in this server's
+	// state will be ignored.
+	//
+	// hcl: peering { enabled = (true|false) }
+	PeeringEnabled bool
+
 	// PidFile is the file to store our PID in.
 	//
 	// hcl: pid_file = string

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5548,6 +5548,16 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 			"tls.grpc was provided but TLS will NOT be enabled on the gRPC listener without an HTTPS listener configured (e.g. via ports.https)",
 		},
 	})
+	run(t, testCase{
+		desc: "peering.enabled defaults to true",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		expected: func(rt *RuntimeConfig) {
+			rt.DataDir = dataDir
+			rt.PeeringEnabled = true
+		},
+	})
 }
 
 func (tc testCase) run(format string, dataDir string) func(t *testing.T) {
@@ -5955,6 +5965,7 @@ func TestLoad_FullConfig(t *testing.T) {
 		NodeMeta:                map[string]string{"5mgGQMBk": "mJLtVMSG", "A7ynFMJB": "0Nx6RGab"},
 		NodeName:                "otlLxGaI",
 		ReadReplica:             true,
+		PeeringEnabled:          true,
 		PidFile:                 "43xN80Km",
 		PrimaryGateways:         []string{"aej8eeZo", "roh2KahS"},
 		PrimaryGatewaysInterval: 18866 * time.Second,

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -235,6 +235,7 @@
     "NodeID": "",
     "NodeMeta": {},
     "NodeName": "",
+    "PeeringEnabled": false,
     "PidFile": "",
     "PrimaryDatacenter": "",
     "PrimaryGateways": [

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -305,6 +305,9 @@ node_meta {
 node_name = "otlLxGaI"
 non_voting_server = true
 partition = ""
+peering {
+    enabled = true
+}
 performance {
     leave_drain_time = "8265s"
     raft_multiplier = 5

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -305,6 +305,9 @@
   "node_name": "otlLxGaI",
   "non_voting_server": true,
   "partition": "",
+  "peering": {
+    "enabled": true
+  },
   "performance": {
     "leave_drain_time": "8265s",
     "raft_multiplier": 5,

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -396,6 +396,9 @@ type Config struct {
 
 	RaftBoltDBConfig RaftBoltDBConfig
 
+	// PeeringEnabled enables cluster peering.
+	PeeringEnabled bool
+
 	// Embedded Consul Enterprise specific configuration
 	*EnterpriseConfig
 }
@@ -511,6 +514,8 @@ func DefaultConfig() *Config {
 		AutopilotInterval:        10 * time.Second,
 		DefaultQueryTime:         300 * time.Second,
 		MaxQueryTime:             600 * time.Second,
+
+		PeeringEnabled: true,
 
 		EnterpriseConfig: DefaultEnterpriseConfig(),
 	}

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -315,7 +315,9 @@ func (s *Server) establishLeadership(ctx context.Context) error {
 
 	s.startFederationStateAntiEntropy(ctx)
 
-	s.startPeeringStreamSync(ctx)
+	if s.config.PeeringEnabled {
+		s.startPeeringStreamSync(ctx)
+	}
 
 	s.startDeferredDeletion(ctx)
 
@@ -758,7 +760,9 @@ func (s *Server) stopACLReplication() {
 }
 
 func (s *Server) startDeferredDeletion(ctx context.Context) {
-	s.startPeeringDeferredDeletion(ctx)
+	if s.config.PeeringEnabled {
+		s.startPeeringDeferredDeletion(ctx)
+	}
 	s.startTenancyDeferredDeletion(ctx)
 }
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -794,6 +794,7 @@ func newGRPCHandlerFromConfig(deps Deps, config *Config, s *Server) connHandler 
 		},
 		Datacenter:     config.Datacenter,
 		ConnectEnabled: config.ConnectEnabled,
+		PeeringEnabled: config.PeeringEnabled,
 	})
 	s.peeringServer = p
 

--- a/docs/config/checklist-adding-config-fields.md
+++ b/docs/config/checklist-adding-config-fields.md
@@ -45,6 +45,8 @@ There are four specific cases covered with increasing complexity:
       - [ ] Add that to `DefaultSource` in `agent/config/defaults.go`.
       - [ ] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
         `agent/config/runtime_test.go`.
+      - [ ] If the config needs to be defaulted for the test server used in unit tests,
+            also add it to `DefaultConfig()` in `agent/consul/defaults.go`.
  - [ ] **If** your config should take effect on a reload/HUP.
       - [ ] Add necessary code to to trigger a safe (locked or atomic) update to
         any state the feature needs changing. This needs to be added to one or

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -551,6 +551,15 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 
 - `max_query_time` Equivalent to the [`-max-query-time` command-line flag](/docs/agent/config/cli-flags#_max_query_time).
 
+- `peering` This object allows setting options for cluster peering.
+
+  The following sub-keys are available:
+
+  - `enabled` ((#peering_enabled)) (Defaults to `true`) Controls whether cluster peering is enabled.
+    Has no effect on Consul clients, only on Consul servers. When disabled, all peering APIs will return
+    an error, any peerings stored in Consul already will be ignored (but they will not be deleted),
+    all peering connections from other clusters will be rejected. This was added in Consul 1.13.0.
+
 - `partition` <EnterpriseAlert inline /> - This flag is used to set
   the name of the admin partition the agent belongs to. An agent can only join
   and communicate with other agents within its admin partition. Review the


### PR DESCRIPTION
Add config:

```
peering {
  enabled = true
}
```

Defaults to true. When disabled:
1. All peering RPC endpoints will return an error
2. Leader won't start its peering establishment goroutines
3. Leader won't start its peering deletion goroutines

## Adding a Simple Config Field for Client Agents

 - [x] Add the field to the Config struct (or an appropriate sub-struct) in
   `agent/config/config.go`.
 - [x] Add the field to the actual RuntimeConfig struct in
   `agent/config/runtime.go`.
 - [x] Add an appropriate parser/setter in `agent/config/builder.go` to
   translate.
 - [x] Add the new field with a random value to both the JSON and HCL files in
   `agent/config/testdata/full-config.*`, which should cause the `TestLoad_FullConfig` test to fail.
   Then update the expected value in `TestLoad_FullConfig` in
   `agent/config/runtime_test.go` to make the test pass again.
 - [x] Run `go test -run TestRuntimeConfig_Sanitize ./agent/config -update` to update
   the expected value for `TestRuntimeConfig_Sanitize`. Look at `git diff` to
   make sure the value changed as you expect.
 - [ ] **If** your new config field needed some validation as it's only valid in
   some cases or with some values (often true).
      - [ ] Add validation to Validate in `agent/config/builder.go`.
      - [ ] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
        `agent/config/runtime_test.go`.
 - [x] **If** your new config field needs a non-zero-value default.
      - [x] Add that to `DefaultSource` in `agent/config/default.go`.
      - [x] Add a test case to the table test `TestLoad_IntegrationWithFlags` in
        `agent/config/runtime_test.go`.
 - [ ] **If** your config should take effect on a reload/HUP.
      - [ ] Add necessary code to trigger a safe (locked or atomic) update to
        any state the feature needs changing. This needs to be added to one or
        more of the following places:
         - `ReloadConfig` in `agent/agent.go` if it needs to affect the local
           client state or another client agent component.
         - `ReloadConfig` in `agent/consul/client.go` if it needs to affect
           state for client agent's RPC client.
      - [ ] Add a test to `agent/agent_test.go` similar to others with prefix
        `TestAgent_reloadConfig*`.
 - [x] Add documentation to `website/content/docs/agent/config/config-files.mdx`.

## Adding a Simple Config Field for Servers
 - [x] Do all of the steps in [Adding a Simple Config
   Field For Client Agents](#adding-a-simple-config-field-for-client-agents).
 - [x] Add the new field to Config struct in `agent/consul/config.go`
 - [x] Add code to set the values from the `RuntimeConfig` in the confusingly
   named `newConsulConfig` method in `agent/agent.go`
 - [ ] **If needed**, add a test to `agent_test.go` if there is some non-trivial
   behavior in the code you added in the previous step. We tend not to test
   simple assignments from one to the other since these are typically caught by
   higher-level tests of the actual functionality that matters but some examples
   can be found prefixed with `TestAgent_consulConfig*`
 - [ ] **If** your config should take effect on a reload/HUP
      - [ ] Add necessary code to `ReloadConfig` in `agent/consul/server.go` this
        needs to be adequately synchronized with any readers of the state being
        updated.
       - [ ] Add a new test or a new assertion to `TestServer_ReloadConfig`
