### PR TITLE
Add Internal.ServiceDump support for querying by PeerName

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -211,7 +211,9 @@ func (s *HTTPHandlers) UIServices(resp http.ResponseWriter, req *http.Request) (
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
-
+	if peer := req.URL.Query().Get("peer"); peer != "" {
+		args.PeerName = peer
+	}
 	if err := s.parseEntMeta(req, &args.EnterpriseMeta); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description
OSS port of a mainly Enterprise change. Should break no existing tests

The UIServices endpoint (`/v1/internal/ui/services`) needs to support querying imported services for a given peer. Initial support was added in https://github.com/hashicorp/consul/pull/13577 but that PR appended all imported services of a partition to the regular service dump response, whereas we want a narrower subset of ONLY imported services for a new UI view.

This PR updates the Internal.ServiceDump endpoint to behave differently when a PeerName is passed: it makes a single query to fetch only Peered services. If PeerName is empty, the endpoint behaves as usual. Non-empty PeerNames were not allowed prior to this PR.
