### PR TITLE
autoencrypt: helpful error for clients with wrong dc

### DIFF
--- a/.changelog/14832.txt
+++ b/.changelog/14832.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: Give better error when client specifies wrong datacenter when auto-encrypt is enabled.
+```

--- a/agent/consul/auto_encrypt_endpoint.go
+++ b/agent/consul/auto_encrypt_endpoint.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/hashicorp/consul/agent/structs"
 )
@@ -23,6 +24,13 @@ func (a *AutoEncrypt) Sign(
 	}
 	if !a.srv.config.AutoEncryptAllowTLS {
 		return ErrAutoEncryptAllowTLSNotEnabled
+	}
+	// There's no reason to forward the AutoEncrypt.Sign RPC to a remote datacenter because its certificates
+	// won't be valid in this datacenter. If the client is requesting a different datacenter, then this is a
+	// misconfiguration, and we can give them a useful error.
+	if args.Datacenter != a.srv.config.Datacenter {
+		return fmt.Errorf("mismatched datacenter (client_dc='%s' server_dc='%s');"+
+			" check client has same datacenter set as servers", args.Datacenter, a.srv.config.Datacenter)
 	}
 	if done, err := a.srv.ForwardRPC("AutoEncrypt.Sign", args, reply); done {
 		return err

--- a/agent/consul/auto_encrypt_endpoint_test.go
+++ b/agent/consul/auto_encrypt_endpoint_test.go
@@ -139,3 +139,58 @@ func TestAutoEncryptSign(t *testing.T) {
 		})
 	}
 }
+
+func TestAutoEncryptSign_MismatchedDC(t *testing.T) {
+	t.Parallel()
+
+	cert := "../../test/key/ourdomain.cer"
+	key := "../../test/key/ourdomain.key"
+	root := "../../test/ca/root.cer"
+	dir, s := testServerWithConfig(t, func(c *Config) {
+		c.AutoEncryptAllowTLS = true
+		c.PrimaryDatacenter = "dc1"
+		c.Bootstrap = true
+		c.TLSConfig.InternalRPC.CAFile = root
+		c.TLSConfig.InternalRPC.VerifyOutgoing = true
+		c.TLSConfig.InternalRPC.CertFile = cert
+		c.TLSConfig.InternalRPC.KeyFile = key
+	})
+	defer os.RemoveAll(dir)
+	defer s.Shutdown()
+	testrpc.WaitForLeader(t, s.RPC, "dc1")
+
+	// Generate a CSR and request signing
+	id := &connect.SpiffeIDAgent{
+		Host:       strings.TrimSuffix("domain", "."),
+		Datacenter: "different",
+		Agent:      "uuid",
+	}
+
+	// Create a new private key
+	pk, _, err := connect.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	// Create a CSR.
+	dnsNames := []string{"localhost"}
+	ipAddresses := []net.IP{net.ParseIP("127.0.0.1")}
+	csr, err := connect.CreateCSR(id, pk, dnsNames, ipAddresses)
+	require.NoError(t, err)
+	require.NotEmpty(t, csr)
+	args := &structs.CASignRequest{
+		Datacenter: "different",
+		CSR:        csr,
+	}
+
+	cfg := tlsutil.Config{
+		AutoTLS: true,
+		Domain:  "consul",
+	}
+	codec, err := insecureRPCClient(s, cfg)
+	require.NoError(t, err)
+
+	var reply structs.SignedResponse
+	err = msgpackrpc.CallWithCodec(codec, "AutoEncrypt.Sign", args, &reply)
+	codec.Close()
+	require.EqualError(t, err, "mismatched datacenter (client_dc='different' server_dc='dc1'); check client has same datacenter set as servers")
+	return
+}

--- a/agent/pool/pool.go
+++ b/agent/pool/pool.go
@@ -607,14 +607,14 @@ func (p *ConnPool) rpcInsecure(dc string, addr net.Addr, method string, args int
 	var codec rpc.ClientCodec
 	conn, _, err := p.dial(dc, addr, 0, RPCTLSInsecure)
 	if err != nil {
-		return fmt.Errorf("rpcinsecure error establishing connection: %w", err)
+		return fmt.Errorf("rpcinsecure: error establishing connection: %w", err)
 	}
 	codec = msgpackrpc.NewCodecFromHandle(true, true, conn, structs.MsgpackHandle)
 
 	// Make the RPC call
 	err = msgpackrpc.CallWithCodec(codec, method, args, reply)
 	if err != nil {
-		return fmt.Errorf("rpcinsecure error making call: %w", err)
+		return fmt.Errorf("rpcinsecure: error making call: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
If clients have set a different datacenter than the servers they're connecting with for autoencrypt, give a helpful error message. Fixes https://github.com/hashicorp/consul/issues/10205

The change is to check when we're about to call `ForwardRPC` if the datacenter matches our current DC. There's no use-case for forwarding to a remote DC so we can short-circuit right there.

### Testing & Reproduction steps
```
# server.hcl
server = true
bootstrap_expect = 1
data_dir = "/tmp/consul-server"
auto_encrypt {
  allow_tls = true
}
tls {
  defaults {
    ca_file = "certs/consul-agent-ca.pem"
    cert_file = "certs/dc1-server-consul-0.pem"
    key_file = "certs/dc1-server-consul-0-key.pem"
  }
}
```

```
# client.hcl
datacenter = "different"
retry_join = ["127.0.0.1:8301"]
ports {
  http = 9501
  dns = 9600
  serf_lan = 9301
}
data_dir = "/tmp/consul-client"
auto_encrypt {
  tls = true
}
```

Old logs:
```
[ERROR] agent.auto_config: AutoEncrypt.Sign RPC failed: addr=172.25.20.152:8300 error="rpcinsecure error making call: No path to datacenter"
[ERROR] agent.auto_config: No servers successfully responded to the auto-encrypt request
```

New logs:
```
2022-10-01T21:58:08.525-0700 [ERROR] agent.auto_config: No servers successfully responded to the auto-encrypt request
2022-10-01T21:59:55.456-0700 [ERROR] agent.auto_config: AutoEncrypt.Sign RPC failed: addr=127.0.0.1:8300 error="rpcinsecure: error making call: mismatched datacenter (client_dc='different' server_dc='dc1'); check client has same datacenter set as servers"
```

### PR Checklist

* [x] updated test coverage
* [x] ~external facing docs updated~
* [x] not a security concern
