### PR TITLE
ci: Use pattern for CRT release branch config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       # Push events on the main branch
       - main
+      - release/**
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       # Push events on the main branch
       - main
       - release/**
+      - eculver/**
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
       # Push events on the main branch
       - main
       - release/**
-      - eculver/**
 
 env:
   PKG_NAME: consul

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -11,10 +11,7 @@ project "consul" {
     repository = "consul"
     release_branches = [
       "main",
-      "release/1.9.x",
-      "release/1.10.x",
-      "release/1.11.x",
-      "release/1.12.x",
+      "release/**",
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -12,7 +12,6 @@ project "consul" {
     release_branches = [
       "main",
       "release/**",
-      "eculver/**",
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -12,6 +12,7 @@ project "consul" {
     release_branches = [
       "main",
       "release/**",
+      "eculver/**",
     ]
   }
 }


### PR DESCRIPTION
This adds a `release/**` pattern to match all of our release branches.

### Description
It was [recently announced](https://hashicorp.atlassian.net/wiki/spaces/ENSV/pages/2383447278/July+15+2022+-+Pattern+matching+now+supported+for+branch+names+in+ci.hcl) that pattern matching is now supported in CRT configuration for branch names. What this means is that with a pattern for our release branches we will no longer have to update `.release/ci.hcl` whenever we need to trigger CRT for a new release branch. 

### Testing & Reproduction steps
This is one of the patterns listed in their examples, so I would imagine it works. We will know once we push a change to the new `release/1.13.x` branch.

Also, I triggered the workflows for my dev branch (technically `eculver/**` to express the wildcard case) which can be seen here: https://github.com/hashicorp/consul/pull/13955/checks.

### Links
- [CRT Newletter: July 15, 2022 - Pattern matching now supported for branch names in ci.hcl!](https://hashicorp.atlassian.net/wiki/spaces/ENSV/pages/2383447278/July+15+2022+-+Pattern+matching+now+supported+for+branch+names+in+ci.hcl)