### PR TITLE
ui: Add support for prefixing the API path

### DIFF
--- a/ui/packages/consul-ui/app/services/client/http.js
+++ b/ui/packages/consul-ui/app/services/client/http.js
@@ -203,12 +203,13 @@ export default class HttpService extends Service {
     // also see adapters/kv content-types in requestForCreate/UpdateRecord
     // also see https://github.com/hashicorp/consul/issues/3804
     params.headers[CONTENT_TYPE] = 'application/json; charset=utf-8';
+    params.url = `${this.env.var('CONSUL_API_PREFIX')}${params.url}`;
     return params;
   }
 
   fetchWithToken(path, params) {
     return this.settings.findBySlug('token').then(token => {
-      return fetch(`${path}`, {
+      return fetch(`${this.env.var('CONSUL_API_PREFIX')}${path}`, {
         ...params,
         headers: {
           'X-Consul-Token': typeof token.SecretID === 'undefined' ? '' : token.SecretID,

--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -132,6 +132,12 @@ export default function(config = {}, win = window, doc = document) {
         return operatorConfig.LocalDatacenter;
       case 'CONSUL_DATACENTER_PRIMARY':
         return operatorConfig.PrimaryDatacenter;
+      case 'CONSUL_API_PREFIX':
+        // we want API prefix to look like an env var for if we ever change
+        // operator config to be an API request, we need this variable before we
+        // make and API request so this specific variable should never be be
+        // retrived via an API request
+        return operatorConfig.APIPrefix;
       case 'CONSUL_UI_CONFIG':
         dashboards = {
           service: undefined,
@@ -246,6 +252,7 @@ export default function(config = {}, win = window, doc = document) {
       case 'CONSUL_UI_CONFIG':
       case 'CONSUL_DATACENTER_LOCAL':
       case 'CONSUL_DATACENTER_PRIMARY':
+      case 'CONSUL_API_PREFIX':
       case 'CONSUL_ACLS_ENABLED':
       case 'CONSUL_NSPACES_ENABLED':
       case 'CONSUL_PEERINGS_ENABLED':

--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -120,6 +120,7 @@ module.exports = function(environment, $ = process.env) {
           enabled: true,
           endpoints: {
             '/v1': '/mock-api/v1',
+            '/prefixed-api': '/mock-api/prefixed-api',
           },
         },
         APP: Object.assign({}, ENV.APP, {

--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -86,6 +86,7 @@ module.exports = function(environment, $ = process.env) {
       PartitionsEnabled: false,
       LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
       PrimaryDatacenter: env('CONSUL_DATACENTER_PRIMARY', 'dc1'),
+      APIPrefix: env('CONSUL_API_PREFIX', '')
     },
 
     // Static variables used in multiple places throughout the UI
@@ -111,6 +112,7 @@ module.exports = function(environment, $ = process.env) {
           PartitionsEnabled: env('CONSUL_PARTITIONS_ENABLED', false),
           LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
           PrimaryDatacenter: env('CONSUL_DATACENTER_PRIMARY', 'dc1'),
+          APIPrefix: env('CONSUL_API_PREFIX', '')
         },
 
         '@hashicorp/ember-cli-api-double': {
@@ -162,6 +164,7 @@ module.exports = function(environment, $ = process.env) {
           PartitionsEnabled: env('CONSUL_PARTITIONS_ENABLED', true),
           LocalDatacenter: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
           PrimaryDatacenter: env('CONSUL_DATACENTER_PRIMARY', 'dc1'),
+          APIPrefix: env('CONSUL_API_PREFIX', '')
         },
 
         '@hashicorp/ember-cli-api-double': {
@@ -176,7 +179,9 @@ module.exports = function(environment, $ = process.env) {
       ENV = Object.assign({}, ENV, {
         // in production operatorConfig is populated at consul runtime from
         // operator configuration
-        operatorConfig: {},
+        operatorConfig: {
+          APIPrefix: ''
+        },
       });
       break;
   }

--- a/ui/packages/consul-ui/mock-api/prefixed-api/v1/catalog/.config
+++ b/ui/packages/consul-ui/mock-api/prefixed-api/v1/catalog/.config
@@ -1,0 +1,7 @@
+---
+"*":
+  GET:
+    "*":
+      headers:
+        response:
+          X-Consul-Default-Acl-Policy: ${env('CONSUL_ACL_POLICY', fake.helpers.randomize(['allow', 'deny']))}

--- a/ui/packages/consul-ui/mock-api/prefixed-api/v1/catalog/datacenters
+++ b/ui/packages/consul-ui/mock-api/prefixed-api/v1/catalog/datacenters
@@ -1,0 +1,13 @@
+[
+  ${
+    range(env('CONSUL_DATACENTER_COUNT', 10)).map((item, i) => {
+      if(i === 0) {
+        return `"${env('CONSUL_DATACENTER_LOCAL', 'dc1')}"`;
+      }
+      return `
+        "${fake.address.countryCode().toLowerCase()}_${ i % 2 ? "west" : "east"}-${i}"
+`;
+        }
+    )
+  }
+]

--- a/ui/packages/consul-ui/mock-api/prefixed-api/v1/internal/acl/authorize
+++ b/ui/packages/consul-ui/mock-api/prefixed-api/v1/internal/acl/authorize
@@ -1,0 +1,14 @@
+[
+${
+  http.body.map(item => {
+    return JSON.stringify(
+      Object.assign(
+        item,
+        {
+          Allow: !!JSON.parse(env(`CONSUL_RESOURCE_${item.Resource.toUpperCase()}_${item.Access.toUpperCase()}`, 'true'))
+        }
+      )
+    );
+  })
+}
+]

--- a/ui/packages/consul-ui/mock-api/prefixed-api/v1/internal/ui/services
+++ b/ui/packages/consul-ui/mock-api/prefixed-api/v1/internal/ui/services
@@ -1,0 +1,22 @@
+[
+    {
+        "Name": "consul",
+        "Datacenter": "dc1",
+        "Tags": null,
+        "Nodes": [
+            "node"
+        ],
+        "ExternalSources": null,
+        "InstanceCount": 1,
+        "ChecksPassing": 1,
+        "ChecksWarning": 0,
+        "ChecksCritical": 0,
+        "GatewayConfig": {},
+        "TransparentProxy": false,
+        "ConnectNative": false,
+        "Partition": "default",
+        "Namespace": "default",
+        "ConnectedWithProxy": false,
+        "ConnectedWithGateway": false
+    }
+]

--- a/ui/packages/consul-ui/node-tests/config/environment.js
+++ b/ui/packages/consul-ui/node-tests/config/environment.js
@@ -11,7 +11,9 @@ test(
       {
         environment: 'production',
         CONSUL_BINARY_TYPE: 'oss',
-        operatorConfig: {}
+        operatorConfig: {
+          APIPrefix: '',
+        }
       },
       {
         environment: 'test',
@@ -24,6 +26,7 @@ test(
           PeeringEnabled: true,
           LocalDatacenter: 'dc1',
           PrimaryDatacenter: 'dc1',
+          APIPrefix: '',
         }
       },
       {
@@ -40,6 +43,7 @@ test(
           PeeringEnabled: true,
           LocalDatacenter: 'dc1',
           PrimaryDatacenter: 'dc1',
+          APIPrefix: '',
         }
       },
       {
@@ -56,6 +60,7 @@ test(
           PeeringEnabled: true,
           LocalDatacenter: 'dc1',
           PrimaryDatacenter: 'dc1',
+          APIPrefix: '',
         }
       },
       {
@@ -69,6 +74,7 @@ test(
           PeeringEnabled: true,
           LocalDatacenter: 'dc1',
           PrimaryDatacenter: 'dc1',
+          APIPrefix: '',
         }
       }
     ].forEach(

--- a/ui/packages/consul-ui/tests/acceptance/api-prefix.feature
+++ b/ui/packages/consul-ui/tests/acceptance/api-prefix.feature
@@ -1,0 +1,7 @@
+@setupApplicationTest
+Feature: api-prefix
+  Scenario:
+    Given 1 datacenter model with the value "dc1"
+    And an API prefix of "/prefixed-api"
+    When I visit the index page
+    Then a GET request was made to "/prefixed-api/v1/catalog/datacenters"

--- a/ui/packages/consul-ui/tests/acceptance/steps/api-prefix-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/api-prefix-steps.js
@@ -1,0 +1,11 @@
+import steps from './steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert)
+    .then('I should find a file', function() {
+      assert.ok(true, this.step);
+    });
+}

--- a/ui/packages/consul-ui/tests/steps.js
+++ b/ui/packages/consul-ui/tests/steps.js
@@ -87,6 +87,7 @@ export default function({
     api.server.respondWith(url.split('?')[0], data);
   };
   const setCookie = function(key, value) {
+    document.cookie = `${key}=${value}`;
     api.server.setCookie(key, value);
   };
 

--- a/ui/packages/consul-ui/tests/steps/doubles/http.js
+++ b/ui/packages/consul-ui/tests/steps/doubles/http.js
@@ -17,5 +17,8 @@ export default function(scenario, respondWith, set, oidc) {
     })
     .given('a network latency of $number', function(number) {
       set('CONSUL_LATENCY', number);
+    })
+    .given('an API prefix of "$prefix"', function(prefix) {
+      set('CONSUL_API_PREFIX', prefix);
     });
 }


### PR DESCRIPTION
### Description
Adds support for prefixing the path of API call made by the UI. Along with [`ui-config.content_path`](https://www.consul.io/docs/agent/config/config-files#ui_config_content_path), this will enable the UI to be usable at different paths behind reverse proxies etc, which is one of the UIs most requested features.

Please note: We have always spoken about the possibility of our `ui_config` being provided by an API requests rather than being supplied via our "env vars". This variable is slightly strange in that it can never be provided by an API call, as it provides us with the information as to where we need to make API calls, therefore this variable should always be thought of as an "env var"

The variable defaults to an empty string, and can be mocked out during development via either our "cookie env vars" or via a real env var at boot time (when running `make start`)


### Links

This (along with some yet to be completed backend changes) will eventually help the following issues, amongst others.

- https://github.com/hashicorp/consul/issues/14295
- https://github.com/hashicorp/consul/issues/11627
- https://github.com/hashicorp/consul/issues/10374
- https://github.com/hashicorp/consul/issues/9829
- https://github.com/hashicorp/consul/issues/8240
- https://github.com/hashicorp/consul/issues/7928


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern

/cc @clly we'll possibly chat about this later
