### PR TITLE
ui: add peers to node search

### DIFF
--- a/ui/packages/consul-ui/app/controllers/_peered-resource.js
+++ b/ui/packages/consul-ui/app/controllers/_peered-resource.js
@@ -1,0 +1,16 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class PeeredResourceController extends Controller {
+  @service abilities;
+
+  get _searchProperties() {
+    const { searchProperties } = this;
+
+    if (!this.abilities.can('use peers')) {
+      return searchProperties.filter(propertyName => propertyName !== 'PeerName');
+    } else {
+      return searchProperties;
+    }
+  }
+}

--- a/ui/packages/consul-ui/app/controllers/dc/nodes/index.js
+++ b/ui/packages/consul-ui/app/controllers/dc/nodes/index.js
@@ -1,0 +1,3 @@
+import PeeredResourceController from 'consul-ui/controllers/_peered-resource';
+
+export default class DcNodesController extends PeeredResourceController {}

--- a/ui/packages/consul-ui/app/controllers/dc/services/index.js
+++ b/ui/packages/consul-ui/app/controllers/dc/services/index.js
@@ -1,0 +1,3 @@
+import PeeredResourceController from 'consul-ui/controllers/_peered-resource';
+
+export default class DcServicesController extends PeeredResourceController {}

--- a/ui/packages/consul-ui/app/search/predicates/node.js
+++ b/ui/packages/consul-ui/app/search/predicates/node.js
@@ -1,5 +1,6 @@
 export default {
   Node: item => item.Node,
   Address: item => item.Address,
+  PeerName: item => item.PeerName,
   Meta: item => Object.entries(item.Meta || {}).reduce((prev, entry) => prev.concat(entry), []),
 };

--- a/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
@@ -44,10 +44,10 @@ as |route|>
       searchproperty=(hash
         value=(if (not-eq searchproperty undefined)
           (split searchproperty ',')
-          searchProperties
+          this._searchProperties
         )
         change=(action (mut searchproperty) value="target.selectedItems")
-        default=searchProperties
+        default=this._searchProperties
       )
     )
 

--- a/ui/packages/consul-ui/app/templates/dc/services/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/index.hbs
@@ -43,10 +43,10 @@ as |route|>
     searchproperty=(hash
       value=(if (not-eq searchproperty undefined)
         (split searchproperty ',')
-        searchProperties
+        this._searchProperties
       )
       change=(action (mut searchproperty) value="target.selectedItems")
-      default=searchProperties
+      default=this._searchProperties
     )
 
   )

--- a/ui/packages/consul-ui/vendor/consul-ui/routes.js
+++ b/ui/packages/consul-ui/vendor/consul-ui/routes.js
@@ -215,7 +215,7 @@
               status: 'status',
               searchproperty: {
                 as: 'searchproperty',
-                empty: [['Node', 'Address', 'Meta']],
+                empty: [['Node', 'Address', 'Meta', 'PeerName']],
               },
               search: {
                 as: 'filter',


### PR DESCRIPTION
### Description
Follow-up of https://github.com/hashicorp/consul/pull/13771 to make the tests execute on CI - couldn't find a way to do this in the old PR.

For discussion please follow the [old PR](https://github.com/hashicorp/consul/pull/13771). Nothing has changed - I'm just creating a new PR so that tests execute properly on CI.

__TLDR;__

This PR:
* makes nodes searchable by peer-name
* fixes peer-name showing up in services search although peers feature was turned off

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
