### PR TITLE
Separate port and socket path validation for local agent

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1123,8 +1123,8 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid Service Meta: %v", err)}
 	}
 
-	// Run validation. This is the same validation that would happen on
-	// the catalog endpoint so it helps ensure the sync will work properly.
+	// Run validation. This same validation would happen on the catalog endpoint,
+	// so it helps ensure the sync will work properly.
 	if err := ns.Validate(); err != nil {
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Validation failed: %v", err.Error())}
 	}
@@ -1164,7 +1164,7 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid SidecarService: %s", err)}
 	}
 	if sidecar != nil {
-		if err := sidecar.Validate(); err != nil {
+		if err := sidecar.ValidateForAgent(); err != nil {
 			return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Failed Validation: %v", err.Error())}
 		}
 		// Make sure we are allowed to register the sidecar using the token

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -339,7 +339,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			}
 
 			ns := tt.sd.NodeService()
-			err := ns.Validate()
+			err := ns.ValidateForAgent()
 			require.NoError(t, err, "Invalid test case - NodeService must validate")
 
 			gotNS, gotChecks, gotToken, err := a.sidecarServiceFromNodeService(ns, tt.token)

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1157,6 +1157,16 @@ func TestStructs_NodeService_ValidateConnectProxy(t *testing.T) {
 	}
 }
 
+func TestStructs_NodeService_ValidateConnectProxyWithAgentAutoAssign(t *testing.T) {
+	t.Run("connect-proxy: no port set", func(t *testing.T) {
+		ns := TestNodeServiceProxy(t)
+		ns.Port = 0
+
+		err := ns.ValidateForAgent()
+		assert.NoError(t, err)
+	})
+}
+
 func TestStructs_NodeService_ValidateConnectProxy_In_Partition(t *testing.T) {
 	cases := []struct {
 		Name   string


### PR DESCRIPTION
### Description
[PR #12881](https://github.com/hashicorp/consul/pull/12881) Introduced a requirement for either port or socket path to be provided in all requests. Due to [a race in automatic port assignment](https://github.com/hashicorp/consul/issues/8254) within the agent, automatic assignment needs [to be moved from the request-building stage to the locked registration stage post-validation](https://github.com/hashicorp/consul/pull/13928). One solution (this PR) is to exempt the port requirement from request validation when the request is coming from an agent that is trying to do auto-assignment.

### Testing & Reproduction steps
* Manually registering a service from the agent still works with and without a port specified.
* Existing unit tests seem to cover many cases, and pass without need for changes.

### Links
[PR #12881](https://github.com/hashicorp/consul/pull/12881)
[Port assignment issue](https://github.com/hashicorp/consul/issues/8254)
[Follow-on PR that will need this](https://github.com/hashicorp/consul/pull/13928)

### PR Checklist

* [x] updated test coverage
* [N/A] external facing docs updated
* [N/A] not a security concern
