### PR TITLE
Add envoy connection balancing.

### DIFF
--- a/.changelog/14616.txt
+++ b/.changelog/14616.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+connect: Add Envoy connection balancing configuration fields.
+```

--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -59,7 +59,7 @@ func ComputeResolvedServiceConfig(
 		if serviceConf.Protocol != "" {
 			thisReply.ProxyConfig["protocol"] = serviceConf.Protocol
 		}
-		if serviceConf.BalanceInboundConnections {
+		if serviceConf.BalanceInboundConnections != "" {
 			thisReply.ProxyConfig["balance_inbound_connections"] = serviceConf.BalanceInboundConnections
 		}
 		if serviceConf.Expose.Checks {

--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -53,15 +53,7 @@ func ComputeResolvedServiceConfig(
 		structs.NewServiceID(args.Name, &args.EnterpriseMeta),
 	)
 	if serviceConf != nil {
-		if thisReply.ProxyConfig == nil {
-			thisReply.ProxyConfig = make(map[string]interface{})
-		}
-		if serviceConf.Protocol != "" {
-			thisReply.ProxyConfig["protocol"] = serviceConf.Protocol
-		}
-		if serviceConf.BalanceInboundConnections != "" {
-			thisReply.ProxyConfig["balance_inbound_connections"] = serviceConf.BalanceInboundConnections
-		}
+
 		if serviceConf.Expose.Checks {
 			thisReply.Expose.Checks = true
 		}
@@ -84,25 +76,29 @@ func ComputeResolvedServiceConfig(
 			thisReply.Destination = *serviceConf.Destination
 		}
 
+		// Populate values for the proxy config map
+		proxyConf := thisReply.ProxyConfig
+		if proxyConf == nil {
+			proxyConf = make(map[string]interface{})
+		}
+		if serviceConf.Protocol != "" {
+			proxyConf["protocol"] = serviceConf.Protocol
+		}
+		if serviceConf.BalanceInboundConnections != "" {
+			proxyConf["balance_inbound_connections"] = serviceConf.BalanceInboundConnections
+		}
 		if serviceConf.MaxInboundConnections > 0 {
-			if thisReply.ProxyConfig == nil {
-				thisReply.ProxyConfig = map[string]interface{}{}
-			}
-			thisReply.ProxyConfig["max_inbound_connections"] = serviceConf.MaxInboundConnections
+			proxyConf["max_inbound_connections"] = serviceConf.MaxInboundConnections
 		}
-
 		if serviceConf.LocalConnectTimeoutMs > 0 {
-			if thisReply.ProxyConfig == nil {
-				thisReply.ProxyConfig = map[string]interface{}{}
-			}
-			thisReply.ProxyConfig["local_connect_timeout_ms"] = serviceConf.LocalConnectTimeoutMs
+			proxyConf["local_connect_timeout_ms"] = serviceConf.LocalConnectTimeoutMs
 		}
-
 		if serviceConf.LocalRequestTimeoutMs > 0 {
-			if thisReply.ProxyConfig == nil {
-				thisReply.ProxyConfig = map[string]interface{}{}
-			}
-			thisReply.ProxyConfig["local_request_timeout_ms"] = serviceConf.LocalRequestTimeoutMs
+			proxyConf["local_request_timeout_ms"] = serviceConf.LocalRequestTimeoutMs
+		}
+		// Add the proxy conf to the response if any fields were populated
+		if len(proxyConf) > 0 {
+			thisReply.ProxyConfig = proxyConf
 		}
 
 		thisReply.Meta = serviceConf.Meta

--- a/agent/configentry/resolve.go
+++ b/agent/configentry/resolve.go
@@ -53,6 +53,15 @@ func ComputeResolvedServiceConfig(
 		structs.NewServiceID(args.Name, &args.EnterpriseMeta),
 	)
 	if serviceConf != nil {
+		if thisReply.ProxyConfig == nil {
+			thisReply.ProxyConfig = make(map[string]interface{})
+		}
+		if serviceConf.Protocol != "" {
+			thisReply.ProxyConfig["protocol"] = serviceConf.Protocol
+		}
+		if serviceConf.BalanceInboundConnections {
+			thisReply.ProxyConfig["balance_inbound_connections"] = serviceConf.BalanceInboundConnections
+		}
 		if serviceConf.Expose.Checks {
 			thisReply.Expose.Checks = true
 		}
@@ -61,12 +70,6 @@ func ComputeResolvedServiceConfig(
 		}
 		if serviceConf.MeshGateway.Mode != structs.MeshGatewayModeDefault {
 			thisReply.MeshGateway.Mode = serviceConf.MeshGateway.Mode
-		}
-		if serviceConf.Protocol != "" {
-			if thisReply.ProxyConfig == nil {
-				thisReply.ProxyConfig = make(map[string]interface{})
-			}
-			thisReply.ProxyConfig["protocol"] = serviceConf.Protocol
 		}
 		if serviceConf.TransparentProxy.OutboundListenerPort != 0 {
 			thisReply.TransparentProxy.OutboundListenerPort = serviceConf.TransparentProxy.OutboundListenerPort

--- a/agent/configentry/resolve_test.go
+++ b/agent/configentry/resolve_test.go
@@ -25,6 +25,26 @@ func Test_ComputeResolvedServiceConfig(t *testing.T) {
 		want *structs.ServiceConfigResponse
 	}{
 		{
+			name: "proxy with balanceinboundconnections",
+			args: args{
+				scReq: &structs.ServiceConfigRequest{
+					Name: "sid",
+				},
+				entries: &ResolvedServiceConfigSet{
+					ServiceDefaults: map[structs.ServiceID]*structs.ServiceConfigEntry{
+						sid: {
+							BalanceInboundConnections: "exact_balance",
+						},
+					},
+				},
+			},
+			want: &structs.ServiceConfigResponse{
+				ProxyConfig: map[string]interface{}{
+					"balance_inbound_connections": "exact_balance",
+				},
+			},
+		},
+		{
 			name: "proxy with maxinboundsconnections",
 			args: args{
 				scReq: &structs.ServiceConfigRequest{

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -38,6 +38,8 @@ const (
 	MeshConfigMesh    string = "mesh"
 
 	DefaultServiceProtocol = "tcp"
+
+	ConnectionExactBalance = "exact_balance"
 )
 
 var AllConfigEntryKinds = []string{
@@ -183,6 +185,10 @@ func (e *ServiceConfigEntry) Validate() error {
 	}
 
 	validationErr := validateConfigEntryMeta(e.Meta)
+
+	if !isValidConnectionBalance(e.BalanceInboundConnections) {
+		validationErr = multierror.Append(validationErr, fmt.Errorf("invalid value for balance_inbound_connections: %v", e.BalanceInboundConnections))
+	}
 
 	// External endpoints are invalid with an existing service's upstream configuration
 	if e.UpstreamConfig != nil && e.Destination != nil {
@@ -925,6 +931,10 @@ func (cfg UpstreamConfig) validate(named bool) error {
 		}
 	}
 
+	if !isValidConnectionBalance(cfg.BalanceOutboundConnections) {
+		validationErr = multierror.Append(validationErr, fmt.Errorf("invalid value for balance_outbound_connections: %v", cfg.BalanceOutboundConnections))
+	}
+
 	return validationErr
 }
 
@@ -1229,4 +1239,8 @@ func validateConfigEntryMeta(meta map[string]string) error {
 
 type ConfigEntryDeleteResponse struct {
 	Deleted bool
+}
+
+func isValidConnectionBalance(s string) bool {
+	return s == "" || s == ConnectionExactBalance
 }

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -765,6 +765,12 @@ type UpstreamConfig struct {
 	// EnterpriseMeta is only accepted within a service-defaults config entry.
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 
+	// EnvoyConnectionBalanceType specifies how envoy connections should
+	// be distributed across worker threads. Currently, only the "exact_balance"
+	// type is accepted.
+	// https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig
+	EnvoyConnectionBalanceType string `json:",omitempty" alias:"envoy_connection_balance_type"`
+
 	// EnvoyListenerJSON is a complete override ("escape hatch") for the upstream's
 	// listener.
 	//
@@ -827,6 +833,9 @@ func (cfg *UpstreamConfig) ServiceName() ServiceName {
 
 func (cfg UpstreamConfig) MergeInto(dst map[string]interface{}) {
 	// Avoid storing empty values in the map, since these can act as overrides
+	if cfg.EnvoyConnectionBalanceType != "" {
+		dst["envoy_connection_balance_type"] = cfg.EnvoyConnectionBalanceType
+	}
 	if cfg.EnvoyListenerJSON != "" {
 		dst["envoy_listener_json"] = cfg.EnvoyListenerJSON
 	}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -111,7 +111,7 @@ type ServiceConfigEntry struct {
 	MaxInboundConnections     int                    `json:",omitempty" alias:"max_inbound_connections"`
 	LocalConnectTimeoutMs     int                    `json:",omitempty" alias:"local_connect_timeout_ms"`
 	LocalRequestTimeoutMs     int                    `json:",omitempty" alias:"local_request_timeout_ms"`
-	BalanceInboundConnections bool                   `json:",omitempty" alias:"balance_inbound_connections"`
+	BalanceInboundConnections string                 `json:",omitempty" alias:"balance_inbound_connections"`
 
 	Meta               map[string]string `json:",omitempty"`
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
@@ -766,10 +766,6 @@ type UpstreamConfig struct {
 	// EnterpriseMeta is only accepted within a service-defaults config entry.
 	acl.EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 
-	// BalanceOutboundConnections indicates that the proxy should attempt to evenly distribute
-	// outbound connections across worker threads. Only used by envoy proxies.
-	BalanceOutboundConnections bool `json:",omitempty" alias:"balance_outbound_connections"`
-
 	// EnvoyListenerJSON is a complete override ("escape hatch") for the upstream's
 	// listener.
 	//
@@ -805,6 +801,10 @@ type UpstreamConfig struct {
 
 	// MeshGatewayConfig controls how Mesh Gateways are configured and used
 	MeshGateway MeshGatewayConfig `json:",omitempty" alias:"mesh_gateway" `
+
+	// BalanceOutboundConnections indicates how the proxy should attempt to distribute
+	// connections across worker threads. Only used by envoy proxies.
+	BalanceOutboundConnections string `json:",omitempty" alias:"balance_outbound_connections"`
 }
 
 func (cfg UpstreamConfig) Clone() UpstreamConfig {
@@ -853,7 +853,7 @@ func (cfg UpstreamConfig) MergeInto(dst map[string]interface{}) {
 	if cfg.PassiveHealthCheck != nil {
 		dst["passive_health_check"] = cfg.PassiveHealthCheck
 	}
-	if cfg.BalanceOutboundConnections {
+	if cfg.BalanceOutboundConnections != "" {
 		dst["balance_outbound_connections"] = cfg.BalanceOutboundConnections
 	}
 }

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -340,6 +340,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				  "moreconfig" {
 					"moar" = "config"
 				  }
+                  "balance_inbound_connections"= true
 				}
 				mesh_gateway {
 					mode = "remote"
@@ -358,6 +359,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				  "moreconfig" {
 					"moar" = "config"
 				  }
+                  "balance_inbound_connections"= true
 				}
 				MeshGateway {
 					Mode = "remote"
@@ -376,6 +378,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"moreconfig": map[string]interface{}{
 						"moar": "config",
 					},
+					"balance_inbound_connections": true,
 				},
 				MeshGateway: MeshGatewayConfig{
 					Mode: MeshGatewayModeRemote,
@@ -415,7 +418,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					defaults {
 						connect_timeout_ms = 5
 						protocol = "http"
-						envoy_connection_balance_type = "something"
+						balance_outbound_connections = true
 						envoy_listener_json = "foo"
 						envoy_cluster_json = "bar"
 						limits {
@@ -455,7 +458,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 						},
 					]
 					Defaults {
-						EnvoyConnectionBalanceType = "something"
 						EnvoyListenerJSON = "foo"
 						EnvoyClusterJSON = "bar"
 						ConnectTimeoutMs = 5
@@ -465,6 +467,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 							MaxPendingRequests = 4
 							MaxConcurrentRequests = 5
 						}
+						BalanceOutboundConnections = true
 					}
 				}
 			`,
@@ -495,16 +498,16 @@ func TestDecodeConfigEntry(t *testing.T) {
 						},
 					},
 					Defaults: &UpstreamConfig{
-						EnvoyConnectionBalanceType: "something",
-						EnvoyListenerJSON:          "foo",
-						EnvoyClusterJSON:           "bar",
-						ConnectTimeoutMs:           5,
-						Protocol:                   "http",
+						EnvoyListenerJSON: "foo",
+						EnvoyClusterJSON:  "bar",
+						ConnectTimeoutMs:  5,
+						Protocol:          "http",
 						Limits: &UpstreamLimits{
 							MaxConnections:        intPointer(3),
 							MaxPendingRequests:    intPointer(4),
 							MaxConcurrentRequests: intPointer(5),
 						},
+						BalanceOutboundConnections: true,
 					},
 				},
 			},
@@ -2668,7 +2671,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 		{
 			name: "kitchen sink",
 			source: UpstreamConfig{
-				EnvoyConnectionBalanceType: "something",
+				BalanceOutboundConnections: true,
 				EnvoyListenerJSON:          "foo",
 				EnvoyClusterJSON:           "bar",
 				ConnectTimeoutMs:           5,
@@ -2686,11 +2689,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 			},
 			destination: make(map[string]interface{}),
 			want: map[string]interface{}{
-				"envoy_connection_balance_type": "something",
-				"envoy_listener_json":           "foo",
-				"envoy_cluster_json":            "bar",
-				"connect_timeout_ms":            5,
-				"protocol":                      "http",
+				"balance_outbound_connections": true,
+				"envoy_listener_json":          "foo",
+				"envoy_cluster_json":           "bar",
+				"connect_timeout_ms":           5,
+				"protocol":                     "http",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(3),
 					MaxPendingRequests:    intPointer(4),
@@ -2706,7 +2709,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 		{
 			name: "kitchen sink override of destination",
 			source: UpstreamConfig{
-				EnvoyConnectionBalanceType: "something",
+				BalanceOutboundConnections: true,
 				EnvoyListenerJSON:          "foo",
 				EnvoyClusterJSON:           "bar",
 				ConnectTimeoutMs:           5,
@@ -2723,11 +2726,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				MeshGateway: MeshGatewayConfig{Mode: MeshGatewayModeRemote},
 			},
 			destination: map[string]interface{}{
-				"envoy_connection_balance_type": "zup",
-				"envoy_listener_json":           "zip",
-				"envoy_cluster_json":            "zap",
-				"connect_timeout_ms":            10,
-				"protocol":                      "grpc",
+				"balance_outbound_connections": false,
+				"envoy_listener_json":          "zip",
+				"envoy_cluster_json":           "zap",
+				"connect_timeout_ms":           10,
+				"protocol":                     "grpc",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(10),
 					MaxPendingRequests:    intPointer(11),
@@ -2740,11 +2743,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				"mesh_gateway": MeshGatewayConfig{Mode: MeshGatewayModeLocal},
 			},
 			want: map[string]interface{}{
-				"envoy_connection_balance_type": "something",
-				"envoy_listener_json":           "foo",
-				"envoy_cluster_json":            "bar",
-				"connect_timeout_ms":            5,
-				"protocol":                      "http",
+				"balance_outbound_connections": true,
+				"envoy_listener_json":          "foo",
+				"envoy_cluster_json":           "bar",
+				"connect_timeout_ms":           5,
+				"protocol":                     "http",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(3),
 					MaxPendingRequests:    intPointer(4),
@@ -2761,11 +2764,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 			name:   "empty source leaves destination intact",
 			source: UpstreamConfig{},
 			destination: map[string]interface{}{
-				"envoy_connection_balance_type": "something",
-				"envoy_listener_json":           "zip",
-				"envoy_cluster_json":            "zap",
-				"connect_timeout_ms":            10,
-				"protocol":                      "grpc",
+				"balance_outbound_connections": true,
+				"envoy_listener_json":          "zip",
+				"envoy_cluster_json":           "zap",
+				"connect_timeout_ms":           10,
+				"protocol":                     "grpc",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(10),
 					MaxPendingRequests:    intPointer(11),
@@ -2779,11 +2782,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				"mesh_gateway": MeshGatewayConfig{Mode: MeshGatewayModeLocal},
 			},
 			want: map[string]interface{}{
-				"envoy_connection_balance_type": "something",
-				"envoy_listener_json":           "zip",
-				"envoy_cluster_json":            "zap",
-				"connect_timeout_ms":            10,
-				"protocol":                      "grpc",
+				"balance_outbound_connections": true,
+				"envoy_listener_json":          "zip",
+				"envoy_cluster_json":           "zap",
+				"connect_timeout_ms":           10,
+				"protocol":                     "grpc",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(10),
 					MaxPendingRequests:    intPointer(11),

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -340,7 +340,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				  "moreconfig" {
 					"moar" = "config"
 				  }
-                  "balance_inbound_connections" = "exact_balance"
+				  "balance_inbound_connections" = "exact_balance"
 				}
 				mesh_gateway {
 					mode = "remote"
@@ -359,7 +359,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				  "moreconfig" {
 					"moar" = "config"
 				  }
-                  "balance_inbound_connections" = "exact_balance"
+				  "balance_inbound_connections" = "exact_balance"
 				}
 				MeshGateway {
 					Mode = "remote"
@@ -399,6 +399,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				mesh_gateway {
 					mode = "remote"
 				}
+				balance_inbound_connections = "exact_balance"
 				upstream_config {
 					overrides = [
 						{
@@ -441,6 +442,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				MeshGateway {
 					Mode = "remote"
 				}
+				BalanceInboundConnections = "exact_balance"
 				UpstreamConfig {
 					Overrides = [
 						{
@@ -483,6 +485,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				MeshGateway: MeshGatewayConfig{
 					Mode: MeshGatewayModeRemote,
 				},
+				BalanceInboundConnections: "exact_balance",
 				UpstreamConfig: &UpstreamConfiguration{
 					Overrides: []*UpstreamConfig{
 						{
@@ -2656,6 +2659,44 @@ func TestServiceConfigEntry(t *testing.T) {
 				},
 			},
 			validateErr: "Duplicate address",
+		},
+		"validate: invalid inbound connection balance": {
+			entry: &ServiceConfigEntry{
+				Kind:                      ServiceDefaults,
+				Name:                      "external",
+				Protocol:                  "http",
+				BalanceInboundConnections: "invalid",
+			},
+			validateErr: "invalid value for balance_inbound_connections",
+		},
+		"validate: invalid default outbound connection balance": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "http",
+				UpstreamConfig: &UpstreamConfiguration{
+					Defaults: &UpstreamConfig{
+						BalanceOutboundConnections: "invalid",
+					},
+				},
+			},
+			validateErr: "invalid value for balance_outbound_connections",
+		},
+		"validate: invalid override outbound connection balance": {
+			entry: &ServiceConfigEntry{
+				Kind:     ServiceDefaults,
+				Name:     "external",
+				Protocol: "http",
+				UpstreamConfig: &UpstreamConfiguration{
+					Overrides: []*UpstreamConfig{
+						{
+							Name:                       "upstream",
+							BalanceOutboundConnections: "invalid",
+						},
+					},
+				},
+			},
+			validateErr: "invalid value for balance_outbound_connections",
 		},
 	}
 	testConfigEntryNormalizeAndValidate(t, cases)

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -415,6 +415,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					defaults {
 						connect_timeout_ms = 5
 						protocol = "http"
+						envoy_connection_balance_type = "something"
 						envoy_listener_json = "foo"
 						envoy_cluster_json = "bar"
 						limits {
@@ -454,6 +455,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 						},
 					]
 					Defaults {
+						EnvoyConnectionBalanceType = "something"
 						EnvoyListenerJSON = "foo"
 						EnvoyClusterJSON = "bar"
 						ConnectTimeoutMs = 5
@@ -493,10 +495,11 @@ func TestDecodeConfigEntry(t *testing.T) {
 						},
 					},
 					Defaults: &UpstreamConfig{
-						EnvoyListenerJSON: "foo",
-						EnvoyClusterJSON:  "bar",
-						ConnectTimeoutMs:  5,
-						Protocol:          "http",
+						EnvoyConnectionBalanceType: "something",
+						EnvoyListenerJSON:          "foo",
+						EnvoyClusterJSON:           "bar",
+						ConnectTimeoutMs:           5,
+						Protocol:                   "http",
 						Limits: &UpstreamLimits{
 							MaxConnections:        intPointer(3),
 							MaxPendingRequests:    intPointer(4),
@@ -2665,10 +2668,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 		{
 			name: "kitchen sink",
 			source: UpstreamConfig{
-				EnvoyListenerJSON: "foo",
-				EnvoyClusterJSON:  "bar",
-				ConnectTimeoutMs:  5,
-				Protocol:          "http",
+				EnvoyConnectionBalanceType: "something",
+				EnvoyListenerJSON:          "foo",
+				EnvoyClusterJSON:           "bar",
+				ConnectTimeoutMs:           5,
+				Protocol:                   "http",
 				Limits: &UpstreamLimits{
 					MaxConnections:        intPointer(3),
 					MaxPendingRequests:    intPointer(4),
@@ -2682,10 +2686,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 			},
 			destination: make(map[string]interface{}),
 			want: map[string]interface{}{
-				"envoy_listener_json": "foo",
-				"envoy_cluster_json":  "bar",
-				"connect_timeout_ms":  5,
-				"protocol":            "http",
+				"envoy_connection_balance_type": "something",
+				"envoy_listener_json":           "foo",
+				"envoy_cluster_json":            "bar",
+				"connect_timeout_ms":            5,
+				"protocol":                      "http",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(3),
 					MaxPendingRequests:    intPointer(4),
@@ -2701,10 +2706,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 		{
 			name: "kitchen sink override of destination",
 			source: UpstreamConfig{
-				EnvoyListenerJSON: "foo",
-				EnvoyClusterJSON:  "bar",
-				ConnectTimeoutMs:  5,
-				Protocol:          "http",
+				EnvoyConnectionBalanceType: "something",
+				EnvoyListenerJSON:          "foo",
+				EnvoyClusterJSON:           "bar",
+				ConnectTimeoutMs:           5,
+				Protocol:                   "http",
 				Limits: &UpstreamLimits{
 					MaxConnections:        intPointer(3),
 					MaxPendingRequests:    intPointer(4),
@@ -2717,10 +2723,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				MeshGateway: MeshGatewayConfig{Mode: MeshGatewayModeRemote},
 			},
 			destination: map[string]interface{}{
-				"envoy_listener_json": "zip",
-				"envoy_cluster_json":  "zap",
-				"connect_timeout_ms":  10,
-				"protocol":            "grpc",
+				"envoy_connection_balance_type": "zup",
+				"envoy_listener_json":           "zip",
+				"envoy_cluster_json":            "zap",
+				"connect_timeout_ms":            10,
+				"protocol":                      "grpc",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(10),
 					MaxPendingRequests:    intPointer(11),
@@ -2733,10 +2740,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				"mesh_gateway": MeshGatewayConfig{Mode: MeshGatewayModeLocal},
 			},
 			want: map[string]interface{}{
-				"envoy_listener_json": "foo",
-				"envoy_cluster_json":  "bar",
-				"connect_timeout_ms":  5,
-				"protocol":            "http",
+				"envoy_connection_balance_type": "something",
+				"envoy_listener_json":           "foo",
+				"envoy_cluster_json":            "bar",
+				"connect_timeout_ms":            5,
+				"protocol":                      "http",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(3),
 					MaxPendingRequests:    intPointer(4),
@@ -2753,10 +2761,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 			name:   "empty source leaves destination intact",
 			source: UpstreamConfig{},
 			destination: map[string]interface{}{
-				"envoy_listener_json": "zip",
-				"envoy_cluster_json":  "zap",
-				"connect_timeout_ms":  10,
-				"protocol":            "grpc",
+				"envoy_connection_balance_type": "something",
+				"envoy_listener_json":           "zip",
+				"envoy_cluster_json":            "zap",
+				"connect_timeout_ms":            10,
+				"protocol":                      "grpc",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(10),
 					MaxPendingRequests:    intPointer(11),
@@ -2770,10 +2779,11 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				"mesh_gateway": MeshGatewayConfig{Mode: MeshGatewayModeLocal},
 			},
 			want: map[string]interface{}{
-				"envoy_listener_json": "zip",
-				"envoy_cluster_json":  "zap",
-				"connect_timeout_ms":  10,
-				"protocol":            "grpc",
+				"envoy_connection_balance_type": "something",
+				"envoy_listener_json":           "zip",
+				"envoy_cluster_json":            "zap",
+				"connect_timeout_ms":            10,
+				"protocol":                      "grpc",
 				"limits": &UpstreamLimits{
 					MaxConnections:        intPointer(10),
 					MaxPendingRequests:    intPointer(11),

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -340,7 +340,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				  "moreconfig" {
 					"moar" = "config"
 				  }
-                  "balance_inbound_connections"= true
+                  "balance_inbound_connections" = "exact_balance"
 				}
 				mesh_gateway {
 					mode = "remote"
@@ -359,7 +359,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				  "moreconfig" {
 					"moar" = "config"
 				  }
-                  "balance_inbound_connections"= true
+                  "balance_inbound_connections" = "exact_balance"
 				}
 				MeshGateway {
 					Mode = "remote"
@@ -378,7 +378,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"moreconfig": map[string]interface{}{
 						"moar": "config",
 					},
-					"balance_inbound_connections": true,
+					"balance_inbound_connections": "exact_balance",
 				},
 				MeshGateway: MeshGatewayConfig{
 					Mode: MeshGatewayModeRemote,
@@ -418,7 +418,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					defaults {
 						connect_timeout_ms = 5
 						protocol = "http"
-						balance_outbound_connections = true
+						balance_outbound_connections = "exact_balance"
 						envoy_listener_json = "foo"
 						envoy_cluster_json = "bar"
 						limits {
@@ -467,7 +467,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 							MaxPendingRequests = 4
 							MaxConcurrentRequests = 5
 						}
-						BalanceOutboundConnections = true
+						BalanceOutboundConnections = "exact_balance"
 					}
 				}
 			`,
@@ -507,7 +507,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 							MaxPendingRequests:    intPointer(4),
 							MaxConcurrentRequests: intPointer(5),
 						},
-						BalanceOutboundConnections: true,
+						BalanceOutboundConnections: "exact_balance",
 					},
 				},
 			},
@@ -2671,7 +2671,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 		{
 			name: "kitchen sink",
 			source: UpstreamConfig{
-				BalanceOutboundConnections: true,
+				BalanceOutboundConnections: "exact_balance",
 				EnvoyListenerJSON:          "foo",
 				EnvoyClusterJSON:           "bar",
 				ConnectTimeoutMs:           5,
@@ -2689,7 +2689,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 			},
 			destination: make(map[string]interface{}),
 			want: map[string]interface{}{
-				"balance_outbound_connections": true,
+				"balance_outbound_connections": "exact_balance",
 				"envoy_listener_json":          "foo",
 				"envoy_cluster_json":           "bar",
 				"connect_timeout_ms":           5,
@@ -2709,7 +2709,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 		{
 			name: "kitchen sink override of destination",
 			source: UpstreamConfig{
-				BalanceOutboundConnections: true,
+				BalanceOutboundConnections: "exact_balance",
 				EnvoyListenerJSON:          "foo",
 				EnvoyClusterJSON:           "bar",
 				ConnectTimeoutMs:           5,
@@ -2726,7 +2726,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				MeshGateway: MeshGatewayConfig{Mode: MeshGatewayModeRemote},
 			},
 			destination: map[string]interface{}{
-				"balance_outbound_connections": false,
+				"balance_outbound_connections": "",
 				"envoy_listener_json":          "zip",
 				"envoy_cluster_json":           "zap",
 				"connect_timeout_ms":           10,
@@ -2743,7 +2743,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				"mesh_gateway": MeshGatewayConfig{Mode: MeshGatewayModeLocal},
 			},
 			want: map[string]interface{}{
-				"balance_outbound_connections": true,
+				"balance_outbound_connections": "exact_balance",
 				"envoy_listener_json":          "foo",
 				"envoy_cluster_json":           "bar",
 				"connect_timeout_ms":           5,
@@ -2764,7 +2764,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 			name:   "empty source leaves destination intact",
 			source: UpstreamConfig{},
 			destination: map[string]interface{}{
-				"balance_outbound_connections": true,
+				"balance_outbound_connections": "exact_balance",
 				"envoy_listener_json":          "zip",
 				"envoy_cluster_json":           "zap",
 				"connect_timeout_ms":           10,
@@ -2782,7 +2782,7 @@ func TestUpstreamConfig_MergeInto(t *testing.T) {
 				"mesh_gateway": MeshGatewayConfig{Mode: MeshGatewayModeLocal},
 			},
 			want: map[string]interface{}{
-				"balance_outbound_connections": true,
+				"balance_outbound_connections": "exact_balance",
 				"envoy_listener_json":          "zip",
 				"envoy_cluster_json":           "zap",
 				"connect_timeout_ms":           10,

--- a/agent/xds/config.go
+++ b/agent/xds/config.go
@@ -27,6 +27,10 @@ type ProxyConfig struct {
 	// Note: This escape hatch is compatible with the discovery chain.
 	PublicListenerJSON string `mapstructure:"envoy_public_listener_json"`
 
+	// BalanceInboundConnections indicates that the proxy should attempt to evenly distribute
+	// inbound connections across worker threads. Only used by envoy proxies.
+	BalanceInboundConnections bool `json:",omitempty" alias:"balance_inbound_connections"`
+
 	// ListenerTracingJSON is a complete override ("escape hatch") for the
 	// listeners tracing configuration.
 	//

--- a/agent/xds/config.go
+++ b/agent/xds/config.go
@@ -27,10 +27,6 @@ type ProxyConfig struct {
 	// Note: This escape hatch is compatible with the discovery chain.
 	PublicListenerJSON string `mapstructure:"envoy_public_listener_json"`
 
-	// BalanceInboundConnections indicates that the proxy should attempt to evenly distribute
-	// inbound connections across worker threads. Only used by envoy proxies.
-	BalanceInboundConnections bool `json:",omitempty" alias:"balance_inbound_connections"`
-
 	// ListenerTracingJSON is a complete override ("escape hatch") for the
 	// listeners tracing configuration.
 	//
@@ -72,6 +68,10 @@ type ProxyConfig struct {
 	// MaxInboundConnections is the maximum number of inbound connections to
 	// the proxy. If not set, the default is 0 (no limit).
 	MaxInboundConnections int `mapstructure:"max_inbound_connections"`
+
+	// BalanceInboundConnections indicates how the proxy should attempt to distribute
+	// connections across worker threads. Only used by envoy proxies.
+	BalanceInboundConnections string `json:",omitempty" alias:"balance_inbound_connections"`
 }
 
 // ParseProxyConfig returns the ProxyConfig parsed from the an opaque map. If an

--- a/agent/xds/config_test.go
+++ b/agent/xds/config_test.go
@@ -160,12 +160,12 @@ func TestParseProxyConfig(t *testing.T) {
 		{
 			name: "balance inbound connections override, bool",
 			input: map[string]interface{}{
-				"balance_inbound_connections": true,
+				"balance_inbound_connections": "exact_balance",
 			},
 			want: ProxyConfig{
 				LocalConnectTimeoutMs:     5000,
 				Protocol:                  "tcp",
-				BalanceInboundConnections: true,
+				BalanceInboundConnections: "exact_balance",
 			},
 		},
 	}

--- a/agent/xds/config_test.go
+++ b/agent/xds/config_test.go
@@ -157,6 +157,17 @@ func TestParseProxyConfig(t *testing.T) {
 				Protocol:              "tcp",
 			},
 		},
+		{
+			name: "balance inbound connections override, bool",
+			input: map[string]interface{}{
+				"balance_inbound_connections": true,
+			},
+			want: ProxyConfig{
+				LocalConnectTimeoutMs:     5000,
+				Protocol:                  "tcp",
+				BalanceInboundConnections: true,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/agent/xds/config_test.go
+++ b/agent/xds/config_test.go
@@ -158,7 +158,7 @@ func TestParseProxyConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "balance inbound connections override, bool",
+			name: "balance inbound connections override, string",
 			input: map[string]interface{}{
 				"balance_inbound_connections": "exact_balance",
 			},

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -193,6 +193,7 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			upstreamListener.FilterChains = []*envoy_listener_v3.FilterChain{
 				filterChain,
 			}
+			injectConnectionBalanceConfig(&cfg, upstreamListener)
 			resources = append(resources, upstreamListener)
 
 			// Avoid creating filter chains below for upstreams that have dedicated listeners
@@ -388,6 +389,7 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			upstreamListener.FilterChains = []*envoy_listener_v3.FilterChain{
 				filterChain,
 			}
+			injectConnectionBalanceConfig(&cfg, upstreamListener)
 			resources = append(resources, upstreamListener)
 
 			// Avoid creating filter chains below for upstreams that have dedicated listeners
@@ -574,6 +576,7 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		upstreamListener.FilterChains = []*envoy_listener_v3.FilterChain{
 			filterChain,
 		}
+		injectConnectionBalanceConfig(&cfg, upstreamListener)
 		resources = append(resources, upstreamListener)
 	}
 
@@ -903,6 +906,14 @@ func makeListenerFromUserConfig(configJSON string) (*envoy_listener_v3.Listener,
 		return nil, err
 	}
 	return &l, nil
+}
+
+func injectConnectionBalanceConfig(cfg *structs.UpstreamConfig, listener *envoy_listener_v3.Listener) {
+	if cfg.EnvoyConnectionBalanceType == "exact_balance" {
+		listener.ConnectionBalanceConfig = &envoy_listener_v3.Listener_ConnectionBalanceConfig{
+			BalanceType: &envoy_listener_v3.Listener_ConnectionBalanceConfig_ExactBalance_{},
+		}
+	}
 }
 
 // Ensure that the first filter in each filter chain of a public listener is

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -190,9 +190,7 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			}
 
 			upstreamListener := makeListener(uid.EnvoyID(), upstreamCfg, envoy_core_v3.TrafficDirection_OUTBOUND)
-			if cfg.BalanceOutboundConnections {
-				injectConnectionBalanceConfig(upstreamListener)
-			}
+			injectConnectionBalanceConfig(cfg.BalanceOutboundConnections, upstreamListener)
 			upstreamListener.FilterChains = []*envoy_listener_v3.FilterChain{
 				filterChain,
 			}
@@ -388,9 +386,8 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 			}
 
 			upstreamListener := makeListener(uid.EnvoyID(), upstreamCfg, envoy_core_v3.TrafficDirection_OUTBOUND)
-			if cfg.BalanceOutboundConnections {
-				injectConnectionBalanceConfig(upstreamListener)
-			}
+			injectConnectionBalanceConfig(cfg.BalanceOutboundConnections, upstreamListener)
+
 			upstreamListener.FilterChains = []*envoy_listener_v3.FilterChain{
 				filterChain,
 			}
@@ -565,9 +562,7 @@ func (s *ResourceGenerator) listenersFromSnapshotConnectProxy(cfgSnap *proxycfg.
 		}
 
 		upstreamListener := makeListener(uid.EnvoyID(), u, envoy_core_v3.TrafficDirection_OUTBOUND)
-		if cfg.BalanceOutboundConnections {
-			injectConnectionBalanceConfig(upstreamListener)
-		}
+		injectConnectionBalanceConfig(cfg.BalanceOutboundConnections, upstreamListener)
 
 		filterChain, err := s.makeUpstreamFilterChain(filterChainOpts{
 			// TODO (SNI partition) add partition for upstream SNI
@@ -914,9 +909,11 @@ func makeListenerFromUserConfig(configJSON string) (*envoy_listener_v3.Listener,
 	return &l, nil
 }
 
-func injectConnectionBalanceConfig(listener *envoy_listener_v3.Listener) {
-	listener.ConnectionBalanceConfig = &envoy_listener_v3.Listener_ConnectionBalanceConfig{
-		BalanceType: &envoy_listener_v3.Listener_ConnectionBalanceConfig_ExactBalance_{},
+func injectConnectionBalanceConfig(balanceType string, listener *envoy_listener_v3.Listener) {
+	if balanceType == "exact_balance" {
+		listener.ConnectionBalanceConfig = &envoy_listener_v3.Listener_ConnectionBalanceConfig{
+			BalanceType: &envoy_listener_v3.Listener_ConnectionBalanceConfig_ExactBalance_{},
+		}
 	}
 }
 
@@ -1236,9 +1233,7 @@ func (s *ResourceGenerator) makeInboundListener(cfgSnap *proxycfg.ConfigSnapshot
 	}
 
 	l = makePortListener(name, addr, port, envoy_core_v3.TrafficDirection_INBOUND)
-	if cfg.BalanceInboundConnections {
-		injectConnectionBalanceConfig(l)
-	}
+	injectConnectionBalanceConfig(cfg.BalanceInboundConnections, l)
 
 	var tracing *envoy_http_v3.HttpConnectionManager_Tracing
 	if cfg.ListenerTracingJSON != "" {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -161,6 +161,22 @@ func TestListenersFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name: "listener-balance-inbound-connections",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
+					ns.Proxy.Config["balance_inbound_connections"] = "exact_balance"
+				}, nil)
+			},
+		},
+		{
+			name: "listener-balance-outbound-connections-bind-port",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
+					ns.Proxy.Upstreams[0].Config["balance_outbound_connections"] = "exact_balance"
+				}, nil)
+			},
+		},
+		{
 			name: "http-public-listener",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {

--- a/agent/xds/testdata/listeners/listener-balance-inbound-connections.latest.golden
+++ b/agent/xds/testdata/listeners/listener-balance-inbound-connections.latest.golden
@@ -1,0 +1,122 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "public_listener",
+                "cluster": "local_app"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND",
+      "connectionBalanceConfig": {
+        "exactBalance": {}
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/listener-balance-outbound-connections-bind-port.latest.golden
+++ b/agent/xds/testdata/listeners/listener-balance-outbound-connections-bind-port.latest.golden
@@ -1,0 +1,122 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND",
+      "connectionBalanceConfig": {
+        "exactBalance": {}
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.rbac",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.rbac.v3.RBAC",
+                "rules": {
+
+                },
+                "statPrefix": "connect_authz"
+              }
+            },
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "public_listener",
+                "cluster": "local_app"
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -142,12 +142,6 @@ type UpstreamConfig struct {
 	// Namespace is only accepted within a service-defaults config entry.
 	Namespace string `json:",omitempty"`
 
-	// EnvoyConnectionBalanceType specifies how envoy connections should
-	// be distributed across worker threads. Currently, only the "exact_balance"
-	// type is accepted.
-	// https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig
-	EnvoyConnectionBalanceType string `json:",omitempty" alias:"envoy_connection_balance_type"`
-
 	// EnvoyListenerJSON is a complete override ("escape hatch") for the upstream's
 	// listener.
 	//
@@ -183,6 +177,10 @@ type UpstreamConfig struct {
 
 	// MeshGatewayConfig controls how Mesh Gateways are configured and used
 	MeshGateway MeshGatewayConfig `json:",omitempty" alias:"mesh_gateway" `
+
+	// BalanceOutboundConnections indicates that the proxy should attempt to evenly distribute
+	// outbound connections across worker threads. Only used by envoy proxies.
+	BalanceOutboundConnections bool `json:",omitempty" alias:"balance_outbound_connections"`
 }
 
 // DestinationConfig represents a virtual service, i.e. one that is external to Consul
@@ -229,24 +227,25 @@ type UpstreamLimits struct {
 }
 
 type ServiceConfigEntry struct {
-	Kind                  string
-	Name                  string
-	Partition             string                  `json:",omitempty"`
-	Namespace             string                  `json:",omitempty"`
-	Protocol              string                  `json:",omitempty"`
-	Mode                  ProxyMode               `json:",omitempty"`
-	TransparentProxy      *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
-	MeshGateway           MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
-	Expose                ExposeConfig            `json:",omitempty"`
-	ExternalSNI           string                  `json:",omitempty" alias:"external_sni"`
-	UpstreamConfig        *UpstreamConfiguration  `json:",omitempty" alias:"upstream_config"`
-	Destination           *DestinationConfig      `json:",omitempty"`
-	MaxInboundConnections int                     `json:",omitempty" alias:"max_inbound_connections"`
-	LocalConnectTimeoutMs int                     `json:",omitempty" alias:"local_connect_timeout_ms"`
-	LocalRequestTimeoutMs int                     `json:",omitempty" alias:"local_request_timeout_ms"`
-	Meta                  map[string]string       `json:",omitempty"`
-	CreateIndex           uint64
-	ModifyIndex           uint64
+	Kind                      string
+	Name                      string
+	Partition                 string                  `json:",omitempty"`
+	Namespace                 string                  `json:",omitempty"`
+	Protocol                  string                  `json:",omitempty"`
+	Mode                      ProxyMode               `json:",omitempty"`
+	TransparentProxy          *TransparentProxyConfig `json:",omitempty" alias:"transparent_proxy"`
+	MeshGateway               MeshGatewayConfig       `json:",omitempty" alias:"mesh_gateway"`
+	Expose                    ExposeConfig            `json:",omitempty"`
+	ExternalSNI               string                  `json:",omitempty" alias:"external_sni"`
+	UpstreamConfig            *UpstreamConfiguration  `json:",omitempty" alias:"upstream_config"`
+	Destination               *DestinationConfig      `json:",omitempty"`
+	MaxInboundConnections     int                     `json:",omitempty" alias:"max_inbound_connections"`
+	LocalConnectTimeoutMs     int                     `json:",omitempty" alias:"local_connect_timeout_ms"`
+	LocalRequestTimeoutMs     int                     `json:",omitempty" alias:"local_request_timeout_ms"`
+	BalanceInboundConnections bool                    `json:",omitempty" alias:"balance_inbound_connections"`
+	Meta                      map[string]string       `json:",omitempty"`
+	CreateIndex               uint64
+	ModifyIndex               uint64
 }
 
 func (s *ServiceConfigEntry) GetKind() string            { return s.Kind }

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -142,6 +142,12 @@ type UpstreamConfig struct {
 	// Namespace is only accepted within a service-defaults config entry.
 	Namespace string `json:",omitempty"`
 
+	// EnvoyConnectionBalanceType specifies how envoy connections should
+	// be distributed across worker threads. Currently, only the "exact_balance"
+	// type is accepted.
+	// https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig
+	EnvoyConnectionBalanceType string `json:",omitempty" alias:"envoy_connection_balance_type"`
+
 	// EnvoyListenerJSON is a complete override ("escape hatch") for the upstream's
 	// listener.
 	//

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -180,7 +180,7 @@ type UpstreamConfig struct {
 
 	// BalanceOutboundConnections indicates that the proxy should attempt to evenly distribute
 	// outbound connections across worker threads. Only used by envoy proxies.
-	BalanceOutboundConnections bool `json:",omitempty" alias:"balance_outbound_connections"`
+	BalanceOutboundConnections string `json:",omitempty" alias:"balance_outbound_connections"`
 }
 
 // DestinationConfig represents a virtual service, i.e. one that is external to Consul
@@ -242,7 +242,7 @@ type ServiceConfigEntry struct {
 	MaxInboundConnections     int                     `json:",omitempty" alias:"max_inbound_connections"`
 	LocalConnectTimeoutMs     int                     `json:",omitempty" alias:"local_connect_timeout_ms"`
 	LocalRequestTimeoutMs     int                     `json:",omitempty" alias:"local_request_timeout_ms"`
-	BalanceInboundConnections bool                    `json:",omitempty" alias:"balance_inbound_connections"`
+	BalanceInboundConnections string                  `json:",omitempty" alias:"balance_inbound_connections"`
 	Meta                      map[string]string       `json:",omitempty"`
 	CreateIndex               uint64
 	ModifyIndex               uint64

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -104,9 +104,10 @@ func TestAPI_ConfigEntries(t *testing.T) {
 				"foo": "bar",
 				"gir": "zim",
 			},
-			MaxInboundConnections: 5,
-			LocalConnectTimeoutMs: 5000,
-			LocalRequestTimeoutMs: 7000,
+			MaxInboundConnections:     5,
+			BalanceInboundConnections: "exact_balance",
+			LocalConnectTimeoutMs:     5000,
+			LocalRequestTimeoutMs:     7000,
 		}
 
 		dest := &DestinationConfig{
@@ -148,6 +149,7 @@ func TestAPI_ConfigEntries(t *testing.T) {
 		require.Equal(t, service.Meta, readService.Meta)
 		require.Equal(t, service.Meta, readService.GetMeta())
 		require.Equal(t, service.MaxInboundConnections, readService.MaxInboundConnections)
+		require.Equal(t, service.BalanceInboundConnections, readService.BalanceInboundConnections)
 		require.Equal(t, service.LocalConnectTimeoutMs, readService.LocalConnectTimeoutMs)
 		require.Equal(t, service.LocalRequestTimeoutMs, readService.LocalRequestTimeoutMs)
 
@@ -446,6 +448,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					"OutboundListenerPort": 808,
 					"DialedDirectly": true
 				},
+				"BalanceInboundConnections": "exact_balance",
 				"UpstreamConfig": {
 					"Overrides": [
 						{
@@ -454,7 +457,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 								"MaxFailures": 3,
 								"Interval": "2s",
 								"EnforcingConsecutive5xx": 60
-							}
+							},
+							"BalanceOutboundConnections": "exact_balance"
 						},
 						{
 							"Name": "finance--billing",
@@ -498,6 +502,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					OutboundListenerPort: 808,
 					DialedDirectly:       true,
 				},
+				BalanceInboundConnections: "exact_balance",
 				UpstreamConfig: &UpstreamConfiguration{
 					Overrides: []*UpstreamConfig{
 						{
@@ -507,6 +512,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 								Interval:                2 * time.Second,
 								EnforcingConsecutive5xx: uint32Pointer(60),
 							},
+							BalanceOutboundConnections: "exact_balance",
 						},
 						{
 							Name:        "finance--billing",

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -359,7 +359,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
     {
       name: 'BalanceInboundConnections',
       type: `string: ""`,
-      description: `Sets the strategy for allocating inbound connections to the service to proxy threads.
+      description: `Sets the strategy for allocating inbound connections to the service across proxy threads.
                       The only supported value is \`exact_balance\` for Enovy proxies or undefined
                       (no connection balancing) behavior. Refer to the
                       [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
@@ -458,7 +458,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
             {
               name: 'BalanceOutboundConnections',
               type: `string: ""`,
-              description: `Sets the strategy for allocating outbound connections from the upstream to proxy threads.
+              description: `Sets the strategy for allocating outbound connections from the upstream across proxy threads.
                   The only supported value is \`exact_balance\` for Enovy proxies or undefined
                   (no connection balancing) behavior. Refer to the
                   [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
@@ -609,7 +609,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
             {
               name: 'BalanceOutboundConnections',
               type: `string: ""`,
-              description: `Sets the strategy for allocating outbound connections from the upstream to proxy threads.
+              description: `Sets the strategy for allocating outbound connections from the upstream across proxy threads.
                   The only supported value is \`exact_balance\` for Enovy proxies or undefined
                   (no connection balancing) behavior. Refer to the
                   [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -363,7 +363,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
                       The only supported value is \`exact_balance\` for Enovy proxies or undefined
                       (no connection balancing) behavior. Refer to the
                       [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
-                      for details.
+                      for details.`
     },
     {
       name: 'Mode',
@@ -462,7 +462,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
                   The only supported value is \`exact_balance\` for Enovy proxies or undefined
                   (no connection balancing) behavior. Refer to the
                   [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
-                  for details.
+                  for details.`
             },
             {
               name: 'Limits',
@@ -613,7 +613,7 @@ represents a location outside the Consul cluster. They can be dialed directly wh
                   The only supported value is \`exact_balance\` for Enovy proxies or undefined
                   (no connection balancing) behavior. Refer to the
                   [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
-                  for details.
+                  for details.`
             },
             {
               name: 'Limits',

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -357,6 +357,15 @@ represents a location outside the Consul cluster. They can be dialed directly wh
                       Supported values are one of \`tcp\`, \`http\`, \`http2\`, or \`grpc\`.`,
     },
     {
+      name: 'BalanceInboundConnections',
+      type: `string: ""`,
+      description: `Sets the strategy for allocating inbound connections to the service to proxy threads.
+                      The only supported value is \`exact_balance\` for Enovy proxies or undefined
+                      (no connection balancing) behavior. Refer to the
+                      [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
+                      for details.
+    },
+    {
       name: 'Mode',
       type: `string: ""`,
       description: `One of \`direct\` or \`transparent\`.
@@ -445,6 +454,15 @@ represents a location outside the Consul cluster. They can be dialed directly wh
                   description: 'One of `none`, `local`, or `remote`.',
                 },
               ],
+            },
+            {
+              name: 'BalanceOutboundConnections',
+              type: `string: ""`,
+              description: `Sets the strategy for allocating outbound connections from the upstream to proxy threads.
+                  The only supported value is \`exact_balance\` for Enovy proxies or undefined
+                  (no connection balancing) behavior. Refer to the
+                  [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
+                  for details.
             },
             {
               name: 'Limits',
@@ -587,6 +605,15 @@ represents a location outside the Consul cluster. They can be dialed directly wh
                   description: 'One of `none`, `local`, or `remote`.',
                 },
               ],
+            },
+            {
+              name: 'BalanceOutboundConnections',
+              type: `string: ""`,
+              description: `Sets the strategy for allocating outbound connections from the upstream to proxy threads.
+                  The only supported value is \`exact_balance\` for Enovy proxies or undefined
+                  (no connection balancing) behavior. Refer to the
+                  [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
+                  for details.
             },
             {
               name: 'Limits',

--- a/website/content/docs/connect/config-entries/service-defaults.mdx
+++ b/website/content/docs/connect/config-entries/service-defaults.mdx
@@ -360,8 +360,8 @@ represents a location outside the Consul cluster. They can be dialed directly wh
       name: 'BalanceInboundConnections',
       type: `string: ""`,
       description: `Sets the strategy for allocating inbound connections to the service across proxy threads.
-                      The only supported value is \`exact_balance\` for Enovy proxies or undefined
-                      (no connection balancing) behavior. Refer to the
+                      The only supported value is \`exact_balance\`. By default, no connection balancing is used.
+                      Refer to the
                       [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
                       for details.`
     },
@@ -459,8 +459,8 @@ represents a location outside the Consul cluster. They can be dialed directly wh
               name: 'BalanceOutboundConnections',
               type: `string: ""`,
               description: `Sets the strategy for allocating outbound connections from the upstream across proxy threads.
-                  The only supported value is \`exact_balance\` for Enovy proxies or undefined
-                  (no connection balancing) behavior. Refer to the
+                  The only supported value is \`exact_balance\`. By default, no connection balancing is used.
+                  Refer to the
                   [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
                   for details.`
             },
@@ -610,8 +610,8 @@ represents a location outside the Consul cluster. They can be dialed directly wh
               name: 'BalanceOutboundConnections',
               type: `string: ""`,
               description: `Sets the strategy for allocating outbound connections from the upstream across proxy threads.
-                  The only supported value is \`exact_balance\` for Enovy proxies or undefined
-                  (no connection balancing) behavior. Refer to the
+                  The only supported value is \`exact_balance\`. By default, no connection balancing is used.
+                  Refer to the
                   [Envoy Connection Balance config](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig)
                   for details.`
             },

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -257,9 +257,8 @@ defaults that are inherited by all services.
   across Envoy worker threads. Consul service mesh Envoy integration supports the
   following `balance_inbound_connections` values:
 
-  - `""` - The default (empty) value. No connection balancing strategy will be used. 
-  - `exact_balance` - If set to this value, inbound connections to the service will
-    use the
+  - `""` - Empty string (default). No connection balancing strategy is used. Consul does not balance inbound connections. 
+  - `exact_balance` - Inbound connections to the service use the
   [Envoy Exact Balance Strategy.](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig-exactbalance)
 
 ### Proxy Upstream Config Options

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -253,6 +253,15 @@ defaults that are inherited by all services.
   specified, inherits the Envoy default for route timeouts (15s). A value of 0 will
   disable request timeouts.
 
+- `balance_inbound_connections` - The strategy used for balancing inbound connections
+  across Envoy worker threads. Connect's Envoy integration currently supports the
+  following `balance_inbound_connections` values:
+
+  - `""` - The default (empty) value. No connection balancing strategy will be used. 
+  - `exact_balance` - If set to this value, inbound connections to the service will
+    use the
+  [Envoy Exact Balance Strategy.](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig-exactbalance)
+
 ### Proxy Upstream Config Options
 
 The following configuration items may be overridden directly in the
@@ -311,6 +320,15 @@ definition](/docs/connect/registration/service-registration) or
     removed from the load balancer.
   -  `enforcing_consecutive_5xx` - The % chance that a host will be actually ejected 
     when an outlier status is detected through consecutive 5xx.
+
+- `balance_outbound_connections` - The strategy used for balancing outbound connections
+  across Envoy worker threads. Connect's Envoy integration currently supports the
+  following `balance_inbound_connections` values:
+
+  - `""` - The default (empty) value. No connection balancing strategy will be used. 
+  - `exact_balance` - If set to this value, outbound connections from the upstream will
+    use the
+  [Envoy Exact Balance Strategy.](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig-exactbalance)
 
 ### Gateway Options
 

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -254,7 +254,7 @@ defaults that are inherited by all services.
   disable request timeouts.
 
 - `balance_inbound_connections` - The strategy used for balancing inbound connections
-  across Envoy worker threads. Connect's Envoy integration currently supports the
+  across Envoy worker threads. Consul service mesh Envoy integration supports the
   following `balance_inbound_connections` values:
 
   - `""` - The default (empty) value. No connection balancing strategy will be used. 

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -323,7 +323,7 @@ definition](/docs/connect/registration/service-registration) or
 
 - `balance_outbound_connections` - The strategy used for balancing outbound connections
   across Envoy worker threads. Connect's Envoy integration currently supports the
-  following `balance_inbound_connections` values:
+  following `balance_outbound_connections` values:
 
   - `""` - The default (empty) value. No connection balancing strategy will be used. 
   - `exact_balance` - If set to this value, outbound connections from the upstream will

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -320,13 +320,12 @@ definition](/docs/connect/registration/service-registration) or
   -  `enforcing_consecutive_5xx` - The % chance that a host will be actually ejected 
     when an outlier status is detected through consecutive 5xx.
 
-- `balance_outbound_connections` - The strategy used for balancing outbound connections
-  across Envoy worker threads. Connect's Envoy integration currently supports the
+- `balance_outbound_connections` - Specifies the strategy for balancing outbound connections
+  across Envoy worker threads. Consul service mesh Envoy integration supports the
   following `balance_outbound_connections` values:
 
-  - `""` - The default (empty) value. No connection balancing strategy will be used. 
-  - `exact_balance` - If set to this value, outbound connections from the upstream will
-    use the
+  - `""` - Empty string (default). No connection balancing strategy is used. Consul does not balance outbound connections. 
+  - `exact_balance` - Outbound connections from the upstream use the
   [Envoy Exact Balance Strategy.](https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig-exactbalance)
 
 ### Gateway Options


### PR DESCRIPTION
### Description

This PR adds support for the Envoy `exact_balance` configuration option.

https://cloudnative.to/envoy/api-v3/config/listener/v3/listener.proto.html#config-listener-v3-listener-connectionbalanceconfig-exactbalance

Without this configuration, connections are randomly allocated to Envoy worker threads. Because connections never change threads in Envoy after creation, this can result in uneven distribution of workload. For long-lived, high-traffic connections, it is best to specify this option to guarantee that connection counts are maintained evenly between Envoy workers.

### Testing & Reproduction steps

Unit tests were added. Manual testing was performed by using the following configuration and toggling the various permutations of the new fields, then inspecting the Envoy admin `config_dump` endpoint.

```
Kind = "service-defaults"
Name = "middle"

BalanceInboundConnections = "exact_balance"
UpstreamConfig {
  Defaults {
    BalanceOutboundConnections = "exact_balance"
  }
  Overrides = [
    {
      Name = "end"
      BalanceOutboundConnections = "exact_balance"
    }
  ]
}
```
```
service {
  name = "middle"
  port = 9001

  connect {
    sidecar_service {
      proxy {
        config {
          balance_inbound_connections = "exact_balance"
        }
        upstreams = [
          {
            destination_name = "end"
            local_bind_port  = 5000
            config {
              balance_outbound_connections = "exact_balance"
            }
          },
          {
            destination_name = "something"
            local_bind_port  = 5001
          }
        ]
      }
    }
  }
}
```

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
