### PR TITLE
Add support for RemoveEmptyTags in API client

### DIFF
--- a/.changelog/14244.txt
+++ b/.changelog/14244.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: add support for RemoveEmptyTags in Prepared Queries templates.
+```

--- a/api/prepared_query.go
+++ b/api/prepared_query.go
@@ -96,6 +96,12 @@ type QueryTemplate struct {
 	// Regexp allows specifying a regex pattern to match against the name
 	// of the query being executed.
 	Regexp string
+
+	// RemoveEmptyTags if set to true, will cause the Tags list inside
+	// the Service structure to be stripped of any empty strings. This is useful
+	// when interpolating into tags in a way where the tag is optional, and
+	// where searching for an empty tag would yield no results from the query.
+	RemoveEmptyTags bool
 }
 
 // PreparedQueryDefinition defines a complete prepared query.

--- a/api/prepared_query_test.go
+++ b/api/prepared_query_test.go
@@ -180,3 +180,55 @@ func TestAPI_PreparedQuery(t *testing.T) {
 		t.Fatalf("bad: %v", defs)
 	}
 }
+
+func TestAPI_PreparedQueryRemoveEmptyTags(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	def := &PreparedQueryDefinition{
+		Name: "test",
+		Service: ServiceQuery{
+			Service: "redis",
+		},
+		Template: QueryTemplate{
+			RemoveEmptyTags: false,
+		},
+	}
+
+	query := c.PreparedQuery()
+	var err error
+	def.ID, _, err = query.Create(def, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	queries, _, err := query.Get(def.ID, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(queries) != 1 {
+		t.Fatalf("wrong length: %#v", queries)
+	}
+	if queries[0].Template.RemoveEmptyTags {
+		t.Fatalf("wrong value: %v", queries[0].Template.RemoveEmptyTags)
+	}
+
+	def.Template.RemoveEmptyTags = true
+	_, err = query.Update(def, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	queries, _, err = query.Get(def.ID, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(queries) != 1 {
+		t.Fatalf("wrong length: %#v", queries)
+	}
+	if !queries[0].Template.RemoveEmptyTags {
+		t.Fatalf("wrong value: %v", queries[0].Template.RemoveEmptyTags)
+	}
+
+}


### PR DESCRIPTION
This change is needed to implement support for RemoveEmptyTags  in the Terraform provider.