### PR TITLE
agent: Close existing active listeners when agent fails on an address

### DIFF
--- a/.changelog/14081.txt
+++ b/.changelog/14081.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixes an issue where an agent that fails to start due to bad addresses won't clean up any existing listeners
+```


### PR DESCRIPTION
### Description
If `startListeners` successfully created listeners for some of its input addresses but eventually failed, the function would return an error and existing listeners would not be cleaned up.

### Testing & Reproduction steps
* Added testcase which fails without this PR

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
