### PR TITLE
ci: update backport-assistant to pick merge commit

### DIFF
--- a/.github/workflows/backport-assistant.yml
+++ b/.github/workflows/backport-assistant.yml
@@ -16,7 +16,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.2.3
+    container: hashicorpdev/backport-assistant:0.2.5
     steps:
       - name: Run Backport Assistant for stable-website
         run: |
@@ -24,6 +24,7 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "type/docs-(?P<target>cherrypick)"
           BACKPORT_TARGET_TEMPLATE: "stable-website"
+          BACKPORT_MERGE_COMMIT: true
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
       - name: Backport changes to latest release branch
         run: |


### PR DESCRIPTION
Refs hashicorp/vault#15571, https://github.com/hashicorp/backport-assistant/issues/37, https://github.com/hashicorp/backport-assistant/pull/40, https://github.com/hashicorp/backport-assistant/issues/26

> Cherry-pick the merge commit instead of the individual commits in the PR. This will be less confusing, as it would eliminate the partial-success case, and may result in fewer failed cherry-picks in the first place.

This actually brings us back [closer to the implementation we had before switching](https://github.com/hashicorp/backport-assistant/issues/25#issuecomment-999895503) over to backport-assistant.