### PR TITLE
Handle breaking change for ServiceVirtualIP restore

### DIFF
--- a/.changelog/14149.txt
+++ b/.changelog/14149.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixed a compatibility issue when restoring snapshots from pre-1.13.0 versions of Consul [[GH-14107](https://github.com/hashicorp/consul/issues/14107)]
+```

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2211,8 +2211,8 @@ type PeeredServiceName struct {
 }
 
 type ServiceName struct {
-	Name string
-	acl.EnterpriseMeta
+	Name               string
+	acl.EnterpriseMeta `mapstructure:",squash"`
 }
 
 func NewServiceName(name string, entMeta *acl.EnterpriseMeta) ServiceName {


### PR DESCRIPTION
fixes https://github.com/hashicorp/consul/issues/14107

### Description
Consul 1.13.0 changed ServiceVirtualIP to use PeeredServiceName instead of ServiceName which was a breaking change for those using service mesh and wanted to restore their snapshot after upgrading to 1.13.0.

This commit handles existing data with older ServiceName and converts it during restore so that there are no incompatibility issues when restoring from older snapshots.

### Testing & Reproduction steps
* Manually tested in OSS and ENT by making a snapshot using Consul 1.12.3, then attempting to restore with the changes in this branch.
* Added unit tests restoring both versions of the struct