### PR TITLE
Add new internal endpoint to list exported services to a peer

### DIFF
--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -91,6 +91,7 @@ func init() {
 	registerEndpoint("/v1/internal/ui/nodes", []string{"GET"}, (*HTTPHandlers).UINodes)
 	registerEndpoint("/v1/internal/ui/node/", []string{"GET"}, (*HTTPHandlers).UINodeInfo)
 	registerEndpoint("/v1/internal/ui/services", []string{"GET"}, (*HTTPHandlers).UIServices)
+	registerEndpoint("/v1/internal/ui/exported-services", []string{"GET"}, (*HTTPHandlers).UIExportedServices)
 	registerEndpoint("/v1/internal/ui/catalog-overview", []string{"GET"}, (*HTTPHandlers).UICatalogOverview)
 	registerEndpoint("/v1/internal/ui/gateway-services-nodes/", []string{"GET"}, (*HTTPHandlers).UIGatewayServicesNodes)
 	registerEndpoint("/v1/internal/ui/gateway-intentions/", []string{"GET"}, (*HTTPHandlers).UIGatewayIntentions)


### PR DESCRIPTION
### Description
In Consul UI we want to display a condensed list of service names that are being exported to a peer. The state store functions already exist so this PR simply exposes a new endpoint.

### Testing & Reproduction steps
* Added new testcases at UI and internal level

### PR Checklist

* [x] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
