### PR TITLE
connect: Bump Envoy 1.20 to 1.20.7

### DIFF
--- a/.changelog/14830.txt
+++ b/.changelog/14830.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+connect: Bump Envoy 1.20 to 1.20.7
+```

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -849,10 +849,10 @@ jobs:
     environment:
       ENVOY_VERSION: "1.19.5"
 
-  envoy-integration-test-1_20_6:
+  envoy-integration-test-1_20_7:
     <<: *ENVOY_TESTS
     environment:
-      ENVOY_VERSION: "1.20.6"
+      ENVOY_VERSION: "1.20.7"
 
   # run integration tests for the connect ca providers
   test-connect-ca-providers:
@@ -1077,7 +1077,7 @@ workflows:
       - envoy-integration-test-1_19_5:
           requires:
             - dev-build
-      - envoy-integration-test-1_20_6:
+      - envoy-integration-test-1_20_7:
           requires:
             - dev-build
       - noop

--- a/agent/xds/envoy_versioning_test.go
+++ b/agent/xds/envoy_versioning_test.go
@@ -132,7 +132,7 @@ func TestDetermineSupportedProxyFeaturesFromString(t *testing.T) {
 	}
 	for _, v := range []string{
 		"1.19.0", "1.19.1", "1.19.2", "1.19.3", "1.19.4", "1.19.5",
-		"1.20.0", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5", "1.20.6",
+		"1.20.0", "1.20.1", "1.20.2", "1.20.3", "1.20.4", "1.20.5", "1.20.6", "1.20.7",
 	} {
 		cases[v] = testcase{expect: supportedProxyFeatures{}}
 	}

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -7,7 +7,7 @@ package proxysupport
 //
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
-	"1.20.6",
+	"1.20.7",
 	"1.19.5",
 	"1.18.6",
 	"1.17.4",

--- a/website/content/docs/connect/proxies/envoy.mdx
+++ b/website/content/docs/connect/proxies/envoy.mdx
@@ -37,7 +37,7 @@ Consul supports **four major Envoy releases** at the beginning of each major Con
 
 | Consul Version      | Compatible Envoy Versions                                                          |
 | ------------------- | -----------------------------------------------------------------------------------|
-| 1.11.x              | 1.20.6, 1.19.5, 1.18.6, 1.17.4<sup>1</sup>                                         |
+| 1.11.x              | 1.20.7, 1.19.5, 1.18.6, 1.17.4<sup>1</sup>                                         |
 | 1.10.x              | 1.18.6, 1.17.4<sup>1</sup>, 1.16.5<sup>1</sup>, 1.15.5<sup>1</sup>                 |
 | 1.9.x               | 1.16.5<sup>1</sup>, 1.15.5<sup>1</sup>, 1.14.7<sup>1,2</sup>, 1.13.7<sup>1,2</sup> |
 


### PR DESCRIPTION
### Description
Self-explanatory. Bumps versions in the test matrix, test code and our docs.

### Testing & Reproduction steps
We should see our integration tests pass with this new patch.
