### PR TITLE
Run integration tests locally using amd64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -816,7 +816,7 @@ jobs:
       # Get go binary from workspace
       - attach_workspace:
           at: .
-      # Build the consul-dev image from the already built binary
+      # Build the consul:local image from the already built binary
       - run:
           command: |
             sudo rm -rf /usr/local/go
@@ -887,8 +887,8 @@ jobs:
       - attach_workspace:
           at: .
       - run: *install-gotestsum
-      # Build the consul-dev image from the already built binary
-      - run: docker build -t consul-dev -f ./build-support/docker/Consul-Dev.dockerfile .
+      # Build the consul:local image from the already built binary
+      - run: docker build -t consul:local -f ./build-support/docker/Consul-Dev.dockerfile .
       - run:
           name: Envoy Integration Tests
           command: |
@@ -902,6 +902,7 @@ jobs:
             GOTESTSUM_JUNITFILE: /tmp/test-results/results.xml
             GOTESTSUM_FORMAT: standard-verbose
             COMPOSE_INTERACTIVE_NO_CLI: 1
+            LAMBDA_TESTS_ENABLED: "true"
             # tput complains if this isn't set to something.
             TERM: ansi
       - store_artifacts:

--- a/test/integration/connect/envoy/Dockerfile-consul-envoy
+++ b/test/integration/connect/envoy/Dockerfile-consul-envoy
@@ -1,7 +1,7 @@
 # Note this arg has to be before the first FROM
 ARG ENVOY_VERSION
 
-FROM consul-dev as consul
+FROM consul:local as consul
 
 FROM docker.mirror.hashicorp.services/envoyproxy/envoy:v${ENVOY_VERSION}
 COPY --from=consul /bin/consul /bin/consul

--- a/test/integration/connect/envoy/case-wanfed-gw/global-setup.sh
+++ b/test/integration/connect/envoy/case-wanfed-gw/global-setup.sh
@@ -17,7 +17,7 @@ consul tls cert create -dc=secondary -server -node=sec
 "
 
 docker rm -f "$container" &>/dev/null || true
-docker run -i --net=none --name="$container" consul-dev:latest sh -c "${scriptlet}"
+docker run -i --net=none --name="$container" consul:local sh -c "${scriptlet}"
 
 # primary
 for f in \

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -16,6 +16,8 @@ ENVOY_VERSION=${ENVOY_VERSION:-"1.23.0"}
 export ENVOY_VERSION
 
 export DOCKER_BUILDKIT=1
+# Always run tests on amd64 because that's what the CI environment uses.
+export DOCKER_DEFAULT_PLATFORM="linux/amd64"
 
 if [ ! -z "$DEBUG" ] ; then
   set -x
@@ -44,17 +46,19 @@ function network_snippet {
 }
 
 function aws_snippet {
-  local snippet=""
+  if [[ ! -z "$LAMBDA_TESTS_ENABLED" ]]; then
+    local snippet=""
 
-  # The Lambda integration cases assume that a Lambda function exists in $AWS_REGION with an ARN of $AWS_LAMBDA_ARN.
-  # The AWS credentials must have permission to invoke the Lambda function.
-  [ -n "$(set | grep '^AWS_ACCESS_KEY_ID=')" ] && snippet="${snippet} -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
-  [ -n "$(set | grep '^AWS_SECRET_ACCESS_KEY=')" ] && snippet="${snippet} -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
-  [ -n "$(set | grep '^AWS_SESSION_TOKEN=')" ] && snippet="${snippet} -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
-  [ -n "$(set | grep '^AWS_LAMBDA_REGION=')" ] && snippet="${snippet} -e AWS_LAMBDA_REGION=$AWS_LAMBDA_REGION"
-  [ -n "$(set | grep '^AWS_LAMBDA_ARN=')" ] && snippet="${snippet} -e AWS_LAMBDA_ARN=$AWS_LAMBDA_ARN"
+    # The Lambda integration cases assume that a Lambda function exists in $AWS_REGION with an ARN of $AWS_LAMBDA_ARN.
+    # The AWS credentials must have permission to invoke the Lambda function.
+    [ -n "$(set | grep '^AWS_ACCESS_KEY_ID=')" ] && snippet="${snippet} -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+    [ -n "$(set | grep '^AWS_SECRET_ACCESS_KEY=')" ] && snippet="${snippet} -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+    [ -n "$(set | grep '^AWS_SESSION_TOKEN=')" ] && snippet="${snippet} -e AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN"
+    [ -n "$(set | grep '^AWS_LAMBDA_REGION=')" ] && snippet="${snippet} -e AWS_LAMBDA_REGION=$AWS_LAMBDA_REGION"
+    [ -n "$(set | grep '^AWS_LAMBDA_ARN=')" ] && snippet="${snippet} -e AWS_LAMBDA_ARN=$AWS_LAMBDA_ARN"
 
-  echo "$snippet"
+    echo "$snippet"
+  fi
 }
 
 function init_workdir {
@@ -222,7 +226,7 @@ function start_consul {
       --hostname "consul-${DC}-server" \
       --network-alias "consul-${DC}-server" \
       -e "CONSUL_LICENSE=$license" \
-      consul-dev \
+      consul:local \
       agent -dev -datacenter "${DC}" \
       -config-dir "/workdir/${DC}/consul" \
       -config-dir "/workdir/${DC}/consul-server" \
@@ -237,7 +241,7 @@ function start_consul {
       --network-alias "consul-${DC}-client" \
       -e "CONSUL_LICENSE=$license" \
       ${ports[@]} \
-      consul-dev \
+      consul:local \
       agent -datacenter "${DC}" \
       -config-dir "/workdir/${DC}/consul" \
       -data-dir "/tmp/consul" \
@@ -256,7 +260,7 @@ function start_consul {
       --network-alias "consul-${DC}-server" \
       -e "CONSUL_LICENSE=$license" \
       ${ports[@]} \
-      consul-dev \
+      consul:local \
       agent -dev -datacenter "${DC}" \
       -config-dir "/workdir/${DC}/consul" \
       -config-dir "/workdir/${DC}/consul-server" \
@@ -290,7 +294,7 @@ function start_partitioned_client {
     --hostname "consul-${PARTITION}-client" \
     --network-alias "consul-${PARTITION}-client" \
     -e "CONSUL_LICENSE=$license" \
-    consul-dev agent \
+    consul:local agent \
     -datacenter "primary" \
     -retry-join "consul-primary-server" \
     -grpc-port 8502 \


### PR DESCRIPTION
Locally, always run integration tests using amd64, even if running
on an arm mac. This ensures the architecture locally always matches
the CI/CD environment.

In addition:
* Use consul:local for envoy integration and upgrade tests. Previously,
  consul:local was used for upgrade tests and consul-dev for integration
  tests. I didn't see a reason to use separate images as it's more
  confusing.
* By default, disable the requirement that aws credentials are set.
  These are only needed for the lambda tests and make it so you
  can't run any tests locally, even if you're not running the
  lambda tests. Now they'll only run if the LAMBDA_TESTS_ENABLED
  env var is set.
* Split out the building of the Docker image for integration
  tests into its own target from `dev-docker`. This allows us to always
  use an amd64 image without messing up the `dev-docker` target.
* Add support for passing GO_TEST_FLAGs to `test-envoy-integ` target.
* Add a wait_for_leader function because tests were failing locally
  without it.

To test on your own mac:

```
make test-envoy-integ GO_TEST_FLAGS="-run TestEnvoy/case-basic"
```