### PR TITLE
ci: Use correct branch name for 1.13 nightly test

### DIFF
--- a/.github/workflows/nightly-test-1.13.x.yaml
+++ b/.github/workflows/nightly-test-1.13.x.yaml
@@ -7,7 +7,7 @@ on:
 env:
   EMBER_PARTITION_TOTAL: 4      # Has to be changed in tandem with the matrix.partition
   BRANCH: "release/1.13.x"
-  BRANCH_NAME: "release/1.13.x" # Used for naming artifacts
+  BRANCH_NAME: "release-1.13.x" # Used for naming artifacts
 
 jobs:
   frontend-test-workspace-node:

--- a/.github/workflows/nightly-test-1.13.x.yaml
+++ b/.github/workflows/nightly-test-1.13.x.yaml
@@ -2,9 +2,6 @@ name: Nightly Test 1.13.x
 on:
   schedule:
     - cron: '0 4 * * *'
-  push:
-    branches:
-      - eculver/fix-nightly-test-1.13
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/nightly-test-1.13.x.yaml
+++ b/.github/workflows/nightly-test-1.13.x.yaml
@@ -2,6 +2,9 @@ name: Nightly Test 1.13.x
 on:
   schedule:
     - cron: '0 4 * * *'
+  push:
+    branches:
+      - eculver/fix-nightly-test-1.13
   workflow_dispatch: {}
 
 env:


### PR DESCRIPTION
### Description
I got the `BRANCH_NAME` wrong in the original addition of this new workflow for 1.13. Apparently, it can't contain a '/' since it's used in the `upload-artifact` action. 

### Testing & Reproduction steps
- I added a temporary branch trigger for my dev branch to ensure it runs as expected. I should have done this in the first place.

### Note for reviewers
This only needs to land on `main` since it's triggered on a cron and the workflow itself knows to checkout the appropriate branch. This means I don't need to backport it to any release branches.