### PR TITLE
add config parameters doc for destination in service-defaults

### DIFF
--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -236,9 +236,9 @@ spec:
 </Tab>
 </Tabs>
 
-### Terminating-gateway Destination
+### Terminating gateway destination
 
-Create a destination to be assigned as a service to a terminating gateway
+Create a default destination that will be assigned to a terminating gateway.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
@@ -669,18 +669,18 @@ Create a destination to be assigned as a service to a terminating gateway
     {
       name: 'Destination',
       type: 'DestinationConfig: <optional>',
-      description: `Controls configuration specific to proxies to destinations through terminating-gateway. Added in v1.13.0.`,
+      description: `Controls configuration specific to destinations through terminating-gateway. Added in v1.13.0.`,
       children: [
         {
           name: 'Addresses',
           type: 'array<string>: []',
-          description: `List of addresses associated with the destination. Could be a hostname or an IP`,
+          description: `List of addresses associated with the destination. This can be a hostname or an IP address.`,
           yaml: false,
         },
         {
           name: 'Port',
           type: 'int: 0',
-          description: `Port number associated with the destination`,
+          description: `Port number associated with the destination.`,
           yaml: false,
         },
       ]

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -257,7 +257,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
   apiVersion: consul.hashicorp.com/v1alpha1
   kind: ServiceDefaults
   metadata:
-    name: test-destination
+  name: test-destination
   spec:
     destination:
       addresses:

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -243,9 +243,9 @@ Create a default destination that will be assigned to a terminating gateway.
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
   ```hcl
-  kind = "service-defaults"
-  name = "test-destination"
-  protocol = "tcp"
+  Kind = "service-defaults"
+  Name = "test-destination"
+  Protocol = "tcp"
   Destination {
     Addresses = ["test.com","test.org"]
     Port = 443
@@ -256,12 +256,13 @@ Create a default destination that will be assigned to a terminating gateway.
   apiVersion: consul.hashicorp.com/v1alpha1
   kind: ServiceDefaults
   metadata:
-  name: test-destination
+    name: test-destination
   spec:
     destination:
-      Addresses: ["test.com","test.org"]
-      Port: 443
-  ```
+      addresses: 
+        - "test.com"
+        - "test.org"
+      port: 443
 
   ```json
   {

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -238,7 +238,8 @@ spec:
 
 ### Terminating gateway destination
 
-Create a default destination that will be assigned to a terminating gateway.
+Create a default destination that will be assigned to a terminating gateway. A destination
+represents a location outside the Consul cluster. They can be dialed directly when transparent proxy mode is enabled.
 
 <CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
 
@@ -259,7 +260,7 @@ Create a default destination that will be assigned to a terminating gateway.
     name: test-destination
   spec:
     destination:
-      addresses: 
+      addresses:
         - "test.com"
         - "test.org"
       port: 443
@@ -675,7 +676,8 @@ Create a default destination that will be assigned to a terminating gateway.
         {
           name: 'Addresses',
           type: 'array<string>: []',
-          description: `List of addresses associated with the destination. This can be a hostname or an IP address.`,
+          description: `List of addresses associated with the destination. This can be a hostname or an IP address.
+          Wildcards are not accepted.`,
           yaml: false,
         },
         {

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -626,6 +626,25 @@ spec:
       ],
     },
     {
+      name: 'Destination',
+      type: 'DestinationConfig: <optional>',
+      description: `Controls configuration specific to proxies to destinations through terminating-gateway. Added in v1.13.0.`,
+      children: [
+        {
+          name: 'Addresses',
+          type: 'array<string>: []',
+          description: `List of addresses associated with the destination. Could be a hostname or an IP`,
+          yaml: false,
+        },
+        {
+          name: 'Port',
+          type: 'int: 0',
+          description: `Port number associated with the destination`,
+          yaml: false,
+        },
+      ]
+    },
+    {
       name: 'MeshGateway',
       type: 'MeshGatewayConfig: <optional>',
       description: `Controls the default

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -677,20 +677,13 @@ represents a location outside the Consul cluster. They can be dialed directly wh
         {
           name: 'Addresses',
           type: 'array<string>: []',
-          description: {
-            hcl:  `List of addresses associated with the destination. This can be a hostname or an IP address.
+          description:`List of addresses associated with the destination. This can be a hostname or an IP address.
           Wildcards are not accepted.`,
-            yaml:  `List of addresses associated with the destination. This can be a hostname or an IP address.
-          Wildcards are not accepted.`,
-          },
         },
         {
           name: 'Port',
           type: 'int: 0',
-          description: {
-            hcl:  `Port number associated with the destination.`,
-            yaml:  `Port number associated with the destination.`,
-          },
+          description: `Port number associated with the destination.`,
         },
       ]
     },

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -677,15 +677,20 @@ represents a location outside the Consul cluster. They can be dialed directly wh
         {
           name: 'Addresses',
           type: 'array<string>: []',
-          description: `List of addresses associated with the destination. This can be a hostname or an IP address.
+          description: {
+            hcl:  `List of addresses associated with the destination. This can be a hostname or an IP address.
           Wildcards are not accepted.`,
-          yaml: false,
+            yaml:  `List of addresses associated with the destination. This can be a hostname or an IP address.
+          Wildcards are not accepted.`,
+          },
         },
         {
           name: 'Port',
           type: 'int: 0',
-          description: `Port number associated with the destination.`,
-          yaml: false,
+          description: {
+            hcl:  `Port number associated with the destination.`,
+            yaml:  `Port number associated with the destination.`,
+          },
         },
       ]
     },

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -257,13 +257,14 @@ represents a location outside the Consul cluster. They can be dialed directly wh
   apiVersion: consul.hashicorp.com/v1alpha1
   kind: ServiceDefaults
   metadata:
-  name: test-destination
+    name: test-destination
   spec:
     destination:
       addresses:
         - "test.com"
         - "test.org"
       port: 443
+  ```
 
   ```json
   {

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -236,6 +236,47 @@ spec:
 </Tab>
 </Tabs>
 
+### Terminating-gateway Destination
+
+Create a destination to be assigned as a service to a terminating gateway
+
+<CodeTabs tabs={[ "HCL", "Kubernetes YAML", "JSON" ]}>
+
+  ```hcl
+  kind = "service-defaults"
+  name = "test-destination"
+  protocol = "tcp"
+  Destination {
+    Addresses = ["test.com","test.org"]
+    Port = 443
+  }
+  ```
+
+  ```yaml
+  apiVersion: consul.hashicorp.com/v1alpha1
+  kind: ServiceDefaults
+  metadata:
+  name: test-destination
+  spec:
+    destination:
+      Addresses: ["test.com","test.org"]
+      Port: 443
+  ```
+
+  ```json
+  {
+    "Kind": "service-defaults",
+    "Name": "test-destination",
+    "Protocol": "http",
+    "Destination": {
+      "Addresses": ["test.com","test.org"],
+      "Port": 443
+    }
+  }
+  ```
+
+</CodeTabs>
+
 ## Available Fields
 
 <ConfigEntryReference

--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -625,9 +625,9 @@ spec:
       description: `A list of services or destinations to link
                       with the gateway. The gateway will proxy traffic to these services. These linked services
                       must be registered with Consul for the gateway to discover their addresses. They must also
-                      be registered in the same Consul datacenter as the terminating gateway. If Consul ACLs are
-                      enabled, the Terminating Gateway's ACL token must grant <code>service:write</code> for all linked services.
-                      Destinations are an exception to this requirement, and only need to be defined as a service-defaults configuration entry in the same datacenter.`,
+                      be registered in the same Consul datacenter as the terminating gateway.
+                      Destinations are an exception to this requirement, and only need to be defined as a service-defaults configuration entry in the same datacenter.
+                      If Consul ACLs are enabled, the Terminating Gateway's ACL token must grant <code>service:write</code> for all linked services.`,
       children: [
         {
           name: 'Name',

--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -622,11 +622,12 @@ spec:
     {
       name: 'Services',
       type: 'array<LinkedService>: <optional>',
-      description: `A list of services to link
+      description: `A list of services or destinations to link
                       with the gateway. The gateway will proxy traffic to these services. These linked services
                       must be registered with Consul for the gateway to discover their addresses. They must also
                       be registered in the same Consul datacenter as the terminating gateway. If Consul ACLs are
-                      enabled, the Terminating Gateway's ACL token must grant <code>service:write</code> for all linked services.`,
+                      enabled, the Terminating Gateway's ACL token must grant <code>service:write</code> for all linked services.
+                      Destinations are an exception to that and only need to be defined as a service-defaults configuration entry in the same datacenter.`,
       children: [
         {
           name: 'Name',

--- a/website/content/docs/connect/config-entries/terminating-gateway.mdx
+++ b/website/content/docs/connect/config-entries/terminating-gateway.mdx
@@ -627,7 +627,7 @@ spec:
                       must be registered with Consul for the gateway to discover their addresses. They must also
                       be registered in the same Consul datacenter as the terminating gateway. If Consul ACLs are
                       enabled, the Terminating Gateway's ACL token must grant <code>service:write</code> for all linked services.
-                      Destinations are an exception to that and only need to be defined as a service-defaults configuration entry in the same datacenter.`,
+                      Destinations are an exception to this requirement, and only need to be defined as a service-defaults configuration entry in the same datacenter.`,
       children: [
         {
           name: 'Name',

--- a/website/content/docs/connect/gateways/terminating-gateway.mdx
+++ b/website/content/docs/connect/gateways/terminating-gateway.mdx
@@ -12,7 +12,7 @@ description: >-
 -> **1.8.0+:** This feature is available in Consul versions 1.8.0 and newer.
 
 Terminating gateways enable connectivity within your organizational network from services in the Consul service mesh to
-services/[destinations](/docs/connect/config-entries/service-defaults#destination) outside the mesh. These gateways effectively act as Connect proxies that can
+services and [destinations](/docs/connect/config-entries/service-defaults#terminating-gateway-destination) outside the mesh. These gateways effectively act as Connect proxies that can
 represent more than one service. They terminate Connect mTLS connections, enforce intentions,
 and forward requests to the appropriate destination.
 
@@ -55,7 +55,7 @@ Each terminating gateway needs:
 
 1. A local Consul client agent to manage its configuration.
 2. General network connectivity to services within its local Consul datacenter.
-3. General network connectivity to services/destinations outside the mesh that are part of the gateway services list.
+3. General network connectivity to services and destinations outside the mesh that are part of the gateway services list.
 
 Terminating gateways also require that your Consul datacenters are configured correctly:
 
@@ -97,7 +97,7 @@ to terminate mTLS connections on behalf of the linked services and then route th
 If the Consul client agent on the gateway's node is not configured to use the default gRPC port, 8502, then the gateway's token
 must also provide `agent:read` for its node's name in order to discover the agent's gRPC port. gRPC is used to expose Envoy's xDS API to Envoy proxies.
 
-Linking services/destinations to a terminating gateway is done with a `terminating-gateway`
+You can link services and destinations to a terminating gateway with a `terminating-gateway`
 [configuration entry](/docs/connect/config-entries/terminating-gateway). This config entry can be applied via the
 [CLI](/commands/config/write) or [API](/api-docs/config#apply-configuration).
 
@@ -123,10 +123,10 @@ However, ensure that the [node name](/api-docs/catalog#node) for external servic
 does not match the node name of any Consul client agent node. If the node name overlaps with the node name of a Consul client agent,
 Consul's [anti-entropy sync](/docs/architecture/anti-entropy) will delete the services registered via the `/catalog/register` HTTP API endpoint.
 
-An exception to that is using [service-defaults](/docs/connect/config-entries/service-defaults) [destinations](/docs/connect/config-entries/service-defaults#destination),
-which allow to define endpoints external to the mesh and routable through a terminating gateway in transparent mode.
-a service-defaults configuration entry needs to be defined for each destination and the service-default name can be used as part of the terminating gateway services list.
-If a service and a destination service-defaults have the same name the destination is ignored in favor of the service.
+Service-defaults [destinations](/docs/connect/config-entries/service-defaults#destination) let you
+define endpoints external to the mesh and routable through a terminating gateway in transparent mode.
+After you define a service-defaults configuration entry for each destination, you can use the service-default name as part of the terminating gateway services list.
+If a service and a destination service-defaults have the same name, the terminating gateway will use the service.
 
 For a complete example of how to register external services review the
 [external services tutorial](https://learn.hashicorp.com/tutorials/consul/service-registration-external-services).

--- a/website/content/docs/connect/gateways/terminating-gateway.mdx
+++ b/website/content/docs/connect/gateways/terminating-gateway.mdx
@@ -12,7 +12,7 @@ description: >-
 -> **1.8.0+:** This feature is available in Consul versions 1.8.0 and newer.
 
 Terminating gateways enable connectivity within your organizational network from services in the Consul service mesh to
-services outside the mesh. These gateways effectively act as Connect proxies that can
+services/[destinations](/docs/connect/config-entries/service-defaults#destination) outside the mesh. These gateways effectively act as Connect proxies that can
 represent more than one service. They terminate Connect mTLS connections, enforce intentions,
 and forward requests to the appropriate destination.
 
@@ -55,6 +55,7 @@ Each terminating gateway needs:
 
 1. A local Consul client agent to manage its configuration.
 2. General network connectivity to services within its local Consul datacenter.
+3. General network connectivity to services/destinations outside the mesh that are part of the gateway services list.
 
 Terminating gateways also require that your Consul datacenters are configured correctly:
 
@@ -96,7 +97,7 @@ to terminate mTLS connections on behalf of the linked services and then route th
 If the Consul client agent on the gateway's node is not configured to use the default gRPC port, 8502, then the gateway's token
 must also provide `agent:read` for its node's name in order to discover the agent's gRPC port. gRPC is used to expose Envoy's xDS API to Envoy proxies.
 
-Linking services to a terminating gateway is done with a `terminating-gateway`
+Linking services/destinations to a terminating gateway is done with a `terminating-gateway`
 [configuration entry](/docs/connect/config-entries/terminating-gateway). This config entry can be applied via the
 [CLI](/commands/config/write) or [API](/api-docs/config#apply-configuration).
 
@@ -121,6 +122,11 @@ not managed by a Consul client agent. All agent-less services with the same addr
 However, ensure that the [node name](/api-docs/catalog#node) for external services registered directly in the catalog
 does not match the node name of any Consul client agent node. If the node name overlaps with the node name of a Consul client agent,
 Consul's [anti-entropy sync](/docs/architecture/anti-entropy) will delete the services registered via the `/catalog/register` HTTP API endpoint.
+
+An exception to that is using [service-defaults](/docs/connect/config-entries/service-defaults) [destinations](/docs/connect/config-entries/service-defaults#destination),
+which allow to define endpoints external to the mesh and routable through a terminating gateway in transparent mode.
+a service-defaults configuration entry needs to be defined for each destination and the service-default name can be used as part of the terminating gateway services list.
+If a service and a destination service-defaults have the same name the destination is ignored in favor of the service.
 
 For a complete example of how to register external services review the
 [external services tutorial](https://learn.hashicorp.com/tutorials/consul/service-registration-external-services).


### PR DESCRIPTION
### Description
This adds documentation around destination feature.
