### PR TITLE
Fix early return in prototest.AssertElementsMatch

### DIFF
--- a/proto/prototest/testing.go
+++ b/proto/prototest/testing.go
@@ -57,7 +57,7 @@ func AssertElementsMatch[V any](
 		}
 	}
 
-	if len(outX) == len(outY) && len(outX) == len(listX) {
+	if len(outX) == len(outY) && len(listX) == len(listY) {
 		return // matches
 	}
 


### PR DESCRIPTION
### Description
`AssertElementsMatch` should mirror the behavior of `testify`'s `ElementsMatch` ([src](https://pkg.go.dev/github.com/stretchr/testify/assert#ElementsMatch)).

However, given inputs `[A,B]` and `[A,B,C]`, `AssertElementsMatch` was returning too early based on the length of matched elements `{A,B}` because of a typo incorrectly comparing `len(outX) == len(listX)` when it should have been `len(listX) == len(listY)`

### Testing & Reproduction steps
* This change should not cause tests to fail; otherwise they should be fixed

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
