### PR TITLE
ui: Add 'self-managed' badge when CONSUL_MANAGEMENT_TYPE=self

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
+++ b/ui/packages/consul-ui/app/components/consul/datacenter/selector/index.hbs
@@ -58,6 +58,9 @@
   {{else}}
     <div class="dc-name" data-test-datacenter-single>
       {{@dcs.firstObject.Name}}
+      {{#if (eq 'self' (env 'CONSUL_MANAGEMENT_TYPE'))}}
+        <span>Self-managed</span>
+      {{/if}}
     </div>
   {{/if}}
 </li>

--- a/ui/packages/consul-ui/app/components/hashicorp-consul/index.scss
+++ b/ui/packages/consul-ui/app/components/hashicorp-consul/index.scss
@@ -13,6 +13,17 @@
   nav .dcs li.is-local span {
     @extend %menu-panel-badge;
   }
+  nav .dcs .dc-name {
+    color: rgb(var(--tone-gray-600));
+    padding: 3.25px 0px;
+    font-weight: var(--typo-weight-semibold)
+  }
+  nav .dcs .dc-name span {
+    @extend %pill-200;
+    margin-left: 1rem;
+    background-color: rgb(var(--tone-gray-300));
+    color: rgb(var(--tone-gray-999));
+  }
   nav li.partitions,
   nav li.nspaces {
     @extend %main-nav-vertical-popover-menu;
@@ -49,11 +60,6 @@
     position: relative;
     top: 2px;
     margin-left: 2px;
-  }
-  .dc-name {
-    color: rgb(var(--tone-gray-600));
-    padding: 3.25px 0px;
-    font-weight: var(--typo-weight-semibold)
   }
 }
 .hashicorp-consul {

--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -132,6 +132,8 @@ export default function(config = {}, win = window, doc = document) {
         return operatorConfig.LocalDatacenter;
       case 'CONSUL_DATACENTER_PRIMARY':
         return operatorConfig.PrimaryDatacenter;
+      case 'CONSUL_MANAGEMENT_TYPE':
+        return operatorConfig.ManagementType;
       case 'CONSUL_API_PREFIX':
         // we want API prefix to look like an env var for if we ever change
         // operator config to be an API request, we need this variable before we
@@ -252,6 +254,7 @@ export default function(config = {}, win = window, doc = document) {
       case 'CONSUL_UI_CONFIG':
       case 'CONSUL_DATACENTER_LOCAL':
       case 'CONSUL_DATACENTER_PRIMARY':
+      case 'CONSUL_MANAGEMENT_TYPE':
       case 'CONSUL_API_PREFIX':
       case 'CONSUL_ACLS_ENABLED':
       case 'CONSUL_NSPACES_ENABLED':


### PR DESCRIPTION
### Description
Adds 'self-managed' badge when an CONSUL_MANAGEMENT_TYPE=self environment variable is set.

Notes:
- For the moment it is fine to only show this when there is one datacenter
- The name of the environment variable will possibly change, I need to sync with the be again :doh:
- For the previous 2 reasons and others, theres probably a little clean up PR to follow at some point.


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
