### PR TITLE
docs: link pq docs to relevant DNS lookup section

### DIFF
--- a/website/content/api-docs/query.mdx
+++ b/website/content/api-docs/query.mdx
@@ -11,7 +11,7 @@ The `/query` endpoints create, update, destroy, and execute prepared queries.
 Prepared queries allow you to register a complex service query and then execute
 it later via its ID or name to get a set of healthy nodes that provide a given
 service. This is particularly useful in combination with Consul's
-[DNS Interface](/docs/discovery/dns) as it allows for much richer queries than
+[DNS Interface](/docs/discovery/dns#prepared-query-lookups) as it allows for much richer queries than
 would be possible given the limited entry points exposed by DNS.
 
 Check the [Geo Failover tutorial](https://learn.hashicorp.com/tutorials/consul/automate-geo-failover) for details and


### PR DESCRIPTION
Minor improvement: link directly to the relevant DNS lookup section for prepared queries, rather than the long DNS overview page.