### PR TITLE
docs: update to Vault secrets backend for partition init service account and Helm values for injector 

### DIFF
--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
@@ -60,24 +60,24 @@ $ vault policy write partition-token-policy partition-token-policy.hcl
 Next, you will create Kubernetes auth roles for the Consul `server-acl-init` job:
 
 ```shell-session
-$ vault write auth/kubernetes/role/consul-server-acl-init \
+$ vault write auth/kubernetes/role/consul-partition-init \
     bound_service_account_names=<Consul server service account> \
     bound_service_account_namespaces=<Consul installation namespace> \
     policies=partition-token-policy \
     ttl=1h
 ```
 
-To find out the service account name of the Consul server,
+To find out the service account name of the `partition-init` job,
 you can run the following `helm template` command with your Consul on Kubernetes values file:
 
 ```shell-session
-$ helm template --release-name ${RELEASE_NAME} -s templates/server-acl-init-serviceaccount.yaml hashicorp/consul
+$ helm template --release-name ${RELEASE_NAME} -s templates/partition-init-serviceaccount.yaml hashicorp/consul
 ```
 
 ## Update Consul on Kubernetes Helm chart
 
 Now that you have configured Vault, you can configure the Consul Helm chart to
-use the  ACL partition token key in Vault:
+use the  ACL partition token key in Vault and the service account for the Partitions role.
 
 <CodeBlockConfig filename="values.yaml">
 
@@ -87,6 +87,7 @@ global:
     vault:
       enabled: true
       manageSystemACLsRole: consul-server-acl-init
+      adminPartitionsRole: consul-partition-init
   acls:
     partitionToken:
       secretName: secret/data/consul/partition-token

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Storing the ACL Partition Token in Vault
 
-This topic describes how to configure the Consul Helm chart to use an ACL partition token stored in Vault.
+This topic describes how to configure the Consul Helm chart to use an ACL partition token stored in Vault when using Admin Partitions in Consul Enterprise.
 
 ## Overview
 Complete the steps outlined in the [Data Integration](/docs/k8s/installation/vault/data-integration) section to use an ACL partition token stored in Vault.

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
@@ -7,7 +7,7 @@ description: >-
 
 # Storing the ACL Partition Token in Vault
 
-This topic describes how to configure the Consul Helm chart to use an ACL partition token stored in Vault when using Admin Partitions in Consul Enterprise.
+This topic describes how to configure the Consul Helm chart to use an ACL partition token stored in Vault when using [Admin Partitions](/docs/enterprise/admin-partitions) in Consul Enterprise.
 
 ## Overview
 Complete the steps outlined in the [Data Integration](/docs/k8s/installation/vault/data-integration) section to use an ACL partition token stored in Vault.

--- a/website/content/docs/k8s/deployment-configurations/vault/systems-integration.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/systems-integration.mdx
@@ -128,11 +128,13 @@ A minimal valid installation of Vault Kubernetes must include the Agent Injector
 ```shell-session
 $ cat <<EOF >> vault-injector.yaml
 # vault-injector.yaml
+global:
+  enabled: true
+  externalVaultAddr: ${VAULT_ADDR}
 server:
   enabled: false
 injector:
   enabled: true
-  externalVaultAddr: ${VAULT_ADDR}
   authPath: auth/${VAULT_AUTH_METHOD_NAME}
 EOF
 ``` 


### PR DESCRIPTION
### Description

- It looks like perhaps there was a typo in this section for Admin Partitions where the server acl init steps were copied for the Admin Partition Role and service account. 
- Update System Integrations page to use the latest Helm values format as externalVaultAddr is now in the global stanza: https://www.vaultproject.io/docs/platform/k8s/helm/configuration#externalvaultaddr

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
