### PR TITLE
docs: bumping requirements for cluster peering to consul k8s 0.47.0 and consul 1.13.1

### DIFF
--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -21,10 +21,10 @@ The following CRDs are used to create and manage a peering connection:
 ## Prerequisites
 
 You must implement the following requirements to create and use cluster peering connections with Kubernetes:
-- Consul version 1.13.0 or later
+- Consul version 1.13.1 or later
 - At least two Kubernetes clusters
 - The Kubernetes clusters must be running in a flat network
-- The network must be running on Consul on Kubernetes version 0.45 or later
+- The network must be running on Consul on Kubernetes version 0.47.0 or later
 
 ### Helm chart configuration
 
@@ -34,7 +34,7 @@ To establish cluster peering through Kubernetes, deploy clusters with the follow
 
   ```yaml
   global:
-    image: "hashicorp/consul:1.13.0"
+    image: "hashicorp/consul:1.13.1"
     peering:
       enabled: true
   connectInject:
@@ -55,7 +55,7 @@ $ export HELM_RELEASE_NAME=cluster-name
 ```
 
 ```shell-session
-$ helm install ${HELM_RELEASE_NAME} hashicorp/consul --version "0.45.0" --values values.yaml
+$ helm install ${HELM_RELEASE_NAME} hashicorp/consul --version "0.47.0" --values values.yaml
 ```
 
 ## Create a peering token


### PR DESCRIPTION
### Description

Bumping versions of Consul K8s and Consul. Consul 1.13.0 is not recommended due to snapshot agent issues with 1.13.0. 

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
