### PR TITLE
Allow setting TLS for gRPC with deprecated options

### DIFF
--- a/.changelog/14644.txt
+++ b/.changelog/14644.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+tls: undo breaking change that prevented setting TLS for gRPC when using config flags available in Consul v1.11.
+```

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -838,7 +838,7 @@ func (a *Agent) listenAndServeGRPC() error {
 	if a.config.GRPCPort > 0 {
 		// Only allow the grpc port to spawn TLS connections if the other grpc_tls port is NOT defined.
 		var tlsConf *tls.Config = nil
-		if a.config.GRPCTLSPort <= 0 && a.tlsConfigurator.GRPCServerUseTLS() {
+		if a.config.GRPCTLSPort <= 0 && a.tlsConfigurator.GRPCServerUseTLS(a.config.HTTPSPort > 0) {
 			a.logger.Warn("deprecated gRPC TLS configuration detected. Consider using `ports.grpc_tls` instead")
 			tlsConf = a.tlsConfigurator.IncomingGRPCConfig()
 		}

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -189,9 +189,10 @@ func newBuilder(opts LoadOpts) (*builder, error) {
 	b.Tail = append(b.Tail, LiteralSource{Name: "flags.values", Config: values})
 	for i, s := range opts.HCL {
 		b.Tail = append(b.Tail, FileSource{
-			Name:   fmt.Sprintf("flags-%d.hcl", i),
-			Format: "hcl",
-			Data:   s,
+			Name:     fmt.Sprintf("flags-%d.hcl", i),
+			Format:   "hcl",
+			Data:     s,
+			FromUser: true,
 		})
 	}
 	b.Tail = append(b.Tail, NonUserSource(), DefaultConsulSource(), OverrideEnterpriseSource(), defaultVersionSource())
@@ -282,7 +283,7 @@ func newSourceFromFile(path string, format string) (Source, error) {
 	if format == "" {
 		format = formatFromFileExtension(path)
 	}
-	return FileSource{Name: path, Data: string(data), Format: format}, nil
+	return FileSource{Name: path, Data: string(data), Format: format, FromUser: true}, nil
 }
 
 // shouldParse file determines whether the file to be read is of a supported extension
@@ -2521,6 +2522,12 @@ func validateAbsoluteURLPath(p string) error {
 
 func (b *builder) buildTLSConfig(rt RuntimeConfig, t TLS) (tlsutil.Config, error) {
 	var c tlsutil.Config
+
+	// This flag indicates whether any of the per-listener configuration was set.
+	// The flag was populated earlier when applying deprecated options.
+	if t.SpecifiedTLSStanza != nil {
+		c.SpecifiedTLSStanza = *t.SpecifiedTLSStanza
+	}
 
 	// Consul makes no outgoing connections to the public gRPC port (internal gRPC
 	// traffic goes through the multiplexed internal RPC port) so return an error

--- a/agent/config/builder_test.go
+++ b/agent/config/builder_test.go
@@ -75,10 +75,10 @@ func TestNewBuilder_PopulatesSourcesFromConfigFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []Source{
-		FileSource{Name: paths[0], Format: "hcl", Data: "content a"},
-		FileSource{Name: paths[1], Format: "json", Data: "content b"},
-		FileSource{Name: filepath.Join(paths[3], "a.hcl"), Format: "hcl", Data: "content a"},
-		FileSource{Name: filepath.Join(paths[3], "b.json"), Format: "json", Data: "content b"},
+		FileSource{Name: paths[0], Format: "hcl", Data: "content a", FromUser: true},
+		FileSource{Name: paths[1], Format: "json", Data: "content b", FromUser: true},
+		FileSource{Name: filepath.Join(paths[3], "a.hcl"), Format: "hcl", Data: "content a", FromUser: true},
+		FileSource{Name: filepath.Join(paths[3], "b.json"), Format: "json", Data: "content b", FromUser: true},
 	}
 	require.Equal(t, expected, b.Sources)
 	require.Len(t, b.Warnings, 2)
@@ -91,12 +91,12 @@ func TestNewBuilder_PopulatesSourcesFromConfigFiles_WithConfigFormat(t *testing.
 	require.NoError(t, err)
 
 	expected := []Source{
-		FileSource{Name: paths[0], Format: "hcl", Data: "content a"},
-		FileSource{Name: paths[1], Format: "hcl", Data: "content b"},
-		FileSource{Name: paths[2], Format: "hcl", Data: "content c"},
-		FileSource{Name: filepath.Join(paths[3], "a.hcl"), Format: "hcl", Data: "content a"},
-		FileSource{Name: filepath.Join(paths[3], "b.json"), Format: "hcl", Data: "content b"},
-		FileSource{Name: filepath.Join(paths[3], "c.yaml"), Format: "hcl", Data: "content c"},
+		FileSource{Name: paths[0], Format: "hcl", Data: "content a", FromUser: true},
+		FileSource{Name: paths[1], Format: "hcl", Data: "content b", FromUser: true},
+		FileSource{Name: paths[2], Format: "hcl", Data: "content c", FromUser: true},
+		FileSource{Name: filepath.Join(paths[3], "a.hcl"), Format: "hcl", Data: "content a", FromUser: true},
+		FileSource{Name: filepath.Join(paths[3], "b.json"), Format: "hcl", Data: "content b", FromUser: true},
+		FileSource{Name: filepath.Join(paths[3], "c.yaml"), Format: "hcl", Data: "content c", FromUser: true},
 	}
 	require.Equal(t, expected, b.Sources)
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/hashicorp/consul/agent/consul"
@@ -30,6 +31,10 @@ type FileSource struct {
 	Name   string
 	Format string
 	Data   string
+
+	// FromUser indicates whether the the file source was provided by the user.
+	// This distinguishes from synthetic file sources that Consul will generate.
+	FromUser bool
 }
 
 func (f FileSource) Source() string {
@@ -79,7 +84,7 @@ func (f FileSource) Parse() (Config, Metadata, error) {
 		return Config{}, m, err
 	}
 
-	c, warns := applyDeprecatedConfig(&target)
+	c, warns := applyDeprecatedConfig(&target, f.FromUser)
 	m.Unused = md.Unused
 	m.Keys = md.Keys
 	m.Warnings = warns
@@ -872,11 +877,27 @@ type TLSProtocolConfig struct {
 	UseAutoCert          *bool   `mapstructure:"use_auto_cert"`
 }
 
+func (c TLSProtocolConfig) IsZero() bool {
+	v := reflect.ValueOf(c)
+
+	hasValues := false
+	for i := 0; i < v.NumField(); i++ {
+		if !v.Field(i).IsNil() {
+			hasValues = true
+		}
+	}
+	return !hasValues
+}
+
 type TLS struct {
 	Defaults    TLSProtocolConfig `mapstructure:"defaults"`
 	InternalRPC TLSProtocolConfig `mapstructure:"internal_rpc"`
 	HTTPS       TLSProtocolConfig `mapstructure:"https"`
 	GRPC        TLSProtocolConfig `mapstructure:"grpc"`
+
+	// SpecifiedTLSStanza indicates whether the per-protocol tls stanza from configuration was used.
+	// If unspecified, and TLS is configured, that implies that the deprecated flags were used.
+	SpecifiedTLSStanza *bool
 
 	// GRPCModifiedByDeprecatedConfig is a flag used to indicate that GRPC was
 	// modified by the deprecated field mapping (as apposed to a user-provided
@@ -890,6 +911,11 @@ type TLS struct {
 	// Note: we use a *struct{} here because a simple bool isn't supported by our
 	// config merging logic.
 	GRPCModifiedByDeprecatedConfig *struct{} `mapstructure:"-"`
+}
+
+// ContainsDefaults indicates whether the user-settable values in this type are the defaults.
+func (t *TLS) ContainsDefaults() bool {
+	return t.Defaults.IsZero() && t.InternalRPC.IsZero() && t.HTTPS.IsZero() && t.GRPC.IsZero()
 }
 
 type Peering struct {

--- a/agent/config/deprecated.go
+++ b/agent/config/deprecated.go
@@ -70,7 +70,7 @@ type DeprecatedConfig struct {
 	TLSPreferServerCipherSuites *bool `mapstructure:"tls_prefer_server_cipher_suites"`
 }
 
-func applyDeprecatedConfig(d *decodeTarget) (Config, []string) {
+func applyDeprecatedConfig(d *decodeTarget, fromUser bool) (Config, []string) {
 	dep := d.DeprecatedConfig
 	var warns []string
 
@@ -172,15 +172,26 @@ func applyDeprecatedConfig(d *decodeTarget) (Config, []string) {
 		warns = append(warns, deprecationWarning("acl_enable_key_list_policy", "acl.enable_key_list_policy"))
 	}
 
-	warns = append(warns, applyDeprecatedTLSConfig(dep, &d.Config)...)
+	warns = append(warns, applyDeprecatedTLSConfig(dep, &d.Config, fromUser)...)
 
 	return d.Config, warns
 }
 
-func applyDeprecatedTLSConfig(dep DeprecatedConfig, cfg *Config) []string {
+func applyDeprecatedTLSConfig(dep DeprecatedConfig, cfg *Config, fromUser bool) []string {
 	var warns []string
 
 	tls := &cfg.TLS
+
+	// If the TLS stanza was specified by the user then we set a flag to indicate that.
+	// This check MUST happen before applying the deprecated options below, or else
+	// the tls struct will never be empty.
+	//
+	// This check was added for compatibility with Consul 1.11 style TLS configuration.
+	// Associated code can be removed once 1.14 is out and 1.11 is no longer supported.
+	if fromUser && !tls.ContainsDefaults() {
+		tls.SpecifiedTLSStanza = pBool(true)
+	}
+
 	defaults := &tls.Defaults
 	internalRPC := &tls.InternalRPC
 	https := &tls.HTTPS

--- a/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
+++ b/agent/config/testdata/TestRuntimeConfig_Sanitize.golden
@@ -374,10 +374,10 @@
             "CipherSuites": [],
             "KeyFile": "hidden",
             "TLSMinVersion": "",
+            "UseAutoCert": false,
             "VerifyIncoming": false,
             "VerifyOutgoing": false,
-            "VerifyServerHostname": false,
-            "UseAutoCert": false
+            "VerifyServerHostname": false
         },
         "HTTPS": {
             "CAFile": "",
@@ -386,10 +386,10 @@
             "CipherSuites": [],
             "KeyFile": "hidden",
             "TLSMinVersion": "",
+            "UseAutoCert": false,
             "VerifyIncoming": false,
             "VerifyOutgoing": false,
-            "VerifyServerHostname": false,
-            "UseAutoCert": false
+            "VerifyServerHostname": false
         },
         "InternalRPC": {
             "CAFile": "",
@@ -398,13 +398,14 @@
             "CipherSuites": [],
             "KeyFile": "hidden",
             "TLSMinVersion": "",
+            "UseAutoCert": false,
             "VerifyIncoming": false,
             "VerifyOutgoing": false,
-            "VerifyServerHostname": false,
-            "UseAutoCert": false
+            "VerifyServerHostname": false
         },
         "NodeName": "",
-        "ServerName": ""
+        "ServerName": "",
+        "SpecifiedTLSStanza": false
     },
     "TaggedAddresses": {},
     "Telemetry": {

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -229,7 +229,7 @@ func testServerWithConfig(t *testing.T, configOpts ...func(*Config)) (string, *S
 		}
 
 		// Apply config to copied fields because many tests only set the old
-		//values.
+		// values.
 		config.ACLResolverSettings.ACLsEnabled = config.ACLsEnabled
 		config.ACLResolverSettings.NodeName = config.NodeName
 		config.ACLResolverSettings.Datacenter = config.Datacenter
@@ -252,7 +252,7 @@ func testServerWithConfig(t *testing.T, configOpts ...func(*Config)) (string, *S
 		require.NoError(t, err)
 
 		// Wrap the listener with TLS
-		if deps.TLSConfigurator.GRPCServerUseTLS() {
+		if deps.TLSConfigurator.GRPCServerUseTLS(false) {
 			ln = tls.NewListener(ln, deps.TLSConfigurator.IncomingGRPCConfig())
 		}
 

--- a/api/peering_test.go
+++ b/api/peering_test.go
@@ -43,6 +43,7 @@ func TestAPI_Peering_ACLDeny(t *testing.T) {
 		serverConfig.ACL.Enabled = true
 		serverConfig.ACL.DefaultPolicy = "deny"
 		serverConfig.Ports.GRPC = 5300
+		serverConfig.Ports.HTTPS = -1
 	})
 	defer s1.Stop()
 
@@ -51,6 +52,7 @@ func TestAPI_Peering_ACLDeny(t *testing.T) {
 		serverConfig.ACL.Enabled = true
 		serverConfig.ACL.DefaultPolicy = "deny"
 		serverConfig.Ports.GRPC = 5301
+		serverConfig.Ports.HTTPS = -1
 		serverConfig.Datacenter = "dc2"
 	})
 	defer s2.Stop()
@@ -263,7 +265,10 @@ func TestAPI_Peering_GenerateToken_ExternalAddresses(t *testing.T) {
 func TestAPI_Peering_GenerateToken_Read_Establish_Delete(t *testing.T) {
 	t.Parallel()
 
-	c, s := makeClient(t) // this is "dc1"
+	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
+		conf.Datacenter = "dc1"
+		conf.Ports.HTTPS = -1
+	})
 	defer s.Stop()
 	s.WaitForSerfCheck(t)
 


### PR DESCRIPTION
### Description
Currently TLS for gRPC can only be enabled using the options nested in the tls.grpc configuration stanza.

That leads to a breaking change where the TLS options deprecated in 1.12 cannot be used to enable TLS for gRPC.

This commit updates the logic for determining whether TLS should be used on the public gRPC port: If the 1.12 tls stanza is not specified we default to the original behavior, which is to enable TLS for gRPC if the HTTPS port is set.

The change allows for consul-k8s to continue to use TLS flags compatible with 1.11 until 1.14 is released.

### Testing & Reproduction steps
* Unit tests
* Manual tests:
  * Given multiple config files where some use the TLS stanza and others don't --> used post 1.13 logic to set TLS since at least one specified the new TLS stanza.
  * Given multiple config files where TLS certs were specified with deprecated flags and the HTTPS port was set --> used old logic and enabled TLS

### Links
Related to:
- #14253
- #13733

### PR Checklist

* [x] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
