### PR TITLE
Fix a breaking change to the API package introduced in #13835

### DIFF
--- a/.changelog/14378.txt
+++ b/.changelog/14378.txt
@@ -1,0 +1,5 @@
+```release-note:bug
+api: Fix a breaking change caused by renaming `QueryDatacenterOptions` to
+`QueryFailoverOptions`. This adds `QueryDatacenterOptions` back as an alias to
+`QueryFailoverOptions` and marks it as deprecated.
+```

--- a/api/prepared_query.go
+++ b/api/prepared_query.go
@@ -17,6 +17,9 @@ type QueryFailoverOptions struct {
 	Targets []QueryFailoverTarget
 }
 
+// Deprecated: use QueryFailoverOptions instead.
+type QueryDatacenterOptions = QueryFailoverOptions
+
 type QueryFailoverTarget struct {
 	// PeerName specifies a peer to try during failover.
 	PeerName string


### PR DESCRIPTION
### Description
`QueryDatacenterOptions` was renamed to `QueryFailoverOptions` without creating an alias. This adds `QueryDatacenterOptions` back as an alias to `QueryFailoverOptions` and marks it as deprecated.