### PR TITLE
Retry docker build steps

### DIFF
--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -555,7 +555,7 @@ function suite_setup {
 
     # pre-build the verify container
     echo "Rebuilding 'bats-verify' image..."
-    docker build -t bats-verify -f Dockerfile-bats .
+    retry_default docker build -t bats-verify -f Dockerfile-bats .
 
     # if this fails on CircleCI your first thing to try would be to upgrade
     # the machine image to the latest version using this listing:
@@ -566,13 +566,13 @@ function suite_setup {
 
     # pre-build the consul+envoy container
     echo "Rebuilding 'consul-dev-envoy:${ENVOY_VERSION}' image..."
-    docker build -t consul-dev-envoy:${ENVOY_VERSION} \
+    retry_default docker build -t consul-dev-envoy:${ENVOY_VERSION} \
         --build-arg ENVOY_VERSION=${ENVOY_VERSION} \
         -f Dockerfile-consul-envoy .
 
     # pre-build the test-sds-server container
     echo "Rebuilding 'test-sds-server' image..."
-    docker build -t test-sds-server -f Dockerfile-test-sds-server test-sds-server
+    retry_default docker build -t test-sds-server -f Dockerfile-test-sds-server test-sds-server
 }
 
 function suite_teardown {
@@ -877,7 +877,7 @@ function common_run_container_tcpdump {
 
     # we cant run this in circle but its only here to temporarily enable.
 
-    docker build -t envoy-tcpdump -f Dockerfile-tcpdump .
+    retry_default docker build -t envoy-tcpdump -f Dockerfile-tcpdump .
 
     docker run -d --name $(container_name_prev) \
         $(network_snippet $DC) \


### PR DESCRIPTION
### Description
Our integration tests regularly fail on docker build steps due to network issues (io timeout, EOF, TLS timeout). I'm adding retries to our build steps to make the tests more consistent.

```
ERR: command exited with status 1
     command:   docker build -t test-sds-server -f Dockerfile-test-sds-server test-sds-server
     line:      575
     function:  suite_setup
     called at: ./run-tests.sh:896
    main_test.go:21: command failed: exit status 1
--- FAIL: TestEnvoy (23.68s)
```
```
failed to solve with frontend dockerfile.v0: failed to create LLB definition: failed to do request: Head "https://registry-1.docker.io/v2/library/alpine/manifests/3.12": EOF
ERR: command exited with status 1
     command:   docker build -t envoy-tcpdump -f Dockerfile-tcpdump .
     line:      880
     function:  common_run_container_tcpdump
     called at: ./run-tests.sh:864
    main_test.go:36: command failed: exit status 1
```
Example fails:
https://app.circleci.com/pipelines/github/hashicorp/consul/36679/workflows/233f6663-bdcd-4acc-97df-02a63eb0fb23/jobs/808336/tests#failed-test-0

https://app.circleci.com/pipelines/github/hashicorp/consul/36619/workflows/d9c76caf-571f-4c0a-af3c-aee9f4469b7c/jobs/806598/tests#failed-test-2

`retry_default` source: https://github.com/hashicorp/consul/blob/af40b9b144f98538bb5c24ccc39f7ac8c001ae6a/test/integration/connect/envoy/helpers.bash#L6-L48