### PR TITLE
add token to the request when creating a cacheIntentions query

### DIFF
--- a/agent/proxycfg-glue/intentions.go
+++ b/agent/proxycfg-glue/intentions.go
@@ -36,6 +36,7 @@ func (c cacheIntentions) Notify(ctx context.Context, req *structs.ServiceSpecifi
 				},
 			},
 		},
+		QueryOptions: structs.QueryOptions{Token: req.QueryOptions.Token},
 	}
 	return c.c.NotifyCallback(ctx, cachetype.IntentionMatchName, query, correlationID, func(ctx context.Context, event cache.UpdateEvent) {
 		e := proxycfg.UpdateEvent{


### PR DESCRIPTION
### Description
testing with 1.13.x branch we noticed this error in consul-k8s tests:
`2022-08-01T22:43:59.619Z [ERROR] agent.client: RPC failed to server: method=Intention.Match server=10.244.0.22:8300 error="rpc error making call: Permission denied: token with AccessorID '00000000-0000-0000-0000-000000000002' lacks permission 'intention:read' on "static-server" in partition "default" in namespace "ns1""`

This was happening because the service token was not propagated correctly in the Intention cache type which made the cache fallback to the agent token (anonymous token) which don't have the right permissions.



### Testing & Reproduction steps
[This](https://app.circleci.com/pipelines/github/hashicorp/consul-k8s/6458/workflows/83324140-cf90-4b4c-a195-bf0bd6a4ba7b/jobs/54618/artifacts) is one reproduction, I was able to run the test locally with the fix and confirm it's fixed
