### PR TITLE
chore: clarify the error message: service.service must not be empty

### DIFF
--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -176,7 +176,7 @@ func servicePreApply(service *structs.NodeService, authz resolver.Result, authzC
 
 	// Verify ServiceName provided if ID.
 	if service.ID != "" && service.Service == "" {
-		return fmt.Errorf("Must provide service name with ID")
+		return fmt.Errorf("Must provide service name (Service.Service) when service ID is provided")
 	}
 
 	// Check the service address here and in the agent endpoint


### PR DESCRIPTION
### Description
Normally, registering a service, we use "name". However, when register service using catalog endpoint, the key of service
name actually should be "service". 

Adding this information to the error message will help user quickly fix in the request.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
