### PR TITLE
Allow uppercase in proxy launch -sidecar-for arg

### DIFF
--- a/.changelog/14034.txt
+++ b/.changelog/14034.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: When launching a sidecar proxy with `consul connect envoy` or `consul connect proxy`, the `-sidecar-for` service ID argument is now treated as case-insensitive.
+```

--- a/command/connect/proxy/proxy.go
+++ b/command/connect/proxy/proxy.go
@@ -232,7 +232,7 @@ func LookupProxyIDForSidecar(client *api.Client, sidecarFor string) (string, err
 	var proxyIDs []string
 	for _, svc := range svcs {
 		if svc.Kind == api.ServiceKindConnectProxy && svc.Proxy != nil &&
-			strings.ToLower(svc.Proxy.DestinationServiceID) == sidecarFor {
+			strings.EqualFold(svc.Proxy.DestinationServiceID, sidecarFor) {
 			proxyIDs = append(proxyIDs, svc.ID)
 		}
 	}

--- a/command/connect/proxy/proxy_test.go
+++ b/command/connect/proxy/proxy_test.go
@@ -110,6 +110,17 @@ func TestCommandConfigWatcher(t *testing.T) {
 				require.Equal(t, 9999, cfg.PublicListener.BindPort)
 			},
 		},
+
+		{
+			Name: "-sidecar-for, one sidecar case-insensitive",
+			Flags: []string{
+				"-sidecar-for", "One-SideCar",
+			},
+			Test: func(t *testing.T, cfg *proxy.Config) {
+				// Sanity check we got the right instance.
+				require.Equal(t, 9999, cfg.PublicListener.BindPort)
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Closes #13114
Closes #9144

Previously, when launching a sidecar proxy with one of the following commands:
- consul connect envoy -sidecar-for=...
- consul connect proxy -sidecar-for=...

... the -sidecar-for argument could only contain lowercase letters, even if
the service was registered with some uppercase letters.

Now, the -sidecar-for argument is treated as case-insensitive.

### Testing & Reproduction steps

Tested with a new unit test case only.

Not tested by attempting to launch sidecar proxies manually.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated [N/A]
* [x] not a security concern
