### PR TITLE
ui: Remove ember-cli-uglify config

### DIFF
--- a/ui/packages/consul-ui/ember-cli-build.js
+++ b/ui/packages/consul-ui/ember-cli-build.js
@@ -161,13 +161,6 @@ module.exports = function (defaults, $ = process.env) {
           'mode/loadmode.js',
         ],
       },
-      'ember-cli-uglify': {
-        uglify: {
-          compress: {
-            keep_fargs: false,
-          },
-        },
-      },
       sassOptions: {
         implementation: require('sass'),
         sourceMapEmbed: sourcemaps,


### PR DESCRIPTION
### Description
In https://github.com/hashicorp/consul/pull/14518 we have upgrade ember to 3.24, this included switching from uglify to terser for JS minification etc, so we need to remove this config to prevent the following warning now that the config doesn't do anything:

<img width="529" alt="Screenshot 2022-09-13 at 10 49 37" src="https://user-images.githubusercontent.com/554604/189873043-0e64dee9-4858-4e90-a908-400471f301ba.png">

I had a quick look to see if there is an equivalent config for terser and there doesn't seem to be.

Note the base branch for this is for https://github.com/hashicorp/consul/pull/14518, I know @LevelbossMike is AFK so I thought it would be best to branch off and make this tiny amend here.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
