### PR TITLE
ui: Adds a HCP home link when in HCP

### DIFF
--- a/ui/packages/consul-hcp/app/components/consul/hcp/home/index.hbs
+++ b/ui/packages/consul-hcp/app/components/consul/hcp/home/index.hbs
@@ -1,0 +1,8 @@
+<div
+  class={{'consul-hcp-home'}}
+  ...attributes
+>
+  <a href={{env 'CONSUL_HCP_URL'}}>
+    Back to HCP
+  </a>
+</div>

--- a/ui/packages/consul-hcp/app/components/consul/hcp/home/index.hbs
+++ b/ui/packages/consul-hcp/app/components/consul/hcp/home/index.hbs
@@ -1,5 +1,5 @@
 <div
-  class={{'consul-hcp-home'}}
+  class="consul-hcp-home"
   ...attributes
 >
   <a href={{env 'CONSUL_HCP_URL'}}>

--- a/ui/packages/consul-hcp/app/components/consul/hcp/home/index.scss
+++ b/ui/packages/consul-hcp/app/components/consul/hcp/home/index.scss
@@ -1,0 +1,11 @@
+.consul-hcp-home {
+  position: relative;
+  top: -22px;
+}
+.consul-hcp-home a::before {
+  content: '';
+  --icon-name: icon-arrow-left;
+  --icon-size: icon-300;
+  margin-right: 8px;
+}
+

--- a/ui/packages/consul-hcp/vendor/consul-hcp/services.js
+++ b/ui/packages/consul-hcp/vendor/consul-hcp/services.js
@@ -1,5 +1,7 @@
 (services => services({
-
+  'component:consul/hcp/home': {
+    class: 'consul-ui/components/consul/hcp/home',
+  },
 }))(
   (json, data = (typeof document !== 'undefined' ? document.currentScript.dataset : module.exports)) => {
     data[`services`] = JSON.stringify(json);

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.hbs
@@ -86,13 +86,14 @@
   </:home-nav>
 
   <:main-nav>
+    <Consul::Hcp::Home />
     <ul>
-        <Consul::Datacenter::Selector
-          @dc={{@dc}}
-          @partition={{@partition}}
-          @nspace={{@nspace}}
-          @dcs={{@dcs}}
-        />
+      <Consul::Datacenter::Selector
+        @dc={{@dc}}
+        @partition={{@partition}}
+        @nspace={{@nspace}}
+        @dcs={{@dcs}}
+      />
       <Consul::Partition::Selector
         @dc={{@dc}}
         @partition={{@partition}}

--- a/ui/packages/consul-ui/app/components/main-nav-vertical/index.scss
+++ b/ui/packages/consul-ui/app/components/main-nav-vertical/index.scss
@@ -8,9 +8,8 @@
   @extend %main-nav-vertical-item;
 }
 /**/
-
 /* actual clickable button-y things plus states */
-%main-nav-vertical > ul > li > a {
+%main-nav-vertical a {
   @extend %main-nav-vertical-action;
 }
 %main-nav-vertical > ul > li.is-active > a {

--- a/ui/packages/consul-ui/app/styles/base/icons/icons/index.scss
+++ b/ui/packages/consul-ui/app/styles/base/icons/icons/index.scss
@@ -2,7 +2,7 @@
 @import './alert-circle-outline/index.scss';
 @import './alert-triangle/index.scss';
 // @import './arrow-down/index.scss';
-// @import './arrow-left/index.scss';
+@import './arrow-left/index.scss';
 @import './arrow-right/index.scss';
 // @import './arrow-up/index.scss';
 // @import './bolt/index.scss';

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -109,3 +109,4 @@
 @import 'consul-ui/components/consul/node/peer-info';
 @import 'consul-ui/components/consul/peer/info';
 @import 'consul-ui/components/consul/peer/form';
+@import 'consul-ui/components/consul/hcp/home';

--- a/ui/packages/consul-ui/vendor/consul-ui/services.js
+++ b/ui/packages/consul-ui/vendor/consul-ui/services.js
@@ -18,6 +18,9 @@
     'component:consul/peer/selector': {
       class: '@glimmer/component',
     },
+    'component:consul/hcp/home': {
+      class: '@glimmer/component',
+    },
   }))(
   (
     json,


### PR DESCRIPTION
### Description
Adds a Back to HCP link only when HCP is enabled, the link uses a yet to exist `CONSUL_HCP_URL` "env var"


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
