### PR TITLE
docs: fix broken markdown

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1998,7 +1998,7 @@ specially crafted certificate signed by the CA can be used to gain full access t
       Certificate Authority from the [`ca_file`](#tls_defaults_ca_file) or
       [`ca_path`](#tls_defaults_ca_path). By default, this is false, and Consul
       will not make use of TLS for outgoing connections. This applies to clients
-      and servers as both will make outgoing connections. This setting *does not*
+      and servers as both will make outgoing connections. This setting does not
       apply to the gRPC interface as Consul makes no outgoing connections on this
       interface.
 
@@ -2071,7 +2071,9 @@ specially crafted certificate signed by the CA can be used to gain full access t
       set to true, Consul verifies the TLS certificate presented by the servers
       match the hostname `server.<datacenter>.<domain>`. By default this is false,
       and Consul does not verify the hostname of the certificate, only that it
-      is signed by a trusted CA. This setting *must* be enabled to prevent a
+      is signed by a trusted CA.
+
+      ~> **Security Note:** `verify_server_hostname` *must* be set to true to prevent a
       compromised client from gaining full read and write access to all cluster
       data *including all ACL tokens and Connect CA root keys*.
 


### PR DESCRIPTION
A few sections of the agent config page aren't rendering properly. Example below:

## Before
![image](https://user-images.githubusercontent.com/85913323/185026166-1f1f5efe-888e-4e2e-828e-fcb88be43701.png)

## After
![image](https://user-images.githubusercontent.com/85913323/185113453-653e15a3-9d48-40ed-b6dc-e79b5089e383.png)

[Preview link](https://consul-mjscn1a01-hashicorp.vercel.app/docs/agent/config/config-files#tls_internal_rpc_verify_server_hostname)