### PR TITLE
Replace ring buffer with async version

### DIFF
--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -295,73 +295,10 @@ func (s *Server) establishStream(ctx context.Context, logger hclog.Logger, ws me
 	streamCtx, cancel := context.WithCancel(ctx)
 	cancelFns[peer.ID] = cancel
 
-	// The following goroutine sends an up-to-date peer server address to nextServerAddr.
-	// It loads the server addresses into a ring buffer and cycles through them until:
-	//   1) streamCtx is cancelled (peer is deleted)
-	//   2) the peer is modified and the watchset fires.
-	// In case (2) we refetch the peering and rebuild the ring buffer.
+	// Start a goroutine to watch for updates to peer server addresses.
+	// The latest valid server address can be received from nextServerAddr.
 	nextServerAddr := make(chan string)
-	go func() {
-		defer close(nextServerAddr)
-
-		// we initialize the ring buffer with the peer passed to `establishStream`
-		// because the caller has pre-checked `peer.ShouldDial`, guaranteeing
-		// at least one server address.
-		//
-		// IMPORTANT: ringbuf must always be length > 0 or else `<-nextServerAddr` may block.
-		ringbuf := ring.New(len(peer.PeerServerAddresses))
-		for _, addr := range peer.PeerServerAddresses {
-			ringbuf.Value = addr
-			ringbuf = ringbuf.Next()
-		}
-		innerWs := memdb.NewWatchSet()
-		_, _, err := s.fsm.State().PeeringReadByID(innerWs, peer.ID)
-		if err != nil {
-			s.logger.Warn("failed to watch for changes to peer; server addresses may become stale over time.",
-				"peer_id", peer.ID,
-				"error", err)
-		}
-
-		fetchAddrs := func() error {
-			// reinstantiate innerWs to prevent it from growing indefinitely
-			innerWs = memdb.NewWatchSet()
-			_, peering, err := s.fsm.State().PeeringReadByID(innerWs, peer.ID)
-			if err != nil {
-				return fmt.Errorf("failed to fetch peer %q: %w", peer.ID, err)
-			}
-			if !peering.IsActive() {
-				return fmt.Errorf("peer %q is no longer active", peer.ID)
-			}
-			if len(peering.PeerServerAddresses) == 0 {
-				return fmt.Errorf("peer %q has no addresses to dial", peer.ID)
-			}
-
-			ringbuf = ring.New(len(peering.PeerServerAddresses))
-			for _, addr := range peering.PeerServerAddresses {
-				ringbuf.Value = addr
-				ringbuf = ringbuf.Next()
-			}
-			return nil
-		}
-
-		for {
-			select {
-			case nextServerAddr <- ringbuf.Value.(string):
-				ringbuf = ringbuf.Next()
-			case err := <-innerWs.WatchCh(streamCtx):
-				if err != nil {
-					// context was cancelled
-					return
-				}
-				// watch fired so we refetch the peering and rebuild the ring buffer
-				if err := fetchAddrs(); err != nil {
-					s.logger.Warn("watchset for peer was fired but failed to update server addresses",
-						"peer_id", peer.ID,
-						"error", err)
-				}
-			}
-		}
-	}()
+	go s.watchPeerServerAddrs(streamCtx, peer, nextServerAddr)
 
 	// Establish a stream-specific retry so that retrying stream/conn errors isn't dependent on state store changes.
 	go retryLoopBackoffPeering(streamCtx, logger, func() error {
@@ -432,6 +369,74 @@ func (s *Server) establishStream(ctx context.Context, logger hclog.Logger, ws me
 	}, peeringRetryTimeout)
 
 	return nil
+}
+
+// watchPeerServerAddrs sends an up-to-date peer server address to nextServerAddr.
+// It loads the server addresses into a ring buffer and cycles through them until:
+//  1. streamCtx is cancelled (peer is deleted)
+//  2. the peer is modified and the watchset fires.
+//
+// In case (2) we refetch the peering and rebuild the ring buffer.
+func (s *Server) watchPeerServerAddrs(ctx context.Context, peer *pbpeering.Peering, nextServerAddr chan<- string) {
+	defer close(nextServerAddr)
+
+	// we initialize the ring buffer with the peer passed to `establishStream`
+	// because the caller has pre-checked `peer.ShouldDial`, guaranteeing
+	// at least one server address.
+	//
+	// IMPORTANT: ringbuf must always be length > 0 or else `<-nextServerAddr` may block.
+	ringbuf := ring.New(len(peer.PeerServerAddresses))
+	for _, addr := range peer.PeerServerAddresses {
+		ringbuf.Value = addr
+		ringbuf = ringbuf.Next()
+	}
+	innerWs := memdb.NewWatchSet()
+	_, _, err := s.fsm.State().PeeringReadByID(innerWs, peer.ID)
+	if err != nil {
+		s.logger.Warn("failed to watch for changes to peer; server addresses may become stale over time.",
+			"peer_id", peer.ID,
+			"error", err)
+	}
+
+	fetchAddrs := func() error {
+		// reinstantiate innerWs to prevent it from growing indefinitely
+		innerWs = memdb.NewWatchSet()
+		_, peering, err := s.fsm.State().PeeringReadByID(innerWs, peer.ID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch peer %q: %w", peer.ID, err)
+		}
+		if !peering.IsActive() {
+			return fmt.Errorf("peer %q is no longer active", peer.ID)
+		}
+		if len(peering.PeerServerAddresses) == 0 {
+			return fmt.Errorf("peer %q has no addresses to dial", peer.ID)
+		}
+
+		ringbuf = ring.New(len(peering.PeerServerAddresses))
+		for _, addr := range peering.PeerServerAddresses {
+			ringbuf.Value = addr
+			ringbuf = ringbuf.Next()
+		}
+		return nil
+	}
+
+	for {
+		select {
+		case nextServerAddr <- ringbuf.Value.(string):
+			ringbuf = ringbuf.Next()
+		case err := <-innerWs.WatchCh(ctx):
+			if err != nil {
+				// context was cancelled
+				return
+			}
+			// watch fired so we refetch the peering and rebuild the ring buffer
+			if err := fetchAddrs(); err != nil {
+				s.logger.Warn("watchset for peer was fired but failed to update server addresses",
+					"peer_id", peer.ID,
+					"error", err)
+			}
+		}
+	}
 }
 
 func (s *Server) startPeeringDeferredDeletion(ctx context.Context) {

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1420,6 +1420,9 @@ func Test_Leader_PeeringSync_ServerAddressUpdates(t *testing.T) {
 	})
 
 	testutil.RunStep(t, "calling establish with active connection does not overwrite server addresses", func(t *testing.T) {
+		ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+		t.Cleanup(cancel)
+
 		// generate a new token from the acceptor
 		req := pbpeering.GenerateTokenRequest{
 			PeerName: "my-peer-dialer",
@@ -1463,6 +1466,7 @@ func Test_Leader_PeeringSync_ServerAddressUpdates(t *testing.T) {
 			"bad",
 		}, p.Peering.PeerServerAddresses...)
 
+		// this write will wake up the watch on the leader to refetch server addresses
 		require.NoError(t, dialer.fsm.State().PeeringWrite(2000, &pbpeering.PeeringWriteRequest{Peering: updated}))
 
 		retry.Run(t, func(r *retry.R) {

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1442,7 +1442,8 @@ func Test_Leader_PeeringSync_ServerAddressUpdates(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		t.Cleanup(cancel)
 
-		// try establishing
+		// Try establishing.
+		// This call will only succeed if the bad address was not used in the calls to exchange the peering secret.
 		establishReq := pbpeering.EstablishRequest{
 			PeerName:     "my-peer-acceptor",
 			PeeringToken: string(badToken),

--- a/agent/consul/state/peering.go
+++ b/agent/consul/state/peering.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/hashicorp/go-memdb"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib/maps"
 	"github.com/hashicorp/consul/proto/pbpeering"
-	"github.com/hashicorp/go-memdb"
 )
 
 const (
@@ -981,7 +982,7 @@ func peeringsForServiceTxn(tx ReadTxn, ws memdb.WatchSet, serviceName string, en
 		if idx > maxIdx {
 			maxIdx = idx
 		}
-		if peering == nil || !peering.IsActive() {
+		if !peering.IsActive() {
 			continue
 		}
 		peerings = append(peerings, peering)

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/consul/proto/pbpeerstream"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
@@ -27,6 +26,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/proto/pbpeering"
+	"github.com/hashicorp/consul/proto/pbpeerstream"
 )
 
 var (
@@ -720,7 +720,7 @@ func (s *Server) PeeringDelete(ctx context.Context, req *pbpeering.PeeringDelete
 		return nil, err
 	}
 
-	if existing == nil || !existing.IsActive() {
+	if !existing.IsActive() {
 		// Return early when the Peering doesn't exist or is already marked for deletion.
 		// We don't return nil because the pb will fail to marshal.
 		return &pbpeering.PeeringDeleteResponse{}, nil

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -379,6 +379,7 @@ func (s *Server) Establish(
 	}
 
 	var id string
+	serverAddrs := tok.ServerAddresses
 	if existing == nil {
 		id, err = lib.GenerateUUID(s.Backend.CheckPeeringUUID)
 		if err != nil {
@@ -386,6 +387,11 @@ func (s *Server) Establish(
 		}
 	} else {
 		id = existing.ID
+		// If there is a connected stream, assume that the existing ServerAddresses
+		// are up to date and do not try to overwrite them with the token's addresses.
+		if status, ok := s.Tracker.StreamStatus(id); ok && status.Connected {
+			serverAddrs = existing.PeerServerAddresses
+		}
 	}
 
 	// validate that this peer name is not being used as an acceptor already
@@ -397,7 +403,7 @@ func (s *Server) Establish(
 		ID:                  id,
 		Name:                req.PeerName,
 		PeerCAPems:          tok.CA,
-		PeerServerAddresses: tok.ServerAddresses,
+		PeerServerAddresses: serverAddrs,
 		PeerServerName:      tok.ServerName,
 		PeerID:              tok.PeerID,
 		Meta:                req.Meta,
@@ -418,9 +424,9 @@ func (s *Server) Establish(
 	}
 	var exchangeResp *pbpeerstream.ExchangeSecretResponse
 
-	// Loop through the token's addresses once, attempting to fetch the long-lived stream secret.
+	// Loop through the known server addresses once, attempting to fetch the long-lived stream secret.
 	var dialErrors error
-	for _, addr := range peering.PeerServerAddresses {
+	for _, addr := range serverAddrs {
 		exchangeResp, err = exchangeSecret(ctx, addr, tlsOption, &exchangeReq)
 		if err != nil {
 			dialErrors = multierror.Append(dialErrors, fmt.Errorf("failed to exchange peering secret with %q: %w", addr, err))

--- a/proto/pbpeering/peering.go
+++ b/proto/pbpeering/peering.go
@@ -143,10 +143,10 @@ func PeeringStateFromAPI(t api.PeeringState) PeeringState {
 }
 
 func (p *Peering) IsActive() bool {
-	if p != nil && p.State == PeeringState_TERMINATED {
+	if p == nil || p.State == PeeringState_TERMINATED {
 		return false
 	}
-	if p == nil || p.DeletedAt == nil {
+	if p.DeletedAt == nil {
 		return true
 	}
 


### PR DESCRIPTION
### Description
Follow-up to https://github.com/hashicorp/consul/pull/14285

Currently we have a static list of server addresses from the peering token that may get stale over time. We need to watch for changes to peerings and update the server addresses which get served by the ring buffer.

### Testing & Reproduction steps
* Added a testcase which updates an established peering with a bad server address, then confirms that we try to dial it at least once.
* Did not test end-to-end from a cluster generating raft autopilot events (mock events were tested in https://github.com/hashicorp/consul/pull/14285)

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
