### PR TITLE
ui: update tab nav steps to use `isVisible` vs `clickable`

### DIFF
--- a/ui/packages/consul-ui/app/components/tab-nav/pageobject.js
+++ b/ui/packages/consul-ui/app/components/tab-nav/pageobject.js
@@ -1,4 +1,4 @@
-import { is, clickable, attribute } from 'ember-cli-page-object';
+import { is, clickable, attribute, isVisible } from 'ember-cli-page-object';
 import ucfirst from 'consul-ui/utils/ucfirst';
 export default function(name, items, blankKey = 'all') {
   return items.reduce(function(prev, item, i, arr) {
@@ -19,6 +19,7 @@ export default function(name, items, blankKey = 'all') {
         [`${key}IsSelected`]: is('.selected', `[data-test-tab="${name}_${item}"]`),
         [`${key}Url`]: attribute('href', `[data-test-tab="${name}_${item}"] a`),
         [key]: clickable(`[data-test-tab="${name}_${item}"] a`),
+        [`${key}IsVisible`]: isVisible(`[data-test-tab="${name}_${item}"] a`),
       },
     };
   }, {});

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/show.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/show.feature
@@ -54,10 +54,10 @@ Feature: dc / nodes / show: Show node
       node: node-0
     ---
     And I see serviceInstancesIsSelected on the tabs
-    And I see healthChecks on the tabs
-    And I see serviceInstances on the tabs
+    And I see healthChecksIsVisible on the tabs
+    And I see serviceInstancesIsVisible on the tabs
     And I don't see roundTripTime on the tabs
-    And I see lockSessions on the tabs
+    And I see lockSessionsIsVisible on the tabs
   Scenario: A node warns when deregistered whilst blocking
     Given 1 node model from yaml
     ---

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/instances/exposed-paths.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/instances/exposed-paths.feature
@@ -33,7 +33,7 @@ Feature: dc / services / instances / Exposed Paths
       id: service-0-with-id
     ---
     Then the url should be /dc1/services/service-0/instances/node-0/service-0-with-id/health-checks
-    And I see exposedPaths on the tabs
+    And I see exposedPathsIsVisible on the tabs
 
     When I click exposedPaths on the tabs
 

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/instances/upstreams.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/instances/upstreams.feature
@@ -33,7 +33,7 @@ Feature: dc / services / instances / Upstreams
       id: service-0-with-id
     ---
     Then the url should be /dc1/services/service-0/instances/node-0/service-0-with-id/health-checks
-    And I see upstreams on the tabs
+    And I see upstreamsIsVisible on the tabs
 
     When I click upstreams on the tabs
 

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show-routing.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show-routing.feature
@@ -15,7 +15,7 @@ Feature: dc / services / show-routing: Show Routing for Service
       service: service-0
     ---
     And the title should be "service-0 - Consul"
-    And I see routing on the tabs
+    And I see routingIsVisible on the tabs
   Scenario: Given connect is disabled, the Routing tab should not display or error
     Given 2 datacenter models from yaml
     ---
@@ -51,7 +51,7 @@ Feature: dc / services / show-routing: Show Routing for Service
       dc: dc2
       service: service-1
     ---
-    And I see routing on the tabs
+    And I see routingIsVisible on the tabs
     And I visit the service page for yaml
     ---
       dc: dc1

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show-topology.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show-topology.feature
@@ -14,7 +14,7 @@ Feature: dc / services / show-topology: Show Topology tab for Service
       dc: dc1
       service: service-0
     ---
-    And I see topology on the tabs
+    And I see topologyIsVisible on the tabs
     Then the url should be /dc1/services/service-0/topology
   Scenario: Given connect is disabled, the Topology tab should not display or error
     Given 1 datacenter model with the value "dc1"

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/intentions/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/intentions/index.feature
@@ -38,7 +38,7 @@ Feature: dc / services / show / intentions / index: Intentions per service
       service: service-0
     ---
     And the title should be "service-0 - Consul"
-    And I see intentions on the tabs
+    And I see intentionsIsVisible on the tabs
     When I click intentions on the tabs
     And I see intentionsIsSelected on the tabs
   Scenario: I can see intentions

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/services.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/services.feature
@@ -16,7 +16,7 @@ Feature: dc / services / show / services
       service: terminating-gateway-1
     ---
     And the title should be "terminating-gateway-1 - Consul"
-    And I see linkedServices on the tabs
+    And I see linkedServicesIsVisible on the tabs
     When I click linkedServices on the tabs
     And I see linkedServicesIsSelected on the tabs
   Scenario: Seeing the list of Linked Services

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/tags.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/tags.feature
@@ -19,7 +19,7 @@ Feature: dc / services / show / tags
       dc: dc1
       service: service
     ---
-    And I see tags on the tabs
+    And I see tagsIsVisible on the tabs
     When I click tags on the tabs
     And I see tagsIsSelected on the tabs
     And I see 3 tag models on the tabs.tagsTab component
@@ -42,7 +42,7 @@ Feature: dc / services / show / tags
       dc: dc1
       service: service
     ---
-    And I see tags on the tabs
+    And I see tagsIsVisible on the tabs
     When I click tags on the tabs
     And I see tagsIsSelected on the tabs
     And I see 3 tag models on the tabs.tagsTab component

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/topology/routing-config.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/topology/routing-config.feature
@@ -24,7 +24,7 @@ Feature: dc / services / show / topology / routing-config
       dc: dc1
       service: service-0
     ---
-    And I see topology on the tabs
+    And I see topologyIsVisible on the tabs
   Scenario: Given the Source is routing config, show Source Type
     Then I see the text "Routing configuration" in "[data-test-topology-metrics-source-type]"
   Scenario: Given the Source is routing config, redirect to Routing Config page

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/topology/stats.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/topology/stats.feature
@@ -14,7 +14,7 @@ Feature: dc / services / show / topology / stats
       dc: dc1
       service: service-0
     ---
-    And I see topology on the tabs
+    And I see topologyIsVisible on the tabs
     And I don't see the "[data-test-topology-metrics-stats]" element
   Scenario: Given metrics is enabled, the Topology tab should display metrics
     Given 1 datacenter model with the value "dc1"
@@ -31,7 +31,7 @@ Feature: dc / services / show / topology / stats
       dc: dc1
       service: service-0
     ---
-    And I see topology on the tabs
+    And I see topologyIsVisible on the tabs
     And I see the "[data-test-topology-metrics-stats]" element
   Scenario: Given metrics is enabled, metrics stats are disabled for an ingress gateway Topology
     Given 1 datacenter model with the value "dc1"
@@ -49,7 +49,7 @@ Feature: dc / services / show / topology / stats
       dc: dc1
       service: ingress-gateway
     ---
-    And I see topology on the tabs
+    And I see topologyIsVisible on the tabs
     And I don't see the "[data-test-topology-metrics-stats]" element
     And I see the "[data-test-topology-metrics-status]" element
   Scenario: Given metrics is enabled, metric stats are disabled for ingress gateway as downstream services
@@ -77,7 +77,7 @@ Feature: dc / services / show / topology / stats
       dc: dc1
       service: service-0
     ---
-    And I see topology on the tabs
+    And I see topologyIsVisible on the tabs
     And I see the "[data-test-sparkline]" element
     And I don't see the "[data-test-topology-metrics-downstream-stats]" element
 

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show/upstreams.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show/upstreams.feature
@@ -16,7 +16,7 @@ Feature: dc / services / show / upstreams
       service: ingress-gateway-1
     ---
     And the title should be "ingress-gateway-1 - Consul"
-    And I see upstreams on the tabs
+    And I see upstreamsIsVisible on the tabs
     When I click upstreams on the tabs
     And I see upstreamsIsSelected on the tabs
   Scenario: Seeing the list of Upstreams


### PR DESCRIPTION
### Description
Change tests that check visibility of tabs to not click, but only check for visibility via `isVisible`.

The tests changed in this PR accidentally clicked the tab because the page-object method being used was `clickable`, although we were only interested in checking for their visibility.

This should get rid of some recent occurred flakiness after upgrading ember-qunit et al.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
