### PR TITLE
PR #14057 follow up fix: service id parsing from sidecar id

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2572,7 +2572,7 @@ func (a *Agent) removeServiceLocked(serviceID structs.ServiceID, persist bool) e
 }
 
 func (a *Agent) removeServiceSidecars(serviceID structs.ServiceID, persist bool) error {
-	sidecarSID := structs.NewServiceID(sidecarServiceID(serviceID.ID), &serviceID.EnterpriseMeta)
+	sidecarSID := structs.NewServiceID(sidecarIDFromServiceID(serviceID.ID), &serviceID.EnterpriseMeta)
 	if sidecar := a.State.Service(sidecarSID); sidecar != nil {
 		// Double check that it's not just an ID collision and we actually added
 		// this from a sidecar.

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -10,31 +10,15 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-const sidecarIDSuffix string = "-sidecar-proxy"
+const sidecarIDSuffix = "-sidecar-proxy"
 
 func sidecarIDFromServiceID(serviceID string) string {
 	return serviceID + sidecarIDSuffix
 }
 
 // reverses the sidecarIDFromServiceID operation
-func serviceIDFromSidecarID(sidecarServiceID string) string {
-	// we only want to un-append "-sidecar-proxy" from the very end
-	// so we reverse the string, remove only the first suffix match
-	// and then reverse the string again to get the result
-	revID := ""
-	for _, v := range sidecarServiceID {
-		revID = string(v) + revID
-	}
-	revSuffix := ""
-	for _, v := range sidecarIDSuffix {
-		revSuffix = string(v) + revSuffix
-	}
-	revSvcID := strings.Replace(revID, revSuffix, "", 1)
-	serviceID := ""
-	for _, v := range revSvcID {
-		serviceID = string(v) + serviceID
-	}
-	return serviceID
+func serviceIDFromSidecarID(sidecarID string) string {
+	return strings.TrimSuffix(sidecarID, sidecarIDSuffix)
 }
 
 // sidecarServiceFromNodeService returns a *structs.NodeService representing a


### PR DESCRIPTION
Follow up to PR #14057

### Description
PR #14057 introduced a bug where a function to extract the serviceID from the sidecarServiceID did not precisely undo the append operation that was used to generate the sidecarServiceID. Submitting a sidecar registration for a service with a hyphen in the ID string creates an incorrect default alias check. This PR changes the serviceIDFromSidecarID function to exactly undo the function as intended.

### Testing & Reproduction steps
* Register a service with a hyphenated name, accompanied by the unexpanded default sidecar syntax. The default sidecar alias check should correctly identify the service and pass (previously would fail).

### PR Checklist

* [x] updated test coverage
* [x] not a security concern
