### PR TITLE
chore: add multi-arch docker build for testing

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -134,6 +134,8 @@ ifdef SKIP_DOCKER_BUILD
 ENVOY_INTEG_DEPS=noop
 endif
 
+SYSTEM_ARCH?=$(shell uname -m)
+
 all: dev-build
 
 # used to make integration dependencies conditional
@@ -152,7 +154,26 @@ dev-docker: linux
 	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
 	@echo "Building Consul Development container - $(CONSUL_DEV_IMAGE)"
 	#  'consul:local' tag is needed to run the integration tests
-	@DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build $(NOCACHE) $(QUIET) -t '$(CONSUL_DEV_IMAGE)' -t 'consul:local' --build-arg CONSUL_IMAGE_VERSION=$(CONSUL_IMAGE_VERSION) $(CURDIR)/pkg/bin/linux_amd64 -f $(CURDIR)/build-support/docker/Consul-Dev.dockerfile
+	docker buildx create --use && docker buildx build -t 'consul:local' \
+       --platform linux/$(SYSTEM_ARCH) \
+	   --build-arg CONSUL_IMAGE_VERSION=$(CONSUL_IMAGE_VERSION) \
+       --load \
+       -f $(CURDIR)/build-support/docker/Consul-Dev-Multiarch.dockerfile $(CURDIR)/pkg/bin/
+
+check-remote-dev-image-env:
+ifndef REMOTE_DEV_IMAGE
+	$(error REMOTE_DEV_IMAGE is undefined: set this image to <your_docker_repo>/<your_docker_image>:<image_tag>, e.g. hashicorp/consul-k8s-dev:latest)
+endif
+
+remote-docker: check-remote-dev-image-env linux-amd64 linux-arm64
+	@echo "Pulling consul container image - $(CONSUL_IMAGE_VERSION)"
+	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
+	@echo "Building and Pushing Consul Development container - $(REMOTE_DEV_IMAGE)"
+	docker buildx create --use && docker buildx build -t '$(REMOTE_DEV_IMAGE)' \
+       --platform linux/amd64,linux/arm64 \
+	   --build-arg CONSUL_IMAGE_VERSION=$(CONSUL_IMAGE_VERSION) \
+       --push \
+       -f $(CURDIR)/build-support/docker/Consul-Dev-Multiarch.dockerfile $(CURDIR)/pkg/bin/
 
 # In CircleCI, the linux binary will be attached from a previous step at bin/. This make target
 # should only run in CI and not locally.
@@ -174,10 +195,18 @@ ifeq ($(CIRCLE_BRANCH), main)
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
 endif
 
-# linux builds a linux binary independent of the source platform
+# linux builds a linux binary compatible with the source platform
 linux:
+	@mkdir -p ./pkg/bin/linux_$(SYSTEM_ARCH)
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(SYSTEM_ARCH) go build -o ./pkg/bin/linux_$(SYSTEM_ARCH) -ldflags "$(GOLDFLAGS)" -tags "$(GOTAGS)"
+
+linux-amd64:
 	@mkdir -p ./pkg/bin/linux_amd64
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./pkg/bin/linux_amd64 -ldflags "$(GOLDFLAGS)" -tags "$(GOTAGS)"
+
+linux-arm64:
+	@mkdir -p ./pkg/bin/linux_arm64
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o ./pkg/bin/linux_arm64 -ldflags "$(GOLDFLAGS)" -tags "$(GOTAGS)"
 
 # dist builds binaries for all platforms and packages them for distribution
 dist:

--- a/build-support/docker/Consul-Dev-Multiarch.dockerfile
+++ b/build-support/docker/Consul-Dev-Multiarch.dockerfile
@@ -1,0 +1,5 @@
+ARG CONSUL_IMAGE_VERSION=latest
+FROM consul:${CONSUL_IMAGE_VERSION}
+RUN apk update && apk add iptables
+ARG TARGETARCH
+COPY linux_${TARGETARCH}/consul /bin/consul


### PR DESCRIPTION
### Description
I wanted an easier way to build and push images that could be consumed anywhere, especially on M1 machines. I tried to add the commands in-place but there is a lot of intersection of CI and other `make` commands with this Dockerfile, so I duplicated the existing one to try and minimize the blast radius. 



### Testing & Reproduction steps
Run: 
* `make dev-docker` for a local image
* ` REMOTE_DEV_IMAGE=ttl.sh/dans/consul-dev-666:24h make remote-docker` to push a remote multi-arch image

### Links
Approach is borrowed from [consul-k8s](https://github.com/hashicorp/consul-k8s/blob/43b4995e374e3197488624cb210e57e3334b6239/Makefile#L35-L45)

### PR Checklist

* [ ] ~updated test coverage~
* [ ] ~external facing docs updated~
* [X] not a security concern
