### PR TITLE
[BUGFIX] Do not use interval as timeout

### DIFF
--- a/.changelog/14619.txt
+++ b/.changelog/14619.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+checks: Do not set interval as timeout value
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2287,7 +2287,7 @@ func (a *Agent) addServiceInternal(req addServiceInternalRequest) error {
 			intervalStr = chkType.Interval.String()
 		}
 		if chkType.Timeout != 0 {
-			timeoutStr = chkType.Interval.String()
+			timeoutStr = chkType.Timeout.String()
 		}
 
 		check := &structs.HealthCheck{


### PR DESCRIPTION
### Description
This PR fix a bug in health checks that sets check's interval value as its timeout.
 
### Testing & Reproduction steps

Register a service with a timeout and interval set to different values. Retrieve the check information and see how interval value is returned for timeout field. 

### Links
The code diff is self explanatory

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
