### PR TITLE
cleanup agents and servers within the tests

### DIFF
--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -1211,7 +1211,7 @@ func TestServer_RPC_MetricsIntercept_Off(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		t.Cleanup(func() { s1.Shutdown() })
+		defer s1.Shutdown()
 
 		var out struct{}
 		if err := s1.RPC("Status.Ping", struct{}{}, &out); err != nil {
@@ -1249,10 +1249,7 @@ func TestServer_RPC_MetricsIntercept_Off(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		t.Cleanup(func() { s2.Shutdown() })
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		defer s2.Shutdown()
 
 		var out struct{}
 		if err := s2.RPC("Status.Ping", struct{}{}, &out); err != nil {
@@ -1284,11 +1281,10 @@ func TestServer_RPC_RequestRecorder(t *testing.T) {
 		require.Error(t, err, "need err when provider func is nil")
 		require.Equal(t, err.Error(), "cannot initialize server without an RPC request recorder provider")
 
-		t.Cleanup(func() {
-			if s1 != nil {
-				s1.Shutdown()
-			}
-		})
+		// if the test failed to error, let's still clean up the server resources
+		if s1 != nil {
+			s1.Shutdown()
+		}
 	})
 
 	t.Run("test nil RequestRecorder", func(t *testing.T) {
@@ -1303,11 +1299,10 @@ func TestServer_RPC_RequestRecorder(t *testing.T) {
 		require.Error(t, err, "need err when RequestRecorder is nil")
 		require.Equal(t, err.Error(), "cannot initialize server with a nil RPC request recorder")
 
-		t.Cleanup(func() {
-			if s2 != nil {
-				s2.Shutdown()
-			}
-		})
+		// if the test failed to error, let's still clean up the server resources
+		if s2 != nil {
+			s2.Shutdown()
+		}
 	})
 }
 

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -357,6 +357,8 @@ func TestIntentionGetExact_PeerIntentions(t *testing.T) {
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	testutil.RunStep(t, "create a peer intentions", func(t *testing.T) {
@@ -414,7 +416,9 @@ func TestIntentionGetExact(t *testing.T) {
 	`
 
 	a1 := NewTestAgent(t, hcl)
+	defer a1.Shutdown()
 	a2 := NewTestAgent(t, hcl)
+	defer a2.Shutdown()
 
 	_, err := a1.JoinLAN([]string{
 		fmt.Sprintf("127.0.0.1:%d", a2.Config.SerfPortLAN),

--- a/agent/peering_endpoint_oss_test.go
+++ b/agent/peering_endpoint_oss_test.go
@@ -25,6 +25,8 @@ func TestHTTP_Peering_GenerateToken_OSS_Failure(t *testing.T) {
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	t.Run("Doesn't allow partitions in OSS HTTP requests", func(t *testing.T) {
@@ -52,6 +54,8 @@ func TestHTTP_PeeringEndpoint_OSS_Failure(t *testing.T) {
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	t.Run("Doesn't allow partitions on PeeringEndpoint in OSS HTTP requests", func(t *testing.T) {

--- a/agent/peering_endpoint_test.go
+++ b/agent/peering_endpoint_test.go
@@ -48,6 +48,7 @@ func TestHTTP_Peering_GenerateToken(t *testing.T) {
 
 	t.Parallel()
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -158,6 +159,8 @@ func TestHTTP_Peering_GenerateToken_EdgeCases(t *testing.T) {
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	body := &pbpeering.GenerateTokenRequest{
@@ -221,6 +224,7 @@ func TestHTTP_Peering_Establish(t *testing.T) {
 
 	t.Parallel()
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -304,6 +308,7 @@ func TestHTTP_Peering_MethodNotAllowed(t *testing.T) {
 
 	t.Parallel()
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -339,6 +344,7 @@ func TestHTTP_Peering_Read(t *testing.T) {
 
 	t.Parallel()
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -407,6 +413,7 @@ func TestHTTP_Peering_Delete(t *testing.T) {
 
 	t.Parallel()
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -474,6 +481,7 @@ func TestHTTP_Peering_List(t *testing.T) {
 
 	t.Parallel()
 	a := NewTestAgent(t, "")
+	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 


### PR DESCRIPTION
This is a bit of a different PR, meant to address flaky-ness due to setup issues in our tests.

#### Hypothesis

A number of flakes occur for “integration” or end-to-end tests that need a free port to stand up agents error out when there is no free port. The retry-able error will look something like:

```
pending ports are still in use; something probably didn't wait around for the port to be closed!
```

Eventually, the test fails since it can't get a free port.

#### Cause

The cause for this is an ordering/ data flow issue. Every test T is a child of the testing T instance ( [ref](https://cs.opensource.google/go/go/+/master:src/testing/testing.go;l=1256-1272;drc=f32519e5fbcf1b12f9654a6175e5e72b09ae8f3a) ). Parallel tests run to completion before calling `t.cleanup` ( [ref](https://cs.opensource.google/go/go/+/master:src/testing/testing.go;l=1404-1415;drc=f32519e5fbcf1b12f9654a6175e5e72b09ae8f3a) ). It would be best to `defer a.Shutdown()` and other clean up tasks as part of the test itself so these resources, like ports in use, get freed up faster.
