### PR TITLE
ui: fix link back to hcp not showing up

### DIFF
--- a/ui/packages/consul-ui/lib/startup/templates/body.html.js
+++ b/ui/packages/consul-ui/lib/startup/templates/body.html.js
@@ -71,6 +71,7 @@ ${
   <script src="${rootURL}assets/consul-nspaces/routes.js"></script>
 {{end}}
 {{if .HCPEnabled}}
+  <script src="${rootURL}assets/consul-hcp/services.js"></script>
   <script src="${rootURL}assets/consul-hcp/routes.js"></script>
 {{end}}
 `


### PR DESCRIPTION
### Description
Make sure to use the "sub-app"-approach of injecting the hcp/back-link properly so that it actually gets bundled in production environments.

#### Notable
This issue probably occurred because testing against a real backend is hard at the moment. We most likely want to create an easy-to-use setup in the near future that allows us to run the UI against a proper consul-agent.

### Testing & Reproduction steps
* run `make ui-docker` and `make docker-dev` after that
* setup a `docker-compose`-file that starts an agent and pass the following flag: `CONSUL_HCP_ENABLED=true`, alternatively you can run proper HCP and boot consul inside of it.

### PR Checklist

* [ ] updated test coverage
* [ ] external facing docs updated
* [x] not a security concern
