### PR TITLE
[OSS] Validate Peering token Locality

### DIFF
--- a/.changelog/14563.txt
+++ b/.changelog/14563.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+peering: Validate peering tokens for server name conflicts
+```

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1370,6 +1370,11 @@ func (s *Server) WANMembers() []serf.Member {
 	return s.serfWAN.Members()
 }
 
+// GetPeeringBackend is a test helper.
+func (s *Server) GetPeeringBackend() peering.Backend {
+	return s.peeringBackend
+}
+
 // RemoveFailedNode is used to remove a failed node from the cluster.
 func (s *Server) RemoveFailedNode(node string, prune bool, entMeta *acl.EnterpriseMeta) error {
 	var removeFn func(*serf.Serf, string) error

--- a/agent/peering_endpoint_test.go
+++ b/agent/peering_endpoint_test.go
@@ -267,8 +267,8 @@ func TestHTTP_Peering_Establish(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		a2 := NewTestAgent(t, "")
-		testrpc.WaitForTestAgent(t, a2.RPC, "dc1")
+		a2 := NewTestAgent(t, `datacenter = "dc2"`)
+		testrpc.WaitForTestAgent(t, a2.RPC, "dc2")
 
 		bodyBytes, err := json.Marshal(&pbpeering.GenerateTokenRequest{
 			PeerName: "foo",

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -194,8 +194,6 @@ func (s *Server) GenerateToken(
 		return nil, fmt.Errorf("meta tags failed validation: %w", err)
 	}
 
-	defer metrics.MeasureSince([]string{"peering", "generate_token"}, time.Now())
-
 	resp := &pbpeering.GenerateTokenResponse{}
 	handled, err := s.ForwardRPC(&writeRequest, func(conn *grpc.ClientConn) error {
 		ctx := external.ForwardMetadataContext(ctx)
@@ -206,6 +204,8 @@ func (s *Server) GenerateToken(
 	if handled || err != nil {
 		return resp, err
 	}
+
+	defer metrics.MeasureSince([]string{"peering", "generate_token"}, time.Now())
 
 	var authzCtx acl.AuthorizerContext
 	entMeta := structs.DefaultEnterpriseMetaInPartition(req.Partition)

--- a/agent/rpc/peering/service_test.go
+++ b/agent/rpc/peering/service_test.go
@@ -345,8 +345,8 @@ func TestPeeringService_Establish_Validation(t *testing.T) {
 	}
 }
 
-// We define a valid peering by a peering that does not occur over the same server addresses
-func TestPeeringService_Establish_validPeeringInPartition(t *testing.T) {
+// Loopback peering within the same cluster/partion should throw an error
+func TestPeeringService_Establish_invalidPeeringInSamePartition(t *testing.T) {
 	// TODO(peering): see note on newTestServer, refactor to not use this
 	s := newTestServer(t, nil)
 	client := pbpeering.NewPeeringServiceClient(s.ClientConn(t))
@@ -369,12 +369,48 @@ func TestPeeringService_Establish_validPeeringInPartition(t *testing.T) {
 	require.Nil(t, respE)
 }
 
+// When tokens have the same name as the dialing cluster but are unknown by ID, we
+// should be throwing an error to note the server name conflict.
+func TestPeeringService_Establish_serverNameConflict(t *testing.T) {
+	// TODO(peering): see note on newTestServer, refactor to not use this
+	s := newTestServer(t, nil)
+	client := pbpeering.NewPeeringServiceClient(s.ClientConn(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	// Manufacture token to have the same server name but a PeerID not in the store.
+	id, err := uuid.GenerateUUID()
+	require.NoError(t, err, "could not generate uuid")
+	peeringToken := structs.PeeringToken{
+		ServerAddresses:     []string{"1.2.3.4:8502"},
+		ServerName:          s.Server.GetPeeringBackend().GetServerName(),
+		EstablishmentSecret: "foo",
+		PeerID:              id,
+	}
+
+	jsonToken, err := json.Marshal(peeringToken)
+	require.NoError(t, err, "could not marshal peering token")
+	base64Token := base64.StdEncoding.EncodeToString(jsonToken)
+
+	establishReq := &pbpeering.EstablishRequest{
+		PeerName:     "peerTwo",
+		PeeringToken: base64Token,
+	}
+
+	respE, errE := client.Establish(ctx, establishReq)
+	require.Error(t, errE)
+	require.Contains(t, errE.Error(), "conflict - peering token's server name matches the current cluster's server name")
+	require.Nil(t, respE)
+}
+
 func TestPeeringService_Establish(t *testing.T) {
 	// TODO(peering): see note on newTestServer, refactor to not use this
 	s1 := newTestServer(t, nil)
 	client1 := pbpeering.NewPeeringServiceClient(s1.ClientConn(t))
 
 	s2 := newTestServer(t, func(conf *consul.Config) {
+		conf.Datacenter = "dc2"
 		conf.GRPCPort = 5301
 	})
 	client2 := pbpeering.NewPeeringServiceClient(s2.ClientConn(t))
@@ -1070,6 +1106,7 @@ func TestPeeringService_validatePeer(t *testing.T) {
 
 	s2 := newTestServer(t, func(conf *consul.Config) {
 		conf.GRPCPort = 5301
+		conf.Datacenter = "dc2"
 	})
 	client2 := pbpeering.NewPeeringServiceClient(s2.ClientConn(t))
 

--- a/api/peering_test.go
+++ b/api/peering_test.go
@@ -51,6 +51,7 @@ func TestAPI_Peering_ACLDeny(t *testing.T) {
 		serverConfig.ACL.Enabled = true
 		serverConfig.ACL.DefaultPolicy = "deny"
 		serverConfig.Ports.GRPC = 5301
+		serverConfig.Datacenter = "dc2"
 	})
 	defer s2.Stop()
 

--- a/command/peering/establish/establish_test.go
+++ b/command/peering/establish/establish_test.go
@@ -32,11 +32,11 @@ func TestEstablishCommand(t *testing.T) {
 	acceptor := agent.NewTestAgent(t, ``)
 	t.Cleanup(func() { _ = acceptor.Shutdown() })
 
-	dialer := agent.NewTestAgent(t, ``)
+	dialer := agent.NewTestAgent(t, `datacenter = "dc2"`)
 	t.Cleanup(func() { _ = dialer.Shutdown() })
 
 	testrpc.WaitForTestAgent(t, acceptor.RPC, "dc1")
-	testrpc.WaitForTestAgent(t, dialer.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, dialer.RPC, "dc2")
 
 	acceptingClient := acceptor.Client()
 	dialingClient := dialer.Client()


### PR DESCRIPTION
### Description
Adding some additional validation when establishing a peering connection as part of enhancements around mesh gateways for peering control plane traffic. The proposed changes look for a matching server name in the token, but an unknown PeerID, which indicates this token is from another cluster with the same datacenter name. This is unsupported.

### Testing & Reproduction steps
* Unit tests + integration tests

### PR Checklist

* [X] updated test coverage
* [ ] ~external facing docs updated~
* [X] not a security concern
