### PR TITLE
[sync] fix empty partitions matching

### DIFF
--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -346,7 +346,7 @@ func (s *Server) Establish(
 		return nil, err
 	}
 
-	if err := s.validatePeeringInPartition(tok.PeerID, entMeta.PartitionOrDefault()); err != nil {
+	if err := s.validatePeeringInPartition(tok.PeerID, entMeta.PartitionOrEmpty()); err != nil {
 		return nil, err
 	}
 
@@ -408,15 +408,8 @@ func (s *Server) validatePeeringInPartition(remotePeerID, partition string) erro
 		return fmt.Errorf("cannot read peering by ID: %w", err)
 	}
 
-	if peering != nil {
-		stateStorePart := peering.Partition
-		if stateStorePart == "" {
-			stateStorePart = "default"
-		}
-
-		if stateStorePart == partition {
-			return fmt.Errorf("cannot create a peering within the same partition (ENT) or cluster (OSS)")
-		}
+	if peering != nil && peering.GetPartition() == partition {
+		return fmt.Errorf("cannot create a peering within the same partition (ENT) or cluster (OSS)")
 	}
 
 	return nil

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -408,7 +408,7 @@ func (s *Server) validatePeeringInPartition(remotePeerID, partition string) erro
 		return fmt.Errorf("cannot read peering by ID: %w", err)
 	}
 
-	if peering != nil && peering.GetPartition() == partition {
+	if peering != nil && acl.EqualPartitions(peering.GetPartition(), partition) {
 		return fmt.Errorf("cannot create a peering within the same partition (ENT) or cluster (OSS)")
 	}
 


### PR DESCRIPTION
This was introduced in `ef7edd79c4515789f767c28c36b443da737a0837` in ENT.

Essentially, `peering` objects from the state store come up with an empty string partition `""`. This overrides that to be called `default`. Maybe there's a better struct / way to do this so please comment if so!