### PR TITLE
ci: Add nightly test workflow for 1.13, remove 1.10

### DIFF
--- a/.github/workflows/nightly-test-1.13.x.yaml
+++ b/.github/workflows/nightly-test-1.13.x.yaml
@@ -1,4 +1,4 @@
-name: Nightly 1.10.x Test
+name: Nightly Test 1.13.x
 on:
   schedule:
     - cron: '0 4 * * *'
@@ -6,8 +6,8 @@ on:
 
 env:
   EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
-  BRANCH: "release/1.10.x"
-  BRANCH_NAME: "release-1.10.x" # Used for naming artifacts
+  BRANCH: "release/1.13.x"
+  BRANCH_NAME: "release/1.13.x" # Used for naming artifacts
 
 jobs:
   frontend-test-workspace-node:
@@ -27,7 +27,7 @@ jobs:
       - name: Install
         id: install
         working-directory: ./ui
-        run: yarn install
+        run: make deps
 
       - name: Workspace Tests
         id: workspace-test
@@ -59,7 +59,7 @@ jobs:
       - name: Install
         id: install
         working-directory: ./ui
-        run: yarn install
+        run: make deps
 
       - name: Ember Build OSS
         id: build-oss
@@ -98,7 +98,7 @@ jobs:
       - name: Install
         id: install
         working-directory: ./ui
-        run: yarn install
+        run: make deps
 
       - name: Download OSS Frontend
         uses: actions/download-artifact@v3
@@ -131,7 +131,7 @@ jobs:
       - name: Install
         id: install
         working-directory: ./ui
-        run: yarn install
+        run: make deps
 
       - name: Ember Build ENT
         id: build-oss
@@ -170,7 +170,7 @@ jobs:
       - name: Install
         id: install
         working-directory: ./ui
-        run: yarn install
+        run: make deps
 
       - name: Download ENT Frontend
         uses: actions/download-artifact@v3
@@ -201,7 +201,7 @@ jobs:
       - name: Install
         id: install
         working-directory: ./ui
-        run: yarn install
+        run: make deps
 
       - name: Download ENT Frontend
         uses: actions/download-artifact@v3


### PR DESCRIPTION
### Description
In preparation for creating a new release series for 1.13, this adds a new nightly job for testing against the new release branch. This needs to land on `main` vs the release branch, so I'll just plan to merge it around the time I create the release branch. It won't run until 4am UTC  which isn't for another 9 hours from the time I am creating this PR. Worst case is that it gets merged and ran before the release branch actually exists in which case, the job will just fail. We can still re-run it.

Signed-off-by: Evan Culver <eculver@hashicorp.com>
