### PR TITLE
docs: Fix misleading phrase about X-Consul-Index header

### DIFF
--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -107,8 +107,9 @@ $ curl \
 - `CreateIndex` is the internal index value that represents when the entry was
   created.
 
-- `ModifyIndex` is the last index that modified this key. It can be used to establish
-  blocking queries by setting the `?index` query parameter.
+- `ModifyIndex` is the last index that modified this key which can be used for
+  Check-and-Set operations on the key. For blocking queries, the `X-Consul-Index`
+  header value should be used to set the `?index` query parameter.
   You can even perform blocking queries against entire subtrees of the KV store:
   if `?recurse` is provided, the returned `X-Consul-Index` corresponds to the
   latest `ModifyIndex` within the prefix, and a blocking query using that

--- a/website/content/api-docs/kv.mdx
+++ b/website/content/api-docs/kv.mdx
@@ -107,9 +107,8 @@ $ curl \
 - `CreateIndex` is the internal index value that represents when the entry was
   created.
 
-- `ModifyIndex` is the last index that modified this key. This index corresponds
-  to the `X-Consul-Index` header value that is returned in responses, and it can
-  be used to establish blocking queries by setting the `?index` query parameter.
+- `ModifyIndex` is the last index that modified this key. It can be used to establish
+  blocking queries by setting the `?index` query parameter.
   You can even perform blocking queries against entire subtrees of the KV store:
   if `?recurse` is provided, the returned `X-Consul-Index` corresponds to the
   latest `ModifyIndex` within the prefix, and a blocking query using that
@@ -152,7 +151,7 @@ is instead `text/plain`.
 response)
 
 !> **Warning:** Consul versions before 1.9.5, 1.8.10 and 1.7.14 detected the content-type
-of the raw KV data which could be used for cross-site scripting (XSS) attacks. This is 
+of the raw KV data which could be used for cross-site scripting (XSS) attacks. This is
 identified publicly as CVE-2020-25864.
 
 ## Create/Update Key


### PR DESCRIPTION
### Description
For KVS GET requests which are non-recurse, the `ModifyIndex` does not correspond to the `X-Consul-Index` header, which is the max Raft index of the entire KVS table: https://github.com/hashicorp/consul/blob/main/agent/consul/state/kvs.go#L193

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
