### PR TITLE
fix missing changelog entries that were released

### DIFF
--- a/.changelog/11500.txt
+++ b/.changelog/11500.txt
@@ -1,4 +1,4 @@
-```release-note:bugfix
+```release-note:bug
 rpc: Adds a deadline to client RPC calls, so that streams will no longer hang
 indefinitely in unstable network conditions. [[GH-8504](https://github.com/hashicorp/consul/issues/8504)]
 ```

--- a/.changelog/14233.txt
+++ b/.changelog/14233.txt
@@ -1,3 +1,3 @@
-```release-note:bugfix
+```release-note:bug
 rpc: Adds max jitter to client deadlines to prevent i/o deadline errors on blocking queries
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ BUG FIXES:
 * cli: When launching a sidecar proxy with `consul connect envoy` or `consul connect proxy`, the `-sidecar-for` service ID argument is now treated as case-insensitive. [[GH-14034](https://github.com/hashicorp/consul/issues/14034)]
 * connect: Fixed a bug where old root CAs would be removed from the primary datacenter after switching providers and restarting the cluster. [[GH-14598](https://github.com/hashicorp/consul/issues/14598)]
 * connect: Fixed an issue where intermediate certificates could build up in the root CA because they were never being pruned after expiring. [[GH-14429](https://github.com/hashicorp/consul/issues/14429)]
+* rpc: Adds a deadline to client RPC calls, so that streams will no longer hang
+indefinitely in unstable network conditions. [[GH-8504](https://github.com/hashicorp/consul/issues/8504)] [[GH-11500](https://github.com/hashicorp/consul/issues/11500)]
+* rpc: Adds max jitter to client deadlines to prevent i/o deadline errors on blocking queries [[GH-14233](https://github.com/hashicorp/consul/issues/14233)]
 
 ## 1.11.8 (August 11, 2022)
 


### PR DESCRIPTION
### Description
Some changelog entries were missed from the 1.11.9 release because of wrong note types. This fixes the notes and adds the missing changelog items for what was already released.