### PR TITLE
ui: fix - proper await page object step

### DIFF
--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -108,7 +108,7 @@
     "ember-cli-flash": "^2.1.1",
     "ember-cli-htmlbars": "^5.2.0",
     "ember-cli-inject-live-reload": "^2.0.2",
-    "ember-cli-page-object": "^1.16.2",
+    "ember-cli-page-object": "^1.17.10",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-string-helpers": "^5.0.0",

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/show.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/show.feature
@@ -53,11 +53,11 @@ Feature: dc / nodes / show: Show node
       dc: dc1
       node: node-0
     ---
+    And I see serviceInstancesIsSelected on the tabs
     And I see healthChecks on the tabs
     And I see serviceInstances on the tabs
     And I don't see roundTripTime on the tabs
     And I see lockSessions on the tabs
-    And I see serviceInstancesIsSelected on the tabs
   Scenario: A node warns when deregistered whilst blocking
     Given 1 node model from yaml
     ---

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show-routing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show-routing.feature
@@ -52,13 +52,6 @@ Feature: dc / services / show-routing: Show Routing for Service
       service: service-1
     ---
     And I see routing on the tabs
-    # something weird is going on with this test
-    # without waiting we issue a url reload that
-    # will make the test timeout.
-    # waiting will "fix" this - we should look into
-    # the underlying reason for this soon. This is
-    # only a quick-fix to land ember-qunit v5.
-    And pause for 1000
     And I visit the service page for yaml
     ---
       dc: dc1

--- a/ui/packages/consul-ui/tests/steps/assertions/page.js
+++ b/ui/packages/consul-ui/tests/steps/assertions/page.js
@@ -184,7 +184,9 @@ export default function(scenario, assert, find, currentPage, $) {
         }
       }
       assert[isNegative ? 'notOk' : 'ok'](target, message);
-      return Promise.resolve();
+
+      // always return promise and handle the fact that `target` could be async
+      return Promise.resolve().then(() => target);
     })
     .then(
       [

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6530,7 +6530,7 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.11.0, 
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.13.2, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5:
+ember-cli-babel@^7.13.2, ember-cli-babel@^7.26.1, ember-cli-babel@^7.26.3, ember-cli-babel@^7.26.5:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -6781,15 +6781,15 @@ ember-cli-normalize-entity-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-page-object@^1.16.2:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.17.7.tgz#a35c4cc1ece147e9752604cbc2266038660a84f6"
-  integrity sha512-sp7lunZa9p57cNm6og86F12SBx5Tt/7dWndfIKGE9Kol3QP2/72qiUVauhbfoUDSjfYLG2xEAFWDbiLHPMPYsg==
+ember-cli-page-object@^1.17.10:
+  version "1.17.10"
+  resolved "https://registry.yarnpkg.com/ember-cli-page-object/-/ember-cli-page-object-1.17.10.tgz#a3145c7b0341e6180dab28e10c858f8b6535e66a"
+  integrity sha512-J7OQZ4IWftHLunsCicFbaVb/GrI+/DMWMPO5EAca9+0x9K+rxml351Tl1Z/Fpr8UmHg1q/KGwqGx9xGodrRxbg==
   dependencies:
     broccoli-file-creator "^2.1.1"
     broccoli-merge-trees "^2.0.0"
     ceibo "~2.0.0"
-    ember-cli-babel "^6.16.0"
+    ember-cli-babel "^7.26.1"
     ember-cli-node-assets "^0.2.2"
     ember-native-dom-helpers "^0.7.0"
     jquery "^3.4.1"


### PR DESCRIPTION
### Description
This PR resolves an issue in the way we were working with ember-cli-page-object in our steps. The change introduced here makes sure we handle the fact that calling a page-object method is asynchronous. We need to return the promise instead of just `Promise.resolve`, so we properly await whatever happens based on the interaction with the page object.

This allows us to remove a (bad) sleep workaround introduced in this PR: https://github.com/hashicorp/consul/pull/14430

In addition to that, properly awaiting page-object promises in the `I see`-step creates the need to change the test order in another tab-nav related test. Because `see`ing a tab-item will actually click the item, we have to change the order of what things are being testing in that test.

This PR also updates ember-cli-page-object to the latest 1.17.x release, which was released recently.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
