### PR TITLE
Remove prefix on docker labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       # Push events on the main branch
       - main
       - release/**
+      - patch-docker-images
 
 env:
   PKG_NAME: consul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
       # Push events on the main branch
       - main
       - release/**
-      - patch-docker-images
 
 env:
   PKG_NAME: consul

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,14 @@ FROM docker.mirror.hashicorp.services/alpine:3.15 as official
 # This is the release of Consul to pull in.
 ARG VERSION
 
-LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
-      org.opencontainers.image.url="https://www.consul.io/" \
-      org.opencontainers.image.documentation="https://www.consul.io/docs" \
-      org.opencontainers.image.source="https://github.com/hashicorp/consul" \
-      org.opencontainers.image.version=$VERSION \
-      org.opencontainers.image.vendor="HashiCorp" \
-      org.opencontainers.image.title="consul" \
-      org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
+LABEL authors="Consul Team <consul@hashicorp.com>" \
+      url="https://www.consul.io/" \
+      documentation="https://www.consul.io/docs" \
+      source="https://github.com/hashicorp/consul" \
+      version=$VERSION \
+      vendor="HashiCorp" \
+      title="consul" \
+      description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
 
 # This is the location of the releases.
 ENV HASHICORP_RELEASES=https://releases.hashicorp.com
@@ -124,14 +124,14 @@ ARG PRODUCT_NAME=$BIN_NAME
 # TARGETOS and TARGETARCH are set automatically when --platform is provided.
 ARG TARGETOS TARGETARCH
 
-LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
-      org.opencontainers.image.url="https://www.consul.io/" \
-      org.opencontainers.image.documentation="https://www.consul.io/docs" \
-      org.opencontainers.image.source="https://github.com/hashicorp/consul" \
-      org.opencontainers.image.version=${PRODUCT_VERSION} \
-      org.opencontainers.image.vendor="HashiCorp" \
-      org.opencontainers.image.title="consul" \
-      org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
+LABEL authors="Consul Team <consul@hashicorp.com>" \
+      url="https://www.consul.io/" \
+      documentation="https://www.consul.io/docs" \
+      source="https://github.com/hashicorp/consul" \
+      version=$PRODUCT_VERSION \
+      vendor="HashiCorp" \
+      title="consul" \
+      description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
 
 # Set up certificates and base tools.
 # libc6-compat is needed to symlink the shared libraries for ARM builds
@@ -206,21 +206,21 @@ ARG BIN_NAME
 # PRODUCT_NAME and PRODUCT_VERSION are the name of the software on releases.hashicorp.com
 # and the version to download. Example: PRODUCT_NAME=consul PRODUCT_VERSION=1.2.3.
 ENV BIN_NAME=$BIN_NAME
-ENV PRODUCT_VERSION=$PRODUCT_VERSION
+ENV VERSION=$PRODUCT_VERSION
 
 ARG PRODUCT_NAME=$BIN_NAME
 
 # TARGETOS and TARGETARCH are set automatically when --platform is provided.
 ARG TARGETOS TARGETARCH
 
-LABEL org.opencontainers.image.authors="Consul Team <consul@hashicorp.com>" \
-      org.opencontainers.image.url="https://www.consul.io/" \
-      org.opencontainers.image.documentation="https://www.consul.io/docs" \
-      org.opencontainers.image.source="https://github.com/hashicorp/consul" \
-      org.opencontainers.image.version=${PRODUCT_VERSION} \
-      org.opencontainers.image.vendor="HashiCorp" \
-      org.opencontainers.image.title="consul" \
-      org.opencontainers.image.description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
+LABEL authors="Consul Team <consul@hashicorp.com>" \
+      url="https://www.consul.io/" \
+      documentation="https://www.consul.io/docs" \
+      source="https://github.com/hashicorp/consul" \
+      version=$PRODUCT_VERSION \
+      vendor="HashiCorp" \
+      title="consul" \
+      description="Consul is a datacenter runtime that provides service discovery, configuration, and orchestration."
 
 # Copy license for Red Hat certification.
 COPY LICENSE /licenses/mozilla.txt


### PR DESCRIPTION
### Description
This is a follow-up / fix-forward of https://github.com/hashicorp/consul/pull/14242. The label name needs to be `version` exactly, and cannot have the prefix that is listed in each label. I removed the label prefixes and verified the docker builds are succeeding and producing the right version. 

### Testing & Reproduction steps
To test locally:

1. Clone consul, checkout this branch, run `make dev-build` && `mkdir dist/linux/amd64/` && `cp ./bin/consul dist/linux/amd64/`
2. Build the ubi image: `docker build --tag=consul:1.13.0-ubi --no-cache --target=ubi --build-arg PRODUCT_VERSION=1.13.1 --build-arg BIN_NAME=consul .`
3. Build the default image: `docker build --tag=consul:1.13.0 --no-cache --target=default --build-arg PRODUCT_VERSION=1.13.1 --build-arg BIN_NAME=consul .`
4. Get the image ID from above built images w/ `docker image  ls | grep consul` 
5. Run `docker inspect --format='{{ index .Config.Labels "version" }}' $IMAGE_ID` with the image ID from above

A test run was also triggered in CI. The docker builds should pass before merging: https://github.com/hashicorp/consul/runs/7889524792?check_suite_focus=true

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
