### PR TITLE
doc(peering): missing network requirement for peering and the partiti…

### DIFF
--- a/website/content/api-docs/peering.mdx
+++ b/website/content/api-docs/peering.mdx
@@ -270,6 +270,11 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | -------------- |
 | `NO`             | `consistent`      | `none`        | `peering:read` |
 
+### Query Parameters
+
+- `partition` `(string: "")` <EnterpriseAlert inline /> - Specifies the partition of the peerings
+  to list. If not specified will default to `default`.
+
 ### Sample Request
 
 ```shell-session

--- a/website/content/api-docs/peering.mdx
+++ b/website/content/api-docs/peering.mdx
@@ -221,8 +221,11 @@ The table below shows this endpoint's support for
 ### Path Parameters
 
 - `name` `(string: <required>)` - Specifies the name of the peering to delete.
-- `partition` `(string: "")` <EnterpriseAlert inline /> - Specifies the partition of the peering
-  to delete. Uses `default` when not specified.
+
+### Query Parameters
+
+- `partition` `(string: "")` <EnterpriseAlert inline /> - Specifies the partition of the peerings
+  to delete. If not specified will default to `default`.
 
 ### Sample Request
 

--- a/website/content/docs/connect/cluster-peering/create-manage-peering.mdx
+++ b/website/content/docs/connect/cluster-peering/create-manage-peering.mdx
@@ -13,7 +13,7 @@ A peering token enables cluster peering between different datacenters. Once you 
 
 ## Create a peering connection
 
-Cluster peering is not enabled by default on Consul servers. To peer clusters, you must first configure all Consul servers so that `peering` is `enabled`. For additional information, refer to [Configuration Files](/docs/agent/config/config-files).
+Cluster peering is not enabled by default on Consul servers. To peer clusters, you must first configure all Consul servers so that `peering` is `enabled` and the gRPC port(8502) accepts traffic from the peering cluster (e.g., `client_addr="0.0.0.0"`). For additional information, refer to [Configuration Files](/docs/agent/config/config-files).
 
 After enabling peering for all Consul servers, complete the following steps in order:
 


### PR DESCRIPTION
### Description
- The peering doc doesn't mention about the gRPC port, which is by defautl only bound to localhost.
- the list peering API allows `partition` query parameter

### Testing & Reproduction steps
- Without setting client_addr to non-localhost address, peering establishment fails
- partition queyr parameter works, but missing in the doc

```
curl http://127.0.0.1:8500/v1/peerings\?partition\=foo 
[
  {
    "ID": "7c25adf4-73cd-6d1d-284c-5f96e36ace33",
    "Name": "dc3",
    "Partition": "foo",
    "State": "ACTIVE",
    "ImportedServiceCount": 0,
    "ExportedServiceCount": 0,
    "CreateIndex": 23,
    "ModifyIndex": 23
  }
]
```

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
