### PR TITLE
[docs] use values.yaml instead of config.yaml everywhere for helm configurations

### DIFF
--- a/website/content/docs/k8s/connect/connect-ca-provider.mdx
+++ b/website/content/docs/k8s/connect/connect-ca-provider.mdx
@@ -98,7 +98,7 @@ $ kubectl create secret generic vault-config --from-file=config=vault-config.jso
 We will provide this secret and the Vault CA secret, to the Consul server via the
 `server.extraVolumes` Helm value.
 
-<CodeBlockConfig filename="config.yaml" highlight="4-13">
+<CodeBlockConfig filename="values.yaml" highlight="4-13">
 
   ```yaml
   global:
@@ -123,7 +123,7 @@ We will provide this secret and the Vault CA secret, to the Consul server via th
 Finally, [install](/docs/k8s/installation/install#installing-consul) the Helm chart using the above config file:
 
 ```shell-session
-$ helm install consul --values config.yaml hashicorp/consul
+$ helm install consul --values values.yaml hashicorp/consul
 ```
 
 Verify that the CA provider is set correctly:

--- a/website/content/docs/k8s/connect/ingress-gateways.mdx
+++ b/website/content/docs/k8s/connect/ingress-gateways.mdx
@@ -26,7 +26,7 @@ Adding an ingress gateway is a multi-step process that consists of the following
 
 When deploying the Helm chart you must provide Helm with a custom YAML file that contains your environment configuration.
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -260,7 +260,7 @@ leaving an open and unauthenticated load balancer alive in your cluster.
 
 To delete the ingress gateway, set enabled to `false` in your Helm configuration:
 
-<CodeBlockConfig filename="config.yaml" highlight="8">
+<CodeBlockConfig filename="values.yaml" highlight="8">
 
 ```yaml
 global:
@@ -282,5 +282,5 @@ ingressGateways:
 And run Helm upgrade:
 
 ```shell-session
-$ helm upgrade consul hashicorp/consul --values config.yaml
+$ helm upgrade consul hashicorp/consul --values values.yaml
 ```

--- a/website/content/docs/k8s/connect/terminating-gateways.mdx
+++ b/website/content/docs/k8s/connect/terminating-gateways.mdx
@@ -23,7 +23,7 @@ Adding a terminating gateway is a multi-step process:
 
 Minimum required Helm options:
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -43,7 +43,7 @@ terminatingGateways:
 The Helm chart may be deployed using the [Consul on Kubernetes CLI](/docs/k8s/k8s-cli).
 
 ```shell-session
-$ consul-k8s install -f config.yaml
+$ consul-k8s install -f values.yaml
 ```
 
 ## Accessing the Consul agent

--- a/website/content/docs/k8s/deployment-configurations/consul-enterprise.mdx
+++ b/website/content/docs/k8s/deployment-configurations/consul-enterprise.mdx
@@ -21,9 +21,9 @@ kubectl create secret generic consul-ent-license --from-literal="key=${secret}"
 
 -> **Note:** If you cannot find your `.hclic` file, please contact your sales team or Technical Account Manager.
 
-In your `config.yaml`, change the value of `global.image` to one of the enterprise [release tags](https://hub.docker.com/r/hashicorp/consul-enterprise/tags).
+In your `values.yaml`, change the value of `global.image` to one of the enterprise [release tags](https://hub.docker.com/r/hashicorp/consul-enterprise/tags).
 
-<CodeBlockConfig filename="config.yaml" highlight="2">
+<CodeBlockConfig filename="values.yaml" highlight="2">
 
 ```yaml
 global:
@@ -34,7 +34,7 @@ global:
 
 Add the name and key of the secret you just created to `server.enterpriseLicense`, if using Consul version 1.10+.
 
-<CodeBlockConfig filename="config.yaml" highlight="4-6">
+<CodeBlockConfig filename="values.yaml" highlight="4-6">
 
 ```yaml
 global:
@@ -51,7 +51,7 @@ If the version of Consul is < 1.10, use the following config with the name and k
 
 -> **Note:** The value of `server.enterpriseLicense.enableLicenseAutoload` must be set to `false`.
 
-<CodeBlockConfig filename="config.yaml" highlight="7">
+<CodeBlockConfig filename="values.yaml" highlight="7">
 
 ```yaml
 global:
@@ -67,7 +67,7 @@ global:
 Now run `helm install`:
 
 ```shell-session
-$ helm install --wait hashicorp hashicorp/consul --values config.yaml
+$ helm install --wait hashicorp hashicorp/consul --values values.yaml
 ```
 
 Once the cluster is up, you can verify the nodes are running Consul Enterprise by

--- a/website/content/docs/k8s/deployment-configurations/multi-cluster/kubernetes.mdx
+++ b/website/content/docs/k8s/deployment-configurations/multi-cluster/kubernetes.mdx
@@ -31,10 +31,10 @@ If you haven't installed Consul on your cluster, continue reading below. If you'
 already installed Consul on a cluster and want to upgrade it to
 support federation, see [Upgrading An Existing Cluster](#upgrading-an-existing-cluster).
 
-You will need to use the following `config.yaml` file for your primary cluster,
+You will need to use the following `values.yaml` file for your primary cluster,
 with the possible modifications listed below.
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -114,7 +114,7 @@ Modifications:
    mesh gateway, for example using a Node Port service or a custom DNS entry,
    see the [Helm reference](/docs/k8s/helm#v-meshgateway) for that setting.
 
-With your `config.yaml` ready to go, follow our [Installation Guide](/docs/k8s/installation/install)
+With your `values.yaml` ready to go, follow our [Installation Guide](/docs/k8s/installation/install)
 to install Consul on your primary cluster.
 
 -> **NOTE:** You must be using consul-helm 0.21.0+. To update, run `helm repo update`.
@@ -124,7 +124,7 @@ to install Consul on your primary cluster.
 If you have an existing cluster, you will need to upgrade it to ensure it has
 the following config:
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -316,7 +316,7 @@ With the primary cluster up and running, and the [federation secret](#federation
 into the secondary cluster, we can now install Consul into the secondary
 cluster.
 
-You will need to use the following `config.yaml` file for your secondary cluster(s),
+You will need to use the following `values.yaml` file for your secondary cluster(s),
 with the modifications listed below.
 
 -> **NOTE: ** You must use a separate Helm config file for each cluster (primary and secondaries) since their
@@ -414,7 +414,7 @@ Modifications:
    mesh gateway, for example using a Node Port service or a custom DNS entry,
    see the [Helm reference](/docs/k8s/helm#v-meshgateway) for that setting.
 
-With your `config.yaml` ready to go, follow our [Installation Guide](/docs/k8s/installation/install)
+With your `values.yaml` ready to go, follow our [Installation Guide](/docs/k8s/installation/install)
 to install Consul on your secondary cluster(s).
 
 ## Verifying Federation

--- a/website/content/docs/k8s/deployment-configurations/servers-outside-kubernetes.mdx
+++ b/website/content/docs/k8s/deployment-configurations/servers-outside-kubernetes.mdx
@@ -9,7 +9,7 @@ description: Running Consul servers outside of Kubernetes
 If you have a Consul cluster already running, you can configure your
 Consul clients inside Kubernetes to join this existing cluster.
 
-The below `config.yaml` file shows how to configure the Helm chart to install
+The below `values.yaml` file shows how to configure the Helm chart to install
 Consul clients that will join an existing cluster.
 
 The `global.enabled` value first disables all chart components by default
@@ -27,7 +27,7 @@ example above, a fake [cloud auto-join](/docs/agent/cloud-auto-join)
 value is specified. This should be set to resolve to the proper addresses of
 your existing Consul cluster.
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -66,7 +66,7 @@ If you would like to use this feature with external Consul servers, you need to 
 so that it can retrieve the clients' CA to use for securing the rest of the cluster.
 To do that, you must add the following values, in addition to the values mentioned above:
 
-<CodeBlockConfig filename="config.yaml" highlight="2-8">
+<CodeBlockConfig filename="values.yaml" highlight="2-8">
 
 ```yaml
 global:
@@ -106,7 +106,7 @@ kubectl create secret generic bootstrap-token --from-literal='token=<your bootst
 
 Then provide that secret to the Helm chart:
 
-<CodeBlockConfig filename="config.yaml" highlight="4-6">
+<CodeBlockConfig filename="values.yaml" highlight="4-6">
 
 ```yaml
 global:
@@ -131,7 +131,7 @@ to create policies, tokens, and an auth method. If you are [enabling Consul Conn
 so that the Consul servers can validate a Kubernetes service account token when using the [Kubernetes auth method](/docs/security/acl/auth-methods/kubernetes)
 with `consul login`.
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 externalServers:
@@ -145,7 +145,7 @@ externalServers:
 
 Your resulting Helm configuration will end up looking similar to this:
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -176,7 +176,7 @@ externalServers:
 If you would like the Helm chart to call the bootstrapping API and set the server tokens for you, then the steps are similar.
 The only difference is that you don't need to set the bootstrap token. The Helm chart will save the bootstrap token as a Kubernetes secret.
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:

--- a/website/content/docs/k8s/deployment-configurations/single-dc-multi-k8s.mdx
+++ b/website/content/docs/k8s/deployment-configurations/single-dc-multi-k8s.mdx
@@ -6,8 +6,8 @@ description: Single Consul Datacenter deployed in multiple Kubernetes clusters
 
 # Single Consul Datacenter in Multiple Kubernetes Clusters
 
-~> **Note:** When running Consul across multiple Kubernetes clusters, we recommend using [admin partitions](/docs/enterprise/admin-partitions) for production environments. This Consul Enterprise feature allows you to accommodate multiple tenants without resource collisions when administering a cluster at scale. Admin partitions also enable you to run Consul on Kubernetes clusters across a non-flat network. 
- 
+~> **Note:** When running Consul across multiple Kubernetes clusters, we recommend using [admin partitions](/docs/enterprise/admin-partitions) for production environments. This Consul Enterprise feature allows you to accommodate multiple tenants without resource collisions when administering a cluster at scale. Admin partitions also enable you to run Consul on Kubernetes clusters across a non-flat network.
+
 This page describes deploying a single Consul datacenter in multiple Kubernetes clusters,
 with servers and clients running in one cluster and only clients in the rest of the clusters.
 This example uses two Kubernetes clusters, but this approach could be extended to using more than two.
@@ -21,7 +21,7 @@ to pods or nodes in another. In many hosted Kubernetes environments, this may ha
   * [Azure AKS CNI](https://docs.microsoft.com/en-us/azure/aks/concepts-network#azure-cni-advanced-networking)
   * [AWS EKS CNI](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html)
   * [GKE VPC-native clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips).
-* Either the Helm release name for each Kubernetes cluster must be unique, or `global.name` for each Kubernetes cluster must be unique to prevent collisions of ACL resources with the same prefix. 
+* Either the Helm release name for each Kubernetes cluster must be unique, or `global.name` for each Kubernetes cluster must be unique to prevent collisions of ACL resources with the same prefix.
 
 ## Prepare Helm release name ahead of installs
 
@@ -42,7 +42,7 @@ Before proceeding with installation, prepare the Helm release names as environme
 
 First, deploy the first cluster with Consul Servers and Clients with the example Helm configuration below.
 
-<CodeBlockConfig filename="cluster1-config.yaml">
+<CodeBlockConfig filename="cluster1-values.yaml">
 
 ```yaml
 global:
@@ -82,13 +82,13 @@ $ kubectl create secret generic consul-gossip-encryption-key --from-literal=key=
 
 Now install Consul cluster with Helm:
 ```shell-session
-$ helm install ${HELM_RELEASE_SERVER} --values cluster1-config.yaml hashicorp/consul
+$ helm install ${HELM_RELEASE_SERVER} --values cluster1-values.yaml hashicorp/consul
 ```
 
 
 Once the installation finishes and all components are running and ready, the following information needs to be extracted (using the below command) and applied to the second Kubernetes cluster.
- * The Gossip encryption key created 
- * The CA certificate generated during installation 
+ * The Gossip encryption key created
+ * The CA certificate generated during installation
  * The ACL bootstrap token generated during installation
 
 ```shell-session
@@ -112,7 +112,7 @@ $ kubectl apply --filename cluster1-credentials.yaml
 ```
 To deploy in the second cluster, the following example Helm configuration will be used:
 
-<CodeBlockConfig filename="cluster2-config.yaml" highlight="6-11,15-17">
+<CodeBlockConfig filename="cluster2-values.yaml" highlight="6-11,15-17">
 
 ```yaml
 global:
@@ -202,7 +202,7 @@ for more details.
 Now, proceed with the installation of the second cluster.
 
 ```shell-session
-$ helm install ${HELM_RELEASE_CLIENT} --values cluster2-config.yaml hashicorp/consul
+$ helm install ${HELM_RELEASE_CLIENT} --values cluster2-values.yaml hashicorp/consul
 ```
 
 ## Verifying the Consul Service Mesh works

--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -225,14 +225,14 @@ Use these links to navigate to a particular top-level stanza.
         ```
         and check the name of `metadata.name`.
 
-      - `controllerRole` ((#v-global-secretsbackend-vault-controllerrole)) (`string: ""`) - The Vault role to read Consul controller's webhook's 
+      - `controllerRole` ((#v-global-secretsbackend-vault-controllerrole)) (`string: ""`) - The Vault role to read Consul controller's webhook's
         CA and issue a certificate and private key.
-        A Vault policy must be created which grants issue capabilities to 
+        A Vault policy must be created which grants issue capabilities to
         `global.secretsBackend.vault.controller.tlsCert.secretName`.
 
       - `connectInjectRole` ((#v-global-secretsbackend-vault-connectinjectrole)) (`string: ""`) - The Vault role to read Consul connect-injector webhook's CA
         and issue a certificate and private key.
-        A Vault policy must be created which grants issue capabilities to 
+        A Vault policy must be created which grants issue capabilities to
         `global.secretsBackend.vault.connectInject.tlsCert.secretName`.
 
       - `consulCARole` ((#v-global-secretsbackend-vault-consulcarole)) (`string: ""`) - The Vault role for all Consul components to read the Consul's server's CA Certificate (unauthenticated).
@@ -295,14 +295,14 @@ Use these links to navigate to a particular top-level stanza.
 
       - `controller` ((#v-global-secretsbackend-vault-controller))
 
-        - `tlsCert` ((#v-global-secretsbackend-vault-controller-tlscert)) - Configuration to the Vault Secret that Kubernetes will use on 
+        - `tlsCert` ((#v-global-secretsbackend-vault-controller-tlscert)) - Configuration to the Vault Secret that Kubernetes will use on
           Kubernetes CRD creation, deletion, and update, to get TLS certificates
           used issued from vault to send webhooks to the controller.
 
           - `secretName` ((#v-global-secretsbackend-vault-controller-tlscert-secretname)) (`string: null`) - The Vault secret path that issues TLS certificates for controller
             webhooks.
 
-        - `caCert` ((#v-global-secretsbackend-vault-controller-cacert)) - Configuration to the Vault Secret that Kubernetes will use on 
+        - `caCert` ((#v-global-secretsbackend-vault-controller-cacert)) - Configuration to the Vault Secret that Kubernetes will use on
           Kubernetes CRD creation, deletion, and update, to get CA certificates
           used issued from vault to send webhooks to the controller.
 
@@ -311,14 +311,14 @@ Use these links to navigate to a particular top-level stanza.
 
       - `connectInject` ((#v-global-secretsbackend-vault-connectinject))
 
-        - `caCert` ((#v-global-secretsbackend-vault-connectinject-cacert)) - Configuration to the Vault Secret that Kubernetes will use on 
+        - `caCert` ((#v-global-secretsbackend-vault-connectinject-cacert)) - Configuration to the Vault Secret that Kubernetes will use on
           Kubernetes pod creation, deletion, and update, to get CA certificates
           used issued from vault to send webhooks to the ConnectInject.
 
           - `secretName` ((#v-global-secretsbackend-vault-connectinject-cacert-secretname)) (`string: null`) - The Vault secret path that contains the CA certificate for
             Connect Inject webhooks.
 
-        - `tlsCert` ((#v-global-secretsbackend-vault-connectinject-tlscert)) - Configuration to the Vault Secret that Kubernetes will use on 
+        - `tlsCert` ((#v-global-secretsbackend-vault-connectinject-tlscert)) - Configuration to the Vault Secret that Kubernetes will use on
           Kubernetes pod creation, deletion, and update, to get TLS certificates
           used issued from vault to send webhooks to the ConnectInject.
 
@@ -564,7 +564,7 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-global-openshift-enabled)) (`boolean: false`) - If true, the Helm chart will create necessary configuration for running
       its components on OpenShift.
 
-  - `consulAPITimeout` ((#v-global-consulapitimeout)) (`string: 5s`) - The time in seconds that the consul API client will wait for a response from 
+  - `consulAPITimeout` ((#v-global-consulapitimeout)) (`string: 5s`) - The time in seconds that the consul API client will wait for a response from
     the API before cancelling the request.
 
 ### server ((#h-server))
@@ -619,7 +619,7 @@ Use these links to navigate to a particular top-level stanza.
 
     Vault Secrets backend:
     If you are using Vault as a secrets backend, a Vault Policy must be created which allows `["create", "update"]`
-    capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`. 
+    capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`.
     Please see the following guide for steps to generate a compatible certificate:
     https://learn.hashicorp.com/tutorials/consul/vault-pki-consul-secure-tls
     Note: when using TLS, both the `server.serverCert` and `global.tls.caCert` which points to the CA endpoint of this PKI engine
@@ -1423,8 +1423,8 @@ Use these links to navigate to a particular top-level stanza.
       already exist, it will be created. Turning this on overrides the
       `consulDestinationNamespace` setting.
       `addK8SNamespaceSuffix` may no longer be needed if enabling this option.
-      If mirroring is enabled, avoid creating any Consul resources in the following 
-      Kubernetes namespaces, as Consul currently reserves these namespaces for 
+      If mirroring is enabled, avoid creating any Consul resources in the following
+      Kubernetes namespaces, as Consul currently reserves these namespaces for
       system use: "system", "universal", "operator", "root".
 
     - `mirroringK8SPrefix` ((#v-synccatalog-consulnamespaces-mirroringk8sprefix)) (`string: ""`) - If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
@@ -1566,7 +1566,7 @@ Use these links to navigate to a particular top-level stanza.
   - `disruptionBudget` ((#v-connectinject-disruptionbudget)) - This configures the PodDisruptionBudget (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
     for the service mesh sidecar injector.
 
-    - `enabled` ((#v-connectinject-disruptionbudget-enabled)) (`boolean: true`) - This will enable/disable registering a PodDisruptionBudget for the 
+    - `enabled` ((#v-connectinject-disruptionbudget-enabled)) (`boolean: true`) - This will enable/disable registering a PodDisruptionBudget for the
       service mesh sidecar injector. If this is enabled, it will only register the budget so long as
       the service mesh is enabled.
 
@@ -1578,7 +1578,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `cni` ((#v-connectinject-cni)) - Configures consul-cni plugin for Consul Service mesh services
 
-    - `enabled` ((#v-connectinject-cni-enabled)) (`boolean: false`) - If true, then all traffic redirection setup will use the consul-cni plugin. 
+    - `enabled` ((#v-connectinject-cni-enabled)) (`boolean: false`) - If true, then all traffic redirection setup will use the consul-cni plugin.
       Requires connectInject.enabled to also be true.
 
     - `logLevel` ((#v-connectinject-cni-loglevel)) (`string: null`) - Log level for the installer and plugin. Overrides global.logLevel
@@ -1694,7 +1694,7 @@ Use these links to navigate to a particular top-level stanza.
     which can lead to hangs. In these environments it is recommend to use "Ignore" instead.
     This setting can be safely disabled by setting to "Ignore".
 
-  - `namespaceSelector` ((#v-connectinject-namespaceselector)) (`string`) - Selector for restricting the webhook to only specific namespaces. 
+  - `namespaceSelector` ((#v-connectinject-namespaceselector)) (`string`) - Selector for restricting the webhook to only specific namespaces.
     Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
     See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
     for more details.
@@ -1750,8 +1750,8 @@ Use these links to navigate to a particular top-level stanza.
       of the same name as their k8s namespace, optionally prefixed if
       `mirroringK8SPrefix` is set below. If the Consul namespace does not
       already exist, it will be created. Turning this on overrides the
-      `consulDestinationNamespace` setting. If mirroring is enabled, avoid creating any Consul 
-      resources in the following Kubernetes namespaces, as Consul currently reserves these 
+      `consulDestinationNamespace` setting. If mirroring is enabled, avoid creating any Consul
+      resources in the following Kubernetes namespaces, as Consul currently reserves these
       namespaces for system use: "system", "universal", "operator", "root".
 
     - `mirroringK8SPrefix` ((#v-connectinject-consulnamespaces-mirroringk8sprefix)) (`string: ""`) - If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
@@ -2385,10 +2385,10 @@ Use these links to navigate to a particular top-level stanza.
 
 ## Helm Chart Examples
 
-The below `config.yaml` results in a single server Consul cluster with a `LoadBalancer` to allow external access to the UI and API.
+The below `values.yaml` results in a single server Consul cluster with a `LoadBalancer` to allow external access to the UI and API.
 
 ```yaml
-# config.yaml
+# values.yaml
 server:
   replicas: 1
   bootstrapExpect: 1
@@ -2398,12 +2398,12 @@ ui:
     type: LoadBalancer
 ```
 
-The below `config.yaml` results in a three server Consul Enterprise cluster with 100GB of storage and automatic Connect injection.
+The below `values.yaml` results in a three server Consul Enterprise cluster with 100GB of storage and automatic Connect injection.
 
 Note, this would require a secret that contains the enterprise license key.
 
 ```yaml
-# config.yaml
+# values.yaml
 global:
   image: 'hashicorp/consul-enterprise:1.4.2-ent'
 

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -78,15 +78,15 @@ mesh](https://learn.hashicorp.com/tutorials/consul/service-mesh-deploy?utm_sourc
 ## Custom installation
 
 If you want to customize your installation,
-create a `config.yaml` file to override the default settings.
+create a `values.yaml` file to override the default settings.
 You can learn what settings are available by running `helm inspect values hashicorp/consul`
 or by reading the [Helm Chart Reference](/docs/k8s/helm).
 
-### Minimal `config.yaml` for Consul service mesh
+### Minimal `values.yaml` for Consul service mesh
 
-The minimal settings to enable [Consul Service Mesh]((/docs/k8s/connect)) would be captured in the following `config.yaml` config file:
+The minimal settings to enable [Consul Service Mesh]((/docs/k8s/connect)) would be captured in the following `values.yaml` config file:
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -99,10 +99,10 @@ controller:
 
 </CodeBlockConfig>
 
-Once you've created your `config.yaml` file, run `helm install` with the `--values` flag:
+Once you've created your `values.yaml` file, run `helm install` with the `--values` flag:
 
 ```shell-session
-$ helm install consul hashicorp/consul --create-namespace --namespace consul --values config.yaml
+$ helm install consul hashicorp/consul --create-namespace --namespace consul --values values.yaml
 NAME: consul
 ...
 ```
@@ -117,11 +117,11 @@ Instead, you can enable the Consul container network interface (CNI) plugin to p
 Because the plugin is executed by the local Kubernetes kubelet, the plugin already has the elevated privileges necessary to configure the network.
 
 The Consul Helm Chart is responsible for installing the Consul CNI plugin.
-To configure the plugin to be installed, add the following configuration to your `config.yaml` file:
+To configure the plugin to be installed, add the following configuration to your `values.yaml` file:
 
 <CodeTabs tabs={[ "Reference configuration","GKE configuration" ]}>
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -136,7 +136,7 @@ connectInject:
 ```
 </CodeBlockConfig>
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -167,7 +167,7 @@ The following table describes the available CNI plugin options:
 
 By default, Consul Service Mesh is enabled on almost all namespaces (with the exception of `kube-system` and `local-path-storage`) within a Kubernetes cluster. You can restrict this to a subset of namespaces by specifying a `namespaceSelector` that matches a label attached to each namespace denoting whether to enable Consul service mesh. In order to default to enabling service mesh on select namespaces by label, the `connectInject.default` value must be set to `true`.
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -194,7 +194,7 @@ $ kubectl label namespace foo connect-inject=enabled
 Next, run `helm install` with the `--values` flag:
 
 ```shell-session
-$ helm install consul hashicorp/consul --create-namespace --namespace consul --values config.yaml
+$ helm install consul hashicorp/consul --create-namespace --namespace consul --values values.yaml
 NAME: consul
 ...
 ```

--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -196,7 +196,6 @@ Next, run `helm install` with the `--values` flag:
 ```shell-session
 $ helm install consul hashicorp/consul --create-namespace --namespace consul --values values.yaml
 NAME: consul
-...
 ```
 
 ### Update your Consul on Kubernetes configuration

--- a/website/content/docs/k8s/upgrade/index.mdx
+++ b/website/content/docs/k8s/upgrade/index.mdx
@@ -18,7 +18,7 @@ for those changes to take effect.
 
 For example, if you've installed Consul with the following:
 
-<CodeBlockConfig filename="config.yaml">
+<CodeBlockConfig filename="values.yaml">
 
 ```yaml
 global:
@@ -26,7 +26,7 @@ global:
 connectInject:
   enabled: false
 ```
-  
+
 </CodeBlockConfig>
 
 And you wish to set `connectInject.enabled` to `true`:
@@ -44,7 +44,7 @@ To update your deployment configuration using Helm, perform the following steps.
 1. Determine your current installed chart version.
 
   ```shell-session
-  $ helm list --filter consul --namespace consul 
+  $ helm list --filter consul --namespace consul
   NAME  	NAMESPACE	REVISION	UPDATED                             	STATUS  	CHART        	APP VERSION
   consul	consul   	2       	2022-02-02 21:49:45.647678 -0800 PST	deployed	consul-0.40.0	1.11.2
   ```
@@ -251,8 +251,8 @@ To initiate the upgrade:
    By default there are 3 servers, so you would set this value to `3`
 1. Set the `updateStrategy` for clients to `OnDelete`
 
-  <CodeBlockConfig filename="config.yaml">
-  
+  <CodeBlockConfig filename="values.yaml">
+
   ```yaml
   global:
     image: 'consul:123.456'
@@ -262,7 +262,7 @@ To initiate the upgrade:
     updateStrategy: |
       type: OnDelete
   ```
-  
+
   </CodeBlockConfig>
 
   The `updatePartition` value controls how many instances of the server


### PR DESCRIPTION
### Description
We have been using `values.yaml` and `config.yaml` interchangeably in our docs to describe the custom helm configurations.
This PR proposes that we use `values.yaml` to describe the helm chart configurations and use `config.yaml` in existing places where it is meant to describe other objects (like CRDs, etc).

This aligns our docs with whats in the consul-k8s repo and also what is described here: https://helm.sh/docs/chart_template_guide/values_files/

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
