### PR TITLE
ui: Update badge / pill icon sizing

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/external-source/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/external-source/index.scss
@@ -1,6 +1,11 @@
 .consul-external-source {
   @extend %pill-200, %frame-gray-600, %p1;
 }
+
+.consul-external-source::before {
+  --icon-size: icon-300;
+}
+
 .consul-external-source.kubernetes::before {
   @extend %with-logo-kubernetes-color-icon, %as-pseudo;
 }
@@ -15,10 +20,10 @@
   @extend %with-logo-consul-color-icon, %as-pseudo;
 }
 .consul-external-source.vault::before {
-  @extend %with-vault-100;
+  @extend %with-vault-300;
 }
 .consul-external-source.aws::before {
-  @extend %with-aws-100;
+  @extend %with-aws-300;
 }
 .consul-external-source.leader::before {
   @extend %with-star-outline-mask, %as-pseudo;

--- a/ui/packages/consul-ui/app/components/consul/kind/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/kind/index.scss
@@ -3,4 +3,5 @@
 }
 .consul-kind::before {
   @extend %with-gateway-mask, %as-pseudo;
+  --icon-size: icon-300;
 }

--- a/ui/packages/consul-ui/app/components/pill/index.scss
+++ b/ui/packages/consul-ui/app/components/pill/index.scss
@@ -18,6 +18,9 @@ span.policy-node-identity::before {
 span.policy-service-identity::before {
   content: 'Service Identity: ';
 }
+%pill::before {
+  --icon-size: icon-300;
+}
 %pill.leader::before {
   @extend %with-star-outline-mask, %as-pseudo;
 }


### PR DESCRIPTION
### Description
Updates the badge and pill icon sizing. As far as I could tell, they're all using the [flight-icons](https://flight-hashicorp.vercel.app/). I've referenced a few of @johncowen's older PRs to try and get a grasp on where the transition is at for the icons, so if I've misunderstood how using flight-icons work, please let me know 😄. 

#### Before
<img width="1915" alt="Screen Shot 2022-08-19 at 4 44 36 PM" src="https://user-images.githubusercontent.com/5448834/185716349-f731b68d-c8d0-4799-b628-870f3e9fb03c.png">
<img width="1915" alt="Screen Shot 2022-08-19 at 4 44 15 PM" src="https://user-images.githubusercontent.com/5448834/185716357-06bb13bc-903e-4d34-9362-4e12850cc2f9.png">


#### After
<img width="1915" alt="Screen Shot 2022-08-19 at 4 36 34 PM" src="https://user-images.githubusercontent.com/5448834/185716202-2612f174-0879-4076-bc46-40a0d83cea24.png">
<img width="1915" alt="Screen Shot 2022-08-19 at 4 36 55 PM" src="https://user-images.githubusercontent.com/5448834/185716208-e4e303bd-4e49-4f90-b1e4-2969a0f78efe.png">


### Links
- [ticket](https://app.asana.com/0/701615483297399/1202765534781835/f)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
