### PR TITLE
[1.12] connect: Update Envoy support to latest patches for 1.20 and 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1124,7 +1124,7 @@ workflows:
       - envoy-integration-test-1_19_5:
           requires:
             - dev-build
-      - envoy-integration-test-1_20_4:
+      - envoy-integration-test-1_20_6:
           requires:
             - dev-build
       - envoy-integration-test-1_21_3:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,15 +891,15 @@ jobs:
           path: *TEST_RESULTS_DIR
       - run: *notify-slack-failure
 
-  envoy-integration-test-1_20_4:
+  envoy-integration-test-1_20_6:
     <<: *ENVOY_TESTS
     environment:
-      ENVOY_VERSION: "1.20.4"
+      ENVOY_VERSION: "1.20.6"
 
   envoy-integration-test-1_21_3:
     <<: *ENVOY_TESTS
     environment:
-      ENVOY_VERSION: "1.21.3"
+      ENVOY_VERSION: "1.21.4"
 
   envoy-integration-test-1_22_2:
     <<: *ENVOY_TESTS

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -8,7 +8,7 @@ package proxysupport
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
 	"1.22.2",
-	"1.21.3",
-	"1.20.4",
+	"1.21.4",
+	"1.20.6",
 	"1.19.5",
 }

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -34,11 +34,11 @@ The following matrix describes Envoy compatibility for the currently supported *
 
 Consul supports **four major Envoy releases** at the beginning of each major Consul release. Consul maintains compatibility with Envoy patch releases for each major version so that users can benefit from bug and security fixes in Envoy. As a policy, Consul will add support for a new major versions of Envoy in a Consul major release. Support for newer versions of Envoy will not be added to existing releases.
 
-| Consul Version      | Compatible Envoy Versions                                                          |
-| ------------------- | -----------------------------------------------------------------------------------|
-| 1.12.x              | 1.22.2, 1.21.3, 1.20.4, 1.19.5                                                     |
-| 1.11.x              | 1.20.2, 1.19.3, 1.18.6, 1.17.4<sup>1</sup>                                         |
-| 1.10.x              | 1.18.6, 1.17.4<sup>1</sup>, 1.16.5<sup>1</sup> , 1.15.5<sup>1</sup>                |
+| Consul Version      | Compatible Envoy Versions                                          |
+| ------------------- | -------------------------------------------------------------------|
+| 1.12.x              | 1.22.2, 1.21.4, 1.20.6, 1.19.5                                     |
+| 1.11.x              | 1.20.6, 1.19.5, 1.18.6, 1.17.4<sup>1</sup>                         |
+| 1.10.x              | 1.18.6, 1.17.4<sup>1</sup>, 1.16.5<sup>1</sup>, 1.15.5<sup>1</sup> |
 
 1. Envoy 1.20.1 and earlier are vulnerable to [CVE-2022-21654](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21654) and [CVE-2022-21655](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21655). Both CVEs were patched in Envoy versions 1.18.6, 1.19.3, and 1.20.2.
 Envoy 1.16.x and older releases are no longer supported (see [HCSEC-2022-07](https://discuss.hashicorp.com/t/hcsec-2022-07-consul-s-connect-service-mesh-affected-by-recent-envoy-security-releases/36332)). Consul 1.9.x clusters should be upgraded to 1.10.x and Envoy upgraded to the latest supported Envoy version for that release, 1.18.6.


### PR DESCRIPTION
### Description
There are currently discrepancies between the docs in each release series, specifically for 1.10. This updates them all to agree. There will be accompanying PRs referenced below for 1.11 and 1.10.

### Links
- [Envoy integration docs (1.13)](https://www.consul.io/docs/v1.13.x/connect/proxies/envoy)
- [Envoy integration docs (1.12)](https://www.consul.io/docs/v1.12.x/connect/proxies/envoy) 
- [Envoy integration docs (1.11)](https://www.consul.io/docs/v1.11.x/connect/proxies/envoy)
- [Envoy integration docs (1.10)](https://www.consul.io/docs/v1.10.x/connect/proxies/envoy)
- https://github.com/hashicorp/consul/pull/14335
- https://github.com/hashicorp/consul/pull/14334
