### PR TITLE
[1.12] Backport of ci: Replace Nomad integration tests with predictable compatibility matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ parameters:
     description: "Boolean whether to run the load test workflow"
 
 references:
+  nomad-versions: &supported_nomad_versions
+    - &default_nomad_version "1.2.10"
+    - "1.1.16"
+    - "1.0.18"
   images:
     # When updating the Go version, remember to also update the versions in the
     # workflows section for go-test-lib jobs.
@@ -546,17 +550,20 @@ jobs:
       - run: make ci.dev-docker
       - run: *notify-slack-failure
 
-  # Nomad 0.8 builds on go1.10
-  # Run integration tests on nomad/v0.8.7
-  nomad-integration-0_8:
+  nomad-integration-test: &NOMAD_TESTS
     docker:
-      - image: docker.mirror.hashicorp.services/cimg/go:1.10
+      - image: docker.mirror.hashicorp.services/cimg/go:1.18
+    parameters:
+      nomad-version:
+        type: enum
+        enum: *supported_nomad_versions
+        default: *default_nomad_version
     environment:
       <<: *ENVIRONMENT
       NOMAD_WORKING_DIR: &NOMAD_WORKING_DIR /home/circleci/go/src/github.com/hashicorp/nomad
-      NOMAD_VERSION: v0.8.7
+      NOMAD_VERSION: << parameters.nomad-version >>
     steps: &NOMAD_INTEGRATION_TEST_STEPS
-      - run: git clone https://github.com/hashicorp/nomad.git --branch ${NOMAD_VERSION} ${NOMAD_WORKING_DIR}
+      - run: git clone https://github.com/hashicorp/nomad.git --branch v${NOMAD_VERSION} ${NOMAD_WORKING_DIR}
 
       # get consul binary
       - attach_workspace:
@@ -586,16 +593,6 @@ jobs:
       - store_artifacts:
           path: *TEST_RESULTS_DIR
       - run: *notify-slack-failure
-
-  # run integration tests on nomad/main
-  nomad-integration-main:
-    docker:
-      - image: docker.mirror.hashicorp.services/cimg/go:1.18
-    environment:
-      <<: *ENVIRONMENT
-      NOMAD_WORKING_DIR: /home/circleci/go/src/github.com/hashicorp/nomad
-      NOMAD_VERSION: main
-    steps: *NOMAD_INTEGRATION_TEST_STEPS
 
   # build frontend yarn cache
   frontend-cache:
@@ -1115,12 +1112,12 @@ workflows:
       - dev-upload-docker:
           <<: *dev-upload
           context: consul-ci
-      - nomad-integration-main:
+      - nomad-integration-test:
           requires:
             - dev-build
-      - nomad-integration-0_8:
-          requires:
-            - dev-build
+          matrix:
+            parameters:
+              nomad-version: *supported_nomad_versions
       - envoy-integration-test-1_19_5:
           requires:
             - dev-build


### PR DESCRIPTION
This is a manual backport of https://github.com/hashicorp/consul/pull/14220 for which the backport assistant failed to backport due to a conflict. The description of the original PR is below. I should note, that there is a notable change from the original backport since I had to go back in time to establish what we expected the compatibility matrix to look like when Consul 1.12 was released. Based on the Consul 1.12 release date, I determined that the three active versions of Nomad at the time were 1.2, 1.1 and 1.0. I chose the latest versions of each of those here.

### Description
Currently, we have two distinct Nomad integration jobs in our CI config: one for 0.8.7 and one for `main`. How we came up with these two is not important. What is important, is that Nomad v0.8.7 was published on Jan. 11, 2019 which makes it two and a half years old. Similarly, `main` is brand new. So new, in fact, that when it updates to say, Go 1.19 ([like was done a few hours ago](https://github.com/hashicorp/nomad/commit/094a455c93450523223cf88ee42345c5446311c7)), our build breaks. 

This is not an optimal situation, so I'm updating our integration tests to use a fixed set of Nomad versions. I chose the most recent three because that is what I assume are still getting updates, just as the three newest versions of Consul are getting updates. Let me know if that's a silly assumption.

Also, I took the liberty of choosing a single version of Go to build them all with. I chose Go 1.19 since it should be compatible with all the given versions. We can address this when we bump the versions in the matrix.

### Testing & Reproduction steps
We are relying upon the successful execution of the job in CI. [Here is an example](https://app.circleci.com/pipelines/github/hashicorp/consul/38009/workflows/fccb000e-c37b-44df-8e85-8cd41b1528ac/jobs/836478). 

### Links
- [Recent Nomad commit that breaks compat with Go 1.18](https://github.com/hashicorp/nomad/commit/094a455c93450523223cf88ee42345c5446311c7)
- [Nomad v0.8.7](https://github.com/hashicorp/nomad/releases/tag/v0.8.7)
- [Passing build for Nomad 1.3.3](https://app.circleci.com/pipelines/github/hashicorp/consul/38009/workflows/fccb000e-c37b-44df-8e85-8cd41b1528ac/jobs/836474)
- [Passing build for Nomad 1.2.10](https://app.circleci.com/pipelines/github/hashicorp/consul/38009/workflows/fccb000e-c37b-44df-8e85-8cd41b1528ac/jobs/836468)
- [Passing build for Nomad 1.1.16](https://app.circleci.com/pipelines/github/hashicorp/consul/38009/workflows/fccb000e-c37b-44df-8e85-8cd41b1528ac/jobs/836478)

### PR Checklist

* [x] updated test coverage
* [ ] ~~external facing docs updated~~
* [ ] ~~not a security concern~~

