### PR TITLE
[OSS] proxycfg: terminate stream on irrecoverable errors

### DIFF
--- a/agent/proxycfg-glue/intention_upstreams.go
+++ b/agent/proxycfg-glue/intention_upstreams.go
@@ -54,13 +54,8 @@ func (s serverIntentionUpstreams) Notify(ctx context.Context, req *structs.Servi
 
 func dispatchBlockingQueryUpdate[ResultType any](ch chan<- proxycfg.UpdateEvent) func(context.Context, string, ResultType, error) {
 	return func(ctx context.Context, correlationID string, result ResultType, err error) {
-		event := proxycfg.UpdateEvent{
-			CorrelationID: correlationID,
-			Result:        result,
-			Err:           err,
-		}
 		select {
-		case ch <- event:
+		case ch <- newUpdateEvent(correlationID, result, err):
 		case <-ctx.Done():
 		}
 	}

--- a/agent/proxycfg/data_sources.go
+++ b/agent/proxycfg/data_sources.go
@@ -2,6 +2,7 @@ package proxycfg
 
 import (
 	"context"
+	"errors"
 
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/structs"
@@ -14,6 +15,28 @@ type UpdateEvent struct {
 	Result        interface{}
 	Err           error
 }
+
+// TerminalError wraps the given error to indicate that the data source is in
+// an irrecoverably broken state (e.g. because the given ACL token has been
+// deleted).
+//
+// Setting UpdateEvent.Err to a TerminalError causes all watches to be canceled
+// which, in turn, terminates the xDS streams.
+func TerminalError(err error) error {
+	return terminalError{err}
+}
+
+// IsTerminalError returns whether the given error indicates that the data
+// source is in an irrecoverably broken state so watches should be torn down
+// and retried at a higher level.
+func IsTerminalError(err error) bool {
+	return errors.As(err, &terminalError{})
+}
+
+type terminalError struct{ err error }
+
+func (e terminalError) Error() string { return e.err.Error() }
+func (e terminalError) Unwrap() error { return e.err }
 
 // DataSources contains the dependencies used to consume data used to configure
 // proxies.

--- a/agent/submatview/local_materializer.go
+++ b/agent/submatview/local_materializer.go
@@ -66,12 +66,24 @@ func (m *LocalMaterializer) Run(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		if m.isTerminalError(err) {
+			return
+		}
+
 		m.mat.handleError(req, err)
 
 		if err := m.mat.retryWaiter.Wait(ctx); err != nil {
 			return
 		}
 	}
+}
+
+// isTerminalError determines whether the given error cannot be recovered from
+// and should cause the materializer to halt and be evicted from the view store.
+//
+// This roughly matches the logic in agent/proxycfg-glue.newUpdateEvent.
+func (m *LocalMaterializer) isTerminalError(err error) bool {
+	return acl.IsErrNotFound(err)
 }
 
 // subscribeOnce opens a new subscription to a local backend and runs

--- a/agent/submatview/store.go
+++ b/agent/submatview/store.go
@@ -47,6 +47,9 @@ type entry struct {
 	// requests is the count of active requests using this entry. This entry will
 	// remain in the store as long as this count remains > 0.
 	requests int
+	// evicting is used to mark an entry that will be evicted when the current in-
+	// flight requests finish.
+	evicting bool
 }
 
 // NewStore creates and returns a Store that is ready for use. The caller must
@@ -89,6 +92,7 @@ func (s *Store) Run(ctx context.Context) {
 
 			// Only stop the materializer if there are no active requests.
 			if e.requests == 0 {
+				s.logger.Trace("evicting item from store", "key", he.Key())
 				e.stop()
 				delete(s.byKey, he.Key())
 			}
@@ -187,13 +191,13 @@ func (s *Store) NotifyCallback(
 					"error", err,
 					"request-type", req.Type(),
 					"index", index)
-				continue
 			}
 
 			index = result.Index
 			cb(ctx, cache.UpdateEvent{
 				CorrelationID: correlationID,
 				Result:        result.Value,
+				Err:           err,
 				Meta:          cache.ResultMeta{Index: result.Index, Hit: result.Cached},
 			})
 		}
@@ -211,6 +215,9 @@ func (s *Store) readEntry(req Request) (string, Materializer, error) {
 	defer s.lock.Unlock()
 	e, ok := s.byKey[key]
 	if ok {
+		if e.evicting {
+			return "", nil, errors.New("item is marked for eviction")
+		}
 		e.requests++
 		s.byKey[key] = e
 		return key, e.materializer, nil
@@ -222,7 +229,18 @@ func (s *Store) readEntry(req Request) (string, Materializer, error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	go mat.Run(ctx)
+	go func() {
+		mat.Run(ctx)
+
+		// Materializers run until they either reach their TTL and are evicted (which
+		// cancels the given context) or encounter an irrecoverable error.
+		//
+		// If the context hasn't been canceled, we know it's the error case so we
+		// trigger an immediate eviction.
+		if ctx.Err() == nil {
+			s.evictNow(key)
+		}
+	}()
 
 	e = entry{
 		materializer: mat,
@@ -231,6 +249,28 @@ func (s *Store) readEntry(req Request) (string, Materializer, error) {
 	}
 	s.byKey[key] = e
 	return key, e.materializer, nil
+}
+
+// evictNow causes the item with the given key to be evicted immediately.
+//
+// If there are requests in-flight, the item is marked for eviction such that
+// once the requests have been served releaseEntry will move it to the top of
+// the expiry heap. If there are no requests in-flight, evictNow will move the
+// item to the top of the expiry heap itself.
+//
+// In either case, the entry's evicting flag prevents it from being served by
+// readEntry (and thereby gaining new in-flight requests).
+func (s *Store) evictNow(key string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	e := s.byKey[key]
+	e.evicting = true
+	s.byKey[key] = e
+
+	if e.requests == 0 {
+		s.expireNowLocked(key)
+	}
 }
 
 // releaseEntry decrements the request count and starts an expiry timer if the
@@ -246,6 +286,11 @@ func (s *Store) releaseEntry(key string) {
 		return
 	}
 
+	if e.evicting {
+		s.expireNowLocked(key)
+		return
+	}
+
 	if e.expiry.Index() == ttlcache.NotIndexed {
 		e.expiry = s.expiryHeap.Add(key, s.idleTTL)
 		s.byKey[key] = e
@@ -253,6 +298,17 @@ func (s *Store) releaseEntry(key string) {
 	}
 
 	s.expiryHeap.Update(e.expiry.Index(), s.idleTTL)
+}
+
+// expireNowLocked moves the item with the given key to the top of the expiry
+// heap, causing it to be picked up by the expiry loop and evicted immediately.
+func (s *Store) expireNowLocked(key string) {
+	e := s.byKey[key]
+	if idx := e.expiry.Index(); idx != ttlcache.NotIndexed {
+		s.expiryHeap.Remove(idx)
+	}
+	e.expiry = s.expiryHeap.Add(key, time.Duration(0))
+	s.byKey[key] = e
 }
 
 // makeEntryKey matches agent/cache.makeEntryKey, but may change in the future.


### PR DESCRIPTION
### Description
This is the OSS portion of enterprise PR 2339.

It improves our handling of "irrecoverable" errors in `proxycfg` data sources.

The canonical example of this is what happens when the ACL token presented by Envoy is deleted/revoked. Previously, the stream would get "stuck" until the xDS server re-checked the token (after 5 minutes) and terminated the stream.

Materializers would also sit burning resources retrying something that could never succeed.

Now, it is possible for data sources to mark errors as "terminal" which causes the xDS stream to be closed immediately. Similarly, the `submatview.Store` will evict materializers when it observes they have encountered such an error.


### Testing & Reproduction steps
Envoy integration tests provide general coverage 🔬 but it's useful to test manually by:

1. Starting a server with ACLs enabled
1. Registering a service and creating it a token (`consul acl token create -service-identity ...`)
1. Starting an envoy proxy with this token
1. Deleting the token (`consul acl token delete ...`)

You should observe the Envoy proxy logging errors indicating that the stream was closed, and see Consul trace logs about the store evicting the materializer.
