### PR TITLE
ui: update Node.js engines in package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,6 +26,6 @@
     "validated-changeset": "0.10.0"
   },
   "engines": {
-    "node": ">=10 <=14"
+    "node": ">=10"
   }
 }

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -180,7 +180,7 @@
     "wayfarer": "^7.0.1"
   },
   "engines": {
-    "node": ">=10 <=14"
+    "node": ">=10"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
### Description
Removes the Node.js v1.14 cap on allowed engines for Consul UI.

### Testing & Reproduction steps
```
❯ git commit -m "wip"
error consul-ui@2.2.0: The engine "node" is incompatible with this module. Expected version ">=10 <=14". Got "18.7.0"
error Commands cannot run with an incompatible environment.
```
Every time after running `brew upgrade` locally, I'm blocked from running `git commit` until re-linking an older version of Node.js with `brew link --overwrite node@14`, I believe due to the [`lint-staged`](https://github.com/hashicorp/consul/blob/6eb349536dd03fc15f1c9dd2bbe4f40fc0bb68ce/ui/packages/consul-ui/package.json#L44) husky pre-commit hook. Can we remove the hard cap on Node.js versions newer than v14, or at least raise it to the current stable release, v18?

---

**EDIT:** Looking at the failing Vercel CI task, maybe this sadly can't happen yet - is this warning still accurate, or does this require additional dependency updates perhaps, such as Ember itself?

> **Warning**
> WARNING: Node v16.15.0 is not tested against Ember CLI on your platform. We recommend that you use the most-recent "Active LTS" version of Node.js. See https://git.io/v7S5n for details.

**Feel free to close this PR if not currently actionable.**

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
