### PR TITLE
Add debugging logs to freeport

### DIFF
--- a/sdk/testutil/types.go
+++ b/sdk/testutil/types.go
@@ -9,4 +9,5 @@ type TestingTB interface {
 	Logf(format string, args ...interface{})
 	Name() string
 	Fatalf(fmt string, args ...interface{})
+	Helper()
 }


### PR DESCRIPTION
### Description
Many of our flaky / failing tests seem to be caused by ports being held by parallel tests. @acpana tried to address this in https://github.com/hashicorp/consul/pull/13997.

```
[WARN] freeport: 1 out of 5 pending ports are still in use; something probably didn't wait around for the port to be closed!
[WARN] freeport: 1 out of 1 pending ports are still in use; something probably didn't wait around for the port to be closed!
[WARN] freeport: 1 out of 1 pending ports are still in use; something probably didn't wait around for the port to be closed!
```

This PR does not attempt a solution but adds debug lines to our tests to better trace which tests are still holding onto ports.
