### PR TITLE
ui: don't surface partitions in services search source dropdown anymore

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/service/search-bar/index.hbs
@@ -139,27 +139,8 @@ as |key value|}}
           </span>
         </BlockSlot>
         <BlockSlot @name="options">
-  {{#let components.Optgroup components.Option as |Optgroup Option|}}
-{{#let
-  (reject-by 'Partition' @partition @partitions)
-as |nonDefaultPartitions|}}
-{{#if (gt nonDefaultPartitions.length 0)}}
-    <Optgroup
-      @label={{t 'common.brand.consul'}}
-    >
-    {{#each @partitions as |partition|}}
-      <Option class="partition" @value={{partition}} @selected={{includes partition @filter.source.value}}>
-        {{partition}}
-      </Option>
-    {{/each}}
-    </Optgroup>
-{{/if}}
-{{/let}}
-
+  {{#let components.Option as |Option|}}
 {{#if (gt @sources.length 0)}}
-    <Optgroup
-      @label={{t 'common.search.integrations'}}
-    >
     {{#each @sources as |source|}}
           <Option class={{source}} @value={{source}} @selected={{includes source @filter.source.value}}>
             {{t (concat "common.brand." source)}}
@@ -168,7 +149,6 @@ as |nonDefaultPartitions|}}
     <Option class="consul" @value='consul' @selected={{includes 'consul' @filter.source.value}}>
       {{t 'common.brand.consul'}}
     </Option>
-    </Optgroup>
 {{/if}}
   {{/let}}
         </BlockSlot>


### PR DESCRIPTION
### Description
Removes the partitions-selection in the sources-dropdown in the services search. Users can search Partitions by name in the search-input. After this change, the sources-dropdown in the services-searchbar will look like in the following screenshot:

<img width="362" alt="Screenshot 2022-08-09 at 16 04 09" src="https://user-images.githubusercontent.com/242299/183670688-a5001d90-249d-4e38-ad1c-fb698b55d07e.png">

__This PR:__
* ~~changes the `Optgroup`-component to only surface the `@label` when we actually pass one - we can use that to not surface a label of an opt-group if we don't want to~~
* removes the partitions-selector in the sources-dropdown in the services search-bar

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
