### PR TITLE
Return mesh gateway addrs if peering through mgw

### DIFF
--- a/agent/consul/peering_backend.go
+++ b/agent/consul/peering_backend.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/acl/resolver"
+	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/consul/stream"
 	"github.com/hashicorp/consul/agent/grpc-external/services/peerstream"
 	"github.com/hashicorp/consul/agent/rpc/peering"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/proto/pbpeering"
 )
 
@@ -57,9 +59,38 @@ func (b *PeeringBackend) GetAgentCACertificates() ([]string, error) {
 	return b.srv.tlsConfigurator.GRPCManualCAPems(), nil
 }
 
-// GetServerAddresses looks up server node addresses from the state store.
+// GetServerAddresses looks up server or mesh gateway addresses from the state store.
 func (b *PeeringBackend) GetServerAddresses() ([]string, error) {
-	state := b.srv.fsm.State()
+	_, rawEntry, err := b.srv.fsm.State().ConfigEntry(nil, structs.MeshConfig, structs.MeshConfigMesh, acl.DefaultEnterpriseMeta())
+	if err != nil {
+		return nil, fmt.Errorf("failed to read mesh config entry: %w", err)
+	}
+
+	meshConfig, ok := rawEntry.(*structs.MeshConfigEntry)
+	if ok && meshConfig.Peering != nil && meshConfig.Peering.PeerThroughMeshGateways {
+		return meshGatewayAdresses(b.srv.fsm.State())
+	}
+	return serverAddresses(b.srv.fsm.State())
+}
+
+func meshGatewayAdresses(state *state.Store) ([]string, error) {
+	_, nodes, err := state.ServiceDump(nil, structs.ServiceKindMeshGateway, true, acl.DefaultEnterpriseMeta(), structs.DefaultPeerKeyword)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dump gateway addresses: %w", err)
+	}
+
+	var addrs []string
+	for _, node := range nodes {
+		_, addr, port := node.BestAddress(true)
+		addrs = append(addrs, ipaddr.FormatAddressPort(addr, port))
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("servers are configured to PeerThroughMeshGateways, but no mesh gateway instances are registered")
+	}
+	return addrs, nil
+}
+
+func serverAddresses(state *state.Store) ([]string, error) {
 	_, nodes, err := state.ServiceNodes(nil, "consul", structs.DefaultEnterpriseMetaInDefaultPartition(), structs.DefaultPeerKeyword)
 	if err != nil {
 		return nil, err

--- a/agent/consul/peering_backend_test.go
+++ b/agent/consul/peering_backend_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/types"
 	"github.com/stretchr/testify/require"
 	gogrpc "google.golang.org/grpc"
@@ -71,7 +72,7 @@ func TestPeeringBackend_GetServerAddresses(t *testing.T) {
 	}
 
 	_, cfg := testServerConfig(t)
-	cfg.GRPCTLSPort = 8505
+	cfg.GRPCTLSPort = freeport.GetOne(t)
 
 	srv, err := newServer(t, cfg)
 	require.NoError(t, err)

--- a/agent/consul/servercert/manager.go
+++ b/agent/consul/servercert/manager.go
@@ -150,7 +150,6 @@ func (m *CertManager) watchServerToken(ctx context.Context) {
 
 		// Cancel existing the leaf cert watch and spin up new one any time the server token changes.
 		// The watch needs the current token as set by the leader since certificate signing requests go to the leader.
-		fmt.Println("canceling and resetting")
 		cancel()
 		notifyCtx, cancel = context.WithCancel(ctx)
 

--- a/agent/grpc-external/services/peerstream/server.go
+++ b/agent/grpc-external/services/peerstream/server.go
@@ -123,5 +123,6 @@ type StateStore interface {
 	CAConfig(ws memdb.WatchSet) (uint64, *structs.CAConfiguration, error)
 	TrustBundleListByService(ws memdb.WatchSet, service, dc string, entMeta acl.EnterpriseMeta) (uint64, []*pbpeering.PeeringTrustBundle, error)
 	ServiceList(ws memdb.WatchSet, entMeta *acl.EnterpriseMeta, peerName string) (uint64, structs.ServiceList, error)
+	ConfigEntry(ws memdb.WatchSet, kind, name string, entMeta *acl.EnterpriseMeta) (uint64, structs.ConfigEntry, error)
 	AbandonCh() <-chan struct{}
 }

--- a/agent/grpc-external/services/peerstream/stream_resources.go
+++ b/agent/grpc-external/services/peerstream/stream_resources.go
@@ -640,9 +640,6 @@ func (s *Server) realHandleStream(streamReq HandleStreamRequest) error {
 					continue
 				}
 
-			case strings.HasPrefix(update.CorrelationID, subMeshGateway):
-				// TODO(Peering): figure out how to sync this separately
-
 			case update.CorrelationID == subCARoot:
 				resp, err = makeCARootsResponse(update)
 				if err != nil {

--- a/agent/rpc/peering/service.go
+++ b/agent/rpc/peering/service.go
@@ -117,7 +117,8 @@ type Backend interface {
 	// GetAgentCACertificates returns the CA certificate to be returned in the peering token data
 	GetAgentCACertificates() ([]string, error)
 
-	// GetServerAddresses returns the addresses used for establishing a peering connection
+	// GetServerAddresses returns the addresses used for establishing a peering connection.
+	// These may be server addresses or mesh gateway addresses if peering through mesh gateways.
 	GetServerAddresses() ([]string, error)
 
 	// GetServerName returns the SNI to be returned in the peering token data which

--- a/lib/retry/retry.go
+++ b/lib/retry/retry.go
@@ -96,7 +96,9 @@ func (w *Waiter) Failures() int {
 // Every call to Wait increments the failures count, so Reset must be called
 // after Wait when there wasn't a failure.
 //
-// Wait will return ctx.Err() if the context is cancelled.
+// The only non-nil error that Wait returns will come from ctx.Err(),
+// such as when the context is canceled. This makes it suitable for
+// long-running routines that do not get re-initialized, such as replication.
 func (w *Waiter) Wait(ctx context.Context) error {
 	w.failures++
 	timer := time.NewTimer(w.delay())


### PR DESCRIPTION
### Description
Exposing servers through mesh gateways will involve sharing mesh gateway addresses with peers instead of true server addresses.

There are two flows where these addresses are shared:

* When generating a peering token.
* When pushing server address updates in the peering stream.

Each flow was addressed in a separate commit.

### Testing & Reproduction steps
* Unit tests

### Links
* NET-644
* PR with config entry changes: #14475

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
