### PR TITLE
stable-website: missed backport to stable-website from 1.13 release

### DIFF
--- a/website/content/docs/connect/cluster-peering/k8s.mdx
+++ b/website/content/docs/connect/cluster-peering/k8s.mdx
@@ -24,7 +24,7 @@ You must implement the following requirements to create and use cluster peering 
 - Consul version 1.13.1 or later
 - At least two Kubernetes clusters
 - The Kubernetes clusters must be running in a flat network
-- The network must be running on Consul on Kubernetes version 0.47.0 or later
+- The installation must be running on Consul on Kubernetes version 0.47.1 or later
 
 ### Helm chart configuration
 
@@ -48,14 +48,19 @@ To establish cluster peering through Kubernetes, deploy clusters with the follow
 
   </CodeBlockConfig>
 
-Install Consul on Kubernetes on each Kubernetes cluster by applying `values.yaml` using the Helm CLI.
+Install Consul on Kubernetes on each Kubernetes cluster by applying `values.yaml` using the Helm CLI. With these values,
+the servers in each cluster will be exposed over a Kubernetes Load balancer service. This service can be customized
+using [`server.exposeService`](/docs/k8s/helm#v-server-exposeservice). When generating a peering token from one of the
+clusters, the address(es) of the load balancer will be used in the peering token, so the peering stream will go through
+the load balancer in front of the servers. For customizing the addresses used in the peering token, see
+ [`global.peering.tokenGeneration`](/docs/k8s/helm#v-global-peering-tokengeneration).
 
 ```shell-session
 $ export HELM_RELEASE_NAME=cluster-name
 ```
 
 ```shell-session
-$ helm install ${HELM_RELEASE_NAME} hashicorp/consul --version "0.47.0" --values values.yaml
+$ helm install ${HELM_RELEASE_NAME} hashicorp/consul --version "0.47.1" --values values.yaml
 ```
 
 ## Create a peering token


### PR DESCRIPTION
### Description

 missed backport to stable-website from 1.13 release

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
