### PR TITLE
Add links to reference arch in storage class helm values

### DIFF
--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -655,13 +655,18 @@ Use these links to navigate to a particular top-level stanza.
 
   - `storageClass` ((#v-server-storageclass)) (`string: null`) - The StorageClass to use for the servers' StatefulSet storage. It must be
     able to be dynamically provisioned if you want the storage
-    to be automatically created. For example, to use local
+    to be automatically created. For example, to use [local]
     (https://kubernetes.io/docs/concepts/storage/storage-classes/#local)
     storage classes, the PersistentVolumeClaims would need to be manually created.
     A `null` value will use the Kubernetes cluster's default StorageClass. If a default
     StorageClass does not exist, you will need to create one.
-    See https://www.consul.io/docs/install/performance#read-write-tuning for considerations around choosing a
-    performant storage class.
+    Refer to the [Read/Write Tuning)(https://www.consul.io/docs/install/performance#read-write-tuning) 
+    section of the Server Performance Requirements documentation for considerations 
+    around choosing a performant storage class.
+    
+      -> **Tip:** The [Reference Architecture](https://learn.hashicorp.com/tutorials/consul/reference-architecture#hardware-sizing-for-consul-servers)
+      contains best practices and recommendations for selecting suitable
+      hardware sizes for your Consul servers.
 
   - `connect` ((#v-server-connect)) (`boolean: true`) - This will enable/disable Connect (https://consul.io/docs/connect). Setting this to true
     _will not_ automatically secure pod communication, this

--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -225,14 +225,14 @@ Use these links to navigate to a particular top-level stanza.
         ```
         and check the name of `metadata.name`.
 
-      - `controllerRole` ((#v-global-secretsbackend-vault-controllerrole)) (`string: ""`) - The Vault role to read Consul controller's webhook's
+      - `controllerRole` ((#v-global-secretsbackend-vault-controllerrole)) (`string: ""`) - The Vault role to read Consul controller's webhook's 
         CA and issue a certificate and private key.
-        A Vault policy must be created which grants issue capabilities to
+        A Vault policy must be created which grants issue capabilities to 
         `global.secretsBackend.vault.controller.tlsCert.secretName`.
 
       - `connectInjectRole` ((#v-global-secretsbackend-vault-connectinjectrole)) (`string: ""`) - The Vault role to read Consul connect-injector webhook's CA
         and issue a certificate and private key.
-        A Vault policy must be created which grants issue capabilities to
+        A Vault policy must be created which grants issue capabilities to 
         `global.secretsBackend.vault.connectInject.tlsCert.secretName`.
 
       - `consulCARole` ((#v-global-secretsbackend-vault-consulcarole)) (`string: ""`) - The Vault role for all Consul components to read the Consul's server's CA Certificate (unauthenticated).
@@ -295,14 +295,14 @@ Use these links to navigate to a particular top-level stanza.
 
       - `controller` ((#v-global-secretsbackend-vault-controller))
 
-        - `tlsCert` ((#v-global-secretsbackend-vault-controller-tlscert)) - Configuration to the Vault Secret that Kubernetes will use on
+        - `tlsCert` ((#v-global-secretsbackend-vault-controller-tlscert)) - Configuration to the Vault Secret that Kubernetes will use on 
           Kubernetes CRD creation, deletion, and update, to get TLS certificates
           used issued from vault to send webhooks to the controller.
 
           - `secretName` ((#v-global-secretsbackend-vault-controller-tlscert-secretname)) (`string: null`) - The Vault secret path that issues TLS certificates for controller
             webhooks.
 
-        - `caCert` ((#v-global-secretsbackend-vault-controller-cacert)) - Configuration to the Vault Secret that Kubernetes will use on
+        - `caCert` ((#v-global-secretsbackend-vault-controller-cacert)) - Configuration to the Vault Secret that Kubernetes will use on 
           Kubernetes CRD creation, deletion, and update, to get CA certificates
           used issued from vault to send webhooks to the controller.
 
@@ -311,14 +311,14 @@ Use these links to navigate to a particular top-level stanza.
 
       - `connectInject` ((#v-global-secretsbackend-vault-connectinject))
 
-        - `caCert` ((#v-global-secretsbackend-vault-connectinject-cacert)) - Configuration to the Vault Secret that Kubernetes will use on
+        - `caCert` ((#v-global-secretsbackend-vault-connectinject-cacert)) - Configuration to the Vault Secret that Kubernetes will use on 
           Kubernetes pod creation, deletion, and update, to get CA certificates
           used issued from vault to send webhooks to the ConnectInject.
 
           - `secretName` ((#v-global-secretsbackend-vault-connectinject-cacert-secretname)) (`string: null`) - The Vault secret path that contains the CA certificate for
             Connect Inject webhooks.
 
-        - `tlsCert` ((#v-global-secretsbackend-vault-connectinject-tlscert)) - Configuration to the Vault Secret that Kubernetes will use on
+        - `tlsCert` ((#v-global-secretsbackend-vault-connectinject-tlscert)) - Configuration to the Vault Secret that Kubernetes will use on 
           Kubernetes pod creation, deletion, and update, to get TLS certificates
           used issued from vault to send webhooks to the ConnectInject.
 
@@ -564,7 +564,7 @@ Use these links to navigate to a particular top-level stanza.
     - `enabled` ((#v-global-openshift-enabled)) (`boolean: false`) - If true, the Helm chart will create necessary configuration for running
       its components on OpenShift.
 
-  - `consulAPITimeout` ((#v-global-consulapitimeout)) (`string: 5s`) - The time in seconds that the consul API client will wait for a response from
+  - `consulAPITimeout` ((#v-global-consulapitimeout)) (`string: 5s`) - The time in seconds that the consul API client will wait for a response from 
     the API before cancelling the request.
 
 ### server ((#h-server))
@@ -619,7 +619,7 @@ Use these links to navigate to a particular top-level stanza.
 
     Vault Secrets backend:
     If you are using Vault as a secrets backend, a Vault Policy must be created which allows `["create", "update"]`
-    capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`.
+    capabilities on the PKI issuing endpoint, which is usually of the form `pki/issue/consul-server`. 
     Please see the following guide for steps to generate a compatible certificate:
     https://learn.hashicorp.com/tutorials/consul/vault-pki-consul-secure-tls
     Note: when using TLS, both the `server.serverCert` and `global.tls.caCert` which points to the CA endpoint of this PKI engine
@@ -655,18 +655,18 @@ Use these links to navigate to a particular top-level stanza.
 
   - `storageClass` ((#v-server-storageclass)) (`string: null`) - The StorageClass to use for the servers' StatefulSet storage. It must be
     able to be dynamically provisioned if you want the storage
-    to be automatically created. For example, to use [local]
-    (https://kubernetes.io/docs/concepts/storage/storage-classes/#local)
+    to be automatically created. For example, to use 
+    local(https://kubernetes.io/docs/concepts/storage/storage-classes/#local)
     storage classes, the PersistentVolumeClaims would need to be manually created.
     A `null` value will use the Kubernetes cluster's default StorageClass. If a default
     StorageClass does not exist, you will need to create one.
-    Refer to the [Read/Write Tuning)(https://www.consul.io/docs/install/performance#read-write-tuning) 
+    Refer to the [Read/Write Tuning](https://www.consul.io/docs/install/performance#read-write-tuning) 
     section of the Server Performance Requirements documentation for considerations 
     around choosing a performant storage class.
-    
-      ~> **Note:** The [Reference Architecture](https://learn.hashicorp.com/tutorials/consul/reference-architecture#hardware-sizing-for-consul-servers)
-      contains best practices and recommendations for selecting suitable
-      hardware sizes for your Consul servers.
+
+    ~> **Note:** The [Reference Architecture](https://learn.hashicorp.com/tutorials/consul/reference-architecture#hardware-sizing-for-consul-servers)
+    contains best practices and recommendations for selecting suitable
+    hardware sizes for your Consul servers.
 
   - `connect` ((#v-server-connect)) (`boolean: true`) - This will enable/disable Connect (https://consul.io/docs/connect). Setting this to true
     _will not_ automatically secure pod communication, this
@@ -1428,8 +1428,8 @@ Use these links to navigate to a particular top-level stanza.
       already exist, it will be created. Turning this on overrides the
       `consulDestinationNamespace` setting.
       `addK8SNamespaceSuffix` may no longer be needed if enabling this option.
-      If mirroring is enabled, avoid creating any Consul resources in the following
-      Kubernetes namespaces, as Consul currently reserves these namespaces for
+      If mirroring is enabled, avoid creating any Consul resources in the following 
+      Kubernetes namespaces, as Consul currently reserves these namespaces for 
       system use: "system", "universal", "operator", "root".
 
     - `mirroringK8SPrefix` ((#v-synccatalog-consulnamespaces-mirroringk8sprefix)) (`string: ""`) - If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace
@@ -1571,7 +1571,7 @@ Use these links to navigate to a particular top-level stanza.
   - `disruptionBudget` ((#v-connectinject-disruptionbudget)) - This configures the PodDisruptionBudget (https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
     for the service mesh sidecar injector.
 
-    - `enabled` ((#v-connectinject-disruptionbudget-enabled)) (`boolean: true`) - This will enable/disable registering a PodDisruptionBudget for the
+    - `enabled` ((#v-connectinject-disruptionbudget-enabled)) (`boolean: true`) - This will enable/disable registering a PodDisruptionBudget for the 
       service mesh sidecar injector. If this is enabled, it will only register the budget so long as
       the service mesh is enabled.
 
@@ -1583,7 +1583,7 @@ Use these links to navigate to a particular top-level stanza.
 
   - `cni` ((#v-connectinject-cni)) - Configures consul-cni plugin for Consul Service mesh services
 
-    - `enabled` ((#v-connectinject-cni-enabled)) (`boolean: false`) - If true, then all traffic redirection setup will use the consul-cni plugin.
+    - `enabled` ((#v-connectinject-cni-enabled)) (`boolean: false`) - If true, then all traffic redirection setup will use the consul-cni plugin. 
       Requires connectInject.enabled to also be true.
 
     - `logLevel` ((#v-connectinject-cni-loglevel)) (`string: null`) - Log level for the installer and plugin. Overrides global.logLevel
@@ -1699,7 +1699,7 @@ Use these links to navigate to a particular top-level stanza.
     which can lead to hangs. In these environments it is recommend to use "Ignore" instead.
     This setting can be safely disabled by setting to "Ignore".
 
-  - `namespaceSelector` ((#v-connectinject-namespaceselector)) (`string`) - Selector for restricting the webhook to only specific namespaces.
+  - `namespaceSelector` ((#v-connectinject-namespaceselector)) (`string`) - Selector for restricting the webhook to only specific namespaces. 
     Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
     See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
     for more details.
@@ -1755,8 +1755,8 @@ Use these links to navigate to a particular top-level stanza.
       of the same name as their k8s namespace, optionally prefixed if
       `mirroringK8SPrefix` is set below. If the Consul namespace does not
       already exist, it will be created. Turning this on overrides the
-      `consulDestinationNamespace` setting. If mirroring is enabled, avoid creating any Consul
-      resources in the following Kubernetes namespaces, as Consul currently reserves these
+      `consulDestinationNamespace` setting. If mirroring is enabled, avoid creating any Consul 
+      resources in the following Kubernetes namespaces, as Consul currently reserves these 
       namespaces for system use: "system", "universal", "operator", "root".
 
     - `mirroringK8SPrefix` ((#v-connectinject-consulnamespaces-mirroringk8sprefix)) (`string: ""`) - If `mirroringK8S` is set to true, `mirroringK8SPrefix` allows each Consul namespace

--- a/website/content/docs/k8s/helm.mdx
+++ b/website/content/docs/k8s/helm.mdx
@@ -664,7 +664,7 @@ Use these links to navigate to a particular top-level stanza.
     section of the Server Performance Requirements documentation for considerations 
     around choosing a performant storage class.
     
-      -> **Tip:** The [Reference Architecture](https://learn.hashicorp.com/tutorials/consul/reference-architecture#hardware-sizing-for-consul-servers)
+      ~> **Note:** The [Reference Architecture](https://learn.hashicorp.com/tutorials/consul/reference-architecture#hardware-sizing-for-consul-servers)
       contains best practices and recommendations for selecting suitable
       hardware sizes for your Consul servers.
 


### PR DESCRIPTION
### Description
Add links to reference arch in storage class helm values. 

> Most customers are using default values for storageclass for Consul helm chart which is not suitable for running enterprise workloads and since Consul is write limited by disk I/O  and as per reference architecture it needs disk with minimum of 3000+ IOPS ( even for Dev clusters) this can result in performance issues.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
