### PR TITLE
proxycfg-glue: remaining server-local data sources

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4268,6 +4268,7 @@ func (a *Agent) proxyDataSources() proxycfg.DataSources {
 		sources.Health = proxycfgglue.ServerHealth(deps, proxycfgglue.ClientHealth(a.rpcClientHealth))
 		sources.Intentions = proxycfgglue.ServerIntentions(deps)
 		sources.IntentionUpstreams = proxycfgglue.ServerIntentionUpstreams(deps)
+		sources.IntentionUpstreamsDestination = proxycfgglue.ServerIntentionUpstreamsDestination(deps)
 		sources.InternalServiceDump = proxycfgglue.ServerInternalServiceDump(deps, proxycfgglue.CacheInternalServiceDump(a.cache))
 		sources.PeeredUpstreams = proxycfgglue.ServerPeeredUpstreams(deps)
 		sources.ResolvedServiceConfig = proxycfgglue.ServerResolvedServiceConfig(deps, proxycfgglue.CacheResolvedServiceConfig(a.cache))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4268,6 +4268,7 @@ func (a *Agent) proxyDataSources() proxycfg.DataSources {
 		sources.Health = proxycfgglue.ServerHealth(deps, proxycfgglue.ClientHealth(a.rpcClientHealth))
 		sources.Intentions = proxycfgglue.ServerIntentions(deps)
 		sources.IntentionUpstreams = proxycfgglue.ServerIntentionUpstreams(deps)
+		sources.InternalServiceDump = proxycfgglue.ServerInternalServiceDump(deps, proxycfgglue.CacheInternalServiceDump(a.cache))
 		sources.PeeredUpstreams = proxycfgglue.ServerPeeredUpstreams(deps)
 		sources.ResolvedServiceConfig = proxycfgglue.ServerResolvedServiceConfig(deps, proxycfgglue.CacheResolvedServiceConfig(a.cache))
 		sources.ServiceList = proxycfgglue.ServerServiceList(deps, proxycfgglue.CacheServiceList(a.cache))

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4269,6 +4269,7 @@ func (a *Agent) proxyDataSources() proxycfg.DataSources {
 		sources.Intentions = proxycfgglue.ServerIntentions(deps)
 		sources.IntentionUpstreams = proxycfgglue.ServerIntentionUpstreams(deps)
 		sources.PeeredUpstreams = proxycfgglue.ServerPeeredUpstreams(deps)
+		sources.ResolvedServiceConfig = proxycfgglue.ServerResolvedServiceConfig(deps, proxycfgglue.CacheResolvedServiceConfig(a.cache))
 		sources.ServiceList = proxycfgglue.ServerServiceList(deps, proxycfgglue.CacheServiceList(a.cache))
 		sources.TrustBundle = proxycfgglue.ServerTrustBundle(deps)
 		sources.TrustBundleList = proxycfgglue.ServerTrustBundleList(deps)

--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -1,0 +1,229 @@
+package configentry
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/copystructure"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func ComputeResolvedServiceConfig(
+	args *structs.ServiceConfigRequest,
+	upstreamIDs []structs.ServiceID,
+	legacyUpstreams bool,
+	entries *ResolvedServiceConfigSet,
+	logger hclog.Logger,
+) (*structs.ServiceConfigResponse, error) {
+	var thisReply structs.ServiceConfigResponse
+
+	thisReply.MeshGateway.Mode = structs.MeshGatewayModeDefault
+
+	// TODO(freddy) Refactor this into smaller set of state store functions
+	// Pass the WatchSet to both the service and proxy config lookups. If either is updated during the
+	// blocking query, this function will be rerun and these state store lookups will both be current.
+	// We use the default enterprise meta to look up the global proxy defaults because they are not namespaced.
+	var proxyConfGlobalProtocol string
+	proxyConf := entries.GetProxyDefaults(args.PartitionOrDefault())
+	if proxyConf != nil {
+		// Apply the proxy defaults to the sidecar's proxy config
+		mapCopy, err := copystructure.Copy(proxyConf.Config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to copy global proxy-defaults: %v", err)
+		}
+		thisReply.ProxyConfig = mapCopy.(map[string]interface{})
+		thisReply.Mode = proxyConf.Mode
+		thisReply.TransparentProxy = proxyConf.TransparentProxy
+		thisReply.MeshGateway = proxyConf.MeshGateway
+		thisReply.Expose = proxyConf.Expose
+
+		// Extract the global protocol from proxyConf for upstream configs.
+		rawProtocol := proxyConf.Config["protocol"]
+		if rawProtocol != nil {
+			var ok bool
+			proxyConfGlobalProtocol, ok = rawProtocol.(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid protocol type %T", rawProtocol)
+			}
+		}
+	}
+
+	serviceConf := entries.GetServiceDefaults(
+		structs.NewServiceID(args.Name, &args.EnterpriseMeta),
+	)
+	if serviceConf != nil {
+		if serviceConf.Expose.Checks {
+			thisReply.Expose.Checks = true
+		}
+		if len(serviceConf.Expose.Paths) >= 1 {
+			thisReply.Expose.Paths = serviceConf.Expose.Paths
+		}
+		if serviceConf.MeshGateway.Mode != structs.MeshGatewayModeDefault {
+			thisReply.MeshGateway.Mode = serviceConf.MeshGateway.Mode
+		}
+		if serviceConf.Protocol != "" {
+			if thisReply.ProxyConfig == nil {
+				thisReply.ProxyConfig = make(map[string]interface{})
+			}
+			thisReply.ProxyConfig["protocol"] = serviceConf.Protocol
+		}
+		if serviceConf.TransparentProxy.OutboundListenerPort != 0 {
+			thisReply.TransparentProxy.OutboundListenerPort = serviceConf.TransparentProxy.OutboundListenerPort
+		}
+		if serviceConf.TransparentProxy.DialedDirectly {
+			thisReply.TransparentProxy.DialedDirectly = serviceConf.TransparentProxy.DialedDirectly
+		}
+		if serviceConf.Mode != structs.ProxyModeDefault {
+			thisReply.Mode = serviceConf.Mode
+		}
+		if serviceConf.Destination != nil {
+			thisReply.Destination = *serviceConf.Destination
+		}
+
+		if serviceConf.MaxInboundConnections > 0 {
+			if thisReply.ProxyConfig == nil {
+				thisReply.ProxyConfig = map[string]interface{}{}
+			}
+			thisReply.ProxyConfig["max_inbound_connections"] = serviceConf.MaxInboundConnections
+		}
+
+		thisReply.Meta = serviceConf.Meta
+	}
+
+	// First collect all upstreams into a set of seen upstreams.
+	// Upstreams can come from:
+	// - Explicitly from proxy registrations, and therefore as an argument to this RPC endpoint
+	// - Implicitly from centralized upstream config in service-defaults
+	seenUpstreams := map[structs.ServiceID]struct{}{}
+
+	var (
+		noUpstreamArgs = len(upstreamIDs) == 0 && len(args.Upstreams) == 0
+
+		// Check the args and the resolved value. If it was exclusively set via a config entry, then args.Mode
+		// will never be transparent because the service config request does not use the resolved value.
+		tproxy = args.Mode == structs.ProxyModeTransparent || thisReply.Mode == structs.ProxyModeTransparent
+	)
+
+	// The upstreams passed as arguments to this endpoint are the upstreams explicitly defined in a proxy registration.
+	// If no upstreams were passed, then we should only return the resolved config if the proxy is in transparent mode.
+	// Otherwise we would return a resolved upstream config to a proxy with no configured upstreams.
+	if noUpstreamArgs && !tproxy {
+		return &thisReply, nil
+	}
+
+	// First store all upstreams that were provided in the request
+	for _, sid := range upstreamIDs {
+		if _, ok := seenUpstreams[sid]; !ok {
+			seenUpstreams[sid] = struct{}{}
+		}
+	}
+
+	// Then store upstreams inferred from service-defaults and mapify the overrides.
+	var (
+		upstreamConfigs  = make(map[structs.ServiceID]*structs.UpstreamConfig)
+		upstreamDefaults *structs.UpstreamConfig
+		// usConfigs stores the opaque config map for each upstream and is keyed on the upstream's ID.
+		usConfigs = make(map[structs.ServiceID]map[string]interface{})
+	)
+	if serviceConf != nil && serviceConf.UpstreamConfig != nil {
+		for i, override := range serviceConf.UpstreamConfig.Overrides {
+			if override.Name == "" {
+				logger.Warn(
+					"Skipping UpstreamConfig.Overrides entry without a required name field",
+					"entryIndex", i,
+					"kind", serviceConf.GetKind(),
+					"name", serviceConf.GetName(),
+					"namespace", serviceConf.GetEnterpriseMeta().NamespaceOrEmpty(),
+				)
+				continue // skip this impossible condition
+			}
+			seenUpstreams[override.ServiceID()] = struct{}{}
+			upstreamConfigs[override.ServiceID()] = override
+		}
+		if serviceConf.UpstreamConfig.Defaults != nil {
+			upstreamDefaults = serviceConf.UpstreamConfig.Defaults
+
+			// Store the upstream defaults under a wildcard key so that they can be applied to
+			// upstreams that are inferred from intentions and do not have explicit upstream configuration.
+			cfgMap := make(map[string]interface{})
+			upstreamDefaults.MergeInto(cfgMap)
+
+			wildcard := structs.NewServiceID(structs.WildcardSpecifier, args.WithWildcardNamespace())
+			usConfigs[wildcard] = cfgMap
+		}
+	}
+
+	for upstream := range seenUpstreams {
+		resolvedCfg := make(map[string]interface{})
+
+		// The protocol of an upstream is resolved in this order:
+		// 1. Default protocol from proxy-defaults (how all services should be addressed)
+		// 2. Protocol for upstream service defined in its service-defaults (how the upstream wants to be addressed)
+		// 3. Protocol defined for the upstream in the service-defaults.(upstream_config.defaults|upstream_config.overrides) of the downstream
+		// 	  (how the downstream wants to address it)
+		protocol := proxyConfGlobalProtocol
+
+		upstreamSvcDefaults := entries.GetServiceDefaults(
+			structs.NewServiceID(upstream.ID, &upstream.EnterpriseMeta),
+		)
+		if upstreamSvcDefaults != nil {
+			if upstreamSvcDefaults.Protocol != "" {
+				protocol = upstreamSvcDefaults.Protocol
+			}
+		}
+
+		if protocol != "" {
+			resolvedCfg["protocol"] = protocol
+		}
+
+		// Merge centralized defaults for all upstreams before configuration for specific upstreams
+		if upstreamDefaults != nil {
+			upstreamDefaults.MergeInto(resolvedCfg)
+		}
+
+		// The MeshGateway value from the proxy registration overrides the one from upstream_defaults
+		// because it is specific to the proxy instance.
+		//
+		// The goal is to flatten the mesh gateway mode in this order:
+		// 	0. Value from centralized upstream_defaults
+		// 	1. Value from local proxy registration
+		// 	2. Value from centralized upstream_config
+		// 	3. Value from local upstream definition. This last step is done in the client's service manager.
+		if !args.MeshGateway.IsZero() {
+			resolvedCfg["mesh_gateway"] = args.MeshGateway
+		}
+
+		if upstreamConfigs[upstream] != nil {
+			upstreamConfigs[upstream].MergeInto(resolvedCfg)
+		}
+
+		if len(resolvedCfg) > 0 {
+			usConfigs[upstream] = resolvedCfg
+		}
+	}
+
+	// don't allocate the slices just to not fill them
+	if len(usConfigs) == 0 {
+		return &thisReply, nil
+	}
+
+	if legacyUpstreams {
+		// For legacy upstreams we return a map that is only keyed on the string ID, since they precede namespaces
+		thisReply.UpstreamConfigs = make(map[string]map[string]interface{})
+
+		for us, conf := range usConfigs {
+			thisReply.UpstreamConfigs[us.ID] = conf
+		}
+
+	} else {
+		thisReply.UpstreamIDConfigs = make(structs.OpaqueUpstreamConfigs, 0, len(usConfigs))
+
+		for us, conf := range usConfigs {
+			thisReply.UpstreamIDConfigs = append(thisReply.UpstreamIDConfigs,
+				structs.OpaqueUpstreamConfig{Upstream: us, Config: conf})
+		}
+	}
+
+	return &thisReply, nil
+}

--- a/agent/configentry/resolve_test.go
+++ b/agent/configentry/resolve_test.go
@@ -1,0 +1,56 @@
+package configentry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func Test_ComputeResolvedServiceConfig(t *testing.T) {
+	type args struct {
+		scReq       *structs.ServiceConfigRequest
+		upstreamIDs []structs.ServiceID
+		entries     *ResolvedServiceConfigSet
+	}
+
+	sid := structs.ServiceID{
+		ID:             "sid",
+		EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+	}
+	tests := []struct {
+		name string
+		args args
+		want *structs.ServiceConfigResponse
+	}{
+		{
+			name: "proxy with maxinboundsconnections",
+			args: args{
+				scReq: &structs.ServiceConfigRequest{
+					Name: "sid",
+				},
+				entries: &ResolvedServiceConfigSet{
+					ServiceDefaults: map[structs.ServiceID]*structs.ServiceConfigEntry{
+						sid: {
+							MaxInboundConnections: 20,
+						},
+					},
+				},
+			},
+			want: &structs.ServiceConfigResponse{
+				ProxyConfig: map[string]interface{}{
+					"max_inbound_connections": 20,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ComputeResolvedServiceConfig(tt.args.scReq, tt.args.upstreamIDs,
+				false, tt.args.entries, nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -12,6 +12,7 @@ import (
 	hashstructure_v2 "github.com/mitchellh/hashstructure/v2"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 )
@@ -510,7 +511,7 @@ func (c *ConfigEntry) ResolveServiceConfig(args *structs.ServiceConfigRequest, r
 				ranOnce = true
 			}
 
-			thisReply, err := computeResolvedServiceConfig(
+			thisReply, err := configentry.ComputeResolvedServiceConfig(
 				args,
 				upstreamIDs,
 				legacyUpstreams,

--- a/agent/consul/merge_service_config.go
+++ b/agent/consul/merge_service_config.go
@@ -3,13 +3,14 @@ package consul
 import (
 	"fmt"
 
-	"github.com/hashicorp/consul/agent/configentry"
-	"github.com/hashicorp/consul/agent/consul/state"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/copystructure"
+
+	"github.com/hashicorp/consul/agent/configentry"
+	"github.com/hashicorp/consul/agent/consul/state"
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 // mergeNodeServiceWithCentralConfig merges a service instance (NodeService) with the
@@ -66,7 +67,7 @@ func mergeNodeServiceWithCentralConfig(
 			ns.ID, err)
 	}
 
-	defaults, err := computeResolvedServiceConfig(
+	defaults, err := configentry.ComputeResolvedServiceConfig(
 		configReq,
 		upstreams,
 		false,
@@ -85,225 +86,6 @@ func mergeNodeServiceWithCentralConfig(
 	}
 
 	return cfgIndex, mergedns, nil
-}
-
-func computeResolvedServiceConfig(
-	args *structs.ServiceConfigRequest,
-	upstreamIDs []structs.ServiceID,
-	legacyUpstreams bool,
-	entries *configentry.ResolvedServiceConfigSet,
-	logger hclog.Logger,
-) (*structs.ServiceConfigResponse, error) {
-	var thisReply structs.ServiceConfigResponse
-
-	thisReply.MeshGateway.Mode = structs.MeshGatewayModeDefault
-
-	// TODO(freddy) Refactor this into smaller set of state store functions
-	// Pass the WatchSet to both the service and proxy config lookups. If either is updated during the
-	// blocking query, this function will be rerun and these state store lookups will both be current.
-	// We use the default enterprise meta to look up the global proxy defaults because they are not namespaced.
-	var proxyConfGlobalProtocol string
-	proxyConf := entries.GetProxyDefaults(args.PartitionOrDefault())
-	if proxyConf != nil {
-		// Apply the proxy defaults to the sidecar's proxy config
-		mapCopy, err := copystructure.Copy(proxyConf.Config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to copy global proxy-defaults: %v", err)
-		}
-		thisReply.ProxyConfig = mapCopy.(map[string]interface{})
-		thisReply.Mode = proxyConf.Mode
-		thisReply.TransparentProxy = proxyConf.TransparentProxy
-		thisReply.MeshGateway = proxyConf.MeshGateway
-		thisReply.Expose = proxyConf.Expose
-
-		// Extract the global protocol from proxyConf for upstream configs.
-		rawProtocol := proxyConf.Config["protocol"]
-		if rawProtocol != nil {
-			var ok bool
-			proxyConfGlobalProtocol, ok = rawProtocol.(string)
-			if !ok {
-				return nil, fmt.Errorf("invalid protocol type %T", rawProtocol)
-			}
-		}
-	}
-
-	serviceConf := entries.GetServiceDefaults(
-		structs.NewServiceID(args.Name, &args.EnterpriseMeta),
-	)
-	if serviceConf != nil {
-		if serviceConf.Expose.Checks {
-			thisReply.Expose.Checks = true
-		}
-		if len(serviceConf.Expose.Paths) >= 1 {
-			thisReply.Expose.Paths = serviceConf.Expose.Paths
-		}
-		if serviceConf.MeshGateway.Mode != structs.MeshGatewayModeDefault {
-			thisReply.MeshGateway.Mode = serviceConf.MeshGateway.Mode
-		}
-		if serviceConf.Protocol != "" {
-			if thisReply.ProxyConfig == nil {
-				thisReply.ProxyConfig = make(map[string]interface{})
-			}
-			thisReply.ProxyConfig["protocol"] = serviceConf.Protocol
-		}
-		if serviceConf.TransparentProxy.OutboundListenerPort != 0 {
-			thisReply.TransparentProxy.OutboundListenerPort = serviceConf.TransparentProxy.OutboundListenerPort
-		}
-		if serviceConf.TransparentProxy.DialedDirectly {
-			thisReply.TransparentProxy.DialedDirectly = serviceConf.TransparentProxy.DialedDirectly
-		}
-		if serviceConf.Mode != structs.ProxyModeDefault {
-			thisReply.Mode = serviceConf.Mode
-		}
-		if serviceConf.Destination != nil {
-			thisReply.Destination = *serviceConf.Destination
-		}
-
-		if serviceConf.MaxInboundConnections > 0 {
-			if thisReply.ProxyConfig == nil {
-				thisReply.ProxyConfig = map[string]interface{}{}
-			}
-			thisReply.ProxyConfig["max_inbound_connections"] = serviceConf.MaxInboundConnections
-		}
-
-		thisReply.Meta = serviceConf.Meta
-	}
-
-	// First collect all upstreams into a set of seen upstreams.
-	// Upstreams can come from:
-	// - Explicitly from proxy registrations, and therefore as an argument to this RPC endpoint
-	// - Implicitly from centralized upstream config in service-defaults
-	seenUpstreams := map[structs.ServiceID]struct{}{}
-
-	var (
-		noUpstreamArgs = len(upstreamIDs) == 0 && len(args.Upstreams) == 0
-
-		// Check the args and the resolved value. If it was exclusively set via a config entry, then args.Mode
-		// will never be transparent because the service config request does not use the resolved value.
-		tproxy = args.Mode == structs.ProxyModeTransparent || thisReply.Mode == structs.ProxyModeTransparent
-	)
-
-	// The upstreams passed as arguments to this endpoint are the upstreams explicitly defined in a proxy registration.
-	// If no upstreams were passed, then we should only return the resolved config if the proxy is in transparent mode.
-	// Otherwise we would return a resolved upstream config to a proxy with no configured upstreams.
-	if noUpstreamArgs && !tproxy {
-		return &thisReply, nil
-	}
-
-	// First store all upstreams that were provided in the request
-	for _, sid := range upstreamIDs {
-		if _, ok := seenUpstreams[sid]; !ok {
-			seenUpstreams[sid] = struct{}{}
-		}
-	}
-
-	// Then store upstreams inferred from service-defaults and mapify the overrides.
-	var (
-		upstreamConfigs  = make(map[structs.ServiceID]*structs.UpstreamConfig)
-		upstreamDefaults *structs.UpstreamConfig
-		// usConfigs stores the opaque config map for each upstream and is keyed on the upstream's ID.
-		usConfigs = make(map[structs.ServiceID]map[string]interface{})
-	)
-	if serviceConf != nil && serviceConf.UpstreamConfig != nil {
-		for i, override := range serviceConf.UpstreamConfig.Overrides {
-			if override.Name == "" {
-				logger.Warn(
-					"Skipping UpstreamConfig.Overrides entry without a required name field",
-					"entryIndex", i,
-					"kind", serviceConf.GetKind(),
-					"name", serviceConf.GetName(),
-					"namespace", serviceConf.GetEnterpriseMeta().NamespaceOrEmpty(),
-				)
-				continue // skip this impossible condition
-			}
-			seenUpstreams[override.ServiceID()] = struct{}{}
-			upstreamConfigs[override.ServiceID()] = override
-		}
-		if serviceConf.UpstreamConfig.Defaults != nil {
-			upstreamDefaults = serviceConf.UpstreamConfig.Defaults
-
-			// Store the upstream defaults under a wildcard key so that they can be applied to
-			// upstreams that are inferred from intentions and do not have explicit upstream configuration.
-			cfgMap := make(map[string]interface{})
-			upstreamDefaults.MergeInto(cfgMap)
-
-			wildcard := structs.NewServiceID(structs.WildcardSpecifier, args.WithWildcardNamespace())
-			usConfigs[wildcard] = cfgMap
-		}
-	}
-
-	for upstream := range seenUpstreams {
-		resolvedCfg := make(map[string]interface{})
-
-		// The protocol of an upstream is resolved in this order:
-		// 1. Default protocol from proxy-defaults (how all services should be addressed)
-		// 2. Protocol for upstream service defined in its service-defaults (how the upstream wants to be addressed)
-		// 3. Protocol defined for the upstream in the service-defaults.(upstream_config.defaults|upstream_config.overrides) of the downstream
-		// 	  (how the downstream wants to address it)
-		protocol := proxyConfGlobalProtocol
-
-		upstreamSvcDefaults := entries.GetServiceDefaults(
-			structs.NewServiceID(upstream.ID, &upstream.EnterpriseMeta),
-		)
-		if upstreamSvcDefaults != nil {
-			if upstreamSvcDefaults.Protocol != "" {
-				protocol = upstreamSvcDefaults.Protocol
-			}
-		}
-
-		if protocol != "" {
-			resolvedCfg["protocol"] = protocol
-		}
-
-		// Merge centralized defaults for all upstreams before configuration for specific upstreams
-		if upstreamDefaults != nil {
-			upstreamDefaults.MergeInto(resolvedCfg)
-		}
-
-		// The MeshGateway value from the proxy registration overrides the one from upstream_defaults
-		// because it is specific to the proxy instance.
-		//
-		// The goal is to flatten the mesh gateway mode in this order:
-		// 	0. Value from centralized upstream_defaults
-		// 	1. Value from local proxy registration
-		// 	2. Value from centralized upstream_config
-		// 	3. Value from local upstream definition. This last step is done in the client's service manager.
-		if !args.MeshGateway.IsZero() {
-			resolvedCfg["mesh_gateway"] = args.MeshGateway
-		}
-
-		if upstreamConfigs[upstream] != nil {
-			upstreamConfigs[upstream].MergeInto(resolvedCfg)
-		}
-
-		if len(resolvedCfg) > 0 {
-			usConfigs[upstream] = resolvedCfg
-		}
-	}
-
-	// don't allocate the slices just to not fill them
-	if len(usConfigs) == 0 {
-		return &thisReply, nil
-	}
-
-	if legacyUpstreams {
-		// For legacy upstreams we return a map that is only keyed on the string ID, since they precede namespaces
-		thisReply.UpstreamConfigs = make(map[string]map[string]interface{})
-
-		for us, conf := range usConfigs {
-			thisReply.UpstreamConfigs[us.ID] = conf
-		}
-
-	} else {
-		thisReply.UpstreamIDConfigs = make(structs.OpaqueUpstreamConfigs, 0, len(usConfigs))
-
-		for us, conf := range usConfigs {
-			thisReply.UpstreamIDConfigs = append(thisReply.UpstreamIDConfigs,
-				structs.OpaqueUpstreamConfig{Upstream: us, Config: conf})
-		}
-	}
-
-	return &thisReply, nil
 }
 
 // MergeServiceConfig merges the service into defaults to produce the final effective

--- a/agent/consul/merge_service_config_test.go
+++ b/agent/consul/merge_service_config_test.go
@@ -3,59 +3,12 @@ package consul
 import (
 	"testing"
 
-	"github.com/hashicorp/consul/agent/configentry"
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
-
-func Test_ComputeResolvedServiceConfig(t *testing.T) {
-	type args struct {
-		scReq       *structs.ServiceConfigRequest
-		upstreamIDs []structs.ServiceID
-		entries     *configentry.ResolvedServiceConfigSet
-	}
-
-	sid := structs.ServiceID{
-		ID:             "sid",
-		EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
-	}
-	tests := []struct {
-		name string
-		args args
-		want *structs.ServiceConfigResponse
-	}{
-		{
-			name: "proxy with maxinboundsconnections",
-			args: args{
-				scReq: &structs.ServiceConfigRequest{
-					Name: "sid",
-				},
-				entries: &configentry.ResolvedServiceConfigSet{
-					ServiceDefaults: map[structs.ServiceID]*structs.ServiceConfigEntry{
-						sid: {
-							MaxInboundConnections: 20,
-						},
-					},
-				},
-			},
-			want: &structs.ServiceConfigResponse{
-				ProxyConfig: map[string]interface{}{
-					"max_inbound_connections": 20,
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := computeResolvedServiceConfig(tt.args.scReq, tt.args.upstreamIDs,
-				false, tt.args.entries, nil)
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
 
 func Test_MergeServiceConfig_TransparentProxy(t *testing.T) {
 	type args struct {

--- a/agent/proxycfg-glue/config_entry.go
+++ b/agent/proxycfg-glue/config_entry.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-hclog"
-
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
-	"github.com/hashicorp/consul/agent/consul/stream"
+	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/submatview"
@@ -17,15 +15,16 @@ import (
 	"github.com/hashicorp/consul/proto/pbsubscribe"
 )
 
-// ServerDataSourceDeps contains the dependencies needed for sourcing data from
-// server-local sources (e.g. materialized views).
-type ServerDataSourceDeps struct {
-	Datacenter     string
-	ViewStore      *submatview.Store
-	EventPublisher *stream.EventPublisher
-	Logger         hclog.Logger
-	ACLResolver    submatview.ACLResolver
-	GetStore       func() Store
+// CacheConfigEntry satisfies the proxycfg.ConfigEntry interface by sourcing
+// data from the agent cache.
+func CacheConfigEntry(c *cache.Cache) proxycfg.ConfigEntry {
+	return &cacheProxyDataSource[*structs.ConfigEntryQuery]{c, cachetype.ConfigEntryName}
+}
+
+// CacheConfigEntryList satisfies the proxycfg.ConfigEntryList interface by
+// sourcing data from the agent cache.
+func CacheConfigEntryList(c *cache.Cache) proxycfg.ConfigEntryList {
+	return &cacheProxyDataSource[*structs.ConfigEntryQuery]{c, cachetype.ConfigEntryListName}
 }
 
 // ServerConfigEntry satisfies the proxycfg.ConfigEntry interface by sourcing

--- a/agent/proxycfg-glue/glue.go
+++ b/agent/proxycfg-glue/glue.go
@@ -3,8 +3,10 @@ package proxycfgglue
 import (
 	"context"
 
-	"github.com/hashicorp/consul/proto/pbpeering"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
+
+	"github.com/hashicorp/consul/proto/pbpeering"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
@@ -12,10 +14,23 @@ import (
 	"github.com/hashicorp/consul/agent/configentry"
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/consul/state"
+	"github.com/hashicorp/consul/agent/consul/stream"
 	"github.com/hashicorp/consul/agent/consul/watch"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/submatview"
 )
+
+// ServerDataSourceDeps contains the dependencies needed for sourcing data from
+// server-local sources (e.g. materialized views).
+type ServerDataSourceDeps struct {
+	Datacenter     string
+	ViewStore      *submatview.Store
+	EventPublisher *stream.EventPublisher
+	Logger         hclog.Logger
+	ACLResolver    submatview.ACLResolver
+	GetStore       func() Store
+}
 
 // Store is the state store interface required for server-local data sources.
 type Store interface {
@@ -25,6 +40,7 @@ type Store interface {
 	FederationStateList(ws memdb.WatchSet) (uint64, []*structs.FederationState, error)
 	GatewayServices(ws memdb.WatchSet, gateway string, entMeta *acl.EnterpriseMeta) (uint64, structs.GatewayServices, error)
 	IntentionTopology(ws memdb.WatchSet, target structs.ServiceName, downstreams bool, defaultDecision acl.EnforcementDecision, intentionTarget structs.IntentionTargetType) (uint64, structs.ServiceList, error)
+	ReadResolvedServiceConfigEntries(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, upstreamIDs []structs.ServiceID, proxyMode structs.ProxyMode) (uint64, *configentry.ResolvedServiceConfigSet, error)
 	ServiceDiscoveryChain(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, req discoverychain.CompileRequest) (uint64, *structs.CompiledDiscoveryChain, *configentry.DiscoveryChainSet, error)
 	PeeringTrustBundleRead(ws memdb.WatchSet, q state.Query) (uint64, *pbpeering.PeeringTrustBundle, error)
 	PeeringTrustBundleList(ws memdb.WatchSet, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error)
@@ -34,24 +50,18 @@ type Store interface {
 
 // CacheCARoots satisfies the proxycfg.CARoots interface by sourcing data from
 // the agent cache.
+//
+// Note: there isn't a server-local equivalent of this data source because
+// "agentless" proxies obtain certificates via SDS served by consul-dataplane.
 func CacheCARoots(c *cache.Cache) proxycfg.CARoots {
 	return &cacheProxyDataSource[*structs.DCSpecificRequest]{c, cachetype.ConnectCARootName}
 }
 
-// CacheConfigEntry satisfies the proxycfg.ConfigEntry interface by sourcing
-// data from the agent cache.
-func CacheConfigEntry(c *cache.Cache) proxycfg.ConfigEntry {
-	return &cacheProxyDataSource[*structs.ConfigEntryQuery]{c, cachetype.ConfigEntryName}
-}
-
-// CacheConfigEntryList satisfies the proxycfg.ConfigEntryList interface by
-// sourcing data from the agent cache.
-func CacheConfigEntryList(c *cache.Cache) proxycfg.ConfigEntryList {
-	return &cacheProxyDataSource[*structs.ConfigEntryQuery]{c, cachetype.ConfigEntryListName}
-}
-
 // CacheDatacenters satisfies the proxycfg.Datacenters interface by sourcing
 // data from the agent cache.
+//
+// Note: there isn't a server-local equivalent of this data source because it
+// relies on polling (so a more efficient method isn't available).
 func CacheDatacenters(c *cache.Cache) proxycfg.Datacenters {
 	return &cacheProxyDataSource[*structs.DatacentersRequest]{c, cachetype.CatalogDatacentersName}
 }
@@ -64,14 +74,11 @@ func CacheServiceGateways(c *cache.Cache) proxycfg.GatewayServices {
 
 // CacheHTTPChecks satisifies the proxycfg.HTTPChecks interface by sourcing
 // data from the agent cache.
+//
+// Note: there isn't a server-local equivalent of this data source because only
+// services registered to the local agent can be health checked by it.
 func CacheHTTPChecks(c *cache.Cache) proxycfg.HTTPChecks {
 	return &cacheProxyDataSource[*cachetype.ServiceHTTPChecksRequest]{c, cachetype.ServiceHTTPChecksName}
-}
-
-// CacheIntentionUpstreams satisfies the proxycfg.IntentionUpstreams interface
-// by sourcing data from the agent cache.
-func CacheIntentionUpstreams(c *cache.Cache) proxycfg.IntentionUpstreams {
-	return &cacheProxyDataSource[*structs.ServiceSpecificRequest]{c, cachetype.IntentionUpstreamsName}
 }
 
 // CacheIntentionUpstreamsDestination satisfies the proxycfg.IntentionUpstreamsDestination interface
@@ -88,20 +95,20 @@ func CacheInternalServiceDump(c *cache.Cache) proxycfg.InternalServiceDump {
 
 // CacheLeafCertificate satisifies the proxycfg.LeafCertificate interface by
 // sourcing data from the agent cache.
+//
+// Note: there isn't a server-local equivalent of this data source because
+// "agentless" proxies obtain certificates via SDS served by consul-dataplane.
 func CacheLeafCertificate(c *cache.Cache) proxycfg.LeafCertificate {
 	return &cacheProxyDataSource[*cachetype.ConnectCALeafRequest]{c, cachetype.ConnectCALeafName}
 }
 
 // CachePrepraredQuery satisfies the proxycfg.PreparedQuery interface by
 // sourcing data from the agent cache.
+//
+// Note: there isn't a server-local equivalent of this data source because it
+// relies on polling (so a more efficient method isn't available).
 func CachePrepraredQuery(c *cache.Cache) proxycfg.PreparedQuery {
 	return &cacheProxyDataSource[*structs.PreparedQueryExecuteRequest]{c, cachetype.PreparedQueryName}
-}
-
-// CacheResolvedServiceConfig satisfies the proxycfg.ResolvedServiceConfig
-// interface by sourcing data from the agent cache.
-func CacheResolvedServiceConfig(c *cache.Cache) proxycfg.ResolvedServiceConfig {
-	return &cacheProxyDataSource[*structs.ServiceConfigRequest]{c, cachetype.ResolvedServiceConfigName}
 }
 
 // cacheProxyDataSource implements a generic wrapper around the agent cache to

--- a/agent/proxycfg-glue/glue.go
+++ b/agent/proxycfg-glue/glue.go
@@ -42,6 +42,7 @@ type Store interface {
 	IntentionTopology(ws memdb.WatchSet, target structs.ServiceName, downstreams bool, defaultDecision acl.EnforcementDecision, intentionTarget structs.IntentionTargetType) (uint64, structs.ServiceList, error)
 	ReadResolvedServiceConfigEntries(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, upstreamIDs []structs.ServiceID, proxyMode structs.ProxyMode) (uint64, *configentry.ResolvedServiceConfigSet, error)
 	ServiceDiscoveryChain(ws memdb.WatchSet, serviceName string, entMeta *acl.EnterpriseMeta, req discoverychain.CompileRequest) (uint64, *structs.CompiledDiscoveryChain, *configentry.DiscoveryChainSet, error)
+	ServiceDump(ws memdb.WatchSet, kind structs.ServiceKind, useKind bool, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.CheckServiceNodes, error)
 	PeeringTrustBundleRead(ws memdb.WatchSet, q state.Query) (uint64, *pbpeering.PeeringTrustBundle, error)
 	PeeringTrustBundleList(ws memdb.WatchSet, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error)
 	TrustBundleListByService(ws memdb.WatchSet, service, dc string, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error)
@@ -85,12 +86,6 @@ func CacheHTTPChecks(c *cache.Cache) proxycfg.HTTPChecks {
 // by sourcing data from the agent cache.
 func CacheIntentionUpstreamsDestination(c *cache.Cache) proxycfg.IntentionUpstreams {
 	return &cacheProxyDataSource[*structs.ServiceSpecificRequest]{c, cachetype.IntentionUpstreamsDestinationName}
-}
-
-// CacheInternalServiceDump satisfies the proxycfg.InternalServiceDump
-// interface by sourcing data from the agent cache.
-func CacheInternalServiceDump(c *cache.Cache) proxycfg.InternalServiceDump {
-	return &cacheProxyDataSource[*structs.ServiceDumpRequest]{c, cachetype.InternalServiceDumpName}
 }
 
 // CacheLeafCertificate satisifies the proxycfg.LeafCertificate interface by

--- a/agent/proxycfg-glue/intention_upstreams.go
+++ b/agent/proxycfg-glue/intention_upstreams.go
@@ -5,11 +5,19 @@ import (
 
 	"github.com/hashicorp/go-memdb"
 
+	"github.com/hashicorp/consul/agent/cache"
+	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/consul/watch"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/structs/aclfilter"
 )
+
+// CacheIntentionUpstreams satisfies the proxycfg.IntentionUpstreams interface
+// by sourcing data from the agent cache.
+func CacheIntentionUpstreams(c *cache.Cache) proxycfg.IntentionUpstreams {
+	return &cacheProxyDataSource[*structs.ServiceSpecificRequest]{c, cachetype.IntentionUpstreamsName}
+}
 
 // ServerIntentionUpstreams satisfies the proxycfg.IntentionUpstreams interface
 // by sourcing data from a blocking query against the server's state store.

--- a/agent/proxycfg-glue/intention_upstreams.go
+++ b/agent/proxycfg-glue/intention_upstreams.go
@@ -14,19 +14,36 @@ import (
 )
 
 // CacheIntentionUpstreams satisfies the proxycfg.IntentionUpstreams interface
-// by sourcing data from the agent cache.
+// by sourcing upstreams for the given service, inferred from intentions, from
+// the agent cache.
 func CacheIntentionUpstreams(c *cache.Cache) proxycfg.IntentionUpstreams {
 	return &cacheProxyDataSource[*structs.ServiceSpecificRequest]{c, cachetype.IntentionUpstreamsName}
 }
 
+// CacheIntentionUpstreamsDestination satisfies the proxycfg.IntentionUpstreams
+// interface by sourcing upstreams for the given destination, inferred from
+// intentions, from the agent cache.
+func CacheIntentionUpstreamsDestination(c *cache.Cache) proxycfg.IntentionUpstreams {
+	return &cacheProxyDataSource[*structs.ServiceSpecificRequest]{c, cachetype.IntentionUpstreamsDestinationName}
+}
+
 // ServerIntentionUpstreams satisfies the proxycfg.IntentionUpstreams interface
-// by sourcing data from a blocking query against the server's state store.
+// by sourcing upstreams for the given service, inferred from intentions, from
+// the server's state store.
 func ServerIntentionUpstreams(deps ServerDataSourceDeps) proxycfg.IntentionUpstreams {
-	return serverIntentionUpstreams{deps}
+	return serverIntentionUpstreams{deps, structs.IntentionTargetService}
+}
+
+// ServerIntentionUpstreamsDestination satisfies the proxycfg.IntentionUpstreams
+// interface by sourcing upstreams for the given destination, inferred from
+// intentions, from the server's state store.
+func ServerIntentionUpstreamsDestination(deps ServerDataSourceDeps) proxycfg.IntentionUpstreams {
+	return serverIntentionUpstreams{deps, structs.IntentionTargetDestination}
 }
 
 type serverIntentionUpstreams struct {
-	deps ServerDataSourceDeps
+	deps   ServerDataSourceDeps
+	target structs.IntentionTargetType
 }
 
 func (s serverIntentionUpstreams) Notify(ctx context.Context, req *structs.ServiceSpecificRequest, correlationID string, ch chan<- proxycfg.UpdateEvent) error {
@@ -40,7 +57,7 @@ func (s serverIntentionUpstreams) Notify(ctx context.Context, req *structs.Servi
 			}
 			defaultDecision := authz.IntentionDefaultAllow(nil)
 
-			index, services, err := store.IntentionTopology(ws, target, false, defaultDecision, structs.IntentionTargetService)
+			index, services, err := store.IntentionTopology(ws, target, false, defaultDecision, s.target)
 			if err != nil {
 				return 0, nil, err
 			}
@@ -58,13 +75,4 @@ func (s serverIntentionUpstreams) Notify(ctx context.Context, req *structs.Servi
 		},
 		dispatchBlockingQueryUpdate[*structs.IndexedServiceList](ch),
 	)
-}
-
-func dispatchBlockingQueryUpdate[ResultType any](ch chan<- proxycfg.UpdateEvent) func(context.Context, string, ResultType, error) {
-	return func(ctx context.Context, correlationID string, result ResultType, err error) {
-		select {
-		case ch <- newUpdateEvent(correlationID, result, err):
-		case <-ctx.Done():
-		}
-	}
 }

--- a/agent/proxycfg-glue/internal_service_dump.go
+++ b/agent/proxycfg-glue/internal_service_dump.go
@@ -1,0 +1,99 @@
+package proxycfgglue
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/go-memdb"
+
+	"github.com/hashicorp/consul/agent/cache"
+	cachetype "github.com/hashicorp/consul/agent/cache-types"
+	"github.com/hashicorp/consul/agent/consul/watch"
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/structs/aclfilter"
+)
+
+// CacheInternalServiceDump satisfies the proxycfg.InternalServiceDump
+// interface by sourcing data from the agent cache.
+func CacheInternalServiceDump(c *cache.Cache) proxycfg.InternalServiceDump {
+	return &cacheInternalServiceDump{c}
+}
+
+// cacheInternalServiceDump wraps the underlying cache-type to return a simpler
+// subset of the response (as this is all we use in proxycfg).
+type cacheInternalServiceDump struct {
+	c *cache.Cache
+}
+
+func (c *cacheInternalServiceDump) Notify(ctx context.Context, req *structs.ServiceDumpRequest, correlationID string, ch chan<- proxycfg.UpdateEvent) error {
+	dispatch := dispatchCacheUpdate(ch)
+
+	return c.c.NotifyCallback(ctx, cachetype.InternalServiceDumpName, req, correlationID,
+		func(ctx context.Context, event cache.UpdateEvent) {
+			if r, _ := event.Result.(*structs.IndexedNodesWithGateways); r != nil {
+				event.Result = &structs.IndexedCheckServiceNodes{
+					Nodes:     r.Nodes,
+					QueryMeta: r.QueryMeta,
+				}
+			}
+			dispatch(ctx, event)
+		})
+}
+
+// ServerInternalServiceDump satisfies the proxycfg.InternalServiceDump
+// interface by sourcing data from a blocking query against the server's
+// state store.
+func ServerInternalServiceDump(deps ServerDataSourceDeps, remoteSource proxycfg.InternalServiceDump) proxycfg.InternalServiceDump {
+	return &serverInternalServiceDump{deps, remoteSource}
+}
+
+type serverInternalServiceDump struct {
+	deps         ServerDataSourceDeps
+	remoteSource proxycfg.InternalServiceDump
+}
+
+func (s *serverInternalServiceDump) Notify(ctx context.Context, req *structs.ServiceDumpRequest, correlationID string, ch chan<- proxycfg.UpdateEvent) error {
+	if req.Datacenter != s.deps.Datacenter {
+		return s.remoteSource.Notify(ctx, req, correlationID, ch)
+	}
+
+	filter, err := bexpr.CreateFilter(req.Filter, nil, structs.CheckServiceNodes{})
+	if err != nil {
+		return err
+	}
+
+	// This is just the small subset of the Internal.ServiceDump RPC handler used
+	// by proxycfg.
+	return watch.ServerLocalNotify(ctx, correlationID, s.deps.GetStore,
+		func(ws memdb.WatchSet, store Store) (uint64, *structs.IndexedCheckServiceNodes, error) {
+			authz, err := s.deps.ACLResolver.ResolveTokenAndDefaultMeta(req.Token, &req.EnterpriseMeta, nil)
+			if err != nil {
+				return 0, nil, err
+			}
+
+			idx, nodes, err := store.ServiceDump(ws, req.ServiceKind, req.UseServiceKind, &req.EnterpriseMeta, structs.DefaultPeerKeyword)
+			if err != nil {
+				return 0, nil, err
+			}
+
+			raw, err := filter.Execute(nodes)
+			if err != nil {
+				return 0, nil, fmt.Errorf("could not filter local service dump: %w", err)
+			}
+			nodes = raw.(structs.CheckServiceNodes)
+
+			aclfilter.New(authz, s.deps.Logger).Filter(&nodes)
+
+			return idx, &structs.IndexedCheckServiceNodes{
+				Nodes: nodes,
+				QueryMeta: structs.QueryMeta{
+					Index:   idx,
+					Backend: structs.QueryBackendBlocking,
+				},
+			}, nil
+		},
+		dispatchBlockingQueryUpdate[*structs.IndexedCheckServiceNodes](ch),
+	)
+}

--- a/agent/proxycfg-glue/internal_service_dump_test.go
+++ b/agent/proxycfg-glue/internal_service_dump_test.go
@@ -1,0 +1,139 @@
+package proxycfgglue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/consul/state"
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func TestServerInternalServiceDump(t *testing.T) {
+	t.Run("remote queries are delegated to the remote source", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		var (
+			req           = &structs.ServiceDumpRequest{Datacenter: "dc2"}
+			correlationID = "correlation-id"
+			ch            = make(chan<- proxycfg.UpdateEvent)
+			result        = errors.New("KABOOM")
+		)
+
+		remoteSource := newMockInternalServiceDump(t)
+		remoteSource.On("Notify", ctx, req, correlationID, ch).Return(result)
+
+		dataSource := ServerInternalServiceDump(ServerDataSourceDeps{Datacenter: "dc1"}, remoteSource)
+		err := dataSource.Notify(ctx, req, correlationID, ch)
+		require.Equal(t, result, err)
+	})
+
+	t.Run("local queries are served from the state store", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		nextIndex := indexGenerator()
+
+		store := state.NewStateStore(nil)
+
+		services := []*structs.NodeService{
+			{
+				Service: "mgw",
+				Kind:    structs.ServiceKindMeshGateway,
+			},
+			{
+				Service: "web",
+				Kind:    structs.ServiceKindTypical,
+			},
+			{
+				Service: "db",
+				Kind:    structs.ServiceKindTypical,
+			},
+		}
+		for idx, service := range services {
+			require.NoError(t, store.EnsureRegistration(nextIndex(), &structs.RegisterRequest{
+				Node:    fmt.Sprintf("node-%d", idx),
+				Service: service,
+			}))
+		}
+
+		authz := newStaticResolver(
+			policyAuthorizer(t, `
+				service "mgw" { policy = "read" }
+				service "web" { policy = "read" }
+				service "db"  { policy = "read" }
+				node_prefix "node-" { policy = "read" }
+			`),
+		)
+
+		dataSource := ServerInternalServiceDump(ServerDataSourceDeps{
+			GetStore:    func() Store { return store },
+			ACLResolver: authz,
+		}, nil)
+
+		t.Run("filter by kind", func(t *testing.T) {
+			eventCh := make(chan proxycfg.UpdateEvent)
+			require.NoError(t, dataSource.Notify(ctx, &structs.ServiceDumpRequest{
+				ServiceKind:    structs.ServiceKindMeshGateway,
+				UseServiceKind: true,
+			}, "", eventCh))
+
+			result := getEventResult[*structs.IndexedCheckServiceNodes](t, eventCh)
+			require.Len(t, result.Nodes, 1)
+			require.Equal(t, "mgw", result.Nodes[0].Service.Service)
+		})
+
+		t.Run("bexpr filtering", func(t *testing.T) {
+			eventCh := make(chan proxycfg.UpdateEvent)
+			require.NoError(t, dataSource.Notify(ctx, &structs.ServiceDumpRequest{
+				QueryOptions: structs.QueryOptions{Filter: `Service.Service == "web"`},
+			}, "", eventCh))
+
+			result := getEventResult[*structs.IndexedCheckServiceNodes](t, eventCh)
+			require.Len(t, result.Nodes, 1)
+			require.Equal(t, "web", result.Nodes[0].Service.Service)
+		})
+
+		t.Run("all services", func(t *testing.T) {
+			eventCh := make(chan proxycfg.UpdateEvent)
+			require.NoError(t, dataSource.Notify(ctx, &structs.ServiceDumpRequest{}, "", eventCh))
+
+			result := getEventResult[*structs.IndexedCheckServiceNodes](t, eventCh)
+			require.Len(t, result.Nodes, 3)
+		})
+
+		t.Run("access denied", func(t *testing.T) {
+			authz.SwapAuthorizer(acl.DenyAll())
+
+			eventCh := make(chan proxycfg.UpdateEvent)
+			require.NoError(t, dataSource.Notify(ctx, &structs.ServiceDumpRequest{}, "", eventCh))
+
+			result := getEventResult[*structs.IndexedCheckServiceNodes](t, eventCh)
+			require.Empty(t, result.Nodes)
+		})
+	})
+}
+
+func newMockInternalServiceDump(t *testing.T) *mockInternalServiceDump {
+	mock := &mockInternalServiceDump{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
+type mockInternalServiceDump struct {
+	mock.Mock
+}
+
+func (m *mockInternalServiceDump) Notify(ctx context.Context, req *structs.ServiceDumpRequest, correlationID string, ch chan<- proxycfg.UpdateEvent) error {
+	return m.Called(ctx, req, correlationID, ch).Error(0)
+}

--- a/agent/proxycfg-glue/resolved_service_config.go
+++ b/agent/proxycfg-glue/resolved_service_config.go
@@ -1,0 +1,70 @@
+package proxycfgglue
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/go-memdb"
+
+	"github.com/hashicorp/consul/agent/cache"
+	cachetype "github.com/hashicorp/consul/agent/cache-types"
+	"github.com/hashicorp/consul/agent/configentry"
+	"github.com/hashicorp/consul/agent/consul/watch"
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// CacheResolvedServiceConfig satisfies the proxycfg.ResolvedServiceConfig
+// interface by sourcing data from the agent cache.
+func CacheResolvedServiceConfig(c *cache.Cache) proxycfg.ResolvedServiceConfig {
+	return &cacheProxyDataSource[*structs.ServiceConfigRequest]{c, cachetype.ResolvedServiceConfigName}
+}
+
+// ServerResolvedServiceConfig satisfies the proxycfg.ResolvedServiceConfig
+// interface by sourcing data from a blocking query against the server's state
+// store.
+func ServerResolvedServiceConfig(deps ServerDataSourceDeps, remoteSource proxycfg.ResolvedServiceConfig) proxycfg.ResolvedServiceConfig {
+	return &serverResolvedServiceConfig{deps, remoteSource}
+}
+
+type serverResolvedServiceConfig struct {
+	deps         ServerDataSourceDeps
+	remoteSource proxycfg.ResolvedServiceConfig
+}
+
+func (s *serverResolvedServiceConfig) Notify(ctx context.Context, req *structs.ServiceConfigRequest, correlationID string, ch chan<- proxycfg.UpdateEvent) error {
+	if req.Datacenter != s.deps.Datacenter {
+		return s.remoteSource.Notify(ctx, req, correlationID, ch)
+	}
+
+	if len(req.Upstreams) != 0 {
+		return errors.New("ServerResolvedServiceConfig does not support the legacy Upstreams parameter")
+	}
+
+	return watch.ServerLocalNotify(ctx, correlationID, s.deps.GetStore,
+		func(ws memdb.WatchSet, store Store) (uint64, *structs.ServiceConfigResponse, error) {
+			authz, err := s.deps.ACLResolver.ResolveTokenAndDefaultMeta(req.Token, &req.EnterpriseMeta, nil)
+			if err != nil {
+				return 0, nil, err
+			}
+
+			if err := authz.ToAllowAuthorizer().ServiceReadAllowed(req.Name, nil); err != nil {
+				return 0, nil, err
+			}
+
+			idx, entries, err := store.ReadResolvedServiceConfigEntries(ws, req.Name, &req.EnterpriseMeta, req.UpstreamIDs, req.Mode)
+			if err != nil {
+				return 0, nil, err
+			}
+
+			reply, err := configentry.ComputeResolvedServiceConfig(req, req.UpstreamIDs, false, entries, s.deps.Logger)
+			if err != nil {
+				return 0, nil, err
+			}
+			reply.Index = idx
+
+			return idx, reply, nil
+		},
+		dispatchBlockingQueryUpdate[*structs.ServiceConfigResponse](ch),
+	)
+}

--- a/agent/proxycfg-glue/resolved_service_config_test.go
+++ b/agent/proxycfg-glue/resolved_service_config_test.go
@@ -1,0 +1,116 @@
+package proxycfgglue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/consul/state"
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+func TestServerResolvedServiceConfig(t *testing.T) {
+	t.Run("remote queries are delegated to the remote source", func(t *testing.T) {
+		var (
+			ctx           = context.Background()
+			req           = &structs.ServiceConfigRequest{Datacenter: "dc2"}
+			correlationID = "correlation-id"
+			ch            = make(chan<- proxycfg.UpdateEvent)
+			result        = errors.New("KABOOM")
+		)
+
+		remoteSource := newMockResolvedServiceConfig(t)
+		remoteSource.On("Notify", ctx, req, correlationID, ch).Return(result)
+
+		dataSource := ServerResolvedServiceConfig(ServerDataSourceDeps{Datacenter: "dc1"}, remoteSource)
+		err := dataSource.Notify(ctx, req, correlationID, ch)
+		require.Equal(t, result, err)
+	})
+
+	t.Run("local queries are served from the state store", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		const (
+			serviceName = "web"
+			datacenter  = "dc1"
+		)
+
+		store := state.NewStateStore(nil)
+		nextIndex := indexGenerator()
+
+		require.NoError(t, store.EnsureConfigEntry(nextIndex(), &structs.ServiceConfigEntry{
+			Name:     serviceName,
+			Protocol: "http",
+		}))
+
+		authz := newStaticResolver(
+			policyAuthorizer(t, fmt.Sprintf(`service "%s" { policy = "read" }`, serviceName)),
+		)
+
+		dataSource := ServerResolvedServiceConfig(ServerDataSourceDeps{
+			Datacenter:  datacenter,
+			ACLResolver: authz,
+			GetStore:    func() Store { return store },
+		}, nil)
+
+		eventCh := make(chan proxycfg.UpdateEvent)
+		require.NoError(t, dataSource.Notify(ctx, &structs.ServiceConfigRequest{Datacenter: datacenter, Name: serviceName}, "", eventCh))
+
+		testutil.RunStep(t, "initial state", func(t *testing.T) {
+			result := getEventResult[*structs.ServiceConfigResponse](t, eventCh)
+			require.Equal(t, map[string]any{"protocol": "http"}, result.ProxyConfig)
+		})
+
+		testutil.RunStep(t, "write proxy defaults", func(t *testing.T) {
+			require.NoError(t, store.EnsureConfigEntry(nextIndex(), &structs.ProxyConfigEntry{
+				Name: structs.ProxyConfigGlobal,
+				Mode: structs.ProxyModeDirect,
+			}))
+			result := getEventResult[*structs.ServiceConfigResponse](t, eventCh)
+			require.Equal(t, structs.ProxyModeDirect, result.Mode)
+		})
+
+		testutil.RunStep(t, "delete service config", func(t *testing.T) {
+			require.NoError(t, store.DeleteConfigEntry(nextIndex(), structs.ServiceDefaults, serviceName, nil))
+
+			result := getEventResult[*structs.ServiceConfigResponse](t, eventCh)
+			require.Empty(t, result.ProxyConfig)
+		})
+
+		testutil.RunStep(t, "revoke access", func(t *testing.T) {
+			authz.SwapAuthorizer(acl.DenyAll())
+
+			require.NoError(t, store.EnsureConfigEntry(nextIndex(), &structs.ServiceConfigEntry{
+				Name:     serviceName,
+				Protocol: "http",
+			}))
+
+			expectNoEvent(t, eventCh)
+		})
+	})
+}
+
+func newMockResolvedServiceConfig(t *testing.T) *mockResolvedServiceConfig {
+	mock := &mockResolvedServiceConfig{}
+	mock.Mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
+type mockResolvedServiceConfig struct {
+	mock.Mock
+}
+
+func (m *mockResolvedServiceConfig) Notify(ctx context.Context, req *structs.ServiceConfigRequest, correlationID string, ch chan<- proxycfg.UpdateEvent) error {
+	return m.Called(ctx, req, correlationID, ch).Error(0)
+}

--- a/agent/proxycfg/data_sources.go
+++ b/agent/proxycfg/data_sources.go
@@ -89,7 +89,7 @@ type DataSources struct {
 
 	// IntentionUpstreamsDestination provides intention-inferred upstream updates on a
 	// notification channel.
-	IntentionUpstreamsDestination IntentionUpstreamsDestination
+	IntentionUpstreamsDestination IntentionUpstreams
 
 	// InternalServiceDump provides updates about services of a given kind (e.g.
 	// mesh gateways) on a notification channel.
@@ -194,12 +194,6 @@ type Intentions interface {
 // IntentionUpstreams is the interface used to consume updates about upstreams
 // inferred from service intentions.
 type IntentionUpstreams interface {
-	Notify(ctx context.Context, req *structs.ServiceSpecificRequest, correlationID string, ch chan<- UpdateEvent) error
-}
-
-// IntentionUpstreamsDestination is the interface used to consume updates about upstreams destination
-// inferred from service intentions.
-type IntentionUpstreamsDestination interface {
 	Notify(ctx context.Context, req *structs.ServiceSpecificRequest, correlationID string, ch chan<- UpdateEvent) error
 }
 

--- a/agent/proxycfg/data_sources.go
+++ b/agent/proxycfg/data_sources.go
@@ -91,8 +91,8 @@ type DataSources struct {
 	// notification channel.
 	IntentionUpstreamsDestination IntentionUpstreamsDestination
 
-	// InternalServiceDump provides updates about a (gateway) service on a
-	// notification channel.
+	// InternalServiceDump provides updates about services of a given kind (e.g.
+	// mesh gateways) on a notification channel.
 	InternalServiceDump InternalServiceDump
 
 	// LeafCertificate provides updates about the service's leaf certificate on a
@@ -203,8 +203,8 @@ type IntentionUpstreamsDestination interface {
 	Notify(ctx context.Context, req *structs.ServiceSpecificRequest, correlationID string, ch chan<- UpdateEvent) error
 }
 
-// InternalServiceDump is the interface used to consume updates about a (gateway)
-// service via the internal ServiceDump RPC.
+// InternalServiceDump is the interface used to consume updates about services
+// of a given kind (e.g. mesh gateways).
 type InternalServiceDump interface {
 	Notify(ctx context.Context, req *structs.ServiceDumpRequest, correlationID string, ch chan<- UpdateEvent) error
 }

--- a/agent/proxycfg/mesh_gateway.go
+++ b/agent/proxycfg/mesh_gateway.go
@@ -491,7 +491,7 @@ func (s *handlerMeshGateway) handleUpdate(ctx context.Context, u UpdateEvent, sn
 			}
 
 		case strings.HasPrefix(u.CorrelationID, "mesh-gateway:"):
-			resp, ok := u.Result.(*structs.IndexedNodesWithGateways)
+			resp, ok := u.Result.(*structs.IndexedCheckServiceNodes)
 			if !ok {
 				return fmt.Errorf("invalid type for response: %T", u.Result)
 			}

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -927,7 +927,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					events: []UpdateEvent{
 						{
 							CorrelationID: "mesh-gateway:dc4",
-							Result: &structs.IndexedNodesWithGateways{
+							Result: &structs.IndexedCheckServiceNodes{
 								Nodes: TestGatewayNodesDC4Hostname(t),
 							},
 							Err: nil,

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -974,7 +974,7 @@ func NewTestDataSources() *TestDataSources {
 		Intentions:                      NewTestDataSource[*structs.ServiceSpecificRequest, structs.Intentions](),
 		IntentionUpstreams:              NewTestDataSource[*structs.ServiceSpecificRequest, *structs.IndexedServiceList](),
 		IntentionUpstreamsDestination:   NewTestDataSource[*structs.ServiceSpecificRequest, *structs.IndexedServiceList](),
-		InternalServiceDump:             NewTestDataSource[*structs.ServiceDumpRequest, *structs.IndexedNodesWithGateways](),
+		InternalServiceDump:             NewTestDataSource[*structs.ServiceDumpRequest, *structs.IndexedCheckServiceNodes](),
 		LeafCertificate:                 NewTestDataSource[*cachetype.ConnectCALeafRequest, *structs.IssuedCert](),
 		PreparedQuery:                   NewTestDataSource[*structs.PreparedQueryExecuteRequest, *structs.PreparedQueryExecuteResponse](),
 		ResolvedServiceConfig:           NewTestDataSource[*structs.ServiceConfigRequest, *structs.ServiceConfigResponse](),
@@ -1000,7 +1000,7 @@ type TestDataSources struct {
 	Intentions                      *TestDataSource[*structs.ServiceSpecificRequest, structs.Intentions]
 	IntentionUpstreams              *TestDataSource[*structs.ServiceSpecificRequest, *structs.IndexedServiceList]
 	IntentionUpstreamsDestination   *TestDataSource[*structs.ServiceSpecificRequest, *structs.IndexedServiceList]
-	InternalServiceDump             *TestDataSource[*structs.ServiceDumpRequest, *structs.IndexedNodesWithGateways]
+	InternalServiceDump             *TestDataSource[*structs.ServiceDumpRequest, *structs.IndexedCheckServiceNodes]
 	LeafCertificate                 *TestDataSource[*cachetype.ConnectCALeafRequest, *structs.IssuedCert]
 	PeeredUpstreams                 *TestDataSource[*structs.PartitionSpecificRequest, *structs.IndexedPeeredServiceList]
 	PreparedQuery                   *TestDataSource[*structs.PreparedQueryExecuteRequest, *structs.PreparedQueryExecuteResponse]

--- a/agent/proxycfg/testing_mesh_gateway.go
+++ b/agent/proxycfg/testing_mesh_gateway.go
@@ -316,19 +316,19 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 		baseEvents = testSpliceEvents(baseEvents, []UpdateEvent{
 			{
 				CorrelationID: "mesh-gateway:dc2",
-				Result: &structs.IndexedNodesWithGateways{
+				Result: &structs.IndexedCheckServiceNodes{
 					Nodes: TestGatewayNodesDC2(t),
 				},
 			},
 			{
 				CorrelationID: "mesh-gateway:dc4",
-				Result: &structs.IndexedNodesWithGateways{
+				Result: &structs.IndexedCheckServiceNodes{
 					Nodes: TestGatewayNodesDC4Hostname(t),
 				},
 			},
 			{
 				CorrelationID: "mesh-gateway:dc6",
-				Result: &structs.IndexedNodesWithGateways{
+				Result: &structs.IndexedCheckServiceNodes{
 					Nodes: TestGatewayNodesDC6Hostname(t),
 				},
 			},
@@ -376,7 +376,7 @@ func TestConfigSnapshotMeshGateway(t testing.T, variant string, nsFn func(ns *st
 					// Have the cross-dc query mechanism not work for dc2 so
 					// fedstates will infill.
 					CorrelationID: "mesh-gateway:dc2",
-					Result: &structs.IndexedNodesWithGateways{
+					Result: &structs.IndexedCheckServiceNodes{
 						Nodes: nil,
 					},
 				},

--- a/agent/proxycfg/testing_upstreams.go
+++ b/agent/proxycfg/testing_upstreams.go
@@ -69,7 +69,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		})
 		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc2:" + dbUID.String(),
-			Result: &structs.IndexedNodesWithGateways{
+			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestGatewayNodesDC2(t),
 			},
 		})
@@ -114,13 +114,13 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		})
 		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc2:" + dbUID.String(),
-			Result: &structs.IndexedNodesWithGateways{
+			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestGatewayNodesDC2(t),
 			},
 		})
 		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc3:" + dbUID.String(),
-			Result: &structs.IndexedNodesWithGateways{
+			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestGatewayNodesDC3(t),
 			},
 		})
@@ -141,7 +141,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		})
 		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc1:" + dbUID.String(),
-			Result: &structs.IndexedNodesWithGateways{
+			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestGatewayNodesDC1(t),
 			},
 		})
@@ -168,7 +168,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		})
 		events = append(events, UpdateEvent{
 			CorrelationID: "mesh-gateway:dc1:" + dbUID.String(),
-			Result: &structs.IndexedNodesWithGateways{
+			Result: &structs.IndexedCheckServiceNodes{
 				Nodes: TestGatewayNodesDC1(t),
 			},
 		})

--- a/agent/proxycfg/upstreams.go
+++ b/agent/proxycfg/upstreams.go
@@ -186,7 +186,7 @@ func (s *handlerUpstreams) handleUpdateUpstreams(ctx context.Context, u UpdateEv
 		}
 
 	case strings.HasPrefix(u.CorrelationID, "mesh-gateway:"):
-		resp, ok := u.Result.(*structs.IndexedNodesWithGateways)
+		resp, ok := u.Result.(*structs.IndexedCheckServiceNodes)
 		if !ok {
 			return fmt.Errorf("invalid type for response: %T", u.Result)
 		}


### PR DESCRIPTION
### Description

This PR contains the remaining server-local data sources.

It is the OSS portions of enterprise PRs 2460, 2489, and 2463. The changes have been reviewed properly in those PRs.

### Testing & Reproduction steps
- As always, the Envoy integration tests are our friends 😉
