### PR TITLE
set PRODUCT_VERSION for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,13 +110,13 @@ CMD ["agent", "-dev", "-client", "0.0.0.0"]
 # Remember, this image cannot be built locally.
 FROM docker.mirror.hashicorp.services/alpine:3.15 as default
 
-ARG VERSION
+ARG PRODUCT_VERSION
 ARG BIN_NAME
 
 # PRODUCT_NAME and PRODUCT_VERSION are the name of the software on releases.hashicorp.com
 # and the version to download. Example: PRODUCT_NAME=consul PRODUCT_VERSION=1.2.3.
 ENV BIN_NAME=$BIN_NAME
-ENV VERSION=$VERSION
+ENV VERSION=$PRODUCT_VERSION
 
 ARG PRODUCT_REVISION
 ARG PRODUCT_NAME=$BIN_NAME
@@ -128,7 +128,7 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
       org.opencontainers.image.url="https://www.consul.io/" \
       org.opencontainers.image.documentation="https://www.consul.io/docs" \
       org.opencontainers.image.source="https://github.com/hashicorp/consul" \
-      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.version=${PRODUCT_VERSION} \
       org.opencontainers.image.vendor="HashiCorp" \
       org.opencontainers.image.title="consul" \
       org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
@@ -217,7 +217,7 @@ LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
       org.opencontainers.image.url="https://www.consul.io/" \
       org.opencontainers.image.documentation="https://www.consul.io/docs" \
       org.opencontainers.image.source="https://github.com/hashicorp/consul" \
-      org.opencontainers.image.version=$VERSION \
+      org.opencontainers.image.version=${PRODUCT_VERSION} \
       org.opencontainers.image.vendor="HashiCorp" \
       org.opencontainers.image.title="consul" \
       org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."


### PR DESCRIPTION
### Description

In `actions-docker-build` we [pass](https://github.com/hashicorp/actions-docker-build/blob/05c370a26e61b06be46c5095d6e914c9f0ea4f3d/scripts/docker_build#L49) `PRODUCT_VERSION` to the docker build command. Since this was not set, the label did not populate properly which is used in a comparison to determine the `minor-latest` and `latest` docker image tags. A change merged in today (https://github.com/hashicorp/actions-docker-build/pull/25) checks for this value being set in the docker build action, and errors out if it does not exist. This is causing docker build failures in this repo, for example: https://github.com/hashicorp/consul/actions/runs/2876677829

### Testing & Reproduction steps
How I've tested this PR:
 - build the image up to the point of label creation and pass in `--build-arg PRODUCT_VERSION=1.2.3`
 - inspect the image for the label with the above command

How I expect reviewers to test this PR:
- same as above

### Links

Related [internal-only] post about this: https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2416934922/August+17+2022-+Docker+Build+Failures
