### PR TITLE
Move sidecar port assignment logic to locked stage of add flow

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2095,6 +2095,18 @@ func (a *Agent) AddService(req AddServiceRequest) error {
 func (a *Agent) addServiceLocked(req addServiceLockedRequest) error {
 	req.Service.EnterpriseMeta.Normalize()
 
+	// Must auto-assign the port and default checks (if needed) here to avoid race collisions.
+	if req.Service.IsSidecarProxy() {
+		port, err := a.sidecarPortFromServiceIDLocked(req.Service.Port, req.Service.CompoundServiceID())
+		if err != nil {
+			return err
+		}
+		req.Service.Port = port
+		if len(req.chkTypes) < 1 {
+			req.chkTypes = sidecarDefaultChecks(req.Service.ID, req.Service.Proxy.LocalServiceAddress, port)
+		}
+	}
+
 	if err := a.validateService(req.Service, req.chkTypes); err != nil {
 		return err
 	}
@@ -3357,7 +3369,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig, snap map[structs.CheckI
 		}
 
 		// Grab and validate sidecar if there is one too
-		sidecar, sidecarChecks, sidecarToken, err := a.sidecarServiceFromNodeService(ns, service.Token)
+		sidecar, sidecarChecks, sidecarToken, err := sidecarServiceFromNodeService(ns, service.Token)
 		if err != nil {
 			return fmt.Errorf("Failed to validate sidecar for service %q: %v", service.Name, err)
 		}

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1123,9 +1123,9 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid Service Meta: %v", err)}
 	}
 
-	// Run validation. This is the same validation that would happen on
-	// the catalog endpoint so it helps ensure the sync will work properly.
-	if err := ns.Validate(); err != nil {
+	// Run validation. This same validation would happen on the catalog endpoint,
+	// so it helps ensure the sync will work properly.
+	if err := ns.ValidateForAgent(); err != nil {
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Validation failed: %v", err.Error())}
 	}
 
@@ -1164,7 +1164,7 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid SidecarService: %s", err)}
 	}
 	if sidecar != nil {
-		if err := sidecar.Validate(); err != nil {
+		if err := sidecar.ValidateForAgent(); err != nil {
 			return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Failed Validation: %v", err.Error())}
 		}
 		// Make sure we are allowed to register the sidecar using the token

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1159,7 +1159,7 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 	}
 
 	// See if we have a sidecar to register too
-	sidecar, sidecarChecks, sidecarToken, err := s.agent.sidecarServiceFromNodeService(ns, token)
+	sidecar, sidecarChecks, sidecarToken, err := sidecarServiceFromNodeService(ns, token)
 	if err != nil {
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid SidecarService: %s", err)}
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2786,7 +2786,7 @@ func TestAgent_DeregisterPersistedSidecarAfterRestart(t *testing.T) {
 		},
 	}
 
-	connectSrv, _, _, err := a.sidecarServiceFromNodeService(srv, "")
+	connectSrv, _, _, err := sidecarServiceFromNodeService(srv, "")
 	require.NoError(t, err)
 
 	// First persist the check

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -30,7 +30,7 @@ func sidecarServiceID(serviceID string) string {
 // registration. This will be the same as the token parameter passed unless the
 // SidecarService definition contains a distinct one.
 // TODO: return AddServiceRequest
-func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token string) (*structs.NodeService, []*structs.CheckType, string, error) {
+func sidecarServiceFromNodeService(ns *structs.NodeService, token string) (*structs.NodeService, []*structs.CheckType, string, error) {
 	if ns.Connect.SidecarService == nil {
 		return nil, nil, "", nil
 	}
@@ -114,9 +114,22 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 		}
 	}
 
+	// Setup checks
+	checks, err := ns.Connect.SidecarService.CheckTypes()
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return sidecar, checks, token, nil
+}
+
+// sidecarPortFromServiceID is used to allocate a unique port for a sidecar proxy.
+// This is called immediately before registration to avoid value collisions. This function assumes the state lock is already held.
+func (a *Agent) sidecarPortFromServiceIDLocked(sidecarPort int, sidecarCompoundServiceID structs.ServiceID) (int, error) {
+
 	// Allocate port if needed (min and max inclusive).
 	rangeLen := a.config.ConnectSidecarMaxPort - a.config.ConnectSidecarMinPort + 1
-	if sidecar.Port < 1 && a.config.ConnectSidecarMinPort > 0 && rangeLen > 0 {
+	if sidecarPort < 1 && a.config.ConnectSidecarMinPort > 0 && rangeLen > 0 {
 		// This did pick at random which was simpler but consul reload would assign
 		// new ports to all the sidecars since it unloads all state and
 		// re-populates. It also made this more difficult to test (have to pin the
@@ -130,11 +143,11 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 			// Check if other port is in auto-assign range
 			if otherNS.Port >= a.config.ConnectSidecarMinPort &&
 				otherNS.Port <= a.config.ConnectSidecarMaxPort {
-				if otherNS.CompoundServiceID() == sidecar.CompoundServiceID() {
+				if otherNS.CompoundServiceID() == sidecarCompoundServiceID {
 					// This sidecar is already registered with an auto-port and is just
 					// being updated so pick the same port as before rather than allocate
 					// a new one.
-					sidecar.Port = otherNS.Port
+					sidecarPort = otherNS.Port
 					break
 				}
 				usedPorts[otherNS.Port] = struct{}{}
@@ -147,54 +160,48 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 
 		// Check we still need to assign a port and didn't find we already had one
 		// allocated.
-		if sidecar.Port < 1 {
+		if sidecarPort < 1 {
 			// Iterate until we find lowest unused port
 			for p := a.config.ConnectSidecarMinPort; p <= a.config.ConnectSidecarMaxPort; p++ {
 				_, used := usedPorts[p]
 				if !used {
-					sidecar.Port = p
+					sidecarPort = p
 					break
 				}
 			}
 		}
 	}
 	// If no ports left (or auto ports disabled) fail
-	if sidecar.Port < 1 {
+	if sidecarPort < 1 {
 		// If ports are set to zero explicitly, config builder switches them to
 		// `-1`. In this case don't show the actual values since we don't know what
 		// was actually in config (zero or negative) and it might be confusing, we
 		// just know they explicitly disabled auto assignment.
 		if a.config.ConnectSidecarMinPort < 1 || a.config.ConnectSidecarMaxPort < 1 {
-			return nil, nil, "", fmt.Errorf("no port provided for sidecar_service " +
+			return 0, fmt.Errorf("no port provided for sidecar_service " +
 				"and auto-assignment disabled in config")
 		}
-		return nil, nil, "", fmt.Errorf("no port provided for sidecar_service and none "+
+		return 0, fmt.Errorf("no port provided for sidecar_service and none "+
 			"left in the configured range [%d, %d]", a.config.ConnectSidecarMinPort,
 			a.config.ConnectSidecarMaxPort)
 	}
 
-	// Setup checks
-	checks, err := ns.Connect.SidecarService.CheckTypes()
-	if err != nil {
-		return nil, nil, "", err
-	}
+	return sidecarPort, nil
+}
 
+func sidecarDefaultChecks(serviceID string, localServiceAddress string, port int) []*structs.CheckType {
 	// Setup default check if none given
-	if len(checks) < 1 {
-		checks = []*structs.CheckType{
-			{
-				Name: "Connect Sidecar Listening",
-				// Default to localhost rather than agent/service public IP. The checks
-				// can always be overridden if a non-loopback IP is needed.
-				TCP:      ipaddr.FormatAddressPort(sidecar.Proxy.LocalServiceAddress, sidecar.Port),
-				Interval: 10 * time.Second,
-			},
-			{
-				Name:         "Connect Sidecar Aliasing " + ns.ID,
-				AliasService: ns.ID,
-			},
-		}
+	return []*structs.CheckType{
+		{
+			Name: "Connect Sidecar Listening",
+			// Default to localhost rather than agent/service public IP. The checks
+			// can always be overridden if a non-loopback IP is needed.
+			TCP:      ipaddr.FormatAddressPort(localServiceAddress, port),
+			Interval: 10 * time.Second,
+		},
+		{
+			Name:         "Connect Sidecar Aliasing " + serviceID,
+			AliasService: serviceID,
+		},
 	}
-
-	return sidecar, checks, token, nil
 }

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -339,7 +339,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			}
 
 			ns := tt.sd.NodeService()
-			err := ns.Validate()
+			err := ns.ValidateForAgent()
 			require.NoError(t, err, "Invalid test case - NodeService must validate")
 
 			gotNS, gotChecks, gotToken, err := a.sidecarServiceFromNodeService(ns, tt.token)

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"github.com/hashicorp/consul/acl"
 	"testing"
 	"time"
 
@@ -16,16 +17,13 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		maxPort           int
-		preRegister       *structs.ServiceDefinition
-		sd                *structs.ServiceDefinition
-		token             string
-		autoPortsDisabled bool
-		wantNS            *structs.NodeService
-		wantChecks        []*structs.CheckType
-		wantToken         string
-		wantErr           string
+		name       string
+		sd         *structs.ServiceDefinition
+		token      string
+		wantNS     *structs.NodeService
+		wantChecks []*structs.CheckType
+		wantToken  string
+		wantErr    string
 	}{
 		{
 			name: "no sidecar",
@@ -55,24 +53,13 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 				Kind:                       structs.ServiceKindConnectProxy,
 				ID:                         "web1-sidecar-proxy",
 				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
+				Port:                       0,
 				LocallyRegisteredAsSidecar: true,
 				Proxy: structs.ConnectProxyConfig{
 					DestinationServiceName: "web",
 					DestinationServiceID:   "web1",
 					LocalServiceAddress:    "127.0.0.1",
 					LocalServicePort:       1111,
-				},
-			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "127.0.0.1:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
 				},
 			},
 			wantToken: "foo",
@@ -142,42 +129,6 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			wantToken: "custom-token",
 		},
 		{
-			name: "no auto ports available",
-			// register another sidecar consuming our 1 and only allocated auto port.
-			preRegister: &structs.ServiceDefinition{
-				Kind: structs.ServiceKindConnectProxy,
-				Name: "api-proxy-sidecar",
-				Port: 2222, // Consume the one available auto-port
-				Proxy: &structs.ConnectProxyConfig{
-					DestinationServiceName: "api",
-				},
-			},
-			sd: &structs.ServiceDefinition{
-				ID:   "web1",
-				Name: "web",
-				Port: 1111,
-				Connect: &structs.ServiceConnect{
-					SidecarService: &structs.ServiceDefinition{},
-				},
-			},
-			token:   "foo",
-			wantErr: "none left in the configured range [2222, 2222]",
-		},
-		{
-			name:              "auto ports disabled",
-			autoPortsDisabled: true,
-			sd: &structs.ServiceDefinition{
-				ID:   "web1",
-				Name: "web",
-				Port: 1111,
-				Connect: &structs.ServiceConnect{
-					SidecarService: &structs.ServiceDefinition{},
-				},
-			},
-			token:   "foo",
-			wantErr: "auto-assignment disabled in config",
-		},
-		{
 			name: "inherit tags and meta",
 			sd: &structs.ServiceDefinition{
 				ID:   "web1",
@@ -194,7 +145,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 				Kind:                       structs.ServiceKindConnectProxy,
 				ID:                         "web1-sidecar-proxy",
 				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
+				Port:                       0,
 				Tags:                       []string{"foo"},
 				Meta:                       map[string]string{"foo": "bar"},
 				LocallyRegisteredAsSidecar: true,
@@ -203,17 +154,6 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 					DestinationServiceID:   "web1",
 					LocalServiceAddress:    "127.0.0.1",
 					LocalServicePort:       1111,
-				},
-			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "127.0.0.1:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
 				},
 			},
 		},
@@ -252,6 +192,56 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			token:   "foo",
 			wantErr: "reserved for internal use",
 		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ns := tt.sd.NodeService()
+			err := ns.Validate()
+			require.NoError(t, err, "Invalid test case - NodeService must validate")
+
+			gotNS, gotChecks, gotToken, err := sidecarServiceFromNodeService(ns, tt.token)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantNS, gotNS)
+			require.Equal(t, tt.wantChecks, gotChecks)
+			require.Equal(t, tt.wantToken, gotToken)
+		})
+	}
+}
+
+func TestAgent_SidecarPortFromServiceIDLocked(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	tests := []struct {
+		name              string
+		autoPortsDisabled bool
+		enterpriseMeta    acl.EnterpriseMeta
+		maxPort           int
+		port              int
+		preRegister       *structs.ServiceDefinition
+		serviceID         string
+		wantPort          int
+		wantErr           string
+	}{
+		{
+			name:      "port pre-specified",
+			serviceID: "web1",
+			wantPort:  2222,
+		},
+		{
+			name:      "use auto ports",
+			serviceID: "web1",
+			port:      1111,
+			wantPort:  1111,
+		},
 		{
 			name: "re-registering same sidecar with no port should pick same one",
 			// Allow multiple ports to be sure we get the right one
@@ -269,42 +259,27 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 					LocalServicePort:       1111,
 				},
 			},
-			// Register same again but with different service port
-			sd: &structs.ServiceDefinition{
-				ID:   "web1",
-				Name: "web",
-				Port: 1112,
-				Connect: &structs.ServiceConnect{
-					SidecarService: &structs.ServiceDefinition{},
+			// Register same again
+			serviceID: "web1-sidecar-proxy",
+			wantPort:  2222, // Should claim the same port as before
+		},
+		{
+			name: "all auto ports already taken",
+			// register another sidecar consuming our 1 and only allocated auto port.
+			preRegister: &structs.ServiceDefinition{
+				Kind: structs.ServiceKindConnectProxy,
+				Name: "api-proxy-sidecar",
+				Port: 2222, // Consume the one available auto-port
+				Proxy: &structs.ConnectProxyConfig{
+					DestinationServiceName: "api",
 				},
 			},
-			token: "foo",
-			wantNS: &structs.NodeService{
-				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
-				Kind:                       structs.ServiceKindConnectProxy,
-				ID:                         "web1-sidecar-proxy",
-				Service:                    "web-sidecar-proxy",
-				Port:                       2222, // Should claim the same port as before
-				LocallyRegisteredAsSidecar: true,
-				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web1",
-					LocalServiceAddress:    "127.0.0.1",
-					LocalServicePort:       1112,
-				},
-			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "127.0.0.1:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
-				},
-			},
-			wantToken: "foo",
+			wantErr: "none left in the configured range [2222, 2222]",
+		},
+		{
+			name:              "auto ports disabled",
+			autoPortsDisabled: true,
+			wantErr:           "auto-assignment disabled in config",
 		},
 	}
 	for _, tt := range tests {
@@ -329,7 +304,6 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 				}
 				`
 			}
-
 			a := StartTestAgent(t, TestAgent{Name: "jones", HCL: hcl})
 			defer a.Shutdown()
 
@@ -338,11 +312,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			ns := tt.sd.NodeService()
-			err := ns.ValidateForAgent()
-			require.NoError(t, err, "Invalid test case - NodeService must validate")
-
-			gotNS, gotChecks, gotToken, err := a.sidecarServiceFromNodeService(ns, tt.token)
+			gotPort, err := a.sidecarPortFromServiceIDLocked(tt.port, structs.ServiceID{ID: tt.serviceID, EnterpriseMeta: tt.enterpriseMeta})
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.wantErr)
@@ -350,9 +320,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, tt.wantNS, gotNS)
-			require.Equal(t, tt.wantChecks, gotChecks)
-			require.Equal(t, tt.wantToken, gotToken)
+			require.Equal(t, tt.wantPort, gotPort)
 		})
 	}
 }

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1157,6 +1157,16 @@ func TestStructs_NodeService_ValidateConnectProxy(t *testing.T) {
 	}
 }
 
+func TestStructs_NodeService_ValidateConnectProxyWithAgentAutoAssign(t *testing.T) {
+	t.Run("connect-proxy: no port set", func(t *testing.T) {
+		ns := TestNodeServiceProxy(t)
+		ns.Port = 0
+
+		err := ns.ValidateForAgent()
+		assert.True(t, err == nil)
+	})
+}
+
 func TestStructs_NodeService_ValidateConnectProxy_In_Partition(t *testing.T) {
 	cases := []struct {
 		Name   string


### PR DESCRIPTION
This PR moved to main project here: https://github.com/hashicorp/consul/pull/14057

### Description
This relocates automatic sidecar port assignment logic to a locked method immediately before registration, thereby preventing collisions when handling simultaneous requests.

### Testing & Reproduction steps
Manual verification:
* Submit many simultaneous requests for registration with sidecar proxy and no port specified:
`for name in $(shuf -i 1-10000); do curl -d '{"name": "'$name'", "connect": {"sidecar_service": {}}}' -X PUT localhost:8500/v1/agent/service/register &; echo registered $name; done`
* See how many duplicate ports have been registered:
`curl localhost:8500/v1/agent/services | jq -r ' . | to_entries | map(select(.key | match("sidecar";"i"))) | map(.value) | .[] | .Port' | sort | uniq -d`
* Before this change: there should be several duplicate ports
* After this change: no duplicate ports

### Links
[GH Issue](https://github.com/hashicorp/consul/issues/8254)

### PR Checklist

* [ ] updated test coverage
* [N/A] external facing docs updated
* [N/A] not a security concern
