### PR TITLE
Add retry in TestAgentConnectCALeafCert_good

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -611,7 +611,7 @@ type Connect struct {
 	MeshGatewayWANFederationEnabled *bool                  `mapstructure:"enable_mesh_gateway_wan_federation"`
 	EnableServerlessPlugin          *bool                  `mapstructure:"enable_serverless_plugin"`
 
-	// TestCALeafRootChangeSpread controls how long after a CA roots change before new leaft certs will be generated.
+	// TestCALeafRootChangeSpread controls how long after a CA roots change before new leaf certs will be generated.
 	// This is only tuned in tests, generally set to 1ns to make tests deterministic with when to expect updated leaf
 	// certs by. This configuration is not exposed to users (not documented, and agent/config/default.go will override it)
 	TestCALeafRootChangeSpread *string `mapstructure:"test_ca_leaf_root_change_spread"`


### PR DESCRIPTION
### Description
There is a race between the CA being updated and the server responding to the leaf cert request. Added retries to make the test more consistent.

Similar retry loop exists in `TestAgentConnectCALeafCert_goodNotLocal`
https://github.com/hashicorp/consul/blob/61f86790115339972c4f6ad7328dd1ea3ccb73e8/agent/agent_endpoint_test.go#L6956-L6979