### PR TITLE
Exit for loop when context is cancelled

### DIFF
--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -391,6 +391,12 @@ func (s *Server) runPeeringDeletions(ctx context.Context) error {
 	// process. This includes deletion of the peerings themselves in addition to any peering data
 	raftLimiter := rate.NewLimiter(defaultDeletionApplyRate, int(defaultDeletionApplyRate))
 	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
 		ws := memdb.NewWatchSet()
 		state := s.fsm.State()
 		_, peerings, err := s.fsm.State().PeeringListDeleted(ws)


### PR DESCRIPTION
### Description
When a server is shutting down and the context passed to leader goroutines are cancelled, I noticed in a test that there was a tight loop that did not exit until the program exited.

```
2022-08-25T11:17:38.739-0400 [ERROR] acceptor.server.peering: Failed to remove trust bundle for peer: peer_id=7d228f34-28fe-0d20-eba9-21b6c09e390b peer_name=my-peer-dialer error="context canceled"
2022-08-25T11:17:38.740-0400 [ERROR] acceptor.server.peering: Failed to remove trust bundle for peer: peer_id=7d228f34-28fe-0d20-eba9-21b6c09e390b peer_name=my-peer-dialer error="context canceled"
2022-08-25T11:17:38.740-0400 [ERROR] acceptor.server.peering: Failed to remove trust bundle for peer: peer_id=7d228f34-28fe-0d20-eba9-21b6c09e390b peer_name=my-peer-dialer error="context canceled"
2022-08-25T11:17:38.740-0400 [ERROR] acceptor.server.peering: Failed to remove trust bundle for peer: peer_id=7d228f34-28fe-0d20-eba9-21b6c09e390b peer_name=my-peer-dialer error="context canceled"
2022-08-25T11:17:38.740-0400 [ERROR] acceptor.server.peering: Failed to remove trust bundle for peer: peer_id=7d228f34-28fe-0d20-eba9-21b6c09e390b peer_name=my-peer-dialer error="context canceled"
2022-08-25T11:17:38.740-0400 [ERROR] acceptor.server.peering: Failed to remove trust bundle for peer: peer_id=7d228f34-28fe-0d20-eba9-21b6c09e390b peer_name=my-peer-dialer error="context canceled"
2022-08-25T11:17:38.740-0400 [ERROR] acceptor.server.peering: Failed to remove trust bundle for peer: peer_id=7d228f34-28fe-0d20-eba9-21b6c09e390b peer_name=my-peer-dialer error="context canceled"
...
```

### Testing & Reproduction steps
* After this change, only one ERROR log appeared during shutdown
