### PR TITLE
ui: During testing ensure that when ui-only feature flags are mocked to true they can be re-mocked to false

### DIFF
--- a/ui/packages/consul-ui/app/utils/get-environment.js
+++ b/ui/packages/consul-ui/app/utils/get-environment.js
@@ -282,10 +282,12 @@ export default function(config = {}, win = window, doc = document) {
       case 'CONSUL_SERVICE_DASHBOARD_URL':
       case 'CONSUL_BASE_UI_URL':
       case 'CONSUL_HTTP_PROTOCOL':
-      case 'CONSUL_HTTP_MAX_CONNECTIONS':
+      case 'CONSUL_HTTP_MAX_CONNECTIONS': {
         // We allow the operator to set these ones via various methods
         // although UI developer config is preferred
-        return ui(str) || operator(str, env);
+        const _ui = ui(str);
+        return typeof _ui !== 'undefined' ? _ui : operator(str, env);
+      }
       default:
         return ui(str);
     }

--- a/ui/packages/consul-ui/tests/unit/utils/get-environment-test.js
+++ b/ui/packages/consul-ui/tests/unit/utils/get-environment-test.js
@@ -207,4 +207,17 @@ module('Unit | Utility | getEnvironment', function() {
     env = getEnvironment(config, win, doc);
     assert.ok(env('CONSUL_NSPACES_ENABLED'));
   });
+  test('it returns the correct dev value when already set via config and is reset to false', function(assert) {
+    const config = {
+      environment: 'test',
+    };
+    const doc = {
+      cookie: 'CONSUL_ACLS_ENABLE=0',
+      getElementsByTagName: makeGetElementsBy(''),
+      getElementsByName: makeGetElementsBy('{}'),
+      querySelector: () => makeOperatorConfig({ ACLsEnabled: true }),
+    };
+    let env = getEnvironment(config, win, doc);
+    assert.notOk(env('CONSUL_ACLS_ENABLED'));
+  });
 });


### PR DESCRIPTION
### Description

In the past we had always just turned on ACLs completely in the UI, and occasionally turned ACLs off in the HTTP API when we needed to do that (generally the UI is a thin client, so whatever the HTTP API says, that is what we do).

Back in https://github.com/hashicorp/consul/pull/11280#discussion_r742231738 we specifically wanted to turn off ACLs to test something in the topology view that didn't depend on the HTTP API, and we noticed that once we'd mocked ACLs out to be turned on (our testing default for ACLs only), we couldn't then turn them off again by setting the mock to something false. Note: All our feature flags are a one time setting only so we only generally 1. test without setting, 2. mock to on and test/retest, we generally never need to turn off again once set.

All the pieces were there to do this, but the problem was a little bug in the plumbing of our test/dev vars, where we would use `||` to check if a dev var existed instead of `typeof !== "undefined"`, therefore ignoring dev vars set explicitly falsey during testing i.e. if we hadn't set the variable at all things would be fine.

Note: The only frontend (not HTTP API) env var we set to explicitly set to true from the outset for all our acceptance tests is `CONSUL_ACLS_ENABLED`

P.S. Sorry if the title/description here is a little wordy, please ask if you have any further questions.

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
