### PR TITLE
docs: Empty commit for stable-website merge

### DIFF
--- a/website/content/docs/connect/gateways/mesh-gateway/service-to-service-traffic-partitions.mdx
+++ b/website/content/docs/connect/gateways/mesh-gateway/service-to-service-traffic-partitions.mdx
@@ -3,7 +3,7 @@ layout: docs
 page_title: Service-to-service Traffic Across Partitions
 description: >-
   This topic describes how to configure mesh gateways to route a service's data to upstreams
-  in other partitions. It describes how to use Envoy and how you can integrate with your preferred gateway. 
+  in other partitions. It describes how to use Envoy and how you can integrate with your preferred gateway.
 ---
 
 # Service-to-service Traffic Across Partitions


### PR DESCRIPTION
The Cluster Peering Beta docs merged into the main branch and v1.13 release, but did not merge into stable-website.

Pushing an empty commit with the type/docs-cherrypick label to force the updates onto stable-website