### PR TITLE
docs: fix k8s prepared query upstream link

### DIFF
--- a/website/content/docs/k8s/annotations-and-labels.mdx
+++ b/website/content/docs/k8s/annotations-and-labels.mdx
@@ -97,7 +97,7 @@ The following Kubernetes resource annotations could be used on a pod to control 
         annotations:
           "consul.hashicorp.com/connect-service-upstreams":"[service-name].[service-namespace].[service-partition]:[port]:[optional datacenter]"
         ```
-    - [Prepared queries](/docs/connect/proxies#dynamic-upstreams-require-native-integration): Prepend the annotation
+    - [Prepared queries](/api-docs/query): Prepend the annotation
       with `prepared_query` and place the name of the query at the beginning of the string.
       ```yaml
       annotations:


### PR DESCRIPTION
The existing link has no relevance to prepared queries and is misleading (can be interpreted as meaning that prepared query annotations are not supported).