### PR TITLE
fix(cli): error message in service deregister subcommand

### DIFF
--- a/command/services/deregister/deregister.go
+++ b/command/services/deregister/deregister.go
@@ -81,7 +81,7 @@ func (c *cmd) Run(args []string) int {
 		}
 
 		if err := client.Agent().ServiceDeregister(id); err != nil {
-			c.UI.Error(fmt.Sprintf("Error registering service %q: %s",
+			c.UI.Error(fmt.Sprintf("Error deregistering service %q: %s",
 				svc.Name, err))
 			return 1
 		}


### PR DESCRIPTION
### Description
When the deregister cli fails, the error message shows `Error registering service`, which should be `Error deregistering service`.

### Testing & Reproduction steps

Run cli to deregister any non-existent service

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
