### PR TITLE
ui: Update empty-state copy throughout app

### DIFF
--- a/ui/packages/consul-lock-sessions/app/templates/dc/nodes/show/sessions.hbs
+++ b/ui/packages/consul-lock-sessions/app/templates/dc/nodes/show/sessions.hbs
@@ -79,6 +79,7 @@ as |route|>
               </BlockSlot>
               <BlockSlot @name="body">
                 {{t 'routes.dc.nodes.show.sessions.empty.body'
+                  canUseACLs=(can "use acls")
                   htmlSafe=true
                 }}
               </BlockSlot>

--- a/ui/packages/consul-nspaces/app/templates/dc/nspaces/index.hbs
+++ b/ui/packages/consul-nspaces/app/templates/dc/nspaces/index.hbs
@@ -105,20 +105,15 @@ as |route|>
             >
               <BlockSlot @name="header">
                 <h2>
-                  {{#if (gt items.length 0)}}
-                    No namespaces found
-                  {{else}}
-                    Welcome to Namespaces
-                  {{/if}}
+                  {{t 'routes.dc.namespaces.index.empty.header'
+                    items=items.length}}
                 </h2>
               </BlockSlot>
               <BlockSlot @name="body">
                 <p>
-                  {{#if (gt items.length 0)}}
-                    No namespaces where found matching that search, or you may not have access to view the namespaces you are searching for.
-                  {{else}}
-                    There don't seem to be any namespaces, or you may not have access to view namespaces yet.
-                  {{/if}}
+                  {{t 'routes.dc.namespaces.index.empty.body'
+                    items=items.length
+                    canUseACLs=(can 'use acls')}}
                 </p>
               </BlockSlot>
               <BlockSlot @name="actions">

--- a/ui/packages/consul-partitions/app/templates/dc/partitions/index.hbs
+++ b/ui/packages/consul-partitions/app/templates/dc/partitions/index.hbs
@@ -111,20 +111,15 @@ as |route|>
             >
               <BlockSlot @name="header">
                 <h2>
-                  {{#if (gt items.length 0)}}
-                    No partitions found
-                  {{else}}
-                    Welcome to Partitions
-                  {{/if}}
+                  {{t 'routes.dc.partitions.index.empty.header'
+                    items=items.length}}
                 </h2>
               </BlockSlot>
               <BlockSlot @name="body">
                 <p>
-                  {{#if (gt items.length 0)}}
-                    No partitions where found matching that search, or you may not have access to view the namespaces you are searching for.
-                  {{else}}
-                    There don't seem to be any partitions, or you may not have access to view partitions yet.
-                  {{/if}}
+                  {{t 'routes.dc.partitions.index.empty.body'
+                    items=items.length
+                    canUseACLs=(can 'use acls')}}
                 </p>
               </BlockSlot>
               <BlockSlot @name="actions">

--- a/ui/packages/consul-peerings/app/templates/dc/peers/index.hbs
+++ b/ui/packages/consul-peerings/app/templates/dc/peers/index.hbs
@@ -193,21 +193,20 @@ as |sort filters items|}}
                 >
                   <BlockSlot @name="header">
                     <h2>
-                      {{#if (gt items.length 0)}}
-                        No peers found
-                      {{else}}
-                        Welcome to Peers
-                      {{/if}}
+                      {{t 'routes.dc.peers.index.empty.header'
+                        items=items.length
+                        }}
                     </h2>
                   </BlockSlot>
                   <BlockSlot @name="body">
-                    {{#if (gt items.length 0)}}
-                      <p>No peers where found matching that search, or you may not have access to view the peers you are searching for.</p>
-                    {{else}}
-                      <p>
-                        Cluster peering is the recommended way to connect services across or within Consul datacenters. Peering is a one-to-one relationship in which each peer is either a open-source Consul datacenter or a Consul enterprise admin partition. There don't seem to be any peers for this {{if (can "use partitions") "admin partition" "datacenter"}}, or you may not have the <code>peering:read</code> permissions to access this view.
-                      </p>
-                    {{/if}}
+                    <p>
+                      {{t 'routes.dc.peers.index.empty.body'
+                        items=items.length
+                        canUsePartitions=(can "use partitions")
+                        canUseACLs=(can "use acls")
+                        htmlSafe=true
+                      }}
+                    </p>
                   </BlockSlot>
                   <BlockSlot @name="actions">
                     <li class="docs-link">

--- a/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/intentions/index.hbs
@@ -114,6 +114,7 @@ as |route|>
                   <BlockSlot @name="body">
                     {{t 'routes.dc.intentions.index.empty.body'
                       items=items.length
+                      canUseACLs=(can "use acls")
                       htmlSafe=true
                     }}
                   </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
@@ -186,6 +186,7 @@ as |sort filters parent items|}}
                   <BlockSlot @name="body">
                     {{t 'routes.dc.kv.index.empty.body'
                       items=items.length
+                      canUseACLs=(can "use acls")
                       htmlSafe=true
                     }}
                   </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
@@ -107,6 +107,18 @@ as |route|>
                   htmlSafe=true
                 }}
               </BlockSlot>
+              <BlockSlot @name="actions">
+                <li class="docs-link">
+                  <a href="{{env 'CONSUL_DOCS_DEVELOPER_URL'}}/agent" rel="noopener noreferrer" target="_blank">
+                    Documentation on Nodes
+                  </a>
+                </li>
+                <li class="learn-link">
+                  <a href="{{env "CONSUL_DOCS_LEARN_URL"}}/tutorials/consul/deployment-guide?in=consul/production-deploy#configure-consul-agents" rel="noopener noreferrer" target="_blank">
+                    Learn guides
+                  </a>
+                </li>
+              </BlockSlot>
             </EmptyState>
           </collection.Empty>
         </DataCollection>

--- a/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
@@ -110,12 +110,12 @@ as |route|>
               <BlockSlot @name="actions">
                 <li class="docs-link">
                   <a href="{{env 'CONSUL_DOCS_DEVELOPER_URL'}}/agent" rel="noopener noreferrer" target="_blank">
-                    Documentation on Nodes
+                    {{t 'routes.dc.nodes.index.empty.documentation'}}
                   </a>
                 </li>
                 <li class="learn-link">
                   <a href="{{env "CONSUL_DOCS_LEARN_URL"}}/tutorials/consul/deployment-guide?in=consul/production-deploy#configure-consul-agents" rel="noopener noreferrer" target="_blank">
-                    Learn guides
+                    {{t 'routes.dc.nodes.index.empty.learn'}}
                   </a>
                 </li>
               </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/nodes/index.hbs
@@ -103,6 +103,7 @@ as |route|>
               <BlockSlot @name="body">
                 {{t 'routes.dc.nodes.index.empty.body'
                   items=items.length
+                  canUseACLs=(can 'use acls')
                   htmlSafe=true
                 }}
               </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/services/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/index.hbs
@@ -113,6 +113,7 @@ as |sort filters items partition nspace|}}
               <BlockSlot @name="body">
                 {{t 'routes.dc.services.index.empty.body'
                   items=items.length
+                  canUseACLs=(can "use acls")
                   htmlSafe=true
                 }}
               </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/intentions/index.hbs
@@ -102,6 +102,7 @@ as |route|>
                   <BlockSlot @name="body">
                     {{t 'routes.dc.services.show.intentions.index.empty.body'
                       items=items.length
+                      canUseACLs=(can 'use acls')
                       htmlSafe=true
                     }}
                   </BlockSlot>

--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -96,6 +96,7 @@ module.exports = function (environment, $ = process.env) {
     CONSUL_DOCS_URL: 'https://www.consul.io/docs',
     CONSUL_DOCS_LEARN_URL: 'https://learn.hashicorp.com',
     CONSUL_DOCS_API_URL: 'https://www.consul.io/api',
+    CONSUL_DOCS_DEVELOPER_URL: 'https://developer.hashicorp.com/consul/docs',
     CONSUL_COPYRIGHT_URL: 'https://www.hashicorp.com',
   });
   switch (true) {

--- a/ui/packages/consul-ui/tests/acceptance/dc/intentions/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/intentions/index.feature
@@ -71,3 +71,28 @@ Feature: dc / intentions / index
     ---
     Then the url should be /dc-1/intentions
     Then I don't see customResourceNotice on the intentionList
+  Scenario: Viewing an empty intentions page with acl enabled
+    Given 1 datacenter model with the value "dc-1"
+    And 0 intention models
+    When I visit the intentions page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/intentions
+    And the title should be "Intentions - Consul"
+    Then I see 0 intention models on the intentionList component
+    And I see the text "There don't seem to be any Intentions in this Consul cluster, or you may not have intentions:read permissions access to this view." in ".empty-state p"
+    And I see the "[data-test-empty-state-login]" element
+  Scenario: Viewing an empty intentions page with acl disabled 
+    Given ACLs are disabled
+    Given 1 datacenter model with the value "dc-1"
+    And 0 intention models
+    When I visit the intentions page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/intentions
+    And the title should be "Intentions - Consul"
+    Then I see 0 intention models on the intentionList component
+    And I see the text "There don't seem to be any Intentions in this Consul cluster." in ".empty-state p"
+    And I don't see the "[data-test-empty-state-login]" element

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/index.feature
@@ -95,3 +95,16 @@ Feature: dc / nodes / index
     ---
     And I see 1 node model
     And I see 1 node model with the name "node-02"
+  Scenario: Viewing an empty nodes page with acl enabled
+    Given 1 datacenter model with the value "dc-1"
+    And 0 nodes models
+    When I visit the nodes page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/nodes
+    And the title should be "Nodes - Consul"
+    Then I see 0 node models
+    And I see the text "There don't seem to be any registered Nodes in this Consul cluster, or you may not have service:read and node:read permissions access to this view." in ".empty-state p"
+    And I see the "[data-test-empty-state-login]" element
+

--- a/ui/packages/consul-ui/tests/acceptance/dc/nodes/sessions/list.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/nodes/sessions/list.feature
@@ -51,3 +51,36 @@ Feature: dc / nodes / sessions / list: List Lock Sessions
     - 18ms
     - 15s
     ---
+  Scenario: Given 0 sessions with ACLs enabled 
+    Given 1 datacenter model with the value "dc1"
+    And 1 node model from yaml
+    ---
+    ID: node-0
+    ---
+    And 0 session models
+    When I visit the node page for yaml
+    ---
+      dc: dc1
+      node: node-0
+    ---
+    And I click lockSessions on the tabs
+    Then I see lockSessionsIsSelected on the tabs
+    And I see the text "Consul provides a session mechanism which can be used to build distributed locks. Sessions act as a binding layer between Nodes, Health Checks, and Key/Value data. There are currently no Lock Sessions present, or you may not have key:read or session:read permissions." in ".empty-state p"
+    And I see the "[data-test-empty-state-login]" element
+  Scenario: Given 0 sessions with ACLs disabled 
+    Given ACLs are disabled
+    Given 1 datacenter model with the value "dc1"
+    And 1 node model from yaml
+    ---
+    ID: node-0
+    ---
+    And 0 session models
+    When I visit the node page for yaml
+    ---
+      dc: dc1
+      node: node-0
+    ---
+    And I click lockSessions on the tabs
+    Then I see lockSessionsIsSelected on the tabs
+    And I see the text "Consul provides a session mechanism which can be used to build distributed locks. Sessions act as a binding layer between Nodes, Health Checks, and Key/Value data. There are currently no Lock Sessions present." in ".empty-state p"
+    And I don't see the "[data-test-empty-state-login]" element

--- a/ui/packages/consul-ui/tests/acceptance/dc/peers/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/peers/index.feature
@@ -41,7 +41,7 @@ Feature: dc / peers / index: Peers List
     ---
     And I see 0 peer model
     Then I see the text "No peers found" in ".empty-state h2"
-    Then I see the text "Cluster peering is the recommended way to connect services across or within Consul datacenters. Peering is a one-to-one relationship in which each peer is either a open-source Consul datacenter or a Consul enterprise admin partition. There don't seem to be any peers for this datacenter, or you may not have the peering:read permissions to access this view." in ".empty-state p"
+    Then I see the text "No peers were found matching that search, or you may not have the peering:read permissions to access this view." in ".empty-state p"
     And I see the "[data-test-empty-state-login]" element
   Scenario: Empty state searching peers with ACLs disabled 
     And ACLs are disabled
@@ -51,4 +51,4 @@ Feature: dc / peers / index: Peers List
     ---
     And I see 0 peer model
     Then I see the text "No peers found" in ".empty-state h2"
-    Then I see the text "Cluster peering is the recommended way to connect services across or within Consul datacenters. Peering is a one-to-one relationship in which each peer is either a open-source Consul datacenter or a Consul enterprise admin partition. There don't seem to be any peers for this datacenter." in ".empty-state p"
+    Then I see the text "No peers were found matching that search." in ".empty-state p"

--- a/ui/packages/consul-ui/tests/acceptance/dc/peers/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/peers/index.feature
@@ -34,4 +34,21 @@ Feature: dc / peers / index: Peers List
     ---
     And I see 1 peer model
     And I see 1 peer model with the name "a-peer"
-
+  Scenario: Empty state searching peers
+    Then I fill in with yaml
+    ---
+    s: no-match 
+    ---
+    And I see 0 peer model
+    Then I see the text "No peers found" in ".empty-state h2"
+    Then I see the text "Cluster peering is the recommended way to connect services across or within Consul datacenters. Peering is a one-to-one relationship in which each peer is either a open-source Consul datacenter or a Consul enterprise admin partition. There don't seem to be any peers for this datacenter, or you may not have the peering:read permissions to access this view." in ".empty-state p"
+    And I see the "[data-test-empty-state-login]" element
+  Scenario: Empty state searching peers with ACLs disabled 
+    And ACLs are disabled
+    Then I fill in with yaml
+    ---
+    s: no-match 
+    ---
+    And I see 0 peer model
+    Then I see the text "No peers found" in ".empty-state h2"
+    Then I see the text "Cluster peering is the recommended way to connect services across or within Consul datacenters. Peering is a one-to-one relationship in which each peer is either a open-source Consul datacenter or a Consul enterprise admin partition. There don't seem to be any peers for this datacenter." in ".empty-state p"

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/index.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/index.feature
@@ -165,3 +165,28 @@ Feature: dc / services / index: List Services
     Then I see 2 service models
     And I don't see associatedServiceCount on the services.0
     And I see associatedServiceCount on the services.1
+  Scenario: Viewing the services index page with no services and ACLs enabled 
+    Given 1 datacenter model with the value "dc-1"
+    And 0 service models
+    When I visit the services page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/services
+    And the title should be "Services - Consul"
+    Then I see 0 service models 
+    And I see the text "There don't seem to be any registered services in this Consul cluster, or you may not have service:read and node:read access to this view. Use Terraform, Kubernetes CRDs, Vault, or the Consul CLI to register Services." in ".empty-state p"
+    And I see the "[data-test-empty-state-login]" element
+  Scenario: Viewing the services index page with no services and ACLs disabled
+    Given ACLs are disabled
+    Given 1 datacenter model with the value "dc-1"
+    And 0 service models
+    When I visit the services page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/services
+    And the title should be "Services - Consul"
+    Then I see 0 service models 
+    And I see the text "There don't seem to be any registered services in this Consul cluster." in ".empty-state p"
+    And I don't see the "[data-test-empty-state-login]" element

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -121,11 +121,11 @@ dc:
             }
         body: |
           {items, select,
-            0 {No peers where found matching that search}
-            other {Cluster peering is the recommended way to connect services across or within Consul datacenters. Peering is a one-to-one relationship in which each peer is either a open-source Consul datacenter or a Consul enterprise admin partition. There don't seem to be any peers for this {canUsePartitions, select,
+            0 {Cluster peering is the recommended way to connect services across or within Consul datacenters. Peering is a one-to-one relationship in which each peer is either a open-source Consul datacenter or a Consul enterprise admin partition. There don't seem to be any peers for this {canUsePartitions, select,
               true {admin partition}
               other {datacenter}
             }}
+            other {No peers were found matching that search}
           }{canUseACLs, select,
             true {, or you may not have the <code>peering:read</code> permissions to access this view.}
             other {.}
@@ -153,7 +153,7 @@ dc:
               true {, or you may not have access to view partitions yet.}
               other {.}
             }}
-            other {No partitions where found matching that search{canUseACLs, select,
+            other {No partitions were found matching that search{canUseACLs, select,
               true {, or you may not have access to view the namesapces you are searching}
               other {.}
             }}
@@ -168,7 +168,7 @@ dc:
           }
         body: |
           {items, select,
-            0 {No namespaces where found matching that search{canUseACLs, select,
+            0 {No namespaces were found matching that search{canUseACLs, select,
               true {, or you may not have access to view the namespaces you are searching for.}
               other {.}
             }}

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -431,15 +431,16 @@ dc:
     auth-methods:
       show:
         binding-rules:
-          empty:
-            header: No Binding Rules
-            body: |
-              <p>
-                Binding rules allow an operator to express a systematic way of automatically linking roles and service identities to newly created tokens without operator intervention.
-              </p>
+          index:
+            empty:
+              header: No binding rules
+              body: |
+                <p>
+                  Binding rules allow an operator to express a systematic way of automatically linking roles and service identities to newly created tokens without operator intervention.
+                </p>
         nspace-rules:
           empty:
-            header: No Namespace Rules
+            header: No namespace rules
             body: |
               <p>
                 A set of rules that can control which namespace tokens created via this auth method will be created within. Unlike binding rules, the first matching namespace rule wins.

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -296,7 +296,10 @@ dc:
                 {items, select,
                   0 {There don't seem to be any Intentions in this Consul cluster}
                   other {No Intentions were found matching your search}
-                }, or you may not have <code>intentions:read</code> permissions access to this view.
+                }{canUseACLs, select,
+                  true {, or you may not have <code>intentions:read</code> permissions access to this view.}
+                  other {.}
+                }
               </p>
 
       instances:

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -71,6 +71,8 @@ dc:
               other {.}
             }
           </p>
+        documentation: Documentation on Nodes
+        learn: Take the tutorial
     show:
       rtt:
         title: Round Trip Time

--- a/ui/packages/consul-ui/translations/routes/en-us.yaml
+++ b/ui/packages/consul-ui/translations/routes/en-us.yaml
@@ -66,7 +66,10 @@ dc:
             {items, select,
               0 {There don't seem to be any registered Nodes in this Consul cluster}
               other {No Nodes were found matching your search}
-          }, or you may not have <code>service:read</code> and <code>node:read</code> permissions access to this view.
+            }{canUseACLs, select,
+              true {, or you may not have <code>service:read</code> and <code>node:read</code> permissions access to this view.}
+              other {.}
+            }
           </p>
     show:
       rtt:
@@ -79,7 +82,10 @@ dc:
           header: Welcome to Lock Sessions
           body: |
             <p>
-            Consul provides a session mechanism which can be used to build distributed locks. Sessions act as a binding layer between Nodes, Health Checks, and Key/Value data. There are currently no Lock Sessions present, or you may not have <code>key:read</code> or <code>session:read</code> permissions.
+            Consul provides a session mechanism which can be used to build distributed locks. Sessions act as a binding layer between Nodes, Health Checks, and Key/Value data. There are currently no Lock Sessions present{canUseACLs, select,
+              true {, or you may not have <code>key:read</code> or <code>session:read</code> permissions.}
+              other {.}
+            }
             </p>
       services:
         title: Service Instances
@@ -107,6 +113,23 @@ dc:
             </p>
   peers:
     index:
+      empty:
+        header: |
+            {items, select,
+              0 {Welcome to Peers}
+              other {No peers found}
+            }
+        body: |
+          {items, select,
+            0 {No peers where found matching that search}
+            other {Cluster peering is the recommended way to connect services across or within Consul datacenters. Peering is a one-to-one relationship in which each peer is either a open-source Consul datacenter or a Consul enterprise admin partition. There don't seem to be any peers for this {canUsePartitions, select,
+              true {admin partition}
+              other {datacenter}
+            }}
+          }{canUseACLs, select,
+            true {, or you may not have the <code>peering:read</code> permissions to access this view.}
+            other {.}
+          }
       detail:
         imported:
           count: |
@@ -116,6 +139,44 @@ dc:
           count: |
            {count} exported services
           tooltip: The number of services exported from {name}
+  partitions:
+    index:
+      empty:
+        header: |
+          {items, select,
+            0 {Welcome to Partitions}
+            other {No partitions found}
+          } 
+        body: |
+          {items, select,
+            0 {There don't seem to be any partitions{canUseACLs, select,
+              true {, or you may not have access to view partitions yet.}
+              other {.}
+            }}
+            other {No partitions where found matching that search{canUseACLs, select,
+              true {, or you may not have access to view the namesapces you are searching}
+              other {.}
+            }}
+          }
+  namespaces:
+    index:
+      empty:
+        header: |
+          {items, select,
+            0 {Welcome to Namespaces}
+            other {No namespaces found}
+          }
+        body: |
+          {items, select,
+            0 {No namespaces where found matching that search{canUseACLs, select,
+              true {, or you may not have access to view the namespaces you are searching for.}
+              other {.}
+            }}
+            other {There don't seem to be any namespaces{canUseACLs, select,
+              true {, or you may not have access to view namespaces yet.}
+              other {.}
+            }}
+          }
   services:
     index:
       empty:
@@ -129,7 +190,10 @@ dc:
             {items, select,
               0 {There don't seem to be any registered services in this Consul cluster}
               other {No Services were found matching your search}
-          }, or you may not have <code>service:read</code> and <code>node:read</code> access to this view. Use Terraform, Kubernetes CRDs, Vault, or the Consul CLI to register Services.
+            }{canUseACLs, select,
+              true {, or you may not have <code>service:read</code> and <code>node:read</code> access to this view. Use Terraform, Kubernetes CRDs, Vault, or the Consul CLI to register Services.}
+              other {.}
+            }
           </p>
     instance:
       exposedpaths:
@@ -290,7 +354,10 @@ dc:
             {items, select,
               0 {There don't seem to be any Intentions in this Consul cluster}
               other {No Intentions were found matching your search}
-            }, or you may not have <code>intentions:read</code> permissions access to this view.
+            }{canUseACLs, select,
+              true {, or you may not have intentions:read permissions access to this view.} 
+              other {.}
+            }
           </p>
   kv:
     index:
@@ -305,7 +372,10 @@ dc:
             {items, select,
               0 {There don't seem to be any K/V pairs in this Consul cluster yet}
               other {No K/V pairs were found matching your search}
-            }, or you may not have <code>key:read</code> permissions access to this view.
+            }{canUseACLs, select,
+              true {, or you may not have <code>key:read</code> permissions access to this view.}
+              other {.}
+            }
           </p>
   acls:
     tokens:


### PR DESCRIPTION
Update empty-states throughout the app to only include mentions of ACLs if the user has ACLs enabled.

### Description
> When ACLs are disabled, we need to conditionally not show the second part of the empty state messaging that references ACL permissions or the "log in with a different token" button. They should still display when ACLs are enabled.

I didn't update any empty states that were under the Access Controls nav section, since I think you need ACLs enabled to access those. Please feel free to correct me here.

### Links
- JIRA: [NET-761](https://hashicorp.atlassian.net/browse/NET-761)
- [Design](https://www.figma.com/file/nJfkXEJ1rZ8KviqVmUTV9X/Empty-states?node-id=4206%3A2726)

### PR Checklist
* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
