### PR TITLE
Move sidecar port assignment logic to locked stage of add flow

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1159,7 +1159,7 @@ func (s *HTTPHandlers) AgentRegisterService(resp http.ResponseWriter, req *http.
 	}
 
 	// See if we have a sidecar to register too
-	sidecar, sidecarChecks, sidecarToken, err := s.agent.sidecarServiceFromNodeService(ns, token)
+	sidecar, sidecarChecks, sidecarToken, err := sidecarServiceFromNodeService(ns, token)
 	if err != nil {
 		return nil, HTTPError{StatusCode: http.StatusBadRequest, Reason: fmt.Sprintf("Invalid SidecarService: %s", err)}
 	}

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -54,7 +54,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 				Kind:                       structs.ServiceKindConnectProxy,
 				ID:                         "web1-sidecar-proxy",
 				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
+				Port:                       0,
 				LocallyRegisteredAsSidecar: true,
 				Proxy: structs.ConnectProxyConfig{
 					DestinationServiceName: "web",
@@ -63,18 +63,8 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 					LocalServicePort:       1111,
 				},
 			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "127.0.0.1:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
-				},
-			},
-			wantToken: "foo",
+			wantChecks: nil,
+			wantToken:  "foo",
 		},
 		{
 			name: "all the allowed overrides",
@@ -157,7 +147,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 				Kind:                       structs.ServiceKindConnectProxy,
 				ID:                         "web1-sidecar-proxy",
 				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
+				Port:                       0,
 				Tags:                       []string{"foo"},
 				Meta:                       map[string]string{"foo": "bar"},
 				LocallyRegisteredAsSidecar: true,
@@ -168,17 +158,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 					LocalServicePort:       1111,
 				},
 			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "127.0.0.1:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
-				},
-			},
+			wantChecks: nil,
 		},
 		{
 			name: "invalid check type",
@@ -215,158 +195,14 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			token:   "foo",
 			wantErr: "reserved for internal use",
 		},
-		{
-			name: "uses proxy address for check",
-			sd: &structs.ServiceDefinition{
-				ID:   "web1",
-				Name: "web",
-				Port: 1111,
-				Connect: &structs.ServiceConnect{
-					SidecarService: &structs.ServiceDefinition{
-						Address: "123.123.123.123",
-						Proxy: &structs.ConnectProxyConfig{
-							LocalServiceAddress: "255.255.255.255",
-						},
-					},
-				},
-				Address: "255.255.255.255",
-			},
-			token: "foo",
-			wantNS: &structs.NodeService{
-				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
-				Kind:                       structs.ServiceKindConnectProxy,
-				ID:                         "web1-sidecar-proxy",
-				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
-				Address:                    "123.123.123.123",
-				LocallyRegisteredAsSidecar: true,
-				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web1",
-					LocalServiceAddress:    "255.255.255.255",
-					LocalServicePort:       1111,
-				},
-			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "123.123.123.123:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
-				},
-			},
-			wantToken: "foo",
-		},
-		{
-			name: "uses proxy.local_service_address for check if proxy address is empty",
-			sd: &structs.ServiceDefinition{
-				ID:   "web1",
-				Name: "web",
-				Port: 1111,
-				Connect: &structs.ServiceConnect{
-					SidecarService: &structs.ServiceDefinition{
-						Address: "", // Proxy address empty.
-						Proxy: &structs.ConnectProxyConfig{
-							LocalServiceAddress: "1.2.3.4",
-						},
-					},
-				},
-				Address: "", // Service address empty.
-			},
-			token: "foo",
-			wantNS: &structs.NodeService{
-				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
-				Kind:                       structs.ServiceKindConnectProxy,
-				ID:                         "web1-sidecar-proxy",
-				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
-				Address:                    "",
-				LocallyRegisteredAsSidecar: true,
-				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web1",
-					LocalServiceAddress:    "1.2.3.4",
-					LocalServicePort:       1111,
-				},
-			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "1.2.3.4:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
-				},
-			},
-			wantToken: "foo",
-		},
-		{
-			name: "uses 127.0.0.1 for check if proxy and proxy.local_service_address are empty",
-			sd: &structs.ServiceDefinition{
-				ID:   "web1",
-				Name: "web",
-				Port: 1111,
-				Connect: &structs.ServiceConnect{
-					SidecarService: &structs.ServiceDefinition{
-						Address: "",
-						Proxy: &structs.ConnectProxyConfig{
-							LocalServiceAddress: "",
-						},
-					},
-				},
-				Address: "",
-			},
-			token: "foo",
-			wantNS: &structs.NodeService{
-				EnterpriseMeta:             *structs.DefaultEnterpriseMetaInDefaultPartition(),
-				Kind:                       structs.ServiceKindConnectProxy,
-				ID:                         "web1-sidecar-proxy",
-				Service:                    "web-sidecar-proxy",
-				Port:                       2222,
-				Address:                    "",
-				LocallyRegisteredAsSidecar: true,
-				Proxy: structs.ConnectProxyConfig{
-					DestinationServiceName: "web",
-					DestinationServiceID:   "web1",
-					LocalServiceAddress:    "127.0.0.1",
-					LocalServicePort:       1111,
-				},
-			},
-			wantChecks: []*structs.CheckType{
-				{
-					Name:     "Connect Sidecar Listening",
-					TCP:      "127.0.0.1:2222",
-					Interval: 10 * time.Second,
-				},
-				{
-					Name:         "Connect Sidecar Aliasing web1",
-					AliasService: "web1",
-				},
-			},
-			wantToken: "foo",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hcl := `
-			ports {
-				sidecar_min_port = 2222
-				sidecar_max_port = 2222
-			}
-			`
-			a := StartTestAgent(t, TestAgent{Name: "jones", HCL: hcl})
-			defer a.Shutdown()
-
 			ns := tt.sd.NodeService()
 			err := ns.Validate()
 			require.NoError(t, err, "Invalid test case - NodeService must validate")
 
-			gotNS, gotChecks, gotToken, err := a.sidecarServiceFromNodeService(ns, tt.token)
+			gotNS, gotChecks, gotToken, err := sidecarServiceFromNodeService(ns, tt.token)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.wantErr)
@@ -464,7 +300,7 @@ func TestAgent_SidecarPortFromServiceID(t *testing.T) {
 				}
 				`
 			}
-			a := StartTestAgent(t, TestAgent{Name: "jones", HCL: hcl})
+			a := NewTestAgent(t, hcl)
 			defer a.Shutdown()
 
 			if tt.preRegister != nil {
@@ -472,7 +308,7 @@ func TestAgent_SidecarPortFromServiceID(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			gotPort, err := a.sidecarPortFromServiceID(structs.ServiceID{ID: tt.serviceID, EnterpriseMeta: tt.enterpriseMeta})
+			gotPort, err := a.sidecarPortFromServiceIDLocked(structs.ServiceID{ID: tt.serviceID, EnterpriseMeta: tt.enterpriseMeta})
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -482,6 +318,55 @@ func TestAgent_SidecarPortFromServiceID(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, tt.wantPort, gotPort)
+		})
+	}
+}
+
+func TestAgent_SidecarDefaultChecks(t *testing.T) {
+	tests := []struct {
+		name                 string
+		svcAddress           string
+		proxyLocalSvcAddress string
+		port                 int
+		wantChecks           []*structs.CheckType
+	}{{
+		name:                 "uses proxy address for check",
+		svcAddress:           "123.123.123.123",
+		proxyLocalSvcAddress: "255.255.255.255",
+		port:                 2222,
+		wantChecks: []*structs.CheckType{
+			{
+				Name:     "Connect Sidecar Listening",
+				TCP:      "123.123.123.123:2222",
+				Interval: 10 * time.Second,
+			},
+			{
+				Name:         "Connect Sidecar Aliasing web1",
+				AliasService: "web1",
+			},
+		},
+	},
+		{
+			name:                 "uses proxy.local_service_address for check if proxy address is empty",
+			proxyLocalSvcAddress: "1.2.3.4",
+			port:                 2222,
+			wantChecks: []*structs.CheckType{
+				{
+					Name:     "Connect Sidecar Listening",
+					TCP:      "1.2.3.4:2222",
+					Interval: 10 * time.Second,
+				},
+				{
+					Name:         "Connect Sidecar Aliasing web1",
+					AliasService: "web1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotChecks := sidecarDefaultChecks("web1", tt.svcAddress, tt.proxyLocalSvcAddress, tt.port)
+			require.Equal(t, tt.wantChecks, gotChecks)
 		})
 	}
 }

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1257,8 +1257,9 @@ type NodeService struct {
 	// a pointer so that we never have to nil-check this.
 	Connect ServiceConnect
 
+	// TODO: rename to reflect that this is used to express future intent to register.
 	// LocallyRegisteredAsSidecar is private as it is only used by a local agent
-	// state to track if the service was registered from a nested sidecar_service
+	// state to track if the service was or will be registered from a nested sidecar_service
 	// block. We need to track that so we can know whether we need to deregister
 	// it automatically too if it's removed from the service definition or if the
 	// parent service is deregistered. Relying only on ID would cause us to


### PR DESCRIPTION
Closes #8254

### Description
This relocates automatic sidecar port assignment logic to a locked method immediately before registration, thereby preventing collisions when handling simultaneous requests.

### Testing & Reproduction steps
Manual verification:
* Submit many simultaneous requests for registration with sidecar proxy and no port specified:
`for name in $(shuf -i 1-10000); do curl -d '{"name": "'$name'", "connect": {"sidecar_service": {}}}' -X PUT localhost:8500/v1/agent/service/register &; echo registered $name; done`
* See how many duplicate ports have been registered:
`curl localhost:8500/v1/agent/services | jq -r ' . | to_entries | map(select(.key | match("sidecar";"i"))) | map(.value) | .[] | .Port' | sort | uniq -d`
* Before this change: there should be several duplicate ports
* After this change: no duplicate ports

### Links
[GH Issue](https://github.com/hashicorp/consul/issues/8254)
[Pre-req PR 1](https://github.com/hashicorp/consul/pull/13906)
[Pre-req PR 2](https://github.com/hashicorp/consul/pull/14056)

### PR Checklist

* [ ] updated test coverage
* [N/A] external facing docs updated
* [N/A] not a security concern

