### PR TITLE
Fix some flaky tests

### DIFF
--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -1213,10 +1213,12 @@ func registerTestRoutingConfigTopologyEntries(t *testing.T, codec rpc.ClientCode
 func registerLocalAndRemoteServicesVIPEnabled(t *testing.T, state *state.Store) {
 	t.Helper()
 
-	_, entry, err := state.SystemMetadataGet(nil, structs.SystemMetadataVirtualIPsEnabled)
-	require.NoError(t, err)
-	require.NotNil(t, entry)
-	require.Equal(t, "true", entry.Value)
+	retry.Run(t, func(r *retry.R) {
+		_, entry, err := state.SystemMetadataGet(nil, structs.SystemMetadataVirtualIPsEnabled)
+		require.NoError(r, err)
+		require.NotNil(r, entry)
+		require.Equal(r, "true", entry.Value)
+	})
 
 	// Register a local connect-native service
 	require.NoError(t, state.EnsureRegistration(10, &structs.RegisterRequest{

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -2782,6 +2782,10 @@ func TestInternal_PeeredUpstreams(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
+	orig := virtualIPVersionCheckInterval
+	virtualIPVersionCheckInterval = 50 * time.Millisecond
+	t.Cleanup(func() { virtualIPVersionCheckInterval = orig })
+
 	t.Parallel()
 	_, s1 := testServerWithConfig(t)
 

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -36,7 +36,7 @@ func TestConnectCA_ConfigurationSet_ChangeKeyConfig_Primary(t *testing.T) {
 		keyBits int
 	}{
 		{connect.DefaultPrivateKeyType, connect.DefaultPrivateKeyBits},
-		{"ec", 256},
+		// {"ec", 256}, skip since values are same as Defaults
 		{"ec", 384},
 		{"rsa", 2048},
 		{"rsa", 4096},
@@ -55,7 +55,7 @@ func TestConnectCA_ConfigurationSet_ChangeKeyConfig_Primary(t *testing.T) {
 				providerState := map[string]string{"foo": "dc1-value"}
 
 				// Initialize primary as the primary DC
-				dir1, srv := testServerWithConfig(t, func(c *Config) {
+				_, srv := testServerWithConfig(t, func(c *Config) {
 					c.Datacenter = "dc1"
 					c.PrimaryDatacenter = "dc1"
 					c.Build = "1.6.0"
@@ -63,12 +63,9 @@ func TestConnectCA_ConfigurationSet_ChangeKeyConfig_Primary(t *testing.T) {
 					c.CAConfig.Config["PrivateKeyBits"] = src.keyBits
 					c.CAConfig.Config["test_state"] = providerState
 				})
-				defer os.RemoveAll(dir1)
-				defer srv.Shutdown()
 				codec := rpcClient(t, srv)
-				defer codec.Close()
 
-				testrpc.WaitForLeader(t, srv.RPC, "dc1")
+				waitForLeaderEstablishment(t, srv)
 				testrpc.WaitForActiveCARoot(t, srv.RPC, "dc1", nil)
 
 				var (

--- a/agent/consul/state/peering.go
+++ b/agent/consul/state/peering.go
@@ -353,7 +353,9 @@ func (s *Store) ExportedServicesForAllPeersByName(ws memdb.WatchSet, entMeta acl
 		}
 		m := list.ListAllDiscoveryChains()
 		if len(m) > 0 {
-			out[peering.Name] = maps.SliceOfKeys(m)
+			sns := maps.SliceOfKeys[structs.ServiceName, structs.ExportedDiscoveryChainInfo](m)
+			sort.Sort(structs.ServiceList(sns))
+			out[peering.Name] = sns
 		}
 	}
 

--- a/agent/proxycfg-glue/exported_peered_services_test.go
+++ b/agent/proxycfg-glue/exported_peered_services_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/proto/pbpeering"
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func TestServerExportedPeeredServices(t *testing.T) {
@@ -59,7 +60,7 @@ func TestServerExportedPeeredServices(t *testing.T) {
 	})
 	require.NoError(t, dataSource.Notify(ctx, &structs.DCSpecificRequest{}, "", eventCh))
 
-	t.Run("initial state", func(t *testing.T) {
+	testutil.RunStep(t, "initial state", func(t *testing.T) {
 		result := getEventResult[*structs.IndexedExportedServiceList](t, eventCh)
 		require.Equal(t,
 			map[string]structs.ServiceList{
@@ -69,7 +70,7 @@ func TestServerExportedPeeredServices(t *testing.T) {
 		)
 	})
 
-	t.Run("update exported services", func(t *testing.T) {
+	testutil.RunStep(t, "update exported services", func(t *testing.T) {
 		require.NoError(t, store.EnsureConfigEntry(nextIndex(), &structs.ExportedServicesConfigEntry{
 			Name: "default",
 			Services: []structs.ExportedService{

--- a/connect/proxy/config_test.go
+++ b/connect/proxy/config_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent"
@@ -143,23 +142,17 @@ func TestAgentConfigWatcherSidecarProxy(t *testing.T) {
 			},
 		},
 	}
-
 	require.Equal(t, expectCfg, cfg)
 
 	// Now keep watching and update the config.
-	go func() {
-		// Wait for watcher to be watching
-		time.Sleep(20 * time.Millisecond)
-		reg.Connect.SidecarService.Proxy.Upstreams = append(reg.Connect.SidecarService.Proxy.Upstreams,
-			api.Upstream{
-				DestinationName:  "cache",
-				LocalBindPort:    9292,
-				LocalBindAddress: "127.10.10.10",
-			})
-		reg.Connect.SidecarService.Proxy.Config["local_connect_timeout_ms"] = 444
-		err := agent.ServiceRegister(reg)
-		require.NoError(t, err)
-	}()
+	reg.Connect.SidecarService.Proxy.Upstreams = append(reg.Connect.SidecarService.Proxy.Upstreams,
+		api.Upstream{
+			DestinationName:  "cache",
+			LocalBindPort:    9292,
+			LocalBindAddress: "127.10.10.10",
+		})
+	reg.Connect.SidecarService.Proxy.Config["local_connect_timeout_ms"] = 444
+	require.NoError(t, agent.ServiceRegister(reg))
 
 	cfg = testGetConfigValTimeout(t, w, 2*time.Second)
 
@@ -173,7 +166,7 @@ func TestAgentConfigWatcherSidecarProxy(t *testing.T) {
 	})
 	expectCfg.PublicListener.LocalConnectTimeoutMs = 444
 
-	assert.Equal(t, expectCfg, cfg)
+	require.Equal(t, expectCfg, cfg)
 }
 
 func testGetConfigValTimeout(t *testing.T, w ConfigWatcher,


### PR DESCRIPTION
### Description

#### TestAgentConfigWatcherSidecarProxy
The watch is established in a background goroutine and the first assertion proves that the watcher is active so there is no reason for the update to happen in a racy goroutine.

Note that this does not completely remove the race condition as the first call to testGetConfigValTimeout could time out before a config is returned.

#### TestServerExportedPeeredServices
The ServiceName slice was being sourced from a non-deterministic `SliceOfKeys` function.
Updated code to sort the names deterministically so tests don't flake on the slice order.

#### TestInternal_PeeredUpstreams
Shortened the polling period for VIP metadata check and added retries (aligned with existing VIP tests)

#### TestConnectCA_ConfigurationSet_ChangeKeyConfig_Primary
This one is one of the top flaked tests but ONLY in arm64 environments. I haven't found the root cause but assuming the environment is low on resources, the 16 parallel tests spinning up servers and RPC polling probably doesn't help. Removed some redundant tests and switched from RPC polling to checking a server's own raft leadership status.

### Testing & Reproduction steps
* No added functionality; tests should pass as-is (at a higher success rate)

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
