### PR TITLE
fix: peering two partitions in the same dc

### DIFF
--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -476,7 +476,7 @@ func (s *Server) validatePeeringLocality(token *structs.PeeringToken, partition 
 
 	// If the token has the same server name as this cluster, but we can't find the peering
 	// in our store, it indicates a naming conflict.
-	if s.Backend.GetServerName() == token.ServerName && peering == nil {
+	if s.Backend.GetServerName() == token.ServerName && peering == nil && partition == "" {
 		return fmt.Errorf("conflict - peering token's server name matches the current cluster's server name, %q, but there is no record in the database", s.Backend.GetServerName())
 	}
 


### PR DESCRIPTION
### Description
Peering 2 partitions in the same datacenter is disallowed by the validation. If this is intended, maybe we can return a better error message.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
