### PR TITLE
ui: Use credentials for all HTTP API requests

### DIFF
--- a/.changelog/14343.txt
+++ b/.changelog/14343.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+ui: Use withCredentials for all HTTP API requests
+```
+

--- a/ui/packages/consul-ui/app/services/client/http.js
+++ b/ui/packages/consul-ui/app/services/client/http.js
@@ -210,6 +210,7 @@ export default class HttpService extends Service {
     return this.settings.findBySlug('token').then(token => {
       return fetch(`${path}`, {
         ...params,
+        credentials: 'include',
         headers: {
           'X-Consul-Token': typeof token.SecretID === 'undefined' ? '' : token.SecretID,
           ...params.headers,

--- a/ui/packages/consul-ui/app/utils/http/xhr.js
+++ b/ui/packages/consul-ui/app/utils/http/xhr.js
@@ -27,6 +27,7 @@ export default function(parseHeaders, XHR) {
     };
     Object.entries(headers).forEach(([key, value]) => xhr.setRequestHeader(key, value));
     options.beforeSend(xhr);
+    xhr.withCredentials = true;
     xhr.send(options.body);
     return xhr;
   };


### PR DESCRIPTION
### Description
Adds `withCredentials`/`credentials` to all HTTP API requests.

As discussed with @i0rek 

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
