### PR TITLE
docs: admin partition docs improvements

### DIFF
--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -104,6 +104,7 @@ One of the primary use cases for admin partitions is for enabling a service mesh
 
 - If you are deploying Consul servers on Kubernetes, then ensure that the Consul servers are deployed within the same Kubernetes cluster. Consul servers may be deployed external to Kubernetes and configured using the `externalServers` stanza.
 - Consul clients deployed on the same Kubernetes cluster as the Consul Servers must use the `default` partition. If the clients are required to run on a non-default partition, then the clients must be deployed in a separate Kubernetes cluster.
+- For K8s clusters that join the Consul DataCenter as Admin Partitions, ensure that a unique `global.name` value is assigned for the Helm `values.yaml` file. 
 - A Consul Enterprise license must be installed on each Kubernetes cluster.
 - The helm chart for consul-k8s v0.39.0 or greater.
 - Consul 1.11.1-ent or greater.
@@ -171,7 +172,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
     enableConsulNamespaces: true
     tls:
       enabled: true
-    image: hashicorp/consul-enterprise:1.12.0-ent
+    image: hashicorp/consul-enterprise:1.13.2-ent
     adminPartitions:
       enabled: true
     acls:
@@ -203,7 +204,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
 1. Install the Consul server(s) using the values file created in the previous step:
 
   ```shell-session
-  $ helm install ${HELM_RELEASE_SERVER} hashicorp/consul --version "0.43.0" --create-namespace --namespace consul --values server.yaml
+  $ helm install ${HELM_RELEASE_SERVER} hashicorp/consul --version "0.48.0" --create-namespace --namespace consul --values server.yaml
   ```
 
 1. After the server starts, get the external IP address for partition service so that it can be added to the client configuration. The IP address is used to bootstrap connectivity between servers and clients. <a name="get-external-ip-address"/>
@@ -248,7 +249,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
   ```
 
 1. Create the workload configuration for client nodes in your cluster. Create a configuration for each admin partition.
-   In the following example, the external IP address and the Kubernetes authentication method IP address from the previous steps have been applied. Also, ensure a unique global name is assigned.
+   In the following example, the external IP address and the Kubernetes authentication method IP address from the previous steps have been applied. Also, ensure a unique `global.name` value is assigned.
 
   <CodeTabs heading="client.yaml">
 
@@ -259,7 +260,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
     name: client
     enabled: false
     enableConsulNamespaces: true
-    image: hashicorp/consul-enterprise:1.12.0-ent
+    image: hashicorp/consul-enterprise:1.13.2-ent
     adminPartitions:
       enabled: true
       name: clients
@@ -308,7 +309,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
 1. Install the workload client clusters:
 
   ```shell-session
-  $ helm install ${HELM_RELEASE_CLIENT} hashicorp/consul --version "0.43.0" --create-namespace --namespace consul --values client.yaml
+  $ helm install ${HELM_RELEASE_CLIENT} hashicorp/consul --version "0.48.0" --create-namespace --namespace consul --values client.yaml
   ```
 
 ### Verifying the Deployment

--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -104,7 +104,7 @@ One of the primary use cases for admin partitions is for enabling a service mesh
 
 - If you are deploying Consul servers on Kubernetes, then ensure that the Consul servers are deployed within the same Kubernetes cluster. Consul servers may be deployed external to Kubernetes and configured using the `externalServers` stanza.
 - Consul clients deployed on the same Kubernetes cluster as the Consul Servers must use the `default` partition. If the clients are required to run on a non-default partition, then the clients must be deployed in a separate Kubernetes cluster.
-- For Kubernetes clusters that join the Consul DataCenter as Admin Partitions, ensure that a unique `global.name` value is assigned for the Helm `values.yaml` file. 
+- For Kubernetes clusters that join the Consul DataCenter as Admin Partitions, ensure that a unique `global.name` value is assigned for the corresponding Helm `values.yaml` file. 
 - A Consul Enterprise license must be installed on each Kubernetes cluster.
 - The helm chart for consul-k8s v0.39.0 or greater.
 - Consul 1.11.1-ent or greater.

--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -104,7 +104,7 @@ One of the primary use cases for admin partitions is for enabling a service mesh
 
 - If you are deploying Consul servers on Kubernetes, then ensure that the Consul servers are deployed within the same Kubernetes cluster. Consul servers may be deployed external to Kubernetes and configured using the `externalServers` stanza.
 - Consul clients deployed on the same Kubernetes cluster as the Consul Servers must use the `default` partition. If the clients are required to run on a non-default partition, then the clients must be deployed in a separate Kubernetes cluster.
-- For Kubernetes clusters that join the Consul DataCenter as Admin Partitions, ensure that a unique `global.name` value is assigned for the corresponding Helm `values.yaml` file. 
+- For Kubernetes clusters that join the Consul datacenter as admin partitions, ensure that a unique `global.name` value is assigned for the corresponding Helm `values.yaml` file. 
 - A Consul Enterprise license must be installed on each Kubernetes cluster.
 - The helm chart for consul-k8s v0.39.0 or greater.
 - Consul 1.11.1-ent or greater.

--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -104,7 +104,7 @@ One of the primary use cases for admin partitions is for enabling a service mesh
 
 - If you are deploying Consul servers on Kubernetes, then ensure that the Consul servers are deployed within the same Kubernetes cluster. Consul servers may be deployed external to Kubernetes and configured using the `externalServers` stanza.
 - Consul clients deployed on the same Kubernetes cluster as the Consul Servers must use the `default` partition. If the clients are required to run on a non-default partition, then the clients must be deployed in a separate Kubernetes cluster.
-- For K8s clusters that join the Consul DataCenter as Admin Partitions, ensure that a unique `global.name` value is assigned for the Helm `values.yaml` file. 
+- For Kubernetes clusters that join the Consul DataCenter as Admin Partitions, ensure that a unique `global.name` value is assigned for the Helm `values.yaml` file. 
 - A Consul Enterprise license must be installed on each Kubernetes cluster.
 - The helm chart for consul-k8s v0.39.0 or greater.
 - Consul 1.11.1-ent or greater.

--- a/website/content/docs/enterprise/admin-partitions.mdx
+++ b/website/content/docs/enterprise/admin-partitions.mdx
@@ -204,7 +204,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
 1. Install the Consul server(s) using the values file created in the previous step:
 
   ```shell-session
-  $ helm install ${HELM_RELEASE_SERVER} hashicorp/consul --version "0.48.0" --create-namespace --namespace consul --values server.yaml
+  $ helm install ${HELM_RELEASE_SERVER} hashicorp/consul --version "0.49.0" --create-namespace --namespace consul --values server.yaml
   ```
 
 1. After the server starts, get the external IP address for partition service so that it can be added to the client configuration. The IP address is used to bootstrap connectivity between servers and clients. <a name="get-external-ip-address"/>
@@ -309,7 +309,7 @@ Verify that your Consul deployment meets the [Kubernetes Requirements](#kubernet
 1. Install the workload client clusters:
 
   ```shell-session
-  $ helm install ${HELM_RELEASE_CLIENT} hashicorp/consul --version "0.48.0" --create-namespace --namespace consul --values client.yaml
+  $ helm install ${HELM_RELEASE_CLIENT} hashicorp/consul --version "0.49.0" --create-namespace --namespace consul --values client.yaml
   ```
 
 ### Verifying the Deployment

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/bootstrap-token.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/bootstrap-token.mdx
@@ -70,7 +70,7 @@ To find out the service account name of the Consul server-acl-init job (i.e. the
 you can run the following `helm template` command with your Consul on Kubernetes values file:
 
 ```shell-session
-$ helm template --release-name ${RELEASE_NAME} -s templates/server-acl-init-serviceaccount.yaml hashicorp/consul
+$ helm template --release-name ${RELEASE_NAME} -s templates/server-acl-init-serviceaccount.yaml hashicorp/consul -f values.yaml
 ```
 
 ## Update Consul on Kubernetes Helm chart

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/connect-ca.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/connect-ca.mdx
@@ -51,7 +51,7 @@ To find out the service account name of the Consul server,
 you can run:
 
 ```shell-session
-$ helm template --release-name ${RELEASE_NAME} --show-only templates/server-serviceaccount.yaml hashicorp/consul
+$ helm template --release-name ${RELEASE_NAME} --show-only templates/server-serviceaccount.yaml hashicorp/consul -f values.yaml
 ```
 
 ## Update Consul on Kubernetes Helm chart

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/enterprise-license.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/enterprise-license.mdx
@@ -79,12 +79,12 @@ you can run the following `helm template` commands with your Consul on Kubernete
 
 - Generate Consul server service account name
   ```shell-session
-  $ helm template --release-name ${RELEASE_NAME} -s templates/server-serviceaccount.yaml hashicorp/consul
+  $ helm template --release-name ${RELEASE_NAME} -s templates/server-serviceaccount.yaml hashicorp/consul -f values.yaml
   ```
 
 - Generate Consul client service account name
   ```shell-session
-  $ helm template --release-name ${RELEASE_NAME} -s templates/client-serviceaccount.yaml hashicorp/consul
+  $ helm template --release-name ${RELEASE_NAME} -s templates/client-serviceaccount.yaml hashicorp/consul -f values.yaml
   ```
 
 ## Update Consul on Kubernetes Helm chart.

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/gossip.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/gossip.mdx
@@ -78,12 +78,12 @@ you can run the following `helm template` commands with your Consul on Kubernete
 
 - Generate Consul server service account name
   ```shell-session
-  $ helm template --release-name ${RELEASE_NAME} -s templates/server-serviceaccount.yaml hashicorp/consul
+  $ helm template --release-name ${RELEASE_NAME} -s templates/server-serviceaccount.yaml hashicorp/consul -f values.yaml
   ```
 
 - Generate Consul client service account name
   ```shell-session
-  $ helm template --release-name ${RELEASE_NAME} -s templates/client-serviceaccount.yaml hashicorp/consul
+  $ helm template --release-name ${RELEASE_NAME} -s templates/client-serviceaccount.yaml hashicorp/consul -f values.yaml
   ```
 
 ## Update Consul on Kubernetes Helm chart

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/partition-token.mdx
@@ -71,7 +71,7 @@ To find out the service account name of the `partition-init` job,
 you can run the following `helm template` command with your Consul on Kubernetes values file:
 
 ```shell-session
-$ helm template --release-name ${RELEASE_NAME} -s templates/partition-init-serviceaccount.yaml hashicorp/consul
+$ helm template --release-name ${RELEASE_NAME} -s templates/partition-init-serviceaccount.yaml hashicorp/consul -f values.yaml
 ```
 
 ## Update Consul on Kubernetes Helm chart

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/server-tls.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/server-tls.mdx
@@ -138,7 +138,7 @@ this is required for the Consul components to communicate with the Consul server
     you can run:
 
     ```shell-session
-    $ helm template --release-name ${RELEASE_NAME} --show-only templates/server-serviceaccount.yaml hashicorp/consul
+    $ helm template --release-name ${RELEASE_NAME} --show-only templates/server-serviceaccount.yaml hashicorp/consul -f values.yaml
     ```
 
     Role for Consul clients:
@@ -153,7 +153,7 @@ this is required for the Consul components to communicate with the Consul server
 
     To find out the service account name of the Consul client, use the command below.
     ```shell-session
-    $ helm template --release-name ${RELEASE_NAME} --show-only templates/client-serviceaccount.yaml hashicorp/consul
+    $ helm template --release-name ${RELEASE_NAME} --show-only templates/client-serviceaccount.yaml hashicorp/consul -f values.yaml
     ```
 
     Role for CA components:

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/snapshot-agent-config.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/snapshot-agent-config.mdx
@@ -70,7 +70,7 @@ To find out the service account name of the Consul snapshot agent,
 you can run the following `helm template` command with your Consul on Kubernetes values file:
 
 ```shell-session
-$ helm template --release-name ${RELEASE_NAME} -s templates/client-snapshot-agent-serviceaccount.yaml hashicorp/consul
+$ helm template --release-name ${RELEASE_NAME} -s templates/client-snapshot-agent-serviceaccount.yaml hashicorp/consul -f values.yaml
 ```
 
 ## Update Consul on Kubernetes Helm chart

--- a/website/content/docs/k8s/deployment-configurations/vault/data-integration/webhook-certs.mdx
+++ b/website/content/docs/k8s/deployment-configurations/vault/data-integration/webhook-certs.mdx
@@ -169,7 +169,7 @@ this is required for the Consul components to communicate with the Consul server
     you can run:
 
     ```shell-session
-    $ helm template --release-name ${RELEASE_NAME} --show-only templates/controller-serviceaccount.yaml hashicorp/consul
+    $ helm template --release-name ${RELEASE_NAME} --show-only templates/controller-serviceaccount.yaml hashicorp/consul -f values.yaml
     ```
 
     Role for Consul connect inject webhooks:
@@ -184,7 +184,7 @@ this is required for the Consul components to communicate with the Consul server
 
     To find out the service account name of the Consul connect inject, use the command below.
     ```shell-session
-    $ helm template --release-name ${RELEASE_NAME} --show-only templates/connect-inject-serviceaccount.yaml hashicorp/consul
+    $ helm template --release-name ${RELEASE_NAME} --show-only templates/connect-inject-serviceaccount.yaml hashicorp/consul -f values.yaml
     ```
 
 ## Update Consul on Kubernetes Helm chart


### PR DESCRIPTION
### Description

- Bump Consul and Consul K8s versions
- Add explicit requirement for global.name to be unique across K8s clusters
- Add -f values.yaml to each helm template command in the Vault Secrets backend integration pages

### Testing & Reproduction steps
* In the case of bugs, describe how to replicate
* If any manual tests were done, document the steps and the conditions to replicate
* Call out any important/ relevant unit tests, e2e tests or integration tests you have added or are adding

### Links
Include any links here that might be helpful for people reviewing your PR (Tickets, GH issues, API docs, external benchmarks, tools docs, etc). If there are none, feel free to delete this section.

Please be mindful not to leak any customer or confidential information. HashiCorp employees may want to use our internal URL shortener to obfuscate links.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [ ] not a security concern
