### PR TITLE
docs: show CLI cmd-specific opts before general opts

### DIFF
--- a/website/content/commands/acl/auth-method/delete.mdx
+++ b/website/content/commands/acl/auth-method/delete.mdx
@@ -23,21 +23,21 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl auth-method delete [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-name=<string>` - The Name of the auth method to delete.
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/auth-method/list.mdx
+++ b/website/content/commands/acl/auth-method/list.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl auth-method list`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-meta` - Indicates that auth method metadata such as the raft indices should
@@ -38,9 +32,15 @@ Usage: `consul acl auth-method list`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/auth-method/read.mdx
+++ b/website/content/commands/acl/auth-method/read.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl auth-method read [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-meta` - Indicates that auth method metadata such as the raft
@@ -40,9 +34,15 @@ Usage: `consul acl auth-method read [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/auth-method/update.mdx
+++ b/website/content/commands/acl/auth-method/update.mdx
@@ -26,12 +26,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl auth-method update [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-description=<string>` - A description of the auth method.
@@ -76,6 +70,8 @@ Usage: `consul acl auth-method update [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
 - `-namespace-rule-bind-namespace=<value>` - Namespace to bind on match. Can
@@ -85,7 +81,11 @@ Usage: `consul acl auth-method update [options] [args]`
   verified identity attributes returned from the auth method during login to
   determine if the namespace rule applies. Added in Consul 1.8.0.
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/binding-rule/create.mdx
+++ b/website/content/commands/acl/binding-rule/create.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl binding-rule create [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-bind-name=<string>` - Name to bind on match. Can use `${var}`
@@ -51,9 +45,15 @@ Usage: `consul acl binding-rule create [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/binding-rule/delete.mdx
+++ b/website/content/commands/acl/binding-rule/delete.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl binding-rule delete [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-id=<string>` - The ID of the binding rule to delete. It may be specified as a
@@ -36,9 +30,15 @@ Usage: `consul acl binding-rule delete [options]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/binding-rule/list.mdx
+++ b/website/content/commands/acl/binding-rule/list.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl binding-rule list`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-meta` - Indicates that binding rule metadata such as the raft indices
@@ -38,9 +32,15 @@ Usage: `consul acl binding-rule list`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/binding-rule/read.mdx
+++ b/website/content/commands/acl/binding-rule/read.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl binding-rule read [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-id=<string>` - The ID of the binding rule to read. It may be specified as a unique ID
@@ -41,9 +35,15 @@ Usage: `consul acl binding-rule read [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/binding-rule/update.mdx
+++ b/website/content/commands/acl/binding-rule/update.mdx
@@ -26,12 +26,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl binding-rule update [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-bind-name=<string>` - Name to bind on match. Can use `${var}`
@@ -58,9 +52,15 @@ Usage: `consul acl binding-rule update [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/bootstrap.mdx
+++ b/website/content/commands/acl/bootstrap.mdx
@@ -26,12 +26,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl bootstrap [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-format={pretty|json}` - Command output format. The default value is `pretty`.
@@ -47,3 +41,9 @@ Create Time:  2018-10-22 11:27:04.479026 -0400 EDT
 Policies:
    00000000-0000-0000-0000-000000000001 - global-management
 ```
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/acl/policy/create.mdx
+++ b/website/content/commands/acl/policy/create.mdx
@@ -35,12 +35,6 @@ support for the legacy ACL system is removed.
 
 Usage: `consul acl policy create [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-description=<string>` - A description of the policy.
@@ -69,9 +63,15 @@ Usage: `consul acl policy create [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/policy/delete.mdx
+++ b/website/content/commands/acl/policy/delete.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl policy delete [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-id=<string>` - The ID of the policy to delete. It may be specified as a
@@ -38,9 +32,15 @@ Usage: `consul acl policy delete [options]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/policy/list.mdx
+++ b/website/content/commands/acl/policy/list.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl policy list`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-meta` - Indicates that policy metadata such as the content hash and
@@ -38,9 +32,15 @@ Usage: `consul acl policy list`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/policy/read.mdx
+++ b/website/content/commands/acl/policy/read.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl policy read [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-id=<string>` - The ID of the policy to read. It may be specified as a unique ID
@@ -43,9 +37,15 @@ Usage: `consul acl policy read [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/policy/update.mdx
+++ b/website/content/commands/acl/policy/update.mdx
@@ -27,12 +27,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl policy update [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-description=<string>` - A description of the policy.
@@ -60,9 +54,15 @@ Usage: `consul acl policy update [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/role/create.mdx
+++ b/website/content/commands/acl/role/create.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl role create [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-description=<string>` - A description of the role.
@@ -56,9 +50,15 @@ Usage: `consul acl role create [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/role/delete.mdx
+++ b/website/content/commands/acl/role/delete.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl role delete [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-id=<string>` - The ID of the role to delete. It may be specified as a
@@ -38,9 +32,15 @@ Usage: `consul acl role delete [options]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/role/list.mdx
+++ b/website/content/commands/acl/role/list.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl role list`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-meta` - Indicates that role metadata such as the content hash and
@@ -38,9 +32,15 @@ Usage: `consul acl role list`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/role/read.mdx
+++ b/website/content/commands/acl/role/read.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl role read [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-id=<string>` - The ID of the role to read. It may be specified as a unique ID
@@ -43,9 +37,15 @@ Usage: `consul acl role read [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/role/update.mdx
+++ b/website/content/commands/acl/role/update.mdx
@@ -27,12 +27,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl role update [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-description=<string>` - A description of the role.
@@ -67,9 +61,15 @@ Usage: `consul acl role update [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/set-agent-token.mdx
+++ b/website/content/commands/acl/set-agent-token.mdx
@@ -26,9 +26,9 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 ## Usage
 
-Usage: `consul acl set-agent-token [options] TYPE TOKEN`
+Usage: `consul acl set-agent-token [options] token_type token_secret_id`
 
-### Token Types
+The token types are:
 
 - `default` - The default token is the token that the agent will use for
   both internal agent operations and operations initiated by the HTTP

--- a/website/content/commands/acl/token/clone.mdx
+++ b/website/content/commands/acl/token/clone.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl token clone [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-description=<string>` - A description of the new cloned token.
@@ -42,9 +36,15 @@ Usage: `consul acl token clone [options]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/token/create.mdx
+++ b/website/content/commands/acl/token/create.mdx
@@ -25,12 +25,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl token create [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-accessor=<string>` - Create the token with this Accessor ID. It must be a UUID. If not
@@ -70,9 +64,15 @@ Usage: `consul acl token create [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/token/delete.mdx
+++ b/website/content/commands/acl/token/delete.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl token delete [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-id=<string>` - The ID of the token to delete. It may be specified as a
@@ -36,9 +30,15 @@ Usage: `consul acl token delete [options]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/token/list.mdx
+++ b/website/content/commands/acl/token/list.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl token list`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-meta` - Indicates that token metadata such as the content hash and
@@ -38,9 +32,15 @@ Usage: `consul acl token list`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/token/read.mdx
+++ b/website/content/commands/acl/token/read.mdx
@@ -23,12 +23,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl token read [options] [args]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-id=<string>` - The ID of the policy to read. It may be specified as a unique ID
@@ -47,9 +41,15 @@ Usage: `consul acl token read [options] [args]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/token/update.mdx
+++ b/website/content/commands/acl/token/update.mdx
@@ -24,12 +24,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl token update [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-description=<string>` - A description of the token
@@ -79,9 +73,15 @@ guide.
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/acl/translate-rules.mdx
+++ b/website/content/commands/acl/translate-rules.mdx
@@ -26,12 +26,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul acl translate-rules [options] TRANSLATE`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `TRANSLATE` - The rules to translate. If `-` is used, then
@@ -46,6 +40,12 @@ Usage: `consul acl translate-rules [options] TRANSLATE`
 - `-token-accessor` - Specifies that what the `TRANSLATE` argument
   holds is not a rule set but rather the token accessor ID of a
   legacy ACL token that holds the rule set.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ### Examples
 

--- a/website/content/commands/catalog/nodes.mdx
+++ b/website/content/commands/catalog/nodes.mdx
@@ -60,13 +60,7 @@ worker-02  d407a592-e93c-4d8e-8a6d-aba853d1e067  10.4.4.158  dc1  lan=10.4.4.158
 
 Usage: `consul catalog nodes [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Catalog List Nodes Options
+#### Command Options
 
 - `-detailed` - Output detailed information about the nodes including their
   addresses and metadata.
@@ -90,3 +84,9 @@ Usage: `consul catalog nodes [options]`
 #### Enterprise Options
 
 @include 'http_api_partition_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/catalog/services.mdx
+++ b/website/content/commands/catalog/services.mdx
@@ -53,19 +53,7 @@ redis
 
 Usage: `consul catalog services [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### Catalog List Nodes Options
+#### Command Options
 
 - `-node=<id or name>` - Node `id or name` for which to list services.
 
@@ -76,3 +64,15 @@ Usage: `consul catalog services [options]`
 
 - `-tags` - Display each service's tags as a comma-separated list beside each
   service entry.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/config/delete.mdx
+++ b/website/content/commands/config/delete.mdx
@@ -38,17 +38,7 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul config delete [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### Config Delete Options
+#### Command Options
 
 - `-kind` - Specifies the kind of the config entry to read.
 
@@ -63,6 +53,16 @@ Usage: `consul config delete [options]`
 
 - `-modify-index=<int>` - Unsigned integer representing the ModifyIndex of the
   config entry. This is used in combination with the -cas flag.
+
+#### Enterprise Options
+
+@include 'http_api_namespace_options.mdx'
+
+@include 'http_api_partition_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/config/list.mdx
+++ b/website/content/commands/config/list.mdx
@@ -38,19 +38,19 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul config list [options]`
 
-#### API Options
+#### Command Options
 
-@include 'http_api_options_client.mdx'
+- `-kind` - Specifies the kind of the config entry to list.
 
 #### Enterprise Options
 
-@include 'http_api_namespace_options.mdx'
-
 @include 'http_api_partition_options.mdx'
 
-#### Config List Options
+@include 'http_api_namespace_options.mdx'
 
-- `-kind` - Specifies the kind of the config entry to list.
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/config/read.mdx
+++ b/website/content/commands/config/read.mdx
@@ -39,16 +39,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul config read [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
 #### Config Read Options
 
 - `-kind` - Specifies the kind of the config entry to read.
@@ -56,6 +46,16 @@ Usage: `consul config read [options]`
 - `-name` - Specifies the name of the config entry to read. The name of the
   `proxy-defaults` config entry must be `global`, and the name of the `mesh`
   config entry must be `mesh`.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/config/write.mdx
+++ b/website/content/commands/config/write.mdx
@@ -41,22 +41,22 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul config write [options] FILE`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### Config Write Options
+#### Command Options
 
 - `-cas` - Specifies to use a Check-And-Set operation. If the index is
   0, Consul will only store the entry if it does not already exist. If the index is
   non-zero, the entry is only set if the current index matches the `ModifyIndex`
   of that entry.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/connect/ca.mdx
+++ b/website/content/commands/connect/ca.mdx
@@ -89,11 +89,13 @@ Usage: `consul connect ca set-config [options]`
 
 Corresponding HTTP API Endpoint: [\[PUT\] /v1/connect/ca/configuration](/api-docs/connect/ca#update-ca-configuration)
 
-#### API Options
+The output looks like this:
 
-@include 'http_api_options_client.mdx'
+```
+Configuration updated!
+```
 
-@include 'http_api_options_server.mdx'
+The return code will indicate success or failure.
 
 #### Command Options
 
@@ -108,10 +110,8 @@ Corresponding HTTP API Endpoint: [\[PUT\] /v1/connect/ca/configuration](/api-doc
   Cross-Signing](/docs/connect/ca#forced-rotation-without-cross-signing)
   for more detail.
 
-The output looks like this:
+#### API Options
 
-```
-Configuration updated!
-```
+@include 'http_api_options_client.mdx'
 
-The return code will indicate success or failure.
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/connect/envoy.mdx
+++ b/website/content/commands/connect/envoy.mdx
@@ -30,26 +30,6 @@ build on but then used in a virtualized environment that can run Envoy.
 
 Usage: `consul connect envoy [options] [-- pass-through options]`
 
-#### API Options
-
-The standard API options are used to connect to the local agent to discover the
-proxy configuration needed.
-
-- `-grpc-addr=<addr>` - Address of the Consul agent with `grpc` port. This can
-  be an IP address or DNS address, but it must include the port. This can also
-  be specified via the CONSUL_GRPC_ADDR environment variable. In Consul 1.3 and
-  later, the default value is 127.0.0.1:8502, and https can optionally
-  be used instead. The scheme can also be set to HTTPS by setting the
-  environment variable CONSUL_HTTP_SSL=true. This may be a unix domain socket
-  using `unix:///path/to/socket` if the [agent is configured to
-  listen](/docs/agent/config/config-files#addresses) that way.
-
-  -> **Note:** gRPC uses the same TLS
-  settings as the HTTPS API. If HTTPS is enabled then gRPC will require HTTPS
-  as well.
-
-  @include 'http_api_options_client.mdx'
-
 #### Envoy Options for both Sidecars and Gateways
 
 - `-proxy-id` - The [proxy service](/docs/connect/registration/service-registration) ID.
@@ -189,9 +169,29 @@ proxy configuration needed.
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+The standard API options are used to connect to the local agent to discover the
+proxy configuration needed.
+
+- `-grpc-addr=<addr>` - Address of the Consul agent with `grpc` port. This can
+  be an IP address or DNS address, but it must include the port. This can also
+  be specified via the CONSUL_GRPC_ADDR environment variable. In Consul 1.3 and
+  later, the default value is 127.0.0.1:8502, and https can optionally
+  be used instead. The scheme can also be set to HTTPS by setting the
+  environment variable CONSUL_HTTP_SSL=true. This may be a unix domain socket
+  using `unix:///path/to/socket` if the [agent is configured to
+  listen](/docs/agent/config/config-files#addresses) that way.
+
+  -> **Note:** gRPC uses the same TLS
+  settings as the HTTPS API. If HTTPS is enabled then gRPC will require HTTPS
+  as well.
+
+  @include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/connect/expose.mdx
+++ b/website/content/commands/connect/expose.mdx
@@ -24,13 +24,7 @@ Usage: consul connect expose [options]
   given protocol and port.
 ```
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Expose Options
+#### Command Options
 
 - `-ingress-gateway` - (Required) The name of the ingress gateway service to use.
   A partition and namespace can optionally be specified as a prefix via the
@@ -49,6 +43,12 @@ Usage: consul connect expose [options]
 
 - `-host` - Additional DNS hostname to use for routing to this service. Can be
   specified multiple times.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/connect/proxy.mdx
+++ b/website/content/commands/connect/proxy.mdx
@@ -19,13 +19,7 @@ can also be used in development to connect to Connect-enabled services.
 
 Usage: `consul connect proxy [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Proxy Options
+#### Command Options
 
 - `-sidecar-for` - The _ID_ (not name if they differ) of the service instance
   this proxy will represent. The target service doesn't need to exist on the
@@ -75,6 +69,12 @@ Usage: `consul connect proxy [options]`
   to use [`consul services register`](/commands/services/register) to
   register a fully configured proxy instance rather than specify config and
   registration via this command.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/connect/redirect-traffic.mdx
+++ b/website/content/commands/connect/redirect-traffic.mdx
@@ -30,11 +30,7 @@ inbound and outbound ports specified in the service registration.
 
 Usage: `consul connect redirect-traffic [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Options for Traffic Redirection Rules
+#### Command Options
 
 - `-consul-dns-ip` - The IP address of the Consul DNS resolver. If provided, DNS queries will be redirected to the provided IP address for name resolution.
 
@@ -60,9 +56,13 @@ Usage: `consul connect redirect-traffic [options]`
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/debug.mdx
+++ b/website/content/commands/debug.mdx
@@ -45,10 +45,6 @@ or otherwise.
 By default, the debug command will capture an archive at the current path for
 all targets for 2 minutes.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Command Options
 
 - `-duration` - Optional, the total time to capture data for from the target agent. Must
@@ -65,6 +61,10 @@ all targets for 2 minutes.
 
 - `-archive` - Optional, if the tool show archive the directory of data into a
   compressed tar file. Defaults to true.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Capture Targets
 

--- a/website/content/commands/event.mdx
+++ b/website/content/commands/event.mdx
@@ -52,12 +52,6 @@ Usage: `consul event [options] [payload]`
 The only required option is `-name` which specifies the event name. An optional
 payload can be provided as the final argument.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-name` - The name of the event.
@@ -69,3 +63,9 @@ payload can be provided as the final argument.
 - `-tag` - Regular expression to filter to only nodes with a service that has
   a matching tag. This must be used with `-service`. As an example, you may
   do `-service mysql -tag secondary`.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/exec.mdx
+++ b/website/content/commands/exec.mdx
@@ -50,12 +50,6 @@ The only required option is a command to execute. This is either given
 as trailing arguments, or by specifying `-`; STDIN will be read to
 completion as a script to evaluate.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-prefix` - Key prefix in the KV store to use for storing request data.
@@ -81,3 +75,9 @@ completion as a script to evaluate.
   to 200 msec.
 
 - `-verbose` - Enables verbose output.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/intention/check.mdx
+++ b/website/content/commands/intention/check.mdx
@@ -46,15 +46,15 @@ Usage: `consul intention check [options] SRC DST`
 
 `SRC` and `DST` can both take [several forms](/commands/intention#source-and-destination-naming).
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
 
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/intention/create.mdx
+++ b/website/content/commands/intention/create.mdx
@@ -41,17 +41,7 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 `SRC` and `DST` can both take [several forms](/commands/intention#source-and-destination-naming).
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### Intention Create Options
+#### Command Options
 
 - `-allow` - Set the action to "allow" for intentions. This is the default.
 
@@ -66,6 +56,16 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 - `-replace` - Replace any matching intention. The replacement is done
   atomically per intention.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/intention/delete.mdx
+++ b/website/content/commands/intention/delete.mdx
@@ -42,15 +42,15 @@ Usage:
 
 `SRC` and `DST` can both take [several forms](/commands/intention#source-and-destination-naming).
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
 
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/intention/get.mdx
+++ b/website/content/commands/intention/get.mdx
@@ -42,15 +42,15 @@ Usage:
 
 `SRC` and `DST` can both take [several forms](/commands/intention#source-and-destination-naming).
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
 
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/intention/list.mdx
+++ b/website/content/commands/intention/list.mdx
@@ -34,13 +34,13 @@ Usage:
 
 - `consul intention list`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Enterprise Options
 
 @include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/intention/match.mdx
+++ b/website/content/commands/intention/match.mdx
@@ -39,21 +39,21 @@ Usage: `consul intention match [options] SRC_OR_DST`
 
 `SRC` and `DST` can both take [several forms](/commands/intention#source-and-destination-naming).
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### Intention Match Options
+#### Command Options
 
 - `-destination` - Match by destination.
 
 - `-source` - Match by source.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/join.mdx
+++ b/website/content/commands/join.mdx
@@ -38,12 +38,12 @@ You may call `join` with multiple addresses if you want attempt to join the clus
 through multiple nodes. Consul will attempt to join all addresses. The join
 command will fail only if Consul was unable to join any of the specified addresses.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Command Options
 
 - `-wan` - For agents running in server mode, the agent will attempt to join
   other servers gossiping in a WAN cluster. This is used to form a bridge between
   multiple datacenters.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'

--- a/website/content/commands/keyring.mdx
+++ b/website/content/commands/keyring.mdx
@@ -49,10 +49,6 @@ Usage: `consul keyring [options]`
 Only one actionable argument may be specified per run, including `-list`,
 `-install`, `-remove`, and `-use`.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Command Options
 
 - `-list` - List all keys currently in use within the cluster.
@@ -75,6 +71,10 @@ Only one actionable argument may be specified per run, including `-list`,
 - `-local-only` - Setting this to true will force a keyring list query to only hit
   local servers (no WAN traffic). Setting `local-only` is only allowed for list
   queries.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Output
 

--- a/website/content/commands/kv/delete.mdx
+++ b/website/content/commands/kv/delete.mdx
@@ -24,28 +24,29 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul kv delete [options] KEY_OR_PREFIX`
 
+#### Command Options
+
+- `-cas` - Perform a Check-And-Set operation.
+  To use this option, the `-modify-index` flag must also be set.
+  The default value is `false`.
+
+- `-modify-index=<int>` - Specifies an unsigned integer that represents
+  the `ModifyIndex` of the key. Used in combination with the `-cas` flag.
+
+- `-recurse` - Recursively delete all keys with the path. The default value is
+  `false`.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
 #### API Options
 
 @include 'http_api_options_client.mdx'
 
 @include 'http_api_options_server.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### KV Delete Options
-
-- `-cas` - Perform a Check-And-Set operation. Specifying this value also
-  requires the -modify-index flag to be set. The default value is false.
-
-- `-modify-index=<int>` - Unsigned integer representing the ModifyIndex of the
-  key. This is used in combination with the -cas flag.
-
-- `-recurse` - Recursively delete all keys with the path. The default value is
-  false.
 
 ## Examples
 

--- a/website/content/commands/kv/export.mdx
+++ b/website/content/commands/kv/export.mdx
@@ -24,17 +24,17 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul kv export [options] [PREFIX]`
 
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
 #### API Options
 
 @include 'http_api_options_client.mdx'
 
 @include 'http_api_options_server.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
 
 ## Examples
 

--- a/website/content/commands/kv/get.mdx
+++ b/website/content/commands/kv/get.mdx
@@ -32,19 +32,7 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul kv get [options] [KEY_OR_PREFIX]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### KV Get Options
+#### Command Options
 
 - `-base64` - Base 64 encode the value. The default value is false.
 
@@ -63,6 +51,18 @@ Usage: `consul kv get [options] [KEY_OR_PREFIX]`
 - `-separator=<string>` - String to use as a separator for recursive lookups. The
   default value is "/", and only used when paired with the `-keys` flag. This will
   limit the prefix of keys returned, only up to the given separator.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/kv/import.mdx
+++ b/website/content/commands/kv/import.mdx
@@ -22,22 +22,22 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul kv import [options] [DATA]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### KV Import Options
+#### Command Options
 
 - `-prefix` - Key prefix for imported data. The default value is empty meaning
   root. Added in Consul 1.10.
 
 #### Enterprise Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_namespace_options.mdx'
 
-@include 'http_api_partition_options.mdx'
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/kv/put.mdx
+++ b/website/content/commands/kv/put.mdx
@@ -28,19 +28,7 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul kv put [options] KEY [DATA]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### KV Put Options
+#### Command Options
 
 - `-acquire` - Obtain a lock on the key. If the key does not exist, this
   operation will create the key and obtain the lock. The session must already
@@ -66,6 +54,18 @@ Usage: `consul kv put [options] KEY [DATA]`
   This is commonly used with the -acquire and -release operations to build
   robust locking, but it can be set on any key. The default value is empty (no
   session).
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/license.mdx
+++ b/website/content/commands/license.mdx
@@ -138,12 +138,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul license put [options] LICENSE`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 The output looks like this:
 
 ```text
@@ -161,6 +155,12 @@ Licensed Features:
         Redundancy Zone
         Advanced Network Federation
 ```
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## get
 
@@ -178,12 +178,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul license get [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 The output looks like this:
 
 ```text
@@ -201,6 +195,12 @@ Licensed Features:
         Redundancy Zone
         Advanced Network Federation
 ```
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## reset
 
@@ -223,12 +223,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul license reset [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 The output looks like this:
 
 ```text
@@ -246,3 +240,9 @@ Licensed Features:
         Redundancy Zone
         Advanced Network Federation
 ```
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/lock.mdx
+++ b/website/content/commands/lock.mdx
@@ -46,12 +46,6 @@ of 5 seconds, a `SIGKILL` will be used to force termination. For Consul agents
 on Windows, the child process is always terminated with a `SIGKILL`, since
 Windows has no POSIX compatible notion for `SIGTERM`.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-child-exit-code` - Exit 2 if the child process exited with an error
@@ -81,6 +75,12 @@ Windows has no POSIX compatible notion for `SIGTERM`.
   are "ns", "us" (or "µs"), "ms", "s", "m", "h". The default value is 0.
 
 - `-verbose` - Enables verbose output.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## SHELL
 

--- a/website/content/commands/login.mdx
+++ b/website/content/commands/login.mdx
@@ -29,10 +29,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul login [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Command Options
 
 - `-bearer-token-file=<string>` - Path to a file containing a secret bearer
@@ -52,10 +48,14 @@ Usage: `consul login [options]`
 
 #### Enterprise Options
 
-@include 'http_api_namespace_options.mdx'
-
 - `-oidc-callback-listen-addr=<string>` - The address to bind a webserver on to
   handle the browser callback from the OIDC workflow. Added in Consul 1.8.0.
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ### Examples
 

--- a/website/content/commands/maint.mdx
+++ b/website/content/commands/maint.mdx
@@ -33,10 +33,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul maint [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Command Options
 
 - `-enable` - Enable node-wide maintenance mode flag. If combined with the
@@ -54,6 +50,10 @@ Usage: `consul maint [options]`
 - `-service` - An optional service ID to control maintenance mode for a given service. By
   providing this flag, the `-enable` and `-disable` flags functionality is
   modified to operate on the given service ID.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## List mode
 

--- a/website/content/commands/members.mdx
+++ b/website/content/commands/members.mdx
@@ -33,14 +33,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul members [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_partition_options.mdx'
-
 #### Command Options
 
 - `-detailed` - If provided, output shows more detailed information
@@ -55,3 +47,11 @@ Usage: `consul members [options]`
 - `-wan` - For agents in Server mode, this will return the list of nodes
   in the WAN gossip pool. These are generally all the server nodes in
   each datacenter.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'

--- a/website/content/commands/monitor.mdx
+++ b/website/content/commands/monitor.mdx
@@ -23,10 +23,6 @@ logs and watch the debug logs if necessary.
 
 Usage: `consul monitor [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
 #### Command Options
 
 - `-log-level` - The log level of the messages to show. By default this
@@ -35,3 +31,7 @@ Usage: `consul monitor [options]`
   "warn", and "error".
 - `-log-json` - Toggles whether the messages are streamed in JSON format.
   By default this is false.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'

--- a/website/content/commands/namespace/create.mdx
+++ b/website/content/commands/namespace/create.mdx
@@ -29,14 +29,6 @@ Usage: `consul namespace create -name <namespace name> [options]`
 Request a namespace to be created. Construction of the namespace definition is handled by this command
 from the CLI arguments.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-@include 'http_api_partition_options.mdx'
-
 #### Command Options
 
 - `-default-policy-id=<value>` - ID of a policy from the default namespace to inject for all tokens
@@ -64,6 +56,14 @@ from the CLI arguments.
 
 - `-show-meta` - Indicates that namespace metadata such as the raft indices should
   be shown for the namespace
+
+#### API Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/namespace/delete.mdx
+++ b/website/content/commands/namespace/delete.mdx
@@ -28,11 +28,11 @@ Usage: `consul namespace delete <name>`
 
 #### API Options
 
+@include 'http_api_partition_options.mdx'
+
 @include 'http_api_options_client.mdx'
 
 @include 'http_api_options_server.mdx'
-
-@include 'http_api_partition_options.mdx'
 
 ## Examples
 

--- a/website/content/commands/namespace/list.mdx
+++ b/website/content/commands/namespace/list.mdx
@@ -31,20 +31,20 @@ the request has been granted any access in the namespace (read, list or write).
 
 Usage: `consul namespace list`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-@include 'http_api_partition_options.mdx'
-
 #### Command Options
 
 - `-format=<string>` - How to output the results. The choices are: pretty or json
 
 - `-meta` - Indicates that namespace metadata such as the raft indices should be
   shown for the namespace
+
+#### API Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/namespace/read.mdx
+++ b/website/content/commands/namespace/read.mdx
@@ -30,20 +30,20 @@ the request has been granted any access in the namespace (read, list or write).
 
 Usage: `consul namespace read <name>`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-@include 'http_api_partition_options.mdx'
-
 #### Command Options
 
 - `-format=<string>` - How to output the results. The choices are: pretty or json
 
 - `-meta` - Indicates that namespace metadata such as the raft indices should be
   shown for the namespace
+
+#### API Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/namespace/update.mdx
+++ b/website/content/commands/namespace/update.mdx
@@ -30,14 +30,6 @@ Request a namespace to be update. Construction of the namespace definition is ha
 from the CLI arguments. Some parts of the Namespace such as ACL configurations and meta can be merged
 with the existing namespace definition.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-@include 'http_api_partition_options.mdx'
-
 #### Command Options
 
 - `-default-policy-id=<value>` - ID of a policy from the default namespace to inject for all tokens
@@ -71,6 +63,14 @@ with the existing namespace definition.
 
 - `-show-meta` - Indicates that namespace metadata such as the raft indices should
   be shown for the namespace
+
+#### API Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/namespace/write.mdx
+++ b/website/content/commands/namespace/write.mdx
@@ -29,20 +29,20 @@ The `<namespace definition>` must either be a file path or `-` to indicate that
 the definition should be read from stdin. The definition can be in either JSON
 or HCL format. See [here](/docs/enterprise/namespaces#namespace-definition) for a description of the namespace definition.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-@include 'http_api_partition_options.mdx'
-
 #### Command Options
 
 - `-format=<string>` - How to output the results. The choices are: pretty or json
 
 - `-meta` - Indicates that namespace metadata such as the raft indices should be
   shown for the namespace
+
+#### API Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## Examples
 

--- a/website/content/commands/operator/area.mdx
+++ b/website/content/commands/operator/area.mdx
@@ -61,11 +61,13 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul operator area create [options]`
 
-#### API Options
+The following example output shows the ID of the newly-created network area:
 
-@include 'http_api_options_client.mdx'
+```text
+Created area "d2872ec5-68ea-b862-b75d-0bee99aca100" with peer datacenter "other"!
+```
 
-@include 'http_api_options_server.mdx'
+The return code indicates success or failure.
 
 #### Command Options
 
@@ -79,13 +81,11 @@ Usage: `consul operator area create [options]`
 - `-use-tls=<value>` Specifies whether gossip over this area should be encrypted with
   TLS if possible. Must be either `true` or `false`.
 
-The output looks like this, displaying the ID of the newly-created network area:
+#### API Options
 
-```text
-Created area "d2872ec5-68ea-b862-b75d-0bee99aca100" with peer datacenter "other"!
-```
+@include 'http_api_options_client.mdx'
 
-The return code will indicate success or failure.
+@include 'http_api_options_server.mdx'
 
 ## delete
 
@@ -103,27 +103,27 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul operator area delete [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Command Options
-
-- `-id=<value>` - Looks up the area to operate on by its ID. This can be given
-  instead of a peer datacenter.
-
-- `-peer-datacenter=<value>` - Looks up the area to operate on by its peer
-  datacenter. This can be given instead of an ID.
-
 The output looks like this:
 
 ```text
 Deleted area "154941b0-80e2-9d69-c560-ab2c02807332"!
 ```
 
-The return code will indicate success or failure.
+The return code indicates success or failure.
+
+#### Command Options
+
+- `-id=<value>` - Specifies the ID of a network area to operate on.
+  Use this option as an alternative to `-peer-datacenter`.
+
+- `-peer-datacenter=<value>` - Specifies the peer datacenter of a network area to operate on.
+  Use this option as an alternative to `-id`.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## join
 
@@ -142,20 +142,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul operator area join [options] ADDRESSES`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Command Options
-
-- `-id=<value>` - Looks up the area to operate on by its ID. This can be given
-  instead of a peer datacenter.
-
-- `-peer-datacenter=<value>` - Looks up the area to operate on by its peer
-  datacenter. This can be given instead of an ID.
-
 The output looks like this:
 
 ```text
@@ -168,7 +154,21 @@ Address   Joined  Error
 The `Error` field will have a human-readable error message if Consul was unable
 to join the given address.
 
-The return code will indicate success or failure.
+The return code indicates success or failure.
+
+#### Command Options
+
+- `-id=<value>` - Specifies the ID of a network area to operate on.
+  Use this option as an alternative to `-peer-datacenter`.
+
+- `-peer-datacenter=<value>` - Specifies the peer datacenter of a network area to operate on.
+  Use this option as an alternative to `-id`.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## list
 
@@ -186,12 +186,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul operator area list [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 The output looks like this:
 
 ```text
@@ -206,7 +200,13 @@ Area                                  PeerDC  RetryJoin
 
 `RetryJoin` is the list of servers to join, defined when the area was created.
 
-The return code will indicate success or failure.
+The return code indicates success or failure.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## members
 
@@ -224,20 +224,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 | `operator:read` |
 
 Usage: `consul operator area members [options]`
-
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Command Options
-
-- `-id=<value>` - Looks up the area to operate on by its ID. This can be given
-  instead of a peer datacenter.
-
-- `-peer-datacenter=<value>` - Looks up the area to operate on by its peer
-  datacenter. This can be given instead of an ID.
 
 The output looks like this:
 
@@ -271,7 +257,21 @@ spoken by the node.
 to the given server, in a human-readable format. This is computed using
 [network coordinates](/docs/architecture/coordinates).
 
-The return code will indicate success or failure.
+The return code indicates success or failure.
+
+#### Command Options
+
+- `-id=<value>` - Specifies the ID of a network area to operate on.
+  Use this option as an alternative to `-peer-datacenter`.
+
+- `-peer-datacenter=<value>` - Specifies the peer datacenter of a network area to operate on.
+  Use this option as an alternative to `-id`.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## update
 
@@ -289,28 +289,27 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul operator area update [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-#### Command Options
-
-- `-id=<value>` - Looks up the area to operate on by its ID. This can be given
-  instead of a peer datacenter.
-
-- `-peer-datacenter=<value>` - Declares the peer Consul datacenter that will make up the other
-  side of this network area. Network areas always involve a pair of datacenters: the datacenter
-  where the area was created, and the peer datacenter. This is required.
-
-- `-use-tls=<value>` Specifies whether gossip over this area should be encrypted with
-  TLS if possible. Must be either `true` or `false`.
-
 The output looks like this:
 
 ```text
 Updated area "d2872ec5-68ea-b862-b75d-0bee99aca100"
 ```
 
-The return code will indicate success or failure.
+The return code indicates success or failure.
+
+#### Command Options
+
+- `-id=<value>` - Specifies the ID of a network area to operate on.
+  Use this option as an alternative to `-peer-datacenter`.
+
+- `-peer-datacenter=<value>` - Specifies the peer datacenter of a network area to operate on.
+  Use this option as an alternative to `-id`.
+
+- `-use-tls=<value>` Specifies whether gossip over this area should be encrypted with
+  TLS if possible. Must be either `true` or `false`.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'

--- a/website/content/commands/operator/autopilot.mdx
+++ b/website/content/commands/operator/autopilot.mdx
@@ -42,13 +42,7 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul operator autopilot get-config [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
-### Command Output
+#### Sample Output
 
 ```sh
 $ consul operator autopilot get-config
@@ -60,6 +54,12 @@ RedundancyZoneTag = ""
 DisableUpgradeMigration = false
 UpgradeMigrationTag = ""
 ```
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'
 
 ## set-config
 
@@ -77,11 +77,14 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul operator autopilot set-config [options]`
 
-#### API Options
+#### Sample Output
 
-@include 'http_api_options_client.mdx'
+```sh
+$ consul operator autopilot set-config -min-quorum=3
+Configuration updated!
+```
 
-@include 'http_api_options_server.mdx'
+The return code indicates success or failure.
 
 #### Command Options
 
@@ -110,14 +113,11 @@ Usage: `consul operator autopilot set-config [options]`
 - `-upgrade-version-tag` <EnterpriseAlert inline /> - Controls the [`-node-meta`](/docs/agent/config/cli-flags#_node_meta)
   tag to use for version info when performing upgrade migrations. If left blank, the Consul version will be used.
 
-### Command Output
+#### API Options
 
-```sh
-$ consul operator autopilot set-config -min-quorum=3
-Configuration updated!
-```
+@include 'http_api_options_client.mdx'
 
-The return code will indicate success or failure.
+@include 'http_api_options_server.mdx'
 
 ## state
 

--- a/website/content/commands/operator/raft.mdx
+++ b/website/content/commands/operator/raft.mdx
@@ -43,10 +43,6 @@ are not supported from commands, but may be from the corresponding HTTP endpoint
 
 Usage: `consul operator raft list-peers -stale=[true|false]`
 
-- `-stale` - Optional and defaults to "false" which means the leader provides
-  the result. If the cluster is in an outage state without a leader, you may need
-  to set this to "true" to get the configuration from a non-leader server.
-
 The output looks like this:
 
 ```text
@@ -69,6 +65,13 @@ Raft configuration.
 
 `Voter` is "true" or "false", indicating if the server has a vote in the Raft
 configuration.
+
+#### Command Options
+
+- `-stale` - Enables non-leader servers to provide cluster state information.
+  If the cluster is in an outage state without a leader,
+  we recommend setting this option to `true.
+  Default is `false`.
 
 ## remove-peer
 

--- a/website/content/commands/rtt.mdx
+++ b/website/content/commands/rtt.mdx
@@ -37,9 +37,21 @@ At least one node name is required. If the second node name isn't given, it
 is set to the agent's node name. These are the node names as known to
 Consul as the `consul members` command would show, not IP addresses.
 
-#### API Options
+## Sample Output
 
-@include 'http_api_options_client.mdx'
+If coordinates are available, the command will print the estimated round trip
+time between the given nodes:
+
+```shell-session
+$ consul rtt n1 n2
+Estimated n1 <-> n2 rtt: 0.610 ms (using LAN coordinates)
+
+$ consul rtt n2 # Running from n1
+Estimated n1 <-> n2 rtt: 0.610 ms (using LAN coordinates)
+
+$ consul rtt -wan n1.dc1 n2.dc2
+Estimated n1.dc1 <-> n2.dc2 rtt: 1.275 ms (using WAN coordinates)
+```
 
 #### Command Options
 
@@ -55,18 +67,6 @@ The following environment variables control accessing the HTTP server via SSL:
 - `CONSUL_HTTP_SSL` Set this to enable SSL
 - `CONSUL_HTTP_SSL_VERIFY` Set this to disable certificate checking (not recommended)
 
-## Output
+#### API Options
 
-If coordinates are available, the command will print the estimated round trip
-time between the given nodes:
-
-```shell-session
-$ consul rtt n1 n2
-Estimated n1 <-> n2 rtt: 0.610 ms (using LAN coordinates)
-
-$ consul rtt n2 # Running from n1
-Estimated n1 <-> n2 rtt: 0.610 ms (using LAN coordinates)
-
-$ consul rtt -wan n1.dc1 n2.dc2
-Estimated n1.dc1 <-> n2.dc2 rtt: 1.275 ms (using WAN coordinates)
-```
+@include 'http_api_options_client.mdx'

--- a/website/content/commands/services/deregister.mdx
+++ b/website/content/commands/services/deregister.mdx
@@ -38,23 +38,20 @@ in HCL or JSON format.
 This flexibility makes it easy to pair the command with the
 `services register` command since the argument syntax is the same.
 
-#### API Options
+#### Command Options
 
-@include 'http_api_options_client.mdx'
+- `-id` - Specifies the ID of a service instance to deregister.
+  Do not use this flag if any FILE arguments are given.
 
 #### Enterprise Options
 
-@include 'http_api_namespace_options.mdx'
-
 @include 'http_api_partition_options.mdx'
 
-#### Service Deregistration Flags
+@include 'http_api_namespace_options.mdx'
 
-The flags below should only be set if _no arguments_ are given. If no
-arguments are given, the flags below can be used to deregister a single
-service.
+#### API Options
 
-- `-id` - The ID of the service.
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/services/register.mdx
+++ b/website/content/commands/services/register.mdx
@@ -57,17 +57,7 @@ restarts.
 services in the local state directory. If this state directory is deleted
 or lost, services registered with this command will need to be reregistered.
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Enterprise Options
-
-@include 'http_api_namespace_options.mdx'
-
-@include 'http_api_partition_options.mdx'
-
-#### Service Registration Flags
+#### Command Options
 
 The flags below should only be set if _no arguments_ are given. If no
 arguments are given, the flags below can be used to register a single
@@ -93,6 +83,16 @@ Please refer to that documentation for full details.
 
 - `-tag value` - Associate a tag with the service instance. This flag can
   be specified multiples times.
+
+#### Enterprise Options
+
+@include 'http_api_partition_options.mdx'
+
+@include 'http_api_namespace_options.mdx'
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/snapshot/agent.mdx
+++ b/website/content/commands/snapshot/agent.mdx
@@ -118,11 +118,7 @@ snapshot agent is deployed across more than one host.
 
 Usage: `consul snapshot agent [options]`
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-#### Config File Options:
+#### Config File Options
 
 - `-config-dir` - Directory to look for JSON config files. Files will be read in
   alphabetical order and must end with the extension ".json". This won't
@@ -352,6 +348,10 @@ From Consul Enterprise version `1.6.1` onwards, you can store snapshots in Googl
 This integration needs the following information:
 
 - `-gcs-bucket` supplies the bucket to use.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
 
 ## Examples
 

--- a/website/content/commands/snapshot/inspect.mdx
+++ b/website/content/commands/snapshot/inspect.mdx
@@ -40,6 +40,23 @@ The following fields are displayed when inspecting a snapshot:
 
 Usage: `consul snapshot inspect [options] FILE`
 
+#### Command Options
+
+- `-kvdetails` - Provides information about space usage for KV data stored in Consul.
+
+- `-kvdepth` - Adjusts the grouping levels of keys.
+  Can only be used with `-kvdetails`.
+  Default is `2`.
+
+- `-kvfilter` - Only keys that match the specified key prefix
+  are included in the response.
+  Can only be used with `-kvdetails`.
+
+- `-format` - Specifies an output format for the response.
+  Specify `pretty` (default) to format the response in a human-readable form
+  as shown in the examples below,
+  or specify `JSON` to format the response as JSON.
+
 ## Examples
 
 To inspect a snapshot from the file "backup.snap":
@@ -137,10 +154,3 @@ $ consul snapshot inspect /opt/consul/raft/snapshots/9-4600669-1618935304715/sta
  ----                       ----         ----
  Total                                   4.3GB
 ```
-
-#### Command Options
-
-- `-kvdetails` - Optional, provides a space usage breakdown for any KV data stored in Consul.
-- `-kvdepth` - Can only be used with `-kvdetails`. Used to adjust the grouping level of keys. Defaults to 2.
-- `-kvfilter` - Can only be used with `-kvdetails`. Used to specify a key prefix that excludes keys that don't match.
-- `-format` - Optional, allows from changing the output to JSON. Parameters accepted are "pretty" and "JSON".

--- a/website/content/commands/tls/ca.mdx
+++ b/website/content/commands/tls/ca.mdx
@@ -23,7 +23,7 @@ $ consul tls ca create
 
 Usage: `consul tls ca create [filename-prefix] [options]`
 
-#### TLS CA Create Options
+#### Command Options
 
 - `-additional-name-constraint=<value>` - Add name constraints for the CA.
   Results in rejecting certificates for other DNS than specified. Can be used

--- a/website/content/commands/tls/cert.mdx
+++ b/website/content/commands/tls/cert.mdx
@@ -47,7 +47,7 @@ $ consul tls cert create -cli
 
 Usage: `consul tls cert create [filename-prefix] [options]`
 
-#### TLS Cert Create Options
+#### Command Options
 
 - `-additional-dnsname=<string>` - Provide an additional dnsname for Subject
   Alternative Names. localhost is always included. This flag may be provided

--- a/website/content/commands/version.mdx
+++ b/website/content/commands/version.mdx
@@ -16,7 +16,7 @@ The `version` command prints the version of Consul and the protocol versions it 
 
 Usage: `consul version [options]`
 
-### Command Options
+#### Command Options
 
 - `-format={pretty|json}` - Command output format. The default value is `pretty`.
 

--- a/website/content/commands/watch.mdx
+++ b/website/content/commands/watch.mdx
@@ -30,12 +30,6 @@ data view. Depending on the type, various options may be required
 or optionally provided. There is more documentation on watch
 [specifications here](/docs/dynamic-app-config/watches).
 
-#### API Options
-
-@include 'http_api_options_client.mdx'
-
-@include 'http_api_options_server.mdx'
-
 #### Command Options
 
 - `-key` - Key to watch. Only for `key` type.
@@ -58,3 +52,9 @@ or optionally provided. There is more documentation on watch
 
 - `-type` - Watch type. Required, one of "`key`, `keyprefix`, `services`,
   `nodes`, `service`, `checks`, or `event`.
+
+#### API Options
+
+@include 'http_api_options_client.mdx'
+
+@include 'http_api_options_server.mdx'


### PR DESCRIPTION
Applies the pattern agreed upon in #12903 to all other CLI commands