### PR TITLE
[1.13] docs: Update Envoy support matrix to match previous releases and code

### DIFF
--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -37,8 +37,8 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
 | 1.13.x              | 1.23.0, 1.22.2, 1.21.4, 1.20.6                                                     |
-| 1.12.x              | 1.22.2, 1.21.3, 1.20.4, 1.19.5                                                     |
-| 1.11.x              | 1.20.2, 1.19.3, 1.18.6, 1.17.4<sup>1</sup>                                         |
+| 1.12.x              | 1.22.2, 1.21.4, 1.20.6, 1.19.5                                                     |
+| 1.11.x              | 1.20.6, 1.19.5, 1.18.6, 1.17.4<sup>1</sup>                                         |
 
 1. Envoy 1.20.1 and earlier are vulnerable to [CVE-2022-21654](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21654) and [CVE-2022-21655](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-21655). Both CVEs were patched in Envoy versions 1.18.6, 1.19.3, and 1.20.2.
 Envoy 1.16.x and older releases are no longer supported (see [HCSEC-2022-07](https://discuss.hashicorp.com/t/hcsec-2022-07-consul-s-connect-service-mesh-affected-by-recent-envoy-security-releases/36332)). Consul 1.9.x clusters should be upgraded to 1.10.x and Envoy upgraded to the latest supported Envoy version for that release, 1.18.6.


### PR DESCRIPTION
### Description
There are currently discrepancies between the docs in each release series, specifically for 1.10. This updates them all to agree. There will be accompanying PRs referenced below for 1.12, 1.11 and 1.10.

### Links
- [Envoy integration docs (1.13)](https://www.consul.io/docs/v1.13.x/connect/proxies/envoy)
- [Envoy integration docs (1.12)](https://www.consul.io/docs/v1.12.x/connect/proxies/envoy) 
- [Envoy integration docs (1.11)](https://www.consul.io/docs/v1.11.x/connect/proxies/envoy)
- [Envoy integration docs (1.10)](https://www.consul.io/docs/v1.10.x/connect/proxies/envoy)
- https://github.com/hashicorp/consul/pull/14336
- https://github.com/hashicorp/consul/pull/14335
- https://github.com/hashicorp/consul/pull/14334

