### PR TITLE
Various peering fixes

### DIFF
--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -1804,8 +1804,6 @@ func TestConfigEntry_ResolveServiceConfig_Upstreams_Blocking(t *testing.T) {
 		t.Skip("too slow for testing.Short")
 	}
 
-	t.Parallel()
-
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -237,7 +237,7 @@ func (s *Server) syncPeeringsAndBlock(ctx context.Context, logger hclog.Logger, 
 		}
 	}
 
-	logger.Trace("checking connected streams", "streams", s.peerStreamServer.ConnectedStreams(), "sequence_id", seq)
+	logger.Trace("checking connected streams", "streams", connectedStreams, "sequence_id", seq)
 
 	// Clean up active streams of peerings that were deleted from the state store.
 	// TODO(peering): This is going to trigger shutting down peerings we generated a token for. Is that OK?

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -447,6 +447,8 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 				// exits. After the method exits this code here won't receive any recv errors and those will be handled
 				// by DrainStream().
 				err = fmt.Errorf("stream ended unexpectedly")
+			} else {
+				err = fmt.Errorf("unexpected error receiving from the stream: %w", err)
 			}
 			status.TrackRecvError(err.Error())
 			return err
@@ -684,10 +686,20 @@ func logTraceProto(logger hclog.Logger, pb proto.Message, received bool) {
 		dir = "received"
 	}
 
+	// Redact the long-lived stream secret to avoid leaking it in trace logs.
+	pbToLog := pb
+	if open, ok := pb.(*pbpeerstream.ReplicationMessage_Open); ok {
+		clone := &pbpeerstream.ReplicationMessage_Open{}
+		proto.Merge(clone, open)
+
+		clone.StreamSecretID = "hidden"
+		pbToLog = clone
+	}
+
 	m := jsonpb.Marshaler{
 		Indent: "  ",
 	}
-	out, err := m.MarshalToString(pb)
+	out, err := m.MarshalToString(pbToLog)
 	if err != nil {
 		out = "<ERROR: " + err.Error() + ">"
 	}

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -693,8 +693,10 @@ func logTraceProto(logger hclog.Logger, pb proto.Message, received bool) {
 		clone := &pbpeerstream.ReplicationMessage{}
 		proto.Merge(clone, msg)
 
-		clone.GetOpen().StreamSecretID = "hidden"
-		pbToLog = clone
+		if clone.GetOpen() != nil {
+			clone.GetOpen().StreamSecretID = "hidden"
+			pbToLog = clone
+		}
 	case *pbpeerstream.ReplicationMessage_Open:
 		clone := &pbpeerstream.ReplicationMessage_Open{}
 		proto.Merge(clone, msg)


### PR DESCRIPTION
### Description
* Avoid logging StreamSecretID
* Wrap additional errors in stream handler
* Fix flakiness in leader test and rename servers for clarity. There was
  a race condition where the peering was being deleted in the test
  after the initial handling in `StreamResources` but before the stream was active. Now the test waits for the stream to be
  connected on both sides before deleting the associated peering.

### Testing & Reproduction steps
* Spotted the secret in peering leader unit test logs

### Links
`StreamSecretID` was introduced in #13977

### PR Checklist

* [x] updated test coverage
* [ ] ~external facing docs updated~
* [ ] not a security concern
