### PR TITLE
feat: propogate local_request_timeout_ms to downstream

### DIFF
--- a/.changelog/14639.txt
+++ b/.changelog/14639.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+proxycfg: progagate `local_request_timeout_ms` downstream, if its value of the upstream is smaller than
+that of the downstream
+```

--- a/agent/proxycfg/manager.go
+++ b/agent/proxycfg/manager.go
@@ -148,7 +148,7 @@ func (m *Manager) Register(id ProxyID, ns *structs.NodeService, source ProxySour
 		return err
 	}
 
-	if _, err = state.Watch(); err != nil {
+	if err = state.Watch(); err != nil {
 		return err
 	}
 	m.proxies[id] = state

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -192,7 +192,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 			setup: func(t *testing.T, dataSources *TestDataSources) {
 				// Note that we deliberately leave the 'geo-cache' prepared query to time out
 				dataSources.Health.Set(dbHealthReq, &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, db.Name),
+					Nodes: TestUpstreamNodes(t, db.Name, structs.ConnectProxyConfig{}),
 				})
 				dataSources.CompiledDiscoveryChain.Set(dbChainReq, &structs.DiscoveryChainResponse{
 					Chain: dbDefaultChain(),
@@ -217,7 +217,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 						},
 						WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
 							dbUID: {
-								"db.default.default.dc1": TestUpstreamNodes(t, db.Name),
+								"db.default.default.dc1": TestUpstreamNodes(t, db.Name, structs.ConnectProxyConfig{}),
 							},
 						},
 						WatchedGateways: nil, // Clone() clears this out
@@ -251,7 +251,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 			setup: func(t *testing.T, dataSources *TestDataSources) {
 				// Note that we deliberately leave the 'geo-cache' prepared query to time out
 				dataSources.Health.Set(db_v1_HealthReq, &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, db.Name),
+					Nodes: TestUpstreamNodes(t, db.Name, structs.ConnectProxyConfig{}),
 				})
 				dataSources.Health.Set(db_v2_HealthReq, &structs.IndexedCheckServiceNodes{
 					Nodes: TestUpstreamNodesAlternate(t),
@@ -279,7 +279,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 						},
 						WatchedUpstreamEndpoints: map[UpstreamID]map[string]structs.CheckServiceNodes{
 							dbUID: {
-								"v1.db.default.default.dc1": TestUpstreamNodes(t, db.Name),
+								"v1.db.default.default.dc1": TestUpstreamNodes(t, db.Name, structs.ConnectProxyConfig{}),
 								"v2.db.default.default.dc1": TestUpstreamNodesAlternate(t),
 							},
 						},

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -245,19 +245,19 @@ type kindHandler interface {
 // registration state and returns a chan to observe updates to the
 // ConfigSnapshot that contains all necessary config state. The chan is closed
 // when the state is Closed.
-func (s *state) Watch() (<-chan ConfigSnapshot, error) {
+func (s *state) Watch() error {
 	var ctx context.Context
 	ctx, s.cancel = context.WithCancel(context.Background())
 
 	snap, err := s.handler.initialize(ctx)
 	if err != nil {
 		s.cancel()
-		return nil, err
+		return err
 	}
 
 	go s.run(ctx, &snap)
 
-	return s.snapCh, nil
+	return nil
 }
 
 // Close discards the state and stops any long-running watches.

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -153,7 +153,7 @@ func TestIntentions() structs.Intentions {
 
 // TestUpstreamNodes returns a sample service discovery result useful to
 // mocking service discovery cache results.
-func TestUpstreamNodes(t testing.T, service string) structs.CheckServiceNodes {
+func TestUpstreamNodes(t testing.T, service string, proxyConfig structs.ConnectProxyConfig) structs.CheckServiceNodes {
 	return structs.CheckServiceNodes{
 		structs.CheckServiceNode{
 			Node: &structs.Node{
@@ -163,7 +163,7 @@ func TestUpstreamNodes(t testing.T, service string) structs.CheckServiceNodes {
 				Datacenter: "dc1",
 				Partition:  structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty(),
 			},
-			Service: structs.TestNodeServiceWithName(t, service),
+			Service: structs.TestNodeServiceWithName(t, service, proxyConfig),
 		},
 		structs.CheckServiceNode{
 			Node: &structs.Node{
@@ -173,7 +173,7 @@ func TestUpstreamNodes(t testing.T, service string) structs.CheckServiceNodes {
 				Datacenter: "dc1",
 				Partition:  structs.NodeEnterpriseMetaInDefaultPartition().PartitionOrEmpty(),
 			},
-			Service: structs.TestNodeServiceWithName(t, service),
+			Service: structs.TestNodeServiceWithName(t, service, proxyConfig),
 		},
 	}
 }

--- a/agent/proxycfg/testing_connect_proxy.go
+++ b/agent/proxycfg/testing_connect_proxy.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestConfigSnapshot returns a fully populated snapshot
-func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), extraUpdates []UpdateEvent) *ConfigSnapshot {
+func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), upstreamProxyConfig structs.ConnectProxyConfig, extraUpdates []UpdateEvent) *ConfigSnapshot {
 	roots, leaf := TestCerts(t)
 
 	// no entries implies we'll get a default chain
@@ -63,7 +63,7 @@ func TestConfigSnapshot(t testing.T, nsFn func(ns *structs.NodeService), extraUp
 		{
 			CorrelationID: "upstream-target:" + dbChain.ID() + ":" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "db"),
+				Nodes: TestUpstreamNodes(t, "db", upstreamProxyConfig),
 			},
 		},
 	}
@@ -223,6 +223,7 @@ func TestConfigSnapshotExposeChecks(t testing.T) *ConfigSnapshot {
 				Checks: true,
 			}
 		},
+		structs.ConnectProxyConfig{},
 		[]UpdateEvent{
 			{
 				CorrelationID: svcChecksWatchIDPrefix + structs.ServiceIDString("web", nil),

--- a/agent/proxycfg/testing_ingress_gateway.go
+++ b/agent/proxycfg/testing_ingress_gateway.go
@@ -181,7 +181,7 @@ func TestConfigSnapshotIngressGatewaySDS_GatewayLevel_MixedTLS(t testing.T) *Con
 		{
 			CorrelationID: "upstream-target:" + secureChain.ID() + ":" + secureUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "secure"),
+				Nodes: TestUpstreamNodes(t, "secure", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -193,7 +193,7 @@ func TestConfigSnapshotIngressGatewaySDS_GatewayLevel_MixedTLS(t testing.T) *Con
 		{
 			CorrelationID: "upstream-target:" + insecureChain.ID() + ":" + insecureUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "insecure"),
+				Nodes: TestUpstreamNodes(t, "insecure", structs.ConnectProxyConfig{}),
 			},
 		},
 	})
@@ -291,7 +291,7 @@ func TestConfigSnapshotIngressGatewaySDS_GatewayAndListenerLevel_HTTP(t testing.
 		{
 			CorrelationID: "upstream-target:" + httpChain.ID() + ":" + httpUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "http"),
+				Nodes: TestUpstreamNodes(t, "http", structs.ConnectProxyConfig{}),
 			},
 		},
 	})
@@ -370,7 +370,7 @@ func TestConfigSnapshotIngressGatewaySDS_ServiceLevel(t testing.T) *ConfigSnapsh
 		{
 			CorrelationID: "upstream-target:" + s1Chain.ID() + ":" + s1UID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "s1"),
+				Nodes: TestUpstreamNodes(t, "s1", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -382,7 +382,7 @@ func TestConfigSnapshotIngressGatewaySDS_ServiceLevel(t testing.T) *ConfigSnapsh
 		{
 			CorrelationID: "upstream-target:" + s2Chain.ID() + ":" + s2UID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "s2"),
+				Nodes: TestUpstreamNodes(t, "s2", structs.ConnectProxyConfig{}),
 			},
 		},
 	})
@@ -460,7 +460,7 @@ func TestConfigSnapshotIngressGatewaySDS_ListenerAndServiceLevel(t testing.T) *C
 		{
 			CorrelationID: "upstream-target:" + s1Chain.ID() + ":" + s1UID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "s1"),
+				Nodes: TestUpstreamNodes(t, "s1", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -472,7 +472,7 @@ func TestConfigSnapshotIngressGatewaySDS_ListenerAndServiceLevel(t testing.T) *C
 		{
 			CorrelationID: "upstream-target:" + s2Chain.ID() + ":" + s2UID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "s2"),
+				Nodes: TestUpstreamNodes(t, "s2", structs.ConnectProxyConfig{}),
 			},
 		},
 	})
@@ -545,7 +545,7 @@ func TestConfigSnapshotIngressGatewaySDS_MixedNoTLS(t testing.T) *ConfigSnapshot
 		{
 			CorrelationID: "upstream-target:" + s1Chain.ID() + ":" + s1UID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "s1"),
+				Nodes: TestUpstreamNodes(t, "s1", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -557,7 +557,7 @@ func TestConfigSnapshotIngressGatewaySDS_MixedNoTLS(t testing.T) *ConfigSnapshot
 		{
 			CorrelationID: "upstream-target:" + s2Chain.ID() + ":" + s2UID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "s2"),
+				Nodes: TestUpstreamNodes(t, "s2", structs.ConnectProxyConfig{}),
 			},
 		},
 	})
@@ -627,7 +627,7 @@ func TestConfigSnapshotIngressGateway_MixedListeners(t testing.T) *ConfigSnapsho
 		{
 			CorrelationID: "upstream-target:" + s1Chain.ID() + ":" + s1UID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "s1"),
+				Nodes: TestUpstreamNodes(t, "s1", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -639,7 +639,7 @@ func TestConfigSnapshotIngressGateway_MixedListeners(t testing.T) *ConfigSnapsho
 		{
 			CorrelationID: "upstream-target:" + s2Chain.ID() + ":" + s2UID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "s2"),
+				Nodes: TestUpstreamNodes(t, "s2", structs.ConnectProxyConfig{}),
 			},
 		},
 	})
@@ -758,7 +758,7 @@ func TestConfigSnapshotIngress_HTTPMultipleServices(t testing.T) *ConfigSnapshot
 		{
 			CorrelationID: "upstream-target:" + fooChain.ID() + ":" + fooUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "foo"),
+				Nodes: TestUpstreamNodes(t, "foo", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -770,7 +770,7 @@ func TestConfigSnapshotIngress_HTTPMultipleServices(t testing.T) *ConfigSnapshot
 		{
 			CorrelationID: "upstream-target:" + barChain.ID() + ":" + barUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "bar"),
+				Nodes: TestUpstreamNodes(t, "bar", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -782,7 +782,7 @@ func TestConfigSnapshotIngress_HTTPMultipleServices(t testing.T) *ConfigSnapshot
 		{
 			CorrelationID: "upstream-target:" + bazChain.ID() + ":" + bazUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "baz"),
+				Nodes: TestUpstreamNodes(t, "baz", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -794,7 +794,7 @@ func TestConfigSnapshotIngress_HTTPMultipleServices(t testing.T) *ConfigSnapshot
 		{
 			CorrelationID: "upstream-target:" + quxChain.ID() + ":" + quxUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "qux"),
+				Nodes: TestUpstreamNodes(t, "qux", structs.ConnectProxyConfig{}),
 			},
 		},
 	})
@@ -885,7 +885,7 @@ func TestConfigSnapshotIngress_GRPCMultipleServices(t testing.T) *ConfigSnapshot
 		{
 			CorrelationID: "upstream-target:" + fooChain.ID() + ":" + fooUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "foo"),
+				Nodes: TestUpstreamNodes(t, "foo", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -897,7 +897,7 @@ func TestConfigSnapshotIngress_GRPCMultipleServices(t testing.T) *ConfigSnapshot
 		{
 			CorrelationID: "upstream-target:" + barChain.ID() + ":" + barUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "bar"),
+				Nodes: TestUpstreamNodes(t, "bar", structs.ConnectProxyConfig{}),
 			},
 		},
 	})
@@ -964,7 +964,7 @@ func TestConfigSnapshotIngress_MultipleListenersDuplicateService(t testing.T) *C
 		{
 			CorrelationID: "upstream-target:" + fooChain.ID() + ":" + fooUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "foo"),
+				Nodes: TestUpstreamNodes(t, "foo", structs.ConnectProxyConfig{}),
 			},
 		},
 		{
@@ -1225,13 +1225,13 @@ func TestConfigSnapshotIngressGatewayWithChain(
 			{
 				CorrelationID: "upstream-target:" + webChain.ID() + ":" + webUID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "web"),
+					Nodes: TestUpstreamNodes(t, "web", structs.ConnectProxyConfig{}),
 				},
 			},
 			{
 				CorrelationID: "upstream-target:" + fooChain.ID() + ":" + fooUID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "foo"),
+					Nodes: TestUpstreamNodes(t, "foo", structs.ConnectProxyConfig{}),
 				},
 			},
 		}
@@ -1382,25 +1382,25 @@ func TestConfigSnapshotIngressGateway_TLSMinVersionListenersGatewayDefaults(t te
 			{
 				CorrelationID: "upstream-target:" + s1Chain.ID() + ":" + s1UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s1"),
+					Nodes: TestUpstreamNodes(t, "s1", structs.ConnectProxyConfig{}),
 				},
 			},
 			{
 				CorrelationID: "upstream-target:" + s2Chain.ID() + ":" + s2UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s2"),
+					Nodes: TestUpstreamNodes(t, "s2", structs.ConnectProxyConfig{}),
 				},
 			},
 			{
 				CorrelationID: "upstream-target:" + s3Chain.ID() + ":" + s3UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s3"),
+					Nodes: TestUpstreamNodes(t, "s3", structs.ConnectProxyConfig{}),
 				},
 			},
 			{
 				CorrelationID: "upstream-target:" + s4Chain.ID() + ":" + s4UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s4"),
+					Nodes: TestUpstreamNodes(t, "s4", structs.ConnectProxyConfig{}),
 				},
 			},
 		})
@@ -1473,13 +1473,13 @@ func TestConfigSnapshotIngressGateway_SingleTLSListener(t testing.T) *ConfigSnap
 			{
 				CorrelationID: "upstream-target:" + s1Chain.ID() + ":" + s1UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s1"),
+					Nodes: TestUpstreamNodes(t, "s1", structs.ConnectProxyConfig{}),
 				},
 			},
 			{
 				CorrelationID: "upstream-target:" + s2Chain.ID() + ":" + s2UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s2"),
+					Nodes: TestUpstreamNodes(t, "s2", structs.ConnectProxyConfig{}),
 				},
 			},
 		})
@@ -1584,19 +1584,19 @@ func TestConfigSnapshotIngressGateway_TLSMixedMinVersionListeners(t testing.T) *
 			{
 				CorrelationID: "upstream-target:" + s1Chain.ID() + ":" + s1UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s1"),
+					Nodes: TestUpstreamNodes(t, "s1", structs.ConnectProxyConfig{}),
 				},
 			},
 			{
 				CorrelationID: "upstream-target:" + s2Chain.ID() + ":" + s2UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s2"),
+					Nodes: TestUpstreamNodes(t, "s2", structs.ConnectProxyConfig{}),
 				},
 			},
 			{
 				CorrelationID: "upstream-target:" + s3Chain.ID() + ":" + s3UID.String(),
 				Result: &structs.IndexedCheckServiceNodes{
-					Nodes: TestUpstreamNodes(t, "s3"),
+					Nodes: TestUpstreamNodes(t, "s3", structs.ConnectProxyConfig{}),
 				},
 			},
 		})

--- a/agent/proxycfg/testing_mesh_gateway.go
+++ b/agent/proxycfg/testing_mesh_gateway.go
@@ -507,9 +507,9 @@ func TestConfigSnapshotPeeredMeshGateway(t testing.T, variant string, nsFn func(
 		discoChains[fooSN] = fooChain
 		discoChains[barSN] = barChain
 		discoChains[girSN] = girChain
-		endpoints[fooSN] = TestUpstreamNodes(t, "foo")
-		endpoints[barSN] = TestUpstreamNodes(t, "bar")
-		endpoints[girSN] = TestUpstreamNodes(t, "gir")
+		endpoints[fooSN] = TestUpstreamNodes(t, "foo", structs.ConnectProxyConfig{})
+		endpoints[barSN] = TestUpstreamNodes(t, "bar", structs.ConnectProxyConfig{})
+		endpoints[girSN] = TestUpstreamNodes(t, "gir", structs.ConnectProxyConfig{})
 
 		extraUpdates = append(extraUpdates,
 			UpdateEvent{
@@ -605,8 +605,8 @@ func TestConfigSnapshotPeeredMeshGateway(t testing.T, variant string, nsFn func(
 		needPeerA = true
 		needLeaf = true
 		discoChains[dbSN] = dbChain
-		endpoints[dbSN] = TestUpstreamNodes(t, "db")
-		endpoints[altSN] = TestUpstreamNodes(t, "alt")
+		endpoints[dbSN] = TestUpstreamNodes(t, "db", structs.ConnectProxyConfig{})
+		endpoints[altSN] = TestUpstreamNodes(t, "alt", structs.ConnectProxyConfig{})
 
 		extraUpdates = append(extraUpdates,
 			UpdateEvent{

--- a/agent/proxycfg/testing_peering.go
+++ b/agent/proxycfg/testing_peering.go
@@ -31,7 +31,7 @@ func TestConfigSnapshotPeering(t testing.T) *ConfigSnapshot {
 			paymentsUpstream,
 			refundsUpstream,
 		}
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: peerTrustBundleIDPrefix + "cloud",
 			Result: &pbpeering.TrustBundleReadResponse{
@@ -148,7 +148,7 @@ func TestConfigSnapshotPeeringTProxy(t testing.T) *ConfigSnapshot {
 			noEndpointsUpstream,
 			apiAUpstream,
 		}
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{

--- a/agent/proxycfg/testing_terminating_gateway.go
+++ b/agent/proxycfg/testing_terminating_gateway.go
@@ -31,7 +31,7 @@ func TestConfigSnapshotTerminatingGateway(t testing.T, populateServices bool, ns
 
 	tgtwyServices := []*structs.GatewayService{}
 	if populateServices {
-		webNodes := TestUpstreamNodes(t, web.Name)
+		webNodes := TestUpstreamNodes(t, web.Name, structs.ConnectProxyConfig{})
 		webNodes[0].Service.Meta = map[string]string{"version": "1"}
 		webNodes[1].Service.Meta = map[string]string{"version": "2"}
 

--- a/agent/proxycfg/testing_tproxy.go
+++ b/agent/proxycfg/testing_tproxy.go
@@ -28,7 +28,7 @@ func TestConfigSnapshotTransparentProxy(t testing.T) *ConfigSnapshot {
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -141,7 +141,7 @@ func TestConfigSnapshotTransparentProxyHTTPUpstream(t testing.T) *ConfigSnapshot
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -245,7 +245,7 @@ func TestConfigSnapshotTransparentProxyCatalogDestinationsOnly(t testing.T) *Con
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -335,7 +335,7 @@ func TestConfigSnapshotTransparentProxyDialDirectly(t testing.T) *ConfigSnapshot
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -473,7 +473,7 @@ func TestConfigSnapshotTransparentProxyTerminatingGatewayCatalogDestinationsOnly
 
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -584,7 +584,7 @@ func TestConfigSnapshotTransparentProxyDestination(t testing.T) *ConfigSnapshot 
 	}
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{
@@ -677,7 +677,7 @@ func TestConfigSnapshotTransparentProxyDestinationHTTP(t testing.T) *ConfigSnaps
 	}
 	return TestConfigSnapshot(t, func(ns *structs.NodeService) {
 		ns.Proxy.Mode = structs.ProxyModeTransparent
-	}, []UpdateEvent{
+	}, structs.ConnectProxyConfig{}, []UpdateEvent{
 		{
 			CorrelationID: meshConfigEntryID,
 			Result: &structs.ConfigEntryResponse{

--- a/agent/proxycfg/testing_upstreams.go
+++ b/agent/proxycfg/testing_upstreams.go
@@ -35,7 +35,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		{
 			CorrelationID: "upstream-target:" + dbChain.ID() + ":" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "db"),
+				Nodes: TestUpstreamNodes(t, "db", structs.ConnectProxyConfig{}),
 			},
 		},
 	}
@@ -194,7 +194,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 		events = append(events, UpdateEvent{
 			CorrelationID: "upstream-target:v1.db.default.default.dc1:" + dbUID.String(),
 			Result: &structs.IndexedCheckServiceNodes{
-				Nodes: TestUpstreamNodes(t, "db"),
+				Nodes: TestUpstreamNodes(t, "db", structs.ConnectProxyConfig{}),
 			},
 		})
 		events = append(events, UpdateEvent{

--- a/agent/structs/testing_catalog.go
+++ b/agent/structs/testing_catalog.go
@@ -42,14 +42,15 @@ func TestRegisterIngressGateway(t testing.T) *RegisterRequest {
 
 // TestNodeService returns a *NodeService representing a valid regular service: "web".
 func TestNodeService(t testing.T) *NodeService {
-	return TestNodeServiceWithName(t, "web")
+	return TestNodeServiceWithName(t, "web", ConnectProxyConfig{})
 }
 
-func TestNodeServiceWithName(t testing.T, name string) *NodeService {
+func TestNodeServiceWithName(t testing.T, name string, proxyConfig ConnectProxyConfig) *NodeService {
 	return &NodeService{
 		Kind:    ServiceKindTypical,
 		Service: name,
 		Port:    8080,
+		Proxy:   proxyConfig,
 	}
 }
 

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -37,7 +37,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-min-version-auto",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -56,7 +56,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-min-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -75,7 +75,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-max-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -94,7 +94,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-cipher-suites",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -121,7 +121,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 						customAppClusterJSON(t, customClusterJSONOptions{
 							Name: "mylocal",
 						})
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 						customAppClusterJSON(t, customClusterJSONOptions{
 							Name: "myservice",
 						})
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							// Attempt to override the TLS context should be ignored
 							TLSContext: `"allowRenegotiation": false`,
 						})
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["local_connect_timeout_ms"] = 1234
 					ns.Proxy.Upstreams[0].Config["connect_timeout_ms"] = 2345
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -178,7 +178,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 						"max_failures":              float64(5),
 						"interval":                  float64(10),
 					}
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -186,7 +186,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["max_inbound_connections"] = 3456
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -206,7 +206,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							"max_connections": 500,
 						}
 					}
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -224,7 +224,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							"max_concurrent_requests": 0,
 						}
 					}
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -242,7 +242,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 							"max_concurrent_requests": 700,
 						}
 					}
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -344,7 +344,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 					ns.Proxy.LocalServiceAddress = ""
 					ns.Proxy.LocalServicePort = 0
 					ns.Proxy.LocalServiceSocketPath = "/tmp/downstream_proxy.sock"
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -2,6 +2,7 @@ package xds
 
 import (
 	"bytes"
+	"fmt"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -18,6 +19,98 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
 )
+
+func TestListenersFromSnapshot2(t *testing.T) {
+	// TODO: we should move all of these to TestAllResourcesFromSnapshot
+	// eventually to test all of the xDS types at once with the same input,
+	// just as it would be triggered by our xDS server.
+	if testing.Short() {
+		t.Skip("too slow for testing.Short")
+	}
+
+	tests := []struct {
+		name   string
+		create func(t testinf.T) *proxycfg.ConfigSnapshot
+		// Setup is called before the test starts. It is passed the snapshot from
+		// TestConfigSnapshot and is allowed to modify it in any way to setup the
+		// test input.
+		setup              func(snap *proxycfg.ConfigSnapshot)
+		overrideGoldenName string
+		generatorSetup     func(*ResourceGenerator)
+	}{
+		{
+			name: "http-upstream-local-request-timeout-rs",
+			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
+				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
+					ns.Proxy.Upstreams[0].Config["protocol"] = "http"
+					ns.Proxy.Config["protocol"] = "http"
+				}, structs.ConnectProxyConfig{
+					Config: map[string]interface{}{
+						"local_request_timeout_ms": float64(9000),
+						"protocol":                 "grpc",
+					},
+				}, nil)
+			},
+		},
+	}
+	latestEnvoyVersion := proxysupport.EnvoyVersions[0]
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
+		sf, err := determineSupportedProxyFeaturesFromString(envoyVersion)
+		require.NoError(t, err)
+		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					// Sanity check default with no overrides first
+					snap := tt.create(t)
+
+					// TODO: it would be nice to be able to ensure these snapshots are always valid before we use them in a test.
+					// require.True(t, snap.Valid())
+
+					// We need to replace the TLS certs with deterministic ones to make golden
+					// files workable. Note we don't update these otherwise they'd change
+					// golder files for every test case and so not be any use!
+					setupTLSRootsAndLeaf(t, snap)
+
+					if tt.setup != nil {
+						tt.setup(snap)
+					}
+
+					// Need server just for logger dependency
+					g := newResourceGenerator(testutil.Logger(t), nil, false)
+					g.ProxyFeatures = sf
+					if tt.generatorSetup != nil {
+						tt.generatorSetup(g)
+					}
+
+					listeners, err := g.listenersFromSnapshot(snap)
+					require.NoError(t, err)
+
+					// The order of listeners returned via LDS isn't relevant, so it's safe
+					// to sort these for the purposes of test comparisons.
+					sort.Slice(listeners, func(i, j int) bool {
+						return listeners[i].(*envoy_listener_v3.Listener).Name < listeners[j].(*envoy_listener_v3.Listener).Name
+					})
+
+					r, err := createResponse(xdscommon.ListenerType, "00000001", "00000001", listeners)
+					require.NoError(t, err)
+
+					t.Run("current", func(t *testing.T) {
+						gotJSON := protoToJSON(t, r)
+
+						gName := tt.name
+						if tt.overrideGoldenName != "" {
+							gName = tt.overrideGoldenName
+						}
+
+						expectedJSON := goldenEnvoy(t, filepath.Join("listeners", gName), envoyVersion, latestEnvoyVersion, gotJSON)
+						require.JSONEq(t, expectedJSON, gotJSON)
+					})
+				})
+			}
+		})
+		break
+	}
+}
 
 func TestListenersFromSnapshot(t *testing.T) {
 	// TODO: we should move all of these to TestAllResourcesFromSnapshot
@@ -40,7 +133,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-outgoing-min-version-auto",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -59,7 +152,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-incoming-min-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -78,7 +171,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-incoming-max-version",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -97,7 +190,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		{
 			name: "connect-proxy-with-tls-incoming-cipher-suites",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, []proxycfg.UpdateEvent{
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "mesh",
 						Result: &structs.ConfigEntryResponse{
@@ -121,7 +214,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["bind_address"] = "127.0.0.2"
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -129,7 +222,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["bind_port"] = 8888
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -138,7 +231,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["bind_address"] = "127.0.0.2"
 					ns.Proxy.Config["bind_port"] = 8888
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -149,7 +242,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 					ns.Proxy.Upstreams[0].LocalBindPort = 0
 					ns.Proxy.Upstreams[0].LocalBindSocketPath = "/tmp/service-mesh/client-1/grpc-employee-server"
 					ns.Proxy.Upstreams[0].LocalBindSocketMode = "0640"
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -157,7 +250,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["max_inbound_connections"] = 222
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -165,7 +258,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["protocol"] = "http"
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -174,7 +267,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshot(t,
 					func(ns *structs.NodeService) {
 						ns.Proxy.Config["protocol"] = "http"
-					},
+					}, structs.ConnectProxyConfig{},
 					[]proxycfg.UpdateEvent{
 						{
 							CorrelationID: "mesh",
@@ -196,7 +289,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 					ns.Proxy.Config["protocol"] = "http"
 					ns.Proxy.Config["local_connect_timeout_ms"] = 1234
 					ns.Proxy.Config["local_request_timeout_ms"] = 2345
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -204,7 +297,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Upstreams[0].Config["protocol"] = "http"
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -215,7 +308,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 						customListenerJSON(t, customListenerJSONOptions{
 							Name: "custom-public-listen",
 						})
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -227,7 +320,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 						customHTTPListenerJSON(t, customHTTPListenerJSONOptions{
 							Name: "custom-public-listen",
 						})
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -240,7 +333,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 							Name:                      "custom-public-listen",
 							HTTPConnectionManagerName: httpConnectionManagerNewName,
 						})
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -252,7 +345,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 						customListenerJSON(t, customListenerJSONOptions{
 							Name: "custom-public-listen",
 						})
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -266,7 +359,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 							// Attempt to override the TLS context should be ignored
 							TLSContext: `"allowRenegotiation": false`,
 						})
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -288,7 +381,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 								Name: uid.EnvoyID() + ":custom-upstream",
 							})
 					}
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -406,7 +499,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 						v.DestinationNamespace = structs.WildcardSpecifier
 						v.DestinationName = structs.WildcardSpecifier
 					}
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -778,7 +871,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 				return proxycfg.TestConfigSnapshot(t, func(ns *structs.NodeService) {
 					ns.Proxy.Config["protocol"] = "http"
 					ns.Proxy.Config["envoy_listener_tracing_json"] = customTraceJSON(t)
-				}, nil)
+				}, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 	}

--- a/agent/xds/resources_test.go
+++ b/agent/xds/resources_test.go
@@ -126,7 +126,7 @@ func TestAllResourcesFromSnapshot(t *testing.T) {
 		{
 			name: "defaults",
 			create: func(t testinf.T) *proxycfg.ConfigSnapshot {
-				return proxycfg.TestConfigSnapshot(t, nil, nil)
+				return proxycfg.TestConfigSnapshot(t, nil, structs.ConnectProxyConfig{}, nil)
 			},
 		},
 		{
@@ -136,7 +136,7 @@ func TestAllResourcesFromSnapshot(t *testing.T) {
 					// This test is only concerned about the SPIFFE cert validator config in the public listener
 					// so we empty out the upstreams to avoid generating unnecessary upstream listeners.
 					ns.Proxy.Upstreams = structs.Upstreams{}
-				}, []proxycfg.UpdateEvent{
+				}, structs.ConnectProxyConfig{}, []proxycfg.UpdateEvent{
 					{
 						CorrelationID: "peering-trust-bundles",
 						Result:        proxycfg.TestPeerTrustBundles(t),

--- a/agent/xds/testdata/listeners/http-upstream-local-request-timeout-rs.latest.golden
+++ b/agent/xds/testdata/listeners/http-upstream-local-request-timeout-rs.latest.golden
@@ -1,0 +1,193 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "upstream.db.default.default.dc1",
+                "routeConfig": {
+                  "name": "db",
+                  "virtualHosts": [
+                    {
+                      "name": "db.default.default.dc1",
+                      "domains": [
+                        "*"
+                      ],
+                      "routes": [
+                        {
+                          "match": {
+                            "prefix": "/"
+                          },
+                          "route": {
+                            "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "tracing": {
+                  "randomSampling": {
+
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.tcp_proxy",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
+                "statPrefix": "upstream.prepared_query_geo-cache",
+                "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "trafficDirection": "OUTBOUND"
+    },
+    {
+      "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.http_connection_manager",
+              "typedConfig": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                "statPrefix": "public_listener",
+                "routeConfig": {
+                  "name": "public_listener",
+                  "virtualHosts": [
+                    {
+                      "name": "public_listener",
+                      "domains": [
+                        "*"
+                      ],
+                      "routes": [
+                        {
+                          "match": {
+                            "prefix": "/"
+                          },
+                          "route": {
+                            "cluster": "local_app",
+                            "timeout": "9s"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "httpFilters": [
+                  {
+                    "name": "envoy.filters.http.rbac",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
+                      "rules": {
+
+                      }
+                    }
+                  },
+                  {
+                    "name": "envoy.filters.http.router",
+                    "typedConfig": {
+                      "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                    }
+                  }
+                ],
+                "tracing": {
+                  "randomSampling": {
+
+                  }
+                },
+                "forwardClientCertDetails": "APPEND_FORWARD",
+                "setCurrentClientCertDetails": {
+                  "subject": true,
+                  "cert": true,
+                  "chain": true,
+                  "dns": true,
+                  "uri": true
+                }
+              }
+            }
+          ],
+          "transportSocket": {
+            "name": "tls",
+            "typedConfig": {
+              "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+              "commonTlsContext": {
+                "tlsParams": {
+
+                },
+                "tlsCertificates": [
+                  {
+                    "certificateChain": {
+                      "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                    },
+                    "privateKey": {
+                      "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                    }
+                  }
+                ],
+                "validationContext": {
+                  "trustedCa": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                  }
+                }
+              },
+              "requireClientCertificate": true
+            }
+          }
+        }
+      ],
+      "trafficDirection": "INBOUND"
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.config.listener.v3.Listener",
+  "nonce": "00000001"
+}

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -250,7 +250,8 @@ defaults that are inherited by all services.
 
 - `local_request_timeout_ms` - In milliseconds, the request timeout for HTTP requests
   to the local application instance. Applies to HTTP based protocols only. If not
-  specified, inherits the Envoy default for route timeouts (15s). A value of 0 will
+  specified, inherits the Envoy default for route timeouts (15s) or the smaller
+  `local_request_timeout_ms` among the upstreams if there is any. A value of 0 will
   disable request timeouts.
 
 ### Proxy Upstream Config Options


### PR DESCRIPTION
### Description
**Situation**: "_If an application is configured with a local_request_timeout_ms value, would it be a good idea to auto-propagate this timeout to consumers/downstreams of that service. That way we don't have to configure the timeout in 2 different places. Maybe downstreams would want to timeout sooner. In that case they could specify the timeout and this would just be a way to modify the default timeout value._"

- The implementation of this PR is to loop over the upstream proxy services to find the smallest `local_request_timeout_ms`. If the value is smaller than the default, will propagate to the downstream proxy service.
    - call `makeInboundListener` after looping all the upstream

- doc is updated
- unit test is added: to make the upstream service to have its own `local_request_timeout_ms`, a new parameter is used to configure the proxy.Config of the upstream proxy service.

### Testing & Reproduction steps

### Links
Address https://github.com/hashicorp/consul/issues/12553

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
