### PR TITLE
docs: clarify license behavior on restart

### DIFF
--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -64,7 +64,7 @@ can operate without a license.
 
 ## Q: Is there a grace period when licenses expire?
 
-**Yes—Consul will continue normal operation after license *expiration*** as defined in
+**Yes—Consul will continue normal operation and can be restarted after license *expiration*** as defined in
 [`expiration_time`](/api-docs/operator/license#getting-the-consul-license).
 As license expiration is approached or passed, Consul will issue warnings in the system logs.
 


### PR DESCRIPTION
Manual backport because the auto-backport failed for some reason: https://github.com/hashicorp/consul/pull/14764