### PR TITLE
peering: add peer health metric

### DIFF
--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1063,6 +1063,9 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 		// mimic tracking exported services
 		mst2.TrackExportedService(structs.ServiceName{Name: "d-service"})
 		mst2.TrackExportedService(structs.ServiceName{Name: "e-service"})
+
+		// pretend that the hearbeat happened
+		mst2.TrackRecvHeartbeat()
 	}
 
 	// set up a metrics sink
@@ -1092,6 +1095,12 @@ func TestLeader_PeeringMetrics_emitPeeringMetrics(t *testing.T) {
 		require.True(r, ok, fmt.Sprintf("did not find the key %q", keyMetric2))
 
 		require.Equal(r, float32(2), metric2.Value) // for d, e services
+
+		keyHealthyMetric2 := fmt.Sprintf("us-west.consul.peering.healthy;peer_name=my-peer-s3;peer_id=%s", s2PeerID2)
+		healthyMetric2, ok := intv.Gauges[keyHealthyMetric2]
+		require.True(r, ok, fmt.Sprintf("did not find the key %q", keyHealthyMetric2))
+
+		require.Equal(r, float32(1), healthyMetric2.Value)
 	})
 }
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -742,6 +742,7 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server) (*Ser
 			return s.ForwardGRPC(s.grpcConnPool, info, fn)
 		},
 	})
+	s.peerStreamTracker.SetHeartbeatTimeout(s.peerStreamServer.Config.IncomingHeartbeatTimeout)
 	s.peerStreamServer.Register(s.externalGRPCServer)
 
 	// Initialize internal gRPC server.

--- a/agent/grpc-external/services/peerstream/server.go
+++ b/agent/grpc-external/services/peerstream/server.go
@@ -42,8 +42,8 @@ type Config struct {
 	// outgoingHeartbeatInterval is how often we send a heartbeat.
 	outgoingHeartbeatInterval time.Duration
 
-	// incomingHeartbeatTimeout is how long we'll wait between receiving heartbeats before we close the connection.
-	incomingHeartbeatTimeout time.Duration
+	// IncomingHeartbeatTimeout is how long we'll wait between receiving heartbeats before we close the connection.
+	IncomingHeartbeatTimeout time.Duration
 }
 
 //go:generate mockery --name ACLResolver --inpackage
@@ -63,8 +63,8 @@ func NewServer(cfg Config) *Server {
 	if cfg.outgoingHeartbeatInterval == 0 {
 		cfg.outgoingHeartbeatInterval = defaultOutgoingHeartbeatInterval
 	}
-	if cfg.incomingHeartbeatTimeout == 0 {
-		cfg.incomingHeartbeatTimeout = defaultIncomingHeartbeatTimeout
+	if cfg.IncomingHeartbeatTimeout == 0 {
+		cfg.IncomingHeartbeatTimeout = defaultIncomingHeartbeatTimeout
 	}
 	return &Server{
 		Config: cfg,

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -406,7 +406,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 
 	// incomingHeartbeatCtx will complete if incoming heartbeats time out.
 	incomingHeartbeatCtx, incomingHeartbeatCtxCancel :=
-		context.WithTimeout(context.Background(), s.incomingHeartbeatTimeout)
+		context.WithTimeout(context.Background(), s.IncomingHeartbeatTimeout)
 	// NOTE: It's important that we wrap the call to cancel in a wrapper func because during the loop we're
 	// re-assigning the value of incomingHeartbeatCtxCancel and we want the defer to run on the last assigned
 	// value, not the current value.
@@ -605,7 +605,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 				// They just can't trace the execution properly for some reason (possibly golang/go#29587).
 				//nolint:govet
 				incomingHeartbeatCtx, incomingHeartbeatCtxCancel =
-					context.WithTimeout(context.Background(), s.incomingHeartbeatTimeout)
+					context.WithTimeout(context.Background(), s.IncomingHeartbeatTimeout)
 			}
 
 		case update := <-subCh:

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -642,6 +642,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 			if err := streamSend(replResp); err != nil {
 				return fmt.Errorf("failed to push data for %q: %w", update.CorrelationID, err)
 			}
+			status.TrackSendSuccess()
 		}
 	}
 }

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -572,7 +572,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 		})
 	})
 
-	var lastSendSuccess time.Time
+	var lastSendAck, lastSendSuccess time.Time
 
 	testutil.RunStep(t, "ack tracked as success", func(t *testing.T) {
 		ack := &pbpeerstream.ReplicationMessage{
@@ -587,19 +587,22 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			},
 		}
 
-		lastSendSuccess = it.FutureNow(1)
+		lastSendAck = time.Date(2000, time.January, 1, 0, 0, 2, 0, time.UTC)
+		lastSendSuccess = time.Date(2000, time.January, 1, 0, 0, 3, 0, time.UTC)
 		err := client.Send(ack)
 		require.NoError(t, err)
 
 		expect := Status{
-			Connected: true,
-			LastAck:   lastSendSuccess,
+			Connected:        true,
+			LastAck:          lastSendAck,
+			heartbeatTimeout: defaultIncomingHeartbeatTimeout,
+			LastSendSuccess:  lastSendSuccess,
 		}
 
 		retry.Run(t, func(r *retry.R) {
-			status, ok := srv.StreamStatus(testPeerID)
+			rStatus, ok := srv.StreamStatus(testPeerID)
 			require.True(r, ok)
-			require.Equal(r, expect, status)
+			require.Equal(r, expect, rStatus)
 		})
 	})
 
@@ -621,23 +624,26 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			},
 		}
 
-		lastNack = it.FutureNow(1)
+		lastSendAck = time.Date(2000, time.January, 1, 0, 0, 4, 0, time.UTC)
+		lastNack = time.Date(2000, time.January, 1, 0, 0, 5, 0, time.UTC)
 		err := client.Send(nack)
 		require.NoError(t, err)
 
 		lastNackMsg = "client peer was unable to apply resource: bad bad not good"
 
 		expect := Status{
-			Connected:       true,
-			LastAck:         lastSendSuccess,
-			LastNack:        lastNack,
-			LastNackMessage: lastNackMsg,
+			Connected:        true,
+			LastAck:          lastSendAck,
+			LastNack:         lastNack,
+			LastNackMessage:  lastNackMsg,
+			heartbeatTimeout: defaultIncomingHeartbeatTimeout,
+			LastSendSuccess:  lastSendSuccess,
 		}
 
 		retry.Run(t, func(r *retry.R) {
-			status, ok := srv.StreamStatus(testPeerID)
+			rStatus, ok := srv.StreamStatus(testPeerID)
 			require.True(r, ok)
-			require.Equal(r, expect, status)
+			require.Equal(r, expect, rStatus)
 		})
 	})
 
@@ -694,13 +700,15 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 
 		expect := Status{
 			Connected:               true,
-			LastAck:                 lastSendSuccess,
+			LastAck:                 lastSendAck,
 			LastNack:                lastNack,
 			LastNackMessage:         lastNackMsg,
 			LastRecvResourceSuccess: lastRecvResourceSuccess,
 			ImportedServices: map[string]struct{}{
 				api.String(): {},
 			},
+			heartbeatTimeout: defaultIncomingHeartbeatTimeout,
+			LastSendSuccess:  lastSendSuccess,
 		}
 
 		retry.Run(t, func(r *retry.R) {
@@ -753,7 +761,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 
 		expect := Status{
 			Connected:               true,
-			LastAck:                 lastSendSuccess,
+			LastAck:                 lastSendAck,
 			LastNack:                lastNack,
 			LastNackMessage:         lastNackMsg,
 			LastRecvResourceSuccess: lastRecvResourceSuccess,
@@ -762,6 +770,8 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			ImportedServices: map[string]struct{}{
 				api.String(): {},
 			},
+			heartbeatTimeout: defaultIncomingHeartbeatTimeout,
+			LastSendSuccess:  lastSendSuccess,
 		}
 
 		retry.Run(t, func(r *retry.R) {
@@ -785,7 +795,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 
 		expect := Status{
 			Connected:               true,
-			LastAck:                 lastSendSuccess,
+			LastAck:                 lastSendAck,
 			LastNack:                lastNack,
 			LastNackMessage:         lastNackMsg,
 			LastRecvResourceSuccess: lastRecvResourceSuccess,
@@ -795,6 +805,8 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			ImportedServices: map[string]struct{}{
 				api.String(): {},
 			},
+			heartbeatTimeout: defaultIncomingHeartbeatTimeout,
+			LastSendSuccess:  lastSendSuccess,
 		}
 
 		retry.Run(t, func(r *retry.R) {
@@ -816,7 +828,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 		expect := Status{
 			Connected:               false,
 			DisconnectErrorMessage:  lastRecvErrorMsg,
-			LastAck:                 lastSendSuccess,
+			LastAck:                 lastSendAck,
 			LastNack:                lastNack,
 			LastNackMessage:         lastNackMsg,
 			DisconnectTime:          disconnectTime,
@@ -827,6 +839,8 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 			ImportedServices: map[string]struct{}{
 				api.String(): {},
 			},
+			heartbeatTimeout: defaultIncomingHeartbeatTimeout,
+			LastSendSuccess:  lastSendSuccess,
 		}
 
 		retry.Run(t, func(r *retry.R) {

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -1129,7 +1129,7 @@ func TestStreamResources_Server_DisconnectsOnHeartbeatTimeout(t *testing.T) {
 
 	srv, store := newTestServer(t, func(c *Config) {
 		c.Tracker.SetClock(it.Now)
-		c.incomingHeartbeatTimeout = 5 * time.Millisecond
+		c.IncomingHeartbeatTimeout = 5 * time.Millisecond
 	})
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")
@@ -1236,7 +1236,7 @@ func TestStreamResources_Server_KeepsConnectionOpenWithHeartbeat(t *testing.T) {
 
 	srv, store := newTestServer(t, func(c *Config) {
 		c.Tracker.SetClock(it.Now)
-		c.incomingHeartbeatTimeout = incomingHeartbeatTimeout
+		c.IncomingHeartbeatTimeout = incomingHeartbeatTimeout
 	})
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -215,7 +215,7 @@ func (s *Status) GetExportedServicesCount() uint64 {
 }
 
 // IsHealthy is a convenience func that returns true/ false for a peering status.
-// We define a peering as unhealthy if its status satisfies the following:
+// We define a peering as unhealthy if its status satisfies one of the following:
 // -  If heartbeat hasn't been received within the IncomingHeartbeatTimeout
 // -  If the last sent error is newer than last sent success
 // -  If the last received error is newer than last received success

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -167,6 +167,9 @@ type Status struct {
 	// LastSendErrorMessage tracks the last error message when sending into the stream.
 	LastSendErrorMessage string
 
+	// LastSendSuccess tracks the time of the last success response sent into the stream.
+	LastSendSuccess time.Time
+
 	// LastRecvHeartbeat tracks when we last received a heartbeat from our peer.
 	LastRecvHeartbeat time.Time
 
@@ -197,7 +200,7 @@ func (s *Status) GetExportedServicesCount() uint64 {
 }
 
 // IsHealthy is a convenience func that returns true/ false for a peering status.
-// We define a peering as unhealthy is its status satisfies the following:
+// We define a peering as unhealthy if its status satisfies the following:
 // -  If heartbeat hasn't been received within the IncomingHeartbeatTimeout
 // -  If the last sent error is newer than last sent success
 // -  If the last received error is newer than last received success
@@ -213,7 +216,7 @@ func (s *Status) IsHealthy() bool {
 	}
 
 	// todo change to LastSentSuccess
-	if s.LastSendError.After(s.LastRecvResourceSuccess) {
+	if s.LastSendError.After(s.LastSendSuccess) {
 		// 2. If last sent error is newer than last sent success - report unhealthy
 		return false
 	}
@@ -250,6 +253,12 @@ func (s *MutableStatus) TrackSendError(error string) {
 	s.mu.Lock()
 	s.LastSendError = s.timeNow().UTC()
 	s.LastSendErrorMessage = error
+	s.mu.Unlock()
+}
+
+func (s *MutableStatus) TrackSendSuccess() {
+	s.mu.Lock()
+	s.LastSendSuccess = s.timeNow().UTC()
 	s.mu.Unlock()
 }
 

--- a/agent/grpc-external/services/peerstream/stream_tracker_test.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker_test.go
@@ -33,7 +33,7 @@ func TestStatus_IsHealthy(t *testing.T) {
 				// set heartbeat
 				status.LastRecvHeartbeat = time.Now()
 
-				//status.LastRecvResourceSuccess = time.Now() // todo -- change to LastSendSuccess
+				status.LastSendSuccess = time.Now()
 				status.LastSendError = time.Now()
 			},
 		},


### PR DESCRIPTION
### Description

It'd be useful to be able to dashboard the "health" of a peering. We define a peering as unhealthy if any of the following is true:

```
// -  If heartbeat hasn't been received within the IncomingHeartbeatTimeout
// -  If the last sent error is newer than last sent success
// -  If the last received error is newer than last received success
```

Otherwise, we call the peering `healthy`.

### testing

* `stream_tracker` and metric level emission testing

#### reviewer note
 
- best viewed by commits


#### pr todo

* [x] normalize status for tests to pass