### PR TITLE
PR - Change configuration example for CTS documentation to reflect localhost instead of upstream cluster url 

### DIFF
--- a/website/content/docs/nia/configuration.mdx
+++ b/website/content/docs/nia/configuration.mdx
@@ -102,7 +102,7 @@ To read more on suggestions for configuring the Consul agent, see [run an agent]
 
 ```hcl
 consul {
-  address = "consul.example.com"
+  address = "localhost:8500"
   auth {}
   tls {}
   token = null


### PR DESCRIPTION
### Description

#### Issue:

The examples for NIA currently reference a configuration block with a url of `consul.example.com`  located [here](https://www.consul.io/docs/nia/configuration#consul)

Customers and partners that are utilizing HCP Consul are generally taking this configuration and replacing `consul.example.com` with the private HCP url. This allows for CTS to connect and register but the service checking requires the local agent to be used. 


#### Suggestion:

Change the block to reflect `localhost:8500` to reduce the issues that users run into. 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links

https://www.consul.io/docs/nia/configuration#consul


### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] not a security concern
