### PR TITLE
Enable backporting to individual patch releases.

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -10,7 +10,7 @@ on:
       - labeled
     branches:
       - main
-      - 'release/*.*.x'
+      - "release/*.*.x"
 
 jobs:
   backport:
@@ -50,4 +50,11 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
           BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+      - name: Run Backport Assistant for Path Release Branches
+        run: |
+          backport-assistant backport -merge-method=squash -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+.\\d+)"
+          BACKPORT_TARGET_TEMPLATE: "release/{{.target}}"
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
This *should* allow us to create a branch like release/1.13.0 and have the backport assistant backport prs to that release branch. In general the flow when we get close to a release would be:

1. create a `release/1.13.x` branch
2. create a `release/1.13.0` branch

At this point in time `main` would target the next major release (e.g. 1.14)

Developers who wanted code to land for 1.13.0 would need to add the following PR labels:

* `backport/1.13.x`
* `backport/1.13.0`

If a developer only wanted to target some future 1.13 release but not an impending patch release then they would just add the `backport/1.13.x` label and omit the patch release specific one.

### Why

What we are trying to avoid is having periods of time in the run up to a release where developers cannot continue to merge to `main` and the `release/<maj>.<min>.x` branches for landing work that should come in a future release but not in the impending release. Our backport process currently satisfies part of this need. Developers omit the backport labels and the changes only end up in `main`. I was thinking having something similar to be able to land work for future patch releases while we are in a feature/code freeze for the impending release would also be nice.

### Questions/Thoughts

I don't love that this requires two labels. It seems like it would be nice if a user could specify a label like `backport/1.13.0` and have the backport assistant smart enough to also backport to `release/1.13.x`


