### PR TITLE
connect/ca: Don't discard old roots on primaryInitialize

### DIFF
--- a/.changelog/14598.txt
+++ b/.changelog/14598.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fixed a bug where old root CAs would be removed from the primary datacenter after switching providers and restarting the cluster.
+```

--- a/agent/consul/leader_connect_ca.go
+++ b/agent/consul/leader_connect_ca.go
@@ -564,22 +564,9 @@ func (c *CAManager) primaryInitialize(provider ca.Provider, conf *structs.CAConf
 		return nil
 	}
 
-	// Get the highest index
-	idx, _, err := state.CARoots(nil)
-	if err != nil {
+	if err := c.persistNewRootAndConfig(provider, rootCA, conf); err != nil {
 		return err
 	}
-
-	// Store the root cert in raft
-	_, err = c.delegate.ApplyCARequest(&structs.CARequest{
-		Op:    structs.CAOpSetRoots,
-		Index: idx,
-		Roots: []*structs.CARoot{rootCA},
-	})
-	if err != nil {
-		return fmt.Errorf("raft apply failed: %w", err)
-	}
-
 	c.setCAProvider(provider, rootCA)
 
 	c.logger.Info("initialized primary datacenter CA with provider", "provider", conf.Provider)


### PR DESCRIPTION
There are a couple cases in `primaryInitialize` in the `CAManager` that can cause the root to need updating when the leader is starting up. Currently when this happens, the old roots are discarded and only the new root is preserved, which could cause problems if the root was just rotated out and we still need to keep the old root around for interoperability during the switch to the new root. 

This PR changes that behavior to keep the old roots around in this case in `primaryInitialize` - they'll still be pruned through the normal leader routine once enough time has passed after they've been rotated out.