### PR TITLE
docs: licensing improvements

### DIFF
--- a/website/content/commands/license.mdx
+++ b/website/content/commands/license.mdx
@@ -12,8 +12,9 @@ Command: `consul license`
 
 <EnterpriseAlert />
 
-The `license` command provides a datacenter-level view of the Consul Enterprise license. This was added
-in Consul 1.1.0 but Consul 1.10.0 removed the ability to set and reset the license using the CLI.
+The `license` command provides a datacenter-level view of the Consul Enterprise license.
+
+~> **Warning**: Consul 1.10.0 removed the ability to set and reset the license using the CLI.
 See the [licensing documentation](/docs/enterprise/license/overview) for more information about
 Consul Enterprise license management.
 

--- a/website/content/commands/license.mdx
+++ b/website/content/commands/license.mdx
@@ -12,7 +12,7 @@ Command: `consul license`
 
 <EnterpriseAlert />
 
-The `license` command provides a datacenter-level view of the Consul Enterprise license.
+The `license` command provides a list of all datacenters that use the Consul Enterprise license applied to the current datacenter.
 
 ~> **Warning**: Consul 1.10.0 removed the ability to set and reset the license using the CLI.
 See the [licensing documentation](/docs/enterprise/license/overview) for more information about

--- a/website/content/docs/agent/config/index.mdx
+++ b/website/content/docs/agent/config/index.mdx
@@ -90,3 +90,4 @@ items which are reloaded include:
     Consul will issue the following warning, `Static Runtime config has changed and need a manual config reload to be applied`.
     You must manually issue the `consul reload` command or send a `SIGHUP` to the Consul process to reload the new values.
 - Watches
+- [License](/docs/enterprise/license/overview)

--- a/website/content/docs/enterprise/license/overview.mdx
+++ b/website/content/docs/enterprise/license/overview.mdx
@@ -40,11 +40,12 @@ may also be licensed in the very same manner.
 However, to avoid the need to configure the license on many client agents and snapshot agents,
 those agents have the capability to retrieve the license automatically under the conditions described below.
 
-Updating the license for an agent depends on the method that was used to apply the license. If the `CONSUL_LICENSE`
-environment variable was used, the agent must be restarted with an updated environment variable. If the
-`CONSUL_LICENSE_PATH` environment variable or the `license_path` configuration item were used, the license file
-must be updated first. Following that, either the agent must be restarted, or a [reload](/commands/reload) of
-the configuration files for the agent must be triggered.
+Updating the license for an agent depends on the method you used to apply the license.
+- **If you used the `CONSUL_LICENSE`
+environment variable**: After updating the environment variable, restart the affected agents. 
+- **If you used the
+`CONSUL_LICENSE_PATH` environment variable**: Update the license file first. Then, restart the affected agents. 
+- **If you used the `license_path` configuration item**: Update the license file first. Then, run [`consul reload`](/commands/reload) for the affected agents.
 
 #### Client Agent License Retrieval
 

--- a/website/content/docs/enterprise/license/overview.mdx
+++ b/website/content/docs/enterprise/license/overview.mdx
@@ -40,6 +40,12 @@ may also be licensed in the very same manner.
 However, to avoid the need to configure the license on many client agents and snapshot agents,
 those agents have the capability to retrieve the license automatically under the conditions described below.
 
+Updating the license for an agent depends on the method that was used to apply the license. If the `CONSUL_LICENSE`
+environment variable was used, the agent must be restarted with an updated environment variable. If the
+`CONSUL_LICENSE_PATH` environment variable or the `license_path` configuration item were used, the license file
+must be updated first. Following that, either the agent must be restarted, or a [reload](/commands/reload) of
+the configuration files for the agent must be triggered.
+
 #### Client Agent License Retrieval
 
 When a client agent starts without a license in its configuration or environment, it will try to retrieve the


### PR DESCRIPTION
### Description
- Adding a paragraph on updating a license in the _Enterprise License Overview_ page since practitioners have found it unclear that a `consul reload` can save them an agent restart.
- Adding the Consul License to the list of reloadable configuration
- Drawing the attention of the practitioner to the fact that `consul license [get|put]` has been deprecated

### Testing & Reproduction steps
Tested that `consul reload` updates license information when the contents of the `license_path` file stanza have been updated.

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [ ] not a security concern
