### PR TITLE
Adds idle_timeout envoy proxy local app config knob

### DIFF
--- a/.changelog/14403.txt
+++ b/.changelog/14403.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+connect: Add local_idle_timeout_ms to allow configuring the Envoy idle timeout on local_app
+```

--- a/agent/xds/config.go
+++ b/agent/xds/config.go
@@ -38,6 +38,12 @@ type ProxyConfig struct {
 	// set.
 	LocalConnectTimeoutMs int `mapstructure:"local_connect_timeout_ms"`
 
+	// LocalIdleTimeoutMs is the number of milliseconds a request's stream to the
+	// local app instance may be idle. If not set, no value is set, Envoy defaults
+	// are respected, and an Envoy stream_idle_timeout (5m) will apply. If set,
+	// this LocalIdleTimeoutMs value will override the Envoy stream_idle_timeout.
+	LocalIdleTimeoutMs *int `mapstructure:"local_idle_timeout_ms"`
+
 	// LocalRequestTimeoutMs is the number of milliseconds to timeout HTTP requests
 	// to the local app instance. If not set, no value is set, Envoy defaults are
 	// respected (15s)

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1193,6 +1193,7 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 		filterName:       name,
 		routeName:        name,
 		cluster:          LocalAppClusterName,
+		idleTimeoutMs:    cfg.LocalIdleTimeoutMs,
 		requestTimeoutMs: cfg.LocalRequestTimeoutMs,
 	}
 	if useHTTPFilter {
@@ -1950,6 +1951,7 @@ type listenerFilterOpts struct {
 	cluster              string
 	statPrefix           string
 	routePath            string
+	idleTimeoutMs        *int
 	requestTimeoutMs     *int
 	ingressGateway       bool
 	httpAuthzFilter      *envoy_http_v3.HttpFilter
@@ -2072,6 +2074,11 @@ func makeHTTPFilter(opts listenerFilterOpts) (*envoy_listener_v3.Filter, error) 
 					},
 				},
 			},
+		}
+
+		if opts.idleTimeoutMs != nil {
+			r := route.GetRoute()
+			r.IdleTimeout = durationpb.New(time.Duration(*opts.idleTimeoutMs) * time.Millisecond)
 		}
 
 		if opts.requestTimeoutMs != nil {


### PR DESCRIPTION
### Description
We require override of envoy's default `stream_idle_timeout` which we are unable to do via Nomad and escape hatches at this time AFAICT.  This has also been asked for in the community.  See refs below.

### Links
* https://github.com/hashicorp/nomad/issues/14403
* https://discuss.hashicorp.com/t/override-stream-idle-timeout-5-min-default-on-envoy/30175

### PR Checklist

* [ ] updated test coverage
* [X] external facing docs updated
* [X] not a security concern
