### PR TITLE
docs: Fix redirect to K8s and VM multi-cluster docs

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1332,7 +1332,7 @@ module.exports = [
   {
     source: '/docs/k8s/installation/multi-cluster/vms-and-kubernetes',
     destination:
-      '/docs/k8s/deployent-configurations/multi-cluster/vms-and-kubernetes',
+      '/docs/k8s/deployment-configurations/multi-cluster/vms-and-kubernetes',
     permanent: true,
   },
   {
@@ -1465,7 +1465,7 @@ module.exports = [
   {
     source: '/docs/k8s/installation/multi-cluster/vms-and-kubernetes',
     destination:
-      '/docs/k8s/deployent-configurations/multi-cluster/vms-and-kubernetes',
+      '/docs/k8s/deployment-configurations/multi-cluster/vms-and-kubernetes',
     permanent: true,
   },
   {


### PR DESCRIPTION
### Description

This commit fixes an oversight from PR #14009 where the K8s and VMs multi-cluster docs were moved, but not redirected to the proper location.