### PR TITLE
ui: Update peerings docs links

### DIFF
--- a/ui/packages/consul-peerings/app/templates/dc/peers/index.hbs
+++ b/ui/packages/consul-peerings/app/templates/dc/peers/index.hbs
@@ -212,12 +212,12 @@ as |sort filters items|}}
                   <BlockSlot @name="actions">
                     <li class="docs-link">
                       {{!-- what's the docs for peering?--}}
-                      <a href="https://www.consul.io/docs/agent/kv" rel="noopener noreferrer" target="_blank">
+                      <a href="{{env 'CONSUL_DOCS_URL'}}/connect/cluster-peering" rel="noopener noreferrer" target="_blank">
                         Documentation on Peers
                       </a>
                     </li>
                     <li class="learn-link">
-                      <a href="https://learn.hashicorp.com/consul/getting-started/kv" rel="noopener noreferrer" target="_blank">
+                      <a href="{{env "CONSUL_DOCS_URL"}}/connect/cluster-peering/create-manage-peering" rel="noopener noreferrer" target="_blank">
                         Take the tutorial
                       </a>
                     </li>


### PR DESCRIPTION
### Description
Updates the links for peering docs to some actual peering related docs.

Follow-up from https://github.com/hashicorp/consul/pull/13757

### Links
- [Documentation on Peers](https://www.consul.io/docs/connect/cluster-peering)
- [Take the tutorial](https://www.consul.io/docs/connect/cluster-peering/create-manage-peering)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
