### PR TITLE
ui: Re-hook up regenerate button

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/chart.xstate.js
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/chart.xstate.js
@@ -20,6 +20,11 @@ export default {
       }
     },
     success: {
+      on: {
+        RESET: {
+          target: 'idle'
+        }
+      }
     },
     error: {},
   },

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/index.hbs
@@ -52,7 +52,10 @@
             item=@item
             token=fsm.state.context.PeeringToken
             regenerate=@regenerate
-            onclick=(queue (set @item 'Name' ''))
+            onclick=(queue
+              (set @item 'Name' '')
+              (fn fsm.dispatch 'RESET')
+            )
           )
           Actions=(component "consul/peer/form/token/actions"
             token=fsm.state.context.PeeringToken


### PR DESCRIPTION
### Description

Erroneously removed here https://github.com/hashicorp/consul/pull/13792#discussion_r924496973

This PR makes the [Generate another token] button work (see below)

<img width="465" alt="Screenshot 2022-08-03 at 11 50 24" src="https://user-images.githubusercontent.com/554604/182579434-cec986da-7cb9-4045-b0ce-1819d91363b0.png">


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
