### PR TITLE
changelog: fix missing backtick

### DIFF
--- a/.changelog/14429.txt
+++ b/.changelog/14429.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
 connect: Fixed an issue where intermediate certificates could build up in the root CA because they were never being pruned after expiring.
-``
+```


### PR DESCRIPTION
### Description
I was reviewing the OSS→Ent backlog for 1.12 and noticed the changelog entry for #14429 was missing a backtick.