### PR TITLE
Fix peering establishment bugs on followers

### DIFF
--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -606,6 +606,15 @@ func isFailedPreconditionErr(err error) bool {
 	if err == nil {
 		return false
 	}
+
+	// Handle wrapped errors, since status.FromError does a naive assertion.
+	var statusErr interface {
+		GRPCStatus() *grpcstatus.Status
+	}
+	if errors.As(err, &statusErr) {
+		return statusErr.GRPCStatus().Code() == codes.FailedPrecondition
+	}
+
 	grpcErr, ok := grpcstatus.FromError(err)
 	if !ok {
 		return false

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -1331,4 +1332,14 @@ func TestLeader_Peering_retryLoopBackoffPeering_cancelContext(t *testing.T) {
 	require.Equal(t, []error{
 		fmt.Errorf("error 1"),
 	}, allErrors)
+}
+
+func Test_isFailedPreconditionErr(t *testing.T) {
+	st := grpcstatus.New(codes.FailedPrecondition, "cannot establish a peering stream on a follower node")
+	err := st.Err()
+	assert.True(t, isFailedPreconditionErr(err))
+
+	// test that wrapped errors are checked correctly
+	werr := fmt.Errorf("wrapped: %w", err)
+	assert.True(t, isFailedPreconditionErr(werr))
 }

--- a/agent/consul/peering_backend_test.go
+++ b/agent/consul/peering_backend_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/proto/pbpeering"
+	"github.com/hashicorp/consul/proto/pbpeerstream"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 )
@@ -75,4 +76,63 @@ func newServerDialer(serverAddr string) func(context.Context, string) (net.Conn,
 
 		return conn, nil
 	}
+}
+
+func TestPeerStreamService_ForwardToLeader(t *testing.T) {
+	t.Parallel()
+
+	_, conf1 := testServerConfig(t)
+	server1, err := newServer(t, conf1)
+	require.NoError(t, err)
+
+	_, conf2 := testServerConfig(t)
+	conf2.Bootstrap = false
+	server2, err := newServer(t, conf2)
+	require.NoError(t, err)
+
+	// server1 is leader, server2 follower
+	testrpc.WaitForLeader(t, server1.RPC, "dc1")
+	joinLAN(t, server2, server1)
+	testrpc.WaitForLeader(t, server2.RPC, "dc1")
+
+	peerId := testUUID()
+
+	// Simulate a GenerateToken call on server1, which stores the establishment secret
+	{
+		require.NoError(t, server1.FSM().State().PeeringWrite(10, &pbpeering.PeeringWriteRequest{
+			Peering: &pbpeering.Peering{
+				Name: "foo",
+				ID:   peerId,
+			},
+			SecretsRequest: &pbpeering.SecretsWriteRequest{
+				PeerID: peerId,
+				Request: &pbpeering.SecretsWriteRequest_GenerateToken{
+					GenerateToken: &pbpeering.SecretsWriteRequest_GenerateTokenRequest{
+						EstablishmentSecret: "389bbcdf-1c31-47d6-ae96-f2a3f4c45f84",
+					},
+				},
+			},
+		}))
+	}
+
+	testutil.RunStep(t, "server2 forwards write to server1", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		t.Cleanup(cancel)
+
+		// We will dial server2 which should forward to server1
+		conn, err := gogrpc.DialContext(ctx, server2.config.RPCAddr.String(),
+			gogrpc.WithContextDialer(newServerDialer(server2.config.RPCAddr.String())),
+			gogrpc.WithInsecure(),
+			gogrpc.WithBlock())
+		require.NoError(t, err)
+		t.Cleanup(func() { conn.Close() })
+
+		peerStreamClient := pbpeerstream.NewPeerStreamServiceClient(conn)
+		req := &pbpeerstream.ExchangeSecretRequest{
+			PeerID:              peerId,
+			EstablishmentSecret: "389bbcdf-1c31-47d6-ae96-f2a3f4c45f84",
+		}
+		_, err = peerStreamClient.ExchangeSecret(ctx, req)
+		require.NoError(t, err)
+	})
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -816,6 +816,7 @@ func newGRPCHandlerFromConfig(deps Deps, config *Config, s *Server) connHandler 
 
 		// Note: these external gRPC services are also exposed on the internal server to
 		// enable RPC forwarding.
+		s.peerStreamServer.Register(srv)
 		s.externalACLServer.Register(srv)
 		s.externalConnectCAServer.Register(srv)
 	}


### PR DESCRIPTION
### Description
1. `isFailedPreconditionErr` did not properly handle wrapped status errors
2. PeerStreamService was not registered with the internal gRPC server, making gRPC forwarding to leaders throw `rpc error: code = Unimplemented desc = unknown service hashicorp.consul.internal.peerstream.PeerStreamService`

### Testing & Reproduction steps
* Added testcase that will break if grpc library ever changes its implementation

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
