### PR TITLE
docs: fix link to enterprise service DNS lookups

### DIFF
--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1342,7 +1342,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     Consul 1.11. Use the [canonical enterprise DNS format](/docs/discovery/dns#namespaced-partitioned-services) instead.** -
     When set to true, in a DNS query for a service, the label between the domain
     and the `service` label will be treated as a namespace name instead of a datacenter.
-    When set to false, the default, the behavior will be the same as non-Enterprise
+    When set to false, the default, the behavior is the same as non-Enterprise
     versions and will assume the label is the datacenter.
 
 - `domain` Equivalent to the [`-domain` command-line flag](/docs/agent/config/cli-flags#_domain).

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1343,7 +1343,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     When set to true, in a DNS query for a service, the label between the domain
     and the `service` label will be treated as a namespace name instead of a datacenter.
     When set to false, the default, the behavior is the same as non-Enterprise
-    versions and will assume the label is the datacenter.
+    versions and assumes the label is the datacenter.
 
 - `domain` Equivalent to the [`-domain` command-line flag](/docs/agent/config/cli-flags#_domain).
 

--- a/website/content/docs/agent/config/config-files.mdx
+++ b/website/content/docs/agent/config/config-files.mdx
@@ -1339,12 +1339,11 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     of `1ns` instead of 0.
 
   - `prefer_namespace` ((#dns_prefer_namespace)) <EnterpriseAlert inline /> **Deprecated in
-    Consul 1.11. Use the [canonical DNS format](/docs/discovery/dns#namespaced-partitioned-services) instead.** -
+    Consul 1.11. Use the [canonical enterprise DNS format](/docs/discovery/dns#namespaced-partitioned-services) instead.** -
     When set to true, in a DNS query for a service, the label between the domain
     and the `service` label will be treated as a namespace name instead of a datacenter.
     When set to false, the default, the behavior will be the same as non-Enterprise
-    versions and will assume the label is the datacenter. See: [this section](/docs/discovery/dns#namespaced-services)
-    for more details.
+    versions and will assume the label is the datacenter.
 
 - `domain` Equivalent to the [`-domain` command-line flag](/docs/agent/config/cli-flags#_domain).
 


### PR DESCRIPTION
Minor fix based on recent DNS docs refactoring