### PR TITLE
Added new auto_encrypt.grpc_server_tls config option to control AutoTLS enabling of GRPC Server's TLS usage (for consul v1.13.*)

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -956,7 +956,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		AutoEncryptDNSSAN:                      autoEncryptDNSSAN,
 		AutoEncryptIPSAN:                       autoEncryptIPSAN,
 		AutoEncryptAllowTLS:                    autoEncryptAllowTLS,
-		AutoEncryptGRPCIncoming:                boolValWithDefault(c.AutoEncrypt.GRPCIncoming, true),
+		AutoEncryptGRPCServerTLS:               boolValWithDefault(c.AutoEncrypt.GRPCServerTLS, true),
 		AutoConfig:                             autoConfig,
 		ConnectEnabled:                         connectEnabled,
 		ConnectCAProvider:                      connectCAProvider,

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -956,6 +956,7 @@ func (b *builder) build() (rt RuntimeConfig, err error) {
 		AutoEncryptDNSSAN:                      autoEncryptDNSSAN,
 		AutoEncryptIPSAN:                       autoEncryptIPSAN,
 		AutoEncryptAllowTLS:                    autoEncryptAllowTLS,
+		AutoEncryptGRPCIncoming:                boolValWithDefault(c.AutoEncrypt.GRPCIncoming, true),
 		AutoConfig:                             autoConfig,
 		ConnectEnabled:                         connectEnabled,
 		ConnectCAProvider:                      connectCAProvider,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -600,7 +600,8 @@ type AutoEncrypt struct {
 	// AutoEncrypt.Sign requests.
 	AllowTLS *bool `mapstructure:"allow_tls"`
 
-	GRPCIncoming *bool `mapstructure:"grpc_incoming"`
+	// Enable AutoEncrypt for (external) gRPC Listener (default: true)
+	GRPCServerTLS *bool `mapstructure:"grpc_server_tls"`
 }
 
 // Connect is the agent-global connect configuration.

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -599,6 +599,8 @@ type AutoEncrypt struct {
 	// AllowTLS enables the RPC endpoint on the server to answer
 	// AutoEncrypt.Sign requests.
 	AllowTLS *bool `mapstructure:"allow_tls"`
+
+	GRPCIncoming *bool `mapstructure:"grpc_incoming"`
 }
 
 // Connect is the agent-global connect configuration.

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -479,7 +479,9 @@ type RuntimeConfig struct {
 	// AutoEncrypt.Sign requests.
 	AutoEncryptAllowTLS bool
 
-	AutoEncryptGRPCIncoming bool
+	// AutoEncryptGRPCServerTLS enables auto_encrypt to be used for TLS
+	// of external gRPC Server listener.
+	AutoEncryptGRPCServerTLS bool
 
 	// AutoConfig is a grouping of the configurations around the agent auto configuration
 	// process including how servers can authorize requests.

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -479,6 +479,8 @@ type RuntimeConfig struct {
 	// AutoEncrypt.Sign requests.
 	AutoEncryptAllowTLS bool
 
+	AutoEncryptGRPCIncoming bool
+
 	// AutoConfig is a grouping of the configurations around the agent auto configuration
 	// process including how servers can authorize requests.
 	AutoConfig AutoConfig

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3146,6 +3146,54 @@ func TestLoad_IntegrationWithFlags(t *testing.T) {
 		},
 	})
 	run(t, testCase{
+		desc: "auto_encrypt.grpc_server_tls defaults to true",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json: []string{`{
+				"auto_encrypt": {}
+			}`},
+		hcl: []string{`
+				auto_encrypt = {}
+			`},
+		expected: func(rt *RuntimeConfig) {
+			rt.DataDir = dataDir
+			rt.AutoEncryptGRPCServerTLS = true
+		},
+	})
+	run(t, testCase{
+		desc: "auto_encrypt.grpc_server_tls is enabled when true",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json: []string{`{
+				"auto_encrypt": { "grpc_server_tls": true }
+			}`},
+		hcl: []string{`
+				auto_encrypt = { grpc_server_tls = true }
+			`},
+		expected: func(rt *RuntimeConfig) {
+			rt.DataDir = dataDir
+			rt.AutoEncryptGRPCServerTLS = true
+		},
+	})
+	run(t, testCase{
+		desc: "auto_encrypt.grpc_server_tls is disabled when false",
+		args: []string{
+			`-data-dir=` + dataDir,
+		},
+		json: []string{`{
+				"auto_encrypt": { "grpc_server_tls": false }
+			}`},
+		hcl: []string{`
+				auto_encrypt = { grpc_server_tls = false }
+			`},
+		expected: func(rt *RuntimeConfig) {
+			rt.DataDir = dataDir
+			rt.AutoEncryptGRPCServerTLS = false
+		},
+	})
+	run(t, testCase{
 		desc: "rpc.enable_streaming = true has no effect when not running in server mode",
 		args: []string{
 			`-data-dir=` + dataDir,

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -61,6 +61,7 @@
     },
     "AutoEncryptAllowTLS": false,
     "AutoEncryptDNSSAN": [],
+    "AutoEncryptGRPCServerTLS": false,
     "AutoEncryptIPSAN": [],
     "AutoEncryptTLS": false,
     "AutoReloadConfig": false,

--- a/agent/config/testdata/full-config.hcl
+++ b/agent/config/testdata/full-config.hcl
@@ -199,6 +199,7 @@ auto_encrypt = {
     dns_san = ["a.com", "b.com"]
     ip_san = ["192.168.4.139", "192.168.4.140"]
     allow_tls = true
+    grpc_server_tls = false
 }
 connect {
     ca_provider = "consul"

--- a/agent/config/testdata/full-config.json
+++ b/agent/config/testdata/full-config.json
@@ -200,7 +200,8 @@
     "tls": false,
     "dns_san": ["a.com", "b.com"],
     "ip_san": ["192.168.4.139", "192.168.4.140"],
-    "allow_tls": true
+    "allow_tls": true,
+    "grpc_server_tls": false
   },
   "connect": {
     "ca_provider": "consul",

--- a/agent/grpc-external/server.go
+++ b/agent/grpc-external/server.go
@@ -1,12 +1,13 @@
 package external
 
 import (
+	"time"
+
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
-	"time"
 
 	agentmiddleware "github.com/hashicorp/consul/agent/grpc-middleware"
 	"github.com/hashicorp/consul/tlsutil"
@@ -34,7 +35,7 @@ func NewServer(logger agentmiddleware.Logger, tls *tlsutil.Configurator) *grpc.S
 			MinTime: 15 * time.Second,
 		}),
 	}
-	if tls != nil && tls.GRPCTLSConfigured() {
+	if tls != nil && tls.GRPCServerUseTLS() {
 		creds := credentials.NewTLS(tls.IncomingGRPCConfig())
 		opts = append(opts, grpc.Creds(creds))
 	}

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -92,6 +92,11 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer) (BaseDeps, error) 
 	if err != nil {
 		return d, err
 	}
+	err = d.TLSConfigurator.SetAutoTLSGRPCIncoming(cfg.AutoEncryptGRPCIncoming)
+	if err != nil {
+		return d, err
+	}
+	d.Logger.Info("AutoEncryptGRPCIncoming", "value", cfg.AutoEncryptGRPCIncoming)
 
 	d.RuntimeConfig = cfg
 	d.Tokens = new(token.Store)

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -92,11 +92,10 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer) (BaseDeps, error) 
 	if err != nil {
 		return d, err
 	}
-	err = d.TLSConfigurator.SetAutoTLSGRPCIncoming(cfg.AutoEncryptGRPCIncoming)
+	err = d.TLSConfigurator.SetAutoTLSGRPCServer(cfg.AutoEncryptGRPCServerTLS)
 	if err != nil {
 		return d, err
 	}
-	d.Logger.Info("AutoEncryptGRPCIncoming", "value", cfg.AutoEncryptGRPCIncoming)
 
 	d.RuntimeConfig = cfg
 	d.Tokens = new(token.Store)

--- a/go.sum
+++ b/go.sum
@@ -113,7 +113,6 @@ github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,7 @@ github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -198,7 +198,7 @@ type Configurator struct {
 		connectCAPems        []string
 		cert                 *tls.Certificate
 		verifyServerHostname bool
-		grpcIncoming         bool
+		grpcServerUseTLS     bool
 	}
 
 	// logger is not protected by a lock. It must never be changed after
@@ -273,17 +273,12 @@ func (c *Configurator) Update(config Config) error {
 	return nil
 }
 
-func (c *Configurator) SetAutoTLSGRPCIncoming(value bool) error {
+// SetAutoTLSGRPCServer sets autoTLS' grpcServerUseTLS value.
+func (c *Configurator) SetAutoTLSGRPCServer(value bool) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.autoTLS.grpcIncoming = value
+	c.autoTLS.grpcServerUseTLS = value
 	return nil
-}
-
-func (c *Configurator) AutoTLSGRPCIncoming() bool {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-	return c.autoTLS.grpcIncoming
 }
 
 // loadProtocolConfig loads the certificates etc. for a given ProtocolConfig
@@ -642,7 +637,7 @@ func (c *Configurator) Cert() *tls.Certificate {
 func (c *Configurator) GRPCServerUseTLS() bool {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.grpc.cert != nil || (c.autoTLS.grpcIncoming && c.autoTLS.cert != nil)
+	return c.grpc.cert != nil || (c.autoTLS.grpcServerUseTLS && c.autoTLS.cert != nil)
 }
 
 // VerifyIncomingRPC returns true if we should verify incoming connnections to

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -1465,7 +1465,7 @@ func TestConfigurator_AuthorizeInternalRPCServerConn(t *testing.T) {
 	})
 }
 
-func TestConfigurator_GRPCTLSConfigured(t *testing.T) {
+func TestConfigurator_GRPCServerUseTLS(t *testing.T) {
 	t.Run("certificate manually configured", func(t *testing.T) {
 		c := makeConfigurator(t, Config{
 			GRPC: ProtocolConfig{
@@ -1473,7 +1473,12 @@ func TestConfigurator_GRPCTLSConfigured(t *testing.T) {
 				KeyFile:  "../test/hostname/Alice.key",
 			},
 		})
-		require.True(t, c.GRPCTLSConfigured())
+		require.True(t, c.GRPCServerUseTLS())
+	})
+
+	t.Run("no certificate", func(t *testing.T) {
+		c := makeConfigurator(t, Config{})
+		require.False(t, c.GRPCServerUseTLS())
 	})
 
 	t.Run("AutoTLS", func(t *testing.T) {
@@ -1482,13 +1487,18 @@ func TestConfigurator_GRPCTLSConfigured(t *testing.T) {
 		bobCert := loadFile(t, "../test/hostname/Bob.crt")
 		bobKey := loadFile(t, "../test/hostname/Bob.key")
 		require.NoError(t, c.UpdateAutoTLSCert(bobCert, bobKey))
-
-		require.True(t, c.GRPCTLSConfigured())
+		require.NoError(t, c.SetAutoTLSGRPCServer(true))
+		require.True(t, c.GRPCServerUseTLS())
 	})
 
-	t.Run("no certificate", func(t *testing.T) {
+	t.Run("AutoTLS w/ GRPC Disabled", func(t *testing.T) {
 		c := makeConfigurator(t, Config{})
-		require.False(t, c.GRPCTLSConfigured())
+
+		bobCert := loadFile(t, "../test/hostname/Bob.crt")
+		bobKey := loadFile(t, "../test/hostname/Bob.key")
+		require.NoError(t, c.UpdateAutoTLSCert(bobCert, bobKey))
+		require.NoError(t, c.SetAutoTLSGRPCServer(false))
+		require.False(t, c.GRPCServerUseTLS())
 	})
 }
 

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1389,6 +1389,10 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     the certificates requested by `auto_encrypt` from the server have these `ip_san`
     set as IP SAN.
 
+  - `grpc_server_tls` (Defaults to `true`) When true, auto_encrypt TLS settings will be
+     applied to gRPC listener. This is mainly intended for disabling TLS on gRPC server
+     while using auto_encrypt for other TLS usages (like HTTPS).
+
 - `encrypt` Equivalent to the [`-encrypt` command-line flag](/docs/agent/config/cli-flags#_encrypt).
 
 - `encrypt_verify_incoming` - This is an optional


### PR DESCRIPTION
### Description
Added new auto_encrypt.grpc_server_tls config option to control AutoTLS enabling of GRPC Server's TLS usage.

### Testing & Reproduction steps
See https://github.com/hashicorp/consul/issues/14253

### PR Checklist

* [X] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
