### PR TITLE
Update max_ejection_percent on outlier detection for peered clusters to 100%

### DIFF
--- a/.changelog/14373.txt
+++ b/.changelog/14373.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+xds: Set `max_ejection_percent` on Envoy's outlier detection to 100% for peered services.
+```

--- a/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams.latest.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-peered-upstreams.latest.golden
@@ -58,7 +58,7 @@
       "dnsRefreshRate": "10s",
       "dnsLookupFamily": "V4_ONLY",
       "outlierDetection": {
-
+        "maxEjectionPercent": 100
       },
       "commonLbConfig": {
         "healthyPanicThreshold": {
@@ -115,7 +115,7 @@
 
       },
       "outlierDetection": {
-
+        "maxEjectionPercent": 100
       },
       "commonLbConfig": {
         "healthyPanicThreshold": {

--- a/agent/xds/testdata/clusters/transparent-proxy-with-peered-upstreams.latest.golden
+++ b/agent/xds/testdata/clusters/transparent-proxy-with-peered-upstreams.latest.golden
@@ -18,7 +18,7 @@
 
       },
       "outlierDetection": {
-
+        "maxEjectionPercent": 100
       },
       "commonLbConfig": {
         "healthyPanicThreshold": {
@@ -75,7 +75,7 @@
 
       },
       "outlierDetection": {
-
+        "maxEjectionPercent": 100
       },
       "commonLbConfig": {
         "healthyPanicThreshold": {
@@ -157,7 +157,7 @@
 
       },
       "outlierDetection": {
-
+        "maxEjectionPercent": 100
       },
       "commonLbConfig": {
         "healthyPanicThreshold": {


### PR DESCRIPTION
### Description
We can't trust health checks when service resolvers, splitters, and routers are used for peered clusters.

### PR Checklist
* [X] updated test coverage
* [ ] external facing docs updated
* [X] not a security concern
