### PR TITLE
Use badge for <sup> tags in nav data JSON file

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -757,7 +757,12 @@
     ]
   },
   {
-    "title": "AWS Lambda <sup>BETA</sup>",
+    "title": "AWS Lambda",
+    "badge": {
+      "text": "BETA",
+      "type": "outlined",
+      "color": "neutral"
+    },
     "routes": [
       {
         "title": "Overview",


### PR DESCRIPTION
Replaces the `<sup>` tags in nav data JSON files with a `badge` property. This is a new feature in DevDot, introduced in https://github.com/hashicorp/dev-portal/pull/562. Each badge has type="outlined" and color="neutral".

Asana task: [[Consul] remove `<sup>` tags from nav data](https://app.asana.com/0/1202702246158644/1202707964020095/f)