### PR TITLE
Remove extra logging from ingress upstream watch shutdown

### DIFF
--- a/agent/proxycfg/ingress_gateway.go
+++ b/agent/proxycfg/ingress_gateway.go
@@ -149,10 +149,6 @@ func (s *handlerIngressGateway) handleUpdate(ctx context.Context, u UpdateEvent,
 		for uid, cancelFn := range snap.IngressGateway.WatchedDiscoveryChains {
 			if _, ok := watchedSvcs[uid]; !ok {
 				for targetID, cancelUpstreamFn := range snap.IngressGateway.WatchedUpstreams[uid] {
-					s.logger.Debug("stopping watch of target",
-						"upstream", uid,
-						"target", targetID,
-					)
 					delete(snap.IngressGateway.WatchedUpstreams[uid], targetID)
 					delete(snap.IngressGateway.WatchedUpstreamEndpoints[uid], targetID)
 					cancelUpstreamFn()


### PR DESCRIPTION
This removes an unneeded debug log statement that got left in by https://github.com/hashicorp/consul/pull/13847