### PR TITLE
Re-document peering disabled

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -556,9 +556,9 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
   The following sub-keys are available:
 
   - `enabled` ((#peering_enabled)) (Defaults to `true`) Controls whether cluster peering is enabled.
-    Has no effect on Consul clients, only on Consul servers. When disabled, all peering APIs will return
+    When disabled, the UI won't show peering, all peering APIs will return
     an error, any peerings stored in Consul already will be ignored (but they will not be deleted),
-    all peering connections from other clusters will be rejected. This was added in Consul 1.13.0.
+    and all peering connections from other clusters will be rejected. This was added in Consul 1.13.0.
 
 - `partition` <EnterpriseAlert inline /> - This flag is used to set
   the name of the admin partition the agent belongs to. An agent can only join


### PR DESCRIPTION
Change wording because it does have effect on clients because it
disables peering in the UI served from that client.
