### PR TITLE
ui: Wrap service names on show and instance routes

### DIFF
--- a/ui/packages/consul-ui/app/components/app-view/index.hbs
+++ b/ui/packages/consul-ui/app/components/app-view/index.hbs
@@ -13,14 +13,16 @@
                   </YieldSlot>
               </nav>
               <div class="title">
-                <YieldSlot @name="header">
-                    {{yield}}
-                </YieldSlot>
-                <div class="actions">
-                    <YieldSlot @name="actions">
-                      <PortalTarget @name="app-view-actions" />
+                <div class="title-left-container">
+                  <YieldSlot @name="header">
                       {{yield}}
-                    </YieldSlot>
+                  </YieldSlot>
+                </div>
+                <div class="actions">
+                  <YieldSlot @name="actions">
+                    <PortalTarget @name="app-view-actions" />
+                    {{yield}}
+                  </YieldSlot>
                 </div>
               </div>
               <YieldSlot @name="nav">

--- a/ui/packages/consul-ui/app/components/app-view/index.scss
+++ b/ui/packages/consul-ui/app/components/app-view/index.scss
@@ -10,6 +10,9 @@
 %app-view-header .title {
   @extend %app-view-title;
 }
+%app-view-title .title-left-container {
+  @extend %app-view-title-left-container;
+}
 %app-view-header .actions {
   @extend %app-view-actions;
 }

--- a/ui/packages/consul-ui/app/components/app-view/layout.scss
+++ b/ui/packages/consul-ui/app/components/app-view/layout.scss
@@ -1,25 +1,38 @@
 /* layout */
 %app-view-title {
-  display: flex;
-  align-items: center;
-  white-space: nowrap;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas: "title actions";
   position: relative;
   z-index: 5;
 }
+%app-view-title-left-container {
+  grid-area: title;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  white-space: normal;
+}
+%app-view-title-left-container > :first-child {
+  flex-basis: 100%;
+}
+
+%app-view-title-left-container > :not(:first-child) {
+  margin-right: 8px;
+}
+
 %app-view-actions {
+  grid-area: actions;
+  align-self: end;
   display: flex;
   align-items: flex-start;
   margin-left: auto;
+  margin-top: 9px;
 }
+
 /* units */
 %app-view-title {
-  padding-bottom: 0.2em;
-}
-%app-view-title > :not(:last-child) {
-  margin-right: 8px;
-}
-%app-view-actions {
-  margin-top: 9px;
+  padding-bottom: 1.4em;
 }
 
 /* content */

--- a/ui/packages/consul-ui/app/components/app-view/skin.scss
+++ b/ui/packages/consul-ui/app/components/app-view/skin.scss
@@ -1,4 +1,4 @@
-%app-view-title > *:first-child {
+%app-view-title-left-container > *:first-child {
   @extend %h100;
 }
 %app-view-title {

--- a/ui/packages/consul-ui/app/components/breadcrumbs/layout.scss
+++ b/ui/packages/consul-ui/app/components/breadcrumbs/layout.scss
@@ -1,6 +1,14 @@
+%breadcrumbs {
+  display: grid;
+  grid-auto-flow: column;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
 %breadcrumbs > li {
   list-style-type: none;
   display: inline-flex;
+  overflow: hidden
 }
 %breadcrumb-milestone::before {
   margin-right: 4px;
@@ -10,6 +18,8 @@
   /* as the separator is a '/' the left margin needs */
   /* to be different from the right in order to center it */
   margin-left: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 %breadcrumb::before {
   margin-right: 8px;

--- a/ui/packages/consul-ui/app/styles/routes/dc/services/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/services/index.scss
@@ -16,6 +16,21 @@ html[data-route^='dc.services.instance'] .app-view > header dl {
 html[data-route^='dc.services.instance'] .app-view > header dt {
   font-weight: var(--typo-weight-bold);
 }
+html[data-route^='dc.services.show'] .app-view > header .title, html[data-route^='dc.services.instance'] .app-view > header .title {
+  flex-wrap: wrap;
+  white-space: normal;
+}
+html[data-route^='dc.services.show'] .app-view > header .title > h1, html[data-route^='dc.services.instance'] .app-view > header .title > h1 {
+  flex-basis: 100%;
+}
+html[data-route^='dc.services.show'] .app-view > header .title > :not(:first-child), html[data-route^='dc.services.instance'] .app-view > header .title > :not(:first-child) {
+  margin-bottom: 20.5px;
+  margin-top: 7.5px;
+}
+html[data-route^='dc.services.show'] .app-view > header .actions, html[data-route^='dc.services.instance'] .app-view > header .actions {
+  display: block;
+  margin-left: unset;
+}
 html[data-route^='dc.services.instance'] .tab-nav {
   border-top: var(--decor-border-100);
 }

--- a/ui/packages/consul-ui/app/styles/routes/dc/services/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/services/index.scss
@@ -16,21 +16,6 @@ html[data-route^='dc.services.instance'] .app-view > header dl {
 html[data-route^='dc.services.instance'] .app-view > header dt {
   font-weight: var(--typo-weight-bold);
 }
-html[data-route^='dc.services.show'] .app-view > header .title, html[data-route^='dc.services.instance'] .app-view > header .title {
-  flex-wrap: wrap;
-  white-space: normal;
-}
-html[data-route^='dc.services.show'] .app-view > header .title > h1, html[data-route^='dc.services.instance'] .app-view > header .title > h1 {
-  flex-basis: 100%;
-}
-html[data-route^='dc.services.show'] .app-view > header .title > :not(:first-child), html[data-route^='dc.services.instance'] .app-view > header .title > :not(:first-child) {
-  margin-bottom: 20.5px;
-  margin-top: 7.5px;
-}
-html[data-route^='dc.services.show'] .app-view > header .actions, html[data-route^='dc.services.instance'] .app-view > header .actions {
-  display: block;
-  margin-left: unset;
-}
 html[data-route^='dc.services.instance'] .tab-nav {
   border-top: var(--decor-border-100);
 }

--- a/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/edit.hbs
@@ -63,6 +63,7 @@ as |parts|}}
         {{! We push on a '' here so make sure we get a trailing slash/separator }}
           <li>
             <Action
+              {{action breadcrumb}}
               @href={{href-to 'dc.kv.folder'
                   (join '/'
                     (append

--- a/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/kv/index.hbs
@@ -108,7 +108,7 @@ as |sort filters parent items|}}
         <ol>
           <li><a href={{href-to 'dc.kv'}}>Key / Values</a></li>
     {{#each (slice 0 -2 (split parent.Key '/')) as |breadcrumb index|}}
-          <li><a href={{href-to 'dc.kv.folder' (join '/' (append (slice 0 (add index 1) (split parent.Key '/')) ''))}}>{{breadcrumb}}</a></li>
+          <li><a {{tooltip breadcrumb}} href={{href-to 'dc.kv.folder' (join '/' (append (slice 0 (add index 1) (split parent.Key '/')) ''))}}>{{breadcrumb}}</a></li>
     {{/each}}
         </ol>
       </BlockSlot>

--- a/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/instance.hbs
@@ -129,7 +129,9 @@ as |item|}}
           <BlockSlot @name="breadcrumbs">
               <ol>
                   <li><a href={{href-to 'dc.services' params=(hash peer=undefined)}}>All Services</a></li>
-                  <li><a data-test-back href={{href-to 'dc.services.show'}}>Service ({{item.Service.Service}})</a></li>
+                  <li><a {{tooltip (concat "Service (" item.Service.Service ")")}} data-test-back href={{href-to 'dc.services.show'}}>
+                    Service ({{item.Service.Service}})
+                  </a></li>
               </ol>
           </BlockSlot>
           <BlockSlot @name="header">


### PR DESCRIPTION
### Description
Moves labels/kinds/sources to the bottom row of the title, and allows wrapping of the title text. Actions (ip, create, edit, etc.) are in their own column on the right and bottom aligned to match with either the labels, if they are present, or the title. 

Makes it so the breadcrumb overflow is hidden with an ellipsis, and a tooltip is show with the value. I think we could rethink breadcrumbs/tooltips so that:
- you don't have to manually add the breadcrumbs for routes in the templates
- you don't have to manually add tooltips to specific breadcrumbs

However, I felt that I didn't need to add more scope to this ticket.


### Screenshots
**Before:**
![Screen Shot 2022-09-27 at 4 30 08 PM](https://user-images.githubusercontent.com/5448834/192649007-026d34cb-3f95-4569-ac1b-cf9da004814d.png)
![Screen Shot 2022-09-27 at 4 29 50 PM](https://user-images.githubusercontent.com/5448834/192649010-bea9a5ef-fe7e-49c7-86ac-4eba85e76080.png)
![Screen Shot 2022-09-27 at 4 29 31 PM](https://user-images.githubusercontent.com/5448834/192649011-19652c73-73fb-4420-a2d9-b7ef2345767a.png)
![Screen Shot 2022-09-27 at 4 29 20 PM](https://user-images.githubusercontent.com/5448834/192649013-3643a44d-4e5e-4428-a15f-4975e0190f5e.png)


**After:**
<img width="1804" alt="Screen Shot 2022-10-03 at 8 30 25 PM" src="https://user-images.githubusercontent.com/5448834/193721810-f4e8e110-943c-4439-9aa2-bfbe686e2370.png">
<img width="1804" alt="Screen Shot 2022-10-03 at 8 30 11 PM" src="https://user-images.githubusercontent.com/5448834/193721820-36529ec3-5ae9-46b2-afaa-32970de59d5c.png">
<img width="1804" alt="Screen Shot 2022-10-03 at 8 29 44 PM" src="https://user-images.githubusercontent.com/5448834/193721821-1eac2da6-2ee2-491c-9a27-3adf897ac634.png">
<img width="1804" alt="Screen Shot 2022-10-03 at 8 29 31 PM" src="https://user-images.githubusercontent.com/5448834/193721823-daf0222a-d86a-4811-9231-3b4daf40619b.png">
<img width="1804" alt="Screen Shot 2022-10-03 at 8 25 29 PM" src="https://user-images.githubusercontent.com/5448834/193721824-016d09ca-1ab0-4154-8e5b-fd00c0ab106f.png">
ant to apply this everywhere. (thinking auth methods, etc.).

### Links
- [NET-964](https://hashicorp.atlassian.net/browse/NET-964)
- [Design](https://www.figma.com/file/D6yYLKYMnuWR40w1QtGcQ2/Wrapping-service-name?node-id=143%3A7970)

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
