### PR TITLE
Allow hostname based addresses in peering token

### DIFF
--- a/agent/rpc/peering/testing.go
+++ b/agent/rpc/peering/testing.go
@@ -31,6 +31,7 @@ not valid
 `
 
 var validAddress = "1.2.3.4:80"
+var validHostnameAddress = "foo.bar.baz:80"
 
 var validServerName = "server.consul"
 

--- a/agent/rpc/peering/validate.go
+++ b/agent/rpc/peering/validate.go
@@ -3,7 +3,6 @@ package peering
 import (
 	"fmt"
 	"net"
-	"net/netip"
 	"strconv"
 
 	"github.com/hashicorp/consul/agent/connect"
@@ -25,7 +24,7 @@ func validatePeeringToken(tok *structs.PeeringToken) error {
 		return errPeeringTokenEmptyServerAddresses
 	}
 	for _, addr := range tok.ServerAddresses {
-		host, portRaw, err := net.SplitHostPort(addr)
+		_, portRaw, err := net.SplitHostPort(addr)
 		if err != nil {
 			return &errPeeringInvalidServerAddress{addr}
 		}
@@ -35,9 +34,6 @@ func validatePeeringToken(tok *structs.PeeringToken) error {
 			return &errPeeringInvalidServerAddress{addr}
 		}
 		if port < 1 || port > 65535 {
-			return &errPeeringInvalidServerAddress{addr}
-		}
-		if _, err := netip.ParseAddr(host); err != nil {
 			return &errPeeringInvalidServerAddress{addr}
 		}
 	}

--- a/agent/rpc/peering/validate_test.go
+++ b/agent/rpc/peering/validate_test.go
@@ -54,16 +54,6 @@ func TestValidatePeeringToken(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid address IP",
-			token: &structs.PeeringToken{
-				CA:              []string{validCA},
-				ServerAddresses: []string{"foo.bar.baz"},
-			},
-			wantErr: &errPeeringInvalidServerAddress{
-				"foo.bar.baz",
-			},
-		},
-		{
 			name: "invalid server name",
 			token: &structs.PeeringToken{
 				CA:              []string{validCA},
@@ -85,6 +75,15 @@ func TestValidatePeeringToken(t *testing.T) {
 			token: &structs.PeeringToken{
 				CA:              []string{validCA},
 				ServerAddresses: []string{validAddress},
+				ServerName:      validServerName,
+				PeerID:          validPeerID,
+			},
+		},
+		{
+			name: "valid token with hostname address",
+			token: &structs.PeeringToken{
+				CA:              []string{validCA},
+				ServerAddresses: []string{validHostnameAddress},
 				ServerName:      validServerName,
 				PeerID:          validPeerID,
 			},


### PR DESCRIPTION
When supplying an external address to put into the peering token, the external address could be a hostname of a load balancer, which for example is the default in EKS. We'd want to allow hostname based addresses in the peering token in this case. 

I was able to test a hostname based load balancer with this change and it worked as the dialer does not require an IP address.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated - docs change for all of the expose servers feature to come in future
* [x] not a security concern 
