### PR TITLE
Fix inconsistent TTL behavior in CA providers

### DIFF
--- a/.changelog/14516.txt
+++ b/.changelog/14516.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ca: Fixed a bug with the Vault CA provider where the intermediate PKI mount and leaf cert role were not being updated when the CA configuration was changed.
+```

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -66,11 +66,10 @@ type VaultProvider struct {
 
 	stopWatcher func()
 
-	isPrimary                    bool
-	clusterID                    string
-	spiffeID                     *connect.SpiffeIDSigning
-	setupIntermediatePKIPathDone bool
-	logger                       hclog.Logger
+	isPrimary bool
+	clusterID string
+	spiffeID  *connect.SpiffeIDSigning
+	logger    hclog.Logger
 }
 
 func NewVaultProvider(logger hclog.Logger) *VaultProvider {
@@ -172,6 +171,11 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 		}
 		v.stopWatcher = cancel
 		go v.renewToken(ctx, lifetimeWatcher)
+	}
+
+	// Update the intermediate (managed) PKI mount and role
+	if err := v.setupIntermediatePKIPath(); err != nil {
+		return err
 	}
 
 	return nil
@@ -363,8 +367,8 @@ func (v *VaultProvider) GenerateIntermediateCSR() (string, error) {
 }
 
 func (v *VaultProvider) setupIntermediatePKIPath() error {
-	if v.setupIntermediatePKIPathDone {
-		return nil
+	mountConfig := vaultapi.MountConfigInput{
+		MaxLeaseTTL: v.config.IntermediateCertTTL.String(),
 	}
 
 	_, err := v.getCA(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath)
@@ -373,9 +377,7 @@ func (v *VaultProvider) setupIntermediatePKIPath() error {
 			err := v.mountNamespaced(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath, &vaultapi.MountInput{
 				Type:        "pki",
 				Description: "intermediate CA backend for Consul Connect",
-				Config: vaultapi.MountConfigInput{
-					MaxLeaseTTL: v.config.IntermediateCertTTL.String(),
-				},
+				Config:      mountConfig,
 			})
 			if err != nil {
 				return err
@@ -383,39 +385,28 @@ func (v *VaultProvider) setupIntermediatePKIPath() error {
 		} else {
 			return err
 		}
-	}
-
-	// Create the role for issuing leaf certs if it doesn't exist yet
-	rolePath := v.config.IntermediatePKIPath + "roles/" + VaultCALeafCertRole
-	role, err := v.readNamespaced(v.config.IntermediatePKINamespace, rolePath)
-
-	if err != nil {
-		return err
-	}
-	if role == nil {
-		_, err := v.writeNamespaced(v.config.IntermediatePKINamespace, rolePath, map[string]interface{}{
-			"allow_any_name":   true,
-			"allowed_uri_sans": "spiffe://*",
-			"key_type":         "any",
-			"max_ttl":          v.config.LeafCertTTL.String(),
-			"no_store":         true,
-			"require_cn":       false,
-		})
-
+	} else {
+		err := v.tuneMountNamespaced(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath, &mountConfig)
 		if err != nil {
 			return err
 		}
 	}
-	v.setupIntermediatePKIPathDone = true
-	return nil
+
+	// Create the role for issuing leaf certs if it doesn't exist yet
+	rolePath := v.config.IntermediatePKIPath + "roles/" + VaultCALeafCertRole
+	_, err = v.writeNamespaced(v.config.IntermediatePKINamespace, rolePath, map[string]interface{}{
+		"allow_any_name":   true,
+		"allowed_uri_sans": "spiffe://*",
+		"key_type":         "any",
+		"max_ttl":          v.config.LeafCertTTL.String(),
+		"no_store":         true,
+		"require_cn":       false,
+	})
+
+	return err
 }
 
 func (v *VaultProvider) generateIntermediateCSR() (string, error) {
-	err := v.setupIntermediatePKIPath()
-	if err != nil {
-		return "", err
-	}
-
 	// Generate a new intermediate CSR for the root to sign.
 	uid, err := connect.CompactUID()
 	if err != nil {
@@ -465,10 +456,6 @@ func (v *VaultProvider) SetIntermediate(intermediatePEM, rootPEM string) error {
 
 // ActiveIntermediate returns the current intermediate certificate.
 func (v *VaultProvider) ActiveIntermediate() (string, error) {
-	if err := v.setupIntermediatePKIPath(); err != nil {
-		return "", err
-	}
-
 	cert, err := v.getCA(v.config.IntermediatePKINamespace, v.config.IntermediatePKIPath)
 
 	// This error is expected when calling initializeSecondaryCA for the
@@ -728,6 +715,19 @@ func (v *VaultProvider) mountNamespaced(namespace, path string, mountInfo *vault
 	defer v.setNamespace(namespace)()
 	r := v.client.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s", path))
 	if err := r.SetJSONBody(mountInfo); err != nil {
+		return err
+	}
+	resp, err := v.client.RawRequest(r)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	return err
+}
+
+func (v *VaultProvider) tuneMountNamespaced(namespace, path string, mountConfig *vaultapi.MountConfigInput) error {
+	defer v.setNamespace(namespace)()
+	r := v.client.NewRequest("POST", fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
+	if err := r.SetJSONBody(mountConfig); err != nil {
 		return err
 	}
 	resp, err := v.client.RawRequest(r)

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -442,10 +442,6 @@ func (c CommonCAProviderConfig) Validate() error {
 		return nil
 	}
 
-	// todo(kyhavlov): should we output some kind of warning here (or in a Warnings() func)
-	// if the intermediate TTL is set in a secondary DC? allowing it to be set and do nothing
-	// seems bad.
-
 	// it's sufficient to check that the root cert ttl >= intermediate cert ttl
 	// since intermediate cert ttl >= 3* leaf cert ttl; so root cert ttl >= 3 * leaf cert ttl > leaf cert ttl
 	if c.RootCertTTL < c.IntermediateCertTTL {

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -382,9 +382,12 @@ func (c *CAConfiguration) GetCommonConfig() (*CommonCAProviderConfig, error) {
 }
 
 type CommonCAProviderConfig struct {
-	LeafCertTTL         time.Duration
+	LeafCertTTL time.Duration
+	RootCertTTL time.Duration
+
+	// IntermediateCertTTL is only valid in the primary datacenter, and determines
+	// the duration that any signed intermediates are valid for.
 	IntermediateCertTTL time.Duration
-	RootCertTTL         time.Duration
 
 	SkipValidate bool
 
@@ -438,6 +441,10 @@ func (c CommonCAProviderConfig) Validate() error {
 	if c.SkipValidate {
 		return nil
 	}
+
+	// todo(kyhavlov): should we output some kind of warning here (or in a Warnings() func)
+	// if the intermediate TTL is set in a secondary DC? allowing it to be set and do nothing
+	// seems bad.
 
 	// it's sufficient to check that the root cert ttl >= intermediate cert ttl
 	// since intermediate cert ttl >= 3* leaf cert ttl; so root cert ttl >= 3 * leaf cert ttl > leaf cert ttl

--- a/website/content/partials/http_api_connect_ca_common_options.mdx
+++ b/website/content/partials/http_api_connect_ca_common_options.mdx
@@ -43,6 +43,15 @@ The following configuration options are supported by all CA providers:
 
   For the Vault provider, this value is only used if the backend is not initialized at first.
 
+- `IntermediateCertTTL` / `intermediate_cert_ttl` (`duration: "8760h"`) The time to live (TTL) for
+  any intermediate certificates signed by root certificate of the primary datacenter. *This field is only
+  valid in the primary datacenter*.
+  Defaults to 1 year as `8760h`.
+
+  This setting applies to all Consul CA providers.
+
+  For the Vault provider, this value is only used if the backend is not initialized at first.
+
 - `PrivateKeyType` / `private_key_type` (`string: "ec"`) - The type of key to generate
   for this CA. This is only used when the provider is generating a new key. If
   `private_key` is set for the Consul provider, or existing root or intermediate


### PR DESCRIPTION
This PR has a couple changes related to CA provider configuration:
- Update the docs to clarify that `IntermediateCertTTL` is only valid in the primary datacenter, as that's where the intermediates are signed. It isn't used at all in the secondary DCs.
- Update the Vault provider to update the intermediate PKI mount and role when `Configure()` is called. Previously these values were only set on creation of the mount/role and then any updates to the CA config were not reflected in Vault. 