### PR TITLE
Ensure connections are closed before WaitGroup marked as done

### DIFF
--- a/connect/proxy/listener.go
+++ b/connect/proxy/listener.go
@@ -166,9 +166,11 @@ func (l *Listener) Serve() error {
 
 // handleConn is the internal connection handler goroutine.
 func (l *Listener) handleConn(src net.Conn) {
-	defer src.Close()
-	// Make sure Listener.Close waits for this conn to be cleaned up.
-	defer l.connWG.Done()
+	defer func() {
+		// Make sure Listener.Close waits for this conn to be cleaned up.
+		src.Close()
+		l.connWG.Done()
+	}()
 
 	dst, err := l.dialFunc()
 	if err != nil {


### PR DESCRIPTION
The previous ordering of defers meant the listener's connWG could fire and wake up other goroutines before the connection closed. Unsure if this caused any real bugs but this commit should make the code more correct.

### Testing & Reproduction steps
* No behavioral change 

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
