### PR TITLE
ui: Add AWS Lambda as potential external source

### DIFF
--- a/ui/packages/consul-ui/app/components/consul/external-source/index.scss
+++ b/ui/packages/consul-ui/app/components/consul/external-source/index.scss
@@ -22,6 +22,7 @@
 .consul-external-source.vault::before {
   @extend %with-vault-300;
 }
+.consul-external-source.lambda::before,
 .consul-external-source.aws::before {
   @extend %with-aws-300;
 }

--- a/ui/packages/consul-ui/app/components/popover-select/index.scss
+++ b/ui/packages/consul-ui/app/components/popover-select/index.scss
@@ -52,6 +52,7 @@
   @extend %with-user-team-mask, %as-pseudo;
   color: rgb(var(--tone-gray-500));
 }
+%popover-select .lambda button::before,
 %popover-select .aws button::before {
   @extend %with-aws-300;
 }

--- a/ui/packages/consul-ui/app/helpers/service/external-source.js
+++ b/ui/packages/consul-ui/app/helpers/service/external-source.js
@@ -9,7 +9,16 @@ export function serviceExternalSource(params, hash) {
   const prefix = typeof hash.prefix === 'undefined' ? '' : hash.prefix;
   if (
     source &&
-    ['consul-api-gateway', 'vault', 'kubernetes', 'terraform', 'nomad', 'consul', 'aws'].includes(
+    [
+      'consul-api-gateway',
+      'vault',
+      'kubernetes',
+      'terraform',
+      'nomad',
+      'consul',
+      'aws',
+      'lambda'
+    ].includes(
       source
     )
   ) {

--- a/ui/packages/consul-ui/mock-api/v1/connect/_
+++ b/ui/packages/consul-ui/mock-api/v1/connect/_
@@ -97,7 +97,16 @@ ${fake.helpers.randomize([
             "Precedence": ${i + 1},
 ${ fake.random.number({min: 1, max: 10}) > 2 ? `
             "Meta": {
-              "external-source": "${fake.helpers.randomize(['kubernetes', 'consul-api-gateway'])}"
+              "external-source": "${fake.helpers.randomize([
+                'consul-api-gateway',
+                'vault',
+                'nomad',
+                'terraform',
+                'kubernetes',
+                'aws',
+                'lambda',
+                ''
+              ])}"
             },
 ` : `` }
             "CreatedAt": "2018-05-21T16:41:27.977155457Z",

--- a/ui/packages/consul-ui/mock-api/v1/health/service/_
+++ b/ui/packages/consul-ui/mock-api/v1/health/service/_
@@ -87,7 +87,16 @@ ${typeof location.search.partition !== 'undefined' ? `
 ${ fake.random.number({min: 1, max: 10}) > 2 ? `
             "Meta": {
               "consul-dashboard-url": "${fake.internet.protocol()}://${fake.internet.domainName()}/?id={{Service}}",
-              "external-source": "${fake.helpers.randomize(['consul-api-gateway', 'vault', 'consul', 'nomad', 'terraform', 'kubernetes', 'aws', ''])}"
+              "external-source": "${fake.helpers.randomize([
+                'consul-api-gateway',
+                'vault',
+                'nomad',
+                'terraform',
+                'kubernetes',
+                'aws',
+                'lambda',
+                ''
+              ])}"
             },
 ` : `
             "Meta": null,

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/gateway-services-nodes/_
@@ -50,7 +50,16 @@ ${ fake.random.number({min: 1, max: 10}) > 2 ? `
         range(fake.random.number({min: 1, max: 1})).map(
           function(item, i)
           {
-            return `"${fake.helpers.randomize(['vault', 'consul', 'nomad', 'terraform', 'kubernetes', 'aws', ''])}"`;
+            return `"${fake.helpers.randomize([
+                'consul-api-gateway',
+                'vault',
+                'nomad',
+                'terraform',
+                'kubernetes',
+                'aws',
+                'lambda',
+                ''
+            ])}"`;
           }
         )
       }

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/node/_
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/node/_
@@ -63,7 +63,14 @@ return `
               ],
 ${ fake.random.number({min: 1, max: 10}) > 2 ? `
             "Meta": {
-              "external-source": "${fake.helpers.randomize(['consul-api-gateway', 'consul', 'nomad', 'terraform', 'kubernetes', ''])}"
+              "external-source": "${fake.helpers.randomize([
+                'consul-api-gateway',
+                'consul',
+                'nomad',
+                'terraform',
+                'kubernetes',
+                ''
+              ])}"
             },
 ` : `` }
               "Address":"",

--- a/ui/packages/consul-ui/mock-api/v1/internal/ui/services
+++ b/ui/packages/consul-ui/mock-api/v1/internal/ui/services
@@ -90,7 +90,16 @@ ${ fake.random.number({min: 1, max: 10}) > 2 ? `
                     range(fake.random.number({min: 1, max: 1})).map(
                         function(item, i)
                         {
-                            return `"${fake.helpers.randomize(['consul-api-gateway', 'vault', 'nomad', 'terraform', 'kubernetes', 'aws', ''])}"`;
+                            return `"${fake.helpers.randomize([
+                              'consul-api-gateway',
+                              'vault',
+                              'nomad',
+                              'terraform',
+                              'kubernetes',
+                              'aws',
+                              'lambda',
+                              ''
+                            ])}"`;
                         }
                     )
                 }

--- a/ui/packages/consul-ui/translations/common/en-us.yaml
+++ b/ui/packages/consul-ui/translations/common/en-us.yaml
@@ -5,6 +5,7 @@ brand:
   nomad: Nomad
   vault: Vault
   aws: AWS
+  lambda: AWS Lambda
   aws-iam: AWS IAM
   kubernetes: Kubernetes
   jwt: JWT


### PR DESCRIPTION
### Description
See title. This is essentially adding to our list of icons and updating the mocks to add the potential new external-source metadata. Currently we are using our existing generic AWS icon. Expects the `external-source` value to be exactly `lambda`.

<img width="1074" alt="Screenshot 2022-09-14 at 11 24 03" src="https://user-images.githubusercontent.com/554604/190130617-31c3bd91-43d3-4123-b567-05d8a3162c4c.png">


### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
