### PR TITLE
ui: Add undefined check for peer model creation

### DIFF
--- a/ui/packages/consul-ui/app/services/repository/peer.js
+++ b/ui/packages/consul-ui/app/services/repository/peer.js
@@ -55,7 +55,7 @@ export default class PeerService extends RepositoryService {
   @dataSource('/:partition/:ns/:dc/peer-initiate/')
   @dataSource('/:partition/:ns/:dc/peer/:name')
   async fetchOne({ partition, ns, dc, name }, { uri }, request) {
-    if (name === '') {
+    if (typeof name === 'undefined' || name === '') {
       const item = this.create({
         Datacenter: dc,
         Namespace: '',


### PR DESCRIPTION
### Description
Follow on from https://github.com/hashicorp/consul/pull/14018

As we don't pass a `:name` through when calling `generate`/`initiate` then we also need to check for `undefined` here. We could have also included `:name` in the DataSource URI, but _not including_ it is more intentional to what we are doing here. Therefore using an undefined check makes more sense.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
