### PR TITLE
ui: Replace file-mask with file-text icon usage on policy list

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -12,6 +12,7 @@ node_modules
 .pnp*
 .sass-cache
 .DS_Store
+.tool-versions
 connect.lock
 coverage
 coverage_*

--- a/ui/packages/consul-ui/app/components/composite-row/index.scss
+++ b/ui/packages/consul-ui/app/components/composite-row/index.scss
@@ -95,7 +95,7 @@
 }
 
 %composite-row-detail .policy::before {
-  @extend %with-file-fill-mask, %as-pseudo;
+  @extend %with-file-text-mask, %as-pseudo;
   margin-right: 3px;
 }
 %composite-row-detail .role::before {

--- a/ui/packages/consul-ui/app/styles/base/icons/icons/index.scss
+++ b/ui/packages/consul-ui/app/styles/base/icons/icons/index.scss
@@ -330,7 +330,7 @@
 // @import './file-minus/index.scss';
 // @import './file-plus/index.scss';
 // @import './file-source/index.scss';
-// @import './file-text/index.scss';
+@import './file-text/index.scss';
 // @import './file-x/index.scss';
 // @import './files/index.scss';
 // @import './film/index.scss';


### PR DESCRIPTION
### Description
Policy lists were using the file-mask icon, where they should be using the file-text icon.

#### Before
<img width="1578" alt="Screen Shot 2022-08-19 at 8 54 24 AM" src="https://user-images.githubusercontent.com/5448834/185646732-4b113b29-1410-4198-9bf4-879cc42490c2.png">
<img width="1578" alt="Screen Shot 2022-08-19 at 8 54 18 AM" src="https://user-images.githubusercontent.com/5448834/185646747-f2066b3e-8eea-4373-b371-fe82541ee5ad.png">


#### After
<img width="1837" alt="Screen Shot 2022-08-19 at 8 37 03 AM" src="https://user-images.githubusercontent.com/5448834/185646433-8b107f92-71f1-43a5-95f5-d0add4011d61.png">
<img width="1837" alt="Screen Shot 2022-08-19 at 8 36 55 AM" src="https://user-images.githubusercontent.com/5448834/185646443-daff8ad5-3961-4d10-a42d-5218d68499dd.png">


### Testing & Reproduction steps
Manual Steps:
- Run in mock data mode
- Enable ACL 
- Visit the Tokens page or Roles page and observe the list of policies and the associated icon

### Links
- [Asana Ticket](https://app.asana.com/0/701615483297399/1202765534781840/f)

### Additional Notes
- I added `.tool-versions` to the `consul-ui/ui` gitignore as I used `asdf` for my node version management instead of nvm (performance reasons)

### PR Checklist
* [x] not a security concern
