### PR TITLE
ui: fix - use actual intention for permission check intentions.edit

### DIFF
--- a/ui/packages/consul-ui/app/templates/dc/intentions/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/edit.hbs
@@ -22,7 +22,7 @@ as |route|>
     <BlockSlot @name="loaded">
 {{#let
   loader.data
-  (not (can "write intention" item=item))
+  (not (can "write intention" item=loader.data))
 as |item readOnly|}}
   <AppView>
       <BlockSlot @name="breadcrumbs">


### PR DESCRIPTION
### Description
We weren't passing in the intention we load to the `can`-helper that checks the permission for the intention in question. This led to the permission check not being able to check an `intention`'s `SourcePeer` and subsequently not showing the `View Intention` headline but `Edit Intention` instead.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
