### PR TITLE
ui: When peerings are enabled add a HTML.class to tell the UI CSS

### DIFF
--- a/ui/packages/consul-ui/app/templates/application.hbs
+++ b/ui/packages/consul-ui/app/templates/application.hbs
@@ -16,6 +16,9 @@ as |route|>
 {{#if (can "use partitions")}}
   {{document-attrs class="has-partitions"}}
 {{/if}}
+{{#if (can "use peers")}}
+  {{document-attrs class="has-peerings"}}
+{{/if}}
 
 {{! Listen out for blocking query/client setting changes }}
 <DataSource


### PR DESCRIPTION
### Description
Whilst working on some upgrades with @LevelbossMike we noticed that a HTML class was missing for when peerings was enabled. This adds that class so it is consistent with other larger feature flagged features and available if/when needed.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
