### PR TITLE
ci: Add PR number and title to oss-merge payload

### DIFF
--- a/.github/workflows/oss-merge-trigger.yml
+++ b/.github/workflows/oss-merge-trigger.yml
@@ -15,12 +15,20 @@ jobs:
     steps:
       - name: Trigger Merge
         env:
-          GIT_REF: ${{ github.ref_name }}
-          GIT_SHA: ${{ github.sha }}
           GH_PAT: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-          GIT_ACTOR: ${{ github.actor }}
         run: |
+          # Build JSON payload to trigger oss-merge GitHub Action in Enterprise
+          # the primary reason for doing this is that jq should handle escaping
+          # JSON strings for us. This only runs the load test pipeline on the 'main' branch.
+          jsonData=$(jq --null-input -r \
+            --arg gitref ${{ github.ref_name }} \
+            --arg gitsha ${{ github.sha }} \
+            --arg gitactor ${{ github.actor }} \
+            --arg prnumber ${{ github.event.pull_request.number }} \
+            --arg prtitle ${{ github.event.pull_request.title }} \
+            '{ "event_type": "oss-merge", "client_payload": { "git-ref": $gitref, "git-sha": $gitsha, "git-actor": $gitactor, "pr-number": $prnumber, "pr-title": $prtitle } }' )
+          echo "Passing JSON payload to GitHub API: $jsonData"
           curl -H "Authorization: token $GH_PAT" \
             -H 'Accept: application/json' \
-            -d "{\"event_type\": \"oss-merge\", \"client_payload\": {\"git-ref\": \"${GIT_REF}\", \"git-sha\": \"${GIT_SHA}\", \"git-actor\": \"${GIT_ACTOR}\" }}" \
+            -d "$jsonData" \
             "https://api.github.com/repos/hashicorp/consul-enterprise/dispatches"


### PR DESCRIPTION
### Description
We want to use the titles from PRs in OSS when we create their accompanying Enterprise merges. With the title and the number in the trigger payload, we can consume it on the Enterprise side when we create the PR. This updates the trigger action to provide those values.

### Testing & Reproduction steps
The biggest hurdle in testing here was dealing with the potential for there to be quotes or other special characters in the PR title that wouldn't play nicely when provided in a `POST` request body to `curl`. I ended up using [the same method that we use for triggering a load test](https://github.com/hashicorp/consul/blob/ca22ac9b298f3b66b57c751e38041335a8c0fa1e/.github/workflows/load-test.yml#L21-L30). This uses `jq --arg` functionality to escape the values in the payload. One thing to note with this is that I had to remove hyphens from the arg names for it to work.