### PR TITLE
Fix incorrect use of loop variable in parallel test

### DIFF
--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -5383,6 +5383,7 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 		}
 		// All those queries should have at max queriesLimited elements
 		for idx, qType := range queriesLimited {
+			qType := qType // capture loop var
 			t.Run(fmt.Sprintf("ARecordLimit %d qType: %d", idx, qType), func(t *testing.T) {
 				t.Parallel()
 				err := checkDNSService(t, test.numNodesTotal, test.aRecordLimit, qType, test.expectedAResults, test.udpSize)


### PR DESCRIPTION
### Description
This fixes a reference to a loop variable in a parallel test
(`TestDNS_ServiceLookup_ARecordLimits`). With the previous code, only
the last DNS record type would be queried. A similar copying occurs
in the same test for the `test` loop variable, but this one went
unnoticed.

Issue automatically found by the `loopvarcapture` linter.

### Testing & Reproduction steps
By running that test specifically, one can verify that only `dns.TypeANY` is ever tested.

### Links
Documentation for `testing` package suggests copying like this when running parallel test in combination with table-driven tests: <https://pkg.go.dev/testing#hdr-Subtests_and_Sub_benchmarks>

### PR Checklist

* [x] updated test coverage (N/A)
* [x] external facing docs updated (N/A)
* [x] not a security concern
