### PR TITLE
Fix: the inboundconnection limit filter should be placed in front of http co…

### DIFF
--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1216,7 +1216,7 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 	}
 
 	// If an inbound connect limit is set, inject a connection limit filter on each chain.
-	if cfg.MaxInboundConnections > 0 && useHTTPFilter {
+	if cfg.MaxInboundConnections > 0 {
 		connectionLimitFilter, err := makeConnectionLimitFilter(cfg.MaxInboundConnections)
 		if err != nil {
 			return nil, err
@@ -1246,7 +1246,6 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 				},
 			},
 		}
-
 	}
 
 	err = s.finalizePublicListenerFromConfig(l, cfgSnap, cfg, useHTTPFilter)

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1251,7 +1251,7 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 	}
 
 	if len(l.FilterChains) > 0 {
-		// An FilterChains has been initialized earlier with a connection limit filter
+		// The list of FilterChains has already been initialized
 		l.FilterChains[0].Filters = append(l.FilterChains[0].Filters, filter)
 	} else {
 		l.FilterChains = []*envoy_listener_v3.FilterChain{
@@ -2016,7 +2016,7 @@ func makeTCPProxyFilter(filterName, cluster, statPrefix string) (*envoy_listener
 
 func makeConnectionLimitFilter(limit int) (*envoy_listener_v3.Filter, error) {
 	cfg := &envoy_connection_limit_v3.ConnectionLimit{
-		StatPrefix:     "inbound connection limit",
+		StatPrefix:     "inbound_connection_limit",
 		MaxConnections: wrapperspb.UInt64(uint64(limit)),
 	}
 	return makeFilter("envoy.filters.network.connection_limit", cfg)

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1214,16 +1214,39 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 			filterOpts.forwardClientPolicy = envoy_http_v3.HttpConnectionManager_APPEND_FORWARD
 		}
 	}
+
+	// If an inbound connect limit is set, inject a connection limit filter on each chain.
+	if cfg.MaxInboundConnections > 0 && useHTTPFilter {
+		connectionLimitFilter, err := makeConnectionLimitFilter(cfg.MaxInboundConnections)
+		if err != nil {
+			return nil, err
+		}
+		l.FilterChains = []*envoy_listener_v3.FilterChain{
+			{
+				Filters: []*envoy_listener_v3.Filter{
+					connectionLimitFilter,
+				},
+			},
+		}
+	}
+
 	filter, err := makeListenerFilter(filterOpts)
 	if err != nil {
 		return nil, err
 	}
-	l.FilterChains = []*envoy_listener_v3.FilterChain{
-		{
-			Filters: []*envoy_listener_v3.Filter{
-				filter,
+
+	if len(l.FilterChains) > 0 {
+		// An FilterChains has been initialized earlier with a connection limit filter
+		l.FilterChains[0].Filters = append(l.FilterChains[0].Filters, filter)
+	} else {
+		l.FilterChains = []*envoy_listener_v3.FilterChain{
+			{
+				Filters: []*envoy_listener_v3.Filter{
+					filter,
+				},
 			},
-		},
+		}
+
 	}
 
 	err = s.finalizePublicListenerFromConfig(l, cfgSnap, cfg, useHTTPFilter)
@@ -1247,17 +1270,6 @@ func (s *ResourceGenerator) finalizePublicListenerFromConfig(l *envoy_listener_v
 	// Always apply TLS certificates
 	if err := s.injectConnectTLSForPublicListener(cfgSnap, l); err != nil {
 		return nil
-	}
-
-	// If an inbound connect limit is set, inject a connection limit filter on each chain.
-	if proxyCfg.MaxInboundConnections > 0 {
-		filter, err := makeConnectionLimitFilter(proxyCfg.MaxInboundConnections)
-		if err != nil {
-			return nil
-		}
-		for idx := range l.FilterChains {
-			l.FilterChains[idx].Filters = append(l.FilterChains[idx].Filters, filter)
-		}
 	}
 
 	return nil
@@ -1990,6 +2002,7 @@ func makeTCPProxyFilter(filterName, cluster, statPrefix string) (*envoy_listener
 
 func makeConnectionLimitFilter(limit int) (*envoy_listener_v3.Filter, error) {
 	cfg := &envoy_connection_limit_v3.ConnectionLimit{
+		StatPrefix:     "inbound connection limit",
 		MaxConnections: wrapperspb.UInt64(uint64(limit)),
 	}
 	return makeFilter("envoy.filters.network.connection_limit", cfg)

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1132,21 +1132,6 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 			return nil, err
 		}
 
-		// If an inbound connect limit is set, inject a connection limit filter on each chain.
-		if cfg.MaxInboundConnections > 0 {
-			connectionLimitFilter, err := makeConnectionLimitFilter(cfg.MaxInboundConnections)
-			if err != nil {
-				return nil, err
-			}
-			l.FilterChains = []*envoy_listener_v3.FilterChain{
-				{
-					Filters: []*envoy_listener_v3.Filter{
-						connectionLimitFilter,
-					},
-				},
-			}
-		}
-
 		// For HTTP-like services attach an RBAC http filter and do a best-effort insert
 		if useHTTPFilter {
 			httpAuthzFilter, err := makeRBACHTTPFilter(

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1132,6 +1132,21 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 			return nil, err
 		}
 
+		// If an inbound connect limit is set, inject a connection limit filter on each chain.
+		if cfg.MaxInboundConnections > 0 {
+			connectionLimitFilter, err := makeConnectionLimitFilter(cfg.MaxInboundConnections)
+			if err != nil {
+				return nil, err
+			}
+			l.FilterChains = []*envoy_listener_v3.FilterChain{
+				{
+					Filters: []*envoy_listener_v3.Filter{
+						connectionLimitFilter,
+					},
+				},
+			}
+		}
+
 		// For HTTP-like services attach an RBAC http filter and do a best-effort insert
 		if useHTTPFilter {
 			httpAuthzFilter, err := makeRBACHTTPFilter(

--- a/agent/xds/testdata/listeners/listener-max-inbound-connections.latest.golden
+++ b/agent/xds/testdata/listeners/listener-max-inbound-connections.latest.golden
@@ -77,7 +77,7 @@
               "name": "envoy.filters.network.connection_limit",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.connection_limit.v3.ConnectionLimit",
-                "statPrefix": "inbound connection limit",
+                "statPrefix": "inbound_connection_limit",
                 "maxConnections": "222"
               }
             },

--- a/agent/xds/testdata/listeners/listener-max-inbound-connections.latest.golden
+++ b/agent/xds/testdata/listeners/listener-max-inbound-connections.latest.golden
@@ -74,18 +74,19 @@
               }
             },
             {
+              "name": "envoy.filters.network.connection_limit",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.connection_limit.v3.ConnectionLimit",
+                "statPrefix": "inbound connection limit",
+                "maxConnections": "222"
+              }
+            },
+            {
               "name": "envoy.filters.network.tcp_proxy",
               "typedConfig": {
                 "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                 "statPrefix": "public_listener",
                 "cluster": "local_app"
-              }
-            },
-            {
-              "name": "envoy.filters.network.connection_limit",
-              "typedConfig": {
-                "@type": "type.googleapis.com/envoy.extensions.filters.network.connection_limit.v3.ConnectionLimit",
-                "maxConnections": "222"
               }
             }
           ],


### PR DESCRIPTION
### Description

- The inboundconnection limit filter should be placed in front of http connection manager

The current implementation of xds server adds the connection limit filter at the end of the filter chain for all protocols, which doesn't work for http. This is because http_connection_manager must be the last filter in a network filter chain.

This PR moves the connection limit filter to the head of the chain to resolve the issue.

### Testing & Reproduction steps
Please refer to the steps in the linked issue #14298 

### Links

fix #14298 
#12373

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
