### PR TITLE
docs: Cluster Peering Beta - Not avail on HCP Consul

### DIFF
--- a/website/content/docs/connect/cluster-peering/create-manage-peering.mdx
+++ b/website/content/docs/connect/cluster-peering/create-manage-peering.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Create and Manage Peering Connections
 
-~> **Cluster peering is currently in beta:** Functionality associated with cluster peering is subject to change. You should never use the beta release in secure environments or production scenarios. Features in beta may have performance issues, scaling issues, and limited support.
+~> **Cluster peering is currently in beta:** Functionality associated with cluster peering is subject to change. You should never use the beta release in secure environments or production scenarios. Features in beta may have performance issues, scaling issues, and limited support.<br  /><br />Cluster peering is not currently available in the HCP Consul offering.
 
 A peering token enables cluster peering between different datacenters. Once you generate a peering token, you can use it to establish a connection between clusters. Then you can export services and create intentions so that peered clusters can call those services.
 

--- a/website/content/docs/connect/cluster-peering/index.mdx
+++ b/website/content/docs/connect/cluster-peering/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # What is Cluster Peering?
 
-~> **Cluster peering is currently in beta**: Functionality associated with cluster peering is subject to change. You should never use the beta release in secure environments or production scenarios. Features in beta may have performance issues, scaling issues, and limited support.
+~> **Cluster peering is currently in beta**: Functionality associated with cluster peering is subject to change. You should never use the beta release in secure environments or production scenarios. Features in beta may have performance issues, scaling issues, and limited support. <br  /><br />Cluster peering is not currently available in the HCP Consul offering.
 
 You can create peering connections between two or more independent clusters so that services deployed to different partitions or datacenters can communicate.
 

--- a/website/content/docs/connect/cluster-peering/index.mdx
+++ b/website/content/docs/connect/cluster-peering/index.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # What is Cluster Peering?
 
-~> **Cluster peering is currently in beta**: Functionality associated with cluster peering is subject to change. You should never use the beta release in secure environments or production scenarios. Features in beta may have performance issues, scaling issues, and limited support. <br  /><br />Cluster peering is not currently available in the HCP Consul offering.
+~> **Cluster peering is currently in beta**: Functionality associated with cluster peering is subject to change. You should never use the beta release in secure environments or production scenarios. Features in beta may have performance issues, scaling issues, and limited support. <br/><br/>Cluster peering is not currently available in the HCP Consul offering.
 
 You can create peering connections between two or more independent clusters so that services deployed to different partitions or datacenters can communicate.
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -9,7 +9,7 @@ description: >-
 
 ~> **Cluster peering is currently in beta:** Functionality associated
 with cluster peering is subject to change. You should never use the beta release in secure environments or production scenarios. Features in
-beta may have performance issues, scaling issues, and limited support.<br  /><br />Cluster peering is not currently available in the HCP Consul offering.
+beta may have performance issues, scaling issues, and limited support.<br/><br/>Cluster peering is not currently available in the HCP Consul offering.
 
 To establish a cluster peering connection on Kubernetes, you need to enable the feature in the Helm chart and create custom resource definitions (CRDs) for each side of the peering.
 

--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -9,7 +9,7 @@ description: >-
 
 ~> **Cluster peering is currently in beta:** Functionality associated
 with cluster peering is subject to change. You should never use the beta release in secure environments or production scenarios. Features in
-beta may have performance issues, scaling issues, and limited support.
+beta may have performance issues, scaling issues, and limited support.<br  /><br />Cluster peering is not currently available in the HCP Consul offering.
 
 To establish a cluster peering connection on Kubernetes, you need to enable the feature in the Helm chart and create custom resource definitions (CRDs) for each side of the peering.
 


### PR DESCRIPTION
This PR serves two functions:

1. Adds a notice that Cluster Peering is not available on HCP Consul to the three main docs pages on Cluster Peering
2. Includes backport/1.13 and type/docs-cherrypick label to add changes to the 1.13 release - the main docs edits for this project are on the main branch but are missing from the release tagged v1.13