### PR TITLE
ui: peering UI fixes - api contract change / wrong link in peerings list

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/list/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/list/index.hbs
@@ -42,14 +42,6 @@ as |item index|>
 {{#if (can 'delete peer' item=item)}}
 
     <Actions as |Action|>
-      <Action
-        data-test-edit-action
-        @href={{href-to 'dc.peers.edit' item.Name}}
-      >
-        <BlockSlot @name="label">
-          View
-        </BlockSlot>
-      </Action>
 {{#if (can "write peer" item=item)}}
         <Action
           data-test-edit-action


### PR DESCRIPTION
### Description

This PR fixes some things that broke the peering UI

* Api contract was changed - we can't send the `Datacenter` attribute anymore when creating a token / establishing a peer
* We were still surfacing a links to `peers.edit` which was breaking the list and surfacing an error whenever we established a peer.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
