### PR TITLE
Remove duplicated "port" key from code sample

### DIFF
--- a/website/content/docs/discovery/services.mdx
+++ b/website/content/docs/discovery/services.mdx
@@ -41,7 +41,6 @@ All possible parameters are included in the following example, but only the top-
 service {
   name = "redis"
   id   = "redis"
-  port = 80
   tags = ["primary"]
 
   meta = {


### PR DESCRIPTION
### Description

The `port` key appears duplicated in line 63, removing the first occurrence so that it is consistent with the JSON sample code.
