### PR TITLE
fix: missing segment and partition

### DIFF
--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -62,7 +62,7 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 		return nil, err
 	}
 
-	addSerfMetricsLabels(conf, false, "", "", "")
+	addSerfMetricsLabels(conf, false, c.config.Segment, c.config.AgentEnterpriseMeta().PartitionOrDefault(), "")
 
 	addEnterpriseSerfTags(conf.Tags, c.config.AgentEnterpriseMeta())
 

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -232,7 +232,7 @@ func (s *Server) setupSerfConfig(opts setupSerfOptions) (*serf.Config, error) {
 
 	conf.ReconnectTimeoutOverride = libserf.NewReconnectOverride(s.logger)
 
-	addSerfMetricsLabels(conf, opts.WAN, "", "", "")
+	addSerfMetricsLabels(conf, opts.WAN, opts.Segment, s.config.AgentEnterpriseMeta().PartitionOrDefault(), "")
 
 	addEnterpriseSerfTags(conf.Tags, s.config.AgentEnterpriseMeta())
 


### PR DESCRIPTION
### Description
This is the follow-up PR to https://github.com/hashicorp/consul/pull/14161 to fix the missing segment and partition in client and server's serf setup for ent

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
