### PR TITLE
fix: ipv4 destination dns resolution

### DIFF
--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -1494,7 +1494,7 @@ func (s *ResourceGenerator) makeTerminatingHostnameCluster(snap *proxycfg.Config
 		// Having an empty config enables outlier detection with default config.
 		OutlierDetection:     &envoy_cluster_v3.OutlierDetection{},
 		ClusterDiscoveryType: &envoy_cluster_v3.Cluster_Type{Type: envoy_cluster_v3.Cluster_LOGICAL_DNS},
-		DnsLookupFamily:      envoy_cluster_v3.Cluster_AUTO,
+		DnsLookupFamily:      envoy_cluster_v3.Cluster_V4_ONLY,
 	}
 
 	rate := 10 * time.Second

--- a/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway-destinations-only.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-terminating-gateway-destinations-only.latest.golden
@@ -138,6 +138,7 @@
         ]
       },
       "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
       "outlierDetection": {
 
       }
@@ -167,6 +168,7 @@
         ]
       },
       "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
       "outlierDetection": {
 
       },
@@ -218,6 +220,7 @@
         ]
       },
       "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
       "outlierDetection": {
 
       }
@@ -247,6 +250,7 @@
         ]
       },
       "dnsRefreshRate": "10s",
+      "dnsLookupFamily": "V4_ONLY",
       "outlierDetection": {
 
       }


### PR DESCRIPTION
### Description
Currently, there are issues with Destination hostnames that resolve to IPV6 addresses.  The terminating gateway can resolve the names into addresses, but when dialing the IPV6 address, it reports the connection unreachable. 

We still need to consider if hardcoding this to IPV4 is a good long-term decision.

### Testing & Reproduction steps
* try contacting `api.myip.com` using Destinations.

### PR Checklist

* [X] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
