### PR TITLE
Return NODATA when node is found but specified query type is not found

### DIFF
--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6804,6 +6804,7 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 	questions := []string{
 		"webv4.service.consul.",
 		"webv4.query.consul.",
+		"foov4.node.consul.",
 	}
 	for _, question := range questions {
 		m := new(dns.Msg)
@@ -6832,6 +6833,7 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 	questions = []string{
 		"webv6.service.consul.",
 		"webv6.query.consul.",
+		"foov6.node.consul.",
 	}
 	for _, question := range questions {
 		m := new(dns.Msg)


### PR DESCRIPTION
DNS Server should return NODATA when the name queried exist but the specified query type is not found.