### PR TITLE
ci: Disable Arm RPM verifications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -410,8 +410,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: ["i386", "x86_64", "armv7hl", "aarch64"]
-      # fail-fast: true
+        # TODO(eculver): re-enable when there is a smaller verification container available
+        arch: ["i386", "x86_64"] #, "armv7hl", "aarch64"]
     env:
       version: ${{ needs.get-product-version.outputs.product-version }}
 


### PR DESCRIPTION
### Description
The `armv7hl` and `aarch64` RPM packages are currently being verified by invoking platform-specific Fedora 36 containers (ie `arm32v7/fedora:36` and `arm64v8/fedora:36`) which, after installing dependencies, are often OOM-killed which fails the entire build. This is not ideal. Until we have a reliable container to do these verifications, I'm commenting them out so they don't impede the release process or dev builds. We can do these verifications manually if we absolutely need to.

### Testing & Reproduction steps
* build + verifications don't fail