### PR TITLE
Fix Link: Consul Enterprise Admin Partitions - Usage - CLI

### DIFF
--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -116,7 +116,7 @@ One of the primary use cases for admin partitions is for enabling a service mesh
 
 ## Usage
 
-This section describes how to deploy Consul admin partitions to Kubernetes clusters. Refer to the [admin partition CLI documentation](/commands/admin-partition) for information about command line usage.
+This section describes how to deploy Consul admin partitions to Kubernetes clusters. Refer to the [admin partition CLI documentation](/commands/partition) for information about command line usage.
 
 ### Deploying Consul with Admin Partitions on Kubernetes
 


### PR DESCRIPTION
### Description
 Admin partition CLI documentation was pointing at /commands/admin-partition.  Updated to point at /commands/partition

### Testing & Reproduction steps
https://www.consul.io/commands/admin-partition returns not found.

### Links
Link to document to verify currently broken link: 
https://www.consul.io/docs/enterprise/admin-partitions#usage

### PR Checklist

* [ ] external facing docs updated
* [ ] not a security concern
