### PR TITLE
fix(txn api): missing proxy config in registering proxy service

### DIFF
--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -724,8 +724,8 @@ func TestTxnEndpoint_NodeService(t *testing.T) {
 				  	"LocalServicePort": 4444,
 				  	"upstreams": [
 						{
-							"destination_name": "fake-backend",
-							"local_bind_port": 25001
+							"DestinationName": "fake-backend",
+							"LocalBindPort": 25001
 						}
 				  	]
 				}

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -585,6 +585,7 @@ func TestTxnEndpoint_UpdateCheck(t *testing.T) {
 				"Output": "success",
 				"ServiceID": "",
 				"ServiceName": "",
+				"ExposedPort": 5678,
 				"Definition": {
 					"IntervalDuration": "15s",
 					"TimeoutDuration": "15s",
@@ -600,12 +601,8 @@ func TestTxnEndpoint_UpdateCheck(t *testing.T) {
 	req, _ := http.NewRequest("PUT", "/v1/txn", buf)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.Txn(resp, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if resp.Code != 200 {
-		t.Fatalf("expected 200, got %d", resp.Code)
-	}
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Code, resp.Body)
 
 	txnResp, ok := obj.(structs.TxnResponse)
 	if !ok {
@@ -662,18 +659,133 @@ func TestTxnEndpoint_UpdateCheck(t *testing.T) {
 			},
 			&structs.TxnResult{
 				Check: &structs.HealthCheck{
-					Node:    a.config.NodeName,
-					CheckID: "nodecheck",
-					Name:    "Node http check",
-					Status:  api.HealthPassing,
-					Notes:   "Http based health check",
-					Output:  "success",
+					Node:        a.config.NodeName,
+					CheckID:     "nodecheck",
+					Name:        "Node http check",
+					Status:      api.HealthPassing,
+					Notes:       "Http based health check",
+					Output:      "success",
+					ExposedPort: 5678,
 					Definition: structs.HealthCheckDefinition{
 						Interval:                       15 * time.Second,
 						Timeout:                        15 * time.Second,
 						DeregisterCriticalServiceAfter: 30 * time.Minute,
 						HTTP:                           "http://localhost:9000",
 						TLSSkipVerify:                  false,
+					},
+					RaftIndex: structs.RaftIndex{
+						CreateIndex: index,
+						ModifyIndex: index,
+					},
+					EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+				},
+			},
+		},
+	}
+	assert.Equal(t, expected, txnResp)
+}
+
+func TestTxnEndpoint_NodeService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	t.Parallel()
+	a := NewTestAgent(t, "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	// Make sure the fields of a check are handled correctly when both creating and
+	// updating, and test both sets of duration fields to ensure backwards compatibility.
+	buf := bytes.NewBuffer([]byte(fmt.Sprintf(`
+[
+	{
+		"Service": {
+		  	"Verb": "set",
+		  	"Node": "%s",
+		  	"Service": {
+				"Service": "test",
+				"Port": 4444
+		  	}
+		}
+	},
+	{
+		"Service": {
+			"Verb": "set",
+			"Node": "%s",
+			"Service": {
+				"Service": "test-sidecar-proxy",
+				"Port": 20000,
+				"Kind": "connect-proxy",
+				"Proxy": {
+				  	"DestinationServiceName": "test",
+				  	"DestinationServiceID": "test",
+				  	"LocalServiceAddress": "127.0.0.1",
+				  	"LocalServicePort": 4444,
+				  	"upstreams": [
+						{
+							"destination_name": "fake-backend",
+							"local_bind_port": 25001
+						}
+				  	]
+				}
+			}
+		}
+	}
+]
+`, a.config.NodeName, a.config.NodeName)))
+	req, _ := http.NewRequest("PUT", "/v1/txn", buf)
+	resp := httptest.NewRecorder()
+	obj, err := a.srv.Txn(resp, req)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Code)
+
+	txnResp, ok := obj.(structs.TxnResponse)
+	if !ok {
+		t.Fatalf("bad type: %T", obj)
+	}
+	require.Equal(t, 2, len(txnResp.Results))
+
+	index := txnResp.Results[0].Service.ModifyIndex
+	expected := structs.TxnResponse{
+		Results: structs.TxnResults{
+			&structs.TxnResult{
+				Service: &structs.NodeService{
+					Service: "test",
+					ID:      "test",
+					Port:    4444,
+					Weights: &structs.Weights{
+						Passing: 1,
+						Warning: 1,
+					},
+					RaftIndex: structs.RaftIndex{
+						CreateIndex: index,
+						ModifyIndex: index,
+					},
+					EnterpriseMeta: *structs.DefaultEnterpriseMetaInDefaultPartition(),
+				},
+			},
+			&structs.TxnResult{
+				Service: &structs.NodeService{
+					Service: "test-sidecar-proxy",
+					ID:      "test-sidecar-proxy",
+					Port:    20000,
+					Kind:    "connect-proxy",
+					Weights: &structs.Weights{
+						Passing: 1,
+						Warning: 1,
+					},
+					Proxy: structs.ConnectProxyConfig{
+						DestinationServiceName: "test",
+						DestinationServiceID:   "test",
+						LocalServiceAddress:    "127.0.0.1",
+						LocalServicePort:       4444,
+					},
+					TaggedAddresses: map[string]structs.ServiceAddress{
+						"consul-virtual": {
+							Address: "240.0.0.1",
+							Port:    20000,
+						},
 					},
 					RaftIndex: structs.RaftIndex{
 						CreateIndex: index,

--- a/api/agent.go
+++ b/api/agent.go
@@ -425,18 +425,18 @@ type ConnectProxyConfig struct {
 
 // Upstream is the response structure for a proxy upstream configuration.
 type Upstream struct {
-	DestinationType      UpstreamDestType `json:",omitempty"`
-	DestinationPartition string           `json:",omitempty"`
-	DestinationNamespace string           `json:",omitempty"`
-	DestinationPeer      string           `json:",omitempty"`
-	DestinationName      string
+	DestinationType      UpstreamDestType       `json:"destination_type,omitempty"`
+	DestinationPartition string                 `json:"destination_partition,omitempty"`
+	DestinationNamespace string                 `json:"destination_namespace,omitempty"`
+	DestinationPeer      string                 `json:"destination_peer,omitempty"`
+	DestinationName      string                 `json:"destination_name,omitempty"`
 	Datacenter           string                 `json:",omitempty"`
-	LocalBindAddress     string                 `json:",omitempty"`
-	LocalBindPort        int                    `json:",omitempty"`
-	LocalBindSocketPath  string                 `json:",omitempty"`
-	LocalBindSocketMode  string                 `json:",omitempty"`
+	LocalBindAddress     string                 `json:"local_bind_address,omitempty"`
+	LocalBindPort        int                    `json:"local_bind_port,omitempty"`
+	LocalBindSocketPath  string                 `json:"local_bind_socket_path,omitempty"`
+	LocalBindSocketMode  string                 `json:"local_bind_socket_mode,omitempty"`
 	Config               map[string]interface{} `json:",omitempty" bexpr:"-"`
-	MeshGateway          MeshGatewayConfig      `json:",omitempty"`
+	MeshGateway          MeshGatewayConfig      `json:"mesh_gateway,omitempty"`
 	CentrallyConfigured  bool                   `json:",omitempty" bexpr:"-"`
 }
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -425,18 +425,18 @@ type ConnectProxyConfig struct {
 
 // Upstream is the response structure for a proxy upstream configuration.
 type Upstream struct {
-	DestinationType      UpstreamDestType       `json:"destination_type,omitempty"`
-	DestinationPartition string                 `json:"destination_partition,omitempty"`
-	DestinationNamespace string                 `json:"destination_namespace,omitempty"`
-	DestinationPeer      string                 `json:"destination_peer,omitempty"`
-	DestinationName      string                 `json:"destination_name,omitempty"`
+	DestinationType      UpstreamDestType `json:",omitempty"`
+	DestinationPartition string           `json:",omitempty"`
+	DestinationNamespace string           `json:",omitempty"`
+	DestinationPeer      string           `json:",omitempty"`
+	DestinationName      string
 	Datacenter           string                 `json:",omitempty"`
-	LocalBindAddress     string                 `json:"local_bind_address,omitempty"`
-	LocalBindPort        int                    `json:"local_bind_port,omitempty"`
-	LocalBindSocketPath  string                 `json:"local_bind_socket_path,omitempty"`
-	LocalBindSocketMode  string                 `json:"local_bind_socket_mode,omitempty"`
+	LocalBindAddress     string                 `json:",omitempty"`
+	LocalBindPort        int                    `json:",omitempty"`
+	LocalBindSocketPath  string                 `json:",omitempty"`
+	LocalBindSocketMode  string                 `json:",omitempty"`
 	Config               map[string]interface{} `json:",omitempty" bexpr:"-"`
-	MeshGateway          MeshGatewayConfig      `json:"mesh_gateway,omitempty"`
+	MeshGateway          MeshGatewayConfig      `json:",omitempty"`
 	CentrallyConfigured  bool                   `json:",omitempty" bexpr:"-"`
 }
 

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -20,6 +20,7 @@ type Node struct {
 	CreateIndex     uint64
 	ModifyIndex     uint64
 	Partition       string `json:",omitempty"`
+	PeerName        string `json:",omitempty"`
 }
 
 type ServiceAddress struct {

--- a/api/health.go
+++ b/api/health.go
@@ -45,6 +45,8 @@ type HealthCheck struct {
 	Type        string
 	Namespace   string `json:",omitempty"`
 	Partition   string `json:",omitempty"`
+	ExposedPort int
+	PeerName    string `json:",omitempty"`
 
 	Definition HealthCheckDefinition
 
@@ -176,8 +178,7 @@ type HealthChecks []*HealthCheck
 // attached, this function determines the best representative of the status as
 // as single string using the following heuristic:
 //
-//  maintenance > critical > warning > passing
-//
+//	maintenance > critical > warning > passing
 func (c HealthChecks) AggregatedStatus() string {
 	var passing, warning, critical, maintenance bool
 	for _, check := range c {


### PR DESCRIPTION
### Description
This PR adds missing fields to `HealthCheck`, `Node`, and `ConnectProxyConfig` in api to sync up with the definition in `agent/structs`

### Testing & Reproduction steps
Please refer o the example in #14341

### Links
#14341 

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
