### PR TITLE
ui: Make DataWriter also deal with more standard shaped errors

### DIFF
--- a/ui/packages/consul-peerings/app/components/consul/peer/form/generate/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/generate/index.hbs
@@ -17,7 +17,20 @@
       id={{id}}
     >
 
-      <fsm.State @matches={{array 'idle'}}>
+      <fsm.State @matches={{array 'idle' 'error'}}>
+        <fsm.State @matches={{'error'}}>
+          <Notice
+            @type="error"
+            role="alert"
+          as |notice|>
+            <notice.Body>
+              <p>
+                <strong>Error</strong><br />
+                {{fsm.state.context.error.message}}
+              </p>
+            </notice.Body>
+          </Notice>
+        </fsm.State>
         {{yield (hash
           Fieldsets=(component "consul/peer/form/generate/fieldsets"
             item=@item
@@ -42,6 +55,9 @@
           @onchange={{queue
             @onchange
             (pick 'data' (fn fsm.dispatch 'SUCCESS'))
+          }}
+          @onerror={{queue
+            (fn fsm.dispatch 'ERROR')
           }}
         />
       </fsm.State>

--- a/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/index.hbs
+++ b/ui/packages/consul-peerings/app/components/consul/peer/form/initiate/index.hbs
@@ -17,6 +17,19 @@
     @label={{'peer'}}
     @onchange={{fn (optional @onsubmit) @item}}
     as |writer|>
+      <BlockSlot @name="error" as |after error|>
+        <Notice
+          @type="error"
+          role="alert"
+        as |notice|>
+          <notice.Body>
+            <p>
+              <strong>Error</strong><br />
+              {{error.message}}
+            </p>
+          </notice.Body>
+        </Notice>
+      </BlockSlot>
       <BlockSlot @name="content">
 {{#let
   (unique-id)
@@ -27,15 +40,15 @@ as |id|}}
         >
           {{yield (hash
             Fieldsets=(component "consul/peer/form/initiate/fieldsets"
-             item=@item
+              item=@item
             )
             Actions=(component "consul/peer/form/initiate/actions"
-             item=@item
-             id=id
+              item=@item
+              id=id
             )
           )}}
         </form>
 {{/let}}
-      </BlockSlot>
+    </BlockSlot>
   </DataWriter>
 </div>

--- a/ui/packages/consul-ui/app/components/data-writer/index.hbs
+++ b/ui/packages/consul-ui/app/components/data-writer/index.hbs
@@ -19,7 +19,7 @@
       @item={{data}}
       @data={{null}}
       @onchange={{action dispatch "SUCCESS"}}
-      @onerror={{queue (action (mut error) value="error.errors.firstObject") (action dispatch "ERROR")}}
+      @onerror={{action "error"}}
     />
   </State>
 
@@ -28,7 +28,7 @@
       @sink={{sink}}
       @item={{data}}
       @onchange={{action dispatch "SUCCESS"}}
-      @onerror={{queue (action (mut error) value="error.errors.firstObject") (action dispatch "ERROR")}}
+      @onerror={{action "error"}}
     />
   </State>
 

--- a/ui/packages/consul-ui/app/components/data-writer/index.js
+++ b/ui/packages/consul-ui/app/components/data-writer/index.js
@@ -21,5 +21,17 @@ export default Component.extend(Slotted, {
       set(this, 'data', data);
       this.dispatch('PERSIST');
     },
+    error: function(data, e) {
+      if (e && typeof e.preventDefault === 'function') {
+        e.preventDefault();
+      }
+      set(
+        this,
+        'error',
+        typeof data.error.errors !== 'undefined' ?
+          data.error.errors.firstObject : data.error
+      );
+      this.dispatch('ERROR');
+    },
   },
 });


### PR DESCRIPTION
### Description
We started out with our application using `ember-data`, but for many reasons we are slowly moving away from using that. As well as a few other benefits it also means our errors (API ones and any others) are all standard shaped errors - all errors are the same standard recognisable javascript errors.

This PR alters our `DataWriter` to work with standard shaped errors as well as `ember-data` shaped ones (as it did previously). This means we can keep deprecating our `ember-data` usage as we go. Eventually, if we get to the point we we aren't using `ember-data` shaped errors anymore, we can remove the majority of this code and just support standard javascript errors.

**Note**: We purposefully used an old style `action` here to keep consistent with the style/APIs already being used in the component (the component is currently an old school ember one). Now is not the time to do a full upgrade of this component and I'd rather the component was consistent using one single style rather than both old school ember and new school Octane both at the same time. Upgrading the component entirely to Octane can be done at some point in the future.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
