### PR TITLE
README: Consul Readme improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Consul provides several key features:
 * **Service Mesh** - Consul Service Mesh enables secure service-to-service
   communication with automatic TLS encryption and identity-based authorization. Applications
   can use sidecar proxies in a service mesh configuration to establish TLS
-  connections for inbound and outbound connections utilizing Transparent Proxy.
+  connections for inbound and outbound connections with Transparent Proxy.
 
 * **Service Discovery** - Consul makes it simple for services to register
   themselves and to discover other services via a DNS or HTTP interface.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A few quick start guides are available on the Consul website:
 
 ## Documentation
 
-Full, comprehensive documentation is available on the Consul website: https://developer.hashicorp.com/consul/docs
+Full, comprehensive documentation is available on the Consul website: https://consul.io/docs
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Consul provides several key features:
 
 Consul runs on Linux, macOS, FreeBSD, Solaris, and Windows and includes an
 optional [browser based UI](https://demo.consul.io). A commercial version
-called [Consul Enterprise](https://developer.hashicorp.com/consul/docs/enterprise) is also
+called [Consul Enterprise](https://www.consul.io/docs/enterprise) is also
 available.
 
 **Please note**: We take Consul's security and our users' trust very seriously. If you

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A few quick start guides are available on the Consul website:
 * **Minikube install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-minikube
 * **Kind install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-kind
 * **Kubernetes install:** https://learn.hashicorp.com/tutorials/consul/kubernetes-deployment-guide
+* **Deploy HCP Consul:** https://learn.hashicorp.com/tutorials/consul/hcp-gs-deploy 
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Consul provides several key features:
 
 Consul runs on Linux, macOS, FreeBSD, Solaris, and Windows and includes an
 optional [browser based UI](https://demo.consul.io). A commercial version
-called [Consul Enterprise](https://www.hashicorp.com/products/consul) is also
+called [Consul Enterprise](https://developer.hashicorp.com/consul/docs/enterprise) is also
 available.
 
 **Please note**: We take Consul's security and our users' trust very seriously. If you

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ A few quick start guides are available on the Consul website:
 
 ## Documentation
 
-Full, comprehensive documentation is available on the Consul website: https://www.consul.io/docs
+Full, comprehensive documentation is available on the Consul website: https://developer.hashicorp.com/consul/docs
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Consul provides several key features:
 * **Multi-Datacenter** - Consul is built to be datacenter aware, and can
   support any number of regions without complex configuration.
 
-* **Service Mesh/Service Segmentation** - Consul Connect enables secure service-to-service
+* **Service Mesh** - Consul Service Mesh enables secure service-to-service
   communication with automatic TLS encryption and identity-based authorization. Applications
   can use sidecar proxies in a service mesh configuration to establish TLS
-  connections for inbound and outbound connections without being aware of Connect at all.
+  connections for inbound and outbound connections utilizing Transparent Proxy.
 
 * **Service Discovery** - Consul makes it simple for services to register
   themselves and to discover other services via a DNS or HTTP interface.
@@ -55,9 +55,7 @@ A few quick start guides are available on the Consul website:
 
 ## Documentation
 
-Full, comprehensive documentation is available on the Consul website:
-
-https://www.consul.io/docs
+Full, comprehensive documentation is available on the Consul website: https://www.consul.io/docs
 
 ## Contributing
 


### PR DESCRIPTION
### Description

- Remove Consul Connect from README and slight formatting changes.
- Add HCP Learn Guide link
- Change link from hashicorp.com Consul page to consul.io/docs/enterprise page for more information about Consul Enterprise.

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
