### PR TITLE
fix TestProxyConfigEntry

### DIFF
--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -2957,8 +2957,9 @@ func TestProxyConfigEntry(t *testing.T) {
 				Name: "",
 			},
 			expected: &ProxyConfigEntry{
-				Name: ProxyConfigGlobal,
-				Kind: ProxyDefaults,
+				Name:           ProxyConfigGlobal,
+				Kind:           ProxyDefaults,
+				EnterpriseMeta: *acl.DefaultEnterpriseMeta(),
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixes a test case in `TestProxyConfigEntry`. The test was failing in OSS->ENT PR. 

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
