### PR TITLE
fix: deregister service id in url format

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -223,6 +223,11 @@ type metricsEncoder struct {
 	flusher http.Flusher
 }
 
+const (
+	// serviceIDQueryKey is used for deregistering service endpoint handler
+	serviceIDQueryKey = "service-id"
+)
+
 func (m metricsEncoder) Encode(summary interface{}) error {
 	if err := m.encoder.Encode(summary); err != nil {
 		m.logger.Error("failed to encode metrics summary", "error", err)
@@ -1218,7 +1223,7 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 }
 
 func (s *HTTPHandlers) AgentDeregisterService(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	serviceID := strings.TrimPrefix(req.URL.Path, "/v1/agent/service/deregister/")
+	serviceID := req.URL.Query().Get(serviceIDQueryKey)
 	sid := structs.NewServiceID(serviceID, nil)
 
 	// Get the provided token, if any, and vet against any ACL policies.

--- a/agent/http.go
+++ b/agent/http.go
@@ -120,6 +120,16 @@ type wrappedMux struct {
 
 // ServeHTTP implements the http.Handler interface.
 func (w *wrappedMux) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+
+	if strings.HasPrefix(req.URL.Path, "/v1/agent/service/deregister/") {
+		// Move the service id to url's query to handle the case where
+		// registerred service is an url (see TestAgent_DeregisterService)
+		serviceID := strings.TrimPrefix(req.URL.Path, "/v1/agent/service/deregister/")
+		req.URL.Path = strings.TrimSuffix(req.URL.Path, serviceID)
+		query := req.URL.Query()
+		query.Add(serviceIDQueryKey, serviceID)
+		req.URL.RawQuery = query.Encode()
+	}
 	w.handler.ServeHTTP(resp, req)
 }
 


### PR DESCRIPTION
### Description

- When deregistering a service with an ID, which has an URL format (e.g., http://myservice.com), the http handler will return 301. This PR move the service id from path to the url’s query so that it can be passed to the agent endpoint’s handler.

### Testing & Reproduction steps

1. Register an service with ID in URL format
2. Use cli to deregister the service and will get error

### Links
fix https://github.com/hashicorp/consul/issues/13913

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
