### PR TITLE
Use the maximum jitter when calculating the timeout

### DIFF
--- a/.changelog/14233.txt
+++ b/.changelog/14233.txt
@@ -1,0 +1,3 @@
+```release-note:bugfix
+rpc: Adds max jitter to client deadlines to prevent i/o deadline errors on blocking queries
+```

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -893,8 +893,8 @@ func TestClient_RPC_Timeout(t *testing.T) {
 		}
 	})
 
-	// waiter will sleep for 50ms
-	require.NoError(t, s1.RegisterEndpoint("Wait", &waiter{duration: 50 * time.Millisecond}))
+	// waiter will sleep for 101ms which is 1ms more than the DefaultQueryTime
+	require.NoError(t, s1.RegisterEndpoint("Wait", &waiter{duration: 101 * time.Millisecond}))
 
 	// Requests with QueryOptions have a default timeout of RPCHoldTimeout (10ms)
 	// so we expect the RPC call to timeout.
@@ -903,7 +903,8 @@ func TestClient_RPC_Timeout(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "rpc error making call: i/o deadline reached")
 
-	// Blocking requests have a longer timeout (100ms) so this should pass
+	// Blocking requests have a longer timeout (100ms) so this should pass since we
+	// add the maximum jitter which should be 16ms
 	out = struct{}{}
 	err = c1.RPC("Wait.Wait", &structs.NodeSpecificRequest{
 		QueryOptions: structs.QueryOptions{

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -353,7 +353,7 @@ func (q QueryOptions) Timeout(rpcHoldTimeout, maxQueryTime, defaultQueryTime tim
 			q.MaxQueryTime = defaultQueryTime
 		}
 		// Timeout after maximum jitter has elapsed.
-		q.MaxQueryTime += lib.RandomStagger(q.MaxQueryTime / JitterFraction)
+		q.MaxQueryTime += q.MaxQueryTime / JitterFraction
 
 		return q.MaxQueryTime + rpcHoldTimeout
 	}


### PR DESCRIPTION
### Description
This is a follow-up to #11500 and fixes #13695. @kisunji actually added back the `RandomStagger` in https://github.com/hashicorp/consul/pull/11500/commits/c8897b2912ddaa0007198c430bef553a18cc06a8

The timeout should include the maximum possible jitter since the server will randomly add to it's timeout a jitter. If the server's timeout is less than the client's timeout then the client will return an i/o deadline reached error.

### Testing & Reproduction steps
Before:
```
time curl 'http://localhost:8500/v1/catalog/service/service?dc=other-dc&stale=&wait=600s&index=15820644'
rpc error making call: i/o deadline reached
real    10m11.469s
user    0m0.018s
sys     0m0.023s
```

After:
```
time curl 'http://localhost:8500/v1/catalog/service/service?dc=other-dc&stale=&wait=600s&index=15820644'
[...]
real    10m35.835s
user    0m0.021s
sys     0m0.021s
```

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
