### PR TITLE
Add new internal endpoint to list exported services for a peer

### DIFF
--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -613,6 +613,7 @@ func (m *Internal) GatewayIntentions(args *structs.IntentionQueryRequest, reply 
 
 // ExportedPeeredServices is used to query the exported services for peers.
 // Returns services as a map of ServiceNames by peer.
+// To get exported services for a single peer, use ExportedServicesForPeer.
 func (m *Internal) ExportedPeeredServices(args *structs.DCSpecificRequest, reply *structs.IndexedExportedServiceList) error {
 	if done, err := m.srv.ForwardRPC("Internal.ExportedPeeredServices", args, reply); done {
 		return err
@@ -637,6 +638,53 @@ func (m *Internal) ExportedPeeredServices(args *structs.DCSpecificRequest, reply
 			}
 
 			reply.Index, reply.Services = index, serviceMap
+			m.srv.filterACLWithAuthorizer(authz, reply)
+			return nil
+		})
+}
+
+// ExportedServicesForPeer returns a list of Service names that are exported for a given peer.
+func (m *Internal) ExportedServicesForPeer(args *structs.ServiceDumpRequest, reply *structs.IndexedServiceList) error {
+	if done, err := m.srv.ForwardRPC("Internal.ExportedServicesForPeer", args, reply); done {
+		return err
+	}
+
+	var authzCtx acl.AuthorizerContext
+	authz, err := m.srv.ResolveTokenAndDefaultMeta(args.Token, &args.EnterpriseMeta, &authzCtx)
+	if err != nil {
+		return err
+	}
+	if err := m.srv.validateEnterpriseRequest(&args.EnterpriseMeta, false); err != nil {
+		return err
+	}
+	if args.PeerName == "" {
+		return fmt.Errorf("must provide PeerName")
+	}
+
+	return m.srv.blockingQuery(
+		&args.QueryOptions,
+		&reply.QueryMeta,
+		func(ws memdb.WatchSet, store *state.Store) error {
+
+			idx, p, err := store.PeeringRead(ws, state.Query{
+				Value:          args.PeerName,
+				EnterpriseMeta: args.EnterpriseMeta,
+			})
+			if err != nil {
+				return fmt.Errorf("error while fetching peer %q: %w", args.PeerName, err)
+			}
+			if p == nil {
+				reply.Index = idx
+				reply.Services = nil
+				return errNotFound
+			}
+			idx, exportedSvcs, err := store.ExportedServicesForPeer(ws, p.ID, "")
+			if err != nil {
+				return fmt.Errorf("error while listing exported services for peer %q: %w", args.PeerName, err)
+			}
+
+			reply.Index = idx
+			reply.Services = exportedSvcs.Services
 			m.srv.filterACLWithAuthorizer(authz, reply)
 			return nil
 		})

--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -91,6 +91,7 @@ func init() {
 	registerEndpoint("/v1/internal/ui/nodes", []string{"GET"}, (*HTTPHandlers).UINodes)
 	registerEndpoint("/v1/internal/ui/node/", []string{"GET"}, (*HTTPHandlers).UINodeInfo)
 	registerEndpoint("/v1/internal/ui/services", []string{"GET"}, (*HTTPHandlers).UIServices)
+	registerEndpoint("/v1/internal/ui/exported-services", []string{"GET"}, (*HTTPHandlers).UIExportedServices)
 	registerEndpoint("/v1/internal/ui/catalog-overview", []string{"GET"}, (*HTTPHandlers).UICatalogOverview)
 	registerEndpoint("/v1/internal/ui/gateway-services-nodes/", []string{"GET"}, (*HTTPHandlers).UIGatewayServicesNodes)
 	registerEndpoint("/v1/internal/ui/gateway-intentions/", []string{"GET"}, (*HTTPHandlers).UIGatewayIntentions)

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -779,3 +779,49 @@ func (s *HTTPHandlers) UIMetricsProxy(resp http.ResponseWriter, req *http.Reques
 	proxy.ServeHTTP(resp, req)
 	return nil, nil
 }
+
+// UIExportedServices is used to list the exported services to a given peer. We return a
+// barebones ServiceListingSummary which only contains the name and enterprise meta of a service.
+// Currently, the request and response mirror UIServices but the API may change in the future.
+func (s *HTTPHandlers) UIExportedServices(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Parse arguments
+	args := structs.ServiceDumpRequest{}
+	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
+		return nil, nil
+	}
+	if peer := req.URL.Query().Get("peer"); peer != "" {
+		args.PeerName = peer
+	}
+	if err := s.parseEntMeta(req, &args.EnterpriseMeta); err != nil {
+		return nil, err
+	}
+
+	// Make the RPC request
+	var out structs.IndexedServiceList
+	defer setMeta(resp, &out.QueryMeta)
+RPC:
+	if err := s.agent.RPC("Internal.ExportedServicesForPeer", &args, &out); err != nil {
+		// Retry the request allowing stale data if no leader
+		if strings.Contains(err.Error(), structs.ErrNoLeader.Error()) && !args.AllowStale {
+			args.AllowStale = true
+			goto RPC
+		}
+		return nil, err
+	}
+	// Ensure at least a zero length slice
+	result := make([]*ServiceListingSummary, 0)
+	for _, svc := range out.Services {
+		// We synthesize a minimal summary for the frontend.
+		// The shape of the data may change in the future but
+		// currently only the service name is required.
+		sum := ServiceListingSummary{
+			ServiceSummary: ServiceSummary{
+				Name:           svc.Name,
+				EnterpriseMeta: svc.EnterpriseMeta,
+				Datacenter:     args.Datacenter,
+			},
+		}
+		result = append(result, &sum)
+	}
+	return result, nil
+}

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -665,6 +666,187 @@ func TestUIServices(t *testing.T) {
 		require.NotNil(t, obj)
 
 		summary := obj.([]*ServiceListingSummary)
+		require.Len(t, summary, 0)
+	})
+}
+
+func TestUIExportedServices(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	a := StartTestAgent(t, TestAgent{Overrides: `peering = { test_allow_peer_registrations = true }`})
+	defer a.Shutdown()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	requests := []*structs.RegisterRequest{
+		// register api service
+		{
+			Datacenter:     "dc1",
+			Node:           "node",
+			SkipNodeUpdate: true,
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindTypical,
+				Service: "api",
+				ID:      "api-1",
+			},
+			Checks: structs.HealthChecks{
+				&structs.HealthCheck{
+					Node:        "node",
+					Name:        "api svc check",
+					ServiceName: "api",
+					ServiceID:   "api-1",
+					Status:      api.HealthWarning,
+				},
+			},
+		},
+		// register api-proxy svc
+		{
+			Datacenter:     "dc1",
+			Node:           "node",
+			SkipNodeUpdate: true,
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				Service: "api-proxy",
+				ID:      "api-proxy-1",
+				Tags:    []string{},
+				Meta:    map[string]string{structs.MetaExternalSource: "k8s"},
+				Port:    1234,
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "api",
+				},
+			},
+			Checks: structs.HealthChecks{
+				&structs.HealthCheck{
+					Node:        "node",
+					Name:        "api proxy listening",
+					ServiceName: "api-proxy",
+					ServiceID:   "api-proxy-1",
+					Status:      api.HealthPassing,
+				},
+			},
+		},
+		// register service web
+		{
+			Datacenter: "dc1",
+			Node:       "bar",
+			Address:    "127.0.0.2",
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindTypical,
+				Service: "web",
+				ID:      "web-1",
+				Tags:    []string{},
+				Meta:    map[string]string{structs.MetaExternalSource: "k8s"},
+				Port:    1234,
+			},
+			Checks: []*structs.HealthCheck{
+				{
+					Node:        "bar",
+					Name:        "web svc check",
+					Status:      api.HealthCritical,
+					ServiceName: "web",
+					ServiceID:   "web-1",
+				},
+			},
+		},
+	}
+
+	for _, args := range requests {
+		var out struct{}
+		require.NoError(t, a.RPC("Catalog.Register", args, &out))
+	}
+
+	// establish "peer1"
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		peerOne := &pbpeering.PeeringWriteRequest{
+			Peering: &pbpeering.Peering{
+				Name:                "peer1",
+				State:               pbpeering.PeeringState_ESTABLISHING,
+				PeerCAPems:          nil,
+				PeerServerName:      "fooservername",
+				PeerServerAddresses: []string{"addr1"},
+			},
+		}
+		_, err := a.rpcClientPeering.PeeringWrite(ctx, peerOne)
+		require.NoError(t, err)
+	}
+
+	{
+		// Register exported services
+		args := &structs.ExportedServicesConfigEntry{
+			Name: "default",
+			Services: []structs.ExportedService{
+				{
+					Name: "api",
+					Consumers: []structs.ServiceConsumer{
+						{
+							PeerName: "peer1",
+						},
+					},
+				},
+			},
+		}
+		req := structs.ConfigEntryRequest{
+			Op:         structs.ConfigEntryUpsert,
+			Datacenter: "dc1",
+			Entry:      args,
+		}
+		var configOutput bool
+		require.NoError(t, a.RPC("ConfigEntry.Apply", &req, &configOutput))
+		require.True(t, configOutput)
+	}
+
+	t.Run("valid peer", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest("GET", "/v1/internal/ui/exported-services?peer=peer1", nil)
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
+
+		decoder := json.NewDecoder(resp.Body)
+		var summary []*ServiceListingSummary
+		require.NoError(t, decoder.Decode(&summary))
+		assertIndex(t, resp)
+
+		require.Len(t, summary, 1)
+
+		// internal accounting that users don't see can be blown away
+		for _, sum := range summary {
+			sum.transparentProxySet = false
+			sum.externalSourceSet = nil
+			sum.checks = nil
+		}
+
+		expected := []*ServiceListingSummary{
+			{
+				ServiceSummary: ServiceSummary{
+					Kind:           structs.ServiceKindTypical,
+					Name:           "api",
+					Datacenter:     "dc1",
+					EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+				},
+			},
+		}
+		require.Equal(t, expected, summary)
+	})
+
+	t.Run("invalid peer", func(t *testing.T) {
+		t.Parallel()
+		req, _ := http.NewRequest("GET", "/v1/internal/ui/exported-services?peer=peer2", nil)
+		resp := httptest.NewRecorder()
+		a.srv.h.ServeHTTP(resp, req)
+		require.Equal(t, http.StatusOK, resp.Code)
+
+		decoder := json.NewDecoder(resp.Body)
+		var summary []*ServiceListingSummary
+		require.NoError(t, decoder.Decode(&summary))
+		assertIndex(t, resp)
+
 		require.Len(t, summary, 0)
 	})
 }


### PR DESCRIPTION
### Description
In Consul UI we want to display a condensed list of service names that are being exported to a peer. The state store functions already exist so this PR simply exposes a new endpoint.

### Testing & Reproduction steps
* Added testcases, enterprise tests will be added separately

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
