### PR TITLE
Updates upgrade docs to clarify Nomad bug is fixed

### DIFF
--- a/website/content/docs/upgrading/upgrade-specific.mdx
+++ b/website/content/docs/upgrading/upgrade-specific.mdx
@@ -50,9 +50,11 @@ style `consul.api.http...` metrics and removing the configuration flag from your
 
 ### Nomad Namespace Incompatibility
 
-Nomad Enterprise users should not upgrade to Consul Enterprise 1.12.0.
+Nomad Enterprise users should not upgrade to Consul Enterprise 1.12.0, and instead should upgrade to 1.12.1 or later.
 
-Consul 1.12.0 Enterprise introduced a change that prevents Nomad Enterprise from removing services from non-default Consul namespaces. To avoid errors, we recommend that Nomad Enterprise users wait to update Consul Enterprise until we fix this issue in a future release.
+Consul 1.12.0 Enterprise introduced a change that prevents Nomad Enterprise from removing services from non-default Consul namespaces.
+
+The Consul Enterprise codebase was updated with a fix for this issue in version 1.12.1.
 
 ### TLS Configuration
 


### PR DESCRIPTION
### Description

We on the Nomad team have gotten questions about when it is safe to upgrade Consul when using Nomad Enterprise because of this line of docs.

I am updating the docs to clarify that this issue has been fixed in 1.12.1 and later.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
