### PR TITLE
Add example code for cross-namespace certificateRefs

### DIFF
--- a/website/content/docs/api-gateway/configuration/gateway.mdx
+++ b/website/content/docs/api-gateway/configuration/gateway.mdx
@@ -183,3 +183,49 @@ tls:
 
 ```
 
+#### Example cross-namespace certificateRef
+
+The following example creates a `Gateway` named `example-gateway` in namespace `gateway-namespace`. This `Gateway` has a `certificateRef` in namespace `secret-namespace`. The reference is allowed because the `ReferenceGrant`, named `reference-grant` in namespace `secret-namespace`, allows `Gateways` in `gateway-namespace` to reference `Secrets` in `secret-namespace`.
+
+<CodeBlockConfig filename="gateway_with_referencegrant.yaml">
+
+  ```yaml
+  apiVersion: gateway.networking.k8s.io/v1beta1
+  kind: Gateway
+  metadata:
+    name: example-gateway
+    namespace: gateway-namespace
+  spec:
+    gatewayClassName: consul-api-gateway
+    listeners:
+    - protocol: HTTPS
+      port: 443
+      name: https
+      allowedRoutes:
+        namespaces:
+          from: Same
+      tls:
+        certificateRefs:
+          - name: cert
+            namespace: secret-namespace
+            group: ""
+            kind: Secret
+  ---
+
+  apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: ReferenceGrant
+  metadata:
+    name: reference-grant
+    namespace: secret-namespace
+  spec:
+    from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: gateway-namespace
+      to:
+      - group: ""
+        kind: Secret
+        name: cert
+  ```
+
+</CodeBlockConfig>

--- a/website/content/docs/api-gateway/configuration/gateway.mdx
+++ b/website/content/docs/api-gateway/configuration/gateway.mdx
@@ -185,9 +185,9 @@ tls:
 
 #### Example cross-namespace certificateRef
 
-The following example creates a `Gateway` named `example-gateway` in namespace `gateway-namespace` (lines 2-4). The gateway has a `certificateRef` in namespace `secret-namespace` (lines 16-18). The reference is allowed because the `ReferenceGrant` configuration, named `reference-grant` in namespace `secret-namespace` (lines 23-26), allows `Gateways` in `gateway-namespace` to reference `Secrets` in `secret-namespace` (lines 30-34).
+The following example creates a `Gateway` named `example-gateway` in namespace `gateway-namespace` (lines 2-4). The gateway has a `certificateRef` in namespace `secret-namespace` (lines 16-18). The reference is allowed because the `ReferenceGrant` configuration, named `reference-grant` in namespace `secret-namespace` (lines 23-26), allows `Gateways` in `gateway-namespace` to reference `Secrets` in `secret-namespace` (lines 30-35).
 
-<CodeBlockConfig filename="gateway_with_referencegrant.yaml" lineNumbers highlight="2-4,16-18,23-26,30-34">
+<CodeBlockConfig filename="gateway_with_referencegrant.yaml" lineNumbers highlight="2-4,16-18,23-26,30-35">
 
   ```yaml
   apiVersion: gateway.networking.k8s.io/v1beta1

--- a/website/content/docs/api-gateway/configuration/gateway.mdx
+++ b/website/content/docs/api-gateway/configuration/gateway.mdx
@@ -187,7 +187,7 @@ tls:
 
 The following example creates a `Gateway` named `example-gateway` in namespace `gateway-namespace` (lines 2-4). The gateway has a `certificateRef` in namespace `secret-namespace` (lines 16-18). The reference is allowed because the `ReferenceGrant` configuration, named `reference-grant` in namespace `secret-namespace` (lines 23-26), allows `Gateways` in `gateway-namespace` to reference `Secrets` in `secret-namespace` (lines 30-34).
 
-<CodeBlockConfig filename="gateway_with_referencegrant.yaml" lineNumbers=true highlight="2-4","16-18","23-26","30-34">
+<CodeBlockConfig filename="gateway_with_referencegrant.yaml" lineNumbers highlight="2-4,16-18,23-26,30-34">
 
   ```yaml
   apiVersion: gateway.networking.k8s.io/v1beta1

--- a/website/content/docs/api-gateway/configuration/gateway.mdx
+++ b/website/content/docs/api-gateway/configuration/gateway.mdx
@@ -185,9 +185,9 @@ tls:
 
 #### Example cross-namespace certificateRef
 
-The following example creates a `Gateway` named `example-gateway` in namespace `gateway-namespace` (lines 2-4). The gateway has a `certificateRef` in namespace `secret-namespace` (lines 16-18). The reference is allowed because the `ReferenceGrant` configuration, named `reference-grant` in namespace `secret-namespace` (lines 23-26), allows `Gateways` in `gateway-namespace` to reference `Secrets` in `secret-namespace` (lines 30-35).
+The following example creates a `Gateway` named `example-gateway` in namespace `gateway-namespace` (lines 2-4). The gateway has a `certificateRef` in namespace `secret-namespace` (lines 16-18). The reference is allowed because the `ReferenceGrant` configuration, named `reference-grant` in namespace `secret-namespace` (lines 24-27), allows `Gateways` in `gateway-namespace` to reference `Secrets` in `secret-namespace` (lines 31-35).
 
-<CodeBlockConfig filename="gateway_with_referencegrant.yaml" lineNumbers highlight="2-4,16-18,23-26,30-35">
+<CodeBlockConfig filename="gateway_with_referencegrant.yaml" lineNumbers highlight="2-4,16-18,24-27,31-35">
 
   ```yaml
   apiVersion: gateway.networking.k8s.io/v1beta1

--- a/website/content/docs/api-gateway/configuration/gateway.mdx
+++ b/website/content/docs/api-gateway/configuration/gateway.mdx
@@ -174,7 +174,7 @@ In the following example, `tls` settings are configured to use a secret named `c
 
 tls:
   certificateRefs:
-    name: consul-server-cert
+  - name: consul-server-cert
     group: ""
     kind: Secret
   mode: Terminate

--- a/website/content/docs/api-gateway/configuration/gateway.mdx
+++ b/website/content/docs/api-gateway/configuration/gateway.mdx
@@ -185,9 +185,9 @@ tls:
 
 #### Example cross-namespace certificateRef
 
-The following example creates a `Gateway` named `example-gateway` in namespace `gateway-namespace`. This `Gateway` has a `certificateRef` in namespace `secret-namespace`. The reference is allowed because the `ReferenceGrant`, named `reference-grant` in namespace `secret-namespace`, allows `Gateways` in `gateway-namespace` to reference `Secrets` in `secret-namespace`.
+The following example creates a `Gateway` named `example-gateway` in namespace `gateway-namespace` (lines 2-4). The gateway has a `certificateRef` in namespace `secret-namespace` (lines 16-18). The reference is allowed because the `ReferenceGrant` configuration, named `reference-grant` in namespace `secret-namespace` (lines 23-26), allows `Gateways` in `gateway-namespace` to reference `Secrets` in `secret-namespace` (lines 30-34).
 
-<CodeBlockConfig filename="gateway_with_referencegrant.yaml">
+<CodeBlockConfig filename="gateway_with_referencegrant.yaml" lineNumbers=true highlight="2-4","16-18","23-26","30-34">
 
   ```yaml
   apiVersion: gateway.networking.k8s.io/v1beta1


### PR DESCRIPTION
### Description
We have an example for using `ReferenceGrants` to allow cross-namespace route `backendRefs` but not one for using `ReferenceGrants` to allow cross-namespace gateway `certificateRefs`. In addition, the [API Gateway Learn tutorial](https://learn.hashicorp.com/tutorials/consul/kubernetes-api-gateway) doesn't demonstrate this use case either. This use case requires slightly different values and is on a different page of the docs with its own context. Added this example to the appropriate page.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
[Here](https://www.consul.io/docs/api-gateway/configuration/routes#example-cross-namespace-backendref) is the example we have for cross-namespace route `backendRefs`.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
