### PR TITLE
Add CSR check for number of URIs.

### DIFF
--- a/.changelog/14579.txt
+++ b/.changelog/14579.txt
@@ -1,0 +1,3 @@
+```release-note:security
+connect: Added URI length checks to ConnectCA CSR requests. Prior to this change, it was possible for a malicious actor to designate multiple SAN URI values in a call to the `ConnectCA.Sign` endpoint. The endpoint now only allows for exactly one SAN URI to be specified.
+```

--- a/agent/consul/auto_config_endpoint.go
+++ b/agent/consul/auto_config_endpoint.go
@@ -394,9 +394,12 @@ func parseAutoConfigCSR(csr string) (*x509.CertificateRequest, *connect.SpiffeID
 		return nil, nil, fmt.Errorf("Failed to parse CSR: %w", err)
 	}
 
-	// ensure that a URI SAN is present
-	if len(x509CSR.URIs) < 1 {
-		return nil, nil, fmt.Errorf("CSR didn't include any URI SANs")
+	// ensure that exactly one URI SAN is present
+	if len(x509CSR.URIs) != 1 {
+		return nil, nil, fmt.Errorf("CSR SAN contains an invalid number of URIs: %v", len(x509CSR.URIs))
+	}
+	if len(x509CSR.EmailAddresses) > 0 {
+		return nil, nil, fmt.Errorf("CSR SAN does not allow specifying email addresses")
 	}
 
 	// Parse the SPIFFE ID

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -1406,10 +1406,15 @@ func (l *connectSignRateLimiter) getCSRRateLimiterWithLimit(limit rate.Limit) *r
 // identified by the SPIFFE ID in the given CSR's SAN. It performs authorization
 // using the given acl.Authorizer.
 func (c *CAManager) AuthorizeAndSignCertificate(csr *x509.CertificateRequest, authz acl.Authorizer) (*structs.IssuedCert, error) {
-	// Parse the SPIFFE ID from the CSR SAN.
-	if len(csr.URIs) == 0 {
-		return nil, connect.InvalidCSRError("CSR SAN does not contain a SPIFFE ID")
+	// Note that only one spiffe id is allowed currently. If more than one is desired
+	// in future implmentations, then each ID should have authorization checks.
+	if len(csr.URIs) != 1 {
+		return nil, connect.InvalidCSRError("CSR SAN contains an invalid number of URIs: %v", len(csr.URIs))
 	}
+	if len(csr.EmailAddresses) > 0 {
+		return nil, connect.InvalidCSRError("CSR SAN does not allow specifying email addresses")
+	}
+	// Parse the SPIFFE ID from the CSR SAN.
 	spiffeID, err := connect.ParseCertURI(csr.URIs[0])
 	if err != nil {
 		return nil, err
@@ -1452,7 +1457,7 @@ func (c *CAManager) AuthorizeAndSignCertificate(csr *x509.CertificateRequest, au
 				"we are %s", v.Datacenter, dc)
 		}
 	default:
-		return nil, connect.InvalidCSRError("SPIFFE ID in CSR must be a service or agent ID")
+		return nil, connect.InvalidCSRError("SPIFFE ID in CSR must be a service, mesh-gateway, or agent ID")
 	}
 
 	return c.SignCertificate(csr, spiffeID)

--- a/agent/consul/leader_connect_ca_test.go
+++ b/agent/consul/leader_connect_ca_test.go
@@ -24,6 +24,7 @@ import (
 	msgpackrpc "github.com/hashicorp/consul-net-rpc/net-rpc-msgpackrpc"
 	"github.com/hashicorp/consul-net-rpc/net/rpc"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
 	ca "github.com/hashicorp/consul/agent/connect/ca"
 	"github.com/hashicorp/consul/agent/consul/fsm"
@@ -1041,4 +1042,141 @@ func setupPrimaryCA(t *testing.T, client *vaultapi.Client, path string, rootPEM 
 	})
 	require.NoError(t, err, "failed to set signed intermediate")
 	return lib.EnsureTrailingNewline(buf.String())
+}
+
+func TestCAManager_AuthorizeAndSignCertificate(t *testing.T) {
+	conf := DefaultConfig()
+	conf.PrimaryDatacenter = "dc1"
+	conf.Datacenter = "dc2"
+	manager := NewCAManager(nil, nil, testutil.Logger(t), conf)
+
+	agentURL := connect.SpiffeIDAgent{
+		Agent:      "test-agent",
+		Datacenter: conf.PrimaryDatacenter,
+		Host:       "test-host",
+	}.URI()
+	serviceURL := connect.SpiffeIDService{
+		Datacenter: conf.PrimaryDatacenter,
+		Namespace:  "ns1",
+		Service:    "test-service",
+	}.URI()
+	meshURL := connect.SpiffeIDMeshGateway{
+		Datacenter: conf.PrimaryDatacenter,
+		Host:       "test-host",
+		Partition:  "test-partition",
+	}.URI()
+
+	tests := []struct {
+		name      string
+		expectErr string
+		getCSR    func() *x509.CertificateRequest
+		authAllow bool
+	}{
+		{
+			name:      "err_not_one_uri",
+			expectErr: "CSR SAN contains an invalid number of URIs",
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{agentURL, agentURL},
+				}
+			},
+		},
+		{
+			name:      "err_email",
+			expectErr: "CSR SAN does not allow specifying email addresses",
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs:           []*url.URL{agentURL},
+					EmailAddresses: []string{"test@example.com"},
+				}
+			},
+		},
+		{
+			name:      "err_invalid_spiffe_id",
+			expectErr: "SPIFFE ID is not in the expected format",
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{connect.SpiffeIDAgent{}.URI()},
+				}
+			},
+		},
+		{
+			name:      "err_service_write_not_allowed",
+			expectErr: "Permission denied",
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{serviceURL},
+				}
+			},
+		},
+		{
+			name:      "err_service_different_dc",
+			expectErr: "SPIFFE ID in CSR from a different datacenter",
+			authAllow: true,
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{serviceURL},
+				}
+			},
+		},
+		{
+			name:      "err_agent_write_not_allowed",
+			expectErr: "Permission denied",
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{agentURL},
+				}
+			},
+		},
+		{
+			name:      "err_meshgw_write_not_allowed",
+			expectErr: "Permission denied",
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{meshURL},
+				}
+			},
+		},
+		{
+			name:      "err_meshgw_different_dc",
+			expectErr: "SPIFFE ID in CSR from a different datacenter",
+			authAllow: true,
+			getCSR: func() *x509.CertificateRequest {
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{meshURL},
+				}
+			},
+		},
+		{
+			name:      "err_invalid_spiffe_type",
+			expectErr: "SPIFFE ID in CSR must be a service, mesh-gateway, or agent ID",
+			getCSR: func() *x509.CertificateRequest {
+				u := connect.SpiffeIDSigning{
+					ClusterID: "test-cluster-id",
+					Domain:    "test-domain",
+				}.URI()
+				return &x509.CertificateRequest{
+					URIs: []*url.URL{u},
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			authz := acl.DenyAll()
+			if tc.authAllow {
+				authz = acl.AllowAll()
+			}
+
+			cert, err := manager.AuthorizeAndSignCertificate(tc.getCSR(), authz)
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, cert)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This is a backport of: https://github.com/hashicorp/consul/pull/14579

It needed to be manually created because cherry-picking failed.