### PR TITLE
Docs: Add OpenShift CNI to list of install options for kubernetes

### DIFF
--- a/website/content/docs/k8s/installation/install.mdx
+++ b/website/content/docs/k8s/installation/install.mdx
@@ -119,7 +119,7 @@ Because the plugin is executed by the local Kubernetes kubelet, the plugin alrea
 The Consul Helm Chart is responsible for installing the Consul CNI plugin.
 To configure the plugin to be installed, add the following configuration to your `values.yaml` file:
 
-<CodeTabs tabs={[ "Reference configuration","GKE configuration" ]}>
+<CodeTabs tabs={[ "Reference configuration","GKE configuration","OpenShift configuration" ]}>
 
 <CodeBlockConfig filename="values.yaml">
 
@@ -151,6 +151,24 @@ connectInject:
 ```
 </CodeBlockConfig>
 
+<CodeBlockConfig filename="values.yaml">
+
+```yaml
+global:
+  name: consul
+  openshift:
+    enabled: true
+connectInject:
+  enabled: true
+  cni:
+    enabled: true
+    logLevel: info
+    multus: true
+    cniBinDir: "/var/lib/cni/bin"
+    cniNetDir: "/etc/kubernetes/cni/net.d"
+```
+</CodeBlockConfig>
+
 </CodeTabs>
 
 
@@ -160,6 +178,7 @@ The following table describes the available CNI plugin options:
 | ---    | ---         | ---     |
 | `cni.enabled` | Boolean value that enables or disables the CNI plugin. If `true`, the plugin is responsible for redirecting traffic in the service mesh. If `false`, redirection is handled by the `connect-inject init` container. | `false` |
 | `cni.logLevel` | String value that specifies the log level for the installer and plugin. You can specify the following values: `info`, `debug`, `error`. | `info` |
+| `cni.multus` | Boolean value that enables multus CNI plugin support. If `true`, multus will be enabled. If `false`, Consul CNI will operate as a chained plugin. | `false` |
 | `cni.cniBinDir` | String value that specifies the location on the Kubernetes node where the CNI plugin is installed. | `/opt/cni/bin` |
 | `cni.cniNetDir` | String value that specifies the location on the Kubernetes node for storing the CNI configuration. | `/etc/cni/net.d` |
 


### PR DESCRIPTION
### Description
Describe why you're making this change, in plain English.

When consul-k8s is released with 0.49.0, around Sept 29th, there will now be support for using the consul-cni plugin on OpenShift.

This change adds that information to the consul-k8s install doc.

### Testing & Reproduction steps

Ran the container locally and validated the changes.

### Links

[CNI: Add support for OpenShift and Multus](https://github.com/hashicorp/consul-k8s/pull/1527)

### PR Checklist

* [ ] updated test coverage
* [x] external facing docs updated
* [x] not a security concern
