### PR TITLE
validate args before deleting proxy defaults

### DIFF
--- a/.changelog/14290.txt
+++ b/.changelog/14290.txt
@@ -1,0 +1,3 @@
+```release-note:bugfix
+envoy: validate name before deleting proxy default configurations. 
+```

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -393,9 +393,6 @@ func (c *ConfigEntry) Delete(args *structs.ConfigEntryRequest, reply *structs.Co
 	if err := args.Entry.Normalize(); err != nil {
 		return err
 	}
-	if err := args.Entry.Validate(); err != nil {
-		return err
-	}
 
 	if err := args.Entry.CanWrite(authz); err != nil {
 		return err

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -393,6 +393,9 @@ func (c *ConfigEntry) Delete(args *structs.ConfigEntryRequest, reply *structs.Co
 	if err := args.Entry.Normalize(); err != nil {
 		return err
 	}
+	if err := args.Entry.Validate(); err != nil {
+		return err
+	}
 
 	if err := args.Entry.CanWrite(authz); err != nil {
 		return err

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -364,6 +364,9 @@ func (e *ProxyConfigEntry) Normalize() error {
 
 	e.Kind = ProxyDefaults
 
+	// proxy default config only accepts global configs
+	// this check is replicated in normalize() and validate(),
+	// since validate is not called by all the endpoints (e.g., delete)
 	if e.Name != "" && e.Name != ProxyConfigGlobal {
 		return fmt.Errorf("invalid name (%q), only %q is supported", e.Name, ProxyConfigGlobal)
 	}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -3,11 +3,12 @@ package structs
 import (
 	"errors"
 	"fmt"
-	"github.com/miekg/dns"
 	"net"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/miekg/dns"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/hashstructure"
@@ -362,6 +363,10 @@ func (e *ProxyConfigEntry) Normalize() error {
 	}
 
 	e.Kind = ProxyDefaults
+
+	if e.Name != "" && e.Name != ProxyConfigGlobal {
+		return fmt.Errorf("invalid name (%q), only %q is supported", e.Name, ProxyConfigGlobal)
+	}
 	e.Name = ProxyConfigGlobal
 
 	e.EnterpriseMeta.Normalize()

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -2865,6 +2865,27 @@ func TestParseUpstreamConfig(t *testing.T) {
 	}
 }
 
+func TestProxyConfigEntry(t *testing.T) {
+	cases := map[string]configEntryTestcase{
+		"proxy config name provided is not global": {
+			entry: &ProxyConfigEntry{
+				Name: "foo",
+			},
+			normalizeErr: `invalid name ("foo"), only "global" is supported`,
+		},
+		"proxy config has no name": {
+			entry: &ProxyConfigEntry{
+				Name: "",
+			},
+			expected: &ProxyConfigEntry{
+				Name: ProxyConfigGlobal,
+				Kind: ProxyDefaults,
+			},
+		},
+	}
+	testConfigEntryNormalizeAndValidate(t, cases)
+}
+
 func requireContainsLower(t *testing.T, haystack, needle string) {
 	t.Helper()
 	require.Contains(t, strings.ToLower(haystack), strings.ToLower(needle))


### PR DESCRIPTION
### Description
This PR fixes a bug where proxy defaults could be deleted by any name. Previously the code did not verify the name before proxy config deletion.

Fixes https://github.com/hashicorp/consul/issues/12684

### Testing & Reproduction steps
* Replications steps are described [here](https://github.com/hashicorp/consul/issues/12684)

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
