### PR TITLE
docs: Fixing merge error

### DIFF
--- a/website/content/docs/connect/gateways/mesh-gateway/service-to-service-traffic-partitions.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/service-to-service-traffic-partitions.mdx
@@ -3,7 +3,7 @@ layout: docs
 page_title: Service-to-service Traffic Across Partitions
 description: >-
   This topic describes how to configure mesh gateways to route a service's data to upstreams
-  in other partitions. It describes how to use Envoy and how you can integrate with your preferred gateway.
+  in other partitions. It describes how to use Envoy and how you can integrate with your preferred gateway. 
 ---
 
 # Service-to-service Traffic Across Partitions


### PR DESCRIPTION
The cluster peering beta docs aren't appearing on the website. I believe this was due to a labeling error. Pushing an empty commit/PR to try to fix this issue.