### PR TITLE
docs: fix website/docs/agent/telemetry labels chart

### DIFF
--- a/website/content/docs/agent/telemetry.mdx
+++ b/website/content/docs/agent/telemetry.mdx
@@ -702,7 +702,9 @@ agent. The table below describes the additional metrics exported by the proxy.
 | `consul.peering.exported_services`    | Counts the number of services exported to a peer cluster.  | count  | gauge   |
 
 ### Labels
-Consul attaches the following labels to metric values. 
+
+Consul attaches the following labels to metric values.
+
 | Label Name                            | Description                                                            | Possible values                            |
 | ------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------ |
 | `peer_name`                           | The name of the peering on the reporting cluster or leader.              | Any defined peer name in the cluster      |


### PR DESCRIPTION

### Description
Labels' chart appears broken when rendered in the website:
<img width="1046" alt="Screenshot 2022-08-17 at 16 35 58" src="https://user-images.githubusercontent.com/1161924/185148571-c79e0ac6-7222-4c07-a419-8b6c529f6ae8.png">


This PR is adding some spacing to fix it.

### Testing & Reproduction steps
* N/A

### Links
https://www.consul.io/docs/agent/telemetry#labels-2

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
