### PR TITLE
Add endpoint to query peering health

### DIFF
--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -353,6 +353,8 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 
 		if err != nil {
 			status.TrackSendError(err.Error())
+		} else {
+			status.TrackSendSuccess()
 		}
 		return err
 	}

--- a/agent/grpc-external/services/peerstream/stream_tracker.go
+++ b/agent/grpc-external/services/peerstream/stream_tracker.go
@@ -214,6 +214,9 @@ type Status struct {
 	// LastSendErrorMessage tracks the last error message when sending into the stream.
 	LastSendErrorMessage string
 
+	// LastSendSuccess tracks the time we last successfully sent a resource TO the peer.
+	LastSendSuccess time.Time
+
 	// LastRecvHeartbeat tracks when we last received a heartbeat from our peer.
 	LastRecvHeartbeat time.Time
 
@@ -268,6 +271,12 @@ func (s *MutableStatus) TrackSendError(error string) {
 	s.mu.Lock()
 	s.LastSendError = s.timeNow().UTC()
 	s.LastSendErrorMessage = error
+	s.mu.Unlock()
+}
+
+func (s *MutableStatus) TrackSendSuccess() {
+	s.mu.Lock()
+	s.LastSendSuccess = s.timeNow().UTC()
 	s.mu.Unlock()
 }
 

--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -103,9 +103,10 @@ func init() {
 	registerEndpoint("/v1/operator/autopilot/configuration", []string{"GET", "PUT"}, (*HTTPHandlers).OperatorAutopilotConfiguration)
 	registerEndpoint("/v1/operator/autopilot/health", []string{"GET"}, (*HTTPHandlers).OperatorServerHealth)
 	registerEndpoint("/v1/operator/autopilot/state", []string{"GET"}, (*HTTPHandlers).OperatorAutopilotState)
+	registerEndpoint("/v1/peering/", []string{"GET", "DELETE"}, (*HTTPHandlers).PeeringEndpoint)
 	registerEndpoint("/v1/peering/token", []string{"POST"}, (*HTTPHandlers).PeeringGenerateToken)
 	registerEndpoint("/v1/peering/establish", []string{"POST"}, (*HTTPHandlers).PeeringEstablish)
-	registerEndpoint("/v1/peering/", []string{"GET", "DELETE"}, (*HTTPHandlers).PeeringEndpoint)
+	registerEndpoint("/v1/peering-health/", []string{"GET"}, (*HTTPHandlers).PeeringHealth)
 	registerEndpoint("/v1/peerings", []string{"GET"}, (*HTTPHandlers).PeeringList)
 	registerEndpoint("/v1/query", []string{"GET", "POST"}, (*HTTPHandlers).PreparedQueryGeneral)
 	// specific prepared query endpoints have more complex rules for allowed methods, so

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2943,3 +2943,32 @@ func TimeToProto(s time.Time) *timestamp.Timestamp {
 func IsZeroProtoTime(t *timestamp.Timestamp) bool {
 	return t.Seconds == 0 && t.Nanos == 0
 }
+
+// PeerSpecificRequest is used to request the information about a single peer.
+type PeerSpecificRequest struct {
+	PeerName string
+
+	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
+	QueryOptions
+}
+
+func (r *PeerSpecificRequest) RequestDatacenter() string {
+	return ""
+}
+
+type PeeringHealthResponse struct {
+	Health PeeringHealth
+
+	QueryMeta
+}
+
+type PeeringHealth struct {
+	State string // matches pbpeering.PeeringState
+
+	// LastHeartbeat represents when the last heartbeat message was received.
+	LastHeartbeat time.Time
+	// LastReceive represents when any message was last received, regardless of success or error.
+	LastReceive time.Time
+	// LastSend represents when any message was last sent, regardless of success or error.
+	LastSend time.Time
+}


### PR DESCRIPTION
### Description
The UI needs an endpoint to query for a given peering stream's health.

Originally I thought it should be internal but wondering if it's valuable to expose publicly since we have no API for that.

Request:
```json
{
  "PeerName": "foo",
  "Partition": "ap1"
}
```

Response:
```json
{
  "State": <currently string form of our enums>
  "LastHeartBeat": <timestamp>
  "LastReceived": <timestamp>
  "LastSent": <timestamp>
}
```

@johncowen I wasn't sure if it was easier for frontend to parse our int-based enums or use strings. Currently we output strings based on https://github.com/hashicorp/consul/blob/09c0fe22f22c274e2005659288c0698b1536532e/proto/pbpeering/peering.pb.go#L53-L59

### Testing & Reproduction steps
* Added test cases


### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated <-TODO
* [x] not a security concern
