### PR TITLE
Skip Lambda integration tests for fork PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,9 @@ commands:
         type: env_var_name
         default: ROLE_ARN
     steps:
+      # Only run the assume-role command for the main repo. The AWS credentials aren't available for forks.
       - run: |
+        if [[ "${CIRCLE_BRANCH%%/*}/" != "pull/" ]]; then
           export AWS_ACCESS_KEY_ID="${<< parameters.access-key >>}"
           export AWS_SECRET_ACCESS_KEY="${<< parameters.secret-key >>}"
           export ROLE_ARN="${<< parameters.role-arn >>}"
@@ -118,6 +120,7 @@ commands:
           echo "export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')" >> $BASH_ENV
           echo "export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')" >> $BASH_ENV
           echo "export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.SessionToken')" >> $BASH_ENV
+        fi
 
   run-go-test-full:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,16 +111,16 @@ commands:
     steps:
       # Only run the assume-role command for the main repo. The AWS credentials aren't available for forks.
       - run: |
-        if [[ "${CIRCLE_BRANCH%%/*}/" != "pull/" ]]; then
-          export AWS_ACCESS_KEY_ID="${<< parameters.access-key >>}"
-          export AWS_SECRET_ACCESS_KEY="${<< parameters.secret-key >>}"
-          export ROLE_ARN="${<< parameters.role-arn >>}"
-          # assume role has duration of 15 min (the minimum allowed)
-          CREDENTIALS="$(aws sts assume-role --duration-seconds 900 --role-arn ${ROLE_ARN} --role-session-name build-${CIRCLE_SHA1} | jq '.Credentials')"
-          echo "export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')" >> $BASH_ENV
-          echo "export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')" >> $BASH_ENV
-          echo "export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.SessionToken')" >> $BASH_ENV
-        fi
+          if [[ "${CIRCLE_BRANCH%%/*}/" != "pull/" ]]; then
+            export AWS_ACCESS_KEY_ID="${<< parameters.access-key >>}"
+            export AWS_SECRET_ACCESS_KEY="${<< parameters.secret-key >>}"
+            export ROLE_ARN="${<< parameters.role-arn >>}"
+            # assume role has duration of 15 min (the minimum allowed)
+            CREDENTIALS="$(aws sts assume-role --duration-seconds 900 --role-arn ${ROLE_ARN} --role-session-name build-${CIRCLE_SHA1} | jq '.Credentials')"
+            echo "export AWS_ACCESS_KEY_ID=$(echo $CREDENTIALS | jq -r '.AccessKeyId')" >> $BASH_ENV
+            echo "export AWS_SECRET_ACCESS_KEY=$(echo $CREDENTIALS | jq -r '.SecretAccessKey')" >> $BASH_ENV
+            echo "export AWS_SESSION_TOKEN=$(echo $CREDENTIALS | jq -r '.SessionToken')" >> $BASH_ENV
+          fi
 
   run-go-test-full:
     parameters:


### PR DESCRIPTION
### Description
The `test-integrations` CI workflow is consistently failing for fork PRs because forked repositories do not contain the necessary AWS credentials to perform an `aws assume-role` command. This PR ensures that `aws assume-role` is only attempted during CI workflows in the main Consul repository.

### Testing & Reproduction steps
* Run the CI pipeline for this fork PR and ensure that it completes successfully.

### PR Checklist

* [x] ~updated test coverage~ N/A
* [x] ~external facing docs updated~ N/A
* [x] not a security concern
