### PR TITLE
Docs/fix node lookup by removing tag/stable website manual backport

### DIFF
--- a/website/content/docs/discovery/dns.mdx
+++ b/website/content/docs/discovery/dns.mdx
@@ -105,7 +105,7 @@ the partition and datacenter of the Consul agent that received the DNS query.
 
 Use the following query format to specify a partition for a node lookup:
 ```text
-[<tag>.]<node>.node.<partition>.ap.<datacenter>.dc.<domain>
+<node>.node.<partition>.ap.<datacenter>.dc.<domain>
 ```
 
 Consul server agents are in the `default` partition.


### PR DESCRIPTION
Replaces https://github.com/hashicorp/consul/pull/14427

Automated backport failed due to some merge conflict. I tried to fix it, but the PR appears to be stuck due to a missing CLA agreement from user "temp" (probably something about our automation).

Manually submitting a PR to stable website to get this fixed.