### PR TITLE
fix: shadowed err in retryJoin()

### DIFF
--- a/agent/retry_join.go
+++ b/agent/retry_join.go
@@ -226,7 +226,8 @@ func (r *retryJoiner) retryJoin() error {
 	for {
 		addrs := retryJoinAddrs(disco, r.variant, r.cluster, r.addrs, r.logger)
 		if len(addrs) > 0 {
-			n, err := r.join(addrs)
+			n := 0
+			n, err = r.join(addrs)
 			if err == nil {
 				if r.variant == retryJoinMeshGatewayVariant {
 					r.logger.Info("Refreshing mesh gateways completed")


### PR DESCRIPTION
### Description
- err value will be used later to surface the error message to stdout if r.join() returns any err.

### Testing & Reproduction steps


### Links

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
