### PR TITLE
[1.11] docs: Update latest Envoy to 1.20.6, make docs consistent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1077,7 +1077,7 @@ workflows:
       - envoy-integration-test-1_19_5:
           requires:
             - dev-build
-      - envoy-integration-test-1_20_4:
+      - envoy-integration-test-1_20_6:
           requires:
             - dev-build
       - noop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -849,10 +849,10 @@ jobs:
     environment:
       ENVOY_VERSION: "1.19.5"
 
-  envoy-integration-test-1_20_4:
+  envoy-integration-test-1_20_6:
     <<: *ENVOY_TESTS
     environment:
-      ENVOY_VERSION: "1.20.4"
+      ENVOY_VERSION: "1.20.6"
 
   # run integration tests for the connect ca providers
   test-connect-ca-providers:

--- a/agent/xds/envoy_versioning_test.go
+++ b/agent/xds/envoy_versioning_test.go
@@ -132,7 +132,7 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 	}
 	for _, v := range []string{
 		"1.19.0", "1.19.1", "1.19.2", "1.19.3", "1.19.4", "1.19.5",
-		"1.20.0", "1.20.1", "1.20.2", "1.20.3", "1.20.4",
+		"1.20.0", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5", "1.20.6",
 	} {
 		cases[v] = testcase{expect: supportedProxyFeatures{}}
 	}

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -7,7 +7,7 @@ package proxysupport
 //
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
-	"1.20.4",
+	"1.20.6",
 	"1.19.5",
 	"1.18.6",
 	"1.17.4",

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -10,7 +10,7 @@ readonly HASHICORP_DOCKER_PROXY="docker.mirror.hashicorp.services"
 DEBUG=${DEBUG:-}
 
 # ENVOY_VERSION to run each test against
-ENVOY_VERSION=${ENVOY_VERSION:-"1.20.4"}
+ENVOY_VERSION=${ENVOY_VERSION:-"1.20.6"}
 export ENVOY_VERSION
 
 export DOCKER_BUILDKIT=1

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -36,8 +36,8 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
-| 1.11.x              | 1.20.4, 1.19.5, 1.18.6, 1.17.4<sup>1</sup>                                         |
-| 1.10.x              | 1.18.6, 1.17.4<sup>1</sup>, 1.16.5<sup>1</sup> , 1.15.5<sup>1</sup>                |
+| 1.11.x              | 1.20.6, 1.19.5, 1.18.6, 1.17.4<sup>1</sup>                                         |
+| 1.10.x              | 1.18.6, 1.17.4<sup>1</sup>, 1.16.5<sup>1</sup>, 1.15.5<sup>1</sup>                 |
 | 1.9.x               | 1.16.5<sup>1</sup>, 1.15.5<sup>1</sup>, 1.14.7<sup>1,2</sup>, 1.13.7<sup>1,2</sup> |
 
 1. Envoy 1.20.1 and earlier are vulnerable to [CVE-2022-21654](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21654) and [CVE-2022-21655](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21655). Both CVEs were patched in Envoy versions 1.18.6, 1.19.3, and 1.20.2.


### PR DESCRIPTION
### Description
There are currently discrepancies between the docs in each release series, specifically for 1.10. This updates them all to agree. There will be an accompanying PR referenced below for 1.10.

### Links
- [Envoy integration docs (1.13)](https://www.consul.io/docs/v1.13.x/connect/proxies/envoy)
- [Envoy integration docs (1.12)](https://www.consul.io/docs/v1.12.x/connect/proxies/envoy) 
- [Envoy integration docs (1.11)](https://www.consul.io/docs/v1.11.x/connect/proxies/envoy)
- [Envoy integration docs (1.10)](https://www.consul.io/docs/v1.10.x/connect/proxies/envoy)
- https://github.com/hashicorp/consul/pull/14334
