### PR TITLE
proxycfg-sources: fix hot loop when service not found in catalog

### DIFF
--- a/agent/proxycfg-sources/catalog/config_source.go
+++ b/agent/proxycfg-sources/catalog/config_source.go
@@ -125,7 +125,7 @@ func (m *ConfigSource) startSync(closeCh <-chan chan struct{}, proxyID proxycfg.
 		case ns == nil:
 			m.Manager.Deregister(proxyID, source)
 			logger.Trace("service does not exist in catalog, de-registering it with proxycfg manager")
-			return nil, err
+			return ws, nil
 		case !ns.Kind.IsProxy():
 			err := errors.New("service must be a sidecar proxy or gateway")
 			logger.Error(err.Error())


### PR DESCRIPTION
### Description
Fixes a bug where a service getting deleted from the catalog would cause the `ConfigSource` to spin in a hot loop attempting to look up the service.

This is because we were returning a nil `WatchSet` which would always unblock the select.

Kudos to @freddygv for discovering this!

### Testing & Reproduction steps
The easiest way to reproduce this is to run a dev server, register a service via the API, start a connect proxy for it, and then restart the agent (clearing out the in-memory state).
