### PR TITLE
Add missing install redirrect to redirrect.js for api-gateway docs

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1265,7 +1265,12 @@ module.exports = [
   },
   {
     source: '/docs/api-gateway/api-gateway-usage',
-    destination: '/docs/api-gateway/consul-api-gateway-install',
+    destination: '/docs/api-gateway/install',
+    permanent: true,
+  },
+  {
+    source: '/docs/api-gateway/api-gateway/consul-api-gateway-install',
+    destination: '/docs/api-gateway/install',
     permanent: true,
   },
   {

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1269,7 +1269,7 @@ module.exports = [
     permanent: true,
   },
   {
-    source: '/docs/api-gateway/api-gateway/consul-api-gateway-install',
+    source: '/docs/api-gateway/consul-api-gateway-install',
     destination: '/docs/api-gateway/install',
     permanent: true,
   },


### PR DESCRIPTION
### Description
After doing a google search, noticed the top result for install consul api gateway was broken. They must have gotten missed in the large docs refactor. Added the redirects in.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
