### PR TITLE
Add changelog entry for peering fix

### DIFF
--- a/.changelog/14119.txt
+++ b/.changelog/14119.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fixed some spurious issues during peering establishment when a follower is dialed
+```


### PR DESCRIPTION
### Description
One of the fixes for [1.13.1](https://github.com/hashicorp/consul/tree/release/1.13.1) didn't get a changelog entry in its PR, so this adds it back for posterity.

### Testing & Reproduction steps
I already ran the changelog tool with this present to generate the changelog for 1.13.1, so I think we're good.

Also, since the next release will base its changelog on `1.13.1` which has this in it already, there shouldn't be any duplication.

### Links
- [1.13.1 CHANGELOG](https://github.com/hashicorp/consul/blob/release/1.13.1/CHANGELOG.md#1131-august-10-2022)
