### PR TITLE
Adjust metrics reporting for peering tracker

### DIFF
--- a/agent/consul/leader_peering.go
+++ b/agent/consul/leader_peering.go
@@ -112,7 +112,7 @@ func (s *Server) emitPeeringMetricsOnce(logger hclog.Logger, metricsImpl *metric
 		if status.NeverConnected {
 			metricsImpl.SetGaugeWithLabels(leaderHealthyPeeringKey, float32(math.NaN()), labels)
 		} else {
-			healthy := status.IsHealthy()
+			healthy := s.peerStreamServer.Tracker.IsHealthy(status)
 			healthyInt := 0
 			if healthy {
 				healthyInt = 1
@@ -305,7 +305,7 @@ func (s *Server) establishStream(ctx context.Context, logger hclog.Logger, ws me
 
 	logger.Trace("establishing stream to peer")
 
-	streamStatus, err := s.peerStreamTracker.Register(peer.ID)
+	streamStatus, err := s.peerStreamServer.Tracker.Register(peer.ID)
 	if err != nil {
 		return fmt.Errorf("failed to register stream: %v", err)
 	}

--- a/agent/consul/leader_peering_test.go
+++ b/agent/consul/leader_peering_test.go
@@ -1216,7 +1216,7 @@ func TestLeader_Peering_NoEstablishmentWhenPeeringDisabled(t *testing.T) {
 	}))
 
 	require.Never(t, func() bool {
-		_, found := s1.peerStreamTracker.StreamStatus(peerID)
+		_, found := s1.peerStreamServer.StreamStatus(peerID)
 		return found
 	}, 7*time.Second, 1*time.Second, "peering should not have been established")
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -742,7 +742,6 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server) (*Ser
 			return s.ForwardGRPC(s.grpcConnPool, info, fn)
 		},
 	})
-	s.peerStreamTracker.SetHeartbeatTimeout(s.peerStreamServer.Config.IncomingHeartbeatTimeout)
 	s.peerStreamServer.Register(s.externalGRPCServer)
 
 	// Initialize internal gRPC server.
@@ -1575,12 +1574,12 @@ func (s *Server) Stats() map[string]map[string]string {
 // GetLANCoordinate returns the coordinate of the node in the LAN gossip
 // pool.
 //
-// - Clients return a single coordinate for the single gossip pool they are
-//   in (default, segment, or partition).
+//   - Clients return a single coordinate for the single gossip pool they are
+//     in (default, segment, or partition).
 //
-// - Servers return one coordinate for their canonical gossip pool (i.e.
-//   default partition/segment) and one per segment they are also ancillary
-//   members of.
+//   - Servers return one coordinate for their canonical gossip pool (i.e.
+//     default partition/segment) and one per segment they are also ancillary
+//     members of.
 //
 // NOTE: servers do not emit coordinates for partitioned gossip pools they
 // are ancillary members of.

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -370,9 +370,9 @@ type Server struct {
 
 	// peerStreamServer is a server used to handle peering streams from external clusters.
 	peerStreamServer *peerstream.Server
+
 	// peeringServer handles peering RPC requests internal to this cluster, like generating peering tokens.
-	peeringServer     *peering.Server
-	peerStreamTracker *peerstream.Tracker
+	peeringServer *peering.Server
 
 	// embedded struct to hold all the enterprise specific data
 	EnterpriseServer
@@ -724,11 +724,9 @@ func NewServer(config *Config, flat Deps, externalGRPCServer *grpc.Server) (*Ser
 		Logger:      logger.Named("grpc-api.server-discovery"),
 	}).Register(s.externalGRPCServer)
 
-	s.peerStreamTracker = peerstream.NewTracker()
 	s.peeringBackend = NewPeeringBackend(s)
 	s.peerStreamServer = peerstream.NewServer(peerstream.Config{
 		Backend:        s.peeringBackend,
-		Tracker:        s.peerStreamTracker,
 		GetStore:       func() peerstream.StateStore { return s.FSM().State() },
 		Logger:         logger.Named("grpc-api.peerstream"),
 		ACLResolver:    s.ACLResolver,
@@ -790,7 +788,7 @@ func newGRPCHandlerFromConfig(deps Deps, config *Config, s *Server) connHandler 
 
 	p := peering.NewServer(peering.Config{
 		Backend: s.peeringBackend,
-		Tracker: s.peerStreamTracker,
+		Tracker: s.peerStreamServer.Tracker,
 		Logger:  deps.Logger.Named("grpc-api.peering"),
 		ForwardRPC: func(info structs.RPCInfo, fn func(*grpc.ClientConn) error) (bool, error) {
 			// Only forward the request if the dc in the request matches the server's datacenter.

--- a/agent/grpc-external/services/peerstream/server.go
+++ b/agent/grpc-external/services/peerstream/server.go
@@ -42,8 +42,8 @@ type Config struct {
 	// outgoingHeartbeatInterval is how often we send a heartbeat.
 	outgoingHeartbeatInterval time.Duration
 
-	// IncomingHeartbeatTimeout is how long we'll wait between receiving heartbeats before we close the connection.
-	IncomingHeartbeatTimeout time.Duration
+	// incomingHeartbeatTimeout is how long we'll wait between receiving heartbeats before we close the connection.
+	incomingHeartbeatTimeout time.Duration
 }
 
 //go:generate mockery --name ACLResolver --inpackage
@@ -63,8 +63,8 @@ func NewServer(cfg Config) *Server {
 	if cfg.outgoingHeartbeatInterval == 0 {
 		cfg.outgoingHeartbeatInterval = defaultOutgoingHeartbeatInterval
 	}
-	if cfg.IncomingHeartbeatTimeout == 0 {
-		cfg.IncomingHeartbeatTimeout = defaultIncomingHeartbeatTimeout
+	if cfg.incomingHeartbeatTimeout == 0 {
+		cfg.incomingHeartbeatTimeout = defaultIncomingHeartbeatTimeout
 	}
 	return &Server{
 		Config: cfg,

--- a/agent/grpc-external/services/peerstream/server.go
+++ b/agent/grpc-external/services/peerstream/server.go
@@ -26,11 +26,12 @@ const (
 
 type Server struct {
 	Config
+
+	Tracker *Tracker
 }
 
 type Config struct {
 	Backend     Backend
-	Tracker     *Tracker
 	GetStore    func() StateStore
 	Logger      hclog.Logger
 	ForwardRPC  func(structs.RPCInfo, func(*grpc.ClientConn) error) (bool, error)
@@ -53,7 +54,6 @@ type ACLResolver interface {
 
 func NewServer(cfg Config) *Server {
 	requireNotNil(cfg.Backend, "Backend")
-	requireNotNil(cfg.Tracker, "Tracker")
 	requireNotNil(cfg.GetStore, "GetStore")
 	requireNotNil(cfg.Logger, "Logger")
 	// requireNotNil(cfg.ACLResolver, "ACLResolver") // TODO(peering): reenable check when ACLs are required
@@ -67,7 +67,8 @@ func NewServer(cfg Config) *Server {
 		cfg.incomingHeartbeatTimeout = defaultIncomingHeartbeatTimeout
 	}
 	return &Server{
-		Config: cfg,
+		Config:  cfg,
+		Tracker: NewTracker(cfg.incomingHeartbeatTimeout),
 	}
 }
 

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -406,7 +406,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 
 	// incomingHeartbeatCtx will complete if incoming heartbeats time out.
 	incomingHeartbeatCtx, incomingHeartbeatCtxCancel :=
-		context.WithTimeout(context.Background(), s.IncomingHeartbeatTimeout)
+		context.WithTimeout(context.Background(), s.incomingHeartbeatTimeout)
 	// NOTE: It's important that we wrap the call to cancel in a wrapper func because during the loop we're
 	// re-assigning the value of incomingHeartbeatCtxCancel and we want the defer to run on the last assigned
 	// value, not the current value.
@@ -575,6 +575,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 					status.TrackRecvResourceSuccess()
 				}
 
+				// We are replying ACK or NACK depending on whether we successfully processed the response.
 				if err := streamSend(reply); err != nil {
 					return fmt.Errorf("failed to send to stream: %v", err)
 				}
@@ -605,7 +606,7 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 				// They just can't trace the execution properly for some reason (possibly golang/go#29587).
 				//nolint:govet
 				incomingHeartbeatCtx, incomingHeartbeatCtxCancel =
-					context.WithTimeout(context.Background(), s.IncomingHeartbeatTimeout)
+					context.WithTimeout(context.Background(), s.incomingHeartbeatTimeout)
 			}
 
 		case update := <-subCh:
@@ -642,7 +643,6 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 			if err := streamSend(replResp); err != nil {
 				return fmt.Errorf("failed to push data for %q: %w", update.CorrelationID, err)
 			}
-			status.TrackSendSuccess()
 		}
 	}
 }

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -499,9 +499,8 @@ func TestStreamResources_Server_Terminate(t *testing.T) {
 		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
 
-	srv, store := newTestServer(t, func(c *Config) {
-		c.Tracker.SetClock(it.Now)
-	})
+	srv, store := newTestServer(t, nil)
+	srv.Tracker.setClock(it.Now)
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")
 	require.Empty(t, p.PeerID, "should be empty if being dialed")
@@ -552,9 +551,8 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 		base: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
 
-	srv, store := newTestServer(t, func(c *Config) {
-		c.Tracker.SetClock(it.Now)
-	})
+	srv, store := newTestServer(t, nil)
+	srv.Tracker.setClock(it.Now)
 
 	// Set the initial roots and CA configuration.
 	_, rootA := writeInitialRootsAndCA(t, store)
@@ -1128,9 +1126,9 @@ func TestStreamResources_Server_DisconnectsOnHeartbeatTimeout(t *testing.T) {
 	}
 
 	srv, store := newTestServer(t, func(c *Config) {
-		c.Tracker.SetClock(it.Now)
 		c.incomingHeartbeatTimeout = 5 * time.Millisecond
 	})
+	srv.Tracker.setClock(it.Now)
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")
 	require.Empty(t, p.PeerID, "should be empty if being dialed")
@@ -1176,9 +1174,9 @@ func TestStreamResources_Server_SendsHeartbeats(t *testing.T) {
 	outgoingHeartbeatInterval := 5 * time.Millisecond
 
 	srv, store := newTestServer(t, func(c *Config) {
-		c.Tracker.SetClock(it.Now)
 		c.outgoingHeartbeatInterval = outgoingHeartbeatInterval
 	})
+	srv.Tracker.setClock(it.Now)
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")
 	require.Empty(t, p.PeerID, "should be empty if being dialed")
@@ -1235,9 +1233,9 @@ func TestStreamResources_Server_KeepsConnectionOpenWithHeartbeat(t *testing.T) {
 	incomingHeartbeatTimeout := 10 * time.Millisecond
 
 	srv, store := newTestServer(t, func(c *Config) {
-		c.Tracker.SetClock(it.Now)
 		c.incomingHeartbeatTimeout = incomingHeartbeatTimeout
 	})
+	srv.Tracker.setClock(it.Now)
 
 	p := writePeeringToBeDialed(t, store, 1, "my-peer")
 	require.Empty(t, p.PeerID, "should be empty if being dialed")
@@ -2746,7 +2744,6 @@ func newTestServer(t *testing.T, configFn func(c *Config)) (*testServer, *state.
 			store: store,
 			pub:   publisher,
 		},
-		Tracker:        NewTracker(),
 		GetStore:       func() StateStore { return store },
 		Logger:         testutil.Logger(t),
 		Datacenter:     "dc1",

--- a/agent/grpc-external/services/peerstream/stream_test.go
+++ b/agent/grpc-external/services/peerstream/stream_test.go
@@ -655,7 +655,7 @@ func TestStreamResources_Server_StreamTracker(t *testing.T) {
 				},
 			},
 		}
-		lastRecvResourceSuccess = it.FutureNow(2)
+		lastRecvResourceSuccess = it.FutureNow(1)
 		err := client.Send(resp)
 		require.NoError(t, err)
 

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -16,8 +16,6 @@ type Tracker struct {
 
 	// timeNow is a shim for testing.
 	timeNow func() time.Time
-
-	heartbeatTimeout time.Duration
 }
 
 func NewTracker() *Tracker {
@@ -35,12 +33,6 @@ func (t *Tracker) SetClock(clock func() time.Time) {
 	}
 }
 
-func (t *Tracker) SetHeartbeatTimeout(heartbeatTimeout time.Duration) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.heartbeatTimeout = heartbeatTimeout
-}
-
 // Register a stream for a given peer but do not mark it as connected.
 func (t *Tracker) Register(id string) (*MutableStatus, error) {
 	t.mu.Lock()
@@ -52,7 +44,7 @@ func (t *Tracker) Register(id string) (*MutableStatus, error) {
 func (t *Tracker) registerLocked(id string, initAsConnected bool) (*MutableStatus, bool, error) {
 	status, ok := t.streams[id]
 	if !ok {
-		status = newMutableStatus(t.timeNow, t.heartbeatTimeout, initAsConnected)
+		status = newMutableStatus(t.timeNow, initAsConnected)
 		t.streams[id] = status
 		return status, true, nil
 	}
@@ -152,8 +144,6 @@ type MutableStatus struct {
 // Status contains information about the replication stream to a peer cluster.
 // TODO(peering): There's a lot of fields here...
 type Status struct {
-	heartbeatTimeout time.Duration
-
 	// Connected is true when there is an open stream for the peer.
 	Connected bool
 
@@ -181,9 +171,6 @@ type Status struct {
 
 	// LastSendErrorMessage tracks the last error message when sending into the stream.
 	LastSendErrorMessage string
-
-	// LastSendSuccess tracks the time of the last success response sent into the stream.
-	LastSendSuccess time.Time
 
 	// LastRecvHeartbeat tracks when we last received a heartbeat from our peer.
 	LastRecvHeartbeat time.Time
@@ -216,38 +203,40 @@ func (s *Status) GetExportedServicesCount() uint64 {
 
 // IsHealthy is a convenience func that returns true/ false for a peering status.
 // We define a peering as unhealthy if its status satisfies one of the following:
-// -  If heartbeat hasn't been received within the IncomingHeartbeatTimeout
-// -  If the last sent error is newer than last sent success
+// -  If it is disconnected
+// -  If the last received Nack is newer than last received Ack
 // -  If the last received error is newer than last received success
 // If none of these conditions apply, we call the peering healthy.
 func (s *Status) IsHealthy() bool {
-	if time.Now().Sub(s.LastRecvHeartbeat) > s.heartbeatTimeout {
-		// 1. If heartbeat hasn't been received for a while - report unhealthy
+	if !s.Connected {
 		return false
 	}
 
-	if s.LastSendError.After(s.LastSendSuccess) {
-		// 2. If last sent error is newer than last sent success - report unhealthy
+	// If stream is in a disconnected state, report unhealthy.
+	// This should be logically equivalent to s.Connected above.
+	if !s.DisconnectTime.IsZero() {
 		return false
 	}
 
+	// If last Nack is after last Ack, it means the peer is unable to
+	// handle our replication messages.
+	if s.LastNack.After(s.LastAck) {
+		return false
+	}
+
+	// If last recv error is newer than last recv success - report unhealthy
 	if s.LastRecvError.After(s.LastRecvResourceSuccess) {
-		// 3. If last recv error is newer than last recv success - report unhealthy
 		return false
 	}
 
 	return true
 }
 
-func newMutableStatus(now func() time.Time, heartbeatTimeout time.Duration, connected bool) *MutableStatus {
-	if heartbeatTimeout.Microseconds() == 0 {
-		heartbeatTimeout = defaultIncomingHeartbeatTimeout
-	}
+func newMutableStatus(now func() time.Time, connected bool) *MutableStatus {
 	return &MutableStatus{
 		Status: Status{
-			Connected:        connected,
-			heartbeatTimeout: heartbeatTimeout,
-			NeverConnected:   !connected,
+			Connected:      connected,
+			NeverConnected: !connected,
 		},
 		timeNow: now,
 		doneCh:  make(chan struct{}),
@@ -268,12 +257,6 @@ func (s *MutableStatus) TrackSendError(error string) {
 	s.mu.Lock()
 	s.LastSendError = s.timeNow().UTC()
 	s.LastSendErrorMessage = error
-	s.mu.Unlock()
-}
-
-func (s *MutableStatus) TrackSendSuccess() {
-	s.mu.Lock()
-	s.LastSendSuccess = s.timeNow().UTC()
 	s.mu.Unlock()
 }
 

--- a/agent/grpc-external/services/peerstream/stream_tracker_test.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker_test.go
@@ -45,7 +45,7 @@ func TestStatus_IsHealthy(t *testing.T) {
 			},
 		},
 		{
-			name:        "receive error before receive success",
+			name:        "nack before ack",
 			expectedVal: false,
 			modifierFunc: func(status *MutableStatus) {
 				now := time.Now()


### PR DESCRIPTION
Follow-up to https://github.com/hashicorp/consul/pull/14004

### Description
https://github.com/hashicorp/consul/pull/14004 introduced a way of computing the health of a peering but I think the implementation could be simplified:


#### 1. Deriving health from heartbeats is redundant (see edit notes)
If heartbeats time out, the stream is disconnected:
https://github.com/hashicorp/consul/blob/64d6b46f75d6c37379a3cfd10b791d643c371f85/agent/grpc-external/services/peerstream/stream_resources.go#L457-L458

Then the error gets tracked:
https://github.com/hashicorp/consul/blob/64d6b46f75d6c37379a3cfd10b791d643c371f85/agent/grpc-external/services/peerstream/stream_resources.go#L277-L280

And eventually the leader retries the connection.

So the heartbeat health (among other classes of transient errors) can simply be inferred from the DisconnectTime. If the leader manages to connect to the peer again, the disconnect time is cleared and the status will be marked healthy.

*EDIT*: I chatted with Matt and we agreed that there should be some grace period for peers to recover before we mark peerings as unhealthy. I am preserving https://github.com/hashicorp/consul/pull/14004 usage of heartbeat timeouts as the deadline for peers to recover.

#### 2. ACK and NACK times should be used to detect "sending health"
https://github.com/hashicorp/consul/pull/14004 introduced `LastSendSuccess` as a data point and compared it with `LastSendError` to measure health. Unfortunately, our current handling of `LastSendError` is not always correct. This means non-send errors can be incorrectly tracked as send errors and make our health reporting inaccurate.

Example:
https://github.com/hashicorp/consul/blob/6ddcc046136d4e5a6a5f05fb59afdac0e070f7d3/agent/consul/leader_peering.go#L379-L386

We should instead use `LastAck` and `LastNack`, which indicate whether the sent messages were processed correctly or not.

If a server were to consistently fail at sending, the stream would be in a disconnected-but-retrying state captured by `DisconnectTime`

#### 3. We should consider "receiving health"
If a server fails to successfully process a resource replicated from the peer, it should also mark the peering as unhealthy.


### Testing & Reproduction steps
* Updated unit tests


### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
