### PR TITLE
Fix: add missing ent meta for test

### DIFF
--- a/agent/consul/merge_service_config_test.go
+++ b/agent/consul/merge_service_config_test.go
@@ -18,7 +18,8 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 	}
 
 	sid := structs.ServiceID{
-		ID: "sid",
+		ID:             "sid",
+		EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
 	}
 	tests := []struct {
 		name string


### PR DESCRIPTION
### Description
- This is to add the ent meta so that it can pass the ent test
- This fix the test issue caused by #14072  in ent


### Links


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
