### PR TITLE
cli: update agent log preamble to reflect per-listener TLS config

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -201,24 +201,29 @@ func (c *cmd) run(args []string) int {
 	if config.ServerMode {
 		segment = "<all>"
 	}
-	ui.Info(fmt.Sprintf("       Version: '%s'", c.versionHuman))
+	ui.Info(fmt.Sprintf("          Version: '%s'", c.versionHuman))
 	if strings.Contains(c.versionHuman, "dev") {
-		ui.Info(fmt.Sprintf("      Revision: '%s'", c.revision))
+		ui.Info(fmt.Sprintf("         Revision: '%s'", c.revision))
 	}
-	ui.Info(fmt.Sprintf("    Build Date: '%s'", c.buildDate))
-	ui.Info(fmt.Sprintf("       Node ID: '%s'", config.NodeID))
-	ui.Info(fmt.Sprintf("     Node name: '%s'", config.NodeName))
+	ui.Info(fmt.Sprintf("       Build Date: '%s'", c.buildDate))
+	ui.Info(fmt.Sprintf("          Node ID: '%s'", config.NodeID))
+	ui.Info(fmt.Sprintf("        Node name: '%s'", config.NodeName))
 	if ap := config.PartitionOrEmpty(); ap != "" {
-		ui.Info(fmt.Sprintf("     Partition: '%s'", ap))
+		ui.Info(fmt.Sprintf("        Partition: '%s'", ap))
 	}
-	ui.Info(fmt.Sprintf("    Datacenter: '%s' (Segment: '%s')", config.Datacenter, segment))
-	ui.Info(fmt.Sprintf("        Server: %v (Bootstrap: %v)", config.ServerMode, config.Bootstrap))
-	ui.Info(fmt.Sprintf("   Client Addr: %v (HTTP: %d, HTTPS: %d, gRPC: %d, DNS: %d)", config.ClientAddrs,
+	ui.Info(fmt.Sprintf("       Datacenter: '%s' (Segment: '%s')", config.Datacenter, segment))
+	ui.Info(fmt.Sprintf("           Server: %v (Bootstrap: %v)", config.ServerMode, config.Bootstrap))
+	ui.Info(fmt.Sprintf("      Client Addr: %v (HTTP: %d, HTTPS: %d, gRPC: %d, DNS: %d)", config.ClientAddrs,
 		config.HTTPPort, config.HTTPSPort, config.GRPCPort, config.DNSPort))
-	ui.Info(fmt.Sprintf("  Cluster Addr: %v (LAN: %d, WAN: %d)", config.AdvertiseAddrLAN,
+	ui.Info(fmt.Sprintf("     Cluster Addr: %v (LAN: %d, WAN: %d)", config.AdvertiseAddrLAN,
 		config.SerfPortLAN, config.SerfPortWAN))
-	ui.Info(fmt.Sprintf("       Encrypt: Gossip: %v, TLS-Outgoing: %v, TLS-Incoming: %v, Auto-Encrypt-TLS: %t",
-		config.EncryptKey != "", config.TLS.InternalRPC.VerifyOutgoing, config.TLS.InternalRPC.VerifyIncoming, config.AutoEncryptTLS || config.AutoEncryptAllowTLS))
+	ui.Info(fmt.Sprintf("Gossip Encryption: %t", config.EncryptKey != ""))
+	ui.Info(fmt.Sprintf(" Auto-Encrypt-TLS: %t", config.AutoEncryptTLS || config.AutoEncryptAllowTLS))
+	ui.Info(fmt.Sprintf("        HTTPS TLS: Verify Incoming: %t, Verify Outgoing: %t, Min Version: %s",
+		config.TLS.HTTPS.VerifyIncoming, config.TLS.HTTPS.VerifyOutgoing, config.TLS.HTTPS.TLSMinVersion))
+	ui.Info(fmt.Sprintf("         gRPC TLS: Verify Incoming: %t, Min Version: %s", config.TLS.GRPC.VerifyIncoming, config.TLS.GRPC.TLSMinVersion))
+	ui.Info(fmt.Sprintf(" Internal RPC TLS: Verify Incoming: %t, Verify Outgoing: %t (Verify Hostname: %t), Min Version: %s",
+		config.TLS.InternalRPC.VerifyIncoming, config.TLS.InternalRPC.VerifyOutgoing, config.TLS.InternalRPC.VerifyServerHostname, config.TLS.InternalRPC.TLSMinVersion))
 	// Enable log streaming
 	ui.Output("")
 	ui.Output("Log data will now stream in as it occurs:\n")


### PR DESCRIPTION
### Description
We made it possible to configure TLS per-listener in Consul 1.12 but never updated the agent log output to reflect this.

Now, each listener/protocol's TLS settings are listed separately for clarity.

```
==> Starting Consul agent...
              Version: '1.13.0-dev'
             Revision: 'e4a579022b+CHANGES'
           Build Date: '2022-08-09 10:08:07 +0000 UTC'
              Node ID: 'f650ac70-0d0d-ee41-17a1-35a4d06dcb31'
            Node name: 'daniel-macbook'
           Datacenter: 'dc1' (Segment: '<all>')
               Server: true (Bootstrap: false)
          Client Addr: [127.0.0.1] (HTTP: 8500, HTTPS: -1, gRPC: 8502, DNS: 8600)
         Cluster Addr: 127.0.0.1 (LAN: 8301, WAN: 8302)
    Gossip Encryption: false
     Auto-Encrypt-TLS: false
            HTTPS TLS: Verify Incoming: false, Verify Outgoing: false, Min Version: TLSv1_2
             gRPC TLS: Verify Incoming: false, Min Version: TLSv1_2
     Internal RPC TLS: Verify Incoming: false, Verify Outgoing: false (Verify Hostname: false), Min Version: TLSv1_2
```
